### PR TITLE
Fix Claude CLI MCP config permissions

### DIFF
--- a/apps/agor-daemon/src/services/claude-cli-integration.test.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.test.ts
@@ -9,6 +9,7 @@ import {
   buildClaudeCliAgorMcpConfig,
   buildSpawnConfigForSession,
   resolveClaudeCliMcpConfigTargetUnixUser,
+  writeClaudeCliMcpConfigFile,
   writeClaudeCliMcpConfigForSession,
 } from './claude-cli-integration';
 
@@ -46,6 +47,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
   for (const filePath of generatedPaths.splice(0)) {
     fs.rmSync(path.dirname(filePath), { recursive: true, force: true });
@@ -136,5 +138,18 @@ describe('Claude CLI Agor MCP config', () => {
         makeSession({ unix_username: 'alice' })
       )
     ).toBe('alice');
+  });
+
+  it('validates target-user config paths before attempting privileged writes', () => {
+    expect(() =>
+      writeClaudeCliMcpConfigFile({
+        mcpConfig: buildClaudeCliAgorMcpConfig({
+          daemonUrl: 'https://agor.example.test',
+          mcpToken: 'tok_123',
+        }),
+        sessionShortId: '019e8abc',
+        targetUnixUser: 'bad user',
+      })
+    ).toThrow('invalid target Unix username');
   });
 });

--- a/apps/agor-daemon/src/services/claude-cli-integration.test.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.test.ts
@@ -8,6 +8,7 @@ import { generateSessionToken } from '../mcp/tokens.js';
 import {
   buildClaudeCliAgorMcpConfig,
   buildSpawnConfigForSession,
+  resolveClaudeCliMcpConfigTargetUnixUser,
   writeClaudeCliMcpConfigForSession,
 } from './claude-cli-integration';
 
