### PR TITLE
Fix gateway session MCP defaults

### DIFF
--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1,0 +1,88 @@
+import type { Branch, GatewayChannel, User } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { resolveGatewaySessionDefaults } from './gateway';
+
+function makeChannel(overrides: Partial<GatewayChannel> = {}): GatewayChannel {
+  return {
+    id: 'channel-1',
+    created_by: 'user-1',
+    name: 'Slack Gateway',
+    channel_type: 'slack',
+    target_branch_id: 'branch-1',
+    agor_user_id: 'user-1',
+    channel_key: 'secret',
+    config: {},
+    agentic_config: { agent: 'claude-code' },
+    enabled: true,
+    created_at: '2026-06-16T00:00:00.000Z',
+    updated_at: '2026-06-16T00:00:00.000Z',
+    last_message_at: null,
+    ...overrides,
+  } as GatewayChannel;
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    user_id: 'user-1',
+    email: 'user@example.com',
+    name: 'User',
+    role: 'member',
+    default_agentic_config: {
+      'claude-code': { mcpServerIds: ['user-mcp'] },
+    },
+    created_at: '2026-06-16T00:00:00.000Z',
+    updated_at: '2026-06-16T00:00:00.000Z',
+    ...overrides,
+  } as User;
+}
+
+function makeBranch(overrides: Partial<Branch> = {}): Pick<Branch, 'mcp_server_ids'> {
+  return {
+    mcp_server_ids: ['branch-mcp'],
+    ...overrides,
+  } as Pick<Branch, 'mcp_server_ids'>;
+}
+
+describe('resolveGatewaySessionDefaults', () => {
+  it('inherits BranchModal default MCP servers when the gateway channel has no MCP override', () => {
+    const resolved = resolveGatewaySessionDefaults({
+      channel: makeChannel({ agentic_config: { agent: 'claude-code' } }),
+      user: makeUser(),
+      branch: makeBranch({ mcp_server_ids: ['branch-mcp-1', 'branch-mcp-2'] }),
+    });
+
+    expect(resolved.mcpServerIds).toEqual(['branch-mcp-1', 'branch-mcp-2']);
+  });
+
+  it('treats an empty gateway MCP array as form-default/no override when branch MCP defaults exist', () => {
+    const resolved = resolveGatewaySessionDefaults({
+      channel: makeChannel({ agentic_config: { agent: 'claude-code', mcpServerIds: [] } }),
+      user: makeUser(),
+      branch: makeBranch({ mcp_server_ids: ['branch-mcp'] }),
+    });
+
+    expect(resolved.mcpServerIds).toEqual(['branch-mcp']);
+  });
+
+  it('preserves non-empty gateway MCP selections as explicit channel overrides', () => {
+    const resolved = resolveGatewaySessionDefaults({
+      channel: makeChannel({
+        agentic_config: { agent: 'claude-code', mcpServerIds: ['gateway-mcp'] },
+      }),
+      user: makeUser(),
+      branch: makeBranch({ mcp_server_ids: ['branch-mcp'] }),
+    });
+
+    expect(resolved.mcpServerIds).toEqual(['gateway-mcp']);
+  });
+
+  it('lets an empty gateway MCP array suppress user defaults when the branch has no MCP defaults', () => {
+    const resolved = resolveGatewaySessionDefaults({
+      channel: makeChannel({ agentic_config: { agent: 'claude-code', mcpServerIds: [] } }),
+      user: makeUser(),
+      branch: makeBranch({ mcp_server_ids: [] }),
+    });
+
+    expect(resolved.mcpServerIds).toEqual([]);
+  });
+});

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  BranchRepository,
   type Database,
   GatewayChannelRepository,
   MCPServerRepository,
@@ -28,6 +29,7 @@ import {
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   AgenticToolName,
+  Branch,
   ChannelType,
   GatewayChannel,
   MCPServerID,
@@ -211,6 +213,60 @@ function buildGatewayContext(channel: GatewayChannel, data: PostMessageData): Ga
   }
 }
 
+export interface ResolvedGatewaySessionDefaults {
+  agenticTool: AgenticToolName;
+  permissionConfig: NonNullable<Session['permission_config']>;
+  modelConfig?: NonNullable<Session['model_config']>;
+  mcpServerIds: string[];
+}
+
+/**
+ * Resolve the session config for a new gateway-created session.
+ *
+ * Gateway channel forms historically persisted `mcpServerIds: []` as the
+ * default empty form value. Treat that as "no channel-level MCP override" when
+ * the target branch has defaults configured, otherwise Slack/GitHub sessions
+ * bypass the BranchModal → General "Default MCP servers" setting. Non-empty
+ * gateway MCP selections remain explicit channel overrides; an empty selection
+ * still suppresses user-level defaults when the branch has no MCP defaults.
+ */
+export function resolveGatewaySessionDefaults(args: {
+  channel: GatewayChannel;
+  user: Pick<User, 'default_agentic_config'>;
+  branch?: Pick<Branch, 'mcp_server_ids'> | null;
+}): ResolvedGatewaySessionDefaults {
+  const { channel, user, branch } = args;
+  const agenticConfig = channel.agentic_config;
+  const agenticTool: AgenticToolName = (agenticConfig?.agent as AgenticToolName) ?? 'claude-code';
+
+  const channelMcpServerIds = agenticConfig?.mcpServerIds;
+  const branchHasMcpDefaults = !!branch?.mcp_server_ids?.length;
+  const mcpServerIdsOverride =
+    channelMcpServerIds !== undefined && (channelMcpServerIds.length > 0 || !branchHasMcpDefaults)
+      ? channelMcpServerIds
+      : undefined;
+
+  const {
+    permission_config: permissionConfig,
+    model_config: modelConfig,
+    mcp_server_ids: mcpServerIds,
+  } = resolveSessionDefaults({
+    agenticTool,
+    user,
+    branch,
+    overrides: {
+      permissionMode: agenticConfig?.permissionMode,
+      modelConfig: agenticConfig?.modelConfig,
+      codexSandboxMode: agenticConfig?.codexSandboxMode,
+      codexApprovalPolicy: agenticConfig?.codexApprovalPolicy,
+      codexNetworkAccess: agenticConfig?.codexNetworkAccess,
+      mcpServerIds: mcpServerIdsOverride,
+    },
+  });
+
+  return { agenticTool, permissionConfig, modelConfig, mcpServerIds };
+}
+
 /**
  * Gateway routing service
  */
