### PR TITLE
Expose assistant home Knowledge namespace setting

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -1,7 +1,9 @@
 import {
   BoardRepository,
   BranchRepository,
+  type Database,
   GroupRepository,
+  KnowledgeNamespaceRepository,
   RepoRepository,
   UsersRepository,
 } from '@agor/core/db';
@@ -806,6 +808,189 @@ describe('BranchesService managed environment control authorization', () => {
       service.startEnvironment(branch.branch_id, paramsFor(member.user_id, 'member'))
     ).rejects.toThrow(/'all' branch permission or admin access/);
     expect(getSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('BranchesService assistant home Knowledge namespace guard', () => {
+  async function createAssistantKbHarness(db: Database) {
+    const users = new UsersRepository(db);
+    const repos = new RepoRepository(db);
+    const branches = new BranchRepository(db);
+    const namespaces = new KnowledgeNamespaceRepository(db);
+
+    const owner = await users.create({
+      email: 'assistant-kb-owner@example.com',
+      name: 'Assistant KB Owner',
+      role: 'member',
+    });
+    const namespaceOwner = await users.create({
+      email: 'assistant-kb-namespace-owner@example.com',
+      name: 'Assistant KB Namespace Owner',
+      role: 'member',
+    });
+    const repo = await repos.create({
+      name: 'assistant-kb-repo',
+      slug: 'assistant-kb-repo',
+      repo_type: 'local',
+      local_path: '/tmp/assistant-kb-repo',
+      default_branch: 'main',
+    });
+
+    const currentNamespace = await namespaces.create({
+      slug: 'assistant-current-home',
+      display_name: 'Assistant Current Home',
+      owner_user_id: namespaceOwner.user_id,
+      others_can: 'read',
+    });
+    const branch = await branches.create({
+      branch_id: '019f0000-0000-7000-8000-00000000e101' as BranchID,
+      repo_id: repo.repo_id,
+      name: 'assistant-kb',
+      ref: 'assistant-kb',
+      path: '/tmp/assistant-kb-repo/assistant-kb',
+      created_by: owner.user_id as UUID,
+      branch_unique_id: 9101,
+      new_branch: true,
+      custom_context: {
+        assistant: {
+          kind: 'assistant',
+          displayName: 'Assistant KB',
+          kb: {
+            primary_namespace_id: currentNamespace.namespace_id,
+            primary_namespace_slug: currentNamespace.slug,
+            memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+            default_visibility: currentNamespace.visibility_default,
+            global_access: 'write',
+            grants: [],
+          },
+        },
+      },
+    });
+
+    const app = {
+      service(path: string) {
+        if (path === 'branches') return { find: vi.fn(async () => []) };
+        throw new Error(`Unknown service: ${path}`);
+      },
+    } as unknown as Application;
+
+    return {
+      owner,
+      namespaceOwner,
+      branch,
+      namespaces,
+      service: new BranchesService(db, app),
+      params: { provider: 'rest', user: owner } as never,
+    };
+  }
+
+  function homeNamespacePatch(namespaceId: string, namespaceSlug: string) {
+    return {
+      custom_context: {
+        assistant: {
+          kb: {
+            primary_namespace_id: namespaceId,
+            primary_namespace_slug: namespaceSlug,
+            memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+            default_visibility: 'public',
+            global_access: 'write',
+            grants: [],
+          },
+        },
+      },
+    };
+  }
+
+  dbTest('allows saving policy when the home namespace is unchanged', async ({ db }) => {
+    const { branch, service, params } = await createAssistantKbHarness(db);
+    const currentKb = (
+      branch.custom_context?.assistant as
+        | { kb?: { primary_namespace_id?: string; primary_namespace_slug?: string } }
+        | undefined
+    )?.kb;
+
+    await expect(
+      service.patch(
+        branch.branch_id,
+        {
+          custom_context: {
+            assistant: {
+              kb: {
+                primary_namespace_id: currentKb?.primary_namespace_id,
+                primary_namespace_slug: currentKb?.primary_namespace_slug,
+                memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+                default_visibility: 'public',
+                global_access: 'read',
+                grants: [],
+              },
+            },
+          },
+        } as never,
+        params
+      )
+    ).resolves.toMatchObject({ branch_id: branch.branch_id });
+  });
+
+  dbTest('rejects changing home namespace to a namespace without write access', async ({ db }) => {
+    const { branch, namespaceOwner, namespaces, service, params } =
+      await createAssistantKbHarness(db);
+    const readOnly = await namespaces.create({
+      slug: 'assistant-read-only-home',
+      display_name: 'Assistant Read Only Home',
+      owner_user_id: namespaceOwner.user_id,
+      others_can: 'read',
+    });
+
+    await expect(
+      service.patch(
+        branch.branch_id,
+        homeNamespacePatch(readOnly.namespace_id, readOnly.slug) as never,
+        params
+      )
+    ).rejects.toThrow(/write access/);
+  });
+
+  dbTest('rejects changing home namespace when ID and slug disagree', async ({ db }) => {
+    const { branch, namespaces, service, params } = await createAssistantKbHarness(db);
+    const writable = await namespaces.create({
+      slug: 'assistant-writable-home',
+      display_name: 'Assistant Writable Home',
+      others_can: 'write',
+    });
+
+    await expect(
+      service.patch(
+        branch.branch_id,
+        homeNamespacePatch(writable.namespace_id, 'wrong-slug') as never,
+        params
+      )
+    ).rejects.toThrow(/slug does not match/);
+  });
+
+  dbTest('allows changing home namespace to a writable namespace', async ({ db }) => {
+    const { branch, namespaces, service, params } = await createAssistantKbHarness(db);
+    const writable = await namespaces.create({
+      slug: 'assistant-writable-home-ok',
+      display_name: 'Assistant Writable Home OK',
+      others_can: 'write',
+    });
+
+    await expect(
+      service.patch(
+        branch.branch_id,
+        homeNamespacePatch(writable.namespace_id, writable.slug) as never,
+        params
+      )
+    ).resolves.toMatchObject({
+      custom_context: {
+        assistant: {
+          kb: {
+            primary_namespace_id: writable.namespace_id,
+            primary_namespace_slug: writable.slug,
+          },
+        },
+      },
+    });
   });
 });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -17,6 +17,7 @@ import {
   BranchRepository,
   type BranchWithZoneAndSessions,
   type Database,
+  KnowledgeNamespaceRepository,
 } from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
 import {
@@ -42,7 +43,7 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { isAssistant } from '@agor/core/types';
+import { getAssistantConfig, isAssistant } from '@agor/core/types';
 import { getGidFromGroupName, spawnEnvironmentCommand } from '@agor/core/unix';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
@@ -553,6 +554,63 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     if (!isAssistant(branch)) return;
     if (!this.containsAssistantKnowledgeConfigMutation(data)) return;
     await this.assertCanManageAssistantKnowledge(branch, params);
+    await this.assertCanUseAssistantHomeNamespace(branch, data, params);
+  }
+
+  private extractAssistantKnowledgeConfigPatch(
+    data: Partial<Branch>
+  ): Record<string, unknown> | null {
+    const customContext = data.custom_context;
+    if (!customContext || typeof customContext !== 'object' || Array.isArray(customContext)) {
+      return null;
+    }
+    for (const key of ['assistant', 'agent']) {
+      const assistantPatch = customContext[key];
+      if (!assistantPatch || typeof assistantPatch !== 'object' || Array.isArray(assistantPatch)) {
+        continue;
+      }
+      const kbPatch = (assistantPatch as Record<string, unknown>).kb;
+      if (kbPatch && typeof kbPatch === 'object' && !Array.isArray(kbPatch)) {
+        return kbPatch as Record<string, unknown>;
+      }
+    }
+    return null;
+  }
+
+  private async assertCanUseAssistantHomeNamespace(
+    branch: Branch,
+    data: Partial<Branch>,
+    params?: BranchParams
+  ): Promise<void> {
+    const kbPatch = this.extractAssistantKnowledgeConfigPatch(data);
+    const namespaceId = kbPatch?.primary_namespace_id;
+    if (typeof namespaceId !== 'string' || !namespaceId) return;
+
+    const currentNamespaceId = getAssistantConfig(branch)?.kb?.primary_namespace_id;
+    if (namespaceId === currentNamespaceId) return;
+
+    const namespaces = new KnowledgeNamespaceRepository(this.db);
+    const namespace = await namespaces.findById(namespaceId);
+    if (!namespace || namespace.archived) {
+      throw new BadRequest('Assistant home Knowledge namespace not found');
+    }
+
+    const namespaceSlug = kbPatch.primary_namespace_slug;
+    if (typeof namespaceSlug === 'string' && namespaceSlug && namespaceSlug !== namespace.slug) {
+      throw new BadRequest('Assistant home Knowledge namespace slug does not match its ID');
+    }
+
+    const user = params?.user;
+    if (isKnowledgeAdmin(user as never)) return;
+    const userId = user?.user_id as UserID | undefined;
+    if (!userId) throw new NotAuthenticated('Authentication required');
+
+    const permission = await namespaces.resolveNamespacePermission(namespace.namespace_id, userId);
+    if (permission !== 'write' && permission !== 'own') {
+      throw new Forbidden(
+        'You need write access to use this Knowledge namespace as assistant home'
+      );
+    }
   }
 
   async ensureAssistantKnowledgeNamespace(

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
@@ -10,6 +10,7 @@ import type { AgorClient, AssistantConfig, Branch, User } from '@agor-live/clien
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BranchModal } from './BranchModal';
+import { buildAssistantKnowledgePatch } from './tabs/KnowledgeTab';
 import {
   makeAssistantBranch,
   makeBranch,
@@ -168,78 +169,31 @@ describe('BranchModal — permissions tab visibility', () => {
     });
   });
 
-  it('saves Knowledge changes back to legacy custom_context.agent storage', async () => {
-    const seb = makeUser({ user_id: 'seb', role: 'member' });
+  it('builds Knowledge patches against legacy custom_context.agent storage', () => {
     const branch = makeBranch({
-      created_by: seb.user_id,
-      board_id: 'board-1' as Branch['board_id'],
       custom_context: {
         agent: {
           kind: 'assistant',
           displayName: 'Legacy Assistant',
           emoji: '🤖',
-          kb: {
-            primary_namespace_id: 'ns-old',
-            primary_namespace_slug: 'old-home',
-            memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
-            default_visibility: 'public',
-            global_access: 'write',
-            grants: [],
-          },
         } as AssistantConfig,
       },
     });
-    const { client, calls } = makeStubClient({
-      owners: [seb],
-      users: [seb],
-      namespaces: [
-        {
-          namespace_id: 'ns-old',
-          slug: 'old-home',
-          display_name: 'Old Home',
-          kind: 'branch',
-          visibility_default: 'public',
-          others_can: 'write',
-          effective_permission: 'own',
-          created_at: new Date(),
-          archived: false,
-        },
-        {
-          namespace_id: 'ns-new',
-          slug: 'new-home',
-          display_name: 'New Home',
-          kind: 'team',
-          visibility_default: 'private',
-          others_can: 'none',
-          effective_permission: 'write',
-          created_at: new Date(),
-          archived: false,
-        },
-      ],
-    });
+    const kb = {
+      primary_namespace_id: 'ns-new',
+      primary_namespace_slug: 'new-home',
+      memory_path_template: 'memory/{{YYYY-MM-DD}}.md' as const,
+      default_visibility: 'private' as const,
+      global_access: 'write' as const,
+      grants: [],
+    };
 
-    renderBranchModal({ branch, currentUser: seb, client });
-
-    fireEvent.click(await screen.findByRole('tab', { name: /knowledge/i }));
-    fireEvent.mouseDown(await screen.findByLabelText(/home knowledge namespace/i));
-    fireEvent.click(await screen.findByText(/New Home/));
-    fireEvent.click(screen.getByRole('button', { name: /save home/i }));
-
-    await waitFor(() => {
-      const branchPatchCall = calls.find(
-        (call) => call.service === 'branches' && call.method === 'patch'
-      );
-      expect(branchPatchCall).toBeDefined();
-      const patch = branchPatchCall?.args[1] as Partial<Branch> | undefined;
-      expect(patch?.custom_context).toEqual({
+    expect(buildAssistantKnowledgePatch(branch, kb)).toEqual({
+      custom_context: {
         agent: {
-          kb: expect.objectContaining({
-            primary_namespace_id: 'ns-new',
-            primary_namespace_slug: 'new-home',
-            default_visibility: 'private',
-          }),
+          kb,
         },
-      });
+      },
     });
   });
 });

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
@@ -6,7 +6,7 @@
  * admin/owner and partial-RBAC-data cases.
  */
 
-import type { AgorClient, Branch, User } from '@agor-live/client';
+import type { AgorClient, AssistantConfig, Branch, User } from '@agor-live/client';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BranchModal } from './BranchModal';
@@ -165,6 +165,81 @@ describe('BranchModal — permissions tab visibility', () => {
           }),
         ])
       );
