### PR TITLE
Add compact Knowledge namespace tree MCP tool

### DIFF
--- a/apps/agor-daemon/src/mcp/routes.test.ts
+++ b/apps/agor-daemon/src/mcp/routes.test.ts
@@ -106,6 +106,7 @@ describeIntegration('MCP Tools - Session Tools', () => {
     expect(toolNames).toContain('agor_user_create');
     expect(toolNames).toContain('agor_kb_namespaces_list');
     expect(toolNames).toContain('agor_kb_namespace_put');
+    expect(toolNames).toContain('agor_kb_tree');
     expect(toolNames).toContain('agor_kb_search');
     expect(toolNames).toContain('agor_kb_get');
     expect(toolNames).toContain('agor_kb_put');

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -38,6 +38,11 @@ vi.mock('@agor/core/types', () => ({
   KNOWLEDGE_GRAPH_EDGE_TYPES: ['references', 'relates_to'],
   KNOWLEDGE_GRAPH_NODE_TYPES: ['document', 'external'],
   KNOWLEDGE_VISIBILITIES: ['public', 'private'],
+  normalizeKnowledgeFolderPath: (folder?: string | null) =>
+    (folder ?? '')
+      .trim()
+      .replace(/^\/+|\/+$/g, '')
+      .replace(/\/+/g, '/'),
   normalizeKnowledgeDocumentIconEmoji: (icon: string | null | undefined) =>
     typeof icon === 'string' && icon.trim() ? icon.trim() : null,
   parseKnowledgeUri: () => undefined,
@@ -605,6 +610,55 @@ describe('Knowledge MCP input schemas', () => {
         kind: 'doc',
         path: 'runbooks/deploy.md',
         uri: 'agor://kb/global/runbooks/deploy.md',
+        reference_uri: 'agor://kb/document/doc-1',
+        status: 'published',
+      },
+    ]);
+  });
+
+  it('normalizes pathPrefix before querying and shaping the tree', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'guides/a.md',
+          uri: 'agor://kb/global/guides/a.md',
+          title: 'A',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: null,
+        score: 0,
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const result = textResultJson(
+      await tools.agor_kb_tree.handler?.({
+        namespace: 'global',
+        pathPrefix: '/guides//',
+      })
+    ) as Record<string, any>;
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          path_prefix: 'guides',
+        }),
+      })
+    );
+    expect(result.path_prefix).toBe('guides');
+    expect(result.tree).toEqual([
+      {
+        type: 'doc',
+        title: 'A',
+        kind: 'doc',
+        path: 'guides/a.md',
+        uri: 'agor://kb/global/guides/a.md',
         reference_uri: 'agor://kb/document/doc-1',
         status: 'published',
       },

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -113,6 +113,18 @@ describe('Knowledge MCP input schemas', () => {
     expect(issueMessages(empty?.error)).toContain('slug cannot be empty.');
   });
 
+  it('requires agor_kb_tree namespace to be non-blank', async () => {
+    const tools = await captureKnowledgeTools();
+
+    const missing = tools.agor_kb_tree.cfg.inputSchema?.safeParse({});
+    const blank = tools.agor_kb_tree.cfg.inputSchema?.safeParse({ namespace: '   ' });
+
+    expect(missing?.success).toBe(false);
+    expect(issueMessages(missing?.error)).toContain('namespace is required and must be a string.');
+    expect(blank?.success).toBe(false);
+    expect(issueMessages(blank?.error)).toContain('namespace cannot be blank.');
+  });
+
   it('allows metadata-only document put payloads for existing documents', async () => {
     const tools = await captureKnowledgeTools();
 
@@ -434,6 +446,121 @@ describe('Knowledge MCP input schemas', () => {
     expect(result[0]).not.toHaveProperty('snippet');
     expect(result[0].current_version).not.toHaveProperty('content_text');
     expect(result[0].document.reference_uri).toBe('agor://kb/document/doc-1');
+  });
+
+  it('returns a compact Knowledge namespace tree without content or version metadata', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'runbooks/deploy.md',
+          uri: 'agor://kb/global/runbooks/deploy.md',
+          title: 'Deploy',
+          icon_emoji: '📘',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+          metadata: { noisy: true },
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: {
+          version_id: 'ver-1',
+          document_id: 'doc-1',
+          version_number: 1,
+          content_text: 'sensitive body',
+        },
+        snippet: 'sensitive body',
+        score: 0,
+      },
+      {
+        document: {
+          document_id: 'doc-2',
+          namespace_id: 'ns-1',
+          path: 'notes/today.md',
+          uri: 'agor://kb/global/notes/today.md',
+          title: 'Today',
+          kind: 'note',
+          visibility: 'private',
+          status: 'draft',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: {
+          version_id: 'ver-2',
+          document_id: 'doc-2',
+          version_number: 1,
+          content_text: 'draft body',
+        },
+        snippet: 'draft body',
+        score: 0,
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const result = textResultJson(
+      await tools.agor_kb_tree.handler?.({ namespace: 'global', depth: 2 })
+    ) as Record<string, any>;
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          q: '',
+          namespace_slug: 'global',
+          include_my_drafts: true,
+          include_other_user_drafts: false,
+          limit: 100,
+        }),
+      })
+    );
+    expect(result).toEqual({
+      namespace: 'global',
+      path_prefix: null,
+      depth: 2,
+      count: 2,
+      truncated: false,
+      tree: [
+        {
+          type: 'folder',
+          name: 'notes',
+          path: 'notes',
+          document_count: 1,
+          children: [
+            {
+              type: 'doc',
+              title: 'Today',
+              kind: 'note',
+              path: 'notes/today.md',
+              uri: 'agor://kb/global/notes/today.md',
+              reference_uri: 'agor://kb/document/doc-2',
+              status: 'draft',
+            },
+          ],
+        },
+        {
+          type: 'folder',
+          name: 'runbooks',
+          path: 'runbooks',
+          document_count: 1,
+          children: [
+            {
+              type: 'doc',
+              icon: '📘',
+              title: 'Deploy',
+              kind: 'doc',
+              path: 'runbooks/deploy.md',
+              uri: 'agor://kb/global/runbooks/deploy.md',
+              reference_uri: 'agor://kb/document/doc-1',
+              status: 'published',
+            },
+          ],
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain('sensitive body');
+    expect(JSON.stringify(result)).not.toContain('current_version');
+    expect(JSON.stringify(result)).not.toContain('metadata');
   });
 
   it('includes full Knowledge search content only when explicitly requested', async () => {

--- a/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.test.ts
@@ -563,6 +563,133 @@ describe('Knowledge MCP input schemas', () => {
     expect(JSON.stringify(result)).not.toContain('metadata');
   });
 
+  it('places an exact pathPrefix document at the tree root', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'runbooks/deploy.md',
+          uri: 'agor://kb/global/runbooks/deploy.md',
+          title: 'Deploy',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: null,
+        score: 0,
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const result = textResultJson(
+      await tools.agor_kb_tree.handler?.({
+        namespace: 'global',
+        pathPrefix: 'runbooks/deploy.md',
+      })
+    ) as Record<string, any>;
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          path_prefix: 'runbooks/deploy.md',
+        }),
+      })
+    );
+    expect(result.tree).toEqual([
+      {
+        type: 'doc',
+        title: 'Deploy',
+        kind: 'doc',
+        path: 'runbooks/deploy.md',
+        uri: 'agor://kb/global/runbooks/deploy.md',
+        reference_uri: 'agor://kb/document/doc-1',
+        status: 'published',
+      },
+    ]);
+  });
+
+  it('expands depth as folder levels below the prefix and groups deeper docs', async () => {
+    const find = vi.fn().mockResolvedValue([
+      {
+        document: {
+          document_id: 'doc-1',
+          namespace_id: 'ns-1',
+          path: 'guides/a.md',
+          uri: 'agor://kb/global/guides/a.md',
+          title: 'A',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: null,
+        score: 0,
+      },
+      {
+        document: {
+          document_id: 'doc-2',
+          namespace_id: 'ns-1',
+          path: 'guides/nested/b.md',
+          uri: 'agor://kb/global/guides/nested/b.md',
+          title: 'B',
+          kind: 'doc',
+          visibility: 'public',
+          status: 'published',
+          edit_policy: 'namespace',
+        },
+        namespace: { namespace_id: 'ns-1', slug: 'global', display_name: 'Global' },
+        current_version: null,
+        score: 0,
+      },
+    ]);
+    const tools = await captureKnowledgeTools({ 'kb/search': { find } });
+
+    const result = textResultJson(
+      await tools.agor_kb_tree.handler?.({ namespace: 'global', depth: 1 })
+    ) as Record<string, any>;
+
+    expect(result.tree).toEqual([
+      {
+        type: 'folder',
+        name: 'guides',
+        path: 'guides',
+        document_count: 2,
+        children: [
+          {
+            type: 'folder',
+            name: '…',
+            path: 'guides/…',
+            document_count: 1,
+            children: [
+              {
+                type: 'doc',
+                title: 'B',
+                kind: 'doc',
+                path: 'guides/nested/b.md',
+                uri: 'agor://kb/global/guides/nested/b.md',
+                reference_uri: 'agor://kb/document/doc-2',
+                status: 'published',
+              },
+            ],
+          },
+          {
+            type: 'doc',
+            title: 'A',
+            kind: 'doc',
+            path: 'guides/a.md',
+            uri: 'agor://kb/global/guides/a.md',
+            reference_uri: 'agor://kb/document/doc-1',
+            status: 'published',
+          },
+        ],
+      },
+    ]);
+  });
+
   it('includes full Knowledge search content only when explicitly requested', async () => {
     const find = vi.fn().mockResolvedValue([
       {

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -408,6 +408,158 @@ function shapeKnowledgeSearchResponse(
   return shapeKnowledgeSearchResult(enrichWithReferenceUri(result), { contentMode, snippetLines });
 }
 
+type KnowledgeTreeDoc = {
+  type: 'doc';
+  icon?: string | null;
+  title?: string;
+  kind?: string;
+  path: string;
+  uri?: string;
+  reference_uri?: string;
+  status?: string;
+};
+
+type KnowledgeTreeFolder = {
+  type: 'folder';
+  name: string;
+  path: string;
+  document_count: number;
+  children: Array<KnowledgeTreeFolder | KnowledgeTreeDoc>;
+};
+
+function knowledgeSearchRows(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) return value as Array<Record<string, unknown>>;
+  const data = (value as { data?: unknown } | undefined)?.data;
+  return Array.isArray(data) ? (data as Array<Record<string, unknown>>) : [];
+}
+
+function compactKnowledgeTreeDoc(row: Record<string, unknown>): KnowledgeTreeDoc | null {
+  const document = row.document as Record<string, unknown> | undefined;
+  if (!document || typeof document !== 'object') return null;
+  const documentId = coerceString(document.document_id);
+  const path = coerceString(document.path);
+  if (!path) return null;
+
+  const doc: KnowledgeTreeDoc = {
+    type: 'doc',
+    path,
+  };
+  if (document.icon_emoji !== undefined) doc.icon = coerceString(document.icon_emoji) ?? null;
+  const title = coerceString(document.title);
+  if (title) doc.title = title;
+  const kind = coerceString(document.kind);
+  if (kind) doc.kind = kind;
+  const uri = coerceString(document.uri);
+  if (uri) doc.uri = uri;
+  if (documentId) doc.reference_uri = buildKnowledgeDocumentUri(documentId);
+  const status = coerceString(document.status);
+  if (status) doc.status = status;
+  return doc;
+}
+
+function folderSortKey(item: KnowledgeTreeFolder | KnowledgeTreeDoc): string {
+  return item.type === 'folder' ? `0:${item.name}` : `1:${item.path}`;
+}
+
+function sortKnowledgeTree(folder: KnowledgeTreeFolder): KnowledgeTreeFolder {
+  folder.children.sort((a, b) => folderSortKey(a).localeCompare(folderSortKey(b)));
+  for (const child of folder.children) {
+    if (child.type === 'folder') sortKnowledgeTree(child);
+  }
+  return folder;
+}
+
+function incrementFolderCounts(folder: KnowledgeTreeFolder, count = 1): void {
+  folder.document_count += count;
+}
+
+function shapeKnowledgeTreeResponse(
+  result: unknown,
+  args: {
+    namespace?: unknown;
+    pathPrefix?: unknown;
+    depth?: unknown;
+    limit?: unknown;
+  }
+): unknown {
+  const rows = knowledgeSearchRows(enrichWithReferenceUri(result));
+  const docs = rows
+    .map(compactKnowledgeTreeDoc)
+    .filter((doc): doc is KnowledgeTreeDoc => Boolean(doc))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  const depth = typeof args.depth === 'number' && Number.isFinite(args.depth) ? args.depth : 3;
+  const prefix = coerceString(args.pathPrefix) ?? '';
+  const root: KnowledgeTreeFolder = {
+    type: 'folder',
+    name: coerceString(args.namespace) ?? 'knowledge',
+    path: prefix,
+    document_count: 0,
+    children: [],
+  };
+
+  const foldersByPath = new Map<string, KnowledgeTreeFolder>([[prefix, root]]);
+  for (const doc of docs) {
+    const relativePath =
+      prefix && doc.path.startsWith(`${prefix}/`) ? doc.path.slice(prefix.length + 1) : doc.path;
+    const segments = relativePath.split('/').filter(Boolean);
+    if (segments.length === 0) continue;
+    const folderSegments = segments.slice(0, -1);
+    const visibleFolderSegments = folderSegments.slice(0, Math.max(depth - 1, 0));
+    let current = root;
+    incrementFolderCounts(current);
+    let currentPath = prefix;
+
+    for (const segment of visibleFolderSegments) {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      let folder = foldersByPath.get(currentPath);
+      if (!folder) {
+        folder = {
+          type: 'folder',
+          name: segment,
+          path: currentPath,
+          document_count: 0,
+          children: [],
+        };
+        foldersByPath.set(currentPath, folder);
+        current.children.push(folder);
+      }
+      incrementFolderCounts(folder);
+      current = folder;
+    }
+
+    if (folderSegments.length > visibleFolderSegments.length) {
+      const hiddenName = '…';
+      const hiddenPath = currentPath ? `${currentPath}/…` : '…';
+      let hidden = foldersByPath.get(hiddenPath);
+      if (!hidden) {
+        hidden = {
+          type: 'folder',
+          name: hiddenName,
+          path: hiddenPath,
+          document_count: 0,
+          children: [],
+        };
+        foldersByPath.set(hiddenPath, hidden);
+        current.children.push(hidden);
+      }
+      incrementFolderCounts(hidden);
+      current = hidden;
+    }
+
+    current.children.push(doc);
+  }
+
+  const limit = typeof args.limit === 'number' && Number.isFinite(args.limit) ? args.limit : 100;
+  return {
+    namespace: coerceString(args.namespace) ?? null,
+    path_prefix: prefix || null,
+    depth,
+    count: docs.length,
+    truncated: docs.length >= limit,
+    tree: sortKnowledgeTree(root).children,
+  };
+}
+
 function optionalNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
@@ -986,10 +1138,89 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
   );
 
   server.registerTool(
+    'agor_kb_tree',
+    {
+      description:
+        'Browse a Knowledge namespace as a compact folder/document tree. Use this for “show me what is in this namespace” before calling agor_kb_get, agor_kb_outline, or agor_kb_get_range. Returns icon/title/kind/path/URI/reference_uri/status only; no version metadata or content. Uses the same readable namespace and draft visibility rules as agor_kb_search.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        namespace: z
+          .string({
+            error: 'namespace is required and must be a string.',
+          })
+          .refine((value) => value.trim().length > 0, 'namespace cannot be blank.')
+          .describe('Namespace/space slug to browse'),
+        pathPrefix: mcpOptionalNonBlankString(
+          'pathPrefix',
+          'Optional folder/document path prefix inside the namespace'
+        ),
+        depth: z
+          .number({
+            error: 'depth must be a positive integer when provided.',
+          })
+          .int('depth must be an integer.')
+          .positive('depth must be greater than 0.')
+          .max(10, 'depth must be less than or equal to 10.')
+          .optional()
+          .describe('Folder depth to expand below pathPrefix (default: 3, max: 10).'),
+        kind: KnowledgeDocumentKindSchema.optional().describe('Filter by document kind'),
+        status: KnowledgeDocumentStatusSchema.optional().describe(
+          'Filter by lifecycle status: draft or published'
+        ),
+        includeMyDrafts: z
+          .boolean()
+          .optional()
+          .describe('Include documents you authored with status=draft (default: true)'),
+        includeOtherUserDrafts: z
+          .boolean()
+          .optional()
+          .describe(
+            "Include other users' draft documents in browsing (default: false). Drafts remain directly accessible by URL when visibility permits."
+          ),
+        includeArchived: z
+          .boolean()
+          .optional()
+          .describe('Include archived documents (admins only; default: false)'),
+        limit: z
+          .number({
+            error: 'limit must be a positive integer when provided.',
+          })
+          .int('limit must be an integer.')
+          .positive('limit must be greater than 0.')
+          .max(100, 'limit must be less than or equal to 100.')
+          .optional()
+          .describe('Maximum number of documents to include (default: 100, max: 100).'),
+      }),
+    },
+    async (args) => {
+      const service = getOptionalService(ctx, 'kb/search');
+      if (!service) return knowledgeNotImplementedResult('agor_kb_tree', ['kb/search']);
+
+      const query: Record<string, unknown> = {
+        q: '',
+        namespace_slug: coerceString(args.namespace),
+        include_archived: args.includeArchived === true,
+        include_my_drafts: args.includeMyDrafts !== false,
+        include_other_user_drafts: args.includeOtherUserDrafts === true,
+        limit: args.limit ?? 100,
+      };
+      if (args.pathPrefix) query.path_prefix = coerceString(args.pathPrefix);
+      if (args.kind) query.kind = args.kind as KnowledgeDocumentKind;
+      if (args.status) query.status = args.status as KnowledgeDocumentStatus;
+
+      if (service.find) {
+        const result = await service.find(mcpParams(ctx, query));
+        return textResult(shapeKnowledgeTreeResponse(result, args));
+      }
+      return knowledgeNotImplementedResult('agor_kb_tree', ['kb/search.find']);
+    }
+  );
+
+  server.registerTool(
     'agor_kb_search',
     {
       description:
-        'Search or browse Agor Knowledge documents. Use this to find candidate docs from metadata and short snippets, then use agor_kb_get, agor_kb_outline, or agor_kb_get_range to read needed content. Supports text, semantic, and hybrid modes when Knowledge embeddings are enabled/configured. Each result carries a `reference_uri` (agor://kb/document/<id>) — embed that link in another doc to create a graph edge to it.',
+        'Search Agor Knowledge documents. For “show me what is in this namespace” browsing, prefer agor_kb_tree for a compact folder tree. Use search to find candidate docs from metadata and short snippets, then use agor_kb_get, agor_kb_outline, or agor_kb_get_range to read needed content. Supports text, semantic, and hybrid modes when Knowledge embeddings are enabled/configured. Each result carries a `reference_uri` (agor://kb/document/<id>) — embed that link in another doc to create a graph edge to it.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         query: z

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -31,6 +31,7 @@ import {
   KNOWLEDGE_GRAPH_NODE_TYPES,
   KNOWLEDGE_VISIBILITIES,
   normalizeKnowledgeDocumentIconEmoji,
+  normalizeKnowledgeFolderPath,
   parseKnowledgeUri,
 } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -478,6 +479,7 @@ function shapeKnowledgeTreeResponse(
   args: {
     namespace?: unknown;
     pathPrefix?: unknown;
+    normalizedPathPrefix?: unknown;
     depth?: unknown;
     limit?: unknown;
   }
@@ -488,7 +490,9 @@ function shapeKnowledgeTreeResponse(
     .filter((doc): doc is KnowledgeTreeDoc => Boolean(doc))
     .sort((a, b) => a.path.localeCompare(b.path));
   const depth = typeof args.depth === 'number' && Number.isFinite(args.depth) ? args.depth : 3;
-  const prefix = coerceString(args.pathPrefix) ?? '';
+  const prefix =
+    coerceString(args.normalizedPathPrefix) ??
+    normalizeKnowledgeFolderPath(coerceString(args.pathPrefix));
   const root: KnowledgeTreeFolder = {
     type: 'folder',
     name: coerceString(args.namespace) ?? 'knowledge',
@@ -1200,6 +1204,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
       const service = getOptionalService(ctx, 'kb/search');
       if (!service) return knowledgeNotImplementedResult('agor_kb_tree', ['kb/search']);
 
+      const normalizedPathPrefix = normalizeKnowledgeFolderPath(coerceString(args.pathPrefix));
       const query: Record<string, unknown> = {
         q: '',
         namespace_slug: coerceString(args.namespace),
@@ -1208,13 +1213,13 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         include_other_user_drafts: args.includeOtherUserDrafts === true,
         limit: args.limit ?? 100,
       };
-      if (args.pathPrefix) query.path_prefix = coerceString(args.pathPrefix);
+      if (normalizedPathPrefix) query.path_prefix = normalizedPathPrefix;
       if (args.kind) query.kind = args.kind as KnowledgeDocumentKind;
       if (args.status) query.status = args.status as KnowledgeDocumentStatus;
 
       if (service.find) {
         const result = await service.find(mcpParams(ctx, query));
-        return textResult(shapeKnowledgeTreeResponse(result, args));
+        return textResult(shapeKnowledgeTreeResponse(result, { ...args, normalizedPathPrefix }));
       }
       return knowledgeNotImplementedResult('agor_kb_tree', ['kb/search.find']);
     }

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -500,11 +500,15 @@ function shapeKnowledgeTreeResponse(
   const foldersByPath = new Map<string, KnowledgeTreeFolder>([[prefix, root]]);
   for (const doc of docs) {
     const relativePath =
-      prefix && doc.path.startsWith(`${prefix}/`) ? doc.path.slice(prefix.length + 1) : doc.path;
+      prefix && doc.path === prefix
+        ? (doc.path.split('/').filter(Boolean).at(-1) ?? doc.path)
+        : prefix && doc.path.startsWith(`${prefix}/`)
+          ? doc.path.slice(prefix.length + 1)
+          : doc.path;
     const segments = relativePath.split('/').filter(Boolean);
     if (segments.length === 0) continue;
     const folderSegments = segments.slice(0, -1);
-    const visibleFolderSegments = folderSegments.slice(0, Math.max(depth - 1, 0));
+    const visibleFolderSegments = folderSegments.slice(0, depth);
     let current = root;
     incrementFolderCounts(current);
     let currentPath = prefix;

--- a/apps/agor-docs/pages/guide/knowledge.mdx
+++ b/apps/agor-docs/pages/guide/knowledge.mdx
@@ -106,8 +106,9 @@ Knowledge has first-class MCP tools, so agents can use it without leaving their 
 
 Common workflows:
 
-- **Search and load context** with `agor_kb_search`, `agor_kb_get`, `agor_kb_outline`, and `agor_kb_get_range`.
-  `agor_kb_search` is optimized for discovery: non-empty searches return metadata plus short snippets by default, while browse/listing calls with `query: ""` return metadata only. Use `contentMode: "none" | "snippet" | "full"` and `snippetLines` to control result verbosity, and prefer `agor_kb_get` or `agor_kb_get_range` when you need to read document content.
+- **Browse, search, and load context** with `agor_kb_tree`, `agor_kb_search`, `agor_kb_get`, `agor_kb_outline`, and `agor_kb_get_range`.
+  Use `agor_kb_tree({ namespace, pathPrefix?, depth? })` for the common “show me what is in this namespace” request. It returns a compact folder/document tree with icon, title, kind, path, URI, reference URI, and status only — no document content or version metadata.
+  `agor_kb_search` is optimized for query discovery: non-empty searches return metadata plus short snippets by default, while browse/listing calls with `query: ""` return metadata only. Use `contentMode: "none" | "snippet" | "full"` and `snippetLines` to control result verbosity, and prefer `agor_kb_get` or `agor_kb_get_range` when you need to read document content.
   For large markdown docs, use `agor_kb_outline` as the map: it returns heading titles, line ranges, compact size hints, duplicate-heading occurrences, and `sectionRef` selectors such as `root.h1[1].h2[2]`. Then call `agor_kb_get_range` with that `sectionRef` (or a line range / `headingPath` + `occurrence`) to read only the needed section with nearby context. For very large sections, page through the selected section with `offsetLines` and `maxLines`.
 - **File new context** with `agor_kb_put` when an agent discovers something worth keeping.
 - **Make targeted edits** with `agor_kb_edit`, including version checks and dry runs.


### PR DESCRIPTION
## Summary

- add `agor_kb_tree` as a compact read-only MCP tool for browsing a Knowledge namespace
- shape namespace browse output as a folder/document tree with icon, title, kind, path, URI, reference URI, and status only
- reuse `kb/search` filtering so RBAC and draft visibility stay consistent with existing search behavior
- document the new agent workflow and add focused MCP tests

## Validation

- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/mcp/tools/knowledge.test.ts src/mcp/routes.test.ts`
