### PR TITLE
Fix executor MCP resolution rejected by runtime scope guard

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -14,7 +14,7 @@ function ctx(overrides: Partial<HookContext>): HookContext {
   return {
     path: 'tasks',
     method: 'find',
-    params: { authentication: { payload }, query: {} },
+    params: { authentication: { payload }, query: {}, provider: 'socketio' },
     ...overrides,
   } as HookContext;
 }
@@ -35,7 +35,11 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'messages',
       method: 'find',
-      params: { authentication: { payload }, query: { session_id: 'session-1' } },
+      params: {
+        authentication: { payload },
+        query: { session_id: 'session-1' },
+        provider: 'socketio',
+      },
     });
 
     await executorRuntimeScopeGuard()(context);
@@ -47,7 +51,11 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'messages',
       method: 'find',
-      params: { authentication: { payload }, query: { session_id: 'session-2' } },
+      params: {
+        authentication: { payload },
+        query: { session_id: 'session-2' },
+        provider: 'socketio',
+      },
     });
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/session scope/);
@@ -57,7 +65,7 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'messages',
       method: 'find',
-      params: { authentication: { payload }, query: { task_id: 'task-1' } },
+      params: { authentication: { payload }, query: { task_id: 'task-1' }, provider: 'socketio' },
     });
 
     await executorRuntimeScopeGuard()(context);
@@ -69,7 +77,7 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'tasks',
       method: 'find',
-      params: { authentication: { payload }, query: { task_id: 'task-2' } },
+      params: { authentication: { payload }, query: { task_id: 'task-2' }, provider: 'socketio' },
     });
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/task scope/);
@@ -89,6 +97,7 @@ describe('executorRuntimeScopeGuard', () => {
           },
         },
         query: {},
+        provider: 'socketio',
       },
     });
 
@@ -198,6 +207,20 @@ describe('executorRuntimeScopeGuard', () => {
     );
   });
 
+  it('bypasses internal (provider-less) service composition', async () => {
+    // Route handlers the executor legitimately reaches fan out to non-allowlisted
+    // services internally (e.g. sessions/:id/mcp-servers reading `mcp-servers`).
+    // Those internal calls carry the executor payload but have no transport
+    // provider and must not be re-scoped/rejected.
+    const context = ctx({
+      path: 'mcp-servers',
+      method: 'find',
+      params: { authentication: { payload }, query: {} },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+  });
+
   it('validates every bulk message payload item against task scope', async () => {
     const context = ctx({
       path: 'messages/bulk',
@@ -261,7 +284,12 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'sessions/:id/genealogy',
       method: 'find',
-      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+      params: {
+        authentication: { payload },
+        query: {},
+        route: { id: 'session-1' },
+        provider: 'socketio',
+      },
     });
 
     await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
@@ -271,7 +299,12 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'sessions/:id/fork',
       method: 'create',
-      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+      params: {
+        authentication: { payload },
+        query: {},
+        route: { id: 'session-1' },
+        provider: 'socketio',
+      },
     });
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
@@ -283,7 +316,12 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'sessions/:id/mcp-servers',
       method: 'find',
-      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+      params: {
+        authentication: { payload },
+        query: {},
+        route: { id: 'session-1' },
+        provider: 'socketio',
+      },
     });
 
     await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
@@ -293,7 +331,12 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'sessions/:id/mcp-servers',
       method: 'create',
-      params: { authentication: { payload }, query: {}, route: { id: 'session-1' } },
+      params: {
+        authentication: { payload },
+        query: {},
+        route: { id: 'session-1' },
+        provider: 'socketio',
+      },
     });
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
@@ -305,7 +348,12 @@ describe('executorRuntimeScopeGuard', () => {
     const context = ctx({
       path: 'sessions/:id/mcp-servers',
       method: 'find',
-      params: { authentication: { payload }, query: {}, route: { id: 'session-2' } },
+      params: {
+        authentication: { payload },
+        query: {},
+        route: { id: 'session-2' },
+        provider: 'socketio',
+      },
     });
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/session scope/);

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -367,4 +367,18 @@ describe('executorRuntimeScopeGuard', () => {
       /not valid for this endpoint/
     );
   });
+
+  it('lets wrapped auth hooks pass internal (provider-less) service composition', async () => {
+    // Mirrors the production failure: the externally-guarded
+    // sessions/:id/mcp-servers handler fans out to the non-allowlisted
+    // mcp-servers service with the executor payload but no transport provider.
+    const requireAuth = async (context: HookContext) => context;
+    const context = ctx({
+      path: 'mcp-servers',
+      method: 'find',
+      params: { authentication: { payload }, query: {} },
+    });
+
+    await expect(scopeExecutorRuntimeAuth(requireAuth)(context)).resolves.toBe(context);
+  });
 });

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -167,6 +167,14 @@ export function scopeExecutorRuntimeAuth(requireAuth: AuthHook): AuthHook {
  */
 export function executorRuntimeScopeGuard() {
   return async (context: HookContext): Promise<HookContext> => {
+    // Only police calls that arrive over the executor's transport. Internal
+    // server-side service composition (provider undefined) is trusted: route
+    // handlers the executor legitimately reached fan out to other services
+    // (e.g. the session MCP-servers route reads `mcp-servers`) while carrying
+    // the executor's auth in `params`. Re-scoping those would reject paths
+    // that are intentionally not in this guard's allow-list.
+    if (!(context.params as Params).provider) return context;
+
     const payload = scopedPayload(context);
     if (!payload) return context;
 


### PR DESCRIPTION
## Summary

Executor sessions were silently losing **all** of their MCP servers (Fellow, Slack, Playwright, etc.), leaving only the built-in Agor server. The failure was systemic — it dropped no-auth stdio servers like Playwright too — which ruled out an OAuth-specific cause.

**Root cause:** The executor-session runtime scope guard (`executorRuntimeScopeGuard`) ran on internal server-side service composition, not just the executor's transport calls.

1. The executor calls the allow-listed `find` on `/sessions/:id/mcp-servers` over its socket (`provider: 'socketio'`) → outer guard passes.
2. That route handler always loads global servers via `listEffectiveServers`, fanning out to `mcpService.find({ ...params, provider: undefined, query: globalQuery })` — spreading the executor's `authentication.payload` into the **non-allow-listed** `mcp-servers` service.
3. The guard rejected that inner call with `Executor token is not valid for this endpoint`.
4. `getMcpServersForSession` caught the error and returned `[]` (fail-safe), dropping every MCP server for the session.

This has been broken since the guard shipped (#1395); #1411 fixed the earlier find-signature crash and exposed this layer underneath.

## Fix

Skip the guard for internal calls (no transport `provider`). The executor's own calls always carry a `provider`, so its external surface stays fully scoped — only trusted daemon-internal service composition is exempted. This is idiomatic Feathers (internal service composition is trusted).

```ts
if (!(context.params as Params).provider) return context;
```

## Security

Verified against #1395's threat model: the executor cannot forge a `provider` (it's set by the transport layer, not the caller), so its external request surface remains fully scoped. Only daemon-internal composition — which already runs with full trust — is exempted.

## Test plan

- [x] `pnpm check` (typecheck + lint + build) passes
- [x] New unit test: `bypasses internal (provider-less) service composition`
- [x] Existing guard tests updated to carry `provider: 'socketio'` and still pass (24/24)
- [x] Daemon `src/auth` + `src/hooks` suites pass (82/82)
- [ ] Deploy to prod and confirm Fellow/Slack/Playwright appear as callable tools in executor sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)