### PR TITLE
fix(ui): clarify and harden markdown note placement

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -43,11 +43,17 @@
 }
 
 .react-flow.tool-mode-markdown .react-flow__pane {
-  cursor: crosshair;
+  cursor:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M6 2h8l4 4v16H6z' fill='white' stroke='%231677ff' stroke-width='2'/%3E%3Cpath d='M14 2v5h5' fill='none' stroke='%231677ff' stroke-width='2'/%3E%3Cpath d='M8 12h8M8 16h8' stroke='%231677ff' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E")
+    12 12,
+    pointer;
 }
 
 .react-flow.tool-mode-markdown .react-flow__node {
-  cursor: crosshair;
+  cursor:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M6 2h8l4 4v16H6z' fill='white' stroke='%231677ff' stroke-width='2'/%3E%3Cpath d='M14 2v5h5' fill='none' stroke='%231677ff' stroke-width='2'/%3E%3Cpath d='M8 12h8M8 16h8' stroke='%231677ff' stroke-width='2' stroke-linecap='round'/%3E%3C/svg%3E")
+    12 12,
+    pointer;
 }
 
 .react-flow.tool-mode-eraser .react-flow__pane {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2255,6 +2255,26 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           return;
         }
 
+        if (activeTool === 'markdown' && reactFlowInstanceRef.current) {
+          if (!mutationGate.canMutate) {
+            return;
+          }
+
+          // `onPaneClick` only fires when the pointer lands on the bare canvas.
+          // Boards often contain large zones/cards that cover the viewport; in
+          // those cases React Flow routes the click through `onNodeClick`
+          // instead. Treat node clicks as valid markdown placement clicks so
+          // the Add Markdown Note tool works regardless of what is under the
+          // cursor.
+          const position = reactFlowInstanceRef.current.screenToFlowPosition({
+            x: event.clientX,
+            y: event.clientY,
+          });
+
+          setMarkdownModal({ position });
+          return;
+        }
+
         // Bring clicked card to front (zones and comments are excluded from this)
         if (node.type !== 'zone' && node.type !== 'comment') {
           setNodes((nds) => {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2504,8 +2504,8 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               <Tooltip
                 title={
                   mutationGate.canMutate
-                    ? 'Add Markdown Note'
-                    : (mutationGate.message ?? 'Add Markdown Note')
+                    ? 'Add Markdown Note — click canvas to place'
+                    : (mutationGate.message ?? 'Add Markdown Note — click canvas to place')
                 }
                 placement="right"
                 mouseEnterDelay={0.3}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2025,6 +2025,23 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       }
     }, [activeTool, drawingZone, board, client, setNodes, mutationGate.canMutate]);
 
+    const openMarkdownPlacementModal = useCallback(
+      (event: Pick<React.MouseEvent, 'clientX' | 'clientY'>): boolean => {
+        if (!mutationGate.canMutate || !reactFlowInstanceRef.current) {
+          return false;
+        }
+
+        const position = reactFlowInstanceRef.current.screenToFlowPosition({
+          x: event.clientX,
+          y: event.clientY,
+        });
+
+        setMarkdownModal({ position });
+        return true;
+      },
+      [mutationGate.canMutate]
+    );
+
     // Pane click handler for comment placement
     const handlePaneClick = useCallback(
       (event: React.MouseEvent) => {
@@ -2042,16 +2059,11 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         }
 
         // Markdown tool: click-to-place
-        if (activeTool === 'markdown' && reactFlowInstanceRef.current) {
-          const position = reactFlowInstanceRef.current.screenToFlowPosition({
-            x: event.clientX,
-            y: event.clientY,
-          });
-
-          setMarkdownModal({ position });
+        if (activeTool === 'markdown') {
+          openMarkdownPlacementModal(event);
         }
       },
-      [activeTool]
+      [activeTool, openMarkdownPlacementModal]
     );
 
     // Handler to create spatial comment
@@ -2255,23 +2267,14 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           return;
         }
 
-        if (activeTool === 'markdown' && reactFlowInstanceRef.current) {
-          if (!mutationGate.canMutate) {
-            return;
-          }
-
+        if (activeTool === 'markdown') {
           // `onPaneClick` only fires when the pointer lands on the bare canvas.
           // Boards often contain large zones/cards that cover the viewport; in
           // those cases React Flow routes the click through `onNodeClick`
           // instead. Treat node clicks as valid markdown placement clicks so
           // the Add Markdown Note tool works regardless of what is under the
           // cursor.
-          const position = reactFlowInstanceRef.current.screenToFlowPosition({
-            x: event.clientX,
-            y: event.clientY,
-          });
-
-          setMarkdownModal({ position });
+          openMarkdownPlacementModal(event);
           return;
         }
 
@@ -2289,7 +2292,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           });
         }
       },
