### PR TITLE
Improve KB MCP outline section ergonomics

### DIFF
--- a/apps/agor-daemon/src/knowledge/markdown-outline.test.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-outline.test.ts
@@ -46,4 +46,21 @@ describe('markdownOutline', () => {
       'root.h1[2].h3[1]',
     ]);
   });
+
+  it('uses heading depth rather than stack length when skipped levels return upward', () => {
+    const headings = markdownOutline(['# A', '#### D', '### C', '## B'].join('\n'));
+
+    expect(headings.map((heading) => heading.headingPath)).toEqual([
+      'A',
+      'A > D',
+      'A > C',
+      'A > B',
+    ]);
+    expect(headings.map((heading) => heading.sectionRef)).toEqual([
+      'root.h1[1]',
+      'root.h1[1].h4[1]',
+      'root.h1[1].h3[1]',
+      'root.h1[1].h2[1]',
+    ]);
+  });
 });

--- a/apps/agor-daemon/src/knowledge/markdown-outline.test.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-outline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { markdownOutline, resolveHeadingRange } from './markdown-outline';
+import { markdownOutline, resolveHeadingRange, resolveSectionRefRange } from './markdown-outline';
 
 describe('markdownOutline', () => {
   it('ignores heading-looking lines inside fenced code blocks', () => {
@@ -15,10 +15,11 @@ describe('markdownOutline', () => {
     const headings = markdownOutline(['# Doc', '', '## Repeat', 'a', '## Repeat', 'b'].join('\n'));
 
     expect(headings.filter((heading) => heading.headingPath === 'Doc > Repeat')).toMatchObject([
-      { occurrence: 1, startLine: 3, endLine: 4 },
-      { occurrence: 2, startLine: 5, endLine: 6 },
+      { occurrence: 1, sectionRef: 'root.h1[1].h2[1]', startLine: 3, endLine: 4 },
+      { occurrence: 2, sectionRef: 'root.h1[1].h2[2]', startLine: 5, endLine: 6 },
     ]);
     expect(resolveHeadingRange(headings, 'Doc > Repeat', 2)).toMatchObject({ startLine: 5 });
+    expect(resolveSectionRefRange(headings, 'root.h1[1].h2[2]')).toMatchObject({ startLine: 5 });
   });
 
   it('extracts heading text recursively through inline markdown and links', () => {
@@ -27,6 +28,22 @@ describe('markdownOutline', () => {
     expect(headings[0]).toMatchObject({
       title: 'Welcome brave reader',
       headingPath: 'Welcome brave reader',
+      chars: '# Welcome *brave* [reader](https://example.com)'.length,
     });
+  });
+
+  it('builds title-independent structural section refs', () => {
+    const headings = markdownOutline(
+      ['# First', '## A', '### Deep', '## B', '# Second', '### Skipped level'].join('\n')
+    );
+
+    expect(headings.map((heading) => heading.sectionRef)).toEqual([
+      'root.h1[1]',
+      'root.h1[1].h2[1]',
+      'root.h1[1].h2[1].h3[1]',
+      'root.h1[1].h2[2]',
+      'root.h1[2]',
+      'root.h1[2].h3[1]',
+    ]);
   });
 });

--- a/apps/agor-daemon/src/knowledge/markdown-outline.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-outline.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import type { Heading, RootContent } from 'mdast';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
@@ -7,21 +6,31 @@ import { unified } from 'unified';
 export interface MarkdownHeadingRange {
   level: number;
   title: string;
+  /**
+   * Title-based breadcrumb, intended for display and convenience selection.
+   * Duplicate title paths are disambiguated by `occurrence`.
+   */
   headingPath: string;
+  /**
+   * Structural selector for this heading, e.g. `root.h1[1].h2[2]`.
+   * This is title-independent within a document version, so it survives heading
+   * renames better than `headingPath`, but it can still change when nearby
+   * headings are inserted, deleted, or reordered.
+   */
+  sectionRef: string;
+  /** Alias for `sectionRef` for callers that prefer explicit terminology. */
+  ordinalPath: string;
   occurrence: number;
   startLine: number;
   endLine: number;
   contentStartLine: number;
+  /** Raw markdown character count for the section, including its heading line. */
+  chars: number;
   anchor: string;
-  contentMd5: string;
 }
 
 export function splitMarkdownLines(content: string): string[] {
   return content.replace(/\r\n/g, '\n').split('\n');
-}
-
-function md5(text: string): string {
-  return createHash('md5').update(text).digest('hex');
 }
 
 function headingAnchor(title: string): string {
@@ -61,14 +70,25 @@ export function markdownOutline(content: string, maxDepth = 6): MarkdownHeadingR
     }))
     .filter((heading) => heading.title.length > 0 && heading.level <= maxDepth);
 
-  const pathStack: string[] = [];
+  const titleStack: string[] = [];
+  const ordinalStack: string[] = [];
   const occurrenceByPath = new Map<string, number>();
+  const ordinalCountsByParentAndLevel = new Map<string, number>();
   return raw.map((heading, index) => {
-    pathStack.length = heading.level - 1;
-    pathStack[heading.level - 1] = heading.title;
-    const headingPath = pathStack.filter(Boolean).join(' > ');
+    while (titleStack.length > heading.level - 1) titleStack.pop();
+    titleStack.push(heading.title);
+    const headingPath = titleStack.join(' > ');
     const occurrence = (occurrenceByPath.get(headingPath) ?? 0) + 1;
     occurrenceByPath.set(headingPath, occurrence);
+
+    while (ordinalStack.length > heading.level - 1) ordinalStack.pop();
+    const parentOrdinalPath = ordinalStack.length > 0 ? ordinalStack.join('.') : 'root';
+    const ordinalCountKey = `${parentOrdinalPath}/h${heading.level}`;
+    const ordinal = (ordinalCountsByParentAndLevel.get(ordinalCountKey) ?? 0) + 1;
+    ordinalCountsByParentAndLevel.set(ordinalCountKey, ordinal);
+    ordinalStack.push(`h${heading.level}[${ordinal}]`);
+    const sectionRef = `root.${ordinalStack.join('.')}`;
+
     const next = raw.slice(index + 1).find((candidate) => candidate.level <= heading.level);
     const endLine = next ? next.line - 1 : lines.length;
     const sectionContent = lines.slice(heading.line - 1, endLine).join('\n');
@@ -76,12 +96,14 @@ export function markdownOutline(content: string, maxDepth = 6): MarkdownHeadingR
       level: heading.level,
       title: heading.title,
       headingPath,
+      sectionRef,
+      ordinalPath: sectionRef,
       occurrence,
       startLine: heading.line,
       endLine,
       contentStartLine: Math.min(heading.line + 1, endLine),
+      chars: sectionContent.length,
       anchor: headingAnchor(heading.title),
-      contentMd5: md5(sectionContent),
     };
   });
 }
