### PR TITLE
Simplify gateway channel identity settings

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1131,7 +1131,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
             if (positionConfirmed) {
               delete localPositionsRef.current[newNode.id];
-              return { ...newNode, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
+              return {
+                ...newNode,
+                selected: existingNode?.selected,
+                zIndex: existingNode?.zIndex ?? newNode.zIndex,
+              };
             }
 
             let positionToUse = localPosition;
@@ -1144,10 +1148,19 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               }
             }
 
-            return { ...newNode, position: positionToUse, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
+            return {
+              ...newNode,
+              position: positionToUse,
+              selected: existingNode?.selected,
+              zIndex: existingNode?.zIndex ?? newNode.zIndex,
+            };
           }
 
-          return { ...newNode, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
+          return {
+            ...newNode,
+            selected: existingNode?.selected,
+            zIndex: existingNode?.zIndex ?? newNode.zIndex,
+          };
         });
       },
       []

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -1,0 +1,54 @@
+import type { Branch, GatewayChannel, MCPServer, User } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntdApp } from 'antd';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { GatewayChannelsTable } from './GatewayChannelsTable';
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <MemoryRouter>
+      <AntdApp>{ui}</AntdApp>
+    </MemoryRouter>
+  );
+}
+
+function makeBranch(): Branch {
+  return {
+    branch_id: 'branch-1',
+    name: 'main',
+    ref: 'main',
+  } as unknown as Branch;
+}
+
+function makeUser(): User {
+  return {
+    user_id: 'user-1',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+  } as unknown as User;
+}
+
+describe('GatewayChannelsTable identity settings', () => {
+  it('collapses Slack post-as and alignment controls into one Identity section', () => {
+    const branch = makeBranch();
+    const user = makeUser();
+
+    renderWithProviders(
+      <GatewayChannelsTable
+        client={null}
+        gatewayChannelById={new Map<string, GatewayChannel>()}
+        branchById={new Map([[branch.branch_id, branch]])}
+        userById={new Map([[user.user_id, user]])}
+        mcpServerById={new Map<string, MCPServer>()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+    expect(screen.getByText('Identity')).toBeInTheDocument();
+    expect(screen.getByText('Align Slack users')).toBeInTheDocument();
+    expect(screen.getByText('Run as selected user')).toBeInTheDocument();
+    expect(screen.queryByText('Post messages as')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -39,6 +39,7 @@ import {
   InputNumber,
   Modal,
   Popconfirm,
+  Radio,
   Result,
   Select,
   Space,
@@ -132,6 +133,26 @@ const SectionLabel: React.FC<{ icon: React.ReactNode; title: string; subtitle?: 
     </span>
   </Space>
 );
+
+const UserSelect: React.FC<{ userById: Map<string, User>; placeholder?: string }> = ({
+  userById,
+  placeholder = 'Select a user',
+}) => (
+  <Select placeholder={placeholder} showSearch optionFilterProp="children">
+    {Array.from(userById.values())
+      .sort((a, b) =>
+        (a.name || a.email || a.user_id).localeCompare(b.name || b.email || b.user_id)
+      )
+      .map((u) => (
+        <Select.Option key={u.user_id} value={u.user_id}>
+          {u.name || u.email || u.user_id}
+        </Select.Option>
+      ))}
+  </Select>
+);
+
+const getIdentitySubtitle = (alignUsers: boolean): string =>
+  alignUsers ? 'align users' : 'run as selected user';
 
 // ============================================================================
 // Environment Variables Editor
@@ -355,25 +376,15 @@ const ChannelFormFields: React.FC<{
         <BranchSelect branchById={branchById} />
       </Form.Item>
 
-      {/* For GitHub channels, "Post messages as" lives in the User Alignment section */}
-      {channelType !== 'github' && (
+      {/* Slack and GitHub choose identity in their platform-specific Identity sections. */}
+      {channelType !== 'slack' && channelType !== 'github' && (
         <Form.Item
           label="Post messages as"
           name="agor_user_id"
           rules={[{ required: true, message: 'Please select a user' }]}
           tooltip="Sessions from this channel will run as this Agor user"
         >
-          <Select placeholder="Select a user" showSearch optionFilterProp="children">
-            {Array.from(userById.values())
-              .sort((a, b) =>
-                (a.name || a.email || a.user_id).localeCompare(b.name || b.email || b.user_id)
-              )
-              .map((u) => (
-                <Select.Option key={u.user_id} value={u.user_id}>
-                  {u.name || u.email || u.user_id}
-                </Select.Option>
-              ))}
-          </Select>
+          <UserSelect userById={userById} />
         </Form.Item>
       )}
 
@@ -598,7 +609,7 @@ const ChannelFormFields: React.FC<{
             <Collapse
               ghost
               destroyOnHidden={false}
-              defaultActiveKey={mode === 'create' ? ['github-config'] : []}
+              defaultActiveKey={mode === 'create' ? ['identity', 'github-config'] : []}
               style={{ marginLeft: -16, marginRight: -16 }}
               items={[
                 // ── Credentials (edit mode) ──
@@ -709,27 +720,48 @@ const ChannelFormFields: React.FC<{
                     </>
                   ),
                 },
-                // ── User Alignment ──
+                // ── Identity ──
                 {
-                  key: 'user-alignment',
+                  key: 'identity',
                   label: (
                     <SectionLabel
                       icon={<UserOutlined />}
-                      title="User Alignment"
-                      subtitle="Map GitHub users to Agor accounts"
+                      title="Identity"
+                      subtitle={getIdentitySubtitle(alignGithubUsers)}
                     />
                   ),
                   children: (
                     <>
-                      <Form.Item
-                        label="Enable User Alignment"
-                        name="github_align_users"
-                        valuePropName="checked"
-                        initialValue={false}
-                        tooltip="When enabled, GitHub users are mapped to Agor users. Unmapped users are rejected."
+                      <Typography.Text
+                        type="secondary"
+                        style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
                       >
-                        <Switch />
+                        Choose which Agor user identity gateway-created sessions run as.
+                      </Typography.Text>
+
+                      <Form.Item name="github_align_users" initialValue={false}>
+                        <Radio.Group style={{ width: '100%' }}>
+                          <Space orientation="vertical" style={{ width: '100%' }}>
+                            <Radio value={true}>
+                              <Space orientation="vertical" size={0}>
+                                <Typography.Text>Align GitHub users</Typography.Text>
+                                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                                  Map GitHub logins to Agor users. Unmapped users are rejected.
+                                </Typography.Text>
+                              </Space>
+                            </Radio>
+                            <Radio value={false}>
+                              <Space orientation="vertical" size={0}>
+                                <Typography.Text>Run as selected user</Typography.Text>
+                                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                                  Every message uses one configured Agor user.
+                                </Typography.Text>
+                              </Space>
+                            </Radio>
+                          </Space>
+                        </Radio.Group>
                       </Form.Item>
+
                       {alignGithubUsers ? (
                         <Form.Item
                           label="User Map"
@@ -744,28 +776,12 @@ const ChannelFormFields: React.FC<{
                         </Form.Item>
                       ) : (
                         <Form.Item
-                          label="Post messages as"
+                          label="Run as"
                           name="agor_user_id"
                           rules={[{ required: true, message: 'Please select a user' }]}
                           tooltip="All sessions from this channel will run as this Agor user"
                         >
-                          <Select
-                            placeholder="Select a user"
-                            showSearch
-                            optionFilterProp="children"
-                          >
-                            {Array.from(userById.values())
-                              .sort((a, b) =>
-                                (a.name || a.email || a.user_id).localeCompare(
-                                  b.name || b.email || b.user_id
-                                )
-                              )
-                              .map((u) => (
-                                <Select.Option key={u.user_id} value={u.user_id}>
-                                  {u.name || u.email || u.user_id}
-                                </Select.Option>
-                              ))}
-                          </Select>
+                          <UserSelect userById={userById} />
                         </Form.Item>
                       )}
                     </>
@@ -839,9 +855,78 @@ const ChannelFormFields: React.FC<{
         <Collapse
           ghost
           destroyOnHidden={false}
-          defaultActiveKey={mode === 'create' ? ['credentials'] : []}
+          defaultActiveKey={mode === 'create' ? ['identity', 'credentials'] : []}
           style={{ marginLeft: -16, marginRight: -16 }}
           items={[
+            // ── Identity ──
+            {
+              key: 'identity',
+              label: (
+                <SectionLabel
+                  icon={<TeamOutlined />}
+                  title="Identity"
+                  subtitle={getIdentitySubtitle(alignSlackUsers)}
+                />
+              ),
+              children: (
+                <>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                  >
+                    Choose which Agor user identity gateway-created sessions run as.
+                  </Typography.Text>
+
+                  <Form.Item name="align_slack_users" initialValue={false}>
+                    <Radio.Group style={{ width: '100%' }}>
+                      <Space orientation="vertical" style={{ width: '100%' }}>
+                        <Radio value={true}>
+                          <Space orientation="vertical" size={0}>
+                            <Typography.Text>Align Slack users</Typography.Text>
+                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                              Match Slack profile email to an Agor user. Unmatched users are
+                              rejected.
+                            </Typography.Text>
+                          </Space>
+                        </Radio>
+                        <Radio value={false}>
+                          <Space orientation="vertical" size={0}>
+                            <Typography.Text>Run as selected user</Typography.Text>
+                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                              Every message uses one configured Agor user.
+                            </Typography.Text>
+                          </Space>
+                        </Radio>
+                      </Space>
+                    </Radio.Group>
+                  </Form.Item>
+
+                  {alignSlackUsers ? (
+                    <Alert
+                      type="info"
+                      showIcon
+                      title="Requires users:read.email scope"
+                      description={
+                        <span>
+                          Add <code>users:read.email</code> to your Slack app so Agor can match
+                          Slack profiles by email.
+                        </span>
+                      }
+                      style={{ fontSize: 12 }}
+                    />
+                  ) : (
+                    <Form.Item
+                      label="Run as"
+                      name="agor_user_id"
+                      rules={[{ required: true, message: 'Please select a user' }]}
+                      tooltip="All sessions from this channel will run as this Agor user"
+                    >
+                      <UserSelect userById={userById} />
+                    </Form.Item>
+                  )}
+                </>
+              ),
+            },
             // ── Credentials ──
             {
               key: 'credentials',
@@ -1007,54 +1092,6 @@ const ChannelFormFields: React.FC<{
                             </li>
                           )}
                         </ul>
-                      }
-                      style={{ fontSize: 12 }}
-                    />
-                  )}
-                </>
-              ),
-            },
-
-            // ── User Alignment ──
-            {
-              key: 'user-alignment',
-              label: (
-                <SectionLabel
-                  icon={<TeamOutlined />}
-                  title="User Alignment"
-                  subtitle={alignSlackUsers ? 'enabled' : 'disabled'}
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 16 }}
-                  >
-                    When enabled, messages are attributed to the Agor user whose email matches the
-                    Slack user&apos;s email. Users without a matching Agor account are rejected.
-                  </Typography.Text>
-
-                  <Form.Item
-                    label="Align Slack Users with Agor Users"
-                    name="align_slack_users"
-                    valuePropName="checked"
-                    initialValue={false}
-                  >
-                    <Switch />
-                  </Form.Item>
-
-                  {alignSlackUsers && (
-                    <Alert
-                      type="info"
-                      showIcon
-                      title="Requires users:read.email scope"
-                      description={
-                        <span>
-                          Add <code>users:read.email</code> to your Slack app to look up user
-                          emails. Without this scope, alignment silently falls back to the
-                          configured &quot;Post messages as&quot; user.
-                        </span>
                       }
                       style={{ fontSize: 12 }}
                     />
@@ -1391,7 +1428,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     };
 
     // Form has preserve={true}, so agor_user_id is retained even when the
-    // "Post messages as" dropdown is hidden (GitHub alignment ON).
+    // run-as selector is hidden (Slack/GitHub alignment ON).
     return {
       name: values.name as string,
       channel_type: values.channel_type as ChannelType,

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -154,6 +154,57 @@ const UserSelect: React.FC<{ userById: Map<string, User>; placeholder?: string }
 const getIdentitySubtitle = (alignUsers: boolean): string =>
   alignUsers ? 'align users' : 'run as selected user';
 
+const PlatformIdentityFields: React.FC<{
+  alignFieldName: string;
+  alignLabel: string;
+  alignDescription: string;
+  alignUsers: boolean;
+  alignedContent: React.ReactNode;
+  userById: Map<string, User>;
+}> = ({ alignFieldName, alignLabel, alignDescription, alignUsers, alignedContent, userById }) => (
+  <>
+    <Typography.Text type="secondary" style={{ fontSize: 12, display: 'block', marginBottom: 12 }}>
+      Choose which Agor user identity gateway-created sessions run as.
+    </Typography.Text>
+
+    <Form.Item name={alignFieldName} initialValue={false}>
+      <Radio.Group style={{ width: '100%' }}>
+        <Space orientation="vertical" style={{ width: '100%' }}>
+          <Radio value={true}>
+            <Space orientation="vertical" size={0}>
+              <Typography.Text>{alignLabel}</Typography.Text>
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                {alignDescription}
+              </Typography.Text>
+            </Space>
+          </Radio>
+          <Radio value={false}>
+            <Space orientation="vertical" size={0}>
+              <Typography.Text>Run as selected user</Typography.Text>
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                Every message uses one configured Agor user.
+              </Typography.Text>
+            </Space>
+          </Radio>
+        </Space>
+      </Radio.Group>
+    </Form.Item>
+
+    {alignUsers ? (
+      alignedContent
+    ) : (
+      <Form.Item
+        label="Run as"
+        name="agor_user_id"
+        rules={[{ required: true, message: 'Please select a user' }]}
+        tooltip="All sessions from this channel will run as this Agor user"
+      >
+        <UserSelect userById={userById} />
+      </Form.Item>
+    )}
+  </>
+);
+
 // ============================================================================
 // Environment Variables Editor
 // ============================================================================
@@ -731,38 +782,13 @@ const ChannelFormFields: React.FC<{
                     />
                   ),
                   children: (
-                    <>
-                      <Typography.Text
-                        type="secondary"
-                        style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                      >
-                        Choose which Agor user identity gateway-created sessions run as.
-                      </Typography.Text>
-
-                      <Form.Item name="github_align_users" initialValue={false}>
-                        <Radio.Group style={{ width: '100%' }}>
-                          <Space orientation="vertical" style={{ width: '100%' }}>
-                            <Radio value={true}>
-                              <Space orientation="vertical" size={0}>
-                                <Typography.Text>Align GitHub users</Typography.Text>
-                                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                                  Map GitHub logins to Agor users. Unmapped users are rejected.
-                                </Typography.Text>
-                              </Space>
-                            </Radio>
-                            <Radio value={false}>
-                              <Space orientation="vertical" size={0}>
-                                <Typography.Text>Run as selected user</Typography.Text>
-                                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                                  Every message uses one configured Agor user.
-                                </Typography.Text>
-                              </Space>
-                            </Radio>
-                          </Space>
-                        </Radio.Group>
-                      </Form.Item>
-
-                      {alignGithubUsers ? (
+                    <PlatformIdentityFields
+                      alignFieldName="github_align_users"
+                      alignLabel="Align GitHub users"
+                      alignDescription="Map GitHub logins to Agor users. Unmapped users are rejected."
+                      alignUsers={alignGithubUsers}
+                      userById={userById}
+                      alignedContent={
                         <Form.Item
                           label="User Map"
                           name="github_user_map"
@@ -774,17 +800,8 @@ const ChannelFormFields: React.FC<{
                             placeholder={'{\n  "octocat": "user@example.com"\n}'}
                           />
                         </Form.Item>
-                      ) : (
-                        <Form.Item
-                          label="Run as"
-                          name="agor_user_id"
-                          rules={[{ required: true, message: 'Please select a user' }]}
-                          tooltip="All sessions from this channel will run as this Agor user"
-                        >
-                          <UserSelect userById={userById} />
-                        </Form.Item>
-                      )}
-                    </>
+                      }
+                    />
                   ),
                 },
                 // ── Agentic Tool Configuration ──
@@ -869,39 +886,13 @@ const ChannelFormFields: React.FC<{
                 />
               ),
               children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                  >
-                    Choose which Agor user identity gateway-created sessions run as.
-                  </Typography.Text>
-
-                  <Form.Item name="align_slack_users" initialValue={false}>
-                    <Radio.Group style={{ width: '100%' }}>
-                      <Space orientation="vertical" style={{ width: '100%' }}>
-                        <Radio value={true}>
-                          <Space orientation="vertical" size={0}>
-                            <Typography.Text>Align Slack users</Typography.Text>
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                              Match Slack profile email to an Agor user. Unmatched users are
-                              rejected.
-                            </Typography.Text>
-                          </Space>
-                        </Radio>
-                        <Radio value={false}>
-                          <Space orientation="vertical" size={0}>
-                            <Typography.Text>Run as selected user</Typography.Text>
-                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                              Every message uses one configured Agor user.
-                            </Typography.Text>
-                          </Space>
-                        </Radio>
-                      </Space>
-                    </Radio.Group>
-                  </Form.Item>
-
-                  {alignSlackUsers ? (
+                <PlatformIdentityFields
+                  alignFieldName="align_slack_users"
+                  alignLabel="Align Slack users"
+                  alignDescription="Match Slack profile email to an Agor user. Unmatched users are rejected."
+                  alignUsers={alignSlackUsers}
+                  userById={userById}
+                  alignedContent={
                     <Alert
                       type="info"
                       showIcon
@@ -914,17 +905,8 @@ const ChannelFormFields: React.FC<{
                       }
                       style={{ fontSize: 12 }}
                     />
-                  ) : (
-                    <Form.Item
-                      label="Run as"
-                      name="agor_user_id"
-                      rules={[{ required: true, message: 'Please select a user' }]}
-                      tooltip="All sessions from this channel will run as this Agor user"
-                    >
-                      <UserSelect userById={userById} />
-                    </Form.Item>
-                  )}
-                </>
+                  }
+                />
               ),
             },
             // ── Credentials ──
@@ -1427,8 +1409,9 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         : {}),
     };
 
-    // Form has preserve={true}, so agor_user_id is retained even when the
-    // run-as selector is hidden (Slack/GitHub alignment ON).
+    // Existing aligned channels may still carry a preserved agor_user_id from a
+    // previous run-as configuration, but newly-created aligned channels can omit it.
+    // The gateway only reads agor_user_id when alignment is OFF.
     return {
       name: values.name as string,
       channel_type: values.channel_type as ChannelType,


### PR DESCRIPTION
## Summary

- Collapse Gateway Channel identity controls into a single **Identity** section for Slack and GitHub.
- Replace separate "Post messages as" and "User Alignment" controls with radio choices for aligning platform users or running as a selected Agor user.
- Preserve existing backend/data model behavior by continuing to write `align_slack_users`, `align_github_users`, and `agor_user_id`.
- Add a focused Settings modal regression test for the simplified Slack identity layout.
- Include a formatter-only fix in `SessionCanvas.tsx` required for repo-level `pnpm check`.

## Behavior

- **Align users**: gateway-created sessions run as the matching Agor user where configured; unmatched users are rejected by existing backend behavior.
- **Run as selected user**: all gateway-created sessions use the configured Agor user (`agor_user_id`).
- No database migration or backend semantic change.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- src/components/SettingsModal/GatewayChannelsTable.test.tsx`

Notes:
- `pnpm i` completed; `node-pty@1.0.0` logged a native rebuild failure due missing `make`, but install finished successfully.
- First `pnpm check` exposed missing cached client declaration artifacts for `@agor-live/client/config`; running `pnpm --filter @agor-live/client build` generated them, then `pnpm check` passed.
- Focused test passes with an existing jsdom warning: `Not implemented: Window's getComputedStyle() method: with pseudo-elements`.
