### PR TITLE
Hide nuke action on branch cards

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -501,6 +501,7 @@ const BranchCardComponent = ({
             onViewLogs={onViewLogs}
             onNukeEnvironment={onNukeEnvironment}
             connectionDisabled={connectionDisabled}
+            showNukeEnvironment={false}
           />
         </Space>
       </div>

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -37,6 +37,8 @@ interface BranchHeaderPillProps {
   connectionDisabled?: boolean;
   /** Show environment status/controls and environment shortcut. Defaults to true. */
   showEnvButtons?: boolean;
+  /** Whether to show the destructive Nuke action when available. Defaults to true. */
+  showNukeEnvironment?: boolean;
   /** Optional link for the branch identity area. Used by session surfaces for deep links. */
   identityLink?: string | null;
   /**
@@ -67,6 +69,7 @@ export function BranchHeaderPill({
   canControlEnvironment,
   connectionDisabled = false,
   showEnvButtons = true,
+  showNukeEnvironment = true,
   identityLink,
   compact = false,
 }: BranchHeaderPillProps) {
@@ -384,7 +387,7 @@ export function BranchHeaderPill({
               )}
 
               {/* Nuke button */}
-              {!compact && onNukeEnvironment && branch.nuke_command && (
+              {showNukeEnvironment && !compact && onNukeEnvironment && branch.nuke_command && (
                 <Tooltip title={controlDisabledTooltip ?? 'Nuke environment (destructive)'}>
                   <Button
                     type="text"

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
@@ -1,6 +1,5 @@
 import type { Branch, Repo } from '@agor-live/client';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('antd', async () => {
@@ -13,6 +12,8 @@ vi.mock('antd', async () => {
       ...props
     }: React.ButtonHTMLAttributes<HTMLButtonElement> & { icon?: React.ReactNode }) =>
       React.createElement('button', props, icon, children),
+    Space: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
     Spin: () => React.createElement('span', null, 'loading'),
     Tooltip: ({ children }: { children: React.ReactNode }) =>
       React.createElement(React.Fragment, null, children),
@@ -27,34 +28,23 @@ vi.mock('antd', async () => {
     theme: {
       useToken: () => ({
         token: {
-          colorBorderSecondary: '#ddd',
           colorError: '#f00',
           colorInfo: '#00f',
           colorSuccess: '#0a0',
           colorTextDisabled: '#999',
           colorWarning: '#fa0',
           fontFamilyCode: 'monospace',
-          fontSizeSM: 12,
         },
       }),
     },
   };
 });
 
-vi.mock('../../hooks/usePermissions', () => ({
-  usePermissions: () => ({
-    role: 'admin',
-    isAdmin: true,
-    isSuperAdmin: false,
-    hasRole: () => true,
-  }),
-}));
-
 vi.mock('../../hooks/useConfirmNukeEnvironment', () => ({
   useConfirmNukeEnvironment: () => vi.fn(),
 }));
 
-import { BranchHeaderPill } from './BranchHeaderPill';
+import { EnvironmentPill } from './EnvironmentPill';
 
 const repo = {
   repo_id: 'repo-1',
@@ -72,23 +62,22 @@ const branch = {
   repo_id: repo.repo_id,
   name: 'feature/remove-nuke',
   nuke_command: 'docker compose down -v',
-  others_can: 'all',
   environment_instance: { status: 'stopped' },
 } as Branch;
 
 const defaultProps = {
   repo,
   branch,
-  onOpenBranch: vi.fn(),
+  onEdit: vi.fn(),
   onStartEnvironment: vi.fn(),
   onStopEnvironment: vi.fn(),
   onViewLogs: vi.fn(),
   onNukeEnvironment: vi.fn(),
 };
 
-describe('BranchHeaderPill', () => {
-  it('hides the destructive nuke action in compact mode', () => {
-    render(<BranchHeaderPill {...defaultProps} compact />);
+describe('EnvironmentPill', () => {
+  it('can hide only the destructive nuke action while preserving other controls', () => {
+    render(<EnvironmentPill {...defaultProps} showNukeEnvironment={false} />);
 
     expect(screen.getByRole('button', { name: 'Start environment' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Stop environment' })).toBeInTheDocument();
@@ -96,36 +85,9 @@ describe('BranchHeaderPill', () => {
     expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
   });
 
-  it('keeps the destructive nuke action in non-compact mode', () => {
-    render(<BranchHeaderPill {...defaultProps} />);
+  it('shows the destructive nuke action by default when configured', () => {
+    render(<EnvironmentPill {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: 'Nuke environment' })).toBeInTheDocument();
-  });
-
-  it('can explicitly hide only the destructive nuke action', () => {
-    render(<BranchHeaderPill {...defaultProps} showNukeEnvironment={false} />);
-
-    expect(screen.getByRole('button', { name: 'Start environment' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Stop environment' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'View environment logs' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
-  });
-
-  it('uses the supplied identity link for the branch identity area', () => {
-    render(<BranchHeaderPill {...defaultProps} identityLink="https://agor.example/ui/s/abc123/" />);
-
-    const link = screen.getByRole('link', { name: /preset-io\/agor.*feature\/remove-nuke/ });
-    expect(link).toHaveAttribute('href', 'https://agor.example/ui/s/abc123/');
-  });
-
-  it('renders basename-aware internal identity links', () => {
-    render(
-      <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
-        <BranchHeaderPill {...defaultProps} identityLink="/s/abc123/" />
-      </MemoryRouter>
-    );
-
-    const link = screen.getByRole('link', { name: /preset-io\/agor.*feature\/remove-nuke/ });
-    expect(link).toHaveAttribute('href', '/ui/s/abc123/');
   });
 });

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -26,6 +26,8 @@ interface EnvironmentPillProps {
   onViewLogs?: (branchId: string) => void;
   canControlEnvironment?: boolean;
   connectionDisabled?: boolean; // Disable actions when disconnected
+  /** Whether to show the destructive Nuke action when available. Defaults to true. */
+  showNukeEnvironment?: boolean;
 }
 
 export function EnvironmentPill({
@@ -38,6 +40,7 @@ export function EnvironmentPill({
   onViewLogs,
   canControlEnvironment,
   connectionDisabled = false,
+  showNukeEnvironment = true,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
   const confirmNuke = useConfirmNukeEnvironment();
@@ -265,6 +268,7 @@ export function EnvironmentPill({
                 <Button
                   type="text"
                   size="small"
+                  aria-label="Start environment"
                   icon={<PlayCircleOutlined />}
                   onClick={(event) => {
                     event.stopPropagation();
@@ -298,6 +302,7 @@ export function EnvironmentPill({
                 <Button
                   type="text"
                   size="small"
+                  aria-label="Stop environment"
                   icon={<StopOutlined />}
                   onClick={(event) => {
                     event.stopPropagation();
@@ -327,6 +332,7 @@ export function EnvironmentPill({
                 <Button
                   type="text"
                   size="small"
+                  aria-label="View environment logs"
                   icon={<FileTextOutlined />}
                   onClick={(event) => {
                     event.stopPropagation();
@@ -344,7 +350,7 @@ export function EnvironmentPill({
                 />
               </Tooltip>
             )}
-            {onNukeEnvironment && branch.nuke_command && (
+            {showNukeEnvironment && onNukeEnvironment && branch.nuke_command && (
               <Tooltip
                 title={
                   controlDisabledTooltip ??


### PR DESCRIPTION
## Summary

- Hide the destructive Nuke environment action from `BranchCard` environment pills.
- Add explicit `showNukeEnvironment` controls to `EnvironmentPill` and `BranchHeaderPill`, defaulting to enabled so conversation/session header usage keeps Nuke available.
- Add focused tests for hiding Nuke while preserving Start, Stop, and Logs controls.

## Validation

- `pnpm i`
- `pnpm check` (passes; existing Biome warnings unrelated to this change)
- `pnpm --dir apps/agor-ui test -- src/components/EnvironmentPill/EnvironmentPill.test.tsx src/components/BranchHeaderPill/BranchHeaderPill.test.tsx`
- `git diff --check`
