### PR TITLE
Optimize board object client indexes

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -265,6 +265,7 @@ function AppContent() {
     sessionsByBranch,
     boardById,
     boardObjectById,
+    boardObjectsByBoardId,
     commentById,
     cardById,
     cardTypeById,
@@ -1457,6 +1458,7 @@ function AppContent() {
       availableAgents={AVAILABLE_AGENTS}
       boardById={boardById}
       boardObjectById={boardObjectById}
+      boardObjectsByBoardId={boardObjectsByBoardId}
       commentById={commentById}
       cardById={cardById}
       cardTypeById={cardTypeById}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -96,6 +96,7 @@ export interface AppProps {
   availableAgents: AgenticToolOption[];
   boardById: Map<string, Board>; // Map-based board storage
   boardObjectById: Map<string, BoardEntityObject>; // Map-based board object storage
+  boardObjectsByBoardId: Map<string, BoardEntityObject[]>;
   commentById: Map<string, BoardComment>; // Map-based comment storage
   cardById: Map<string, CardWithType>; // Map-based card storage
   cardTypeById: Map<string, CardType>; // Map-based card type storage
@@ -196,6 +197,9 @@ export interface AppProps {
 // common no-MCP case so that downstream React.memo bailouts are not defeated.
 // Frozen at runtime; the consuming components only read it.
 const EMPTY_STRING_ARRAY: string[] = Object.freeze([] as string[]) as string[];
+const EMPTY_BOARD_OBJECTS: BoardEntityObject[] = Object.freeze(
+  [] as BoardEntityObject[]
+) as BoardEntityObject[];
 
 // 320px keeps the three left-panel tabs (Assistant / All sessions / Comments)
 // on one readable line with Ant's tab padding at the 768px desktop breakpoint.
@@ -218,6 +222,7 @@ export const App: React.FC<AppProps> = ({
   availableAgents,
   boardById,
   boardObjectById,
+  boardObjectsByBoardId,
   commentById,
   cardById,
   cardTypeById,
@@ -572,8 +577,16 @@ export const App: React.FC<AppProps> = ({
     }
   }, [currentBoardId, createDialogOpen]);
 
+  const currentBoardObjects = useMemo(
+    () =>
+      currentBoardId
+        ? boardObjectsByBoardId.get(currentBoardId) || EMPTY_BOARD_OBJECTS
+        : EMPTY_BOARD_OBJECTS,
+    [boardObjectsByBoardId, currentBoardId]
+  );
+
   // Update favicon based on session activity on current board
-  useFaviconStatus(currentBoardId, sessionsByBranch, mapToArray(boardObjectById));
+  useFaviconStatus(currentBoardId, sessionsByBranch, currentBoardObjects);
 
   // Check if event stream is enabled in user preferences (default: true)
   const eventStreamEnabled = user?.preferences?.eventStream?.enabled ?? true;
@@ -917,11 +930,11 @@ export const App: React.FC<AppProps> = ({
   // every BranchCard re-rendering.
   const boardBranches = useMemo(
     () =>
-      mapToArray(boardObjectById)
-        .filter((bo: BoardEntityObject) => bo.board_id === currentBoard?.board_id && bo.branch_id)
+      currentBoardObjects
+        .filter((bo: BoardEntityObject) => bo.branch_id)
         .map((bo: BoardEntityObject) => branchById.get(bo.branch_id!))
         .filter((wt): wt is Branch => wt !== undefined),
-    [boardObjectById, currentBoard?.board_id, branchById]
+    [currentBoardObjects, branchById]
   );
 
   // Check if current user is mentioned in active comments
@@ -1238,6 +1251,7 @@ export const App: React.FC<AppProps> = ({
                             primaryAssistantId={primaryAssistantId}
                             branchById={branchById}
                             boardObjectById={boardObjectById}
+                            boardObjectsByBoardId={boardObjectsByBoardId}
                             commentById={commentById}
                             cardById={cardById}
                             currentUserId={user?.user_id}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -101,6 +101,7 @@ interface SessionCanvasProps {
   primaryAssistantId?: string | null;
   branchById: Map<string, Branch>;
   boardObjectById: Map<string, BoardEntityObject>; // Map-based board object storage
+  boardObjectsByBoardId: Map<string, BoardEntityObject[]>;
   commentById: Map<string, BoardComment>; // Map-based comment storage
   cardById: Map<string, CardWithType>; // Map-based card storage for this board
   currentUserId?: string;
@@ -335,6 +336,10 @@ const nodeTypes = {
   artifactNode: ArtifactNode,
 };
 
+const EMPTY_BOARD_ENTITY_OBJECTS: BoardEntityObject[] = Object.freeze(
+  [] as BoardEntityObject[]
+) as BoardEntityObject[];
+
 const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
   (
     {
@@ -346,7 +351,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       branches,
       primaryAssistantId,
       branchById,
-      boardObjectById,
+      boardObjectsByBoardId,
       commentById,
       cardById,
       userById,
@@ -407,48 +412,32 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // Note: sessionsByBranch is now passed as prop (no longer computed locally)
     // This enables efficient O(1) lookups and stable references across re-renders
 
-    // Stabilize board objects for this board using a JSON key for deep equality
-    // This prevents recomputation when board objects on OTHER boards change
-    // biome-ignore lint/correctness/useExhaustiveDependencies: Using board_id instead of board for targeted memoization
-    const boardObjectsKey = useMemo(() => {
-      if (!board) return '[]';
-      const boardObjectsArray: BoardEntityObject[] = [];
-      for (const boardObject of boardObjectById.values()) {
-        if (boardObject.board_id === board.board_id) {
-          boardObjectsArray.push(boardObject);
-        }
-      }
-      // Sort by object_id for stable JSON key
-      boardObjectsArray.sort((a, b) => a.object_id.localeCompare(b.object_id));
-      // Include full object data (position, zone_id) so changes trigger re-renders
-      return JSON.stringify(boardObjectsArray);
-    }, [board?.board_id, boardObjectById]);
+    const boardId = board?.board_id;
+    const boardObjectsForBoard = useMemo(
+      () =>
+        boardId
+          ? boardObjectsByBoardId.get(boardId) || EMPTY_BOARD_ENTITY_OBJECTS
+          : EMPTY_BOARD_ENTITY_OBJECTS,
+      [boardId, boardObjectsByBoardId]
+    );
 
-    // Index by branch_id for O(1) lookups
-    // biome-ignore lint/correctness/useExhaustiveDependencies: Using JSON key for deep equality of board objects
+    // Board-scoped placement maps: rebuild only when this board's object array
+    // changes. This replaces the old global scan + JSON.stringify stabilizer.
     const boardObjectByBranch = useMemo(() => {
-      if (!board) return new Map<string, BoardEntityObject>();
       const map = new Map<string, BoardEntityObject>();
-      for (const boardObject of boardObjectById.values()) {
-        if (boardObject.board_id === board.board_id && boardObject.branch_id) {
-          map.set(boardObject.branch_id, boardObject);
-        }
+      for (const boardObject of boardObjectsForBoard) {
+        if (boardObject.branch_id) map.set(boardObject.branch_id, boardObject);
       }
       return map;
-    }, [board?.board_id, boardObjectsKey]);
+    }, [boardObjectsForBoard]);
 
-    // Index by card_id for O(1) lookups
-    // biome-ignore lint/correctness/useExhaustiveDependencies: Using JSON key for deep equality of board objects
     const boardObjectByCard = useMemo(() => {
-      if (!board) return new Map<string, BoardEntityObject>();
       const map = new Map<string, BoardEntityObject>();
-      for (const boardObject of boardObjectById.values()) {
-        if (boardObject.board_id === board.board_id && boardObject.card_id) {
-          map.set(boardObject.card_id, boardObject);
-        }
+      for (const boardObject of boardObjectsForBoard) {
+        if (boardObject.card_id) map.set(boardObject.card_id, boardObject);
       }
       return map;
-    }, [board?.board_id, boardObjectsKey]);
+    }, [boardObjectsForBoard]);
 
     // Card modal state
     const [selectedCard, setSelectedCard] = useState<CardWithType | null>(null);
@@ -585,7 +574,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       client,
       sessionsByBranch,
       branches,
-      boardObjectById,
+      boardObjectsForBoard,
       setNodes,
       deletedObjectsRef,
       eraserMode: activeTool === 'eraser',

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -56,6 +56,7 @@ describe('SessionCanvas zoom shortcuts', () => {
         branches={[]}
         branchById={new Map()}
         boardObjectById={new Map()}
+        boardObjectsByBoardId={new Map()}
         commentById={new Map()}
         cardById={new Map()}
       />

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -12,14 +12,13 @@ import type {
 } from '@agor-live/client';
 import { useCallback, useMemo, useRef } from 'react';
 import type { Node } from 'reactflow';
-import { mapToArray } from '@/utils/mapHelpers';
 
 interface UseBoardObjectsProps {
   board: Board | null;
   client: AgorClient | null;
   sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
   branches: Branch[];
-  boardObjectById: Map<string, BoardEntityObject>; // Map-based board object storage
+  boardObjectsForBoard: BoardEntityObject[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   deletedObjectsRef: React.MutableRefObject<Set<string>>;
   eraserMode?: boolean;
@@ -36,7 +35,7 @@ export const useBoardObjects = ({
   client,
   sessionsByBranch,
   branches,
-  boardObjectById,
+  boardObjectsForBoard,
   setNodes,
   deletedObjectsRef,
   eraserMode = false,
@@ -283,7 +282,7 @@ export const useBoardObjects = ({
         let sessionCount = 0;
         if (objectData.type === 'zone') {
           // Count branches pinned to this zone via board_objects.zone_id
-          for (const boardObj of mapToArray(boardObjectById)) {
+          for (const boardObj of boardObjectsForBoard) {
             if (boardObj.zone_id === objectId) {
               // Count sessions in this branch using O(1) Map lookup
               const branchSessions = boardObj.branch_id
@@ -333,7 +332,7 @@ export const useBoardObjects = ({
       });
   }, [
     boardObjects, // Use stabilized boardObjects instead of board?.objects
-    boardObjectById,
+    boardObjectsForBoard,
     sessionsByBranch,
     handleUpdateObject,
     deleteZone,

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -104,6 +104,16 @@ const makeSession = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const makeBoardObject = (overrides: Record<string, unknown> = {}) => ({
+  object_id: 'bo-1',
+  board_id: 'board-1',
+  branch_id: 'b-1',
+  entity_type: 'branch',
+  position: { x: 10, y: 20 },
+  created_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
 /**
  * Wait until the hook has finished its initial fetch AND populated the
  * byId maps. The two flip in separate setState calls — `itemCounts` is
@@ -306,5 +316,98 @@ describe('useAgorData — socket-event bailouts', () => {
     act(() => emit('artifacts', 'patched', { ...artifact }));
 
     expect(result.current.artifactById).toBe(before);
+  });
+
+  it('builds derived board-object indexes during initial load', async () => {
+    const branchObject = makeBoardObject({ object_id: 'bo-branch', branch_id: 'b-1' });
+    const cardObject = makeBoardObject({
+      object_id: 'bo-card',
+      branch_id: undefined,
+      card_id: 'c-1',
+      entity_type: 'card',
+    });
+    const otherBoardObject = makeBoardObject({
+      object_id: 'bo-other',
+      board_id: 'board-2',
+      branch_id: 'b-2',
+    });
+    const { client } = makeMockClient({
+      'board-objects': [branchObject, cardObject, otherBoardObject],
+    });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    expect(result.current.boardObjectById.get('bo-branch')).toMatchObject({ branch_id: 'b-1' });
+    expect(result.current.boardObjectsByBoardId.get('board-1')?.map((bo) => bo.object_id)).toEqual([
+      'bo-branch',
+      'bo-card',
+    ]);
+    expect(result.current.boardObjectsByBoardId.get('board-2')?.map((bo) => bo.object_id)).toEqual([
+      'bo-other',
+    ]);
+    expect(result.current.boardObjectByBranchId.get('b-1')?.object_id).toBe('bo-branch');
+    expect(result.current.boardObjectByCardId.get('c-1')?.object_id).toBe('bo-card');
+  });
+
+  it('keeps board-object derived indexes in sync across patch and remove events', async () => {
+    const boardObject = makeBoardObject({
+      object_id: 'bo-1',
+      board_id: 'board-1',
+      branch_id: 'b-1',
+      zone_id: 'zone-a',
+    });
+    const { client, emit } = makeMockClient({ 'board-objects': [boardObject] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    act(() =>
+      emit('board-objects', 'patched', {
+        ...boardObject,
+        board_id: 'board-2',
+        branch_id: 'b-2',
+        zone_id: 'zone-b',
+      })
+    );
+
+    expect(result.current.boardObjectsByBoardId.has('board-1')).toBe(false);
+    expect(result.current.boardObjectsByBoardId.get('board-2')?.map((bo) => bo.object_id)).toEqual([
+      'bo-1',
+    ]);
+    expect(result.current.boardObjectByBranchId.has('b-1')).toBe(false);
+    expect(result.current.boardObjectByBranchId.get('b-2')?.zone_id).toBe('zone-b');
+
+    act(() => emit('board-objects', 'removed', { ...boardObject, board_id: 'board-2' }));
+
+    expect(result.current.boardObjectById.has('bo-1')).toBe(false);
+    expect(result.current.boardObjectsByBoardId.has('board-2')).toBe(false);
+    expect(result.current.boardObjectByBranchId.has('b-2')).toBe(false);
+  });
+
+  it('keeps unrelated board-object buckets reference-stable on other-board patches', async () => {
+    const currentBoardObject = makeBoardObject({ object_id: 'bo-current', board_id: 'board-1' });
+    const otherBoardObject = makeBoardObject({
+      object_id: 'bo-other',
+      board_id: 'board-2',
+      branch_id: 'b-2',
+    });
+    const { client, emit } = makeMockClient({
+      'board-objects': [currentBoardObject, otherBoardObject],
+    });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    const beforeCurrentBoardBucket = result.current.boardObjectsByBoardId.get('board-1');
+
+    act(() =>
+      emit('board-objects', 'patched', {
+        ...otherBoardObject,
+        zone_id: 'zone-on-other-board',
+      })
+    );
+
+    expect(result.current.boardObjectsByBoardId.get('board-1')).toBe(beforeCurrentBoardBucket);
+    expect(result.current.boardObjectsByBoardId.get('board-2')?.[0]?.zone_id).toBe(
+      'zone-on-other-board'
+    );
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -70,6 +70,14 @@ type DataMaps = {
   sessionsByBranch: Map<string, Session[]>;
   boardById: Map<string, Board>;
   boardObjectById: Map<string, BoardEntityObject>;
+  boardObjectsByBoardId: Map<string, BoardEntityObject[]>;
+  // Global placement lookup. Branch placements are unique because a branch can
+  // only have one board-object row at a time.
+  boardObjectByBranchId: Map<string, BoardEntityObject>;
+  // Global placement lookup. Cards follow the same one-row-per-card service
+  // contract as branches; callers needing board-scoped iteration should use
+  // boardObjectsByBoardId instead.
+  boardObjectByCardId: Map<string, BoardEntityObject>;
   commentById: Map<string, BoardComment>;
   cardById: Map<string, CardWithType>;
   cardTypeById: Map<string, CardType>;
@@ -88,6 +96,9 @@ const EMPTY_MAPS: DataMaps = {
   sessionsByBranch: new Map(),
   boardById: new Map(),
   boardObjectById: new Map(),
+  boardObjectsByBoardId: new Map(),
+  boardObjectByBranchId: new Map(),
+  boardObjectByCardId: new Map(),
   commentById: new Map(),
   cardById: new Map(),
   cardTypeById: new Map(),
@@ -129,6 +140,130 @@ function replaceIfChanged<T extends object>(
   return next;
 }
 
+function removeBoardObjectFromBoardBucket(
+  buckets: Map<string, BoardEntityObject[]>,
+  boardObject: BoardEntityObject
+): Map<string, BoardEntityObject[]> {
+  const bucket = buckets.get(boardObject.board_id);
+  if (!bucket?.some((item) => item.object_id === boardObject.object_id)) return buckets;
+
+  const next = new Map(buckets);
+  const filtered = bucket.filter((item) => item.object_id !== boardObject.object_id);
+  if (filtered.length > 0) next.set(boardObject.board_id, filtered);
+  else next.delete(boardObject.board_id);
+  return next;
+}
+
+function upsertBoardObjectInMaps(
+  prev: DataMaps,
+  boardObject: BoardEntityObject,
+  mode: 'create' | 'patch'
+): DataMaps {
+  const existing = prev.boardObjectById.get(boardObject.object_id);
+  if (mode === 'create' && existing) return prev;
+  if (mode === 'patch' && existing && shallowEqualEntity(existing, boardObject)) return prev;
+
+  const boardObjectById = new Map(prev.boardObjectById);
+  boardObjectById.set(boardObject.object_id, boardObject);
+
+  let boardObjectsByBoardId = prev.boardObjectsByBoardId;
+  if (existing && existing.board_id !== boardObject.board_id) {
+    boardObjectsByBoardId = removeBoardObjectFromBoardBucket(boardObjectsByBoardId, existing);
+  }
+
+  const bucket = boardObjectsByBoardId.get(boardObject.board_id) ?? [];
+  const bucketIndex = bucket.findIndex((item) => item.object_id === boardObject.object_id);
+  if (
+    bucketIndex === -1 ||
+    bucket[bucketIndex] !== boardObject ||
+    !shallowEqualEntity(bucket[bucketIndex], boardObject)
+  ) {
+    const nextBuckets = new Map(boardObjectsByBoardId);
+    if (bucketIndex === -1) {
+      nextBuckets.set(boardObject.board_id, [...bucket, boardObject]);
+    } else {
+      const updatedBucket = [...bucket];
+      updatedBucket[bucketIndex] = boardObject;
+      nextBuckets.set(boardObject.board_id, updatedBucket);
+    }
+    boardObjectsByBoardId = nextBuckets;
+  }
+
+  let boardObjectByBranchId = prev.boardObjectByBranchId;
+  if (existing?.branch_id && existing.branch_id !== boardObject.branch_id) {
+    boardObjectByBranchId = new Map(boardObjectByBranchId);
+    boardObjectByBranchId.delete(existing.branch_id);
+  }
+  if (boardObject.branch_id) {
+    const existingByBranch = boardObjectByBranchId.get(boardObject.branch_id);
+    if (!existingByBranch || !shallowEqualEntity(existingByBranch, boardObject)) {
+      boardObjectByBranchId =
+        boardObjectByBranchId === prev.boardObjectByBranchId
+          ? new Map(boardObjectByBranchId)
+          : boardObjectByBranchId;
+      boardObjectByBranchId.set(boardObject.branch_id, boardObject);
+    }
+  }
+
+  let boardObjectByCardId = prev.boardObjectByCardId;
+  if (existing?.card_id && existing.card_id !== boardObject.card_id) {
+    boardObjectByCardId = new Map(boardObjectByCardId);
+    boardObjectByCardId.delete(existing.card_id);
+  }
+  if (boardObject.card_id) {
+    const existingByCard = boardObjectByCardId.get(boardObject.card_id);
+    if (!existingByCard || !shallowEqualEntity(existingByCard, boardObject)) {
+      boardObjectByCardId =
+        boardObjectByCardId === prev.boardObjectByCardId
+          ? new Map(boardObjectByCardId)
+          : boardObjectByCardId;
+      boardObjectByCardId.set(boardObject.card_id, boardObject);
+    }
+  }
+
+  return {
+    ...prev,
+    boardObjectById,
+    boardObjectsByBoardId,
+    boardObjectByBranchId,
+    boardObjectByCardId,
+  };
+}
+
+function removeBoardObjectFromMaps(prev: DataMaps, boardObject: BoardEntityObject): DataMaps {
+  const existing = prev.boardObjectById.get(boardObject.object_id);
+  if (!existing) return prev;
+
+  const boardObjectById = new Map(prev.boardObjectById);
+  boardObjectById.delete(existing.object_id);
+
+  let boardObjectByBranchId = prev.boardObjectByBranchId;
+  if (
+    existing.branch_id &&
+    boardObjectByBranchId.get(existing.branch_id)?.object_id === existing.object_id
+  ) {
+    boardObjectByBranchId = new Map(boardObjectByBranchId);
+    boardObjectByBranchId.delete(existing.branch_id);
+  }
+
+  let boardObjectByCardId = prev.boardObjectByCardId;
+  if (
+    existing.card_id &&
+    boardObjectByCardId.get(existing.card_id)?.object_id === existing.object_id
+  ) {
+    boardObjectByCardId = new Map(boardObjectByCardId);
+    boardObjectByCardId.delete(existing.card_id);
+  }
+
+  return {
+    ...prev,
+    boardObjectById,
+    boardObjectsByBoardId: removeBoardObjectFromBoardBucket(prev.boardObjectsByBoardId, existing),
+    boardObjectByBranchId,
+    boardObjectByCardId,
+  };
+}
+
 /**
  * Fetch and subscribe to Agor data from daemon
  *
@@ -165,7 +300,6 @@ export function useAgorData(
   const setSessionById = setMapSlice('sessionById');
   const setSessionsByBranch = setMapSlice('sessionsByBranch');
   const setBoardById = setMapSlice('boardById');
-  const setBoardObjectById = setMapSlice('boardObjectById');
   const setCommentById = setMapSlice('commentById');
   const setCardById = setMapSlice('cardById');
   const setCardTypeById = setMapSlice('cardTypeById');
@@ -412,10 +546,27 @@ export function useAgorData(
         for (const board of boardsList) {
           boardsMap.set(board.board_id, board);
         }
-        // Build board object Map for efficient lookups
+        // Build board object Maps for efficient lookups
         const boardObjectsMap = new Map<string, BoardEntityObject>();
+        const boardObjectsByBoardMap = new Map<string, BoardEntityObject[]>();
+        const boardObjectByBranchMap = new Map<string, BoardEntityObject>();
+        const boardObjectByCardMap = new Map<string, BoardEntityObject>();
         for (const boardObject of boardObjectsList) {
           boardObjectsMap.set(boardObject.object_id, boardObject);
+
+          const boardObjectsForBoard = boardObjectsByBoardMap.get(boardObject.board_id);
+          if (boardObjectsForBoard) {
+            boardObjectsForBoard.push(boardObject);
+          } else {
+            boardObjectsByBoardMap.set(boardObject.board_id, [boardObject]);
+          }
+
+          if (boardObject.branch_id) {
+            boardObjectByBranchMap.set(boardObject.branch_id, boardObject);
+          }
+          if (boardObject.card_id) {
+            boardObjectByCardMap.set(boardObject.card_id, boardObject);
+          }
         }
         // Build comment Map for efficient lookups
         const commentsMap = new Map<string, BoardComment>();
@@ -479,6 +630,9 @@ export function useAgorData(
           sessionsByBranch: sessionsByBranchId,
           boardById: boardsMap,
           boardObjectById: boardObjectsMap,
+          boardObjectsByBoardId: boardObjectsByBoardMap,
+          boardObjectByBranchId: boardObjectByBranchMap,
+          boardObjectByCardId: boardObjectByCardMap,
           commentById: commentsMap,
           cardById: cardsMap,
           cardTypeById: cardTypesMap,
@@ -737,23 +891,13 @@ export function useAgorData(
     // Subscribe to board object events
     const boardObjectsService = client.service('board-objects');
     const handleBoardObjectCreated = (boardObject: BoardEntityObject) => {
-      setBoardObjectById((prev) => {
-        if (prev.has(boardObject.object_id)) return prev; // Already exists, shouldn't happen
-        const next = new Map(prev);
-        next.set(boardObject.object_id, boardObject);
-        return next;
-      });
+      setMaps((prev) => upsertBoardObjectInMaps(prev, boardObject, 'create'));
     };
     const handleBoardObjectPatched = (boardObject: BoardEntityObject) => {
-      setBoardObjectById((prev) => replaceIfChanged(prev, boardObject.object_id, boardObject));
+      setMaps((prev) => upsertBoardObjectInMaps(prev, boardObject, 'patch'));
     };
     const handleBoardObjectRemoved = (boardObject: BoardEntityObject) => {
-      setBoardObjectById((prev) => {
-        if (!prev.has(boardObject.object_id)) return prev; // Doesn't exist, nothing to remove
-        const next = new Map(prev);
-        next.delete(boardObject.object_id);
-        return next;
-      });
+      setMaps((prev) => removeBoardObjectFromMaps(prev, boardObject));
     };
 
     boardObjectsService.on('created', handleBoardObjectCreated);

--- a/apps/agor-ui/src/hooks/useFaviconStatus.ts
+++ b/apps/agor-ui/src/hooks/useFaviconStatus.ts
@@ -16,7 +16,7 @@ import { createFaviconWithDot } from '../utils/faviconDot';
 export function useFaviconStatus(
   currentBoardId: string | null,
   sessionsByBranch: Map<string, Session[]>,
-  boardObjects: BoardEntityObject[]
+  boardObjectsForCurrentBoard: BoardEntityObject[]
 ) {
   const [baseFaviconUrl] = useState(`${import.meta.env.BASE_URL}favicon.png`);
   const { token } = theme.useToken();
@@ -33,11 +33,8 @@ export function useFaviconStatus(
       return;
     }
 
-    // Find branches on current board
     const branchesOnBoard = new Set(
-      boardObjects
-        .filter((obj) => obj.board_id === currentBoardId && obj.branch_id)
-        .map((obj) => obj.branch_id!)
+      boardObjectsForCurrentBoard.filter((obj) => obj.branch_id).map((obj) => obj.branch_id!)
     );
 
     // Find sessions for those branches using O(1) Map lookups
@@ -61,5 +58,11 @@ export function useFaviconStatus(
         }
       }
     );
-  }, [currentBoardId, sessionsByBranch, boardObjects, baseFaviconUrl, token.colorSuccessText]);
+  }, [
+    currentBoardId,
+    sessionsByBranch,
+    boardObjectsForCurrentBoard,
+    baseFaviconUrl,
+    token.colorSuccessText,
+  ]);
 }


### PR DESCRIPTION
## Summary

This is the main-targeted recovery PR for #1456, which was accidentally merged into the stacked base branch (`instrument-initial-load-debug-timings`) instead of `main`.

It cherry-picks the already-reviewed board-object client-index optimization onto `main`.

- Add derived board-object indexes to `useAgorData` while preserving the global `boardObjectById` contract.
- Use board-scoped board-object arrays for current-board branch lookup, favicon status, SessionCanvas placement maps, and zone counts.
- Remove SessionCanvas's board-object `JSON.stringify` stabilization in favor of stable board-scoped index references.
- Keep global branch/card lookup indexes with comments documenting their uniqueness assumptions.

## Validation

Previously on #1456:
- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- src/hooks/useAgorData.test.tsx src/components/SessionCanvas/SessionCanvas.zoom.test.tsx`

After cherry-picking onto `main`:
- `pnpm exec biome check apps/agor-ui/src/hooks/useAgorData.ts apps/agor-ui/src/App.tsx apps/agor-ui/src/components/App/App.tsx apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts apps/agor-ui/src/hooks/useFaviconStatus.ts apps/agor-ui/src/hooks/useAgorData.test.tsx apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx`
- `pnpm --filter agor-ui test -- src/hooks/useAgorData.test.tsx src/components/SessionCanvas/SessionCanvas.zoom.test.tsx`
