### PR TITLE
Improve KB MCP search result shaping

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -29,6 +29,8 @@ vi.mock('../server.js', () => ({
 
 vi.mock('@agor/core/types', () => ({
   buildKnowledgeDocumentUri: (id: string) => `agor://kb/document/${id}`,
+  getAssistantConfig: (branch: { assistant?: unknown }) => branch.assistant,
+  isAssistant: (branch: { assistant?: unknown }) => Boolean(branch.assistant),
   KNOWLEDGE_DOCUMENT_KINDS: ['doc', 'note'],
   KNOWLEDGE_DOCUMENT_STATUSES: ['draft', 'published'],
   KNOWLEDGE_DOCUMENT_URI_PREFIX: 'agor://kb/document/',
@@ -47,7 +49,8 @@ type CapturedTool = {
 };
 
 async function captureKnowledgeTools(
-  services: Record<string, unknown> = {}
+  services: Record<string, unknown> = {},
+  ctxOverrides: Record<string, unknown> = {}
 ): Promise<Record<string, CapturedTool>> {
   const { registerKnowledgeTools } = await import('./knowledge.js');
   const captured: Record<string, CapturedTool> = {};
@@ -63,6 +66,7 @@ async function captureKnowledgeTools(
     userId: 'user-1' as any,
     authenticatedUser: { user_id: 'user-1', role: 'member' } as any,
     baseServiceParams: {},
+    ...ctxOverrides,
   });
 
   return captured;
@@ -233,6 +237,43 @@ describe('Knowledge MCP input schemas', () => {
     expect(result[0].snippet).toBe('matched line 1\nmatched line 2\n…');
   });
 
+  it('caps Knowledge search snippets by characters even for single-line snippets', async () => {
+    const longSnippet = 'x'.repeat(1300);
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'long.md',
+          uri: 'agor://kb/global/long.md',
+          title: 'Long',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: {
+          version_id: 'ver-1',
+          document_id: 'doc-1',
+          version_number: 1,
+          content_text: longSnippet,
+        },
+        snippet: longSnippet,
+        score: 10,
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const result = textResultJson(await tools.agor_kb_search.handler?.({ query: 'long' })) as Array<
+      Record<string, any>
+    >;
+
+    expect(result[0].snippet).toHaveLength(1201);
+    expect(result[0].snippet.endsWith('…')).toBe(true);
+    expect(result[0].current_version).not.toHaveProperty('content_text');
+  });
+
   it('returns metadata-only Knowledge browse results by default for query empty string', async () => {
     const find = vi.fn().mockResolvedValue([
       {
@@ -310,5 +351,74 @@ describe('Knowledge MCP input schemas', () => {
         query: expect.objectContaining({ include_chunks: true }),
       })
     );
+  });
+
+  it('applies Knowledge search content shaping to assistant memory search', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'memory/today.md',
+          uri: 'agor://kb/assistant/memory/today.md',
+          title: 'Today',
+          kind: 'doc',
+          visibility: 'private',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'assistant', display_name: 'Assistant' },
+        current_version: {
+          version_id: 'ver-1',
+          document_id: 'doc-1',
+          version_number: 1,
+          content_text: 'memory body',
+        },
+        snippet: 'memory body',
+        score: 10,
+      },
+    ]);
+    const tools = await captureKnowledgeTools(
+      {
+        sessions: { get: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) },
+        branches: {
+          get: vi.fn().mockResolvedValue({
+            branch_id: 'branch-1',
+            assistant: {
+              kb: {
+                primary_namespace_id: 'ns-1',
+                primary_namespace_slug: 'assistant',
+                global_access: 'write',
+              },
+            },
+          }),
+        },
+        'kb/namespaces': {
+          get: vi.fn().mockResolvedValue({
+            namespace_id: 'ns-1',
+            slug: 'assistant',
+            archived: false,
+          }),
+        },
+        'kb/search': { find },
+      },
+      { sessionId: 'session-1' }
+    );
+
+    const result = textResultJson(
+      await tools.agor_assistant_memory_search.handler?.({ query: 'memory' })
+    ) as Array<Record<string, any>>;
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          q: 'memory',
+          namespace_slug: 'assistant',
+          path_prefix: 'memory/',
+        }),
+      })
+    );
+    expect(result[0].current_version).not.toHaveProperty('content_text');
+    expect(result[0].snippet).toBe('memory body');
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -421,4 +421,69 @@ describe('Knowledge MCP input schemas', () => {
     expect(result[0].current_version).not.toHaveProperty('content_text');
     expect(result[0].snippet).toBe('memory body');
   });
