### PR TITLE
Improve session footer MCP and run settings UX

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -59,6 +59,7 @@ import {
 import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLifecycle';
 import { isMobileDevice } from './utils/deviceDetection';
 import { useThemedMessage } from './utils/message';
+import { updateSessionMcpServers } from './utils/sessionMcpServers';
 
 type RouteModuleKey = RouteSurfaceId | 'mobile';
 
@@ -1373,24 +1374,7 @@ function AppContent() {
     try {
       // Get current session-MCP relationships for this session
       const currentIds = sessionMcpServerIds.get(sessionId) || [];
-
-      // Find servers to add (in new list but not in current)
-      const toAdd = mcpServerIds.filter((id) => !currentIds.includes(id));
-
-      // Find servers to remove (in current list but not in new)
-      const toRemove = currentIds.filter((id) => !mcpServerIds.includes(id));
-
-      // Add new relationships
-      for (const serverId of toAdd) {
-        await client.service(`sessions/${sessionId}/mcp-servers`).create({
-          mcpServerId: serverId,
-        });
-      }
-
-      // Remove old relationships
-      for (const serverId of toRemove) {
-        await client.service(`sessions/${sessionId}/mcp-servers`).remove(serverId);
-      }
+      await updateSessionMcpServers(client, sessionId, currentIds, mcpServerIds);
 
       // Note: Don't show success message here - it's part of the session settings save
       // The main "Session updated" message will appear from handleUpdateSession

--- a/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
+++ b/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
@@ -21,6 +21,8 @@ interface EffortSelectorProps {
   onChange?: (effort: EffortLevel) => void;
   size?: 'small' | 'middle' | 'large';
   compact?: boolean;
+  plain?: boolean;
+  fullWidth?: boolean;
 }
 
 const EFFORT_OPTIONS: {
@@ -48,6 +50,8 @@ export const EffortSelector: React.FC<EffortSelectorProps> = ({
   onChange,
   size = 'middle',
   compact = false,
+  plain = false,
+  fullWidth = false,
 }) => {
   const { token } = theme.useToken();
 
@@ -58,14 +62,16 @@ export const EffortSelector: React.FC<EffortSelectorProps> = ({
         onChange={onChange}
         size={size}
         style={{
-          width: compact ? undefined : 160,
+          width: fullWidth ? '100%' : compact ? undefined : 160,
           fontSize: compact ? token.fontSizeSM : undefined,
         }}
         popupMatchSelectWidth={false}
         optionLabelProp="label"
         options={EFFORT_OPTIONS.map((opt) => ({
           value: opt.value,
-          label: compact ? (
+          label: plain ? (
+            opt.label
+          ) : compact ? (
             <span style={{ fontSize: token.fontSizeSM }}>
               <BulbOutlined style={{ fontSize: token.fontSizeSM - 1, marginRight: 2 }} />
               {opt.shortLabel}

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -77,6 +77,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
   // waiting for a full MCPServer re-fetch from the parent.
   const [expiresAtOverride, setExpiresAtOverride] = useState<number | undefined>(undefined);
 
+  const isOAuthServer = server.auth?.type === 'oauth';
   const expiresAt = expiresAtOverride ?? server.auth?.oauth_token_expires_at;
 
   const handleOAuthClick = async () => {
@@ -154,7 +155,9 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
   // see both the relative countdown and the absolute wall-clock time — handy
   // for spotting providers with suspiciously short or long TTLs.
   let authedTooltip: React.ReactNode;
-  if (expiresAt) {
+  if (!isOAuthServer) {
+    authedTooltip = `${server.transport.toUpperCase()} MCP server`;
+  } else if (expiresAt) {
     const date = new Date(expiresAt);
     const { verb, phrase } = formatExpiresIn(expiresAt);
     authedTooltip = (
@@ -193,8 +196,8 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({ server, needsAuth,
           icon={
             needsAuth ? <LoginOutlined /> : refreshing ? <ReloadOutlined spin /> : <ApiOutlined />
           }
-          style={{ cursor: refreshing ? 'wait' : 'pointer' }}
-          onClick={needsAuth ? handleOAuthClick : handleRefreshClick}
+          style={{ cursor: refreshing ? 'wait' : isOAuthServer ? 'pointer' : 'default' }}
+          onClick={needsAuth ? handleOAuthClick : isOAuthServer ? handleRefreshClick : undefined}
         >
           {server.display_name || server.name}
           {isAdmin && (

--- a/apps/agor-ui/src/components/MCPServer/mcp-session-summary.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-session-summary.test.ts
@@ -1,0 +1,46 @@
+import type { MCPServer } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import { summarizeSessionMcpServers } from './mcp-session-summary';
+
+const server = (id: string, auth?: MCPServer['auth']): MCPServer =>
+  ({
+    mcp_server_id: id,
+    name: id,
+    display_name: id,
+    enabled: true,
+    transport: 'http',
+    scope: 'global',
+    auth,
+  }) as MCPServer;
+
+describe('summarizeSessionMcpServers', () => {
+  it('summarizes empty sessions', () => {
+    expect(summarizeSessionMcpServers([], new Map(), new Set())).toMatchObject({
+      attachedCount: 0,
+      healthyCount: 0,
+      tone: 'default',
+      label: 'MCP (0)',
+    });
+  });
+
+  it('uses warning tone when attached OAuth servers need user auth', () => {
+    const servers = new Map([['s1', server('s1', { type: 'oauth', oauth_mode: 'per_user' })]]);
+
+    expect(summarizeSessionMcpServers(['s1'], servers, new Set())).toMatchObject({
+      attachedCount: 1,
+      needsAuthCount: 1,
+      missingCount: 0,
+      healthyCount: 0,
+      tone: 'warning',
+    });
+  });
+
+  it('uses error tone when an attached server record is missing', () => {
+    expect(summarizeSessionMcpServers(['missing'], new Map(), new Set())).toMatchObject({
+      attachedCount: 1,
+      needsAuthCount: 0,
+      missingCount: 1,
+      tone: 'error',
+    });
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/mcp-session-summary.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-session-summary.ts
@@ -1,0 +1,53 @@
+import type { MCPServer } from '@agor-live/client';
+import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
+
+export interface SessionMcpSummary {
+  attachedCount: number;
+  missingCount: number;
+  needsAuthCount: number;
+  healthyCount: number;
+  tone: 'default' | 'warning' | 'error';
+  label: string;
+  tooltip: string;
+}
+
+export function summarizeSessionMcpServers(
+  serverIds: string[],
+  mcpServerById: Map<string, MCPServer>,
+  userAuthenticatedMcpServerIds: Set<string>
+): SessionMcpSummary {
+  let missingCount = 0;
+  let needsAuthCount = 0;
+
+  for (const serverId of serverIds) {
+    const server = mcpServerById.get(serverId);
+    if (!server) {
+      missingCount += 1;
+      continue;
+    }
+    if (mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)) {
+      needsAuthCount += 1;
+    }
+  }
+
+  const attachedCount = serverIds.length;
+  const healthyCount = Math.max(0, attachedCount - missingCount - needsAuthCount);
+  const problemCount = missingCount + needsAuthCount;
+  const tone: SessionMcpSummary['tone'] =
+    missingCount > 0 ? 'error' : needsAuthCount > 0 ? 'warning' : 'default';
+
+  return {
+    attachedCount,
+    missingCount,
+    needsAuthCount,
+    healthyCount,
+    tone,
+    label: `MCP (${attachedCount})`,
+    tooltip:
+      problemCount > 0
+        ? `${problemCount} MCP server${problemCount === 1 ? '' : 's'} need attention`
+        : attachedCount > 0
+          ? `${attachedCount} MCP server${attachedCount === 1 ? '' : 's'} attached`
+          : 'No MCP servers attached',
+  };
+}

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -10,7 +10,7 @@ import {
   type GeminiModel,
 } from '@agor-live/client';
 import { InfoCircleOutlined } from '@ant-design/icons';
-import { Input, Radio, Select, Space, Tooltip } from 'antd';
+import { Input, Radio, Select, Space, Tooltip, theme } from 'antd';
 import { useEffect, useState } from 'react';
 import {
   DEFAULT_CURSOR_MODEL,
@@ -54,6 +54,8 @@ export interface ModelSelectorProps {
    * client, the picker only shows static models.
    */
   client?: AgorClient | null;
+  /** Render as a single compact dropdown suitable for popovers/toolbars. */
+  compact?: boolean;
 }
 
 interface DynamicModelOption {
@@ -127,7 +129,10 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   agent,
   agentic_tool,
   client,
+  compact = false,
 }) => {
+  const { token } = theme.useToken();
+
   // Determine which model list to use based on agentic_tool (with backwards compat for agent prop)
   const effectiveTool = agentic_tool || agent || 'claude-code';
 
@@ -306,6 +311,30 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       });
     }
   };
+
+  if (compact) {
+    const currentValue = value?.model || fallbackModel;
+    const options = modelList.map((m) => ({
+      value: m.id,
+      label: m.id,
+    }));
+    if (currentValue && !options.some((option) => option.value === currentValue)) {
+      options.unshift({ value: currentValue, label: currentValue });
+    }
+
+    return (
+      <Select
+        value={currentValue}
+        onChange={handleModelChange}
+        size="small"
+        showSearch
+        optionFilterProp="label"
+        popupMatchSelectWidth={false}
+        style={{ width: '100%', fontSize: token.fontSizeSM }}
+        options={options}
+      />
+    );
+  }
 
   return (
     <Space orientation="vertical" style={{ width: '100%' }}>

--- a/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
+++ b/apps/agor-ui/src/components/PermissionModeSelector/PermissionModeSelector.tsx
@@ -38,6 +38,9 @@ export interface PermissionModeSelectorProps {
    * only the icon fits. The tooltip preserves the label either way.
    */
   iconOnly?: boolean;
+  /** Render compact selects with plain text labels (useful in popovers/forms). */
+  plain?: boolean;
+  fullWidth?: boolean;
   /** Size for compact mode */
   size?: 'small' | 'middle' | 'large';
   /** Codex-specific: sandbox mode value */
@@ -267,6 +270,8 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
   agentic_tool = 'claude-code',
   compact = false,
   iconOnly = false,
+  plain = false,
+  fullWidth = false,
   size = 'middle',
   codexSandboxMode,
   codexApprovalPolicy,
@@ -291,14 +296,18 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
     // (used by SessionPanel for inline Codex controls)
     if (agentic_tool === 'codex' && onCodexChange) {
       return (
-        <Space size={4}>
+        <Space size={4} direction={fullWidth ? 'vertical' : 'horizontal'} style={{ width: '100%' }}>
           <Select
             value={effectiveCodexSandboxMode}
             onChange={(val) => onCodexChange(val, effectiveCodexApprovalPolicy)}
             size={size}
             placeholder="Sandbox"
             popupMatchSelectWidth={false}
-            style={{ minWidth: 70, fontSize: token.fontSizeSM }}
+            style={{
+              minWidth: 70,
+              width: fullWidth ? '100%' : undefined,
+              fontSize: token.fontSizeSM,
+            }}
             optionLabelProp="label"
             options={CODEX_SANDBOX_MODES.map(({ value, label, description }) => ({
               label,
@@ -320,7 +329,11 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
             size={size}
             placeholder="Approval"
             popupMatchSelectWidth={false}
-            style={{ minWidth: 70, fontSize: token.fontSizeSM }}
+            style={{
+              minWidth: 70,
+              width: fullWidth ? '100%' : undefined,
+              fontSize: token.fontSizeSM,
+            }}
             optionLabelProp="label"
             options={CODEX_APPROVAL_POLICIES.map(({ value, label, description }) => ({
               label,
@@ -352,12 +365,14 @@ export const PermissionModeSelector: React.FC<PermissionModeSelectorProps> = ({
         <Select
           value={effectiveValue}
           onChange={onChange}
-          style={{ fontSize: token.fontSizeSM }}
+          style={{ fontSize: token.fontSizeSM, width: fullWidth ? '100%' : undefined }}
           size={size}
           popupMatchSelectWidth={false}
           optionLabelProp="label"
           options={modes.map(({ mode, label, description, icon, color }) => ({
-            label: iconOnly ? (
+            label: plain ? (
+              label
+            ) : iconOnly ? (
               <span style={{ color, fontSize: token.fontSizeSM }}>{icon}</span>
             ) : (
               <Space size={4} style={{ fontSize: token.fontSizeSM }}>

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -32,6 +32,7 @@ import { resolveContextWindowPercentage } from '../../utils/contextWindow';
 import { parseGitStateSha } from '../../utils/gitState';
 import { type SessionForIds, SessionIdsList } from '../SessionIds';
 import { Tag } from '../Tag';
+import { getModelDisplayName } from './modelDisplay';
 import { getUrlDisplayLabel, isGitHubUrl, type UrlDisplayRepo } from './url-helpers';
 
 /**
@@ -477,43 +478,9 @@ interface ModelPillProps extends BasePillProps {
 }
 
 export const ModelPill: React.FC<ModelPillProps> = ({ model, style }) => {
-  // Simplify model name for display
-  // Examples:
-  // - "claude-sonnet-4-5-20250929" -> "sonnet-4.5"
-  // - "gpt-4o" -> "gpt-4o"
-  // - "gpt-3.5-turbo" -> "gpt-3.5-turbo"
-  const getDisplayName = (modelId: string) => {
-    // Claude models: extract version from pattern
-    if (modelId.includes('sonnet')) {
-      const match = modelId.match(/sonnet-(\d)-(\d)/);
-      return match ? `sonnet-${match[1]}.${match[2]}` : 'sonnet';
-    }
-    if (modelId.includes('haiku')) {
-      const match = modelId.match(/haiku-(\d)-(\d)/);
-      return match ? `haiku-${match[1]}.${match[2]}` : 'haiku';
-    }
-    if (modelId.includes('opus')) {
-      const match = modelId.match(/opus-(\d)-(\d)/);
-      return match ? `opus-${match[1]}.${match[2]}` : 'opus';
-    }
-
-    // OpenAI GPT models: show as-is (e.g., "gpt-4o", "gpt-3.5-turbo", "gpt-4-turbo")
-    if (modelId.startsWith('gpt-')) {
-      return modelId;
-    }
-
-    // Gemini models: show as-is (e.g., "gemini-2.5-flash", "gemini-2.5-pro")
-    if (modelId.startsWith('gemini-')) {
-      return modelId;
-    }
-
-    // Fallback to full ID for unknown models
-    return modelId;
-  };
-
   return (
     <Tag icon={<RobotOutlined />} color={PILL_COLORS.model} style={style}>
-      {getDisplayName(model)}
+      {getModelDisplayName(model)}
     </Tag>
   );
 };

--- a/apps/agor-ui/src/components/Pill/modelDisplay.ts
+++ b/apps/agor-ui/src/components/Pill/modelDisplay.ts
@@ -1,0 +1,16 @@
+export function getModelDisplayName(modelId: string): string {
+  if (modelId.includes('sonnet')) {
+    const match = modelId.match(/sonnet-(\d)-(\d)/);
+    return match ? `sonnet-${match[1]}.${match[2]}` : 'sonnet';
+  }
+  if (modelId.includes('haiku')) {
+    const match = modelId.match(/haiku-(\d)-(\d)/);
+    return match ? `haiku-${match[1]}.${match[2]}` : 'haiku';
+  }
+  if (modelId.includes('opus')) {
+    const match = modelId.match(/opus-(\d)-(\d)/);
+    return match ? `opus-${match[1]}.${match[2]}` : 'opus';
+  }
+
+  return modelId;
+}

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -1,0 +1,155 @@
+import type { AgorClient, MCPServer } from '@agor-live/client';
+import { ApiOutlined, PlusOutlined, SettingOutlined } from '@ant-design/icons';
+import { Tag as AntTag, Button, Divider, Popover, Space, Typography, theme } from 'antd';
+import React from 'react';
+import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
+import { useThemedMessage } from '../../utils/message';
+import { updateSessionMcpServers } from '../../utils/sessionMcpServers';
+import { MCPServerPill } from '../MCPServer';
+import { summarizeSessionMcpServers } from '../MCPServer/mcp-session-summary';
+import { MCPServerSelect } from '../MCPServerSelect';
+import { Tag } from '../Tag';
+
+export interface SessionMcpFooterControlProps {
+  client: AgorClient | null;
+  sessionId: string;
+  sessionMcpServerIds: string[];
+  mcpServerById: Map<string, MCPServer>;
+  userAuthenticatedMcpServerIds: Set<string>;
+  onOpenSessionSettings?: (sessionId: string) => void;
+}
+
+export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = ({
+  client,
+  sessionId,
+  sessionMcpServerIds,
+  mcpServerById,
+  userAuthenticatedMcpServerIds,
+  onOpenSessionSettings,
+}) => {
+  const { token } = theme.useToken();
+  const { showSuccess, showError } = useThemedMessage();
+  const [open, setOpen] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+
+  const summary = React.useMemo(
+    () =>
+      summarizeSessionMcpServers(sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds),
+    [sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds]
+  );
+
+  const attachedServers = React.useMemo(
+    () =>
+      sessionMcpServerIds
+        .map((id) => mcpServerById.get(id))
+        .filter((server): server is MCPServer => Boolean(server)),
+    [sessionMcpServerIds, mcpServerById]
+  );
+
+  const handleChange = async (nextIds: string[]) => {
+    if (!client) return;
+    setSaving(true);
+    try {
+      await updateSessionMcpServers(client, sessionId, sessionMcpServerIds, nextIds);
+      showSuccess('Session MCP servers updated');
+    } catch (err) {
+      showError(
+        `Failed to update MCP servers: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const content = (
+    <div style={{ width: 340, maxWidth: 'min(340px, 80vw)' }}>
+      <Space direction="vertical" size={10} style={{ width: '100%' }}>
+        <div>
+          <Typography.Text strong>Session MCP servers</Typography.Text>
+          <Typography.Paragraph type="secondary" style={{ margin: `${token.sizeUnit}px 0 0` }}>
+            Attach tools/connectors that the agent can use in this conversation.
+          </Typography.Paragraph>
+        </div>
+
+        {attachedServers.length > 0 && (
+          <Space size={6} wrap>
+            {attachedServers.map((server) => (
+              <MCPServerPill
+                key={server.mcp_server_id}
+                server={server}
+                needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
+                client={client}
+              />
+            ))}
+          </Space>
+        )}
+
+        <MCPServerSelect
+          mcpServers={Array.from(mcpServerById.values())}
+          placeholder="Attach MCP servers…"
+          value={sessionMcpServerIds}
+          onChange={handleChange}
+          loading={saving}
+          disabled={!client}
+          style={{ width: '100%' }}
+        />
+
+        <Divider style={{ margin: `${token.sizeUnit}px 0` }} />
+        <Button
+          block
+          icon={<SettingOutlined />}
+          onClick={() => {
+            setOpen(false);
+            onOpenSessionSettings?.(sessionId);
+          }}
+        >
+          Open session settings
+        </Button>
+      </Space>
+    </div>
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      trigger="click"
+      placement="top"
+      getPopupContainer={(trigger) => trigger.parentElement ?? document.body}
+      title={null}
+      content={content}
+    >
+      <Tag
+        icon={<ApiOutlined />}
+        color="default"
+        title={`${summary.tooltip}. Click to add or change MCP servers.`}
+        style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+      >
+        <span>MCP</span>
+        <AntTag
+          color={
+            summary.tone === 'error' ? 'error' : summary.tone === 'warning' ? 'warning' : undefined
+          }
+          style={{
+            marginInlineStart: token.sizeUnit,
+            marginInlineEnd: 0,
+            minWidth: 16,
+            height: 14,
+            paddingInline: 4,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            lineHeight: '12px',
+            fontSize: 10,
+            textAlign: 'center',
+            fontVariantNumeric: 'tabular-nums',
+            verticalAlign: 'middle',
+          }}
+        >
+          {summary.attachedCount}
+        </AntTag>
+        <PlusOutlined style={{ marginLeft: token.sizeUnit * 1.5 }} />
+      </Tag>
+    </Popover>
+  );
+};

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -4,6 +4,7 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  MCPServer,
   PermissionMode,
   Session,
   SessionID,
@@ -20,16 +21,32 @@ import {
 } from '@agor-live/client';
 import {
   AimOutlined,
+  ApiOutlined,
   BranchesOutlined,
   CloseOutlined,
   CodeOutlined,
   ForkOutlined,
+  PlusOutlined,
   QuestionCircleOutlined,
+  RobotOutlined,
   SendOutlined,
   SettingOutlined,
   StopOutlined,
 } from '@ant-design/icons';
-import { Alert, App, Badge, Button, Space, Spin, Tooltip, Typography, theme } from 'antd';
+import {
+  Alert,
+  Tag as AntTag,
+  App,
+  Badge,
+  Button,
+  Divider,
+  Popover,
+  Space,
+  Spin,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -48,10 +65,14 @@ import { CallbackToggleButton } from '../CallbackToggleButton';
 import { EffortSelector } from '../EffortSelector';
 import { FileUpload, FileUploadButton } from '../FileUpload';
 import { MCPServerPill } from '../MCPServer';
+import { summarizeSessionMcpServers } from '../MCPServer/mcp-session-summary';
+import { MCPServerSelect } from '../MCPServerSelect';
+import { type ModelConfig, ModelSelector } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
 import { PermissionModeSelector } from '../PermissionModeSelector';
-import { ContextWindowPill, ModelPill, TimerPill, TokenCountPill } from '../Pill';
+import { ContextWindowPill, TimerPill, TokenCountPill } from '../Pill';
 import { SessionIdsButton } from '../SessionIds';
+import { Tag } from '../Tag';
 import { ToolIcon } from '../ToolIcon';
 import { SessionPanelContent } from './SessionPanelContent';
 
@@ -207,6 +228,313 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
 );
 
 PromptInput.displayName = 'PromptInput';
+
+// ---------------------------------------------------------------------------
+
+interface SessionMcpFooterControlProps {
+  client: AgorClient | null;
+  sessionId: string;
+  sessionMcpServerIds: string[];
+  mcpServerById: Map<string, MCPServer>;
+  userAuthenticatedMcpServerIds: Set<string>;
+  onOpenSessionSettings?: (sessionId: string) => void;
+}
+
+const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = ({
+  client,
+  sessionId,
+  sessionMcpServerIds,
+  mcpServerById,
+  userAuthenticatedMcpServerIds,
+  onOpenSessionSettings,
+}) => {
+  const { token } = theme.useToken();
+  const { showSuccess, showError } = useThemedMessage();
+  const [open, setOpen] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+
+  const summary = React.useMemo(
+    () =>
+      summarizeSessionMcpServers(sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds),
+    [sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds]
+  );
+
+  const attachedServers = React.useMemo(
+    () =>
+      sessionMcpServerIds
+        .map((id) => mcpServerById.get(id))
+        .filter((server): server is MCPServer => Boolean(server)),
+    [sessionMcpServerIds, mcpServerById]
+  );
+
+  const handleChange = async (nextIds: string[]) => {
+    if (!client) return;
+    setSaving(true);
+    try {
+      const current = new Set(sessionMcpServerIds);
+      const next = new Set(nextIds);
+
+      await Promise.all([
+        ...nextIds
+          .filter((id) => !current.has(id))
+          .map((id) =>
+            client.service(`sessions/${sessionId}/mcp-servers`).create({ mcpServerId: id })
+          ),
+        ...sessionMcpServerIds
+          .filter((id) => !next.has(id))
+          .map((id) => client.service(`sessions/${sessionId}/mcp-servers`).remove(id)),
+      ]);
+
+      showSuccess('Session MCP servers updated');
+    } catch (err) {
+      showError(
+        `Failed to update MCP servers: ${err instanceof Error ? err.message : String(err)}`
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const content = (
+    <div style={{ width: 340, maxWidth: 'min(340px, 80vw)' }}>
+      <Space direction="vertical" size={10} style={{ width: '100%' }}>
+        <div>
+          <Typography.Text strong>Session MCP servers</Typography.Text>
+          <Typography.Paragraph type="secondary" style={{ margin: `${token.sizeUnit}px 0 0` }}>
+            Attach tools/connectors that the agent can use in this conversation.
+          </Typography.Paragraph>
+        </div>
+
+        {attachedServers.length > 0 && (
+          <Space size={6} wrap>
+            {attachedServers.map((server) => (
+              <MCPServerPill
+                key={server.mcp_server_id}
+                server={server}
+                needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
+                client={client}
+              />
+            ))}
+          </Space>
+        )}
+
+        <MCPServerSelect
+          mcpServers={Array.from(mcpServerById.values())}
+          placeholder="Attach MCP servers…"
+          value={sessionMcpServerIds}
+          onChange={handleChange}
+          loading={saving}
+          disabled={!client}
+          style={{ width: '100%' }}
+        />
+
+        <Divider style={{ margin: `${token.sizeUnit}px 0` }} />
+        <Button
+          block
+          icon={<SettingOutlined />}
+          onClick={() => {
+            setOpen(false);
+            onOpenSessionSettings?.(sessionId);
+          }}
+        >
+          Open session settings
+        </Button>
+      </Space>
+    </div>
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      trigger="click"
+      placement="top"
+      getPopupContainer={(trigger) => trigger.parentElement ?? document.body}
+      title={null}
+      content={content}
+    >
+      <Tag
+        icon={<ApiOutlined />}
+        color="default"
+        title={`${summary.tooltip}. Click to add or change MCP servers.`}
+        style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+      >
+        <span>MCP</span>
+        <AntTag
+          color={
+            summary.tone === 'error' ? 'error' : summary.tone === 'warning' ? 'warning' : undefined
+          }
+          style={{
+            marginInlineStart: token.sizeUnit,
+            marginInlineEnd: 0,
+            minWidth: 16,
+            height: 14,
+            paddingInline: 4,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            lineHeight: '12px',
+            fontSize: 10,
+            textAlign: 'center',
+            fontVariantNumeric: 'tabular-nums',
+            verticalAlign: 'middle',
+          }}
+        >
+          {summary.attachedCount}
+        </AntTag>
+        <PlusOutlined style={{ marginLeft: token.sizeUnit * 1.5 }} />
+      </Tag>
+    </Popover>
+  );
+};
+
+// ---------------------------------------------------------------------------
+
+interface SessionRunSettingsPopoverProps {
+  client: AgorClient | null;
+  session: Session;
+  modelLabel?: string;
+  modelConfig?: ModelConfig;
+  onModelConfigChange: (config: ModelConfig) => void;
+  effortLevel: EffortLevel;
+  onEffortChange: (effort: EffortLevel) => void;
+  permissionMode: PermissionMode;
+  onPermissionModeChange: (mode: PermissionMode) => void;
+  codexSandboxMode: CodexSandboxMode;
+  codexApprovalPolicy: CodexApprovalPolicy;
+  onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) => void;
+}
+
+const SessionRunSettingsPopover: React.FC<SessionRunSettingsPopoverProps> = ({
+  client,
+  session,
+  modelLabel,
+  modelConfig,
+  onModelConfigChange,
+  effortLevel,
+  onEffortChange,
+  permissionMode,
+  onPermissionModeChange,
+  codexSandboxMode,
+  codexApprovalPolicy,
+  onCodexPermissionChange,
+}) => {
+  const { token } = theme.useToken();
+
+  const getModelDisplayName = (modelId: string) => {
+    if (modelId.includes('sonnet')) {
+      const match = modelId.match(/sonnet-(\d)-(\d)/);
+      return match ? `sonnet-${match[1]}.${match[2]}` : 'sonnet';
+    }
+    if (modelId.includes('haiku')) {
+      const match = modelId.match(/haiku-(\d)-(\d)/);
+      return match ? `haiku-${match[1]}.${match[2]}` : 'haiku';
+    }
+    if (modelId.includes('opus')) {
+      const match = modelId.match(/opus-(\d)-(\d)/);
+      return match ? `opus-${match[1]}.${match[2]}` : 'opus';
+    }
+    return modelId;
+  };
+
+  const content = (
+    <div style={{ width: 320, maxWidth: 'min(320px, 80vw)' }}>
+      <Space direction="vertical" size={12} style={{ width: '100%' }}>
+        <div>
+          <Typography.Text strong>Quick session settings</Typography.Text>
+        </div>
+
+        {modelLabel && (
+          <div>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Model
+            </Typography.Text>
+            <div style={{ marginTop: token.sizeUnit }}>
+              <ModelSelector
+                value={modelConfig}
+                onChange={onModelConfigChange}
+                agentic_tool={session.agentic_tool}
+                client={client}
+                compact
+              />
+            </div>
+          </div>
+        )}
+
+        {session.agentic_tool === 'claude-code' && (
+          <div>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Reasoning effort
+            </Typography.Text>
+            <div style={{ marginTop: token.sizeUnit }}>
+              <EffortSelector
+                value={effortLevel}
+                onChange={onEffortChange}
+                size="small"
+                compact
+                plain
+                fullWidth
+              />
+            </div>
+          </div>
+        )}
+
+        <div>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            Permissions
+          </Typography.Text>
+          <div style={{ marginTop: token.sizeUnit }}>
+            <PermissionModeSelector
+              value={permissionMode}
+              onChange={onPermissionModeChange}
+              agentic_tool={session.agentic_tool}
+              codexSandboxMode={codexSandboxMode}
+              codexApprovalPolicy={codexApprovalPolicy}
+              onCodexChange={onCodexPermissionChange}
+              compact
+              iconOnly={false}
+              plain
+              fullWidth
+              size="small"
+            />
+          </div>
+        </div>
+      </Space>
+    </div>
+  );
+
+  const trigger = modelLabel ? (
+    <Tag
+      icon={<RobotOutlined />}
+      color="default"
+      title="Model and run settings"
+      style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+    >
+      <span>{getModelDisplayName(modelLabel)}</span>
+      <SettingOutlined style={{ marginLeft: token.sizeUnit * 1.5 }} />
+    </Tag>
+  ) : (
+    <Tag
+      icon={<SettingOutlined />}
+      color="default"
+      style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+    >
+      Run
+    </Tag>
+  );
+
+  return (
+    <Popover
+      trigger="click"
+      placement="top"
+      getPopupContainer={(node) => node.parentElement ?? document.body}
+      content={content}
+      title={null}
+    >
+      {trigger}
+    </Popover>
+  );
+};
 
 // ---------------------------------------------------------------------------
 
@@ -683,6 +1011,20 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
+  const handleModelConfigChange = (newConfig: ModelConfig) => {
+    if (session && onUpdateSession) {
+      onUpdateSession(session.session_id, {
+        model_config: {
+          ...session.model_config,
+          mode: newConfig.mode,
+          model: newConfig.model,
+          ...(newConfig.provider ? { provider: newConfig.provider } : {}),
+          updated_at: new Date().toISOString(),
+        },
+      });
+    }
+  };
+
   const getStatusColor = () => {
     switch (session.status) {
       case 'running':
@@ -697,6 +1039,20 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         return 'default';
     }
   };
+
+  const modelLabel =
+    session.model_config?.model &&
+    session.agentic_tool === 'opencode' &&
+    session.model_config.provider
+      ? `${session.model_config.provider}/${session.model_config.model}`
+      : session.model_config?.model;
+  const modelConfig: ModelConfig | undefined = session.model_config?.model
+    ? {
+        mode: session.model_config.mode || 'alias',
+        model: session.model_config.model,
+        provider: session.model_config.provider,
+      }
+    : undefined;
 
   // Footer controls
   const footerControls = (
@@ -747,7 +1103,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                 not authenticated — click to sign in.
               </span>
             }
-            style={{ marginBottom: 0 }}
+            style={{ marginBottom: 0, borderRadius: token.borderRadius }}
             banner
           />
         )}
@@ -792,6 +1148,14 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           }}
         >
           <Space size={4} wrap>
+            <SessionMcpFooterControl
+              client={client}
+              sessionId={session.session_id}
+              sessionMcpServerIds={sessionMcpServerIds}
+              mcpServerById={mcpServerById}
+              userAuthenticatedMcpServerIds={userAuthenticatedMcpServerIds}
+              onOpenSessionSettings={onOpenSettings}
+            />
             {footerTimerTask && (
               <TimerPill
                 status={footerTimerTask.status}
@@ -806,17 +1170,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               />
             )}
             <SessionIdsButton session={session} />
-            {session.model_config?.model && (
-              <ModelPill
-                model={
-                  session.agentic_tool === 'opencode' &&
-                  session.model_config.provider &&
-                  session.model_config.model
-                    ? `${session.model_config.provider}/${session.model_config.model}`
-                    : session.model_config.model
-                }
-              />
-            )}
             {tokenBreakdown.total > 0 && (
               <TokenCountPill
                 count={tokenBreakdown.total}
@@ -836,27 +1189,22 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             )}
           </Space>
           <Space size={4} wrap style={{ marginLeft: 'auto' }}>
-            {session.agentic_tool === 'claude-code' && (
-              <EffortSelector
-                value={effortLevel}
-                onChange={handleEffortChange}
-                size="small"
-                compact
-              />
-            )}
-            <PermissionModeSelector
-              value={permissionMode}
-              onChange={handlePermissionModeChange}
-              agentic_tool={session.agentic_tool}
-              codexSandboxMode={codexSandboxMode}
-              codexApprovalPolicy={codexApprovalPolicy}
-              onCodexChange={handleCodexPermissionChange}
-              compact
-              iconOnly
-              size="small"
-            />
             {isRunning && <Spin size="small" />}
             <CallbackToggleButton session={session} />
+            <SessionRunSettingsPopover
+              client={client}
+              session={session}
+              modelLabel={modelLabel}
+              modelConfig={modelConfig}
+              onModelConfigChange={handleModelConfigChange}
+              effortLevel={effortLevel}
+              onEffortChange={handleEffortChange}
+              permissionMode={permissionMode}
+              onPermissionModeChange={handlePermissionModeChange}
+              codexSandboxMode={codexSandboxMode}
+              codexApprovalPolicy={codexApprovalPolicy}
+              onCodexPermissionChange={handleCodexPermissionChange}
+            />
             <Space.Compact>
               <Tooltip
                 title={

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -4,7 +4,6 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
-  MCPServer,
   PermissionMode,
   Session,
   SessionID,
@@ -21,32 +20,16 @@ import {
 } from '@agor-live/client';
 import {
   AimOutlined,
-  ApiOutlined,
   BranchesOutlined,
   CloseOutlined,
   CodeOutlined,
   ForkOutlined,
-  PlusOutlined,
   QuestionCircleOutlined,
-  RobotOutlined,
   SendOutlined,
   SettingOutlined,
   StopOutlined,
 } from '@ant-design/icons';
-import {
-  Alert,
-  Tag as AntTag,
-  App,
-  Badge,
-  Button,
-  Divider,
-  Popover,
-  Space,
-  Spin,
-  Tooltip,
-  Typography,
-  theme,
-} from 'antd';
+import { Alert, App, Badge, Button, Space, Spin, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -62,19 +45,16 @@ import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessi
 import { ArchiveActionButton } from '../ArchiveButton';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { CallbackToggleButton } from '../CallbackToggleButton';
-import { EffortSelector } from '../EffortSelector';
 import { FileUpload, FileUploadButton } from '../FileUpload';
 import { MCPServerPill } from '../MCPServer';
-import { summarizeSessionMcpServers } from '../MCPServer/mcp-session-summary';
-import { MCPServerSelect } from '../MCPServerSelect';
-import { type ModelConfig, ModelSelector } from '../ModelSelector';
+import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
-import { PermissionModeSelector } from '../PermissionModeSelector';
 import { ContextWindowPill, TimerPill, TokenCountPill } from '../Pill';
 import { SessionIdsButton } from '../SessionIds';
-import { Tag } from '../Tag';
 import { ToolIcon } from '../ToolIcon';
+import { SessionMcpFooterControl } from './SessionMcpFooterControl';
 import { SessionPanelContent } from './SessionPanelContent';
+import { SessionRunSettingsPopover } from './SessionRunSettingsPopover';
 
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
@@ -230,311 +210,6 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
 PromptInput.displayName = 'PromptInput';
 
 // ---------------------------------------------------------------------------
-
-interface SessionMcpFooterControlProps {
-  client: AgorClient | null;
-  sessionId: string;
-  sessionMcpServerIds: string[];
-  mcpServerById: Map<string, MCPServer>;
-  userAuthenticatedMcpServerIds: Set<string>;
-  onOpenSessionSettings?: (sessionId: string) => void;
-}
-
-const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = ({
-  client,
-  sessionId,
-  sessionMcpServerIds,
-  mcpServerById,
-  userAuthenticatedMcpServerIds,
-  onOpenSessionSettings,
-}) => {
-  const { token } = theme.useToken();
-  const { showSuccess, showError } = useThemedMessage();
-  const [open, setOpen] = React.useState(false);
-  const [saving, setSaving] = React.useState(false);
-
-  const summary = React.useMemo(
-    () =>
-      summarizeSessionMcpServers(sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds),
-    [sessionMcpServerIds, mcpServerById, userAuthenticatedMcpServerIds]
-  );
-
-  const attachedServers = React.useMemo(
-    () =>
-      sessionMcpServerIds
-        .map((id) => mcpServerById.get(id))
-        .filter((server): server is MCPServer => Boolean(server)),
-    [sessionMcpServerIds, mcpServerById]
-  );
-
-  const handleChange = async (nextIds: string[]) => {
-    if (!client) return;
-    setSaving(true);
-    try {
-      const current = new Set(sessionMcpServerIds);
-      const next = new Set(nextIds);
-
-      await Promise.all([
-        ...nextIds
-          .filter((id) => !current.has(id))
-          .map((id) =>
-            client.service(`sessions/${sessionId}/mcp-servers`).create({ mcpServerId: id })
-          ),
-        ...sessionMcpServerIds
-          .filter((id) => !next.has(id))
-          .map((id) => client.service(`sessions/${sessionId}/mcp-servers`).remove(id)),
-      ]);
-
-      showSuccess('Session MCP servers updated');
-    } catch (err) {
-      showError(
-        `Failed to update MCP servers: ${err instanceof Error ? err.message : String(err)}`
-      );
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const content = (
-    <div style={{ width: 340, maxWidth: 'min(340px, 80vw)' }}>
-      <Space direction="vertical" size={10} style={{ width: '100%' }}>
-        <div>
-          <Typography.Text strong>Session MCP servers</Typography.Text>
-          <Typography.Paragraph type="secondary" style={{ margin: `${token.sizeUnit}px 0 0` }}>
-            Attach tools/connectors that the agent can use in this conversation.
-          </Typography.Paragraph>
-        </div>
-
-        {attachedServers.length > 0 && (
-          <Space size={6} wrap>
-            {attachedServers.map((server) => (
-              <MCPServerPill
-                key={server.mcp_server_id}
-                server={server}
-                needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
-                client={client}
-              />
-            ))}
-          </Space>
-        )}
-
-        <MCPServerSelect
-          mcpServers={Array.from(mcpServerById.values())}
-          placeholder="Attach MCP servers…"
-          value={sessionMcpServerIds}
-          onChange={handleChange}
-          loading={saving}
-          disabled={!client}
-          style={{ width: '100%' }}
-        />
-
-        <Divider style={{ margin: `${token.sizeUnit}px 0` }} />
-        <Button
-          block
-          icon={<SettingOutlined />}
-          onClick={() => {
-            setOpen(false);
-            onOpenSessionSettings?.(sessionId);
-          }}
-        >
-          Open session settings
-        </Button>
-      </Space>
-    </div>
-  );
-
-  return (
-    <Popover
-      open={open}
-      onOpenChange={setOpen}
-      trigger="click"
-      placement="top"
-      getPopupContainer={(trigger) => trigger.parentElement ?? document.body}
-      title={null}
-      content={content}
-    >
-      <Tag
-        icon={<ApiOutlined />}
-        color="default"
-        title={`${summary.tooltip}. Click to add or change MCP servers.`}
-        style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
-      >
-        <span>MCP</span>
-        <AntTag
-          color={
-            summary.tone === 'error' ? 'error' : summary.tone === 'warning' ? 'warning' : undefined
-          }
-          style={{
-            marginInlineStart: token.sizeUnit,
-            marginInlineEnd: 0,
-            minWidth: 16,
-            height: 14,
-            paddingInline: 4,
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            lineHeight: '12px',
-            fontSize: 10,
-            textAlign: 'center',
-            fontVariantNumeric: 'tabular-nums',
-            verticalAlign: 'middle',
-          }}
-        >
-          {summary.attachedCount}
-        </AntTag>
-        <PlusOutlined style={{ marginLeft: token.sizeUnit * 1.5 }} />
-      </Tag>
-    </Popover>
-  );
-};
-
-// ---------------------------------------------------------------------------
-
-interface SessionRunSettingsPopoverProps {
-  client: AgorClient | null;
-  session: Session;
-  modelLabel?: string;
-  modelConfig?: ModelConfig;
-  onModelConfigChange: (config: ModelConfig) => void;
-  effortLevel: EffortLevel;
-  onEffortChange: (effort: EffortLevel) => void;
-  permissionMode: PermissionMode;
-  onPermissionModeChange: (mode: PermissionMode) => void;
-  codexSandboxMode: CodexSandboxMode;
-  codexApprovalPolicy: CodexApprovalPolicy;
-  onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) => void;
-}
-
-const SessionRunSettingsPopover: React.FC<SessionRunSettingsPopoverProps> = ({
-  client,
-  session,
-  modelLabel,
-  modelConfig,
-  onModelConfigChange,
-  effortLevel,
-  onEffortChange,
-  permissionMode,
-  onPermissionModeChange,
-  codexSandboxMode,
-  codexApprovalPolicy,
-  onCodexPermissionChange,
-}) => {
-  const { token } = theme.useToken();
-
-  const getModelDisplayName = (modelId: string) => {
-    if (modelId.includes('sonnet')) {
-      const match = modelId.match(/sonnet-(\d)-(\d)/);
-      return match ? `sonnet-${match[1]}.${match[2]}` : 'sonnet';
-    }
-    if (modelId.includes('haiku')) {
-      const match = modelId.match(/haiku-(\d)-(\d)/);
-      return match ? `haiku-${match[1]}.${match[2]}` : 'haiku';
-    }
-    if (modelId.includes('opus')) {
-      const match = modelId.match(/opus-(\d)-(\d)/);
-      return match ? `opus-${match[1]}.${match[2]}` : 'opus';
-    }
-    return modelId;
-  };
-
-  const content = (
-    <div style={{ width: 320, maxWidth: 'min(320px, 80vw)' }}>
-      <Space direction="vertical" size={12} style={{ width: '100%' }}>
-        <div>
-          <Typography.Text strong>Quick session settings</Typography.Text>
-        </div>
-
-        {modelLabel && (
-          <div>
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              Model
-            </Typography.Text>
-            <div style={{ marginTop: token.sizeUnit }}>
-              <ModelSelector
-                value={modelConfig}
-                onChange={onModelConfigChange}
-                agentic_tool={session.agentic_tool}
-                client={client}
-                compact
-              />
-            </div>
-          </div>
-        )}
-
-        {session.agentic_tool === 'claude-code' && (
-          <div>
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              Reasoning effort
-            </Typography.Text>
-            <div style={{ marginTop: token.sizeUnit }}>
-              <EffortSelector
-                value={effortLevel}
-                onChange={onEffortChange}
-                size="small"
-                compact
-                plain
-                fullWidth
-              />
-            </div>
-          </div>
-        )}
-
-        <div>
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            Permissions
-          </Typography.Text>
-          <div style={{ marginTop: token.sizeUnit }}>
-            <PermissionModeSelector
-              value={permissionMode}
-              onChange={onPermissionModeChange}
-              agentic_tool={session.agentic_tool}
-              codexSandboxMode={codexSandboxMode}
-              codexApprovalPolicy={codexApprovalPolicy}
-              onCodexChange={onCodexPermissionChange}
-              compact
-              iconOnly={false}
-              plain
-              fullWidth
-              size="small"
-            />
-          </div>
-        </div>
-      </Space>
-    </div>
-  );
-
-  const trigger = modelLabel ? (
-    <Tag
-      icon={<RobotOutlined />}
-      color="default"
-      title="Model and run settings"
-      style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
-    >
-      <span>{getModelDisplayName(modelLabel)}</span>
-      <SettingOutlined style={{ marginLeft: token.sizeUnit * 1.5 }} />
-    </Tag>
-  ) : (
-    <Tag
-      icon={<SettingOutlined />}
-      color="default"
-      style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
-    >
-      Run
-    </Tag>
-  );
-
-  return (
-    <Popover
-      trigger="click"
-      placement="top"
-      getPopupContainer={(node) => node.parentElement ?? document.body}
-      content={content}
-      title={null}
-    >
-      {trigger}
-    </Popover>
-  );
-};
 
 // ---------------------------------------------------------------------------
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -14,13 +14,11 @@ import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAppMcpData, useAppRepoData, useAppUserData } from '../../contexts/AppDataContext';
 import { copyToClipboard } from '../../utils/clipboard';
-import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { BranchHeaderPill } from '../BranchHeaderPill';
 import { ConversationView } from '../ConversationView';
 import { EmbeddedTerminal } from '../EmbeddedTerminal/EmbeddedTerminal';
 import { ForkSpawnModal } from '../ForkSpawnModal';
-import { MCPServerPill } from '../MCPServer';
 import { IssuePill, PullRequestPill } from '../Pill';
 
 export interface SessionPanelContentProps {
@@ -54,7 +52,6 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     session,
     branch = null,
     currentUserId,
-    sessionMcpServerIds = [],
     scrollToBottom,
     scrollToTop,
     setScrollToBottom,
@@ -77,8 +74,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     // entity churn (e.g. repo edits invalidating user/MCP consumers).
     const { userById } = useAppUserData();
     const { repoById } = useAppRepoData();
-    const { mcpServerById, userAuthenticatedMcpServerIds } = useAppMcpData();
-
+    const { mcpServerById } = useAppMcpData();
     // Get actions from context
     const {
       onOpenBranch,
@@ -114,7 +110,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
           }}
         >
           {/* Pills section (only shown if there's content) */}
-          {(branch || sessionMcpServerIds.length > 0) && (
+          {branch && (
             <Space size={8} wrap style={{ flex: 1 }}>
               {/* Unified Branch Pill */}
               {branch && repo && (
@@ -136,22 +132,10 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
               {branch?.pull_request_url && (
                 <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo ?? undefined} />
               )}
-              {/* MCP Servers */}
-              {sessionMcpServerIds
-                .map((serverId) => mcpServerById.get(serverId))
-                .filter(Boolean)
-                .map((server) => (
-                  <MCPServerPill
-                    key={server!.mcp_server_id}
-                    server={server!}
-                    needsAuth={mcpServerNeedsAuth(server, userAuthenticatedMcpServerIds)}
-                    client={client}
-                  />
-                ))}
             </Space>
           )}
           {/* Spacer if no pills */}
-          {!(branch || sessionMcpServerIds.length > 0) && <div style={{ flex: 1 }} />}
+          {!branch && <div style={{ flex: 1 }} />}
           {/* Scroll Navigation Buttons - always visible */}
           <Space size={4}>
             <Tooltip title="Scroll to top of conversation">

--- a/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
@@ -1,0 +1,144 @@
+import type {
+  AgorClient,
+  CodexApprovalPolicy,
+  CodexSandboxMode,
+  EffortLevel,
+  PermissionMode,
+  Session,
+} from '@agor-live/client';
+import { RobotOutlined, SettingOutlined } from '@ant-design/icons';
+import { Popover, Space, Typography, theme } from 'antd';
+import type React from 'react';
+import { EffortSelector } from '../EffortSelector';
+import { type ModelConfig, ModelSelector } from '../ModelSelector';
+import { PermissionModeSelector } from '../PermissionModeSelector';
+import { getModelDisplayName } from '../Pill/modelDisplay';
+import { Tag } from '../Tag';
+
+export interface SessionRunSettingsPopoverProps {
+  client: AgorClient | null;
+  session: Session;
+  modelLabel?: string;
+  modelConfig?: ModelConfig;
+  onModelConfigChange: (config: ModelConfig) => void;
+  effortLevel: EffortLevel;
+  onEffortChange: (effort: EffortLevel) => void;
+  permissionMode: PermissionMode;
+  onPermissionModeChange: (mode: PermissionMode) => void;
+  codexSandboxMode: CodexSandboxMode;
+  codexApprovalPolicy: CodexApprovalPolicy;
+  onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) => void;
+}
+
+export const SessionRunSettingsPopover: React.FC<SessionRunSettingsPopoverProps> = ({
+  client,
+  session,
+  modelLabel,
+  modelConfig,
+  onModelConfigChange,
+  effortLevel,
+  onEffortChange,
+  permissionMode,
+  onPermissionModeChange,
+  codexSandboxMode,
+  codexApprovalPolicy,
+  onCodexPermissionChange,
+}) => {
+  const { token } = theme.useToken();
+
+  const content = (
+    <div style={{ width: 320, maxWidth: 'min(320px, 80vw)' }}>
+      <Space direction="vertical" size={12} style={{ width: '100%' }}>
+        <div>
+          <Typography.Text strong>Quick session settings</Typography.Text>
+        </div>
+
+        <div>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            Model
+          </Typography.Text>
+          <div style={{ marginTop: token.sizeUnit }}>
+            <ModelSelector
+              value={modelConfig}
+              onChange={onModelConfigChange}
+              agentic_tool={session.agentic_tool}
+              client={client}
+              compact
+            />
+          </div>
+        </div>
+
+        {session.agentic_tool === 'claude-code' && (
+          <div>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Reasoning effort
+            </Typography.Text>
+            <div style={{ marginTop: token.sizeUnit }}>
+              <EffortSelector
+                value={effortLevel}
+                onChange={onEffortChange}
+                size="small"
+                compact
+                plain
+                fullWidth
+              />
+            </div>
+          </div>
+        )}
+
+        <div>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            Permissions
+          </Typography.Text>
+          <div style={{ marginTop: token.sizeUnit }}>
+            <PermissionModeSelector
+              value={permissionMode}
+              onChange={onPermissionModeChange}
+              agentic_tool={session.agentic_tool}
+              codexSandboxMode={codexSandboxMode}
+              codexApprovalPolicy={codexApprovalPolicy}
+              onCodexChange={onCodexPermissionChange}
+              compact
+              iconOnly={false}
+              plain
+              fullWidth
+              size="small"
+            />
+          </div>
+        </div>
+      </Space>
+    </div>
+  );
+
+  const trigger = modelLabel ? (
+    <Tag
+      icon={<RobotOutlined />}
+      color="default"
+      title="Model and run settings"
+      style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+    >
+      <span>{getModelDisplayName(modelLabel)}</span>
+      <SettingOutlined style={{ marginLeft: token.sizeUnit * 1.5 }} />
+    </Tag>
+  ) : (
+    <Tag
+      icon={<SettingOutlined />}
+      color="default"
+      style={{ cursor: 'pointer', height: 22, display: 'inline-flex', alignItems: 'center' }}
+    >
+      Run
+    </Tag>
+  );
+
+  return (
+    <Popover
+      trigger="click"
+      placement="top"
+      getPopupContainer={(node) => node.parentElement ?? document.body}
+      content={content}
+      title={null}
+    >
+      {trigger}
+    </Popover>
+  );
+};

--- a/apps/agor-ui/src/hooks/useSettingsRoute.ts
+++ b/apps/agor-ui/src/hooks/useSettingsRoute.ts
@@ -49,6 +49,8 @@ export interface SettingsRouteState {
 export function useSettingsRoute() {
   const location = useLocation();
   const navigate = useNavigate();
+  const settingsBackgroundPath =
+    (location.state as { settingsBackgroundPath?: string } | null)?.settingsBackgroundPath ?? null;
 
   // Parse the current location to extract settings state
   const routeState = useMemo<SettingsRouteState>(() => {
@@ -88,28 +90,31 @@ export function useSettingsRoute() {
   const openSettings = useCallback(
     (section: SettingsSection = 'boards', itemId?: string) => {
       const path = itemId ? `/settings/${section}/${itemId}/` : `/settings/${section}/`;
-      navigate(path);
+      const backgroundPath = location.pathname.startsWith('/settings')
+        ? settingsBackgroundPath || '/'
+        : `${location.pathname}${location.search}${location.hash}`;
+      navigate(path, { state: { settingsBackgroundPath: backgroundPath } });
     },
-    [navigate]
+    [location.hash, location.pathname, location.search, navigate, settingsBackgroundPath]
   );
 
   /**
    * Close the settings modal (navigate back or to root)
    */
   const closeSettings = useCallback(() => {
-    // Navigate to root or previous non-settings route
-    // For now, just go to root. Could be improved to remember previous location.
-    navigate('/');
-  }, [navigate]);
+    navigate(settingsBackgroundPath || '/');
+  }, [navigate, settingsBackgroundPath]);
 
   /**
    * Change the current settings section
    */
   const setSection = useCallback(
     (section: SettingsSection) => {
-      navigate(`/settings/${section}/`);
+      navigate(`/settings/${section}/`, {
+        state: settingsBackgroundPath ? { settingsBackgroundPath } : undefined,
+      });
     },
-    [navigate]
+    [navigate, settingsBackgroundPath]
   );
 
   /**
@@ -117,17 +122,21 @@ export function useSettingsRoute() {
    */
   const openItem = useCallback(
     (itemId: string) => {
-      navigate(`/settings/${routeState.section}/${itemId}/`);
+      navigate(`/settings/${routeState.section}/${itemId}/`, {
+        state: settingsBackgroundPath ? { settingsBackgroundPath } : undefined,
+      });
     },
-    [navigate, routeState.section]
+    [navigate, routeState.section, settingsBackgroundPath]
   );
 
   /**
    * Close the item modal but stay in the section
    */
   const closeItem = useCallback(() => {
-    navigate(`/settings/${routeState.section}/`);
-  }, [navigate, routeState.section]);
+    navigate(`/settings/${routeState.section}/`, {
+      state: settingsBackgroundPath ? { settingsBackgroundPath } : undefined,
+    });
+  }, [navigate, routeState.section, settingsBackgroundPath]);
 
   return {
     ...routeState,

--- a/apps/agor-ui/src/utils/sessionMcpServers.ts
+++ b/apps/agor-ui/src/utils/sessionMcpServers.ts
@@ -1,0 +1,20 @@
+import type { AgorClient } from '@agor-live/client';
+
+export async function updateSessionMcpServers(
+  client: AgorClient,
+  sessionId: string,
+  currentIds: string[],
+  nextIds: string[]
+): Promise<void> {
+  const current = new Set(currentIds);
+  const next = new Set(nextIds);
+
+  await Promise.all([
+    ...nextIds
+      .filter((id) => !current.has(id))
+      .map((id) => client.service(`sessions/${sessionId}/mcp-servers`).create({ mcpServerId: id })),
+    ...currentIds
+      .filter((id) => !next.has(id))
+      .map((id) => client.service(`sessions/${sessionId}/mcp-servers`).remove(id)),
+  ]);
+}


### PR DESCRIPTION
## Summary

- Move session MCP visibility/actions into the conversation footer near the prompt.
- Add a compact MCP popover for attach/detach, sign-in visibility, and settings access.
- Collapse model/effort/permission controls into a quick session settings popover.
- Keep session headers cleaner by removing MCP pills from the header row.
- Preserve settings overlay background route so Escape returns to the originating board/session.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- mcp-session-summary.test.ts modelDefaults.test.ts`
- Playwright spot-check on the session footer/popover at the provided dev URL

## Notes

`pnpm i` completed, though install logs included a non-fatal optional/native `node-pty@1.0.0` rebuild failure due missing `make`; pnpm still completed successfully.
