### PR TITLE
Support Claude advisor model config

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -35,10 +35,14 @@ const agenticToolConfigSchema = z
         mode: z.enum(['alias', 'exact']).optional(),
         model: mcpOptionalString('model_config.model', 'Model name override.'),
         effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
+        advisorModel: mcpOptionalString(
+          'model_config.advisorModel',
+          "Claude Code advisor model override (e.g. 'opus', 'sonnet', 'fable')."
+        ),
       })
       .optional()
       .describe(
-        'Optional model override (canonical DefaultModelConfig shape). Omit to inherit the agent default; set { model } to override; set { mode, model, effort } for full control.'
+        'Optional model override (canonical DefaultModelConfig shape). Omit to inherit the agent default; set { model } to override; set { mode, model, effort, advisorModel } for full control.'
       ),
     mcp_server_ids: z
       .array(mcpRequiredId('mcp_server_ids[]', 'MCP server'))

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -691,11 +691,11 @@ describe('MCP session input validation clarity', () => {
 
 describe('modelConfig schema (string shorthand coercion)', () => {
   // The MCP-tool boundary historically required `modelConfig` as a structured
-  // `{ mode, model, effort, provider }` object. Several MCP clients silently
-  // mangle nested objects in tool args, and asking an agent to construct that
-  // shape just to pin a model is hostile UX. We now accept either form. The
-  // schema validates the union without transforming (so `toJSONSchema` works);
-  // handlers normalize the string form to `{ model: <id> }` internally.
+  // `{ mode, model, effort, advisorModel, provider }` object. Several MCP
+  // clients silently mangle nested objects in tool args, and asking an agent to
+  // construct that shape just to pin a model is hostile UX. We now accept either
+  // form. The schema validates the union without transforming (so `toJSONSchema`
+  // works); handlers normalize the string form to `{ model: <id> }` internally.
   it('accepts a plain string for modelConfig', async () => {
     const tools = await registerAndCaptureTools(
       { app: {}, userId: 'user-1', sessionId: 'sess-caller' },

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -51,7 +51,8 @@ import { listAttachedMcpServers } from './mcp-servers.js';
  * Shared Zod schema for specifying a model override at session-create / spawn /
  * subsession time. Mirrors Session['model_config']: `model` is required (the
  * whole point of this object is to pin a specific model), while `mode`,
- * `effort`, and `provider` are optional and fall back to sensible defaults.
+ * `effort`, `advisorModel`, and `provider` are optional and fall back to
+ * sensible defaults.
  * Wired through to `session.model_config` so the executor actually spawns on
  * the requested model (see query-builder.ts).
  *
@@ -61,8 +62,8 @@ import { listAttachedMcpServers } from './mcp-servers.js';
  *     want to pin a model — forcing them to construct the full object is
  *     hostile UX (and several MCP clients silently drop nested objects in
  *     tool args, see PR #1056 background).
- *   - Full object: `{ mode, model, effort, provider }` for callers that need
- *     to override `mode`/`effort`/`provider`.
+ *   - Full object: `{ mode, model, effort, advisorModel, provider }` for
+ *     callers that need to override `mode`/`effort`/`advisorModel`/`provider`.
  *
  * IMPORTANT — no `.transform()` here. Zod's JSON-Schema converter
  * (`zod/v4-mini`'s `toJSONSchema`, used in `mcp/server.ts` to populate the
@@ -812,7 +813,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_create',
     {
       description:
-        'Create a new session in an existing branch. Use for starting fresh work on a new task in the same codebase (e.g., new feature branch, separate investigation). Unlike spawn, this creates an independent session with no parent-child relationship. MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
+        'Create a new session in an existing branch. Use for starting fresh work on a new task in the same codebase (e.g., new feature branch, separate investigation). Unlike spawn, this creates an independent session with no parent-child relationship. MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, advisorModel, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
       inputSchema: z.object({
         branchId: mcpRequiredId(
           'branchId',

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -87,6 +87,10 @@ const modelConfigObjectSchema = z.object({
     .enum(['low', 'medium', 'high', 'max'])
     .optional()
     .describe('Reasoning effort level (default: high)'),
+  advisorModel: mcpOptionalString(
+    'modelConfig.advisorModel',
+    "Claude Code advisor model override (e.g. 'opus', 'sonnet', 'fable', or a full model ID)."
+  ),
   provider: mcpOptionalString(
     'modelConfig.provider',
     "Provider ID (OpenCode only, e.g. 'anthropic')"
@@ -103,7 +107,7 @@ const modelConfigInputSchema = z
   ])
   .optional()
   .describe(
-    "Model override for this session. Pass either a model ID string (e.g. 'claude-opus-4-6') or a full { mode, model, effort, provider } object. Overrides the user default model_config and is threaded through to the spawned agent process. Call agor_models_list to discover valid model IDs per agenticTool."
+    "Model override for this session. Pass either a model ID string (e.g. 'claude-opus-4-6') or a full { mode, model, effort, advisorModel, provider } object. Overrides the user default model_config and is threaded through to the spawned agent process. Call agor_models_list to discover valid model IDs per agenticTool."
   );
 
 /**
@@ -408,6 +412,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         title: session.title,
         model: session.model_config?.model || null,
         effort: session.model_config?.effort || null,
+        advisorModel: session.model_config?.advisorModel || null,
 
         // User (who is authenticated / who is prompting)
         user_name: user.name,

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -1029,6 +1029,7 @@ export function buildSpawnConfigForSession(
     displayName: `cli-${shortId(session.session_id)}`,
     model: session.model_config?.model,
     effort: session.model_config?.effort as ClaudeCliSpawnConfig['effort'] | undefined,
+    advisorModel: session.model_config?.advisorModel,
     permissionMode: permissionModeForCli(session.permission_config?.mode),
     addDirs: [branchCwd],
     mcpConfigPath: opts.mcpConfigPath,

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
@@ -110,6 +110,32 @@ describe('applySessionConfigDefaults', () => {
     );
   });
 
+  it("fills missing advisorModel from the user's model default", async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'claude-code', created_by: ALICE },
+      users: {
+        [ALICE]: {
+          user_id: ALICE,
+          default_agentic_config: {
+            'claude-code': {
+              modelConfig: { model: 'claude-sonnet-4-6', advisorModel: 'opus' },
+            },
+          },
+        },
+      },
+    });
+    await hook(ctx);
+    expect(
+      (ctx.data as { model_config: { model: string; advisorModel: string } }).model_config
+    ).toMatchObject({
+      model: 'claude-sonnet-4-6',
+      advisorModel: 'opus',
+    });
+  });
+
   it('fills a partial effort-only model_config with the default model and preserves effort', async () => {
     const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
     const ctx = makeContext({
@@ -129,6 +155,29 @@ describe('applySessionConfigDefaults', () => {
       mode: 'alias',
       model: 'claude-sonnet-4-6',
       effort: 'max',
+    });
+  });
+
+  it('fills a partial advisor-only model_config with the default model and preserves advisorModel', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'claude-code',
+        created_by: ALICE,
+        model_config: { advisorModel: 'opus', updated_at: 'client-time' },
+      },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+    await hook(ctx);
+    expect(
+      (ctx.data as { model_config: { mode: string; model: string; advisorModel: string } })
+        .model_config
+    ).toMatchObject({
+      mode: 'alias',
+      model: 'claude-sonnet-4-6',
+      advisorModel: 'opus',
     });
   });
 

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -102,28 +102,6 @@ const CURSOR_MODEL_OPTIONS = [
   },
 ];
 
-const CLAUDE_ADVISOR_MODEL_OPTIONS = [
-  {
-    value: 'opus',
-    label: 'Opus',
-    description: 'Most capable advisor for hard reasoning',
-  },
-  {
-    value: 'sonnet',
-    label: 'Sonnet',
-    description: 'Balanced advisor',
-  },
-  {
-    value: 'fable',
-    label: 'Fable',
-    description: 'Latest-generation advisor, when available',
-  },
-  {
-    value: 'claude-haiku-4-5',
-    label: 'Haiku 4.5',
-    description: 'Fastest/cheapest advisor',
-  },
-];
 function preferDefaultModel<T extends { id: string }>(models: T[], defaultModel: string): T[] {
   const defaultIndex = models.findIndex((model) => model.id === defaultModel);
   if (defaultIndex <= 0) return models;
@@ -345,6 +323,8 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           {mode === 'alias' && (
             <div style={{ marginLeft: 24, marginTop: 8 }}>
               <Select
+                showSearch
+                optionFilterProp="label"
                 value={value?.model || fallbackModel}
                 onChange={handleModelChange}
                 style={{ width: '100%', minWidth: 400 }}
@@ -449,13 +429,15 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           </Space>
           <Select
             allowClear
+            showSearch
+            optionFilterProp="label"
             placeholder="Not set"
             value={value?.advisorModel}
             onChange={handleAdvisorModelChange}
             style={{ width: '100%', minWidth: 400, marginTop: 8 }}
-            options={CLAUDE_ADVISOR_MODEL_OPTIONS.map((option) => ({
-              value: option.value,
-              label: `${option.label} · ${option.description}`,
+            options={AVAILABLE_CLAUDE_MODEL_ALIASES.map((model) => ({
+              value: model.id,
+              label: model.id,
             }))}
           />
         </div>

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -22,6 +22,8 @@ import { type OpenCodeModelConfig, OpenCodeModelSelector } from './OpenCodeModel
 export interface ModelConfig {
   mode: 'alias' | 'exact';
   model: string;
+  // Claude Code-specific: server-side advisor tool model.
+  advisorModel?: string;
   // OpenCode-specific: provider + model
   provider?: string;
 }
@@ -97,6 +99,29 @@ const CURSOR_MODEL_OPTIONS = [
     id: DEFAULT_CURSOR_MODEL,
     label: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].displayName,
     description: CURSOR_MODEL_METADATA[DEFAULT_CURSOR_MODEL].description,
+  },
+];
+
+const CLAUDE_ADVISOR_MODEL_OPTIONS = [
+  {
+    value: 'opus',
+    label: 'Opus',
+    description: 'Most capable advisor for hard reasoning',
+  },
+  {
+    value: 'sonnet',
+    label: 'Sonnet',
+    description: 'Balanced advisor',
+  },
+  {
+    value: 'fable',
+    label: 'Fable',
+    description: 'Latest-generation advisor, when available',
+  },
+  {
+    value: 'claude-haiku-4-5',
+    label: 'Haiku 4.5',
+    description: 'Fastest/cheapest advisor',
   },
 ];
 function preferDefaultModel<T extends { id: string }>(models: T[], defaultModel: string): T[] {
@@ -276,6 +301,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       // When switching modes, provide the same effective default the daemon
       // applies if the form is submitted without a model_config.
       onChange({
+        ...value,
         mode: newMode,
         model: value?.model || fallbackModel,
       });
@@ -285,8 +311,20 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   const handleModelChange = (newModel: string) => {
     if (onChange) {
       onChange({
+        ...value,
         mode,
         model: newModel,
+      });
+    }
+  };
+
+  const handleAdvisorModelChange = (advisorModel: string | undefined) => {
+    if (onChange) {
+      onChange({
+        ...value,
+        mode,
+        model: value?.model || fallbackModel,
+        advisorModel,
       });
     }
   };
@@ -400,6 +438,28 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           )}
         </Space>
       </Radio.Group>
+
+      {(effectiveTool === 'claude-code' || effectiveTool === 'claude-code-cli') && (
+        <div>
+          <Space size={4}>
+            <span>Advisor model</span>
+            <Tooltip title="Optional Claude Code advisor tool model. Leave unset to use existing Claude settings or disable session-level override.">
+              <InfoCircleOutlined />
+            </Tooltip>
+          </Space>
+          <Select
+            allowClear
+            placeholder="Not set"
+            value={value?.advisorModel}
+            onChange={handleAdvisorModelChange}
+            style={{ width: '100%', minWidth: 400, marginTop: 8 }}
+            options={CLAUDE_ADVISOR_MODEL_OPTIONS.map((option) => ({
+              value: option.value,
+              label: `${option.label} · ${option.description}`,
+            }))}
+          />
+        </div>
+      )}
     </Space>
   );
 };

--- a/packages/core/src/claude-cli/spawn-config.test.ts
+++ b/packages/core/src/claude-cli/spawn-config.test.ts
@@ -77,6 +77,11 @@ describe('buildClaudeCliSpawn', () => {
     expect(args.slice(i + 1, i + 3)).toEqual(['/repo/a', '/repo/b']);
   });
 
+  it('emits --advisor when an advisor model is configured', () => {
+    const { args } = buildClaudeCliSpawn({ advisorModel: 'opus' });
+    expect(args).toEqual(['--advisor', 'opus']);
+  });
+
   it('builds a full realistic spawn', () => {
     const { args } = buildClaudeCliSpawn({
       sessionId: '019e2747-cd3c-7669-af2e-aeb5b1e80ed9',

--- a/packages/core/src/claude-cli/spawn-config.test.ts
+++ b/packages/core/src/claude-cli/spawn-config.test.ts
@@ -82,6 +82,11 @@ describe('buildClaudeCliSpawn', () => {
     expect(args).toEqual(['--advisor', 'opus']);
   });
 
+  it('strips [1m] suffix and emits beta flag for advisor model', () => {
+    const { args } = buildClaudeCliSpawn({ advisorModel: 'claude-opus-4-7[1m]' });
+    expect(args).toEqual(['--advisor', 'claude-opus-4-7', '--betas', 'context-1m-2025-08-07']);
+  });
+
   it('builds a full realistic spawn', () => {
     const { args } = buildClaudeCliSpawn({
       sessionId: '019e2747-cd3c-7669-af2e-aeb5b1e80ed9',

--- a/packages/core/src/claude-cli/spawn-config.ts
+++ b/packages/core/src/claude-cli/spawn-config.ts
@@ -13,6 +13,7 @@
  *   --model <alias>                e.g. claude-opus-4-8. Stripped of [1m] suffix.
  *   --betas <flag>                 e.g. context-1m-2025-08-07 (only with [1m] models).
  *   --effort <level>               low | medium | high | xhigh | max
+ *   --advisor <model>              Claude Code server-side advisor model.
  *   --permission-mode <mode>       default|acceptEdits|bypassPermissions|plan|dontAsk|auto.
  *                                  Mutually exclusive with --dangerously-skip-permissions.
  *   --dangerously-skip-permissions Distinct argv per Anthropic's flag design — same
@@ -92,6 +93,9 @@ export interface ClaudeCliSpawnConfig {
 
   /** Reasoning effort. */
   effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+  /** Claude Code advisor model (e.g., 'opus', 'sonnet', 'fable', or full model ID). */
+  advisorModel?: string;
 
   /** Permission handling at spawn. See type comment. */
   permissionMode?: ClaudeCliPermissionMode;
@@ -196,6 +200,10 @@ export function buildClaudeCliSpawn(cfg: ClaudeCliSpawnConfig): BuiltSpawn {
 
   if (cfg.effort) {
     args.push('--effort', cfg.effort);
+  }
+
+  if (cfg.advisorModel) {
+    args.push('--advisor', cfg.advisorModel);
   }
 
   if (cfg.permissionMode) {

--- a/packages/core/src/claude-cli/spawn-config.ts
+++ b/packages/core/src/claude-cli/spawn-config.ts
@@ -178,6 +178,14 @@ export function permissionModeForCli(
  */
 export function buildClaudeCliSpawn(cfg: ClaudeCliSpawnConfig): BuiltSpawn {
   const args: string[] = [];
+  const emittedBetas = new Set<string>();
+  const pushBetas = (betas: string[]) => {
+    for (const beta of betas) {
+      if (emittedBetas.has(beta)) continue;
+      emittedBetas.add(beta);
+      args.push('--betas', beta);
+    }
+  };
 
   if (cfg.resumeSessionId) {
     args.push('--resume', cfg.resumeSessionId);
@@ -193,9 +201,7 @@ export function buildClaudeCliSpawn(cfg: ClaudeCliSpawnConfig): BuiltSpawn {
   if (cfg.model) {
     const { model, betas } = parseModelWithBetas(cfg.model);
     args.push('--model', model);
-    for (const beta of betas) {
-      args.push('--betas', beta);
-    }
+    pushBetas(betas);
   }
 
   if (cfg.effort) {
@@ -203,7 +209,9 @@ export function buildClaudeCliSpawn(cfg: ClaudeCliSpawnConfig): BuiltSpawn {
   }
 
   if (cfg.advisorModel) {
-    args.push('--advisor', cfg.advisorModel);
+    const { model, betas } = parseModelWithBetas(cfg.advisorModel);
+    args.push('--advisor', model);
+    pushBetas(betas);
   }
 
   if (cfg.permissionMode) {

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -926,6 +926,7 @@ export const users = pgTable(
               mode?: 'alias' | 'exact';
               model?: string;
               effort?: EffortLevel;
+              advisorModel?: string;
             };
             permissionMode?: string;
             mcpServerIds?: string[];
@@ -935,6 +936,7 @@ export const users = pgTable(
               mode?: 'alias' | 'exact';
               model?: string;
               effort?: EffortLevel;
+              advisorModel?: string;
             };
             permissionMode?: string;
             mcpServerIds?: string[];

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -948,6 +948,7 @@ export const users = sqliteTable(
               mode?: 'alias' | 'exact';
               model?: string;
               effort?: EffortLevel;
+              advisorModel?: string;
             };
             permissionMode?: string;
             mcpServerIds?: string[];
@@ -957,6 +958,7 @@ export const users = sqliteTable(
               mode?: 'alias' | 'exact';
               model?: string;
               effort?: EffortLevel;
+              advisorModel?: string;
             };
             permissionMode?: string;
             mcpServerIds?: string[];

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -172,6 +172,40 @@ describe('resolveModelConfigWithFallback', () => {
     });
   });
 
+  it('accumulates split model-less overrides onto the tool fallback', () => {
+    const result = resolveModelConfigWithFallback(
+      'claude-code',
+      [{ advisorModel: 'opus' }, { effort: 'max' }],
+      { now }
+    );
+    expect(result).toEqual({
+      mode: 'alias',
+      model: 'claude-sonnet-4-6',
+      effort: 'max',
+      advisorModel: 'opus',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+  });
+
+  it('preserves higher-priority model-less overrides when accumulating', () => {
+    const result = resolveModelConfigWithFallback(
+      'claude-code',
+      [
+        { advisorModel: 'opus' },
+        { advisorModel: 'sonnet', effort: 'medium' },
+        { model: 'claude-haiku-4-5' },
+      ],
+      { now }
+    );
+    expect(result).toEqual({
+      mode: 'alias',
+      model: 'claude-haiku-4-5',
+      effort: 'medium',
+      advisorModel: 'opus',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+  });
+
   it('does not carry model-less mode/provider onto a fallback model', () => {
     const result = resolveModelConfigWithFallback(
       'claude-code',

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -40,6 +40,14 @@ describe('resolveModelConfig', () => {
     expect(withoutEffort).not.toHaveProperty('effort');
   });
 
+  it('includes advisorModel only when defined (omits the key otherwise)', () => {
+    const withAdvisor = resolveModelConfig({ model: 'x', advisorModel: 'opus' }, { now });
+    expect(withAdvisor).toHaveProperty('advisorModel', 'opus');
+
+    const withoutAdvisor = resolveModelConfig({ model: 'x' }, { now });
+    expect(withoutAdvisor).not.toHaveProperty('advisorModel');
+  });
+
   it('includes provider only when defined (omits the key otherwise)', () => {
     const withProvider = resolveModelConfig(
       { model: 'claude-sonnet-4-6', provider: 'anthropic' },
@@ -148,6 +156,18 @@ describe('resolveModelConfigWithFallback', () => {
       mode: 'alias',
       model: 'claude-sonnet-4-6',
       effort: 'max',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+  });
+
+  it('merges advisor-only input onto the tool fallback when no source has a model', () => {
+    const result = resolveModelConfigWithFallback('claude-code', [{ advisorModel: 'opus' }], {
+      now,
+    });
+    expect(result).toEqual({
+      mode: 'alias',
+      model: 'claude-sonnet-4-6',
+      advisorModel: 'opus',
       updated_at: '2026-04-23T00:00:00.000Z',
     });
   });

--- a/packages/core/src/models/resolve-config.ts
+++ b/packages/core/src/models/resolve-config.ts
@@ -35,6 +35,7 @@ export type ModelConfigInput = {
   mode?: 'alias' | 'exact';
   model?: string;
   effort?: EffortLevel;
+  advisorModel?: string;
   provider?: string;
 };
 
@@ -53,7 +54,7 @@ export type ResolvedModelConfig = NonNullable<Session['model_config']>;
  * - `mode` defaults to `'alias'` (matches every legacy call site).
  * - `updated_at` is stamped from `opts.now ?? new Date()` (injectable for
  *   determinism in tests).
- * - `effort` and `provider` are only included when explicitly defined, so
+ * - Optional fields are only included when explicitly defined, so
  *   we never write `undefined` values onto the persisted object.
  */
 export function resolveModelConfig(
@@ -66,6 +67,7 @@ export function resolveModelConfig(
     model: input.model,
     updated_at: (opts?.now ?? new Date()).toISOString(),
     ...(input.effort !== undefined && { effort: input.effort }),
+    ...(input.advisorModel !== undefined && { advisorModel: input.advisorModel }),
     ...(input.provider !== undefined && { provider: input.provider }),
   };
 }
@@ -119,17 +121,20 @@ export function getDefaultModelForTool(tool: AgenticToolName): string | undefine
 function getModelLessFallbackOverrides(
   input: ModelConfigInput | undefined | null
 ): ModelConfigInput | undefined {
-  if (input?.effort === undefined) return undefined;
-  return { effort: input.effort };
+  const overrides: ModelConfigInput = {};
+  if (input?.effort !== undefined) overrides.effort = input.effort;
+  if (input?.advisorModel !== undefined) overrides.advisorModel = input.advisorModel;
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
 /**
  * Resolve model config at a session-create boundary.
  *
  * Full model configs remain first-wins and are not merged with lower-priority
- * sources. However, a higher-priority source that only carries `effort` (from
- * the UI's separate effort selector) is merged onto the next source that
- * supplies the actual model, or onto the tool fallback. We intentionally do not
+ * sources. However, a higher-priority source that only carries model-less
+ * overrides (for example `effort` or Claude Code `advisorModel`) is merged onto
+ * the next source that supplies the actual model, or onto the tool fallback.
+ * We intentionally do not
  * carry model-less `mode` / `provider` because their meaning depends on the
  * missing model value. This prevents partial persisted model_config objects
  * while preserving the user's explicit effort choice.

--- a/packages/core/src/models/resolve-config.ts
+++ b/packages/core/src/models/resolve-config.ts
@@ -127,17 +127,31 @@ function getModelLessFallbackOverrides(
   return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
+/** Merge model-less overrides, preserving higher-priority values already seen. */
+function mergeModelLessFallbackOverrides(
+  existing: ModelConfigInput | undefined,
+  next: ModelConfigInput | undefined
+): ModelConfigInput | undefined {
+  if (!existing) return next;
+  if (!next) return existing;
+  return {
+    ...next,
+    ...existing,
+  };
+}
+
 /**
  * Resolve model config at a session-create boundary.
  *
  * Full model configs remain first-wins and are not merged with lower-priority
- * sources. However, a higher-priority source that only carries model-less
- * overrides (for example `effort` or Claude Code `advisorModel`) is merged onto
- * the next source that supplies the actual model, or onto the tool fallback.
+ * sources. However, higher-priority sources that only carry model-less
+ * overrides (for example `effort` or Claude Code `advisorModel`) are accumulated
+ * with per-field precedence and merged onto the next source that supplies the
+ * actual model, or onto the tool fallback.
  * We intentionally do not
  * carry model-less `mode` / `provider` because their meaning depends on the
  * missing model value. This prevents partial persisted model_config objects
- * while preserving the user's explicit effort choice.
+ * while preserving explicit effort/advisor choices.
  */
 export function resolveModelConfigWithFallback(
   tool: AgenticToolName,
@@ -155,9 +169,10 @@ export function resolveModelConfigWithFallback(
         opts
       );
     }
-    if (!pendingModelLessOverrides) {
-      pendingModelLessOverrides = getModelLessFallbackOverrides(source);
-    }
+    pendingModelLessOverrides = mergeModelLessFallbackOverrides(
+      pendingModelLessOverrides,
+      getModelLessFallbackOverrides(source)
+    );
   }
 
   const toolDefault = getDefaultModelForTool(tool);

--- a/packages/core/src/sessions/resolve-child-session-config.test.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.test.ts
@@ -102,6 +102,7 @@ describe('resolveChildSessionConfig', () => {
         mode: 'alias',
         model: 'claude-opus-4-7',
         effort: 'high',
+        advisorModel: 'opus',
         updated_at: '2026-05-01T00:00:00.000Z',
       },
       permission_config: { mode: 'bypassPermissions' },
@@ -117,6 +118,7 @@ describe('resolveChildSessionConfig', () => {
       // Parent wins over user default on same-tool spawns.
       expect(r.model_config?.model).toBe('claude-opus-4-7');
       expect(r.model_config?.effort).toBe('high');
+      expect(r.model_config?.advisorModel).toBe('opus');
     });
 
     it('inherits parent permission_config when child tool === parent tool', () => {
@@ -141,6 +143,24 @@ describe('resolveChildSessionConfig', () => {
       });
       expect(r.model_config?.model).toBe('claude-haiku-4-5');
       expect(r.permission_config.mode).toBe('plan');
+    });
+
+    it('merges advisor-only override onto inherited parent model config', () => {
+      const r = resolveChildSessionConfig({
+        parent,
+        effectiveTool: 'claude-code',
+        overrides: {
+          modelConfig: { advisorModel: 'sonnet' },
+        },
+        now,
+      });
+      expect(r.model_config).toEqual({
+        mode: 'alias',
+        model: 'claude-opus-4-7',
+        effort: 'high',
+        advisorModel: 'sonnet',
+        updated_at: now.toISOString(),
+      });
     });
 
     it('defaults effectiveTool to parent.agentic_tool when omitted', () => {

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -175,6 +175,22 @@ describe('resolveSessionDefaults', () => {
       expect(r.model_config?.updated_at).toBe(now.toISOString());
     });
 
+    it("preserves advisorModel from the user's tool default", () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({
+          'claude-code': { modelConfig: { model: 'claude-sonnet-4-6', advisorModel: 'opus' } },
+        }),
+        now,
+      });
+      expect(r.model_config).toEqual({
+        mode: 'alias',
+        model: 'claude-sonnet-4-6',
+        advisorModel: 'opus',
+        updated_at: now.toISOString(),
+      });
+    });
+
     it('merges an effort-only override onto the tool default model', () => {
       const r = resolveSessionDefaults({
         agenticTool: 'claude-code',
@@ -200,6 +216,24 @@ describe('resolveSessionDefaults', () => {
         mode: 'alias',
         model: 'claude-opus-4-6',
         effort: 'max',
+        updated_at: now.toISOString(),
+      });
+    });
+
+    it('merges split advisor/effort overrides onto the user default model', () => {
+      const r = resolveSessionDefaults({
+        agenticTool: 'claude-code',
+        user: makeUser({
+          'claude-code': { modelConfig: { model: 'claude-opus-4-6', effort: 'high' } },
+        }),
+        overrides: { modelConfig: { advisorModel: 'sonnet' } },
+        now,
+      });
+      expect(r.model_config).toEqual({
+        mode: 'alias',
+        model: 'claude-opus-4-6',
+        effort: 'high',
+        advisorModel: 'sonnet',
         updated_at: now.toISOString(),
       });
     });

--- a/packages/core/src/templates/spawn-subsession-template.ts
+++ b/packages/core/src/templates/spawn-subsession-template.ts
@@ -23,6 +23,7 @@ export interface SpawnSubsessionContext {
     mode?: string;
     model?: string;
     effort?: string;
+    advisorModel?: string;
   };
   codexSandboxMode?: string;
   codexApprovalPolicy?: string;
@@ -59,7 +60,9 @@ REQUEST: """
     -
     {{modelConfig.model}}{{#if modelConfig.effort}}
       (effort:
-      {{modelConfig.effort}}){{/if}}
+      {{modelConfig.effort}}){{/if}}{{#if modelConfig.advisorModel}}
+      (advisor:
+      {{modelConfig.advisorModel}}){{/if}}
   {{/if}}
   {{#if codexSandboxMode}}
     - Codex Sandbox Mode:
@@ -110,7 +113,9 @@ hashing and JWT for tokens."
 {{#if modelConfig}}
   - modelConfig: { mode: "{{modelConfig.mode}}", model: "{{modelConfig.model}}"{{#if
     modelConfig.effort
-  }}, effort: "{{modelConfig.effort}}"{{/if}}
+  }}, effort: "{{modelConfig.effort}}"{{/if}}{{#if
+    modelConfig.advisorModel
+  }}, advisorModel: "{{modelConfig.advisorModel}}"{{/if}}
   }
 {{/if}}
 {{#if codexSandboxMode}}
@@ -152,7 +157,9 @@ session will do YOUR EXACT TOOL CALL MUST BE: agor_sessions_spawn({ "prompt": "{
   "permissionMode": "{{permissionMode}}",{{/if}}{{#if modelConfig}}
   "modelConfig": { "mode": "{{modelConfig.mode}}", "model": "{{modelConfig.model}}"{{#if
     modelConfig.effort
-  }}, "effort": "{{modelConfig.effort}}"{{/if}}
+  }}, "effort": "{{modelConfig.effort}}"{{/if}}{{#if
+    modelConfig.advisorModel
+  }}, "advisorModel": "{{modelConfig.advisorModel}}"{{/if}}
   },{{/if}}{{#if codexSandboxMode}}
   "codexSandboxMode": "{{codexSandboxMode}}",{{/if}}{{#if codexApprovalPolicy}}
   "codexApprovalPolicy": "{{codexApprovalPolicy}}",{{/if}}{{#if codexNetworkAccess}}

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -252,6 +252,8 @@ export interface Session {
     notes?: string;
     /** Effort level for reasoning depth (default: high) */
     effort?: EffortLevel;
+    /** Claude Code advisor model (e.g., 'opus', 'sonnet', 'fable'); unset means no session override */
+    advisorModel?: string;
     /**
      * Provider ID for OpenCode sessions (e.g., 'openai', 'anthropic', 'opencode')
      * Used in combination with model to specify which provider's API to use
@@ -616,6 +618,8 @@ export interface SpawnConfig {
     mode?: 'alias' | 'exact';
     model?: string;
     effort?: EffortLevel;
+    /** Claude Code advisor model (e.g., 'opus', 'sonnet', 'fable'); ignored for non-Claude tools. */
+    advisorModel?: string;
     /**
      * Provider ID (OpenCode only, e.g. 'anthropic', 'openai', 'opencode').
      * Persisted on session.model_config.provider. Ignored for non-OpenCode tools.

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -92,6 +92,8 @@ export interface DefaultModelConfig {
   model?: string;
   /** Effort level for reasoning depth */
   effort?: EffortLevel;
+  /** Claude Code advisor model (e.g., 'opus', 'sonnet', 'fable'); unset means no session override */
+  advisorModel?: string;
 }
 
 /**

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -83,6 +83,25 @@ describe('setupQuery - Local Settings Support', () => {
     const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
     expect(callArgs.options.disallowedTools).toEqual([...CLAUDE_CODE_DISALLOWED_TOOLS]);
   });
+
+  it('passes session advisorModel through Claude Code SDK settings', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      model_config: {
+        mode: 'alias',
+        model: 'claude-sonnet-4-6',
+        updated_at: '2026-06-11T00:00:00.000Z',
+        advisorModel: 'opus',
+      },
+    } as any);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(callArgs.options.settings).toMatchObject({ advisorModel: 'opus' });
+  });
 });
 
 describe('setupQuery - canUseTool registration', () => {

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -102,6 +102,26 @@ describe('setupQuery - Local Settings Support', () => {
     const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
     expect(callArgs.options.settings).toMatchObject({ advisorModel: 'opus' });
   });
+
+  it('strips advisorModel [1m] suffix and adds the required SDK beta', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      model_config: {
+        mode: 'alias',
+        model: 'claude-sonnet-4-6',
+        updated_at: '2026-06-11T00:00:00.000Z',
+        advisorModel: 'claude-opus-4-7[1m]',
+      },
+    } as any);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(callArgs.options.settings).toMatchObject({ advisorModel: 'claude-opus-4-7' });
+    expect(callArgs.options.betas).toEqual(['context-1m-2025-08-07']);
+  });
 });
 
 describe('setupQuery - canUseTool registration', () => {

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -177,6 +177,7 @@ export async function setupQuery(
   const modelConfig = session.model_config;
   const rawModel = modelConfig?.model || DEFAULT_CLAUDE_MODEL;
   const { model, betas } = parseModelWithBetas(rawModel);
+  const sdkBetas = new Set(betas);
 
   // Determine CWD from branch (if session has one)
   let cwd = process.cwd();
@@ -311,8 +312,10 @@ export async function setupQuery(
   // Configure Claude Code's server-side advisor tool model when a session-level
   // override is present. The Agent SDK exposes this through Claude Code settings
   // (not as a first-class top-level option or MCP tool declaration).
-  const advisorModel = session.model_config?.advisorModel?.trim();
-  if (advisorModel) {
+  const rawAdvisorModel = session.model_config?.advisorModel?.trim();
+  if (rawAdvisorModel) {
+    const { model: advisorModel, betas: advisorBetas } = parseModelWithBetas(rawAdvisorModel);
+    for (const beta of advisorBetas) sdkBetas.add(beta);
     queryOptions.settings = {
       ...((queryOptions.settings as Record<string, unknown> | undefined) ?? {}),
       advisorModel,
@@ -321,9 +324,10 @@ export async function setupQuery(
   }
 
   // Add beta flags (e.g., 1M context window for [1m] model variants)
-  if (betas.length > 0) {
-    queryOptions.betas = betas;
-    console.log(`🔬 Beta flags: ${betas.join(', ')}`);
+  const betaList = [...sdkBetas];
+  if (betaList.length > 0) {
+    queryOptions.betas = betaList;
+    console.log(`🔬 Beta flags: ${betaList.join(', ')}`);
   }
 
   // Add canUseTool callback if permission service is available and taskId provided.

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -308,6 +308,18 @@ export async function setupQuery(
     console.log(`🧠 Effort level: high (default)`);
   }
 
+  // Configure Claude Code's server-side advisor tool model when a session-level
+  // override is present. The Agent SDK exposes this through Claude Code settings
+  // (not as a first-class top-level option or MCP tool declaration).
+  const advisorModel = session.model_config?.advisorModel?.trim();
+  if (advisorModel) {
+    queryOptions.settings = {
+      ...((queryOptions.settings as Record<string, unknown> | undefined) ?? {}),
+      advisorModel,
+    };
+    console.log(`🧭 Advisor model: ${advisorModel}`);
+  }
+
   // Add beta flags (e.g., 1M context window for [1m] model variants)
   if (betas.length > 0) {
     queryOptions.betas = betas;


### PR DESCRIPTION
## Summary

- Adds optional Claude Code `advisorModel` to session/default model config.
- Adds an Advisor model dropdown under the Claude model selector.
- Threads advisor config through Claude Agent SDK settings and Claude Code CLI `--advisor`.
- Exposes `advisorModel` in MCP session/schedule model config schemas and spawn prompts.

Fixes #1412.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/models/resolve-config.test.ts src/claude-cli/spawn-config.test.ts src/templates/spawn-subsession-template.test.ts`
- `pnpm --filter @agor/executor test -- src/sdk-handlers/claude/query-builder.test.ts`
- `pnpm --filter @agor/daemon test -- src/mcp/tools/sessions.test.ts`
