### PR TITLE
fix(ui): Fix missing scrollbar on All sessions left-panel tab

### DIFF
--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -389,7 +389,7 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
             key: 'all-sessions',
             label: 'All sessions',
             children: board ? (
-              <div style={{ height: 'calc(100vh - 112px)' }}>
+              <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
                 <BoardSessionList
                   board={board}
                   currentBoardId={board.board_id}


### PR DESCRIPTION
## Summary

- The **All sessions** tab container in `BoardAssistantPanel` had `height: 'calc(100vh - 112px)'` but no `overflow` property, so the list was not scrollable when sessions exceeded the panel height.
- Added `overflow: 'auto'` to the container, matching the identical pattern already used on the adjacent **Assistant** tab.

## Change

```diff
- <div style={{ height: 'calc(100vh - 112px)' }}>
+ <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
```

## Test plan

- [ ] Open the Agor UI with enough sessions to overflow the panel height
- [ ] Switch to the **All sessions** tab in the left panel
- [ ] Verify the list is now scrollable and all sessions are reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)