### PR TITLE
Authorize executor API key resolution

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -359,13 +359,26 @@ describe('executorRuntimeScopeGuard', () => {
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/session scope/);
   });
 
-  it('wraps auth hooks with executor runtime scope validation', async () => {
+  it('wraps auth hooks and allows task-scoped API key resolution', async () => {
     const requireAuth = async (context: HookContext) => context;
-    const context = ctx({ path: 'config/resolve-api-key', method: 'create' });
+    const context = ctx({
+      path: 'config/resolve-api-key',
+      method: 'create',
+      data: { keyName: 'OPENAI_API_KEY', tool: 'codex' },
+    });
 
-    await expect(scopeExecutorRuntimeAuth(requireAuth)(context)).rejects.toThrow(
-      /not valid for this endpoint/
-    );
+    await expect(scopeExecutorRuntimeAuth(requireAuth)(context)).resolves.toBe(context);
+    expect(context.data).toMatchObject({ taskId: 'task-1' });
+  });
+
+  it('rejects API key resolution for another task under executor token auth', async () => {
+    const context = ctx({
+      path: 'config/resolve-api-key',
+      method: 'create',
+      data: { taskId: 'task-2', keyName: 'OPENAI_API_KEY', tool: 'codex' },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/task scope/);
   });
 
   it('lets wrapped auth hooks pass internal (provider-less) service composition', async () => {

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -299,6 +299,13 @@ export function executorRuntimeScopeGuard() {
         throw new Forbidden('Executor token is not valid for this endpoint');
       }
       requireMatchingSessionRoute(context, scope);
+    } else if (path === 'config/resolve-api-key') {
+      if (context.method !== 'create') {
+        throw new Forbidden('Executor token is not valid for this endpoint');
+      }
+      const taskId = expectClaim(scope.taskId, 'task');
+      expectMatch(taskId, data.taskId ?? data.task_id, 'task');
+      setIfAbsent(data, 'taskId', taskId);
     } else {
       throw new Forbidden('Executor token is not valid for this endpoint');
     }

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -156,4 +156,33 @@ describe('ConfigService.resolveApiKey', () => {
 
     expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
   });
+
+  it('rejects executor runtime tokens for tools without a canonical API key mapping', async () => {
+    const service = new ConfigService({} as never);
+    service.app = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return { get: vi.fn(async () => ({ created_by: 'creator-1', session_id: 'session-1' })) };
+        }
+        if (name === 'sessions') {
+          return { get: vi.fn(async () => ({ agentic_tool: 'opencode' })) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await expect(
+      service.resolveApiKey(
+        { taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY', tool: 'opencode' },
+        {
+          provider: 'socketio',
+          authentication: {
+            payload: { type: 'executor-session', purpose: 'executor-task', task_id: 'task-1' },
+          },
+        } as never
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+
+    expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
+  });
 });

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -90,4 +90,70 @@ describe('ConfigService.resolveApiKey', () => {
       tool: 'codex',
     });
   });
+
+  it('allows task-scoped executor runtime tokens for the matching session tool', async () => {
+    const service = new ConfigService({} as never);
+    service.app = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return {
+            get: vi.fn(async () => ({
+              created_by: 'creator-1' as UserID,
+              session_id: 'session-1',
+            })),
+          };
+        }
+        if (name === 'sessions') {
+          return { get: vi.fn(async () => ({ agentic_tool: 'codex' })) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    const result = await service.resolveApiKey(
+      { taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY', tool: 'codex' },
+      {
+        provider: 'socketio',
+        authentication: {
+          payload: { type: 'executor-session', purpose: 'executor-task', task_id: 'task-1' },
+        },
+      } as never
+    );
+
+    expect(result).toMatchObject({ apiKey: 'resolved-test-key', source: 'user' });
+    expect(configMocks.resolveApiKey).toHaveBeenCalledWith('OPENAI_API_KEY', {
+      userId: 'creator-1',
+      db: {},
+      tool: 'codex',
+    });
+  });
+
+  it('rejects executor runtime tokens for a different API key than the session tool uses', async () => {
+    const service = new ConfigService({} as never);
+    service.app = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return { get: vi.fn(async () => ({ created_by: 'creator-1', session_id: 'session-1' })) };
+        }
+        if (name === 'sessions') {
+          return { get: vi.fn(async () => ({ agentic_tool: 'codex' })) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await expect(
+      service.resolveApiKey(
+        { taskId: 'task-1' as TaskID, keyName: 'ANTHROPIC_API_KEY', tool: 'codex' },
+        {
+          provider: 'socketio',
+          authentication: {
+            payload: { type: 'executor-session', purpose: 'executor-task', task_id: 'task-1' },
+          },
+        } as never
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+
+    expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
+  });
 });

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -207,7 +207,7 @@ export class ConfigService {
         throw new BadRequest('Tool is required for executor API key resolution');
       }
       const expectedKeyName = TOOL_API_KEY_NAMES[tool];
-      if (expectedKeyName && expectedKeyName !== keyName) {
+      if (!expectedKeyName || expectedKeyName !== keyName) {
         throw new Forbidden('Executor token is not valid for this API key');
       }
       const sessionsService = this.app?.service('sessions');

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -15,12 +15,13 @@ import {
 import type { Database } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
-import type {
-  AgenticToolName,
-  AuthenticatedParams,
-  Params,
-  TaskID,
-  UserID,
+import {
+  type AgenticToolName,
+  type AuthenticatedParams,
+  type Params,
+  type TaskID,
+  TOOL_API_KEY_NAMES,
+  type UserID,
 } from '@agor/core/types';
 
 const RESOLVABLE_API_KEY_NAMES: Record<ApiKeyName, true> = {
@@ -35,6 +36,21 @@ const RESOLVABLE_API_KEY_NAMES: Record<ApiKeyName, true> = {
 
 function isResolvableApiKeyName(value: string): value is ApiKeyName {
   return Object.hasOwn(RESOLVABLE_API_KEY_NAMES, value);
+}
+
+type ExecutorTokenPayload = {
+  type?: string;
+  purpose?: string;
+  task_id?: string;
+};
+
+function getExecutorTokenPayload(params?: Params): ExecutorTokenPayload | undefined {
+  const payload = (params as AuthenticatedParams | undefined)?.authentication?.payload as
+    | ExecutorTokenPayload
+    | undefined;
+  return payload?.type === 'executor-session' && payload.purpose === 'executor-task'
+    ? payload
+    : undefined;
 }
 
 /**
@@ -132,35 +148,76 @@ export class ConfigService {
     useNativeAuth: boolean;
     decryptionFailed?: boolean;
   }> {
-    // This method returns plaintext secret material and is only for trusted
-    // daemon/executor flows. External callers must authenticate with an
-    // executor service JWT; normal user/API-key auth may read masked config via
-    // /config but must not resolve raw configured keys.
-    if (params?.provider) {
-      const caller = (params as AuthenticatedParams | undefined)?.user;
-      if (!caller) {
-        throw new NotAuthenticated('Authentication required');
-      }
-      if (caller._isServiceAccount !== true) {
-        throw new Forbidden('Only the executor service account may resolve API keys');
-      }
-    }
-
     const { taskId, keyName, tool } = data;
     if (!isResolvableApiKeyName(keyName)) {
       throw new BadRequest('Unsupported API key name');
     }
 
-    // Fetch task to get creator user ID
+    // This method returns plaintext secret material and is only for trusted
+    // daemon/executor flows. External callers must authenticate either as the
+    // service account or with a task-scoped executor runtime JWT. Normal
+    // user/API-key auth may read masked config via /config but must not resolve
+    // raw configured keys.
+    const executorPayload = getExecutorTokenPayload(params);
+    if (params?.provider) {
+      const caller = (params as AuthenticatedParams | undefined)?.user;
+      const isServiceAccount = caller?._isServiceAccount === true;
+      if (!isServiceAccount && !executorPayload) {
+        if (!caller) {
+          throw new NotAuthenticated('Authentication required');
+        }
+        throw new Forbidden('Only executor runtime credentials may resolve API keys');
+      }
+      if (executorPayload?.task_id && executorPayload.task_id !== taskId) {
+        throw new Forbidden('Executor token task scope does not match this request');
+      }
+    }
+
+    // Fetch task to get creator user ID and session. This is required for
+    // executor-token calls and best-effort for internal/service-account calls.
     let userId: UserID | undefined;
+    let sessionId: string | undefined;
     try {
       const tasksService = this.app?.service('tasks');
       if (tasksService) {
         const task = await tasksService.get(taskId, { provider: undefined });
         userId = task?.created_by;
+        sessionId = task?.session_id;
       }
     } catch (err) {
       console.warn(`[Config.resolveApiKey] Failed to fetch task ${taskId}:`, err);
+      if (executorPayload) {
+        throw new Forbidden('Executor token task scope could not be verified');
+      }
+    }
+
+    if (executorPayload && (!userId || !sessionId)) {
+      throw new Forbidden('Executor token task scope could not be verified');
+    }
+
+    // Executor runtime calls are narrowly scoped to the SDK for this session.
+    // Do not let a compromised executor token ask for another tool's bucket or
+    // an unrelated credential name.
+    if (executorPayload) {
+      const verifiedSessionId = sessionId;
+      if (!verifiedSessionId) {
+        throw new Forbidden('Executor token task scope could not be verified');
+      }
+      if (!tool) {
+        throw new BadRequest('Tool is required for executor API key resolution');
+      }
+      const expectedKeyName = TOOL_API_KEY_NAMES[tool];
+      if (expectedKeyName && expectedKeyName !== keyName) {
+        throw new Forbidden('Executor token is not valid for this API key');
+      }
+      const sessionsService = this.app?.service('sessions');
+      if (!sessionsService) {
+        throw new Forbidden('Executor token tool scope could not be verified');
+      }
+      const session = await sessionsService.get(verifiedSessionId, { provider: undefined });
+      if (session?.agentic_tool !== tool) {
+        throw new Forbidden('Executor token tool scope does not match this session');
+      }
     }
 
     // Use core resolveApiKey with database access


### PR DESCRIPTION
## Summary

- Authorize executor runtime JWTs to call `config/resolve-api-key` only for their scoped task.
- Add defense-in-depth in `ConfigService.resolveApiKey` so executor runtime calls must match the task's session tool and that tool's canonical API-key name.
- Update daemon tests for the new narrow credential-resolution contract and cross-task/cross-tool rejection cases.

## Rationale

Executor startup already calls `config/resolve-api-key` to preserve the intended credential precedence:

1. per-user encrypted key
2. app-level `config.yaml`
3. OS environment
4. native SDK auth

The previous runtime-scope allowlist rejected that route, causing expected 403s and fallback behavior. This PR keeps the daemon-resolved credential contract but narrows authorization to task-scoped executor runtime tokens instead of broadening general config access or passing secret material through additional payload fields.

## Validation

- `pnpm i`
- `pnpm check` — passes; existing lint warnings remain unrelated
- `pnpm --filter @agor/daemon test -- src/auth/executor-runtime-scope.test.ts src/services/config.test.ts`
- `git diff --check`
