### PR TITLE
Add image thumbnail previews to upload modal and fix upload CORS

### DIFF
--- a/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
+++ b/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
@@ -2,7 +2,7 @@ import { PaperClipOutlined, UploadOutlined } from '@ant-design/icons';
 import { Button, Checkbox, Input, Modal, Radio, Space, Typography, Upload } from 'antd';
 import type { RcFile, UploadFile } from 'antd/es/upload/interface';
 import type React from 'react';
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { useThemedMessage } from '../../utils/message';
 import { ACCESS_TOKEN_KEY } from '../../utils/tokenRefresh';
 
@@ -44,18 +44,46 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   const [agentMessage, setAgentMessage] = useState('Please review this file: {filepath}');
   const [uploading, setUploading] = useState(false);
 
+  // Mirror fileList in a ref so cleanup (unmount/reset) can revoke object URLs
+  // without re-running effects on every keystroke.
+  const fileListRef = useRef<UploadFile[]>([]);
+  fileListRef.current = fileList;
+
+  // Build an UploadFile, generating a local thumbnail URL for images so Ant
+  // Design's picture list can render a preview without any server round-trip.
+  const buildUploadFile = useCallback((file: File): UploadFile => {
+    const rc = file as RcFile; // Ant Design's extended File type
+    const isImage = file.type.startsWith('image/');
+    return {
+      uid: rc.uid || `${Date.now()}-${file.name}`,
+      name: file.name,
+      status: 'done',
+      originFileObj: rc,
+      thumbUrl: isImage ? URL.createObjectURL(file) : undefined,
+    };
+  }, []);
+
+  const revokeThumb = useCallback((file: UploadFile) => {
+    if (file.thumbUrl?.startsWith('blob:')) {
+      URL.revokeObjectURL(file.thumbUrl);
+    }
+  }, []);
+
+  const resetFileList = useCallback(() => {
+    fileListRef.current.forEach(revokeThumb);
+    setFileList([]);
+  }, [revokeThumb]);
+
+  // Revoke any outstanding object URLs when the modal unmounts.
+  useEffect(() => () => fileListRef.current.forEach(revokeThumb), [revokeThumb]);
+
   // Populate fileList when initialFiles are provided (replaces existing list to prevent duplicates)
   useEffect(() => {
     if (initialFiles && initialFiles.length > 0 && open) {
-      const uploadFiles: UploadFile[] = initialFiles.map((file) => ({
-        uid: `${Date.now()}-${file.name}`,
-        name: file.name,
-        status: 'done',
-        originFileObj: file as RcFile, // Cast File to RcFile (Ant Design's extended File type)
-      }));
-      setFileList(uploadFiles); // Replace instead of append to prevent duplicate accumulation
+      fileListRef.current.forEach(revokeThumb);
+      setFileList(initialFiles.map(buildUploadFile)); // Replace to prevent duplicate accumulation
     }
-  }, [initialFiles, open]);
+  }, [initialFiles, open, buildUploadFile, revokeThumb]);
 
   const handleUpload = async () => {
     if (fileList.length === 0) {
@@ -96,7 +124,10 @@ export const FileUpload: React.FC<FileUploadProps> = ({
         method: 'POST',
         headers,
         body: formData,
-        credentials: 'include', // Include cookies for session
+        // No `credentials: 'include'` — the upload endpoint is Bearer-only
+        // (cookie auth was removed to avoid CSRF). Sending credentials would
+        // also force a non-wildcard Access-Control-Allow-Origin, which the
+        // daemon's CORS layer answers with '*', breaking the preflight.
       });
 
       if (!response.ok) {
@@ -134,7 +165,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
       }
 
       // Reset and close
-      setFileList([]);
+      resetFileList();
       setNotifyAgent(false);
       setAgentMessage('Please review this file: {filepath}');
       onClose();
@@ -147,7 +178,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   };
 
   const handleCancel = () => {
-    setFileList([]);
+    resetFileList();
     setNotifyAgent(false);
     setAgentMessage('Please review this file: {filepath}');
     onClose();
@@ -168,19 +199,14 @@ export const FileUpload: React.FC<FileUploadProps> = ({
         {/* File selector */}
         <Upload
           multiple
+          listType="picture"
           fileList={fileList}
           beforeUpload={(file) => {
-            // Create UploadFile object with originFileObj preserved
-            const uploadFile: UploadFile = {
-              uid: file.uid || `${Date.now()}-${file.name}`,
-              name: file.name,
-              status: 'done',
-              originFileObj: file,
-            };
-            setFileList((prev) => [...prev, uploadFile]);
+            setFileList((prev) => [...prev, buildUploadFile(file)]);
             return false; // Prevent auto upload
           }}
           onRemove={(file) => {
+            revokeThumb(file);
             setFileList((prev) => prev.filter((f) => f.uid !== file.uid));
           }}
         >


### PR DESCRIPTION
## Summary
- Render staged **image** files as thumbnails in the file-upload modal (Ant Design `listType="picture"` + client-side `URL.createObjectURL`), so you can preview an image before sending it alongside your prompt. No server round-trip; non-image files keep the default file icon.
- Revoke the generated object URLs on remove, reset, and unmount to avoid blob-URL leaks.
- Drop `credentials: 'include'` from the upload `fetch`. The upload endpoint is **Bearer-token only** (cookie auth was intentionally removed to avoid CSRF), and sending credentials forced the browser to reject the daemon's wildcard `Access-Control-Allow-Origin` on the preflight — breaking uploads in wildcard-CORS (dev/local) environments.

Before
<img width="1198" height="996" alt="Screen Shot 2026-06-16 at 16 57 37 PM" src="https://github.com/user-attachments/assets/cc81e205-eaaa-4914-8bf3-35cae1dd0c15" />

Now
<img width="1192" height="936" alt="Screen Shot 2026-06-16 at 16 57 59 PM" src="https://github.com/user-attachments/assets/238f376c-c198-4cee-8984-4fccb2b222ee" />

## Test plan
- [ ] Drop/paste or select an **image** in the prompt box → modal shows a thumbnail preview.
- [ ] Select a non-image (PDF/CSV) → shows default file icon, no errors.
- [ ] Remove a staged image / cancel / re-open the modal → no console errors, no leaked blob URLs.
- [ ] Upload a file in a wildcard-CORS dev env → no CORS preflight error, upload succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)