@@ -17,7 +18,12 @@ vi.mock('../mcp/tokens.js', () => ({
 
 const generatedPaths: string[] = [];
 
-function makeApp(config: { daemon?: { mcpEnabled?: boolean } } = {}): Application {
+function makeApp(
+  config: {
+    daemon?: { mcpEnabled?: boolean };
+    execution?: { unix_user_mode?: string; executor_unix_user?: string | null };
+  } = {}
+): Application {
   return {
     get: (key: string) => (key === 'config' ? config : undefined),
   } as unknown as Application;
@@ -112,5 +118,23 @@ describe('Claude CLI Agor MCP config', () => {
       makeSession().session_id,
       'user-1'
     );
+  });
+
+  it('resolves the MCP config file owner from Unix isolation mode', () => {
+    expect(resolveClaudeCliMcpConfigTargetUnixUser(undefined, makeSession())).toBeUndefined();
+
+    expect(
+      resolveClaudeCliMcpConfigTargetUnixUser(
+        { execution: { unix_user_mode: 'insulated', executor_unix_user: 'agor_executor' } },
+        makeSession({ unix_username: 'alice' })
+      )
+    ).toBe('agor_executor');
+
+    expect(
+      resolveClaudeCliMcpConfigTargetUnixUser(
+        { execution: { unix_user_mode: 'strict' } },
+        makeSession({ unix_username: 'alice' })
+      )
+    ).toBe('alice');
   });
 });

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -34,7 +34,7 @@
  *   - Subagent JSONL discovery
  */
 
-import { execFileSync, spawn as spawnProcess } from 'node:child_process';
+import * as childProcess from 'node:child_process';
 import * as fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -68,6 +68,7 @@ import {
   TaskStatus,
 } from '@agor/core/types';
 import {
+  getHomedirFromUsername,
   isValidUnixUsername,
   resolveUnixUserForImpersonation,
   type UnixUserMode,
@@ -283,7 +284,7 @@ export function isClaudeRunningFor(sessionId: SessionID): Promise<boolean> {
     // pgrep uses extended regex with -f. `(--session-id|--resume) <id>`
     // covers both spawn forms `buildClaudeCliSpawn` emits.
     const pattern = `claude .*(--session-id|--resume) ${sessionId}`;
-    const proc = spawnProcess('pgrep', ['-f', pattern], { stdio: 'ignore' });
+    const proc = childProcess.spawn('pgrep', ['-f', pattern], { stdio: 'ignore' });
     proc.on('exit', (code) => resolve(code === 0));
     proc.on('error', () => resolve(true));
     setTimeout(() => {
@@ -1116,13 +1117,6 @@ function writePrivateMcpConfigAsUser(params: {
   targetUnixUser: string;
 }): string {
   const { content, sessionShortId, targetUnixUser } = params;
-  if (!isValidUnixUsername(targetUnixUser)) {
-    throw new Error(`invalid target Unix username: ${JSON.stringify(targetUnixUser)}`);
-  }
-  if (!/^[a-zA-Z0-9_-]+$/.test(sessionShortId)) {
-    throw new Error(`invalid session short id: ${JSON.stringify(sessionShortId)}`);
-  }
-
   const script = [
     'set -euo pipefail',
     'umask 077',
@@ -1132,16 +1126,30 @@ function writePrivateMcpConfigAsUser(params: {
     'printf "%s\\n" "$dir/mcp.json"',
   ].join('; ');
 
-  return execFileSync(
-    'sudo',
-    ['-n', '-u', targetUnixUser, 'bash', '-c', script, '--', sessionShortId],
-    {
-      input: content,
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000,
-    }
-  ).trim();
+  return childProcess
+    .execFileSync(
+      'sudo',
+      ['-n', '-u', targetUnixUser, 'bash', '-c', script, '--', sessionShortId],
+      {
+        input: content,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 5000,
+      }
+    )
+    .trim();
+}
+
+function assertValidMcpConfigWriteParams(params: {
+  sessionShortId: string;
+  targetUnixUser?: string;
+}): void {
+  if (!/^[a-zA-Z0-9_-]+$/.test(params.sessionShortId)) {
+    throw new Error(`invalid session short id: ${JSON.stringify(params.sessionShortId)}`);
+  }
+  if (params.targetUnixUser && !isValidUnixUsername(params.targetUnixUser)) {
+    throw new Error(`invalid target Unix username: ${JSON.stringify(params.targetUnixUser)}`);
+  }
 }
 
 function writePrivateMcpConfigAsDaemon(params: {
@@ -1157,7 +1165,11 @@ function writePrivateMcpConfigAsDaemon(params: {
   // privileged. Chown both path components so a 0700 dir + 0600 file remain
   // readable only by the target process owner.
   if (params.targetUnixUser) {
-    const homeStat = fs.statSync(`/home/${params.targetUnixUser}`);
+    const targetHome = getHomedirFromUsername(params.targetUnixUser);
+    if (!targetHome) {
+      throw new Error(`could not resolve home directory for ${params.targetUnixUser}`);
+    }
+    const homeStat = fs.statSync(targetHome);
     fs.chownSync(dir, homeStat.uid, homeStat.gid);
     fs.chownSync(filePath, homeStat.uid, homeStat.gid);
   }
@@ -1170,6 +1182,7 @@ export function writeClaudeCliMcpConfigFile(params: {
   sessionShortId: string;
   targetUnixUser?: string;
 }): string {
+  assertValidMcpConfigWriteParams(params);
   const content = `${JSON.stringify(params.mcpConfig, null, 2)}\n`;
 
   if (params.targetUnixUser) {

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -34,7 +34,7 @@
  *   - Subagent JSONL discovery
  */
 
-import { spawn as spawnProcess } from 'node:child_process';
+import { execFileSync, spawn as spawnProcess } from 'node:child_process';
 import * as fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -67,6 +67,11 @@ import {
   type TaskID,
   TaskStatus,
 } from '@agor/core/types';
+import {
+  isValidUnixUsername,
+  resolveUnixUserForImpersonation,
+  type UnixUserMode,
+} from '@agor/core/unix';
 import { DrizzleService } from '../adapters/drizzle';
 import { buildInitialUserMessage } from '../utils/build-initial-user-message.js';
 import { canReceiveMcpTokenForSession } from '../utils/mcp-token-authorization.js';
@@ -1046,6 +1051,14 @@ export interface ClaudeCliAgorMcpConfig {
   };
 }
 
+interface ClaudeCliMcpConfigRuntimeConfig {
+  daemon?: { mcpEnabled?: boolean };
+  execution?: {
+    unix_user_mode?: string;
+    executor_unix_user?: string | null;
+  };
+}
+
 /**
  * Build the Claude CLI `--mcp-config` payload for Agor's built-in MCP server.
  *
@@ -1076,6 +1089,119 @@ export function buildClaudeCliAgorMcpConfig(params: {
 }
 
 /**
+ * Resolve the Unix user that will read Claude CLI's `--mcp-config` file.
+ *
+ * The file carries an MCP bearer token, so it should stay mode 0600 and be
+ * owned by the same account that runs the Zellij/Claude process:
+ *   - simple: daemon user (no explicit target)
+ *   - insulated: shared executor_unix_user
+ *   - strict: session creator's immutable unix_username
+ */
+export function resolveClaudeCliMcpConfigTargetUnixUser(
+  config: ClaudeCliMcpConfigRuntimeConfig | undefined,
+  session: Session
+): string | undefined {
+  const mode = (config?.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
+  const result = resolveUnixUserForImpersonation({
+    mode,
+    userUnixUsername: session.unix_username,
+    executorUnixUser: config?.execution?.executor_unix_user,
+  });
+  return result.unixUser ?? undefined;
+}
+
+function writePrivateMcpConfigAsUser(params: {
+  content: string;
+  sessionShortId: string;
+  targetUnixUser: string;
+}): string {
+  const { content, sessionShortId, targetUnixUser } = params;
+  if (!isValidUnixUsername(targetUnixUser)) {
+    throw new Error(`invalid target Unix username: ${JSON.stringify(targetUnixUser)}`);
+  }
+  if (!/^[a-zA-Z0-9_-]+$/.test(sessionShortId)) {
+    throw new Error(`invalid session short id: ${JSON.stringify(sessionShortId)}`);
+  }
+
+  const script = [
+    'set -euo pipefail',
+    'umask 077',
+    'tmp="/tmp"',
+    'dir="$(mktemp -d "$tmp/agor-mcp-$1-XXXXXX")"',
+    'cat > "$dir/mcp.json"',
+    'printf "%s\\n" "$dir/mcp.json"',
+  ].join('; ');
+
+  return execFileSync(
+    'sudo',
+    ['-n', '-u', targetUnixUser, 'bash', '-c', script, '--', sessionShortId],
+    {
+      input: content,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    }
+  ).trim();
+}
+
+function writePrivateMcpConfigAsDaemon(params: {
+  content: string;
+  sessionShortId: string;
+  targetUnixUser?: string;
+}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `agor-mcp-${params.sessionShortId}-`));
+  const filePath = path.join(dir, 'mcp.json');
+  fs.writeFileSync(filePath, params.content, { mode: 0o600 });
+
+  // Root fallback for deployments where sudo is unavailable but the daemon is
+  // privileged. Chown both path components so a 0700 dir + 0600 file remain
+  // readable only by the target process owner.
+  if (params.targetUnixUser) {
+    const homeStat = fs.statSync(`/home/${params.targetUnixUser}`);
+    fs.chownSync(dir, homeStat.uid, homeStat.gid);
+    fs.chownSync(filePath, homeStat.uid, homeStat.gid);
+  }
+
+  return filePath;
+}
+
+export function writeClaudeCliMcpConfigFile(params: {
+  mcpConfig: ClaudeCliAgorMcpConfig;
+  sessionShortId: string;
+  targetUnixUser?: string;
+}): string {
+  const content = `${JSON.stringify(params.mcpConfig, null, 2)}\n`;
+
+  if (params.targetUnixUser) {
+    try {
+      return writePrivateMcpConfigAsUser({
+        content,
+        sessionShortId: params.sessionShortId,
+        targetUnixUser: params.targetUnixUser,
+      });
+    } catch (err) {
+      if (typeof process.getuid === 'function' && process.getuid() === 0) {
+        console.warn(
+          `[claude-cli-integration] sudo write of MCP config for ${params.targetUnixUser} failed; falling back to root chown:`,
+          err instanceof Error ? err.message : String(err)
+        );
+        return writePrivateMcpConfigAsDaemon({
+          content,
+          sessionShortId: params.sessionShortId,
+          targetUnixUser: params.targetUnixUser,
+        });
+      }
+      throw err;
+    }
+  }
+
+  return writePrivateMcpConfigAsDaemon({
+    content,
+    sessionShortId: params.sessionShortId,
+  });
+}
+
+/**
  * Write a per-session Claude CLI MCP config file and return its path.
  *
  * Best-effort by design: failing to write this file should not block opening a
@@ -1100,7 +1226,7 @@ export async function writeClaudeCliMcpConfigForSession(
     actor?: { user_id?: string; role?: string } | null;
   } = {}
 ): Promise<string | undefined> {
-  const config = app.get('config') as { daemon?: { mcpEnabled?: boolean } } | undefined;
+  const config = app.get('config') as ClaudeCliMcpConfigRuntimeConfig | undefined;
   if (config?.daemon?.mcpEnabled === false) return undefined;
 
   if (
@@ -1129,30 +1255,11 @@ export async function writeClaudeCliMcpConfigForSession(
       mcpToken,
     });
 
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `agor-mcp-${shortId(session.session_id)}-`));
-    const filePath = path.join(dir, 'mcp.json');
-    fs.writeFileSync(filePath, `${JSON.stringify(mcpConfig, null, 2)}\n`, { mode: 0o600 });
-
-    // In strict Unix-user mode the CLI process may run as the session's Unix
-    // user. If the daemon is privileged, hand ownership of the temp config to
-    // that user so we can keep 0600 instead of making bearer tokens world-
-    // readable in /tmp. Non-root deployments where chown is unavailable still
-    // work in simple mode (same Unix user); otherwise the warning below tells
-    // operators why MCP is missing.
-    if (session.unix_username && typeof process.getuid === 'function' && process.getuid() === 0) {
-      try {
-        const homeStat = fs.statSync(`/home/${session.unix_username}`);
-        fs.chownSync(dir, homeStat.uid, homeStat.gid);
-        fs.chownSync(filePath, homeStat.uid, homeStat.gid);
-      } catch (err) {
-        console.warn(
-          `[claude-cli-integration] failed to chown MCP config for ${session.unix_username}:`,
-          err instanceof Error ? err.message : String(err)
-        );
-      }
-    }
-
-    return filePath;
+    return writeClaudeCliMcpConfigFile({
+      mcpConfig,
+      sessionShortId: shortId(session.session_id),
+      targetUnixUser: resolveClaudeCliMcpConfigTargetUnixUser(config, session),
+    });
   } catch (err) {
     console.warn(
       `[claude-cli-integration] failed to write MCP config for session ${shortId(session.session_id)}; Agor MCP tools will be unavailable in Claude CLI/RemoteTrigger:`,


### PR DESCRIPTION
## Summary

- Fix Claude Code CLI MCP config creation for Unix-isolated sessions by writing the temporary config as the Unix user that will run Claude.
- Keep MCP bearer tokens in private `0700` temp dirs and `0600` files instead of making configs world-readable.
- Add coverage for resolving the expected config owner across simple, insulated, and strict modes.

## Root cause

Claude CLI receives `--mcp-config /tmp/agor-mcp-.../mcp.json`, but the daemon wrote that temp directory/file as the daemon user with private permissions. In strict or insulated Unix isolation, the Zellij/Claude process runs as a different Unix user, so Claude could not read the file and failed startup with `EACCES`.

## Validation

- `pnpm i`
- `pnpm --filter @agor/daemon test -- src/services/claude-cli-integration.test.ts`
- `pnpm check`
- `git diff --check`

Notes: `pnpm i` completed successfully; node-pty reported a native rebuild warning about missing `make`, but install exited 0. `pnpm check` passed with existing repository lint warnings unrelated to this change.