+
+  it('applies Knowledge search content shaping to assistant knowledge search', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'docs/context.md',
+          uri: 'agor://kb/global/docs/context.md',
+          title: 'Context',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: {
+          version_id: 'ver-1',
+          document_id: 'doc-1',
+          version_number: 1,
+          content_text: 'knowledge body',
+        },
+        snippet: 'knowledge body',
+        score: 10,
+      },
+    ]);
+    const tools = await captureKnowledgeTools(
+      {
+        sessions: { get: vi.fn().mockResolvedValue({ branch_id: 'branch-1' }) },
+        branches: {
+          get: vi.fn().mockResolvedValue({
+            branch_id: 'branch-1',
+            assistant: {
+              kb: {
+                primary_namespace_id: 'ns-1',
+                primary_namespace_slug: 'assistant',
+                global_access: 'write',
+              },
+            },
+          }),
+        },
+        'kb/namespaces': {
+          get: vi.fn().mockResolvedValue({
+            namespace_id: 'ns-1',
+            slug: 'assistant',
+            archived: false,
+          }),
+        },
+        'kb/search': { find },
+      },
+      { sessionId: 'session-1' }
+    );
+
+    const result = textResultJson(
+      await tools.agor_assistant_knowledge_search.handler?.({ query: 'knowledge' })
+    ) as Array<Record<string, any>>;
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ q: 'knowledge' }),
+      })
+    );
+    expect(result[0].current_version).not.toHaveProperty('content_text');
+    expect(result[0].snippet).toBe('knowledge body');
+  });
 });

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -75,6 +75,12 @@ function issueMessages(error: unknown): string[] {
   );
 }
 
