### PR TITLE
Instrument initial load debug timings

### DIFF
--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -23,6 +23,10 @@ import type {
 import { PAGINATION } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { shallowEqualEntity } from '../utils/shallowEqual';
+import {
+  createInitialLoadDebugTimer,
+  isInitialLoadDebugEnabled,
+} from '../utils/initialLoadDebug';
 import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 
 // Canonical list of initial-load items tracked by the loading checklist.
@@ -225,10 +229,18 @@ export function useAgorData(
         return;
       }
 
+      const debugTimer =
+        !silent && isInitialLoadDebugEnabled()
+          ? createInitialLoadDebugTimer(INITIAL_LOAD_ITEMS)
+          : null;
+      let debugFinishStatus: 'success' | 'error' | null = null;
+      let debugFinishError: unknown;
+
       try {
         if (!silent) {
           setLoading(true);
           setLoadingStage('fetching');
+          debugTimer?.markStage('fetching');
           setError(null);
           setItemCounts({});
         }
@@ -239,14 +251,17 @@ export function useAgorData(
         const track = <T extends ReadonlyArray<unknown>>(
           key: InitialLoadItemKey,
           p: Promise<T>
-        ): Promise<T> =>
-          p.then((r) => {
+        ): Promise<T> => {
+          const timedPromise = debugTimer?.track(key, p) ?? p;
+          return timedPromise.then((r) => {
             if (!silent) setItemCounts((prev) => ({ ...prev, [key]: r.length }));
             return r;
           });
+        };
 
         // Fetch sessions, boards, board-objects, comments, repos, branches, users, mcp servers, session-mcp relationships in parallel.
         // Task/message detail now comes from per-session reactive state in conversation components.
+        debugTimer?.startFetchPhase();
         const [
           sessionsList,
           boardsList,
@@ -358,9 +373,12 @@ export function useAgorData(
             .find()
             .catch(() => ({ authenticated_server_ids: [] })),
         ]);
+        debugTimer?.endFetchPhase();
 
         if (!silent) {
           setLoadingStage('indexing');
+          debugTimer?.markStage('indexing');
+          debugTimer?.startIndexing();
           // Give the browser one paint opportunity so large instances can
           // visibly advance from "loading lists" to "indexing workspace data"
           // before the synchronous Map construction below.
@@ -476,6 +494,8 @@ export function useAgorData(
           sessionMcpServerIds: sessionMcpMap,
           userAuthenticatedMcpServerIds,
         });
+        debugTimer?.endIndexing();
+        debugFinishStatus = 'success';
 
         // Silent refetch succeeded — clear the retry flag so future token
         // refreshes don't trigger another wasted re-fetch.
@@ -491,12 +511,18 @@ export function useAgorData(
           console.warn('[useAgorData] silent refetch failed:', err);
           lastSilentFetchFailedRef.current = true;
         } else {
+          debugFinishStatus = 'error';
+          debugFinishError = err;
           setError(err instanceof Error ? err.message : 'Failed to fetch data');
         }
       } finally {
         if (!silent) {
           setLoading(false);
           setLoadingStage('idle');
+          debugTimer?.markStage('idle');
+          if (debugFinishStatus) {
+            debugTimer?.finish(debugFinishStatus, debugFinishError);
+          }
         }
       }
     },

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -22,11 +22,8 @@ import type {
 } from '@agor-live/client';
 import { PAGINATION } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createInitialLoadDebugTimer, isInitialLoadDebugEnabled } from '../utils/initialLoadDebug';
 import { shallowEqualEntity } from '../utils/shallowEqual';
-import {
-  createInitialLoadDebugTimer,
-  isInitialLoadDebugEnabled,
-} from '../utils/initialLoadDebug';
 import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 
 // Canonical list of initial-load items tracked by the loading checklist.

--- a/apps/agor-ui/src/utils/initialLoadDebug.test.ts
+++ b/apps/agor-ui/src/utils/initialLoadDebug.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createInitialLoadDebugTimer,
+  isInitialLoadDebugEnabled,
+  syncInitialLoadDebugFlagFromUrl,
+  type InitialLoadDebugTimings,
+} from './initialLoadDebug';
+
+const originalUrl = window.location.href;
+
+afterEach(() => {
+  window.history.replaceState({}, '', originalUrl);
+  window.localStorage.clear();
+  delete (window as Window & { __AGOR_INITIAL_LOAD_TIMINGS__?: InitialLoadDebugTimings })
+    .__AGOR_INITIAL_LOAD_TIMINGS__;
+  vi.restoreAllMocks();
+});
+
+describe('initial load debug flag', () => {
+  it('persists when debugLoad=1 is present', () => {
+    window.history.replaceState({}, '', '/?debugLoad=1');
+
+    expect(syncInitialLoadDebugFlagFromUrl()).toBe(true);
+    expect(window.localStorage.getItem('agor.debug.initialLoad')).toBe('1');
+  });
+
+  it('removes the persisted flag when debugLoad=0 is present', () => {
+    window.localStorage.setItem('agor.debug.initialLoad', '1');
+    window.history.replaceState({}, '', '/?debugLoad=0');
+
+    expect(syncInitialLoadDebugFlagFromUrl()).toBe(false);
+    expect(window.localStorage.getItem('agor.debug.initialLoad')).toBeNull();
+  });
+
+  it('uses the persisted flag when the URL has no override', () => {
+    window.localStorage.setItem('agor.debug.initialLoad', '1');
+    window.history.replaceState({}, '', '/boards');
+
+    expect(isInitialLoadDebugEnabled()).toBe(true);
+  });
+});
+
+describe('initial load debug timer', () => {
+  it('captures fetch status, counts, stage transitions, and exposes the latest payload', async () => {
+    vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+    vi.spyOn(console, 'table').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
+
+    const timer = createInitialLoadDebugTimer([{ key: 'sessions', label: 'Sessions' }]);
+    timer.markStage('fetching');
+    timer.startFetchPhase();
+    await timer.track('sessions', Promise.resolve([{}, {}]));
+    timer.endFetchPhase();
+    timer.markStage('indexing');
+    timer.startIndexing();
+    timer.endIndexing();
+    timer.markStage('idle');
+
+    const timings = timer.finish('success');
+
+    expect(timings.status).toBe('success');
+    expect(timings.fetches).toMatchObject([
+      { key: 'sessions', label: 'Sessions', count: 2, status: 'success' },
+    ]);
+    expect(timings.stageTransitions.map((transition) => transition.stage)).toEqual([
+      'fetching',
+      'indexing',
+      'idle',
+    ]);
+    expect(
+      (window as Window & { __AGOR_INITIAL_LOAD_TIMINGS__?: InitialLoadDebugTimings })
+        .__AGOR_INITIAL_LOAD_TIMINGS__
+    ).toBe(timings);
+  });
+
+  it('records fetch errors without swallowing them', async () => {
+    vi.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+    vi.spyOn(console, 'table').mockImplementation(() => undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'groupEnd').mockImplementation(() => undefined);
+
+    const timer = createInitialLoadDebugTimer([{ key: 'branches', label: 'Branches' }]);
+
+    await expect(timer.track('branches', Promise.reject(new Error('boom')))).rejects.toThrow(
+      'boom'
+    );
+
+    const timings = timer.finish('error', new Error('boom'));
+    expect(timings).toMatchObject({ status: 'error', error: 'boom' });
+    expect(timings.fetches).toMatchObject([
+      { key: 'branches', label: 'Branches', count: null, status: 'error', error: 'boom' },
+    ]);
+  });
+});

