### PR TITLE
Use bulb icon for Knowledge

### DIFF
--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -10,7 +10,7 @@ import type {
 } from '@agor-live/client';
 import {
   ApiOutlined,
-  BookOutlined,
+  BulbOutlined,
   CommentOutlined,
   QuestionCircleOutlined,
   SettingOutlined,
@@ -315,7 +315,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
         <Tooltip title="Knowledge" placement="bottom">
           <Button
             type="text"
-            icon={<BookOutlined style={{ fontSize: token.fontSizeLG }} />}
+            icon={<BulbOutlined style={{ fontSize: token.fontSizeLG }} />}
             style={headerIconButtonStyle}
             href={knowledgeHref}
             aria-label="Knowledge"

--- a/apps/agor-ui/src/components/HomePage/HomeKnowledgeSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeKnowledgeSection.tsx
@@ -1,5 +1,5 @@
 import type { AgorClient } from '@agor-live/client';
-import { BookOutlined, FileOutlined } from '@ant-design/icons';
+import { BulbOutlined, FileOutlined } from '@ant-design/icons';
 import { Card, Empty, List, Space, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useState } from 'react';
@@ -112,7 +112,7 @@ export const HomeKnowledgeSection: React.FC<{ client: AgorClient | null; connect
     >
       <HomeSectionHeader
         title="Recent Knowledge"
-        icon={<BookOutlined />}
+        icon={<BulbOutlined />}
         info={`Up to ${HOME_KNOWLEDGE_LIMIT} recently updated readable Knowledge documents from kb/documents. Access checks remain server-side through the existing Knowledge service.`}
       />
       <div style={{ overflow: 'auto', minHeight: 0 }}>

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -26,6 +26,7 @@ import type { AgorClient, Group, User } from '@agor-live/client';
 import {
   ApartmentOutlined,
   ArrowLeftOutlined,
+  BulbOutlined,
   DeleteOutlined,
   DownOutlined,
   EditOutlined,
@@ -2865,8 +2866,19 @@ export function KnowledgePage({
               if (await confirmDiscardUnsavedChanges()) navigate('/');
             }}
           />
-          <BrandLogo level={5} />
-          <Text strong style={{ fontSize: 15, cursor: 'pointer' }} onClick={goToGraphHome}>
+          <BrandLogo level={3} style={{ marginTop: -4 }} />
+          <Text
+            strong
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 15,
+              cursor: 'pointer',
+            }}
+            onClick={goToGraphHome}
+          >
+            <BulbOutlined style={{ color: token.colorTextSecondary }} />
             Knowledge
           </Text>
           <Tooltip title="Knowledge is in beta — expect rough edges while the data model, MCP tools, and editor settle.">


### PR DESCRIPTION
## Summary

- Replace Knowledge branding icons with Ant Design `BulbOutlined` in the main header and home Knowledge section.
- Add a subtle bulb icon to the Knowledge page header for consistency.
- Align the Knowledge page `agor` brand sizing with the main navbar.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm -C apps/agor-ui test AppHeader.test.tsx KnowledgePage.routing.test.ts`