+function textResultJson(result: unknown): unknown {
+  const text = (result as { content?: Array<{ text?: string }> })?.content?.[0]?.text;
+  if (typeof text !== 'string') throw new Error('Expected text result');
+  return JSON.parse(text);
+}
+
 describe('Knowledge MCP input schemas', () => {
   it('rejects renamed branch_id instead of accepting it as an alias', async () => {
     const tools = await captureKnowledgeTools();
@@ -172,6 +178,137 @@ describe('Knowledge MCP input schemas', () => {
         'startLine must be an integer.',
         'contextLines must be greater than or equal to 0.',
       ])
+    );
+  });
+
+  it('omits full Knowledge search content by default while returning snippets for text search', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'runbooks/deploy.md',
+          uri: 'agor://kb/global/runbooks/deploy.md',
+          url: 'http://localhost/ui/kb/global/runbooks/deploy.md',
+          title: 'Deploy',
+          icon_emoji: '📘',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: {
+          version_id: 'ver-1',
+          document_id: 'doc-1',
+          version_number: 1,
+          content_text: 'line 1\nline 2\nline 3\nline 4',
+        },
+        snippet: 'matched line 1\nmatched line 2\nmatched line 3\nmatched line 4',
+        score: 10,
+        mode: 'text',
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const result = textResultJson(
+      await tools.agor_kb_search.handler?.({ query: 'deploy', snippetLines: 2 })
+    ) as Array<Record<string, any>>;
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ q: 'deploy' }),
+      })
+    );
+    expect(result[0].document).toEqual(
+      expect.objectContaining({
+        document_id: 'doc-1',
+        path: 'runbooks/deploy.md',
+        title: 'Deploy',
+        icon_emoji: '📘',
+        reference_uri: 'agor://kb/document/doc-1',
+      })
+    );
+    expect(result[0].current_version).not.toHaveProperty('content_text');
+    expect(result[0].snippet).toBe('matched line 1\nmatched line 2\n…');
+  });
+
+  it('returns metadata-only Knowledge browse results by default for query empty string', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'notes/private.md',
+          uri: 'agor://kb/global/notes/private.md',
+          title: 'Private note',
+          kind: 'doc',
+          visibility: 'private',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: {
+          version_id: 'ver-1',
+          document_id: 'doc-1',
+          version_number: 1,
+          content_text: 'sensitive body',
+        },
+        snippet: 'sensitive body',
+        score: 0,
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const result = textResultJson(await tools.agor_kb_search.handler?.({ query: '' })) as Array<
+      Record<string, any>
+    >;
+
+    expect(result[0]).not.toHaveProperty('snippet');
+    expect(result[0].current_version).not.toHaveProperty('content_text');
+    expect(result[0].document.reference_uri).toBe('agor://kb/document/doc-1');
+  });
+
+  it('includes full Knowledge search content only when explicitly requested', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'runbooks/deploy.md',
+          uri: 'agor://kb/global/runbooks/deploy.md',
+          title: 'Deploy',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: {
+          version_id: 'ver-1',
+          document_id: 'doc-1',
+          version_number: 1,
+          content_text: 'full body',
+        },
+        snippet: 'full body',
+        score: 10,
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const contentModeResult = textResultJson(
+      await tools.agor_kb_search.handler?.({ query: 'deploy', contentMode: 'full' })
+    ) as Array<Record<string, any>>;
+    const includeContentResult = textResultJson(
+      await tools.agor_kb_search.handler?.({ query: 'deploy', includeContent: true })
+    ) as Array<Record<string, any>>;
+
+    expect(contentModeResult[0].current_version.content_text).toBe('full body');
+    expect(includeContentResult[0].current_version.content_text).toBe('full body');
+    expect(find).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ include_chunks: true }),
+      })
     );
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -81,6 +81,33 @@ type KnowledgeSearchContentMode = z.infer<typeof KnowledgeSearchContentModeSchem
 
 const DEFAULT_KB_SEARCH_SNIPPET_LINES = 3;
 const MAX_KB_SEARCH_SNIPPET_LINES = 20;
