### PR TITLE
Polish login admin setup copy

### DIFF
--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -29,6 +29,15 @@ describe('LoginPage external launch redirect', () => {
     expect(screen.queryByRole('button', { name: 'Sign In' })).not.toBeInTheDocument();
   });
 
+  it('shows concise first-time admin setup guidance on the local login form', () => {
+    render(<LoginPage onLogin={vi.fn()} />);
+
+    expect(screen.getByText(/First-time server setup/)).toBeInTheDocument();
+    expect(screen.getByText('agor user create-admin')).toBeInTheDocument();
+    expect(screen.queryByText(/New user/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/💡/)).not.toBeInTheDocument();
+  });
+
   it('offers local login as a secondary fallback for configured deployments', () => {
     render(
       <LoginPage
@@ -70,6 +79,7 @@ describe('LoginPage external launch redirect', () => {
 
     expect(screen.getByText('Login Failed')).toBeInTheDocument();
     expect(screen.queryByText('Launch sign-in failed')).not.toBeInTheDocument();
-    expect(screen.getByText(/First time setting up/)).toBeInTheDocument();
+    expect(screen.getByText(/First-time server setup/)).toBeInTheDocument();
+    expect(screen.getByText('agor user create-admin')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -12,6 +12,33 @@ import { ParticleBackground } from './ParticleBackground';
 
 const { Text } = Typography;
 
+const ADMIN_SETUP_COMMAND = 'agor user create-admin';
+
+function AdminSetupHint() {
+  const { token } = theme.useToken();
+
+  return (
+    <Space orientation="vertical" size={4} style={{ width: '100%' }}>
+      <Text type="secondary" style={{ fontSize: 12 }}>
+        First-time server setup? Create the initial admin account:
+      </Text>
+      <Text
+        code
+        copyable={{ text: ADMIN_SETUP_COMMAND }}
+        style={{
+          fontSize: 12,
+          background: token.colorFillTertiary,
+          border: `1px solid ${token.colorBorderSecondary}`,
+          borderRadius: token.borderRadiusSM,
+          padding: '2px 6px',
+        }}
+      >
+        {ADMIN_SETUP_COMMAND}
+      </Text>
+    </Space>
+  );
+}
+
 interface LoginPageProps {
   onLogin: (email: string, password: string) => Promise<boolean>;
   loading?: boolean;
@@ -138,11 +165,7 @@ export function LoginPage({
                       borderTop: `1px solid ${token.colorBorderSecondary}`,
                     }}
                   >
-                    <Text type="secondary" style={{ fontSize: 12 }}>
-                      💡 First time setting up? Create an admin user:
-                    </Text>
-                    <br />
-                    <code style={{ fontSize: 11 }}>agor user create-admin</code>
+                    <AdminSetupHint />
                   </div>
                 )}
               </Space>
@@ -225,13 +248,9 @@ export function LoginPage({
         )}
 
         {/* Footer */}
-        {showLoginForm && (
+        {showLoginForm && !error && (
           <div style={{ textAlign: 'center', marginTop: 24 }}>
-            <Space orientation="vertical" size={4}>
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                New user? <code>agor user create-admin</code>
-              </Text>
-            </Space>
+            <AdminSetupHint />
           </div>
         )}
       </Card>

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1131,7 +1131,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
             if (positionConfirmed) {
               delete localPositionsRef.current[newNode.id];
-              return { ...newNode, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
+              return {
+                ...newNode,
+                selected: existingNode?.selected,
+                zIndex: existingNode?.zIndex ?? newNode.zIndex,
+              };
             }
 
             let positionToUse = localPosition;
@@ -1144,10 +1148,19 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               }
             }
 
-            return { ...newNode, position: positionToUse, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
+            return {
+              ...newNode,
+              position: positionToUse,
+              selected: existingNode?.selected,
+              zIndex: existingNode?.zIndex ?? newNode.zIndex,
+            };
           }
 
-          return { ...newNode, selected: existingNode?.selected, zIndex: existingNode?.zIndex ?? newNode.zIndex };
+          return {
+            ...newNode,
+            selected: existingNode?.selected,
+            zIndex: existingNode?.zIndex ?? newNode.zIndex,
+          };
         });
       },
       []


### PR DESCRIPTION
## Summary

- Replace the login page's first-time setup copy with concise admin setup guidance.
- Show `agor user create-admin` as a copyable Ant Design code affordance.
- Add focused LoginPage coverage for the new setup guidance and removal of old "New user?" / emoji copy.
- Apply a formatter-only cleanup in `SessionCanvas.tsx` required for `pnpm check`.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- LoginPage.test.tsx`
