### PR TITLE
Optimize initial session load summaries

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -72,7 +72,7 @@ export interface Repository<T> {
  * Emits events for real-time WebSocket broadcasting.
  */
 // biome-ignore lint/suspicious/noExplicitAny: Generic service adapter needs default any type
-export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> {
+export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params, F = T> {
   id: string;
   paginate?: PaginationOptions;
   multi: boolean | string[];
@@ -190,7 +190,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   /**
    * Apply pagination to data
    */
-  private paginateData(data: T[], query: Query, total: number): Paginated<T> | T[] {
+  private paginateData(data: F[], query: Query, total: number): Paginated<F> | F[] {
     const limit = query.$limit ?? this.paginate?.default ?? data.length;
     const skip = query.$skip ?? 0;
 
@@ -217,7 +217,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   /**
    * Find records
    */
-  async find(params?: P): Promise<Paginated<T> | T[]> {
+  async find(params?: P): Promise<Paginated<F> | F[]> {
     const query = this.getQuery(params);
 
     // Get all data from repository
@@ -236,7 +236,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
     const selected = this.selectFields(data, query.$select);
 
     // Apply pagination
-    return this.paginateData(selected as T[], query, total);
+    return this.paginateData(selected as F[], query, total);
   }
 
   /**

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -21,6 +21,7 @@ import { resolveChildSessionConfig } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
   Branch,
+  InitialSessionSummary,
   MCPServerID,
   Paginated,
   QueryParams,
@@ -80,6 +81,7 @@ export type SessionParams = QueryParams<{
   board_id?: string;
   include_last_message?: boolean | 'true' | 'false'; // Opt-in last message enrichment
   last_message_truncation_length?: number; // Default: 500 chars, min: 50, max: 10000
+  initial_summary?: boolean | 'true' | 'false'; // Slim list projection for initial UI load
 }> &
   AuthenticatedParams &
   InternalEnrichmentParams & {
@@ -102,7 +104,12 @@ export type ExecuteTaskData = {
 /**
  * Extended sessions service with custom methods
  */
-export class SessionsService extends DrizzleService<Session, Partial<Session>, SessionParams> {
+export class SessionsService extends DrizzleService<
+  Session,
+  Partial<Session>,
+  SessionParams,
+  Session | InitialSessionSummary
+> {
   private sessionRepo: SessionRepository;
   private app: Application;
   private sessionMCPRepo: SessionMCPServerRepository;
@@ -732,7 +739,17 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    *
    * Note: Last message is NOT included in list operations - only on single GET
    */
-  async find(params?: SessionParams): Promise<Paginated<Session> | Session[]> {
+  async find(
+    params?: SessionParams
+  ): Promise<Paginated<Session | InitialSessionSummary> | Array<Session | InitialSessionSummary>> {
+    const initialSummary = params?.query?.initial_summary;
+    if (initialSummary === true || initialSummary === 'true') {
+      return this.sessionRepo.findInitialSummaries({
+        archived: typeof params?.query?.archived === 'boolean' ? params.query.archived : undefined,
+        sortUpdatedDesc: params?.query?.$sort?.updated_at === -1,
+      });
+    }
+
     // Use default find to ensure all hooks and scoping are applied
     return super.find(params);
   }

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -644,19 +644,31 @@ export function scopeSessionQuery(
     const userRole = context.params.user?.role as string | undefined;
     const allowSuperadmin = options?.allowSuperadmin ?? true;
 
+    const q = context.params.query as Record<string, unknown> | undefined;
+    const wantsInitialSummary = q?.initial_summary === true || q?.initial_summary === 'true';
+
     // Use optimized repository method (single SQL query with JOINs)
-    const accessibleSessions = isSuperAdmin(userRole, allowSuperadmin)
-      ? await sessionRepo.findAll()
-      : await sessionRepo.findAccessibleSessions(userId);
+    const accessibleSessions = wantsInitialSummary
+      ? isSuperAdmin(userRole, allowSuperadmin)
+        ? await sessionRepo.findInitialSummaries({
+            archived: typeof q?.archived === 'boolean' ? q.archived : undefined,
+            sortUpdatedDesc: (q?.$sort as Record<string, unknown> | undefined)?.updated_at === -1,
+          })
+        : await sessionRepo.findAccessibleInitialSummaries(userId, {
+            archived: typeof q?.archived === 'boolean' ? q.archived : undefined,
+            sortUpdatedDesc: (q?.$sort as Record<string, unknown> | undefined)?.updated_at === -1,
+          })
+      : isSuperAdmin(userRole, allowSuperadmin)
+        ? await sessionRepo.findAll()
+        : await sessionRepo.findAccessibleSessions(userId);
 
     // Apply remaining query filters (branch_id, schedule_id, status, etc.)
     // client-side. Without this pass, `sessions.find({ schedule_id })`
     // silently returns all accessible sessions — which is what the
     // ScheduleRunsPanel was hitting before this fix.
-    context.result = paginateClientSide(
-      accessibleSessions,
-      context.params.query as Record<string, unknown> | undefined
-    );
+    const queryForClientPagination = { ...(q ?? {}) };
+    delete queryForClientPagination.initial_summary;
+    context.result = paginateClientSide(accessibleSessions, queryForClientPagination);
     return context;
   };
 }

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -13,6 +13,7 @@ import type {
   CreateRepoRequest,
   CreateUserInput,
   GatewayChannel,
+  InitialSessionSummary,
   MCPServer,
   PermissionMode,
   Repo,
@@ -91,8 +92,8 @@ export interface AppProps {
   user?: User | null;
   connected?: boolean;
   connecting?: boolean;
-  sessionById: Map<string, Session>; // O(1) lookups by session_id - efficient, stable references
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch-scoped filtering
+  sessionById: Map<string, InitialSessionSummary>; // O(1) lookups by session_id - efficient, stable references
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch-scoped filtering
   availableAgents: AgenticToolOption[];
   boardById: Map<string, Board>; // Map-based board storage
   boardObjectById: Map<string, BoardEntityObject>; // Map-based board object storage
@@ -450,6 +451,9 @@ export const App: React.FC<AppProps> = ({
   const [terminalCommands, setTerminalCommands] = useState<string[]>([]);
   const [terminalBranchId, setTerminalBranchId] = useState<string | undefined>(undefined);
   const [sessionSettingsId, setSessionSettingsId] = useState<string | null>(null);
+  const [sessionSettingsFullSession, setSessionSettingsFullSession] = useState<Session | null>(
+    null
+  );
   const [branchModalBranchId, setBranchModalBranchId] = useState<string | null>(null);
   const [branchModalTab, setBranchModalTab] = useState<BranchModalTab | undefined>(undefined);
   const [logsModalBranchId, setLogsModalBranchId] = useState<string | null>(null);
@@ -858,7 +862,30 @@ export const App: React.FC<AppProps> = ({
     }
   }, [selectedSessionId, sessionById]);
 
-  const sessionSettingsSession = sessionSettingsId ? sessionById.get(sessionSettingsId) : null;
+  const sessionSettingsSession = sessionSettingsId ? sessionSettingsFullSession : null;
+
+  useEffect(() => {
+    if (!client || !sessionSettingsId) {
+      setSessionSettingsFullSession(null);
+      return;
+    }
+
+    let cancelled = false;
+    client
+      .service('sessions')
+      .get(sessionSettingsId)
+      .then((session) => {
+        if (!cancelled) setSessionSettingsFullSession(session as Session);
+      })
+      .catch((error) => {
+        console.warn('Failed to fetch full session for settings:', error);
+        if (!cancelled) setSessionSettingsFullSession(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, sessionSettingsId]);
   const primaryAssistantId = currentBoard?.primary_assistant_id ?? null;
   const primaryAssistantBranch = primaryAssistantId
     ? branchById.get(primaryAssistantId)

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -4,8 +4,8 @@ import type {
   Board,
   BoardID,
   Branch,
+  InitialSessionSummary,
   MCPServer,
-  Session,
   User,
 } from '@agor-live/client';
 import {
@@ -70,7 +70,7 @@ export interface AppHeaderProps {
   /** Live entity maps for the global-search dropdown. Passed through from App.tsx.
    * GlobalSearch calls useAppNavigation directly, so it needs boardById (for
    * slug-aware path building) on top of the entity maps. */
-  sessionById: Map<string, Session>;
+  sessionById: Map<string, InitialSessionSummary>;
   artifactById: Map<string, Artifact>;
   mcpServerById: Map<string, MCPServer>;
 }

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -4,8 +4,8 @@ import type {
   BoardComment,
   BoardObject,
   Branch,
+  InitialSessionSummary,
   Repo,
-  Session,
   SpawnConfig,
   User,
 } from '@agor-live/client';
@@ -43,7 +43,7 @@ interface BoardAssistantPanelProps {
   primaryAssistantBranch?: Branch;
   primaryAssistantRepo?: Repo;
   primaryAssistantInaccessible: boolean;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   branchById: Map<string, Branch>;
   repoById: Map<string, Repo>;
   userById: Map<string, User>;

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -1,4 +1,12 @@
-import type { AgorClient, Branch, Repo, Session, SpawnConfig, User } from '@agor-live/client';
+import type {
+  AgorClient,
+  Branch,
+  InitialSessionSummary,
+  Repo,
+  Session,
+  SpawnConfig,
+  User,
+} from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import {
   BranchesOutlined,
@@ -30,7 +38,7 @@ const PEEK_SESSIONS_STORAGE_KEY_PREFIX = 'agor:branch-card:peeked-session-ids:';
 interface BranchCardProps {
   branch: Branch;
   repo: Repo;
-  sessions: Session[]; // Sessions for this specific branch
+  sessions: InitialSessionSummary[]; // Sessions for this specific branch
   userById: Map<string, User>;
   currentUserId?: string;
   selectedSessionId?: string | null; // Currently open session in drawer
@@ -118,7 +126,9 @@ const BranchCardComponent = ({
   );
   const peekableSessionById = useMemo(
     () =>
-      new Map<string, Session>(peekableSessions.map((session) => [session.session_id, session])),
+      new Map<string, InitialSessionSummary>(
+        peekableSessions.map((session) => [session.session_id, session])
+      ),
     [peekableSessions]
   );
 

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionPeekSection.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionPeekSection.tsx
@@ -1,4 +1,4 @@
-import type { AgorClient, Session, User } from '@agor-live/client';
+import type { AgorClient, InitialSessionSummary, User } from '@agor-live/client';
 import { CloseOutlined } from '@ant-design/icons';
 import { Button, Space, Typography, theme } from 'antd';
 import React from 'react';
@@ -8,7 +8,7 @@ import { SessionLatestTaskPeek } from './SessionLatestTaskPeek';
 
 interface BranchSessionPeekSectionProps {
   client: AgorClient | null;
-  sessions: Session[];
+  sessions: InitialSessionSummary[];
   userById: Map<string, User>;
   currentUserId?: string;
   branchName?: string;

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -1,4 +1,12 @@
-import type { AgorClient, Branch, Session, SessionID, SpawnConfig, User } from '@agor-live/client';
+import type {
+  AgorClient,
+  Branch,
+  InitialSessionSummary,
+  Session,
+  SessionID,
+  SpawnConfig,
+  User,
+} from '@agor-live/client';
 import {
   getGatewaySource as getGatewaySourceCore,
   isGatewaySession as isGatewaySessionCore,
@@ -39,7 +47,11 @@ import {
   sessionToolMatches,
   sortSessions,
 } from '../../utils/sessionSearch';
-import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
+import {
+  getSessionDisplayTitle,
+  getSessionPromptPreview,
+  getSessionTitleStyles,
+} from '../../utils/sessionTitle';
 import { ArchiveActionButton } from '../ArchiveButton';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { HighlightMatch } from '../HighlightMatch';
@@ -57,7 +69,7 @@ export type BranchSessionSectionsMode = 'card' | 'panel';
 
 export interface BranchSessionSectionsProps {
   branch: Branch;
-  sessions: Session[];
+  sessions: InitialSessionSummary[];
   userById: Map<string, User>;
   currentUserId?: string;
   selectedSessionId?: string | null;
@@ -261,11 +273,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   );
 
   const getGatewaySource = useCallback(
-    (session: Session) => getGatewaySourceCore(session) ?? undefined,
+    (session: InitialSessionSummary) => getGatewaySourceCore(session) ?? undefined,
     []
   );
 
-  const isGatewaySession = useCallback((session: Session): boolean => {
+  const isGatewaySession = useCallback((session: InitialSessionSummary): boolean => {
     return isGatewaySessionCore(session);
   }, []);
 
@@ -336,7 +348,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     setExpandedKeys(collectKeysWithChildren(sessionTreeData));
   }, [sessionTreeData]);
 
-  const sessionRowStyle = (session: Session): React.CSSProperties => {
+  const sessionRowStyle = (session: InitialSessionSummary): React.CSSProperties => {
     const isSessionSelected = session.session_id === selectedSessionId;
     return {
       border: session.ready_for_prompt
@@ -357,7 +369,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   };
 
   const renderSessionTitle = (
-    session: Session,
+    session: InitialSessionSummary,
     options: { strong?: boolean; secondary?: boolean; query?: string } = {}
   ) => {
     const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
@@ -378,12 +390,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     );
   };
 
-  const renderFlatSessionRow = (session: Session, query = '') => {
+  const renderFlatSessionRow = (session: InitialSessionSummary, query = '') => {
     const isActive = session.status === 'running' || session.status === 'stopping';
     const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
     const descriptionSnippet =
-      query && session.title && session.description
-        ? getMatchSnippet(session.description, query)
+      query && session.title && getSessionPromptPreview(session)
+        ? getMatchSnippet(getSessionPromptPreview(session)!, query)
         : null;
     const toolMatches = query ? sessionToolMatches(session, query) : false;
     const sourceLabel = session.scheduled_from_branch

--- a/apps/agor-ui/src/components/BranchCard/SessionLatestTaskPeek.tsx
+++ b/apps/agor-ui/src/components/BranchCard/SessionLatestTaskPeek.tsx
@@ -1,4 +1,10 @@
-import type { AgorClient, Message, Session, StreamingMessageState, User } from '@agor-live/client';
+import type {
+  AgorClient,
+  InitialSessionSummary,
+  Message,
+  StreamingMessageState,
+  User,
+} from '@agor-live/client';
 import { TaskStatus } from '@agor-live/client';
 import { Alert, Button, Empty, Input, Spin, theme } from 'antd';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -11,7 +17,7 @@ import { chooseLatestSessionTask } from './latestSessionTask';
 
 interface SessionLatestTaskPeekProps {
   client: AgorClient | null;
-  session: Session;
+  session: InitialSessionSummary;
   userById: Map<string, User>;
   currentUserId?: string;
   branchName?: string;

--- a/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
+++ b/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
@@ -5,14 +5,14 @@
  * Returns Ant Design Tree DataNode format
  */
 
-import type { Session } from '@agor-live/client';
+import type { InitialSessionSummary } from '@agor-live/client';
 import type { DataNode } from 'antd/es/tree';
 
 export type SessionRelationshipType = 'root' | 'spawn' | 'fork';
 
 export interface SessionTreeNode extends DataNode {
   key: string;
-  session: Session;
+  session: InitialSessionSummary;
   relationshipType: SessionRelationshipType;
   children?: SessionTreeNode[];
 }
@@ -22,10 +22,10 @@ export interface SessionTreeNode extends DataNode {
  *
  * Returns array of root sessions (no parent/fork) with their full subtrees in DataNode format
  */
-export function buildSessionTree(sessions: Session[]): SessionTreeNode[] {
-  const sessionMap = new Map<string, Session>();
-  const childrenMap = new Map<string, Session[]>();
-  const roots: Session[] = [];
+export function buildSessionTree(sessions: InitialSessionSummary[]): SessionTreeNode[] {
+  const sessionMap = new Map<string, InitialSessionSummary>();
+  const childrenMap = new Map<string, InitialSessionSummary[]>();
+  const roots: InitialSessionSummary[] = [];
 
   // Build maps
   for (const session of sessions) {
@@ -53,7 +53,7 @@ export function buildSessionTree(sessions: Session[]): SessionTreeNode[] {
   }
 
   // Build tree recursively
-  function buildNode(session: Session, isRoot = false): SessionTreeNode {
+  function buildNode(session: InitialSessionSummary, isRoot = false): SessionTreeNode {
     const children = childrenMap.get(session.session_id) || [];
 
     // Determine relationship type

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -1,4 +1,4 @@
-import type { Board, Branch, Repo, Session } from '@agor-live/client';
+import type { Board, Branch, InitialSessionSummary, Repo, Session } from '@agor-live/client';
 import { SearchOutlined } from '@ant-design/icons';
 import { Badge, Drawer, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
@@ -14,7 +14,7 @@ import {
   sortSessions,
 } from '../../utils/sessionSearch';
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
-import { getSessionDisplayTitle } from '../../utils/sessionTitle';
+import { getSessionDisplayTitle, getSessionPromptPreview } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
 import { HighlightMatch } from '../HighlightMatch';
 import { BranchPill } from '../Pill';
@@ -30,7 +30,7 @@ interface BranchListDrawerProps {
   onBoardChange: (boardId: string) => void;
   branchById: Map<string, Branch>;
   repoById: Map<string, Repo>;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   onSessionClick: (sessionId: string) => void;
 }
 
@@ -39,7 +39,7 @@ export interface BoardSessionListProps {
   currentBoardId: string;
   branchById: Map<string, Branch>;
   repoById: Map<string, Repo>;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   onSessionClick: (sessionId: string) => void;
   onAfterSessionClick?: () => void;
 }
@@ -200,8 +200,8 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
               includeAgentFallback: true,
             });
             const descriptionSnippet =
-              searchActive && session.title && session.description
-                ? getMatchSnippet(session.description, trimmedQuery)
+              searchActive && session.title && getSessionPromptPreview(session)
+                ? getMatchSnippet(getSessionPromptPreview(session)!, trimmedQuery)
                 : null;
             const toolMatches = searchActive && sessionToolMatches(session, trimmedQuery);
 

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -3,9 +3,9 @@ import type {
   Board,
   BoardEntityObject,
   Branch,
+  InitialSessionSummary,
   MCPServer,
   Repo,
-  Session,
   User,
 } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
@@ -38,7 +38,7 @@ export interface BranchModalProps {
   onClose: () => void;
   branch: Branch | null;
   repo: Repo | null;
-  sessions: Session[]; // Used for GeneralTab session count
+  sessions: InitialSessionSummary[]; // Used for GeneralTab session count
   boardById?: Map<string, Board>;
   boardObjects?: BoardEntityObject[];
   mcpServerById?: Map<string, MCPServer>;

--- a/apps/agor-ui/src/components/BranchModal/tabs/GeneralTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/GeneralTab.tsx
@@ -1,4 +1,4 @@
-import type { Board, Branch, MCPServer, Repo, Session } from '@agor-live/client';
+import type { Board, Branch, InitialSessionSummary, MCPServer, Repo } from '@agor-live/client';
 import { isAssistant } from '@agor-live/client';
 import { FolderOutlined, LinkOutlined } from '@ant-design/icons';
 import { Descriptions, Form, Input, Select, Space, Tooltip, Typography } from 'antd';
@@ -18,7 +18,7 @@ const { TextArea } = Input;
 interface GeneralTabProps {
   branch: Branch;
   repo: Repo;
-  sessions: Session[]; // Used to gauge environment risk on Archive/Delete
+  sessions: InitialSessionSummary[]; // Used to gauge environment risk on Archive/Delete
   boards?: Board[];
   mcpServers?: MCPServer[];
   canEdit: boolean;

--- a/apps/agor-ui/src/components/BranchModal/tabs/SessionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/SessionsTab.tsx
@@ -1,4 +1,10 @@
-import type { AgorClient, Branch, Session, SessionID } from '@agor-live/client';
+import type {
+  AgorClient,
+  Branch,
+  InitialSessionSummary,
+  Session,
+  SessionID,
+} from '@agor-live/client';
 import { EyeInvisibleOutlined, EyeOutlined, SearchOutlined } from '@ant-design/icons';
 import { Badge, Input, Space, Switch, Table, Tag, Tooltip, Typography, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -12,10 +18,12 @@ import { ToolIcon } from '../../ToolIcon/ToolIcon';
 
 interface SessionsTabProps {
   branch: Branch;
-  sessions: Session[];
+  sessions: InitialSessionSummary[];
   client: AgorClient | null;
   onSessionClick?: (sessionId: string) => void;
 }
+
+type DisplaySession = InitialSessionSummary | Session;
 
 const SessionsTabInner: React.FC<SessionsTabProps> = ({
   branch,
@@ -27,9 +35,9 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
   const { showSuccess, showError } = useThemedMessage();
   const [searchText, setSearchText] = useState('');
   const [showArchived, setShowArchived] = useState(false);
-  const [activeSessions, setActiveSessions] = useState<Session[]>([]);
+  const [activeSessions, setActiveSessions] = useState<DisplaySession[]>([]);
   const [activeLoading, setActiveLoading] = useState(false);
-  const [archivedSessions, setArchivedSessions] = useState<Session[]>([]);
+  const [archivedSessions, setArchivedSessions] = useState<DisplaySession[]>([]);
   const [archivedLoaded, setArchivedLoaded] = useState(false);
   const [archivedLoading, setArchivedLoading] = useState(false);
   const [archivingIds, setArchivingIds] = useState<Set<string>>(new Set());
@@ -42,14 +50,17 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
   const clientRef = useRef(client);
   clientRef.current = client;
 
-  const upsertSession = useCallback((list: Session[], session: Session): Session[] => {
-    const index = list.findIndex((s) => s.session_id === session.session_id);
-    if (index === -1) return [session, ...list];
-    if (list[index] === session) return list;
-    const next = [...list];
-    next[index] = session;
-    return next;
-  }, []);
+  const upsertSession = useCallback(
+    (list: DisplaySession[], session: DisplaySession): DisplaySession[] => {
+      const index = list.findIndex((s) => s.session_id === session.session_id);
+      if (index === -1) return [session, ...list];
+      if (list[index] === session) return list;
+      const next = [...list];
+      next[index] = session;
+      return next;
+    },
+    []
+  );
 
   const loadActiveSessions = useCallback(async () => {
     const currentClient = clientRef.current;
@@ -214,7 +225,7 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
   const combinedSessions = useMemo(() => {
     if (!showArchived) return activeSessions;
     const seen = new Set<string>();
-    const merged: Session[] = [];
+    const merged: DisplaySession[] = [];
     for (const session of activeSessions) {
       seen.add(session.session_id);
       merged.push(session);
@@ -263,7 +274,7 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
   const activeCount = activeSessions.length;
   const archivedCount = archivedSessions.length;
 
-  const columns: ColumnsType<Session> = [
+  const columns: ColumnsType<DisplaySession> = [
     {
       title: 'Session',
       key: 'title',
@@ -403,7 +414,7 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
         </div>
 
         {/* Sessions table */}
-        <Table<Session>
+        <Table<DisplaySession>
           columns={columns}
           dataSource={filteredSessions}
           rowKey="session_id"

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
@@ -1,4 +1,4 @@
-import type { Session } from '@agor-live/client';
+import type { InitialSessionSummary } from '@agor-live/client';
 import { shortId } from '@agor-live/client';
 import { LinkOutlined, PhoneOutlined } from '@ant-design/icons';
 import { Badge, Space, Typography, theme } from 'antd';
@@ -8,7 +8,7 @@ import { useAppLiveData } from '../../contexts/AppDataContext';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 
 interface CallbackTargetDisplayProps {
-  session: Session;
+  session: InitialSessionSummary;
   /** Called after the user clicks the parent link, so the host modal can close. */
   onNavigate?: () => void;
 }

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
@@ -1,4 +1,4 @@
-import type { Session } from '@agor-live/client';
+import type { InitialSessionSummary } from '@agor-live/client';
 import { shortId } from '@agor-live/client';
 import { PhoneOutlined } from '@ant-design/icons';
 import { Badge, Button, Tooltip, Typography, theme } from 'antd';
@@ -8,7 +8,7 @@ import { useAppLiveData } from '../../contexts/AppDataContext';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 
 interface CallbackToggleButtonProps {
-  session: Session;
+  session: InitialSessionSummary;
 }
 
 /**

--- a/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
+++ b/apps/agor-ui/src/components/EventStreamPanel/EventItem.tsx
@@ -2,7 +2,14 @@
  * EventItem - Display a single socket event with timestamp, type, and data
  */
 
-import type { AgorClient, Branch, Repo, Session, SpawnConfig, User } from '@agor-live/client';
+import type {
+  AgorClient,
+  Branch,
+  InitialSessionSummary,
+  Repo,
+  SpawnConfig,
+  User,
+} from '@agor-live/client';
 import {
   AimOutlined,
   ApiOutlined,
@@ -38,8 +45,8 @@ export interface BranchActions {
 export interface EventItemProps {
   event: SocketEvent;
   branchById: Map<string, Branch>;
-  sessionById: Map<string, Session>;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionById: Map<string, InitialSessionSummary>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   repos: Repo[];
   userById: Map<string, User>;
   currentUserId?: string;

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -8,8 +8,8 @@
 import type {
   AgenticToolName,
   AgorClient,
+  InitialSessionSummary,
   MCPServer,
-  Session,
   SpawnConfig,
   User,
 } from '@agor-live/client';
@@ -17,6 +17,7 @@ import { getDefaultPermissionMode } from '@agor-live/client';
 import { DownOutlined } from '@ant-design/icons';
 import { Checkbox, Collapse, Form, Modal, Radio, Typography } from 'antd';
 import { useCallback, useEffect, useState } from 'react';
+import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { AgentSelectionGrid } from '../AgentSelectionGrid/AgentSelectionGrid';
 import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
@@ -28,7 +29,7 @@ export type ForkSpawnAction = 'fork' | 'spawn';
 export interface ForkSpawnModalProps {
   open: boolean;
   action: ForkSpawnAction;
-  session: Session | null;
+  session: InitialSessionSummary | null;
   currentUser?: User | null;
   mcpServerById?: Map<string, MCPServer>;
   initialPrompt?: string;
@@ -196,7 +197,7 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
       title={
         <div>
           <Typography.Text strong>
-            {actionLabel} Session: {session?.title || session?.description || 'Untitled'}
+            {actionLabel} Session: {session ? getSessionDisplayTitle(session) : 'Untitled'}
           </Typography.Text>
         </div>
       }

--- a/apps/agor-ui/src/components/GlobalSearch/types.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/types.ts
@@ -1,4 +1,4 @@
-import type { Artifact, Board, Branch, MCPServer, Session } from '@agor-live/client';
+import type { Artifact, Board, Branch, InitialSessionSummary, MCPServer } from '@agor-live/client';
 
 export type SearchEntityType = 'session' | 'branch' | 'assistant' | 'artifact' | 'board' | 'mcp';
 
@@ -56,7 +56,7 @@ export const SECTION_LABELS: Record<SearchEntityType, string> = {
 };
 
 export type SearchResultItem =
-  | { type: 'session'; item: Session; parentBranch?: Branch }
+  | { type: 'session'; item: InitialSessionSummary; parentBranch?: Branch }
   | { type: 'branch'; item: Branch }
   | { type: 'assistant'; item: Branch }
   | { type: 'artifact'; item: Artifact; parentBranch?: Branch }
@@ -109,7 +109,7 @@ export const EMPTY_COUNTS: SearchCounts = {
  * hook can all consume the same shape via composition.
  */
 export interface GlobalSearchEntityMaps {
-  sessionById: Map<string, Session>;
+  sessionById: Map<string, InitialSessionSummary>;
   branchById: Map<string, Branch>;
   artifactById: Map<string, Artifact>;
   boardById: Map<string, Board>;

--- a/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
+++ b/apps/agor-ui/src/components/GlobalSearch/useGlobalSearch.ts
@@ -5,6 +5,7 @@ import {
   tokenizeSearchQuery,
 } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getSessionPromptPreview } from '../../utils/sessionTitle';
 import {
   type ChipFilter,
   EMPTY_COUNTS,
@@ -89,7 +90,15 @@ export function useGlobalSearch({
     // Sessions (timestamp field is `last_updated`, not `updated_at`)
     const sessions = Array.from(sessionById.values())
       .filter((s) => !ownedByMe || s.created_by === currentUserId)
-      .filter((s) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.session(s)))
+      .filter((s) =>
+        matchSearchTokens(tokens, [
+          s.title,
+          getSessionPromptPreview(s),
+          s.agentic_tool,
+          s.status,
+          s.session_id,
+        ])
+      )
       .sort(byTimestamp((s) => s.last_updated));
 
     // Branches + Assistants share one registry entry: the field set covers

--- a/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
@@ -1,4 +1,4 @@
-import type { Branch, Session } from '@agor-live/client';
+import type { Branch, InitialSessionSummary } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import {
   BranchesOutlined,
@@ -146,7 +146,7 @@ export const HomeActivitySection: React.FC<
   );
 
   const sessionMessage = useCallback(
-    (session: Session) => {
+    (session: InitialSessionSummary) => {
       const branch = branchById.get(session.branch_id);
       const board = branch?.board_id ? boardById.get(branch.board_id) : undefined;
       const actor = userById.get(session.created_by);

--- a/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
@@ -1,4 +1,4 @@
-import type { Board, Branch, Session } from '@agor-live/client';
+import type { Board, Branch, InitialSessionSummary, Session } from '@agor-live/client';
 import { getAssistantConfig } from '@agor-live/client';
 import {
   ApartmentOutlined,
@@ -29,7 +29,7 @@ const activeStatuses = new Set<Session['status']>([
 interface BoardHomeRow {
   board: Board;
   branches: Branch[];
-  sessions: Session[];
+  sessions: InitialSessionSummary[];
   primaryAssistant?: Branch;
   latest: number;
   visitRank: number;
@@ -47,9 +47,9 @@ const groupBranchesByBoard = (branchById: Map<string, Branch>): Map<string, Bran
 };
 
 const groupVisibleSessionsByBranch = (
-  sessionsByBranch: Map<string, Session[]>
-): Map<string, Session[]> => {
-  const grouped = new Map<string, Session[]>();
+  sessionsByBranch: Map<string, InitialSessionSummary[]>
+): Map<string, InitialSessionSummary[]> => {
+  const grouped = new Map<string, InitialSessionSummary[]>();
   for (const [branchId, sessions] of sessionsByBranch) {
     const visibleSessions = sessions.filter((session) => !session.archived);
     if (visibleSessions.length > 0) grouped.set(branchId, visibleSessions);
@@ -101,7 +101,7 @@ const deriveBoardRows = ({
 const BoardHomeCard: React.FC<{
   board: Board;
   branches: Branch[];
-  sessions: Session[];
+  sessions: InitialSessionSummary[];
   primaryAssistant?: Branch;
   onClick: () => void;
 }> = ({ board, branches, sessions, primaryAssistant, onClick }) => {

--- a/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
@@ -1,4 +1,4 @@
-import type { Board, Branch, Repo, Session } from '@agor-live/client';
+import type { Board, Branch, InitialSessionSummary, Repo, Session } from '@agor-live/client';
 import { UnorderedListOutlined } from '@ant-design/icons';
 import { Badge, Card, Empty, List, Space, Tag, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
@@ -14,7 +14,7 @@ import {
   sortSessions,
 } from '../../utils/sessionSearch';
 import { getSessionStatusTone } from '../../utils/sessionStatus';
-import { getSessionDisplayTitle } from '../../utils/sessionTitle';
+import { getSessionDisplayTitle, getSessionPromptPreview } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
 import { HighlightMatch } from '../HighlightMatch';
 import { BoardPill, BranchPill } from '../Pill';
@@ -35,7 +35,7 @@ const attentionStatuses = new Set<Session['status']>([
 ]);
 
 const HomeSessionRow: React.FC<{
-  session: Session;
+  session: InitialSessionSummary;
   branch?: Branch;
   board?: Board;
   repo?: Repo;
@@ -47,8 +47,8 @@ const HomeSessionRow: React.FC<{
   const title = getSessionDisplayTitle(session, { includeAgentFallback: true });
   const tone = getSessionStatusTone(session.status);
   const descriptionSnippet =
-    searchActive && session.title && session.description
-      ? getMatchSnippet(session.description, searchQuery)
+    searchActive && session.title && getSessionPromptPreview(session)
+      ? getMatchSnippet(getSessionPromptPreview(session)!, searchQuery)
       : null;
   const toolMatches = searchActive && sessionToolMatches(session, searchQuery);
   return (

--- a/apps/agor-ui/src/components/HomePage/types.ts
+++ b/apps/agor-ui/src/components/HomePage/types.ts
@@ -1,5 +1,12 @@
 import type { KnowledgeDocument as CoreKnowledgeDocument } from '@agor/core/types';
-import type { AgorClient, Board, Branch, Repo, Session, User } from '@agor-live/client';
+import type {
+  AgorClient,
+  Board,
+  Branch,
+  InitialSessionSummary,
+  Repo,
+  User,
+} from '@agor-live/client';
 
 export interface HomePageProps {
   client: AgorClient | null;
@@ -8,8 +15,8 @@ export interface HomePageProps {
   recentBoardIds?: string[];
   branchById: Map<string, Branch>;
   repoById: Map<string, Repo>;
-  sessionById: Map<string, Session>;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionById: Map<string, InitialSessionSummary>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   userById: Map<string, User>;
   currentUserId?: string;
   onBoardClick: (boardId: string) => void;

--- a/apps/agor-ui/src/components/Pill/SessionMetadataCard.tsx
+++ b/apps/agor-ui/src/components/Pill/SessionMetadataCard.tsx
@@ -5,7 +5,7 @@
  * Compact, read-only design focused on quick context ("what is this session?")
  */
 
-import type { Branch, Repo, Session, User } from '@agor-live/client';
+import type { Branch, InitialSessionSummary, Repo, User } from '@agor-live/client';
 import { FolderOutlined } from '@ant-design/icons';
 import { Space, Typography, theme } from 'antd';
 import type React from 'react';
@@ -19,7 +19,7 @@ import { ForkPill, PILL_COLORS, RepoPill, SpawnPill, StatusPill } from './Pill';
 const { Text } = Typography;
 
 export interface SessionMetadataCardProps {
-  session: Session;
+  session: InitialSessionSummary;
   branch?: Branch;
   repo?: Repo;
   userById?: Map<string, User>;

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -10,6 +10,7 @@ import type {
   Branch,
   BranchID,
   CardWithType,
+  InitialSessionSummary,
   MCPServer,
   Repo,
   Session,
@@ -93,8 +94,8 @@ import { ZoneTriggerModal } from './canvas/ZoneTriggerModal';
 interface SessionCanvasProps {
   board: Board | null;
   client: AgorClient | null;
-  sessionById: Map<string, Session>; // O(1) ID lookups
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessionById: Map<string, InitialSessionSummary>; // O(1) ID lookups
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch filtering
   userById: Map<string, User>; // Map-based user storage
   repoById: Map<string, Repo>; // Map-based repo storage
   branches: Branch[];
@@ -166,7 +167,7 @@ interface SessionNodeData {
 // `sessionsByBranch.get(id) || []` produces a new `[]` on every render,
 // breaking referential equality and forcing memoized children to re-render
 // on every unrelated socket event.
-const EMPTY_SESSIONS: Session[] = [];
+const EMPTY_SESSIONS: InitialSessionSummary[] = [];
 
 // Custom node component that renders SessionCard (memoized to prevent re-renders on unrelated node changes)
 const SessionNode = React.memo(({ data }: { data: SessionNodeData }) => {
@@ -193,7 +194,7 @@ const SessionNode = React.memo(({ data }: { data: SessionNodeData }) => {
 interface BranchNodeData {
   branch: Branch;
   repo: Repo;
-  sessions: Session[];
+  sessions: InitialSessionSummary[];
   userById: Map<string, User>;
   currentUserId?: string;
   onTaskClick?: (taskId: string) => void;

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -10,9 +10,9 @@ import type {
   AgorClient,
   Branch,
   BranchID,
+  InitialSessionSummary,
   MCPServer,
   PermissionMode,
-  Session,
   User,
   ZoneTrigger,
 } from '@agor-live/client';
@@ -25,7 +25,7 @@ import { DownOutlined } from '@ant-design/icons';
 import { Alert, Collapse, Form, Input, Modal, Radio, Select, Space, Spin, Typography } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import type { AgenticToolOption } from '../../../types';
-import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
+import { getSessionDisplayTitle, getSessionPromptPreview } from '../../../utils/sessionTitle';
 // Async server-side renderer — keeps Handlebars out of the browser bundle so
 // the page doesn't need CSP `script-src 'unsafe-eval'`.
 import { renderTemplate } from '../../../utils/templates';
@@ -39,7 +39,7 @@ interface ZoneTriggerModalProps {
   client: AgorClient | null;
   branchId: BranchID;
   branch: Branch | undefined;
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch filtering
   zoneName: string;
   trigger: ZoneTrigger;
   boardName?: string;
@@ -213,30 +213,46 @@ export const ZoneTriggerModal = ({
       setIsRendering(false);
       return;
     }
-    const selectedSessionForCtx =
-      mode === 'reuse_existing' && selectedSessionId
-        ? branchSessions.find((s) => s.session_id === selectedSessionId)
-        : undefined;
-    const context = buildZoneTriggerContext({
-      branch,
-      board: {
-        name: boardName,
-        description: boardDescription,
-        custom_context: boardCustomContext,
-      },
-      zone: { label: zoneName },
-      session: selectedSessionForCtx
-        ? {
-            description: selectedSessionForCtx.description,
-            custom_context: selectedSessionForCtx.custom_context,
-          }
-        : undefined,
-    });
-
     setIsRendering(true);
-    renderTemplate(client, trigger.template, context, 'raw').then((rendered) => {
+
+    const render = async () => {
+      const selectedSessionForCtx =
+        mode === 'reuse_existing' && selectedSessionId
+          ? branchSessions.find((s) => s.session_id === selectedSessionId)
+          : undefined;
+      const fullSelectedSession =
+        selectedSessionForCtx && client
+          ? await client
+              .service('sessions')
+              .get(selectedSessionForCtx.session_id)
+              .catch(() => selectedSessionForCtx)
+          : undefined;
+      const context = buildZoneTriggerContext({
+        branch,
+        board: {
+          name: boardName,
+          description: boardDescription,
+          custom_context: boardCustomContext,
+        },
+        zone: { label: zoneName },
+        session: fullSelectedSession
+          ? {
+              description: getSessionPromptPreview(fullSelectedSession),
+              custom_context: fullSelectedSession.custom_context,
+            }
+          : undefined,
+      });
+
+      const rendered = await renderTemplate(client, trigger.template, context, 'raw');
       if (!cancelled) {
         setEditableTemplate(rendered);
+        setIsRendering(false);
+      }
+    };
+
+    render().catch(() => {
+      if (!cancelled) {
+        setEditableTemplate(trigger.template);
         setIsRendering(false);
       }
     });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -8,7 +8,7 @@ import type {
   BoardEntityObject,
   BoardObject,
   Branch,
-  Session,
+  InitialSessionSummary,
 } from '@agor-live/client';
 import { useCallback, useMemo, useRef } from 'react';
 import type { Node } from 'reactflow';
@@ -17,7 +17,7 @@ import { mapToArray } from '@/utils/mapHelpers';
 interface UseBoardObjectsProps {
   board: Board | null;
   client: AgorClient | null;
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch filtering
   branches: Branch[];
   boardObjectById: Map<string, BoardEntityObject>; // Map-based board object storage
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;

--- a/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
+++ b/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
@@ -1,4 +1,4 @@
-import type { Session, Task, User } from '@agor-live/client';
+import type { InitialSessionSummary, Task, User } from '@agor-live/client';
 import {
   BranchesOutlined,
   CloseOutlined,
@@ -13,7 +13,11 @@ import {
 import { App, Button, Card, Collapse, Space, Typography } from 'antd';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { parseGitStateSha } from '../../utils/gitState';
-import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
+import {
+  getSessionDisplayTitle,
+  getSessionPromptPreview,
+  getSessionTitleStyles,
+} from '../../utils/sessionTitle';
 import { CreatedByTag } from '../metadata';
 import { Tag } from '../Tag';
 import TaskListItem from '../TaskListItem';
@@ -23,7 +27,7 @@ import { ToolIcon } from '../ToolIcon';
 const SESSION_CARD_MAX_WIDTH = 560;
 
 interface SessionCardProps {
-  session: Session;
+  session: InitialSessionSummary;
   tasks?: Task[]; // Optional snapshot passed by parent
   userById: Map<string, User>;
   currentUserId?: string;
@@ -235,7 +239,7 @@ const SessionCard = ({
       {/* Session metadata */}
       <div className="nodrag">
         {/* Title/Description */}
-        {(session.title || session.description) && (
+        {(session.title || getSessionPromptPreview(session)) && (
           <Typography.Text
             strong
             style={{

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -4,8 +4,8 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  InitialSessionSummary,
   PermissionMode,
-  Session,
   SessionID,
   SpawnConfig,
   Task,
@@ -215,7 +215,7 @@ PromptInput.displayName = 'PromptInput';
 
 export interface SessionPanelProps {
   client: AgorClient | null;
-  session: Session | null;
+  session: InitialSessionSummary | null;
   branch?: Branch | null;
   currentUserId?: string;
   sessionMcpServerIds?: string[];

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -1,4 +1,10 @@
-import type { AgorClient, Branch, Session, SpawnConfig, Task } from '@agor-live/client';
+import type {
+  AgorClient,
+  Branch,
+  InitialSessionSummary,
+  SpawnConfig,
+  Task,
+} from '@agor-live/client';
 import { getAssistantConfig, isAssistant, sessionPath, shortId } from '@agor-live/client';
 import {
   CodeOutlined,
@@ -23,7 +29,7 @@ import { IssuePill, PullRequestPill } from '../Pill';
 
 export interface SessionPanelContentProps {
   client: AgorClient | null;
-  session: Session;
+  session: InitialSessionSummary;
   branch?: Branch | null;
   currentUserId?: string;
   sessionMcpServerIds?: string[];

--- a/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionRunSettingsPopover.tsx
@@ -3,8 +3,8 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  InitialSessionSummary,
   PermissionMode,
-  Session,
 } from '@agor-live/client';
 import { RobotOutlined, SettingOutlined } from '@ant-design/icons';
 import { Popover, Space, Typography, theme } from 'antd';
@@ -17,7 +17,7 @@ import { Tag } from '../Tag';
 
 export interface SessionRunSettingsPopoverProps {
   client: AgorClient | null;
-  session: Session;
+  session: InitialSessionSummary;
   modelLabel?: string;
   modelConfig?: ModelConfig;
   onModelConfigChange: (config: ModelConfig) => void;

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -3,8 +3,8 @@ import type {
   Board,
   Branch,
   CreateRepoRequest,
+  InitialSessionSummary,
   Repo,
-  Session,
   User,
 } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
@@ -40,7 +40,7 @@ interface AssistantsTableProps {
   branchById: Map<string, Branch>;
   repoById: Map<string, Repo>;
   boardById: Map<string, Board>;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   userById: Map<string, User>;
   client: AgorClient | null;
   onArchiveOrDelete?: (

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -6,7 +6,7 @@ import type {
   BranchFsAccessLevel,
   BranchPermissionLevel,
   Group,
-  Session,
+  InitialSessionSummary,
   User,
   UUID,
 } from '@agor-live/client';
@@ -43,7 +43,7 @@ import { JSONEditor, validateJSON } from '../JSONEditor';
 interface BoardsTableProps {
   client: AgorClient | null;
   boardById: Map<string, Board>;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   branchById: Map<string, Branch>;
   onCreate?: (board: Partial<Board>) => void;
   onUpdate?: (boardId: string, updates: Partial<Board>) => void;

--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
@@ -1,4 +1,4 @@
-import type { AgorClient, Board, Branch, Repo, Session } from '@agor-live/client';
+import type { AgorClient, Board, Branch, InitialSessionSummary, Repo } from '@agor-live/client';
 import { isAssistant } from '@agor-live/client';
 import {
   AimOutlined,
@@ -38,7 +38,7 @@ interface BranchesTableProps {
   branchById: Map<string, Branch>;
   repoById: Map<string, Repo>;
   boardById: Map<string, Board>;
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch filtering
   onArchiveOrDelete?: (
     branchId: string,
     options: {

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -11,9 +11,9 @@ import type {
   CreateRepoRequest,
   CreateUserInput,
   GatewayChannel,
+  InitialSessionSummary,
   MCPServer,
   Repo,
-  Session,
   UpdateUserInput,
   User,
 } from '@agor-live/client';
@@ -64,8 +64,8 @@ export interface SettingsModalProps {
   boardObjects: BoardEntityObject[];
   repoById: Map<string, Repo>;
   branchById: Map<string, Branch>;
-  sessionById: Map<string, Session>; // O(1) ID lookups - efficient, stable references
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessionById: Map<string, InitialSessionSummary>; // O(1) ID lookups - efficient, stable references
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch filtering
   userById: Map<string, User>;
   mcpServerById: Map<string, MCPServer>;
   cardById?: Map<string, CardWithType>;
@@ -168,7 +168,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
 }) => {
   const [selectedBranch, setSelectedBranch] = useState<Branch | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null);
-  const [branchSessions, setBranchSessions] = useState<Session[]>([]);
+  const [branchSessions, setBranchSessions] = useState<InitialSessionSummary[]>([]);
   const [branchModalOpen, setBranchModalOpen] = useState(false);
 
   const handleBranchRowClick = (branch: Branch) => {

--- a/apps/agor-ui/src/components/mobile/MobileApp.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileApp.tsx
@@ -3,8 +3,8 @@ import type {
   Board,
   BoardComment,
   Branch,
+  InitialSessionSummary,
   Repo,
-  Session,
   User,
 } from '@agor-live/client';
 import { Drawer, Layout, Typography } from 'antd';
@@ -21,8 +21,8 @@ const { Text } = Typography;
 interface MobileAppProps {
   client: AgorClient | null;
   user?: User | null;
-  sessionById: Map<string, Session>; // O(1) ID lookups
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessionById: Map<string, InitialSessionSummary>; // O(1) ID lookups
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch filtering
   boardById: Map<string, Board>;
   commentById: Map<string, BoardComment>;
   repoById: Map<string, Repo>;

--- a/apps/agor-ui/src/components/mobile/MobileNavTree.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileNavTree.tsx
@@ -1,4 +1,4 @@
-import type { Board, BoardComment, Branch, Session } from '@agor-live/client';
+import type { Board, BoardComment, Branch, InitialSessionSummary } from '@agor-live/client';
 import { CommentOutlined, DownOutlined } from '@ant-design/icons';
 import { Badge, Button, Collapse, Space, Typography, theme } from 'antd';
 import { useNavigate } from 'react-router-dom';
@@ -11,7 +11,7 @@ const { Text } = Typography;
 interface MobileNavTreeProps {
   boardById: Map<string, Board>;
   branchById: Map<string, Branch>;
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // O(1) branch filtering
   commentById: Map<string, BoardComment>;
   onNavigate?: () => void;
 }
@@ -68,7 +68,7 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
   );
 
   // Get session title with mobile-friendly 50-char limit
-  const getSessionTitle = (session: Session): string => {
+  const getSessionTitle = (session: InitialSessionSummary): string => {
     return getSessionDisplayTitle(session, {
       fallbackChars: 50,
       includeIdFallback: true,
@@ -76,7 +76,7 @@ export const MobileNavTree: React.FC<MobileNavTreeProps> = ({
   };
 
   // Get session status icon
-  const getSessionStatusIcon = (session: Session): string => {
+  const getSessionStatusIcon = (session: InitialSessionSummary): string => {
     if (session.status === 'running') return '▶️';
     if (session.status === 'completed') return '✅';
     if (session.status === 'failed') return '❌';

--- a/apps/agor-ui/src/components/mobile/SessionPage.tsx
+++ b/apps/agor-ui/src/components/mobile/SessionPage.tsx
@@ -1,9 +1,9 @@
 import type {
   AgorClient,
   Branch,
+  InitialSessionSummary,
   PermissionMode,
   Repo,
-  Session,
   SessionID,
   User,
 } from '@agor-live/client';
@@ -17,7 +17,7 @@ import { MobilePromptInput } from './MobilePromptInput';
 
 interface SessionPageProps {
   client: AgorClient | null;
-  sessionById: Map<string, Session>; // O(1) ID lookups
+  sessionById: Map<string, InitialSessionSummary>; // O(1) ID lookups
   branchById: Map<string, Branch>;
   repoById: Map<string, Repo>;
   userById: Map<string, User>;

--- a/apps/agor-ui/src/contexts/AppDataContext.tsx
+++ b/apps/agor-ui/src/contexts/AppDataContext.tsx
@@ -1,4 +1,4 @@
-import type { Branch, MCPServer, Repo, Session, User } from '@agor-live/client';
+import type { Branch, InitialSessionSummary, MCPServer, Repo, User } from '@agor-live/client';
 import type React from 'react';
 import { createContext, useContext, useMemo } from 'react';
 
@@ -51,9 +51,9 @@ export interface AppEntityDataContextValue
 
 export interface AppLiveDataContextValue {
   // Sessions and branches — patched on every status flip / activity tick
-  sessionById: Map<string, Session>;
+  sessionById: Map<string, InitialSessionSummary>;
   branchById: Map<string, Branch>;
-  sessionsByBranch: Map<string, Session[]>; // Indexed for quick filtering
+  sessionsByBranch: Map<string, InitialSessionSummary[]>; // Indexed for quick filtering
 }
 
 const AppRepoDataContext = createContext<AppRepoDataContextValue | undefined>(undefined);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -15,6 +15,7 @@ import type {
   CardType,
   CardWithType,
   GatewayChannel,
+  InitialSessionSummary,
   MCPServer,
   Repo,
   Session,
@@ -66,8 +67,8 @@ export type InitialLoadingStage = 'idle' | 'fetching' | 'indexing';
  * `setMaps(EMPTY_MAPS)` in the reset effect covers every field automatically.
  */
 type DataMaps = {
-  sessionById: Map<string, Session>;
-  sessionsByBranch: Map<string, Session[]>;
+  sessionById: Map<string, InitialSessionSummary>;
+  sessionsByBranch: Map<string, InitialSessionSummary[]>;
   boardById: Map<string, Board>;
   boardObjectById: Map<string, BoardEntityObject>;
   commentById: Map<string, BoardComment>;
@@ -280,10 +281,11 @@ export function useAgorData(
             client.service('sessions').findAll({
               query: {
                 archived: false,
+                initial_summary: true,
                 $limit: PAGINATION.DEFAULT_LIMIT,
                 $sort: { updated_at: -1 },
               },
-            })
+            }) as Promise<InitialSessionSummary[]>
           ),
           track(
             'boards',
@@ -392,8 +394,8 @@ export function useAgorData(
         }
 
         // Build session Maps for efficient lookups
-        const sessionsById = new Map<string, Session>();
-        const sessionsByBranchId = new Map<string, Session[]>();
+        const sessionsById = new Map<string, InitialSessionSummary>();
+        const sessionsByBranchId = new Map<string, InitialSessionSummary[]>();
 
         for (const session of sessionsList) {
           // sessionById: O(1) ID lookups

--- a/apps/agor-ui/src/hooks/useAppNavigation.ts
+++ b/apps/agor-ui/src/hooks/useAppNavigation.ts
@@ -24,7 +24,15 @@
  * a flipping identity would defeat the memoization, cascading
  * re-renders on every stream patch.
  */
-import type { Artifact, ArtifactID, Branch, BranchID, Session, SessionID } from '@agor-live/client';
+import type {
+  Artifact,
+  ArtifactID,
+  Branch,
+  BranchID,
+  InitialSessionSummary,
+  Session,
+  SessionID,
+} from '@agor-live/client';
 import { artifactPath, branchPath, sessionPath } from '@agor-live/client';
 import { useCallback, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -48,7 +56,7 @@ interface UseAppNavigationOptions {
    *  only needed for the same-URL recenter fallback (re-click on the
    *  entity that's already focused), which silently no-ops when the
    *  map is empty. */
-  sessionById?: Map<string, Session>;
+  sessionById?: Map<string, InitialSessionSummary>;
   branchById?: Map<string, Branch>;
   artifactById?: Map<string, Artifact>;
 }

--- a/apps/agor-ui/src/hooks/useFaviconStatus.ts
+++ b/apps/agor-ui/src/hooks/useFaviconStatus.ts
@@ -7,7 +7,7 @@
  * - No dots: Nothing active on current board
  */
 
-import type { BoardEntityObject, Session } from '@agor-live/client';
+import type { BoardEntityObject, InitialSessionSummary } from '@agor-live/client';
 import { SessionStatus } from '@agor-live/client';
 import { theme } from 'antd';
 import { useEffect, useState } from 'react';
@@ -15,7 +15,7 @@ import { createFaviconWithDot } from '../utils/faviconDot';
 
 export function useFaviconStatus(
   currentBoardId: string | null,
-  sessionsByBranch: Map<string, Session[]>,
+  sessionsByBranch: Map<string, InitialSessionSummary[]>,
   boardObjects: BoardEntityObject[]
 ) {
   const [baseFaviconUrl] = useState(`${import.meta.env.BASE_URL}favicon.png`);

--- a/apps/agor-ui/src/utils/initialLoadDebug.ts
+++ b/apps/agor-ui/src/utils/initialLoadDebug.ts
@@ -10,6 +10,7 @@ export interface InitialLoadDebugFetchTiming {
   label: string;
   durationMs: number;
   count: number | null;
+  approxBytes?: number;
   status: 'success' | 'error';
   error?: string;
 }
@@ -52,6 +53,18 @@ function roundMs(ms: number): number {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function approxJsonBytes(value: unknown): number | undefined {
+  try {
+    const json = JSON.stringify(value);
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(json).length;
+    }
+    return json.length;
+  } catch {
+    return undefined;
+  }
 }
 
 export function syncInitialLoadDebugFlagFromUrl(win = getWindow()): boolean {
@@ -119,6 +132,7 @@ export function createInitialLoadDebugTimer(items: readonly InitialLoadDebugItem
             label: labels.get(key) ?? key,
             durationMs: roundMs(getNow() - itemStart),
             count: result.length,
+            approxBytes: approxJsonBytes(result),
             status: 'success',
           });
           return result;

--- a/apps/agor-ui/src/utils/sessionSearch.ts
+++ b/apps/agor-ui/src/utils/sessionSearch.ts
@@ -1,10 +1,10 @@
 import {
+  type InitialSessionSummary,
   matchSearchTokens,
-  SEARCHABLE_FIELDS,
   type Session,
   tokenizeSearchQuery,
 } from '@agor-live/client';
-import { getSessionDisplayTitle } from './sessionTitle';
+import { getSessionDisplayTitle, getSessionPromptPreview } from './sessionTitle';
 
 export const SESSION_SORT_STORAGE_KEY = 'agor:session-sort';
 export const SESSION_SEARCH_MIN_QUERY_LENGTH = 2;
@@ -12,7 +12,7 @@ export const SESSION_SEARCH_MIN_QUERY_LENGTH = 2;
 export type SessionSort = 'recent' | 'oldest' | 'alpha';
 
 export interface SearchSessionResult {
-  session: Session;
+  session: InitialSessionSummary;
   score: number;
 }
 
@@ -45,13 +45,18 @@ export function getSearchTerms(query: string, minLength = 1): string[] {
   return uniqueTerms(tokenizeSearchQuery(query).filter((part) => part.length >= minLength));
 }
 
-export function scoreSession(session: Session, query: string, now = Date.now()): number {
+export function scoreSession(
+  session: InitialSessionSummary | Session,
+  query: string,
+  now = Date.now()
+): number {
   const q = normalizeSessionQuery(query);
   if (!q) return 0;
 
   const words = getSearchTerms(q);
-  const displayTitle = (session.title || session.description || '').toLowerCase();
-  const desc = (session.description ?? '').toLowerCase();
+  const promptPreview = getSessionPromptPreview(session) ?? '';
+  const displayTitle = (session.title || promptPreview || '').toLowerCase();
+  const desc = promptPreview.toLowerCase();
   const tool = session.agentic_tool.toLowerCase();
 
   let score = 0;
@@ -108,7 +113,7 @@ export function scoreSession(session: Session, query: string, now = Date.now()):
 }
 
 export function searchSessions(
-  sessions: Session[],
+  sessions: InitialSessionSummary[],
   query: string,
   options: { now?: number } = {}
 ): SearchSessionResult[] {
@@ -117,7 +122,15 @@ export function searchSessions(
   const tokens = tokenizeSearchQuery(q);
 
   return sessions
-    .filter((session) => matchSearchTokens(tokens, SEARCHABLE_FIELDS.session(session)))
+    .filter((session) =>
+      matchSearchTokens(tokens, [
+        session.title,
+        getSessionPromptPreview(session),
+        session.agentic_tool,
+        session.status,
+        session.session_id,
+      ])
+    )
     .map((session) => ({ session, score: scoreSession(session, q, options.now) }))
     .filter(({ score }) => score > 0)
     .sort((a, b) => b.score - a.score || compareByRecent(a.session, b.session));
@@ -127,7 +140,10 @@ export function isSessionSearchActive(query: string): boolean {
   return normalizeSessionQuery(query).length >= SESSION_SEARCH_MIN_QUERY_LENGTH;
 }
 
-export function sessionToolMatches(session: Session, query: string): boolean {
+export function sessionToolMatches(
+  session: InitialSessionSummary | Session,
+  query: string
+): boolean {
   const terms = getSearchTerms(query);
   if (terms.length === 0) return false;
   const tool = session.agentic_tool.toLowerCase();
@@ -161,7 +177,10 @@ export function getMatchSnippet(text: string, query: string, contextLen = 60): s
   return `${prefix}${text.slice(start, end)}${suffix}`;
 }
 
-export function sortSessions(sessions: Session[], sort: SessionSort): Session[] {
+export function sortSessions(
+  sessions: InitialSessionSummary[],
+  sort: SessionSort
+): InitialSessionSummary[] {
   const copy = [...sessions];
 
   switch (sort) {
@@ -174,15 +193,24 @@ export function sortSessions(sessions: Session[], sort: SessionSort): Session[] 
   }
 }
 
-function compareByRecent(a: Session, b: Session): number {
+function compareByRecent(
+  a: InitialSessionSummary | Session,
+  b: InitialSessionSummary | Session
+): number {
   return new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime();
 }
 
-function compareByOldest(a: Session, b: Session): number {
+function compareByOldest(
+  a: InitialSessionSummary | Session,
+  b: InitialSessionSummary | Session
+): number {
   return new Date(a.last_updated).getTime() - new Date(b.last_updated).getTime();
 }
 
-function compareByTitle(a: Session, b: Session): number {
+function compareByTitle(
+  a: InitialSessionSummary | Session,
+  b: InitialSessionSummary | Session
+): number {
   return getSessionDisplayTitle(a, { includeAgentFallback: true }).localeCompare(
     getSessionDisplayTitle(b, { includeAgentFallback: true }),
     undefined,

--- a/apps/agor-ui/src/utils/sessionTitle.ts
+++ b/apps/agor-ui/src/utils/sessionTitle.ts
@@ -5,7 +5,7 @@
  * Uses CSS line-clamp for responsive truncation that adapts to container width.
  */
 
-import type { Session } from '@agor-live/client';
+import type { InitialSessionSummary, Session } from '@agor-live/client';
 import { shortId } from '@agor-live/client';
 import type { CSSProperties } from 'react';
 
@@ -46,8 +46,19 @@ export interface FormatSessionTitleOptions {
  * </Typography.Text>
  * ```
  */
+type SessionTitleLike = Pick<Session, 'title' | 'agentic_tool' | 'session_id'> &
+  Partial<Pick<Session, 'description'>> &
+  Partial<Pick<InitialSessionSummary, 'first_prompt_preview'>>;
+
+export function getSessionPromptPreview(
+  session: Partial<Pick<Session, 'description'>> &
+    Partial<Pick<InitialSessionSummary, 'first_prompt_preview'>>
+): string | undefined {
+  return session.first_prompt_preview ?? session.description;
+}
+
 export function getSessionDisplayTitle(
-  session: Pick<Session, 'title' | 'description' | 'agentic_tool' | 'session_id'>,
+  session: SessionTitleLike,
   options: FormatSessionTitleOptions = {}
 ): string {
   const { fallbackChars = 200, includeAgentFallback = false, includeIdFallback = false } = options;
@@ -57,15 +68,16 @@ export function getSessionDisplayTitle(
     return session.title;
   }
 
-  // 2. Use description (first prompt) - let CSS handle truncation in most cases
-  if (session.description) {
+  // 2. Use first prompt preview / legacy description fallback.
+  const firstPromptPreview = getSessionPromptPreview(session);
+  if (firstPromptPreview) {
     // Only truncate EXTREMELY long descriptions to prevent performance issues
     // CSS line-clamp will handle the visual truncation at 2 lines
-    if (session.description.length > fallbackChars) {
-      return `${session.description.substring(0, fallbackChars)}...`;
+    if (firstPromptPreview.length > fallbackChars) {
+      return `${firstPromptPreview.substring(0, fallbackChars)}...`;
     }
     // Return full description, CSS will clamp to 2 lines at any container width
-    return session.description;
+    return firstPromptPreview;
   }
 
   // 3. Fallback to agentic tool name if enabled

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -260,6 +260,59 @@ describe('SessionRepository.create', () => {
   });
 });
 
+describe('SessionRepository.findInitialSummaries', () => {
+  dbTest(
+    'returns a slim Session-like summary without full tasks/custom context/description',
+    async ({ db }) => {
+      const repo = new SessionRepository(db);
+      const branch = await createTestBranch(db);
+      const taskIds = [generateId(), generateId()];
+      const longDescription = 'x'.repeat(1000);
+
+      const created = await repo.create(
+        createSessionData({
+          branch_id: branch.branch_id,
+          title: '',
+          description: longDescription,
+          tasks: taskIds,
+          custom_context: {
+            huge: 'y'.repeat(1000),
+            slash_commands: ['/test'],
+            skills: ['skill-a'],
+            gateway_source: {
+              channel_id: 'c1',
+              channel_name: 'general',
+              channel_type: 'slack',
+              thread_id: 't1',
+            },
+          },
+        })
+      );
+
+      const summaries = await repo.findInitialSummaries({
+        archived: false,
+        sortUpdatedDesc: true,
+      });
+      const summary = summaries.find((s) => s.session_id === created.session_id);
+
+      expect(summary).toBeDefined();
+      expect(summary?.first_prompt_preview).toHaveLength(320);
+      expect(summary?.title).toMatch(/^x{80}\.\.\.$/);
+      expect(summary?.custom_context).toEqual({
+        slash_commands: ['/test'],
+        skills: ['skill-a'],
+        gateway_source: {
+          channel_id: 'c1',
+          channel_name: 'general',
+          channel_type: 'slack',
+          thread_id: 't1',
+        },
+      });
+      expect(summary?.git_state).toEqual(created.git_state);
+    }
+  );
+});
+
 // ============================================================================
 // FindById (with short ID support)
 // ============================================================================

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -4,14 +4,22 @@
  * Type-safe CRUD operations for sessions with short ID support.
  */
 
-import type { BranchID, Session, SessionID, UUID } from '@agor/core/types';
+import type { BranchID, InitialSessionSummary, Session, SessionID, UUID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { and, desc, eq, inArray, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId, shortId } from '../../lib/ids';
 import { getSessionUrl } from '../../utils/url';
 import type { Database } from '../client';
-import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
+import {
+  deleteFrom,
+  insert,
+  jsonExtract,
+  lockRowForUpdate,
+  select,
+  txAsDb,
+  update,
+} from '../database-wrapper';
 import {
   branches,
   branchOwners,
@@ -38,6 +46,49 @@ export interface SessionWithLastMessage extends Session {
   last_message?: string;
 }
 
+type InitialSessionSummaryRow = {
+  session_id: string;
+  created_at: Date | string | number;
+  updated_at: Date | string | number | null;
+  created_by: string;
+  unix_username: string | null;
+  status: Session['status'];
+  agentic_tool: Session['agentic_tool'];
+  branch_id: string;
+  branch_board_id: string | null;
+  parent_session_id: string | null;
+  forked_from_session_id: string | null;
+  scheduled_run_at: number | null;
+  scheduled_from_branch: boolean | number | null;
+  schedule_id: string | null;
+  ready_for_prompt: boolean | number | null;
+  archived: boolean | number;
+  archived_reason: Session['archived_reason'] | null;
+  agentic_tool_version: unknown;
+  sdk_session_id: unknown;
+  title: unknown;
+  first_prompt_preview: unknown;
+  git_state: unknown;
+  genealogy_children: unknown;
+  fork_point_task_id: unknown;
+  fork_point_message_index: unknown;
+  spawn_point_task_id: unknown;
+  spawn_point_message_index: unknown;
+  contextFiles: unknown;
+  permission_config: unknown;
+  model_config: unknown;
+  callback_config: unknown;
+  fork_origin: unknown;
+  current_context_usage: unknown;
+  context_window_limit: unknown;
+  last_context_update_at: unknown;
+  billing_mode: unknown;
+  gateway_source: unknown;
+  slash_commands: unknown;
+  skills: unknown;
+  scheduled_run: unknown;
+};
+
 /**
  * Patches that only acknowledge UI attention state should not make a session
  * look recently active. Keep this intentionally value-aware: setting
@@ -50,6 +101,52 @@ export interface SessionWithLastMessage extends Session {
 function isSessionTimestampNeutralPatch(updates: Partial<Session>): boolean {
   const keys = Object.keys(updates);
   return keys.length === 1 && keys[0] === 'ready_for_prompt' && updates.ready_for_prompt === false;
+}
+
+function parseJsonValue<T>(value: unknown, fallback: T): T {
+  if (value == null) return fallback;
+  if (typeof value !== 'string') return value as T;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function parseJsonArray<T>(value: unknown): T[] {
+  const parsed = parseJsonValue<unknown>(value, []);
+  return Array.isArray(parsed) ? (parsed as T[]) : [];
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | undefined {
+  const parsed = parseJsonValue<unknown>(value, undefined);
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function deriveTitle(title: unknown, descriptionPreview: unknown): string | undefined {
+  const storedTitle = asString(title);
+  if (storedTitle) return storedTitle;
+
+  const description = asString(descriptionPreview)?.trim();
+  if (!description) return undefined;
+
+  const collapsed = description.replace(/\s+/g, ' ');
+  return collapsed.length > 80 ? `${collapsed.slice(0, 80)}...` : collapsed;
 }
 
 /**
@@ -111,6 +208,152 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       current_context_usage: row.data.current_context_usage,
       context_window_limit: row.data.context_window_limit,
       last_context_update_at: row.data.last_context_update_at,
+    };
+  }
+
+  /**
+   * SQL projection for the initial UI load.
+   *
+   * Avoid selecting sessions.data wholesale: the data blob contains the largest
+   * initial payload fields (full description/first prompt, custom_context,
+   * tasks). Extract only the small JSON paths the board/session-list UI needs.
+   */
+  private initialSummaryColumns() {
+    const description = jsonExtract(this.db, sessions.data, 'description');
+    return {
+      session_id: sessions.session_id,
+      created_at: sessions.created_at,
+      updated_at: sessions.updated_at,
+      created_by: sessions.created_by,
+      unix_username: sessions.unix_username,
+      status: sessions.status,
+      agentic_tool: sessions.agentic_tool,
+      branch_id: sessions.branch_id,
+      branch_board_id: branches.board_id,
+      parent_session_id: sessions.parent_session_id,
+      forked_from_session_id: sessions.forked_from_session_id,
+      scheduled_run_at: sessions.scheduled_run_at,
+      scheduled_from_branch: sessions.scheduled_from_branch,
+      schedule_id: sessions.schedule_id,
+      ready_for_prompt: sessions.ready_for_prompt,
+      archived: sessions.archived,
+      archived_reason: sessions.archived_reason,
+      agentic_tool_version: jsonExtract(this.db, sessions.data, 'agentic_tool_version'),
+      sdk_session_id: jsonExtract(this.db, sessions.data, 'sdk_session_id'),
+      title: jsonExtract(this.db, sessions.data, 'title'),
+      first_prompt_preview: sql<string | null>`substr(${description}, 1, 320)`,
+      git_state: jsonExtract(this.db, sessions.data, 'git_state'),
+      genealogy_children: jsonExtract(this.db, sessions.data, 'genealogy.children'),
+      fork_point_task_id: jsonExtract(this.db, sessions.data, 'genealogy.fork_point_task_id'),
+      fork_point_message_index: jsonExtract(
+        this.db,
+        sessions.data,
+        'genealogy.fork_point_message_index'
+      ),
+      spawn_point_task_id: jsonExtract(this.db, sessions.data, 'genealogy.spawn_point_task_id'),
+      spawn_point_message_index: jsonExtract(
+        this.db,
+        sessions.data,
+        'genealogy.spawn_point_message_index'
+      ),
+      contextFiles: jsonExtract(this.db, sessions.data, 'contextFiles'),
+      permission_config: jsonExtract(this.db, sessions.data, 'permission_config'),
+      model_config: jsonExtract(this.db, sessions.data, 'model_config'),
+      callback_config: jsonExtract(this.db, sessions.data, 'callback_config'),
+      fork_origin: jsonExtract(this.db, sessions.data, 'fork_origin'),
+      current_context_usage: jsonExtract(this.db, sessions.data, 'current_context_usage'),
+      context_window_limit: jsonExtract(this.db, sessions.data, 'context_window_limit'),
+      last_context_update_at: jsonExtract(this.db, sessions.data, 'last_context_update_at'),
+      billing_mode: jsonExtract(this.db, sessions.data, 'billing_mode'),
+      gateway_source: jsonExtract(this.db, sessions.data, 'custom_context.gateway_source'),
+      slash_commands: jsonExtract(this.db, sessions.data, 'custom_context.slash_commands'),
+      skills: jsonExtract(this.db, sessions.data, 'custom_context.skills'),
+      scheduled_run: jsonExtract(this.db, sessions.data, 'custom_context.scheduled_run'),
+    };
+  }
+
+  private rowToInitialSummary(
+    row: InitialSessionSummaryRow,
+    baseUrl?: string
+  ): InitialSessionSummary {
+    const sessionId = row.session_id as SessionID;
+    const boardId = (row.branch_board_id ?? null) as UUID | null;
+    const firstPromptPreview = asString(row.first_prompt_preview);
+
+    const customContext: NonNullable<InitialSessionSummary['custom_context']> = {};
+    const gatewaySource = parseJsonObject(row.gateway_source);
+    const slashCommands = parseJsonArray<unknown>(row.slash_commands);
+    const skills = parseJsonArray<unknown>(row.skills);
+    const scheduledRun = parseJsonObject(row.scheduled_run);
+    if (gatewaySource) customContext.gateway_source = gatewaySource;
+    if (slashCommands.length > 0) customContext.slash_commands = slashCommands;
+    if (skills.length > 0) customContext.skills = skills;
+    if (scheduledRun) {
+      customContext.scheduled_run = scheduledRun as unknown as NonNullable<
+        Session['custom_context']
+      >['scheduled_run'];
+    }
+
+    return {
+      session_id: sessionId,
+      status: row.status,
+      agentic_tool: row.agentic_tool,
+      agentic_tool_version: asString(row.agentic_tool_version),
+      sdk_session_id: asString(row.sdk_session_id),
+      created_at: new Date(row.created_at).toISOString(),
+      last_updated: row.updated_at
+        ? new Date(row.updated_at).toISOString()
+        : new Date(row.created_at).toISOString(),
+      created_by: row.created_by,
+      unix_username: row.unix_username || null,
+      branch_id: row.branch_id as UUID,
+      branch_board_id: boardId,
+      url: baseUrl && boardId ? getSessionUrl(sessionId, baseUrl) : null,
+      git_state: parseJsonValue<Session['git_state']>(row.git_state, {
+        ref: 'main',
+        base_sha: '',
+        current_sha: '',
+      }),
+      contextFiles: parseJsonValue<Session['contextFiles']>(row.contextFiles, []),
+      genealogy: {
+        parent_session_id: (row.parent_session_id as UUID | null) ?? undefined,
+        forked_from_session_id: (row.forked_from_session_id as UUID | null) ?? undefined,
+        fork_point_task_id: asString(row.fork_point_task_id) as UUID | undefined,
+        fork_point_message_index: asNumber(row.fork_point_message_index),
+        spawn_point_task_id: asString(row.spawn_point_task_id) as UUID | undefined,
+        spawn_point_message_index: asNumber(row.spawn_point_message_index),
+        children: parseJsonValue<string[]>(row.genealogy_children, []).map((id) => id as UUID),
+      },
+      title: deriveTitle(row.title, firstPromptPreview),
+      first_prompt_preview: firstPromptPreview,
+      permission_config: parseJsonValue<Session['permission_config'] | undefined>(
+        row.permission_config,
+        undefined
+      ),
+      model_config: parseJsonValue<Session['model_config'] | undefined>(
+        row.model_config,
+        undefined
+      ),
+      callback_config: parseJsonValue<Session['callback_config'] | undefined>(
+        row.callback_config,
+        undefined
+      ),
+      fork_origin: asString(row.fork_origin) === 'btw' ? 'btw' : undefined,
+      custom_context: Object.keys(customContext).length > 0 ? customContext : undefined,
+      current_context_usage: asNumber(row.current_context_usage),
+      context_window_limit: asNumber(row.context_window_limit),
+      last_context_update_at: asString(row.last_context_update_at),
+      billing_mode: ['subscription', 'api-key', 'unknown'].includes(
+        asString(row.billing_mode) ?? ''
+      )
+        ? (row.billing_mode as InitialSessionSummary['billing_mode'])
+        : undefined,
+      scheduled_run_at: row.scheduled_run_at ?? undefined,
+      scheduled_from_branch: Boolean(row.scheduled_from_branch),
+      schedule_id: (row.schedule_id as UUID | null) ?? undefined,
+      ready_for_prompt: Boolean(row.ready_for_prompt),
+      archived: Boolean(row.archived),
+      archived_reason: row.archived_reason ?? undefined,
     };
   }
 
@@ -316,6 +559,85 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
     } catch (error) {
       throw new RepositoryError(
         `Failed to find all sessions: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Find lightweight session summaries for initial UI loads.
+   *
+   * This path filters archived rows in SQL and projects only needed columns /
+   * JSON paths instead of hydrating the full Session data blob.
+   */
+  async findInitialSummaries(options?: {
+    archived?: boolean;
+    sortUpdatedDesc?: boolean;
+  }): Promise<InitialSessionSummary[]> {
+    try {
+      const baseUrl = await getBaseUrl();
+      const conditions = [];
+      if (typeof options?.archived === 'boolean') {
+        conditions.push(eq(sessions.archived, options.archived));
+      }
+
+      const query = select(this.db, this.initialSummaryColumns())
+        .from(sessions)
+        .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
+        .where(conditions.length > 0 ? and(...conditions) : sql`true`)
+        .orderBy(options?.sortUpdatedDesc ? desc(sessions.updated_at) : sql`1`);
+
+      const results = await query.all();
+      return (results as InitialSessionSummaryRow[]).map((row) =>
+        this.rowToInitialSummary(row, baseUrl)
+      );
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find initial session summaries: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Find lightweight session summaries scoped to branches visible to a user.
+   *
+   * Mirrors findAccessibleSessions' set-based RBAC logic but keeps the initial
+   * load projection slim.
+   */
+  async findAccessibleInitialSummaries(
+    userId: UUID,
+    options?: { archived?: boolean; sortUpdatedDesc?: boolean }
+  ): Promise<InitialSessionSummary[]> {
+    try {
+      const baseUrl = await getBaseUrl();
+      const conditions = [visibleBranchAccessCondition(this.db, userId)];
+      if (typeof options?.archived === 'boolean') {
+        conditions.push(eq(sessions.archived, options.archived));
+      }
+
+      const results = await select(this.db, this.initialSummaryColumns())
+        .from(sessions)
+        .innerJoin(branches, eq(sessions.branch_id, branches.branch_id))
+        .leftJoin(
+          branchOwners,
+          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+        )
+        .where(and(...conditions))
+        .orderBy(options?.sortUpdatedDesc ? desc(sessions.updated_at) : sql`1`)
+        .all();
+
+      const seen = new Set<string>();
+      const sessionsOut: InitialSessionSummary[] = [];
+      for (const row of results as InitialSessionSummaryRow[]) {
+        if (seen.has(row.session_id)) continue;
+        seen.add(row.session_id);
+        sessionsOut.push(this.rowToInitialSummary(row, baseUrl));
+      }
+      return sessionsOut;
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find accessible initial session summaries: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -111,6 +111,7 @@ export const sessionQuerySchema = createQuerySchema(
     schedule_id: Type.Optional(CommonSchemas.uuid),
     created_by: Type.Optional(CommonSchemas.uuid),
     archived: Type.Optional(CommonSchemas.boolean),
+    initial_summary: Type.Optional(CommonSchemas.boolean),
     created_at: Type.Optional(CommonSchemas.timestamp),
     updated_at: Type.Optional(CommonSchemas.timestamp),
   })

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -480,6 +480,34 @@ export interface Session {
 }
 
 /**
+ * Lightweight session shape used by initial UI workspace loads.
+ *
+ * The full Session row can carry large, rarely-needed fields in the JSON data
+ * blob (notably tasks, full description, and arbitrary custom_context). Initial
+ * load should only ship data needed to render boards, session lists, search
+ * previews, relationship trees, and prompt controls. Consumers that need the
+ * full editable session payload should fetch the session by id.
+ */
+export type InitialSessionSummary = Omit<Session, 'tasks' | 'description' | 'custom_context'> & {
+  /**
+   * Short preview of the legacy `description` field, which usually stores the
+   * first prompt rather than a user-authored description. Full `description`
+   * remains available from the full Session GET path.
+   */
+  first_prompt_preview?: string;
+  /**
+   * Small allowlist of custom_context keys needed during normal workspace
+   * rendering. Full custom_context is deferred to session detail/settings GETs.
+   */
+  custom_context?: Partial<
+    Pick<
+      NonNullable<Session['custom_context']>,
+      'gateway_source' | 'slash_commands' | 'skills' | 'scheduled_run'
+    >
+  >;
+};
+
+/**
  * Gateway source metadata denormalized into session.custom_context.gateway_source
  *
  * Present on sessions created via messaging platform integrations (Slack, Discord, GitHub).


### PR DESCRIPTION
## Summary

- add an `initial_summary` sessions query path backed by selected SQL columns instead of full session rows
- type the UI initial session store as `InitialSessionSummary`, omitting large/deferred fields like `tasks`, full `description`, and full `custom_context`
- expose a capped `first_prompt_preview` for initial-load display/search and fetch full session data on demand for settings/template flows
- add initial-load byte instrumentation for `?debugLoad=1`

## Notes

- The DB column remains `description` for compatibility, but initial-load consumers now use the derived `first_prompt_preview` field.
- `tasks` is intentionally omitted from the initial summary type rather than filled with `[]`, so accidental full-session assumptions are caught by TypeScript.
- `genealogy` and `git_state` remain in the summary because the tree/fork/SHA UI still depends on them.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- sessions.test.ts --run`
- `pnpm --filter agor-ui test -- useAgorData.test.tsx --run`