@@ -102,5 +124,17 @@ export function resolveHeadingRange(
       `Heading "${headingPath}" occurrence ${occurrence} not found (matches: ${matches.length})`
     );
   }
+  return match;
+}
+
+export function resolveSectionRefRange(
+  headings: MarkdownHeadingRange[],
+  sectionRef: string
+): MarkdownHeadingRange {
+  const normalized = sectionRef.trim();
+  const match = headings.find(
+    (heading) => heading.sectionRef === normalized || heading.ordinalPath === normalized
+  );
+  if (!match) throw new Error(`Section ref not found: ${sectionRef}`);
   return match;
 }

--- a/apps/agor-daemon/src/knowledge/markdown-outline.ts
+++ b/apps/agor-daemon/src/knowledge/markdown-outline.ts
@@ -18,8 +18,6 @@ export interface MarkdownHeadingRange {
    * headings are inserted, deleted, or reordered.
    */
   sectionRef: string;
-  /** Alias for `sectionRef` for callers that prefer explicit terminology. */
-  ordinalPath: string;
   occurrence: number;
   startLine: number;
   endLine: number;
@@ -70,24 +68,27 @@ export function markdownOutline(content: string, maxDepth = 6): MarkdownHeadingR
     }))
     .filter((heading) => heading.title.length > 0 && heading.level <= maxDepth);
 
