### PR TITLE
feat(ui): add board locator icon to session cards

### DIFF
--- a/apps/agor-ui/src/components/BranchBoardLocatorIcon.tsx
+++ b/apps/agor-ui/src/components/BranchBoardLocatorIcon.tsx
@@ -1,0 +1,32 @@
+import type { Branch } from '@agor-live/client';
+import { AimOutlined } from '@ant-design/icons';
+import { Tooltip } from 'antd';
+import type React from 'react';
+import { useRecenterMap } from '../contexts/CanvasNavigationContext';
+
+interface BranchBoardLocatorIconProps {
+  branch: Branch | undefined;
+  size?: number;
+}
+
+export const BranchBoardLocatorIcon: React.FC<BranchBoardLocatorIconProps> = ({
+  branch,
+  size = 12,
+}) => {
+  const recenterMap = useRecenterMap();
+  const boardId = branch?.board_id;
+
+  if (!branch || !boardId) return null;
+
+  return (
+    <Tooltip title="Go to card on board">
+      <AimOutlined
+        style={{ fontSize: size, cursor: 'pointer', flexShrink: 0, opacity: 0.5 }}
+        onClick={(e) => {
+          e.stopPropagation();
+          recenterMap(branch.branch_id, { boardId });
+        }}
+      />
+    </Tooltip>
+  );
+};

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../utils/sessionSearch';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { ArchiveActionButton } from '../ArchiveButton';
+import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { HighlightMatch } from '../HighlightMatch';
 import { ChannelPill } from '../Pill';
@@ -442,6 +443,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 </Typography.Text>
               )}
             </div>
+            <BranchBoardLocatorIcon branch={branch} />
           </div>
         </div>
       </SessionItemWithActions>
@@ -481,6 +483,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             <SessionRelationshipIcon session={session} size={10} />
             {renderSessionTitle(session, { strong: true })}
+            <BranchBoardLocatorIcon branch={branch} />
           </div>
         </div>
       </SessionItemWithActions>

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -3,6 +3,7 @@ import { SearchOutlined } from '@ant-design/icons';
 import { Badge, Drawer, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useMemo, useState } from 'react';
+import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import {
   getMatchSnippet,
@@ -253,6 +254,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
                     <HighlightMatch text={titleText} query={trimmedQuery} />
                   </Typography.Text>
                   <SessionRelationshipIcon session={session} />
+                  <BranchBoardLocatorIcon branch={branch} />
                 </div>
 
                 {toolMatches && (

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -3,7 +3,6 @@ import { SearchOutlined } from '@ant-design/icons';
 import { Badge, Drawer, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useMemo, useState } from 'react';
-import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import {
   getMatchSnippet,
@@ -17,6 +16,7 @@ import {
 import { getSessionStatusTone, type StatusTone } from '../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime, formatTimestampWithRelative } from '../../utils/time';
+import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
 import { HighlightMatch } from '../HighlightMatch';
 import { BranchPill } from '../Pill';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';


### PR DESCRIPTION
## Summary

- Adds a `BranchBoardLocatorIcon` component (`AimOutlined` icon, shown only when the session's branch has a `board_id`)
- Icon appears on every session row in the **assistant panel** (`BranchSessionSections`) and the **all-sessions panel** (`BoardSessionList`)
- Clicking the icon calls `useRecenterMap` to pan/zoom to the branch card on the board — cross-board navigation is handled automatically (switches board if needed, then centers on the card)

## Test plan

- [ ] Open a board with branches that have sessions
- [ ] Verify the aim icon (⊕) appears next to session titles when the branch is placed on a board
- [ ] Verify no icon appears for sessions whose branch has no board placement
- [ ] Click the icon from the assistant panel — confirm canvas pans/zooms to the branch card
- [ ] Click the icon from the all-sessions panel — confirm same behavior
- [ ] Test cross-board: session on a different board — confirm board switches then zooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)