+const MAX_KB_SEARCH_SNIPPET_CHARS = 1200;
+
+const KnowledgeSearchContentControlSchemaShape = {
+  contentMode: KnowledgeSearchContentModeSchema.optional().describe(
+    'Controls body content in results. "none" returns metadata only; "snippet" includes short snippets; "full" includes full current_version.content_text when available. Defaults: "snippet" for non-empty searches, "none" for browse/listing with query:"". Prefer agor_kb_get/agor_kb_get_range for reading content.'
+  ),
+  snippetLines: z
+    .number({
+      error: 'snippetLines must be a positive integer when provided.',
+    })
+    .int('snippetLines must be an integer.')
+    .positive('snippetLines must be greater than 0.')
+    .max(
+      MAX_KB_SEARCH_SNIPPET_LINES,
+      `snippetLines must be less than or equal to ${MAX_KB_SEARCH_SNIPPET_LINES}.`
+    )
+    .optional()
+    .describe(
+      `Maximum lines per returned snippet when contentMode:"snippet" (default: ${DEFAULT_KB_SEARCH_SNIPPET_LINES}, max: ${MAX_KB_SEARCH_SNIPPET_LINES}). Snippets are also capped at ${MAX_KB_SEARCH_SNIPPET_CHARS} characters.`
+    ),
+  includeContent: z
+    .boolean()
+    .optional()
+    .describe(
+      'Compatibility alias. Use contentMode instead. true maps to contentMode:"full"; false keeps the default metadata/snippet behavior.'
+    ),
+};
 
 function mcpOptionalVersionToken(fieldName: string, description: string) {
   return z
@@ -291,8 +318,10 @@ function clampKbSearchSnippetLines(value: unknown): number {
 function limitSnippetLines(value: unknown, snippetLines: number): string | null {
   if (typeof value !== 'string' || value.length === 0) return null;
   const lines = value.split(/\r?\n/);
-  if (lines.length <= snippetLines) return value;
-  return `${lines.slice(0, snippetLines).join('\n')}\n…`;
+  const lineLimited =
+    lines.length <= snippetLines ? value : `${lines.slice(0, snippetLines).join('\n')}\n…`;
+  if (lineLimited.length <= MAX_KB_SEARCH_SNIPPET_CHARS) return lineLimited;
+  return `${lineLimited.slice(0, MAX_KB_SEARCH_SNIPPET_CHARS)}…`;
 }
 
 function removeKnowledgeContentFields(value: Record<string, unknown>): Record<string, unknown> {
@@ -362,6 +391,20 @@ function resolveKnowledgeSearchContentMode(args: {
   if (args.includeContent === true) return 'full';
   const query = typeof args.query === 'string' ? args.query.trim() : '';
   return query ? 'snippet' : 'none';
+}
+
+function shapeKnowledgeSearchResponse(
+  result: unknown,
+  args: {
+    query?: unknown;
+    contentMode?: unknown;
+    snippetLines?: unknown;
+    includeContent?: unknown;
+  }
+): unknown {
+  const contentMode = resolveKnowledgeSearchContentMode(args);
+  const snippetLines = clampKbSearchSnippetLines(args.snippetLines);
+  return shapeKnowledgeSearchResult(enrichWithReferenceUri(result), { contentMode, snippetLines });
 }
 
 function optionalNumber(value: unknown): number | undefined {
@@ -642,6 +685,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         query: z.string().describe('Search text. Use an empty string to browse memory.'),
         limit: z.number().int().min(1).max(50).optional(),
         mode: z.enum(['text', 'semantic', 'hybrid']).optional(),
+        ...KnowledgeSearchContentControlSchemaShape,
       }),
     },
     async (args) => {
@@ -651,19 +695,18 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       if (!service?.find) {
         return knowledgeNotImplementedResult('agor_assistant_memory_search', ['kb/search.find']);
       }
-      return textResult(
-        enrichWithReferenceUri(
-          await service.find(
-            mcpParams(ctx, {
-              q: coerceString(args.query) ?? '',
-              namespace_slug: namespace.slug,
-              path_prefix: 'memory/',
-              limit: args.limit ?? 10,
-              mode: args.mode,
-            })
-          )
-        )
+      const contentMode = resolveKnowledgeSearchContentMode(args);
+      const result = await service.find(
+        mcpParams(ctx, {
+          q: coerceString(args.query) ?? '',
+          namespace_slug: namespace.slug,
+          path_prefix: 'memory/',
+          limit: args.limit ?? 10,
+          mode: args.mode,
+          ...(contentMode === 'full' ? { include_chunks: true } : {}),
+        })
       );
+      return textResult(shapeKnowledgeSearchResponse(result, args));
     }
   );
 
@@ -682,6 +725,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         pathPrefix: z.string().optional().describe('Optional path prefix filter.'),
         limit: z.number().int().min(1).max(50).optional(),
         mode: z.enum(['text', 'semantic', 'hybrid']).optional(),
+        ...KnowledgeSearchContentControlSchemaShape,
       }),
     },
     async (args) => {
@@ -708,19 +752,18 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         );
       }
 
