### PR TITLE
Improve Knowledge namespace select

### DIFF
--- a/apps/agor-ui/src/pages/KnowledgePage.routing.test.ts
+++ b/apps/agor-ui/src/pages/KnowledgePage.routing.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { filterSelectOptionBySearchText } from '../utils/selectSearch';
 import {
   areKnowledgeSearchResultsFresh,
   buildKnowledgeDocumentRouteUrl,
+  buildKnowledgeNamespaceSelectOptions,
   buildKnowledgeQueryString,
   buildKnowledgeSearchResultKey,
   isKnowledgeDocumentContentReady,
@@ -220,5 +222,69 @@ describe('KnowledgePage global search helpers', () => {
       false
     );
     expect(areKnowledgeSearchResultsFresh({ resultKey, query: '', mode: 'text' })).toBe(false);
+  });
+});
+
+describe('KnowledgePage namespace select helpers', () => {
+  it('sorts namespace options by display name with slug fallback and searchable text', () => {
+    expect(
+      buildKnowledgeNamespaceSelectOptions([
+        {
+          namespace_id: 'ns-z',
+          slug: 'zebra',
+          display_name: 'Zebra Space',
+        },
+        {
+          namespace_id: 'ns-a',
+          slug: 'alpha-slug',
+          display_name: 'Alpha Space',
+        },
+        {
+          namespace_id: 'ns-b',
+          slug: 'beta',
+          display_name: null,
+        },
+        {
+          namespace_id: 'ns-a2',
+          slug: 'alpha-slug-2',
+          display_name: 'Alpha Space',
+        },
+      ])
+    ).toEqual([
+      {
+        label: 'Alpha Space',
+        value: 'alpha-slug',
+        searchText: 'alpha space alpha-slug',
+      },
+      {
+        label: 'Alpha Space',
+        value: 'alpha-slug-2',
+        searchText: 'alpha space alpha-slug-2',
+      },
+      {
+        label: 'beta',
+        value: 'beta',
+        searchText: 'beta beta',
+      },
+      {
+        label: 'Zebra Space',
+        value: 'zebra',
+        searchText: 'zebra space zebra',
+      },
+    ]);
+  });
+
+  it('makes namespace options filterable by display name and slug', () => {
+    const [option] = buildKnowledgeNamespaceSelectOptions([
+      {
+        namespace_id: 'ns-product',
+        slug: 'product-docs',
+        display_name: 'Product Knowledge',
+      },
+    ]);
+
+    expect(filterSelectOptionBySearchText('product knowledge', option)).toBe(true);
+    expect(filterSelectOptionBySearchText('product-docs', option)).toBe(true);
+    expect(filterSelectOptionBySearchText('engineering', option)).toBe(false);
   });
 });

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -108,6 +108,7 @@ import {
 } from '../utils/knowledgeRoutes';
 import { useThemedModal } from '../utils/modal';
 import { slugify } from '../utils/repoSlug';
+import { searchableSelectProps } from '../utils/selectSearch';
 
 const { Header, Content } = Layout;
 const { Text, Title } = Typography;
@@ -547,6 +548,42 @@ export const areKnowledgeSearchResultsFresh = (args: {
 }) =>
   Boolean(args.query.trim()) &&
   args.resultKey === buildKnowledgeSearchResultKey(args.query, args.mode);
+
+type KnowledgeNamespaceOptionSource = Pick<
+  KnowledgeNamespace,
+  'namespace_id' | 'slug' | 'display_name'
+>;
+
+const knowledgeNamespaceDisplayName = (namespace: KnowledgeNamespaceOptionSource) =>
+  namespace.display_name?.trim() || namespace.slug;
+
+export function buildKnowledgeNamespaceSelectOptions(namespaces: KnowledgeNamespaceOptionSource[]) {
+  return [...namespaces]
+    .sort((a, b) => {
+      const displayCompare = knowledgeNamespaceDisplayName(a).localeCompare(
+        knowledgeNamespaceDisplayName(b),
+        undefined,
+        { sensitivity: 'base', numeric: true }
+      );
+      if (displayCompare !== 0) return displayCompare;
+
+      const slugCompare = a.slug.localeCompare(b.slug, undefined, {
+        sensitivity: 'base',
+        numeric: true,
+      });
+      if (slugCompare !== 0) return slugCompare;
+
+      return a.namespace_id.localeCompare(b.namespace_id);
+    })
+    .map((namespace) => {
+      const label = knowledgeNamespaceDisplayName(namespace);
+      return {
+        label,
+        value: namespace.slug,
+        searchText: `${label} ${namespace.slug}`.toLowerCase(),
+      };
+    });
+}
 
 const compactKnowledgeSnippet = (value?: string | null) =>
   (value ?? '')
@@ -2768,10 +2805,8 @@ export function KnowledgePage({
     </div>
   );
 
-  const spaceOptions = [
-    { label: 'All Spaces', value: 'all' },
-    ...namespaces.map((ns) => ({ label: ns.display_name || ns.slug, value: ns.slug })),
-  ];
+  const namespaceOptions = buildKnowledgeNamespaceSelectOptions(namespaces);
+  const spaceOptions = [{ label: 'All Spaces', value: 'all' }, ...namespaceOptions];
   const createFolderError = validateKnowledgePath(createFolder, { allowEmpty: true });
   const newFolderParentError = validateKnowledgePath(newFolderParent, { allowEmpty: true });
   const newFolderNameError = normalizeFolderPath(newFolderName)
@@ -2988,6 +3023,7 @@ export function KnowledgePage({
                     Space
                   </Text>
                   <Select
+                    {...searchableSelectProps}
                     value={activeSpace}
                     onChange={changeKnowledgeSpace}
                     style={{ width: '100%' }}
@@ -4114,12 +4150,10 @@ export function KnowledgePage({
           </Form.Item>
           <Form.Item label="Space">
             <Select
+              {...searchableSelectProps}
               value={createNamespace}
               onChange={setCreateNamespace}
-              options={namespaces.map((ns) => ({
-                label: ns.display_name || ns.slug,
-                value: ns.slug,
-              }))}
+              options={namespaceOptions}
             />
           </Form.Item>
           <Form.Item


### PR DESCRIPTION
## Summary

- Sort Knowledge namespace select options alphabetically by display name, falling back to slug.
- Enable searchable namespace selects using the existing shared Select search helper.
- Add focused coverage for namespace option ordering and display-name/slug filtering.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- KnowledgePage.routing.test.ts selectSearch.test.tsx`
