### PR TITLE
Fix session/task state divergence

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1578,7 +1578,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         return await withSessionTurnLock(sessionTurnLocks, task.session_id, async () => {
           // Re-read session state inside the lock — it may have flipped to
           // RUNNING while we waited for our turn.
-          const session = await sessionsService.get(task.session_id, params);
+          const session = await reconcileSessionPromptStateIfStuck(
+            await sessionsService.get(task.session_id, params),
+            taskRepo,
+            params
+          );
 
           if (session.status === SessionStatus.STOPPING) {
             throw new BadRequest('Cannot run task: session is currently stopping');

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -46,6 +46,7 @@ import type {
   ScheduleID,
   ServiceGroupName,
   ServiceTier,
+  Session,
   SessionID,
   SessionMCPServer,
   StreamingEventType,
@@ -116,6 +117,10 @@ import {
 } from './utils/mcp-header-secrets.js';
 import { canControlCliSession } from './utils/mcp-token-authorization.js';
 import { ensureScheduleRunsAsCaller } from './utils/schedule-hooks.js';
+import {
+  sessionCanStartTask,
+  shouldReconcileSessionPromptState,
+} from './utils/session-task-state.js';
 import { findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
@@ -893,12 +898,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
    */
   const sessionTurnLocks: SessionTurnLocks = new Map();
 
-  function sessionCanStartTask(status: SessionStatus, readyForPrompt?: boolean): boolean {
-    return (
-      status === SessionStatus.IDLE || (status === SessionStatus.FAILED && readyForPrompt === true)
-    );
-  }
-
   /**
    * Helper: Safely patch an entity, returning false if it was deleted mid-execution
    */
@@ -922,6 +921,32 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       }
       throw error;
     }
+  }
+
+  async function reconcileSessionPromptStateIfStuck(
+    session: Session,
+    taskRepo: TaskRepository,
+    params: RouteParams
+  ): Promise<Session> {
+    if (session.status !== SessionStatus.FAILED || session.ready_for_prompt === true) {
+      return session;
+    }
+
+    const sessionTasks = await taskRepo.findBySession(session.session_id);
+    if (!shouldReconcileSessionPromptState(session, sessionTasks)) return session;
+
+    console.warn(
+      `🧹 [PromptState] Repairing stuck session ${shortId(session.session_id)} ` +
+        `(status=${session.status}, ready_for_prompt=${session.ready_for_prompt})`
+    );
+    return (await app.service('sessions').patch(
+      session.session_id,
+      {
+        status: SessionStatus.IDLE,
+        ready_for_prompt: true,
+      },
+      params
+    )) as Session;
   }
 
   /**
@@ -1345,13 +1370,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         const createdBy = params.user.user_id;
 
         return await withSessionTurnLock(sessionTurnLocks, id as SessionID, async () => {
-          const lockedSession = await sessionsService.get(id, params);
+          let lockedSession = await sessionsService.get(id, params);
           if (lockedSession.status === SessionStatus.STOPPING) {
             // The earlier STOPPING check was against pre-lock state — re-check
             // here so a session that entered STOPPING while we waited for our
             // turn doesn't accept a prompt.
             throw new Error('Cannot send prompt: session is currently stopping');
           }
+          lockedSession = await reconcileSessionPromptStateIfStuck(lockedSession, taskRepo, params);
           const queuedTasks = await taskRepo.findQueued(id as SessionID);
           const shouldQueue =
             !sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt) ||
@@ -2204,7 +2230,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         `with user context: ${queuedByUser ? shortId(queuedByUser.user_id) : 'none'}`
     );
 
-    const session = await sessionsService.get(sessionId, taskParams);
+    const session = await reconcileSessionPromptStateIfStuck(
+      await sessionsService.get(sessionId, taskParams),
+      taskRepo,
+      taskParams
+    );
 
     if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
       console.log(

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -926,14 +926,15 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   async function reconcileSessionPromptStateIfStuck(
     session: Session,
     taskRepo: TaskRepository,
-    params: RouteParams
+    params: RouteParams,
+    options: { ignoredTaskIds?: readonly string[] } = {}
   ): Promise<Session> {
     if (session.status !== SessionStatus.FAILED || session.ready_for_prompt === true) {
       return session;
     }
 
     const sessionTasks = await taskRepo.findBySession(session.session_id);
-    if (!shouldReconcileSessionPromptState(session, sessionTasks)) return session;
+    if (!shouldReconcileSessionPromptState(session, sessionTasks, options)) return session;
 
     console.warn(
       `🧹 [PromptState] Repairing stuck session ${shortId(session.session_id)} ` +
@@ -1581,7 +1582,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           const session = await reconcileSessionPromptStateIfStuck(
             await sessionsService.get(task.session_id, params),
             taskRepo,
-            params
+            params,
+            { ignoredTaskIds: [task.task_id] }
           );
 
           if (session.status === SessionStatus.STOPPING) {

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
@@ -13,7 +13,6 @@ describe('ExecutorHeartbeatSupervisor', () => {
       last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
     };
     const failForLostHeartbeat = vi.fn().mockResolvedValue({});
-    const sessionsPatch = vi.fn().mockResolvedValue({});
     const app = {
       service: (name: string) => {
         if (name === 'tasks') {
@@ -22,9 +21,6 @@ describe('ExecutorHeartbeatSupervisor', () => {
             get: vi.fn().mockResolvedValue(staleTask),
             failForLostHeartbeat,
           };
-        }
-        if (name === 'sessions') {
-          return { patch: sessionsPatch };
         }
         throw new Error(`unknown service ${name}`);
       },
@@ -46,10 +42,6 @@ describe('ExecutorHeartbeatSupervisor', () => {
     expect(failForLostHeartbeat).toHaveBeenCalledWith(staleTask.task_id, {
       completed_at: '2026-01-01T00:00:05.000Z',
       error_message: EXECUTOR_HEARTBEAT_LOST_MESSAGE,
-    });
-    expect(sessionsPatch).toHaveBeenCalledWith(staleTask.session_id, {
-      status: 'failed',
-      ready_for_prompt: true,
     });
   });
 

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
@@ -60,15 +60,6 @@ export class ExecutorHeartbeatSupervisor {
             completed_at: this.now().toISOString(),
             error_message: EXECUTOR_HEARTBEAT_LOST_MESSAGE,
           });
-          await this.options.app
-            .service('sessions')
-            .patch(task.session_id, { status: 'failed', ready_for_prompt: true })
-            .catch((error: unknown) => {
-              console.warn(
-                `[executor-heartbeat] Failed to mark session ${shortId(task.session_id)} failed after stale heartbeat:`,
-                error instanceof Error ? error.message : String(error)
-              );
-            });
           console.warn(
             `[executor-heartbeat] Marked task ${shortId(task.task_id)} failed after stale heartbeat (${nowMs - currentHeartbeatMs}ms old)`
           );

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -79,11 +79,51 @@ describe('TasksService executor heartbeat helpers', () => {
     expect(triggerQueueProcessing).not.toHaveBeenCalled();
   });
 
-  it('does not let a late terminal executor patch rewrite a heartbeat failure', async () => {
+  it('does not mark session failed when heartbeat failure loses to normal completion', async () => {
     const taskId = '018f0000-0000-7000-8000-000000000003';
-    const failedTask = {
+    const completedTask = {
       task_id: taskId,
       session_id: '018f0000-0000-7000-8000-000000000004',
+      status: TaskStatus.COMPLETED,
+      created_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-01T00:00:04.000Z',
+    };
+    const sessionsPatch = vi.fn();
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      app: unknown;
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(completedTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+    service.app = {
+      service: (name: string) => {
+        if (name === 'sessions') {
+          return { patch: sessionsPatch };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    };
+
+    const result = await service.failForLostHeartbeat(taskId, {
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'Executor heartbeat lost',
+    });
+
+    expect(result).toBe(completedTask);
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(sessionsPatch).not.toHaveBeenCalled();
+  });
+
+  it('does not let a late terminal executor patch rewrite a heartbeat failure', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000005';
+    const failedTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000006',
       status: TaskStatus.FAILED,
       created_at: '2026-01-01T00:00:00.000Z',
       completed_at: '2026-01-01T00:00:05.000Z',

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { TasksService } from './tasks';
 
 describe('TasksService executor heartbeat helpers', () => {
-  it('fails lost heartbeat tasks without idling the session or draining its queue', async () => {
+  it('fails lost heartbeat tasks and marks the session failed without draining its queue', async () => {
     const taskId = '018f0000-0000-7000-8000-000000000001';
     const sessionId = '018f0000-0000-7000-8000-000000000002';
     const currentTask = {
@@ -18,7 +18,7 @@ describe('TasksService executor heartbeat helpers', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
       error_message: 'Executor heartbeat lost',
     };
-    const sessionsPatch = vi.fn();
+    const sessionsPatch = vi.fn().mockResolvedValue(undefined);
     const triggerQueueProcessing = vi.fn();
     const service = Object.create(TasksService.prototype) as TasksService & {
       app: unknown;
@@ -48,10 +48,16 @@ describe('TasksService executor heartbeat helpers', () => {
       },
     };
 
-    const result = await service.failForLostHeartbeat(taskId, {
-      completed_at: '2026-01-01T00:00:05.000Z',
-      error_message: 'Executor heartbeat lost',
-    });
+    const result = await service.failForLostHeartbeat(
+      taskId,
+      {
+        completed_at: '2026-01-01T00:00:05.000Z',
+        error_message: 'Executor heartbeat lost',
+      },
+      {
+        user: { user_id: '018f0000-0000-7000-8000-000000000009' },
+      }
+    );
 
     expect(result).toMatchObject({
       task_id: '018f0000-0000-7000-8000-000000000001',
@@ -63,7 +69,44 @@ describe('TasksService executor heartbeat helpers', () => {
       error_message: 'Executor heartbeat lost',
       duration_ms: 5000,
     });
-    expect(sessionsPatch).not.toHaveBeenCalled();
+    expect(sessionsPatch).toHaveBeenCalledWith(
+      sessionId,
+      { status: 'failed', ready_for_prompt: true },
+      expect.objectContaining({
+        user: { user_id: '018f0000-0000-7000-8000-000000000009' },
+      })
+    );
     expect(triggerQueueProcessing).not.toHaveBeenCalled();
+  });
+
+  it('does not let a late terminal executor patch rewrite a heartbeat failure', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000003';
+    const failedTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000004',
+      status: TaskStatus.FAILED,
+      created_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'Executor heartbeat lost',
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(failedTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    const result = await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:06.000Z',
+    });
+
+    expect(result).toBe(failedTask);
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -119,11 +119,52 @@ describe('TasksService executor heartbeat helpers', () => {
     expect(sessionsPatch).not.toHaveBeenCalled();
   });
 
-  it('does not let a late terminal executor patch rewrite a heartbeat failure', async () => {
+  it('does not mark session failed when heartbeat failure loses to an earlier task failure', async () => {
     const taskId = '018f0000-0000-7000-8000-000000000005';
     const failedTask = {
       task_id: taskId,
       session_id: '018f0000-0000-7000-8000-000000000006',
+      status: TaskStatus.FAILED,
+      created_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-01T00:00:04.000Z',
+      error_message: 'Executor exited with code 1',
+    };
+    const sessionsPatch = vi.fn();
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      app: unknown;
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(failedTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+    service.app = {
+      service: (name: string) => {
+        if (name === 'sessions') {
+          return { patch: sessionsPatch };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    };
+
+    const result = await service.failForLostHeartbeat(taskId, {
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'Executor heartbeat lost',
+    });
+
+    expect(result).toBe(failedTask);
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(sessionsPatch).not.toHaveBeenCalled();
+  });
+
+  it('does not let a late terminal executor patch rewrite a heartbeat failure', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000007';
+    const failedTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000008',
       status: TaskStatus.FAILED,
       created_at: '2026-01-01T00:00:00.000Z',
       completed_at: '2026-01-01T00:00:05.000Z',

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -30,6 +30,7 @@ import {
   ExecutorHeartbeatCallbackRunner,
 } from '../utils/executor-heartbeat-callback.js';
 import { ensureRepoOriginAlignedById } from '../utils/realign-repo-origin';
+import { isTerminalTaskStatus } from '../utils/session-task-state.js';
 import type { SessionsService } from './sessions';
 
 /**
@@ -276,7 +277,17 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
         suppressTerminalQueueProcessing: true,
       }
     );
-    return result as Task;
+    const failedTask = result as Task;
+    await this.app
+      .service('sessions')
+      .patch(failedTask.session_id, { status: 'failed', ready_for_prompt: true }, params)
+      .catch((error: unknown) => {
+        console.warn(
+          `[executor-heartbeat] Failed to mark session ${shortId(failedTask.session_id)} failed after stale heartbeat:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      });
+    return failedTask;
   }
 
   private async handleExecutorHeartbeat(task: Task, heartbeatAt: string): Promise<void> {
@@ -315,6 +326,17 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     const mayTransitionStatus =
       nextStatus === TaskStatus.RUNNING || isAnalyticsTerminalTaskStatus(nextStatus);
     const currentTask = mayTransitionStatus ? await this.get(id, params) : undefined;
+    if (
+      currentTask &&
+      isTerminalTaskStatus(currentTask.status) &&
+      isTerminalTaskStatus(nextStatus)
+    ) {
+      console.warn(
+        `⏭️ [TasksService] Ignoring terminal status rewrite for task ${shortId(currentTask.task_id)} ` +
+          `(${currentTask.status} → ${nextStatus})`
+      );
+      return currentTask;
+    }
     const isAnalyticsTerminalTransition =
       isAnalyticsTerminalTaskStatus(nextStatus) &&
       !isAnalyticsTerminalTaskStatus(currentTask?.status);

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -40,13 +40,6 @@ import type { SessionsService } from './sessions';
 /**
  * Task service params
  */
-const ANALYTICS_TERMINAL_TASK_STATUSES = new Set<Task['status']>([
-  TaskStatus.COMPLETED,
-  TaskStatus.FAILED,
-  TaskStatus.STOPPED,
-  TaskStatus.TIMED_OUT,
-]);
-
 const COMPLETION_SIDE_EFFECT_TASK_STATUSES = new Set<Task['status']>([
   TaskStatus.COMPLETED,
   TaskStatus.FAILED,
@@ -54,7 +47,7 @@ const COMPLETION_SIDE_EFFECT_TASK_STATUSES = new Set<Task['status']>([
 ]);
 
 function isAnalyticsTerminalTaskStatus(status: Task['status'] | undefined): boolean {
-  return status !== undefined && ANALYTICS_TERMINAL_TASK_STATUSES.has(status);
+  return isTerminalTaskStatus(status);
 }
 
 function isCompletionSideEffectTaskStatus(status: Task['status'] | undefined): boolean {
@@ -282,9 +275,14 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       }
     );
     const failedTask = result as Task;
-    if (failedTask.status !== TaskStatus.FAILED) {
+    const heartbeatFailureWon =
+      failedTask.status === TaskStatus.FAILED &&
+      failedTask.error_message === data.error_message &&
+      (!data.completed_at || failedTask.completed_at === data.completed_at);
+    if (!heartbeatFailureWon) {
       console.log(
-        `⏭️ [TasksService] Skipping heartbeat session failure for task ${shortId(failedTask.task_id)}; task is already ${failedTask.status}`
+        `⏭️ [TasksService] Skipping heartbeat session failure for task ${shortId(failedTask.task_id)}; ` +
+          `heartbeat failure did not win (status=${failedTask.status})`
       );
       return failedTask;
     }

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -22,7 +22,12 @@ import type {
   Task,
   TaskID,
 } from '@agor/core/types';
-import { type TaskMetadata, TaskStatus } from '@agor/core/types';
+import {
+  isTerminalTaskStatus,
+  SessionStatus,
+  type TaskMetadata,
+  TaskStatus,
+} from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 import { appendSystemMessage } from '../utils/append-system-message.js';
 import {
@@ -30,7 +35,6 @@ import {
   ExecutorHeartbeatCallbackRunner,
 } from '../utils/executor-heartbeat-callback.js';
 import { ensureRepoOriginAlignedById } from '../utils/realign-repo-origin';
-import { isTerminalTaskStatus } from '../utils/session-task-state.js';
 import type { SessionsService } from './sessions';
 
 /**
@@ -278,9 +282,19 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       }
     );
     const failedTask = result as Task;
+    if (failedTask.status !== TaskStatus.FAILED) {
+      console.log(
+        `⏭️ [TasksService] Skipping heartbeat session failure for task ${shortId(failedTask.task_id)}; task is already ${failedTask.status}`
+      );
+      return failedTask;
+    }
     await this.app
       .service('sessions')
-      .patch(failedTask.session_id, { status: 'failed', ready_for_prompt: true }, params)
+      .patch(
+        failedTask.session_id,
+        { status: SessionStatus.FAILED, ready_for_prompt: true },
+        params
+      )
       .catch((error: unknown) => {
         console.warn(
           `[executor-heartbeat] Failed to mark session ${shortId(failedTask.session_id)} failed after stale heartbeat:`,

--- a/apps/agor-daemon/src/utils/session-task-state.test.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.test.ts
@@ -1,0 +1,44 @@
+import { type Session, SessionStatus, type Task, TaskStatus } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { sessionCanStartTask, shouldReconcileSessionPromptState } from './session-task-state';
+
+const baseSession = {
+  session_id: '018f0000-0000-7000-8000-000000000001',
+  status: SessionStatus.FAILED,
+  ready_for_prompt: false,
+} as Session;
+
+function task(status: Task['status']): Task {
+  return {
+    task_id: `018f0000-0000-7000-8000-0000000000${status.length}`,
+    session_id: baseSession.session_id,
+    status,
+  } as Task;
+}
+
+describe('session task state reconciliation', () => {
+  it('allows failed sessions explicitly marked ready to start a task', () => {
+    expect(sessionCanStartTask(SessionStatus.FAILED, true)).toBe(true);
+    expect(sessionCanStartTask(SessionStatus.FAILED, false)).toBe(false);
+  });
+
+  it('repairs failed/not-ready sessions when all non-queued tasks are terminal', () => {
+    expect(
+      shouldReconcileSessionPromptState(baseSession, [
+        task(TaskStatus.COMPLETED),
+        task(TaskStatus.STOPPED),
+        task(TaskStatus.QUEUED),
+      ])
+    ).toBe(true);
+  });
+
+  it('does not repair while a non-terminal task still owns the session turn', () => {
+    expect(
+      shouldReconcileSessionPromptState(baseSession, [
+        task(TaskStatus.COMPLETED),
+        task(TaskStatus.RUNNING),
+        task(TaskStatus.QUEUED),
+      ])
+    ).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/session-task-state.test.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.test.ts
@@ -41,4 +41,15 @@ describe('session task state reconciliation', () => {
       ])
     ).toBe(false);
   });
+
+  it('can ignore a just-created task that is about to own the session turn', () => {
+    const createdTask = task(TaskStatus.CREATED);
+
+    expect(shouldReconcileSessionPromptState(baseSession, [createdTask])).toBe(false);
+    expect(
+      shouldReconcileSessionPromptState(baseSession, [createdTask], {
+        ignoredTaskIds: [createdTask.task_id],
+      })
+    ).toBe(true);
+  });
 });

--- a/apps/agor-daemon/src/utils/session-task-state.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.ts
@@ -1,16 +1,5 @@
 import type { Session, Task } from '@agor/core/types';
-import { SessionStatus, TaskStatus } from '@agor/core/types';
-
-export const TERMINAL_TASK_STATUSES: ReadonlySet<Task['status']> = new Set<Task['status']>([
-  TaskStatus.COMPLETED,
-  TaskStatus.FAILED,
-  TaskStatus.STOPPED,
-  TaskStatus.TIMED_OUT,
-]);
-
-export function isTerminalTaskStatus(status: Task['status'] | undefined): boolean {
-  return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
-}
+import { isTerminalTaskStatus, SessionStatus, TaskStatus } from '@agor/core/types';
 
 export function isTaskBlockingPrompt(task: Task): boolean {
   return task.status !== TaskStatus.QUEUED && !isTerminalTaskStatus(task.status);

--- a/apps/agor-daemon/src/utils/session-task-state.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.ts
@@ -1,0 +1,34 @@
+import type { Session, Task } from '@agor/core/types';
+import { SessionStatus, TaskStatus } from '@agor/core/types';
+
+export const TERMINAL_TASK_STATUSES: ReadonlySet<Task['status']> = new Set<Task['status']>([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.STOPPED,
+  TaskStatus.TIMED_OUT,
+]);
+
+export function isTerminalTaskStatus(status: Task['status'] | undefined): boolean {
+  return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
+}
+
+export function isTaskBlockingPrompt(task: Task): boolean {
+  return task.status !== TaskStatus.QUEUED && !isTerminalTaskStatus(task.status);
+}
+
+export function sessionCanStartTask(status: Session['status'], readyForPrompt?: boolean): boolean {
+  return (
+    status === SessionStatus.IDLE || (status === SessionStatus.FAILED && readyForPrompt === true)
+  );
+}
+
+/**
+ * Detects the limbo state where persisted session status says "failed/not ready",
+ * but there is no active task left to own that busy state. QUEUED tasks are not
+ * blockers: they need the session to become promptable so the drainer can run.
+ */
+export function shouldReconcileSessionPromptState(session: Session, tasks: Task[]): boolean {
+  if (session.status !== SessionStatus.FAILED) return false;
+  if (session.ready_for_prompt === true) return false;
+  return !tasks.some(isTaskBlockingPrompt);
+}

--- a/apps/agor-daemon/src/utils/session-task-state.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.ts
@@ -16,8 +16,13 @@ export function sessionCanStartTask(status: Session['status'], readyForPrompt?: 
  * but there is no active task left to own that busy state. QUEUED tasks are not
  * blockers: they need the session to become promptable so the drainer can run.
  */
-export function shouldReconcileSessionPromptState(session: Session, tasks: Task[]): boolean {
+export function shouldReconcileSessionPromptState(
+  session: Session,
+  tasks: Task[],
+  options: { ignoredTaskIds?: readonly string[] } = {}
+): boolean {
   if (session.status !== SessionStatus.FAILED) return false;
   if (session.ready_for_prompt === true) return false;
-  return !tasks.some(isTaskBlockingPrompt);
+  const ignoredTaskIds = new Set(options.ignoredTaskIds ?? []);
+  return !tasks.some((task) => !ignoredTaskIds.has(task.task_id) && isTaskBlockingPrompt(task));
 }

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -76,6 +76,17 @@ export function isNaturalCompletion(status: TaskStatus): boolean {
   return status === TaskStatus.COMPLETED || status === TaskStatus.FAILED;
 }
 
+export const TERMINAL_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
+  TaskStatus.COMPLETED,
+  TaskStatus.FAILED,
+  TaskStatus.STOPPED,
+  TaskStatus.TIMED_OUT,
+]);
+
+export function isTerminalTaskStatus(status: TaskStatus | undefined): boolean {
+  return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
+}
+
 /**
  * Authoritative context-window snapshot captured at task completion.
  *


### PR DESCRIPTION
## Summary

Fixes a session/task state divergence where a session could remain failed/not-ready while its latest task was no longer failed, leaving prompts queued and the session effectively stuck.

Changes:
- Treat task terminal status as first-writer-wins so late executor completion cannot rewrite a heartbeat failure from `failed` to `completed`.
- Centralize heartbeat-loss session failure handling in `TasksService.failForLostHeartbeat`.
- Add prompt-state reconciliation for existing stuck sessions: when a failed/not-ready session has no active non-queued tasks, prompt and queue-drain paths repair it to idle/ready so queued work can proceed.
- Add focused regression tests for terminal rewrite prevention and failed/not-ready reconciliation.

## Validation

- `pnpm i`
  - Completed; optional `node-pty` native build reported missing `make`, but install exited successfully.
- `pnpm check`
  - Passed.
  - Biome reports existing warnings in unrelated files.
- `pnpm --filter @agor/daemon test -- src/services/tasks.executor-heartbeat.test.ts src/services/executor-heartbeat-supervisor.test.ts src/utils/session-task-state.test.ts`
  - Passed: 3 files, 7 tests.
