### PR TITLE
Reduce daemon startup and runtime log noise

### DIFF
--- a/apps/agor-daemon/src/auth/session-token-strategy.ts
+++ b/apps/agor-daemon/src/auth/session-token-strategy.ts
@@ -43,7 +43,7 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
     // Debug logging. SECURITY: never log any portion of the token value —
     // session tokens are bearer credentials, even an 8-char prefix narrows a
     // guess significantly. Log presence booleans only.
-    console.log('[SessionTokenStrategy] parse() called:', {
+    console.debug('[SessionTokenStrategy] parse() called:', {
       socketId: socket?.id,
       hasFeathers: !!socket?.feathers,
       feathersKeys: socket?.feathers ? Object.keys(socket.feathers) : [],
@@ -61,16 +61,18 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
 
     // Only parse if we have a UUID-format token
     if (hasSessionToken && token) {
-      console.log('[SessionTokenStrategy] parse() returning session token (UUID format detected)');
+      console.debug(
+        '[SessionTokenStrategy] parse() returning session token (UUID format detected)'
+      );
       return { sessionToken: token };
     }
 
     if (auth?.strategy === 'session-token' && auth?.accessToken) {
-      console.log('[SessionTokenStrategy] parse() returning session token (strategy match)');
+      console.debug('[SessionTokenStrategy] parse() returning session token (strategy match)');
       return { sessionToken: auth.accessToken };
     }
 
-    console.log('[SessionTokenStrategy] parse() returning null (not session-token)');
+    console.debug('[SessionTokenStrategy] parse() returning null (not session-token)');
     return null;
   }
 
@@ -80,7 +82,7 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
   ): Promise<AuthenticationResult> {
     // SECURITY: do not log the authentication object — it contains the
     // session token. Log shape only.
-    console.log('[SessionTokenStrategy] authenticate() CALLED with:', {
+    console.debug('[SessionTokenStrategy] authenticate() CALLED with:', {
       authKeys: Object.keys(authentication || {}),
       hasSessionToken: !!authentication?.sessionToken,
     });
@@ -88,7 +90,7 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
     const { sessionToken } = authentication;
 
     if (!sessionToken) {
-      console.log('[SessionTokenStrategy] authenticate() FAILED: no token');
+      console.debug('[SessionTokenStrategy] authenticate() FAILED: no token');
       throw new Error('No session token provided');
     }
 
@@ -116,7 +118,7 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
         strategy: 'session-token',
         accessToken: sessionToken,
       };
-      console.log('[SessionTokenStrategy] ✅ Stored auth on socket during authenticate():', {
+      console.debug('[SessionTokenStrategy] ✅ Stored auth on socket during authenticate():', {
         socketId,
         storedStrategy: socket.feathers.authentication.strategy,
         // SECURITY: no token preview — bearer credentials must never be logged.
@@ -140,7 +142,7 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
       session_id: sessionInfo.session_id,
     };
 
-    console.log('[SessionTokenStrategy] authenticate() returning:', {
+    console.debug('[SessionTokenStrategy] authenticate() returning:', {
       strategy: result.authentication.strategy,
       // SECURITY: no token preview.
       user_id: sessionInfo.user_id,
@@ -155,7 +157,7 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
    */
   async verifyAccessToken(accessToken: string): Promise<AuthenticationResult> {
     // SECURITY: no token preview.
-    console.log('[SessionTokenStrategy] verifyAccessToken() called:', {
+    console.debug('[SessionTokenStrategy] verifyAccessToken() called:', {
       hasToken: !!accessToken,
     });
 
@@ -164,11 +166,11 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
     const sessionInfo = await this.sessionTokenService.validateToken(accessToken);
 
     if (!sessionInfo) {
-      console.log('[SessionTokenStrategy] verifyAccessToken() FAILED: invalid token');
+      console.debug('[SessionTokenStrategy] verifyAccessToken() FAILED: invalid token');
       throw new Error('Invalid or expired session token');
     }
 
-    console.log('[SessionTokenStrategy] verifyAccessToken() SUCCESS');
+    console.debug('[SessionTokenStrategy] verifyAccessToken() SUCCESS');
     return {
       authentication: {
         strategy: 'session-token',
@@ -188,14 +190,14 @@ export class SessionTokenStrategy extends AuthenticationBaseStrategy {
    * Override to skip database lookup since we already have user info from token
    */
   async getEntity(id: string): Promise<unknown> {
-    console.log('[SessionTokenStrategy] getEntity() called:', { user_id: id });
+    console.debug('[SessionTokenStrategy] getEntity() called:', { user_id: id });
     // Session tokens already include user_id, so we return a minimal user object
     // This prevents Feathers from trying to lookup the user in the database
     const user = {
       user_id: id,
       email: '',
     };
-    console.log('[SessionTokenStrategy] getEntity() returning:', user);
+    console.debug('[SessionTokenStrategy] getEntity() returning:', user);
     return user;
   }
 }

--- a/apps/agor-daemon/src/knowledge/pgvector.test.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.test.ts
@@ -11,7 +11,13 @@ function fakePostgresDb(execute: (query: unknown) => unknown | Promise<unknown>)
 describe('Knowledge pgvector capability detection', () => {
   it('treats postgres-js array results as available when extension and storage exist', async () => {
     const db = fakePostgresDb(() => [
-      { extension_installed: true, extension_available: true, storage_ready: true },
+      {
+        extension_installed: true,
+        extension_available: true,
+        table_ready: true,
+        space_index_ready: true,
+        hnsw_index_ready: true,
+      },
     ]);
 
     await expect(getKnowledgePgvectorCapability(db)).resolves.toMatchObject({
@@ -28,7 +34,15 @@ describe('Knowledge pgvector capability detection', () => {
     const execute = vi.fn(() => {
       calls += 1;
       if (calls === 2) throw new Error('permission denied');
-      return [{ extension_installed: false, extension_available: true, storage_ready: false }];
+      return [
+        {
+          extension_installed: false,
+          extension_available: true,
+          table_ready: false,
+          space_index_ready: false,
+          hnsw_index_ready: false,
+        },
+      ];
     });
     const db = fakePostgresDb(execute);
 
@@ -37,5 +51,24 @@ describe('Knowledge pgvector capability detection', () => {
       reason: expect.stringContaining('permission denied'),
       setupHint: expect.stringContaining('CREATE EXTENSION vector'),
     });
+  });
+
+  it('does not issue CREATE statements when pgvector storage objects already exist', async () => {
+    const execute = vi.fn(() => [
+      {
+        extension_installed: true,
+        extension_available: true,
+        table_ready: true,
+        space_index_ready: true,
+        hnsw_index_ready: true,
+      },
+    ]);
+    const db = fakePostgresDb(execute);
+
+    await expect(ensureKnowledgePgvectorStorage(db)).resolves.toMatchObject({
+      available: true,
+      storageReady: true,
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/agor-daemon/src/knowledge/pgvector.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.ts
@@ -132,7 +132,7 @@ export async function ensureKnowledgePgvectorStorage(
     if (!capability.tableReady) {
       await executeRaw(
         db,
-        sql`CREATE TABLE kb_unit_embeddings (
+        sql`CREATE TABLE IF NOT EXISTS kb_unit_embeddings (
           unit_id varchar(36) NOT NULL REFERENCES public.kb_document_units(unit_id) ON DELETE cascade,
           embedding_space_id varchar(36) NOT NULL REFERENCES public.kb_embedding_spaces(embedding_space_id) ON DELETE cascade,
           content_sha256 text NOT NULL,
@@ -148,7 +148,7 @@ export async function ensureKnowledgePgvectorStorage(
     if (!capability.spaceIndexReady) {
       await executeRaw(
         db,
-        sql`CREATE INDEX kb_unit_embeddings_space_idx ON kb_unit_embeddings USING btree (embedding_space_id)`
+        sql`CREATE INDEX IF NOT EXISTS kb_unit_embeddings_space_idx ON kb_unit_embeddings USING btree (embedding_space_id)`
       );
       capability.spaceIndexReady = true;
     }
@@ -157,7 +157,7 @@ export async function ensureKnowledgePgvectorStorage(
       try {
         await executeRaw(
           db,
-          sql`CREATE INDEX kb_unit_embeddings_embedding_1536_hnsw_idx
+          sql`CREATE INDEX IF NOT EXISTS kb_unit_embeddings_embedding_1536_hnsw_idx
             ON kb_unit_embeddings USING hnsw ((embedding::vector(1536)) vector_cosine_ops)
             WHERE vector_dims(embedding) = 1536`
         );

--- a/apps/agor-daemon/src/knowledge/pgvector.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.ts
@@ -9,6 +9,12 @@ export interface KnowledgePgvectorCapability {
   setupHint: string | null;
 }
 
+interface KnowledgePgvectorStorageState extends KnowledgePgvectorCapability {
+  tableReady: boolean;
+  spaceIndexReady: boolean;
+  hnswIndexReady: boolean;
+}
+
 const SETUP_HINT =
   'Install the pgvector package on the Postgres server and have a database owner run `CREATE EXTENSION vector;`, or grant the Agor database user permission to create the extension, then re-enable/reindex Knowledge semantic search.';
 
@@ -26,13 +32,16 @@ export function semanticUnavailableMessage(reason?: string | null): string {
   return `Semantic Knowledge search is unavailable${reason ? `: ${reason}` : ''}. ${SETUP_HINT}`;
 }
 
-async function readCapability(db: Database): Promise<KnowledgePgvectorCapability> {
+async function readCapability(db: Database): Promise<KnowledgePgvectorStorageState> {
   if (!isPostgresDatabase(db)) {
     return {
       available: false,
       extensionInstalled: false,
       extensionAvailable: false,
       storageReady: false,
+      tableReady: false,
+      spaceIndexReady: false,
+      hnswIndexReady: false,
       reason: 'the configured database is not PostgreSQL',
       setupHint: 'Use text Knowledge search, or switch Agor to PostgreSQL and enable pgvector.',
     };
@@ -44,12 +53,17 @@ async function readCapability(db: Database): Promise<KnowledgePgvectorCapability
       sql`SELECT
           EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS extension_installed,
           EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS extension_available,
-          to_regclass('public.kb_unit_embeddings') IS NOT NULL AS storage_ready`
+          to_regclass('public.kb_unit_embeddings') IS NOT NULL AS table_ready,
+          to_regclass('public.kb_unit_embeddings_space_idx') IS NOT NULL AS space_index_ready,
+          to_regclass('public.kb_unit_embeddings_embedding_1536_hnsw_idx') IS NOT NULL AS hnsw_index_ready`
     );
     const first = rowsOf(result)[0] ?? {};
     const extensionInstalled = boolValue(first.extension_installed);
     const extensionAvailable = boolValue(first.extension_available);
-    const storageReady = boolValue(first.storage_ready);
+    const tableReady = boolValue(first.table_ready);
+    const spaceIndexReady = boolValue(first.space_index_ready);
+    const hnswIndexReady = boolValue(first.hnsw_index_ready);
+    const storageReady = tableReady;
     const reason = !extensionInstalled
       ? extensionAvailable
         ? 'the pgvector extension is available on the server but is not enabled in this database'
@@ -62,6 +76,9 @@ async function readCapability(db: Database): Promise<KnowledgePgvectorCapability
       extensionInstalled,
       extensionAvailable,
       storageReady,
+      tableReady,
+      spaceIndexReady,
+      hnswIndexReady,
       reason,
       setupHint: reason ? SETUP_HINT : null,
     };
@@ -71,6 +88,9 @@ async function readCapability(db: Database): Promise<KnowledgePgvectorCapability
       extensionInstalled: false,
       extensionAvailable: false,
       storageReady: false,
+      tableReady: false,
+      spaceIndexReady: false,
+      hnswIndexReady: false,
       reason: `unable to inspect pgvector capability (${error instanceof Error ? error.message : String(error)})`,
       setupHint: SETUP_HINT,
     };
@@ -104,10 +124,15 @@ export async function ensureKnowledgePgvectorStorage(
     if (!capability.extensionInstalled) return capability;
   }
 
+  if (capability.tableReady && capability.spaceIndexReady && capability.hnswIndexReady) {
+    return capability;
+  }
+
   try {
-    await executeRaw(
-      db,
-      sql`CREATE TABLE IF NOT EXISTS kb_unit_embeddings (
+    if (!capability.tableReady) {
+      await executeRaw(
+        db,
+        sql`CREATE TABLE kb_unit_embeddings (
           unit_id varchar(36) NOT NULL REFERENCES public.kb_document_units(unit_id) ON DELETE cascade,
           embedding_space_id varchar(36) NOT NULL REFERENCES public.kb_embedding_spaces(embedding_space_id) ON DELETE cascade,
           content_sha256 text NOT NULL,
@@ -117,24 +142,32 @@ export async function ensureKnowledgePgvectorStorage(
           updated_at timestamp with time zone NOT NULL,
           CONSTRAINT kb_unit_embeddings_unit_id_embedding_space_id_pk PRIMARY KEY(unit_id, embedding_space_id)
         )`
-    );
-    await executeRaw(
-      db,
-      sql`CREATE INDEX IF NOT EXISTS kb_unit_embeddings_space_idx ON kb_unit_embeddings USING btree (embedding_space_id)`
-    );
-
-    try {
+      );
+      capability.tableReady = true;
+    }
+    if (!capability.spaceIndexReady) {
       await executeRaw(
         db,
-        sql`CREATE INDEX IF NOT EXISTS kb_unit_embeddings_embedding_1536_hnsw_idx
+        sql`CREATE INDEX kb_unit_embeddings_space_idx ON kb_unit_embeddings USING btree (embedding_space_id)`
+      );
+      capability.spaceIndexReady = true;
+    }
+
+    if (!capability.hnswIndexReady) {
+      try {
+        await executeRaw(
+          db,
+          sql`CREATE INDEX kb_unit_embeddings_embedding_1536_hnsw_idx
             ON kb_unit_embeddings USING hnsw ((embedding::vector(1536)) vector_cosine_ops)
             WHERE vector_dims(embedding) = 1536`
-      );
-    } catch (error) {
-      console.warn(
-        '[knowledge-pgvector] vector storage is available, but creating the HNSW index failed:',
-        error instanceof Error ? error.message : error
-      );
+        );
+        capability.hnswIndexReady = true;
+      } catch (error) {
+        console.warn(
+          '[knowledge-pgvector] vector storage is available, but creating the HNSW index failed:',
+          error instanceof Error ? error.message : error
+        );
+      }
     }
   } catch (error) {
     return {

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -11,6 +11,7 @@ import {
   kbDocumentVersions,
   kbEmbeddingSpaces,
   select,
+  shortId,
   sql,
   update,
 } from '@agor/core/db';
@@ -31,6 +32,7 @@ const DEFAULT_TICK_MS = 30_000;
 
 interface PendingUnitRow {
   unit_id: string;
+  document_id: string;
   content_text: string | null;
   content_md5: string | null;
 }
@@ -409,6 +411,19 @@ export class KnowledgeEmbeddingIndexer {
       );
     }
 
+    // Hot idle path: first ask the core Knowledge table whether there is
+    // anything to index. Avoid pgvector DDL/capability setup, embedding-space
+    // lookup, and provider work on ticks where no units are pending.
+    const pending = (await select(this.db, { unit_id: kbDocumentUnits.unit_id })
+      .from(kbDocumentUnits)
+      .where(
+        sql`${kbDocumentUnits.embedding_status} IN ('pending', 'stale') AND ${kbDocumentUnits.content_text} IS NOT NULL`
+      )
+      .orderBy(kbDocumentUnits.created_at)
+      .limit(1)
+      .one()) as { unit_id: string } | undefined;
+    if (!pending) return this.idle();
+
     const pgvector = await ensureKnowledgePgvectorStorage(this.db);
     if (!pgvector.available) {
       this.lastError = pgvector.reason ?? 'Knowledge pgvector storage is unavailable';
@@ -447,6 +462,24 @@ export class KnowledgeEmbeddingIndexer {
       this.lastIndexedAt = new Date();
       return reused;
     }
+
+    const chunksByDocument = new Map<string, number>();
+    let totalChars = 0;
+    for (const row of rows) {
+      chunksByDocument.set(row.document_id, (chunksByDocument.get(row.document_id) ?? 0) + 1);
+      totalChars += row.content_text?.length ?? 0;
+    }
+    const docSummary = [...chunksByDocument.entries()]
+      .slice(0, 5)
+      .map(([documentId, count]) => `${shortId(documentId)}=${count}`)
+      .join(', ');
+    const extraDocs = Math.max(0, chunksByDocument.size - 5);
+    console.info(
+      `[knowledge-indexer] Computing ${rows.length} embedding chunk(s) across ${
+        chunksByDocument.size
+      } document(s) (${docSummary}${extraDocs > 0 ? `, +${extraDocs} more` : ''}); ` +
+        `model=${model}, dimensions=${dimensions}, chars=${totalChars}`
+    );
 
     let results: Awaited<ReturnType<OpenAIEmbeddingProvider['embed']>>;
     try {

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -104,7 +104,7 @@ export class SessionTokenService {
       use_count: 0,
     });
 
-    console.log(
+    console.debug(
       `[SessionTokenService] Generated JWT for session=${sessionId}, expires=${expiresAt.toISOString()}`
     );
 
@@ -147,18 +147,23 @@ export class SessionTokenService {
       return null;
     }
 
-    // Check max uses (if configured)
+    // Check max uses (if configured). Reusable executor tokens are validated
+    // on every protected daemon service call, so avoid mutating a diagnostic
+    // counter for the normal unlimited-use path.
     if (data.max_uses > 0 && data.use_count >= data.max_uses) {
       console.warn(`[SessionTokenService] Token max uses exceeded`);
       this.tokens.delete(token);
       return null;
     }
 
-    // Increment use count
-    data.use_count++;
+    if (data.max_uses > 0) {
+      data.use_count++;
+    }
 
-    console.log(
-      `[SessionTokenService] Token validated: session=${data.session_id}, uses=${data.use_count}/${data.max_uses === -1 ? '∞' : data.max_uses}`
+    console.debug(
+      data.max_uses > 0
+        ? `[SessionTokenService] Token validated: session=${data.session_id}, uses=${data.use_count}/${data.max_uses}`
+        : `[SessionTokenService] Reusable token validated: session=${data.session_id}`
     );
 
     return {
@@ -174,7 +179,7 @@ export class SessionTokenService {
    */
   revokeToken(token: string): void {
     if (this.tokens.delete(token)) {
-      console.log(`[SessionTokenService] Token revoked`);
+      console.debug(`[SessionTokenService] Token revoked`);
     }
   }
 
@@ -192,7 +197,7 @@ export class SessionTokenService {
     }
 
     if (count > 0) {
-      console.log(`[SessionTokenService] Revoked ${count} tokens for session=${sessionId}`);
+      console.debug(`[SessionTokenService] Revoked ${count} tokens for session=${sessionId}`);
     }
   }
 
@@ -218,7 +223,7 @@ export class SessionTokenService {
     }
 
     if (count > 0) {
-      console.log(`[SessionTokenService] Cleaned up ${count} expired tokens`);
+      console.debug(`[SessionTokenService] Cleaned up ${count} expired tokens`);
     }
   }
 

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -749,7 +749,7 @@ export function createSocketIOConfig(
       for (const [, socket] of io.sockets.sockets) {
         if ((socket as FeathersSocket).feathers === context.connection) {
           socket.join(userRoomName(userId));
-          console.log(
+          console.debug(
             `🏠 Socket ${socket.id} joined user room after login: user:${shortId(userId)}`
           );
           break;
@@ -805,7 +805,7 @@ export function configureChannels(app: Application): void {
   app.on('login', (authResult: unknown, context: { connection?: unknown }) => {
     if (context.connection) {
       const result = authResult as { user?: { user_id?: string; email?: string } };
-      console.log('✅ Login event fired:', result.user?.user_id, result.user?.email);
+      console.debug('✅ Login event fired:', result.user?.user_id, result.user?.email);
 
       // SECURITY: Only now does the connection receive broadcast events
       app.channel('authenticated').join(context.connection as never);

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -78,7 +78,7 @@ describe('configured executor spawning', () => {
         '-c',
         expect.stringMatching(/^kubectl run executor-[0-9a-f]{8} --user agor-exec -- prompt$/),
       ],
-      { stdio: ['pipe', 'pipe', 'pipe'] }
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
     );
     expect(JSON.parse(proc.written)).toMatchObject({
       command: 'prompt',
@@ -104,9 +104,11 @@ describe('configured executor spawning', () => {
       }
     );
 
-    expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'explicit explicit-user git.clone'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'explicit explicit-user git.clone'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    );
   });
 
   it('calls onExit for templated spawns', async () => {
@@ -139,9 +141,33 @@ describe('configured executor spawning', () => {
 
     injectedSpawner({ command: 'prompt' });
 
-    expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'injected injected-user prompt'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'injected injected-user prompt'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] })
+    );
+  });
+
+  it('passes LOG_LEVEL to templated executor processes and exposes a template variable', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { spawnExecutor } = await import('./spawn-executor');
+
+    spawnExecutor(
+      { command: 'prompt' },
+      {
+        executorCommandTemplate: 'run --log-level={log_level} -- {command}',
+        env: { LOG_LEVEL: 'warn' },
+      }
+    );
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'sh',
+      ['-c', 'run --log-level=warn -- prompt'],
+      expect.objectContaining({
+        env: expect.objectContaining({ LOG_LEVEL: 'warn' }),
+      })
+    );
   });
 
   it('propagates an explicit LOG_LEVEL to local executor processes at startup', async () => {

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -50,6 +50,11 @@ describe('configured executor spawning', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
+    const unix = await import('@agor/core/unix');
+    vi.mocked(unix.buildSpawnArgs).mockReturnValue({ cmd: 'node', args: ['executor', '--stdin'] });
+    vi.mocked(unix.isSecretEnvKey).mockReturnValue(false);
+    vi.mocked(unix.attachEnvFileCleanup).mockImplementation(() => {});
+
     const { configureExecutor } = await import('./spawn-executor');
     configureExecutor(null);
   });
@@ -137,5 +142,58 @@ describe('configured executor spawning', () => {
     expect(spawnMock).toHaveBeenCalledWith('sh', ['-c', 'injected injected-user prompt'], {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
+  });
+
+  it('propagates an explicit LOG_LEVEL to local executor processes at startup', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const { spawnExecutor } = await import('./spawn-executor');
+
+    spawnExecutor(
+      { command: 'prompt' },
+      {
+        env: { PATH: '/usr/bin', LOG_LEVEL: 'warn' },
+      }
+    );
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'node',
+      ['executor', '--stdin'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          DAEMON_URL: expect.any(String),
+          LOG_LEVEL: 'warn',
+        }),
+      })
+    );
+  });
+
+  it('derives LOG_LEVEL for executor processes when only NODE_ENV is set', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const previousNodeEnv = process.env.NODE_ENV;
+    const previousLogLevel = process.env.LOG_LEVEL;
+    process.env.NODE_ENV = 'production';
+    delete process.env.LOG_LEVEL;
+
+    try {
+      const { spawnExecutor } = await import('./spawn-executor');
+      spawnExecutor({ command: 'prompt' }, { env: { PATH: '/usr/bin' } });
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+      if (previousLogLevel === undefined) delete process.env.LOG_LEVEL;
+      else process.env.LOG_LEVEL = previousLogLevel;
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'node',
+      ['executor', '--stdin'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          LOG_LEVEL: 'info',
+        }),
+      })
+    );
   });
 });

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -32,6 +32,7 @@ import {
   isSecretEnvKey,
   prepareImpersonationEnv,
 } from '@agor/core/unix';
+import { getCurrentLogLevel } from '@agor/core/utils/logger';
 import type { SignOptions } from 'jsonwebtoken';
 import { issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { withResolvedConfig } from './build-resolved-config-slice.js';
@@ -39,10 +40,7 @@ import { withResolvedConfig } from './build-resolved-config-slice.js';
 let configuredDaemonUrl: string | null = null;
 
 function resolveExecutorLogLevel(env: Record<string, string>): string {
-  if (env.LOG_LEVEL) return env.LOG_LEVEL;
-  const debug = process.env.DEBUG;
-  if (debug === '*' || debug?.includes('agor')) return 'debug';
-  return process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+  return env.LOG_LEVEL || getCurrentLogLevel();
 }
 
 function withDaemonExecutorEnv(
@@ -91,6 +89,7 @@ export interface ExecutorTemplateVariables {
   unix_user_gid?: number;
   session_id?: string;
   branch_id?: string;
+  log_level?: string;
 }
 
 export interface SpawnExecutorOptions {
@@ -151,6 +150,7 @@ export function substituteTemplateVariables(
     unix_user_gid: variables.unix_user_gid,
     session_id: variables.session_id,
     branch_id: variables.branch_id,
+    log_level: variables.log_level,
   };
 
   for (const [key, value] of Object.entries(substitutions)) {
@@ -235,6 +235,7 @@ export function spawnExecutor(
         command: payloadWithConfig.command as string,
         task_id: generateTaskId(),
         unix_user: asUser,
+        log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
         ...templateVariables,
       },
       logPrefix,
@@ -389,6 +390,7 @@ function spawnExecutorWithTemplate(
   }
 ): void {
   const { executorCommandTemplate, templateVariables, logPrefix = '[Executor]' } = options;
+  const logLevel = templateVariables.log_level ?? getCurrentLogLevel();
 
   const command = substituteTemplateVariables(executorCommandTemplate, templateVariables);
 
@@ -398,6 +400,7 @@ function spawnExecutorWithTemplate(
   console.log(`${logPrefix} Template command (first 200 chars): ${command.slice(0, 200)}...`);
 
   const executorProcess = spawn('sh', ['-c', command], {
+    env: { ...process.env, LOG_LEVEL: logLevel },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
@@ -508,6 +511,7 @@ export async function runExecutorCommand(
         command: payloadWithConfig.command as string,
         task_id: generateTaskId(),
         unix_user: asUser,
+        log_level: resolveExecutorLogLevel(options.env ?? (process.env as Record<string, string>)),
         ...templateVariables,
       },
       logPrefix,
@@ -684,6 +688,7 @@ function runExecutorCommandWithTemplate(
     logPrefix = '[Executor]',
     timeoutMs = 60_000,
   } = options;
+  const logLevel = templateVariables.log_level ?? getCurrentLogLevel();
   const command = substituteTemplateVariables(executorCommandTemplate, templateVariables);
 
   console.log(`${logPrefix} Running templated executor command: ${payload.command ?? '?'}`);
@@ -694,6 +699,7 @@ function runExecutorCommandWithTemplate(
     let settled = false;
 
     const child = spawn('sh', ['-c', command], {
+      env: { ...process.env, LOG_LEVEL: logLevel },
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -38,6 +38,24 @@ import { withResolvedConfig } from './build-resolved-config-slice.js';
 
 let configuredDaemonUrl: string | null = null;
 
+function resolveExecutorLogLevel(env: Record<string, string>): string {
+  if (env.LOG_LEVEL) return env.LOG_LEVEL;
+  const debug = process.env.DEBUG;
+  if (debug === '*' || debug?.includes('agor')) return 'debug';
+  return process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+}
+
+function withDaemonExecutorEnv(
+  env: Record<string, string>,
+  daemonUrl: string
+): Record<string, string> {
+  return {
+    ...env,
+    DAEMON_URL: daemonUrl,
+    LOG_LEVEL: resolveExecutorLogLevel(env),
+  };
+}
+
 /** Set the daemon URL for executor payloads. Call once at daemon startup. */
 export function configureDaemonUrl(url: string): void {
   configuredDaemonUrl = url;
@@ -252,28 +270,31 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   const daemonUrl = getDaemonUrl();
 
   const envWithDaemonUrl: Record<string, string> = preparedEnv
-    ? { DAEMON_URL: daemonUrl, ...preparedEnv }
+    ? withDaemonExecutorEnv(preparedEnv, daemonUrl)
     : asUser
-      ? Object.fromEntries(
-          Object.entries({
-            DAEMON_URL: daemonUrl,
-            PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
-            NODE_ENV: env.NODE_ENV,
-            // HOME: not set - sudo will set it to the target user's home directory
-            ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
-            ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
-            ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
-            CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
-            OPENAI_API_KEY: env.OPENAI_API_KEY,
-            OPENAI_BASE_URL: env.OPENAI_BASE_URL,
-            GEMINI_API_KEY: env.GEMINI_API_KEY,
-            GOOGLE_API_KEY: env.GOOGLE_API_KEY,
-            // Forward git hardening pairs across the sudo boundary (sudoers
-            // env_keep is the belt; this is the suspenders for this path).
-            GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
-          }).filter(([_, v]) => v !== undefined)
+      ? withDaemonExecutorEnv(
+          Object.fromEntries(
+            Object.entries({
+              PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
+              NODE_ENV: env.NODE_ENV,
+              LOG_LEVEL: env.LOG_LEVEL,
+              // HOME: not set - sudo will set it to the target user's home directory
+              ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+              ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
+              ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
+              CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
+              OPENAI_API_KEY: env.OPENAI_API_KEY,
+              OPENAI_BASE_URL: env.OPENAI_BASE_URL,
+              GEMINI_API_KEY: env.GEMINI_API_KEY,
+              GOOGLE_API_KEY: env.GOOGLE_API_KEY,
+              // Forward git hardening pairs across the sudo boundary (sudoers
+              // env_keep is the belt; this is the suspenders for this path).
+              GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
+            }).filter(([_, v]) => v !== undefined)
+          ),
+          daemonUrl
         )
-      : { ...env, DAEMON_URL: daemonUrl };
+      : withDaemonExecutorEnv(env as Record<string, string>, daemonUrl);
 
   const prepared = asUser
     ? preparedEnvFilePath
@@ -526,25 +547,28 @@ function runExecutorCommandLocal(
 
   const daemonUrl = getDaemonUrl();
   const envWithDaemonUrl: Record<string, string> = preparedEnv
-    ? { DAEMON_URL: daemonUrl, ...preparedEnv }
+    ? withDaemonExecutorEnv(preparedEnv, daemonUrl)
     : asUser
-      ? Object.fromEntries(
-          Object.entries({
-            DAEMON_URL: daemonUrl,
-            PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
-            NODE_ENV: env.NODE_ENV,
-            ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
-            ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
-            ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
-            CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
-            OPENAI_API_KEY: env.OPENAI_API_KEY,
-            OPENAI_BASE_URL: env.OPENAI_BASE_URL,
-            GEMINI_API_KEY: env.GEMINI_API_KEY,
-            GOOGLE_API_KEY: env.GOOGLE_API_KEY,
-            GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
-          }).filter(([_, v]) => v !== undefined)
+      ? withDaemonExecutorEnv(
+          Object.fromEntries(
+            Object.entries({
+              PATH: env.PATH || '/usr/local/bin:/usr/bin:/bin',
+              NODE_ENV: env.NODE_ENV,
+              LOG_LEVEL: env.LOG_LEVEL,
+              ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+              ANTHROPIC_AUTH_TOKEN: env.ANTHROPIC_AUTH_TOKEN,
+              ANTHROPIC_BASE_URL: env.ANTHROPIC_BASE_URL,
+              CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN,
+              OPENAI_API_KEY: env.OPENAI_API_KEY,
+              OPENAI_BASE_URL: env.OPENAI_BASE_URL,
+              GEMINI_API_KEY: env.GEMINI_API_KEY,
+              GOOGLE_API_KEY: env.GOOGLE_API_KEY,
+              GIT_CONFIG_PARAMETERS: env.GIT_CONFIG_PARAMETERS,
+            }).filter(([_, v]) => v !== undefined)
+          ),
+          daemonUrl
         )
-      : { ...env, DAEMON_URL: daemonUrl };
+      : withDaemonExecutorEnv(env as Record<string, string>, daemonUrl);
 
   const prepared = asUser
     ? preparedEnvFilePath

--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -214,6 +214,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
       // Setup socket event listeners BEFORE connecting
       client.io.on('connect', async () => {
         if (mounted) {
+          const isReconnect = hasConnectedOnce;
           hasConnectedOnce = true; // Mark that we've successfully connected
           // Reset manual-reconnect backoff now that we're connected again.
           manualReconnectAttempts = 0;
@@ -221,6 +222,15 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
           // Cancel any pending "flip to disconnected" — we made it back in
           // time, so consumers never saw a disabled frame.
           clearDisconnectGrace();
+
+          // Initial authentication is performed by the connect() flow after
+          // its "wait for connection" promise resolves. If we authenticate
+          // here too, the first socket connection fires two back-to-back
+          // daemon login events for the same user. Only this event handler's
+          // reconnect path should re-authenticate.
+          if (!isReconnect) {
+            return;
+          }
 
           // Re-authenticate on reconnection (e.g., after daemon restart or
           // network recovery). Read the token from the ref to pick up any

--- a/context/explorations/daemon-log-startup-analysis.md
+++ b/context/explorations/daemon-log-startup-analysis.md
@@ -1,0 +1,164 @@
+# Daemon startup/runtime log analysis (2026-06-11)
+
+Scope: inspected `journalctl -u agor-daemon --no-pager -n 2000` and `--since '2 hours ago'` on the production-ish host. I did not copy secrets into this note. The current shell cannot see all system journal entries (`journalctl` reports that this user is not in `adm` / `systemd-journal`), so the captured logs are mostly executor child-process output under the `agor-daemon` unit, not the main daemon boot banner. `systemctl status agor-daemon` showed the main daemon was active since `2026-06-11 00:51:13 UTC`, but `journalctl` returned no visible main-process startup entries for that window.
+
+## High-signal findings
+
+### 1. Per-Codex executor startup scans `/tmp` and logs one stack trace per stale instructions file
+
+In the last 2h sample, normalized counts showed:
+
+- 400 `Failed to sweep /tmp/agor-codex-instructions-... EPERM` warnings
+- plus ~2,000 stack/object-detail lines produced by those 400 warnings
+- the same sweep happens during Codex prompt service construction, i.e. on every ephemeral executor startup
+
+Source: `packages/executor/src/sdk-handlers/codex/prompt-service.ts` constructor calls `sweepStaleInstructionsFiles()`, which scans `os.tmpdir()` and `~/.agor/tmp`, then previously logged `console.warn(..., err)` for every failed unlink.
+
+Interpretation: this is both noisy and potentially real wasted startup work. In strict/insulated/user-switched execution, many `/tmp/agor-codex-instructions-*` files may belong to other Unix users, so EPERM is expected. Logging a full stack per file makes executor startup look broken and floods the daemon unit logs.
+
+Fix applied: summarize failures by error code at debug level instead of warning per file, and keep successful deletion summary debug-only.
+
+Follow-up worth considering: avoid scanning global `/tmp` on every executor. Prefer only the per-user fallback dir, a daemon-owned cleanup job, or a marker/mtime cache that runs the sweep at most once per user/process interval.
+
+### 2. Codex streams log every SDK event at info level
+
+In the last 2h sample:
+
+- 528 `Event N: item.completed`
+- 485 `Event N: item.started`
+- 165/154 of those appeared in just the last 2,000 lines
+
+Source: `packages/executor/src/sdk-handlers/codex/prompt-service.ts` logs every `for await (const event of events)` iteration.
+
+Interpretation: event-by-event logging is low value during normal operation and scales with response/tool activity. It dominates the journal during active sessions and obscures actual warnings/errors.
+
+Fix applied: move Codex per-event and per-run setup chatter (`Starting prompt execution`, permissions, MCP breakdown, runStreamed start, etc.) to `console.debug`. Also patch executor console filtering so debug logs can be hidden in production the same way daemon logs are.
+
+### 3. Executor-token authorization failures are repeated on every task
+
+In the last 2h sample there were 42 occurrences of each of these, with stack traces in several paths:
+
+- `[API Key Resolution] Failed to resolve via daemon service: Forbidden: Executor token is not valid for this endpoint`
+- `Failed to resolve MCP servers: Forbidden: Executor token is not valid for this endpoint`
+- `[codex git.safe-directory] Failed to load repo ... for safe.directory setup: Executor token is not valid for this endpoint`
+
+Sources:
+
+- `packages/executor/src/handlers/sdk/base-executor.ts` calls `/config/resolve-api-key`.
+- `packages/executor/src/sdk-handlers/base/mcp-scoping.ts` resolves MCP servers.
+- `packages/executor/src/handlers/sdk/git-safe-directory.ts` tries to read the repo for `safe.directory` setup.
+- `apps/agor-daemon/src/auth/executor-runtime-scope.ts` currently rejects endpoints outside its allowlist; `config/resolve-api-key` is explicitly covered by a test asserting rejection.
+
+Interpretation: this is more than log noise. Executors are attempting daemon calls that the runtime-scope guard forbids, then falling back or continuing with degraded behavior. That means repeated unnecessary round trips and lost functionality (per-user API key resolution and user/session MCP server resolution appear to fall back to none in these logs).
+
+Fix applied only for logging: API-key and MCP failures now log concise messages instead of full stack traces. I did not change the authorization model because allowing these endpoints needs a security review and targeted tests.
+
+Recommended follow-up: decide whether executor runtime tokens should be allowed to call:
+
+- `config/resolve-api-key.create` scoped to their own `taskId`
+- the specific MCP-server read paths needed by `getMcpServersForSession`
+- `repos.get` for the repo attached to the executor-scoped branch
+
+If yes, update `executor-runtime-scope.ts` and the existing rejection tests to enforce task/session/branch scoping instead of blanket rejection.
+
+### 4. API-key resolution fallback logs too many negative checks
+
+Each Codex task with no app/env key produced a multi-line sequence: resolving key, skipping user check, checking config, no config key, checking env, no env key, fallback to native auth, and Codex subscription-auth explanation.
+
+Source: `packages/core/src/config/key-resolver.ts`, `packages/executor/src/handlers/sdk/base-executor.ts`, and Codex prompt-service constructor.
+
+Interpretation: useful when debugging auth, low-value on every normal task. It is especially noisy because the forbidden daemon-service call prevents per-user lookup first.
+
+Fix applied: demote key-resolution trace and native-auth explanation to debug. Keep decryption failures/errors as normal errors.
+
+### 5. Node `punycode` deprecation warning appears once per executor
+
+The 2h sample had 42 copies of Node's `[DEP0040]` warning. This likely comes from a dependency loaded by each executor process.
+
+No fix applied. Recommended follow-up: run one executor with `node --trace-deprecation` in a safe dev environment to identify the importer, or suppress process deprecation warnings in production if it is known third-party noise.
+
+## Files changed
+
+- `packages/executor/src/index.ts`
+  - Applies the shared console log-level patch in executor processes.
+- `packages/executor/src/sdk-handlers/codex/prompt-service.ts`
+  - Summarizes stale instructions sweep results; demotes verbose Codex setup/MCP/event logs to debug.
+- `packages/executor/src/sdk-handlers/base/mcp-scoping.ts`
+  - Demotes normal MCP-resolution trace to debug; logs concise warning on resolution failure.
+- `packages/executor/src/handlers/sdk/base-executor.ts`
+  - Demotes API-key resolution success/fallback chatter to debug; concise warning for daemon-service failure.
+- `packages/core/src/config/key-resolver.ts`
+  - Demotes step-by-step key resolver tracing to debug.
+
+## Validation notes
+
+Run after edits:
+
+- `git diff --check`
+
+No targeted tests were added because the changes are logging-only and nearby tests mostly assert authorization behavior that I intentionally did not change.
+
+## Addendum: SessionTokenService chatter
+
+Max also reported seeing lots of `SessionTokenService` lines. I could not see those lines in my limited journal view, but source inspection confirms they were normal per-token lifecycle logs at info level:
+
+- `generateToken()` logged every executor JWT issuance.
+- `validateToken()` logged every successful validation, including use count.
+- revocation/cleanup logged at info level.
+- `SessionTokenStrategy` also had verbose parse/authenticate/verify/getEntity logs.
+
+Cost assessment from source: `SessionTokenService.validateToken()` itself is cheap: one in-memory `Map.get(token)`, a `Date` comparison, a few string comparisons for expected session/task/branch scope, and an integer increment. The heavier part is the surrounding Feathers/JWT authentication path, which must parse/verify the JWT and run auth hooks for protected service calls. That cost is still likely tiny compared with an SDK turn, git operations, or database work, but the frequency can be high because executors make many daemon service calls while streaming a task.
+
+Necessity: validation is security-sensitive because it enforces revocation, expiration, max-use counting, and executor scope. We should not remove it casually. However, with the current default unlimited-use executor tokens, validating on every protected service call may be stricter than necessary after a socket has authenticated. A real optimization would need a deliberate design: e.g. cache validation for the lifetime of an authenticated socket, or cache per token for a short TTL while preserving revocation/max-use semantics. That should come with auth tests and probably metrics first.
+
+Fix applied: demoted successful generation/validation/revocation/cleanup and `SessionTokenStrategy` trace logs to debug. Warnings for missing/expired/scope-mismatched/max-use-exceeded tokens remain warnings. For unlimited reusable tokens (`max_uses === -1`), validation no longer increments the diagnostic use counter on every request; finite max-use tokens still count/enforce exactly as before.
+
+## Addendum: repeated `Login event fired` for the same user
+
+Source: `apps/agor-daemon/src/setup/socketio.ts` logs `✅ Login event fired` from the Feathers `app.on('login')` channel hook. That event fires every time a socket client calls `client.authenticate()`.
+
+I found one frontend path that could cause duplicate login events on an initial socket connection:
+
+- `apps/agor-ui/src/hooks/useAgorClient.ts` registered a `client.io.on('connect')` handler that authenticated immediately.
+- The outer `connect()` flow also waited for the same connect event and then authenticated.
+- On first connection this can produce two back-to-back socket authentications for the same token/user. Reconnects and token-refresh reauths can also legitimately produce login events, but the initial double-auth was avoidable.
+
+Fix applied:
+
+- The socket `connect` handler now re-authenticates only on reconnects. Initial auth remains in the outer `connect()` flow.
+- Demoted normal socket login/user-room join logs to debug so production logs do not show a line for every routine socket auth.
+
+This suggests the frontend was not necessarily "going crazy", but it was at least doing redundant initial socket authentication. If repeated login events continue after this, the next suspects are multiple tabs/windows, token refresh reauths, or reconnect loops.
+
+### What `uses=N/∞` means and why it climbs quickly
+
+`SessionTokenService` prints `uses=${use_count}/${max_uses}`. `∞` is rendered when `max_uses === -1`, meaning the executor token is unlimited-use until expiry/revocation. The numerator is not CPU cycles; it is the count of successful validations for that same bearer token.
+
+Why it can increment several times in the same second: the executor uses a Feathers client and each protected daemon service call passes through the auth hook. During one agent task, the executor can call services for task patches, message writes, streaming/thinking events (`/messages/streaming`), heartbeat updates, session/branch/repo lookups, API-key/MCP resolution attempts, and terminal-state fallbacks. Each of those calls can cause the JWT strategy to re-validate the executor-session token.
+
+Current design is conservative/stateless per request. "Once per executor socket" may be viable, but it would be a behavior change: we'd need to cache trusted executor auth on the socket/connection while preserving token expiry, revocation, task/branch/session scope, and any finite max-use semantics. If we do that, add targeted auth tests and ideally counters for validations per task/path before/after.
+
+Follow-up assessment: the repeated `uses=N/∞` lines were a sign that the log was added under an assumption closer to 'token checked once per executor' than the actual implementation, where executor JWTs pass through auth on every protected service call. We should treat successful auth validation as a hot-path debug-only event, not an operational info event.
+
+## Addendum: Knowledge pgvector `relation already exists, skipping` NOTICE spam
+
+The pasted logs are Postgres NOTICE objects, not application errors. They come from `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` in `apps/agor-daemon/src/knowledge/pgvector.ts`. Postgres emits NOTICE `42P07` for "already exists, skipping", and postgres.js prints those notices as structured objects.
+
+The bigger issue was not just the log level: `KnowledgeEmbeddingIndexer.indexBatch()` called `ensureKnowledgePgvectorStorage()` before first checking whether any Knowledge units were pending. With semantic search enabled and an API key configured, every 30s tick could re-run pgvector storage DDL even when there was no indexing work to do. The DDL was idempotent, but it is still startup/runtime junk and not aligned with the expected "get pending rows, then process them" flow.
+
+Fix applied:
+
+- `KnowledgeEmbeddingIndexer.indexBatch()` now checks `kb_document_units` for one pending/stale unit before pgvector storage setup. Idle ticks return before DDL/capability/index setup.
+- `ensureKnowledgePgvectorStorage()` now inspects the table/index regclasses and returns immediately when all expected storage objects exist.
+- When storage objects are missing, it creates only the missing object(s), instead of always issuing `CREATE ... IF NOT EXISTS` for all of them.
+- Added a pgvector unit test asserting no CREATE statements are issued when storage already exists.
+
+This should remove the repeated Postgres NOTICE objects during normal idle ticks and reduce unnecessary Knowledge indexer startup/runtime work.
+
+### Embedding provider cost log
+
+There previously was no normal success log immediately before the paid embedding provider call; only tick/wake failures were logged. Added one info-level line per provider batch:
+
+`[knowledge-indexer] Computing N embedding chunk(s) across M document(s) (docShort=count, ...); model=..., dimensions=..., chars=...`
+
+This is intentionally one line per outbound embedding batch so operators can see paid work without dumping content or per-chunk detail.

--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -77,6 +77,8 @@ export const ALLOWED_ENV_VARS = new Set([
   // Node.js (safe subset — NOT NODE_OPTIONS which could inject code)
   'NODE_PATH',
   'NODE_EXTRA_CA_CERTS',
+  // Logging controls. Keep executor log filtering aligned with the daemon.
+  'LOG_LEVEL',
 
   // Git identity
   'GIT_AUTHOR_NAME',

--- a/packages/core/src/config/key-resolver.ts
+++ b/packages/core/src/config/key-resolver.ts
@@ -55,7 +55,7 @@ export async function resolveApiKey(
   keyName: ApiKeyName,
   context: KeyResolutionContext = {}
 ): Promise<KeyResolutionResult> {
-  console.log(
+  console.debug(
     `🔍 [API Key Resolution] Resolving ${keyName} for user ${context.userId ? shortId(context.userId) : 'none'}`
   );
 
@@ -67,7 +67,7 @@ export async function resolveApiKey(
   //    is omitted (CLI / generic callers), we fall back to sweeping every
   //    bucket to preserve the legacy "any user key for this name" semantic.
   if (context.userId && context.db) {
-    console.log(`   → Checking user-level configuration...`);
+    console.debug(`   → Checking user-level configuration...`);
     const row = await select(context.db).from(users).where(eq(users.user_id, context.userId)).one();
 
     if (row) {
@@ -92,7 +92,7 @@ export async function resolveApiKey(
         try {
           const decryptedKey = decryptApiKey(encryptedKey);
           if (decryptedKey && decryptedKey.length > 0) {
-            console.log(
+            console.debug(
               `   ✓ Found user-level API key for ${keyName} (user: ${shortId(context.userId)})`
             );
             return { apiKey: decryptedKey, source: 'user', useNativeAuth: false };
@@ -109,9 +109,9 @@ export async function resolveApiKey(
       }
     }
   } else if (!context.userId) {
-    console.log(`   → Skipping user-level check (no user ID provided)`);
+    console.debug(`   → Skipping user-level check (no user ID provided)`);
   } else if (!context.db) {
-    console.log(`   → Skipping user-level check (no database connection)`);
+    console.debug(`   → Skipping user-level check (no database connection)`);
   }
 
   // 2. Check global config.yaml (second precedence). Only the keys that have a
@@ -119,26 +119,26 @@ export async function resolveApiKey(
   //    CLAUDE_CODE_OAUTH_TOKEN / COPILOT_GITHUB_TOKEN are skipped here and fall
   //    through to the env-var lookup below.
   if (isConfigCredentialKey(keyName)) {
-    console.log(`   → Checking app-level configuration (config.yaml)...`);
+    console.debug(`   → Checking app-level configuration (config.yaml)...`);
     const globalKey = getCredential(keyName);
     if (globalKey && globalKey.length > 0) {
-      console.log(`   ✓ Found app-level API key for ${keyName} (from config.yaml)`);
+      console.debug(`   ✓ Found app-level API key for ${keyName} (from config.yaml)`);
       return { apiKey: globalKey, source: 'config', useNativeAuth: false };
     }
-    console.log(`   ✗ No app-level API key for ${keyName}`);
+    console.debug(`   ✗ No app-level API key for ${keyName}`);
   }
 
   // 3. Check environment variable (third precedence)
-  console.log(`   → Checking OS-level environment variables...`);
+  console.debug(`   → Checking OS-level environment variables...`);
   const envKey = process.env[keyName];
   if (envKey && envKey.length > 0) {
-    console.log(`   ✓ Found OS-level environment variable ${keyName}`);
+    console.debug(`   ✓ Found OS-level environment variable ${keyName}`);
     return { apiKey: envKey, source: 'env', useNativeAuth: false };
   }
-  console.log(`   ✗ No OS-level environment variable ${keyName}`);
+  console.debug(`   ✗ No OS-level environment variable ${keyName}`);
 
   // 4. No key found - SDK should fall back to native auth (OAuth, CLI login, etc.)
-  console.log(`   ℹ️  No API key found for ${keyName} - SDK will use native authentication`);
+  console.debug(`   ℹ️  No API key found for ${keyName} - SDK will use native authentication`);
   return { apiKey: undefined, source: 'none', useNativeAuth: true };
 }
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -22,7 +22,7 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   error: 3,
 };
 
-function getCurrentLogLevel(): LogLevel {
+export function getCurrentLogLevel(): LogLevel {
   const logLevel = process.env.LOG_LEVEL?.toLowerCase();
   if (logLevel && logLevel in LOG_LEVELS) {
     return logLevel as LogLevel;

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -332,10 +332,14 @@ async function resolveApiKeyForTask(
       keyName,
       tool,
     })) as import('@agor/core/config').KeyResolutionResult;
-    console.log(`[API Key Resolution] Resolved ${keyName} via daemon (source: ${result.source})`);
+    console.debug(`[API Key Resolution] Resolved ${keyName} via daemon (source: ${result.source})`);
     return result;
   } catch (err) {
-    console.warn('[API Key Resolution] Failed to resolve via daemon service:', err);
+    console.warn(
+      `[API Key Resolution] Failed to resolve via daemon service: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
     // Fall back to sync resolution (config + env only, no per-user keys)
     return resolveApiKey(keyName, {});
   }
@@ -394,9 +398,11 @@ export async function executeToolTask(params: {
 
   // Log resolution result
   if (resolution.apiKey) {
-    console.log(`[${toolName}] Using API key from ${resolution.source} level for ${apiKeyEnvVar}`);
+    console.debug(
+      `[${toolName}] Using API key from ${resolution.source} level for ${apiKeyEnvVar}`
+    );
   } else {
-    console.log(
+    console.debug(
       `[${toolName}] No API key found - SDK will use native authentication (OAuth/CLI login)`
     );
   }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -17,11 +17,14 @@ import type {
   TaskID,
 } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
+import { patchConsole } from '@agor/core/utils/logger';
 import { type ExecutorHeartbeatHandle, startExecutorHeartbeat } from './executor-heartbeat.js';
 import type { ResolvedConfigSlice } from './payload-types.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
 import { tryMarkTaskTerminal } from './terminal-task.js';
+
+patchConsole();
 
 export interface ExecutorConfig {
   sessionToken: string;

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -99,7 +99,7 @@ export async function getMcpServersForSession(
 
     if (typeof deps.sessionMCPRepo.listEffectiveServers === 'function') {
       const effectiveServers = await deps.sessionMCPRepo.listEffectiveServers(sessionId, true);
-      console.log(`   📍 Effective session scope: ${effectiveServers.length} server(s)`);
+      console.debug(`   📍 Effective session scope: ${effectiveServers.length} server(s)`);
 
       for (const server of effectiveServers) {
         addServer(server, server.scope === 'global' ? 'global' : 'session-assigned');
@@ -107,7 +107,7 @@ export async function getMcpServersForSession(
     } else {
       // STEP 1: Get ALL global-scoped MCP servers (available to all sessions)
       // Pass forUserId for per-user OAuth token injection
-      console.log(
+      console.debug(
         `   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`
       );
       const globalServers = await deps.mcpServerRepo.findAll(
@@ -118,7 +118,7 @@ export async function getMcpServersForSession(
         deps.forUserId
       );
 
-      console.log(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
+      console.debug(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
 
       for (const server of globalServers ?? []) {
         addServer(server, 'global');
@@ -127,7 +127,7 @@ export async function getMcpServersForSession(
       // STEP 2: Get session-scoped MCP servers assigned to this specific session
       const sessionServers = await deps.sessionMCPRepo.listServers(sessionId, true); // enabledOnly
 
-      console.log(`   📍 Session-assigned: ${sessionServers.length} server(s)`);
+      console.debug(`   📍 Session-assigned: ${sessionServers.length} server(s)`);
 
       for (const server of sessionServers) {
         addServer(server, 'session-assigned');
@@ -136,12 +136,12 @@ export async function getMcpServersForSession(
 
     // Log summary (before template resolution)
     if (servers.length > 0) {
-      console.log(`   ✅ Total: ${servers.length} MCP server(s) resolved`);
+      console.debug(`   ✅ Total: ${servers.length} MCP server(s) resolved`);
       for (const { server, source } of servers) {
-        console.log(`      - ${server.name} (${server.transport}) [${source}]`);
+        console.debug(`      - ${server.name} (${server.transport}) [${source}]`);
       }
     } else {
-      console.log('   ℹ️  No MCP servers available for this session');
+      console.debug('   ℹ️  No MCP servers available for this session');
     }
 
     // STEP 3: Resolve templates in config fields (url, env.*, auth.*)
@@ -195,10 +195,10 @@ export async function getMcpServersForSession(
     }
 
     if (templatesResolved > 0) {
-      console.log(`   🔧 Resolved templates in ${templatesResolved} MCP server(s)`);
+      console.debug(`   🔧 Resolved templates in ${templatesResolved} MCP server(s)`);
     }
     if (serversSkipped > 0) {
-      console.log(
+      console.warn(
         `   ⚠️  Skipped ${serversSkipped} MCP server(s) due to unresolved required templates`
       );
     }

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -79,8 +79,8 @@ export async function getMcpServersForSession(
   }
 
   try {
-    console.log('🔌 Resolving MCP servers for session...');
-    console.log(`   [MCP Scoping] forUserId: ${deps.forUserId || 'NOT SET'}`);
+    console.debug('🔌 Resolving MCP servers for session...');
+    console.debug(`   [MCP Scoping] forUserId: ${deps.forUserId || 'NOT SET'}`);
 
     // Track seen server IDs to prevent duplicates
     const seenServerIds = new Set<string>();
@@ -203,7 +203,9 @@ export async function getMcpServersForSession(
       );
     }
   } catch (error) {
-    console.error('❌ Failed to resolve MCP servers:', error);
+    console.warn(
+      `⚠️  Failed to resolve MCP servers: ${error instanceof Error ? error.message : String(error)}`
+    );
     // Return empty array on error to avoid breaking session creation
     return [];
   }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -220,7 +220,7 @@ export class CodexPromptService {
     if (this.apiKey) {
       // Source already logged by base-executor via resolveApiKeyForTask().
     } else if (this.useNativeAuth) {
-      console.log(
+      console.debug(
         '🔓 [Codex] No API key configured — falling back to ChatGPT subscription auth from $CODEX_HOME/auth.json. ' +
           'Run `codex login` if you have not authenticated yet.'
       );
@@ -268,6 +268,9 @@ export class CodexPromptService {
       } catch {
         continue;
       }
+      let deleted = 0;
+      let failed = 0;
+      const failedByCode = new Map<string, number>();
       for (const name of entries) {
         if (!name.startsWith('agor-codex-instructions-') || !name.endsWith('.md')) continue;
         const full = path.join(dir, name);
@@ -275,12 +278,26 @@ export class CodexPromptService {
           const stat = await fs.stat(full);
           if (stat.mtimeMs < cutoffMs) {
             await fs.unlink(full);
+            deleted++;
           }
         } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-            console.warn(`⚠️  [Codex] Failed to sweep ${full}:`, err);
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== 'ENOENT') {
+            failed++;
+            failedByCode.set(code ?? 'UNKNOWN', (failedByCode.get(code ?? 'UNKNOWN') ?? 0) + 1);
           }
         }
+      }
+      if (deleted > 0) {
+        console.debug(`🧹 [Codex] Swept ${deleted} stale instructions file(s) from ${dir}`);
+      }
+      if (failed > 0) {
+        const summary = [...failedByCode.entries()]
+          .map(([code, count]) => `${code}=${count}`)
+          .join(', ');
+        console.debug(
+          `🧹 [Codex] Skipped ${failed} stale instructions file(s) in ${dir} (${summary})`
+        );
       }
     }
   }
@@ -395,7 +412,7 @@ export class CodexPromptService {
       return;
     }
 
-    console.log(
+    console.debug(
       `🔄 [Codex] Per-session config changed, reinitializing SDK (apiKey=${this.apiKey ? 'set' : 'unset'}, useNativeAuth=${this.useNativeAuth})`
     );
     this.codex = new Codex.Codex(this.buildCodexOptions(this.apiKey, baseUrl, config));
@@ -441,7 +458,7 @@ export class CodexPromptService {
     }
 
     this.instructionsFilePaths.set(sessionId, filePath);
-    console.log(`✅ [Codex] Wrote per-session instructions file at ${filePath}`);
+    console.debug(`✅ [Codex] Wrote per-session instructions file at ${filePath}`);
     return filePath;
   }
 
@@ -501,8 +518,8 @@ export class CodexPromptService {
     mcpToken: string | undefined,
     forUserId: UserID | undefined
   ): Promise<{ servers: CodexConfigObject; total: number }> {
-    console.log(`🔍 [Codex MCP] Fetching MCP servers for session ${shortId(sessionId)}...`);
-    console.log(`   [Codex MCP] forUserId: ${forUserId || 'NOT SET'}`);
+    console.debug(`🔍 [Codex MCP] Fetching MCP servers for session ${shortId(sessionId)}...`);
+    console.debug(`   [Codex MCP] forUserId: ${forUserId || 'NOT SET'}`);
 
     const serversWithSource = await getMcpServersForSession(sessionId, {
       sessionMCPRepo: this.sessionMCPServerRepo,
@@ -512,15 +529,17 @@ export class CodexPromptService {
 
     const mcpServers = serversWithSource.map((s) => s.server);
 
-    console.log(`📊 [Codex MCP] Found ${mcpServers.length} MCP server(s) for session`);
+    console.debug(`📊 [Codex MCP] Found ${mcpServers.length} MCP server(s) for session`);
     if (mcpServers.length > 0) {
-      console.log(`   Servers: ${mcpServers.map((s) => `${s.name} (${s.transport})`).join(', ')}`);
+      console.debug(
+        `   Servers: ${mcpServers.map((s) => `${s.name} (${s.transport})`).join(', ')}`
+      );
     }
 
     const stdioServers = mcpServers.filter((s) => s.transport === 'stdio');
     const httpServers = mcpServers.filter((s) => s.transport === 'http' || s.transport === 'sse');
 
-    console.log(
+    console.debug(
       `   📊 [Codex MCP] Transport breakdown: ${stdioServers.length} STDIO, ${httpServers.length} HTTP/SSE`
     );
 
@@ -541,7 +560,7 @@ export class CodexPromptService {
         required: false,
         ...MCP_AUTO_APPROVE,
       };
-      console.log(
+      console.debug(
         `   📝 [Codex MCP] Configuring built-in Agor MCP server (HTTP) at ${daemonUrl}/mcp`
       );
     }
@@ -854,9 +873,9 @@ export class CodexPromptService {
     // This ensures hot-reload of credentials from Settings UI while avoiding process accumulation
     this.refreshClient(currentApiKey);
 
-    console.log(`🔍 [Codex] Starting prompt execution for session ${shortId(sessionId)}`);
-    console.log(`   Permission mode: ${permissionMode || 'not specified (will use default)'}`);
-    console.log(`   Existing thread ID: ${session.sdk_session_id || 'none (will create new)'}`);
+    console.debug(`🔍 [Codex] Starting prompt execution for session ${shortId(sessionId)}`);
+    console.debug(`   Permission mode: ${permissionMode || 'not specified (will use default)'}`);
+    console.debug(`   Existing thread ID: ${session.sdk_session_id || 'none (will create new)'}`);
 
     // Codex permission settings split across two surfaces:
     // - sandboxMode, approvalPolicy, networkAccessEnabled: per-thread via ThreadOptions
@@ -879,7 +898,7 @@ export class CodexPromptService {
     const approvalPolicy = codexConfig?.approvalPolicy ?? defaults.approvalPolicy;
     const networkAccess = codexConfig?.networkAccess ?? defaults.networkAccess;
 
-    console.log(
+    console.debug(
       `   Using Codex permissions: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}`
     );
 
@@ -918,7 +937,7 @@ export class CodexPromptService {
     // apiKey/baseUrl) actually changed — issue #133 protection.
     this.ensureCodexClient(codexConfigPayload);
 
-    console.log(
+    console.debug(
       `   Configured: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}, ${mcpServerCount} MCP server(s)`
     );
 
@@ -928,7 +947,7 @@ export class CodexPromptService {
       throw new Error(`Branch ${session.branch_id} not found for session ${sessionId}`);
     }
 
-    console.log(`   Working directory: ${branch.path}`);
+    console.debug(`   Working directory: ${branch.path}`);
 
     await this.ensureForkedCodexThread(sessionId, session);
 
@@ -1003,7 +1022,7 @@ export class CodexPromptService {
     // Start or resume thread
     let thread: Thread;
     if (session.sdk_session_id) {
-      console.log(`🔄 [Codex] Resuming thread: ${session.sdk_session_id}`);
+      console.debug(`🔄 [Codex] Resuming thread: ${session.sdk_session_id}`);
 
       thread = this.codex.resumeThread(session.sdk_session_id, threadOptions);
 
@@ -1029,9 +1048,9 @@ export class CodexPromptService {
         }
       }
     } else {
-      console.log(`🆕 [Codex] Creating new thread`);
+      console.debug(`🆕 [Codex] Creating new thread`);
       if (mcpServerCount > 0) {
-        console.log(
+        console.debug(
           `✅ [Codex MCP] New thread will have ${mcpServerCount} MCP server(s) available via --config flags`
         );
       }
@@ -1039,7 +1058,7 @@ export class CodexPromptService {
     }
 
     try {
-      console.log(
+      console.debug(
         `▶️  [Codex] Running prompt: "${prompt.substring(0, 50)}${prompt.length > 50 ? '...' : ''}"`
       );
 
@@ -1058,10 +1077,10 @@ export class CodexPromptService {
 
       // Use streaming API with abort signal for proper cancellation support
       // The signal is passed to Codex SDK which will throw AbortError when aborted
-      console.log(`🎬 [Codex] Starting runStreamed() for session ${shortId(sessionId)}`);
+      console.debug(`🎬 [Codex] Starting runStreamed() for session ${shortId(sessionId)}`);
       const turnOptions = abortController ? { signal: abortController.signal } : undefined;
       const { events } = await thread.runStreamed(prompt, turnOptions);
-      console.log(`✅ [Codex] runStreamed() returned, starting event iteration`);
+      console.debug(`✅ [Codex] runStreamed() returned, starting event iteration`);
 
       const currentMessage: Array<{
         type: string;
@@ -1083,7 +1102,7 @@ export class CodexPromptService {
 
       for await (const event of events) {
         eventCount++;
-        console.log(`📨 [Codex] Event ${eventCount}: ${event.type}`);
+        console.debug(`📨 [Codex] Event ${eventCount}: ${event.type}`);
 
         // Check if stop was requested
         if (this.stopRequested.get(sessionId)) {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -573,18 +573,18 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
-      console.log(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
+      console.debug(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
       if (server.command) {
         serverConfig.command = server.command;
-        console.log(`      command: ${server.command}`);
+        console.debug(`      command: ${server.command}`);
       }
       if (server.args && server.args.length > 0) {
         serverConfig.args = server.args as CodexConfigValue[];
-        console.log(`      args: ${JSON.stringify(server.args)}`);
+        console.debug(`      args: ${JSON.stringify(server.args)}`);
       }
       if (server.env && Object.keys(server.env).length > 0) {
         serverConfig.env = server.env as CodexConfigObject;
-        console.log(`      env vars: ${Object.keys(server.env).length} variable(s)`);
+        console.debug(`      env vars: ${Object.keys(server.env).length} variable(s)`);
       }
 
       result[serverName] = serverConfig;
@@ -598,10 +598,10 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
-      console.log(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
+      console.debug(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
       if (server.url) {
         serverConfig.url = server.url;
-        console.log(`      url: ${server.url}`);
+        console.debug(`      url: ${server.url}`);
       }
 
       // Resolve the Authorization header via the shared MCP auth helper —
@@ -618,7 +618,7 @@ export class CodexPromptService {
         if (customHeaders) delete customHeaders.Authorization;
         if (customHeaders && Object.keys(customHeaders).length > 0) {
           serverConfig.headers = customHeaders;
-          console.log(`      custom headers: ${Object.keys(customHeaders).length} header(s)`);
+          console.debug(`      custom headers: ${Object.keys(customHeaders).length} header(s)`);
         }
         if (authHeader) {
           const bearerToken = /^Bearer\s+(.+)$/i.exec(authHeader)?.[1];
@@ -626,7 +626,7 @@ export class CodexPromptService {
             const envVarName = `AGOR_MCP_${shortId(sessionId)}_${serverName.toUpperCase()}`;
             process.env[envVarName] = bearerToken;
             serverConfig.bearer_token_env_var = envVarName;
-            console.log(`      auth: ${server.auth?.type ?? 'bearer'} token via ${envVarName}`);
+            console.debug(`      auth: ${server.auth?.type ?? 'bearer'} token via ${envVarName}`);
           } else {
             console.warn(
               `      ⚠️  auth: resolved Authorization header for "${server.name}" is not a Bearer scheme (Codex CLI only supports bearer); skipping injection`
@@ -652,13 +652,7 @@ export class CodexPromptService {
 
     const total = stdioServers.length + httpServers.length + (mcpToken ? 1 : 0);
     if (total > 0) {
-      const parts: string[] = [];
-      if (mcpToken) parts.push('Agor (HTTP)');
-      if (stdioServers.length > 0)
-        parts.push(`${stdioServers.length} STDIO (${stdioServers.map((s) => s.name).join(', ')})`);
-      if (httpServers.length > 0)
-        parts.push(`${httpServers.length} HTTP (${httpServers.map((s) => s.name).join(', ')})`);
-      console.log(`✅ [Codex MCP] Configured ${total} MCP server(s): ${parts.join(', ')}`);
+      console.info(`✅ [Codex MCP] Configured ${total} MCP server(s)`);
     }
 
     return { servers: result, total };


### PR DESCRIPTION
## Summary

- Demote noisy daemon/executor logs from routine Codex setup, streaming events, API-key resolution, MCP resolution, session-token validation, and socket login paths.
- Reduce repeated startup/runtime work from Codex stale-instructions sweeps and Knowledge pgvector storage setup.
- Fix duplicate initial socket authentication in the UI so one first connection does not fire two login events.
- Add a concise info log for paid Knowledge embedding batches.
- Capture findings in `context/explorations/daemon-log-startup-analysis.md`.

## Details

### Executor/Codex logging

- Apply shared console log-level filtering in executor processes.
- Move per-event Codex stream logs and routine per-run setup logs to debug.
- Summarize stale Codex instructions-file sweep failures by error code instead of logging one warning + stack per file.
- Replace MCP/API-key failure stack dumps with concise warnings while leaving real failures visible.

### Auth/socket logging

- Move successful `SessionTokenService` and `SessionTokenStrategy` trace logs to debug.
- Avoid incrementing unlimited-token diagnostic use counts on every validation.
- Move routine socket login/user-room join logs to debug.
- Avoid duplicate UI socket authentication on initial connect; reconnect auth still happens in the socket `connect` handler.

### Knowledge indexing

- Check for pending/stale Knowledge units before pgvector setup on indexer ticks.
- Inspect pgvector table/index existence and only create missing objects, avoiding repeated Postgres NOTICE spam.
- Add a one-line info log before paid embedding provider calls with chunk/doc counts, model/dimensions, and total chars.

## Validation

- `pnpm i`
  - Completed. Note: optional/native `node-pty@1.0.0` rebuild reported missing `make`, but install completed successfully.
- `pnpm check`
  - Passed.
  - Biome reported existing warnings for unused suppressions/descending CSS specificity, but no errors.
- `pnpm --filter @agor/daemon test -- pgvector.test.ts knowledge-embedding-indexer.test.ts session-token-service.test.ts`
  - Passed: 3 files, 8 tests.
- `pnpm --filter agor-ui test -- singleFlightRefresh`
  - Passed: 1 file, 12 tests.
- `pnpm --filter agor-ui test -- useAgorClient`
  - No matching test files exist; not applicable.
