### PR TITLE
fix(executor): route advisor model through --advisor flag (fix EACCES crash + allow turn-off)

### DIFF
--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -350,7 +350,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       options.unshift({ value: currentValue, label: currentValue });
     }
 
-    return (
+    const modelSelect = (
       <Select
         value={currentValue}
         onChange={handleModelChange}
@@ -361,6 +361,33 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
         style={{ width: '100%', fontSize: token.fontSizeSM }}
         options={options}
       />
+    );
+
+    // Surface the optional Claude Code advisor model in compact contexts too
+    // (e.g. the session run-settings popover) so it can be set OR cleared per
+    // session. `allowClear` → undefined removes the session-level override.
+    const showAdvisor = effectiveTool === 'claude-code' || effectiveTool === 'claude-code-cli';
+    if (!showAdvisor) return modelSelect;
+
+    return (
+      <Space orientation="vertical" size={6} style={{ width: '100%' }}>
+        {modelSelect}
+        <Select
+          allowClear
+          showSearch
+          size="small"
+          optionFilterProp="label"
+          placeholder="Advisor model: off"
+          value={value?.advisorModel}
+          onChange={handleAdvisorModelChange}
+          popupMatchSelectWidth={false}
+          style={{ width: '100%', fontSize: token.fontSizeSM }}
+          options={(claudeServerOptions ?? AVAILABLE_CLAUDE_MODEL_ALIASES).map((model) => ({
+            value: model.id,
+            label: `Advisor: ${model.id}`,
+          }))}
+        />
+      </Space>
     );
   }
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -688,15 +688,23 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const handleModelConfigChange = (newConfig: ModelConfig) => {
     if (session && onUpdateSession) {
-      onUpdateSession(session.session_id, {
-        model_config: {
-          ...session.model_config,
-          mode: newConfig.mode,
-          model: newConfig.model,
-          ...(newConfig.provider ? { provider: newConfig.provider } : {}),
-          updated_at: new Date().toISOString(),
-        },
-      });
+      const nextConfig: NonNullable<Session['model_config']> = {
+        ...session.model_config,
+        mode: newConfig.mode,
+        model: newConfig.model,
+        ...(newConfig.provider ? { provider: newConfig.provider } : {}),
+        updated_at: new Date().toISOString(),
+      };
+      // Honor the advisor selector's clear action. `model_config` is
+      // column-replaced on patch, so we must DELETE the key when the user clears
+      // it (allowClear → undefined) — the spread above would otherwise silently
+      // carry the previous value forward (root cause of "no way to turn it off").
+      if (newConfig.advisorModel) {
+        nextConfig.advisorModel = newConfig.advisorModel;
+      } else {
+        delete nextConfig.advisorModel;
+      }
+      onUpdateSession(session.session_id, { model_config: nextConfig });
     }
   };
 
@@ -726,6 +734,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         mode: session.model_config.mode || 'alias',
         model: session.model_config.model,
         provider: session.model_config.provider,
+        advisorModel: session.model_config.advisorModel,
       }
     : undefined;
 

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -206,6 +206,25 @@ describe('resolveModelConfigWithFallback', () => {
     });
   });
 
