### PR TITLE
Centralize surface branding & fix Knowledge favicon on deep links

### DIFF
--- a/apps/agor-docs/components/Hero.tsx
+++ b/apps/agor-docs/components/Hero.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
+import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
 import { GifGallery } from './GifGallery';
 import styles from './Hero.module.css';
 import { ParticleBackground } from './ParticleBackground';
@@ -30,7 +31,7 @@ export function Hero({
       <div className={styles.hero}>
         <div className={styles.heroContent}>
           {/* biome-ignore lint/performance/noImgElement: Using img for static assets in docs */}
-          <img src="/logo.png" alt="agor logo" className={styles.heroLogo} />
+          <img src={LOGO_PATH} alt={`${BRAND_NAME} logo`} className={styles.heroLogo} />
           <h1 className={styles.heroTitle}>{title}</h1>
           <p className={styles.heroSubtitle}>{subtitle}</p>
           {description && <p className={styles.heroDescription}>{description}</p>}

--- a/apps/agor-docs/lib/siteMetadata.ts
+++ b/apps/agor-docs/lib/siteMetadata.ts
@@ -1,5 +1,18 @@
 const DEFAULT_SITE_URL = 'https://agor.live';
 
+/**
+ * Docs-site branding. Deliberately distinct from the in-app (agor-ui) brand,
+ * which lives in apps/agor-ui/src/branding/brand.ts: the docs use a lowercase
+ * "agor" wordmark and an en-dash title separator. Centralized here so
+ * theme.config.tsx and the social-metadata validator share one source and the
+ * favicon/logo/theme-color can't drift. Asset paths are public/-relative and
+ * get the Next.js basePath applied at render time.
+ */
+export const BRAND_NAME = 'agor';
+export const THEME_COLOR = '#2e9a92';
+export const FAVICON_PATH = '/favicon.png';
+export const LOGO_PATH = '/logo.png';
+
 export const DEFAULT_DESCRIPTION =
   'Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants — Claude Code, Codex, Gemini — anchored on git branches, with real-time multiplayer and an MCP surface agents drive themselves.';
 

--- a/apps/agor-docs/pages/guide/index.mdx
+++ b/apps/agor-docs/pages/guide/index.mdx
@@ -3,9 +3,11 @@ title: agor Documentation
 description: Team command center for all things agentic. A shared canvas for coding agents and long-lived assistants, anchored on git branches, with real-time multiplayer and an MCP surface agents drive themselves.
 ---
 
+import { LOGO_PATH } from '../../lib/siteMetadata';
+
 <div style={{ textAlign: 'center', marginTop: '2rem', marginBottom: '2rem' }}>
   <img
-    src="/logo.png"
+    src={LOGO_PATH}
     alt="agor logo - team command center for all things agentic"
     style={{ width: '135px', height: '135px', borderRadius: '50%', opacity: 0.9 }}
   />

--- a/apps/agor-docs/scripts/validate-social-metadata.ts
+++ b/apps/agor-docs/scripts/validate-social-metadata.ts
@@ -3,9 +3,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   DEFAULT_SOCIAL_IMAGE,
+  FAVICON_PATH,
   type FrontMatterLike,
   getSocialImage,
   isAbsoluteUrl,
+  LOGO_PATH,
   SOCIAL_IMAGE_FIELDS,
 } from '../lib/siteMetadata';
 
@@ -82,6 +84,8 @@ const pages: PageMetadata[] = walk(pagesDir)
 const errors: string[] = [];
 
 assertLocalPublicImageExists(DEFAULT_SOCIAL_IMAGE, 'default social image', errors);
+assertLocalPublicImageExists(FAVICON_PATH, 'favicon (siteMetadata.FAVICON_PATH)', errors);
+assertLocalPublicImageExists(LOGO_PATH, 'logo (siteMetadata.LOGO_PATH)', errors);
 
 for (const page of pages) {
   const socialImage = getSocialImage(page.frontMatter);

--- a/apps/agor-docs/theme.config.tsx
+++ b/apps/agor-docs/theme.config.tsx
@@ -4,11 +4,15 @@ import { useConfig } from 'nextra-theme-docs';
 import { NavbarCloudCTA } from './components/NavbarCloudCTA';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from './lib/links';
 import {
+  BRAND_NAME,
   DEFAULT_DESCRIPTION,
+  FAVICON_PATH,
   getBasePath,
   getCanonicalUrl,
   getSiteUrl,
   getSocialImage,
+  LOGO_PATH,
+  THEME_COLOR,
 } from './lib/siteMetadata';
 
 const basePath = getBasePath();
@@ -20,8 +24,8 @@ const config: DocsThemeConfig = {
       {/* eslint-disable-next-line @next/next/no-img-element */}
       {/* biome-ignore lint/performance/noImgElement: Using img for static assets in docs */}
       <img
-        src={`${basePath}/logo.png`}
-        alt="agor"
+        src={`${basePath}${LOGO_PATH}`}
+        alt={BRAND_NAME}
         style={{ height: '42px', width: '42px', borderRadius: '50%' }}
         suppressHydrationWarning
       />
@@ -135,7 +139,7 @@ const config: DocsThemeConfig = {
 
         {/* Open Graph */}
         <meta property="og:type" content={ogType} />
-        <meta property="og:site_name" content="agor" />
+        <meta property="og:site_name" content={BRAND_NAME} />
         <meta property="og:title" content={fullTitle} />
         <meta property="og:description" content={description} />
         <meta property="og:image" content={socialImage} />
@@ -151,8 +155,8 @@ const config: DocsThemeConfig = {
         <meta name="twitter:image" content={socialImage} />
 
         {/* Additional Meta */}
-        <meta name="theme-color" content="#2e9a92" />
-        <link rel="icon" type="image/png" href={`${basePath}/favicon.png`} />
+        <meta name="theme-color" content={THEME_COLOR} />
+        <link rel="icon" type="image/png" href={`${basePath}${FAVICON_PATH}`} />
         <link rel="canonical" href={canonicalUrl} />
 
         {/* JSON-LD Structured Data */}
@@ -179,7 +183,7 @@ const config: DocsThemeConfig = {
                       name: 'Agor',
                       logo: {
                         '@type': 'ImageObject',
-                        url: `${siteUrl}${basePath}/logo.png`,
+                        url: `${siteUrl}${basePath}${LOGO_PATH}`,
                       },
                     },
                   }

--- a/apps/agor-ui/index.html
+++ b/apps/agor-ui/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="favicon.png" />
+    <!-- Root-absolute so Vite rebases it to the configured base (/ui/ in prod);
+         a relative href would 404 on deep-linked nested routes. -->
+    <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agor</title>
     <style>

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -49,6 +49,7 @@ import {
   useServerVersion,
   useSessionActions,
 } from './hooks';
+import { useSurfaceBranding } from './hooks/useSurfaceBranding';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
 import type { RouteSurfaceId } from './surfaces/surfaceRegistry';
 import {
@@ -185,6 +186,12 @@ function AppContent() {
   const { currentSurface, workspaceSurfaceShouldRun } = useWorkspaceSurfaceLifecycle(
     location.pathname
   );
+  // Apply each surface's declared favicon/title centrally. Non-dynamic surfaces
+  // get the absolute brand mark + static title here; the 'dynamic' Workspace
+  // shell no-ops and manages its own via useFaviconStatus/useBoardTitle. This
+  // makes the registry's `branding` field the single enforcement point so a new
+  // static surface can't forget to wire it.
+  useSurfaceBranding(currentSurface);
   const sharedSurfaceOwnsUserSettings = currentSurface.usesSharedUserSettings;
   const routeModuleKey = getRouteModuleKey(currentSurface.id, location.pathname);
   const [routeModuleReady, setRouteModuleReady] = useState(() =>

--- a/apps/agor-ui/src/branding/brand.test.ts
+++ b/apps/agor-ui/src/branding/brand.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { BRAND, brandMarkHref, surfaceTitle } from './brand';
+
+describe('brandMarkHref', () => {
+  it('prefixes the mark file with the Vite base path', () => {
+    expect(brandMarkHref('/ui/')).toBe('/ui/favicon.png');
+    expect(brandMarkHref('/')).toBe('/favicon.png');
+  });
+
+  it('returns an absolute (base-rooted) URL, never a bare relative href', () => {
+    // A relative href (e.g. "favicon.png") resolves against the current
+    // document path and 404s on nested SPA routes like /ui/knowledge/<ns>/<doc>.
+    for (const base of ['/', '/ui/', '/some/deep/base/']) {
+      expect(brandMarkHref(base).startsWith('/')).toBe(true);
+    }
+  });
+
+  it('defaults to the build-time base path', () => {
+    expect(brandMarkHref()).toBe(`${import.meta.env.BASE_URL}${BRAND.markFile}`);
+  });
+});
+
+describe('surfaceTitle', () => {
+  it('joins a surface label to the brand name', () => {
+    expect(surfaceTitle('Knowledge')).toBe('Knowledge · Agor');
+  });
+
+  it('returns the bare brand name when no label is given', () => {
+    expect(surfaceTitle()).toBe('Agor');
+    expect(surfaceTitle(null)).toBe('Agor');
+    expect(surfaceTitle('')).toBe('Agor');
+  });
+});

--- a/apps/agor-ui/src/branding/brand.ts
+++ b/apps/agor-ui/src/branding/brand.ts
@@ -1,0 +1,40 @@
+/**
+ * Single source of truth for agor-ui's surface branding: the Agor mark asset
+ * (used as both favicon and in-chrome logo) and the document-title format.
+ *
+ * Every web surface in this app (Workspace, Knowledge, Artifact fullscreen, …)
+ * consumes these helpers so favicon/title metadata can't drift as new surfaces
+ * are added. See surfaceRegistry.ts for the per-surface branding declarations
+ * and brand.test.ts / surfaceRegistry.test.ts for the regression guards.
+ *
+ * The docs site (apps/agor-docs) is a standalone Next.js package with
+ * deliberately distinct branding (lowercase "agor" wordmark, en-dash title
+ * separator, social-card metadata). It centralizes its own constants in
+ * apps/agor-docs/lib/siteMetadata.ts and cannot import this module.
+ */
+
+export const BRAND = {
+  /** Wordmark used in document titles and image alt text. */
+  name: 'Agor',
+  /** Agor mark asset, served from the Vite public dir (favicon + logo). */
+  markFile: 'favicon.png',
+  /** Separator between a surface label and the brand name in tab titles. */
+  titleSeparator: ' · ',
+} as const;
+
+/**
+ * Absolute, base-aware URL to the Agor mark asset (favicon / logo).
+ *
+ * MUST be absolute (base-prefixed), never a bare relative `favicon.png`: SPA
+ * surfaces live at nested paths (e.g. `/ui/knowledge/<ns>/<doc>`) and a
+ * relative href resolves against the current document URL → 404. This is the
+ * bug that made the Knowledge surface's favicon disappear on deep links.
+ */
+export function brandMarkHref(baseUrl: string = import.meta.env.BASE_URL): string {
+  return `${baseUrl}${BRAND.markFile}`;
+}
+
+/** Build a document title for a surface, e.g. `surfaceTitle('Knowledge')` → "Knowledge · Agor". */
+export function surfaceTitle(label?: string | null): string {
+  return label ? `${label}${BRAND.titleSeparator}${BRAND.name}` : BRAND.name;
+}

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -17,6 +17,7 @@ import {
 } from '@ant-design/icons';
 import { Badge, Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
 import { useHref, useNavigate } from 'react-router-dom';
+import { BRAND, brandMarkHref } from '../../branding/brand';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { BoardSwitcher } from '../BoardSwitcher';
 import { BrandLogo } from '../BrandLogo';
@@ -186,8 +187,8 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           }}
         >
           <img
-            src={`${import.meta.env.BASE_URL}favicon.png`}
-            alt="Agor logo"
+            src={brandMarkHref()}
+            alt={BRAND.name}
             style={{
               height: 50,
               borderRadius: '50%',

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -15,6 +15,7 @@ import { shortId, TaskStatus } from '@agor-live/client';
 import { BranchesOutlined, CopyOutlined, ForkOutlined } from '@ant-design/icons';
 import { Alert, Button, Spin, Typography, theme } from 'antd';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { BRAND, brandMarkHref } from '../../branding/brand';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { useStreamingMessagesByTask } from '../../hooks/useStreamingMessagesByTask';
 import { useCopyToClipboard } from '../../utils/clipboard';
@@ -561,8 +562,8 @@ export const ConversationView = React.memo<ConversationViewProps>(
           }}
         >
           <img
-            src={`${import.meta.env.BASE_URL}favicon.png`}
-            alt="Agor"
+            src={brandMarkHref()}
+            alt={BRAND.name}
             style={{
               width: 160,
               height: 160,

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -7,6 +7,7 @@
 import { LockOutlined, MailOutlined } from '@ant-design/icons';
 import { Alert, Button, Card, Divider, Form, Input, Space, Typography, theme } from 'antd';
 import { useState } from 'react';
+import { BRAND, brandMarkHref } from '../../branding/brand';
 import { BrandLogo } from '../BrandLogo';
 import { ParticleBackground } from './ParticleBackground';
 
@@ -127,8 +128,8 @@ export function LoginPage({
         <Space orientation="vertical" size="large" style={{ width: '100%', marginBottom: 24 }}>
           <div style={{ textAlign: 'center' }}>
             <img
-              src={`${import.meta.env.BASE_URL}favicon.png`}
-              alt="Agor Logo"
+              src={brandMarkHref()}
+              alt={BRAND.name}
               style={{
                 width: 72,
                 height: 72,

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -25,6 +25,7 @@ import { Bubble } from '@ant-design/x';
 import { Tooltip, theme } from 'antd';
 
 import React from 'react';
+import { BRAND, brandMarkHref } from '../../branding/brand';
 import { formatTimestampWithRelative } from '../../utils/time';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
 import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
@@ -215,8 +216,8 @@ function getAgentAvatar({
   if (isCallback) {
     return (
       <img
-        src={`${import.meta.env.BASE_URL}favicon.png`}
-        alt="Agor"
+        src={brandMarkHref()}
+        alt={BRAND.name}
         style={{ width: 32, height: 32, borderRadius: '50%' }}
       />
     );

--- a/apps/agor-ui/src/components/mobile/MobileApp.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileApp.tsx
@@ -10,6 +10,7 @@ import type {
 import { Drawer, Layout, Typography } from 'antd';
 import { useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { BRAND, brandMarkHref } from '../../branding/brand';
 import { MobileCommentsPage } from './MobileCommentsPage';
 import { MobileHeader } from './MobileHeader';
 import { MobileNavTree } from './MobileNavTree';
@@ -106,8 +107,8 @@ export const MobileApp: React.FC<MobileAppProps> = ({
                 }}
               >
                 <img
-                  src={`${import.meta.env.BASE_URL}favicon.png`}
-                  alt="Agor"
+                  src={brandMarkHref()}
+                  alt={BRAND.name}
                   style={{
                     width: 160,
                     height: 160,

--- a/apps/agor-ui/src/components/mobile/MobileHeader.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileHeader.tsx
@@ -1,6 +1,7 @@
 import type { User } from '@agor-live/client';
 import { UnorderedListOutlined } from '@ant-design/icons';
 import { Button, Layout, Space, Typography, theme } from 'antd';
+import { BRAND, brandMarkHref } from '../../branding/brand';
 
 const { Header } = Layout;
 const { Title } = Typography;
@@ -38,8 +39,8 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({
       <Space size={8} align="center" style={{ flex: 1 }}>
         {showLogo && (
           <img
-            src={`${import.meta.env.BASE_URL}favicon.png`}
-            alt="Agor logo"
+            src={brandMarkHref()}
+            alt={BRAND.name}
             style={{
               height: 32, // Smaller for mobile
               borderRadius: '50%',

--- a/apps/agor-ui/src/hooks/useBoardTitle.ts
+++ b/apps/agor-ui/src/hooks/useBoardTitle.ts
@@ -7,8 +7,9 @@
 
 import type { Board } from '@agor-live/client';
 import { useEffect } from 'react';
+import { surfaceTitle } from '../branding/brand';
 
-const DEFAULT_TITLE = 'Agor';
+const DEFAULT_TITLE = surfaceTitle();
 
 export function useBoardTitle(currentBoard: Board | undefined) {
   useEffect(() => {

--- a/apps/agor-ui/src/hooks/useFaviconStatus.ts
+++ b/apps/agor-ui/src/hooks/useFaviconStatus.ts
@@ -11,6 +11,7 @@ import type { BoardEntityObject, Session } from '@agor-live/client';
 import { SessionStatus } from '@agor-live/client';
 import { theme } from 'antd';
 import { useEffect, useState } from 'react';
+import { brandMarkHref } from '../branding/brand';
 import { createFaviconWithDot } from '../utils/faviconDot';
 
 export function useFaviconStatus(
@@ -18,7 +19,7 @@ export function useFaviconStatus(
   sessionsByBranch: Map<string, Session[]>,
   boardObjectsForCurrentBoard: BoardEntityObject[]
 ) {
-  const [baseFaviconUrl] = useState(`${import.meta.env.BASE_URL}favicon.png`);
+  const [baseFaviconUrl] = useState(brandMarkHref());
   const { token } = theme.useToken();
 
   useEffect(() => {

--- a/apps/agor-ui/src/hooks/useFaviconStatus.ts
+++ b/apps/agor-ui/src/hooks/useFaviconStatus.ts
@@ -23,15 +23,26 @@ export function useFaviconStatus(
   const { token } = theme.useToken();
 
   useEffect(() => {
+    // createFaviconWithDot is async (it decodes an <img> and rasterizes to a
+    // canvas). If it resolves after this effect re-runs or the Workspace shell
+    // unmounts (e.g. navigating to a static surface that pins its own favicon),
+    // applying the stale result would clobber the new favicon. Guard with a
+    // cancellation flag cleared on cleanup.
+    let cancelled = false;
+    const applyFavicon = (dataUrl: string) => {
+      if (cancelled) return;
+      const link = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
+      if (link) {
+        link.href = dataUrl;
+      }
+    };
+
     if (!currentBoardId) {
       // No board selected - restore default favicon
-      createFaviconWithDot(baseFaviconUrl, false, false, token.colorSuccessText).then((dataUrl) => {
-        const link = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
-        if (link) {
-          link.href = dataUrl;
-        }
-      });
-      return;
+      createFaviconWithDot(baseFaviconUrl, false, false, token.colorSuccessText).then(applyFavicon);
+      return () => {
+        cancelled = true;
+      };
     }
 
     const branchesOnBoard = new Set(
@@ -52,13 +63,12 @@ export function useFaviconStatus(
     // Update favicon with appropriate dots
     // White dot (lower-left) for running, green dot (lower-right) for ready
     createFaviconWithDot(baseFaviconUrl, hasRunning, hasReady, token.colorSuccessText).then(
-      (dataUrl) => {
-        const link = document.querySelector("link[rel~='icon']") as HTMLLinkElement;
-        if (link) {
-          link.href = dataUrl;
-        }
-      }
+      applyFavicon
     );
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     currentBoardId,
     sessionsByBranch,

--- a/apps/agor-ui/src/hooks/useSurfaceBranding.test.tsx
+++ b/apps/agor-ui/src/hooks/useSurfaceBranding.test.tsx
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { brandMarkHref } from '../branding/brand';
+import { SURFACE_REGISTRY } from '../surfaces/surfaceRegistry';
+import { useSurfaceBranding } from './useSurfaceBranding';
+
+function setIconLink(href: string): void {
+  let link = document.querySelector("link[rel~='icon']") as HTMLLinkElement | null;
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    document.head.appendChild(link);
+  }
+  link.setAttribute('href', href);
+}
+
+function currentIconHref(): string | null {
+  return document.querySelector("link[rel~='icon']")?.getAttribute('href') ?? null;
+}
+
+const STATIC_SURFACES = SURFACE_REGISTRY.filter((s) => s.branding !== 'dynamic');
+const DYNAMIC_SURFACE = SURFACE_REGISTRY.find((s) => s.branding === 'dynamic');
+
+describe('useSurfaceBranding', () => {
+  beforeEach(() => {
+    for (const el of document.head.querySelectorAll("link[rel~='icon']")) el.remove();
+    document.title = 'initial';
+  });
+
+  // Every static surface in the registry must end up with the absolute brand
+  // mark + its declared title — so a newly added static surface inherits the
+  // behavior for free through the central AppContent call.
+  it.each(STATIC_SURFACES)('applies favicon + title for static surface "$id"', (surface) => {
+    setIconLink('/stale-from-previous-surface.png');
+    renderHook(() => useSurfaceBranding(surface));
+
+    expect(document.title).toBe(surface.branding);
+    expect(currentIconHref()).toBe(brandMarkHref());
+  });
+
+  it('leaves favicon + title untouched for the dynamic Workspace surface', () => {
+    expect(DYNAMIC_SURFACE).toBeDefined();
+    setIconLink('/board-status-dot.png');
+    document.title = 'workspace-managed';
+
+    renderHook(() => useSurfaceBranding(DYNAMIC_SURFACE!));
+
+    // The Workspace shell owns the favicon/title via useFaviconStatus /
+    // useBoardTitle; this hook must not stomp them.
+    expect(document.title).toBe('workspace-managed');
+    expect(currentIconHref()).toBe('/board-status-dot.png');
+  });
+
+  it('no-ops gracefully when no favicon link exists yet', () => {
+    expect(STATIC_SURFACES.length).toBeGreaterThan(0);
+    expect(() => renderHook(() => useSurfaceBranding(STATIC_SURFACES[0]))).not.toThrow();
+    expect(document.title).toBe(STATIC_SURFACES[0].branding);
+  });
+});
+
+describe('central branding wiring', () => {
+  it('AppContent applies branding from the current surface', () => {
+    // Structural guard: branding is enforced centrally off the registry, not
+    // per-page. If this call is removed, static surfaces silently regress.
+    const appSource = readFileSync(path.resolve(process.cwd(), 'src/App.tsx'), 'utf8');
+    expect(appSource).toMatch(/useSurfaceBranding\(\s*currentSurface\s*\)/);
+  });
+});

--- a/apps/agor-ui/src/hooks/useSurfaceBranding.ts
+++ b/apps/agor-ui/src/hooks/useSurfaceBranding.ts
@@ -1,0 +1,25 @@
+/**
+ * Applies a surface's static branding (favicon + document title) for surfaces
+ * that render outside the Workspace shell and therefore don't run
+ * useFaviconStatus / useBoardTitle.
+ *
+ * Pins the favicon to the absolute, base-aware brand mark so deep-linked nested
+ * routes (e.g. `/ui/knowledge/<ns>/<doc>`) don't fall back to the relative
+ * index.html href, which resolves against the current path and 404s.
+ */
+
+import { useEffect } from 'react';
+import { brandMarkHref } from '../branding/brand';
+import type { RouteSurfaceDefinition } from '../surfaces/surfaceRegistry';
+
+export function useSurfaceBranding(surface: RouteSurfaceDefinition) {
+  useEffect(() => {
+    if (surface.branding === 'dynamic') return;
+
+    const link = document.querySelector("link[rel~='icon']") as HTMLLinkElement | null;
+    if (link) {
+      link.href = brandMarkHref();
+    }
+    document.title = surface.branding;
+  }, [surface]);
+}

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -23,6 +23,8 @@ import { BrandLogo } from '../components/BrandLogo';
 import { GlobalUserMenu } from '../components/GlobalUserMenu';
 import { withBodyReset } from '../components/SessionCanvas/canvas/utils/sandpackDefaults';
 import { ThemeSwitcher } from '../components/ThemeSwitcher';
+import { useSurfaceBranding } from '../hooks/useSurfaceBranding';
+import { ARTIFACT_FULLSCREEN_SURFACE } from '../surfaces/surfaceRegistry';
 
 ensureSandpackCryptoSubtle();
 
@@ -147,6 +149,7 @@ export function ArtifactFullscreenPage({
   onUserSettingsClick,
   onLogout,
 }: ArtifactFullscreenPageProps) {
+  useSurfaceBranding(ARTIFACT_FULLSCREEN_SURFACE);
   const { token } = theme.useToken();
   const { artifactShortId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -23,8 +23,6 @@ import { BrandLogo } from '../components/BrandLogo';
 import { GlobalUserMenu } from '../components/GlobalUserMenu';
 import { withBodyReset } from '../components/SessionCanvas/canvas/utils/sandpackDefaults';
 import { ThemeSwitcher } from '../components/ThemeSwitcher';
-import { useSurfaceBranding } from '../hooks/useSurfaceBranding';
-import { ARTIFACT_FULLSCREEN_SURFACE } from '../surfaces/surfaceRegistry';
 
 ensureSandpackCryptoSubtle();
 
@@ -149,7 +147,6 @@ export function ArtifactFullscreenPage({
   onUserSettingsClick,
   onLogout,
 }: ArtifactFullscreenPageProps) {
-  useSurfaceBranding(ARTIFACT_FULLSCREEN_SURFACE);
   const { token } = theme.useToken();
   const { artifactShortId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -99,9 +99,7 @@ import { KnowledgeGraph } from '../components/KnowledgeGraph';
 import { MarkdownRenderer } from '../components/MarkdownRenderer';
 import { ThemeSwitcher } from '../components/ThemeSwitcher';
 import { DiffBlock } from '../components/ToolUseRenderer/renderers/DiffBlock';
-import { useSurfaceBranding } from '../hooks/useSurfaceBranding';
 import { useUserLocalStorage } from '../hooks/useUserLocalStorage';
-import { KNOWLEDGE_SURFACE } from '../surfaces/surfaceRegistry';
 import {
   buildKnowledgeRoutePath,
   decodeKnowledgeRoutePath,
@@ -811,8 +809,6 @@ export function KnowledgePage({
   const sidebarPanelRef = useRef<ImperativePanelHandle>(null);
   const sidebarResizeDraggingRef = useRef(false);
   const globalSearchContainerRef = useRef<HTMLDivElement>(null);
-
-  useSurfaceBranding(KNOWLEDGE_SURFACE);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -99,7 +99,9 @@ import { KnowledgeGraph } from '../components/KnowledgeGraph';
 import { MarkdownRenderer } from '../components/MarkdownRenderer';
 import { ThemeSwitcher } from '../components/ThemeSwitcher';
 import { DiffBlock } from '../components/ToolUseRenderer/renderers/DiffBlock';
+import { useSurfaceBranding } from '../hooks/useSurfaceBranding';
 import { useUserLocalStorage } from '../hooks/useUserLocalStorage';
+import { KNOWLEDGE_SURFACE } from '../surfaces/surfaceRegistry';
 import {
   buildKnowledgeRoutePath,
   decodeKnowledgeRoutePath,
@@ -810,9 +812,7 @@ export function KnowledgePage({
   const sidebarResizeDraggingRef = useRef(false);
   const globalSearchContainerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    document.title = 'Knowledge · Agor';
-  }, []);
+  useSurfaceBranding(KNOWLEDGE_SURFACE);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.test.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { BRAND, surfaceTitle } from '../branding/brand';
 import {
   getRouteSurface,
   isKnowledgeRoutePath,
@@ -6,6 +9,7 @@ import {
   routeStartsWorkspaceRuntime,
   routeUsesDeviceRouter,
   routeUsesSharedUserSettings,
+  SURFACE_REGISTRY,
 } from './surfaceRegistry';
 
 describe('surface route registry', () => {
@@ -71,5 +75,46 @@ describe('surface route registry', () => {
   it('does not treat similarly prefixed paths as Knowledge', () => {
     expect(isKnowledgeRoutePath('/kbish')).toBe(false);
     expect(isKnowledgeRoutePath('/knowledge-base')).toBe(false);
+  });
+});
+
+describe('surface branding declarations', () => {
+  it('every surface declares branding (favicon + title) behavior', () => {
+    // Forces a new surface to opt into the shared branding contract instead of
+    // silently inheriting the static index.html favicon/title.
+    for (const surface of SURFACE_REGISTRY) {
+      expect(surface.branding, `surface "${surface.id}" must declare branding`).toBeTruthy();
+    }
+  });
+
+  it('exactly one surface manages favicon/title dynamically (the Workspace shell)', () => {
+    const dynamic = SURFACE_REGISTRY.filter((s) => s.branding === 'dynamic');
+    expect(dynamic.map((s) => s.id)).toEqual(['workspace']);
+  });
+
+  it('static-branding surfaces use the centralized title format', () => {
+    for (const surface of SURFACE_REGISTRY) {
+      if (surface.branding === 'dynamic') continue;
+      // Must be a surfaceTitle()-shaped string ending in the brand wordmark, so
+      // titles can't drift in separator/casing across surfaces.
+      const label = surface.branding.split(BRAND.titleSeparator)[0];
+      expect(surface.branding).toBe(surfaceTitle(label));
+      expect(surface.branding.endsWith(BRAND.name)).toBe(true);
+    }
+  });
+});
+
+describe('index.html favicon', () => {
+  it('references the mark with a root-absolute href (Vite rebases to the base)', () => {
+    // vitest runs with cwd at the package root, where index.html lives.
+    const html = readFileSync(path.resolve(process.cwd(), 'index.html'), 'utf8');
+    const iconMatch = html.match(/<link[^>]*rel=["']icon["'][^>]*>/i);
+    expect(iconMatch, 'index.html must declare a <link rel="icon">').not.toBeNull();
+
+    const href = iconMatch?.[0].match(/href=["']([^"']+)["']/i)?.[1] ?? '';
+    // Root-absolute only. A relative href (e.g. "favicon.png") 404s on nested
+    // SPA deep-links — exactly the Knowledge-surface favicon bug.
+    expect(href.startsWith('/')).toBe(true);
+    expect(href.endsWith(BRAND.markFile)).toBe(true);
   });
 });

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.ts
@@ -1,4 +1,5 @@
 import { matchPath } from 'react-router-dom';
+import { surfaceTitle } from '../branding/brand';
 
 export type RouteSurfaceId = 'workspace' | 'knowledge' | 'artifact-fullscreen' | 'demo';
 
@@ -14,6 +15,22 @@ export interface RouteSurfaceDefinition {
   usesDeviceRouter: boolean;
   /** Whether user settings are owned by the shared shell instead of Workspace App. */
   usesSharedUserSettings: boolean;
+  /**
+   * Branding behavior for the browser tab (favicon + title).
+   *
+   * - `'dynamic'`: the surface manages the favicon/title itself at runtime
+   *   (the Workspace shell rewrites the favicon with status dots via
+   *   useFaviconStatus and sets the title from the active board). Exactly one
+   *   surface may be dynamic.
+   * - a string: a static document title applied via useSurfaceBranding, which
+   *   also pins the favicon to the absolute brand mark so deep-linked nested
+   *   routes don't fall back to the relative index.html href (which 404s).
+   *
+   * Build with surfaceTitle() so the wordmark/separator stay centralized. Every
+   * surface MUST declare this so new surfaces can't silently inherit a broken
+   * favicon — enforced by surfaceRegistry.test.ts.
+   */
+  branding: 'dynamic' | string;
 }
 
 const normalizePathname = (pathname: string): string =>
@@ -45,6 +62,7 @@ export const KNOWLEDGE_SURFACE = defineSurface({
   startsWorkspaceRuntime: false,
   usesDeviceRouter: false,
   usesSharedUserSettings: true,
+  branding: surfaceTitle('Knowledge'),
 });
 
 export const ARTIFACT_FULLSCREEN_ROUTE_PATHS = ['/a/:artifactShortId/fullscreen'] as const;
@@ -56,6 +74,7 @@ export const ARTIFACT_FULLSCREEN_SURFACE = defineSurface({
   startsWorkspaceRuntime: false,
   usesDeviceRouter: false,
   usesSharedUserSettings: true,
+  branding: surfaceTitle('Artifact'),
 });
 
 export const DEMO_SURFACE = defineSurface({
@@ -65,6 +84,7 @@ export const DEMO_SURFACE = defineSurface({
   startsWorkspaceRuntime: false,
   usesDeviceRouter: false,
   usesSharedUserSettings: false,
+  branding: surfaceTitle('Streamdown demo'),
 });
 
 export const WORKSPACE_SURFACE = defineSurface({
@@ -74,6 +94,9 @@ export const WORKSPACE_SURFACE = defineSurface({
   startsWorkspaceRuntime: true,
   usesDeviceRouter: true,
   usesSharedUserSettings: false,
+  // The Workspace shell drives favicon (status dots) and title (active board)
+  // at runtime via useFaviconStatus / useBoardTitle.
+  branding: 'dynamic',
 });
 
 export const SURFACE_REGISTRY = [


### PR DESCRIPTION
## Summary

The Knowledge Base favicon was wrong on deep links, and favicon/title/branding metadata had drifted across surfaces. This centralizes it and fixes the bug.

**Root cause of the KB favicon bug:** The Knowledge (`/knowledge/:ns/*`) and artifact-fullscreen surfaces render outside the Workspace shell, so they never run `useFaviconStatus` (which rewrites the favicon to an absolute `data:` URL). They fell back to `index.html`'s **relative** `favicon.png` href, which the browser resolves against the current document path — so a deep link like `/ui/knowledge/<ns>/<doc>` requested `/ui/knowledge/<ns>/favicon.png` → 404. The Workspace surface masked the same latent bug.

## What changed

**agor-ui (the real fix + centralization):**
- New `src/branding/brand.ts` — single source of truth: `BRAND`, `brandMarkHref()` (absolute, base-aware), `surfaceTitle()`.
- `surfaceRegistry.ts` — each surface now declares a `branding` field (`'dynamic'` for the Workspace shell, or a `surfaceTitle()` string for static surfaces).
- New `useSurfaceBranding()` hook — non-Workspace surfaces (Knowledge, artifact-fullscreen) apply it to pin the favicon to the absolute mark and set their title.
- `index.html` icon href is now root-absolute (`/favicon.png`) so Vite rebases it to the configured base (`/ui/` in prod) — no more relative-path 404 on first paint.
- Replaced the favicon path / `Agor` strings hardcoded across 8 spots with the shared helpers.

**agor-docs (standalone package, intentionally distinct branding):**
- Centralized its `BRAND_NAME` / `THEME_COLOR` / `FAVICON_PATH` / `LOGO_PATH` in `lib/siteMetadata.ts`; `theme.config.tsx` consumes them.

## Regressions prevented
- `surfaceRegistry.test.ts`: every surface must declare `branding`; exactly one is `'dynamic'`; static titles use the shared format; `index.html`'s icon href must be root-absolute.
- `brand.test.ts`: `brandMarkHref()` is always base-rooted; title format centralized.
- Docs `validate:social-metadata` now asserts the favicon and logo assets exist under `public/`.

## Test plan
- [x] `vitest run` for `brand.test.ts` + `surfaceRegistry.test.ts` — 29 passed
- [x] `tsc --noEmit` for agor-ui — clean
- [x] `biome check` on changed files — clean
- [x] docs `validate:social-metadata` — passed (42 pages + favicon/logo)
- [x] docs `tsc --noEmit` — clean
- [ ] Manual: load a `/ui/knowledge/<ns>/<doc>` deep link and confirm favicon renders (no dev server in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)