### PR TITLE
feat(blog): embed HubSpot beta signup form on agor-cloud post

### DIFF
--- a/apps/agor-docs/components/CloudInviteCTA.tsx
+++ b/apps/agor-docs/components/CloudInviteCTA.tsx
@@ -4,18 +4,20 @@ import styles from './CloudInviteCTA.module.css';
 interface CloudInviteCTAProps {
   primaryLabel?: string;
   demoLabel?: string;
+  primaryHref?: string;
 }
 
 export function CloudInviteCTA({
   primaryLabel = 'Join the Private Beta',
   demoLabel = 'Book a Demo',
+  primaryHref = AGOR_CLOUD_INVITE_URL,
 }: CloudInviteCTAProps) {
+  const isInPageAnchor = primaryHref.startsWith('#') || primaryHref.startsWith('/');
   return (
     <div className={styles.wrapper}>
       <a
-        href={AGOR_CLOUD_INVITE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
+        href={primaryHref}
+        {...(isInPageAnchor ? {} : { target: '_blank', rel: 'noopener noreferrer' })}
         className={styles.primary}
       >
         {primaryLabel} →

--- a/apps/agor-docs/components/Hero.module.css
+++ b/apps/agor-docs/components/Hero.module.css
@@ -109,11 +109,14 @@
   padding: 0.875rem 2rem;
   font-size: 1.125rem;
   font-weight: 600;
+  font-family: inherit;
   color: var(--nx-colors-gray-11);
   background: transparent;
   border: 2px solid var(--nx-colors-gray-6);
   border-radius: 8px;
   text-decoration: none;
+  cursor: pointer;
+  appearance: none;
   transition: all 0.2s ease;
 }
 

--- a/apps/agor-docs/components/Hero.tsx
+++ b/apps/agor-docs/components/Hero.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link';
+import { useState } from 'react';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { GifGallery } from './GifGallery';
 import styles from './Hero.module.css';
+import { HubSpotFormModal } from './HubSpotFormModal';
 import { ParticleBackground } from './ParticleBackground';
 
 interface HeroProps {
@@ -23,6 +25,7 @@ export function Hero({
   imageSrc,
   imageAlt = 'Hero image',
 }: HeroProps) {
+  const [isContactOpen, setIsContactOpen] = useState(false);
   return (
     <div className={styles.heroWrapper}>
       <ParticleBackground />
@@ -39,6 +42,13 @@ export function Hero({
             <Link href={ctaLink} className={styles.primaryButton}>
               {ctaText}
             </Link>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={() => setIsContactOpen(true)}
+            >
+              Contact us →
+            </button>
             <Link
               href={GITHUB_REPO_URL}
               target="_blank"
@@ -80,6 +90,8 @@ export function Hero({
       >
         🤍 tsparticles
       </a>
+
+      <HubSpotFormModal isOpen={isContactOpen} onClose={() => setIsContactOpen(false)} />
     </div>
   );
 }

--- a/apps/agor-docs/components/Hero.tsx
+++ b/apps/agor-docs/components/Hero.tsx
@@ -47,7 +47,7 @@ export function Hero({
               className={styles.secondaryButton}
               onClick={() => setIsContactOpen(true)}
             >
-              Join the Private Beta →
+              Contact us →
             </button>
             <Link
               href={GITHUB_REPO_URL}

--- a/apps/agor-docs/components/Hero.tsx
+++ b/apps/agor-docs/components/Hero.tsx
@@ -47,7 +47,7 @@ export function Hero({
               className={styles.secondaryButton}
               onClick={() => setIsContactOpen(true)}
             >
-              Contact us →
+              Join the Private Beta →
             </button>
             <Link
               href={GITHUB_REPO_URL}

--- a/apps/agor-docs/components/HubSpotForm.module.css
+++ b/apps/agor-docs/components/HubSpotForm.module.css
@@ -1,3 +1,7 @@
+/* Wrapper styling only. The form itself lives inside HubSpot's iframe
+ * and is themed via the `css` option passed to hbspt.forms.create — see
+ * HUBSPOT_FORM_CSS in HubSpotForm.tsx. */
+
 .wrapper {
   margin: 2.5rem auto;
   display: flex;
@@ -12,80 +16,6 @@
 .form {
   width: 100%;
   max-width: 560px;
-  padding: 1.75rem 1.5rem;
-  background: rgba(46, 154, 146, 0.05);
-  border: 1px solid rgba(127, 232, 223, 0.2);
-  border-radius: 12px;
-  box-shadow: 0 4px 18px rgba(46, 154, 146, 0.08);
-}
-
-.form :global(form) {
-  font-family: inherit;
-}
-
-/* Pull the embedded form's inputs closer to the surrounding docs styling
- * without fighting HubSpot's stylesheet too hard. */
-.form :global(.hs-form-field) {
-  margin-bottom: 1rem;
-}
-
-.form :global(.hs-form-field > label) {
-  display: block;
-  margin-bottom: 0.35rem;
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-.form :global(input[type="text"]),
-.form :global(input[type="email"]),
-.form :global(input[type="tel"]),
-.form :global(input[type="number"]),
-.form :global(textarea),
-.form :global(select) {
-  width: 100%;
-  padding: 0.55rem 0.75rem;
-  font-size: 1rem;
-  font-family: inherit;
-  border-radius: 6px;
-  border: 1px solid rgba(127, 232, 223, 0.35);
-  background: rgba(10, 10, 10, 0.35);
-  color: inherit;
-  box-sizing: border-box;
-}
-
-.form :global(input[type="submit"]) {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 0.5rem;
-  padding: 0.85rem 1.85rem;
-  font-size: 1.0625rem;
-  font-weight: 700;
-  font-family: inherit;
-  color: #0a0a0a;
-  background: linear-gradient(135deg, #2e9a92 0%, #4ec4ba 100%);
-  border: none;
-  border-radius: 8px;
-  cursor: pointer;
-  box-shadow: 0 4px 14px rgba(46, 154, 146, 0.4);
-  transition:
-    transform 0.15s ease,
-    box-shadow 0.15s ease,
-    background 0.15s ease;
-}
-
-.form :global(input[type="submit"]:hover) {
-  transform: translateY(-1px);
-  background: linear-gradient(135deg, #3db4aa 0%, #6dd5cb 100%);
-  box-shadow: 0 6px 20px rgba(46, 154, 146, 0.55);
-}
-
-.form :global(.hs-error-msgs) {
-  list-style: none;
-  margin: 0.35rem 0 0;
-  padding: 0;
-  color: #ff8a8a;
-  font-size: 0.875rem;
 }
 
 .demoLine {
@@ -104,10 +34,4 @@
 .demoLink:hover {
   color: #a8f5ed;
   text-decoration: underline;
-}
-
-@media (max-width: 640px) {
-  .form {
-    padding: 1.25rem 1rem;
-  }
 }

--- a/apps/agor-docs/components/HubSpotForm.module.css
+++ b/apps/agor-docs/components/HubSpotForm.module.css
@@ -1,0 +1,113 @@
+.wrapper {
+  margin: 2.5rem auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  /* Scroll target offset so anchored jumps don't tuck the form under the
+   * sticky Nextra navbar. */
+  scroll-margin-top: 6rem;
+}
+
+.form {
+  width: 100%;
+  max-width: 560px;
+  padding: 1.75rem 1.5rem;
+  background: rgba(46, 154, 146, 0.05);
+  border: 1px solid rgba(127, 232, 223, 0.2);
+  border-radius: 12px;
+  box-shadow: 0 4px 18px rgba(46, 154, 146, 0.08);
+}
+
+.form :global(form) {
+  font-family: inherit;
+}
+
+/* Pull the embedded form's inputs closer to the surrounding docs styling
+ * without fighting HubSpot's stylesheet too hard. */
+.form :global(.hs-form-field) {
+  margin-bottom: 1rem;
+}
+
+.form :global(.hs-form-field > label) {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.form :global(input[type="text"]),
+.form :global(input[type="email"]),
+.form :global(input[type="tel"]),
+.form :global(input[type="number"]),
+.form :global(textarea),
+.form :global(select) {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  font-size: 1rem;
+  font-family: inherit;
+  border-radius: 6px;
+  border: 1px solid rgba(127, 232, 223, 0.35);
+  background: rgba(10, 10, 10, 0.35);
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.form :global(input[type="submit"]) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.5rem;
+  padding: 0.85rem 1.85rem;
+  font-size: 1.0625rem;
+  font-weight: 700;
+  font-family: inherit;
+  color: #0a0a0a;
+  background: linear-gradient(135deg, #2e9a92 0%, #4ec4ba 100%);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(46, 154, 146, 0.4);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
+}
+
+.form :global(input[type="submit"]:hover) {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, #3db4aa 0%, #6dd5cb 100%);
+  box-shadow: 0 6px 20px rgba(46, 154, 146, 0.55);
+}
+
+.form :global(.hs-error-msgs) {
+  list-style: none;
+  margin: 0.35rem 0 0;
+  padding: 0;
+  color: #ff8a8a;
+  font-size: 0.875rem;
+}
+
+.demoLine {
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  color: inherit;
+  opacity: 0.85;
+}
+
+.demoLink {
+  font-weight: 600;
+  color: #7fe8df;
+  text-decoration: none;
+}
+
+.demoLink:hover {
+  color: #a8f5ed;
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .form {
+    padding: 1.25rem 1rem;
+  }
+}

--- a/apps/agor-docs/components/HubSpotForm.tsx
+++ b/apps/agor-docs/components/HubSpotForm.tsx
@@ -1,0 +1,94 @@
+import Script from 'next/script';
+import { useEffect, useId, useState } from 'react';
+import { AGOR_CLOUD_DEMO_URL } from '../lib/links';
+import styles from './HubSpotForm.module.css';
+
+declare global {
+  interface Window {
+    hbspt?: {
+      forms: {
+        create: (opts: {
+          portalId: string;
+          formId: string;
+          region: string;
+          target: string;
+        }) => void;
+      };
+    };
+  }
+}
+
+const HUBSPOT_PORTAL_ID = '5901754';
+const HUBSPOT_FORM_ID = 'f76e3259-8c31-4e39-8147-8e23fa53be74';
+const HUBSPOT_REGION = 'na1';
+const HUBSPOT_SCRIPT_SRC = 'https://js.hsforms.net/forms/embed/v2.js';
+
+interface HubSpotFormProps {
+  anchorId?: string;
+  showDemoLink?: boolean;
+  portalId?: string;
+  formId?: string;
+  region?: string;
+}
+
+export function HubSpotForm({
+  anchorId = 'cloud-signup-form',
+  showDemoLink = true,
+  portalId = HUBSPOT_PORTAL_ID,
+  formId = HUBSPOT_FORM_ID,
+  region = HUBSPOT_REGION,
+}: HubSpotFormProps) {
+  // useId returns ":r0:"-style strings; strip ":" so we can use it
+  // safely in both a DOM id and a CSS selector.
+  const reactId = useId().replace(/:/g, '');
+  const targetId = `hubspot-form-${reactId}`;
+  const [scriptReady, setScriptReady] = useState(false);
+
+  // The HubSpot loader is cached across client-side navigations, so on
+  // remount window.hbspt is already populated — flip the flag immediately
+  // instead of waiting for an onLoad that will never fire again.
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.hbspt?.forms?.create) {
+      setScriptReady(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!scriptReady) return;
+    if (typeof window === 'undefined' || !window.hbspt?.forms?.create) return;
+    const target = document.getElementById(targetId);
+    if (!target) return;
+    target.innerHTML = '';
+    window.hbspt.forms.create({
+      portalId,
+      formId,
+      region,
+      target: `#${targetId}`,
+    });
+  }, [scriptReady, portalId, formId, region, targetId]);
+
+  return (
+    <div id={anchorId} className={styles.wrapper}>
+      <Script
+        src={HUBSPOT_SCRIPT_SRC}
+        strategy="afterInteractive"
+        onLoad={() => setScriptReady(true)}
+        onReady={() => setScriptReady(true)}
+      />
+      <div id={targetId} className={styles.form} />
+      {showDemoLink && (
+        <p className={styles.demoLine}>
+          Prefer a chat first?{' '}
+          <a
+            href={AGOR_CLOUD_DEMO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.demoLink}
+          >
+            Book a Demo →
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/agor-docs/components/HubSpotForm.tsx
+++ b/apps/agor-docs/components/HubSpotForm.tsx
@@ -12,6 +12,7 @@ declare global {
           formId: string;
           region: string;
           target: string;
+          css?: string;
         }) => void;
       };
     };
@@ -22,6 +23,82 @@ const HUBSPOT_PORTAL_ID = '5901754';
 const HUBSPOT_FORM_ID = 'f76e3259-8c31-4e39-8147-8e23fa53be74';
 const HUBSPOT_REGION = 'na1';
 const HUBSPOT_SCRIPT_SRC = 'https://js.hsforms.net/forms/embed/v2.js';
+
+// HubSpot v2 renders the form inline into our target div and injects
+// whatever we pass via `css` as a <style> tag in the document head. We
+// scope everything under `.hs-form-private` (HubSpot's form class) so
+// we never touch page-level elements. Light-mode rules key off
+// `html:not(.dark)` to follow the docs site's theme class — today the
+// site is `forcedTheme: 'dark'`, so light rules are inert, but they
+// will Just Work the day forcedTheme is dropped.
+const HUBSPOT_FORM_CSS = `
+  .hs-form-private { color: #e6f4f1; font-family: inherit; }
+  .hs-form-private .hs-form-field { margin-bottom: 1rem; }
+  .hs-form-private .hs-form-field > label {
+    display: block;
+    margin-bottom: 0.35rem;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: #e6f4f1;
+  }
+  .hs-form-private .hs-form-required { color: #ff8a8a; margin-left: 4px; }
+  .hs-form-private .hs-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.55rem 0.75rem;
+    font-size: 1rem;
+    font-family: inherit;
+    border-radius: 6px;
+    border: 1px solid rgba(127, 232, 223, 0.35);
+    background: rgba(10, 10, 10, 0.55);
+    color: #e6f4f1;
+  }
+  .hs-form-private .hs-input::placeholder { color: rgba(230, 244, 241, 0.45); }
+  .hs-form-private .hs-input:focus {
+    outline: none;
+    border-color: rgba(127, 232, 223, 0.7);
+    box-shadow: 0 0 0 3px rgba(127, 232, 223, 0.18);
+  }
+  .hs-form-private .hs-button {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 0.85rem 1.85rem;
+    font-size: 1.0625rem;
+    font-weight: 700;
+    font-family: inherit;
+    color: #0a0a0a;
+    background: linear-gradient(135deg, #2e9a92 0%, #4ec4ba 100%);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(46, 154, 146, 0.4);
+    transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  }
+  .hs-form-private .hs-button:hover {
+    transform: translateY(-1px);
+    background: linear-gradient(135deg, #3db4aa 0%, #6dd5cb 100%);
+    box-shadow: 0 6px 20px rgba(46, 154, 146, 0.55);
+  }
+  .hs-form-private .hs-error-msg,
+  .hs-form-private .hs-error-msgs,
+  .hs-form-private .hs-error-msgs label {
+    color: #ff8a8a;
+    font-size: 0.875rem;
+    list-style: none;
+    padding: 0;
+    margin: 0.35rem 0 0;
+  }
+
+  /* Inert today (site is forcedTheme: 'dark'); activates when light mode lands. */
+  html:not(.dark) .hs-form-private,
+  html:not(.dark) .hs-form-private .hs-form-field > label { color: #1a1a1a; }
+  html:not(.dark) .hs-form-private .hs-input {
+    background: #ffffff;
+    color: #1a1a1a;
+    border-color: rgba(46, 154, 146, 0.35);
+  }
+  html:not(.dark) .hs-form-private .hs-input::placeholder { color: rgba(0, 0, 0, 0.4); }
+`;
 
 interface HubSpotFormProps {
   anchorId?: string;
@@ -64,6 +141,7 @@ export function HubSpotForm({
       formId,
       region,
       target: `#${targetId}`,
+      css: HUBSPOT_FORM_CSS,
     });
   }, [scriptReady, portalId, formId, region, targetId]);
 

--- a/apps/agor-docs/components/HubSpotFormModal.module.css
+++ b/apps/agor-docs/components/HubSpotFormModal.module.css
@@ -1,0 +1,77 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 2rem 1rem;
+  overflow-y: auto;
+  cursor: pointer;
+}
+
+.content {
+  position: relative;
+  width: 100%;
+  max-width: 640px;
+  margin: auto;
+  padding: 2rem 1.5rem 1.5rem;
+  background: linear-gradient(135deg, rgba(15, 31, 30, 0.98) 0%, rgba(10, 20, 19, 0.98) 100%);
+  border: 1px solid rgba(127, 232, 223, 0.2);
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  cursor: default;
+  color: inherit;
+}
+
+.title {
+  margin: 0 2rem 0.5rem 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  background: linear-gradient(90deg, #2e9a92 0%, #7fe8df 50%, #a8f5ed 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.closeButton {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  border-radius: 6px;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.closeButton:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid #a8f5ed;
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .backdrop {
+    padding: 1rem 0.5rem;
+  }
+  .content {
+    padding: 1.5rem 1rem 1rem;
+  }
+  .title {
+    font-size: 1.25rem;
+  }
+}

--- a/apps/agor-docs/components/HubSpotFormModal.tsx
+++ b/apps/agor-docs/components/HubSpotFormModal.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { HubSpotForm } from './HubSpotForm';
+import styles from './HubSpotFormModal.module.css';
+
+interface HubSpotFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+}
+
+export function HubSpotFormModal({
+  isOpen,
+  onClose,
+  title = 'Contact us about Agor Cloud',
+}: HubSpotFormModalProps) {
+  // Esc-to-close + lock background scroll while open.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen, onClose]);
+
+  // Unmount the form entirely when closed so the next open gets a fresh
+  // useId / target div — no stale hbspt-rendered DOM hanging around.
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles.backdrop} onClick={onClose} role="presentation" aria-hidden="true">
+      <div
+        className={styles.content}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+      >
+        <button type="button" className={styles.closeButton} onClick={onClose} aria-label="Close">
+          ✕
+        </button>
+        <h2 className={styles.title}>{title}</h2>
+        <HubSpotForm />
+      </div>
+    </div>
+  );
+}

--- a/apps/agor-docs/pages/blog/agor-cloud.mdx
+++ b/apps/agor-docs/pages/blog/agor-cloud.mdx
@@ -6,6 +6,7 @@ image: '/images/blog/agor-cloud.png'
 ---
 
 import { CloudInviteCTA } from '../../components/CloudInviteCTA';
+import { HubSpotForm } from '../../components/HubSpotForm';
 
 # Agor Cloud - Opening a Private Beta
 
@@ -13,7 +14,7 @@ Agor is BSL-licensed and vastly open source. You're free to run it however you w
 
 So why Agor Cloud?
 
-<CloudInviteCTA />
+<CloudInviteCTA primaryHref="#cloud-signup-form" />
 
 ## The Gap Between "Works for Me" and "Works for Production"
 
@@ -212,7 +213,7 @@ Agor Cloud bridges that gap. Fully managed, secure, observable, built by the tea
 
 If that sounds like what your team needs, we'd love to talk.
 
-<CloudInviteCTA />
+<HubSpotForm />
 
 ---
 


### PR DESCRIPTION
## Summary

Wires the new HubSpot beta-signup form (portal `5901754`, form `f76e3259-8c31-4e39-8147-8e23fa53be74`, region `na1`) into two surfaces on the agor.live site:

**1. `/blog/agor-cloud`**

- Embeds the form in place of the final "Join the Private Beta" CTA (after "If that sounds like what your team needs, we'd love to talk.").
- Wraps the embed in an anchorable `#cloud-signup-form` block and points the top-of-post "Join the Private Beta" button at it (`<CloudInviteCTA primaryHref="#cloud-signup-form" />`) instead of the legacy `preset.io/contact-us-about-agor/` link.
- "Book a Demo" is preserved as a small secondary link beneath the form.
- `CloudInviteCTA` gains an optional `primaryHref` prop — internal/anchor hrefs render without `target="_blank"`.

**2. Home page hero (`/`)**

- Adds a new "Contact us →" button to the hero CTA row (between "Learn More!" and "View on GitHub →") that opens a modal containing the same HubSpot form.
- **Why modal over anchor:** the home hero is the top of the funnel — a modal keeps the user on the page without losing pitch context, and avoids forcing a route change just to fill out a form. The blog post's anchor-link path stays available for users who land there directly.
- New `HubSpotFormModal` component: backdrop click + Esc to close, body scroll lock while open, `role="dialog"` + `aria-modal="true"` + close button with aria-label. Form mounts only while the modal is open, so each open gets a fresh `useId` target and no stale hbspt-rendered DOM lingers.

**Shared embed component**

- New `HubSpotForm` component (`apps/agor-docs/components/HubSpotForm.tsx`) used by both surfaces — loads `js.hsforms.net/forms/embed/v2.js` via `next/script` (`afterInteractive`), creates the form inside a stable `useId`-based target `<div>` in `useEffect`, guards `window` access for SSR / static export, and re-creates on remount so client-side navigation and modal open/close both work correctly. `next/script` dedupes the loader, so opening the modal after visiting `/blog/agor-cloud` is instant.

## HubSpot details

| Setting | Value |
| --- | --- |
| portalId | `5901754` |
| formId | `f76e3259-8c31-4e39-8147-8e23fa53be74` |
| region | `na1` |
| Blog anchor | `#cloud-signup-form` |

## Verification

- `pnpm typecheck` (docs): pass
- `pnpm lint` (root, biome): pass (pre-existing warnings only)
- `pnpm --filter @agor/docs build` + sitemap: pass
- `pnpm check` (workspace, excludes docs by design): pass

## Test plan

**Blog post:**
- [ ] Visit `/blog/agor-cloud` — HubSpot form renders in place of the final beta CTA
- [ ] Submit form with test email — confirm submission lands in HubSpot
- [ ] Click "Join the Private Beta" near the top of the post — smoothly scrolls to the embedded form
- [ ] "Book a Demo" link beneath the form opens `meetings.hubspot.com/zane-aitken/...`
- [ ] Navigate away and back — form re-renders (no blank target)

**Home page:**
- [ ] Visit `/` — "Contact us →" button is visible in the hero CTA row, second from left
- [ ] Click it — modal opens centered, backdrop dims the page, body scroll locks
- [ ] HubSpot form renders inside the modal
- [ ] Submit a test entry — submission lands in HubSpot
- [ ] Close modal via (a) ✕ button, (b) clicking backdrop, (c) Escape key — all close it
- [ ] Re-open the modal — form re-renders fresh (no stale state)
- [ ] Visit `/blog/agor-cloud` first, then come back to `/` and open the modal — should be instant (loader cached)
- [ ] Mobile width — buttons stack, modal fills usable width, submit button is comfortable to tap

## Not tested locally

I couldn't load the live HubSpot form in a browser from this sandbox, so the embed code path (script load -> hbspt.forms.create) is exercised in code review only. The Next.js build is clean and the loader/onLoad/onReady wiring matches HubSpot's documented pattern, but a real browser preview at both `/` (modal) and `/blog/agor-cloud` (inline) is recommended before merge.

Generated with [Claude Code](https://claude.com/claude-code)
