### PR TITLE
Add search to settings lists

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
@@ -16,10 +16,12 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { mapToArray, mapToSortedArray } from '@/utils/mapHelpers';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { uiRouteHref } from '@/utils/uiRoutes';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
+import { HighlightMatch } from '../HighlightMatch';
 
 interface ArtifactsTableProps {
   artifactById: Map<string, Artifact>;
@@ -49,6 +51,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
 }) => {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingArtifact, setEditingArtifact] = useState<Artifact | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
 
   // Reuses the `artifactById` prop so we don't read the same data via
@@ -115,10 +118,12 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
       key: 'name',
       render: (name: string, artifact: Artifact) => (
         <Space orientation="vertical" size={0}>
-          <Typography.Text strong>{name}</Typography.Text>
+          <Typography.Text strong>
+            <HighlightMatch text={name} query={searchTerm} />
+          </Typography.Text>
           {artifact.description && (
             <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              {artifact.description}
+              <HighlightMatch text={artifact.description} query={searchTerm} />
             </Typography.Text>
           )}
         </Space>
@@ -130,7 +135,9 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
       key: 'template',
       width: 120,
       render: (template: string) => (
-        <Tag color={templateColors[template] || 'default'}>{template}</Tag>
+        <Tag color={templateColors[template] || 'default'}>
+          <HighlightMatch text={template} query={searchTerm} />
+        </Tag>
       ),
     },
     {
@@ -161,7 +168,9 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
         if (!branchId) return <Typography.Text type="secondary">—</Typography.Text>;
         const branch = branchById.get(branchId);
         return (
-          <Typography.Text type="secondary">{branch?.name || shortId(branchId)}</Typography.Text>
+          <Typography.Text type="secondary">
+            <HighlightMatch text={branch?.name || shortId(branchId)} query={searchTerm} />
+          </Typography.Text>
         );
       },
     },
@@ -174,7 +183,10 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
         const board = boardById.get(boardId);
         return (
           <Typography.Text type="secondary">
-            {board ? `${board.icon || ''} ${board.name}`.trim() : shortId(boardId)}
+            <HighlightMatch
+              text={board ? `${board.icon || ''} ${board.name}`.trim() : shortId(boardId)}
+              query={searchTerm}
+            />
           </Typography.Text>
         );
       },
@@ -241,16 +253,47 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
     },
   ];
 
-  const dataSource = mapToSortedArray(artifactById, (a, b) =>
-    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-  ).filter((artifact) => !artifact.archived);
+  const dataSource = useMemo(() => {
+    const activeArtifacts = mapToSortedArray(artifactById, (a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    ).filter((artifact) => !artifact.archived);
+    return filterBySettingsSearch(activeArtifacts, searchTerm, [
+      (artifact) => artifact.name,
+      (artifact) => artifact.description,
+      (artifact) => artifact.template,
+      (artifact) => artifact.build_status,
+      (artifact) => artifact.artifact_id,
+      (artifact) => {
+        const branch = artifact.branch_id ? branchById.get(artifact.branch_id) : undefined;
+        return [branch?.name, branch?.ref, artifact.branch_id];
+      },
+      (artifact) => {
+        const board = boardById.get(artifact.board_id);
+        return [board?.name, board?.slug, artifact.board_id];
+      },
+    ]);
+  }, [artifactById, searchTerm, branchById, boardById]);
 
   return (
     <div>
-      <div style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          marginBottom: 16,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         <Typography.Text type="secondary">
           Live web application artifacts created by agents via MCP tools.
         </Typography.Text>
+        <Input
+          allowClear
+          placeholder="Search name, description, template, branch, or board"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          style={{ width: 360 }}
+        />
       </div>
 
       {dataSource.length === 0 ? (

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -32,6 +32,7 @@ import { ArchiveActionButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
 import { AssistantFormFields } from '../forms/AssistantFormFields';
+import { HighlightMatch } from '../HighlightMatch';
 import { MarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
 import { UserAvatar } from '../metadata/UserAvatar';
 
@@ -223,7 +224,9 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
             ) : (
               <RobotOutlined style={{ color: token.colorInfo }} />
             )}
-            <Typography.Text strong>{config?.displayName ?? record.name}</Typography.Text>
+            <Typography.Text strong>
+              <HighlightMatch text={config?.displayName ?? record.name} query={searchTerm} />
+            </Typography.Text>
           </Space>
         );
       },
@@ -274,7 +277,7 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
                 cursor: 'help',
               }}
             >
