### PR TITLE
Optimize board objects initial load path

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -68,6 +68,7 @@ import type {
 } from './declarations.js';
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
+import { normalizeBoardObjectFindQuery } from './services/board-objects.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
 import { isLocalAuthenticationLookup } from './services/users.js';
@@ -502,44 +503,31 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 const userId = context.params.user?.user_id as
                   | import('@agor/core/types').UUID
                   | undefined;
-                const query = context.params.query ?? {};
-                const requestedSkip = Number(query.$skip ?? 0);
-                const requestedLimit = typeof query.$limit === 'number' ? query.$limit : undefined;
+                const normalized = normalizeBoardObjectFindQuery(context.params.query);
 
                 if (!userId) {
                   context.result = {
                     total: 0,
-                    limit: requestedLimit ?? 100,
-                    skip: requestedSkip,
+                    limit: normalized.limit,
+                    skip: normalized.skip,
                     data: [],
                   };
                   return context;
                 }
 
-                const filters = Object.fromEntries(
-                  Object.entries({
-                    board_id: query.board_id,
-                    branch_id: query.branch_id,
-                    card_id: query.card_id,
-                    zone_id: query.zone_id,
-                    entity_type: query.entity_type,
-                  }).filter(([, value]) => value !== undefined)
-                );
                 const [total, data] = await Promise.all([
-                  boardObjectRepository.countVisibleToUser(userId, filters),
+                  boardObjectRepository.countVisibleToUser(userId, normalized.filters),
                   boardObjectRepository.findVisibleToUser(
                     userId,
-                    filters,
-                    requestedLimit !== undefined || requestedSkip > 0
-                      ? { limit: requestedLimit, offset: requestedSkip }
-                      : {}
+                    normalized.filters,
+                    normalized.pagination
                   ),
                 ]);
 
                 context.result = {
                   total,
-                  limit: requestedLimit ?? 100,
-                  skip: requestedSkip,
+                  limit: normalized.limit,
+                  skip: normalized.skip,
                   data,
                 };
                 (context.params as { _boardObjectsRbacScoped?: boolean })._boardObjectsRbacScoped =

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -17,6 +17,7 @@ import {
 } from '@agor/core/config';
 import {
   ArtifactRepository,
+  BoardObjectRepository,
   BoardRepository,
   type BranchRepository,
   type Database,
@@ -477,6 +478,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // ============================================================================
   // Board objects hooks
   // ============================================================================
+  const boardObjectRepository = new BoardObjectRepository(db);
 
   safeService('board-objects')?.hooks({
     before: {
@@ -485,12 +487,68 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireAuth,
         requireMinimumRole(ROLES.MEMBER, 'manage board objects'),
       ],
-      // NOTE: We deliberately do NOT add scopeFindToAccessibleBranches here.
+      // NOTE: We deliberately do NOT add the generic scopeFindToAccessibleBranches here.
       // Board-objects may reference `branch_id` (branch cards) OR `card_id`
       // (kanban cards with no branch) OR neither (zones, layout objects).
-      // The before-hook would filter out rows with null branch_id, breaking
-      // card-only boards. Access control lives in the after-hook below, which
-      // correctly preserves card/zone rows while scoping branch-bound ones.
+      // That generic hook would filter out rows with null branch_id, breaking
+      // card-only boards. The RBAC find hook below uses a board-object-specific
+      // SQL query that preserves card/zone rows while scoping branch-bound ones.
+      find: [
+        ...(branchRbacEnabled
+          ? [
+              async (context: HookContext) => {
+                if (!context.params.provider) return context;
+
+                const userId = context.params.user?.user_id as
+                  | import('@agor/core/types').UUID
+                  | undefined;
+                const query = context.params.query ?? {};
+                const requestedSkip = Number(query.$skip ?? 0);
+                const requestedLimit = typeof query.$limit === 'number' ? query.$limit : undefined;
+
+                if (!userId) {
+                  context.result = {
+                    total: 0,
+                    limit: requestedLimit ?? 100,
+                    skip: requestedSkip,
+                    data: [],
+                  };
+                  return context;
+                }
+
+                const filters = Object.fromEntries(
+                  Object.entries({
+                    board_id: query.board_id,
+                    branch_id: query.branch_id,
+                    card_id: query.card_id,
+                    zone_id: query.zone_id,
+                    entity_type: query.entity_type,
+                  }).filter(([, value]) => value !== undefined)
+                );
+                const [total, data] = await Promise.all([
+                  boardObjectRepository.countVisibleToUser(userId, filters),
+                  boardObjectRepository.findVisibleToUser(
+                    userId,
+                    filters,
+                    requestedLimit !== undefined || requestedSkip > 0
+                      ? { limit: requestedLimit, offset: requestedSkip }
+                      : {}
+                  ),
+                ]);
+
+                context.result = {
+                  total,
+                  limit: requestedLimit ?? 100,
+                  skip: requestedSkip,
+                  data,
+                };
+                (context.params as { _boardObjectsRbacScoped?: boolean })._boardObjectsRbacScoped =
+                  true;
+                return context;
+              },
+            ]
+          : []),
+      ],
     },
     after: {
       find: [
@@ -498,6 +556,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           ? [
               // Filter board-objects based on branch access permissions
               async (context: HookContext) => {
+                if (
+                  (context.params as { _boardObjectsRbacScoped?: boolean })._boardObjectsRbacScoped
+                ) {
+                  return context;
+                }
+
                 // Skip for internal calls
                 if (!context.params.provider) {
                   return context;

--- a/apps/agor-daemon/src/services/board-objects.test.ts
+++ b/apps/agor-daemon/src/services/board-objects.test.ts
@@ -6,34 +6,8 @@ import { BoardObjectsService } from './board-objects.js';
 describe('BoardObjectsService.find', () => {
   it('filters board entities by zone/type and applies explicit pagination', async () => {
     const service = new BoardObjectsService({} as Database);
-    const findByBoardId = vi.fn(async () => [
-      {
-        object_id: 'obj-1',
-        board_id: 'board-1',
-        branch_id: 'branch-1',
-        entity_type: 'branch',
-        position: { x: 0, y: 0 },
-        zone_id: 'zone-review',
-        created_at: '2026-06-01T00:00:00.000Z',
-      },
-      {
-        object_id: 'obj-2',
-        board_id: 'board-1',
-        card_id: 'card-1',
-        entity_type: 'card',
-        position: { x: 10, y: 10 },
-        zone_id: 'zone-review',
-        created_at: '2026-06-01T00:00:00.000Z',
-      },
-      {
-        object_id: 'obj-3',
-        board_id: 'board-1',
-        branch_id: 'branch-2',
-        entity_type: 'branch',
-        position: { x: 20, y: 20 },
-        zone_id: 'zone-done',
-        created_at: '2026-06-01T00:00:00.000Z',
-      },
+    const count = vi.fn(async () => 2);
+    const findAll = vi.fn(async () => [
       {
         object_id: 'obj-4',
         board_id: 'board-1',
@@ -48,10 +22,11 @@ describe('BoardObjectsService.find', () => {
     (
       service as unknown as {
         boardObjectRepo: {
-          findByBoardId: typeof findByBoardId;
+          count: typeof count;
+          findAll: typeof findAll;
         };
       }
-    ).boardObjectRepo = { findByBoardId };
+    ).boardObjectRepo = { count, findAll };
 
     const result = await service.find({
       query: {
@@ -63,7 +38,19 @@ describe('BoardObjectsService.find', () => {
       },
     });
 
-    expect(findByBoardId).toHaveBeenCalledWith('board-1');
+    expect(count).toHaveBeenCalledWith({
+      board_id: 'board-1',
+      zone_id: 'zone-review',
+      entity_type: 'branch',
+    });
+    expect(findAll).toHaveBeenCalledWith(
+      {
+        board_id: 'board-1',
+        zone_id: 'zone-review',
+        entity_type: 'branch',
+      },
+      { offset: 1, limit: 1 }
+    );
     expect(result.total).toBe(2);
     expect(result.skip).toBe(1);
     expect(result.limit).toBe(1);
@@ -73,6 +60,7 @@ describe('BoardObjectsService.find', () => {
 
   it('preserves legacy unpaginated data when no $limit/$skip is requested', async () => {
     const service = new BoardObjectsService({} as Database);
+    const count = vi.fn(async () => 2);
     const findAll = vi.fn(async () => [
       {
         object_id: 'obj-1',
@@ -95,13 +83,16 @@ describe('BoardObjectsService.find', () => {
     (
       service as unknown as {
         boardObjectRepo: {
+          count: typeof count;
           findAll: typeof findAll;
         };
       }
-    ).boardObjectRepo = { findAll };
+    ).boardObjectRepo = { count, findAll };
 
     const result = await service.find();
 
+    expect(count).toHaveBeenCalledWith({});
+    expect(findAll).toHaveBeenCalledWith({}, {});
     expect(result.total).toBe(2);
     expect(result.limit).toBe(100);
     expect(result.skip).toBe(0);

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -5,7 +5,12 @@
  * Supports both session cards and branch cards (Phase 1: Hybrid support).
  */
 
-import { BoardObjectRepository, type Database } from '@agor/core/db';
+import {
+  type BoardObjectFindFilters,
+  type BoardObjectFindOptions,
+  BoardObjectRepository,
+  type Database,
+} from '@agor/core/db';
 import type {
   BoardEntityObject,
   BoardEntityType,
@@ -38,6 +43,36 @@ export type BoardObjectParams = QueryParams<{
   zone_id?: string;
   entity_type?: BoardEntityType;
 }>;
+
+export interface NormalizedBoardObjectFindQuery {
+  filters: BoardObjectFindFilters;
+  pagination: BoardObjectFindOptions;
+  limit: number;
+  skip: number;
+}
+
+export function normalizeBoardObjectFindQuery(
+  query: BoardObjectParams['query'] = {}
+): NormalizedBoardObjectFindQuery {
+  const { board_id, branch_id, card_id, zone_id, entity_type } = query;
+  const requestedSkip = Number(query.$skip ?? 0);
+  const requestedLimit = typeof query.$limit === 'number' ? query.$limit : undefined;
+  const filters = Object.fromEntries(
+    Object.entries({ board_id, branch_id, card_id, zone_id, entity_type }).filter(
+      ([, value]) => value !== undefined
+    )
+  ) as BoardObjectFindFilters;
+
+  return {
+    filters,
+    pagination:
+      requestedLimit !== undefined || requestedSkip > 0
+        ? { limit: requestedLimit, offset: requestedSkip }
+        : {},
+    limit: requestedLimit ?? 100,
+    skip: requestedSkip,
+  };
+}
 
 /**
  * Board objects service implementation
@@ -90,28 +125,16 @@ export class BoardObjectsService {
    * Find board objects
    */
   async find(params?: BoardObjectParams) {
-    const { board_id, branch_id, card_id, zone_id, entity_type } = params?.query || {};
-    const requestedSkip = params?.query?.$skip ?? 0;
-    const requestedLimit = params?.query?.$limit;
-    const filters = Object.fromEntries(
-      Object.entries({ board_id, branch_id, card_id, zone_id, entity_type }).filter(
-        ([, value]) => value !== undefined
-      )
-    );
+    const normalized = normalizeBoardObjectFindQuery(params?.query);
     const [total, data] = await Promise.all([
-      this.boardObjectRepo.count(filters),
-      this.boardObjectRepo.findAll(
-        filters,
-        requestedLimit !== undefined || requestedSkip > 0
-          ? { limit: requestedLimit, offset: requestedSkip }
-          : {}
-      ),
+      this.boardObjectRepo.count(normalized.filters),
+      this.boardObjectRepo.findAll(normalized.filters, normalized.pagination),
     ]);
 
     return {
       total,
-      limit: requestedLimit ?? 100,
-      skip: requestedSkip,
+      limit: normalized.limit,
+      skip: normalized.skip,
       data,
     };
   }

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -91,40 +91,22 @@ export class BoardObjectsService {
    */
   async find(params?: BoardObjectParams) {
     const { board_id, branch_id, card_id, zone_id, entity_type } = params?.query || {};
-
-    let objects: BoardEntityObject[];
-
-    // If board_id filter is provided, use repository method
-    if (board_id) {
-      objects = await this.boardObjectRepo.findByBoardId(board_id);
-    } else {
-      // No board_id - return ALL board objects
-      objects = await this.boardObjectRepo.findAll();
-    }
-
-    if (branch_id) {
-      objects = objects.filter((object) => object.branch_id === branch_id);
-    }
-    if (card_id) {
-      objects = objects.filter((object) => object.card_id === card_id);
-    }
-    if (zone_id) {
-      objects = objects.filter((object) => object.zone_id === zone_id);
-    }
-    if (entity_type) {
-      objects = objects.filter((object) => object.entity_type === entity_type);
-    }
-
-    const total = objects.length;
     const requestedSkip = params?.query?.$skip ?? 0;
     const requestedLimit = params?.query?.$limit;
-    const data =
-      requestedLimit !== undefined || requestedSkip > 0
-        ? objects.slice(
-            requestedSkip,
-            requestedLimit === undefined ? undefined : requestedSkip + requestedLimit
-          )
-        : objects;
+    const filters = Object.fromEntries(
+      Object.entries({ board_id, branch_id, card_id, zone_id, entity_type }).filter(
+        ([, value]) => value !== undefined
+      )
+    );
+    const [total, data] = await Promise.all([
+      this.boardObjectRepo.count(filters),
+      this.boardObjectRepo.findAll(
+        filters,
+        requestedLimit !== undefined || requestedSkip > 0
+          ? { limit: requestedLimit, offset: requestedSkip }
+          : {}
+      ),
+    ]);
 
     return {
       total,

--- a/packages/core/src/db/repositories/board-objects.test.ts
+++ b/packages/core/src/db/repositories/board-objects.test.ts
@@ -262,6 +262,87 @@ describe('BoardObjectRepository.findAll', () => {
     );
   });
 
+  dbTest(
+    'should apply filters, count, and pagination in SQL-facing findAll APIs',
+    async ({ db }) => {
+      const repoRepo = new RepoRepository(db);
+      const wtRepo = new BranchRepository(db);
+      const boRepo = new BoardObjectRepository(db);
+
+      const repo = await repoRepo.create(createRepoData());
+      const wt1 = await wtRepo.create(createBranchData({ repo_id: repo.repo_id, name: 'wt1' }));
+      const wt2 = await wtRepo.create(createBranchData({ repo_id: repo.repo_id, name: 'wt2' }));
+      const wt3 = await wtRepo.create(createBranchData({ repo_id: repo.repo_id, name: 'wt3' }));
+      const boardId1 = await createBoard(db, { name: 'Board 1' });
+      const boardId2 = await createBoard(db, { name: 'Board 2' });
+
+      await boRepo.create({
+        board_id: boardId1,
+        branch_id: wt1.branch_id,
+        position: { x: 0, y: 0 },
+        zone_id: 'zone-review',
+      });
+      await boRepo.create({
+        board_id: boardId1,
+        branch_id: wt2.branch_id,
+        position: { x: 100, y: 100 },
+        zone_id: 'zone-review',
+      });
+      await boRepo.create({
+        board_id: boardId2,
+        branch_id: wt3.branch_id,
+        position: { x: 200, y: 200 },
+        zone_id: 'zone-done',
+      });
+
+      await expect(
+        boRepo.count({ board_id: boardId1, zone_id: 'zone-review', entity_type: 'branch' })
+      ).resolves.toBe(2);
+
+      const page = await boRepo.findAll(
+        { board_id: boardId1, zone_id: 'zone-review', entity_type: 'branch' },
+        { limit: 1, offset: 1 }
+      );
+
+      expect(page).toHaveLength(1);
+      expect([wt1.branch_id, wt2.branch_id]).toContain(page[0].branch_id);
+    }
+  );
+
+  dbTest('should scope visible board objects with SQL RBAC predicates', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const wtRepo = new BranchRepository(db);
+    const boRepo = new BoardObjectRepository(db);
+
+    const repo = await repoRepo.create(createRepoData());
+    const visibleBranch = await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'visible' })
+    );
+    const hiddenBranch = await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'hidden' })
+    );
+    await wtRepo.update(hiddenBranch.branch_id, { others_can: 'none' });
+    const boardId = await createBoard(db);
+
+    await boRepo.create({
+      board_id: boardId,
+      branch_id: visibleBranch.branch_id,
+      position: { x: 0, y: 0 },
+    });
+    await boRepo.create({
+      board_id: boardId,
+      branch_id: hiddenBranch.branch_id,
+      position: { x: 100, y: 100 },
+    });
+
+    const userId = generateId() as UUID;
+
+    await expect(boRepo.countVisibleToUser(userId, { board_id: boardId })).resolves.toBe(1);
+    await expect(boRepo.findVisibleToUser(userId, { board_id: boardId })).resolves.toMatchObject([
+      { branch_id: visibleBranch.branch_id },
+    ]);
+  });
+
   dbTest('should include all fields in returned objects', async ({ db }) => {
     const repoRepo = new RepoRepository(db);
     const wtRepo = new BranchRepository(db);

--- a/packages/core/src/db/repositories/board-objects.test.ts
+++ b/packages/core/src/db/repositories/board-objects.test.ts
@@ -9,7 +9,7 @@ import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { boards } from '../schema';
+import { boardObjects, boards } from '../schema';
 import { dbTest } from '../test-helpers';
 import { EntityNotFoundError, RepositoryError } from './base';
 import { BoardObjectRepository } from './board-objects';
@@ -323,6 +323,7 @@ describe('BoardObjectRepository.findAll', () => {
     );
     await wtRepo.update(hiddenBranch.branch_id, { others_can: 'none' });
     const boardId = await createBoard(db);
+    const layoutObjectId = generateId();
 
     await boRepo.create({
       board_id: boardId,
@@ -334,13 +335,23 @@ describe('BoardObjectRepository.findAll', () => {
       branch_id: hiddenBranch.branch_id,
       position: { x: 100, y: 100 },
     });
+    await (db as any).insert(boardObjects).values({
+      object_id: layoutObjectId,
+      board_id: boardId,
+      created_at: new Date(),
+      branch_id: null,
+      card_id: null,
+      data: { position: { x: 200, y: 200 } },
+    });
 
     const userId = generateId() as UUID;
 
-    await expect(boRepo.countVisibleToUser(userId, { board_id: boardId })).resolves.toBe(1);
-    await expect(boRepo.findVisibleToUser(userId, { board_id: boardId })).resolves.toMatchObject([
-      { branch_id: visibleBranch.branch_id },
-    ]);
+    await expect(boRepo.countVisibleToUser(userId, { board_id: boardId })).resolves.toBe(2);
+
+    const visibleObjects = await boRepo.findVisibleToUser(userId, { board_id: boardId });
+    expect(visibleObjects.map((object) => object.object_id)).toContain(layoutObjectId);
+    expect(visibleObjects.map((object) => object.branch_id)).toContain(visibleBranch.branch_id);
+    expect(visibleObjects.map((object) => object.branch_id)).not.toContain(hiddenBranch.branch_id);
   });
 
   dbTest('should include all fields in returned objects', async ({ db }) => {

--- a/packages/core/src/db/repositories/board-objects.ts
+++ b/packages/core/src/db/repositories/board-objects.ts
@@ -11,14 +11,35 @@ import type {
   BoardID,
   BranchID,
   CardID,
+  UUID,
 } from '@agor/core/types';
-import { eq } from 'drizzle-orm';
+import { and, eq, getTableColumns, isNotNull, isNull, or, type SQL, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import { toAbsolutePosition } from '../../utils/board-placement.js';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
-import { type BoardObjectInsert, type BoardObjectRow, boardObjects } from '../schema';
+import { deleteFrom, insert, jsonExtract, select, update } from '../database-wrapper';
+import {
+  type BoardObjectInsert,
+  type BoardObjectRow,
+  boardObjects,
+  branches,
+  branchOwners,
+} from '../schema';
 import { EntityNotFoundError, RepositoryError } from './base';
+import { visibleBranchAccessCondition } from './branch-access';
+
+export interface BoardObjectFindFilters {
+  board_id?: BoardID;
+  branch_id?: BranchID;
+  card_id?: CardID;
+  zone_id?: string;
+  entity_type?: BoardEntityType;
+}
+
+export interface BoardObjectFindOptions {
+  limit?: number;
+  offset?: number;
+}
 
 /**
  * Board object repository implementation
@@ -26,17 +47,155 @@ import { EntityNotFoundError, RepositoryError } from './base';
 export class BoardObjectRepository {
   constructor(private db: Database) {}
 
+  private buildFindConditions(filters: BoardObjectFindFilters = {}): SQL[] {
+    const conditions: SQL[] = [];
+
+    if (filters.board_id) {
+      conditions.push(eq(boardObjects.board_id, filters.board_id));
+    }
+    if (filters.branch_id) {
+      conditions.push(eq(boardObjects.branch_id, filters.branch_id));
+    }
+    if (filters.card_id) {
+      conditions.push(eq(boardObjects.card_id, filters.card_id));
+    }
+    if (filters.zone_id) {
+      conditions.push(
+        sql`${jsonExtract(this.db, boardObjects.data, 'zone_id')} = ${filters.zone_id}`
+      );
+    }
+    if (filters.entity_type === 'branch') {
+      conditions.push(isNull(boardObjects.card_id));
+    } else if (filters.entity_type === 'card') {
+      conditions.push(isNotNull(boardObjects.card_id));
+    }
+
+    return conditions;
+  }
+
+  private buildVisibleToUserCondition(userId: UUID): SQL {
+    return (
+      or(isNull(boardObjects.branch_id), visibleBranchAccessCondition(this.db, userId)) ??
+      sql`false`
+    );
+  }
+
   /**
    * Find all board objects
    */
-  async findAll(): Promise<BoardEntityObject[]> {
+  async findAll(
+    filters: BoardObjectFindFilters = {},
+    options: BoardObjectFindOptions = {}
+  ): Promise<BoardEntityObject[]> {
     try {
-      const rows = await select(this.db).from(boardObjects).all();
+      const conditions = this.buildFindConditions(filters);
+      let query = select(this.db).from(boardObjects);
+
+      if (conditions.length > 0) {
+        query = query.where(and(...conditions));
+      }
+      if (options.limit !== undefined) {
+        query = query.limit(options.limit);
+      }
+      if (options.offset !== undefined) {
+        query = query.offset(options.offset);
+      }
+
+      const rows = await query.all();
 
       return rows.map(this.rowToEntity);
     } catch (error) {
       throw new RepositoryError(
         `Failed to find all board objects: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Count board objects matching filters without hydrating/parsing JSON rows.
+   */
+  async count(filters: BoardObjectFindFilters = {}): Promise<number> {
+    try {
+      const conditions = this.buildFindConditions(filters);
+      const query = select(this.db, { count: sql<number>`count(*)` }).from(boardObjects);
+      const row =
+        conditions.length > 0 ? await query.where(and(...conditions)).one() : await query.one();
+
+      return Number(row?.count ?? 0);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to count board objects: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Find board objects visible to a user under branch RBAC.
+   *
+   * Branch-bound rows require view+ access to the referenced branch. Rows
+   * without a branch reference (card/layout rows) are preserved.
+   */
+  async findVisibleToUser(
+    userId: UUID,
+    filters: BoardObjectFindFilters = {},
+    options: BoardObjectFindOptions = {}
+  ): Promise<BoardEntityObject[]> {
+    try {
+      const conditions = [
+        ...this.buildFindConditions(filters),
+        this.buildVisibleToUserCondition(userId),
+      ];
+      let query = select(this.db, getTableColumns(boardObjects))
+        .from(boardObjects)
+        .leftJoin(branches, eq(branches.branch_id, boardObjects.branch_id))
+        .leftJoin(
+          branchOwners,
+          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+        )
+        .where(and(...conditions));
+
+      if (options.limit !== undefined) {
+        query = query.limit(options.limit);
+      }
+      if (options.offset !== undefined) {
+        query = query.offset(options.offset);
+      }
+
+      const rows = await query.all();
+      return rows.map(this.rowToEntity);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find visible board objects: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Count board objects visible to a user without hydrating rows.
+   */
+  async countVisibleToUser(userId: UUID, filters: BoardObjectFindFilters = {}): Promise<number> {
+    try {
+      const conditions = [
+        ...this.buildFindConditions(filters),
+        this.buildVisibleToUserCondition(userId),
+      ];
+      const row = await select(this.db, { count: sql<number>`count(*)` })
+        .from(boardObjects)
+        .leftJoin(branches, eq(branches.branch_id, boardObjects.branch_id))
+        .leftJoin(
+          branchOwners,
+          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+        )
+        .where(and(...conditions))
+        .one();
+
+      return Number(row?.count ?? 0);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to count visible board objects: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }

--- a/packages/core/src/db/repositories/board-objects.ts
+++ b/packages/core/src/db/repositories/board-objects.ts
@@ -13,7 +13,7 @@ import type {
   CardID,
   UUID,
 } from '@agor/core/types';
-import { and, eq, getTableColumns, isNotNull, isNull, or, type SQL, sql } from 'drizzle-orm';
+import { and, asc, eq, getTableColumns, isNotNull, isNull, or, type SQL, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import { toAbsolutePosition } from '../../utils/board-placement.js';
 import type { Database } from '../client';
@@ -94,6 +94,7 @@ export class BoardObjectRepository {
       if (conditions.length > 0) {
         query = query.where(and(...conditions));
       }
+      query = query.orderBy(asc(boardObjects.created_at), asc(boardObjects.object_id));
       if (options.limit !== undefined) {
         query = query.limit(options.limit);
       }
@@ -156,6 +157,7 @@ export class BoardObjectRepository {
         )
         .where(and(...conditions));
 
+      query = query.orderBy(asc(boardObjects.created_at), asc(boardObjects.object_id));
       if (options.limit !== undefined) {
         query = query.limit(options.limit);
       }
@@ -205,19 +207,7 @@ export class BoardObjectRepository {
    * Find all board objects for a board
    */
   async findByBoardId(boardId: BoardID): Promise<BoardEntityObject[]> {
-    try {
-      const rows = await select(this.db)
-        .from(boardObjects)
-        .where(eq(boardObjects.board_id, boardId))
-        .all();
-
-      return rows.map(this.rowToEntity);
-    } catch (error) {
-      throw new RepositoryError(
-        `Failed to find board objects: ${error instanceof Error ? error.message : String(error)}`,
-        error
-      );
-    }
+    return this.findAll({ board_id: boardId });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Move `board-objects.find` filtering, counting, and pagination into the repository/SQL layer.
- Add RBAC-aware SQL scoping for external `board-objects.find` calls so initial load no longer performs a per-row branch permission lookup.
- Preserve current client semantics: the initial load still receives the same globally visible `board-objects` list, but the backend avoids full-table post-filtering and RBAC N+1 work.
- Add targeted coverage for service pagination/filter delegation and repository SQL/RBAC behavior.

## Why

Production initial load showed `board-objects` as one of the slowest phases after PR #1447. The client intentionally loads all shared data into `useAgorData`, so narrowing to only the current board is not safe without broader app changes. The expensive path was instead backend work:

- `BoardObjectsService.find` materialized rows before filters/pagination.
- With branch RBAC enabled, the `board-objects` after-hook checked each branch-bound row one at a time (`findById` + `resolveUserPermission`), creating an N+1 pattern during the initial load.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/board-objects.test.ts`
- `pnpm --filter @agor/core test -- src/db/repositories/board-objects.test.ts`