+  it('does not inherit a lower-priority advisorModel onto a higher-priority model source (turn-off contract)', () => {
+    // Regression guard for "remove the advisor": once a higher-priority source
+    // supplies its own model WITHOUT an advisor (e.g. an explicit session-level
+    // model_config), a lower-priority source's advisorModel (e.g. the user
+    // default) must NOT leak back in. The high-priority full config wins
+    // first-wins, so advisor stays cleared.
+    const result = resolveModelConfigWithFallback(
+      'claude-code',
+      [{ model: 'claude-opus-4-6' }, { model: 'claude-sonnet-4-6', advisorModel: 'opus' }],
+      { now }
+    );
+    expect(result).toEqual({
+      mode: 'alias',
+      model: 'claude-opus-4-6',
+      updated_at: '2026-04-23T00:00:00.000Z',
+    });
+    expect(result).not.toHaveProperty('advisorModel');
+  });
+
   it('does not carry model-less mode/provider onto a fallback model', () => {
     const result = resolveModelConfigWithFallback(
       'claude-code',

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -84,7 +84,7 @@ describe('setupQuery - Local Settings Support', () => {
     expect(callArgs.options.disallowedTools).toEqual([...CLAUDE_CODE_DISALLOWED_TOOLS]);
   });
 
-  it('passes session advisorModel through Claude Code SDK settings', async () => {
+  it('passes session advisorModel through the --advisor CLI flag, NOT settings', async () => {
     const deps = createMockDeps();
     vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
       session_id: 'test-session' as SessionID,
@@ -100,10 +100,15 @@ describe('setupQuery - Local Settings Support', () => {
     await setupQuery('test-session' as SessionID, 'test prompt', deps);
 
     const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
-    expect(callArgs.options.settings).toMatchObject({ advisorModel: 'opus' });
+    // The advisor goes through the SDK's extraArgs → `--advisor opus`.
+    expect(callArgs.options.extraArgs).toMatchObject({ advisor: 'opus' });
+    // EACCES regression guard: we must NOT pass `settings` as an object, which
+    // makes the CLI materialize a content-addressed /tmp/claude-settings-*.json
+    // that collides across sessions/users (EACCES on open). See query-builder.ts.
+    expect(callArgs.options.settings).toBeUndefined();
   });
 
-  it('strips advisorModel [1m] suffix and adds the required SDK beta', async () => {
+  it('strips advisorModel [1m] suffix, passes base model via --advisor, adds the SDK beta', async () => {
     const deps = createMockDeps();
     vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
       session_id: 'test-session' as SessionID,
@@ -119,8 +124,55 @@ describe('setupQuery - Local Settings Support', () => {
     await setupQuery('test-session' as SessionID, 'test prompt', deps);
 
     const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
-    expect(callArgs.options.settings).toMatchObject({ advisorModel: 'claude-opus-4-7' });
+    expect(callArgs.options.extraArgs).toMatchObject({ advisor: 'claude-opus-4-7' });
+    expect(callArgs.options.settings).toBeUndefined();
     expect(callArgs.options.betas).toEqual(['context-1m-2025-08-07']);
+  });
+
+  it('omits --advisor (and settings) entirely when no advisorModel is set', async () => {
+    // Turn-off contract: clearing the advisor leaves no --advisor flag and no
+    // settings object, so the session starts exactly as it did pre-advisor.
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      model_config: {
+        mode: 'alias',
+        model: 'claude-sonnet-4-6',
+        updated_at: '2026-06-11T00:00:00.000Z',
+        // no advisorModel
+      },
+    } as any);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(
+      (callArgs.options.extraArgs as Record<string, unknown> | undefined)?.advisor
+    ).toBeUndefined();
+    expect(callArgs.options.settings).toBeUndefined();
+  });
+
+  it('ignores a whitespace-only advisorModel (no --advisor, no settings)', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      model_config: {
+        mode: 'alias',
+        model: 'claude-sonnet-4-6',
+        updated_at: '2026-06-11T00:00:00.000Z',
+        advisorModel: '   ',
+      },
+    } as any);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(
+      (callArgs.options.extraArgs as Record<string, unknown> | undefined)?.advisor
+    ).toBeUndefined();
+    expect(callArgs.options.settings).toBeUndefined();
   });
 });
 

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -310,17 +310,28 @@ export async function setupQuery(
   }
 
   // Configure Claude Code's server-side advisor tool model when a session-level
-  // override is present. The Agent SDK exposes this through Claude Code settings
-  // (not as a first-class top-level option or MCP tool declaration).
+  // override is present. Pass it through the CLI's first-class `--advisor` flag
+  // (via the SDK's `extraArgs`) — NOT through the `settings` object.
+  //
+  // Why not `settings`: passing `settings` as an object makes the Agent SDK emit
+  // `--settings '<inline JSON>'`, which the Claude CLI can materialize into a
+  // CONTENT-ADDRESSED temp file at `${os.tmpdir()}/claude-settings-<hash>.json`
+  // when it hands the resolved flag-settings layer to its workers. In the daemon,
+  // `os.tmpdir()` resolves to the shared, sticky-bit `/tmp` (the daemon runs with
+  // TMPDIR stripped), so every session with identical advisor settings targets the
+  // SAME path. The first writer owns it mode 0600; later sessions — or other Unix
+  // users under insulated/strict isolation — then fail to open it with
+  // `EACCES ... claude-settings-*.json`, crashing the CLI before the first message.
+  // `--advisor <model>` is the CLI's dedicated, server-validated flag (Claude Code
+  // >= 2.1.175) and writes no settings file, so it sidesteps the collision entirely.
   const rawAdvisorModel = session.model_config?.advisorModel?.trim();
   if (rawAdvisorModel) {
     const { model: advisorModel, betas: advisorBetas } = parseModelWithBetas(rawAdvisorModel);
     for (const beta of advisorBetas) sdkBetas.add(beta);
-    queryOptions.settings = {
-      ...((queryOptions.settings as Record<string, unknown> | undefined) ?? {}),
-      advisorModel,
-    };
-    console.log(`🧭 Advisor model: ${advisorModel}`);
+    const extraArgs = (queryOptions.extraArgs as Record<string, string | null> | undefined) ?? {};
+    extraArgs.advisor = advisorModel;
+    queryOptions.extraArgs = extraArgs;
+    console.log(`🧭 Advisor model: ${advisorModel} (via --advisor)`);
   }
 
   // Add beta flags (e.g., 1M context window for [1m] model variants)


### PR DESCRIPTION
## What & why

Switching a session to use an **advisor model** crashed session startup with:

```
Claude SDK error after 0 messages: Claude Code process exited with code 1
Error processing settings: EACCES: permission denied, open '/tmp/claude-settings-26b6501e7630f720.json'
```

…and once set, there was **no way to turn the advisor back off**. This fixes both.

## Root cause (verified against the CLI binary + Agent SDK dist)

The SDK code path passed the advisor as a **`settings` object**. The Agent SDK turns `options.settings` into `--settings '<inline JSON>'` (confirmed in `sdk.mjs`: `--settings` is pushed only `if (this.options.settings)`). The Claude CLI then materializes inline settings JSON into a **content-addressed** temp file:

```js
// claude CLI:
oQe("claude-settings", ".json", { contentHash: json })
//  → path.join(os.tmpdir(), `claude-settings-${sha256(json).slice(0,16)}.json`)
```

Because the path is content-addressed, every session with identical advisor settings targets the **same** file. The daemon strips `TMPDIR`, so `os.tmpdir()` resolves to the shared sticky `/tmp`; the first writer owns it `0600` and later (or cross-uid) sessions fail `EACCES`. The error's `…-26b6501e7630f720.json` is exactly that 16-hex content hash.

## The fix

**1. EACCES** — pass the advisor through the CLI's first-class `--advisor` flag via the SDK's `extraArgs` instead of a `settings` object. Verified in the installed SDK (`0.3.170`) that `extraArgs: { advisor: 'opus' }` translates to `V.push('--advisor', 'opus')`. `--advisor` writes **no settings file**, so the collision can't happen on any CLI version. This also makes the SDK path identical to the `claude-code-cli` spawn path (`spawn-config.ts`), which already used `--advisor` and never had the bug.

**2. Turn-off** — the compact session model popover now shows a **clearable** advisor `Select`; `SessionPanel.handleModelConfigChange` now **deletes** `advisorModel` from `model_config` on clear (the old code spread the existing config back in, so the key could never be removed). A precedence regression test confirms a lower-priority advisor (e.g. user default) can't leak back onto a higher-priority explicit model.

## Files

- `packages/executor/src/sdk-handlers/claude/query-builder.ts` — `--advisor` via `extraArgs`, no more `settings` object
- `apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx` — clearable advisor Select in compact mode
- `apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx` — delete `advisorModel` on clear
- `packages/{executor,core}/…/*.test.ts` — see Tests

## Tests

- **Rewrote** 2 executor tests to assert `extraArgs.advisor` **and** `settings === undefined` (EACCES regression guard).
- **Added** executor cases: no `--advisor`/settings when advisor is unset; whitespace-only advisor ignored.
- **Added** core `resolve-config` precedence guard for the turn-off contract.
- Verified: core `2551 passed / 1 skipped`; executor query-builder `10/10`; core resolve-config `25/25`; typecheck clean (core/executor/UI); biome clean. Two pre-existing executor failures (`opencode-tool`, `cursor`) are unrelated to this change.

## Reviewer notes

- ⚠️ **Deploy step:** the executor is **not** in the daemon's watch (it loads `dist/cli.js`). After merge, rebuild the executor (`pnpm build` in `packages/executor`) and restart the daemon for the fix to take effect. UI edits hot-reload via Vite.
- No UI-level test for the new clearable Select / delete path yet (logic verified by reading + the executor/core unit tests). Can add a component test if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)