-              {firstLine}
+              <HighlightMatch text={firstLine} query={searchTerm} />
             </Typography.Text>
           </Popover>
         );

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -34,8 +34,10 @@ import {
 import { useMemo, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { ArchiveToggleButton } from '../ArchiveButton';
 import { BoardFormFields, extractBoardFormValues, isCustomCSS } from '../forms/BoardFormFields';
+import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 
 interface BoardsTableProps {
@@ -70,6 +72,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   const [allUsers, setAllUsers] = useState<User[]>([]);
   const [allGroups, setAllGroups] = useState<Group[]>([]);
   const [archiveFilter, setArchiveFilter] = useState<'active' | 'archived' | 'all'>('active');
+  const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
 
   // Calculate session count per board (branch-centric model)
@@ -341,6 +344,23 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
     </Form.Item>
   );
 
+  const boards = useMemo(() => {
+    const filteredByArchive = mapToSortedArray(boardById, (a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    ).filter((board) => {
+      if (archiveFilter === 'active') return !board.archived;
+      if (archiveFilter === 'archived') return board.archived;
+      return true;
+    });
+
+    return filterBySettingsSearch(filteredByArchive, searchTerm, [
+      (board) => board.name,
+      (board) => board.slug,
+      (board) => board.description,
+      (board) => board.board_id,
+    ]);
+  }, [boardById, archiveFilter, searchTerm]);
+
   const columns = [
     {
       title: 'Icon',
@@ -353,12 +373,17 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
+      render: (name: string) => <HighlightMatch text={name} query={searchTerm} />,
     },
     {
       title: 'Description',
       dataIndex: 'description',
       key: 'description',
-      render: (desc: string) => <Typography.Text type="secondary">{desc || '—'}</Typography.Text>,
+      render: (desc: string) => (
+        <Typography.Text type="secondary">
+          {desc ? <HighlightMatch text={desc} query={searchTerm} /> : '—'}
+        </Typography.Text>
+      ),
     },
     {
       title: 'Sessions',
@@ -449,6 +474,13 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
               { value: 'archived', label: 'Archived' },
             ]}
           />
+          <Input
+            allowClear
+            placeholder="Search name, slug, description, or ID"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            style={{ width: 300 }}
+          />
           <Button icon={<UploadOutlined />} onClick={handleImportClick}>
             Import Board
           </Button>
@@ -459,13 +491,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
       </div>
 
       <Table
-        dataSource={mapToSortedArray(boardById, (a, b) =>
-          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-        ).filter((board) => {
-          if (archiveFilter === 'active') return !board.archived;
-          if (archiveFilter === 'archived') return board.archived;
-          return true; // 'all'
-        })}
+        dataSource={boards}
         columns={columns}
         rowKey="board_id"
         pagination={false}

--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
@@ -30,6 +30,7 @@ import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { ArchiveToggleButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import { BranchFormFields } from '../BranchFormFields';
+import { HighlightMatch } from '../HighlightMatch';
 import { renderEnvCell } from './BranchEnvColumn';
 
 interface BranchesTableProps {
@@ -326,7 +327,9 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
           ) : (
             <BranchesOutlined />
           )}
-          <Typography.Text strong>{name}</Typography.Text>
+          <Typography.Text strong>
+            <HighlightMatch text={name} query={searchTerm} />
+          </Typography.Text>
         </Space>
       ),
     },
@@ -347,7 +350,9 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
       render: (repoId: string) => (
         <Space>
           <FolderOutlined />
-          <Typography.Text>{getRepoName(repoId)}</Typography.Text>
+          <Typography.Text>
+            <HighlightMatch text={getRepoName(repoId)} query={searchTerm} />
+          </Typography.Text>
         </Space>
       ),
     },
@@ -355,7 +360,11 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
       title: 'Branch',
       dataIndex: 'ref',
       key: 'ref',
