### PR TITLE
feat(unix): add execution.posix_acl_enabled flag with chmod fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,37 @@ execution:
 
   # Web terminal (xterm.js modal) for members+
   allow_web_terminal: boolean # default: true
+
+  # POSIX ACL support on the host filesystem (setfacl/getfacl)
+  posix_acl_enabled: boolean # default: true
 ```
+
+### POSIX ACL Support (`posix_acl_enabled`)
+
+**Default: `true`.** Agor's Unix isolation (`insulated` / `strict`) normally uses
+POSIX.1e ACLs (`setfacl`/`getfacl`) to manage branch and repo permissions. ACLs
+give two things plain mode bits can't: **default ACLs** so new files inherit
+group access regardless of the creating process's umask, and a **per-user grant**
+that lets the daemon reach branch files even when its supplementary groups are
+stale.
+
+Some filesystems — notably certain **NFS mounts** — reject `setfacl`. Set
+`execution.posix_acl_enabled: false` there. When disabled, the permission
+builders fall back to `chgrp` + `chmod` + setgid:
+
+- The owner/group/others restriction is **preserved** via mode bits (e.g. a
+  private `none` branch still clears the others bits — the fallback fails closed,
+  not open).
+- What's lost is ACL-only behavior: default-ACL inheritance for new files (now
+  relies on setgid + umask) and the per-user daemon grant. Because of the latter,
+  the **daemon must be a member of every repo/branch group** and may need a
+  restart to pick up newly created groups.
+
+The daemon emits a single startup warning when `posix_acl_enabled: false` is
+combined with active Unix isolation. This flag only gates ACL commands; it does
+not provide an alternative isolation mechanism — operators on ACL-less
+filesystems should supply isolation another way (dedicated mounts, chroot, or an
+executor command template).
 
 ### Web Terminal Access
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,10 @@ builders fall back to `chgrp` + `chmod` + setgid:
   the **daemon must be a member of every repo/branch group** and may need a
   restart to pick up newly created groups.
 
+Disabling the flag only stops Agor from issuing `setfacl`; it does **not** strip
+pre-existing ACLs on an ACL-capable filesystem. Use it for filesystems that
+reject ACLs, not as an ACL cleanup or migration mode.
+
 The daemon emits a single startup warning when `posix_acl_enabled: false` is
 combined with active Unix isolation. This flag only gates ACL commands; it does
 not provide an alternative isolation mechanism — operators on ACL-less

--- a/apps/agor-cli/src/commands/admin/sync-unix.ts
+++ b/apps/agor-cli/src/commands/admin/sync-unix.ts
@@ -282,6 +282,7 @@ export default class SyncUnix extends Command {
       // (process.env.USER would return 'root' which is wrong)
       const config = await loadConfig();
       const daemonUser = config.daemon?.unix_user;
+      const aclEnabled = config.execution?.posix_acl_enabled !== false;
 
       if (!daemonUser) {
         this.error(
@@ -478,7 +479,8 @@ export default class SyncUnix extends Command {
               const rootCmds = UnixGroupCommands.setDirectoryGroupShallow(
                 repoPath,
                 expectedGroup,
-                REPO_GIT_PERMISSION_MODE
+                REPO_GIT_PERMISSION_MODE,
+                { aclEnabled }
               );
               const cmds = existsSync(gitPath)
                 ? [
@@ -486,7 +488,8 @@ export default class SyncUnix extends Command {
                     ...UnixGroupCommands.setDirectoryGroup(
                       gitPath,
                       expectedGroup,
-                      REPO_GIT_PERMISSION_MODE
+                      REPO_GIT_PERMISSION_MODE,
+                      { aclEnabled }
                     ),
                   ]
                 : rootCmds;
@@ -1209,7 +1212,8 @@ export default class SyncUnix extends Command {
           const permCmds = UnixGroupCommands.setDirectoryGroup(
             branchPath,
             rawBranch.unix_group,
-            permissionMode
+            permissionMode,
+            { aclEnabled }
           );
           if (await execAllCmds(permCmds)) {
             branchesSynced++;
@@ -1221,7 +1225,7 @@ export default class SyncUnix extends Command {
 
           // Apply daemon user ACL so the running daemon can access without restart
           if (daemonUser && (dirExists || action === 'create')) {
-            const aclCmds = UnixGroupCommands.setUserAcl(branchPath, daemonUser);
+            const aclCmds = UnixGroupCommands.setUserAcl(branchPath, daemonUser, { aclEnabled });
             if (await execAllCmds(aclCmds)) {
               daemonAclsApplied++;
               if (verbose) {

--- a/apps/agor-cli/src/commands/admin/sync-unix.ts
+++ b/apps/agor-cli/src/commands/admin/sync-unix.ts
@@ -1225,15 +1225,23 @@ export default class SyncUnix extends Command {
 
           // Apply daemon user ACL so the running daemon can access without restart
           if (daemonUser && (dirExists || action === 'create')) {
-            const aclCmds = UnixGroupCommands.setUserAcl(branchPath, daemonUser, { aclEnabled });
-            if (await execAllCmds(aclCmds)) {
-              daemonAclsApplied++;
+            if (!aclEnabled) {
               if (verbose) {
-                this.log(chalk.green(`   ✓ Applied daemon ACL for ${daemonUser}`));
+                this.log(
+                  chalk.gray('   ⊘ Daemon ACL skipped (posix_acl_enabled=false; relies on group)')
+                );
               }
             } else {
-              syncErrors++;
-              this.log(chalk.red(`   ✗ Failed to set daemon ACL`));
+              const aclCmds = UnixGroupCommands.setUserAcl(branchPath, daemonUser, { aclEnabled });
+              if (await execAllCmds(aclCmds)) {
+                daemonAclsApplied++;
+                if (verbose) {
+                  this.log(chalk.green(`   ✓ Applied daemon ACL for ${daemonUser}`));
+                }
+              } else {
+                syncErrors++;
+                this.log(chalk.red(`   ✗ Failed to set daemon ACL`));
+              }
             }
           }
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -9,6 +9,7 @@
 import { analyticsLogger } from '@agor/core/analytics';
 import {
   type AgorConfig,
+  isPosixAclEnabled,
   isUnixImpersonationEnabled,
   loadConfig,
   type UnknownJson,
@@ -1105,6 +1106,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                       params: {
                         branchId: branch.branch_id,
                         daemonUser: config.daemon?.unix_user,
+                        aclEnabled: isPosixAclEnabled(),
                       },
                     },
                     { logPrefix: '[Executor/branch.patch]' }
@@ -2362,6 +2364,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                         params: {
                           branchId: session.branch_id,
                           daemonUser: config.daemon?.unix_user,
+                          aclEnabled: isPosixAclEnabled(),
                         },
                       },
                       { logPrefix: '[Executor/session.create.unix-group]' }

--- a/apps/agor-daemon/src/services/branch-owners.ts
+++ b/apps/agor-daemon/src/services/branch-owners.ts
@@ -18,6 +18,7 @@
  * @see context/guides/rbac-and-unix-isolation.md
  */
 
+import { isPosixAclEnabled } from '@agor/core/config';
 import type { BranchRepository } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
 import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
@@ -268,6 +269,7 @@ export function setupBranchOwnersService(
               params: {
                 branchId,
                 daemonUser: config.daemonUser,
+                aclEnabled: isPosixAclEnabled(),
               },
             },
             { logPrefix: '[Executor/branch-owners.create]' }
@@ -302,6 +304,7 @@ export function setupBranchOwnersService(
               params: {
                 branchId,
                 daemonUser: config.daemonUser,
+                aclEnabled: isPosixAclEnabled(),
               },
             },
             { logPrefix: '[Executor/branch-owners.remove]' }

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -485,6 +485,21 @@ export async function startup(ctx: StartupContext): Promise<void> {
     }
   }
 
+  // Notice: POSIX ACLs disabled while Unix isolation is active. Permission sync
+  // falls back to chmod-only (no per-user daemon grant, no default-ACL
+  // inheritance); the others-restriction still holds via mode bits.
+  if (config.execution?.posix_acl_enabled === false) {
+    const unixMode = config.execution?.unix_user_mode ?? 'simple';
+    if (config.execution?.branch_rbac || unixMode !== 'simple') {
+      console.warn(
+        '\x1b[33m⚠️  execution.posix_acl_enabled=false with Unix isolation active.\x1b[0m\n' +
+          '   setfacl/getfacl are skipped; permissions use chgrp + chmod only.\n' +
+          '   The daemon relies on group membership (no per-user ACL grant), so it\n' +
+          '   must be a member of every repo/branch group — restart after group changes.'
+      );
+    }
+  }
+
   // 5. Start executor heartbeat stale supervisor
   const heartbeatConfig = resolveExecutorHeartbeatConfig(config.execution);
   const heartbeatSupervisor = new ExecutorHeartbeatSupervisor({ app, config: heartbeatConfig });

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -490,7 +490,9 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // inheritance); the others-restriction still holds via mode bits.
   if (config.execution?.posix_acl_enabled === false) {
     const unixMode = config.execution?.unix_user_mode ?? 'simple';
-    if (config.execution?.branch_rbac || unixMode !== 'simple') {
+    // Groups/ACLs only exist in insulated/strict — simple mode (even with RBAC)
+    // never runs setfacl, so the fallback warning is irrelevant there.
+    if (unixMode !== 'simple') {
       console.warn(
         '\x1b[33m⚠️  execution.posix_acl_enabled=false with Unix isolation active.\x1b[0m\n' +
           '   setfacl/getfacl are skipped; permissions use chgrp + chmod only.\n' +

--- a/apps/agor-daemon/src/utils/unix-group-init.ts
+++ b/apps/agor-daemon/src/utils/unix-group-init.ts
@@ -13,7 +13,7 @@
 
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
-import { getDaemonUser } from '@agor/core/config';
+import { getDaemonUser, isPosixAclEnabled } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
 import { shortId, UsersRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
@@ -60,6 +60,7 @@ export async function initializeRepoUnixGroup(
 ): Promise<string> {
   const groupName = generateRepoGroupName(repoId as RepoID);
   const daemonUser = getDaemonUser();
+  const aclEnabled = isPosixAclEnabled();
 
   console.log(`[unix-group-init] Creating repo group ${groupName} for repo ${shortId(repoId)}`);
 
@@ -78,13 +79,14 @@ export async function initializeRepoUnixGroup(
   const permCommands = UnixGroupCommands.setDirectoryGroup(
     repoPath,
     groupName,
-    REPO_GIT_PERMISSION_MODE
+    REPO_GIT_PERMISSION_MODE,
+    { aclEnabled }
   );
   await runCommands(permCommands);
 
-  // Set explicit user ACL for daemon
+  // Set explicit user ACL for daemon (skipped when ACLs disabled)
   if (daemonUser) {
-    await runCommands(UnixGroupCommands.setUserAcl(repoPath, daemonUser));
+    await runCommands(UnixGroupCommands.setUserAcl(repoPath, daemonUser, { aclEnabled }));
   }
   console.log(`[unix-group-init] Set repo directory permissions with group ${groupName}`);
 
@@ -139,6 +141,7 @@ export async function initializeBranchUnixGroup(
 ): Promise<string> {
   const groupName = generateBranchGroupName(branchId as BranchID);
   const daemonUser = getDaemonUser();
+  const aclEnabled = isPosixAclEnabled();
 
   console.log(
     `[unix-group-init] Creating branch group ${groupName} for branch ${shortId(branchId)}`
@@ -157,12 +160,14 @@ export async function initializeBranchUnixGroup(
 
   // Set permissions on branch directory
   const permissionMode = getBranchPermissionMode(othersAccess);
-  const permCommands = UnixGroupCommands.setDirectoryGroup(branchPath, groupName, permissionMode);
+  const permCommands = UnixGroupCommands.setDirectoryGroup(branchPath, groupName, permissionMode, {
+    aclEnabled,
+  });
   await runCommands(permCommands);
 
-  // Set explicit user ACL for daemon
+  // Set explicit user ACL for daemon (skipped when ACLs disabled)
   if (daemonUser) {
-    await runCommands(UnixGroupCommands.setUserAcl(branchPath, daemonUser));
+    await runCommands(UnixGroupCommands.setUserAcl(branchPath, daemonUser, { aclEnabled }));
   }
 
   // Add daemon user to branch group
@@ -222,11 +227,12 @@ export async function initializeBranchUnixGroup(
     const gitDirPermCommands = UnixGroupCommands.setDirectoryGroup(
       branchGitDir,
       repo.unix_group,
-      REPO_GIT_PERMISSION_MODE
+      REPO_GIT_PERMISSION_MODE,
+      { aclEnabled }
     );
     await runCommands(gitDirPermCommands);
     if (daemonUser) {
-      await runCommands(UnixGroupCommands.setUserAcl(branchGitDir, daemonUser));
+      await runCommands(UnixGroupCommands.setUserAcl(branchGitDir, daemonUser, { aclEnabled }));
     }
   }
 

--- a/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
@@ -325,6 +325,10 @@ When disabled, the permission commands fall back to `chgrp` + `chmod` + setgid:
 The daemon prints a single startup warning when `posix_acl_enabled: false` is
 combined with active Unix isolation.
 
+This fallback does **not** strip pre-existing ACLs on an ACL-capable filesystem
+— it simply stops issuing `setfacl`. Use it for filesystems that reject ACLs,
+not as an ACL cleanup or migration mode.
+
 > ⚠️ This flag only **gates** ACL commands; it does not provide an alternative
 > isolation mechanism. If your filesystem can't do ACLs and you still need hard
 > isolation, supply it another way — dedicated per-branch mounts, a chroot, or a

--- a/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
@@ -88,6 +88,10 @@ All filesystem operations are **strictly scoped** to Agor-managed paths:
 - PostgreSQL (recommended for production)
 - sudo access for initial setup
 - tmux (for multiplayer terminal sessions)
+- POSIX ACL support on the filesystem backing branches/repos (the `acl` package
+  providing `setfacl`/`getfacl`). On filesystems that reject `setfacl` — e.g.
+  some NFS mounts — set `execution.posix_acl_enabled: false` (see
+  [POSIX ACL Support](#4c-posix-acl-support) below) to fall back to plain mode bits.
 
 ### 1. PostgreSQL Configuration
 
@@ -287,6 +291,44 @@ When set to `false`:
 > For any deployment where you do not trust all members with daemon-level
 > access, either run in `insulated`/`strict` mode or set
 > `allow_web_terminal: false`.
+
+### 4c. POSIX ACL Support
+
+In `insulated` / `strict` mode, Agor manages branch and repo permissions with
+POSIX.1e ACLs (`setfacl`/`getfacl`) by default. ACLs provide two things plain
+Unix mode bits cannot:
+
+- **Default ACLs** — new files and directories inherit group access regardless
+  of the creating process's umask.
+- **A per-user grant** — the daemon user keeps direct access to branch files
+  even when its supplementary group list is stale (groups added after the
+  process started aren't picked up until restart).
+
+Some filesystems reject `setfacl` — most commonly certain **NFS mounts**. On
+those hosts, disable ACLs:
+
+```yaml
+execution:
+  posix_acl_enabled: false # default: true
+```
+
+When disabled, the permission commands fall back to `chgrp` + `chmod` + setgid:
+
+- The owner / group / others restriction is **still enforced** through mode
+  bits. A private (`others_fs_access: none`) branch still clears the "others"
+  bits — the fallback **fails closed**, never silently widening access.
+- ACL-only behavior is lost: new files rely on setgid + umask instead of default
+  ACLs, and there is no per-user daemon grant. Because of the latter, the
+  **daemon user must be a member of every repo and branch group**, and the
+  daemon may need a restart to pick up newly created groups.
+
+The daemon prints a single startup warning when `posix_acl_enabled: false` is
+combined with active Unix isolation.
+
+> ⚠️ This flag only **gates** ACL commands; it does not provide an alternative
+> isolation mechanism. If your filesystem can't do ACLs and you still need hard
+> isolation, supply it another way — dedicated per-branch mounts, a chroot, or a
+> custom executor command template.
 
 ### 5. Observability Setup
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -21,6 +21,7 @@ import {
   getDefaultConfig,
   getReposDir,
   initConfig,
+  isPosixAclEnabled,
   loadConfig,
   loadConfigSync,
   PublicBaseUrlNotConfiguredError,
@@ -1249,5 +1250,47 @@ describe('resolveBranchStorageConfig + ensureBranchStorageModeAllowed', () => {
     // v0.20+ default allows both — operators have to opt out to forbid clone.
     expect(() => ensureBranchStorageModeAllowed('worktree')).not.toThrow();
     expect(() => ensureBranchStorageModeAllowed('clone')).not.toThrow();
+  });
+});
+
+describe('isPosixAclEnabled', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-acl-test-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
+    __resetConfigCacheForTests();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    __resetConfigCacheForTests();
+  });
+
+  async function writeConfig(config: AgorConfig): Promise<void> {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(path.join(agorDir, 'config.yaml'), yaml.dump(config), 'utf-8');
+    __resetConfigCacheForTests();
+  }
+
+  it('defaults to true when no config file exists', () => {
+    expect(isPosixAclEnabled()).toBe(true);
+  });
+
+  it('defaults to true when execution.posix_acl_enabled is unset', async () => {
+    await writeConfig({ execution: { branch_rbac: true } });
+    expect(isPosixAclEnabled()).toBe(true);
+  });
+
+  it('returns true when explicitly enabled', async () => {
+    await writeConfig({ execution: { posix_acl_enabled: true } });
+    expect(isPosixAclEnabled()).toBe(true);
+  });
+
+  it('returns false only when explicitly disabled', async () => {
+    await writeConfig({ execution: { posix_acl_enabled: false } });
+    expect(isPosixAclEnabled()).toBe(false);
   });
 });

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -840,6 +840,26 @@ export function isUnixImpersonationEnabled(): boolean {
 }
 
 /**
+ * Check whether POSIX.1e ACLs (`setfacl`/`getfacl`) are enabled.
+ *
+ * Defaults to `true` — disabling is an explicit opt-out for filesystems that
+ * don't support POSIX ACLs (e.g. some NFS mounts). When `false`, Unix-group
+ * permission setup falls back to `chgrp` + `chmod` + setgid and skips all
+ * `setfacl` invocations. See {@link AgorExecutionSettings.posix_acl_enabled}.
+ *
+ * Returns `true` (the default) when config can't be loaded, preserving the
+ * historical always-on ACL behaviour.
+ */
+export function isPosixAclEnabled(): boolean {
+  try {
+    const config = loadConfigSync();
+    return config.execution?.posix_acl_enabled !== false;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Resolve `execution.branch_storage` with defaults applied.
  *
  * Default posture (v0.20+): both storage modes are enabled out of the box so

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -348,6 +348,21 @@ export interface AgorExecutionSettings {
   /** Unix user mode: simple (no isolation), insulated (branch groups), strict (enforce process impersonation) */
   unix_user_mode?: UnixUserMode;
 
+  /**
+   * Whether the host filesystem supports POSIX.1e ACLs (`setfacl`/`getfacl`).
+   * Default: `true`. Set to `false` on filesystems that reject `setfacl`
+   * (e.g. some NFS mounts).
+   *
+   * Only relevant under Unix isolation (`insulated`/`strict`). When disabled,
+   * branch/repo permission setup falls back to `chgrp` + `chmod` + setgid: the
+   * `others_fs_access` restriction is still enforced via mode bits, but ACL-only
+   * properties are dropped (default-ACL inheritance → setgid + umask; per-user
+   * daemon grant → group membership). Both losses fail closed. Provide finer
+   * isolation at another layer (mount/chroot/`executor_command_template`).
+   * See `context/guides/rbac-and-unix-isolation.md`.
+   */
+  posix_acl_enabled?: boolean;
+
   /** Enable branch RBAC and ownership system (default: false). When enabled, enforces permission checks and Unix group isolation. */
   branch_rbac?: boolean;
 

--- a/packages/core/src/seed/dev-fixtures.ts
+++ b/packages/core/src/seed/dev-fixtures.ts
@@ -89,6 +89,7 @@ export async function seedDevFixtures(options: SeedOptions): Promise<SeedResult>
     unixIntegrationService = new UnixIntegrationService(db, new DirectExecutor(), {
       enabled: true,
       daemonUser,
+      aclEnabled: config.execution?.posix_acl_enabled !== false,
     });
   }
 

--- a/packages/core/src/unix/group-manager.test.ts
+++ b/packages/core/src/unix/group-manager.test.ts
@@ -216,12 +216,24 @@ describe('group-manager', () => {
           'sudo -n setfacl -R -d -m u:agorpg:rwX "/data/branch"',
         ]);
       });
+
+      it('returns no commands when ACLs are disabled (no mode-bit equivalent)', () => {
+        const cmds = UnixGroupCommands.setUserAcl('/data/branch', 'agorpg', { aclEnabled: false });
+        expect(cmds).toEqual([]);
+      });
     });
 
     describe('setUserAclShallow', () => {
       it('returns non-recursive ACL command for a specific user', () => {
         const cmds = UnixGroupCommands.setUserAclShallow('/data/repo', 'agorpg');
         expect(cmds).toEqual(['sudo -n setfacl -m u:agorpg:rwX "/data/repo"']);
+      });
+
+      it('returns no commands when ACLs are disabled', () => {
+        const cmds = UnixGroupCommands.setUserAclShallow('/data/repo', 'agorpg', {
+          aclEnabled: false,
+        });
+        expect(cmds).toEqual([]);
       });
     });
 
@@ -264,6 +276,50 @@ describe('group-manager', () => {
           'sudo -n find "/data/public" -type d -exec chmod g+s {} +',
         ]);
       });
+
+      describe('when ACLs are disabled', () => {
+        it('never emits setfacl, falling back to chgrp + chmod + setgid', () => {
+          for (const mode of ['2770', '2775', '2777']) {
+            const cmds = UnixGroupCommands.setDirectoryGroup('/data/p', 'g', mode, {
+              aclEnabled: false,
+            });
+            expect(cmds.some((c) => c.includes('setfacl'))).toBe(false);
+          }
+        });
+
+        it('clears others bits for no-access mode (2770)', () => {
+          const cmds = UnixGroupCommands.setDirectoryGroup('/data/secret', 'admins', '2770', {
+            aclEnabled: false,
+          });
+          expect(cmds).toEqual([
+            'sudo -n chgrp -R admins "/data/secret"',
+            'sudo -n chmod -R u=rwX,g=rwX,o= "/data/secret"',
+            'sudo -n find "/data/secret" -type d -exec chmod g+s {} +',
+          ]);
+        });
+
+        it('grants others read for read mode (2775)', () => {
+          const cmds = UnixGroupCommands.setDirectoryGroup('/data/project', 'developers', '2775', {
+            aclEnabled: false,
+          });
+          expect(cmds).toEqual([
+            'sudo -n chgrp -R developers "/data/project"',
+            'sudo -n chmod -R u=rwX,g=rwX,o=rX "/data/project"',
+            'sudo -n find "/data/project" -type d -exec chmod g+s {} +',
+          ]);
+        });
+
+        it('grants others write for write mode (2777)', () => {
+          const cmds = UnixGroupCommands.setDirectoryGroup('/data/public', 'everyone', '2777', {
+            aclEnabled: false,
+          });
+          expect(cmds).toEqual([
+            'sudo -n chgrp -R everyone "/data/public"',
+            'sudo -n chmod -R u=rwX,g=rwX,o=rwX "/data/public"',
+            'sudo -n find "/data/public" -type d -exec chmod g+s {} +',
+          ]);
+        });
+      });
     });
 
     describe('setDirectoryGroupShallow', () => {
@@ -277,6 +333,23 @@ describe('group-manager', () => {
           'sudo -n setfacl -m m::rwX "/data/repo"',
           'sudo -n chmod g+s "/data/repo"',
         ]);
+      });
+
+      it('falls back to chgrp + chmod + setgid when ACLs are disabled', () => {
+        const cmds = UnixGroupCommands.setDirectoryGroupShallow(
+          '/data/repo',
+          'developers',
+          '2770',
+          {
+            aclEnabled: false,
+          }
+        );
+        expect(cmds).toEqual([
+          'sudo -n chgrp developers "/data/repo"',
+          'sudo -n chmod u=rwX,g=rwX,o= "/data/repo"',
+          'sudo -n chmod g+s "/data/repo"',
+        ]);
+        expect(cmds.some((c) => c.includes('setfacl'))).toBe(false);
       });
     });
   });

--- a/packages/core/src/unix/group-manager.ts
+++ b/packages/core/src/unix/group-manager.ts
@@ -104,6 +104,31 @@ export function isValidRepoGroupName(groupName: string): boolean {
 export const AGOR_USERS_GROUP = 'agor_users';
 
 /**
+ * Options for the directory/user permission command builders.
+ *
+ * `aclEnabled` defaults to `true`. When `false` (filesystems without POSIX
+ * ACL support, e.g. some NFS mounts), the builders fall back to
+ * `chgrp` + `chmod` + setgid instead of `setfacl`. See
+ * `execution.posix_acl_enabled`.
+ */
+export interface UnixPermissionCommandOptions {
+  aclEnabled?: boolean;
+}
+
+// Symbolic `chmod` "others" spec for the ACL-less fallback. Capital `X`
+// mirrors ACL `rwX`: execute only on directories, never forced onto files.
+function othersSymbolicChmod(othersDigit: string): string {
+  switch (othersDigit) {
+    case '7':
+      return 'rwX';
+    case '5':
+      return 'rX';
+    default:
+      return ''; // `o=` clears all "others" bits
+  }
+}
+
+/**
  * Unix group management commands
  *
  * Commands are returned as shell strings with sudo already included where needed.
@@ -194,13 +219,30 @@ export const UnixGroupCommands = {
    * @param path - Directory path
    * @param groupName - Group to own the directory
    * @param permissions - Permissions mode (e.g., '2770' for no others access)
+   * @param options - {@link UnixPermissionCommandOptions} (e.g. `aclEnabled`)
    * @returns Array of command strings with sudo to execute sequentially
    */
-  setDirectoryGroup: (path: string, groupName: string, permissions: string): string[] => {
+  setDirectoryGroup: (
+    path: string,
+    groupName: string,
+    permissions: string,
+    options: UnixPermissionCommandOptions = {}
+  ): string[] => {
     // Determine "others" ACL based on permissions mode
     // 2770 = no others, 2775 = others r-X, 2777 = others rwX
     // Using capital X means: execute only on directories, not files
     const othersDigit = permissions.charAt(3); // Last digit is "others"
+
+    // ACL-less fallback: same owner/group/others restriction via mode bits.
+    // Loses default-ACL inheritance (new files rely on setgid + umask).
+    if (options.aclEnabled === false) {
+      return [
+        `sudo -n chgrp -R ${groupName} "${path}"`,
+        `sudo -n chmod -R u=rwX,g=rwX,o=${othersSymbolicChmod(othersDigit)} "${path}"`,
+        `sudo -n find "${path}" -type d -exec chmod g+s {} +`,
+      ];
+    }
+
     let othersAcl: string;
     switch (othersDigit) {
       case '7':
@@ -249,8 +291,23 @@ export const UnixGroupCommands = {
    * @param permissions - Permissions mode (e.g., '2770' for no others access)
    * @returns Array of command strings with sudo to execute sequentially
    */
-  setDirectoryGroupShallow: (path: string, groupName: string, permissions: string): string[] => {
+  setDirectoryGroupShallow: (
+    path: string,
+    groupName: string,
+    permissions: string,
+    options: UnixPermissionCommandOptions = {}
+  ): string[] => {
     const othersDigit = permissions.charAt(3);
+
+    // ACL-less fallback: see setDirectoryGroup.
+    if (options.aclEnabled === false) {
+      return [
+        `sudo -n chgrp ${groupName} "${path}"`,
+        `sudo -n chmod u=rwX,g=rwX,o=${othersSymbolicChmod(othersDigit)} "${path}"`,
+        `sudo -n chmod g+s "${path}"`,
+      ];
+    }
+
     let othersAcl: string;
     switch (othersDigit) {
       case '7':
@@ -284,14 +341,25 @@ export const UnixGroupCommands = {
    *
    * @param path - Directory path
    * @param username - Unix username to grant access to
-   * @returns Array of command strings with sudo to execute sequentially
+   * @param options - {@link UnixPermissionCommandOptions} (e.g. `aclEnabled`)
+   * @returns Array of command strings with sudo to execute sequentially.
+   *          Empty when `aclEnabled === false` — there is no mode-bit
+   *          equivalent of a per-user grant, so the caller falls back to the
+   *          user's group membership for access.
    */
-  setUserAcl: (path: string, username: string): string[] => [
-    // Set ACL on all existing files and directories
-    `sudo -n setfacl -R -m u:${username}:rwX "${path}"`,
-    // Set default ACL so new files/dirs inherit the same access
-    `sudo -n setfacl -R -d -m u:${username}:rwX "${path}"`,
-  ],
+  setUserAcl: (
+    path: string,
+    username: string,
+    options: UnixPermissionCommandOptions = {}
+  ): string[] =>
+    options.aclEnabled === false
+      ? []
+      : [
+          // Set ACL on all existing files and directories
+          `sudo -n setfacl -R -m u:${username}:rwX "${path}"`,
+          // Set default ACL so new files/dirs inherit the same access
+          `sudo -n setfacl -R -d -m u:${username}:rwX "${path}"`,
+        ],
 
   /**
    * Set explicit user ACL on a single directory (non-recursive)
@@ -300,11 +368,16 @@ export const UnixGroupCommands = {
    *
    * @param path - Directory path
    * @param username - Unix username to grant access to
-   * @returns Array of command strings with sudo to execute sequentially
+   * @param options - {@link UnixPermissionCommandOptions} (e.g. `aclEnabled`)
+   * @returns Array of command strings with sudo to execute sequentially.
+   *          Empty when `aclEnabled === false`.
    */
-  setUserAclShallow: (path: string, username: string): string[] => [
-    `sudo -n setfacl -m u:${username}:rwX "${path}"`,
-  ],
+  setUserAclShallow: (
+    path: string,
+    username: string,
+    options: UnixPermissionCommandOptions = {}
+  ): string[] =>
+    options.aclEnabled === false ? [] : [`sudo -n setfacl -m u:${username}:rwX "${path}"`],
 } as const;
 
 /**

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -76,6 +76,10 @@ export interface UnixIntegrationConfig {
   /** Unix user the daemon runs as. Added to all Unix groups to ensure daemon has access.
    * Should be resolved via getAgorDaemonUser() before passing to the service. */
   daemonUser?: string;
+
+  /** Whether the host filesystem supports POSIX ACLs (`setfacl`). Default: true.
+   * When false, builders fall back to chmod-only permissions. */
+  aclEnabled?: boolean;
 }
 
 /**
@@ -93,7 +97,10 @@ export interface UnixOperationResult {
  * Orchestrates all Unix-level operations for Agor RBAC.
  */
 export class UnixIntegrationService {
-  private config: Required<Omit<UnixIntegrationConfig, 'daemonUser'>> & { daemonUser?: string };
+  private config: Required<Omit<UnixIntegrationConfig, 'daemonUser' | 'aclEnabled'>> & {
+    daemonUser?: string;
+  };
+  private aclEnabled: boolean;
   private executor: CommandExecutor;
   private branchRepo: BranchRepository;
   private usersRepo: UsersRepository;
@@ -113,6 +120,7 @@ export class UnixIntegrationService {
       autoManageSymlinks: config.autoManageSymlinks ?? config.enabled,
       daemonUser: config.daemonUser,
     };
+    this.aclEnabled = config.aclEnabled ?? true;
     this.executor = config.enabled ? executor : new NoOpExecutor();
     this.branchRepo = new BranchRepository(db);
     this.usersRepo = new UsersRepository(db);
@@ -400,14 +408,20 @@ export class UnixIntegrationService {
     );
 
     await this.executor.execAll(
-      UnixGroupCommands.setDirectoryGroup(branchPath, branch.unix_group, permissionMode)
+      UnixGroupCommands.setDirectoryGroup(branchPath, branch.unix_group, permissionMode, {
+        aclEnabled: this.aclEnabled,
+      })
     );
 
     // Set explicit user ACL for the daemon user so it can access branch files
     // even when its supplementary groups are stale (groups added after process
     // startup are not picked up by the running process)
     if (this.config.daemonUser) {
-      await this.executor.execAll(UnixGroupCommands.setUserAcl(branchPath, this.config.daemonUser));
+      await this.executor.execAll(
+        UnixGroupCommands.setUserAcl(branchPath, this.config.daemonUser, {
+          aclEnabled: this.aclEnabled,
+        })
+      );
     }
   }
 
@@ -555,13 +569,18 @@ export class UnixIntegrationService {
       UnixGroupCommands.setDirectoryGroupShallow(
         repoPath,
         repo.unix_group,
-        REPO_GIT_PERMISSION_MODE
+        REPO_GIT_PERMISSION_MODE,
+        {
+          aclEnabled: this.aclEnabled,
+        }
       )
     );
 
     if (gitExists) {
       await this.executor.execAll(
-        UnixGroupCommands.setDirectoryGroup(gitPath, repo.unix_group, REPO_GIT_PERMISSION_MODE)
+        UnixGroupCommands.setDirectoryGroup(gitPath, repo.unix_group, REPO_GIT_PERMISSION_MODE, {
+          aclEnabled: this.aclEnabled,
+        })
       );
     }
 
@@ -570,10 +589,16 @@ export class UnixIntegrationService {
     // - `.git` (recursive): git operations even with stale supplementary groups
     if (this.config.daemonUser) {
       await this.executor.execAll(
-        UnixGroupCommands.setUserAclShallow(repoPath, this.config.daemonUser)
+        UnixGroupCommands.setUserAclShallow(repoPath, this.config.daemonUser, {
+          aclEnabled: this.aclEnabled,
+        })
       );
       if (gitExists) {
-        await this.executor.execAll(UnixGroupCommands.setUserAcl(gitPath, this.config.daemonUser));
+        await this.executor.execAll(
+          UnixGroupCommands.setUserAcl(gitPath, this.config.daemonUser, {
+            aclEnabled: this.aclEnabled,
+          })
+        );
       }
     }
   }
@@ -617,13 +642,17 @@ export class UnixIntegrationService {
     );
 
     await this.executor.execAll(
-      UnixGroupCommands.setDirectoryGroup(branchGitDir, repo.unix_group, REPO_GIT_PERMISSION_MODE)
+      UnixGroupCommands.setDirectoryGroup(branchGitDir, repo.unix_group, REPO_GIT_PERMISSION_MODE, {
+        aclEnabled: this.aclEnabled,
+      })
     );
 
     // Set explicit user ACL for the daemon user on .git/worktrees/<name>
     if (this.config.daemonUser) {
       await this.executor.execAll(
-        UnixGroupCommands.setUserAcl(branchGitDir, this.config.daemonUser)
+        UnixGroupCommands.setUserAcl(branchGitDir, this.config.daemonUser, {
+          aclEnabled: this.aclEnabled,
+        })
       );
     }
   }

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -179,6 +179,7 @@ export async function handleUnixSyncRepo(
     }
 
     const groupName = generateRepoGroupName(repoId as RepoID);
+    const aclEnabled = payload.params.aclEnabled ?? true;
     console.log(`[unix.sync-repo] Syncing repo ${shortId(repoId)} with group ${groupName}`);
 
     // Ensure group exists
@@ -193,12 +194,15 @@ export async function handleUnixSyncRepo(
     const permCommands = UnixGroupCommands.setDirectoryGroup(
       gitPath,
       groupName,
-      REPO_GIT_PERMISSION_MODE
+      REPO_GIT_PERMISSION_MODE,
+      { aclEnabled }
     );
     await runCommands(permCommands);
     // Set explicit user ACL for daemon to bypass stale supplementary groups
     if (payload.params.daemonUser) {
-      await runCommands(UnixGroupCommands.setUserAcl(gitPath, payload.params.daemonUser));
+      await runCommands(
+        UnixGroupCommands.setUserAcl(gitPath, payload.params.daemonUser, { aclEnabled })
+      );
     }
     console.log(`[unix.sync-repo] Set .git/ permissions`);
 
@@ -341,6 +345,7 @@ export async function handleUnixSyncBranch(
     }
 
     const groupName = generateBranchGroupName(branchId as BranchID);
+    const aclEnabled = payload.params.aclEnabled ?? true;
     console.log(`[unix.sync-branch] Syncing branch ${shortId(branchId)} with group ${groupName}`);
 
     // Ensure group exists
@@ -356,12 +361,15 @@ export async function handleUnixSyncBranch(
     const permCommands = UnixGroupCommands.setDirectoryGroup(
       branch.path,
       groupName,
-      permissionMode
+      permissionMode,
+      { aclEnabled }
     );
     await runCommands(permCommands);
     // Set explicit user ACL for daemon to bypass stale supplementary groups
     if (payload.params.daemonUser) {
-      await runCommands(UnixGroupCommands.setUserAcl(branch.path, payload.params.daemonUser));
+      await runCommands(
+        UnixGroupCommands.setUserAcl(branch.path, payload.params.daemonUser, { aclEnabled })
+      );
     }
     console.log(`[unix.sync-branch] Set branch permissions (mode: ${permissionMode})`);
 
@@ -539,13 +547,16 @@ export async function handleUnixSyncBranch(
               const fixCommands = UnixGroupCommands.setDirectoryGroup(
                 branchGitDir,
                 repo.unix_group,
-                REPO_GIT_PERMISSION_MODE
+                REPO_GIT_PERMISSION_MODE,
+                { aclEnabled }
               );
               await runCommands(fixCommands);
               // Set explicit user ACL for daemon to bypass stale supplementary groups
               if (payload.params.daemonUser) {
                 await runCommands(
-                  UnixGroupCommands.setUserAcl(branchGitDir, payload.params.daemonUser)
+                  UnixGroupCommands.setUserAcl(branchGitDir, payload.params.daemonUser, {
+                    aclEnabled,
+                  })
                 );
               }
               console.log(`[unix.sync-branch] Fixed .git/worktrees/${branchName}/ permissions`);

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -612,6 +612,13 @@ export const UnixSyncBranchPayloadSchema = BasePayloadSchema.extend({
     /** Daemon Unix user (added to all groups for daemon access) */
     daemonUser: z.string().optional(),
 
+    /**
+     * Whether POSIX ACLs (`setfacl`) are available on the target filesystem.
+     * Defaults to `true` in the handler when absent. Daemon sets this from
+     * `execution.posix_acl_enabled` since the executor can't read config.
+     */
+    aclEnabled: z.boolean().optional(),
+
     /** If true, delete the group instead of syncing (for branch removal) */
     delete: z.boolean().optional(),
   }),
@@ -641,6 +648,13 @@ export const UnixSyncRepoPayloadSchema = BasePayloadSchema.extend({
 
     /** Daemon Unix user (added to repo group for daemon access) */
     daemonUser: z.string().optional(),
+
+    /**
+     * Whether POSIX ACLs (`setfacl`) are available on the target filesystem.
+     * Defaults to `true` in the handler when absent. Daemon sets this from
+     * `execution.posix_acl_enabled` since the executor can't read config.
+     */
+    aclEnabled: z.boolean().optional(),
 
     /** If true, delete the group instead of syncing (for repo removal) */
     delete: z.boolean().optional(),

--- a/scripts/create-rbac-test-users.ts
+++ b/scripts/create-rbac-test-users.ts
@@ -90,6 +90,7 @@ async function main() {
     unixIntegrationService = new UnixIntegrationService(db, new DirectExecutor(), {
       enabled: true,
       daemonUser,
+      aclEnabled: config.execution?.posix_acl_enabled !== false,
     });
   }
 


### PR DESCRIPTION
## Summary

Adds a config-level flag **`execution.posix_acl_enabled`** (default `true`) that
controls whether the host filesystem supports POSIX ACLs (`setfacl`/`getfacl`).

Some filesystems — notably many NFS mounts — reject `setfacl`, which previously
broke Unix group/branch isolation setup. When this flag is set to `false`, the
Unix permission builders fall back to `chgrp` + `chmod` + setgid while preserving
the same owner/group/others restriction (**fail closed** — never silently widens
access).

## How it works

- **Single source of truth in the builders.** The ACL decision is centralized
  inside `UnixGroupCommands.*` in `packages/core/src/unix/group-manager.ts`. Call
  sites only pass a resolved `{ aclEnabled }` boolean — no scattered `if` checks.
- **Fallback semantics:**
  - `setDirectoryGroup` / `setDirectoryGroupShallow`: emit `chgrp` + `chmod`
    (`o=` / `o=rX` / `o=rwX` matching 2770/2775/2777) + `chmod g+s`, dropping the
    `setfacl` default-ACL inheritance (new files rely on setgid + umask).
  - `setUserAcl` / `setUserAclShallow`: return `[]` — there is no mode-bit
    equivalent of a per-user grant, so the daemon falls back to group membership.
- **Daemon resolves, executor consumes.** The executor never reads config from
  disk (enforced by `contract.test.ts`). The daemon resolves the flag via
  `isPosixAclEnabled()` and threads `aclEnabled` through the `unix.sync-branch` /
  `unix.sync-repo` RPC payload. A missing value defaults to ACL-enabled, so
  existing installs see **no behavior change**.
- **One startup warning.** Rather than per-operation logs, `startup.ts` prints a
  single warning when the flag is off *and* Unix isolation is active, noting that
  the daemon must be a member of every repo/branch group (no per-user ACL grant).

## Files changed

- `packages/core/src/config/types.ts` — `posix_acl_enabled?: boolean` on exec settings
- `packages/core/src/config/config-manager.ts` — `isPosixAclEnabled()` accessor
- `packages/core/src/unix/group-manager.ts` — `aclEnabled` option + chmod fallback in builders
- `packages/core/src/unix/unix-integration-service.ts` — thread `aclEnabled` to builders
- `apps/agor-daemon/src/{register-hooks,services/branch-owners,utils/unix-group-init}.ts` — resolve + pass flag at sync-branch/sync-repo spawn sites
- `apps/agor-daemon/src/startup.ts` — single operator warning
- `apps/agor-cli/src/commands/admin/sync-unix.ts` — thread flag to builder calls
- `packages/executor/src/{commands/unix,payload-types}.ts` — read `payload.params.aclEnabled ?? true`
- `packages/core/src/seed/dev-fixtures.ts`, `scripts/create-rbac-test-users.ts` — pass flag to service
- `AGENTS.md`, `apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx` — docs + config example

## Tests

- `group-manager.test.ts` — disabled-mode cases: no `setfacl` emitted across
  2770/2775/2777; correct `o=`/`o=rX`/`o=rwX`; `setUserAcl*` return `[]`
- `config-manager.test.ts` — accessor defaults true (unset/no file), false only when explicitly set
- Core (130) + executor contract (3) + executor unix security (12) suites pass
- `pnpm check` (typecheck + lint + shortid + build) green

## Safety verdict

Fail-closed: the chmod fallback enforces the same owner/group/others mode bits as
the ACL path, so dropping `setfacl` is strictly equal-or-more-restrictive. The
only loss is convenience (default-ACL inheritance and the per-user daemon grant),
mitigated by setgid + required daemon group membership.

## Test plan

- [ ] On an NFS/no-ACL host, set `execution.posix_acl_enabled: false` and confirm branch/repo group sync no longer errors on `setfacl`
- [ ] Confirm default install (flag unset) still emits `setfacl` commands and behaves identically
- [ ] Verify the single startup warning fires only when the flag is off and isolation is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)