### PR TITLE
Improve artifact publish validation

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/artifacts.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.test.ts
@@ -92,4 +92,22 @@ describe('artifact MCP tool input schemas', () => {
       message: 'requiredEnvVars[] cannot be empty.',
     });
   });
+
+  it('accepts waitForStatus publish options', () => {
+    const parsed = captureConfig('agor_artifacts_publish').inputSchema?.safeParse({
+      folderPath: '/tmp/artifact',
+      waitForStatus: true,
+      waitTimeoutMs: 15000,
+    });
+
+    expect(parsed?.success).toBe(true);
+  });
+
+  it('registers validate_folder as the clearer build-check alias', () => {
+    const parsed = captureConfig('agor_artifacts_validate_folder').inputSchema?.safeParse({
+      folderPath: '/tmp/artifact',
+    });
+
+    expect(parsed?.success).toBe(true);
+  });
 });

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -128,6 +128,8 @@ DECLARATIVE CONFIG:
 
 CONSENT MODEL (TOFU): when the viewer is NOT the artifact author, the daemon does NOT inject env vars or grants without an explicit trust grant. Untrusted artifacts render with empty env values and a "Trust to render with secrets" badge.
 
+SYNCHRONOUS-ISH VALIDATION: pass \`waitForStatus: true\` to wait briefly for YOUR browser render to report Sandpack boot status, errors, and console output. This is not a headless/server build: Sandpack runs in the browser, and logs are per-viewer to avoid leaking secret-derived output. If no browser tab for you is viewing the artifact, the validation returns \`observed:false\` with a note instead of pretending success.
+
 IMPORTANT:
 - Secret VALUES are never sent to the LLM as-is — they're only injected into the served \`.env\` at view time. CAVEAT: if your artifact renders a secret-derived value into the DOM (e.g. \`<div>API: {key}</div>\`), an agent calling \`agor_artifacts_query_dom\` against your own running render WILL see the rendered text. Treat any \`agor_artifacts_query_*\` reply as potentially carrying secret-derived output if the artifact renders one.
 - Missing user env vars render as "" — your app should detect that and surface a "configure SOMETHING in Settings" message rather than calling APIs with empty creds.
@@ -192,6 +194,16 @@ IMPORTANT:
           .number()
           .optional()
           .describe('Height in pixels (default: 400, only used on create)'),
+        waitForStatus: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, wait for this user's browser render to report Sandpack status/errors/console logs before returning. Requires an open board/fullscreen tab for this user; otherwise returns observed:false after timeout."
+          ),
+        waitTimeoutMs: mcpOptionalPositiveInt(
+          'waitTimeoutMs',
+          'Maximum milliseconds to wait for browser-reported Sandpack status when waitForStatus=true (default 10000, max 60000).'
+        ),
       }),
     },
     async (args) => {
@@ -233,12 +245,43 @@ IMPORTANT:
         ctx.authenticatedUser.role as UserRole
       );
 
+      const publishValidation = args.waitForStatus
+        ? await service.waitForRuntimeStatus(artifact.artifact_id, ctx.userId, {
+            timeoutMs: args.waitTimeoutMs,
+          })
+        : undefined;
+      const publishDiagnostic = publishValidation
+        ? service.buildStatusDiagnostic(publishValidation)
+        : undefined;
+
       const { files: _files, ...artifactSummary } = artifact;
+      const baseInstructions = args.artifactId
+        ? 'Artifact updated. Changes are live on the board.'
+        : 'Artifact created and placed on the board. To update it later, call agor_artifacts_publish again with the artifact_id.';
+      const validationInstructions = publishValidation
+        ? publishValidation.ok
+          ? ' Browser runtime validation observed a successful Sandpack boot.'
+          : publishValidation.observed
+            ? ' Browser runtime validation observed a failure; inspect publish_validation.build_errors, sandpack_error, and console_logs, then fix and republish.'
+            : publishValidation.timed_out
+              ? ' Browser runtime validation was inconclusive because no current browser render reported status before the timeout. Open the artifact as this user and call agor_artifacts_status, or republish with waitForStatus once the board/fullscreen view is open.'
+              : ' Publish validation failed before browser boot; inspect publish_validation.build_errors, then fix and republish.'
+        : '';
       return textResult({
         artifact: artifactSummary,
-        instructions: args.artifactId
-          ? 'Artifact updated. Changes are live on the board.'
-          : 'Artifact created and placed on the board. To update it later, call agor_artifacts_publish again with the artifact_id.',
+        urls: {
+          board: artifactSummary.url ?? null,
+          fullscreen: artifactSummary.fullscreen_url ?? null,
+        },
+        next_actions: {
+          open_fullscreen: artifactSummary.fullscreen_url ?? null,
+          check_status: `agor_artifacts_status({ artifactId: "${artifact.artifact_id}" })`,
+          republish: `agor_artifacts_publish({ artifactId: "${artifact.artifact_id}", ... })`,
+        },
+        ...(publishValidation
+          ? { publish_validation: { ...publishValidation, diagnostic: publishDiagnostic } }
+          : {}),
+        instructions: `${baseInstructions}${validationInstructions}`,
       });
     }
   );
@@ -248,7 +291,7 @@ IMPORTANT:
     'agor_artifacts_check_build',
     {
       description:
-        'Check build readiness of artifact files in a branch-relative folder (branchId + subpath preferred) or legacy absolute folderPath. Verifies source files exist and are non-empty (does not run a real build or syntax check). Use this before publishing to verify basic structure.',
+        'Browserless artifact folder validation in a branch-relative folder (branchId + subpath preferred) or legacy absolute folderPath. Checks source presence/non-empty files, package.json syntax, configured entry existence, missing local imports, and common env/template footguns. Does NOT run Sandpack; use publish(waitForStatus=true) or agor_artifacts_status for browser runtime validation.',
       inputSchema: z.object({
         folderPath: mcpOptionalString(
           'folderPath',
@@ -291,6 +334,59 @@ IMPORTANT:
       return textResult({
         build_status: result.status,
         build_errors: result.errors,
+        build_warnings: result.warnings,
+        diagnostics: result.diagnostics,
+      });
+    }
+  );
+
+  // Tool 2b: agor_artifacts_validate_folder
+  server.registerTool(
+    'agor_artifacts_validate_folder',
+    {
+      description:
+        'Browserless artifact folder validation. Clearer alias for agor_artifacts_check_build: verifies source files, package.json syntax, configured entry existence, missing local imports, and common env/template footguns. It still does NOT run Sandpack; use agor_artifacts_publish(waitForStatus=true) or agor_artifacts_status for browser runtime validation.',
+      inputSchema: z.object({
+        folderPath: mcpOptionalString(
+          'folderPath',
+          'Legacy absolute path to the artifact folder. Prefer branchId + subpath.'
+        ),
+        branchId: mcpOptionalId(
+          'branchId',
+          'Branch',
+          'Branch ID (UUID or short ID). Prefer this with subpath.'
+        ),
+        subpath: mcpOptionalString(
+          'subpath',
+          'Branch-relative subpath pointing at the artifact folder (required with branchId).'
+        ),
+      }),
+    },
+    async (args) => {
+      const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
+      const branchIdRaw = coerceString(args.branchId);
+      const resolvedBranchId = branchIdRaw ? await resolveBranchId(ctx, branchIdRaw) : undefined;
+      const folderPath = coerceString(args.folderPath);
+      const subpath = coerceString(args.subpath);
+      if (!folderPath && (!resolvedBranchId || !subpath)) {
+        throw new Error(
+          'Provide either legacy folderPath or branchId + subpath to validate artifact files.'
+        );
+      }
+      const result = await service.checkBuildFromFolder(
+        {
+          folderPath,
+          branch_id: resolvedBranchId,
+          subpath,
+        },
+        ctx.userId,
+        ctx.authenticatedUser.role as UserRole
+      );
+      return textResult({
+        build_status: result.status,
+        build_errors: result.errors,
+        build_warnings: result.warnings,
+        diagnostics: result.diagnostics,
       });
     }
   );
@@ -306,8 +402,10 @@ build_status reflects both file validation AND Sandpack runtime state. If the Sa
 Fields:
 - build_status: 'success' | 'error' | 'unknown' — reflects the worst of file validation and Sandpack runtime
 - build_errors: array of error messages (includes Sandpack errors prefixed with [Sandpack])
+- diagnostic: compact deterministic diagnosis + suggested_fix when an error/no-observation pattern is recognized
 - sandpack_error: the raw Sandpack bundler/runtime error object (null if no error)
 - sandpack_status: Sandpack bundler status ('idle', 'running', 'timeout', etc.)
+- runtime_observed_at: when your browser last reported current-content status/logs
 - console_logs: console.log/warn/error output from the running app
 
 NOTE: sandpack_error and console_logs require a browser to be viewing the artifact. They are scoped to the calling user's render — you only see your own console output, never another viewer's.`,
