### PR TITLE
feat(session-panel): declutter header with attachments + more menu

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -1,4 +1,4 @@
-import { GithubOutlined, LinkOutlined, PaperClipOutlined } from '@ant-design/icons';
+import { GithubOutlined, GlobalOutlined, LinkOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Badge, Button, Dropdown, Tooltip } from 'antd';
 import type React from 'react';
@@ -20,7 +20,7 @@ function getIcon(url: string): React.ReactNode {
   } catch {
     // ignore
   }
-  return <LinkOutlined />;
+  return <GlobalOutlined />;
 }
 
 export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
@@ -51,7 +51,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
     <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
       <Tooltip title="Attachments">
         <Badge count={items.length} size="small" offset={[-4, 4]}>
-          <Button type="text" icon={<PaperClipOutlined />} />
+          <Button type="text" icon={<LinkOutlined />} />
         </Badge>
       </Tooltip>
     </Dropdown>

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -1,0 +1,59 @@
+import { GithubOutlined, LinkOutlined, PaperClipOutlined } from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+import { Badge, Button, Dropdown, Tooltip } from 'antd';
+import type React from 'react';
+
+export interface SessionAttachmentItem {
+  key: string;
+  name: string;
+  url: string;
+}
+
+interface Props {
+  items: SessionAttachmentItem[];
+}
+
+function getIcon(url: string): React.ReactNode {
+  try {
+    const { hostname } = new URL(url);
+    if (hostname === 'github.com' || hostname.endsWith('.github.com')) return <GithubOutlined />;
+  } catch {
+    // ignore
+  }
+  return <LinkOutlined />;
+}
+
+export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
+  if (items.length === 0) return null;
+
+  const menuItems: MenuProps['items'] = items.map((item) => ({
+    key: item.key,
+    icon: getIcon(item.url),
+    label: (
+      <Tooltip title={item.name.length > 40 ? item.name : undefined} placement="left">
+        <span
+          style={{
+            display: 'inline-block',
+            maxWidth: 200,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {item.name}
+        </span>
+      </Tooltip>
+    ),
+    onClick: () => window.open(item.url, '_blank'),
+  }));
+
+  return (
+    <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
+      <Tooltip title="Attachments">
+        <Badge count={items.length} size="small" offset={[-4, 4]}>
+          <Button type="text" icon={<PaperClipOutlined />} />
+        </Badge>
+      </Tooltip>
+    </Dropdown>
+  );
+};

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -23,13 +23,16 @@ import {
   BranchesOutlined,
   CloseOutlined,
   CodeOutlined,
+  EllipsisOutlined,
   ForkOutlined,
+  InboxOutlined,
   QuestionCircleOutlined,
   SendOutlined,
   SettingOutlined,
   StopOutlined,
 } from '@ant-design/icons';
-import { Alert, App, Badge, Button, Space, Spin, Tooltip, Typography, theme } from 'antd';
+import type { MenuProps } from 'antd';
+import { Alert, App, Badge, Button, Dropdown, Space, Spin, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -42,7 +45,6 @@ import { getContextWindowGradient } from '../../utils/contextWindow';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
-import { ArchiveActionButton } from '../ArchiveButton';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { CallbackToggleButton } from '../CallbackToggleButton';
 import { FileUpload, FileUploadButton } from '../FileUpload';
@@ -50,8 +52,11 @@ import { MCPServerPill } from '../MCPServer';
 import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
 import { ContextWindowPill, TimerPill, TokenCountPill } from '../Pill';
+import { getUrlDisplayLabel } from '../Pill/url-helpers';
 import { SessionIdsButton } from '../SessionIds';
 import { ToolIcon } from '../ToolIcon';
+import type { SessionAttachmentItem } from './SessionAttachmentsDropdown';
+import { SessionAttachmentsDropdown } from './SessionAttachmentsDropdown';
 import { SessionMcpFooterControl } from './SessionMcpFooterControl';
 import { SessionPanelContent } from './SessionPanelContent';
 import { SessionRunSettingsPopover } from './SessionRunSettingsPopover';
@@ -459,6 +464,25 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     return null;
   }, [tasks, session?.agentic_tool]);
 