-      [activeTool, deleteObject, mutationGate.canMutate, setNodes]
+      [activeTool, deleteObject, mutationGate.canMutate, openMarkdownPlacementModal, setNodes]
     );
 
     // Clear comment placement state when switching away from comment tool
@@ -2512,6 +2515,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               >
                 <span>
                   <ControlButton
+                    aria-label="Add Markdown Note"
                     disabled={!mutationGate.canMutate}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -1,6 +1,6 @@
 import type { Board } from '@agor-live/client';
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import type { MouseEventHandler, ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import SessionCanvas from './SessionCanvas';
@@ -12,11 +12,12 @@ vi.mock('reactflow', () => ({
   ControlButton: ({
     children,
     onClick,
+    ...props
   }: {
     children?: ReactNode;
     onClick?: MouseEventHandler<HTMLButtonElement>;
-  }) => (
-    <button type="button" onClick={onClick}>
+  } & ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" onClick={onClick} {...props}>
       {children}
     </button>
   ),
@@ -125,8 +126,8 @@ describe('SessionCanvas zoom shortcuts', () => {
       });
     });
 
-    // Zoom in/out/fit, select, zone, comment, markdown.
-    fireEvent.click(screen.getAllByRole('button')[6]);
+    fireEvent.click(screen.getByRole('button', { name: 'Add Markdown Note' }));
+    await waitFor(() => expect(reactFlowProps?.className).toBe('tool-mode-markdown'));
 
     act(() => {
       (reactFlowProps?.onNodeClick as (event: unknown, node: unknown) => void)?.(

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -1,6 +1,8 @@
-import { render } from '@testing-library/react';
+import type { Board } from '@agor-live/client';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { MouseEventHandler, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import SessionCanvas from './SessionCanvas';
 
 let reactFlowProps: Record<string, unknown> | null = null;
@@ -64,5 +66,75 @@ describe('SessionCanvas zoom shortcuts', () => {
 
     expect(reactFlowProps?.panOnScroll).toBe(true);
     expect(reactFlowProps?.zoomActivationKeyCode).toEqual(['Meta', 'Control']);
+  });
+
+  it('opens the markdown note modal when the markdown tool clicks a board node', async () => {
+    render(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <SessionCanvas
+          board={
+            {
+              board_id: 'board-1',
+              name: 'Board',
+              slug: 'board',
+              objects: {
+                'zone-1': {
+                  type: 'zone',
+                  x: 0,
+                  y: 0,
+                  width: 1200,
+                  height: 900,
+                  label: 'Large Zone',
+                  borderColor: '#d9d9d9',
+                  backgroundColor: '#d9d9d91a',
+                },
+              },
+              created_at: '2026-06-18T00:00:00.000Z',
+              last_updated: '2026-06-18T00:00:00.000Z',
+              created_by: 'user-1',
+              url: 'http://localhost/ui/b/board/',
+              archived: false,
+            } as unknown as Board
+          }
+          client={null}
+          sessionById={new Map()}
+          sessionsByBranch={new Map()}
+          userById={new Map()}
+          repoById={new Map()}
+          branches={[]}
+          branchById={new Map()}
+          boardObjectById={new Map()}
+          boardObjectsByBoardId={new Map()}
+          commentById={new Map()}
+          cardById={new Map()}
+        />
+      </ConnectionProvider>
+    );
+
+    act(() => {
+      (reactFlowProps?.onInit as (instance: unknown) => void)?.({
+        screenToFlowPosition: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+      });
+    });
+
+    // Zoom in/out/fit, select, zone, comment, markdown.
+    fireEvent.click(screen.getAllByRole('button')[6]);
+
+    act(() => {
+      (reactFlowProps?.onNodeClick as (event: unknown, node: unknown) => void)?.(
+        { clientX: 240, clientY: 320 },
+        { id: 'zone-1', type: 'zone' }
+      );
+    });
+
+    expect(await screen.findByText('Add Markdown Note')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Clarify the Markdown Note tool tooltip so users know it is click-to-place: "Add Markdown Note — click canvas to place"
- Replace the markdown tool crosshair cursor with a document/note cursor to avoid suggesting drag-to-create
- Harden placement so clicking on an existing board node (for example a large zone/card) opens the markdown note modal instead of doing nothing
- Consolidate markdown placement through one helper and add an accessible label so tests target the tool by name instead of toolbox index

Fixes #1484

## Why
Issue #1484 appears to be partly UX confusion: the tool is click-to-place, not drag-to-create. The previous crosshair cursor made it look like a drag gesture. There was also a real edge case where clicks on zones/cards were routed through React Flow's node-click handler rather than pane-click handler, so markdown placement did not trigger if the board was covered by a zone/card.

## Tests
- pnpm i
- pnpm check
- pnpm -C apps/agor-ui test -- SessionCanvas.zoom.test.tsx