### PR TITLE
feat: add native Usage analytics page

### DIFF
--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -328,6 +328,54 @@ describe('LeaderboardService dimensions', () => {
     );
     expect(aliceOpus?.totalTokens).toBe(6_000);
   });
+
+  dbTest('groupBy: "repo" populates repoName from the repo slug', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'repo' } });
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].repoId).toBeDefined();
+    expect(result.data[0].repoName).toBe('main');
+  });
+
+  dbTest('repoName resolves per-repo when multiple repos exist', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    // Second repo + branch + session + task attributed to Bob.
+    await seedRepoAndBranch(db, {
+      slug: 'analytics',
+      branchId: 'wt-analytics',
+      branchName: 'analytics-wt',
+      uniqueId: 2,
+    });
+    await seedSession(db, { sessionId: 'sess-analytics', branchId: 'wt-analytics', tool: 'codex' });
+    await seedTask(db, {
+      sessionId: 'sess-analytics',
+      createdBy: 'user-bob',
+      createdAt: tsAt({ daysOffset: 0 }),
+      model: 'gpt-5',
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.01,
+      durationMs: 500,
+    });
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'repo' } });
+    const byName = new Map(result.data.map((r) => [r.repoName, r]));
+    expect(new Set(byName.keys())).toEqual(new Set(['main', 'analytics']));
+    expect(byName.get('analytics')?.taskCount).toBe(1);
+  });
+
+  dbTest('repoName is absent when repo is not in groupBy', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'user' } });
+    for (const row of result.data) {
+      expect(row.repoName).toBeUndefined();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -18,85 +18,25 @@ import {
   gte,
   jsonExtract,
   lte,
+  repos,
   type SQL,
   sessions,
   sql,
   tasks,
   users,
 } from '@agor/core/db';
+import type {
+  LeaderboardDimension,
+  LeaderboardEntry,
+  LeaderboardQuery,
+  LeaderboardResult,
+} from '@agor/core/types';
 
 interface Params {
   query?: Record<string, unknown>;
 }
 
-/**
- * Supported groupBy dimensions. Callers can combine these in a comma-separated string,
- * e.g. `'user,model'` or `'tool,branch,repo'`.
- */
-export type LeaderboardDimension = 'user' | 'branch' | 'repo' | 'model' | 'tool';
-
 const ALL_DIMENSIONS: LeaderboardDimension[] = ['user', 'branch', 'repo', 'model', 'tool'];
-
-export interface LeaderboardQuery {
-  // Filters
-  userId?: string;
-  branchId?: string;
-  repoId?: string;
-
-  // Time period (optional - ISO timestamps)
-  startDate?: string;
-  endDate?: string;
-
-  // Group by dimensions (optional, comma-separated). Default matches legacy behaviour.
-  // Supported values: 'user' | 'branch' | 'repo' | 'model' | 'tool' (any combination).
-  groupBy?: string;
-
-  // Time bucket (optional). When set, adds a `bucket` field (ISO-8601 UTC timestamp
-  // truncated to the given granularity) to each row and to the GROUP BY.
-  bucket?: DateBucket;
-
-  // Sorting. When bucket is set, results are ordered by bucket ASC first, then by
-  // sortBy within each bucket.
-  sortBy?: 'tokens' | 'cost';
-  sortOrder?: 'asc' | 'desc';
-
-  // Pagination
-  limit?: number;
-  offset?: number;
-}
-
-export interface LeaderboardEntry {
-  // Dimension fields (present only when the corresponding dimension is in groupBy)
-  userId?: string;
-  userName?: string;
-  userEmail?: string;
-  userEmoji?: string;
-  branchId?: string;
-  branchName?: string;
-  repoId?: string;
-  repoName?: string;
-  model?: string;
-  tool?: string;
-
-  // Time-series field (present only when `bucket` is set)
-  bucket?: string;
-
-  // Metrics (always present)
-  totalTokens: number;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalCost: number;
-  taskCount: number;
-  sessionCount: number;
-  totalDurationMs: number;
-}
-
-export interface LeaderboardResult {
-  data: LeaderboardEntry[];
-  total: number;
-  limit: number;
-  offset: number;
-}
 
 const VALID_BUCKETS = new Set<DateBucket>(['hour', 'day', 'week', 'month']);
 
@@ -268,6 +208,7 @@ export class LeaderboardService {
     }
     if (includeRepo) {
       selectFields.repoId = branches.repo_id;
+      selectFields.repoName = repos.slug;
     }
     if (includeModel) {
       selectFields.model = sql<string>`${modelExpr}`.as('model');
@@ -295,7 +236,10 @@ export class LeaderboardService {
       groupByFields.push(branches.branch_id);
       groupByFields.push(branches.name);
     }
-    if (includeRepo) groupByFields.push(branches.repo_id);
+    if (includeRepo) {
+      groupByFields.push(branches.repo_id);
+      groupByFields.push(repos.slug);
+    }
     if (includeModel) groupByFields.push(sql`${modelExpr}`);
     if (includeTool) groupByFields.push(sessions.agentic_tool);
     if (bucketExpr) groupByFields.push(sql`${bucketExpr}`);
@@ -319,6 +263,9 @@ export class LeaderboardService {
 
     if (includeUser) {
       qb = qb.leftJoin(users, eq(tasks.created_by, users.user_id));
+    }
+    if (includeRepo) {
+      qb = qb.leftJoin(repos, eq(branches.repo_id, repos.repo_id));
     }
 
     const results = await qb
@@ -347,6 +294,9 @@ export class LeaderboardService {
       if (includeUser) {
         countInner = countInner.leftJoin(users, eq(tasks.created_by, users.user_id));
       }
+      if (includeRepo) {
+        countInner = countInner.leftJoin(repos, eq(branches.repo_id, repos.repo_id));
+      }
 
       const groupedSubquery = countInner
         .where(whereClause)
@@ -370,6 +320,7 @@ export class LeaderboardService {
       branchId?: string;
       branchName?: string;
       repoId?: string;
+      repoName?: string | null;
       model?: string | null;
       tool?: string | null;
       bucket?: string | null;
@@ -396,7 +347,7 @@ export class LeaderboardService {
           branchId: r.branchId as string,
           branchName: r.branchName as string,
         }),
-        ...(includeRepo && { repoId: r.repoId as string }),
+        ...(includeRepo && { repoId: r.repoId as string, repoName: r.repoName || undefined }),
         ...(includeModel && { model: r.model || undefined }),
         ...(includeTool && { tool: r.tool || undefined }),
         ...(bucketExpr && { bucket: r.bucket || undefined }),

--- a/apps/agor-ui/package.json
+++ b/apps/agor-ui/package.json
@@ -37,6 +37,7 @@
     "antd": "^6.4.3",
     "cronstrue": "^3.14.0",
     "d3-force": "^3.0.0",
+    "dayjs": "^1.11.21",
     "diff": "^7.0.0",
     "emoji-picker-react": "^4.19.1",
     "emojibase": "^17.0.0",
@@ -49,6 +50,7 @@
     "react-router-dom": "^7.16.0",
     "react-syntax-highlighter": "^16.1.1",
     "reactflow": "^11.11.4",
+    "recharts": "^2.15.0",
     "streamdown": "^1.5.1"
   },
   "devDependencies": {

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -55,6 +55,7 @@ import {
   ARTIFACT_FULLSCREEN_ROUTE_PATHS,
   KNOWLEDGE_ROUTE_PATHS,
   routeUsesDeviceRouter,
+  USAGE_ROUTE_PATHS,
 } from './surfaces/surfaceRegistry';
 import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLifecycle';
 import { isMobileDevice } from './utils/deviceDetection';
@@ -91,6 +92,11 @@ const loadKnowledgePage = cacheRouteLoader(
   () => import('./pages/KnowledgePage'),
   (module) => ({ default: module.KnowledgePage })
 );
+const loadUsagePage = cacheRouteLoader(
+  'usage',
+  () => import('./pages/UsagePage'),
+  (module) => ({ default: module.UsagePage })
+);
 const loadArtifactFullscreenPage = cacheRouteLoader(
   'artifact-fullscreen',
   () => import('./pages/ArtifactFullscreenPage'),
@@ -109,6 +115,7 @@ const loadStreamdownDemoPage = cacheRouteLoader(
 
 const AgorApp = lazy(loadAgorApp);
 const KnowledgePage = lazy(loadKnowledgePage);
+const UsagePage = lazy(loadUsagePage);
 const ArtifactFullscreenPage = lazy(loadArtifactFullscreenPage);
 const MobileApp = lazy(loadMobileApp);
 const StreamdownDemoPage = lazy(loadStreamdownDemoPage);
@@ -116,6 +123,7 @@ const StreamdownDemoPage = lazy(loadStreamdownDemoPage);
 const routeModuleLoaders = {
   workspace: loadAgorApp,
   knowledge: loadKnowledgePage,
+  usage: loadUsagePage,
   'artifact-fullscreen': loadArtifactFullscreenPage,
   demo: loadStreamdownDemoPage,
   mobile: loadMobileApp,
@@ -1487,6 +1495,15 @@ function AppContent() {
     />
   );
 
+  const usagePageElement = (
+    <UsagePage
+      client={client}
+      currentUser={currentUser}
+      onUserSettingsClick={() => setOpenUserSettings(true)}
+      onLogout={logout}
+    />
+  );
+
   const artifactFullscreenElement = (
     <ArtifactFullscreenPage
       client={client}
@@ -1662,6 +1679,11 @@ function AppContent() {
             {/* Knowledge route shell. `/kb` is a short alias for the same surface. */}
             {KNOWLEDGE_ROUTE_PATHS.map((path) => (
               <Route key={path} path={path} element={knowledgePageElement} />
+            ))}
+
+            {/* Usage analytics surface. */}
+            {USAGE_ROUTE_PATHS.map((path) => (
+              <Route key={path} path={path} element={usagePageElement} />
             ))}
 
             {/* Lightweight artifact fullscreen surface. Uses the shared auth shell,

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -93,3 +93,36 @@ describe('AppHeader Knowledge link', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });
+
+describe('AppHeader Usage link', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders a basename-aware href and is visible to all users', () => {
+    renderHeader();
+
+    expect(screen.getByRole('link', { name: 'Usage' })).toHaveAttribute('href', '/ui/usage');
+  });
+
+  it('uses SPA navigation and prevents default for plain left clicks', () => {
+    renderHeader();
+
+    const eventWasNotCancelled = fireEvent.click(screen.getByRole('link', { name: 'Usage' }));
+
+    expect(eventWasNotCancelled).toBe(false);
+    expect(mockNavigate).toHaveBeenCalledExactlyOnceWith('/usage');
+  });
+
+  it('lets modified clicks fall through to the browser', () => {
+    renderHeader();
+
+    const usageLink = screen.getByRole('link', { name: 'Usage' });
+    usageLink.removeAttribute('href');
+
+    const eventWasNotCancelled = fireEvent.click(usageLink, { metaKey: true });
+
+    expect(eventWasNotCancelled).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@agor-live/client';
 import {
   ApiOutlined,
+  AreaChartOutlined,
   BookOutlined,
   CommentOutlined,
   QuestionCircleOutlined,
@@ -150,6 +151,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   const { token } = theme.useToken();
   const navigate = useNavigate();
   const knowledgeHref = useHref('/knowledge');
+  const usageHref = useHref('/usage');
   // Single source of truth for "is the daemon usable right now?". Captures
   // disconnected, the 1.5s reconnect grace window, and out-of-sync. Don't
   // gate off raw `connected` — it stays true through the grace window.
@@ -312,6 +314,29 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             />
           </Tooltip>
         )}
+        <Tooltip title="Usage" placement="bottom">
+          <Button
+            type="text"
+            icon={<AreaChartOutlined style={{ fontSize: token.fontSizeLG }} />}
+            style={headerIconButtonStyle}
+            href={usageHref}
+            aria-label="Usage"
+            onClick={(event) => {
+              if (event.defaultPrevented) return;
+              if (
+                event.button !== 0 ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.altKey
+              ) {
+                return;
+              }
+              event.preventDefault();
+              navigate('/usage');
+            }}
+          />
+        </Tooltip>
         <Tooltip title="Knowledge" placement="bottom">
           <Button
             type="text"

--- a/apps/agor-ui/src/pages/UsagePage.tsx
+++ b/apps/agor-ui/src/pages/UsagePage.tsx
@@ -1,0 +1,825 @@
+import type { LeaderboardBucket, LeaderboardEntry, LeaderboardResult } from '@agor/core/types';
+import type { AgorClient, User } from '@agor-live/client';
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import {
+  Alert,
+  Button,
+  Card,
+  DatePicker,
+  Empty,
+  Layout,
+  Segmented,
+  Space,
+  Spin,
+  Typography,
+  theme,
+} from 'antd';
+import dayjs, { type Dayjs } from 'dayjs';
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Cell,
+  Pie,
+  PieChart,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { BrandLogo } from '../components/BrandLogo';
+import { GlobalUserMenu } from '../components/GlobalUserMenu';
+import { ThemeSwitcher } from '../components/ThemeSwitcher';
+import {
+  buildAggregates,
+  buildChartSeries,
+  CHART_COLORS,
+  type DateRange,
+  DIMENSION_ORDER,
+  DIMENSIONS,
+  type DimensionKey,
+  fmtCompact,
+  fmtHours,
+  fmtInt,
+  fmtMoney,
+  METRIC_ORDER,
+  METRICS,
+  type MetricKey,
+  OTHER_COLOR,
+  type RankedRow,
+  type UsageData,
+  WINDOWS,
+  type WindowKey,
+} from './usage/usageTransforms';
+
+const { Header, Content } = Layout;
+const { Text } = Typography;
+
+/* ------------------------------------------------------------------ */
+/*  Data fetching                                                     */
+/* ------------------------------------------------------------------ */
+
+function findLeaderboard(
+  client: AgorClient,
+  query: Record<string, string | number | undefined>
+): Promise<LeaderboardResult> {
+  return client.service('leaderboard').find({ query }) as unknown as Promise<LeaderboardResult>;
+}
+
+function useUsageData(
+  client: AgorClient | null,
+  dim: DimensionKey,
+  bucket: LeaderboardBucket,
+  range: DateRange
+): { data: UsageData | null; loading: boolean; error: string | null } {
+  const [data, setData] = useState<UsageData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const seriesPromise = findLeaderboard(client, {
+      groupBy: dim,
+      bucket,
+      ...range,
+      limit: 10000,
+    });
+    const overviewPromises = DIMENSION_ORDER.map((d) =>
+      findLeaderboard(client, { groupBy: d, ...range, limit: 500 })
+    );
+
+    Promise.all([seriesPromise, ...overviewPromises])
+      .then(([series, ...overviews]) => {
+        if (cancelled) return;
+        const overview = Object.fromEntries(
+          DIMENSION_ORDER.map((d, i) => [d, overviews[i].data])
+        ) as Record<DimensionKey, LeaderboardEntry[]>;
+        setData({ series: series.data, overview });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, dim, bucket, range]);
+
+  return { data, loading, error };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                              */
+/* ------------------------------------------------------------------ */
+
+interface UsagePageProps {
+  client: AgorClient | null;
+  currentUser?: User | null;
+  onUserSettingsClick?: () => void;
+  onLogout?: () => void;
+}
+
+export function UsagePage({
+  client,
+  currentUser = null,
+  onUserSettingsClick,
+  onLogout,
+}: UsagePageProps) {
+  const { token } = theme.useToken();
+  const navigate = useNavigate();
+
+  const [metric, setMetric] = useState<MetricKey>('cost');
+  const [dim, setDim] = useState<DimensionKey>('user');
+  const [bucket, setBucket] = useState<LeaderboardBucket>('week');
+  const [win, setWin] = useState<WindowKey>('90d');
+  const [customRange, setCustomRange] = useState<[Dayjs, Dayjs] | null>(null);
+
+  const range = useMemo<DateRange>(() => {
+    if (win === 'custom') {
+      if (!customRange) return {};
+      return {
+        startDate: customRange[0].startOf('day').toISOString(),
+        endDate: customRange[1].endOf('day').toISOString(),
+      };
+    }
+    const days = WINDOWS[win].days;
+    if (!days) return {};
+    return { startDate: dayjs().subtract(days, 'day').startOf('day').toISOString() };
+  }, [win, customRange]);
+
+  const { data, loading, error } = useUsageData(client, dim, bucket, range);
+
+  /* ---- pivot bucketed rows into stacked series ---- */
+  const chart = useMemo(
+    () => (data ? buildChartSeries(data, metric, dim, bucket) : { rows: [], keys: [] }),
+    [data, metric, dim, bucket]
+  );
+
+  /* ---- aggregate overview rows for KPIs / leaderboards / donuts ---- */
+  const agg = useMemo(() => (data ? buildAggregates(data, metric) : null), [data, metric]);
+
+  const M = METRICS[metric];
+  const cardStyle: React.CSSProperties = { background: token.colorBgContainer };
+
+  return (
+    <Layout style={{ minHeight: '100vh', background: token.colorBgLayout }}>
+      <Header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          height: 56,
+          padding: '0 16px',
+          background: token.colorBgContainer,
+          borderBottom: `1px solid ${token.colorBorderSecondary}`,
+        }}
+      >
+        <Space size={12}>
+          <Button type="text" icon={<ArrowLeftOutlined />} onClick={() => navigate('/')} />
+          <BrandLogo level={5} />
+          <Text strong style={{ fontSize: 15 }}>
+            Usage
+          </Text>
+        </Space>
+        <Space size={8}>
+          <ThemeSwitcher />
+          <GlobalUserMenu
+            user={currentUser}
+            onUserSettingsClick={onUserSettingsClick}
+            onLogout={onLogout}
+          />
+        </Space>
+      </Header>
+
+      <Content style={{ padding: 16, maxWidth: 1280, width: '100%', margin: '0 auto' }}>
+        <Space direction="vertical" size={12} style={{ width: '100%' }}>
+          {/* Controls */}
+          <Space wrap size={8} style={{ justifyContent: 'space-between', width: '100%' }}>
+            <Space wrap size={8}>
+              <Segmented
+                options={(Object.keys(WINDOWS) as Exclude<WindowKey, 'custom'>[])
+                  .map((k) => ({ label: WINDOWS[k].label, value: k as WindowKey }))
+                  .concat([{ label: 'Custom', value: 'custom' }])}
+                value={win}
+                onChange={(v) => setWin(v as WindowKey)}
+              />
+              {win === 'custom' && (
+                <DatePicker.RangePicker
+                  value={customRange}
+                  onChange={(values) =>
+                    setCustomRange(values?.[0] && values?.[1] ? [values[0], values[1]] : null)
+                  }
+                  allowClear
+                />
+              )}
+            </Space>
+            <Space wrap size={8}>
+              <Segmented
+                options={DIMENSION_ORDER.map((k) => ({ label: DIMENSIONS[k].label, value: k }))}
+                value={dim}
+                onChange={(v) => setDim(v as DimensionKey)}
+              />
+              <Segmented
+                options={[
+                  { label: 'Day', value: 'day' },
+                  { label: 'Week', value: 'week' },
+                  { label: 'Month', value: 'month' },
+                ]}
+                value={bucket}
+                onChange={(v) => setBucket(v as LeaderboardBucket)}
+              />
+            </Space>
+          </Space>
+
+          {error && (
+            <Alert type="error" showIcon message="Failed to load usage data" description={error} />
+          )}
+
+          {!data && !error && (
+            <div style={{ padding: 80, textAlign: 'center' }}>
+              <Spin size="large" />
+            </div>
+          )}
+
+          {data && agg && (
+            <Spin spinning={loading}>
+              <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                {/* KPI strip */}
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+                    gap: 12,
+                  }}
+                >
+                  <KpiCard
+                    label="Total Cost"
+                    value={fmtMoney(agg.kpis.totalCost)}
+                    color={METRICS.cost.color}
+                    active={metric === 'cost'}
+                    onClick={() => setMetric('cost')}
+                    token={token}
+                  />
+                  <KpiCard
+                    label="Prompts"
+                    value={fmtInt(agg.kpis.totalPrompts)}
+                    color={METRICS.prompts.color}
+                    active={metric === 'prompts'}
+                    onClick={() => setMetric('prompts')}
+                    token={token}
+                  />
+                  <KpiCard
+                    label="Sessions"
+                    value={fmtInt(agg.kpis.totalSessions)}
+                    color={METRICS.sessions.color}
+                    active={metric === 'sessions'}
+                    onClick={() => setMetric('sessions')}
+                    token={token}
+                  />
+                  <KpiCard
+                    label="Output Tokens"
+                    value={fmtCompact(agg.kpis.totalTokens)}
+                    color={METRICS.tokens.color}
+                    active={metric === 'tokens'}
+                    onClick={() => setMetric('tokens')}
+                    token={token}
+                  />
+                  <KpiCard
+                    label="Agent Hours"
+                    value={fmtHours(agg.kpis.totalMs)}
+                    color={METRICS.hours.color}
+                    active={metric === 'hours'}
+                    onClick={() => setMetric('hours')}
+                    token={token}
+                  />
+                </div>
+
+                {/* Derived stats */}
+                <Card size="small" style={cardStyle}>
+                  <Space size={24} wrap>
+                    <DerivedStat
+                      label="$ / prompt"
+                      value={
+                        agg.kpis.totalPrompts
+                          ? `$${(agg.kpis.totalCost / agg.kpis.totalPrompts).toFixed(3)}`
+                          : '—'
+                      }
+                      token={token}
+                    />
+                    <DerivedStat
+                      label="Prompts / session"
+                      value={
+                        agg.kpis.totalSessions
+                          ? (agg.kpis.totalPrompts / agg.kpis.totalSessions).toFixed(1)
+                          : '—'
+                      }
+                      token={token}
+                    />
+                    <DerivedStat
+                      label="Avg session"
+                      value={
+                        agg.kpis.totalSessions
+                          ? `${(agg.kpis.totalMs / agg.kpis.totalSessions / 60000).toFixed(1)} min`
+                          : '—'
+                      }
+                      token={token}
+                    />
+                    <DerivedStat
+                      label="Opus cost share"
+                      value={
+                        agg.kpis.totalCost
+                          ? `${Math.round((agg.kpis.opusCost / agg.kpis.totalCost) * 100)}%`
+                          : '—'
+                      }
+                      token={token}
+                    />
+                    <DerivedStat
+                      label="Active users"
+                      value={fmtInt(agg.kpis.activeUsers)}
+                      token={token}
+                    />
+                  </Space>
+                </Card>
+
+                {/* Time series */}
+                <Card
+                  size="small"
+                  style={cardStyle}
+                  title={`${M.label} over time · by ${DIMENSIONS[dim].label.toLowerCase()}`}
+                  extra={
+                    <Segmented
+                      size="small"
+                      options={METRIC_ORDER.map((k) => ({ label: METRICS[k].label, value: k }))}
+                      value={metric}
+                      onChange={(v) => setMetric(v as MetricKey)}
+                    />
+                  }
+                >
+                  {chart.rows.length === 0 ? (
+                    <Empty description="No usage in this period" />
+                  ) : (
+                    <ResponsiveContainer width="100%" height={340}>
+                      <AreaChart
+                        data={chart.rows}
+                        margin={{ top: 8, right: 12, left: 4, bottom: 0 }}
+                      >
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke={token.colorBorderSecondary}
+                          vertical={false}
+                        />
+                        <XAxis
+                          dataKey="period"
+                          tick={{ fill: token.colorTextTertiary, fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={{ stroke: token.colorBorderSecondary }}
+                        />
+                        <YAxis
+                          tick={{ fill: token.colorTextTertiary, fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                          tickFormatter={(v: number) => M.axis(v)}
+                          width={56}
+                        />
+                        <RechartsTooltip
+                          content={<SeriesTooltip metric={metric} token={token} />}
+                        />
+                        {chart.keys.map((key, i) => (
+                          <Area
+                            key={key}
+                            type="monotone"
+                            dataKey={key}
+                            stackId="1"
+                            stroke={
+                              key === 'Other' ? OTHER_COLOR : CHART_COLORS[i % CHART_COLORS.length]
+                            }
+                            fill={
+                              key === 'Other' ? OTHER_COLOR : CHART_COLORS[i % CHART_COLORS.length]
+                            }
+                            fillOpacity={0.35}
+                            strokeWidth={1.4}
+                          />
+                        ))}
+                      </AreaChart>
+                    </ResponsiveContainer>
+                  )}
+                  <ChartLegend keys={chart.keys} token={token} />
+                </Card>
+
+                {/* Leaderboards */}
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                    gap: 12,
+                  }}
+                >
+                  <RankedCard
+                    title="Top Users"
+                    rows={agg.users}
+                    metric={metric}
+                    showEmoji
+                    token={token}
+                    style={cardStyle}
+                  />
+                  <RankedCard
+                    title="Top Repos"
+                    rows={agg.repos}
+                    metric={metric}
+                    token={token}
+                    style={cardStyle}
+                  />
+                  <RankedCard
+                    title="Top Branches"
+                    rows={agg.branches}
+                    metric={metric}
+                    token={token}
+                    style={cardStyle}
+                  />
+                </div>
+
+                {/* Share donuts */}
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
+                    gap: 12,
+                  }}
+                >
+                  <ShareCard
+                    title={`${M.label} by Agent`}
+                    rows={agg.tools}
+                    metric={metric}
+                    token={token}
+                    style={cardStyle}
+                  />
+                  <ShareCard
+                    title={`${M.label} by Model`}
+                    rows={agg.models}
+                    metric={metric}
+                    token={token}
+                    style={cardStyle}
+                  />
+                </div>
+
+                {/* Placeholder: session auto-categorization */}
+                <Card size="small" style={cardStyle} title="Usage by Category">
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="Session auto-categorization is coming soon — usage will be broken down by what sessions actually work on."
+                  />
+                </Card>
+
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  Token counts are not comparable across agents — some agents report large token
+                  totals with $0 cost, so cost is the only reliable cross-agent metric. "Prompts" =
+                  tasks (one user turn each).
+                </Text>
+              </Space>
+            </Spin>
+          )}
+        </Space>
+      </Content>
+    </Layout>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Subcomponents                                                     */
+/* ------------------------------------------------------------------ */
+
+type ThemeToken = ReturnType<typeof theme.useToken>['token'];
+
+const KpiCard: React.FC<{
+  label: string;
+  value: string;
+  color: string;
+  active: boolean;
+  onClick: () => void;
+  token: ThemeToken;
+}> = ({ label, value, color, active, onClick, token }) => (
+  <Card
+    size="small"
+    hoverable
+    onClick={onClick}
+    style={{
+      background: token.colorBgContainer,
+      borderColor: active ? color : token.colorBorderSecondary,
+    }}
+  >
+    <Text type="secondary" style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+      {label}
+    </Text>
+    <div style={{ fontSize: 24, fontWeight: 700, color, marginTop: 2 }}>{value}</div>
+  </Card>
+);
+
+const DerivedStat: React.FC<{ label: string; value: string; token: ThemeToken }> = ({
+  label,
+  value,
+  token,
+}) => (
+  <div>
+    <div style={{ fontSize: 16, fontWeight: 600, color: token.colorText }}>{value}</div>
+    <Text type="secondary" style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+      {label}
+    </Text>
+  </div>
+);
+
+const ChartLegend: React.FC<{ keys: string[]; token: ThemeToken }> = ({ keys, token }) => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 14px', marginTop: 8 }}>
+    {keys.map((key, i) => (
+      <Space key={key} size={5} style={{ fontSize: 11, color: token.colorTextSecondary }}>
+        <span
+          style={{
+            width: 9,
+            height: 9,
+            borderRadius: 2,
+            display: 'inline-block',
+            background: key === 'Other' ? OTHER_COLOR : CHART_COLORS[i % CHART_COLORS.length],
+          }}
+        />
+        <span
+          style={{
+            maxWidth: 140,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {key}
+        </span>
+      </Space>
+    ))}
+  </div>
+);
+
+const RankedCard: React.FC<{
+  title: string;
+  rows: RankedRow[];
+  metric: MetricKey;
+  showEmoji?: boolean;
+  token: ThemeToken;
+  style: React.CSSProperties;
+}> = ({ title, rows, metric, showEmoji, token, style }) => {
+  const M = METRICS[metric];
+  const top = rows.slice(0, 10);
+  const max = top.length ? top[0].value : 1;
+  return (
+    <Card size="small" title={title} style={style}>
+      <Space direction="vertical" size={7} style={{ width: '100%' }}>
+        {top.map((row, i) => (
+          <div
+            key={row.name}
+            style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}
+          >
+            <span
+              style={{
+                width: 16,
+                textAlign: 'right',
+                color: token.colorTextQuaternary,
+                fontSize: 10,
+              }}
+            >
+              {i + 1}
+            </span>
+            <span
+              style={{
+                width: 140,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                color: token.colorText,
+              }}
+              title={row.name}
+            >
+              {showEmoji && row.emoji ? `${row.emoji} ` : ''}
+              {row.name}
+            </span>
+            <div
+              style={{
+                flex: 1,
+                height: 7,
+                background: token.colorFillSecondary,
+                borderRadius: 4,
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  height: '100%',
+                  width: `${Math.max(2, (row.value / max) * 100)}%`,
+                  background: CHART_COLORS[i % CHART_COLORS.length],
+                  borderRadius: 4,
+                }}
+              />
+            </div>
+            <span
+              style={{
+                width: 62,
+                textAlign: 'right',
+                fontWeight: 600,
+                color: token.colorText,
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {M.fmt(row.value)}
+            </span>
+          </div>
+        ))}
+        {!top.length && (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No data in window" />
+        )}
+      </Space>
+    </Card>
+  );
+};
+
+const ShareCard: React.FC<{
+  title: string;
+  rows: RankedRow[];
+  metric: MetricKey;
+  token: ThemeToken;
+  style: React.CSSProperties;
+}> = ({ title, rows, metric, token, style }) => {
+  const M = METRICS[metric];
+  const top = rows.slice(0, 8);
+  const total = rows.reduce((s, r) => s + r.value, 0);
+  return (
+    <Card size="small" title={title} style={style}>
+      {top.length === 0 ? (
+        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No data in window" />
+      ) : (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <ResponsiveContainer width="50%" height={180}>
+            <PieChart>
+              <Pie
+                data={top}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={42}
+                outerRadius={70}
+                paddingAngle={2}
+                stroke="none"
+              >
+                {top.map((row, i) => (
+                  <Cell key={row.name} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                ))}
+              </Pie>
+              <RechartsTooltip content={<ShareTooltip metric={metric} token={token} />} />
+            </PieChart>
+          </ResponsiveContainer>
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {top.map((row, i) => (
+              <div
+                key={row.name}
+                style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11 }}
+              >
+                <span
+                  style={{
+                    width: 9,
+                    height: 9,
+                    borderRadius: 2,
+                    flexShrink: 0,
+                    background: CHART_COLORS[i % CHART_COLORS.length],
+                  }}
+                />
+                <span
+                  style={{
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    color: token.colorText,
+                  }}
+                  title={row.name}
+                >
+                  {row.name}
+                </span>
+                <span
+                  style={{ color: token.colorTextTertiary, fontVariantNumeric: 'tabular-nums' }}
+                >
+                  {total ? Math.round((row.value / total) * 100) : 0}%
+                </span>
+                <span
+                  style={{
+                    width: 56,
+                    textAlign: 'right',
+                    fontWeight: 600,
+                    color: token.colorText,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {M.fmt(row.value)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+/* ------------------------------------------------------------------ */
+/*  Chart tooltips                                                    */
+/* ------------------------------------------------------------------ */
+
+interface TooltipPayloadItem {
+  name: string;
+  value: number;
+  color?: string;
+  payload?: RankedRow;
+}
+
+const tooltipBoxStyle = (token: ThemeToken): React.CSSProperties => ({
+  background: token.colorBgElevated,
+  border: `1px solid ${token.colorBorderSecondary}`,
+  borderRadius: token.borderRadius,
+  padding: '8px 12px',
+  fontSize: 12,
+  color: token.colorText,
+  boxShadow: token.boxShadowSecondary,
+});
+
+const SeriesTooltip: React.FC<{
+  metric: MetricKey;
+  token: ThemeToken;
+  active?: boolean;
+  label?: string;
+  payload?: TooltipPayloadItem[];
+}> = ({ metric, token, active, label, payload }) => {
+  if (!active || !payload?.length) return null;
+  const M = METRICS[metric];
+  const rows = payload.filter((p) => p.value > 0).sort((a, b) => b.value - a.value);
+  const total = rows.reduce((s, p) => s + p.value, 0);
+  return (
+    <div style={tooltipBoxStyle(token)}>
+      <div style={{ fontWeight: 600, marginBottom: 6 }}>{label}</div>
+      {rows.slice(0, 14).map((p) => (
+        <div
+          key={p.name}
+          style={{ display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 2 }}
+        >
+          <span
+            style={{
+              color: p.color,
+              maxWidth: 160,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {p.name}
+          </span>
+          <span style={{ fontWeight: 500 }}>{M.fmt(p.value)}</span>
+        </div>
+      ))}
+      <div
+        style={{
+          borderTop: `1px solid ${token.colorBorderSecondary}`,
+          marginTop: 4,
+          paddingTop: 4,
+          fontWeight: 600,
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 16,
+        }}
+      >
+        <span>Total</span>
+        <span>{M.fmt(total)}</span>
+      </div>
+    </div>
+  );
+};
+
+const ShareTooltip: React.FC<{
+  metric: MetricKey;
+  token: ThemeToken;
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}> = ({ metric, token, active, payload }) => {
+  if (!active || !payload?.length) return null;
+  const M = METRICS[metric];
+  const p = payload[0];
+  return (
+    <div style={tooltipBoxStyle(token)}>
+      <div style={{ fontWeight: 600, marginBottom: 2 }}>{p.payload?.name ?? p.name}</div>
+      <div>{M.fmt(p.value)}</div>
+    </div>
+  );
+};

--- a/apps/agor-ui/src/pages/usage/usageTransforms.test.ts
+++ b/apps/agor-ui/src/pages/usage/usageTransforms.test.ts
@@ -1,0 +1,223 @@
+import type { LeaderboardEntry } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import {
+  buildAggregates,
+  buildChartSeries,
+  fmtCompact,
+  fmtHours,
+  fmtInt,
+  fmtMoney,
+  labelForRow,
+  shortModel,
+  type UsageData,
+} from './usageTransforms';
+
+/**
+ * Build a LeaderboardEntry with sane metric defaults so tests only specify the
+ * fields they care about.
+ */
+function entry(partial: Partial<LeaderboardEntry>): LeaderboardEntry {
+  return {
+    totalTokens: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCost: 0,
+    taskCount: 0,
+    sessionCount: 0,
+    totalDurationMs: 0,
+    ...partial,
+  };
+}
+
+describe('formatters', () => {
+  it('fmtInt rounds and applies thousands separators', () => {
+    expect(fmtInt(0)).toBe('0');
+    expect(fmtInt(1234.6)).toBe('1,235');
+    expect(fmtInt(Number.NaN)).toBe('0');
+  });
+
+  it('fmtMoney scales by magnitude', () => {
+    expect(fmtMoney(0)).toBe('$0.00');
+    expect(fmtMoney(12.5)).toBe('$12.50');
+    expect(fmtMoney(250)).toBe('$250');
+    expect(fmtMoney(12_345)).toBe('$12.3k');
+  });
+
+  it('fmtCompact abbreviates large numbers', () => {
+    expect(fmtCompact(42)).toBe('42');
+    expect(fmtCompact(1_500)).toBe('1.5k');
+    expect(fmtCompact(2_300_000)).toBe('2.3M');
+    expect(fmtCompact(4_100_000_000)).toBe('4.1B');
+  });
+
+  it('fmtHours converts milliseconds to hours', () => {
+    expect(fmtHours(0)).toBe('0.0h');
+    expect(fmtHours(1.8e6)).toBe('0.5h'); // 30 min
+    expect(fmtHours(3.6e7)).toBe('10h'); // 10 h
+    expect(fmtHours(3.6e9)).toBe('1.0k h'); // 1000 h
+  });
+
+  it('shortModel strips the claude- prefix and date suffix', () => {
+    expect(shortModel('claude-opus-4-6-20250101')).toBe('opus-4-6');
+    expect(shortModel('claude-sonnet-4-5')).toBe('sonnet-4-5');
+    expect(shortModel(undefined)).toBe('unknown');
+  });
+});
+
+describe('labelForRow', () => {
+  it('prefers the human-friendly identifier per dimension', () => {
+    expect(labelForRow(entry({ userName: 'Ada', userEmail: 'ada@x.io' }), 'user')).toBe('Ada');
+    expect(labelForRow(entry({ tool: 'claude-code' }), 'tool')).toBe('claude-code');
+    expect(labelForRow(entry({ model: 'claude-opus-4-6-20250101' }), 'model')).toBe('opus-4-6');
+    expect(labelForRow(entry({ repoName: 'agor' }), 'repo')).toBe('agor');
+    expect(labelForRow(entry({ branchName: 'feat-x' }), 'branch')).toBe('feat-x');
+  });
+
+  it('falls back to a truncated id, then to "unknown"', () => {
+    expect(labelForRow(entry({ userEmail: 'a@b.io' }), 'user')).toBe('a@b.io');
+    expect(labelForRow(entry({ userId: 'abcdef1234567890' }), 'user')).toBe('abcdef12');
+    expect(labelForRow(entry({}), 'user')).toBe('unknown');
+    expect(labelForRow(entry({ repoId: 'repo-aaaabbbb' }), 'repo')).toBe('repo-aaa');
+    expect(labelForRow(entry({}), 'tool')).toBe('unknown');
+  });
+});
+
+function usageData(partial: Partial<UsageData>): UsageData {
+  return {
+    series: [],
+    overview: { user: [], tool: [], model: [], repo: [], branch: [] },
+    ...partial,
+  };
+}
+
+describe('buildChartSeries', () => {
+  it('pivots bucketed rows into per-period stacked entries', () => {
+    const data = usageData({
+      series: [
+        entry({ bucket: '2026-04-13T00:00:00.000Z', userName: 'Ada', totalCost: 10 }),
+        entry({ bucket: '2026-04-13T00:00:00.000Z', userName: 'Lin', totalCost: 4 }),
+        entry({ bucket: '2026-04-20T00:00:00.000Z', userName: 'Ada', totalCost: 6 }),
+      ],
+    });
+
+    const { rows, keys } = buildChartSeries(data, 'cost', 'user', 'week');
+
+    expect(keys).toEqual(['Ada', 'Lin']); // Ada (16) ranks above Lin (4)
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ Ada: 10, Lin: 4 });
+    expect(rows[1]).toMatchObject({ Ada: 6 });
+    // chronological order preserved by ISO sort
+    expect(rows[0].__bucket).toBe('2026-04-13T00:00:00.000Z');
+    expect(rows[1].__bucket).toBe('2026-04-20T00:00:00.000Z');
+  });
+
+  it('folds everything beyond the top 12 keys into "Other"', () => {
+    const series: LeaderboardEntry[] = [];
+    for (let i = 0; i < 15; i++) {
+      series.push(
+        entry({ bucket: '2026-04-13T00:00:00.000Z', userName: `u${i}`, totalCost: 100 - i })
+      );
+    }
+    const { keys, rows } = buildChartSeries(usageData({ series }), 'cost', 'user', 'week');
+
+    expect(keys).toHaveLength(13); // 12 named + Other
+    expect(keys[12]).toBe('Other');
+    // Top 12 are costs 100..89; the remaining 3 (88 + 87 + 86) fold into Other.
+    expect(rows[0].Other).toBe(261);
+  });
+
+  it('drops non-positive values and rows without a bucket', () => {
+    const data = usageData({
+      series: [
+        entry({ bucket: '2026-04-13T00:00:00.000Z', userName: 'Ada', totalCost: 5 }),
+        entry({ bucket: '2026-04-13T00:00:00.000Z', userName: 'Zero', totalCost: 0 }),
+        entry({ userName: 'NoBucket', totalCost: 9 }),
+      ],
+    });
+    const { rows, keys } = buildChartSeries(data, 'cost', 'user', 'week');
+
+    expect(keys).toEqual(['Ada']);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].Zero).toBeUndefined();
+  });
+
+  it('returns empty rows when no series data is present', () => {
+    expect(buildChartSeries(usageData({}), 'cost', 'user', 'week')).toEqual({ rows: [], keys: [] });
+  });
+});
+
+describe('buildAggregates', () => {
+  const data = usageData({
+    overview: {
+      user: [
+        entry({
+          userName: 'Ada',
+          userEmoji: '🦊',
+          totalCost: 30,
+          taskCount: 9,
+          sessionCount: 3,
+          totalOutputTokens: 1000,
+          totalDurationMs: 7.2e6,
+        }),
+        entry({
+          userName: 'Lin',
+          totalCost: 10,
+          taskCount: 1,
+          sessionCount: 1,
+          totalOutputTokens: 500,
+          totalDurationMs: 3.6e6,
+        }),
+        entry({ userName: 'Idle', totalCost: 0 }),
+      ],
+      tool: [
+        entry({ tool: 'claude-code', totalCost: 25 }),
+        entry({ tool: 'codex', totalCost: 15 }),
+      ],
+      model: [
+        entry({ model: 'claude-opus-4-6', totalCost: 28 }),
+        entry({ model: 'claude-sonnet-4-5', totalCost: 12 }),
+      ],
+      repo: [entry({ repoName: 'agor', totalCost: 40 })],
+      branch: [entry({ branchName: 'feat-x', totalCost: 22 })],
+    },
+  });
+
+  it('ranks each dimension descending and drops zero-valued rows', () => {
+    const agg = buildAggregates(data, 'cost');
+
+    expect(agg.users.map((r) => r.name)).toEqual(['Ada', 'Lin']); // Idle dropped
+    expect(agg.users[0]).toMatchObject({ name: 'Ada', value: 30, emoji: '🦊' });
+    expect(agg.tools[0].name).toBe('claude-code');
+    expect(agg.repos[0].name).toBe('agor');
+  });
+
+  it('sums KPIs from the user dimension', () => {
+    const { kpis } = buildAggregates(data, 'cost');
+
+    expect(kpis.totalCost).toBe(40);
+    expect(kpis.totalPrompts).toBe(10);
+    expect(kpis.totalSessions).toBe(4);
+    expect(kpis.totalTokens).toBe(1500);
+    expect(kpis.totalMs).toBe(10.8e6);
+    expect(kpis.activeUsers).toBe(3); // counts all rows, including the idle one
+  });
+
+  it('derives opus cost share from the model dimension', () => {
+    expect(buildAggregates(data, 'cost').kpis.opusCost).toBe(28);
+  });
+
+  it('re-ranks by the selected metric', () => {
+    const data2 = usageData({
+      overview: {
+        ...data.overview,
+        user: [
+          entry({ userName: 'Cheap', totalCost: 1, taskCount: 100 }),
+          entry({ userName: 'Pricey', totalCost: 50, taskCount: 2 }),
+        ],
+      },
+    });
+
+    expect(buildAggregates(data2, 'cost').users[0].name).toBe('Pricey');
+    expect(buildAggregates(data2, 'prompts').users[0].name).toBe('Cheap');
+  });
+});

--- a/apps/agor-ui/src/pages/usage/usageTransforms.ts
+++ b/apps/agor-ui/src/pages/usage/usageTransforms.ts
@@ -1,0 +1,293 @@
+/**
+ * Pure data-shaping helpers for the Usage analytics page.
+ *
+ * Kept free of React / recharts so the pivot + aggregation logic can be unit
+ * tested in isolation. `UsagePage.tsx` owns the data fetching and rendering.
+ */
+
+import type { LeaderboardBucket, LeaderboardEntry } from '@agor/core/types';
+import dayjs from 'dayjs';
+
+/* ------------------------------------------------------------------ */
+/*  Config                                                            */
+/* ------------------------------------------------------------------ */
+
+export const CHART_COLORS = [
+  '#6366f1',
+  '#22d3ee',
+  '#f59e0b',
+  '#10b981',
+  '#ec4899',
+  '#8b5cf6',
+  '#f97316',
+  '#14b8a6',
+  '#ef4444',
+  '#38bdf8',
+  '#a78bfa',
+  '#34d399',
+];
+export const OTHER_COLOR = '#64748b';
+const TOP_SERIES_KEYS = 12;
+
+export type MetricKey = 'cost' | 'prompts' | 'sessions' | 'tokens' | 'hours';
+export type DimensionKey = 'user' | 'tool' | 'model' | 'repo' | 'branch';
+export type WindowKey = '7d' | '30d' | '90d' | 'all' | 'custom';
+
+export interface MetricDef {
+  field: keyof Pick<
+    LeaderboardEntry,
+    'totalCost' | 'taskCount' | 'sessionCount' | 'totalOutputTokens' | 'totalDurationMs'
+  >;
+  label: string;
+  color: string;
+  fmt: (v: number) => string;
+  axis: (v: number) => string;
+}
+
+export const METRICS: Record<MetricKey, MetricDef> = {
+  cost: {
+    field: 'totalCost',
+    label: 'Cost',
+    color: '#6366f1',
+    fmt: fmtMoney,
+    axis: (v) => `$${fmtCompact(v)}`,
+  },
+  prompts: {
+    field: 'taskCount',
+    label: 'Prompts',
+    color: '#22d3ee',
+    fmt: fmtInt,
+    axis: fmtCompact,
+  },
+  sessions: {
+    field: 'sessionCount',
+    label: 'Sessions',
+    color: '#10b981',
+    fmt: fmtInt,
+    axis: fmtCompact,
+  },
+  tokens: {
+    field: 'totalOutputTokens',
+    label: 'Output Tokens',
+    color: '#f59e0b',
+    fmt: fmtCompact,
+    axis: fmtCompact,
+  },
+  hours: {
+    field: 'totalDurationMs',
+    label: 'Agent Hours',
+    color: '#ec4899',
+    fmt: fmtHours,
+    axis: (v) => `${fmtCompact(v / 3.6e6)}h`,
+  },
+};
+export const METRIC_ORDER: MetricKey[] = ['cost', 'prompts', 'sessions', 'tokens', 'hours'];
+
+export const DIMENSIONS: Record<DimensionKey, { label: string }> = {
+  user: { label: 'User' },
+  tool: { label: 'Agent' },
+  model: { label: 'Model' },
+  repo: { label: 'Repo' },
+  branch: { label: 'Branch' },
+};
+export const DIMENSION_ORDER: DimensionKey[] = ['user', 'tool', 'model', 'repo', 'branch'];
+
+export const WINDOWS: Record<
+  Exclude<WindowKey, 'custom'>,
+  { label: string; days: number | null }
+> = {
+  '7d': { label: '7 days', days: 7 },
+  '30d': { label: '30 days', days: 30 },
+  '90d': { label: '90 days', days: 90 },
+  all: { label: 'All time', days: null },
+};
+
+/* ------------------------------------------------------------------ */
+/*  Formatting helpers                                                */
+/* ------------------------------------------------------------------ */
+
+export function fmtInt(v: number): string {
+  return Math.round(v || 0).toLocaleString('en-US');
+}
+
+export function fmtMoney(v: number): string {
+  const n = v || 0;
+  if (n >= 10000) return `$${(n / 1000).toFixed(1)}k`;
+  if (n >= 100) return `$${Math.round(n).toLocaleString('en-US')}`;
+  return `$${n.toFixed(2)}`;
+}
+
+export function fmtCompact(v: number): string {
+  const n = v || 0;
+  if (n >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
+export function fmtHours(ms: number): string {
+  const h = (ms || 0) / 3.6e6;
+  if (h >= 1000) return `${(h / 1000).toFixed(1)}k h`;
+  if (h >= 10) return `${Math.round(h)}h`;
+  return `${h.toFixed(1)}h`;
+}
+
+export function shortModel(model?: string): string {
+  if (!model) return 'unknown';
+  return model.replace(/^claude-/, '').replace(/-\d{8}$/, '');
+}
+
+export function labelForRow(row: LeaderboardEntry, dim: DimensionKey): string {
+  switch (dim) {
+    case 'user':
+      return row.userName || row.userEmail || (row.userId ? row.userId.slice(0, 8) : 'unknown');
+    case 'tool':
+      return row.tool || 'unknown';
+    case 'model':
+      return shortModel(row.model);
+    case 'repo':
+      return row.repoName || (row.repoId ? row.repoId.slice(0, 8) : 'unknown');
+    case 'branch':
+      return row.branchName || (row.branchId ? row.branchId.slice(0, 8) : 'unknown');
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Data shapes                                                       */
+/* ------------------------------------------------------------------ */
+
+export interface DateRange {
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface UsageData {
+  /** Bucketed rows for the time series: one row per (bucket × dimension value). */
+  series: LeaderboardEntry[];
+  /** Un-bucketed rows per dimension for KPIs, leaderboards, and share donuts. */
+  overview: Record<DimensionKey, LeaderboardEntry[]>;
+}
+
+export interface RankedRow {
+  name: string;
+  value: number;
+  emoji?: string;
+}
+
+export interface ChartSeries {
+  rows: Record<string, number | string>[];
+  keys: string[];
+}
+
+export interface UsageAggregates {
+  users: RankedRow[];
+  repos: RankedRow[];
+  branches: RankedRow[];
+  tools: RankedRow[];
+  models: RankedRow[];
+  kpis: {
+    totalCost: number;
+    totalPrompts: number;
+    totalSessions: number;
+    totalTokens: number;
+    totalMs: number;
+    opusCost: number;
+    activeUsers: number;
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Transforms                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Pivot bucketed leaderboard rows into stacked-area series. Keeps the top
+ * {@link TOP_SERIES_KEYS} dimension values by total and folds the rest into an
+ * "Other" series. Empty (≤0) values are dropped so the chart stays sparse.
+ */
+export function buildChartSeries(
+  data: UsageData,
+  metric: MetricKey,
+  dim: DimensionKey,
+  bucket: LeaderboardBucket
+): ChartSeries {
+  const field = METRICS[metric].field;
+
+  const totals = new Map<string, number>();
+  for (const row of data.series) {
+    if (!row.bucket) continue;
+    const label = labelForRow(row, dim);
+    totals.set(label, (totals.get(label) || 0) + (Number(row[field]) || 0));
+  }
+  const topKeys = [...totals.entries()]
+    .filter(([, v]) => v > 0)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, TOP_SERIES_KEYS)
+    .map(([k]) => k);
+  const topSet = new Set(topKeys);
+
+  const byBucket = new Map<string, Record<string, number | string>>();
+  let hasOther = false;
+  for (const row of data.series) {
+    if (!row.bucket) continue;
+    const value = Number(row[field]) || 0;
+    if (value <= 0) continue;
+    let entry = byBucket.get(row.bucket);
+    if (!entry) {
+      entry = { __bucket: row.bucket };
+      byBucket.set(row.bucket, entry);
+    }
+    const label = labelForRow(row, dim);
+    if (topSet.has(label)) {
+      entry[label] = ((entry[label] as number) || 0) + value;
+    } else {
+      entry.Other = ((entry.Other as number) || 0) + value;
+      hasOther = true;
+    }
+  }
+
+  const fmt = bucket === 'month' ? 'MMM YY' : bucket === 'hour' ? 'MMM D HH:mm' : 'MMM D';
+  const rows = [...byBucket.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([iso, entry]) => ({ ...entry, period: dayjs(iso).format(fmt) }));
+
+  return { rows, keys: hasOther ? [...topKeys, 'Other'] : topKeys };
+}
+
+/**
+ * Collapse the per-dimension overview rows into ranked leaderboards plus the
+ * KPI totals. Ranked rows are sorted descending by the selected metric and
+ * drop zero-valued entries.
+ */
+export function buildAggregates(data: UsageData, metric: MetricKey): UsageAggregates {
+  const field = METRICS[metric].field;
+  const sum = (rows: LeaderboardEntry[], f: MetricDef['field']) =>
+    rows.reduce((s, r) => s + (Number(r[f]) || 0), 0);
+  const ranked = (rows: LeaderboardEntry[], d: DimensionKey): RankedRow[] =>
+    rows
+      .map((r) => ({ name: labelForRow(r, d), value: Number(r[field]) || 0, emoji: r.userEmoji }))
+      .filter((r) => r.value > 0)
+      .sort((a, b) => b.value - a.value);
+
+  const byUser = data.overview.user;
+  const opusCost = data.overview.model
+    .filter((r) => (r.model || '').includes('opus'))
+    .reduce((s, r) => s + (Number(r.totalCost) || 0), 0);
+
+  return {
+    users: ranked(byUser, 'user'),
+    repos: ranked(data.overview.repo, 'repo'),
+    branches: ranked(data.overview.branch, 'branch'),
+    tools: ranked(data.overview.tool, 'tool'),
+    models: ranked(data.overview.model, 'model'),
+    kpis: {
+      totalCost: sum(byUser, 'totalCost'),
+      totalPrompts: sum(byUser, 'taskCount'),
+      totalSessions: sum(byUser, 'sessionCount'),
+      totalTokens: sum(byUser, 'totalOutputTokens'),
+      totalMs: sum(byUser, 'totalDurationMs'),
+      opusCost,
+      activeUsers: byUser.length,
+    },
+  };
+}

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
@@ -43,6 +43,20 @@ describe('surface route registry', () => {
     expect(routeUsesSharedUserSettings(path)).toBe(false);
   });
 
+  it('classifies /usage as a lightweight shared-shell surface', () => {
+    expect(getRouteSurface('/usage').id).toBe('usage');
+    expect(isKnowledgeRoutePath('/usage')).toBe(false);
+    expect(isWorkspaceRoutePath('/usage')).toBe(false);
+    expect(routeStartsWorkspaceRuntime('/usage')).toBe(false);
+    expect(routeUsesDeviceRouter('/usage')).toBe(false);
+    expect(routeUsesSharedUserSettings('/usage')).toBe(true);
+  });
+
+  it('does not treat similarly prefixed paths as Usage', () => {
+    expect(getRouteSurface('/usages').id).toBe('workspace');
+    expect(getRouteSurface('/usage/extra').id).toBe('workspace');
+  });
+
   it.each(['/a/artifact/fullscreen'])('classifies %s as Artifact fullscreen', (path) => {
     expect(getRouteSurface(path).id).toBe('artifact-fullscreen');
     expect(isKnowledgeRoutePath(path)).toBe(false);

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.ts
@@ -1,6 +1,6 @@
 import { matchPath } from 'react-router-dom';
 
-export type RouteSurfaceId = 'workspace' | 'knowledge' | 'artifact-fullscreen' | 'demo';
+export type RouteSurfaceId = 'workspace' | 'knowledge' | 'usage' | 'artifact-fullscreen' | 'demo';
 
 export interface RouteSurfaceDefinition {
   id: RouteSurfaceId;
@@ -47,6 +47,17 @@ export const KNOWLEDGE_SURFACE = defineSurface({
   usesSharedUserSettings: true,
 });
 
+export const USAGE_ROUTE_PATHS = ['/usage'] as const;
+
+export const USAGE_SURFACE = defineSurface({
+  id: 'usage',
+  label: 'Usage',
+  routePaths: USAGE_ROUTE_PATHS,
+  startsWorkspaceRuntime: false,
+  usesDeviceRouter: false,
+  usesSharedUserSettings: true,
+});
+
 export const ARTIFACT_FULLSCREEN_ROUTE_PATHS = ['/a/:artifactShortId/fullscreen'] as const;
 
 export const ARTIFACT_FULLSCREEN_SURFACE = defineSurface({
@@ -78,6 +89,7 @@ export const WORKSPACE_SURFACE = defineSurface({
 
 export const SURFACE_REGISTRY = [
   KNOWLEDGE_SURFACE,
+  USAGE_SURFACE,
   ARTIFACT_FULLSCREEN_SURFACE,
   DEMO_SURFACE,
   WORKSPACE_SURFACE,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -17,6 +17,7 @@ export * from './gateway';
 export * from './group';
 export * from './id';
 export * from './knowledge';
+export * from './leaderboard';
 export * from './mcp';
 export * from './message';
 export * from './presence';

--- a/packages/core/src/types/leaderboard.ts
+++ b/packages/core/src/types/leaderboard.ts
@@ -1,0 +1,76 @@
+/**
+ * Leaderboard / usage analytics types.
+ *
+ * Shared between the daemon's `/leaderboard` service and UI consumers
+ * (Usage page, board artifacts via the public API).
+ */
+
+/**
+ * Supported groupBy dimensions. Callers can combine these in a comma-separated string,
+ * e.g. `'user,model'` or `'tool,branch,repo'`.
+ */
+export type LeaderboardDimension = 'user' | 'branch' | 'repo' | 'model' | 'tool';
+
+/** Time-bucket granularity for usage time series. */
+export type LeaderboardBucket = 'hour' | 'day' | 'week' | 'month';
+
+export interface LeaderboardQuery {
+  // Filters
+  userId?: string;
+  branchId?: string;
+  repoId?: string;
+
+  // Time period (optional - ISO timestamps)
+  startDate?: string;
+  endDate?: string;
+
+  // Group by dimensions (optional, comma-separated). Default matches legacy behaviour.
+  // Supported values: 'user' | 'branch' | 'repo' | 'model' | 'tool' (any combination).
+  groupBy?: string;
+
+  // Time bucket (optional). When set, adds a `bucket` field (ISO-8601 UTC timestamp
+  // truncated to the given granularity) to each row and to the GROUP BY.
+  bucket?: LeaderboardBucket;
+
+  // Sorting. When bucket is set, results are ordered by bucket ASC first, then by
+  // sortBy within each bucket.
+  sortBy?: 'tokens' | 'cost';
+  sortOrder?: 'asc' | 'desc';
+
+  // Pagination
+  limit?: number;
+  offset?: number;
+}
+
+export interface LeaderboardEntry {
+  // Dimension fields (present only when the corresponding dimension is in groupBy)
+  userId?: string;
+  userName?: string;
+  userEmail?: string;
+  userEmoji?: string;
+  branchId?: string;
+  branchName?: string;
+  repoId?: string;
+  repoName?: string;
+  model?: string;
+  tool?: string;
+
+  // Time-series field (present only when `bucket` is set)
+  bucket?: string;
+
+  // Metrics (always present)
+  totalTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCost: number;
+  taskCount: number;
+  sessionCount: number;
+  totalDurationMs: number;
+}
+
+export interface LeaderboardResult {
+  data: LeaderboardEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       d3-force:
         specifier: ^3.0.0
         version: 3.0.0
+      dayjs:
+        specifier: ^1.11.21
+        version: 1.11.21
       diff:
         specifier: '>=8.0.3 <9'
         version: 8.0.3
@@ -414,6 +417,9 @@ importers:
       reactflow:
         specifier: ^11.11.4
         version: 11.11.4(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^2.15.0
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       streamdown:
         specifier: ^1.5.1
         version: 1.5.1(@types/mdast@4.0.4)(@types/react@18.3.26)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@18.3.1)(unified@11.0.5)
@@ -5291,11 +5297,8 @@ packages:
     resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
     engines: {node: '>=20'}
 
-  dayjs@1.11.19:
-    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
-
-  dayjs@1.11.20:
-    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -5322,6 +5325,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -5414,6 +5420,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -5836,6 +5845,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -7752,6 +7765,9 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -7847,6 +7863,9 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -7895,11 +7914,23 @@ packages:
       react-dom:
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-syntax-highlighter@16.1.1:
     resolution: {integrity: sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==}
     engines: {node: '>= 16.20.2'}
     peerDependencies:
       react: '>= 0.14.0'
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -7929,6 +7960,17 @@ packages:
 
   reading-time@1.5.0:
     resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -8595,6 +8637,9 @@ packages:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
     engines: {node: '>=12.22'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tiny-jsonc@1.0.2:
     resolution: {integrity: sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw==}
 
@@ -8930,6 +8975,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-plugin-compression@0.5.1:
     resolution: {integrity: sha512-5QJKBDc+gNYVqL/skgFAP81Yuzo9R+EAf19d+EtsMF/i8kFUpNi3J/H01QD3Oo8zBQn+NzoCIFkpPLynoOzaJg==}
@@ -12177,7 +12225,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@rc-component/picker@1.10.0(dayjs@1.11.20)(luxon@3.7.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@rc-component/picker@1.10.0(dayjs@1.11.21)(luxon@3.7.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@rc-component/overflow': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/resize-observer': 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12187,7 +12235,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      dayjs: 1.11.20
+      dayjs: 1.11.21
       luxon: 3.7.2
 
   '@rc-component/portal@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -13684,7 +13732,7 @@ snapshots:
       '@rc-component/mutate-observer': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/notification': 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/pagination': 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@rc-component/picker': 1.10.0(dayjs@1.11.20)(luxon@3.7.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rc-component/picker': 1.10.0(dayjs@1.11.21)(luxon@3.7.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/progress': 1.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/qrcode': 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/rate': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -13704,7 +13752,7 @@ snapshots:
       '@rc-component/upload': 1.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rc-component/util': 1.11.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
-      dayjs: 1.11.20
+      dayjs: 1.11.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       scroll-into-view-if-needed: 3.1.0
@@ -14439,9 +14487,7 @@ snapshots:
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
 
-  dayjs@1.11.19: {}
-
-  dayjs@1.11.20: {}
+  dayjs@1.11.21: {}
 
   debug@2.6.9:
     dependencies:
@@ -14456,6 +14502,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -14520,6 +14568,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dom-serializer@2.0.0:
     dependencies:
@@ -15010,6 +15063,8 @@ snapshots:
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -16564,7 +16619,7 @@ snapshots:
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.13
-      dayjs: 1.11.19
+      dayjs: 1.11.21
       dompurify: 3.4.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -16590,7 +16645,7 @@ snapshots:
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
-      dayjs: 1.11.20
+      dayjs: 1.11.21
       dompurify: 3.4.5
       es-toolkit: 1.46.1
       katex: 0.16.47
@@ -17578,6 +17633,12 @@ snapshots:
       retry: 0.12.0
     optional: true
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -17704,6 +17765,8 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
@@ -17756,6 +17819,14 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   react-syntax-highlighter@16.1.1(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -17765,6 +17836,15 @@ snapshots:
       prismjs: 1.30.0
       react: 18.3.1
       refractor: 5.0.0
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -17807,6 +17887,23 @@ snapshots:
   readdirp@4.1.2: {}
 
   reading-time@1.5.0: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -18805,6 +18902,8 @@ snapshots:
 
   throttle-debounce@5.0.2: {}
 
+  tiny-invariant@1.3.3: {}
+
   tiny-jsonc@1.0.2: {}
 
   tinybench@2.9.0: {}
@@ -19130,6 +19229,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-plugin-compression@0.5.1(vite@8.0.16(@types/node@24.10.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary
- Promotes the board usage-dashboard artifacts into a first-class nav feature: a **Usage** button in the header (`AreaChartOutlined`) opens a `/usage` page backed by the existing `/leaderboard` service. The button is visible to all authenticated users.
- The page renders a KPI strip (cost, prompts, sessions, output tokens, agent hours), a stacked time-series chart (recharts) with window/granularity/dimension/metric controls, ranked leaderboards (users/repos/branches), share donuts (agent/model), and a placeholder card for future session auto-categorization.
- Backend populates `repoName` on leaderboard rows (joins `repos` for the slug), and the leaderboard types move to `@agor/core/types` so the UI can reuse them.
- Adds `/usage` as a lightweight shared-shell route surface (no Workspace runtime), wired via the existing `cacheRouteLoader` + `React.lazy` pattern.

## Test plan
- [x] Unit tests: 43 UI (`usageTransforms`, `surfaceRegistry`, `AppHeader`) + 19 daemon (`leaderboard` repoName cases) green.
- [x] Manual: `/usage` renders on the SQLite branch instance; window/granularity/dimension/metric switches refetch and rerender; light + dark themes look right.
- [ ] Reviewer: confirm `repoName` join behavior on a Postgres instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)