-      render: (ref: string) => <Typography.Text code>{ref}</Typography.Text>,
+      render: (ref: string) => (
+        <Typography.Text code>
+          <HighlightMatch text={ref} query={searchTerm} />
+        </Typography.Text>
+      ),
     },
     {
       title: 'Sessions',

--- a/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
@@ -24,8 +24,10 @@ import {
 import { useMemo, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import CardModal from '../CardModal/CardModal';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
+import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 import { MetaRow } from '../MetaRow';
 
@@ -55,12 +57,24 @@ export const CardsTable: React.FC<CardsTableProps> = ({
   const [editTypeModalOpen, setEditTypeModalOpen] = useState(false);
   const [editingType, setEditingType] = useState<CardType | null>(null);
   const [cardModalCard, setCardModalCard] = useState<CardWithType | null>(null);
+  const [typeSearchTerm, setTypeSearchTerm] = useState('');
+  const [cardSearchTerm, setCardSearchTerm] = useState('');
   const [form] = Form.useForm();
 
   // Derived data
   const cardTypes = useMemo(
     () => mapToArray(cardTypeById).sort((a, b) => a.name.localeCompare(b.name)),
     [cardTypeById]
+  );
+
+  const filteredCardTypes = useMemo(
+    () =>
+      filterBySettingsSearch(cardTypes, typeSearchTerm, [
+        (cardType) => cardType.name,
+        (cardType) => cardType.emoji,
+        (cardType) => JSON.stringify(cardType.json_schema ?? {}),
+      ]),
+    [cardTypes, typeSearchTerm]
   );
 
   // Build card_id → zone info lookup from board_objects
@@ -85,10 +99,22 @@ export const CardsTable: React.FC<CardsTableProps> = ({
 
   const cardsForType = useMemo(() => {
     if (!selectedTypeId) return [];
-    return mapToArray(cardById)
+    const cards = mapToArray(cardById)
       .filter((c) => c.card_type_id === selectedTypeId && !c.archived)
       .sort((a, b) => a.title.localeCompare(b.title));
-  }, [cardById, selectedTypeId]);
+    return filterBySettingsSearch(cards, cardSearchTerm, [
+      (card) => card.title,
+      (card) => {
+        const board = boardById.get(card.board_id);
+        return [board?.name, board?.slug, card.board_id];
+      },
+      (card) => {
+        const zone = cardZoneInfo.get(card.card_id);
+        return zone?.zoneName;
+      },
+      (card) => JSON.stringify(card.data ?? {}),
+    ]);
+  }, [cardById, selectedTypeId, cardSearchTerm, boardById, cardZoneInfo]);
 
   // Card type CRUD handlers
   const handleCreateType = async () => {
@@ -172,7 +198,9 @@ export const CardsTable: React.FC<CardsTableProps> = ({
       render: (title: string, record: CardWithType) => (
         <Space>
           {record.effective_emoji && <span>{record.effective_emoji}</span>}
-          <Typography.Text>{title}</Typography.Text>
+          <Typography.Text>
+            <HighlightMatch text={title} query={cardSearchTerm} />
+          </Typography.Text>
         </Space>
       ),
     },
@@ -185,7 +213,14 @@ export const CardsTable: React.FC<CardsTableProps> = ({
         const board = boardById.get(boardId);
         return (
           <Typography.Text type="secondary">
-            {board ? `${board.icon ? `${board.icon} ` : ''}${board.name}` : '—'}
+            {board ? (
+              <HighlightMatch
+                text={`${board.icon ? `${board.icon} ` : ''}${board.name}`}
+                query={cardSearchTerm}
+              />
+            ) : (
+              '—'
+            )}
           </Typography.Text>
         );
       },
@@ -200,7 +235,9 @@ export const CardsTable: React.FC<CardsTableProps> = ({
         return (
           <Space size={4}>
             {info.zoneColor && <PushpinFilled style={{ color: info.zoneColor, fontSize: 12 }} />}
-            <Typography.Text style={{ fontSize: 13 }}>{info.zoneName}</Typography.Text>
+            <Typography.Text style={{ fontSize: 13 }}>
+              <HighlightMatch text={info.zoneName} query={cardSearchTerm} />
+            </Typography.Text>
           </Space>
         );
       },
@@ -318,12 +355,23 @@ export const CardsTable: React.FC<CardsTableProps> = ({
               New
             </Button>
           </div>
+          {cardTypes.length > 0 && (
+            <div style={{ padding: '8px 12px' }}>
+              <Input
+                allowClear
+                size="small"
+                placeholder="Search types"
+                value={typeSearchTerm}
+                onChange={(event) => setTypeSearchTerm(event.target.value)}
+              />
+            </div>
+          )}
           {cardTypes.length === 0 ? (
             <div style={{ padding: 24, textAlign: 'center' }}>
               <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No card types yet" />
             </div>
           ) : (
-            cardTypes.map((ct) => (
+            filteredCardTypes.map((ct) => (
               <div
                 key={ct.card_type_id}
                 onClick={() => setSelectedTypeId(ct.card_type_id)}
@@ -345,7 +393,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
                   avatar={<span style={{ fontSize: 18 }}>{ct.emoji || '📋'}</span>}
                   title={
                     <Typography.Text style={{ fontSize: 13 }} ellipsis>
-                      {ct.name}
+                      <HighlightMatch text={ct.name} query={typeSearchTerm} />
                     </Typography.Text>
                   }
                 />
@@ -386,7 +434,14 @@ export const CardsTable: React.FC<CardsTableProps> = ({
         <Content style={{ minWidth: 0 }}>
           {selectedType ? (
             <div>
-              <div style={{ marginBottom: 12 }}>
+              <div
+                style={{
+                  marginBottom: 12,
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                }}
+              >
                 <Space>
                   <span style={{ fontSize: 20 }}>{selectedType.emoji || '📋'}</span>
                   <Typography.Title level={5} style={{ margin: 0 }}>
@@ -396,6 +451,13 @@ export const CardsTable: React.FC<CardsTableProps> = ({
                     ({cardsForType.length} card{cardsForType.length !== 1 ? 's' : ''})
                   </Typography.Text>
                 </Space>
+                <Input
+                  allowClear
+                  placeholder="Search title, board, zone, or data"
+                  value={cardSearchTerm}
+                  onChange={(event) => setCardSearchTerm(event.target.value)}
+                  style={{ width: 300 }}
+                />
               </div>
               <Table
                 dataSource={cardsForType}

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -57,10 +57,12 @@ import { getDaemonUrl } from '@/config/daemon';
 import { copyToClipboard } from '@/utils/clipboard';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { ACCESS_TOKEN_KEY } from '@/utils/tokenRefresh';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { AgentSelectionGrid } from '../AgentSelectionGrid';
 import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
+import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 import { BranchSelect } from './BranchSelect';
 
@@ -1180,6 +1182,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const [selectedAgent, setSelectedAgent] = useState<string>('claude-code');
   const [createdChannelKey, setCreatedChannelKey] = useState<string | null>(null);
   const [createdChannelType, setCreatedChannelType] = useState<ChannelType | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
   const [createForm] = Form.useForm();
   const [editForm] = Form.useForm();
   const [referencedBranchesById, setReferencedBranchesById] = useState<Map<string, Branch>>(
@@ -1545,6 +1548,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       dataIndex: 'name',
       key: 'name',
       width: 180,
+      render: (name: string) => <HighlightMatch text={name} query={searchTerm} />,
     },
     {
       title: 'Type',
@@ -1566,7 +1570,14 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         const wt = branchOptionsById.get(branchId);
         return (
           <Typography.Text type="secondary">
-            {wt ? `${wt.name || wt.ref || branchId}${wt.archived ? ' (archived)' : ''}` : branchId}
+            <HighlightMatch
+              text={
+                wt
+                  ? `${wt.name || wt.ref || branchId}${wt.archived ? ' (archived)' : ''}`
+                  : branchId
+              }
+              query={searchTerm}
+            />
           </Typography.Text>
         );
       },
@@ -1621,9 +1632,23 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     },
   ];
 
-  const channels = mapToSortedArray(gatewayChannelById, (a, b) =>
-    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-  );
+  const channels = useMemo(() => {
+    const sorted = mapToSortedArray(gatewayChannelById, (a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    );
+    return filterBySettingsSearch(sorted, searchTerm, [
+      (channel) => channel.name,
+      (channel) => channel.channel_type,
+      (channel) => channel.channel_key,
+      (channel) => (channel.enabled ? 'enabled' : 'disabled'),
+      (channel) => channel.last_message_at,
+      (channel) => {
+        const branch = branchOptionsById.get(channel.target_branch_id);
+        return [branch?.name, branch?.ref, channel.target_branch_id];
+      },
+      (channel) => JSON.stringify(channel.config ?? {}),
+    ]);
+  }, [gatewayChannelById, searchTerm, branchOptionsById]);
 
   return (
     <div>
@@ -1638,9 +1663,18 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         <Typography.Text type="secondary">
           Route messages from Slack, GitHub, and other platforms to Agor sessions.
         </Typography.Text>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-          Add Channel
-        </Button>
+        <Space>
+          <Input
+            allowClear
+            placeholder="Search name, type, target branch, key, or config"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            style={{ width: 360 }}
+          />
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
+            Add Channel
+          </Button>
+        </Space>
       </div>
 
       <Alert

--- a/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
@@ -17,7 +17,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { slugify } from '@/utils/repoSlug';
 import { searchableSelectProps, toUserSelectOption } from '@/utils/selectSearch';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { useThemedMessage } from '../../utils/message';
+import { HighlightMatch } from '../HighlightMatch';
 import { syncGroupMembersForGroup } from './groupMembershipSync';
 
 interface GroupsTableProps {
@@ -33,6 +35,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
   const [editingGroup, setEditingGroup] = useState<Group | null>(null);
   const [editingMemberIds, setEditingMemberIds] = useState<string[]>([]);
   const [createOpen, setCreateOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
   const [editForm] = Form.useForm();
   const createSlugEditedRef = useRef(false);
@@ -156,20 +159,50 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
   const userOptions = mapToSortedArray(userById, (a, b) => a.email.localeCompare(b.email)).map(
     toUserSelectOption
   );
+  const filteredGroups = filterBySettingsSearch(
+    [...groups].sort((a, b) => a.name.localeCompare(b.name)),
+    searchTerm,
+    [
+      (group) => group.name,
+      (group) => group.slug,
+      (group) => group.description,
+      (group) =>
+        (membershipsByGroup.get(group.group_id) || [])
+          .map((userId) => userById.get(userId))
+          .filter((user): user is User => Boolean(user))
+          .flatMap((user) => [user.name, user.email, user.unix_username]),
+    ]
+  );
   return (
     <div>
-      <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between' }}>
+      <div
+        style={{
+          marginBottom: 16,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
         <Typography.Text type="secondary">Manage groups and user memberships.</Typography.Text>
-        <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
-          New Group
-        </Button>
+        <Space>
+          <Input
+            allowClear
+            placeholder="Search name, slug, description, or members"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            style={{ width: 320 }}
+          />
+          <Button type="primary" icon={<PlusOutlined />} onClick={openCreateModal}>
+            New Group
+          </Button>
+        </Space>
       </div>
 
       <Table
         rowKey="group_id"
         size="small"
         pagination={false}
-        dataSource={[...groups].sort((a, b) => a.name.localeCompare(b.name))}
+        dataSource={filteredGroups}
         columns={[
           {
             title: 'Group',
@@ -177,12 +210,20 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
             render: (_: string, group: Group) => (
               <Space>
                 <TeamOutlined />
-                <span>{group.name}</span>
-                <Tag>{group.slug}</Tag>
+                <span>
+                  <HighlightMatch text={group.name} query={searchTerm} />
+                </span>
+                <Tag>
+                  <HighlightMatch text={group.slug || ''} query={searchTerm} />
+                </Tag>
               </Space>
             ),
           },
-          { title: 'Description', dataIndex: 'description', render: (v?: string) => v || '—' },
+          {
+            title: 'Description',
+            dataIndex: 'description',
+            render: (v?: string) => (v ? <HighlightMatch text={v} query={searchTerm} /> : '—'),
+          },
           {
             title: 'Members',
             render: (_: unknown, group: Group) => (

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   Descriptions,
   Form,
+  Input,
   Modal,
   Popconfirm,
   Space,
@@ -12,9 +13,11 @@ import {
   Tag,
   Typography,
 } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
+import { HighlightMatch } from '../HighlightMatch';
 import { MCPServerEditModal, MCPServerFormFields } from '../MCPServer';
 import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from '../MCPServer/mcp-oauth-utils';
 
@@ -54,6 +57,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
   const [testing, setTesting] = useState(false);
   const [alreadyCreatedInOAuthFlow, setAlreadyCreatedInOAuthFlow] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
 
   // Sync editing server when mcpServerById updates (real-time WebSocket updates).
   // Also keeps the open edit modal in sync if the underlying record changes.
@@ -269,9 +273,11 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       width: 180,
       render: (_: string, server: MCPServer) => (
         <div>
-          <div>{server.display_name || server.name}</div>
+          <div>
+            <HighlightMatch text={server.display_name || server.name} query={searchTerm} />
+          </div>
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            {server.name}
+            <HighlightMatch text={server.name} query={searchTerm} />
           </Typography.Text>
         </div>
       ),
@@ -332,7 +338,11 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
       dataIndex: 'source',
       key: 'source',
       width: 100,
-      render: (source: string) => <Typography.Text type="secondary">{source}</Typography.Text>,
+      render: (source: string) => (
+        <Typography.Text type="secondary">
+          <HighlightMatch text={source} query={searchTerm} />
+        </Typography.Text>
+      ),
     },
     {
       title: 'Actions',
@@ -369,6 +379,25 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     },
   ];
 
+  const servers = useMemo(() => {
+    const sorted = mapToSortedArray(mcpServerById, (a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    );
+    return filterBySettingsSearch(sorted, searchTerm, [
+      (server) => server.name,
+      (server) => server.display_name,
+      (server) => server.description,
+      (server) => server.transport,
+      (server) => server.scope,
+      (server) => server.source,
+      (server) => server.url,
+      (server) => server.command,
+      (server) => server.args,
+      (server) => server.enabled,
+      (server) => server.tools?.flatMap((tool) => [tool.name, tool.description]),
+    ]);
+  }, [mcpServerById, searchTerm]);
+
   return (
     <div>
       <div
@@ -382,15 +411,22 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
         <Typography.Text type="secondary">
           Configure Model Context Protocol servers for enhanced AI capabilities.
         </Typography.Text>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-          New MCP Server
-        </Button>
+        <Space>
+          <Input
+            allowClear
+            placeholder="Search name, URL, command, tools, transport, or scope"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            style={{ width: 360 }}
+          />
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
+            New MCP Server
+          </Button>
+        </Space>
       </div>
 
       <Table
-        dataSource={mapToSortedArray(mcpServerById, (a, b) =>
-          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
-        )}
+        dataSource={servers}
         columns={columns}
         rowKey="mcp_server_id"
         pagination={{ pageSize: 10, showSizeChanger: true }}

--- a/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/PersonalApiKeysTab.tsx
@@ -1,9 +1,11 @@
 import type { AgorClient } from '@agor-live/client';
 import { CopyOutlined, DeleteOutlined, KeyOutlined, PlusOutlined } from '@ant-design/icons';
 import { Alert, Button, Input, Modal, Popconfirm, Space, Table, Typography, theme } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
 import { useThemedMessage } from '../../utils/message';
+import { filterBySettingsSearch } from '../../utils/settingsSearch';
+import { HighlightMatch } from '../HighlightMatch';
 
 interface ApiKeyEntry {
   id: string;
@@ -25,6 +27,7 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [newlyCreatedKey, setNewlyCreatedKey] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
 
@@ -90,6 +93,7 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
+      render: (name: string) => <HighlightMatch text={name} query={searchTerm} />,
     },
     {
       title: 'Key',
@@ -97,7 +101,8 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }
       key: 'prefix',
       render: (prefix: string) => (
         <Typography.Text code style={{ fontSize: 12 }}>
-          {prefix}...
+          <HighlightMatch text={prefix} query={searchTerm} />
+          ...
         </Typography.Text>
       ),
     },
@@ -137,6 +142,18 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }
     },
   ];
 
+  const filteredKeys = useMemo(
+    () =>
+      filterBySettingsSearch(keys, searchTerm, [
+        (key) => key.name,
+        (key) => key.prefix,
+        (key) => key.id,
+        (key) => key.created_at,
+        (key) => key.last_used_at,
+      ]),
+    [keys, searchTerm]
+  );
+
   return (
     <div>
       <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
@@ -144,17 +161,21 @@ export const PersonalApiKeysTab: React.FC<PersonalApiKeysTabProps> = ({ client }
         external tools. Tokens have the same permissions as your user account.
       </Typography.Paragraph>
 
-      <Button
-        type="primary"
-        icon={<PlusOutlined />}
-        onClick={() => setShowCreateModal(true)}
-        style={{ marginBottom: 16 }}
-      >
-        Create New Key
-      </Button>
+      <Space style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between' }}>
+        <Input
+          allowClear
+          placeholder="Search name, prefix, or dates"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+          style={{ width: 300 }}
+        />
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => setShowCreateModal(true)}>
+          Create New Key
+        </Button>
+      </Space>
 
       <Table
-        dataSource={keys}
+        dataSource={filteredKeys}
         columns={columns}
         rowKey="id"
         loading={loading}

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.test.tsx
@@ -1,0 +1,54 @@
+import type { Repo } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReposTable } from './ReposTable';
+
+function makeRepo(overrides: Partial<Repo>): Repo {
+  return {
+    repo_id: overrides.repo_id ?? 'repo-1',
+    name: overrides.name ?? 'Repository',
+    slug: overrides.slug ?? 'org/repository',
+    default_branch: overrides.default_branch ?? 'main',
+    repo_type: overrides.repo_type ?? 'remote',
+    remote_url: overrides.remote_url ?? 'https://github.com/org/repository.git',
+    local_path: overrides.local_path,
+    ...overrides,
+  } as Repo;
+}
+
+describe('ReposTable search', () => {
+  it('filters repositories by URL/path fields and highlights visible matches', () => {
+    const repoById = new Map<string, Repo>([
+      [
+        'repo-1',
+        makeRepo({
+          repo_id: 'repo-1',
+          name: 'Agor',
+          slug: 'preset-io/agor',
+          remote_url: 'https://github.com/preset-io/agor.git',
+        }),
+      ],
+      [
+        'repo-2',
+        makeRepo({
+          repo_id: 'repo-2',
+          name: 'Docs Site',
+          slug: 'preset-io/docs',
+          repo_type: 'local',
+          remote_url: undefined,
+          local_path: '/workspace/preset-docs',
+        }),
+      ],
+    ]);
+
+    render(<ReposTable repoById={repoById} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Search name, slug, URL/i), {
+      target: { value: 'preset-docs' },
+    });
+
+    expect(screen.queryByText('Agor')).not.toBeInTheDocument();
+    expect(screen.getByText('Docs Site')).toBeInTheDocument();
+    expect(screen.getByText('preset-docs').tagName.toLowerCase()).toBe('mark');
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -1,10 +1,12 @@
 import type { CreateLocalRepoRequest, CreateRepoRequest, Repo } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, FolderOutlined, PlusOutlined } from '@ant-design/icons';
 import type { RadioChangeEvent } from 'antd';
-import { Button, Card, Empty, Form, Modal, Space, Typography } from 'antd';
-import { useState } from 'react';
+import { Button, Card, Empty, Form, Input, Modal, Space, Typography } from 'antd';
+import { useMemo, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { RepoFormFields } from '../forms/RepoFormFields';
+import { HighlightMatch } from '../HighlightMatch';
 import { Tag } from '../Tag';
 
 interface ReposTableProps {
@@ -23,6 +25,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
   onDelete,
 }) => {
   const repos = mapToArray(repoById).sort((a, b) => a.name.localeCompare(b.name));
+  const [searchTerm, setSearchTerm] = useState('');
   const [repoModalOpen, setRepoModalOpen] = useState(false);
   const [editingRepo, setEditingRepo] = useState<Repo | null>(null);
   const [repoMode, setRepoMode] = useState<'remote' | 'local'>('remote');
@@ -31,6 +34,18 @@ export const ReposTable: React.FC<ReposTableProps> = ({
   const [repoToDelete, setRepoToDelete] = useState<Repo | null>(null);
 
   const isEditing = !!editingRepo;
+  const filteredRepos = useMemo(
+    () =>
+      filterBySettingsSearch(repos, searchTerm, [
+        (repo) => repo.name,
+        (repo) => repo.slug,
+        (repo) => repo.remote_url,
+        (repo) => repo.local_path,
+        (repo) => repo.default_branch,
+        (repo) => repo.repo_type,
+      ]),
+    [repos, searchTerm]
+  );
 
   const handleOpenDeleteModal = (repo: Repo) => {
     setRepoToDelete(repo);
@@ -134,9 +149,18 @@ export const ReposTable: React.FC<ReposTableProps> = ({
         <Typography.Text type="secondary">
           Connect remote or local git repositories for your sessions.
         </Typography.Text>
-        <Button type="primary" icon={<PlusOutlined />} onClick={handleOpenCreateModal}>
-          New Repository
-        </Button>
+        <Space>
+          <Input
+            allowClear
+            placeholder="Search name, slug, URL, path, type, or branch"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            style={{ width: 340 }}
+          />
+          <Button type="primary" icon={<PlusOutlined />} onClick={handleOpenCreateModal}>
+            New Repository
+          </Button>
+        </Space>
       </div>
 
       {repos.length === 0 && (
@@ -160,7 +184,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
 
       {repos.length > 0 && (
         <Space orientation="vertical" size={16} style={{ width: '100%' }}>
-          {repos.map((repo: Repo) => {
+          {filteredRepos.map((repo: Repo) => {
             const isLocal = repo.repo_type === 'local';
             const tagColor = isLocal ? 'green' : 'blue';
             const tagLabel = isLocal ? 'Local' : 'Remote';
@@ -172,9 +196,11 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                 title={
                   <Space>
                     <FolderOutlined />
-                    <Typography.Text strong>{repo.name}</Typography.Text>
+                    <Typography.Text strong>
+                      <HighlightMatch text={repo.name} query={searchTerm} />
+                    </Typography.Text>
                     <Tag color={tagColor} style={{ marginLeft: 8 }}>
-                      {tagLabel}
+                      <HighlightMatch text={tagLabel} query={searchTerm} />
                     </Tag>
                   </Space>
                 }
@@ -203,7 +229,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                       Slug:{' '}
                     </Typography.Text>
                     <Typography.Text code style={{ fontSize: 12 }}>
-                      {repo.slug}
+                      <HighlightMatch text={repo.slug} query={searchTerm} />
                     </Typography.Text>
                   </div>
 
@@ -212,7 +238,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                       Type:{' '}
                     </Typography.Text>
                     <Typography.Text code style={{ fontSize: 11 }}>
-                      {tagLabel.toLowerCase()}
+                      <HighlightMatch text={tagLabel.toLowerCase()} query={searchTerm} />
                     </Typography.Text>
                   </div>
 
@@ -221,7 +247,11 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                       Remote:{' '}
                     </Typography.Text>
                     <Typography.Text code style={{ fontSize: 11 }}>
-                      {repo.remote_url ?? '—'}
+                      {repo.remote_url ? (
+                        <HighlightMatch text={repo.remote_url} query={searchTerm} />
+                      ) : (
+                        '—'
+                      )}
                     </Typography.Text>
                   </div>
 
@@ -231,7 +261,7 @@ export const ReposTable: React.FC<ReposTableProps> = ({
                         Path:{' '}
                       </Typography.Text>
                       <Typography.Text code style={{ fontSize: 11 }}>
-                        {repo.local_path}
+                        <HighlightMatch text={repo.local_path} query={searchTerm} />
                       </Typography.Text>
                     </div>
                   )}

--- a/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ReposTable.tsx
@@ -24,7 +24,10 @@ export const ReposTable: React.FC<ReposTableProps> = ({
   onUpdate,
   onDelete,
 }) => {
-  const repos = mapToArray(repoById).sort((a, b) => a.name.localeCompare(b.name));
+  const repos = useMemo(
+    () => mapToArray(repoById).sort((a, b) => a.name.localeCompare(b.name)),
+    [repoById]
+  );
   const [searchTerm, setSearchTerm] = useState('');
   const [repoModalOpen, setRepoModalOpen] = useState(false);
   const [editingRepo, setEditingRepo] = useState<Repo | null>(null);

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -25,8 +25,10 @@ import {
 } from 'antd';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { mapToSortedArray } from '@/utils/mapHelpers';
+import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { useThemedMessage } from '../../utils/message';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
+import { HighlightMatch } from '../HighlightMatch';
 import { UserSettingsModal } from './UserSettingsModal';
 
 interface UsersTableProps {
@@ -53,6 +55,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [groups, setGroups] = useState<Group[]>([]);
   const [memberships, setMemberships] = useState<GroupMembership[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
 
@@ -92,6 +95,23 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     () => new Map(groups.map((group) => [group.group_id, group])),
     [groups]
   );
+
+  const users = useMemo(() => {
+    const sorted = mapToSortedArray(userById, (a, b) =>
+      a.email.localeCompare(b.email, undefined, { sensitivity: 'base' })
+    );
+    return filterBySettingsSearch(sorted, searchTerm, [
+      (user) => user.email,
+      (user) => user.name,
+      (user) => user.unix_username,
+      (user) => user.role,
+      (user) =>
+        (groupsByUser.get(user.user_id) || [])
+          .map((groupId) => groupById.get(groupId))
+          .filter((group): group is Group => Boolean(group))
+          .flatMap((group) => [group.name, group.slug]),
+    ]);
+  }, [userById, searchTerm, groupsByUser, groupById]);
 
   const handleDelete = (userId: string) => {
     onDelete?.(userId);
@@ -141,7 +161,9 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       render: (email: string, user: User) => (
         <Space>
           <span style={{ fontSize: 20 }}>{user.emoji || '👤'}</span>
-          <span>{email}</span>
+          <span>
+            <HighlightMatch text={email} query={searchTerm} />
+          </span>
         </Space>
       ),
     },
@@ -149,7 +171,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
-      render: (name: string) => <Typography.Text>{name || '—'}</Typography.Text>,
+      render: (name: string) => (
+        <Typography.Text>
+          {name ? <HighlightMatch text={name} query={searchTerm} /> : '—'}
+        </Typography.Text>
+      ),
     },
     {
       title: 'Role',
@@ -175,7 +201,9 @@ export const UsersTable: React.FC<UsersTableProps> = ({
               .filter((group): group is Group => Boolean(group))
               .sort((a, b) => a.name.localeCompare(b.name))
               .map((group) => (
-                <Tag key={group.group_id}>{group.name}</Tag>
+                <Tag key={group.group_id}>
+                  <HighlightMatch text={group.name} query={searchTerm} />
+                </Tag>
               ))}
           </Space>
         );
@@ -219,15 +247,22 @@ export const UsersTable: React.FC<UsersTableProps> = ({
         }}
       >
         <Typography.Text type="secondary">Manage user accounts and permissions.</Typography.Text>
-        <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-          New User
-        </Button>
+        <Space>
+          <Input
+            allowClear
+            placeholder="Search name, email, username, role, or groups"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            style={{ width: 320 }}
+          />
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
+            New User
+          </Button>
+        </Space>
       </div>
 
       <Table
-        dataSource={mapToSortedArray(userById, (a, b) =>
-          a.email.localeCompare(b.email, undefined, { sensitivity: 'base' })
-        )}
+        dataSource={users}
         columns={columns}
         rowKey="user_id"
         pagination={false}

--- a/apps/agor-ui/src/utils/settingsSearch.test.ts
+++ b/apps/agor-ui/src/utils/settingsSearch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterBySettingsSearch,
+  matchesSettingsSearch,
+  type SearchAccessor,
+} from './settingsSearch';
+
+interface Row {
+  name: string;
+  email: string;
+  groups: string[];
+  role: string;
+}
+
+describe('settingsSearch', () => {
+  const rows: Row[] = [
+    { name: 'Alice Admin', email: 'alice@example.com', groups: ['Platform'], role: 'admin' },
+    { name: 'Bob Builder', email: 'bob@example.com', groups: ['Design Systems'], role: 'member' },
+  ];
+  const accessors: Array<SearchAccessor<Row>> = [
+    (row) => row.name,
+    (row) => row.email,
+    (row) => row.groups,
+    (row) => row.role,
+  ];
+
+  it('matches all query tokens across searchable fields', () => {
+    expect(matchesSettingsSearch(rows[0], 'alice platform', accessors)).toBe(true);
+    expect(matchesSettingsSearch(rows[0], 'alice design', accessors)).toBe(false);
+  });
+
+  it('filters case-insensitively and supports array fields', () => {
+    expect(filterBySettingsSearch(rows, 'DESIGN', accessors).map((row) => row.name)).toEqual([
+      'Bob Builder',
+    ]);
+  });
+
+  it('returns original items for blank queries', () => {
+    expect(filterBySettingsSearch(rows, '   ', accessors)).toBe(rows);
+  });
+});

--- a/apps/agor-ui/src/utils/settingsSearch.ts
+++ b/apps/agor-ui/src/utils/settingsSearch.ts
@@ -1,4 +1,4 @@
-import { tokenizeSearchQuery } from '@agor-live/client';
+import { matchSearchTokens, tokenizeSearchQuery } from '@agor-live/client';
 
 export type SearchableValue = string | number | boolean | null | undefined | SearchableValue[];
 
@@ -24,12 +24,8 @@ export function matchesSettingsSearch<T>(
   const tokens = getSettingsSearchTokens(query);
   if (tokens.length === 0) return true;
 
-  const haystack = accessors
-    .flatMap((accessor) => flattenSearchableValue(accessor(item)))
-    .join(' ')
-    .toLowerCase();
-
-  return tokens.every((token) => haystack.includes(token));
+  const fields = accessors.flatMap((accessor) => flattenSearchableValue(accessor(item)));
+  return matchSearchTokens(tokens, fields);
 }
 
 export function filterBySettingsSearch<T>(

--- a/apps/agor-ui/src/utils/settingsSearch.ts
+++ b/apps/agor-ui/src/utils/settingsSearch.ts
@@ -1,0 +1,42 @@
+import { tokenizeSearchQuery } from '@agor-live/client';
+
+export type SearchableValue = string | number | boolean | null | undefined | SearchableValue[];
+
+export type SearchAccessor<T> = (item: T) => SearchableValue;
+
+export function getSettingsSearchTokens(query: string): string[] {
+  return tokenizeSearchQuery(query)
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function flattenSearchableValue(value: SearchableValue): string[] {
+  if (value === null || value === undefined) return [];
+  if (Array.isArray(value)) return value.flatMap(flattenSearchableValue);
+  return [String(value)];
+}
+
+export function matchesSettingsSearch<T>(
+  item: T,
+  query: string,
+  accessors: Array<SearchAccessor<T>>
+): boolean {
+  const tokens = getSettingsSearchTokens(query);
+  if (tokens.length === 0) return true;
+
+  const haystack = accessors
+    .flatMap((accessor) => flattenSearchableValue(accessor(item)))
+    .join(' ')
+    .toLowerCase();
+
+  return tokens.every((token) => haystack.includes(token));
+}
+
+export function filterBySettingsSearch<T>(
+  items: T[],
+  query: string,
+  accessors: Array<SearchAccessor<T>>
+): T[] {
+  if (getSettingsSearchTokens(query).length === 0) return items;
+  return items.filter((item) => matchesSettingsSearch(item, query, accessors));
+}


### PR DESCRIPTION
## Summary
- add a shared Settings search helper and wire clearable search inputs across Settings CRUD/list views
- highlight matching text in visible Settings table/list cells using the existing `HighlightMatch` component
- cover search helper behavior and repository list filtering/highlighting with focused tests

## Settings search inventory
- Already had search: Branches, Assistants
- Added search: Users, Groups, Repositories, Boards, Cards/Card Types, Artifacts, MCP Servers, Gateway Channels, Personal API Keys
- Not changed: non-list configuration tabs such as About, Agentic Tools, Audio/OpenCode-style settings

## Validation
- `pnpm i`
- `pnpm check`
- `pnpm -C apps/agor-ui test src/utils/settingsSearch.test.ts src/components/SettingsModal/ReposTable.test.tsx src/components/SettingsModal/BranchesTable.test.tsx`
