### PR TITLE
feat: edit-on-cancel — restore prompt to composer when no agent output yet

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -121,7 +121,7 @@ import {
   sessionCanStartTask,
   shouldReconcileSessionPromptState,
 } from './utils/session-task-state.js';
-import { findActiveTasksForSession } from './utils/session-tasks.js';
+import { discardTaskIfNoOutput, findActiveTasksForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import {
@@ -2096,47 +2096,49 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           );
         }
 
-        // Edit-on-cancel: if the executor never emitted user-visible output
-        // (no assistant text/tool_use; pure "thinking" doesn't count), treat
-        // the prompt as never-really-sent — delete the task + its user
-        // message and hand the original prompt back to the caller so the UI
-        // can repopulate the composer. Otherwise, fall through to today's
-        // behavior (mark STOPPED, history intact).
-        let restoredPrompt: string | undefined;
-        try {
-          const taskMessages = await messagesService.findByTask(latestTask.task_id);
-          const hasAgentOutput = taskMessages.some((msg) => {
-            if (msg.role !== MessageRole.ASSISTANT) return false;
-            const content = msg.content;
-            if (typeof content === 'string') return content.trim().length > 0;
-            if (Array.isArray(content)) {
-              return content.some(
-                (block) => block.type === 'text' || block.type === 'tool_use'
-              );
-            }
-            return false;
-          });
+        // SIGTERM has a 3s grace period before SIGKILL (see executor-tracking.ts).
+        // Give the executor's handler a brief window to flush any in-flight
+        // writes before we snapshot — the set-based delete inside
+        // `discardTaskIfNoOutput` will sweep stragglers either way, but a
+        // small wait avoids spurious "agent has output" reads from writes
+        // that are essentially trailing edges of the killed turn.
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
-          if (!hasAgentOutput) {
-            // Delete by single id (per-row): the multi-remove path in the
-            // Drizzle adapter loads ALL messages via findAll before filtering,
-            // which is O(N) over the entire table. We already have the rows
-            // we want to drop in `taskMessages`, so delete them directly.
-            for (const msg of taskMessages) {
-              await messagesService.remove(msg.message_id, params);
+        // Edit-on-cancel: if the executor never emitted user-visible output,
+        // treat the prompt as never-really-sent — hard-delete the task and
+        // all its messages atomically, then return the original prompt so
+        // the UI can repopulate the composer. Otherwise, fall through to
+        // today's behavior (mark STOPPED, history intact).
+        type StopOutcome =
+          | { kind: 'restored'; prompt: string }
+          | { kind: 'stopped' }
+          | { kind: 'error' };
+        let outcome: StopOutcome;
+        try {
+          const discardResult = await discardTaskIfNoOutput(db, latestTask.task_id);
+
+          if (discardResult.kind === 'discarded') {
+            // The transaction skipped service-level emits; fire `removed`
+            // events manually so subscribed clients prune the bubble and
+            // queue entries reactively.
+            for (const msg of discardResult.removedMessages) {
+              app.service('messages').emit('removed', msg);
             }
-            await tasksService.remove(latestTask.task_id, params);
-            restoredPrompt = latestTask.full_prompt;
+            app.service('tasks').emit('removed', discardResult.task);
+
             console.log(
               `↩️  [Stop] Edit-on-cancel: dropped task ${shortId(latestTask.task_id)} (no agent output yet)`
             );
+            outcome = { kind: 'restored', prompt: latestTask.full_prompt };
+          } else {
+            outcome = { kind: 'stopped' };
           }
         } catch (error) {
           console.error(`❌ [Stop] Edit-on-cancel check failed:`, error);
-          restoredPrompt = undefined;
+          outcome = { kind: 'error' };
         }
 
-        if (restoredPrompt === undefined) {
+        if (outcome.kind === 'stopped' || outcome.kind === 'error') {
           try {
             await tasksService.patch(latestTask.task_id, {
               status: TaskStatus.STOPPED,
@@ -2151,14 +2153,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // ready_for_prompt: true so the post-patch hook drains any QUEUED tasks.
           // Stop is "skip current", not "wipe everything" — queued prompts represent
           // user intent and should still execute.
-          await app.service('sessions').patch(
-            id,
-            {
-              status: SessionStatus.IDLE,
-              ready_for_prompt: true,
-            },
-            params
-          );
+          //
+          // When the task was hard-deleted, also strip it from session.tasks
+          // so downstream consumers (CLI listings, footer pills) don't keep
+          // pointing at a ghost id.
+          const sessionPatch: Record<string, unknown> = {
+            status: SessionStatus.IDLE,
+            ready_for_prompt: true,
+          };
+          if (outcome.kind === 'restored') {
+            sessionPatch.tasks = session.tasks.filter((tid) => tid !== latestTask.task_id);
+          }
+          await app.service('sessions').patch(id, sessionPatch, params);
         } catch (error) {
           console.error(`❌ [Stop] Failed to patch session to IDLE:`, error);
         }
@@ -2166,8 +2172,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         return {
           success: true,
           status: SessionStatus.IDLE,
-          edit_on_cancel: restoredPrompt !== undefined,
-          restored_prompt: restoredPrompt,
+          prompt_restored: outcome.kind === 'restored',
+          restored_prompt: outcome.kind === 'restored' ? outcome.prompt : undefined,
         };
       },
     },

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2030,6 +2030,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Stop endpoint
   // ============================================================================
 
+  // Brief settle period between SIGTERM and the edit-on-cancel predicate
+  // read, so the executor's exit handler has a window to flush any
+  // trailing-edge writes before we snapshot.
+  const SIGTERM_SETTLE_MS = 100;
+
   registerAuthenticatedRoute(
     app,
     '/sessions/:id/stop',
@@ -2098,11 +2103,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
         // SIGTERM has a 3s grace period before SIGKILL (see executor-tracking.ts).
         // Give the executor's handler a brief window to flush any in-flight
-        // writes before we snapshot — the set-based delete inside
-        // `discardTaskIfNoOutput` will sweep stragglers either way, but a
-        // small wait avoids spurious "agent has output" reads from writes
+        // writes before we run the predicate — `discardTaskIfNoOutput`'s
+        // set-based DELETE...RETURNING will sweep stragglers either way, but
+        // a small wait avoids spurious "agent has output" reads from writes
         // that are essentially trailing edges of the killed turn.
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        await new Promise((resolve) => setTimeout(resolve, SIGTERM_SETTLE_MS));
 
         // Edit-on-cancel: if the executor never emitted user-visible output,
         // treat the prompt as never-really-sent — hard-delete the task and
@@ -2156,13 +2161,17 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           //
           // When the task was hard-deleted, also strip it from session.tasks
           // so downstream consumers (CLI listings, footer pills) don't keep
-          // pointing at a ghost id.
+          // pointing at a ghost id. Re-fetch `session.tasks` right before the
+          // patch — the original snapshot is ~150ms stale by now and a
+          // concurrent queue-drain / callback may have appended a new task id
+          // that we'd otherwise clobber.
           const sessionPatch: Record<string, unknown> = {
             status: SessionStatus.IDLE,
             ready_for_prompt: true,
           };
           if (outcome.kind === 'restored') {
-            sessionPatch.tasks = session.tasks.filter((tid) => tid !== latestTask.task_id);
+            const fresh = await sessionsService.get(id, params);
+            sessionPatch.tasks = fresh.tasks.filter((tid) => tid !== latestTask.task_id);
           }
           await app.service('sessions').patch(id, sessionPatch, params);
         } catch (error) {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2096,13 +2096,55 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           );
         }
 
+        // Edit-on-cancel: if the executor never emitted user-visible output
+        // (no assistant text/tool_use; pure "thinking" doesn't count), treat
+        // the prompt as never-really-sent — delete the task + its user
+        // message and hand the original prompt back to the caller so the UI
+        // can repopulate the composer. Otherwise, fall through to today's
+        // behavior (mark STOPPED, history intact).
+        let restoredPrompt: string | undefined;
         try {
-          await tasksService.patch(latestTask.task_id, {
-            status: TaskStatus.STOPPED,
-            completed_at: new Date().toISOString(),
+          const taskMessages = await messagesService.findByTask(latestTask.task_id);
+          const hasAgentOutput = taskMessages.some((msg) => {
+            if (msg.role !== MessageRole.ASSISTANT) return false;
+            const content = msg.content;
+            if (typeof content === 'string') return content.trim().length > 0;
+            if (Array.isArray(content)) {
+              return content.some(
+                (block) => block.type === 'text' || block.type === 'tool_use'
+              );
+            }
+            return false;
           });
+
+          if (!hasAgentOutput) {
+            // Delete by single id (per-row): the multi-remove path in the
+            // Drizzle adapter loads ALL messages via findAll before filtering,
+            // which is O(N) over the entire table. We already have the rows
+            // we want to drop in `taskMessages`, so delete them directly.
+            for (const msg of taskMessages) {
+              await messagesService.remove(msg.message_id, params);
+            }
+            await tasksService.remove(latestTask.task_id, params);
+            restoredPrompt = latestTask.full_prompt;
+            console.log(
+              `↩️  [Stop] Edit-on-cancel: dropped task ${shortId(latestTask.task_id)} (no agent output yet)`
+            );
+          }
         } catch (error) {
-          console.error(`❌ [Stop] Failed to patch task to STOPPED:`, error);
+          console.error(`❌ [Stop] Edit-on-cancel check failed:`, error);
+          restoredPrompt = undefined;
+        }
+
+        if (restoredPrompt === undefined) {
+          try {
+            await tasksService.patch(latestTask.task_id, {
+              status: TaskStatus.STOPPED,
+              completed_at: new Date().toISOString(),
+            });
+          } catch (error) {
+            console.error(`❌ [Stop] Failed to patch task to STOPPED:`, error);
+          }
         }
 
         try {
@@ -2121,7 +2163,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           console.error(`❌ [Stop] Failed to patch session to IDLE:`, error);
         }
 
-        return { success: true, status: SessionStatus.IDLE };
+        return {
+          success: true,
+          status: SessionStatus.IDLE,
+          edit_on_cancel: restoredPrompt !== undefined,
+          restored_prompt: restoredPrompt,
+        };
       },
     },
     {

--- a/apps/agor-daemon/src/utils/session-tasks.test.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for `hasAgentOutput` — the predicate that decides whether the stop
+ * route enters edit-on-cancel (drop the orphan task) or the regular STOPPED
+ * path. Single-sourced here so any drift between Agor and Claude Code CLI's
+ * "single-Esc while still internal" carve-out is caught fast.
+ */
+
+import type { Message, MessageID, SessionID, TaskID, UUID } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { hasAgentOutput } from './session-tasks';
+
+const SESSION_ID = '01999999-9999-7999-8999-999999999999' as SessionID;
+const TASK_ID = '01888888-8888-7888-8888-888888888888' as TaskID;
+
+let messageCounter = 0;
+function makeMessage(overrides: Partial<Message>): Message {
+  messageCounter += 1;
+  return {
+    message_id: `01777777-7777-7777-7777-${String(messageCounter).padStart(12, '0')}` as MessageID,
+    session_id: SESSION_ID as UUID,
+    task_id: TASK_ID as UUID,
+    type: 'user',
+    role: MessageRole.USER,
+    index: messageCounter - 1,
+    timestamp: new Date('2026-01-01T00:00:00Z').toISOString(),
+    content_preview: '',
+    content: '',
+    ...overrides,
+  };
+}
+
+describe('hasAgentOutput', () => {
+  it('returns false for an empty message list', () => {
+    expect(hasAgentOutput([])).toBe(false);
+  });
+
+  it('ignores USER and SYSTEM messages no matter their content', () => {
+    expect(
+      hasAgentOutput([
+        makeMessage({ role: MessageRole.USER, type: 'user', content: 'the original prompt' }),
+        makeMessage({
+          role: MessageRole.SYSTEM,
+          type: 'system',
+          content: [{ type: 'system_status', text: 'Brewed for 2s' }],
+        }),
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false for an ASSISTANT message containing only thinking blocks', () => {
+    expect(
+      hasAgentOutput([
+        makeMessage({
+          role: MessageRole.ASSISTANT,
+          type: 'assistant',
+          content: [{ type: 'thinking', thinking: 'planning...' }],
+        }),
+      ])
+    ).toBe(false);
+  });
+
+  it('returns true for an ASSISTANT message with a text block', () => {
+    expect(
+      hasAgentOutput([
+        makeMessage({
+          role: MessageRole.ASSISTANT,
+          type: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'planning...' },
+            { type: 'text', text: 'Here is the answer.' },
+          ],
+        }),
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for an ASSISTANT message with a tool_use block', () => {
+    expect(
+      hasAgentOutput([
+        makeMessage({
+          role: MessageRole.ASSISTANT,
+          type: 'assistant',
+          content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }],
+        }),
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for an ASSISTANT message with non-empty string content', () => {
+    expect(
+      hasAgentOutput([
+        makeMessage({
+          role: MessageRole.ASSISTANT,
+          type: 'assistant',
+          content: 'Plain text reply',
+        }),
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false for an ASSISTANT message with whitespace-only string content', () => {
+    expect(
+      hasAgentOutput([
+        makeMessage({
+          role: MessageRole.ASSISTANT,
+          type: 'assistant',
+          content: '   \n\t',
+        }),
+      ])
+    ).toBe(false);
+  });
+
+  it('returns true as soon as any one ASSISTANT message qualifies', () => {
+    expect(
+      hasAgentOutput([
+        makeMessage({ role: MessageRole.USER, type: 'user', content: 'prompt' }),
+        makeMessage({
+          role: MessageRole.ASSISTANT,
+          type: 'assistant',
+          content: [{ type: 'thinking', thinking: '...' }],
+        }),
+        makeMessage({
+          role: MessageRole.ASSISTANT,
+          type: 'assistant',
+          content: [{ type: 'text', text: 'reply' }],
+        }),
+      ])
+    ).toBe(true);
+  });
+});

--- a/apps/agor-daemon/src/utils/session-tasks.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.ts
@@ -14,9 +14,11 @@
  * drift. Keep this as the single source.
  */
 
+import { MessagesRepository, TaskRepository, txAsDb } from '@agor/core/db';
+import type { Database } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Paginated, Params, SessionID, Task } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import type { Message, Paginated, Params, SessionID, Task, TaskID } from '@agor/core/types';
+import { MessageRole, TaskStatus } from '@agor/core/types';
 
 /** Statuses considered "active" — an executor may still be doing work. */
 export const ACTIVE_TASK_STATUSES: ReadonlySet<string> = new Set<string>([
@@ -82,4 +84,80 @@ export async function findHostTaskForSession(
   const all = await findTasksForSession(app, sessionId, params);
   if (all.length === 0) return undefined;
   return all.find((t) => ACTIVE_TASK_STATUSES.has(t.status)) ?? all[0];
+}
+
+/**
+ * Predicate: have we seen any user-visible output from the agent on this
+ * task yet? `text` and `tool_use` content blocks (or non-empty string
+ * content on an ASSISTANT message) count. Pure `thinking`,
+ * `system_status`, and other internal-only blocks do NOT — matching
+ * Claude Code CLI's "single-Esc while still internal" carve-out.
+ *
+ * Used by the stop route to decide between "edit-on-cancel" (drop the
+ * orphan task, hand the prompt back) and the regular "mark STOPPED"
+ * path. Centralized here to keep the definition single-sourced — other
+ * call sites that need "has this task started producing visible output"
+ * should reuse this instead of growing parallel checks.
+ */
+export function hasAgentOutput(messages: ReadonlyArray<Message>): boolean {
+  return messages.some((msg) => {
+    if (msg.role !== MessageRole.ASSISTANT) return false;
+    const content = msg.content;
+    if (typeof content === 'string') return content.trim().length > 0;
+    if (Array.isArray(content)) {
+      return content.some((block) => block.type === 'text' || block.type === 'tool_use');
+    }
+    return false;
+  });
+}
+
+/**
+ * Outcome of `discardTaskIfNoOutput`. The `discarded` branch is the only
+ * one that mutates DB state; callers use the returned rows to fire the
+ * matching `removed` WebSocket events so subscribed UIs reactively prune
+ * their transcripts.
+ */
+export type DiscardTaskOutcome =
+  | { kind: 'discarded'; removedMessages: Message[]; task: Task }
+  | { kind: 'has_output' }
+  | { kind: 'not_found' };
+
+/**
+ * Atomically drop a task and all its messages if the agent hasn't
+ * produced user-visible output yet. Wraps the predicate re-check + both
+ * deletes in a single DB transaction so a stray late executor write
+ * either lands before the snapshot (caught by `hasAgentOutput`, leaves
+ * the task as STOPPED) or after the set-based delete (FK violation —
+ * insert fails, no orphan).
+ *
+ * Why a set-based delete rather than the per-row snapshot? The snapshot
+ * could be stale by the time we commit — the set-based `deleteByTaskId`
+ * sweeps anything still tagged with that task_id, including writes that
+ * landed between snapshot and commit.
+ *
+ * Callers are responsible for emitting `messages.removed` / `tasks.removed`
+ * service events using the returned rows so connected clients prune
+ * their local state; the helper deliberately stays at the repo layer to
+ * keep the transaction atomic.
+ */
+export async function discardTaskIfNoOutput(
+  db: Database,
+  taskId: TaskID
+): Promise<DiscardTaskOutcome> {
+  return await db.transaction(async (tx) => {
+    const txDb = txAsDb(tx);
+    const txTasksRepo = new TaskRepository(txDb);
+    const txMessagesRepo = new MessagesRepository(txDb);
+
+    const task = await txTasksRepo.findById(taskId);
+    if (!task) return { kind: 'not_found' };
+
+    const messages = await txMessagesRepo.findByTaskId(taskId);
+    if (hasAgentOutput(messages)) return { kind: 'has_output' };
+
+    await txMessagesRepo.deleteByTaskId(taskId);
+    await txTasksRepo.delete(taskId);
+
+    return { kind: 'discarded', removedMessages: messages, task };
+  });
 }

--- a/apps/agor-daemon/src/utils/session-tasks.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.ts
@@ -14,6 +14,7 @@
  * drift. Keep this as the single source.
  */
 
+import type { Database } from '@agor/core/db';
 import {
   eq,
   lockRowForUpdate,
@@ -22,7 +23,6 @@ import {
   tasks as tasksTable,
   txAsDb,
 } from '@agor/core/db';
-import type { Database } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Message, Paginated, Params, SessionID, Task, TaskID } from '@agor/core/types';
 import { MessageRole, TaskStatus } from '@agor/core/types';

--- a/apps/agor-daemon/src/utils/session-tasks.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.ts
@@ -14,7 +14,14 @@
  * drift. Keep this as the single source.
  */
 
-import { MessagesRepository, TaskRepository, txAsDb } from '@agor/core/db';
+import {
+  eq,
+  lockRowForUpdate,
+  MessagesRepository,
+  TaskRepository,
+  tasks as tasksTable,
+  txAsDb,
+} from '@agor/core/db';
 import type { Database } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Message, Paginated, Params, SessionID, Task, TaskID } from '@agor/core/types';
@@ -112,10 +119,16 @@ export function hasAgentOutput(messages: ReadonlyArray<Message>): boolean {
 }
 
 /**
- * Outcome of `discardTaskIfNoOutput`. The `discarded` branch is the only
- * one that mutates DB state; callers use the returned rows to fire the
- * matching `removed` WebSocket events so subscribed UIs reactively prune
- * their transcripts.
+ * Outcome of {@link discardTaskIfNoOutput}. The `discarded` branch is the
+ * only one that mutates DB state.
+ *
+ * Contract: callers MUST fire `messages.removed` for each row in
+ * `removedMessages` and `tasks.removed` for `task` after the call returns —
+ * the helper deliberately stays at the repo layer to keep its DELETEs
+ * atomic, so the matching WebSocket events are the caller's responsibility.
+ * `removedMessages` is the set-based DELETE's `RETURNING` output, so it
+ * includes any executor stragglers that landed between the predicate read
+ * and the DELETE.
  */
 export type DiscardTaskOutcome =
   | { kind: 'discarded'; removedMessages: Message[]; task: Task }
@@ -124,21 +137,17 @@ export type DiscardTaskOutcome =
 
 /**
  * Atomically drop a task and all its messages if the agent hasn't
- * produced user-visible output yet. Wraps the predicate re-check + both
+ * produced user-visible output yet. Wraps the predicate read + both
  * deletes in a single DB transaction so a stray late executor write
- * either lands before the snapshot (caught by `hasAgentOutput`, leaves
- * the task as STOPPED) or after the set-based delete (FK violation —
- * insert fails, no orphan).
+ * either lands before the read (caught by `hasAgentOutput`, leaves the
+ * task as STOPPED) or after — in which case the set-based
+ * `deleteByTaskId` returns it too, so the caller can emit the matching
+ * `removed` event and the UI reactively prunes the late bubble.
  *
- * Why a set-based delete rather than the per-row snapshot? The snapshot
- * could be stale by the time we commit — the set-based `deleteByTaskId`
- * sweeps anything still tagged with that task_id, including writes that
- * landed between snapshot and commit.
- *
- * Callers are responsible for emitting `messages.removed` / `tasks.removed`
- * service events using the returned rows so connected clients prune
- * their local state; the helper deliberately stays at the repo layer to
- * keep the transaction atomic.
+ * On Postgres, the function acquires `SELECT ... FOR UPDATE` on the task
+ * row at the top of the transaction so concurrent executor writes block
+ * until commit; on SQLite this is a no-op (the dialect serializes writes
+ * implicitly via its single-writer transaction model).
  */
 export async function discardTaskIfNoOutput(
   db: Database,
@@ -152,12 +161,20 @@ export async function discardTaskIfNoOutput(
     const task = await txTasksRepo.findById(taskId);
     if (!task) return { kind: 'not_found' };
 
+    // Block concurrent executor writes from racing the predicate check
+    // on Postgres. SQLite's transaction model already serializes writes.
+    await lockRowForUpdate(txDb, db, tasksTable, eq(tasksTable.task_id, task.task_id));
+
     const messages = await txMessagesRepo.findByTaskId(taskId);
     if (hasAgentOutput(messages)) return { kind: 'has_output' };
 
-    await txMessagesRepo.deleteByTaskId(taskId);
+    // Set-based DELETE with RETURNING: the returned rows are the
+    // ground-truth list of what was actually removed, including any
+    // stragglers the executor flushed after the predicate read but
+    // before this statement. Use these for emitting `removed` events.
+    const removedMessages = await txMessagesRepo.deleteByTaskId(taskId);
     await txTasksRepo.delete(taskId);
 
-    return { kind: 'discarded', removedMessages: messages, task };
+    return { kind: 'discarded', removedMessages, task };
   });
 }

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -562,9 +562,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
     setStopRequestInFlight(true);
     try {
-      const response = (await client
-        .service(`sessions/${session.session_id}/stop`)
-        .create({})) as { prompt_restored?: boolean; restored_prompt?: string };
+      const response = (await client.service(`sessions/${session.session_id}/stop`).create({})) as {
+        prompt_restored?: boolean;
+        restored_prompt?: string;
+      };
 
       // Edit-on-cancel: server dropped the orphan task because the agent
       // hadn't produced any output yet. Restore the prompt to the composer

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -564,13 +564,15 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     try {
       const response = (await client
         .service(`sessions/${session.session_id}/stop`)
-        .create({})) as { edit_on_cancel?: boolean; restored_prompt?: string };
+        .create({})) as { prompt_restored?: boolean; restored_prompt?: string };
 
       // Edit-on-cancel: server dropped the orphan task because the agent
       // hadn't produced any output yet. Restore the prompt to the composer
       // ONLY if the user hasn't started typing something new in the meantime
-      // — we never overwrite an in-progress draft.
-      if (response?.edit_on_cancel && response.restored_prompt) {
+      // — we never overwrite an in-progress draft. (If the user has typed,
+      // the server has already cleaned up; the original prompt is dropped
+      // on the floor by design.)
+      if (response?.prompt_restored && response.restored_prompt) {
         const draft = promptRef.current?.getValue() ?? '';
         if (!draft.trim()) {
           promptRef.current?.insertText(response.restored_prompt);

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -562,7 +562,20 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
     setStopRequestInFlight(true);
     try {
-      await client.service(`sessions/${session.session_id}/stop`).create({});
+      const response = (await client
+        .service(`sessions/${session.session_id}/stop`)
+        .create({})) as { edit_on_cancel?: boolean; restored_prompt?: string };
+
+      // Edit-on-cancel: server dropped the orphan task because the agent
+      // hadn't produced any output yet. Restore the prompt to the composer
+      // ONLY if the user hasn't started typing something new in the meantime
+      // — we never overwrite an in-progress draft.
+      if (response?.edit_on_cancel && response.restored_prompt) {
+        const draft = promptRef.current?.getValue() ?? '';
+        if (!draft.trim()) {
+          promptRef.current?.insertText(response.restored_prompt);
+        }
+      }
     } catch (error) {
       console.error('Failed to stop execution:', error);
       showError('Failed to stop execution. You can try again.');

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -198,6 +198,19 @@ export class MessagesRepository {
   }
 
   /**
+   * Delete all messages belonging to a task in a single set-based statement.
+   *
+   * The messages.task_id FK is `onDelete: 'set null'`, so deleting the task
+   * row alone would leave its messages as orphans with task_id=null but
+   * still attached to the session — visible in the transcript. Callers that
+   * hard-delete a task must call this first (ideally in the same
+   * transaction) to keep the conversation consistent.
+   */
+  async deleteByTaskId(taskId: TaskID): Promise<void> {
+    await deleteFrom(this.db, messages).where(eq(messages.task_id, taskId)).run();
+  }
+
+  /**
    * Delete a single message
    */
   async delete(messageId: MessageID): Promise<void> {

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -205,9 +205,19 @@ export class MessagesRepository {
    * still attached to the session — visible in the transcript. Callers that
    * hard-delete a task must call this first (ideally in the same
    * transaction) to keep the conversation consistent.
+   *
+   * Returns the rows actually deleted so callers can emit matching
+   * `messages.removed` service events. Using `.returning()` (rather than
+   * a separate pre-delete snapshot) catches anything the executor wrote
+   * between the predicate check and this statement — important when a
+   * SIGTERM'd executor flushes one last message before exit.
    */
-  async deleteByTaskId(taskId: TaskID): Promise<void> {
-    await deleteFrom(this.db, messages).where(eq(messages.task_id, taskId)).run();
+  async deleteByTaskId(taskId: TaskID): Promise<Message[]> {
+    const deleted = await deleteFrom(this.db, messages)
+      .where(eq(messages.task_id, taskId))
+      .returning()
+      .all();
+    return deleted.map((r: MessageRow) => this.rowToMessage(r));
   }
 
   /**


### PR DESCRIPTION
## Summary

Matches Claude Code CLI's single-Esc behavior: when the user stops a running task **before** the agent has emitted any user-visible output, treat the prompt as never-really-sent and hand it back to the composer for editing.

- **No assistant text/tool_use yet** → delete the task + its user message, return original prompt; UI repopulates the composer if it's empty.
- **Assistant already produced output** → today's behavior, task stays as `STOPPED`.
- **Composer mid-draft** → server still cleans up the orphan task, but the draft is preserved (we never overwrite it).

Pure `thinking` blocks and `system_*` traces do NOT count as output — same carve-out as CC.

## Changes

- `apps/agor-daemon/src/register-routes.ts` — `/sessions/:id/stop` checks `hasAgentOutput` on the active task's messages and either drops the task or marks it `STOPPED`. Response now includes `edit_on_cancel` + `restored_prompt`.
- `apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx` — `handleStop` reads the response and calls `promptRef.current.insertText(restored_prompt)` only when the composer is empty.

## Test plan

- [ ] Send a slow prompt, hit Stop during "thinking" phase → user bubble disappears, prompt reappears in composer
- [ ] Send a prompt, wait for assistant text/tool to appear, hit Stop → task remains as STOPPED in history, composer untouched
- [ ] Send a prompt, immediately type in composer, hit Stop before any output → task disappears from history, draft preserved
- [ ] Confirm queued tasks still drain after stop (session resets to IDLE with ready_for_prompt: true in both branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)