-      return textResult(
-        enrichWithReferenceUri(
-          await service.find(
-            mcpParams(ctx, {
-              q: coerceString(args.query) ?? '',
-              ...(namespaceSlug ? { namespace_slug: namespaceSlug } : {}),
-              ...(args.pathPrefix ? { path_prefix: coerceString(args.pathPrefix) } : {}),
-              limit: args.limit ?? 10,
-              mode: args.mode,
-            })
-          )
-        )
+      const contentMode = resolveKnowledgeSearchContentMode(args);
+      const result = await service.find(
+        mcpParams(ctx, {
+          q: coerceString(args.query) ?? '',
+          ...(namespaceSlug ? { namespace_slug: namespaceSlug } : {}),
+          ...(args.pathPrefix ? { path_prefix: coerceString(args.pathPrefix) } : {}),
+          limit: args.limit ?? 10,
+          mode: args.mode,
+          ...(contentMode === 'full' ? { include_chunks: true } : {}),
+        })
       );
+      return textResult(shapeKnowledgeSearchResponse(result, args));
     }
   );
 
@@ -980,29 +1023,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .describe(
             'Include per-document embedding/indexing summary: derived state, chunk counts, queue depth, model, and last error.'
           ),
-        contentMode: KnowledgeSearchContentModeSchema.optional().describe(
-          'Controls body content in results. "none" returns metadata only; "snippet" includes short snippets; "full" includes full current_version.content_text when available. Defaults: "snippet" for non-empty searches, "none" for browse/listing with query:"". Prefer agor_kb_get/agor_kb_get_range for reading content.'
-        ),
-        snippetLines: z
-          .number({
-            error: 'snippetLines must be a positive integer when provided.',
-          })
-          .int('snippetLines must be an integer.')
-          .positive('snippetLines must be greater than 0.')
-          .max(
-            MAX_KB_SEARCH_SNIPPET_LINES,
-            `snippetLines must be less than or equal to ${MAX_KB_SEARCH_SNIPPET_LINES}.`
-          )
-          .optional()
-          .describe(
-            `Maximum lines per returned snippet when contentMode:"snippet" (default: ${DEFAULT_KB_SEARCH_SNIPPET_LINES}, max: ${MAX_KB_SEARCH_SNIPPET_LINES}).`
-          ),
-        includeContent: z
-          .boolean()
-          .optional()
-          .describe(
-            'Deprecated legacy alias. Use contentMode instead. true maps to contentMode:"full"; false keeps the default metadata/snippet behavior.'
-          ),
+        ...KnowledgeSearchContentControlSchemaShape,
         includeArchived: z
           .boolean()
           .optional()
@@ -1035,12 +1056,11 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       if (args.limit) query.limit = args.limit;
       if (args.mode) query.mode = args.mode;
       const contentMode = resolveKnowledgeSearchContentMode(args);
-      const snippetLines = clampKbSearchSnippetLines(args.snippetLines);
       if (contentMode === 'full') query.include_chunks = true;
 
       if (service.find) {
-        const result = enrichWithReferenceUri(await service.find(mcpParams(ctx, query)));
-        return textResult(shapeKnowledgeSearchResult(result, { contentMode, snippetLines }));
+        const result = await service.find(mcpParams(ctx, query));
+        return textResult(shapeKnowledgeSearchResponse(result, args));
       }
       return knowledgeNotImplementedResult('agor_kb_search', ['kb/search.find']);
     }

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -75,6 +75,12 @@ const KnowledgeVisibilitySchema = z.enum(KNOWLEDGE_VISIBILITIES);
 const KnowledgeEditPolicySchema = z.enum(KNOWLEDGE_EDIT_POLICIES);
 const KnowledgeGraphNodeTypeSchema = z.enum(KNOWLEDGE_GRAPH_NODE_TYPES);
 const KnowledgeGraphEdgeTypeSchema = z.enum(KNOWLEDGE_GRAPH_EDGE_TYPES);
