### PR TITLE
Fix app loading screen theme colors

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -457,21 +457,7 @@ function AppContent() {
   // NOW handle conditional rendering based on state
   // Show loading while fetching auth config
   if (authConfigLoading) {
-    return (
-      <div
-        style={{
-          height: '100vh',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: token.colorBgLayout,
-        }}
-      >
-        <Spin size="large" />
-        <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>Loading...</div>
-      </div>
-    );
+    return <InitialLoadingScreen message="Loading…" />;
   }
 
   // Show auth config error ONLY if we don't have a config yet (first load)
@@ -529,42 +515,12 @@ function AppContent() {
   // Show reconnecting state if we have tokens but lost connection.
   // ONLY show fullscreen on initial connection, not during reconnections.
   if (hasTokens && (!connected || !authenticated) && workspaceSurfaceShouldRun && !hasLoadedOnce) {
-    return (
-      <div
-        style={{
-          height: '100vh',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: token.colorBgLayout,
-        }}
-      >
-        <Spin size="large" />
-        <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>
-          Reconnecting to daemon...
-        </div>
-      </div>
-    );
+    return <InitialLoadingScreen message="Reconnecting to daemon…" />;
   }
 
   // Show loading while checking authentication
   if (authLoading) {
-    return (
-      <div
-        style={{
-          height: '100vh',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: token.colorBgLayout,
-        }}
-      >
-        <Spin size="large" />
-        <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>Authenticating...</div>
-      </div>
-    );
+    return <InitialLoadingScreen message="Authenticating…" />;
   }
 
   // Show connection error

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -25,7 +25,7 @@ import {
   sessionPath,
   UI_MOUNT_PATH,
 } from '@agor-live/client';
-import { Alert, App as AntApp, ConfigProvider, Spin, theme } from 'antd';
+import { Alert, App as AntApp, ConfigProvider } from 'antd';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AVAILABLE_AGENTS } from './components/AgentSelectionGrid';
@@ -179,7 +179,6 @@ function DeviceRouter() {
 }
 
 function AppContent() {
-  const { token } = theme.useToken();
   const { showSuccess, showError, showWarning, showLoading, destroy } = useThemedMessage();
   const navigate = useNavigate();
   const location = useLocation();
@@ -347,19 +346,7 @@ function AppContent() {
   const routeFallback = workspaceSurfaceShouldRun ? (
     workspaceLoadingFallback
   ) : (
-    <div
-      style={{
-        height: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: token.colorBgLayout,
-      }}
-    >
-      <Spin size="large" />
-      <div style={{ marginTop: 16, color: token.colorTextSecondary }}>Loading surface...</div>
-    </div>
+    <InitialLoadingScreen message="Loading surface…" />
   );
 
   // Get current user from users Map (real-time updates via WebSocket)

--- a/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
+++ b/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
@@ -60,7 +60,7 @@ export const CodePreviewModal = ({ file, open, onClose, loading }: CodePreviewMo
       ]}
     >
       {loading ? (
-        <Spin style={{ display: 'block', padding: '2rem' }} tip="Loading file…" />
+        <Spin style={{ display: 'block', padding: '2rem' }} description="Loading file…" />
       ) : (
         <ThemedSyntaxHighlighter language={language} showLineNumbers>
           {file.content}

--- a/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
+++ b/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
@@ -1,6 +1,6 @@
 import type { FileDetail } from '@agor-live/client';
 import { CopyOutlined } from '@ant-design/icons';
-import { Button, Modal } from 'antd';
+import { Button, Modal, Spin } from 'antd';
 import { ThemedSyntaxHighlighter } from '@/components/ThemedSyntaxHighlighter';
 import { copyToClipboard } from '@/utils/clipboard';
 import { getLanguageFromPath } from '@/utils/language';
@@ -60,7 +60,7 @@ export const CodePreviewModal = ({ file, open, onClose, loading }: CodePreviewMo
       ]}
     >
       {loading ? (
-        <div style={{ textAlign: 'center', padding: '2rem' }}>Loading...</div>
+        <Spin style={{ display: 'block', padding: '2rem' }} tip="Loading file…" />
       ) : (
         <ThemedSyntaxHighlighter language={language} showLineNumbers>
           {file.content}

--- a/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.tsx
+++ b/apps/agor-ui/src/components/ForcePasswordChangeModal/ForcePasswordChangeModal.tsx
@@ -7,7 +7,7 @@
 
 import type { User } from '@agor-live/client';
 import { LockOutlined, WarningOutlined } from '@ant-design/icons';
-import { Alert, Form, Input, Modal, Typography } from 'antd';
+import { Alert, Form, Input, Modal, Typography, theme } from 'antd';
 import { useState } from 'react';
 
 const { Text } = Typography;
@@ -28,6 +28,7 @@ export function ForcePasswordChangeModal({
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { token } = theme.useToken();
 
   const handleSubmit = async () => {
     if (!user) return;
@@ -56,7 +57,7 @@ export function ForcePasswordChangeModal({
     <Modal
       title={
         <span>
-          <WarningOutlined style={{ color: '#faad14', marginRight: 8 }} />
+          <WarningOutlined style={{ color: token.colorWarning, marginRight: 8 }} />
           Password Change Required
         </span>
       }
@@ -99,7 +100,7 @@ export function ForcePasswordChangeModal({
           ]}
         >
           <Input.Password
-            prefix={<LockOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
+            prefix={<LockOutlined style={{ color: token.colorTextQuaternary }} />}
             placeholder="Enter new password"
             autoComplete="new-password"
           />
@@ -122,7 +123,7 @@ export function ForcePasswordChangeModal({
           ]}
         >
           <Input.Password
-            prefix={<LockOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
+            prefix={<LockOutlined style={{ color: token.colorTextQuaternary }} />}
             placeholder="Confirm new password"
             autoComplete="new-password"
           />

--- a/apps/agor-ui/src/components/InitialLoadingScreen.test.tsx
+++ b/apps/agor-ui/src/components/InitialLoadingScreen.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { describe, expect, it } from 'vitest';
+import { InitialLoadingScreen } from './InitialLoadingScreen';
+
+const lightTheme = {
+  token: {
+    colorBgLayout: '#fafafa',
+    colorTextSecondary: 'rgba(0, 0, 0, 0.65)',
+  },
+};
+
+describe('InitialLoadingScreen', () => {
+  it('uses Ant Design theme tokens for the page background in light mode', () => {
+    const { container } = render(
+      <ConfigProvider theme={lightTheme}>
+        <InitialLoadingScreen message="Loading…" />
+      </ConfigProvider>
+    );
+
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveStyle({ backgroundColor: '#fafafa' });
+  });
+
+  it('renders themed checklist rows when workspace data is loading', () => {
+    render(
+      <ConfigProvider theme={lightTheme}>
+        <InitialLoadingScreen
+          items={[
+            { key: 'sessions', label: 'Sessions', done: true, count: 2 },
+            { key: 'boards', label: 'Boards', done: false, count: 0 },
+          ]}
+        />
+      </ConfigProvider>
+    );
+
+    expect(screen.getByText('Loading workspace…')).toBeInTheDocument();
+    expect(screen.getByText('Sessions')).toBeInTheDocument();
+    expect(screen.getByText('Boards')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/InitialLoadingScreen.tsx
+++ b/apps/agor-ui/src/components/InitialLoadingScreen.tsx
@@ -1,80 +1,66 @@
-import { Spin, theme } from 'antd';
+import { CheckCircleFilled } from '@ant-design/icons';
+import { Flex, Spin, Tag, Typography, theme } from 'antd';
 import type { InitialLoadItem, LoaderPhase } from '../hooks';
-import { Tag } from './Tag';
 
 interface Props {
-  phase: LoaderPhase;
-  connecting: boolean;
-  items: InitialLoadItem[];
+  phase?: LoaderPhase;
+  connecting?: boolean;
+  items?: InitialLoadItem[];
+  message?: string;
 }
 
-export function InitialLoadingScreen({ phase, connecting, items }: Props) {
+export function InitialLoadingScreen({
+  phase = 'loading',
+  connecting = false,
+  items = [],
+  message,
+}: Props) {
   const { token } = theme.useToken();
-  const statusMessage = connecting ? 'Connecting to daemon…' : 'Loading workspace…';
+  const statusMessage = message ?? (connecting ? 'Connecting to daemon…' : 'Loading workspace…');
+  const showItems = !connecting && items.length > 0;
 
   return (
-    <div
+    <Flex
+      vertical
+      align="center"
+      justify="center"
       style={{
-        height: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
+        minHeight: '100vh',
         backgroundColor: token.colorBgLayout,
         opacity: phase === 'fading' ? 0 : 1,
         transition: 'opacity 280ms ease-out',
       }}
     >
       <Spin size="large" />
-      <div style={{ marginTop: 16, color: 'rgba(255, 255, 255, 0.65)' }}>{statusMessage}</div>
-      {!connecting && (
-        <div style={{ marginTop: 24, display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <Typography.Text type="secondary" style={{ marginTop: token.marginMD }}>
+        {statusMessage}
+      </Typography.Text>
+      {showItems && (
+        <Flex vertical gap={token.sizeXXS} style={{ marginTop: token.marginLG, minWidth: 200 }}>
           {items.map(({ key, label, done, count }) => (
-            <div
-              key={key}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                gap: 10,
-                minWidth: 200,
-                color: done ? 'rgba(255,255,255,0.65)' : 'rgba(255,255,255,0.35)',
-              }}
-            >
-              <span style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                <span
-                  style={{
-                    width: 16,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
+            <Flex key={key} align="center" justify="space-between" gap={token.sizeSM}>
+              <Flex align="center" gap={token.sizeSM}>
+                <Flex align="center" justify="center" style={{ width: token.sizeMD }}>
                   {done ? (
-                    <span style={{ color: token.colorSuccess }}>✓</span>
+                    <CheckCircleFilled style={{ color: token.colorSuccess }} />
                   ) : (
                     <Spin size="small" />
                   )}
-                </span>
-                <span style={{ fontSize: 13 }}>{label}</span>
-              </span>
+                </Flex>
+                <Typography.Text type={done ? 'secondary' : undefined} disabled={!done}>
+                  {label}
+                </Typography.Text>
+              </Flex>
               <Tag
                 color={done ? 'success' : 'default'}
-                style={{
-                  margin: 0,
-                  fontSize: 11,
-                  lineHeight: '16px',
-                  padding: '0 6px',
-                  minWidth: 28,
-                  textAlign: 'center',
-                }}
+                style={{ marginInlineEnd: 0, minWidth: 28 }}
               >
                 {count}
               </Tag>
-            </div>
+            </Flex>
           ))}
-        </div>
+        </Flex>
       )}
-    </div>
+    </Flex>
   );
 }

--- a/apps/agor-ui/src/components/InitialLoadingScreen.tsx
+++ b/apps/agor-ui/src/components/InitialLoadingScreen.tsx
@@ -1,6 +1,7 @@
 import { CheckCircleFilled } from '@ant-design/icons';
-import { Flex, Spin, Tag, Typography, theme } from 'antd';
+import { Flex, Spin, Typography, theme } from 'antd';
 import type { InitialLoadItem, LoaderPhase } from '../hooks';
+import { Tag } from './Tag';
 
 interface Props {
   phase?: LoaderPhase;

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { LockOutlined, MailOutlined } from '@ant-design/icons';
-import { Alert, Button, Card, Divider, Form, Input, Space, Typography } from 'antd';
+import { Alert, Button, Card, Divider, Form, Input, Space, Typography, theme } from 'antd';
 import { useState } from 'react';
 import { BrandLogo } from '../BrandLogo';
 import { ParticleBackground } from './ParticleBackground';
@@ -28,6 +28,7 @@ export function LoginPage({
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
   const [showLocalLogin, setShowLocalLogin] = useState(false);
+  const { token } = theme.useToken();
   const useExternalLaunch = !!externalLaunchLoginRedirectUrl;
   const showLoginForm = !useExternalLaunch || showLocalLogin;
   const isLaunchError = error?.startsWith('Launch sign-in failed') ?? false;
@@ -134,7 +135,7 @@ export function LoginPage({
                     style={{
                       marginTop: 8,
                       paddingTop: 8,
-                      borderTop: '1px solid rgba(255,255,255,0.1)',
+                      borderTop: `1px solid ${token.colorBorderSecondary}`,
                     }}
                   >
                     <Text type="secondary" style={{ fontSize: 12 }}>
@@ -197,7 +198,7 @@ export function LoginPage({
                 ]}
               >
                 <Input
-                  prefix={<MailOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
+                  prefix={<MailOutlined style={{ color: token.colorTextQuaternary }} />}
                   placeholder="Email address"
                   autoComplete="email"
                 />
@@ -208,7 +209,7 @@ export function LoginPage({
                 rules={[{ required: true, message: 'Please enter your password' }]}
               >
                 <Input.Password
-                  prefix={<LockOutlined style={{ color: 'rgba(255, 255, 255, 0.45)' }} />}
+                  prefix={<LockOutlined style={{ color: token.colorTextQuaternary }} />}
                   placeholder="Password"
                   autoComplete="current-password"
                 />

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -363,7 +363,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 }))}
               />
               {effectiveTool === 'copilot' && copilotSource && (
-                <div style={{ marginTop: 6, fontSize: 12, color: 'rgba(255, 255, 255, 0.45)' }}>
+                <div style={{ marginTop: 6, fontSize: 12, color: token.colorTextTertiary }}>
                   {copilotSource === 'dynamic' ? (
                     <>
                       Live list from your Copilot account (via SDK <code>listModels()</code>).
@@ -377,7 +377,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 </div>
               )}
               {effectiveTool === 'cursor' && cursorSource && (
-                <div style={{ marginTop: 6, fontSize: 12, color: 'rgba(255, 255, 255, 0.45)' }}>
+                <div style={{ marginTop: 6, fontSize: 12, color: token.colorTextTertiary }}>
                   {cursorSource === 'dynamic' ? (
                     <>
                       Live list from your Cursor account (via SDK <code>Cursor.models.list()</code>
@@ -421,7 +421,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
                 }
                 style={{ width: '100%', minWidth: 400 }}
               />
-              <div style={{ marginTop: 8, fontSize: 12, color: 'rgba(255, 255, 255, 0.45)' }}>
+              <div style={{ marginTop: 8, fontSize: 12, color: token.colorTextTertiary }}>
                 Enter any model ID to pin to a specific version.{' '}
                 <a
                   href={


### PR DESCRIPTION
## Summary

- Replace the initial app/auth loading screens' hard-coded white text with Ant Design components and theme tokens.
- Reuse the themed `InitialLoadingScreen` for auth config, authentication, reconnecting, and workspace-data loading states.
- Clean up nearby obvious theme-token issues in login/password/model/loading UI.
- Add focused tests for the initial loading screen's light-theme token usage and checklist rendering.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- InitialLoadingScreen.test.tsx`