+    });
+  });
+
+  it('saves Knowledge changes back to legacy custom_context.agent storage', async () => {
+    const seb = makeUser({ user_id: 'seb', role: 'member' });
+    const branch = makeBranch({
+      created_by: seb.user_id,
+      board_id: 'board-1' as Branch['board_id'],
+      custom_context: {
+        agent: {
+          kind: 'assistant',
+          displayName: 'Legacy Assistant',
+          emoji: '🤖',
+          kb: {
+            primary_namespace_id: 'ns-old',
+            primary_namespace_slug: 'old-home',
+            memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+            default_visibility: 'public',
+            global_access: 'write',
+            grants: [],
+          },
+        } as AssistantConfig,
+      },
+    });
+    const { client, calls } = makeStubClient({
+      owners: [seb],
+      users: [seb],
+      namespaces: [
+        {
+          namespace_id: 'ns-old',
+          slug: 'old-home',
+          display_name: 'Old Home',
+          kind: 'branch',
+          visibility_default: 'public',
+          others_can: 'write',
+          effective_permission: 'own',
+          created_at: new Date(),
+          archived: false,
+        },
+        {
+          namespace_id: 'ns-new',
+          slug: 'new-home',
+          display_name: 'New Home',
+          kind: 'team',
+          visibility_default: 'private',
+          others_can: 'none',
+          effective_permission: 'write',
+          created_at: new Date(),
+          archived: false,
+        },
+      ],
+    });
+
+    renderBranchModal({ branch, currentUser: seb, client });
+
+    fireEvent.click(await screen.findByRole('tab', { name: /knowledge/i }));
+    fireEvent.mouseDown(await screen.findByLabelText(/home knowledge namespace/i));
+    fireEvent.click(await screen.findByText(/New Home/));
+    fireEvent.click(screen.getByRole('button', { name: /save home/i }));
+
+    await waitFor(() => {
+      const branchPatchCall = calls.find(
+        (call) => call.service === 'branches' && call.method === 'patch'
+      );
+      expect(branchPatchCall).toBeDefined();
+      const patch = branchPatchCall?.args[1] as Partial<Branch> | undefined;
+      expect(patch?.custom_context).toEqual({
+        agent: {
+          kb: expect.objectContaining({
+            primary_namespace_id: 'ns-new',
+            primary_namespace_slug: 'new-home',
+            default_visibility: 'private',
+          }),
+        },
+      });
     });
   });
 });

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { AgorClient, Branch, User } from '@agor-live/client';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BranchModal } from './BranchModal';
 import {
@@ -89,5 +89,82 @@ describe('BranchModal — permissions tab visibility', () => {
 
     expect(await screen.findByRole('tab', { name: /assistant/i })).toBeInTheDocument();
     expect(await screen.findByRole('tab', { name: /permissions/i })).toBeInTheDocument();
+  });
+
+  it('lets assistant owners change the home Knowledge namespace from the Knowledge tab', async () => {
+    const seb = makeUser({ user_id: 'seb', role: 'member' });
+    const branch = makeAssistantBranch(
+      { created_by: seb.user_id },
+      {
+        kb: {
+          primary_namespace_id: 'ns-old',
+          primary_namespace_slug: 'old-home',
+          memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+          default_visibility: 'public',
+          global_access: 'write',
+          grants: [],
+        },
+      }
+    );
+    const { client, calls } = makeStubClient({
+      owners: [seb],
+      users: [seb],
+      namespaces: [
+        {
+          namespace_id: 'ns-old',
+          slug: 'old-home',
+          display_name: 'Old Home',
+          kind: 'branch',
+          visibility_default: 'public',
+          others_can: 'write',
+          effective_permission: 'own',
+          created_at: new Date(),
+          archived: false,
+        },
+        {
+          namespace_id: 'ns-new',
+          slug: 'new-home',
+          display_name: 'New Home',
+          kind: 'team',
+          visibility_default: 'private',
+          others_can: 'none',
+          effective_permission: 'write',
+          created_at: new Date(),
+          archived: false,
+        },
+      ],
+    });
+
+    renderBranchModal({ branch, currentUser: seb, client });
+
+    fireEvent.click(await screen.findByRole('tab', { name: /knowledge/i }));
+    fireEvent.mouseDown(await screen.findByLabelText(/home knowledge namespace/i));
+    fireEvent.click(await screen.findByText(/New Home/));
+    fireEvent.click(screen.getByRole('button', { name: /save home/i }));
+
+    await waitFor(() => {
+      expect(calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            service: 'branches',
+            method: 'patch',
+            args: expect.arrayContaining([
+              branch.branch_id,
+              expect.objectContaining({
+                custom_context: expect.objectContaining({
+                  assistant: expect.objectContaining({
+                    kb: expect.objectContaining({
+                      primary_namespace_id: 'ns-new',
+                      primary_namespace_slug: 'new-home',
+                      default_visibility: 'private',
+                    }),
+                  }),
+                }),
+              }),
+            ]),
+          }),
+        ])
+      );
+    });
   });
 });

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { AgorClient, AssistantConfig, Branch, User } from '@agor-live/client';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BranchModal } from './BranchModal';
 import { buildAssistantKnowledgePatch } from './tabs/KnowledgeTab';
