### PR TITLE
fix(ui): board locator icon — hover-only, click opens session panel

### DIFF
--- a/apps/agor-ui/src/components/BranchBoardLocatorIcon.tsx
+++ b/apps/agor-ui/src/components/BranchBoardLocatorIcon.tsx
@@ -7,11 +7,17 @@ import { useRecenterMap } from '../contexts/CanvasNavigationContext';
 interface BranchBoardLocatorIconProps {
   branch: Branch | undefined;
   size?: number;
+  /** When false, the icon is hidden (opacity 0, no pointer events). Defaults to true. */
+  visible?: boolean;
+  /** Called after zooming to the card — use to open the session in the right panel. */
+  onSessionClick?: () => void;
 }
 
 export const BranchBoardLocatorIcon: React.FC<BranchBoardLocatorIconProps> = ({
   branch,
   size = 12,
+  visible = true,
+  onSessionClick,
 }) => {
   const recenterMap = useRecenterMap();
   const boardId = branch?.board_id;
@@ -21,10 +27,18 @@ export const BranchBoardLocatorIcon: React.FC<BranchBoardLocatorIconProps> = ({
   return (
     <Tooltip title="Go to card on board">
       <AimOutlined
-        style={{ fontSize: size, cursor: 'pointer', flexShrink: 0, opacity: 0.5 }}
+        style={{
+          fontSize: size,
+          cursor: 'pointer',
+          flexShrink: 0,
+          opacity: visible ? 0.5 : 0,
+          pointerEvents: visible ? 'auto' : 'none',
+          transition: 'opacity 0.15s ease-in-out',
+        }}
         onClick={(e) => {
           e.stopPropagation();
           recenterMap(branch.branch_id, { boardId });
+          onSessionClick?.();
         }}
       />
     </Tooltip>

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -409,9 +409,18 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         }
       >
         {(hovered) => (
-          <div style={sessionRowStyle(session)} onClick={() => onSessionClick?.(session.session_id)}>
-            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
-              {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+          <div
+            style={sessionRowStyle(session)}
+            onClick={() => onSessionClick?.(session.session_id)}
+          >
+            <div
+              style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}
+            >
+              {isActive ? (
+                <Spin size="small" />
+              ) : (
+                <ToolIcon tool={session.agentic_tool} size={20} />
+              )}
               <SessionRelationshipIcon session={session} size={10} />
               <div style={{ flex: 1, minWidth: 0 }}>
                 {renderSessionTitle(session, { strong: true, query })}
@@ -489,7 +498,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             }}
           >
             <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
-              {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+              {isActive ? (
+                <Spin size="small" />
+              ) : (
+                <ToolIcon tool={session.agentic_tool} size={20} />
+              )}
               <SessionRelationshipIcon session={session} size={10} />
               {renderSessionTitle(session, { strong: true })}
               <BranchBoardLocatorIcon

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -82,7 +82,7 @@ const SessionItemWithActions: React.FC<{
   onArchive: (sessionId: string, e: React.MouseEvent) => void;
   onSettings?: (sessionId: string, e: React.MouseEvent) => void;
   onTogglePeek?: (sessionId: string, e: React.MouseEvent) => void;
-  children: React.ReactNode;
+  children: React.ReactNode | ((hovered: boolean) => React.ReactNode);
 }> = ({
   sessionId,
   isArchiving,
@@ -119,7 +119,7 @@ const SessionItemWithActions: React.FC<{
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      {children}
+      {typeof children === 'function' ? children(hovered) : children}
       <div
         style={{
           position: 'absolute',
@@ -408,44 +408,52 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             : undefined
         }
       >
-        <div style={sessionRowStyle(session)} onClick={() => onSessionClick?.(session.session_id)}>
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
-            {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
-            <SessionRelationshipIcon session={session} size={10} />
-            <div style={{ flex: 1, minWidth: 0 }}>
-              {renderSessionTitle(session, { strong: true, query })}
-              {(sourceLabel || toolMatches) && (
-                <Typography.Text
-                  type="secondary"
-                  style={{ fontSize: 11, display: 'block', marginTop: 2 }}
-                >
-                  {sourceLabel}
-                  {sourceLabel && toolMatches ? ' · ' : ''}
-                  {toolMatches && (
-                    <>
-                      Agent: <HighlightMatch text={session.agentic_tool} query={query} />
-                    </>
-                  )}
-                </Typography.Text>
-              )}
-              {descriptionSnippet && descriptionSnippet !== titleText && (
-                <Typography.Text
-                  type="secondary"
-                  style={{
-                    fontSize: 11,
-                    fontStyle: 'italic',
-                    lineHeight: 1.4,
-                    display: 'block',
-                    marginTop: 2,
-                  }}
-                >
-                  <HighlightMatch text={descriptionSnippet} query={query} />
-                </Typography.Text>
-              )}
+        {(hovered) => (
+          <div style={sessionRowStyle(session)} onClick={() => onSessionClick?.(session.session_id)}>
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
+              {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+              <SessionRelationshipIcon session={session} size={10} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                {renderSessionTitle(session, { strong: true, query })}
+                {(sourceLabel || toolMatches) && (
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: 11, display: 'block', marginTop: 2 }}
+                  >
+                    {sourceLabel}
+                    {sourceLabel && toolMatches ? ' · ' : ''}
+                    {toolMatches && (
+                      <>
+                        Agent: <HighlightMatch text={session.agentic_tool} query={query} />
+                      </>
+                    )}
+                  </Typography.Text>
+                )}
+                {descriptionSnippet && descriptionSnippet !== titleText && (
+                  <Typography.Text
+                    type="secondary"
+                    style={{
+                      fontSize: 11,
+                      fontStyle: 'italic',
+                      lineHeight: 1.4,
+                      display: 'block',
+                      marginTop: 2,
+                    }}
+                  >
+                    <HighlightMatch text={descriptionSnippet} query={query} />
+                  </Typography.Text>
+                )}
+              </div>
+              <BranchBoardLocatorIcon
+                branch={branch}
+                visible={hovered}
+                onSessionClick={
+                  onSessionClick ? () => onSessionClick(session.session_id) : undefined
+                }
+              />
             </div>
-            <BranchBoardLocatorIcon branch={branch} />
           </div>
-        </div>
+        )}
       </SessionItemWithActions>
     );
   };
@@ -470,22 +478,30 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             : undefined
         }
       >
-        <div
-          style={sessionRowStyle(session)}
-          onClick={() => onSessionClick?.(session.session_id)}
-          onContextMenu={(e) => {
-            if (onForkSession || onSpawnSession) {
-              e.preventDefault();
-            }
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
-            {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
-            <SessionRelationshipIcon session={session} size={10} />
-            {renderSessionTitle(session, { strong: true })}
-            <BranchBoardLocatorIcon branch={branch} />
+        {(hovered) => (
+          <div
+            style={sessionRowStyle(session)}
+            onClick={() => onSessionClick?.(session.session_id)}
+            onContextMenu={(e) => {
+              if (onForkSession || onSpawnSession) {
+                e.preventDefault();
+              }
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
+              {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+              <SessionRelationshipIcon session={session} size={10} />
+              {renderSessionTitle(session, { strong: true })}
+              <BranchBoardLocatorIcon
+                branch={branch}
+                visible={hovered}
+                onSessionClick={
+                  onSessionClick ? () => onSessionClick(session.session_id) : undefined
+                }
+              />
+            </div>
           </div>
-        </div>
+        )}
       </SessionItemWithActions>
     );
   };

--- a/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
+++ b/apps/agor-ui/src/components/BranchListDrawer/BranchListDrawer.tsx
@@ -58,6 +58,139 @@ const getBadgeTone = (
   return tone === 'success' || tone === 'default' ? null : tone;
 };
 
+interface SessionListRowProps {
+  session: Session;
+  branch: Branch | undefined;
+  repo: Repo | undefined;
+  titleText: string;
+  descriptionSnippet: string | null;
+  toolMatches: boolean;
+  trimmedQuery: string;
+  onSessionClick: (sessionId: string) => void;
+  onAfterSessionClick?: () => void;
+}
+
+const SessionListRow: React.FC<SessionListRowProps> = ({
+  session,
+  branch,
+  repo,
+  titleText,
+  descriptionSnippet,
+  toolMatches,
+  trimmedQuery,
+  onSessionClick,
+  onAfterSessionClick,
+}) => {
+  const [hovered, setHovered] = useState(false);
+  const { token } = theme.useToken();
+
+  return (
+    <div
+      style={{
+        cursor: 'pointer',
+        padding: '10px 24px',
+        transition: 'background 0.2s',
+        background: hovered ? token.colorBgTextHover : 'transparent',
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={() => {
+        onSessionClick(session.session_id);
+        onAfterSessionClick?.();
+      }}
+    >
+      {/* Line 1: tool icon (with corner status badge) · title · genealogy */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, minWidth: 0 }}>
+        <span style={{ flexShrink: 0, display: 'inline-flex' }}>
+          {(() => {
+            const tone = getBadgeTone(session.status);
+            const icon = <ToolIcon tool={session.agentic_tool} size={18} />;
+            return tone ? (
+              <Badge dot status={tone} offset={[-3, 3]}>
+                {icon}
+              </Badge>
+            ) : (
+              icon
+            );
+          })()}
+        </span>
+        <Typography.Text ellipsis={{ tooltip: titleText }} style={{ flex: 1, minWidth: 0 }}>
+          <HighlightMatch text={titleText} query={trimmedQuery} />
+        </Typography.Text>
+        <SessionRelationshipIcon session={session} />
+        <BranchBoardLocatorIcon
+          branch={branch}
+          visible={hovered}
+          onSessionClick={() => {
+            onSessionClick(session.session_id);
+            onAfterSessionClick?.();
+          }}
+        />
+      </div>
+
+      {toolMatches && (
+        <Typography.Text
+          type="secondary"
+          style={{ display: 'block', fontSize: 11, marginTop: 3, marginLeft: 26 }}
+        >
+          Agent: <HighlightMatch text={session.agentic_tool} query={trimmedQuery} />
+        </Typography.Text>
+      )}
+
+      {descriptionSnippet && descriptionSnippet !== titleText && (
+        <Typography.Text
+          type="secondary"
+          style={{
+            fontSize: 11,
+            display: 'block',
+            marginTop: 3,
+            marginLeft: 26,
+            lineHeight: 1.4,
+            fontStyle: 'italic',
+          }}
+        >
+          <HighlightMatch text={descriptionSnippet} query={trimmedQuery} />
+        </Typography.Text>
+      )}
+
+      {/* Line 2: compact, non-interactive branch pill · relative timestamp */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 8,
+          marginTop: 6,
+          marginLeft: 26,
+          minWidth: 0,
+        }}
+      >
+        <div style={{ minWidth: 0, overflow: 'hidden' }}>
+          {branch ? (
+            <BranchPill
+              branch={branch.name}
+              compact
+              title={repo ? `${repo.slug} / ${branch.name}` : branch.name}
+            />
+          ) : (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              No branch
+            </Typography.Text>
+          )}
+        </div>
+        <Tooltip title={formatTimestampWithRelative(session.last_updated)}>
+          <Typography.Text
+            type="secondary"
+            style={{ fontSize: 11, whiteSpace: 'nowrap', flexShrink: 0 }}
+          >
+            {formatRelativeTime(session.last_updated)}
+          </Typography.Text>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
 export const BranchListDrawer: React.FC<BranchListDrawerProps> = ({
   open,
   onClose,
@@ -197,9 +330,7 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
           displaySessions.map((session) => {
             const branch = session.branch_id ? branchById.get(session.branch_id) : undefined;
             const repo = branch ? repoById.get(branch.repo_id) : undefined;
-            const titleText = getSessionDisplayTitle(session, {
-              includeAgentFallback: true,
-            });
+            const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
             const descriptionSnippet =
               searchActive && session.title && session.description
                 ? getMatchSnippet(session.description, trimmedQuery)
@@ -207,121 +338,18 @@ export const BoardSessionList: React.FC<BoardSessionListProps> = ({
             const toolMatches = searchActive && sessionToolMatches(session, trimmedQuery);
 
             return (
-              <div
+              <SessionListRow
                 key={session.session_id}
-                style={{
-                  cursor: 'pointer',
-                  padding: '10px 24px',
-                  transition: 'background 0.2s',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = token.colorBgTextHover;
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = 'transparent';
-                }}
-                onClick={() => {
-                  onSessionClick(session.session_id);
-                  onAfterSessionClick?.();
-                }}
-              >
-                {/* Line 1: tool icon (with corner status badge) · title · genealogy */}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    gap: 8,
-                    minWidth: 0,
-                  }}
-                >
-                  <span style={{ flexShrink: 0, display: 'inline-flex' }}>
-                    {(() => {
-                      const tone = getBadgeTone(session.status);
-                      const icon = <ToolIcon tool={session.agentic_tool} size={18} />;
-                      return tone ? (
-                        <Badge dot status={tone} offset={[-3, 3]}>
-                          {icon}
-                        </Badge>
-                      ) : (
-                        icon
-                      );
-                    })()}
-                  </span>
-                  <Typography.Text
-                    ellipsis={{ tooltip: titleText }}
-                    style={{ flex: 1, minWidth: 0 }}
-                  >
-                    <HighlightMatch text={titleText} query={trimmedQuery} />
-                  </Typography.Text>
-                  <SessionRelationshipIcon session={session} />
-                  <BranchBoardLocatorIcon branch={branch} />
-                </div>
-
-                {toolMatches && (
-                  <Typography.Text
-                    type="secondary"
-                    style={{
-                      display: 'block',
-                      fontSize: 11,
-                      marginTop: 3,
-                      marginLeft: 26,
-                    }}
-                  >
-                    Agent: <HighlightMatch text={session.agentic_tool} query={trimmedQuery} />
-                  </Typography.Text>
-                )}
-
-                {descriptionSnippet && descriptionSnippet !== titleText && (
-                  <Typography.Text
-                    type="secondary"
-                    style={{
-                      fontSize: 11,
-                      display: 'block',
-                      marginTop: 3,
-                      marginLeft: 26,
-                      lineHeight: 1.4,
-                      fontStyle: 'italic',
-                    }}
-                  >
-                    <HighlightMatch text={descriptionSnippet} query={trimmedQuery} />
-                  </Typography.Text>
-                )}
-
-                {/* Line 2: compact, non-interactive branch pill · relative timestamp */}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    gap: 8,
-                    marginTop: 6,
-                    marginLeft: 26, // align under title (icon 18 + gap 8)
-                    minWidth: 0,
-                  }}
-                >
-                  <div style={{ minWidth: 0, overflow: 'hidden' }}>
-                    {branch ? (
-                      <BranchPill
-                        branch={branch.name}
-                        compact
-                        title={repo ? `${repo.slug} / ${branch.name}` : branch.name}
-                      />
-                    ) : (
-                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                        No branch
-                      </Typography.Text>
-                    )}
-                  </div>
-                  <Tooltip title={formatTimestampWithRelative(session.last_updated)}>
-                    <Typography.Text
-                      type="secondary"
-                      style={{ fontSize: 11, whiteSpace: 'nowrap', flexShrink: 0 }}
-                    >
-                      {formatRelativeTime(session.last_updated)}
-                    </Typography.Text>
-                  </Tooltip>
-                </div>
-              </div>
+                session={session}
+                branch={branch}
+                repo={repo}
+                titleText={titleText}
+                descriptionSnippet={descriptionSnippet}
+                toolMatches={toolMatches}
+                trimmedQuery={trimmedQuery}
+                onSessionClick={onSessionClick}
+                onAfterSessionClick={onAfterSessionClick}
+              />
             );
           })
         )}

--- a/apps/agor-ui/src/components/SessionPanel/ChildSessionsSection.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/ChildSessionsSection.tsx
@@ -6,8 +6,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAppLiveData } from '../../contexts/AppDataContext';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
-import { buildSessionTree, type SessionTreeNode } from '../BranchCard/buildSessionTree';
 import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
+import { buildSessionTree, type SessionTreeNode } from '../BranchCard/buildSessionTree';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
 

--- a/apps/agor-ui/src/components/SessionPanel/ChildSessionsSection.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/ChildSessionsSection.tsx
@@ -1,4 +1,4 @@
-import type { Session } from '@agor-live/client';
+import type { Branch, Session } from '@agor-live/client';
 import { BranchesOutlined } from '@ant-design/icons';
 import { Badge, Collapse, ConfigProvider, Space, Spin, Tree, Typography, theme } from 'antd';
 import type React from 'react';
@@ -7,8 +7,62 @@ import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAppLiveData } from '../../contexts/AppDataContext';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { buildSessionTree, type SessionTreeNode } from '../BranchCard/buildSessionTree';
+import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
+
+const ChildSessionNode: React.FC<{
+  session: Session;
+  branchById: Map<string, Branch>;
+  onSessionClick?: ((sessionId: string) => void) | null;
+}> = ({ session: s, branchById, onSessionClick }) => {
+  const [hovered, setHovered] = useState(false);
+  const isActive = s.status === 'running' || s.status === 'stopping';
+  const title = getSessionDisplayTitle(s, { includeAgentFallback: true, includeIdFallback: true });
+  const branch = s.branch_id ? branchById.get(s.branch_id) : undefined;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '3px 0',
+        cursor: onSessionClick ? 'pointer' : 'default',
+        opacity: s.archived ? 0.55 : 1,
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={() => onSessionClick?.(s.session_id)}
+    >
+      {isActive ? <Spin size="small" /> : <ToolIcon tool={s.agentic_tool} size={16} />}
+      <SessionRelationshipIcon session={s} size={10} />
+      <Typography.Text
+        style={{
+          fontSize: 12,
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+        type={s.archived ? 'secondary' : undefined}
+      >
+        {title}
+        {s.archived && (
+          <Typography.Text type="secondary" style={{ fontSize: 11, marginLeft: 4 }}>
+            (archived)
+          </Typography.Text>
+        )}
+      </Typography.Text>
+      <BranchBoardLocatorIcon
+        branch={branch}
+        visible={hovered}
+        onSessionClick={onSessionClick ? () => onSessionClick(s.session_id) : undefined}
+      />
+    </div>
+  );
+};
 
 interface ChildSessionsSectionProps {
   session: Session;
@@ -22,7 +76,7 @@ interface ChildSessionsSectionProps {
 export const ChildSessionsSection: React.FC<ChildSessionsSectionProps> = ({ session }) => {
   const { token } = theme.useToken();
   const { onSessionClick } = useAppActions();
-  const { sessionById, sessionsByBranch } = useAppLiveData();
+  const { sessionById, sessionsByBranch, branchById } = useAppLiveData();
   const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
 
   const descendantSessions = useMemo(() => {
@@ -102,49 +156,13 @@ export const ChildSessionsSection: React.FC<ChildSessionsSectionProps> = ({ sess
 
   if (descendantSessions.length === 0) return null;
 
-  const renderSessionNode = (node: SessionTreeNode) => {
-    const s = node.session;
-    const isActive = s.status === 'running' || s.status === 'stopping';
-    const title = getSessionDisplayTitle(s, {
-      includeAgentFallback: true,
-      includeIdFallback: true,
-    });
-
-    return (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          padding: '3px 0',
-          cursor: onSessionClick ? 'pointer' : 'default',
-          opacity: s.archived ? 0.55 : 1,
-        }}
-        onClick={() => onSessionClick?.(s.session_id)}
-      >
-        {isActive ? <Spin size="small" /> : <ToolIcon tool={s.agentic_tool} size={16} />}
-        <SessionRelationshipIcon session={s} size={10} />
-        <Typography.Text
-          style={{
-            fontSize: 12,
-            flex: 1,
-            minWidth: 0,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-          type={s.archived ? 'secondary' : undefined}
-        >
-          {title}
-          {s.archived && (
-            <Typography.Text type="secondary" style={{ fontSize: 11, marginLeft: 4 }}>
-              (archived)
-            </Typography.Text>
-          )}
-        </Typography.Text>
-      </div>
-    );
-  };
+  const renderSessionNode = (node: SessionTreeNode) => (
+    <ChildSessionNode
+      session={node.session}
+      branchById={branchById}
+      onSessionClick={onSessionClick}
+    />
+  );
 
   const header = (
     <Space size={4} align="center">


### PR DESCRIPTION
## Summary

Follow-up fixes for the board-locator icon introduced in #1470.

- **Hover-only visibility**: The icon now fades in only when the session row is hovered (opacity 0 → 0.5 with a 150 ms transition), matching how the archive/settings action buttons behave. Achieved via a render-prop pattern on `SessionItemWithActions` (forwards `hovered: boolean` to children) and a new `SessionListRow` component in `BranchListDrawer` that owns its own hover state.

- **Conditional render**: The icon already returned `null` when `branch.board_id` is absent — no logic change needed; the guard is confirmed correct.

- **Click opens session in right panel**: The icon's click handler now calls `onSessionClick` (in addition to the existing `recenterMap` zoom) so the session opens in the right panel alongside the board zoom.

- **ChildSessionsSection tree nodes**: Extracted the `renderSessionNode` callback to a `ChildSessionNode` component that owns its own hover state. Each node looks up its branch via `branchById` (necessary for cross-branch sessions) and renders the locator icon with `visible={hovered}`.

## Test plan

- [ ] Open the branch list drawer — session rows show no locator icon by default; hover a row and the icon fades in
- [ ] Click the locator icon: board zooms to the branch card AND the session opens in the right panel, AND the drawer closes
- [ ] Hover a session row in a BranchCard (panel mode) — locator icon fades in on hover; click zooms board and opens session panel
- [ ] Sessions whose branch has no `board_id` show no locator icon at all
- [ ] Open the session panel for a session that has child sessions — hover a node in the child sessions tree and confirm the locator icon fades in (only for children whose branch has a board placement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)