-  const titleStack: string[] = [];
-  const ordinalStack: string[] = [];
+  const titleStack: Array<{ depth: number; title: string }> = [];
+  const ordinalStack: Array<{ depth: number; segment: string }> = [];
   const occurrenceByPath = new Map<string, number>();
   const ordinalCountsByParentAndLevel = new Map<string, number>();
   return raw.map((heading, index) => {
-    while (titleStack.length > heading.level - 1) titleStack.pop();
-    titleStack.push(heading.title);
-    const headingPath = titleStack.join(' > ');
+    while (titleStack.at(-1) && titleStack.at(-1)!.depth >= heading.level) titleStack.pop();
+    titleStack.push({ depth: heading.level, title: heading.title });
+    const headingPath = titleStack.map((item) => item.title).join(' > ');
     const occurrence = (occurrenceByPath.get(headingPath) ?? 0) + 1;
     occurrenceByPath.set(headingPath, occurrence);
 
-    while (ordinalStack.length > heading.level - 1) ordinalStack.pop();
-    const parentOrdinalPath = ordinalStack.length > 0 ? ordinalStack.join('.') : 'root';
+    while (ordinalStack.at(-1) && ordinalStack.at(-1)!.depth >= heading.level) {
+      ordinalStack.pop();
+    }
+    const parentOrdinalPath =
+      ordinalStack.length > 0 ? ordinalStack.map((item) => item.segment).join('.') : 'root';
     const ordinalCountKey = `${parentOrdinalPath}/h${heading.level}`;
     const ordinal = (ordinalCountsByParentAndLevel.get(ordinalCountKey) ?? 0) + 1;
     ordinalCountsByParentAndLevel.set(ordinalCountKey, ordinal);
-    ordinalStack.push(`h${heading.level}[${ordinal}]`);
-    const sectionRef = `root.${ordinalStack.join('.')}`;
+    ordinalStack.push({ depth: heading.level, segment: `h${heading.level}[${ordinal}]` });
+    const sectionRef = `root.${ordinalStack.map((item) => item.segment).join('.')}`;
 
     const next = raw.slice(index + 1).find((candidate) => candidate.level <= heading.level);
     const endLine = next ? next.line - 1 : lines.length;
@@ -97,7 +98,6 @@ export function markdownOutline(content: string, maxDepth = 6): MarkdownHeadingR
       title: heading.title,
       headingPath,
       sectionRef,
-      ordinalPath: sectionRef,
       occurrence,
       startLine: heading.line,
       endLine,
@@ -132,9 +132,7 @@ export function resolveSectionRefRange(
   sectionRef: string
 ): MarkdownHeadingRange {
   const normalized = sectionRef.trim();
-  const match = headings.find(
-    (heading) => heading.sectionRef === normalized || heading.ordinalPath === normalized
-  );
+  const match = headings.find((heading) => heading.sectionRef === normalized);
   if (!match) throw new Error(`Section ref not found: ${sectionRef}`);
   return match;
 }

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -185,6 +185,132 @@ describe('Knowledge MCP input schemas', () => {
     );
   });
 
+  it('returns structural section refs from Knowledge outlines', async () => {
+    const get = vi.fn().mockResolvedValue({
+      document: {
+        document_id: 'doc-1',
+        path: 'guide.md',
+        uri: 'agor://kb/global/guide.md',
+      },
+      current_version: {
+        version_id: 'ver-1',
+        document_id: 'doc-1',
+        version_number: 1,
+      },
+      content: ['# Guide', 'intro', '## Setup', 'steps', '## Setup', 'more steps'].join('\n'),
+    });
+    const tools = await captureKnowledgeTools({ 'kb/documents': { get } });
+
+    const result = textResultJson(
+      await tools.agor_kb_outline.handler?.({ documentId: 'doc-1' })
+    ) as Record<string, any>;
+
+    expect(result.headings).toMatchObject([
+      {
+        headingPath: 'Guide',
+        sectionRef: 'root.h1[1]',
+        startLine: 1,
+        endLine: 6,
+        chars: '# Guide\nintro\n## Setup\nsteps\n## Setup\nmore steps'.length,
+      },
+      {
+        headingPath: 'Guide > Setup',
+        occurrence: 1,
+        sectionRef: 'root.h1[1].h2[1]',
+        startLine: 3,
+        endLine: 4,
+      },
+      {
+        headingPath: 'Guide > Setup',
+        occurrence: 2,
+        sectionRef: 'root.h1[1].h2[2]',
+        startLine: 5,
+        endLine: 6,
+      },
+    ]);
+    expect(result.version).toEqual({
+      version_id: 'ver-1',
+      version_number: 1,
+      content_sha256: null,
+      etag: 'kbv:ver-1',
+    });
+  });
+
+  it('reads Knowledge sections by sectionRef from the outline', async () => {
+    const get = vi.fn().mockResolvedValue({
+      document: {
+        document_id: 'doc-1',
+        path: 'guide.md',
+        uri: 'agor://kb/global/guide.md',
+      },
+      current_version: {
+        version_id: 'ver-1',
+        document_id: 'doc-1',
+        version_number: 1,
+      },
+      content: ['# Guide', 'intro', '## Setup', 'steps', '## Setup', 'more steps'].join('\n'),
+    });
+    const tools = await captureKnowledgeTools({ 'kb/documents': { get } });
+
+    const result = textResultJson(
+      await tools.agor_kb_get_range.handler?.({
+        documentId: 'doc-1',
+        sectionRef: 'root.h1[1].h2[2]',
+        contextLines: 0,
+      })
+    ) as Record<string, any>;
+
+    expect(result.range).toMatchObject({
+      startLine: 5,
+      endLine: 6,
+      contextStartLine: 5,
+      contextEndLine: 6,
+      content: '## Setup\nmore steps',
+      numberedContent: '5: ## Setup\n6: more steps',
+    });
+    expect(result.range).not.toHaveProperty('sourceRange');
+  });
+
+  it('pages within a Knowledge section using offsetLines and maxLines', async () => {
+    const get = vi.fn().mockResolvedValue({
+      document: {
+        document_id: 'doc-1',
+        path: 'guide.md',
+        uri: 'agor://kb/global/guide.md',
+      },
+      current_version: {
+        version_id: 'ver-1',
+        document_id: 'doc-1',
+        version_number: 1,
+      },
+      content: ['# Guide', 'intro', '## Large', 'a', 'b', 'c', 'd', 'e'].join('\n'),
+    });
+    const tools = await captureKnowledgeTools({ 'kb/documents': { get } });
+
+    const result = textResultJson(
+      await tools.agor_kb_get_range.handler?.({
+        documentId: 'doc-1',
+        sectionRef: 'root.h1[1].h2[1]',
+        offsetLines: 2,
+        maxLines: 2,
+        contextLines: 0,
+      })
+    ) as Record<string, any>;
+
+    expect(result.range).toMatchObject({
+      startLine: 5,
+      endLine: 6,
+      sourceRange: {
+        startLine: 3,
+        endLine: 8,
+        omittedBefore: 2,
+        omittedAfter: 2,
+      },
+      content: 'b\nc',
+      numberedContent: '5: b\n6: c',
+    });
+  });
+
   it('omits full Knowledge search content by default while returning snippets for text search', async () => {
     const find = vi.fn().mockResolvedValue([
       {

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -39,6 +39,7 @@ import { z } from 'zod';
 import {
   markdownOutline,
   resolveHeadingRange,
+  resolveSectionRefRange,
   splitMarkdownLines,
 } from '../../knowledge/markdown-outline.js';
 import {
@@ -1166,7 +1167,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
     'agor_kb_outline',
     {
       description:
-        'Return a markdown heading outline for a Knowledge document, including 1-based line ranges and the current version token. Use this before targeted edits to avoid reading the full document.',
+        'Return a compact markdown heading outline/skeleton for a Knowledge document, including 1-based line ranges, title breadcrumbs, sectionRef selectors like root.h1[1].h2[2], per-section char counts, and the current version token. Use this before targeted reads/edits to avoid loading the full document.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
@@ -1217,7 +1218,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
     'agor_kb_get_range',
     {
       description:
-        'Read a bounded line range or heading section from a Knowledge document. Returns current version metadata and optional line numbers so agents can edit without loading the full document.',
+        'Read a bounded line range, section, or section-relative page from a Knowledge document. Prefer sectionRef from agor_kb_outline for title-independent section reads; headingPath + occurrence is also supported for convenience. Returns current version metadata and optional line numbers so agents can edit without loading the full document.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         documentId: mcpOptionalId('documentId', 'Knowledge document'),
@@ -1234,6 +1235,10 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         startLine: mcpOptionalPositiveInt('startLine', '1-based inclusive start line'),
         endLine: mcpOptionalPositiveInt('endLine', '1-based inclusive end line'),
         headingPath: mcpOptionalNonBlankString('headingPath', 'Heading path from agor_kb_outline'),
+        sectionRef: mcpOptionalNonBlankString(
+          'sectionRef',
+          'Title-independent section selector from agor_kb_outline, e.g. root.h1[1].h2[2]'
+        ),
         occurrence: mcpOptionalPositiveInt(
           'occurrence',
           'Occurrence for duplicate heading paths (default: 1)'
@@ -1247,6 +1252,27 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
           .max(20, 'contextLines must be less than or equal to 20.')
           .optional()
           .describe('Extra lines before/after the requested range (default: 2)'),
+        offsetLines: z
+          .number({
+            error: 'offsetLines must be a non-negative integer when provided.',
+          })
+          .int('offsetLines must be an integer.')
+          .min(0, 'offsetLines must be greater than or equal to 0.')
+          .optional()
+          .describe(
+            'Skip this many lines from the selected line range/section before reading (default: 0). Useful for paging through large sections.'
+          ),
+        maxLines: z
+          .number({
+            error: 'maxLines must be a positive integer when provided.',
+          })
+          .int('maxLines must be an integer.')
+          .positive('maxLines must be greater than 0.')
+          .max(1000, 'maxLines must be less than or equal to 1000.')
+          .optional()
+          .describe(
+            'Maximum selected lines to read after offsetLines, before contextLines are added (max: 1000). Omit to read the full selected range/section.'
+          ),
         includeLineNumbers: z
           .boolean()
           .optional()
@@ -1266,18 +1292,35 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       const lines = splitMarkdownLines(content);
       let startLine = args.startLine;
       let endLine = args.endLine;
+      const sectionRef = coerceString(args.sectionRef);
       const headingPath = coerceString(args.headingPath);
-      if (headingPath) {
-        const heading = resolveHeadingRange(markdownOutline(content), headingPath, args.occurrence);
+      if (sectionRef || headingPath) {
+        const outline = markdownOutline(content);
+        const heading = sectionRef
+          ? resolveSectionRefRange(outline, sectionRef)
+          : resolveHeadingRange(outline, headingPath as string, args.occurrence);
         startLine = heading.startLine;
         endLine = heading.endLine;
       }
       if (!startLine || !endLine) {
-        throw new Error('Provide startLine + endLine, or headingPath.');
+        throw new Error('Provide startLine + endLine, sectionRef, or headingPath.');
       }
       if (endLine < startLine)
         throw new Error('endLine must be greater than or equal to startLine');
       if (endLine > lines.length) throw new Error('Requested range exceeds document length');
+      const selectedStartLine = startLine;
+      const selectedEndLine = endLine;
+      const isPaged = args.offsetLines !== undefined || args.maxLines !== undefined;
+      if (isPaged) {
+        const offsetLines = args.offsetLines ?? 0;
+        const selectedLineCount = endLine - startLine + 1;
+        if (offsetLines >= selectedLineCount) {
+          throw new Error('offsetLines must be less than the selected range length');
+        }
+        startLine = startLine + offsetLines;
+        endLine =
+          args.maxLines === undefined ? endLine : Math.min(endLine, startLine + args.maxLines - 1);
+      }
       const contextLines = args.contextLines ?? 2;
       const contextStartLine = Math.max(1, startLine - contextLines);
       const contextEndLine = Math.min(lines.length, endLine + contextLines);
@@ -1297,6 +1340,16 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
             endLine,
             contextStartLine,
             contextEndLine,
+            ...(isPaged
+              ? {
+                  sourceRange: {
+                    startLine: selectedStartLine,
+                    endLine: selectedEndLine,
+                    omittedBefore: Math.max(0, startLine - selectedStartLine),
+                    omittedAfter: Math.max(0, selectedEndLine - endLine),
+                  },
+                }
+              : {}),
             content: rangeContent,
             numberedContent,
             contentMd5: md5(lines.slice(startLine - 1, endLine).join('\n')),

--- a/apps/agor-docs/pages/guide/knowledge.mdx
+++ b/apps/agor-docs/pages/guide/knowledge.mdx
@@ -108,6 +108,7 @@ Common workflows:
 
 - **Search and load context** with `agor_kb_search`, `agor_kb_get`, `agor_kb_outline`, and `agor_kb_get_range`.
   `agor_kb_search` is optimized for discovery: non-empty searches return metadata plus short snippets by default, while browse/listing calls with `query: ""` return metadata only. Use `contentMode: "none" | "snippet" | "full"` and `snippetLines` to control result verbosity, and prefer `agor_kb_get` or `agor_kb_get_range` when you need to read document content.
+  For large markdown docs, use `agor_kb_outline` as the map: it returns heading titles, line ranges, compact size hints, duplicate-heading occurrences, and `sectionRef` selectors such as `root.h1[1].h2[2]`. Then call `agor_kb_get_range` with that `sectionRef` (or a line range / `headingPath` + `occurrence`) to read only the needed section with nearby context. For very large sections, page through the selected section with `offsetLines` and `maxLines`.
 - **File new context** with `agor_kb_put` when an agent discovers something worth keeping.
 - **Make targeted edits** with `agor_kb_edit`, including version checks and dry runs.
 - **Round-trip through a worktree** with `agor_kb_materialize` and `agor_kb_publish_from_worktree`, where branch permissions allow local workspace access.

--- a/context/explorations/kb-agent-targeted-edits.md
+++ b/context/explorations/kb-agent-targeted-edits.md
@@ -335,7 +335,6 @@ agor_kb_outline({
     title: string;
     headingPath: string;       // display/convenience, not a permanent id
     sectionRef: string;        // structural selector, e.g. "root.h1[1].h2[2]"
-    ordinalPath: string;       // alias for sectionRef
     occurrence: number;        // disambiguates duplicate heading paths
     startLine: number;         // 1-based inclusive
     endLine: number;           // 1-based inclusive section end
@@ -898,7 +897,7 @@ Then add filesystem materialization as an explicit Agor workspace feature, not a
 - `kb/document-edits` service applies `KnowledgeEditOp[]` sequentially and reuses `putDocument` so only one version is minted per successful call. Dry runs skip the commit and can optionally return the post-edit content via `returnContent:"full"`.
 - The MCP tool `agor_kb_edit` surfaces the same guarantee and encourages batching to avoid version spam.
 - Artifact publish/check now prefer `branchId + subpath` and enforce branch RBAC when paths resolve inside a registered worktree; legacy `folderPath` is still accepted but inherits the same permission gate. The service-level `branchId` path now requires a non-empty branch-relative `subpath` so branch-root reads are not implicit.
-- `agor_kb_outline` and `agor_kb_get_range` provide bounded remote reads for large documents, returning line ranges, content hashes, and the current version token.
+- `agor_kb_outline` and `agor_kb_get_range` provide bounded remote reads for large documents, returning line ranges, compact outline size hints, exact-read content hashes, and the current version token.
 - `agor_kb_materialize` writes a KB markdown snapshot plus a `.agor-kb.json` sidecar into a branch worktree after branch `session` permission and containment checks. `agor_kb_publish_from_worktree` reads the branch-relative file back, uses the sidecar for document/version context when present, and updates existing documents through the targeted edit service so one publish creates one KB version.
 - Automatic markdown link extraction is KB-document-link oriented. Links to sessions, boards, branches, external URLs, etc. should be represented with explicit `agor_kb_link` calls until/unless broader auto-link extraction is intentionally added.
 - Review follow-up moved branch workspace path/RBAC/canonical containment into a shared daemon utility used by KB and artifacts, and moved markdown outline/range parsing into a shared daemon knowledge helper backed by the existing remark parser so fenced code blocks do not create false headings.

--- a/context/explorations/kb-agent-targeted-edits.md
+++ b/context/explorations/kb-agent-targeted-edits.md
@@ -334,17 +334,19 @@ agor_kb_outline({
     level: number;
     title: string;
     headingPath: string;       // display/convenience, not a permanent id
+    sectionRef: string;        // structural selector, e.g. "root.h1[1].h2[2]"
+    ordinalPath: string;       // alias for sectionRef
     occurrence: number;        // disambiguates duplicate heading paths
     startLine: number;         // 1-based inclusive
     endLine: number;           // 1-based inclusive section end
     contentStartLine: number;  // first line after heading
+    chars: number;             // raw markdown chars in this section
     anchor?: string;
-    contentMd5?: string;       // hash of this section in this version
   }>;
 }
 ```
 
-Implementation can reuse/extend `knowledgeUnitsForMarkdown` or add a lightweight markdown-outline utility. Do not expose `kb_document_units.unit_id` as a stable edit id in V1.
+`headingPath` is easy to read but collides when titles repeat and changes when titles are renamed. `occurrence` disambiguates duplicates. `sectionRef` is the preferred selector for agent follow-up reads: it is title-independent within a document version and therefore survives heading renames, but can still change when sections are inserted, deleted, or reordered. Keep outline metadata dense: line counts are inferable from `startLine`/`endLine`, and one `chars` hint is enough for agents to decide whether to read or page a section. Do not expose `kb_document_units.unit_id` as a stable edit id in V1.
 
 ### 5.4 `agor_kb_get_range`
 
@@ -363,8 +365,11 @@ agor_kb_get_range({
 
   headingPath?: string;
   occurrence?: number;
+  sectionRef?: string; // preferred selector copied from agor_kb_outline
 
   contextLines?: number; // default 2, cap e.g. 20
+  offsetLines?: number; // section/range-relative pagination offset
+  maxLines?: number; // cap selected lines before adding context
   includeLineNumbers?: boolean; // default true
 }) -> {
   document: KnowledgeDocument;
@@ -375,6 +380,12 @@ agor_kb_get_range({
     endLine: number;
     contextStartLine: number;
     contextEndLine: number;
+    sourceRange?: {           // present only when offsetLines/maxLines paged a larger selection
+      startLine: number;
+      endLine: number;
+      omittedBefore: number;
+      omittedAfter: number;
+    };
     content: string;
     numberedContent?: string;
     contentMd5: string;


### PR DESCRIPTION
## Summary

- Add compact structural `sectionRef` selectors to KB markdown outlines, e.g. `root.h1[1].h2[2]`, alongside existing heading paths and line ranges.
- Add a dense `chars` size hint per outlined section while avoiding heavier outline metadata.
- Teach `agor_kb_get_range` to read by `sectionRef` and page within a selected section/range using `offsetLines` and `maxLines`.
- Update Knowledge docs and targeted-edit design notes for the search → outline → range-read workflow.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/knowledge/markdown-outline.test.ts src/mcp/tools/knowledge.test.ts`