+const KnowledgeSearchContentModeSchema = z.enum(['none', 'snippet', 'full']);
+
+type KnowledgeSearchContentMode = z.infer<typeof KnowledgeSearchContentModeSchema>;
+
+const DEFAULT_KB_SEARCH_SNIPPET_LINES = 3;
+const MAX_KB_SEARCH_SNIPPET_LINES = 20;
 
 function mcpOptionalVersionToken(fieldName: string, description: string) {
   return z
@@ -275,6 +281,87 @@ function enrichWithReferenceUri(value: unknown): unknown {
     next = { ...next, document: enrichWithReferenceUri(obj.document) };
   }
   return next;
+}
+
+function clampKbSearchSnippetLines(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_KB_SEARCH_SNIPPET_LINES;
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_KB_SEARCH_SNIPPET_LINES);
+}
+
+function limitSnippetLines(value: unknown, snippetLines: number): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const lines = value.split(/\r?\n/);
+  if (lines.length <= snippetLines) return value;
+  return `${lines.slice(0, snippetLines).join('\n')}\n…`;
+}
+
+function removeKnowledgeContentFields(value: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...value };
+  delete next.content_text;
+  delete next.content_blob;
+  return next;
+}
+
+function shapeKnowledgeSearchResult(
+  value: unknown,
+  options: {
+    contentMode: KnowledgeSearchContentMode;
+    snippetLines: number;
+  }
+): unknown {
+  if (Array.isArray(value)) return value.map((item) => shapeKnowledgeSearchResult(item, options));
+  if (!value || typeof value !== 'object') return value;
+
+  const obj = value as Record<string, unknown>;
+  if (Array.isArray(obj.data)) {
+    return { ...obj, data: obj.data.map((item) => shapeKnowledgeSearchResult(item, options)) };
+  }
+  if (!obj.document || typeof obj.document !== 'object') return obj;
+
+  const currentVersion =
+    obj.current_version && typeof obj.current_version === 'object'
+      ? (obj.current_version as Record<string, unknown>)
+      : null;
+  const contentText = currentVersion?.content_text;
+  const next: Record<string, unknown> = { ...obj };
+
+  if (options.contentMode === 'full') return next;
+
+  if (currentVersion) next.current_version = removeKnowledgeContentFields(currentVersion);
+
+  if (options.contentMode === 'none') {
+    delete next.snippet;
+  } else {
+    next.snippet =
+      limitSnippetLines(obj.snippet, options.snippetLines) ??
+      limitSnippetLines(contentText, options.snippetLines);
+  }
+
+  if (Array.isArray(obj.chunks)) {
+    next.chunks = obj.chunks.map((chunk) => {
+      if (!chunk || typeof chunk !== 'object') return chunk;
+      const shapedChunk = removeKnowledgeContentFields(chunk as Record<string, unknown>);
+      if (options.contentMode === 'none') delete shapedChunk.snippet;
+      else shapedChunk.snippet = limitSnippetLines(shapedChunk.snippet, options.snippetLines);
+      return shapedChunk;
+    });
+  }
+
+  return next;
+}
+
+function resolveKnowledgeSearchContentMode(args: {
+  query?: unknown;
+  contentMode?: unknown;
+  includeContent?: unknown;
+}): KnowledgeSearchContentMode {
+  const explicitMode = args.contentMode;
+  if (explicitMode === 'none' || explicitMode === 'snippet' || explicitMode === 'full') {
+    return explicitMode;
+  }
+  if (args.includeContent === true) return 'full';
+  const query = typeof args.query === 'string' ? args.query.trim() : '';
+  return query ? 'snippet' : 'none';
 }
 
 function optionalNumber(value: unknown): number | undefined {
@@ -858,7 +945,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
     'agor_kb_search',
     {
       description:
-        'Search Agor Knowledge documents. Supports text, semantic, and hybrid modes when Knowledge embeddings are enabled/configured. Each result carries a `reference_uri` (agor://kb/document/<id>) — embed that link in another doc to create a graph edge to it.',
+        'Search or browse Agor Knowledge documents. Use this to find candidate docs from metadata and short snippets, then use agor_kb_get, agor_kb_outline, or agor_kb_get_range to read needed content. Supports text, semantic, and hybrid modes when Knowledge embeddings are enabled/configured. Each result carries a `reference_uri` (agor://kb/document/<id>) — embed that link in another doc to create a graph edge to it.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         query: z
@@ -893,6 +980,29 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .describe(
             'Include per-document embedding/indexing summary: derived state, chunk counts, queue depth, model, and last error.'
           ),
+        contentMode: KnowledgeSearchContentModeSchema.optional().describe(
+          'Controls body content in results. "none" returns metadata only; "snippet" includes short snippets; "full" includes full current_version.content_text when available. Defaults: "snippet" for non-empty searches, "none" for browse/listing with query:"". Prefer agor_kb_get/agor_kb_get_range for reading content.'
+        ),
+        snippetLines: z
+          .number({
+            error: 'snippetLines must be a positive integer when provided.',
+          })
+          .int('snippetLines must be an integer.')
+          .positive('snippetLines must be greater than 0.')
+          .max(
+            MAX_KB_SEARCH_SNIPPET_LINES,
+            `snippetLines must be less than or equal to ${MAX_KB_SEARCH_SNIPPET_LINES}.`
+          )
+          .optional()
+          .describe(
+            `Maximum lines per returned snippet when contentMode:"snippet" (default: ${DEFAULT_KB_SEARCH_SNIPPET_LINES}, max: ${MAX_KB_SEARCH_SNIPPET_LINES}).`
+          ),
+        includeContent: z
+          .boolean()
+          .optional()
+          .describe(
+            'Deprecated legacy alias. Use contentMode instead. true maps to contentMode:"full"; false keeps the default metadata/snippet behavior.'
+          ),
         includeArchived: z
           .boolean()
           .optional()
@@ -924,9 +1034,14 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       if (args.includeIndexing === true) query.include_indexing = true;
       if (args.limit) query.limit = args.limit;
       if (args.mode) query.mode = args.mode;
+      const contentMode = resolveKnowledgeSearchContentMode(args);
+      const snippetLines = clampKbSearchSnippetLines(args.snippetLines);
+      if (contentMode === 'full') query.include_chunks = true;
 
-      if (service.find)
-        return textResult(enrichWithReferenceUri(await service.find(mcpParams(ctx, query))));
+      if (service.find) {
+        const result = enrichWithReferenceUri(await service.find(mcpParams(ctx, query)));
+        return textResult(shapeKnowledgeSearchResult(result, { contentMode, snippetLines }));
+      }
       return knowledgeNotImplementedResult('agor_kb_search', ['kb/search.find']);
     }
   );

