### PR TITLE
feat(mcp): auto-link parent session when agor_sessions_create is called via MCP

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -328,6 +328,8 @@ describe('agor_sessions_create', () => {
             ...(data as Record<string, unknown>),
           };
         },
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': { create: async () => ({}) },
     });
@@ -366,6 +368,8 @@ describe('agor_sessions_create', () => {
           sessionCreates.push(data);
           return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
         },
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': { create: async () => ({}) },
     });
@@ -401,6 +405,8 @@ describe('agor_sessions_create', () => {
           session_id: 'sess-new',
           ...(data as Record<string, unknown>),
         }),
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
         create: async (data: unknown, params: unknown) => {
@@ -437,6 +443,8 @@ describe('agor_sessions_create', () => {
       branches: { get: async () => baseBranch },
       sessions: {
         create: async () => ({ session_id: 'sess-new' }),
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
         create: async () => {
@@ -472,6 +480,8 @@ describe('agor_sessions_create', () => {
       branches: { get: async () => branchWithMcps },
       sessions: {
         create: async () => ({ session_id: 'sess-new' }),
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
         create: async () => {
@@ -493,6 +503,162 @@ describe('agor_sessions_create', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.mcpAttachFailures).toBeUndefined();
+  });
+
+  it('auto-links to calling session when ctx.sessionId is set', async () => {
+    const patchCalls: Array<{ id: unknown; data: unknown }> = [];
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          genealogy: { children: ['existing-child'] },
+        }),
+        patch: async (id: unknown, data: unknown) => {
+          patchCalls.push({ id, data });
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+    });
+
+    // New session genealogy should reference the calling session as parent
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBe('sess-caller');
+
+    // Parent's children list should be updated to include the new session
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0].id).toBe('sess-caller');
+    const patchData = patchCalls[0].data as Record<string, any>;
+    expect(patchData.genealogy.children).toContain('sess-new');
+    expect(patchData.genealogy.children).toContain('existing-child');
+
+    // Note in response should mention the parent link
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.note).toContain('sess-caller');
+  });
+
+  it('does not set parent_session_id when called without session context', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        patch: async (id: unknown, data: unknown) => {
+          patchCalls.push({ id, data });
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1' }, // no sessionId
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBeUndefined();
+    expect(patchCalls).toHaveLength(0);
+  });
+
+  it('respects explicit parentSessionId when provided', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: Array<{ id: unknown; data: unknown }> = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async (id: unknown, data: unknown) => {
+          patchCalls.push({ id, data });
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+      parentSessionId: 'sess-explicit-parent',
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    // Explicit value overrides ctx.sessionId
+    expect(created.genealogy.parent_session_id).toBe('sess-explicit-parent');
+    expect(patchCalls[0].id).toBe('sess-explicit-parent');
+  });
+
+  it('creates root session (no parent) when parentSessionId: null is passed', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        patch: async (...args: unknown[]) => {
+          patchCalls.push(args);
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+      parentSessionId: null,
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBeUndefined();
+    // No patch to update a parent's children list
+    expect(patchCalls).toHaveLength(0);
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -813,7 +813,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_create',
     {
       description:
-        'Create a new session in an existing branch. Use for starting fresh work on a new task in the same codebase (e.g., new feature branch, separate investigation). Unlike spawn, this creates an independent session with no parent-child relationship. MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, advisorModel, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
+        'Create a new session in an existing branch. When called from an MCP session context (the default for orchestrator agents), the new session is automatically linked to the calling session as its parent — pass `parentSessionId: null` to create an unlinked root session instead. Use for starting work on a new task in the same codebase (e.g., new feature branch, separate investigation). MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, advisorModel, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
       inputSchema: z.object({
         branchId: mcpRequiredId(
           'branchId',
@@ -859,6 +859,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .optional()
           .describe(
             'Callback firing mode: "once" (default) fires on first completion then auto-disables, "persistent" fires on every completion'
+          ),
+        parentSessionId: z
+          .string()
+          .min(1, 'parentSessionId cannot be empty when provided.')
+          .nullish()
+          .describe(
+            'Parent session ID to link this session to in the genealogy tree. When omitted and called from a session MCP context, automatically defaults to the calling session. Pass null to explicitly create a root session with no parent.'
           ),
         mcpServerIds: z
           .array(mcpRequiredId('mcpServerIds[]', 'MCP server'))
@@ -948,6 +955,17 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         callbackConfig.callback_mode = args.callbackMode ?? 'once';
       }
 
+      // Determine the parent session to link to in the genealogy:
+      // - explicit string: resolve (supports short IDs) and use
+      // - explicit null: opt out — create a root session with no parent
+      // - undefined (omitted): auto-link to the calling session when available
+      const resolvedParentSessionId =
+        args.parentSessionId !== undefined
+          ? args.parentSessionId !== null
+            ? await resolveSessionId(ctx, args.parentSessionId)
+            : undefined
+          : ctx.sessionId;
+
       const sessionData: Record<string, unknown> = {
         branch_id: branch.branch_id,
         agentic_tool: agenticTool,
@@ -965,11 +983,31 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           base_sha: currentSha,
           current_sha: currentSha,
         },
-        genealogy: { children: [] },
+        genealogy: {
+          ...(resolvedParentSessionId && { parent_session_id: resolvedParentSessionId }),
+          children: [],
+        },
         tasks: [],
       };
 
       const session = await ctx.app.service('sessions').create(sessionData, ctx.baseServiceParams);
+
+      // Update the parent session's children list to include the new session.
+      if (resolvedParentSessionId) {
+        const parentSession = await ctx.app
+          .service('sessions')
+          .get(resolvedParentSessionId, ctx.baseServiceParams);
+        await ctx.app.service('sessions').patch(
+          resolvedParentSessionId,
+          {
+            genealogy: {
+              ...parentSession.genealogy,
+              children: [...(parentSession.genealogy?.children ?? []), session.session_id],
+            },
+          },
+          ctx.baseServiceParams
+        );
+      }
 
       // Attach MCP servers (inherited from branch or user defaults, or
       // explicitly requested via args.mcpServerIds). Explicit failures are
@@ -1018,6 +1056,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         ? ` Callback will be sent to session ${shortId(callbackConfig.callback_session_id as string)} on completion.`
         : '';
 
+      const parentNote = resolvedParentSessionId
+        ? ` Linked to parent session ${shortId(resolvedParentSessionId)}.`
+        : '';
+
       const mcpFailureNote =
         mcpAttachFailures.length > 0
           ? ` Warning: ${mcpAttachFailures.length} requested MCP server(s) failed to attach — see mcpAttachFailures.`
@@ -1027,8 +1069,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         session: redactSessionForMcp(session),
         taskId: initialTask?.task_id,
         note: args.initialPrompt
-          ? `Session created and initial prompt execution started.${callbackNote}${mcpFailureNote}`
-          : `Session created successfully.${callbackNote}${mcpFailureNote}`,
+          ? `Session created and initial prompt execution started.${parentNote}${callbackNote}${mcpFailureNote}`
+          : `Session created successfully.${parentNote}${callbackNote}${mcpFailureNote}`,
         ...(mcpAttachFailures.length > 0 && { mcpAttachFailures }),
       });
     }


### PR DESCRIPTION
## Why

When an agent session creates child sessions via \`agor_sessions_create\`, the new sessions have \`parent_session_id: null\` and appear as orphans — disconnected from the session that spawned them. The server already knows the calling session from the MCP JWT context, so the parent link can be set automatically without any opt-in.

## What changed

- **\`sessions.ts\`**: When \`agor_sessions_create\` is called via MCP and the JWT contains a session ID, the new session's \`parent_session_id\` is automatically set to the calling session. The parent's \`children\` array is updated bidirectionally, matching the existing \`spawn()\` pattern.
- **New \`parentSessionId\` input on the MCP tool schema**:
  - omitted → auto-link to the calling session (new default)
  - \`null\` → opt out, create a root session
  - \`"<id>"\` → link to a specific session (overrides auto-detect)
- Non-MCP callers (REST / API-key without session context) are unaffected.
- **\`sessions.test.ts\`**: 5 existing tests updated to mock the new \`sessions.get\`/\`sessions.patch\` calls; 4 new tests covering each branch of the logic.

## Test plan

- [ ] Call \`agor_sessions_create\` from within an agent session (via MCP) — new session's \`parent_session_id\` is set to the calling session, and the calling session's \`genealogy.children\` includes the new session ID
- [ ] Pass \`parentSessionId: null\` explicitly — new session is a root with no parent
- [ ] Pass \`parentSessionId: "<other-id>"\` — new session is linked to the specified session, not the caller
- [ ] Call \`agor_sessions_create\` via REST with an API key (no session context) — no parent link set, existing behaviour unchanged