@@ -92,80 +92,23 @@ describe('BranchModal — permissions tab visibility', () => {
     expect(await screen.findByRole('tab', { name: /permissions/i })).toBeInTheDocument();
   });
 
-  it('lets assistant owners change the home Knowledge namespace from the Knowledge tab', async () => {
-    const seb = makeUser({ user_id: 'seb', role: 'member' });
-    const branch = makeAssistantBranch(
-      { created_by: seb.user_id },
-      {
-        kb: {
-          primary_namespace_id: 'ns-old',
-          primary_namespace_slug: 'old-home',
-          memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
-          default_visibility: 'public',
-          global_access: 'write',
-          grants: [],
-        },
-      }
-    );
-    const { client, calls } = makeStubClient({
-      owners: [seb],
-      users: [seb],
-      namespaces: [
-        {
-          namespace_id: 'ns-old',
-          slug: 'old-home',
-          display_name: 'Old Home',
-          kind: 'branch',
-          visibility_default: 'public',
-          others_can: 'write',
-          effective_permission: 'own',
-          created_at: new Date(),
-          archived: false,
-        },
-        {
-          namespace_id: 'ns-new',
-          slug: 'new-home',
-          display_name: 'New Home',
-          kind: 'team',
-          visibility_default: 'private',
-          others_can: 'none',
-          effective_permission: 'write',
-          created_at: new Date(),
-          archived: false,
-        },
-      ],
-    });
+  it('builds Knowledge patches against modern custom_context.assistant storage', () => {
+    const branch = makeAssistantBranch();
+    const kb = {
+      primary_namespace_id: 'ns-new',
+      primary_namespace_slug: 'new-home',
+      memory_path_template: 'memory/{{YYYY-MM-DD}}.md' as const,
+      default_visibility: 'private' as const,
+      global_access: 'write' as const,
+      grants: [],
+    };
 
-    renderBranchModal({ branch, currentUser: seb, client });
-
-    fireEvent.click(await screen.findByRole('tab', { name: /knowledge/i }));
-    fireEvent.mouseDown(await screen.findByLabelText(/home knowledge namespace/i));
-    fireEvent.click(await screen.findByText(/New Home/));
-    fireEvent.click(screen.getByRole('button', { name: /save home/i }));
-
-    await waitFor(() => {
-      expect(calls).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            service: 'branches',
-            method: 'patch',
-            args: expect.arrayContaining([
-              branch.branch_id,
-              expect.objectContaining({
-                custom_context: expect.objectContaining({
-                  assistant: expect.objectContaining({
-                    kb: expect.objectContaining({
-                      primary_namespace_id: 'ns-new',
-                      primary_namespace_slug: 'new-home',
-                      default_visibility: 'private',
-                    }),
-                  }),
-                }),
-              }),
-            ]),
-          }),
-        ])
-      );
+    expect(buildAssistantKnowledgePatch(branch, kb)).toEqual({
+      custom_context: {
+        assistant: {
+          kb,
+        },
+      },
     });
   });
 

