### PR TITLE
Add artifact source session link

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -226,6 +226,7 @@ IMPORTANT:
         {
           folderPath,
           branch_id: resolvedBranchId,
+          source_session_id: ctx.sessionId,
           subpath,
           board_id: resolvedBoardId,
           name: coerceString(args.name),

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -218,6 +218,49 @@ describe('ArtifactRepository source session provenance', () => {
   });
 });
 
+describe('ArtifactsService source session provenance', () => {
+  dbTest('ignores source_session_id in generic metadata patch', async ({ db }) => {
+    const tmpRoot = mkdtempSync(path.join(tmpdir(), 'artifact-source-session-patch-'));
+    try {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const branch = await seedRepoAndBranch(db, tmpRoot);
+      const originalSession = await seedSession(db, branch.branch_id);
+      const spoofedSession = await seedSession(db, branch.branch_id);
+      const artifactRepo = new ArtifactRepository(db);
+
+      const artifact = await artifactRepo.create({
+        board_id: board.board_id,
+        name: 'Original',
+        template: 'react',
+        files: { '/index.js': 'console.log("hi")' },
+        source_session_id: originalSession.session_id,
+        created_by: 'user-owner',
+      });
+
+      const patched = await service.patch(artifact.artifact_id, {
+        name: 'Renamed',
+        source_session_id: spoofedSession.session_id,
+      });
+
+      expect(patched.name).toBe('Renamed');
+      expect(patched.source_session_id).toBe(originalSession.session_id);
+
+      const updated = await service.update(artifact.artifact_id, {
+        description: 'Updated metadata',
+        source_session_id: spoofedSession.session_id,
+      });
+
+      expect(updated.description).toBe('Updated metadata');
+      expect(updated.source_session_id).toBe(originalSession.session_id);
+      const fetched = await artifactRepo.findById(artifact.artifact_id);
+      expect(fetched?.source_session_id).toBe(originalSession.session_id);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('ArtifactsService.updateMetadata', () => {
   dbTest('moves artifact to a new board and preserves placement', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -15,11 +15,12 @@ import {
   BranchRepository,
   type Database,
   RepoRepository,
+  SessionRepository,
   shortId,
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Artifact, BoardID, BranchID, UUID } from '@agor/core/types';
+import type { Artifact, BoardID, BranchID, SessionID, UUID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
@@ -69,6 +70,16 @@ async function seedRepoAndBranch(db: Database, branchPath: string) {
     path: branchPath,
     created_by: 'user-owner' as UUID,
     others_can: 'session',
+  });
+}
+
+async function seedSession(db: Database, branchId: BranchID, userId = 'user-owner') {
+  return new SessionRepository(db).create({
+    session_id: generateId() as SessionID,
+    branch_id: branchId,
+    created_by: userId as UUID,
+    tasks: [],
+    genealogy: { children: [] },
   });
 }
 
@@ -176,6 +187,33 @@ describe('ArtifactRepository URL fields', () => {
       } else {
         process.env.AGOR_BASE_URL = previousBaseUrl;
       }
+    }
+  });
+});
+
+describe('ArtifactRepository source session provenance', () => {
+  dbTest('persists and returns source_session_id', async ({ db }) => {
+    const tmpRoot = mkdtempSync(path.join(tmpdir(), 'artifact-source-session-'));
+    try {
+      const board = await seedBoard(db);
+      const branch = await seedRepoAndBranch(db, tmpRoot);
+      const session = await seedSession(db, branch.branch_id);
+      const artifactRepo = new ArtifactRepository(db);
+
+      const created = await artifactRepo.create({
+        board_id: board.board_id,
+        name: 'Session-linked artifact',
+        template: 'react',
+        files: { '/index.js': 'console.log("hi")' },
+        source_session_id: session.session_id,
+        created_by: 'user-owner',
+      });
+
+      expect(created.source_session_id).toBe(session.session_id);
+      const fetched = await artifactRepo.findById(created.artifact_id);
+      expect(fetched?.source_session_id).toBe(session.session_id);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
 });

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -446,6 +446,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     data: {
       folderPath?: string;
       branch_id?: string;
+      source_session_id?: string | null;
       subpath?: string;
       board_id?: string;
       name?: string;
@@ -547,6 +548,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       const updated = await this.artifactRepo.update(existing.artifact_id, {
         name: resolvedName,
         branch_id: matchedBranchId ?? existing.branch_id ?? null,
+        source_session_id: data.source_session_id ?? existing.source_session_id ?? null,
         files,
         dependencies: cachedDeps,
         entry: cachedEntry,
@@ -584,6 +586,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       artifact_id: artifactId,
       board_id: resolvedBoardId,
       branch_id: matchedBranchId,
+      source_session_id: data.source_session_id ?? null,
       name: resolvedName,
       path: folderPath,
       template,
@@ -1002,6 +1005,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
     const payload: ArtifactPayload = {
       artifact_id: artifact.artifact_id,
+      source_session_id: artifact.source_session_id ?? null,
       name: artifact.name,
       description: artifact.description,
       template: artifact.template,

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -48,6 +48,7 @@ import type {
   SandpackConfig,
   SandpackError,
   SandpackTemplate,
+  SessionID,
   UserID,
   UserRole,
 } from '@agor/core/types';
@@ -357,6 +358,25 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   }
 
   /**
+   * Direct REST/service updates are metadata-only and must not rewrite
+   * provenance. `source_session_id` is stamped by publishArtifact() from the
+   * trusted MCP/session context; letting generic PATCH/UPDATE mutate it would
+   * make the "created by session" link spoofable.
+   */
+  private stripClientControlledProvenance(data: Partial<Artifact>): Partial<Artifact> {
+    const { source_session_id: _sourceSessionId, ...safeData } = data;
+    return safeData;
+  }
+
+  async update(id: string | number, data: Partial<Artifact>, params?: unknown): Promise<Artifact> {
+    return (await super.update(
+      id,
+      this.stripClientControlledProvenance(data),
+      params as never
+    )) as Artifact;
+  }
+
+  /**
    * Patch override: route board_id and placement changes through
    * updateMetadata so the board_objects entry is moved/resized alongside the
    * row update. Plain metadata patches fall through to the default
@@ -398,7 +418,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       );
     }
 
-    return (await super.patch(id, data as Partial<Artifact>, params as never)) as Artifact;
+    return (await super.patch(
+      id,
+      this.stripClientControlledProvenance(data) as Partial<Artifact>,
+      params as never
+    )) as Artifact;
   }
 
   /**
@@ -446,7 +470,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     data: {
       folderPath?: string;
       branch_id?: string;
-      source_session_id?: string | null;
+      source_session_id?: SessionID | null;
       subpath?: string;
       board_id?: string;
       name?: string;

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -262,6 +262,8 @@ function AppContent() {
   // rows). Mounted exactly once so all consumers share the same baseline.
   const { capturedSha, currentSha, outOfSync } = useServerVersion(client);
 
+  const directSessionIdFromPath = location.pathname.match(/^\/s\/([^/]+)\/?$/)?.[1] ?? null;
+
   // Pass the stable client lifetime, not `connected ? client : null`:
   // useAgorData owns reconnect refetches and `null` is reserved for logout /
   // token removal. See the reset-effect comment in useAgorData.ts for the full
@@ -291,6 +293,7 @@ function AppContent() {
     error: dataError,
   } = useAgorData(client, {
     enabled: workspaceSurfaceShouldRun && !user?.must_change_password,
+    directSessionId: directSessionIdFromPath,
   });
 
   // Session actions

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -3,8 +3,9 @@ import type {
   ArtifactID,
   ArtifactPayload,
   BoardObject,
+  SessionID,
 } from '@agor-live/client';
-import { artifactFullscreenPath, shortId } from '@agor-live/client';
+import { artifactFullscreenPath, sessionPath, shortId } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -15,6 +16,7 @@ import {
   FullscreenOutlined,
   LoadingOutlined,
   LockOutlined,
+  MessageOutlined,
   ReloadOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
@@ -235,6 +237,15 @@ export const ArtifactNode = ({
     window.dispatchEvent(new CustomEvent(`agor:export-codesandbox-${data.artifactId}`));
   }, [data.artifactId]);
 
+  const handleOpenCreatingSession = useCallback(() => {
+    if (!payload?.source_session_id) return;
+    window.open(
+      uiRouteHref(sessionPath(payload.source_session_id as SessionID)),
+      '_blank',
+      'noopener,noreferrer'
+    );
+  }, [payload?.source_session_id]);
+
   const handleOpenFullscreen = useCallback(() => {
     window.open(
       uiRouteHref(artifactFullscreenPath(data.artifactId as ArtifactID)),
@@ -308,6 +319,19 @@ export const ArtifactNode = ({
               onClick={(e) => {
                 e.stopPropagation();
                 setConsentOpen(true);
+              }}
+            />
+          </Tooltip>
+        )}
+        {payload?.source_session_id && (
+          <Tooltip title="Open session that created this artifact">
+            <Button
+              type="text"
+              size="small"
+              icon={<MessageOutlined />}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleOpenCreatingSession();
               }}
             />
           </Tooltip>

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -130,6 +130,42 @@ async function waitForInitialLoad(result: { current: ReturnType<typeof useAgorDa
 }
 
 describe('useAgorData — socket-event bailouts', () => {
+  it('hydrates a direct archived session and its archived branch by id without broadening active lists', async () => {
+    const archivedSession = makeSession({
+      session_id: 's-archived-full',
+      branch_id: 'b-archived',
+      archived: true,
+    });
+    const archivedBranch = makeBranch({
+      branch_id: 'b-archived',
+      archived: true,
+      board_id: 'board-archived',
+    });
+    const { client } = makeMockClient({
+      // Initial lists model the normal active-only fetches: the archived
+      // target is omitted until the direct /s/<id> fallback asks for it.
+      sessions: [],
+      branches: [],
+      'sessions:get': archivedSession,
+      'branches:get': archivedBranch,
+    });
+
+    const { result } = renderHook(() => useAgorData(client, { directSessionId: 's-archived' }));
+    await waitForInitialLoad(result);
+
+    expect(result.current.sessionById.get('s-archived-full')).toMatchObject({
+      archived: true,
+      branch_id: 'b-archived',
+    });
+    expect(result.current.sessionsByBranch.get('b-archived')?.map((s) => s.session_id)).toEqual([
+      's-archived-full',
+    ]);
+    expect(result.current.branchById.get('b-archived')).toMatchObject({
+      archived: true,
+      board_id: 'board-archived',
+    });
+  });
+
   it('drops a duplicate `sessions.patched` (content-equal) without changing byId references', async () => {
     const session = makeSession();
     const { client, emit } = makeMockClient({ sessions: [session] });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -271,13 +271,16 @@ function removeBoardObjectFromMaps(prev: DataMaps, boardObject: BoardEntityObjec
  * @param options - Optional configuration
  * @param options.enabled - Whether to enable data fetching (default: true). Set to false to skip
  *                          all data fetching (useful when user needs to change password first).
+ * @param options.directSessionId - Optional session short/full ID from a direct URL. If the
+ *                                  active-list query omits it because it is archived, fetch it by ID.
  * @returns Sessions, boards, loading state, and refetch function
  */
 export function useAgorData(
   client: AgorClient | null,
-  options?: { enabled?: boolean }
+  options?: { enabled?: boolean; directSessionId?: string | null }
 ): UseAgorDataResult {
   const enabled = options?.enabled ?? true;
+  const directSessionId = options?.directSessionId ?? null;
   // Single state for all server-backed maps — reset is setMaps(EMPTY_MAPS), one call, can't miss a field.
   const [maps, setMaps] = useState<DataMaps>(EMPTY_MAPS);
 
@@ -479,6 +482,7 @@ export function useAgorData(
                 $select: [
                   'artifact_id',
                   'branch_id',
+                  'source_session_id',
                   'board_id',
                   'name',
                   'description',
@@ -505,6 +509,39 @@ export function useAgorData(
             .catch(() => ({ authenticated_server_ids: [] })),
         ]);
         debugTimer?.endFetchPhase();
+
+        // Direct /s/<id>/ opens should work for archived sessions without broadening
+        // the default active-session list. If the active query missed the URL target,
+        // fetch just that session (and its branch if necessary) by ID/short ID.
+        if (
+          directSessionId &&
+          !sessionsList.some((s) => s.session_id.startsWith(directSessionId))
+        ) {
+          try {
+            const directSession = (await client
+              .service('sessions')
+              .get(directSessionId)) as Session;
+            if (!sessionsList.some((s) => s.session_id === directSession.session_id)) {
+              sessionsList.push(directSession);
+            }
+            if (
+              directSession.branch_id &&
+              !branchesList.some((branch) => branch.branch_id === directSession.branch_id)
+            ) {
+              try {
+                const directBranch = (await client
+                  .service('branches')
+                  .get(directSession.branch_id)) as Branch;
+                branchesList.push(directBranch);
+              } catch {
+                // The session can still open; it just won't be able to switch/recenter
+                // if the branch is inaccessible or gone.
+              }
+            }
+          } catch {
+            // Leave normal URL resolution to report/not-heal unresolved session links.
+          }
+        }
 
         if (!silent) {
           setLoadingStage('indexing');
@@ -677,7 +714,7 @@ export function useAgorData(
         }
       }
     },
-    [client, enabled]
+    [client, directSessionId, enabled]
   );
 
   // Clear all data when client goes away (logout / token revocation).
@@ -697,6 +734,73 @@ export function useAgorData(
     setMaps(EMPTY_MAPS);
     setHasInitiallyFetched(false);
   }, [client]);
+
+  // If the user navigates to /s/<id>/ after the initial active-session fetch,
+  // load that one session by ID as well. This keeps direct links to archived
+  // sessions openable without changing the default list query.
+  useEffect(() => {
+    if (!client || !enabled || !hasInitiallyFetched || !directSessionId) return;
+    if (maps.sessionById.has(directSessionId)) return;
+    if ([...maps.sessionById.values()].some((s) => s.session_id.startsWith(directSessionId))) {
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const directSession = (await client.service('sessions').get(directSessionId)) as Session;
+        if (cancelled) return;
+
+        setSessionById((prev) => {
+          if (prev.has(directSession.session_id)) return prev;
+          const next = new Map(prev);
+          next.set(directSession.session_id, directSession);
+          return next;
+        });
+        setSessionsByBranch((prev) => {
+          const branchSessions = prev.get(directSession.branch_id) || [];
+          if (branchSessions.some((s) => s.session_id === directSession.session_id)) return prev;
+          const next = new Map(prev);
+          next.set(directSession.branch_id, [...branchSessions, directSession]);
+          return next;
+        });
+
+        if (directSession.branch_id && !maps.branchById.has(directSession.branch_id)) {
+          try {
+            const directBranch = (await client
+              .service('branches')
+              .get(directSession.branch_id)) as Branch;
+            if (cancelled) return;
+            setBranchById((prev) => {
+              if (prev.has(directBranch.branch_id)) return prev;
+              const next = new Map(prev);
+              next.set(directBranch.branch_id, directBranch);
+              return next;
+            });
+          } catch {
+            // Session can still be selected if its branch is inaccessible/gone.
+          }
+        }
+      } catch {
+        // Keep unresolved session URLs sticky; the normal URL resolver will
+        // avoid self-healing until a matching session exists.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    client,
+    directSessionId,
+    enabled,
+    hasInitiallyFetched,
+    maps.branchById,
+    maps.sessionById,
+    setBranchById,
+    setSessionById,
+    setSessionsByBranch,
+  ]);
 
   // Subscribe to real-time updates
   // biome-ignore lint/correctness/useExhaustiveDependencies: setter helpers only close over stable setMaps; listing them would add noise without preventing stale closures

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -1,7 +1,9 @@
-import type { AgorClient, Artifact, ArtifactPayload, User } from '@agor-live/client';
+import type { AgorClient, Artifact, ArtifactPayload, SessionID, User } from '@agor-live/client';
+import { sessionPath } from '@agor-live/client';
 import {
   ArrowLeftOutlined,
   EyeInvisibleOutlined,
+  MessageOutlined,
   ReloadOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
@@ -18,6 +20,7 @@ import {
 import { getDaemonUrl } from '@/config/daemon';
 import { getAuthHeaders } from '@/utils/authHeaders';
 import { ensureSandpackCryptoSubtle } from '@/utils/sandpackCrypto';
+import { uiRouteHref } from '@/utils/uiRoutes';
 import { ArtifactConsentModal } from '../components/ArtifactConsentModal/ArtifactConsentModal';
 import { BrandLogo } from '../components/BrandLogo';
 import { GlobalUserMenu } from '../components/GlobalUserMenu';
@@ -122,6 +125,22 @@ function ArtifactFullscreenNavbar({
         {trustBadge}
       </Space>
       <Space style={{ flexShrink: 0 }}>
+        {(payload?.source_session_id || artifact?.source_session_id) && (
+          <Tooltip title="Open session that created this artifact">
+            <Button
+              icon={<MessageOutlined />}
+              href={uiRouteHref(
+                sessionPath(
+                  (payload?.source_session_id ?? artifact?.source_session_id) as SessionID
+                )
+              )}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Session
+            </Button>
+          </Tooltip>
+        )}
         {artifact?.url && (
           <Button href={artifact.url} target="_blank" rel="noopener noreferrer">
             Open board link

--- a/packages/core/drizzle/postgres/0050_artifact_source_session.sql
+++ b/packages/core/drizzle/postgres/0050_artifact_source_session.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "artifacts" ADD COLUMN "source_session_id" varchar(36);--> statement-breakpoint
+ALTER TABLE "artifacts" ADD CONSTRAINT "artifacts_source_session_id_sessions_session_id_fk" FOREIGN KEY ("source_session_id") REFERENCES "sessions"("session_id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "artifacts_source_session_idx" ON "artifacts" USING btree ("source_session_id");

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1781500000000,
       "tag": "0049_kb_document_icon_emoji",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1781600000000,
+      "tag": "0050_artifact_source_session",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0059_artifact_source_session.sql
+++ b/packages/core/drizzle/sqlite/0059_artifact_source_session.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `artifacts` ADD `source_session_id` text(36);--> statement-breakpoint
+CREATE INDEX `artifacts_source_session_idx` ON `artifacts` (`source_session_id`);

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1781500000000,
       "tag": "0058_kb_document_icon_emoji",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "6",
+      "when": 1781600000000,
+      "tag": "0059_artifact_source_session",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -14,6 +14,7 @@ import type {
   BoardID,
   BranchID,
   SandpackTemplate,
+  SessionID,
   UUID,
 } from '@agor/core/types';
 import { and, eq, like, or } from 'drizzle-orm';
@@ -50,6 +51,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
     return {
       artifact_id: artifactId as UUID,
       branch_id: (row.branch_id as BranchID) ?? null,
+      source_session_id: (row.source_session_id as SessionID | null) ?? null,
       board_id: row.board_id as BoardID,
       name: row.name,
       description: row.description ?? undefined,
@@ -95,6 +97,7 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       const insertData: ArtifactInsert = {
         artifact_id: artifactId,
         branch_id: data.branch_id ?? null,
+        source_session_id: data.source_session_id ?? null,
         board_id: data.board_id ?? '',
         name: data.name ?? 'Untitled Artifact',
         description: data.description ?? null,
@@ -281,6 +284,9 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
         setData.agor_grants = updates.agor_grants ?? null;
       }
       if (updates.public !== undefined) setData.public = updates.public;
+      if (updates.source_session_id !== undefined) {
+        setData.source_session_id = updates.source_session_id ?? null;
+      }
       if (updates.archived !== undefined) setData.archived = updates.archived;
       if (updates.archived_at !== undefined) {
         setData.archived_at = updates.archived_at ? new Date(updates.archived_at) : null;

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1332,6 +1332,12 @@ export const artifacts = pgTable(
     branch_id: varchar('branch_id', { length: 36 }).references(() => branches.branch_id, {
       onDelete: 'set null',
     }),
+    source_session_id: varchar('source_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
     board_id: varchar('board_id', { length: 36 })
       .notNull()
       .references(() => boards.board_id, { onDelete: 'cascade' }),
@@ -1358,6 +1364,7 @@ export const artifacts = pgTable(
   },
   (table) => ({
     branchIdx: index('artifacts_branch_idx').on(table.branch_id),
+    sourceSessionIdx: index('artifacts_source_session_idx').on(table.source_session_id),
     boardIdx: index('artifacts_board_idx').on(table.board_id),
     archivedIdx: index('artifacts_archived_idx').on(table.archived),
     publicIdx: index('artifacts_public_idx').on(table.public),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1357,6 +1357,12 @@ export const artifacts = sqliteTable(
     branch_id: text('branch_id', { length: 36 }).references(() => branches.branch_id, {
       onDelete: 'set null',
     }),
+    source_session_id: text('source_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
     board_id: text('board_id', { length: 36 })
       .notNull()
       .references(() => boards.board_id, { onDelete: 'cascade' }),
@@ -1383,6 +1389,7 @@ export const artifacts = sqliteTable(
   },
   (table) => ({
     branchIdx: index('artifacts_branch_idx').on(table.branch_id),
+    sourceSessionIdx: index('artifacts_source_session_idx').on(table.source_session_id),
     boardIdx: index('artifacts_board_idx').on(table.board_id),
     archivedIdx: index('artifacts_archived_idx').on(table.archived),
     publicIdx: index('artifacts_public_idx').on(table.public),

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -14,7 +14,7 @@
  */
 
 import type { SandpackTemplate } from './board';
-import type { ArtifactID, BoardID, BranchID, UserID, UUID } from './id';
+import type { ArtifactID, BoardID, BranchID, SessionID, UserID, UUID } from './id';
 
 /**
  * Build status for artifacts
@@ -133,6 +133,9 @@ export interface Artifact {
   /** Branch provenance (nullable — survives branch deletion via SET NULL) */
   branch_id: BranchID | null;
 
+  /** Session that most recently created/published this artifact, when known. */
+  source_session_id?: SessionID | null;
+
   /** Board this artifact is displayed on */
   board_id: BoardID;
 
@@ -243,6 +246,8 @@ export interface Artifact {
  */
 export interface ArtifactPayload {
   artifact_id: ArtifactID;
+  /** Session that most recently created/published this artifact, when known. */
+  source_session_id?: SessionID | null;
   name: string;
   description?: string;
   template: SandpackTemplate;


### PR DESCRIPTION
## Summary
- store the publishing session on artifact rows when MCP publish has session context
- expose source_session_id through artifact metadata/payloads and add compact artifact header buttons to open that session
- keep direct /s/<id>/ links working for archived sessions by fetching only that direct session when omitted from the active list

## Tests
- pnpm --filter @agor/core typecheck
- pnpm exec biome check packages/core/src/types/artifact.ts packages/core/src/db/repositories/artifacts.ts packages/core/src/db/schema.sqlite.ts packages/core/src/db/schema.postgres.ts apps/agor-daemon/src/services/artifacts.ts apps/agor-daemon/src/mcp/tools/artifacts.ts apps/agor-daemon/src/services/artifacts.test.ts apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx apps/agor-ui/src/hooks/useAgorData.ts apps/agor-ui/src/App.tsx

## Notes
- Attempted: pnpm --filter @agor/daemon test -- src/services/artifacts.test.ts (blocked because @agor/core package entry/dist is unresolved in this worktree without running a build)
- Attempted: pnpm --filter agor-ui typecheck (blocked for the same unbuilt @agor-live/client/@agor/core package outputs)
