### PR TITLE
Fix knowledge graph node label layout

### DIFF
--- a/apps/agor-ui/src/components/KnowledgeGraph/KnowledgeGraph.test.tsx
+++ b/apps/agor-ui/src/components/KnowledgeGraph/KnowledgeGraph.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KnowledgeGraphDocNodeLabel } from './KnowledgeGraph';
+
+describe('KnowledgeGraphDocNodeLabel', () => {
+  it('lays out emoji and title as centered, spaced flex items', () => {
+    render(<KnowledgeGraphDocNodeLabel title="Roadmap" iconEmoji="🚀" />);
+
+    const title = screen.getByText('Roadmap');
+    const label = title.parentElement;
+    if (!label) {
+      throw new Error('Expected title to be rendered inside the label wrapper');
+    }
+
+    expect(label).toHaveStyle({
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+    });
+    expect(screen.getByText('🚀')).toHaveStyle({
+      display: 'inline-flex',
+      alignItems: 'center',
+    });
+    expect(title).toHaveStyle({ minWidth: '0', flex: '1 1 auto' });
+  });
+});

--- a/apps/agor-ui/src/components/KnowledgeGraph/KnowledgeGraph.tsx
+++ b/apps/agor-ui/src/components/KnowledgeGraph/KnowledgeGraph.tsx
@@ -78,6 +78,51 @@ interface DocNodeData {
   iconEmoji?: string | null;
 }
 
+interface DocNodeLabelProps {
+  title: string;
+  iconEmoji?: string | null;
+}
+
+export function KnowledgeGraphDocNodeLabel({ title, iconEmoji }: DocNodeLabelProps) {
+  return (
+    <span
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        minWidth: 0,
+        lineHeight: 1.3,
+      }}
+    >
+      {iconEmoji ? (
+        <span
+          aria-hidden="true"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            flex: '0 0 auto',
+            lineHeight: 1,
+          }}
+        >
+          {iconEmoji}
+        </span>
+      ) : null}
+      <Text
+        style={{
+          fontSize: 12,
+          fontWeight: 500,
+          lineHeight: 1.3,
+          minWidth: 0,
+          flex: '1 1 auto',
+        }}
+        ellipsis={{ tooltip: title }}
+      >
+        {title}
+      </Text>
+    </span>
+  );
+}
+
 const DocNode = memo(({ id, data }: NodeProps<DocNodeData>) => {
   const { token } = theme.useToken();
   const { focusId, neighborIds, hasFocus } = useContext(HighlightContext);
@@ -90,6 +135,8 @@ const DocNode = memo(({ id, data }: NodeProps<DocNodeData>) => {
     <div
       style={{
         position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
         maxWidth: 180,
         padding: '6px 12px',
         borderRadius: token.borderRadiusLG,
@@ -103,12 +150,7 @@ const DocNode = memo(({ id, data }: NodeProps<DocNodeData>) => {
       }}
     >
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
-      <Text
-        style={{ fontSize: 12, fontWeight: 500, lineHeight: 1.3 }}
-        ellipsis={{ tooltip: data.title }}
-      >
-        {data.iconEmoji ? `${data.iconEmoji} ${data.title}` : data.title}
-      </Text>
+      <KnowledgeGraphDocNodeLabel title={data.title} iconEmoji={data.iconEmoji} />
       <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
     </div>
   );

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -818,6 +818,7 @@ export function KnowledgePage({
     [activeDocId, activeDocSnapshot, documents, draftDocument]
   );
   const isDraftDocument = activeDoc?.document_id === DRAFT_DOCUMENT_ID;
+  const activeDocIconEmoji = activeDoc ? (isEditing ? iconEmojiDraft : activeDoc.icon_emoji) : null;
   const activeDocContentReady = isKnowledgeDocumentContentReady({
     activeDocId,
     activeDocDocumentId: activeDoc?.document_id,
@@ -3156,20 +3157,22 @@ export function KnowledgePage({
                               disabled={!client && !isDraftDocument}
                               style={{
                                 fontSize: 30,
-                                width: 44,
-                                height: 44,
+                                width: 52,
+                                height: 52,
                                 padding: 0,
-                                color: (isEditing ? iconEmojiDraft : activeDoc.icon_emoji)
-                                  ? undefined
-                                  : token.colorTextTertiary,
+                                color: activeDocIconEmoji ? undefined : token.colorTextTertiary,
                               }}
                               aria-label={
-                                (isEditing ? iconEmojiDraft : activeDoc.icon_emoji)
+                                activeDocIconEmoji
                                   ? 'Change Knowledge document emoji icon'
                                   : 'Add Knowledge document emoji icon'
                               }
                             >
-                              {(isEditing ? iconEmojiDraft : activeDoc.icon_emoji) || (
+                              {activeDocIconEmoji ? (
+                                <span style={{ fontSize: 39, lineHeight: 1 }}>
+                                  {activeDocIconEmoji}
+                                </span>
+                              ) : (
                                 <FileOutlined />
                               )}
                             </Button>


### PR DESCRIPTION
## Summary

- Render Knowledge graph node emoji and title as separate flex-aligned items
- Add a small visual gap between document emoji icons and titles
- Keep node cards vertically centered while preserving existing graph behavior
- Add a focused label layout test

## Validation

- `pnpm i`
- `pnpm check` *(passes; existing Biome warnings about unused suppressions/descending specificity remain)*
- `pnpm --filter agor-ui test -- src/components/KnowledgeGraph/KnowledgeGraph.test.tsx`
