### PR TITLE
Reduce daemon startup and runtime log noise

### DIFF
--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -48,6 +48,15 @@ import { registerTaskTools } from './tools/tasks.js';
 import { registerUserTools } from './tools/users.js';
 import { registerWidgetTools } from './tools/widgets.js';
 
+const DEBUG_MCP_REQUESTS =
+  process.env.AGOR_DEBUG_MCP_REQUESTS === '1' || process.env.DEBUG?.includes('mcp-requests');
+
+function mcpRequestDebug(...args: unknown[]): void {
+  if (DEBUG_MCP_REQUESTS) {
+    console.debug(...args);
+  }
+}
+
 /**
  * Shared context passed to every tool handler.
  */
@@ -497,7 +506,7 @@ export function setupMCPRoutes(
 
   const handler = async (req: Request, res: Response) => {
     try {
-      console.log(`🔌 Incoming MCP request: ${req.method} /mcp`);
+      mcpRequestDebug(`🔌 Incoming MCP request: ${req.method} /mcp`);
 
       // Reject session tokens in query strings — they leak via Referer, browser
       // history, reverse-proxy access logs, and any verbose request logger that
@@ -611,7 +620,7 @@ export function setupMCPRoutes(
         }
       }
 
-      console.log(
+      mcpRequestDebug(
         `🔌 MCP request authenticated (user: ${shortId(userId)}, session: ${sessionId ? shortId(sessionId) : 'none'})`
       );
 

--- a/apps/agor-daemon/src/mcp/tokens.test.ts
+++ b/apps/agor-daemon/src/mcp/tokens.test.ts
@@ -128,18 +128,28 @@ describe('generateSessionToken', () => {
     expect((decoded.exp as number) - (decoded.iat as number)).toBe(60);
   });
 
-  dbTest('each issuance produces a different jti', async ({ db }) => {
-    initMcpTokens({ db });
-    const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
+  dbTest('reuses cached tokens until they approach expiry', async ({ db }) => {
+    const baseMs = Date.now();
+    vi.useFakeTimers({ now: baseMs, shouldAdvanceTime: false });
+    try {
+      initMcpTokens({ db, expirationMs: 60_000 });
+      const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
 
-    const t1 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
-    const t2 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
-    const d1 = jwt.decode(t1) as { jti?: string };
-    const d2 = jwt.decode(t2) as { jti?: string };
+      const t1 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
+      const t2 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
+      expect(t2).toBe(t1);
 
-    expect(d1.jti).toBeDefined();
-    expect(d2.jti).toBeDefined();
-    expect(d1.jti).not.toBe(d2.jti);
+      vi.setSystemTime(new Date(baseMs + 31_000));
+      const t3 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
+      const d1 = jwt.decode(t1) as { jti?: string };
+      const d3 = jwt.decode(t3) as { jti?: string };
+
+      expect(d1.jti).toBeDefined();
+      expect(d3.jti).toBeDefined();
+      expect(d3.jti).not.toBe(d1.jti);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   dbTest('throws when the session does not exist', async ({ db }) => {

--- a/apps/agor-daemon/src/mcp/tokens.ts
+++ b/apps/agor-daemon/src/mcp/tokens.ts
@@ -12,8 +12,10 @@
  * - `exp`  — unix seconds, enforced by `jsonwebtoken.verify`
  * - `jti`  — per-issuance UUID (useful for log correlation)
  *
- * No revocation mechanics. Tokens are re-minted fresh on every `session.get` /
- * `session.create` and carry a short `exp` (default 24h); any suspected
+ * No revocation mechanics. Tokens are minted lazily and cached briefly per
+ * `(session,user)` so high-frequency `session.get` calls don't perform
+ * redundant JWT signing and session-existence probes. Tokens carry a short
+ * `exp` (default 24h); any suspected
  * compromise is addressed by rotating the JWT signing secret or letting the
  * token expire. MCP is internal-only (loopback) — if/when it goes external
  * we'd design auth from scratch (OAuth / API keys) rather than extending this.
@@ -32,6 +34,15 @@ import {
   type UserID,
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
+
+const DEBUG_MCP_TOKENS =
+  process.env.AGOR_DEBUG_MCP_TOKENS === '1' || process.env.DEBUG?.includes('mcp-tokens');
+
+function mcpTokenDebug(...args: unknown[]): void {
+  if (DEBUG_MCP_TOKENS) {
+    console.debug(...args);
+  }
+}
 
 // Re-exported so daemon callers don't have to reach into @agor/core/types.
 export { MCP_TOKEN_AUDIENCE, MCP_TOKEN_ISSUER } from '@agor/core/types';
@@ -72,6 +83,13 @@ interface ModuleState {
   sessionRepo: SessionRepository;
   expirationMs: number;
   now: () => number;
+  tokenCache: Map<string, CachedMcpToken>;
+  lastCachePruneAtMs: number;
+}
+
+interface CachedMcpToken {
+  token: string;
+  expiresAtMs: number;
 }
 
 let _state: ModuleState | null = null;
@@ -101,6 +119,8 @@ export function initMcpTokens(options: McpTokenInitOptions): void {
     sessionRepo: new SessionRepository(options.db),
     expirationMs,
     now,
+    tokenCache: new Map(),
+    lastCachePruneAtMs: 0,
   };
 
   console.log(`[mcp-tokens] initialized: exp=${expirationMs}ms`);
@@ -118,7 +138,7 @@ export function shutdownMcpTokens(): void {
 // ============================================================================
 
 /**
- * Mint a fresh MCP token for a session.
+ * Mint or reuse an MCP token for a session.
  *
  * @throws if the module isn't initialized, the session doesn't exist, or the
  *   app lacks a JWT secret.
@@ -134,15 +154,36 @@ export async function generateSessionToken(
     throw new Error('MCP token generation failed: JWT secret not configured in app settings');
   }
 
+  const nowMs = s.now();
+  if (nowMs - s.lastCachePruneAtMs > 5 * 60 * 1000) {
+    for (const [key, entry] of s.tokenCache) {
+      if (entry.expiresAtMs <= nowMs) {
+        s.tokenCache.delete(key);
+      }
+    }
+    s.lastCachePruneAtMs = nowMs;
+  }
+
+  const cacheKey = `${sessionId}:${userId}`;
+  const cached = s.tokenCache.get(cacheKey);
+  // Keep a buffer so callers never receive a token that is about to expire.
+  const refreshBufferMs = Math.min(5 * 60 * 1000, Math.max(30 * 1000, s.expirationMs * 0.1));
+  if (cached && cached.expiresAtMs - nowMs > refreshBufferMs) {
+    mcpTokenDebug(`🎫 MCP token cache hit: session=${shortId(sessionId)}`);
+    return cached.token;
+  }
+
   const sessionExists = await s.sessionRepo.exists(sessionId);
   if (!sessionExists) {
+    s.tokenCache.delete(cacheKey);
     throw new Error(
       `MCP token generation failed: session ${sessionId} not found — cannot mint token for a non-existent session`
     );
   }
 
-  const nowSec = Math.floor(s.now() / 1000);
+  const nowSec = Math.floor(nowMs / 1000);
   const expSec = nowSec + Math.floor(s.expirationMs / 1000);
+  const expiresAtMs = expSec * 1000;
   const jti = generateId();
 
   const payload: McpTokenPayload = {
@@ -156,8 +197,9 @@ export async function generateSessionToken(
   };
 
   const token = jwt.sign(payload, jwtSecret, { algorithm: 'HS256' });
+  s.tokenCache.set(cacheKey, { token, expiresAtMs });
 
-  console.log(
+  mcpTokenDebug(
     `🎫 MCP token issued: session=${shortId(sessionId)} jti=${jti.substring(0, 8)} exp=+${Math.floor(s.expirationMs / 1000)}s`
   );
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2126,7 +2126,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     after: {
       get: [
         async (context) => {
-          // Regenerate MCP token for fetched session (deterministic, no DB storage)
+          // Attach an MCP token for fetched session (cached/reused when still valid).
           if (config.daemon?.mcpEnabled === false) {
             return context;
           }
@@ -2160,10 +2160,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             userId as import('@agor/core/types').UserID
           );
 
-          mcpTokenDebug(`🔄 Regenerated MCP token for session ${shortId(session.session_id)}`);
+          mcpTokenDebug(`🔄 Resolved MCP token for session ${shortId(session.session_id)}`);
 
-          // Add token to result (not stored in DB, regenerated on-demand with
-          // a fresh `jti` and `exp`)
+          // Add token to result. Tokens are not stored on the session row; the
+          // token module may reuse a still-valid issued token or mint a new one.
           context.result = { ...session, mcp_token: mcpToken };
 
           return context;
@@ -2216,7 +2216,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             return context;
           }
 
-          // Mint MCP token for this session (jti + exp + gen embedded)
+          // Resolve MCP token for this session (cached/reused when still valid).
           const { generateSessionToken } = await import('./mcp/tokens.js');
           const session = context.result as Session;
           const userId = session.created_by || 'unknown';

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -129,6 +129,15 @@ import {
   spawnExecutorFireAndForget,
 } from './utils/spawn-executor.js';
 
+const DEBUG_MCP_TOKENS =
+  process.env.AGOR_DEBUG_MCP_TOKENS === '1' || process.env.DEBUG?.includes('mcp-tokens');
+
+function mcpTokenDebug(...args: unknown[]): void {
+  if (DEBUG_MCP_TOKENS) {
+    console.debug(...args);
+  }
+}
+
 const BRANCH_ENV_FIELDS = [
   'start_command',
   'stop_command',
@@ -2151,7 +2160,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             userId as import('@agor/core/types').UserID
           );
 
-          console.log(`🔄 Regenerated MCP token for session ${shortId(session.session_id)}`);
+          mcpTokenDebug(`🔄 Regenerated MCP token for session ${shortId(session.session_id)}`);
 
           // Add token to result (not stored in DB, regenerated on-demand with
           // a fresh `jti` and `exp`)

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -126,6 +126,24 @@ import {
 } from './utils/upload.js';
 import { resolveWidget } from './widgets/submissions.js';
 
+const DEBUG_AUTH_EVENTS =
+  process.env.AGOR_DEBUG_AUTH_EVENTS === '1' || process.env.DEBUG?.includes('auth-events');
+
+function authEventDebug(...args: unknown[]): void {
+  if (DEBUG_AUTH_EVENTS) {
+    console.debug(...args);
+  }
+}
+
+const DEBUG_TASK_QUEUE =
+  process.env.AGOR_DEBUG_TASK_QUEUE === '1' || process.env.DEBUG?.includes('task-queue');
+
+function taskQueueDebug(...args: unknown[]): void {
+  if (DEBUG_TASK_QUEUE) {
+    console.debug(...args);
+  }
+}
+
 export class AgorLocalStrategy extends LocalStrategy {
   async findEntity(username: string, params: Params) {
     markLocalAuthenticationLookup(params);
@@ -370,7 +388,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       create: [
         // biome-ignore lint/suspicious/noExplicitAny: FeathersJS context type not fully typed
         async (context: any) => {
-          console.log('✅ Authentication succeeded:', {
+          authEventDebug('✅ Authentication succeeded:', {
             strategy: context.result?.authentication?.strategy,
             hasUser: !!context.result?.user,
             user_id: context.result?.user?.user_id,
@@ -2165,7 +2183,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     const nextTask = await taskRepo.getNextQueued(sessionId);
 
     if (!nextTask) {
-      console.log(`📭 No queued tasks for session ${shortId(sessionId)}`);
+      taskQueueDebug(`📭 No queued tasks for session ${shortId(sessionId)}`);
       return;
     }
 

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -18,6 +18,15 @@ import type { Branch, BranchID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { BranchesServiceImpl } from '../declarations';
 
+const DEBUG_HEALTH_MONITOR =
+  process.env.AGOR_DEBUG_HEALTH_MONITOR === '1' || process.env.DEBUG?.includes('health-monitor');
+
+function healthMonitorDebug(...args: unknown[]): void {
+  if (DEBUG_HEALTH_MONITOR) {
+    console.debug(...args);
+  }
+}
+
 /**
  * Health Monitor - Singleton service for periodic health checks
  */
@@ -65,13 +74,13 @@ export class HealthMonitor {
       // Start monitoring if not already monitored
       // Monitor both 'running' and 'starting' - health checks will transition 'starting' → 'running'
       if (!this.intervals.has(branch.branch_id)) {
-        console.log(`🏥 Starting health monitoring for branch: ${branch.name}`);
+        healthMonitorDebug(`🏥 Starting health monitoring for branch: ${branch.name}`);
         this.startMonitoring(branch.branch_id);
       }
     } else {
       // Stop monitoring if status is not running or starting
       if (this.intervals.has(branch.branch_id)) {
-        console.log(`🏥 Stopping health monitoring for branch: ${branch.name}`);
+        healthMonitorDebug(`🏥 Stopping health monitoring for branch: ${branch.name}`);
         this.stopMonitoring(branch.branch_id);
       }
     }
@@ -161,8 +170,6 @@ export class HealthMonitor {
    * Called on daemon startup to resume monitoring existing environments
    */
   async initialize() {
-    console.log('🏥 Initializing Health Monitor...');
-
     try {
       const branchesService = this.app.service('branches');
 
@@ -184,14 +191,10 @@ export class HealthMonitor {
           w.environment_instance?.status === 'starting'
       );
 
-      if (activeBranches.length > 0) {
-        console.log(`   Found ${activeBranches.length} active environment(s)`);
-        for (const branch of activeBranches) {
-          this.startMonitoring(branch.branch_id);
-        }
-      } else {
-        console.log('   No active environments found');
+      for (const branch of activeBranches) {
+        this.startMonitoring(branch.branch_id);
       }
+      console.log(`🏥 Health Monitor initialized (${activeBranches.length} active environment(s))`);
     } catch (error) {
       console.error('❌ Failed to initialize Health Monitor:', error);
     }
@@ -203,17 +206,16 @@ export class HealthMonitor {
    * Called on daemon shutdown
    */
   cleanup() {
-    console.log('🏥 Cleaning up Health Monitor...');
     this.isShuttingDown = true;
 
     // Clear all intervals
-    for (const [branchId, interval] of this.intervals.entries()) {
+    const stoppedCount = this.intervals.size;
+    for (const interval of this.intervals.values()) {
       clearInterval(interval);
-      console.log(`   Stopped monitoring: ${shortId(branchId)}`);
     }
 
     this.intervals.clear();
-    console.log('   Health Monitor cleaned up');
+    console.log(`🏥 Health Monitor cleaned up (${stoppedCount} monitor(s) stopped)`);
   }
 
   /**

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -191,6 +191,7 @@ export class KnowledgeEmbeddingIndexer {
   private provider = new OpenAIEmbeddingProvider();
   private lastError: string | null = null;
   private lastIndexedAt: Date | null = null;
+  private pgvectorStorageReady = false;
 
   constructor(private db: Database) {
     this.variables = new AppVariableRepository(db);
@@ -424,10 +425,13 @@ export class KnowledgeEmbeddingIndexer {
       .one()) as { unit_id: string } | undefined;
     if (!pending) return this.idle();
 
-    const pgvector = await ensureKnowledgePgvectorStorage(this.db);
-    if (!pgvector.available) {
-      this.lastError = pgvector.reason ?? 'Knowledge pgvector storage is unavailable';
-      return 0;
+    if (!this.pgvectorStorageReady) {
+      const pgvector = await ensureKnowledgePgvectorStorage(this.db);
+      if (!pgvector.available) {
+        this.lastError = pgvector.reason ?? 'Knowledge pgvector storage is unavailable';
+        return 0;
+      }
+      this.pgvectorStorageReady = true;
     }
 
     const batchSize = Math.min(Math.max(semantic.indexing?.batch_size ?? 32, 1), 128);

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -239,7 +239,9 @@ export class SchedulerService {
       return;
     }
 
-    console.log(`🔄 Starting scheduler (tick interval: ${this.config.tickInterval}ms)`);
+    if (this.config.debug) {
+      console.log(`🔄 Starting scheduler (tick interval: ${this.config.tickInterval}ms)`);
+    }
     this.isRunning = true;
 
     // Run first tick immediately
@@ -264,7 +266,7 @@ export class SchedulerService {
       return;
     }
 
-    console.log('🛑 Stopping scheduler');
+    console.log('🛑 Scheduler stopped');
     this.isRunning = false;
 
     if (this.intervalHandle) {

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -13,6 +13,15 @@
 
 import jwt from 'jsonwebtoken';
 
+const DEBUG_SESSION_TOKENS =
+  process.env.AGOR_DEBUG_SESSION_TOKENS === '1' || process.env.DEBUG?.includes('session-token');
+
+function sessionTokenDebug(...args: unknown[]): void {
+  if (DEBUG_SESSION_TOKENS) {
+    console.debug(...args);
+  }
+}
+
 interface SessionTokenData {
   session_id: string;
   task_id?: string;
@@ -160,7 +169,7 @@ export class SessionTokenService {
       data.use_count++;
     }
 
-    console.debug(
+    sessionTokenDebug(
       data.max_uses > 0
         ? `[SessionTokenService] Token validated: session=${data.session_id}, uses=${data.use_count}/${data.max_uses}`
         : `[SessionTokenService] Reusable token validated: session=${data.session_id}`

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -23,6 +23,15 @@ import type { TerminalsService } from './services/terminals.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { scrubManagedGitRemoteCredentials } from './utils/git-remote-credential-scan.js';
 
+const DEBUG_STARTUP =
+  process.env.AGOR_DEBUG_STARTUP === '1' || process.env.DEBUG?.includes('startup');
+
+function startupDebug(...args: unknown[]): void {
+  if (DEBUG_STARTUP) {
+    console.debug(...args);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Context
 // ---------------------------------------------------------------------------
@@ -102,6 +111,8 @@ interface OrphanCleanupResult {
   orphanedTasks: Task[];
   orphanedSessions: Session[];
   sessionIdsWithOrphanedTasks: Set<string>;
+  queuedTasks: Task[];
+  sessionsResetFromOrphanedTasks: number;
 }
 
 async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanupResult> {
@@ -110,8 +121,6 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   // Get tasks service from the app (registered during services phase)
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
 
-  console.log('🧹 Cleaning up orphaned task/session state...');
-
   // Determine restart type before touching anything — sentinel is consumed here
   const wasGraceful = await readAndClearSentinel();
 
@@ -119,12 +128,13 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   const orphanedTasks = await tasksService.getOrphaned();
 
   if (orphanedTasks.length > 0) {
-    console.log(`   Found ${orphanedTasks.length} orphaned task(s)`);
     for (const task of orphanedTasks) {
       await tasksService.patch(task.task_id, {
         status: TaskStatus.STOPPED,
       });
-      console.log(`   ✓ Marked task ${task.task_id} as stopped (was: ${task.status})`);
+      startupDebug(
+        `[startup] stopped orphaned task ${shortId(task.task_id)} (was: ${task.status})`
+      );
     }
   }
 
@@ -144,7 +154,6 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   }
 
   if (orphanedSessions.length > 0) {
-    console.log(`   Found ${orphanedSessions.length} orphaned session(s)`);
     for (const session of orphanedSessions) {
       // IMPORTANT: Use app.service() instead of sessionsService to go through
       // FeathersJS service layer and trigger app.publish() for WebSocket events
@@ -156,7 +165,7 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
         },
         {}
       );
-      console.log(
+      startupDebug(
         `   ✓ Marked session ${shortId(session.session_id)} as idle (was: ${session.status})`
       );
     }
@@ -166,10 +175,8 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   const sessionIdsWithOrphanedTasks = new Set(
     orphanedTasks.map((t: Task) => t.session_id as string)
   );
+  let sessionsResetFromOrphanedTasks = 0;
   if (sessionIdsWithOrphanedTasks.size > 0) {
-    console.log(
-      `   Checking ${sessionIdsWithOrphanedTasks.size} session(s) with orphaned tasks...`
-    );
     for (const sessionId of sessionIdsWithOrphanedTasks) {
       const session = await sessionsService.get(sessionId as Id);
       // If session is still in an active state after orphaned task cleanup, set to IDLE
@@ -187,7 +194,8 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
           },
           {}
         );
-        console.log(
+        sessionsResetFromOrphanedTasks++;
+        startupDebug(
           `   ✓ Marked session ${shortId(sessionId)} as idle (had orphaned tasks, was: ${session.status})`
         );
       }
@@ -206,7 +214,6 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   const queuedTasks = queuedResult.data;
 
   if (queuedTasks.length > 0) {
-    console.log(`   Found ${queuedTasks.length} queued task(s) — wiping queue on restart`);
     for (const task of queuedTasks) {
       await tasksService.patch(task.task_id, {
         status: TaskStatus.STOPPED,
@@ -214,15 +221,23 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
     }
   }
 
-  if (orphanedTasks.length === 0 && orphanedSessions.length === 0 && queuedTasks.length === 0) {
-    console.log('   No orphaned tasks or sessions found');
+  const cleanupParts: string[] = [
+    `${orphanedTasks.length} orphaned task(s) stopped`,
+    `${orphanedSessions.length} active session(s) reset`,
+    `${queuedTasks.length} queued task(s) stopped`,
+  ];
+  if (sessionsResetFromOrphanedTasks > 0) {
+    cleanupParts.push(`${sessionsResetFromOrphanedTasks} task-owned session(s) reset`);
   }
+  console.log(`[startup] orphan cleanup: ${cleanupParts.join(', ')}`);
 
   return {
     wasGraceful,
     orphanedTasks,
     orphanedSessions,
     sessionIdsWithOrphanedTasks,
+    queuedTasks,
+    sessionsResetFromOrphanedTasks,
   };
 }
 
@@ -349,7 +364,7 @@ export function runPostStartJob(name: string, job: () => Promise<void> | void): 
   void Promise.resolve()
     .then(() => job())
     .then(() => {
-      console.log(`[startup] post-start job completed: ${name}`);
+      startupDebug(`[startup] post-start job completed: ${name}`);
     })
     .catch((error: unknown) => {
       console.warn(`[startup] post-start job failed: ${name}`, error);
@@ -428,19 +443,9 @@ export async function startup(ctx: StartupContext): Promise<void> {
   console.log(
     `🚀 Agor daemon running at http://${displayHost}:${DAEMON_PORT} (bound to ${DAEMON_HOST})`
   );
-  console.log(`   Health: http://${displayHost}:${DAEMON_PORT}/health`);
-  console.log(`   Authentication: 🔐 Required`);
-  console.log(`   Login: POST http://${displayHost}:${DAEMON_PORT}/authentication`);
-  console.log(`   Services:`);
-  console.log(`     - /sessions`);
-  console.log(`     - /tasks`);
-  console.log(`     - /messages`);
-  console.log(`     - /boards`);
-  console.log(`     - /repos`);
-  console.log(`     - /mcp-servers`);
-  console.log(`     - /config`);
-  console.log(`     - /context`);
-  console.log(`     - /users`);
+  console.log(
+    `   health=/health auth=required services=/sessions,/tasks,/messages,/boards,/repos,/mcp-servers,/config,/context,/users`
+  );
 
   runPostStartJob('health-monitor-initialize', () => healthMonitor.initialize());
   runPostStartJob('daemon-restart-notices', () => injectRestartNotices(ctx, orphanCleanupResult));
@@ -459,7 +464,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
     const { resolveHostIpAddress } = await import('@agor/core/utils/host-ip');
     const hostIp = resolveHostIpAddress(config.daemon?.host_ip_address);
     const source = config.daemon?.host_ip_address ? 'config' : hostIp ? 'autodetected' : 'unknown';
-    console.log(`🌐 Host IP for env templates: ${hostIp ?? '(none)'} (source: ${source})`);
+    startupDebug(`🌐 Host IP for env templates: ${hostIp ?? '(none)'} (source: ${source})`);
   });
 
   // Security warning: web terminal + simple unix mode = daemon-user shell access.

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -10,6 +10,16 @@ import {
   type RealtimeAccessSessionRepository,
 } from './realtime-access-cache.js';
 
+const DEBUG_REALTIME_PUBLISH =
+  process.env.AGOR_DEBUG_REALTIME_PUBLISH === '1' ||
+  process.env.DEBUG?.includes('realtime-publish');
+
+function realtimePublishDebug(...args: unknown[]): void {
+  if (DEBUG_REALTIME_PUBLISH) {
+    console.debug(...args);
+  }
+}
+
 type PublishContext = Pick<HookContext, 'path' | 'method' | 'id' | 'event' | 'app' | 'params'>;
 
 type ConnectionLike = {
@@ -308,7 +318,7 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
 
   app.publish(async (data: unknown, context: HookContext) => {
     if (context.path && context.method && !isStreamingEvent(context)) {
-      console.log(
+      realtimePublishDebug(
         `📡 [Publish] ${context.path} ${context.method}`,
         context.id
           ? `id: ${typeof context.id === 'string' ? shortId(context.id) : context.id}`

--- a/packages/core/src/config/key-resolver.ts
+++ b/packages/core/src/config/key-resolver.ts
@@ -10,6 +10,15 @@ import { getCredential, isConfigCredentialKey } from './config-manager';
 // bundle and executor without a config→types circular dependency.
 export type { ApiKeyName } from '../types';
 
+const DEBUG_KEY_RESOLUTION =
+  process.env.AGOR_DEBUG_KEY_RESOLUTION === '1' || process.env.DEBUG?.includes('key-resolution');
+
+function debugKeyResolution(message: string): void {
+  if (DEBUG_KEY_RESOLUTION) {
+    console.debug(message);
+  }
+}
+
 export interface KeyResolutionContext {
   /** User ID for per-user key lookup */
   userId?: UserID;
@@ -55,8 +64,10 @@ export async function resolveApiKey(
   keyName: ApiKeyName,
   context: KeyResolutionContext = {}
 ): Promise<KeyResolutionResult> {
-  console.debug(
-    `🔍 [API Key Resolution] Resolving ${keyName} for user ${context.userId ? shortId(context.userId) : 'none'}`
+  debugKeyResolution(
+    `🔍 [API Key Resolution] Resolving ${keyName} for user ${
+      context.userId ? shortId(context.userId) : 'none'
+    }`
   );
 
   // 1. Check per-user key (highest precedence). Storage lives at
@@ -67,7 +78,7 @@ export async function resolveApiKey(
   //    is omitted (CLI / generic callers), we fall back to sweeping every
   //    bucket to preserve the legacy "any user key for this name" semantic.
   if (context.userId && context.db) {
-    console.debug(`   → Checking user-level configuration...`);
+    debugKeyResolution(`   → Checking user-level configuration...`);
     const row = await select(context.db).from(users).where(eq(users.user_id, context.userId)).one();
 
     if (row) {
@@ -92,7 +103,7 @@ export async function resolveApiKey(
         try {
           const decryptedKey = decryptApiKey(encryptedKey);
           if (decryptedKey && decryptedKey.length > 0) {
-            console.debug(
+            debugKeyResolution(
               `   ✓ Found user-level API key for ${keyName} (user: ${shortId(context.userId)})`
             );
             return { apiKey: decryptedKey, source: 'user', useNativeAuth: false };
@@ -109,9 +120,9 @@ export async function resolveApiKey(
       }
     }
   } else if (!context.userId) {
-    console.debug(`   → Skipping user-level check (no user ID provided)`);
+    debugKeyResolution(`   → Skipping user-level check (no user ID provided)`);
   } else if (!context.db) {
-    console.debug(`   → Skipping user-level check (no database connection)`);
+    debugKeyResolution(`   → Skipping user-level check (no database connection)`);
   }
 
   // 2. Check global config.yaml (second precedence). Only the keys that have a
@@ -119,26 +130,26 @@ export async function resolveApiKey(
   //    CLAUDE_CODE_OAUTH_TOKEN / COPILOT_GITHUB_TOKEN are skipped here and fall
   //    through to the env-var lookup below.
   if (isConfigCredentialKey(keyName)) {
-    console.debug(`   → Checking app-level configuration (config.yaml)...`);
+    debugKeyResolution(`   → Checking app-level configuration (config.yaml)...`);
     const globalKey = getCredential(keyName);
     if (globalKey && globalKey.length > 0) {
-      console.debug(`   ✓ Found app-level API key for ${keyName} (from config.yaml)`);
+      debugKeyResolution(`   ✓ Found app-level API key for ${keyName} (from config.yaml)`);
       return { apiKey: globalKey, source: 'config', useNativeAuth: false };
     }
-    console.debug(`   ✗ No app-level API key for ${keyName}`);
+    debugKeyResolution(`   ✗ No app-level API key for ${keyName}`);
   }
 
   // 3. Check environment variable (third precedence)
-  console.debug(`   → Checking OS-level environment variables...`);
+  debugKeyResolution(`   → Checking OS-level environment variables...`);
   const envKey = process.env[keyName];
   if (envKey && envKey.length > 0) {
-    console.debug(`   ✓ Found OS-level environment variable ${keyName}`);
+    debugKeyResolution(`   ✓ Found OS-level environment variable ${keyName}`);
     return { apiKey: envKey, source: 'env', useNativeAuth: false };
   }
-  console.debug(`   ✗ No OS-level environment variable ${keyName}`);
+  debugKeyResolution(`   ✗ No OS-level environment variable ${keyName}`);
 
   // 4. No key found - SDK should fall back to native auth (OAuth, CLI login, etc.)
-  console.debug(`   ℹ️  No API key found for ${keyName} - SDK will use native authentication`);
+  debugKeyResolution(`   ℹ️  No API key found for ${keyName} - SDK will use native authentication`);
   return { apiKey: undefined, source: 'none', useNativeAuth: true };
 }
 

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -26,6 +26,15 @@ import {
   type PromptPayload,
 } from './payload-types.js';
 
+const DEBUG_EXECUTOR_CLI =
+  process.env.AGOR_DEBUG_EXECUTOR_CLI === '1' || process.env.DEBUG?.includes('executor-cli');
+
+function executorCliDebug(...args: unknown[]): void {
+  if (DEBUG_EXECUTOR_CLI) {
+    console.debug(...args);
+  }
+}
+
 /**
  * Read all input from stdin
  */
@@ -73,7 +82,7 @@ async function handleStdinMode(options: { dryRun: boolean }): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`[executor] Received command: ${payload.command}`);
+  executorCliDebug(`[executor] Received command: ${payload.command}`);
 
   // Special handling for prompt command - needs long-running WebSocket connection
   if (isPromptPayload(payload)) {
@@ -146,9 +155,9 @@ async function handlePromptPayload(
     const { filterEnv } = await import('@agor/core/config');
     const { env: safeEnv, rejected } = filterEnv(payload.env as Record<string, string>, (key) => {
       // Log key only — never the value, which is attacker-controlled.
-      console.warn(`[executor] Rejected denied env var from payload: ${key}`);
+      executorCliDebug(`[executor] Rejected denied env var from payload: ${key}`);
     });
-    console.log(
+    executorCliDebug(
       `[executor] Applying ${Object.keys(safeEnv).length} env vars from payload` +
         (rejected.length > 0 ? ` (${rejected.length} rejected)` : '')
     );

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -1,0 +1,68 @@
+import { resolveApiKey } from '@agor/core/config';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveApiKeyForTask } from './base-executor.js';
+
+vi.mock('@agor/core/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/config')>();
+  return {
+    ...actual,
+    resolveApiKey: vi.fn(),
+  };
+});
+
+function makeClient(error: unknown) {
+  return {
+    service(name: string) {
+      if (name !== 'config/resolve-api-key') {
+        throw new Error(`unexpected service ${name}`);
+      }
+      return {
+        create: vi.fn(async () => {
+          throw error;
+        }),
+      };
+    },
+  } as never;
+}
+
+describe('resolveApiKeyForTask', () => {
+  beforeEach(() => {
+    vi.mocked(resolveApiKey).mockReset();
+  });
+
+  it('does not fall back to local secret resolution after daemon authorization rejection', async () => {
+    const forbidden = Object.assign(new Error('Executor token is not valid for this task'), {
+      code: 403,
+    });
+
+    await expect(
+      resolveApiKeyForTask(
+        'OPENAI_API_KEY',
+        makeClient(forbidden),
+        'task-1' as never,
+        'codex' as never
+      )
+    ).rejects.toThrow('Executor token is not valid for this task');
+
+    expect(resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('keeps local fallback for legacy or unavailable daemon resolution', async () => {
+    vi.mocked(resolveApiKey).mockReturnValue({
+      apiKey: 'local-key',
+      source: 'env',
+      useNativeAuth: false,
+    });
+
+    await expect(
+      resolveApiKeyForTask(
+        'OPENAI_API_KEY',
+        makeClient(new Error('fetch failed')),
+        'task-1' as never,
+        'codex' as never
+      )
+    ).resolves.toMatchObject({ apiKey: 'local-key', source: 'env' });
+
+    expect(resolveApiKey).toHaveBeenCalledWith('OPENAI_API_KEY', {});
+  });
+});

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -26,6 +26,15 @@ import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.j
 import type { AgorClient } from '../../services/feathers-client.js';
 import { configureSessionGitSafeDirectories } from './git-safe-directory.js';
 
+const DEBUG_SDK_EXECUTOR =
+  process.env.AGOR_DEBUG_SDK_EXECUTOR === '1' || process.env.DEBUG?.includes('sdk-executor');
+
+function sdkDebug(...args: unknown[]): void {
+  if (DEBUG_SDK_EXECUTOR) {
+    console.debug(...args);
+  }
+}
+
 /**
  * Tool interface that all SDK wrappers must implement
  */
@@ -332,14 +341,14 @@ async function resolveApiKeyForTask(
       keyName,
       tool,
     })) as import('@agor/core/config').KeyResolutionResult;
-    console.debug(`[API Key Resolution] Resolved ${keyName} via daemon (source: ${result.source})`);
+    sdkDebug(`[API Key Resolution] Resolved ${keyName} via daemon (source: ${result.source})`);
     return result;
   } catch (err) {
-    console.warn(
-      `[API Key Resolution] Failed to resolve via daemon service: ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    );
+    const message = err instanceof Error ? err.message : String(err);
+    const code = (err as { code?: number })?.code;
+    const log =
+      code === 403 || message.includes('Executor token is not valid') ? sdkDebug : console.warn;
+    log(`[API Key Resolution] Falling back to local resolution: ${message}`);
     // Fall back to sync resolution (config + env only, no per-user keys)
     return resolveApiKey(keyName, {});
   }
@@ -398,11 +407,9 @@ export async function executeToolTask(params: {
 
   // Log resolution result
   if (resolution.apiKey) {
-    console.debug(
-      `[${toolName}] Using API key from ${resolution.source} level for ${apiKeyEnvVar}`
-    );
+    sdkDebug(`[${toolName}] Using API key from ${resolution.source} level for ${apiKeyEnvVar}`);
   } else {
-    console.debug(
+    sdkDebug(
       `[${toolName}] No API key found - SDK will use native authentication (OAuth/CLI login)`
     );
   }

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -325,7 +325,25 @@ export async function stampGitStateAtTaskStart(
  *
  * Returns resolution result with key, source, and useNativeAuth flag
  */
-async function resolveApiKeyForTask(
+function shouldFallbackToLocalApiKeyResolution(err: unknown): boolean {
+  const code = (err as { code?: number })?.code;
+  if (code === 400 || code === 401 || code === 403) {
+    return false;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  if (
+    message.includes('Executor token is not valid') ||
+    message.includes('not authorized') ||
+    message.includes('Forbidden')
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function resolveApiKeyForTask(
   keyName: ApiKeyName,
   client: AgorClient,
   taskId: TaskID,
@@ -345,10 +363,12 @@ async function resolveApiKeyForTask(
     return result;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const code = (err as { code?: number })?.code;
-    const log =
-      code === 403 || message.includes('Executor token is not valid') ? sdkDebug : console.warn;
-    log(`[API Key Resolution] Falling back to local resolution: ${message}`);
+    if (!shouldFallbackToLocalApiKeyResolution(err)) {
+      sdkDebug(`[API Key Resolution] Daemon rejected API key resolution: ${message}`);
+      throw err;
+    }
+
+    console.warn(`[API Key Resolution] Falling back to local resolution: ${message}`);
     // Fall back to sync resolution (config + env only, no per-user keys)
     return resolveApiKey(keyName, {});
   }

--- a/packages/executor/src/handlers/sdk/git-safe-directory.ts
+++ b/packages/executor/src/handlers/sdk/git-safe-directory.ts
@@ -64,7 +64,7 @@ export async function configureSessionGitSafeDirectories(
         const repo = (await client.service('repos').get(branch.repo_id)) as RepoForSafeDirectory;
         if (repo?.local_path) paths.push(repo.local_path);
       } catch (error) {
-        gitSafeDirectoryDebug(
+        console.warn(
           `${logPrefix} Failed to load repo ${branch.repo_id} for safe.directory setup:`,
           error instanceof Error ? error.message : String(error)
         );

--- a/packages/executor/src/handlers/sdk/git-safe-directory.ts
+++ b/packages/executor/src/handlers/sdk/git-safe-directory.ts
@@ -11,6 +11,16 @@ type RepoForSafeDirectory = {
   local_path?: string | null;
 };
 
+const DEBUG_GIT_SAFE_DIRECTORY =
+  process.env.AGOR_DEBUG_GIT_SAFE_DIRECTORY === '1' ||
+  process.env.DEBUG?.includes('git-safe-directory');
+
+function gitSafeDirectoryDebug(...args: unknown[]): void {
+  if (DEBUG_GIT_SAFE_DIRECTORY) {
+    console.debug(...args);
+  }
+}
+
 function appendGitConfigParameterPairs(pairs: readonly string[]): void {
   const encoded = buildGitConfigParameters(pairs);
   if (!encoded) return;
@@ -54,7 +64,7 @@ export async function configureSessionGitSafeDirectories(
         const repo = (await client.service('repos').get(branch.repo_id)) as RepoForSafeDirectory;
         if (repo?.local_path) paths.push(repo.local_path);
       } catch (error) {
-        console.warn(
+        gitSafeDirectoryDebug(
           `${logPrefix} Failed to load repo ${branch.repo_id} for safe.directory setup:`,
           error instanceof Error ? error.message : String(error)
         );
@@ -72,7 +82,7 @@ export async function configureSessionGitSafeDirectories(
   appendGitConfigParameterPairs(uniquePaths.map((path) => `safe.directory=${path}`));
 
   if (uniquePaths.length > 0) {
-    console.log(
+    gitSafeDirectoryDebug(
       `${logPrefix} Added ${uniquePaths.length} safe.directory entr${uniquePaths.length === 1 ? 'y' : 'ies'} for session git commands`
     );
   }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -26,6 +26,15 @@ import { tryMarkTaskTerminal } from './terminal-task.js';
 
 patchConsole();
 
+const DEBUG_EXECUTOR =
+  process.env.AGOR_DEBUG_EXECUTOR === '1' || process.env.DEBUG?.includes('executor');
+
+function executorDebug(...args: unknown[]): void {
+  if (DEBUG_EXECUTOR) {
+    console.debug(...args);
+  }
+}
+
 export interface ExecutorConfig {
   sessionToken: string;
   sessionId: string;
@@ -66,19 +75,17 @@ export class AgorExecutor {
    * Start the executor process
    */
   async start(): Promise<void> {
-    console.log('[executor] Starting Agor Executor (Feathers mode)');
     const uid = typeof process.getuid === 'function' ? process.getuid() : 'N/A';
-    console.log(`[executor] User: ${process.env.USER || 'unknown'} (uid: ${uid})`);
-    console.log(`[executor] Session: ${shortId(this.config.sessionId)}`);
-    console.log(`[executor] Task: ${shortId(this.config.taskId)}`);
-    console.log(`[executor] Tool: ${this.config.tool}`);
-    console.log(`[executor] Daemon: ${this.config.daemonUrl}`);
+    console.log(
+      `[executor] Starting ${this.config.tool} task ${shortId(this.config.taskId)} ` +
+        `for session ${shortId(this.config.sessionId)} as ${process.env.USER || 'unknown'} (uid: ${uid})`
+    );
 
     try {
       // Connect to daemon via Feathers/WebSocket
-      console.log('[executor] Connecting to daemon via Feathers...');
+      executorDebug('[executor] Connecting to daemon via Feathers...');
       this.client = await createFeathersClient(this.config.daemonUrl, this.config.sessionToken);
-      console.log('[executor] Connected to daemon');
+      executorDebug('[executor] Connected to daemon');
 
       // Setup event listeners
       this.setupEventListeners();
@@ -139,7 +146,7 @@ export class AgorExecutor {
       }
     });
 
-    console.log('[executor] Event listeners registered');
+    executorDebug('[executor] Event listeners registered');
   }
 
   /**
@@ -160,7 +167,7 @@ export class AgorExecutor {
       intervalMs: heartbeatConfig?.interval_ms,
     });
 
-    console.log(`[executor] Executing task with ${this.config.tool}...`);
+    executorDebug(`[executor] Executing task with ${this.config.tool}...`);
 
     try {
       // Import and initialize tool registry

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -24,6 +24,15 @@ import type {
   SessionMCPServerRepository,
 } from '../../db/feathers-repositories.js';
 
+const DEBUG_MCP_SCOPING =
+  process.env.AGOR_DEBUG_MCP_SCOPING === '1' || process.env.DEBUG?.includes('mcp-scoping');
+
+function mcpDebug(...args: unknown[]): void {
+  if (DEBUG_MCP_SCOPING) {
+    console.debug(...args);
+  }
+}
+
 /**
  * MCP server with source metadata
  */
@@ -79,8 +88,8 @@ export async function getMcpServersForSession(
   }
 
   try {
-    console.debug('🔌 Resolving MCP servers for session...');
-    console.debug(`   [MCP Scoping] forUserId: ${deps.forUserId || 'NOT SET'}`);
+    mcpDebug('🔌 Resolving MCP servers for session...');
+    mcpDebug(`   [MCP Scoping] forUserId: ${deps.forUserId || 'NOT SET'}`);
 
     // Track seen server IDs to prevent duplicates
     const seenServerIds = new Set<string>();
@@ -99,7 +108,7 @@ export async function getMcpServersForSession(
 
     if (typeof deps.sessionMCPRepo.listEffectiveServers === 'function') {
       const effectiveServers = await deps.sessionMCPRepo.listEffectiveServers(sessionId, true);
-      console.debug(`   📍 Effective session scope: ${effectiveServers.length} server(s)`);
+      mcpDebug(`   📍 Effective session scope: ${effectiveServers.length} server(s)`);
 
       for (const server of effectiveServers) {
         addServer(server, server.scope === 'global' ? 'global' : 'session-assigned');
@@ -107,9 +116,7 @@ export async function getMcpServersForSession(
     } else {
       // STEP 1: Get ALL global-scoped MCP servers (available to all sessions)
       // Pass forUserId for per-user OAuth token injection
-      console.debug(
-        `   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`
-      );
+      mcpDebug(`   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`);
       const globalServers = await deps.mcpServerRepo.findAll(
         {
           scope: 'global',
@@ -118,7 +125,7 @@ export async function getMcpServersForSession(
         deps.forUserId
       );
 
-      console.debug(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
+      mcpDebug(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
 
       for (const server of globalServers ?? []) {
         addServer(server, 'global');
@@ -127,7 +134,7 @@ export async function getMcpServersForSession(
       // STEP 2: Get session-scoped MCP servers assigned to this specific session
       const sessionServers = await deps.sessionMCPRepo.listServers(sessionId, true); // enabledOnly
 
-      console.debug(`   📍 Session-assigned: ${sessionServers.length} server(s)`);
+      mcpDebug(`   📍 Session-assigned: ${sessionServers.length} server(s)`);
 
       for (const server of sessionServers) {
         addServer(server, 'session-assigned');
@@ -136,12 +143,12 @@ export async function getMcpServersForSession(
 
     // Log summary (before template resolution)
     if (servers.length > 0) {
-      console.debug(`   ✅ Total: ${servers.length} MCP server(s) resolved`);
+      mcpDebug(`   ✅ Total: ${servers.length} MCP server(s) resolved`);
       for (const { server, source } of servers) {
-        console.debug(`      - ${server.name} (${server.transport}) [${source}]`);
+        mcpDebug(`      - ${server.name} (${server.transport}) [${source}]`);
       }
     } else {
-      console.debug('   ℹ️  No MCP servers available for this session');
+      mcpDebug('   ℹ️  No MCP servers available for this session');
     }
 
     // STEP 3: Resolve templates in config fields (url, env.*, auth.*)
@@ -195,7 +202,7 @@ export async function getMcpServersForSession(
     }
 
     if (templatesResolved > 0) {
-      console.debug(`   🔧 Resolved templates in ${templatesResolved} MCP server(s)`);
+      mcpDebug(`   🔧 Resolved templates in ${templatesResolved} MCP server(s)`);
     }
     if (serversSkipped > 0) {
       console.warn(

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -57,6 +57,16 @@ import {
 import type { ProcessedEvent } from './message-processor.js';
 import { ClaudePromptService } from './prompt-service.js';
 
+const DEBUG_CLAUDE_STREAMING =
+  process.env.AGOR_DEBUG_CLAUDE_STREAMING === '1' ||
+  process.env.DEBUG?.includes('claude-streaming');
+
+function claudeStreamingDebug(...args: unknown[]): void {
+  if (DEBUG_CLAUDE_STREAMING) {
+    console.debug(...args);
+  }
+}
+
 /**
  * Format a human-readable rate limit message for the conversation UI.
  *
@@ -490,7 +500,7 @@ export class ClaudeTool implements ITool {
             currentThinkingMessageId = generateId() as MessageID;
             const thinkingStartTime = Date.now();
             const ttfb = thinkingStartTime - streamStartTime;
-            console.debug(`⏱️ [SDK] TTFB (thinking): ${ttfb}ms`);
+            claudeStreamingDebug(`⏱️ [SDK] TTFB (thinking): ${ttfb}ms`);
 
             if (streamingCallbacks.onThinkingStart) {
               // Note: budget is extracted from thinking block if available
@@ -718,7 +728,7 @@ export class ClaudeTool implements ITool {
           currentTextMessageId = generateId() as MessageID;
           firstTokenTime = Date.now();
           const ttfb = firstTokenTime - streamStartTime;
-          console.debug(`⏱️ [SDK] TTFB (text): ${ttfb}ms`);
+          claudeStreamingDebug(`⏱️ [SDK] TTFB (text): ${ttfb}ms`);
 
           if (streamingCallbacks) {
             await streamingCallbacks.onStreamStart(currentTextMessageId, {
@@ -748,7 +758,7 @@ export class ClaudeTool implements ITool {
           await streamingCallbacks.onStreamEnd(currentTextMessageId);
           const totalTime = streamEndTime - streamStartTime;
           const streamingTime = firstTokenTime ? streamEndTime - firstTokenTime : 0;
-          console.debug(
+          claudeStreamingDebug(
             `⏱️ [Streaming] Complete - TTFB: ${firstTokenTime ? firstTokenTime - streamStartTime : 0}ms, streaming: ${streamingTime}ms, total: ${totalTime}ms`
           );
         }

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -29,6 +29,15 @@ import type {
 import type { SessionID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 
+const DEBUG_CLAUDE_MESSAGES =
+  process.env.AGOR_DEBUG_CLAUDE_MESSAGES === '1' || process.env.DEBUG?.includes('claude-messages');
+
+function claudeMessageDebug(...args: unknown[]): void {
+  if (DEBUG_CLAUDE_MESSAGES) {
+    console.debug(...args);
+  }
+}
+
 /**
  * Content block interface for SDK messages
  */
@@ -247,7 +256,7 @@ export class SDKMessageProcessor {
 
     // Log message type for debugging (skip stream_event as it's too verbose)
     if (this.state.messageCount % 10 === 0 && msg.type !== 'stream_event') {
-      console.debug(`📨 SDK message ${this.state.messageCount}: type=${msg.type}`);
+      claudeMessageDebug(`📨 SDK message ${this.state.messageCount}: type=${msg.type}`);
     }
 
     // Add detailed logging for debugging SDK behavior
@@ -372,7 +381,7 @@ export class SDKMessageProcessor {
       const toolResults = content.filter((b) => b.type === 'tool_result');
       const errorCount = toolResults.filter((tr) => tr.is_error).length;
       const successCount = toolResults.length - errorCount;
-      console.log(
+      claudeMessageDebug(
         `🔧 SDK user message with ${toolResults.length} tool result(s) (✅ ${successCount}, ❌ ${errorCount})`
       );
 
@@ -391,7 +400,7 @@ export class SDKMessageProcessor {
     } else if (hasText) {
       const textBlocks = content.filter((b) => b.type === 'text');
       const textPreview = textBlocks[0]?.text?.substring(0, 100) || '';
-      console.log(
+      claudeMessageDebug(
         `👤 SDK user message (uuid: ${uuid ? shortId(uuid) : 'unknown'}): "${textPreview}"`
       );
 
@@ -408,8 +417,8 @@ export class SDKMessageProcessor {
         },
       ];
     } else {
-      console.log(`👤 SDK user message (uuid: ${uuid ? shortId(uuid) : 'unknown'})`);
-      console.log(
+      claudeMessageDebug(`👤 SDK user message (uuid: ${uuid ? shortId(uuid) : 'unknown'})`);
+      claudeMessageDebug(
         `   Content types:`,
         Array.isArray(content) ? content.map((b) => b.type) : 'no content'
       );
@@ -430,7 +439,7 @@ export class SDKMessageProcessor {
 
     // Message start event
     if (event?.type === 'message_start') {
-      console.debug(`🎬 Message start`);
+      claudeMessageDebug(`🎬 Message start`);
       events.push({
         type: 'message_start',
         agentSessionId: this.state.capturedAgentSessionId,
@@ -469,7 +478,7 @@ export class SDKMessageProcessor {
           agentSessionId: this.state.capturedAgentSessionId,
         });
       } else if (block?.type === 'thinking') {
-        console.debug(`🧠 Thinking block start`);
+        claudeMessageDebug(`🧠 Thinking block start`);
         // Track thinking blocks
         this.state.contentBlockStack.push({
           index: blockIndex,
@@ -542,7 +551,7 @@ export class SDKMessageProcessor {
           agentSessionId: this.state.capturedAgentSessionId,
         });
       } else {
-        console.debug(`🏁 Content block ${blockIndex} complete`);
+        claudeMessageDebug(`🏁 Content block ${blockIndex} complete`);
       }
 
       // Remove from stack
@@ -553,7 +562,7 @@ export class SDKMessageProcessor {
 
     // Message stop event
     if (event?.type === 'message_stop') {
-      console.debug(`🏁 Message complete`);
+      claudeMessageDebug(`🏁 Message complete`);
       events.push({
         type: 'message_complete',
         agentSessionId: this.state.capturedAgentSessionId,
@@ -832,7 +841,7 @@ export class SDKMessageProcessor {
     const msgType = msg.type || 'unknown';
 
     if (SDKMessageProcessor.SUPPRESSED_MESSAGE_TYPES.has(msgType)) {
-      console.debug(`🔇 Suppressed SDK message type: ${msgType}`);
+      claudeMessageDebug(`🔇 Suppressed SDK message type: ${msgType}`);
       return [];
     }
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -90,6 +90,14 @@ type CodexConfigValue = CodexConfigObject[string];
  */
 const MCP_AUTO_APPROVE: CodexConfigObject = { default_tools_approval_mode: 'approve' };
 
+const DEBUG_CODEX = process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex');
+
+function codexDebug(...args: unknown[]): void {
+  if (DEBUG_CODEX) {
+    console.debug(...args);
+  }
+}
+
 export interface CodexPromptResult {
   /** Complete assistant response from Codex */
   messages: Array<{
@@ -220,7 +228,7 @@ export class CodexPromptService {
     if (this.apiKey) {
       // Source already logged by base-executor via resolveApiKeyForTask().
     } else if (this.useNativeAuth) {
-      console.debug(
+      codexDebug(
         '🔓 [Codex] No API key configured — falling back to ChatGPT subscription auth from $CODEX_HOME/auth.json. ' +
           'Run `codex login` if you have not authenticated yet.'
       );
@@ -232,7 +240,7 @@ export class CodexPromptService {
     }
 
     if (baseUrl) {
-      console.debug(`🔗 [Codex] Using custom OPENAI_BASE_URL`);
+      codexDebug(`🔗 [Codex] Using custom OPENAI_BASE_URL`);
     }
 
     // Bootstrap Codex SDK without per-session config (rebuilt lazily in
@@ -289,13 +297,13 @@ export class CodexPromptService {
         }
       }
       if (deleted > 0) {
-        console.debug(`🧹 [Codex] Swept ${deleted} stale instructions file(s) from ${dir}`);
+        codexDebug(`🧹 [Codex] Swept ${deleted} stale instructions file(s) from ${dir}`);
       }
       if (failed > 0) {
         const summary = [...failedByCode.entries()]
           .map(([code, count]) => `${code}=${count}`)
           .join(', ');
-        console.debug(
+        codexDebug(
           `🧹 [Codex] Skipped ${failed} stale instructions file(s) in ${dir} (${summary})`
         );
       }
@@ -412,7 +420,7 @@ export class CodexPromptService {
       return;
     }
 
-    console.debug(
+    codexDebug(
       `🔄 [Codex] Per-session config changed, reinitializing SDK (apiKey=${this.apiKey ? 'set' : 'unset'}, useNativeAuth=${this.useNativeAuth})`
     );
     this.codex = new Codex.Codex(this.buildCodexOptions(this.apiKey, baseUrl, config));
@@ -458,7 +466,7 @@ export class CodexPromptService {
     }
 
     this.instructionsFilePaths.set(sessionId, filePath);
-    console.debug(`✅ [Codex] Wrote per-session instructions file at ${filePath}`);
+    codexDebug(`✅ [Codex] Wrote per-session instructions file at ${filePath}`);
     return filePath;
   }
 
@@ -518,8 +526,8 @@ export class CodexPromptService {
     mcpToken: string | undefined,
     forUserId: UserID | undefined
   ): Promise<{ servers: CodexConfigObject; total: number }> {
-    console.debug(`🔍 [Codex MCP] Fetching MCP servers for session ${shortId(sessionId)}...`);
-    console.debug(`   [Codex MCP] forUserId: ${forUserId || 'NOT SET'}`);
+    codexDebug(`🔍 [Codex MCP] Fetching MCP servers for session ${shortId(sessionId)}...`);
+    codexDebug(`   [Codex MCP] forUserId: ${forUserId || 'NOT SET'}`);
 
     const serversWithSource = await getMcpServersForSession(sessionId, {
       sessionMCPRepo: this.sessionMCPServerRepo,
@@ -529,17 +537,15 @@ export class CodexPromptService {
 
     const mcpServers = serversWithSource.map((s) => s.server);
 
-    console.debug(`📊 [Codex MCP] Found ${mcpServers.length} MCP server(s) for session`);
+    codexDebug(`📊 [Codex MCP] Found ${mcpServers.length} MCP server(s) for session`);
     if (mcpServers.length > 0) {
-      console.debug(
-        `   Servers: ${mcpServers.map((s) => `${s.name} (${s.transport})`).join(', ')}`
-      );
+      codexDebug(`   Servers: ${mcpServers.map((s) => `${s.name} (${s.transport})`).join(', ')}`);
     }
 
     const stdioServers = mcpServers.filter((s) => s.transport === 'stdio');
     const httpServers = mcpServers.filter((s) => s.transport === 'http' || s.transport === 'sse');
 
-    console.debug(
+    codexDebug(
       `   📊 [Codex MCP] Transport breakdown: ${stdioServers.length} STDIO, ${httpServers.length} HTTP/SSE`
     );
 
@@ -560,7 +566,7 @@ export class CodexPromptService {
         required: false,
         ...MCP_AUTO_APPROVE,
       };
-      console.debug(
+      codexDebug(
         `   📝 [Codex MCP] Configuring built-in Agor MCP server (HTTP) at ${daemonUrl}/mcp`
       );
     }
@@ -573,18 +579,18 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
-      console.debug(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
+      codexDebug(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
       if (server.command) {
         serverConfig.command = server.command;
-        console.debug(`      command: ${server.command}`);
+        codexDebug(`      command: ${server.command}`);
       }
       if (server.args && server.args.length > 0) {
         serverConfig.args = server.args as CodexConfigValue[];
-        console.debug(`      args: ${JSON.stringify(server.args)}`);
+        codexDebug(`      args: ${JSON.stringify(server.args)}`);
       }
       if (server.env && Object.keys(server.env).length > 0) {
         serverConfig.env = server.env as CodexConfigObject;
-        console.debug(`      env vars: ${Object.keys(server.env).length} variable(s)`);
+        codexDebug(`      env vars: ${Object.keys(server.env).length} variable(s)`);
       }
 
       result[serverName] = serverConfig;
@@ -598,10 +604,10 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
-      console.debug(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
+      codexDebug(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
       if (server.url) {
         serverConfig.url = server.url;
-        console.debug(`      url: ${server.url}`);
+        codexDebug(`      url: ${server.url}`);
       }
 
       // Resolve the Authorization header via the shared MCP auth helper —
@@ -618,7 +624,7 @@ export class CodexPromptService {
         if (customHeaders) delete customHeaders.Authorization;
         if (customHeaders && Object.keys(customHeaders).length > 0) {
           serverConfig.headers = customHeaders;
-          console.debug(`      custom headers: ${Object.keys(customHeaders).length} header(s)`);
+          codexDebug(`      custom headers: ${Object.keys(customHeaders).length} header(s)`);
         }
         if (authHeader) {
           const bearerToken = /^Bearer\s+(.+)$/i.exec(authHeader)?.[1];
@@ -626,7 +632,7 @@ export class CodexPromptService {
             const envVarName = `AGOR_MCP_${shortId(sessionId)}_${serverName.toUpperCase()}`;
             process.env[envVarName] = bearerToken;
             serverConfig.bearer_token_env_var = envVarName;
-            console.debug(`      auth: ${server.auth?.type ?? 'bearer'} token via ${envVarName}`);
+            codexDebug(`      auth: ${server.auth?.type ?? 'bearer'} token via ${envVarName}`);
           } else {
             console.warn(
               `      ⚠️  auth: resolved Authorization header for "${server.name}" is not a Bearer scheme (Codex CLI only supports bearer); skipping injection`
@@ -867,9 +873,9 @@ export class CodexPromptService {
     // This ensures hot-reload of credentials from Settings UI while avoiding process accumulation
     this.refreshClient(currentApiKey);
 
-    console.debug(`🔍 [Codex] Starting prompt execution for session ${shortId(sessionId)}`);
-    console.debug(`   Permission mode: ${permissionMode || 'not specified (will use default)'}`);
-    console.debug(`   Existing thread ID: ${session.sdk_session_id || 'none (will create new)'}`);
+    codexDebug(`🔍 [Codex] Starting prompt execution for session ${shortId(sessionId)}`);
+    codexDebug(`   Permission mode: ${permissionMode || 'not specified (will use default)'}`);
+    codexDebug(`   Existing thread ID: ${session.sdk_session_id || 'none (will create new)'}`);
 
     // Codex permission settings split across two surfaces:
     // - sandboxMode, approvalPolicy, networkAccessEnabled: per-thread via ThreadOptions
@@ -892,7 +898,7 @@ export class CodexPromptService {
     const approvalPolicy = codexConfig?.approvalPolicy ?? defaults.approvalPolicy;
     const networkAccess = codexConfig?.networkAccess ?? defaults.networkAccess;
 
-    console.debug(
+    codexDebug(
       `   Using Codex permissions: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}`
     );
 
@@ -931,7 +937,7 @@ export class CodexPromptService {
     // apiKey/baseUrl) actually changed — issue #133 protection.
     this.ensureCodexClient(codexConfigPayload);
 
-    console.debug(
+    codexDebug(
       `   Configured: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}, ${mcpServerCount} MCP server(s)`
     );
 
@@ -941,7 +947,7 @@ export class CodexPromptService {
       throw new Error(`Branch ${session.branch_id} not found for session ${sessionId}`);
     }
 
-    console.debug(`   Working directory: ${branch.path}`);
+    codexDebug(`   Working directory: ${branch.path}`);
 
     await this.ensureForkedCodexThread(sessionId, session);
 
@@ -1016,7 +1022,7 @@ export class CodexPromptService {
     // Start or resume thread
     let thread: Thread;
     if (session.sdk_session_id) {
-      console.debug(`🔄 [Codex] Resuming thread: ${session.sdk_session_id}`);
+      codexDebug(`🔄 [Codex] Resuming thread: ${session.sdk_session_id}`);
 
       thread = this.codex.resumeThread(session.sdk_session_id, threadOptions);
 
@@ -1042,9 +1048,9 @@ export class CodexPromptService {
         }
       }
     } else {
-      console.debug(`🆕 [Codex] Creating new thread`);
+      codexDebug(`🆕 [Codex] Creating new thread`);
       if (mcpServerCount > 0) {
-        console.debug(
+        codexDebug(
           `✅ [Codex MCP] New thread will have ${mcpServerCount} MCP server(s) available via --config flags`
         );
       }
@@ -1052,7 +1058,7 @@ export class CodexPromptService {
     }
 
     try {
-      console.debug(
+      codexDebug(
         `▶️  [Codex] Running prompt: "${prompt.substring(0, 50)}${prompt.length > 50 ? '...' : ''}"`
       );
 
@@ -1071,10 +1077,10 @@ export class CodexPromptService {
 
       // Use streaming API with abort signal for proper cancellation support
       // The signal is passed to Codex SDK which will throw AbortError when aborted
-      console.debug(`🎬 [Codex] Starting runStreamed() for session ${shortId(sessionId)}`);
+      codexDebug(`🎬 [Codex] Starting runStreamed() for session ${shortId(sessionId)}`);
       const turnOptions = abortController ? { signal: abortController.signal } : undefined;
       const { events } = await thread.runStreamed(prompt, turnOptions);
-      console.debug(`✅ [Codex] runStreamed() returned, starting event iteration`);
+      codexDebug(`✅ [Codex] runStreamed() returned, starting event iteration`);
 
       const currentMessage: Array<{
         type: string;
@@ -1096,7 +1102,7 @@ export class CodexPromptService {
 
       for await (const event of events) {
         eventCount++;
-        console.debug(`📨 [Codex] Event ${eventCount}: ${event.type}`);
+        codexDebug(`📨 [Codex] Event ${eventCount}: ${event.type}`);
 
         // Check if stop was requested
         if (this.stopRequested.get(sessionId)) {

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -10,6 +10,15 @@ import { type AgorClient, createClient } from '@agor/core/api';
 // Re-export AgorClient type for use in other executor files
 export type { AgorClient } from '@agor/core/api';
 
+const DEBUG_FEATHERS_CLIENT =
+  process.env.AGOR_DEBUG_FEATHERS_CLIENT === '1' || process.env.DEBUG?.includes('feathers-client');
+
+function feathersClientDebug(...args: unknown[]): void {
+  if (DEBUG_FEATHERS_CLIENT) {
+    console.debug(...args);
+  }
+}
+
 /**
  * In-memory storage for executor authentication
  * Executors need to store authentication for subsequent requests but can't use localStorage
@@ -47,7 +56,7 @@ export async function createExecutorClient(
 
   // Create client with custom storage (don't auto-connect, we'll connect manually)
   const client = createClient(daemonUrl, false, {
-    verbose: true, // Log connection status for debugging
+    verbose: DEBUG_FEATHERS_CLIENT, // Log connection status for debugging
     reconnectionAttempts: 5, // Allow more retries for transient network hiccups during long-running tasks
   });
 
@@ -77,7 +86,7 @@ export async function createExecutorClient(
     });
   });
 
-  console.log('[executor] Connected to daemon via Feathers client');
+  feathersClientDebug('[executor] Connected to daemon via Feathers client');
 
   // Authenticate with session token (which is now a JWT!)
   // This uses the standard JWT strategy - no custom strategy needed
@@ -87,7 +96,7 @@ export async function createExecutorClient(
     accessToken: sessionToken,
   });
 
-  console.log('[executor] Authenticated with session token (JWT)');
+  feathersClientDebug('[executor] Authenticated with session token (JWT)');
 
   // Re-authenticate automatically on socket reconnect
   // When socket.io reconnects after a transport error, the new socket is unauthenticated.


### PR DESCRIPTION
## Summary

This PR follows up on a deeper `journalctl -u agor-daemon` audit focused on daemon startup/runtime noise, especially patterns from the last 24h log dump.

Changes include:

- Gate high-volume debug logs behind explicit env flags instead of relying on `console.debug` (which still reaches journald under systemd)
- Reduce startup/health/scheduler chatter and aggregate cleanup/startup logs
- Cache MCP session tokens per `(session,user)` until near expiry to avoid re-signing/re-validating on every high-frequency `sessions.get`
- Cache successful knowledge pgvector storage readiness to avoid repeated DDL/capability checks and Postgres `relation already exists` NOTICE spam while indexing is pending
- Gate executor/Codex/Claude/MCP scoping/API-key-resolution trace logs that dominated daemon logs via child process stdout/stderr bridging
- Update MCP token tests for the new cache semantics

## Log audit highlights

Approximate 24h offenders from `/tmp/agor-daemon-24h.log`:

- ~193k session-token validation success logs
- ~115k realtime publish fanout logs
- ~83k MCP token issue/regeneration logs
- ~41k `loadSessionBranch` trace logs
- ~8.8k auth success object dumps
- ~7.3k Postgres pgvector DDL NOTICE lines
- thousands of executor/Codex/Claude event lifecycle/debug logs

## Follow-ups split out

Two meatier items were split into their own Agor branches/sessions:

1. `daemon-rbac-loadsession-audit` — investigate whether `loadSessionBranch` is doing duplicate DB work, not just noisy logging.
2. `executor-api-key-resolution-contract` — resolve the executor `config/resolve-api-key` 403/fallback contract instead of only gating logs.

## Validation

- `pnpm i`
  - Completed successfully; optional `node-pty@1.0.0` native rebuild reported `make` missing, but install completed.
- `pnpm check`
  - Passed.
  - Lint emitted existing warnings about unused suppressions / docs CSS descending specificity.
- `pnpm --filter @agor/daemon test -- src/mcp/tokens.test.ts src/utils/sandpack-config.test.ts`
  - Passed: 27 tests.
- `git diff --check`
  - Passed before commit.
