### PR TITLE
fix: update broken docs.agor.live link to agor.live in Gateway Channels

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -1688,7 +1688,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             platforms grants anyone who can message your bot potential access to Agor sessions and
             the underlying branch environment.{' '}
             <Typography.Link
-              href="https://docs.agor.live/guide/message-gateway"
+              href="https://agor.live/guide/message-gateway"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Summary
- The `docs.agor.live` subdomain is no longer active, causing a broken link in the Settings modal under Gateway Channels
- Updated the message gateway documentation link from `https://docs.agor.live/guide/message-gateway` to `https://agor.live/guide/message-gateway` (confirmed 200 OK)

## Test plan
- [ ] Open Settings → Gateway Channels
- [ ] Confirm the "Read the full security guidance" link navigates correctly to `https://agor.live/guide/message-gateway`

🤖 Generated with [Claude Code](https://claude.com/claude-code)