--- a/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
@@ -57,6 +57,20 @@ function namespaceSelectLabel(namespace: KnowledgeNamespace) {
   return `${namespace.display_name} (${namespace.slug}) · ${permission}`;
 }
 
+export function buildAssistantKnowledgePatch(
+  branch: Pick<Branch, 'custom_context'>,
+  nextKb: Partial<AssistantKnowledgeConfig>
+): Partial<Branch> {
+  const assistantConfigKey = branch.custom_context?.assistant ? 'assistant' : 'agent';
+  return {
+    custom_context: {
+      [assistantConfigKey]: {
+        kb: nextKb,
+      },
+    },
+  };
+}
+
 export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({ branch, client, canEdit }) => {
   const { showSuccess, showError } = useThemedMessage();
   const assistant = useMemo(() => getAssistantConfig(branch), [branch]);
@@ -143,14 +157,9 @@ export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({ branch, client, canE
     if (!client) return;
     setSavingPolicy(true);
     try {
-      const assistantConfigKey = branch.custom_context?.assistant ? 'assistant' : 'agent';
-      const updated = (await client.service('branches').patch(branch.branch_id, {
-        custom_context: {
-          [assistantConfigKey]: {
-            kb: nextKb,
-          },
-        },
-      } as Partial<Branch>)) as Branch;
+      const updated = (await client
+        .service('branches')
+        .patch(branch.branch_id, buildAssistantKnowledgePatch(branch, nextKb))) as Branch;
       const savedKb = getAssistantConfig(updated)?.kb ?? nextKb;
       setKb(savedKb);
       showSuccess('Assistant Knowledge policy saved');

--- a/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
@@ -27,7 +27,6 @@ interface KnowledgeTabProps {
   branch: Branch;
   client: AgorClient | null;
   canEdit: boolean;
-  onBranchUpdated?: (branch: Branch) => void;
 }
 
 type EditableGrant = AssistantKnowledgeGrant & { key: string };
@@ -58,12 +57,7 @@ function namespaceSelectLabel(namespace: KnowledgeNamespace) {
   return `${namespace.display_name} (${namespace.slug}) · ${permission}`;
 }
 
-export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
-  branch,
-  client,
-  canEdit,
-  onBranchUpdated,
-}) => {
+export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({ branch, client, canEdit }) => {
   const { showSuccess, showError } = useThemedMessage();
   const assistant = useMemo(() => getAssistantConfig(branch), [branch]);
   const initialKb = assistant?.kb;
@@ -135,7 +129,6 @@ export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
       setNamespace(result.namespace);
       const nextKb = getAssistantConfig(result.branch)?.kb ?? kb;
       setKb(nextKb);
-      onBranchUpdated?.(result.branch);
       showSuccess('Assistant Knowledge namespace is ready');
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -152,16 +145,13 @@ export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
     try {
       const updated = (await client.service('branches').patch(branch.branch_id, {
         custom_context: {
-          ...(branch.custom_context ?? {}),
           assistant: {
-            ...assistant,
             kb: nextKb,
           },
         },
       } as Partial<Branch>)) as Branch;
       const savedKb = getAssistantConfig(updated)?.kb ?? nextKb;
       setKb(savedKb);
-      onBranchUpdated?.(updated);
       showSuccess('Assistant Knowledge policy saved');
     } catch (err) {
       showError(err instanceof Error ? err.message : String(err));

--- a/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
@@ -38,6 +38,8 @@ const ACCESS_OPTIONS: Array<{ label: string; value: AssistantKnowledgeGrantAcces
   { label: 'Write', value: 'write' },
 ];
 
+const HOME_NAMESPACE_PERMISSIONS = new Set(['write', 'own']);
+
 function emptyKbConfig(): Partial<AssistantKnowledgeConfig> {
   return {
     memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
@@ -49,6 +51,11 @@ function emptyKbConfig(): Partial<AssistantKnowledgeConfig> {
 
 function grantKey(grant: Pick<AssistantKnowledgeGrant, 'namespace_id' | 'namespace_slug'>) {
   return grant.namespace_id || grant.namespace_slug;
+}
+
+function namespaceSelectLabel(namespace: KnowledgeNamespace) {
+  const permission = namespace.effective_permission ?? 'unknown';
+  return `${namespace.display_name} (${namespace.slug}) · ${permission}`;
 }
 
 export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
@@ -145,6 +152,7 @@ export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
     try {
       const updated = (await client.service('branches').patch(branch.branch_id, {
         custom_context: {
+          ...(branch.custom_context ?? {}),
           assistant: {
             ...assistant,
             kb: nextKb,
@@ -160,6 +168,19 @@ export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
     } finally {
       setSavingPolicy(false);
     }
+  };
+
+  const selectHomeNamespace = (namespaceId: string) => {
+    const selected = namespaceById.get(namespaceId);
+    if (!selected) return;
+    setKb((current) => ({
+      ...current,
+      primary_namespace_id: selected.namespace_id,
+      primary_namespace_slug: selected.slug,
+      default_visibility: selected.visibility_default,
+      memory_path_template: current.memory_path_template ?? 'memory/{{YYYY-MM-DD}}.md',
+    }));
+    setNamespace(selected);
   };
 
   const updateGrant = (key: string, patch: Partial<AssistantKnowledgeGrant>) => {
@@ -233,39 +254,81 @@ export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({
             </Space>
           }
         >
-          {loading ? (
-            <Spin />
-          ) : missing ? (
-            <Alert
-              type="warning"
-              showIcon
-              message="Home namespace is missing or unavailable"
-              description={error || 'namespace for this agent is not set up'}
-            />
-          ) : (
-            <Descriptions column={1} size="small">
-              <Descriptions.Item label="Name">{namespace?.display_name}</Descriptions.Item>
-              <Descriptions.Item label="Slug">
-                <Typography.Text code>
-                  {namespace?.slug ?? kb.primary_namespace_slug}
-                </Typography.Text>
-              </Descriptions.Item>
-              <Descriptions.Item label="Your permission">
-                <Tag>{namespace?.effective_permission ?? 'unknown'}</Tag>
-              </Descriptions.Item>
-              <Descriptions.Item label="Default document visibility">
-                <Tag>{namespace?.visibility_default ?? kb.default_visibility}</Tag>
-              </Descriptions.Item>
-              <Descriptions.Item label="Others can">
-                <Tag>{namespace?.others_can ?? 'unknown'}</Tag>
-              </Descriptions.Item>
-              <Descriptions.Item label="Memory path">
-                <Typography.Text code>
-                  {kb.memory_path_template ?? 'memory/{{YYYY-MM-DD}}.md'}
-                </Typography.Text>
-              </Descriptions.Item>
-            </Descriptions>
-          )}
+          <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+            <Typography.Paragraph type="secondary" style={{ marginBottom: 0 }}>
+              The home namespace is where this assistant stores its memory and where
+              assistant-specific Knowledge tools start by default. Choose a namespace you can write
+              to.
+            </Typography.Paragraph>
+
+            {canEdit && (
+              <Space.Compact style={{ width: '100%' }}>
+                <Select
+                  showSearch
+                  aria-label="Home Knowledge namespace"
+                  placeholder="Select home Knowledge namespace"
+                  value={kb.primary_namespace_id}
+                  loading={loading}
+                  disabled={!client || repairing}
+                  optionFilterProp="label"
+                  onChange={selectHomeNamespace}
+                  style={{ minWidth: 360, flex: 1 }}
+                  options={namespaces.map((item) => {
+                    const canUseAsHome = HOME_NAMESPACE_PERMISSIONS.has(
+                      item.effective_permission ?? 'none'
+                    );
+                    return {
+                      label: namespaceSelectLabel(item),
+                      value: item.namespace_id,
+                      disabled: !canUseAsHome && item.namespace_id !== kb.primary_namespace_id,
+                    };
+                  })}
+                />
+                <Button
+                  type="primary"
+                  onClick={() => patchKb(kb)}
+                  loading={savingPolicy}
+                  disabled={!client || !kb.primary_namespace_id}
+                >
+                  Save home
+                </Button>
+              </Space.Compact>
+            )}
+
+            {loading ? (
+              <Spin />
+            ) : missing ? (
+              <Alert
+                type="warning"
+                showIcon
+                message="Home namespace is missing or unavailable"
+                description={error || 'namespace for this agent is not set up'}
+              />
+            ) : (
+              <Descriptions column={1} size="small">
+                <Descriptions.Item label="Name">{namespace?.display_name}</Descriptions.Item>
+                <Descriptions.Item label="Slug">
+                  <Typography.Text code>
+                    {namespace?.slug ?? kb.primary_namespace_slug}
+                  </Typography.Text>
+                </Descriptions.Item>
+                <Descriptions.Item label="Your permission">
+                  <Tag>{namespace?.effective_permission ?? 'unknown'}</Tag>
+                </Descriptions.Item>
+                <Descriptions.Item label="Default document visibility">
+                  <Tag>{namespace?.visibility_default ?? kb.default_visibility}</Tag>
+                </Descriptions.Item>
+                <Descriptions.Item label="Others can">
+                  <Tag>{namespace?.others_can ?? 'unknown'}</Tag>
+                </Descriptions.Item>
+                <Descriptions.Item label="Memory path">
+                  <Typography.Text code>
+                    {kb.memory_path_template ?? 'memory/{{YYYY-MM-DD}}.md'}
+                  </Typography.Text>
+                </Descriptions.Item>
+              </Descriptions>
+            )}
+          </Space>
         </Card>
 
         <Card

--- a/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/KnowledgeTab.tsx
@@ -143,9 +143,10 @@ export const KnowledgeTab: React.FC<KnowledgeTabProps> = ({ branch, client, canE
     if (!client) return;
     setSavingPolicy(true);
     try {
+      const assistantConfigKey = branch.custom_context?.assistant ? 'assistant' : 'agent';
       const updated = (await client.service('branches').patch(branch.branch_id, {
         custom_context: {
-          assistant: {
+          [assistantConfigKey]: {
             kb: nextKb,
           },
         },

--- a/apps/agor-ui/src/components/BranchModal/testUtils.tsx
+++ b/apps/agor-ui/src/components/BranchModal/testUtils.tsx
@@ -1,4 +1,11 @@
-import type { AgorClient, AssistantConfig, Branch, Repo, User } from '@agor-live/client';
+import type {
+  AgorClient,
+  AssistantConfig,
+  Branch,
+  KnowledgeNamespace,
+  Repo,
+  User,
+} from '@agor-live/client';
 import { render } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ReactElement, ReactNode } from 'react';
@@ -28,6 +35,7 @@ export interface StubClientOptions {
   failBranchPatch?: boolean;
   /** Throw a 500-style error on the initial owners.find load. */
   failOwnersFind?: boolean;
+  namespaces?: KnowledgeNamespace[];
 }
 
 export function makeStubClient(opts: StubClientOptions = {}): {
@@ -70,7 +78,20 @@ export function makeStubClient(opts: StubClientOptions = {}): {
           if (path === 'branches/:id/effective-access') {
             return opts.effectiveAccess ?? { can: 'session', is_owner: false, source: 'others' };
           }
+          if (path === 'kb/namespaces') {
+            return opts.namespaces ?? [];
+          }
           return [];
+        },
+        async get(id: string) {
+          if (path === 'kb/namespaces') {
+            const namespace = opts.namespaces?.find((item) => item.namespace_id === id);
+            if (namespace) return namespace;
+            const err = new Error('not found') as Error & { code?: number };
+            err.code = 404;
+            throw err;
+          }
+          return { id };
         },
         async findAll(args: unknown) {
           calls.push({ service: path, method: 'findAll', args: [args] });


### PR DESCRIPTION
## Summary

- Add a searchable home Knowledge namespace selector to assistant branch settings.
- Save changes through the existing `custom_context.assistant.kb.primary_namespace_*` model.
- Enforce that changing an assistant home namespace targets a namespace the caller can write/own.

## Details

Assistant Knowledge already had a home namespace model (`primary_namespace_id` / `primary_namespace_slug`), but the UI only displayed or repaired it. This adds a `BranchModal → Knowledge → Home namespace` control so assistant owners can move an assistant to another Knowledge namespace without editing raw config.

The selector uses the existing `kb/namespaces` service, so namespace visibility is still governed by backend permissions. Read-only namespaces remain visible when returned by the service but are disabled as home targets because assistant memory tools write to the home namespace.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm -C apps/agor-ui test -- BranchModal.test.tsx`
- `pnpm -C apps/agor-daemon test -- branches.test.ts assistant-knowledge.test.ts knowledge.test.ts`

Note: `pnpm check` completed successfully with existing Biome warnings in unrelated files.
