### PR TITLE
docs(blog): link to HubSpot form editor near embed constants

### DIFF
--- a/apps/agor-docs/components/HubSpotForm.tsx
+++ b/apps/agor-docs/components/HubSpotForm.tsx
@@ -19,6 +19,8 @@ declare global {
   }
 }
 
+// Source form (edit submit button copy, fields, etc. in HubSpot):
+// https://app.hubspot.com/forms/5901754/editor/f76e3259-8c31-4e39-8147-8e23fa53be74/edit
 const HUBSPOT_PORTAL_ID = '5901754';
 const HUBSPOT_FORM_ID = 'f76e3259-8c31-4e39-8147-8e23fa53be74';
 const HUBSPOT_REGION = 'na1';


### PR DESCRIPTION
## Summary

Adds a one-line comment above the HubSpot portal/form ID constants in `apps/agor-docs/components/HubSpotForm.tsx` pointing to the source form in the HubSpot editor:

\`\`\`ts
// Source form (edit submit button copy, fields, etc. in HubSpot):
// https://app.hubspot.com/forms/5901754/editor/f76e3259-8c31-4e39-8147-8e23fa53be74/edit
\`\`\`

So whoever needs to tweak the submit button copy ("Talk to an expert today!" is HubSpot-side, not in code) or add a field doesn't have to dig through the HubSpot UI to find the right form.

## On exposure

The portal ID and form ID already ship to every browser as part of the client-side \`hbspt.forms.create()\` call — they're necessarily public. The editor URL just requires a HubSpot login to be useful; pasting it in a public repo grants no additional access.

## Test plan

- [ ] Hover the link in the code, confirm it routes to the right form in HubSpot

Generated with [Claude Code](https://claude.com/claude-code)