--- a/apps/agor-ui/src/utils/initialLoadDebug.test.ts
+++ b/apps/agor-ui/src/utils/initialLoadDebug.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createInitialLoadDebugTimer,
+  type InitialLoadDebugTimings,
   isInitialLoadDebugEnabled,
   syncInitialLoadDebugFlagFromUrl,
-  type InitialLoadDebugTimings,
 } from './initialLoadDebug';
 
 const originalUrl = window.location.href;

--- a/apps/agor-ui/src/utils/initialLoadDebug.ts
+++ b/apps/agor-ui/src/utils/initialLoadDebug.ts
@@ -1,0 +1,181 @@
+const DEBUG_INITIAL_LOAD_STORAGE_KEY = 'agor.debug.initialLoad';
+
+export interface InitialLoadDebugItem {
+  key: string;
+  label: string;
+}
+
+export interface InitialLoadDebugFetchTiming {
+  key: string;
+  label: string;
+  durationMs: number;
+  count: number | null;
+  status: 'success' | 'error';
+  error?: string;
+}
+
+export interface InitialLoadDebugStageTransition {
+  stage: string;
+  atMs: number;
+}
+
+export interface InitialLoadDebugTimings {
+  label: string;
+  startedAt: string;
+  totalMs: number;
+  fetchPhaseMs: number | null;
+  indexingMs: number | null;
+  status: 'success' | 'error';
+  error?: string;
+  fetches: InitialLoadDebugFetchTiming[];
+  stageTransitions: InitialLoadDebugStageTransition[];
+}
+
+type DebugWindow = Window & {
+  __AGOR_INITIAL_LOAD_TIMINGS__?: InitialLoadDebugTimings;
+};
+
+function getWindow(): DebugWindow | null {
+  return typeof window === 'undefined' ? null : (window as DebugWindow);
+}
+
+function getNow(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function roundMs(ms: number): number {
+  return Math.round(ms * 10) / 10;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function syncInitialLoadDebugFlagFromUrl(win = getWindow()): boolean {
+  if (!win) return false;
+
+  let value: string | null = null;
+  try {
+    value = new URLSearchParams(win.location.search).get('debugLoad');
+  } catch {
+    value = null;
+  }
+
+  try {
+    if (value === '1') {
+      win.localStorage.setItem(DEBUG_INITIAL_LOAD_STORAGE_KEY, '1');
+    } else if (value === '0') {
+      win.localStorage.removeItem(DEBUG_INITIAL_LOAD_STORAGE_KEY);
+    }
+
+    return win.localStorage.getItem(DEBUG_INITIAL_LOAD_STORAGE_KEY) === '1';
+  } catch {
+    return value === '1';
+  }
+}
+
+export function isInitialLoadDebugEnabled(): boolean {
+  return syncInitialLoadDebugFlagFromUrl();
+}
+
+export function createInitialLoadDebugTimer(items: readonly InitialLoadDebugItem[]) {
+  const start = getNow();
+  const startedAt = new Date().toISOString();
+  const labels = new Map(items.map((item) => [item.key, item.label]));
+  const fetches: InitialLoadDebugFetchTiming[] = [];
+  const stageTransitions: InitialLoadDebugStageTransition[] = [];
+  let fetchStart: number | null = null;
+  let fetchEnd: number | null = null;
+  let indexingStart: number | null = null;
+  let indexingEnd: number | null = null;
+
+  const markStage = (stage: string) => {
+    stageTransitions.push({ stage, atMs: roundMs(getNow() - start) });
+  };
+
+  return {
+    markStage,
+    startFetchPhase() {
+      fetchStart = getNow();
+    },
+    endFetchPhase() {
+      fetchEnd = getNow();
+    },
+    startIndexing() {
+      indexingStart = getNow();
+    },
+    endIndexing() {
+      indexingEnd = getNow();
+    },
+    track<T extends ReadonlyArray<unknown>>(key: string, promise: Promise<T>): Promise<T> {
+      const itemStart = getNow();
+      return promise.then(
+        (result) => {
+          fetches.push({
+            key,
+            label: labels.get(key) ?? key,
+            durationMs: roundMs(getNow() - itemStart),
+            count: result.length,
+            status: 'success',
+          });
+          return result;
+        },
+        (error) => {
+          fetches.push({
+            key,
+            label: labels.get(key) ?? key,
+            durationMs: roundMs(getNow() - itemStart),
+            count: null,
+            status: 'error',
+            error: errorMessage(error),
+          });
+          throw error;
+        }
+      );
+    },
+    finish(status: 'success' | 'error', error?: unknown): InitialLoadDebugTimings {
+      const timings: InitialLoadDebugTimings = {
+        label: 'Agor initial load',
+        startedAt,
+        totalMs: roundMs(getNow() - start),
+        fetchPhaseMs:
+          fetchStart === null ? null : roundMs((fetchEnd ?? getNow()) - fetchStart),
+        indexingMs:
+          indexingStart === null ? null : roundMs((indexingEnd ?? getNow()) - indexingStart),
+        status,
+        error: error === undefined ? undefined : errorMessage(error),
+        fetches: [...fetches].sort((a, b) => a.key.localeCompare(b.key)),
+        stageTransitions: [...stageTransitions],
+      };
+
+      const win = getWindow();
+      if (win) {
+        win.__AGOR_INITIAL_LOAD_TIMINGS__ = timings;
+      }
+
+      if (typeof console !== 'undefined') {
+        const group = console.groupCollapsed ?? console.group;
+        group?.call(console, '[Agor initial load]', {
+          status: timings.status,
+          totalMs: timings.totalMs,
+          fetchPhaseMs: timings.fetchPhaseMs,
+          indexingMs: timings.indexingMs,
+        });
+        console.table?.(timings.fetches);
+        if (timings.stageTransitions.length > 0) {
+          console.log('stageTransitions', timings.stageTransitions);
+        }
+        if (timings.error) {
+          console.warn('[Agor initial load] failed', timings.error);
+        }
+        console.log('Copy from window.__AGOR_INITIAL_LOAD_TIMINGS__', timings);
+        console.groupEnd?.();
+      }
+
+      return timings;
+    },
+  };
+}

--- a/apps/agor-ui/src/utils/initialLoadDebug.ts
+++ b/apps/agor-ui/src/utils/initialLoadDebug.ts
@@ -141,8 +141,7 @@ export function createInitialLoadDebugTimer(items: readonly InitialLoadDebugItem
         label: 'Agor initial load',
         startedAt,
         totalMs: roundMs(getNow() - start),
-        fetchPhaseMs:
-          fetchStart === null ? null : roundMs((fetchEnd ?? getNow()) - fetchStart),
+        fetchPhaseMs: fetchStart === null ? null : roundMs((fetchEnd ?? getNow()) - fetchStart),
         indexingMs:
           indexingStart === null ? null : roundMs((indexingEnd ?? getNow()) - indexingStart),
         status,


### PR DESCRIPTION
## Summary

- Adds hidden production-friendly initial-load instrumentation behind `?debugLoad=1`.
- Persists the flag in `localStorage` as `agor.debug.initialLoad`; `?debugLoad=0` disables/removes it.
- Records per-fetch timings/counts/status, fetch phase duration, indexing duration, total duration, and loading stage transitions.
- Prints a compact console group/table and exposes the latest payload at `window.__AGOR_INITIAL_LOAD_TIMINGS__` for copy/paste from production.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- src/utils/initialLoadDebug.test.ts src/hooks/useAgorData.test.tsx`
