### PR TITLE
fix(ui): preserve all spaces knowledge selection

### DIFF
--- a/apps/agor-ui/src/pages/KnowledgePage.routing.test.ts
+++ b/apps/agor-ui/src/pages/KnowledgePage.routing.test.ts
@@ -9,6 +9,7 @@ import {
   isKnowledgeDocumentContentReady,
   matchesKnowledgeSidebarFilter,
   resolveActiveKnowledgeDocument,
+  resolveKnowledgeSpaceAfterNamespacesLoad,
   shouldDeferKnowledgeUrlMirrorForRoute,
   shouldShowKnowledgeGraphView,
   shouldShowKnowledgeRouteDocumentLoading,
@@ -226,6 +227,18 @@ describe('KnowledgePage global search helpers', () => {
 });
 
 describe('KnowledgePage namespace select helpers', () => {
+  it('keeps All Spaces selected after namespaces refresh', () => {
+    expect(
+      resolveKnowledgeSpaceAfterNamespacesLoad('all', [
+        {
+          namespace_id: 'ns-global',
+          slug: 'global',
+          display_name: 'Global',
+        },
+      ])
+    ).toBe('all');
+  });
+
   it('sorts namespace options by display name with slug fallback and searchable text', () => {
     expect(
       buildKnowledgeNamespaceSelectOptions([

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -558,6 +558,16 @@ type KnowledgeNamespaceOptionSource = Pick<
 const knowledgeNamespaceDisplayName = (namespace: KnowledgeNamespaceOptionSource) =>
   namespace.display_name?.trim() || namespace.slug;
 
+export function resolveKnowledgeSpaceAfterNamespacesLoad(
+  activeSpace: string,
+  namespaces: KnowledgeNamespaceOptionSource[]
+) {
+  if (activeSpace === 'all' || namespaces.some((ns) => ns.slug === activeSpace)) {
+    return activeSpace;
+  }
+  return namespaces.find((ns) => ns.slug === 'global')?.slug ?? namespaces[0]?.slug ?? 'global';
+}
+
 export function buildKnowledgeNamespaceSelectOptions(namespaces: KnowledgeNamespaceOptionSource[]) {
   return [...namespaces]
     .sort((a, b) => {
@@ -1142,9 +1152,7 @@ export function KnowledgePage({
     const result = await client.service('kb/namespaces').find({ query: { archived: false } });
     const rows = normalizeFindResult<KnowledgeNamespace>(result as KnowledgeNamespace[]);
     setNamespaces(rows);
-    if (!rows.some((ns) => ns.slug === activeSpace)) {
-      setActiveSpace(rows.find((ns) => ns.slug === 'global')?.slug ?? rows[0]?.slug ?? 'global');
-    }
+    setActiveSpace(resolveKnowledgeSpaceAfterNamespacesLoad(activeSpace, rows));
   }, [client, activeSpace]);
 
   // Load every readable doc (no namespace/kind filter) so `@` can reference


### PR DESCRIPTION
## Summary
- preserve the synthetic `All Spaces` selection when Knowledge namespaces refresh
- add a regression test for the namespace-refresh fallback

Fixes #1492

## Root Cause
Selecting `All Spaces` set `activeSpace` to `all`, but `loadNamespaces` treated any value not present in the fetched namespace rows as invalid and reset the selector to `global`.

## Validation
- `pnpm --filter agor-ui test -- KnowledgePage.routing.test.ts`
- `pnpm exec biome check apps/agor-ui/src/pages/KnowledgePage.tsx apps/agor-ui/src/pages/KnowledgePage.routing.test.ts`