@@ -218,6 +274,7 @@ export class GatewayService {
   private channelRepo: GatewayChannelRepository;
   private threadMapRepo: ThreadSessionMapRepository;
   private usersRepo: UsersRepository;
+  private branchRepo: BranchRepository;
 
   private mcpServerRepo: MCPServerRepository;
   private userTokenRepo: UserMCPOAuthTokenRepository;
@@ -247,6 +304,7 @@ export class GatewayService {
     this.channelRepo = new GatewayChannelRepository(db);
     this.threadMapRepo = new ThreadSessionMapRepository(db);
     this.usersRepo = new UsersRepository(db);
+    this.branchRepo = new BranchRepository(db);
 
     this.mcpServerRepo = new MCPServerRepository(db);
     this.userTokenRepo = new UserMCPOAuthTokenRepository(db);
@@ -521,30 +579,37 @@ export class GatewayService {
     let created = false;
     let mcpAuthWarning: string | undefined;
 
-    // Resolve agentic config: channel config > user defaults > system defaults.
-    // Channel-level agentic_config maps to the helper's `overrides` (it's the
-    // gateway's analogue of an MCP tool's explicit args). Codex sub-config and
-    // MCP server lists are first-class fields on `GatewayAgenticConfig`, so
-    // thread them all through the helper — otherwise the executor's per-tool
-    // settings (which Codex reads from `permission_config.codex`, not `mode`)
-    // get silently dropped.
-    const agenticConfig = channel.agentic_config;
-    const agenticTool: AgenticToolName = (agenticConfig?.agent as AgenticToolName) ?? 'claude-code';
+    let targetBranch: Branch | null = null;
+    try {
+      targetBranch = await this.branchRepo.findById(channel.target_branch_id);
+      if (!targetBranch) {
+        console.warn(
+          `[gateway] Target branch ${shortId(channel.target_branch_id)} not found while resolving session defaults`
+        );
+      }
+    } catch (error) {
+      console.warn(
+        `[gateway] Failed to load target branch ${shortId(channel.target_branch_id)} for session defaults:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+
+    // Resolve agentic config: channel config > branch defaults > user defaults
+    // > system defaults. Channel-level agentic_config maps to the helper's
+    // `overrides` (it's the gateway's analogue of an MCP tool's explicit args).
+    // Codex sub-config and MCP server lists are first-class fields on
+    // `GatewayAgenticConfig`, so thread them all through the helper — otherwise
+    // the executor's per-tool settings (which Codex reads from
+    // `permission_config.codex`, not `mode`) get silently dropped.
     const {
-      permission_config: gatewayPermissionConfig,
-      model_config: gatewayModelConfig,
-      mcp_server_ids: gatewayMcpServerIds,
-    } = resolveSessionDefaults({
       agenticTool,
+      permissionConfig: gatewayPermissionConfig,
+      modelConfig: gatewayModelConfig,
+      mcpServerIds: gatewayMcpServerIds,
+    } = resolveGatewaySessionDefaults({
+      channel,
       user,
-      overrides: {
-        permissionMode: agenticConfig?.permissionMode,
-        modelConfig: agenticConfig?.modelConfig,
-        codexSandboxMode: agenticConfig?.codexSandboxMode,
-        codexApprovalPolicy: agenticConfig?.codexApprovalPolicy,
-        codexNetworkAccess: agenticConfig?.codexNetworkAccess,
-        mcpServerIds: agenticConfig?.mcpServerIds,
-      },
+      branch: targetBranch,
     });
     const permissionMode = gatewayPermissionConfig.mode;
 


### PR DESCRIPTION
## Summary

- Load the gateway channel's target branch before resolving defaults for Slack/GitHub-created sessions.
- Centralize gateway session default resolution in `resolveGatewaySessionDefaults()`.
- Ensure BranchModal → General default MCP servers are inherited by gateway-created sessions.
- Treat a persisted empty gateway `mcpServerIds: []` as the form-default/no channel MCP override when branch MCP defaults exist, while preserving non-empty gateway MCP selections as explicit overrides.

## Root cause

Gateway-created sessions called the shared session default resolver without branch context, so `branch.mcp_server_ids` could never participate in MCP inheritance. Gateway channel forms can also persist an empty MCP array, which previously acted as an explicit no-MCP override and bypassed branch defaults.

## Tests

- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/gateway.test.ts`
- `pnpm --filter @agor/core test -- src/sessions/resolve-session-defaults.test.ts`
