### PR TITLE
Fix migration error messages to expose root cause

### DIFF
--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -41,6 +41,14 @@ export class MigrationError extends Error {
   }
 }
 
+function getRootCause(error: unknown): unknown {
+  let current = error;
+  while (current instanceof Error && current.cause) {
+    current = current.cause;
+  }
+  return current;
+}
+
 /**
  * Check if migrations tracking table exists (dialect-aware)
  */
@@ -61,8 +69,13 @@ async function hasMigrationsTable(db: Database): Promise<boolean> {
     }
     return false;
   } catch (error) {
+    const rootCause = getRootCause(error);
+    const rootMsg =
+      rootCause !== error
+        ? ` (root cause: ${rootCause instanceof Error ? rootCause.message : String(rootCause)})`
+        : '';
     throw new MigrationError(
-      `Failed to check migrations table: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to check migrations table: ${error instanceof Error ? error.message : String(error)}${rootMsg}`,
       error
     );
   }
@@ -200,8 +213,13 @@ export async function checkMigrationStatus(
       applied,
     };
   } catch (error) {
+    const rootCause = getRootCause(error);
+    const rootMsg =
+      rootCause !== error
+        ? ` (root cause: ${rootCause instanceof Error ? rootCause.message : String(rootCause)})`
+        : '';
     throw new MigrationError(
-      `Failed to check migration status: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to check migration status: ${error instanceof Error ? error.message : String(error)}${rootMsg}`,
       error
     );
   }


### PR DESCRIPTION
## Summary

- Adds a `getRootCause()` helper in `migrate.ts` that traverses the error cause chain
- Appends the root cause message to both `hasMigrationsTable` and `checkMigrationStatus` error wraps

## Why

`DrizzleQueryError` wraps the real postgres error but exposes only a generic `"Failed query: <SQL>\nparams: "` message. Each of our catch layers re-wraps using `error.message`, so the actual postgres error (e.g. `no pg_hba.conf entry for host "...", no encryption`) is silently dropped. This made a simple missing-SSL misconfiguration appear as an opaque failed SQL query with no actionable hint.

## Test plan

- [ ] Reproduce a postgres connection failure (e.g. remove `?sslmode=require`) and confirm the error now includes `(root cause: no pg_hba.conf entry...)`
- [ ] Confirm normal SQLite and postgres migration runs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)