### PR TITLE
Reduce RBAC session branch reloads

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.test.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.test.ts
@@ -58,6 +58,17 @@ function makeService(repo: Repository<Widget>): {
 }
 
 describe('DrizzleService event emission', () => {
+  it('reuses a hook-prefetched record on get()', async () => {
+    const prefetched = { id: 'w1', name: 'from hook' };
+    const repo = makeRepo([{ id: 'w1', name: 'from repo' }]);
+    const { service } = makeService(repo);
+
+    const result = await service.get('w1', { _agorPrefetchedRecord: prefetched } as never);
+
+    expect(result).toBe(prefetched);
+    expect(repo.findById).not.toHaveBeenCalled();
+  });
+
   it('emits only `created` on create()', async () => {
     const repo = makeRepo();
     const { service, events } = makeService(repo);

--- a/apps/agor-daemon/src/adapters/drizzle.test.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.test.ts
@@ -63,10 +63,25 @@ describe('DrizzleService event emission', () => {
     const repo = makeRepo([{ id: 'w1', name: 'from repo' }]);
     const { service } = makeService(repo);
 
-    const result = await service.get('w1', { _agorPrefetchedRecord: prefetched } as never);
+    const result = await service.get('w1', {
+      _agorPrefetchedRecord: { id: 'w1', idField: 'id', record: prefetched },
+    } as never);
 
     expect(result).toBe(prefetched);
     expect(repo.findById).not.toHaveBeenCalled();
+  });
+
+  it('ignores a hook-prefetched record for a different id field', async () => {
+    const prefetched = { id: 'w1', name: 'from hook' };
+    const repo = makeRepo([{ id: 'w1', name: 'from repo' }]);
+    const { service } = makeService(repo);
+
+    const result = await service.get('w1', {
+      _agorPrefetchedRecord: { id: 'w1', idField: 'session_id', record: prefetched },
+    } as never);
+
+    expect(result).toEqual({ id: 'w1', name: 'from repo' });
+    expect(repo.findById).toHaveBeenCalledTimes(1);
   });
 
   it('emits only `created` on create()', async () => {

--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -243,6 +243,20 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
    * Get a single record by ID
    */
   async get(id: Id, _params?: P): Promise<T> {
+    // RBAC before-hooks sometimes have to load the target record to resolve
+    // its parent session/branch before the service method runs. When they do,
+    // they stash that exact record on params so the service get/patch/remove
+    // path does not immediately perform the same primary-key read again.
+    const prefetched = (_params as { _agorPrefetchedRecord?: T } | undefined)
+      ?._agorPrefetchedRecord;
+    if (
+      prefetched &&
+      (prefetched as Record<string, unknown>)[this.id] !== undefined &&
+      String((prefetched as Record<string, unknown>)[this.id]) === String(id)
+    ) {
+      return prefetched;
+    }
+
     const result = await this.repository.findById(String(id));
 
     if (!result) {

--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -245,16 +245,27 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   async get(id: Id, _params?: P): Promise<T> {
     // RBAC before-hooks sometimes have to load the target record to resolve
     // its parent session/branch before the service method runs. When they do,
-    // they stash that exact record on params so the service get/patch/remove
-    // path does not immediately perform the same primary-key read again.
-    const prefetched = (_params as { _agorPrefetchedRecord?: T } | undefined)
-      ?._agorPrefetchedRecord;
+    // they stash that exact record (scoped by id field + id) on params so the
+    // service get path does not immediately perform the same primary-key read
+    // again. patch/remove benefit through their initial get() existence read.
+    const prefetched = (
+      _params as
+        | {
+            _agorPrefetchedRecord?: {
+              id: string;
+              idField: string;
+              record: T;
+            };
+          }
+        | undefined
+    )?._agorPrefetchedRecord;
     if (
       prefetched &&
-      (prefetched as Record<string, unknown>)[this.id] !== undefined &&
-      String((prefetched as Record<string, unknown>)[this.id]) === String(id)
+      prefetched.idField === this.id &&
+      prefetched.id === String(id) &&
+      String((prefetched.record as Record<string, unknown>)[this.id]) === String(id)
     ) {
-      return prefetched;
+      return prefetched.record;
     }
 
     const result = await this.repository.findById(String(id));

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -324,6 +324,8 @@ describe('request-scoped RBAC loading', () => {
 
     expect(sessionService.get).toHaveBeenCalledTimes(1);
     expect(branchRepo.findById).toHaveBeenCalledTimes(1);
+    expect(branchRepo.isOwner).toHaveBeenCalledTimes(1);
+    expect(branchRepo.resolveUserPermission).toHaveBeenCalledTimes(1);
   });
 
   it('marks sessions.get hook-loaded session as prefetched for the service get()', async () => {
@@ -343,7 +345,13 @@ describe('request-scoped RBAC loading', () => {
 
     expect(sessionService.get).toHaveBeenCalledTimes(1);
     expect(ctx.params.session).toBe(session);
-    expect((ctx.params as { _agorPrefetchedRecord?: unknown })._agorPrefetchedRecord).toBe(session);
+    expect(
+      (ctx.params as { _agorPrefetchedRecord?: { record: unknown } })._agorPrefetchedRecord
+    ).toMatchObject({
+      id: session.session_id,
+      idField: 'session_id',
+      record: session,
+    });
   });
 
   it('resolves id-addressed message context from the stored record, not spoofed query', async () => {
@@ -368,9 +376,13 @@ describe('request-scoped RBAC loading', () => {
     await resolveSessionContext()(ctx);
 
     expect(ctx.params.sessionId).toBe(session.session_id);
-    expect((ctx.params as { _agorPrefetchedRecord?: unknown })._agorPrefetchedRecord).toBe(
-      existingMessage
-    );
+    expect(
+      (ctx.params as { _agorPrefetchedRecord?: { record: unknown } })._agorPrefetchedRecord
+    ).toMatchObject({
+      id: existingMessage.message_id,
+      idField: 'message_id',
+      record: existingMessage,
+    });
   });
 });
 

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -7,13 +7,17 @@
 
 import type { Branch, BranchPermissionLevel, HookContext, Session } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   ensureCanPromptInSession,
   hasBranchPermission,
   isSuperAdmin,
+  loadBranchFromSession,
+  loadSession,
+  loadSessionBranch,
   paginateClientSide,
   resolveBranchPermission,
+  resolveSessionContext,
 } from './branch-authorization';
 
 /** Minimal branch fixture for permission tests */
@@ -280,6 +284,93 @@ describe('ensureCanPromptInSession', () => {
       ctx.params.provider = undefined;
       expect(() => hook(ctx)).not.toThrow();
     });
+  });
+});
+
+describe('request-scoped RBAC loading', () => {
+  const branch = makeBranch({ branch_id: 'branch-cache-1' as Branch['branch_id'] });
+  const session = {
+    session_id: 'session-cache-1',
+    branch_id: branch.branch_id,
+    created_by: USER_ID,
+  } as Session;
+
+  function makeBranchRepo() {
+    return {
+      findById: vi.fn(async () => branch),
+      isOwner: vi.fn(async () => false),
+      resolveUserPermission: vi.fn(async () => 'session' as BranchPermissionLevel),
+    };
+  }
+
+  it('reuses a loaded session and branch across RBAC hooks in one request', async () => {
+    const sessionService = { get: vi.fn(async () => session) };
+    const branchRepo = makeBranchRepo();
+    const ctx = {
+      path: 'messages',
+      method: 'create',
+      data: { session_id: session.session_id },
+      params: {
+        provider: 'rest',
+        user: { user_id: USER_ID, role: ROLES.MEMBER },
+        sessionId: session.session_id,
+      },
+    } as unknown as HookContext;
+
+    await loadSession(sessionService)(ctx);
+    await loadSession(sessionService)(ctx);
+    await loadBranchFromSession(branchRepo as never)(ctx);
+    await loadBranchFromSession(branchRepo as never)(ctx);
+
+    expect(sessionService.get).toHaveBeenCalledTimes(1);
+    expect(branchRepo.findById).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks sessions.get hook-loaded session as prefetched for the service get()', async () => {
+    const sessionService = { get: vi.fn(async () => session) };
+    const branchRepo = makeBranchRepo();
+    const ctx = {
+      path: 'sessions',
+      method: 'get',
+      id: session.session_id,
+      params: {
+        provider: 'rest',
+        user: { user_id: USER_ID, role: ROLES.MEMBER },
+      },
+    } as unknown as HookContext;
+
+    await loadSessionBranch(sessionService, branchRepo as never)(ctx);
+
+    expect(sessionService.get).toHaveBeenCalledTimes(1);
+    expect(ctx.params.session).toBe(session);
+    expect((ctx.params as { _agorPrefetchedRecord?: unknown })._agorPrefetchedRecord).toBe(session);
+  });
+
+  it('resolves id-addressed message context from the stored record, not spoofed query', async () => {
+    const existingMessage = {
+      message_id: 'message-cache-1',
+      session_id: session.session_id,
+    };
+    const ctx = {
+      path: 'messages',
+      method: 'get',
+      id: existingMessage.message_id,
+      params: {
+        provider: 'rest',
+        query: { session_id: 'spoofed-session' },
+        user: { user_id: USER_ID, role: ROLES.MEMBER },
+      },
+      service: {
+        get: vi.fn(async () => existingMessage),
+      },
+    } as unknown as HookContext;
+
+    await resolveSessionContext()(ctx);
+
+    expect(ctx.params.sessionId).toBe(session.session_id);
+    expect((ctx.params as { _agorPrefetchedRecord?: unknown })._agorPrefetchedRecord).toBe(
+      existingMessage
+    );
   });
 });
 

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -57,13 +57,24 @@ const REQUEST_RBAC_CACHE_LIMIT = 32;
 interface RequestScopedRbacCache {
   sessions: Map<string, Session>;
   branches: Map<string, Branch>;
+  branchAccess: Map<
+    string,
+    {
+      isOwner: boolean;
+      branchPermission: BranchPermissionLevel;
+    }
+  >;
 }
 
 type PrefetchParams = AuthenticatedParams & {
   branch?: Branch;
   session?: Session;
   _agorRbacCache?: RequestScopedRbacCache;
-  _agorPrefetchedRecord?: unknown;
+  _agorPrefetchedRecord?: {
+    id: string;
+    idField: string;
+    record: unknown;
+  };
 };
 
 function getRequestRbacCache(params: AuthenticatedParams): RequestScopedRbacCache {
@@ -72,6 +83,7 @@ function getRequestRbacCache(params: AuthenticatedParams): RequestScopedRbacCach
     prefetchParams._agorRbacCache = {
       sessions: new Map(),
       branches: new Map(),
+      branchAccess: new Map(),
     };
   }
   return prefetchParams._agorRbacCache;
@@ -86,8 +98,32 @@ function rememberBounded<T>(map: Map<string, T>, key: string, value: T): T {
   return value;
 }
 
-function rememberPrefetchedRecord(context: HookContext, record: unknown): void {
-  (context.params as PrefetchParams)._agorPrefetchedRecord = record;
+function inferIdFieldForPath(path: string): string | undefined {
+  switch (path) {
+    case 'branches':
+      return 'branch_id';
+    case 'sessions':
+      return 'session_id';
+    case 'tasks':
+      return 'task_id';
+    case 'messages':
+      return 'message_id';
+    default:
+      return undefined;
+  }
+}
+
+function rememberPrefetchedRecord(
+  context: HookContext,
+  record: unknown,
+  idField: string,
+  id: string
+): void {
+  (context.params as PrefetchParams)._agorPrefetchedRecord = {
+    id,
+    idField,
+    record,
+  };
 }
 
 async function loadCachedSession(
@@ -216,13 +252,21 @@ export async function cacheBranchAccess(
   branchRepo: BranchRepository,
   branch: Branch
 ): Promise<void> {
-  rememberBounded(getRequestRbacCache(params).branches, branch.branch_id as string, branch);
+  const cache = getRequestRbacCache(params);
+  rememberBounded(cache.branches, branch.branch_id as string, branch);
 
   const userId = params.user?.user_id as UUID | undefined;
-  const isOwner = userId ? await branchRepo.isOwner(branch.branch_id, userId) : false;
-  const branchPermission = userId
-    ? await branchRepo.resolveUserPermission(branch, userId)
-    : (branch.others_can ?? 'session');
+  const accessKey = `${branch.branch_id}:${userId ?? '__anonymous__'}`;
+  let access = cache.branchAccess.get(accessKey);
+  if (!access) {
+    access = {
+      isOwner: userId ? await branchRepo.isOwner(branch.branch_id, userId) : false,
+      branchPermission: userId
+        ? await branchRepo.resolveUserPermission(branch, userId)
+        : (branch.others_can ?? 'session'),
+    };
+    rememberBounded(cache.branchAccess, accessKey, access);
+  }
 
   const rbacParams = params as AuthenticatedParams & {
     branch?: Branch;
@@ -230,8 +274,8 @@ export async function cacheBranchAccess(
     branchPermission?: BranchPermissionLevel;
   };
   rbacParams.branch = branch;
-  rbacParams.isBranchOwner = isOwner;
-  rbacParams.branchPermission = branchPermission;
+  rbacParams.isBranchOwner = access.isOwner;
+  rbacParams.branchPermission = access.branchPermission;
 }
 
 /**
@@ -332,7 +376,7 @@ export function loadBranch(branchRepo: BranchRepository, branchIdField = 'branch
 
     const branch = await loadCachedBranch(context.params, branchRepo, branchId);
     if (context.path === 'branches' && context.id && String(context.id) === branchId) {
-      rememberPrefetchedRecord(context, branch);
+      rememberPrefetchedRecord(context, branch, 'branch_id', branchId);
     }
 
     // Cache on context for downstream hooks (type-safe via RBACParams)
@@ -734,7 +778,10 @@ export function loadSessionBranch(
               provider: undefined, // Bypass provider to avoid recursion
             });
             sessionId = existingRecord?.session_id;
-            if (existingRecord) rememberPrefetchedRecord(context, existingRecord);
+            const idField = inferIdFieldForPath(context.path);
+            if (existingRecord && idField) {
+              rememberPrefetchedRecord(context, existingRecord, idField, String(context.id));
+            }
           } catch (error) {
             console.error(
               `[loadSessionBranch] Failed to load existing ${context.path} record for session_id:`,
@@ -756,7 +803,7 @@ export function loadSessionBranch(
 
     const session = await loadCachedSession(context.params, sessionService, sessionId);
     if (context.path === 'sessions' && context.id && String(context.id) === sessionId) {
-      rememberPrefetchedRecord(context, session);
+      rememberPrefetchedRecord(context, session, 'session_id', sessionId);
     }
 
     const branch = await loadCachedBranch(context.params, branchRepo, session.branch_id);
@@ -822,7 +869,10 @@ export function resolveSessionContext() {
               provider: undefined,
             });
             sessionId = existing?.session_id;
-            if (existing) rememberPrefetchedRecord(context, existing);
+            const idField = inferIdFieldForPath(context.path);
+            if (existing && idField) {
+              rememberPrefetchedRecord(context, existing, idField, String(context.id));
+            }
           } catch (error) {
             console.error(`[resolveSessionContext] Failed to load existing record:`, error);
           }
@@ -873,7 +923,7 @@ export function loadSession(
 
     const session = await loadCachedSession(context.params, sessionService, sessionId);
     if (context.path === 'sessions' && context.id && String(context.id) === sessionId) {
-      rememberPrefetchedRecord(context, session);
+      rememberPrefetchedRecord(context, session, 'session_id', sessionId);
     }
 
     // Cache on context for downstream hooks (type-safe via RBACParams)

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -52,6 +52,87 @@ export const PERMISSION_RANK: Record<BranchPermissionLevel, number> = Object.fro
   BRANCH_PERMISSION_LEVELS.map((level, i) => [level, i - 1])
 ) as Record<BranchPermissionLevel, number>;
 
+const REQUEST_RBAC_CACHE_LIMIT = 32;
+
+interface RequestScopedRbacCache {
+  sessions: Map<string, Session>;
+  branches: Map<string, Branch>;
+}
+
+type PrefetchParams = AuthenticatedParams & {
+  branch?: Branch;
+  session?: Session;
+  _agorRbacCache?: RequestScopedRbacCache;
+  _agorPrefetchedRecord?: unknown;
+};
+
+function getRequestRbacCache(params: AuthenticatedParams): RequestScopedRbacCache {
+  const prefetchParams = params as PrefetchParams;
+  if (!prefetchParams._agorRbacCache) {
+    prefetchParams._agorRbacCache = {
+      sessions: new Map(),
+      branches: new Map(),
+    };
+  }
+  return prefetchParams._agorRbacCache;
+}
+
+function rememberBounded<T>(map: Map<string, T>, key: string, value: T): T {
+  if (!map.has(key) && map.size >= REQUEST_RBAC_CACHE_LIMIT) {
+    const oldestKey = map.keys().next().value;
+    if (oldestKey) map.delete(oldestKey);
+  }
+  map.set(key, value);
+  return value;
+}
+
+function rememberPrefetchedRecord(context: HookContext, record: unknown): void {
+  (context.params as PrefetchParams)._agorPrefetchedRecord = record;
+}
+
+async function loadCachedSession(
+  params: AuthenticatedParams,
+  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
+  sessionService: any,
+  sessionId: string
+): Promise<Session> {
+  const cachedParamSession = (params as PrefetchParams).session as Session | undefined;
+  if (cachedParamSession?.session_id === sessionId) {
+    return cachedParamSession;
+  }
+
+  const cache = getRequestRbacCache(params);
+  const cached = cache.sessions.get(sessionId);
+  if (cached) return cached;
+
+  const session = (await sessionService.get(sessionId, { provider: undefined })) as Session | null;
+  if (!session) {
+    throw new Forbidden(`Session not found: ${sessionId}`);
+  }
+  return rememberBounded(cache.sessions, sessionId, session);
+}
+
+async function loadCachedBranch(
+  params: AuthenticatedParams,
+  branchRepo: BranchRepository,
+  branchId: string
+): Promise<Branch> {
+  const cachedParamBranch = (params as PrefetchParams).branch as Branch | undefined;
+  if (cachedParamBranch?.branch_id === branchId) {
+    return cachedParamBranch;
+  }
+
+  const cache = getRequestRbacCache(params);
+  const cached = cache.branches.get(branchId);
+  if (cached) return cached;
+
+  const branch = await branchRepo.findById(branchId);
+  if (!branch) {
+    throw new Forbidden(`Branch not found: ${branchId}`);
+  }
+  return rememberBounded(cache.branches, branchId, branch);
+}
+
 /**
  * Check if user has minimum required permission level on a branch
  *
@@ -135,6 +216,8 @@ export async function cacheBranchAccess(
   branchRepo: BranchRepository,
   branch: Branch
 ): Promise<void> {
+  rememberBounded(getRequestRbacCache(params).branches, branch.branch_id as string, branch);
+
   const userId = params.user?.user_id as UUID | undefined;
   const isOwner = userId ? await branchRepo.isOwner(branch.branch_id, userId) : false;
   const branchPermission = userId
@@ -247,10 +330,9 @@ export function loadBranch(branchRepo: BranchRepository, branchIdField = 'branch
       throw new Error(`Cannot load branch: ${branchIdField} not found`);
     }
 
-    // Load branch
-    const branch = await branchRepo.findById(branchId);
-    if (!branch) {
-      throw new Forbidden(`Branch not found: ${branchId}`);
+    const branch = await loadCachedBranch(context.params, branchRepo, branchId);
+    if (context.path === 'branches' && context.id && String(context.id) === branchId) {
+      rememberPrefetchedRecord(context, branch);
     }
 
     // Cache on context for downstream hooks (type-safe via RBACParams)
@@ -626,10 +708,6 @@ export function loadSessionBranch(
       return context;
     }
 
-    console.log(
-      `[loadSessionBranch] method=${context.method}, path=${context.path}, id=${context.id || 'none'}`
-    );
-
     // Extract session_id from data, query, or id
     let sessionId: string | undefined;
 
@@ -645,29 +723,27 @@ export function loadSessionBranch(
       if (context.path === 'sessions') {
         sessionId = context.id as string;
       } else {
-        // For tasks/messages, session_id should be in data/query
-        sessionId = data?.session_id || query?.session_id;
-
-        // If session_id not provided in patch/remove, load existing record
-        if (!sessionId && (context.method === 'patch' || context.method === 'remove')) {
-          console.log(
-            `[loadSessionBranch] Loading existing ${context.path} record to get session_id. ID: ${context.id}`
-          );
+        // For id-addressed nested resources, trust the stored parent pointer,
+        // not client-supplied data/query. Otherwise a caller could authorize
+        // against a session they can access while fetching/patching/removing a
+        // task/message that actually belongs to a different session.
+        if (context.method === 'get' || context.method === 'patch' || context.method === 'remove') {
           try {
             // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
             const existingRecord = await (context.service as any).get(context.id, {
               provider: undefined, // Bypass provider to avoid recursion
             });
             sessionId = existingRecord?.session_id;
-            console.log(
-              `[loadSessionBranch] Loaded session_id from existing record: ${sessionId ? shortId(sessionId) : 'NOT FOUND'}`
-            );
+            if (existingRecord) rememberPrefetchedRecord(context, existingRecord);
           } catch (error) {
             console.error(
               `[loadSessionBranch] Failed to load existing ${context.path} record for session_id:`,
               error
             );
           }
+        } else {
+          // For create/find on nested resources, session_id should be in data/query.
+          sessionId = data?.session_id || query?.session_id;
         }
       }
     } else if (query?.session_id) {
@@ -678,17 +754,12 @@ export function loadSessionBranch(
       throw new Error('Cannot load session branch: session_id not found');
     }
 
-    // Load session (bypass provider to avoid recursion)
-    const session = await sessionService.get(sessionId, { provider: undefined });
-    if (!session) {
-      throw new Forbidden(`Session not found: ${sessionId}`);
+    const session = await loadCachedSession(context.params, sessionService, sessionId);
+    if (context.path === 'sessions' && context.id && String(context.id) === sessionId) {
+      rememberPrefetchedRecord(context, session);
     }
 
-    // Load branch
-    const branch = await branchRepo.findById(session.branch_id);
-    if (!branch) {
-      throw new Forbidden(`Branch not found: ${session.branch_id}`);
-    }
+    const branch = await loadCachedBranch(context.params, branchRepo, session.branch_id);
 
     // Cache on context for downstream hooks (type-safe via RBACParams)
     context.params.session = session;
@@ -703,7 +774,7 @@ export function loadSessionBranch(
  *
  * Extracts session_id from various sources based on the operation:
  * - Sessions: context.id (for get/patch/remove) or data.session_id (for create)
- * - Tasks/Messages: data.session_id (for create) or load from existing record (for patch/remove)
+ * - Tasks/Messages: data.session_id (for create/find) or load from existing record (for get/patch/remove)
  *
  * Caches session_id on context.params.sessionId for downstream hooks.
  *
@@ -735,34 +806,23 @@ export function resolveSessionContext() {
     else if (context.path === 'tasks' || context.path === 'messages') {
       if (context.method === 'create') {
         sessionId = data?.session_id;
-      } else if (context.method === 'patch' || context.method === 'remove') {
-        // Try data/query first
-        sessionId = data?.session_id || query?.session_id;
-
-        // If not found, load existing record
-        if (!sessionId && context.id) {
+      } else if (
+        context.method === 'get' ||
+        context.method === 'patch' ||
+        context.method === 'remove'
+      ) {
+        // Id-addressed nested resources must authorize against the stored
+        // parent session, not a client-supplied session_id in data/query. The
+        // prefetched record is reused by DrizzleService.get/patch/remove, so
+        // this safety read does not add a second primary-key read later.
+        if (context.id) {
           try {
             // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type
             const existing = await (context.service as any).get(context.id, {
               provider: undefined,
             });
             sessionId = existing?.session_id;
-          } catch (error) {
-            console.error(`[resolveSessionContext] Failed to load existing record:`, error);
-          }
-        }
-      } else if (context.method === 'get') {
-        // Try query first (if session_id provided in params)
-        sessionId = query?.session_id;
-
-        // If not found and we have an ID, load existing record
-        if (!sessionId && context.id) {
-          try {
-            // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type
-            const existing = await (context.service as any).get(context.id, {
-              provider: undefined,
-            });
-            sessionId = existing?.session_id;
+            if (existing) rememberPrefetchedRecord(context, existing);
           } catch (error) {
             console.error(`[resolveSessionContext] Failed to load existing record:`, error);
           }
@@ -811,11 +871,9 @@ export function loadSession(
       throw new Error('resolveSessionContext hook must run before loadSession');
     }
 
-    // Load session (bypass provider to avoid recursion)
-    const session = await sessionService.get(sessionId, { provider: undefined });
-
-    if (!session) {
-      throw new Forbidden(`Session not found: ${sessionId}`);
+    const session = await loadCachedSession(context.params, sessionService, sessionId);
+    if (context.path === 'sessions' && context.id && String(context.id) === sessionId) {
+      rememberPrefetchedRecord(context, session);
     }
 
     // Cache on context for downstream hooks (type-safe via RBACParams)
@@ -853,12 +911,7 @@ export function loadBranchFromSession(branchRepo: BranchRepository) {
       throw new Error('loadSession hook must run before loadBranchFromSession');
     }
 
-    // Load branch
-    const branch = await branchRepo.findById(session.branch_id);
-
-    if (!branch) {
-      throw new Forbidden(`Branch not found: ${session.branch_id}`);
-    }
+    const branch = await loadCachedBranch(context.params, branchRepo, session.branch_id);
 
     // Cache on context for downstream hooks (type-safe via RBACParams)
     await cacheBranchAccess(context.params, branchRepo, branch);


### PR DESCRIPTION
## Summary

- Add a bounded request-scoped RBAC cache for session/branch loads in daemon authorization hooks.
- Reuse hook-prefetched records in the Drizzle adapter to avoid immediate duplicate primary-key reads for `get`/`patch`/`remove` flows.
- Authorize id-addressed task/message operations using the stored `session_id` instead of client-supplied query/data, closing a spoofable-context edge case.
- Remove the noisy unconditional `loadSessionBranch` request log path.

## Validation

- `pnpm i`
- `pnpm check`
  - Passed; existing lint warnings remain unrelated to this change.
- `pnpm --filter @agor/daemon test -- src/adapters/drizzle.test.ts src/utils/branch-authorization.test.ts`
  - 2 files passed, 68 tests passed.
