### PR TITLE
Clarify Claude and Codex CLI auth options

### DIFF
--- a/apps/agor-docs/pages/guide/extended-install.mdx
+++ b/apps/agor-docs/pages/guide/extended-install.mdx
@@ -113,7 +113,7 @@ Follow the browser/device-code flow. Codex writes auth state under `~/.codex/` f
 
 The wizard's default. Each user pastes their own key in **Settings → Agentic Tools**. Keys are encrypted at rest, scoped per-user, and never exposed to other users on the instance. Get keys at:
 
-- Anthropic: [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys)
+- Anthropic: [platform.claude.com/settings/keys](https://platform.claude.com/settings/keys)
 - OpenAI: [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 - Google AI: [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
 

--- a/apps/agor-docs/pages/guide/extended-install.mdx
+++ b/apps/agor-docs/pages/guide/extended-install.mdx
@@ -58,61 +58,56 @@ If pgvector is missing or the Agor DB user cannot enable it, semantic search ret
 
 ## Authentication
 
-Agor supports Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot. The [onboarding wizard](/guide/getting-started#meet-your-first-assistant) handles the simple case — paste an API key, done. This section covers the alternatives: subscription-based auth, server-side CLI login, workspace-wide fallbacks, and how Agor resolves them when several are present.
+Agor supports Claude Code, Codex, Gemini, OpenCode, and GitHub Copilot. The [onboarding wizard](/guide/getting-started#meet-your-first-assistant) handles the simple case — paste an API key, done. This section covers the alternatives: subscription tokens, machine-level CLI auth, workspace-wide fallbacks, and how Agor resolves them when several are present.
 
 ### Credential resolution order
 
 When a session starts, Agor looks for credentials in this order and uses the first one it finds:
 
-1. **Per-user credentials** — encrypted in the DB, scoped to the user. Set via the wizard or **Settings → Agentic Tools → _tool_**. For Claude Code this means either an `ANTHROPIC_API_KEY` (pay-as-you-go) or a `CLAUDE_CODE_OAUTH_TOKEN` (Pro/Max subscription, from `claude setup-token`); the SDK prefers the OAuth token when both are set.
-2. **`claude login` credentials** — `~/.claude/` on the daemon host.
-3. **Workspace env vars** — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_AI_API_KEY`. Visible to all users on the instance.
+1. **Per-user credentials** — encrypted in the DB, scoped to the user. Set via the wizard or **Settings → Agentic Tools → _tool_**. Claude Code accepts either `ANTHROPIC_API_KEY` (pay-as-you-go) or `CLAUDE_CODE_OAUTH_TOKEN` (subscription token from `claude setup-token`). Codex accepts `OPENAI_API_KEY`.
+2. **Instance/global credentials** — `credentials.*` in `~/.agor/config.yaml`, or the admin **Settings → Agentic Tools** global fallback.
+3. **Daemon environment variables** — for example `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GEMINI_API_KEY` in the daemon process environment.
+4. **Machine-level CLI auth** — if no key is found, supported tools fall back to local CLI auth available to the Unix user running the session. For Codex this is `~/.codex/auth.json` from `codex login --device-auth`; for Claude Code this includes Claude CLI subscription login state.
 
-Mixing is fine: one user can run on a Max Pro token while teammates use per-user API keys.
+Agor uses these credentials only to authenticate the agent runtime with the provider SDK/CLI. Stored secrets are encrypted at rest and are not written into the prompt transcript or intentionally sent to the model as text.
+
+Mixing is fine: one user can run on a Claude subscription token while teammates use per-user API keys, and a self-hosted single-user instance can rely on machine-level CLI auth.
 
 <a id="claude-max-pro" />
 
-### Claude Max / Pro plan
+### Claude subscription auth (`claude setup-token`)
 
-If you have a Claude Max or Pro subscription, you can use it instead of an API key.
+Use this when you have Claude Pro, Max, Team, or Enterprise subscription access and want Agor to run Claude Code without an Anthropic Console API key. Run the command on the machine where Agor sessions execute. In `strict` Unix isolation, run it as the same Unix user that will own the sessions.
 
-**1. Install the Claude CLI locally** (skip if already installed):
+**1. Install the Claude CLI** (skip if already installed):
 
 ```bash
 npm install -g @anthropic-ai/claude-code
 ```
 
-**2. Generate a session token:**
+**2. Generate a long-lived OAuth token:**
 
 ```bash
 claude setup-token
 ```
 
-Copy the output.
+Copy the printed token.
 
-**3. Paste it into Agor:** open **User Settings → Agentic Tools → Claude Code** and paste the token into the **Claude Subscription Token** field. All your Claude Code sessions will use the subscription.
+**3. Paste it into Agor:** open **User Settings → Agentic Tools → Claude Code** and paste the token into **Claude Subscription Token**. Agor stores it as `CLAUDE_CODE_OAUTH_TOKEN` for your user.
 
-### CLI login on the daemon host (self-hosted)
+If you prefer ordinary interactive machine login for a solo/self-hosted setup, sign in with the Claude CLI as the daemon/session Unix user instead. For exact options and current behavior, see Anthropic's [Claude Code authentication docs](https://docs.anthropic.com/en/docs/claude-code/iam).
 
-If you can SSH into the machine running the daemon:
+### Codex account auth (`codex login --device-auth`)
 
-```bash
-claude login
-```
+Use this when you want Codex to authenticate with a ChatGPT/Codex account on the machine instead of storing an `OPENAI_API_KEY` in Agor. This is especially useful on remote or headless hosts.
 
-Credentials land in `~/.claude/` and Agor picks them up automatically. This is the lowest-config path for solo self-hosted setups.
-
-### Workspace env vars (global fallback)
-
-For instances where everyone shares one set of credentials:
+Run this on the machine where Agor sessions execute. In `strict` Unix isolation, run it as the same Unix user that will own the sessions.
 
 ```bash
-export ANTHROPIC_API_KEY="sk-ant-..."
-export OPENAI_API_KEY="sk-..."
-export GOOGLE_AI_API_KEY="..."
+codex login --device-auth
 ```
 
-Or via **Settings → Environment Variables** (admin only). These are visible to every user on the instance — pick this only if that's intentional.
+Follow the browser/device-code flow. Codex writes auth state under `~/.codex/` for that Unix user; Agor's Codex sessions fall back to that auth when no `OPENAI_API_KEY` is configured. For exact setup steps, see OpenAI's [Codex authentication docs](https://developers.openai.com/codex/auth).
 
 ### Per-user API keys (recommended for teams)
 
@@ -121,6 +116,20 @@ The wizard's default. Each user pastes their own key in **Settings → Agentic T
 - Anthropic: [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys)
 - OpenAI: [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
 - Google AI: [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey)
+
+Choose raw API keys when you want explicit usage/billing through API-provider accounts, shared automation, or a setup that does not depend on local CLI login state.
+
+### Workspace env vars (global fallback)
+
+For instances where everyone intentionally shares one set of credentials:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+export OPENAI_API_KEY="sk-..."
+export GEMINI_API_KEY="..."
+```
+
+Or use the admin **Settings → Agentic Tools** global fallback fields. These credentials are available as a fallback for every user on the instance — pick this only if that's intentional.
 
 ---
 

--- a/apps/agor-docs/pages/guide/getting-started.mdx
+++ b/apps/agor-docs/pages/guide/getting-started.mdx
@@ -52,7 +52,7 @@ Agor runs out of the box on SQLite as a single-user instance, but it's designed 
 - **Docker Compose** and source builds
 - **Custom config / database paths** for non-default install layouts
 
-For any of those, see [Extended Installation](/guide/extended-install). For credential alternatives (Claude Max/Pro plan, server-side `claude login`, workspace-wide env vars), see [Authentication](/guide/extended-install#authentication).
+For any of those, see [Extended Installation](/guide/extended-install). For credential alternatives (`claude setup-token`, `codex login --device-auth`, workspace-wide env vars), see [Authentication](/guide/extended-install#authentication).
 
 ## What's next
 

--- a/apps/agor-docs/pages/guide/multiplayer-social.mdx
+++ b/apps/agor-docs/pages/guide/multiplayer-social.mdx
@@ -129,7 +129,7 @@ The settings panel is split into two surfaces:
 
 **Agentic Tools**
 
-- **Claude Code / Codex / Gemini / OpenCode / Copilot** — per-runtime config: provider credentials, default model, permission mode, extra arguments. Each tool screen carries its own auth field(s) (e.g. Claude Code accepts either an Anthropic API key or a Pro/Max subscription token). Each user authenticates the SDKs they actually use; no shared "agor-bot" credentials.
+- **Claude Code / Codex / Gemini / OpenCode / Copilot** — per-runtime config: provider credentials, default model, permission mode, extra arguments. Each tool screen carries its own auth field(s) (e.g. Claude Code accepts either an Anthropic API key or a subscription token from `claude setup-token`; Codex can also use machine-level `codex login --device-auth`). Each user authenticates the SDKs they actually use; no shared "agor-bot" credentials.
 
 ### Why per-user matters in multiplayer
 

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -49,6 +49,11 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
       description: '(pay-as-you-go / Console)',
       placeholder: 'sk-ant-api03-...',
       docUrl: 'https://console.anthropic.com',
+      helper: (
+        <Text type="secondary" style={{ fontSize: 12 }}>
+          If you use a Claude subscription, use the Claude Subscription Token below instead.
+        </Text>
+      ),
     },
     {
       field: 'CLAUDE_CODE_OAUTH_TOKEN',
@@ -78,6 +83,18 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
       description: '(Codex)',
       placeholder: 'sk-proj-...',
       docUrl: 'https://platform.openai.com/api-keys',
+      helper: (
+        <Text type="secondary" style={{ fontSize: 12 }}>
+          Alternative: on the machine Agor runs sessions on, run{' '}
+          <Text code style={{ fontSize: 12 }}>
+            codex login --device-auth
+          </Text>{' '}
+          to use Codex CLI account auth without storing an OpenAI key in Agor.{' '}
+          <Link href="https://agor.live/guide/extended-install#authentication" target="_blank">
+            Learn more →
+          </Link>
+        </Text>
+      ),
     },
     {
       field: 'OPENAI_BASE_URL',
@@ -125,6 +142,11 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
       description: '(pay-as-you-go / Console)',
       placeholder: 'sk-ant-api03-...',
       docUrl: 'https://console.anthropic.com',
+      helper: (
+        <Text type="secondary" style={{ fontSize: 12 }}>
+          If you use a Claude subscription, use the Claude Subscription Token below instead.
+        </Text>
+      ),
     },
     {
       field: 'CLAUDE_CODE_OAUTH_TOKEN',
@@ -287,12 +309,12 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
           {/* Built-in per-field helpers retained from the legacy component. */}
           {field === 'CLAUDE_CODE_OAUTH_TOKEN' && !isSet && (
             <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-              Run{' '}
+              On the machine Agor runs sessions on, run{' '}
               <Text code style={{ fontSize: token.fontSizeSM }}>
                 claude setup-token
               </Text>{' '}
-              in a terminal where the Claude CLI is installed and signed in to your Pro/Max plan,
-              then paste the resulting token here.
+              and paste the printed token here. This uses Claude subscription auth instead of a raw
+              API key.
             </Text>
           )}
           {field === 'ANTHROPIC_AUTH_TOKEN' && (

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -48,7 +48,7 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
       label: 'Anthropic API Key',
       description: '(pay-as-you-go / Console)',
       placeholder: 'sk-ant-api03-...',
-      docUrl: 'https://console.anthropic.com',
+      docUrl: 'https://platform.claude.com/settings/keys',
       helper: (
         <Text type="secondary" style={{ fontSize: 12 }}>
           If you use a Claude subscription, use the Claude Subscription Token below instead.
@@ -141,7 +141,7 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
       label: 'Anthropic API Key',
       description: '(pay-as-you-go / Console)',
       placeholder: 'sk-ant-api03-...',
-      docUrl: 'https://console.anthropic.com',
+      docUrl: 'https://platform.claude.com/settings/keys',
       helper: (
         <Text type="secondary" style={{ fontSize: 12 }}>
           If you use a Claude subscription, use the Claude Subscription Token below instead.

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -111,6 +111,8 @@ describe('OnboardingWizard', () => {
     const codexOption = providerOptions.find((option) => option.value === 'codex');
     expect(claudeOption).toBeInstanceOf(HTMLInputElement);
     expect(claudeOption).toBeChecked();
+    expect(screen.getAllByText(/ANTHROPIC_API_KEY/).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByText('Subscription'));
     expect(screen.getByText(/claude setup-token/)).toBeInTheDocument();
     expect(codexOption).toBeInstanceOf(HTMLInputElement);
     expect(codexOption).not.toBeChecked();
@@ -139,7 +141,7 @@ describe('OnboardingWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
     fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
 
-    fireEvent.click(await screen.findByLabelText(/use claude subscription token/i));
+    fireEvent.click(await screen.findByText('Subscription'));
     fireEvent.change(screen.getByPlaceholderText('sk-ant-oat01-...'), {
       target: { value: 'sk-ant-oat01-test' },
     });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -111,6 +111,7 @@ describe('OnboardingWizard', () => {
     const codexOption = providerOptions.find((option) => option.value === 'codex');
     expect(claudeOption).toBeInstanceOf(HTMLInputElement);
     expect(claudeOption).toBeChecked();
+    expect(screen.getByText('claude setup-token')).toBeInTheDocument();
     expect(codexOption).toBeInstanceOf(HTMLInputElement);
     expect(codexOption).not.toBeChecked();
     codexOption?.focus();
@@ -128,6 +129,7 @@ describe('OnboardingWizard', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: /use a different provider/i }));
     expect(codexOption).toBeChecked();
     expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
+    expect(screen.getByText('codex login --device-auth')).toBeInTheDocument();
   });
 
   it('detects an existing Cursor credential when selecting Cursor', async () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -111,7 +111,7 @@ describe('OnboardingWizard', () => {
     const codexOption = providerOptions.find((option) => option.value === 'codex');
     expect(claudeOption).toBeInstanceOf(HTMLInputElement);
     expect(claudeOption).toBeChecked();
-    expect(screen.getByText('claude setup-token')).toBeInTheDocument();
+    expect(screen.getByText(/claude setup-token/)).toBeInTheDocument();
     expect(codexOption).toBeInstanceOf(HTMLInputElement);
     expect(codexOption).not.toBeChecked();
     codexOption?.focus();
@@ -129,7 +129,30 @@ describe('OnboardingWizard', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: /use a different provider/i }));
     expect(codexOption).toBeChecked();
     expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
-    expect(screen.getByText('codex login --device-auth')).toBeInTheDocument();
+    expect(screen.getAllByText(/codex login --device-auth/).length).toBeGreaterThan(0);
+  });
+
+  it('can save a Claude subscription token during onboarding', async () => {
+    const onUpdateUser = vi.fn();
+    renderWizard({ onUpdateUser });
+
+    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
+
+    fireEvent.click(await screen.findByLabelText(/use claude subscription token/i));
+    fireEvent.change(screen.getByPlaceholderText('sk-ant-oat01-...'), {
+      target: { value: 'sk-ant-oat01-test' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    expect(onUpdateUser).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({
+        agentic_tools: {
+          'claude-code': { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' },
+        },
+      })
+    );
   });
 
   it('detects an existing Cursor credential when selecting Cursor', async () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -44,6 +44,7 @@ import {
   Input,
   Modal,
   Popconfirm,
+  Radio,
   Result,
   Select,
   Space,
@@ -78,6 +79,8 @@ const CLONE_TIMEOUT_MS = 120_000;
 type WizardPath = 'assistant' | 'own-repo';
 
 type WizardStep = 'welcome' | 'identity' | 'add-repo' | 'clone' | 'board' | 'branch' | 'api-keys';
+
+type AuthMethod = 'api-key' | 'claude-subscription-token' | 'codex-cli-auth';
 
 export interface OnboardingWizardProps {
   open: boolean;
@@ -154,13 +157,19 @@ function getStepIndex(steps: WizardStep[], step: WizardStep): number {
   return steps.indexOf(step);
 }
 
-function apiKeyNameForAgent(agent: AgenticToolName): string {
+function apiKeyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-key'): string {
+  if (agent === 'claude-code' && authMethod === 'claude-subscription-token') {
+    return 'CLAUDE_CODE_OAUTH_TOKEN';
+  }
   // opencode has no canonical key of its own; wizard collects an Anthropic key
   // and routes it to the claude-code bucket (see handleSaveApiKey).
   return TOOL_API_KEY_NAMES[agent] ?? 'ANTHROPIC_API_KEY';
 }
 
-function apiKeyPlaceholder(agent: AgenticToolName): string {
+function apiKeyPlaceholder(agent: AgenticToolName, authMethod: AuthMethod = 'api-key'): string {
+  if (agent === 'claude-code' && authMethod === 'claude-subscription-token') {
+    return 'sk-ant-oat01-...';
+  }
   switch (agent) {
     case 'claude-code':
       return 'sk-ant-...';
@@ -278,6 +287,44 @@ const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string }
   opencode: null,
 };
 
+function defaultAuthMethodForAgent(agent: AgenticToolName): AuthMethod {
+  return agent === 'codex' ? 'codex-cli-auth' : 'api-key';
+}
+
+function authMethodOptionsForAgent(agent: AgenticToolName) {
+  if (agent === 'claude-code') {
+    return [
+      {
+        value: 'api-key' as const,
+        label: 'Use Anthropic API key',
+        description: 'Best for pay-as-you-go API billing.',
+      },
+      {
+        value: 'claude-subscription-token' as const,
+        label: 'Use Claude subscription token',
+        description: 'Run claude setup-token, then paste the token here.',
+      },
+    ];
+  }
+
+  if (agent === 'codex') {
+    return [
+      {
+        value: 'codex-cli-auth' as const,
+        label: 'Use Codex CLI account auth',
+        description: 'Run codex login --device-auth on this machine.',
+      },
+      {
+        value: 'api-key' as const,
+        label: 'Use OpenAI API key',
+        description: 'Best for API billing, automation, or team-managed keys.',
+      },
+    ];
+  }
+
+  return null;
+}
+
 // ─── Component ──────────────────────────────────────────
 
 export function OnboardingWizard({
@@ -331,6 +378,7 @@ export function OnboardingWizard({
   const [assistantDisplayName, setAssistantDisplayName] = useState('My Assistant');
   const [assistantEmoji, setAssistantEmoji] = useState('🤖');
   const [apiKey, setApiKey] = useState('');
+  const [authMethod, setAuthMethod] = useState<AuthMethod>('api-key');
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
   const [lastRecommendedAgent, setLastRecommendedAgent] = useState<AgenticToolName>('claude-code');
   const [useDifferentProvider, setUseDifferentProvider] = useState(false);
@@ -425,6 +473,7 @@ export function OnboardingWizard({
   const selectAgent = useCallback(
     (agent: AgenticToolName, options: { useDifferentProvider?: boolean } = {}) => {
       setSelectedAgent(agent);
+      setAuthMethod(defaultAuthMethodForAgent(agent));
       if (RECOMMENDED_AGENT_VALUES.has(agent)) {
         setLastRecommendedAgent(agent);
       }
@@ -1163,7 +1212,7 @@ export function OnboardingWizard({
       // own (`OpencodeConfig` has no fields). The onboarding fallback for
       // opencode collects an Anthropic key, so we route it to claude-code's
       // bucket where it's modeled, surfaced in settings, and resolvable.
-      const keyName = apiKeyNameForAgent(selectedAgent);
+      const keyName = apiKeyNameForAgent(selectedAgent, authMethod);
       const targetTool: AgenticToolName =
         selectedAgent === 'opencode' ? 'claude-code' : selectedAgent;
       await onUpdateUser(user.user_id, {
@@ -1177,7 +1226,7 @@ export function OnboardingWizard({
       setLoading(false);
       setError(`Failed to save API key: ${err instanceof Error ? err.message : String(err)}`);
     }
-  }, [user, apiKey, selectedAgent, path, onUpdateUser, setCurrentStep]);
+  }, [user, apiKey, authMethod, selectedAgent, path, onUpdateUser, setCurrentStep]);
 
   const handleAdvanceFromApiKeys = useCallback(() => {
     setCurrentStep(path === 'own-repo' ? 'add-repo' : 'clone');
@@ -1187,10 +1236,13 @@ export function OnboardingWizard({
     if (!onCheckAuth) return;
     setTestAuthLoading(true);
     setManualTestResult(null);
-    const result = await onCheckAuth(selectedAgent, apiKey.trim() || undefined);
+    const result = await onCheckAuth(
+      selectedAgent,
+      authMethod === 'codex-cli-auth' ? undefined : apiKey.trim() || undefined
+    );
     setTestAuthLoading(false);
     setManualTestResult(result);
-  }, [onCheckAuth, selectedAgent, apiKey]);
+  }, [onCheckAuth, selectedAgent, apiKey, authMethod]);
 
   const handleSkip = useCallback(() => {
     if (!user) return;
@@ -1599,28 +1651,63 @@ export function OnboardingWizard({
     // the Save step.
     const isAuthenticated = hasKey;
 
+    const authMethodOptions = authMethodOptionsForAgent(selectedAgent);
+    const usesCodexCliAuth = selectedAgent === 'codex' && authMethod === 'codex-cli-auth';
+    const currentKeyName = apiKeyNameForAgent(selectedAgent, authMethod);
+
     const renderAuthHint = () => {
       if (selectedAgent === 'claude-code') {
-        // No "Permission defaults" note: Claude defaults to `acceptEdits`,
-        // which IS the SDK's recommended mode (auto-accept edits, prompt for
-        // Bash/MCP). Users can flip to bypass per-session in Session Settings.
+        if (authMethod === 'claude-subscription-token') {
+          return (
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginBottom: 16, textAlign: 'left' }}
+              title="Generate a Claude subscription token"
+              description={
+                <span>
+                  On the machine Agor runs sessions on, run <Text code>claude setup-token</Text>,
+                  then paste the printed token below. Agor stores it for your user as{' '}
+                  <Text code>CLAUDE_CODE_OAUTH_TOKEN</Text>.
+                </span>
+              }
+            />
+          );
+        }
+
         return (
           <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste an <Text code>ANTHROPIC_API_KEY</Text>. For Claude subscription auth, run{' '}
-            <Text code>claude setup-token</Text> on the machine Agor runs sessions on, then paste
-            the token in <Text strong>Settings → Agentic Tools → Claude Code</Text>.
+            Paste an <Text code>ANTHROPIC_API_KEY</Text> from Anthropic Console. Best for
+            pay-as-you-go API billing.
           </Paragraph>
         );
       }
+
       if (selectedAgent === 'codex') {
-        // Single-line surfacing of the non-obvious Codex default: auto-approve
-        // is wired through Codex's per-server MCP approval mode + workspace-write
-        // sandbox. Worth a one-liner so it's not a surprise.
+        if (usesCodexCliAuth) {
+          return (
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginBottom: 16, textAlign: 'left' }}
+              title="Use Codex CLI account auth"
+              description={
+                <span>
+                  On the machine Agor runs sessions on, run{' '}
+                  <Text code>codex login --device-auth</Text>. Agor will use that local Codex auth
+                  when no <Text code>OPENAI_API_KEY</Text> is configured. Use Test Connection to
+                  verify this machine is signed in.
+                </span>
+              }
+            />
+          );
+        }
+
         return (
           <>
             <Paragraph type="secondary" style={{ marginBottom: 8 }}>
-              Paste an <Text code>OPENAI_API_KEY</Text>, or run{' '}
-              <Text code>codex login --device-auth</Text> on the machine Agor runs sessions on.
+              Paste an <Text code>OPENAI_API_KEY</Text> from OpenAI Platform. Best for API billing,
+              automation, or team-managed keys.
             </Paragraph>
             <Paragraph type="secondary" style={{ marginBottom: 16, fontSize: 12 }}>
               Defaults: auto-approves tool calls inside the branch sandbox. Tighten in{' '}
@@ -1629,10 +1716,11 @@ export function OnboardingWizard({
           </>
         );
       }
+
       if (AGENT_KEY_CONSOLES[selectedAgent]) {
         return (
           <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste your {apiKeyNameForAgent(selectedAgent)} below. Get one at{' '}
+            Paste your {currentKeyName} below. Get one at{' '}
             <Typography.Link
               href={AGENT_KEY_CONSOLES[selectedAgent]?.url}
               target="_blank"
@@ -1771,6 +1859,31 @@ export function OnboardingWizard({
                 </Button>
               </div>
             )}
+            {authMethodOptions && (
+              <Radio.Group
+                value={authMethod}
+                onChange={(event) => {
+                  setAuthMethod(event.target.value);
+                  setApiKey('');
+                  setManualTestResult(null);
+                }}
+                style={{ width: '100%', marginBottom: 16 }}
+              >
+                <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+                  {authMethodOptions.map((option) => (
+                    <Radio key={option.value} value={option.value} style={{ width: '100%' }}>
+                      <Space orientation="vertical" size={0}>
+                        <Text strong>{option.label}</Text>
+                        <Text type="secondary" style={{ fontSize: 12 }}>
+                          {option.description}
+                        </Text>
+                      </Space>
+                    </Radio>
+                  ))}
+                </Space>
+              </Radio.Group>
+            )}
+
             {renderAuthHint()}
 
             {selectedAgent === 'opencode' && (
@@ -1780,19 +1893,21 @@ export function OnboardingWizard({
               </Paragraph>
             )}
 
-            <Form layout="vertical">
-              <Form.Item label={apiKeyNameForAgent(selectedAgent)}>
-                <Input.Password
-                  placeholder={apiKeyPlaceholder(selectedAgent)}
-                  value={apiKey}
-                  onChange={(e) => {
-                    setApiKey(e.target.value);
-                    // Editing the key invalidates any prior test result.
-                    setManualTestResult(null);
-                  }}
-                />
-              </Form.Item>
-            </Form>
+            {!usesCodexCliAuth && (
+              <Form layout="vertical">
+                <Form.Item label={currentKeyName}>
+                  <Input.Password
+                    placeholder={apiKeyPlaceholder(selectedAgent, authMethod)}
+                    value={apiKey}
+                    onChange={(e) => {
+                      setApiKey(e.target.value);
+                      // Editing the key invalidates any prior test result.
+                      setManualTestResult(null);
+                    }}
+                  />
+                </Form.Item>
+              </Form>
+            )}
 
             {error && <Alert type="error" message={error} showIcon style={{ marginBottom: 16 }} />}
 
@@ -1803,7 +1918,12 @@ export function OnboardingWizard({
                   showIcon
                   style={{ marginBottom: 16, textAlign: 'left' }}
                   message="Connection works"
-                  description={manualTestResult.hint || 'Click Save & Continue to store this key.'}
+                  description={
+                    manualTestResult.hint ||
+                    (usesCodexCliAuth
+                      ? 'Click Continue with Codex CLI auth to use this machine login.'
+                      : 'Click Save & Continue to store this key.')
+                  }
                 />
               ) : (
                 <Alert
@@ -1816,23 +1936,31 @@ export function OnboardingWizard({
               ))}
 
             <Space wrap>
-              <Button
-                type="primary"
-                onClick={handleSaveApiKey}
-                loading={loading}
-                disabled={!apiKey.trim()}
-                icon={<KeyOutlined />}
-              >
-                Save & Continue
-              </Button>
+              {usesCodexCliAuth ? (
+                <Button type="primary" onClick={handleAdvanceFromApiKeys} disabled={loading}>
+                  Continue with Codex CLI auth
+                </Button>
+              ) : (
+                <Button
+                  type="primary"
+                  onClick={handleSaveApiKey}
+                  loading={loading}
+                  disabled={!apiKey.trim()}
+                  icon={<KeyOutlined />}
+                >
+                  Save & Continue
+                </Button>
+              )}
               {onCheckAuth && (
                 <Button onClick={handleTestAuth} loading={testAuthLoading} disabled={loading}>
                   Test Connection
                 </Button>
               )}
-              <Button onClick={handleAdvanceFromApiKeys} disabled={loading}>
-                Continue without key
-              </Button>
+              {!usesCodexCliAuth && (
+                <Button onClick={handleAdvanceFromApiKeys} disabled={loading}>
+                  Continue without key
+                </Button>
+              )}
             </Space>
           </>
         )}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1587,7 +1587,7 @@ export function OnboardingWizard({
     const hasKey = hasKeyForAgent(selectedAgent);
     // "Already auth'd" covers both stored credentials (agentic_tools / env vars
     // / system credentials) AND ambient CLI auth detected by onCheckAuth —
-    // e.g. the user already ran `claude auth login` outside the wizard.
+    // e.g. the user already configured Claude/Codex CLI auth outside the wizard.
     // Auto-flip to "{tool} is configured → Continue" ONLY when the current
     // user has THEIR OWN stored per-user credential. We intentionally do not
     // gate on `detectedAuth?.authenticated` here: the ambient probe reads
@@ -1606,8 +1606,9 @@ export function OnboardingWizard({
         // Bash/MCP). Users can flip to bypass per-session in Session Settings.
         return (
           <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste an <Text code>ANTHROPIC_API_KEY</Text>, or run <Text code>claude auth login</Text>{' '}
-            on the host.
+            Paste an <Text code>ANTHROPIC_API_KEY</Text>. For Claude subscription auth, run{' '}
+            <Text code>claude setup-token</Text> on the machine Agor runs sessions on, then paste
+            the token in <Text strong>Settings → Agentic Tools → Claude Code</Text>.
           </Paragraph>
         );
       }
@@ -1618,8 +1619,8 @@ export function OnboardingWizard({
         return (
           <>
             <Paragraph type="secondary" style={{ marginBottom: 8 }}>
-              Paste an <Text code>OPENAI_API_KEY</Text>, or run <Text code>codex login</Text> in
-              Agor's terminal.
+              Paste an <Text code>OPENAI_API_KEY</Text>, or run{' '}
+              <Text code>codex login --device-auth</Text> on the machine Agor runs sessions on.
             </Paragraph>
             <Paragraph type="secondary" style={{ marginBottom: 16, fontSize: 12 }}>
               Defaults: auto-approves tool calls inside the branch sandbox. Tighten in{' '}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1693,13 +1693,10 @@ export function OnboardingWizard({
               type="info"
               showIcon
               style={{ marginBottom: 16, textAlign: 'left' }}
-              title="Use Codex CLI account auth"
               description={
                 <span>
-                  On the machine Agor runs sessions on, run{' '}
-                  <Text code>codex login --device-auth</Text>. Agor will use that local Codex auth
-                  when no <Text code>OPENAI_API_KEY</Text> is configured. Use Test Connection to
-                  verify this machine is signed in.
+                  Run <Text code>codex login --device-auth</Text> on the machine Agor runs sessions
+                  on; Agor uses that local auth when no <Text code>OPENAI_API_KEY</Text> is set.
                 </span>
               }
             />

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -286,7 +286,7 @@ const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string }
     label: 'platform.claude.com/settings/keys',
     url: 'https://platform.claude.com/settings/keys',
   },
-  codex: { label: 'platform.openai.com', url: 'https://platform.openai.com/api-keys' },
+  codex: { label: 'platform.openai.com/api-keys', url: 'https://platform.openai.com/api-keys' },
   gemini: { label: 'aistudio.google.com', url: 'https://aistudio.google.com/apikey' },
   copilot: { label: 'github.com/features/copilot', url: 'https://github.com/features/copilot' },
   cursor: { label: 'cursor.com', url: 'https://cursor.com' },
@@ -1709,8 +1709,11 @@ export function OnboardingWizard({
         return (
           <>
             <Paragraph type="secondary" style={{ marginBottom: 8 }}>
-              Paste an <Text code>OPENAI_API_KEY</Text> from OpenAI Platform. Best for API billing,
-              automation, or team-managed keys.
+              Paste an <Text code>OPENAI_API_KEY</Text> from{' '}
+              <Typography.Link href="https://platform.openai.com/api-keys" target="_blank">
+                OpenAI Platform
+              </Typography.Link>{' '}
+              for API billing, automation, or team-managed keys.
             </Paragraph>
             <Paragraph type="secondary" style={{ marginBottom: 16, fontSize: 12 }}>
               Defaults: auto-approves tool calls inside the branch sandbox. Tighten in{' '}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -277,9 +277,15 @@ const RECOMMENDED_AGENT_VALUES = new Set<AgenticToolName>(
 );
 
 const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string } | null> = {
-  'claude-code': { label: 'console.anthropic.com', url: 'https://console.anthropic.com/' },
+  'claude-code': {
+    label: 'platform.claude.com/settings/keys',
+    url: 'https://platform.claude.com/settings/keys',
+  },
   // Claude Code CLI uses the same Anthropic credentials.
-  'claude-code-cli': { label: 'console.anthropic.com', url: 'https://console.anthropic.com/' },
+  'claude-code-cli': {
+    label: 'platform.claude.com/settings/keys',
+    url: 'https://platform.claude.com/settings/keys',
+  },
   codex: { label: 'platform.openai.com', url: 'https://platform.openai.com/api-keys' },
   gemini: { label: 'aistudio.google.com', url: 'https://aistudio.google.com/apikey' },
   copilot: { label: 'github.com/features/copilot', url: 'https://github.com/features/copilot' },
@@ -1671,8 +1677,11 @@ export function OnboardingWizard({
 
         return (
           <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste an <Text code>ANTHROPIC_API_KEY</Text> from Anthropic Console. Best for
-            pay-as-you-go API billing.
+            Paste an <Text code>ANTHROPIC_API_KEY</Text> from{' '}
+            <Typography.Link href="https://platform.claude.com/settings/keys" target="_blank">
+              Claude Console
+            </Typography.Link>{' '}
+            for pay-as-you-go API billing.
           </Paragraph>
         );
       }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1659,12 +1659,10 @@ export function OnboardingWizard({
               type="info"
               showIcon
               style={{ marginBottom: 16, textAlign: 'left' }}
-              title="Generate a Claude subscription token"
               description={
                 <span>
-                  On the machine Agor runs sessions on, run <Text code>claude setup-token</Text>,
-                  then paste the printed token below. Agor stores it for your user as{' '}
-                  <Text code>CLAUDE_CODE_OAUTH_TOKEN</Text>.
+                  Run <Text code>claude setup-token</Text> on the machine Agor runs sessions on,
+                  then paste the printed token below.
                 </span>
               }
             />

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -295,14 +295,12 @@ function authMethodOptionsForAgent(agent: AgenticToolName) {
   if (agent === 'claude-code') {
     return [
       {
-        value: 'api-key' as const,
-        label: 'Use Anthropic API key',
-        description: 'Best for pay-as-you-go API billing.',
+        value: 'claude-subscription-token' as const,
+        label: 'Subscription',
       },
       {
-        value: 'claude-subscription-token' as const,
-        label: 'Use Claude subscription token',
-        description: 'Run claude setup-token, then paste the token here.',
+        value: 'api-key' as const,
+        label: 'API key',
       },
     ];
   }
@@ -311,13 +309,11 @@ function authMethodOptionsForAgent(agent: AgenticToolName) {
     return [
       {
         value: 'codex-cli-auth' as const,
-        label: 'Use Codex CLI account auth',
-        description: 'Run codex login --device-auth on this machine.',
+        label: 'CLI sign-in',
       },
       {
         value: 'api-key' as const,
-        label: 'Use OpenAI API key',
-        description: 'Best for API billing, automation, or team-managed keys.',
+        label: 'API key',
       },
     ];
   }
@@ -1869,18 +1865,35 @@ export function OnboardingWizard({
                 }}
                 style={{ width: '100%', marginBottom: 16 }}
               >
-                <Space orientation="vertical" size="small" style={{ width: '100%' }}>
-                  {authMethodOptions.map((option) => (
-                    <Radio key={option.value} value={option.value} style={{ width: '100%' }}>
-                      <Space orientation="vertical" size={0}>
-                        <Text strong>{option.label}</Text>
-                        <Text type="secondary" style={{ fontSize: 12 }}>
-                          {option.description}
-                        </Text>
-                      </Space>
-                    </Radio>
-                  ))}
-                </Space>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+                    gap: 8,
+                  }}
+                >
+                  {authMethodOptions.map((option) => {
+                    const selected = authMethod === option.value;
+                    return (
+                      <Radio
+                        key={option.value}
+                        value={option.value}
+                        style={{
+                          alignItems: 'center',
+                          border: selected
+                            ? '1px solid var(--ant-color-primary)'
+                            : '1px solid var(--ant-color-border)',
+                          borderRadius: 8,
+                          display: 'flex',
+                          marginInlineEnd: 0,
+                          padding: '8px 12px',
+                        }}
+                      >
+                        <Text strong={selected}>{option.label}</Text>
+                      </Radio>
+                    );
+                  })}
+                </div>
               </Radio.Group>
             )}
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1704,19 +1704,13 @@ export function OnboardingWizard({
         }
 
         return (
-          <>
-            <Paragraph type="secondary" style={{ marginBottom: 8 }}>
-              Paste an <Text code>OPENAI_API_KEY</Text> from{' '}
-              <Typography.Link href="https://platform.openai.com/api-keys" target="_blank">
-                OpenAI Platform
-              </Typography.Link>{' '}
-              for API billing, automation, or team-managed keys.
-            </Paragraph>
-            <Paragraph type="secondary" style={{ marginBottom: 16, fontSize: 12 }}>
-              Defaults: auto-approves tool calls inside the branch sandbox. Tighten in{' '}
-              <Text strong>Session Settings</Text>.
-            </Paragraph>
-          </>
+          <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+            Paste an <Text code>OPENAI_API_KEY</Text> from{' '}
+            <Typography.Link href="https://platform.openai.com/api-keys" target="_blank">
+              OpenAI Platform
+            </Typography.Link>{' '}
+            for API billing, automation, or team-managed keys.
+          </Paragraph>
         );
       }
 

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -69,10 +69,10 @@ const ApiKeyTabContent: React.FC<{
       <Alert
         title={
           <span>
-            This is the <strong>global API key</strong> for all users. Per-user keys can be set in
-            the Users tab.{' '}
+            This is the <strong>global API key</strong> fallback for users without their own
+            credentials. CLI login alternatives are configured on the machine Agor runs sessions on.{' '}
             <a
-              href="https://agor.live/guide/authentication"
+              href="https://agor.live/guide/extended-install#authentication"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -286,6 +286,11 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         label: 'Integrations',
         type: 'group' as const,
         children: [
+          {
+            key: 'agentic-tools',
+            label: 'Agentic Tools',
+            icon: <ThunderboltOutlined />,
+          },
           ...(mcpEnabled && isAdmin
             ? [
                 {
@@ -295,11 +300,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                 },
               ]
             : []),
-          {
-            key: 'agentic-tools',
-            label: 'Agentic Tools',
-            icon: <ThunderboltOutlined />,
-          },
           ...(gatewayEnabled && isAdmin
             ? [
                 {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -873,8 +873,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         const authPane = (
           <>
             <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
-              Per-user credentials and config for {displayNames[toolName]}. Encrypted at rest; take
-              precedence over the daemon's global configuration and your global env vars.
+              Per-user credentials and config for {displayNames[toolName]}. Encrypted at rest;
+              injected into the agent runtime, not the prompt transcript; and preferred over daemon
+              globals and env vars.
             </Typography.Paragraph>
             <ApiKeyFields
               tool={toolName}


### PR DESCRIPTION
## Summary

- clarify Claude Code and Codex auth copy in onboarding and Agentic Tools settings
- document when to use raw API keys vs `claude setup-token` and `codex login --device-auth`
- add onboarding test coverage for the Claude/Codex CLI auth command hints

## Validation

- `pnpm --filter agor-ui test -- OnboardingWizard.test.tsx` ✅
- `pnpm exec biome check apps/agor-ui/src/components/ApiKeyFields.tsx apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx apps/agor-docs/pages/guide/extended-install.mdx apps/agor-docs/pages/guide/getting-started.mdx apps/agor-docs/pages/guide/multiplayer-social.mdx` ✅
- `pnpm check` ⚠️ fails in existing `@agor/cli#build` module-resolution errors for workspace packages; typecheck/lint/check:shortid completed before the build failure, with existing Biome warnings unrelated to this change.