--- a/apps/agor-docs/pages/guide/knowledge.mdx
+++ b/apps/agor-docs/pages/guide/knowledge.mdx
@@ -107,6 +107,7 @@ Knowledge has first-class MCP tools, so agents can use it without leaving their 
 Common workflows:
 
 - **Search and load context** with `agor_kb_search`, `agor_kb_get`, `agor_kb_outline`, and `agor_kb_get_range`.
+  `agor_kb_search` is optimized for discovery: non-empty searches return metadata plus short snippets by default, while browse/listing calls with `query: ""` return metadata only. Use `contentMode: "none" | "snippet" | "full"` and `snippetLines` to control result verbosity, and prefer `agor_kb_get` or `agor_kb_get_range` when you need to read document content.
 - **File new context** with `agor_kb_put` when an agent discovers something worth keeping.
 - **Make targeted edits** with `agor_kb_edit`, including version checks and dry runs.
 - **Round-trip through a worktree** with `agor_kb_materialize` and `agor_kb_publish_from_worktree`, where branch permissions allow local workspace access.


### PR DESCRIPTION
## Summary

- Add `contentMode` and `snippetLines` controls to `agor_kb_search` MCP input
- Default non-empty searches to snippets and browse/listing (`query: ""`) to metadata-only results
- Strip `current_version.content_text` / content blobs at the MCP boundary unless full content is explicitly requested
- Keep legacy `includeContent: true` as a deprecated alias for full content
- Document the discovery-first MCP workflow for Knowledge search

## Validation

- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/mcp/tools/knowledge.test.ts`