@@ -319,7 +417,10 @@ NOTE: sandpack_error and console_logs require a browser to be viewing the artifa
     async (args) => {
       const service = ctx.app.service('artifacts') as unknown as ArtifactsService;
       const status = await service.getStatus(coerceString(args.artifactId)!, ctx.userId);
-      return textResult(status);
+      return textResult({
+        ...status,
+        diagnostic: service.buildStatusDiagnostic(status),
+      });
     }
   );
 
@@ -435,6 +536,16 @@ Caller must own the artifact (or be an admin).`,
         agorRuntime: AgorRuntimeSchema.describe(
           "Replace the artifact's agor_runtime config (controls agor-runtime.js injection)."
         ),
+        waitForStatus: z
+          .boolean()
+          .optional()
+          .describe(
+            "If true, wait for this user's browser render to report Sandpack status/errors/console logs after the metadata update. Most useful when changing sandpackConfig, requiredEnvVars, agorGrants, or agorRuntime."
+          ),
+        waitTimeoutMs: mcpOptionalPositiveInt(
+          'waitTimeoutMs',
+          'Maximum milliseconds to wait for browser-reported Sandpack status when waitForStatus=true (default 10000, max 60000).'
+        ),
       }),
     },
     async (args) => {
@@ -465,10 +576,34 @@ Caller must own the artifact (or be an admin).`,
         ctx.authenticatedUser.role as UserRole
       );
 
+      const updateValidation = args.waitForStatus
+        ? await service.waitForRuntimeStatus(updated.artifact_id, ctx.userId, {
+            timeoutMs: args.waitTimeoutMs,
+          })
+        : undefined;
+      const updateDiagnostic = updateValidation
+        ? service.buildStatusDiagnostic(updateValidation)
+        : undefined;
+
       const { files: _files, ...artifactSummary } = updated;
       return textResult({
         artifact: artifactSummary,
-        instructions: 'Artifact metadata updated.',
+        urls: {
+          board: artifactSummary.url ?? null,
+          fullscreen: artifactSummary.fullscreen_url ?? null,
+        },
+        next_actions: {
+          open_fullscreen: artifactSummary.fullscreen_url ?? null,
+          check_status: `agor_artifacts_status({ artifactId: "${updated.artifact_id}" })`,
+        },
+        ...(updateValidation
+          ? { publish_validation: { ...updateValidation, diagnostic: updateDiagnostic } }
+          : {}),
+        instructions: updateValidation
+          ? updateValidation.ok
+            ? 'Artifact metadata updated. Browser runtime validation observed a successful Sandpack boot.'
+            : 'Artifact metadata updated, but validation did not observe a successful render. Inspect publish_validation for details.'
+          : 'Artifact metadata updated.',
       });
     }
   );

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -658,7 +658,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       '/artifacts/:id/console',
       {
         async create(
-          data: { entries: Array<{ timestamp: number; level: string; message: string }> },
+          data: {
+            entries: Array<{ timestamp: number; level: string; message: string }>;
+            content_hash?: string;
+          },
           _params: RouteParams
         ) {
           const artifactId = _params.route?.id;
@@ -673,7 +676,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           if (!artifactsService.isVisibleTo(artifact, userId)) {
             throw new Error(`Artifact ${artifactId} not found`);
           }
-          artifactsService.appendConsoleLogs(artifactId, userId, data.entries as never);
+          await artifactsService.appendConsoleLogs(
+            artifactId,
+            userId,
+            data.entries as never,
+            data.content_hash
+          );
           return { success: true };
         },
       },
@@ -691,6 +699,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           data: {
             error: import('@agor/core/types').SandpackError | null;
             status?: string;
+            content_hash?: string;
           },
           _params: RouteParams
         ) {
@@ -703,7 +712,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           if (!artifactsService.isVisibleTo(artifact, userId)) {
             throw new Error(`Artifact ${artifactId} not found`);
           }
-          artifactsService.setSandpackError(artifactId, userId, data.error, data.status);
+          await artifactsService.setSandpackError(
+            artifactId,
+            userId,
+            data.error,
+            data.status,
+            data.content_hash
+          );
           return { success: true };
         },
       },

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1075,6 +1075,58 @@ describe('ArtifactsService.getStatus + console isolation', () => {
     }
   );
 