+  const attachmentItems = React.useMemo((): SessionAttachmentItem[] => {
+    const acc: SessionAttachmentItem[] = [];
+    if (branch?.issue_url) {
+      acc.push({
+        key: 'issue',
+        name: `Issue: ${getUrlDisplayLabel(branch.issue_url)}`,
+        url: branch.issue_url,
+      });
+    }
+    if (branch?.pull_request_url) {
+      acc.push({
+        key: 'pr',
+        name: `PR: ${getUrlDisplayLabel(branch.pull_request_url)}`,
+        url: branch.pull_request_url,
+      });
+    }
+    return acc;
+  }, [branch?.issue_url, branch?.pull_request_url]);
+
   const footerGradient = React.useMemo(() => {
     if (!latestContextWindow) return undefined;
     return getContextWindowGradient(
@@ -534,6 +558,48 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       },
     });
   };
+
+  const hasBranchActions = !!branch;
+  const moreMenuItems: MenuProps['items'] = [
+    ...(branch
+      ? [
+          {
+            key: 'center-map',
+            icon: <AimOutlined />,
+            label: 'Center map on branch',
+            onClick: () => recenterMap(branch.branch_id, { boardId: branch.board_id ?? undefined }),
+          },
+        ]
+      : []),
+    ...(onOpenTerminal && branch
+      ? [
+          {
+            key: 'terminal',
+            icon: <CodeOutlined />,
+            label: 'Open terminal',
+            onClick: () => onOpenTerminal([`cd ${branch.path}`], branch.branch_id),
+          },
+        ]
+      : []),
+    ...(hasBranchActions ? [{ type: 'divider' as const }] : []),
+    ...(onOpenSettings
+      ? [
+          {
+            key: 'settings',
+            icon: <SettingOutlined />,
+            label: 'Session Settings',
+            onClick: () => onOpenSettings(session.session_id),
+          },
+        ]
+      : []),
+    {
+      key: 'archive',
+      icon: <InboxOutlined />,
+      label: connectionDisabled ? 'Archive (disconnected)' : 'Archive session',
+      disabled: connectionDisabled || !client,
+      onClick: handleArchive,
+    },
+  ];
 
   const isRunning =
     session.status === SessionStatus.RUNNING || session.status === SessionStatus.STOPPING;
@@ -1017,43 +1083,12 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </div>
           </Space>
           <Space size={4}>
-            {branch && (
-              <Tooltip title="Center map on branch">
-                <Button
-                  type="text"
-                  icon={<AimOutlined />}
-                  onClick={() =>
-                    recenterMap(branch.branch_id, {
-                      boardId: branch.board_id ?? undefined,
-                    })
-                  }
-                />
+            <SessionAttachmentsDropdown items={attachmentItems} />
+            <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
+              <Tooltip title="More actions">
+                <Button type="text" icon={<EllipsisOutlined />} />
               </Tooltip>
-            )}
-            {onOpenTerminal && branch && (
-              <Tooltip title="Open terminal in branch directory">
-                <Button
-                  type="text"
-                  icon={<CodeOutlined />}
-                  onClick={() => onOpenTerminal([`cd ${branch.path}`], branch.branch_id)}
-                />
-              </Tooltip>
-            )}
-            {onOpenSettings && (
-              <Tooltip title="Session Settings">
-                <Button
-                  type="text"
-                  icon={<SettingOutlined />}
-                  onClick={() => onOpenSettings(session.session_id)}
-                />
-              </Tooltip>
-            )}
-            <ArchiveActionButton
-              tooltip={connectionDisabled ? 'Disconnected from daemon' : 'Archive session'}
-              size="middle"
-              disabled={connectionDisabled || !client}
-              onClick={handleArchive}
-            />
+            </Dropdown>
             <Tooltip title="Close Panel">
               <Button
                 type="text"

