### PR TITLE
feat(ui): expose nuke environment button on branch cards

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -501,7 +501,7 @@ const BranchCardComponent = ({
             onViewLogs={onViewLogs}
             onNukeEnvironment={onNukeEnvironment}
             connectionDisabled={connectionDisabled}
-            showNukeEnvironment={false}
+            showNukeEnvironment={true}
           />
         </Space>
       </div>

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -501,7 +501,6 @@ const BranchCardComponent = ({
             onViewLogs={onViewLogs}
             onNukeEnvironment={onNukeEnvironment}
             connectionDisabled={connectionDisabled}
-            showNukeEnvironment={true}
           />
         </Space>
       </div>

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.test.tsx
@@ -76,18 +76,16 @@ const defaultProps = {
 };
 
 describe('EnvironmentPill', () => {
-  it('can hide only the destructive nuke action while preserving other controls', () => {
-    render(<EnvironmentPill {...defaultProps} showNukeEnvironment={false} />);
-
-    expect(screen.getByRole('button', { name: 'Start environment' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Stop environment' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'View environment logs' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
-  });
-
-  it('shows the destructive nuke action by default when configured', () => {
+  it('shows the destructive nuke action when nuke_command is configured', () => {
     render(<EnvironmentPill {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: 'Nuke environment' })).toBeInTheDocument();
+  });
+
+  it('hides the destructive nuke action when nuke_command is not configured', () => {
+    render(<EnvironmentPill {...defaultProps} branch={{ ...branch, nuke_command: undefined }} />);
+
+    expect(screen.getByRole('button', { name: 'Start environment' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -26,8 +26,6 @@ interface EnvironmentPillProps {
   onViewLogs?: (branchId: string) => void;
   canControlEnvironment?: boolean;
   connectionDisabled?: boolean; // Disable actions when disconnected
-  /** Whether to show the destructive Nuke action when available. Defaults to true. */
-  showNukeEnvironment?: boolean;
 }
 
 export function EnvironmentPill({
@@ -40,7 +38,6 @@ export function EnvironmentPill({
   onViewLogs,
   canControlEnvironment,
   connectionDisabled = false,
-  showNukeEnvironment = true,
 }: EnvironmentPillProps) {
   const { token } = theme.useToken();
   const confirmNuke = useConfirmNukeEnvironment();
@@ -350,7 +347,7 @@ export function EnvironmentPill({
                 />
               </Tooltip>
             )}
-            {showNukeEnvironment && onNukeEnvironment && branch.nuke_command && (
+            {onNukeEnvironment && branch.nuke_command && (
               <Tooltip
                 title={
                   controlDisabledTooltip ??


### PR DESCRIPTION
## Summary
Today the only place the Nuke environment button is exposed is inside a session. That means whenever an environment needs to be wiped — even on a fresh branch with no work going on — you have to spin up a throwaway session just to reach the button. That's friction for a destructive-but-routine action.

This PR surfaces the same Nuke button on the branch card on the board, so the environment can be nuked directly from where you already manage start/stop/logs — no dummy session required.

The full nuke pipeline (callback in `AppActionsContext`, `useConfirmNukeEnvironment` modal, `branches/:id/nuke` Feathers method) was already plumbed through to `BranchCard`; only the `showNukeEnvironment` flag on `EnvironmentPill` was hard-coded to `false`. The fix lights up the existing Fire icon under the same gating: only renders when `branch.nuke_command` is configured, and respects `connectionDisabled` / env-control permissions.

## Commits
1. `872892e` — flip the `EnvironmentPill` flag on `BranchCard` so the Fire icon renders on the board card.
2. `4993050` — follow-up cleanup. After (1) there were no remaining call sites that overrode `showNukeEnvironment`, so the prop became dead weight on top of the real capability gate (`branch.nuke_command`). Drops the prop from `EnvironmentPill` entirely (interface + default + JSDoc + the `&&` in the gate) and replaces the now-tautological "prop hides the button" test with one that exercises the actual capability boundary (`nuke_command` present vs. absent). `BranchHeaderPill` keeps its `showNukeEnvironment` prop for now because its `!compact` callers entangle with it — separate concern, out of scope here.

## Test plan
- [ ] Open a board with a branch that has `nuke_command` configured — confirm the Fire icon appears in the branch card env toolbar (next to start/stop/logs).
- [ ] Click it → destructive confirmation modal appears → confirm fires `branches/:id/nuke` and updates env status — all without opening a session.
- [ ] Open a branch that has NO `nuke_command` configured — confirm the button does not render.
- [ ] Verify the button respects `connectionDisabled` and `resolvedCanControlEnvironment` (disabled when user lacks env-control permission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)