+  dbTest(
+    'waitForRuntimeStatus ignores stale reports after metadata-only render changes',
+    async ({ db }) => {
+      vi.useFakeTimers();
+      try {
+        const service = new ArtifactsService(db, makeFakeApp());
+        const board = await seedBoard(db);
+        const artifactRepo = new ArtifactRepository(db);
+        const created = await artifactRepo.create({
+          artifact_id: generateId(),
+          board_id: board.board_id,
+          name: 'wait-stale-metadata',
+          template: 'react',
+          files: { '/index.js': 'console.log("x")' },
+          content_hash: 'same-file-hash',
+          public: true,
+          created_by: 'user-owner',
+        });
+        const beforePayload = await service.getPayload(created.artifact_id, 'viewer-A' as never);
+
+        const updated = await service.updateMetadata(
+          created.artifact_id,
+          { sandpack_config: { options: { showNavigator: true } } },
+          'user-owner',
+          'admin'
+        );
+        expect(updated.content_hash).toBe('same-file-hash');
+
+        const waitPromise = service.waitForRuntimeStatus(created.artifact_id, 'viewer-A' as never, {
+          timeoutMs: 500,
+          settleMs: 0,
+        });
+        await service.setSandpackError(
+          created.artifact_id,
+          'viewer-A',
+          null,
+          'idle',
+          beforePayload.runtime_report_hash
+        );
+        await vi.advanceTimersByTimeAsync(600);
+
+        const result = await waitPromise;
+        expect(result.ok).toBe(false);
+        expect(result.observed).toBe(false);
+        expect(result.timed_out).toBe(true);
+        expect(result.sandpack_status).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+  );
+
   dbTest('getStatus rejects when artifact is not visible to caller', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -21,7 +21,7 @@ import {
 import type { Application } from '@agor/core/feathers';
 import type { Artifact, BoardID, BranchID, UUID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
-import { afterEach, beforeEach, describe, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { ArtifactsService } from './artifacts';
 
@@ -928,6 +928,44 @@ describe('ArtifactsService.grantTrust', () => {
   });
 });
 
+describe('ArtifactsService.checkBuildFromFolder validation diagnostics', () => {
+  dbTest('reports missing local imports and malformed package.json', async ({ db }) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'agor-artifact-validate-'));
+    try {
+      writeFileSync(path.join(root, 'index.js'), "import './missing';\nconsole.log('hello');\n");
+      writeFileSync(path.join(root, 'package.json'), '{ invalid json');
+
+      const service = new ArtifactsService(db, makeFakeApp());
+      const result = await service.checkBuildFromFolder({ folderPath: root });
+
+      expect(result.status).toBe('error');
+      expect(result.diagnostics.map((d) => d.code)).toContain('missing_local_import');
+      expect(result.diagnostics.map((d) => d.code)).toContain('malformed_package_json');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  dbTest('warns about declared env vars on templates without dotenv injection', async ({ db }) => {
+    const root = mkdtempSync(path.join(tmpdir(), 'agor-artifact-validate-'));
+    try {
+      writeFileSync(path.join(root, 'index.js'), "console.log('hello');\n");
+      writeFileSync(
+        path.join(root, 'agor.artifact.json'),
+        JSON.stringify({ template: 'vanilla', required_env_vars: ['API_KEY'] })
+      );
+
+      const service = new ArtifactsService(db, makeFakeApp());
+      const result = await service.checkBuildFromFolder({ folderPath: root });
+
+      expect(result.status).toBe('success');
+      expect(result.diagnostics.map((d) => d.code)).toContain('env_vars_not_injected_for_template');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('ArtifactsService.getStatus + console isolation', () => {
   dbTest('console logs and sandpack errors are scoped per viewer', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
@@ -946,13 +984,18 @@ describe('ArtifactsService.getStatus + console isolation', () => {
     // Two different viewers post console output. Viewer A's output may
     // contain values derived from their own injected secrets — those must
     // never leak into viewer B's status read.
-    service.appendConsoleLogs(created.artifact_id, 'viewer-A', [
+    await service.appendConsoleLogs(created.artifact_id, 'viewer-A', [
       { timestamp: 1, level: 'log', message: 'A_SECRET=alpha' },
     ]);
-    service.appendConsoleLogs(created.artifact_id, 'viewer-B', [
+    await service.appendConsoleLogs(created.artifact_id, 'viewer-B', [
       { timestamp: 2, level: 'log', message: 'B_SECRET=bravo' },
     ]);
-    service.setSandpackError(created.artifact_id, 'viewer-A', { message: 'A-only error' }, 'idle');
+    await service.setSandpackError(
+      created.artifact_id,
+      'viewer-A',
+      { message: 'A-only error' },
+      'idle'
+    );
 
     const statusA = await service.getStatus(created.artifact_id, 'viewer-A' as never);
     expect(statusA.console_logs.map((l) => l.message)).toEqual(['A_SECRET=alpha']);
@@ -962,6 +1005,75 @@ describe('ArtifactsService.getStatus + console isolation', () => {
     expect(statusB.console_logs.map((l) => l.message)).toEqual(['B_SECRET=bravo']);
     expect(statusB.sandpack_error).toBeNull();
   });
+
+  dbTest('waitForRuntimeStatus resolves with browser-reported Sandpack failure', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const board = await seedBoard(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const created = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'wait-failure',
+      template: 'react',
+      files: { '/index.js': 'console.log("x")' },
+      public: true,
+      created_by: 'user-owner',
+    });
+
+    const waitPromise = service.waitForRuntimeStatus(created.artifact_id, 'viewer-A' as never, {
+      timeoutMs: 5000,
+      settleMs: 0,
+    });
+    await service.setSandpackError(
+      created.artifact_id,
+      'viewer-A',
+      { message: 'Cannot find module ./missing' },
+      'idle'
+    );
+
+    const result = await waitPromise;
+    expect(result.ok).toBe(false);
+    expect(result.observed).toBe(true);
+    expect(result.build_status).toBe('error');
+    expect(result.build_errors?.join('\n')).toMatch(/Cannot find module/);
+  });
+
+  dbTest(
+    'waitForRuntimeStatus ignores stale content-hash reports and times out',
+    async ({ db }) => {
+      vi.useFakeTimers();
+      try {
+        const service = new ArtifactsService(db, makeFakeApp());
+        const board = await seedBoard(db);
+        const artifactRepo = new ArtifactRepository(db);
+        const created = await artifactRepo.create({
+          artifact_id: generateId(),
+          board_id: board.board_id,
+          name: 'wait-stale',
+          template: 'react',
+          files: { '/index.js': 'console.log("x")' },
+          content_hash: 'current',
+          public: true,
+          created_by: 'user-owner',
+        });
+
+        const waitPromise = service.waitForRuntimeStatus(created.artifact_id, 'viewer-A' as never, {
+          timeoutMs: 500,
+          settleMs: 0,
+        });
+        await service.setSandpackError(created.artifact_id, 'viewer-A', null, 'idle', 'old');
+        await vi.advanceTimersByTimeAsync(600);
+
+        const result = await waitPromise;
+        expect(result.ok).toBe(false);
+        expect(result.observed).toBe(false);
+        expect(result.timed_out).toBe(true);
+        expect(result.sandpack_status).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+  );
 
   dbTest('getStatus rejects when artifact is not visible to caller', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -150,6 +150,21 @@ interface ArtifactSidecar {
   agor_runtime?: AgorRuntimeConfig;
 }
 
+interface ArtifactValidationDiagnostic {
+  code: string;
+  severity: 'error' | 'warning';
+  message: string;
+  file?: string;
+  suggested_fix?: string;
+}
+
+interface ArtifactValidationResult {
+  status: ArtifactBuildStatus;
+  errors: string[];
+  warnings: string[];
+  diagnostics: ArtifactValidationDiagnostic[];
+}
+
 /**
  * Read `agor.artifact.json` from a folder if present. Returns null when the
  * file is missing or unparseable — the caller treats absence and corruption
@@ -223,6 +238,16 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   /** In-memory Sandpack status, keyed by `${artifactId}:${userId}`. */
   private sandpackStatuses: Map<string, string> = new Map();
+
+  /** Latest browser runtime report time, keyed by `${artifactId}:${userId}`. */
+  private runtimeObservedAt: Map<string, string> = new Map();
+
+  /**
+   * Runtime-status waiters for synchronous-ish artifact publishing. Keyed by
+   * `${artifactId}:${userId}` so a caller can only wait on their own browser
+   * render; no other viewer's logs/errors are exposed.
+   */
+  private runtimeStatusWaiters: Map<string, Set<() => void>> = new Map();
 
   /**
    * Just-once / session-scope grants live here only — never persisted.
@@ -513,7 +538,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const contentHash = this.computeHashFromFiles(files);
 
     if (existing) {
-      const buildResult = this.validateFiles(files);
+      const buildResult = this.validateArtifactFiles(files, {
+        template,
+        sandpackConfig: resolvedSandpackConfig,
+        requiredEnvVars,
+      });
 
       const updated = await this.artifactRepo.update(existing.artifact_id, {
         name: resolvedName,
@@ -545,7 +574,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     }
 
     const artifactId = generateId();
-    const buildResult = this.validateFiles(files);
+    const buildResult = this.validateArtifactFiles(files, {
+      template,
+      sandpackConfig: resolvedSandpackConfig,
+      requiredEnvVars,
+    });
 
     const artifact = await this.artifactRepo.create({
       artifact_id: artifactId,
@@ -740,6 +773,15 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           // Old board may not have this object.
         }
       }
+    }
+
+    if (
+      updates.sandpack_config !== undefined ||
+      updates.required_env_vars !== undefined ||
+      updates.agor_grants !== undefined ||
+      updates.agor_runtime !== undefined
+    ) {
+      this.clearAllViewerBuffersFor(fullArtifactId);
     }
 
     this.app.service('artifacts').emit('patched', updated);
@@ -952,7 +994,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       ? withInjectedAgorRuntime(artifact.sandpack_config)
       : artifact.sandpack_config;
 
-    const contentHash = this.computeHashFromFiles(filesOut);
+    const contentHash = this.computeHashFromFiles({
+      ...filesOut,
+      '/.agor/sandpack-config.json': JSON.stringify(servedSandpackConfig ?? {}),
+    });
     const legacy = detectLegacyFormat(artifact);
 
     const payload: ArtifactPayload = {
@@ -965,6 +1010,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       dependencies: artifact.dependencies,
       entry: artifact.entry,
       content_hash: contentHash,
+      artifact_content_hash: artifact.content_hash,
       required_env_vars: requiredEnvVars.length > 0 ? requiredEnvVars : undefined,
       agor_grants: Object.keys(grants).length > 0 ? grants : undefined,
       trust_state: trustState,
@@ -1582,16 +1628,28 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     input: { folderPath?: string; branch_id?: string; subpath?: string },
     userId?: string,
     userRole?: UserRole
-  ): Promise<{
-    status: ArtifactBuildStatus;
-    errors: string[];
-  }> {
+  ): Promise<ArtifactValidationResult> {
     const { folderPath } = await this.resolveArtifactSource(input, userId, userRole);
     if (!fs.existsSync(folderPath)) {
-      return { status: 'error', errors: [`Folder not found: ${folderPath}`] };
+      return {
+        status: 'error',
+        errors: [`Folder not found: ${folderPath}`],
+        warnings: [],
+        diagnostics: [
+          {
+            code: 'folder_not_found',
+            severity: 'error',
+            message: `Folder not found: ${folderPath}`,
+          },
+        ],
+      };
     }
+    const sidecar = readArtifactSidecar(folderPath);
+    const sandpackConfig = sanitizeSandpackConfig(sidecar?.sandpack_config);
+    const template = (sandpackConfig.template ?? sidecar?.template ?? 'react') as SandpackTemplate;
+    const requiredEnvVars = sanitizeEnvVarNames(sidecar?.required_env_vars);
     const files = this.readFilesRecursive(folderPath, folderPath);
-    return this.validateFiles(files);
+    return this.validateArtifactFiles(files, { template, sandpackConfig, requiredEnvVars });
   }
 
   async checkBuild(artifactId: string): Promise<{
@@ -1599,7 +1657,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     errors: string[];
   }> {
     const payload = await this.getPayload(artifactId);
-    const result = this.validateFiles(payload.files);
+    const result = this.validateArtifactFiles(payload.files, {
+      template: payload.sandpack_config?.template ?? payload.template,
+      sandpackConfig: payload.sandpack_config,
+      requiredEnvVars: payload.required_env_vars ?? [],
+    });
     await this.artifactRepo.updateBuildStatus(
       artifactId,
       result.status,
@@ -1625,9 +1687,21 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     for (const key of this.sandpackStatuses.keys()) {
       if (key.startsWith(prefix)) this.sandpackStatuses.delete(key);
     }
+    for (const key of this.runtimeObservedAt.keys()) {
+      if (key.startsWith(prefix)) this.runtimeObservedAt.delete(key);
+    }
+    for (const key of this.runtimeStatusWaiters.keys()) {
+      if (key.startsWith(prefix)) this.notifyRuntimeStatusWaiters(key);
+    }
   }
 
-  appendConsoleLogs(artifactId: string, userId: string, entries: ArtifactConsoleEntry[]): void {
+  async appendConsoleLogs(
+    artifactId: string,
+    userId: string,
+    entries: ArtifactConsoleEntry[],
+    contentHash?: string
+  ): Promise<void> {
+    if (!(await this.isCurrentContentHash(artifactId, contentHash))) return;
     const key = this.viewerKey(artifactId, userId);
     const existing = this.consoleLogs.get(key) ?? [];
     const combined = [...existing, ...entries];
@@ -1636,19 +1710,37 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     } else {
       this.consoleLogs.set(key, combined);
     }
+    this.runtimeObservedAt.set(key, new Date().toISOString());
+    this.notifyRuntimeStatusWaiters(key);
   }
 
-  setSandpackError(
+  async setSandpackError(
     artifactId: string,
     userId: string,
     error: SandpackError | null,
-    status?: string
-  ): void {
+    status?: string,
+    contentHash?: string
+  ): Promise<void> {
+    if (!(await this.isCurrentContentHash(artifactId, contentHash))) return;
     const key = this.viewerKey(artifactId, userId);
     this.sandpackErrors.set(key, error);
     if (status !== undefined) {
       this.sandpackStatuses.set(key, status);
     }
+    this.runtimeObservedAt.set(key, new Date().toISOString());
+    this.notifyRuntimeStatusWaiters(key);
+  }
+
+  private async isCurrentContentHash(artifactId: string, contentHash?: string): Promise<boolean> {
+    if (!contentHash) return true;
+    const artifact = await this.artifactRepo.findById(artifactId);
+    return artifact?.content_hash === contentHash;
+  }
+
+  private notifyRuntimeStatusWaiters(key: string): void {
+    const waiters = this.runtimeStatusWaiters.get(key);
+    if (!waiters) return;
+    for (const notify of waiters) notify();
   }
 
   /**
@@ -1667,6 +1759,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const key = userId ? this.viewerKey(artifactId, userId) : null;
     const sandpackError = key ? (this.sandpackErrors.get(key) ?? null) : null;
     const sandpackStatus = key ? this.sandpackStatuses.get(key) : undefined;
+    const runtimeObservedAt = key ? this.runtimeObservedAt.get(key) : undefined;
     const consoleLogs = key ? (this.consoleLogs.get(key) ?? []) : [];
 
     let buildStatus = artifact.build_status;
@@ -1684,9 +1777,220 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       build_errors: buildErrors ?? [],
       sandpack_error: sandpackError,
       sandpack_status: sandpackStatus,
+      runtime_observed_at: runtimeObservedAt,
       console_logs: consoleLogs,
       content_hash: artifact.content_hash,
     };
+  }
+
+  buildStatusDiagnostic(status: ArtifactStatus): {
+    diagnosis: string;
+    primary_error?: string;
+    suggested_fix?: string;
+  } | null {
+    const messages = [
+      status.sandpack_error?.message,
+      ...(status.build_errors ?? []),
+      ...status.console_logs
+        .filter((entry) => entry.level === 'error')
+        .map((entry) => entry.message),
+    ].filter((msg): msg is string => !!msg && msg.length > 0);
+    const primary = messages[0];
+    if (!primary) {
+      if (!status.runtime_observed_at) {
+        return {
+          diagnosis: 'no_browser_observation',
+          suggested_fix:
+            'Open the artifact on the board/fullscreen as this user, then call agor_artifacts_status or publish with waitForStatus=true.',
+        };
+      }
+      return null;
+    }
+
+    if (/could not find module|cannot find module|module not found/i.test(primary)) {
+      return {
+        diagnosis: 'missing_local_import_or_dependency',
+        primary_error: primary,
+        suggested_fix:
+          'If the missing specifier starts with ./ or ../, create that file or fix the import path. Otherwise add the package to package.json dependencies or sandpackConfig.customSetup.dependencies.',
+      };
+    }
+    if (/package\.json|JSON|Unexpected token/i.test(primary)) {
+      return {
+        diagnosis: 'malformed_package_json_or_syntax',
+        primary_error: primary,
+        suggested_fix: 'Check package.json and the referenced source file for syntax errors.',
+      };
+    }
+    if (/process is not defined|import\.meta|env/i.test(primary)) {
+      return {
+        diagnosis: 'environment_variable_access',
+        primary_error: primary,
+        suggested_fix:
+          'Check the template-specific env convention. React/CRA exposes declared vars as process.env.REACT_APP_NAME; Vite-style apps use import.meta.env.VITE_NAME.',
+      };
+    }
+    return {
+      diagnosis: 'runtime_or_build_error',
+      primary_error: primary,
+      suggested_fix:
+        'Inspect build_errors, sandpack_error, and console_logs; fix the referenced file and republish.',
+    };
+  }
+
+  /**
+   * Wait for the caller's own browser render to report a Sandpack status for
+   * the artifact. This is deliberately not a server-side build: Sandpack runs
+   * in the browser, and logs/errors are per-viewer because rendered code may
+   * contain secret-derived values.
+   *
+   * Resolution states:
+   * - observed + ok=true: Sandpack reached a non-running status and no quick
+   *   console.error arrived during the settle window.
+   * - observed + ok=false: Sandpack reported an error/timeout, or the app
+   *   emitted console.error.
+   * - observed=false: no browser for this user reported status before timeout.
+   */
+  async waitForRuntimeStatus(
+    artifactId: string,
+    userId: UserID | undefined,
+    options: { timeoutMs?: number; settleMs?: number } = {}
+  ): Promise<
+    ArtifactStatus & { ok: boolean; observed: boolean; timed_out: boolean; note?: string }
+  > {
+    if (!userId) {
+      const status = await this.getStatus(artifactId, userId);
+      return {
+        ...status,
+        ok: false,
+        observed: false,
+        timed_out: false,
+        note: 'Runtime validation requires an authenticated user so logs stay scoped to one viewer.',
+      };
+    }
+
+    // Visibility and not-found behavior are delegated to getStatus().
+    const timeoutMs = Math.min(Math.max(options.timeoutMs ?? 10000, 500), 60000);
+    const settleMs = Math.min(Math.max(options.settleMs ?? 1000, 0), 5000);
+    const key = this.viewerKey(artifactId, userId);
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const classify = async (): Promise<
+      | (ArtifactStatus & { ok: boolean; observed: boolean; timed_out: boolean; note?: string })
+      | null
+    > => {
+      const status = await this.getStatus(artifactId, userId);
+      const errorLogs = status.console_logs.filter((entry) => entry.level === 'error');
+      if (status.sandpack_error || status.sandpack_status === 'timeout' || errorLogs.length > 0) {
+        return {
+          ...status,
+          build_status: 'error',
+          build_errors: [
+            ...(status.build_errors ?? []),
+            ...errorLogs.map((entry) => `[console.error] ${entry.message}`),
+          ],
+          ok: false,
+          observed: true,
+          timed_out: false,
+          note: status.sandpack_error
+            ? 'Sandpack reported a bundler/runtime error in your browser render.'
+            : 'The artifact emitted console.error during boot/render.',
+        };
+      }
+      if (status.build_status === 'error' && (status.build_errors?.length ?? 0) > 0) {
+        return {
+          ...status,
+          ok: false,
+          observed: false,
+          timed_out: false,
+          note: 'Server-side file validation failed before browser runtime validation.',
+        };
+      }
+      if (status.sandpack_status && status.sandpack_status !== 'running') {
+        return { ...status, ok: true, observed: true, timed_out: false };
+      }
+      return null;
+    };
+
+    const initial = await classify();
+    if (initial && !initial.ok) return initial;
+    if (initial?.ok && settleMs === 0) return initial;
+
+    return new Promise((resolve) => {
+      const cleanup = () => {
+        if (timeoutTimer) clearTimeout(timeoutTimer);
+        if (settleTimer) clearTimeout(settleTimer);
+        const waiters = this.runtimeStatusWaiters.get(key);
+        if (waiters) {
+          waiters.delete(onUpdate);
+          if (waiters.size === 0) this.runtimeStatusWaiters.delete(key);
+        }
+      };
+
+      const finish = (
+        result: ArtifactStatus & {
+          ok: boolean;
+          observed: boolean;
+          timed_out: boolean;
+          note?: string;
+        }
+      ) => {
+        cleanup();
+        resolve(result);
+      };
+
+      const scheduleSuccess = (status: ArtifactStatus) => {
+        if (settleTimer) return;
+        settleTimer = setTimeout(async () => {
+          settleTimer = null;
+          const latest = await classify();
+          if (latest) finish(latest);
+        }, settleMs);
+      };
+
+      const onUpdate = () => {
+        void (async () => {
+          const latest = await classify();
+          if (!latest) return;
+          if (!latest.ok) {
+            finish(latest);
+            return;
+          }
+          if (settleMs === 0) {
+            finish(latest);
+          } else {
+            scheduleSuccess(latest);
+          }
+        })();
+      };
+
+      const waiters = this.runtimeStatusWaiters.get(key) ?? new Set<() => void>();
+      waiters.add(onUpdate);
+      this.runtimeStatusWaiters.set(key, waiters);
+
+      timeoutTimer = setTimeout(async () => {
+        const latest = await classify();
+        if (latest) {
+          finish(latest);
+          return;
+        }
+        const status = await this.getStatus(artifactId, userId);
+        finish({
+          ...status,
+          ok: false,
+          observed: false,
+          timed_out: true,
+          note: `No Sandpack status was reported by your browser within ${timeoutMs}ms. Open the artifact on the board/fullscreen as this user and retry, or use agor_artifacts_status after viewing it. Server-side publish can only validate the file map; Sandpack boot happens in the browser.`,
+        });
+      }, timeoutMs);
+
+      // Close the small race between the initial classify() and waiter
+      // registration: a browser POST may have updated the in-memory status
+      // just before we subscribed. Re-read once now that the waiter exists.
+      onUpdate();
+      if (initial?.ok) scheduleSuccess(initial);
+    });
   }
 
   /**
@@ -1770,27 +2074,198 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     );
   }
 
-  private validateFiles(files: Record<string, string>): {
-    status: ArtifactBuildStatus;
-    errors: string[];
-  } {
-    const errors: string[] = [];
+  private validateArtifactFiles(
+    files: Record<string, string>,
+    options: {
+      template?: SandpackTemplate;
+      sandpackConfig?: SandpackConfig;
+      requiredEnvVars?: string[];
+    } = {}
+  ): ArtifactValidationResult {
+    const diagnostics: ArtifactValidationDiagnostic[] = [];
+    const add = (
+      severity: 'error' | 'warning',
+      code: string,
+      message: string,
+      extra: Pick<ArtifactValidationDiagnostic, 'file' | 'suggested_fix'> = {}
+    ) => diagnostics.push({ severity, code, message, ...extra });
 
     const sourceFiles = Object.entries(files).filter(([fp]) =>
       /\.(js|jsx|ts|tsx|html|css)$/.test(fp)
     );
 
     if (sourceFiles.length === 0) {
-      errors.push('No source files found in artifact');
+      add('error', 'no_source_files', 'No source files found in artifact', {
+        suggested_fix: 'Add at least one .js, .jsx, .ts, .tsx, .html, or .css file.',
+      });
     }
 
     for (const [filePath, content] of sourceFiles) {
       if (!content || content.trim().length === 0) {
-        errors.push(`${filePath}: file is empty`);
+        add('error', 'empty_source_file', `${filePath}: file is empty`, {
+          file: filePath,
+          suggested_fix: 'Add source code to the file or remove the empty file.',
+        });
       }
     }
 
-    return { status: errors.length > 0 ? 'error' : 'success', errors };
+    const pkgPath = files['/package.json'] !== undefined ? '/package.json' : 'package.json';
+    const pkg = files[pkgPath];
+    if (pkg !== undefined) {
+      try {
+        JSON.parse(pkg);
+      } catch (err) {
+        add(
+          'error',
+          'malformed_package_json',
+          `${pkgPath}: package.json is not valid JSON (${err instanceof Error ? err.message : String(err)})`,
+          {
+            file: pkgPath,
+            suggested_fix: 'Fix package.json syntax, especially trailing commas and quotes.',
+          }
+        );
+      }
+    }
+
+    const entry = options.sandpackConfig?.customSetup?.entry;
+    if (entry && !this.hasFile(files, entry)) {
+      add('error', 'missing_custom_entry', `Configured Sandpack entry file not found: ${entry}`, {
+        file: entry,
+        suggested_fix: 'Create the entry file or update sandpackConfig.customSetup.entry.',
+      });
+    } else if (!entry && !this.findLikelyEntry(files)) {
+      add(
+        'warning',
+        'no_likely_entry',
+        'No common Sandpack entry file found (for example /src/index.tsx, /src/main.tsx, /index.js, or /index.html).',
+        {
+          suggested_fix:
+            'Add a conventional entry file or set sandpackConfig.customSetup.entry to the correct file.',
+        }
+      );
+    }
+
+    for (const [filePath, content] of Object.entries(files)) {
+      if (!/\.(js|jsx|ts|tsx)$/.test(filePath)) continue;
+      for (const specifier of this.extractRelativeImportSpecifiers(content)) {
+        if (!this.resolveRelativeImport(files, filePath, specifier)) {
+          add(
+            'error',
+            'missing_local_import',
+            `${filePath}: local import not found: ${specifier}`,
+            {
+              file: filePath,
+              suggested_fix: `Create the referenced module (${specifier}) or fix/remove the import in ${filePath}.`,
+            }
+          );
+        }
+      }
+    }
+
+    const template = options.template ?? 'react';
+    const requiredEnvVars = options.requiredEnvVars ?? [];
+    if (requiredEnvVars.length > 0 && envVarPrefixForTemplate(template) === null) {
+      add(
+        'warning',
+        'env_vars_not_injected_for_template',
+        `required_env_vars are declared, but template '${template}' has no verified dotenv injection path.`,
+        {
+          suggested_fix:
+            'Use a React/React-TS template or change the app to read configuration another way.',
+        }
+      );
+    }
+
+    const prefix = envVarPrefixForTemplate(template);
+    if (prefix) {
+      for (const [filePath, content] of Object.entries(files)) {
+        if (!/\.(js|jsx|ts|tsx)$/.test(filePath)) continue;
+        for (const envName of requiredEnvVars) {
+          const prefixed = `${prefix}${envName}`;
+          if (
+            content.includes(`process.env.${envName}`) &&
+            !content.includes(`process.env.${prefixed}`)
+          ) {
+            add(
+              'warning',
+              'possibly_unprefixed_env_var',
+              `${filePath}: '${envName}' is declared, but ${template} exposes it as '${prefixed}'.`,
+              {
+                file: filePath,
+                suggested_fix: `Read process.env.${prefixed} instead of process.env.${envName}.`,
+              }
+            );
+          }
+        }
+      }
+    }
+
+    const errors = diagnostics.filter((d) => d.severity === 'error').map((d) => d.message);
+    const warnings = diagnostics.filter((d) => d.severity === 'warning').map((d) => d.message);
+    return { status: errors.length > 0 ? 'error' : 'success', errors, warnings, diagnostics };
+  }
+
+  private hasFile(files: Record<string, string>, candidate: string): boolean {
+    const normalized = candidate.startsWith('/') ? candidate : `/${candidate}`;
+    return files[normalized] !== undefined || files[normalized.slice(1)] !== undefined;
+  }
+
+  private findLikelyEntry(files: Record<string, string>): string | null {
+    const candidates = [
+      '/src/index.tsx',
+      '/src/index.jsx',
+      '/src/index.ts',
+      '/src/index.js',
+      '/src/main.tsx',
+      '/src/main.jsx',
+      '/src/main.ts',
+      '/src/main.js',
+      '/index.tsx',
+      '/index.jsx',
+      '/index.ts',
+      '/index.js',
+      '/index.html',
+    ];
+    return candidates.find((candidate) => this.hasFile(files, candidate)) ?? null;
+  }
+
+  private extractRelativeImportSpecifiers(source: string): string[] {
+    const specs = new Set<string>();
+    const patterns = [
+      /(?:import|export)\s+(?:type\s+)?(?:[^'";]+?\s+from\s+)?['"](\.{1,2}\/[^'"]+)['"]/g,
+      /import\(\s*['"](\.{1,2}\/[^'"]+)['"]\s*\)/g,
+      /require\(\s*['"](\.{1,2}\/[^'"]+)['"]\s*\)/g,
+    ];
+    for (const pattern of patterns) {
+      for (const match of source.matchAll(pattern)) {
+        if (match[1]) specs.add(match[1]);
+      }
+    }
+    return [...specs];
+  }
+
+  private resolveRelativeImport(
+    files: Record<string, string>,
+    fromFile: string,
+    specifier: string
+  ): boolean {
+    const fromDir = path.posix.dirname(fromFile.startsWith('/') ? fromFile : `/${fromFile}`);
+    const base = path.posix.normalize(path.posix.join(fromDir, specifier));
+    const candidates = [
+      base,
+      `${base}.ts`,
+      `${base}.tsx`,
+      `${base}.js`,
+      `${base}.jsx`,
+      `${base}.json`,
+      `${base}.css`,
+      path.posix.join(base, 'index.ts'),
+      path.posix.join(base, 'index.tsx'),
+      path.posix.join(base, 'index.js'),
+      path.posix.join(base, 'index.jsx'),
+      path.posix.join(base, 'index.css'),
+    ];
+    return candidates.some((candidate) => this.hasFile(files, candidate));
   }
 
   private extractDependenciesFromPackageJson(

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -1010,7 +1010,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       dependencies: artifact.dependencies,
       entry: artifact.entry,
       content_hash: contentHash,
-      artifact_content_hash: artifact.content_hash,
+      runtime_report_hash: this.computeRuntimeReportHash(artifact),
       required_env_vars: requiredEnvVars.length > 0 ? requiredEnvVars : undefined,
       agor_grants: Object.keys(grants).length > 0 ? grants : undefined,
       trust_state: trustState,
@@ -1701,7 +1701,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     entries: ArtifactConsoleEntry[],
     contentHash?: string
   ): Promise<void> {
-    if (!(await this.isCurrentContentHash(artifactId, contentHash))) return;
+    if (!(await this.isCurrentRuntimeReportHash(artifactId, contentHash))) return;
     const key = this.viewerKey(artifactId, userId);
     const existing = this.consoleLogs.get(key) ?? [];
     const combined = [...existing, ...entries];
@@ -1721,7 +1721,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     status?: string,
     contentHash?: string
   ): Promise<void> {
-    if (!(await this.isCurrentContentHash(artifactId, contentHash))) return;
+    if (!(await this.isCurrentRuntimeReportHash(artifactId, contentHash))) return;
     const key = this.viewerKey(artifactId, userId);
     this.sandpackErrors.set(key, error);
     if (status !== undefined) {
@@ -1731,10 +1731,44 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     this.notifyRuntimeStatusWaiters(key);
   }
 
-  private async isCurrentContentHash(artifactId: string, contentHash?: string): Promise<boolean> {
-    if (!contentHash) return true;
+  private async isCurrentRuntimeReportHash(
+    artifactId: string,
+    runtimeReportHash?: string
+  ): Promise<boolean> {
+    if (!runtimeReportHash) return true;
     const artifact = await this.artifactRepo.findById(artifactId);
-    return artifact?.content_hash === contentHash;
+    if (!artifact) return false;
+    return this.computeRuntimeReportHash(artifact) === runtimeReportHash;
+  }
+
+  private computeRuntimeReportHash(
+    artifact: Pick<
+      Artifact,
+      | 'artifact_id'
+      | 'board_id'
+      | 'template'
+      | 'files'
+      | 'sandpack_config'
+      | 'required_env_vars'
+      | 'agor_grants'
+      | 'agor_runtime'
+      | 'entry'
+    >
+  ): string {
+    const files = artifact.files ?? {};
+    return this.computeHashFromFiles({
+      ...files,
+      '/.agor/runtime-report-inputs.json': JSON.stringify({
+        artifact_id: artifact.artifact_id,
+        board_id: artifact.board_id,
+        template: artifact.template,
+        entry: artifact.entry ?? null,
+        sandpack_config: artifact.sandpack_config ?? null,
+        required_env_vars: artifact.required_env_vars ?? [],
+        agor_grants: artifact.agor_grants ?? {},
+        agor_runtime_enabled: artifact.agor_runtime?.enabled !== false,
+      }),
+    });
   }
 
   private notifyRuntimeStatusWaiters(key: string): void {

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -125,18 +125,21 @@ Agents manage artifacts through Agor's [MCP tools](/guide/internal-mcp):
 
 | Tool | Purpose |
 |------|---------|
-| `agor_artifacts_publish` | Publish a folder as a new artifact, OR re-publish an existing one with `artifactId` |
+| `agor_artifacts_publish` | Publish a folder as a new artifact, OR re-publish an existing one with `artifactId`. Optional `waitForStatus: true` waits for this user's browser-reported Sandpack status/logs. |
 | `agor_artifacts_get` | Read an artifact's full file map + declarative metadata |
 | `agor_artifacts_land` | Materialize an artifact's stored files back into a branch (round-trip with publish) |
 | `agor_artifacts_update` | Patch metadata only (board move, name, `requiredEnvVars`, `agorGrants`, `sandpackConfig`) |
-| `agor_artifacts_check_build` | Verify source files exist and are non-empty |
-| `agor_artifacts_status` | Get build status + Sandpack errors + console logs for debugging |
+| `agor_artifacts_check_build` | Browserless folder validation: source presence, package.json syntax, configured entry, missing local imports, env/template warnings. Does not run Sandpack. |
+| `agor_artifacts_validate_folder` | Clearer alias for `agor_artifacts_check_build`; prefer this name for new agent workflows. |
+| `agor_artifacts_status` | Get build status + Sandpack errors + console logs + compact diagnostic suggestions for debugging |
 | `agor_artifacts_list` | List visible artifacts (optionally filtered by board) |
 | `agor_artifacts_delete` | Remove an artifact (DB record + board placement) |
 | `agor_artifacts_export_codesandbox` | Eject the artifact to CodeSandbox (returns a sandbox URL). Daemon-supplied capabilities won't work there — set required env vars via CodeSandbox Secret Keys |
 | `agor_artifacts_query_dom` | Query the rendered DOM via CSS selector. Round-trips through the viewer's open tab (no headless browser). Requires `agor_runtime.enabled !== false` and a browser tab logged in as you currently viewing the artifact |
 
 The typical agent workflow: **publish** the folder, **iterate** by editing files locally and republishing with the same `artifactId`. To pick up where you left off from another branch, **land** the artifact back to disk first.
+
+`agor_artifacts_publish({ waitForStatus: true })` is synchronous-ish, not a server-side build. Sandpack boots in the viewer's browser, and runtime logs are scoped per viewer because rendered code may include secret-derived values. If the publishing user has the artifact open on the board or fullscreen page, publish waits for that browser to report Sandpack status, bundler/runtime errors, and early `console.error` output. If no browser render reports before `waitTimeoutMs`, the tool returns `publish_validation.observed: false` with guidance instead of claiming the artifact rendered successfully. `agor_artifacts_validate_folder` / `agor_artifacts_check_build` are browserless smoke checks only: they catch obvious file/import/config mistakes, but they do not run Sandpack.
 
 ---
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -599,11 +599,11 @@ export const ArtifactNode = ({
             />
             <ArtifactConsoleReporter
               artifactId={data.artifactId}
-              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+              contentHash={payload.runtime_report_hash ?? payload.content_hash}
             />
             <ArtifactSandpackErrorReporter
               artifactId={data.artifactId}
-              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+              contentHash={payload.runtime_report_hash ?? payload.content_hash}
             />
             <ArtifactRuntimeBridge artifactId={data.artifactId} />
             <CodeSandboxExporter artifactId={data.artifactId} />

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -597,8 +597,14 @@ export const ArtifactNode = ({
               showOpenInCodeSandbox={false}
               showRefreshButton={interactMode}
             />
-            <ArtifactConsoleReporter artifactId={data.artifactId} />
-            <ArtifactSandpackErrorReporter artifactId={data.artifactId} />
+            <ArtifactConsoleReporter
+              artifactId={data.artifactId}
+              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+            />
+            <ArtifactSandpackErrorReporter
+              artifactId={data.artifactId}
+              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+            />
             <ArtifactRuntimeBridge artifactId={data.artifactId} />
             <CodeSandboxExporter artifactId={data.artifactId} />
           </SandpackProvider>

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -17,7 +17,13 @@ const RUNTIME_QUERY_DEFAULT_TIMEOUT_MS = 6000;
  * Captures Sandpack console events and forwards them to the daemon.
  * Must be rendered inside a SandpackProvider.
  */
-export function ArtifactConsoleReporter({ artifactId }: { artifactId: string }) {
+export function ArtifactConsoleReporter({
+  artifactId,
+  contentHash,
+}: {
+  artifactId: string;
+  contentHash?: string;
+}) {
   const { logs } = useSandpackConsole({ resetOnPreviewRestart: false });
   const lastSentRef = useRef(0);
   const lastSendTimeRef = useRef(0);
@@ -50,7 +56,7 @@ export function ArtifactConsoleReporter({ artifactId }: { artifactId: string }) 
       fetch(`${getDaemonUrl()}/artifacts/${artifactId}/console`, {
         method: 'POST',
         headers: getAuthHeaders(),
-        body: JSON.stringify({ entries }),
+        body: JSON.stringify({ entries, content_hash: contentHash }),
       }).catch(() => {});
     };
 
@@ -70,7 +76,7 @@ export function ArtifactConsoleReporter({ artifactId }: { artifactId: string }) 
         timerRef.current = null;
       }
     };
-  }, [logs, artifactId]);
+  }, [logs, artifactId, contentHash]);
 
   return null;
 }
@@ -79,7 +85,13 @@ export function ArtifactConsoleReporter({ artifactId }: { artifactId: string }) 
  * Captures Sandpack bundler/runtime errors and forwards them to the daemon.
  * Must be rendered inside a SandpackProvider.
  */
-export function ArtifactSandpackErrorReporter({ artifactId }: { artifactId: string }) {
+export function ArtifactSandpackErrorReporter({
+  artifactId,
+  contentHash,
+}: {
+  artifactId: string;
+  contentHash?: string;
+}) {
   const { sandpack } = useSandpack();
   const lastSentRef = useRef<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -118,7 +130,7 @@ export function ArtifactSandpackErrorReporter({ artifactId }: { artifactId: stri
       fetch(`${getDaemonUrl()}/artifacts/${artifactId}/sandpack-error`, {
         method: 'POST',
         headers: getAuthHeaders(),
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ ...payload, content_hash: contentHash }),
       }).catch(() => {});
     };
 
@@ -136,7 +148,7 @@ export function ArtifactSandpackErrorReporter({ artifactId }: { artifactId: stri
         pendingSendRef.current?.();
       }
     };
-  }, [sandpack.error, sandpack.status, artifactId]);
+  }, [sandpack.error, sandpack.status, artifactId, contentHash]);
 
   return null;
 }

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -327,11 +327,11 @@ export function ArtifactFullscreenPage({
             />
             <ArtifactConsoleReporter
               artifactId={payload.artifact_id}
-              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+              contentHash={payload.runtime_report_hash ?? payload.content_hash}
             />
             <ArtifactSandpackErrorReporter
               artifactId={payload.artifact_id}
-              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+              contentHash={payload.runtime_report_hash ?? payload.content_hash}
             />
             <ArtifactRuntimeBridge artifactId={payload.artifact_id} />
           </SandpackProvider>

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -325,8 +325,14 @@ export function ArtifactFullscreenPage({
               showOpenInCodeSandbox={false}
               showRefreshButton
             />
-            <ArtifactConsoleReporter artifactId={payload.artifact_id} />
-            <ArtifactSandpackErrorReporter artifactId={payload.artifact_id} />
+            <ArtifactConsoleReporter
+              artifactId={payload.artifact_id}
+              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+            />
+            <ArtifactSandpackErrorReporter
+              artifactId={payload.artifact_id}
+              contentHash={payload.artifact_content_hash ?? payload.content_hash}
+            />
             <ArtifactRuntimeBridge artifactId={payload.artifact_id} />
           </SandpackProvider>
         </div>

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -253,6 +253,8 @@ export interface ArtifactPayload {
   dependencies?: Record<string, string>;
   entry?: string;
   content_hash: string;
+  /** DB file-map hash, excluding per-viewer synthesized files. Used to reject stale browser reports. */
+  artifact_content_hash?: string;
   /** Names of env vars the artifact requires (without prefix). */
   required_env_vars?: string[];
   /** Grants the artifact requested. */
@@ -328,6 +330,8 @@ export interface ArtifactStatus {
   sandpack_error?: SandpackError | null;
   /** Sandpack bundler status: 'idle', 'running', 'timeout', etc. */
   sandpack_status?: string;
+  /** ISO timestamp for the latest current-content browser runtime report from this viewer. */
+  runtime_observed_at?: string;
   console_logs: ArtifactConsoleEntry[];
   content_hash?: string;
 }

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -253,8 +253,12 @@ export interface ArtifactPayload {
   dependencies?: Record<string, string>;
   entry?: string;
   content_hash: string;
-  /** DB file-map hash, excluding per-viewer synthesized files. Used to reject stale browser reports. */
-  artifact_content_hash?: string;
+  /**
+   * Non-secret hash of files plus persisted render-affecting metadata. Browser
+   * runtime reports include this so the daemon can reject stale reports after
+   * metadata-only render changes.
+   */
+  runtime_report_hash?: string;
   /** Names of env vars the artifact requires (without prefix). */
   required_env_vars?: string[];
   /** Grants the artifact requested. */


### PR DESCRIPTION
## Summary

- Add `waitForStatus` / `waitTimeoutMs` to artifact publish and metadata update so agents can wait for the caller's browser-reported Sandpack boot status.
- Add stronger browserless artifact folder validation, including missing local imports, malformed `package.json`, missing configured entry files, and env/template footgun warnings.
- Add compact runtime diagnostics, runtime observation timestamps, artifact URLs, and next-action hints to artifact MCP outputs.
- Harden browser runtime log/error reporting with content-hash correlation so stale reports from previous artifact versions are ignored.

## Notes

Sandpack still boots in the browser, not the daemon. `waitForStatus` is therefore synchronous-ish: it returns actionable runtime feedback when the calling user has the artifact open, and returns `observed: false` when no current browser render reports status before timeout.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- artifacts.test.ts`