--- a/apps/agor-ui/vite.config.ts
+++ b/apps/agor-ui/vite.config.ts
@@ -14,7 +14,9 @@ const agorConfig = (() => {
 })();
 
 const defaults = getDefaultConfig();
-const daemonPort = agorConfig.daemon?.port || defaults.daemon?.port || 3030;
+const daemonPort = process.env.VITE_DAEMON_PORT
+  ? Number(process.env.VITE_DAEMON_PORT)
+  : agorConfig.daemon?.port || defaults.daemon?.port || 3030;
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Problem

**In plain English:** The tough questions raised, answered honestly, including where we are still guessing.

**Q: Why reduce the icons at all? What's actually wrong with more icons?**
Two things compound each other. First, the navbar already has icons — profile, board controls, notifications — so by the time a user looks at a session header they're already scanning a visually busy screen. Second, the header had 4–5 *per-session* icons that all looked equally important and equally clickable. The result: hesitation. Users couldn't confidently say what each button did without hovering, which is friction for actions they need to do often (close, archive) and for ones they barely use (center map). Too many equally-weighted choices is worse than fewer choices.

**Q: Where do the links go? Agents create things — issues, PRs, Shortcut stories, Notion docs — and right now there's nowhere obvious to find them.**
That's the actual gap this closes. Previously those links lived inside the session body (if the agent mentioned them in a message) or nowhere visible. The new link icon gives them a permanent home in the header, always in the same place, zero scrolling required. One click surfaces everything the agent created or linked. Badge count tells you at a glance whether anything exists.

**Q: What counts as a "link"? Who decides what goes in that dropdown?**
Currently: `branch.issue_url` and `branch.pull_request_url` — the two fields agents already set when they create a GitHub issue or PR. These cover the most common case (code agent creates a branch + PR). Shortcut, Notion, Linear, and others are not yet wired in; that requires either the agent setting a generic `external_links` field or a dedicated field per provider. We are guessing that issue + PR covers ~80% of the value for now. The component is designed to take any `SessionAttachmentItem[]` so extending it is a one-liner.

**Q: Will users find the \`...\` menu? Hiding actions behind a dropdown risks them feeling lost.**
Fair concern and we are not certain. The bet: the four actions moved into \`...\` (center map, terminal, settings, archive) are all low-frequency. Power users who use them regularly will find them within one session. Casual users who barely used them won't notice they moved. The genuine risk is archive — it used to be a visible button and is now two clicks. We are treating that as acceptable given how rarely it's used, but worth watching.

---

## What changed

Reduces visible session panel header icons from 4–5 to max 3:

- **Link icon** (hidden when no links exist) — opens a dropdown of all issue/PR URLs attached to the branch. Compact display names (`Issue: #123`, `PR: preset-io/agor#45`), tooltips for long names, opens in new tab.
- **Ellipsis `...`** (always visible) — Center Map, Open Terminal, Session Settings, Archive.
- **Close** (always visible, unchanged).

| Before | After |
|---|---|
| AimOutlined (center map) | → `...` menu |
| CodeOutlined (terminal) | → `...` menu |
| SettingOutlined (settings) | → `...` menu |
| ArchiveButton (archive) | → `...` menu |
| — | Link icon (new, only when links exist) |

## New file

`SessionAttachmentsDropdown.tsx` — takes `SessionAttachmentItem[]`, renders badge-counted link button + dropdown. Hidden when empty. Extend by passing more items; no changes to the component needed.

## Test plan

- [ ] Session with branch that has issue + PR URL set → link icon appears with badge count 2
- [ ] Click link icon → both links open in new tab with compact names
- [ ] Long names (>40 chars) → tooltip on hover
- [ ] Click `...` → center map, terminal, settings, archive all present and functional
- [ ] Session with no branch → only `...` and Close (no link icon, no aim/terminal in menu)
- [ ] Session with branch but no issue/PR URLs → only `...` and Close