### PR TITLE
docs: clarify local artifact Chrome network access

### DIFF
--- a/apps/agor-docs/pages/guide/api-proxies.mdx
+++ b/apps/agor-docs/pages/guide/api-proxies.mdx
@@ -11,6 +11,12 @@ The Agor daemon ships a thin **HTTP proxy** to solve this. Anything sent to
 daemon already accepts requests from `*.codesandbox.io`, so artifact code
 sees a normal CORS response.
 
+This proxy is for **upstream API CORS** (for example Shortcut's API not allowing
+browser access). It is not a Chrome Private Network Access workaround by itself:
+when running Agor locally with the hosted Sandpack iframe, Chrome may still
+block `https://*.codesandbox.io → http://localhost:<port>` before the request
+reaches `/proxies/...`. See the [artifacts local Chrome note](/guide/artifacts#local-chrome-note-private-network-access) for that browser setting/debug path.
+
 ## What this is, and is not
 
 This is a **dumb pass-through proxy**:

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -237,6 +237,38 @@ if (!apiKey) {
 | `agor_artifact_id: true` | `AGOR_ARTIFACT_ID` | Pure metadata — no consent. |
 | `agor_board_id: true` | `AGOR_BOARD_ID` | Pure metadata — no consent. |
 
+#### Local Chrome note: Private Network Access
+
+When Agor runs locally, `AGOR_API_URL` is usually `http://localhost:3030`, but
+the default Sandpack preview iframe is hosted at `https://*.codesandbox.io`.
+Chrome treats `https://*.codesandbox.io → http://localhost` as a **Private
+Network Access / Local Network Access** request and may block the artifact's
+`fetch()` before the daemon sees it. The common symptom is a generic
+`TypeError: Failed to fetch` in the artifact, even though the URL and token were
+injected correctly.
+
+To confirm this is Chrome-specific, open the same artifact in Firefox. If it
+works there but fails in Chrome or Edge, you're probably hitting Chrome's local
+network protection rather than an Agor token, CSP, or app-code bug.
+
+For local development in Chrome, allow local network access for the Agor/Sandpack
+page if Chrome shows that site permission. If your Chrome version exposes it
+only as a flag, open `chrome://flags/#local-network-access-check`, disable the
+check for local development, and restart Chrome. Older Chrome builds may expose
+the related preflight flag as
+`chrome://flags/#private-network-access-respect-preflight-results`.
+
+Other ways around the Chrome-only local-network block:
+
+- Build/run with Agor's self-hosted Sandpack bundler so the preview is served
+  locally instead of from `https://*.codesandbox.io`.
+- Use a public HTTPS Agor URL, as hosted Agor does.
+
+Agor's [API Proxies](/guide/api-proxies) solve a different problem: third-party
+APIs like Shortcut that do not allow browser CORS. They are useful once the
+artifact can reach the daemon, but they do not by themselves bypass Chrome's
+hosted-Sandpack → localhost block.
+
 ### TOFU consent
 
 When the viewer is **not** the artifact's author, the daemon won't inject secrets or grants without an explicit trust grant:

--- a/context/concepts/security.md
+++ b/context/concepts/security.md
@@ -38,19 +38,19 @@ security:
   csp:
     # (1) APPEND to built-in defaults — the 95% case.
     extras:
-      script-src: ["https://plausible.io"]
-      connect-src: ["https://api.anthropic.com"]
-      frame-src: ["https://my-sandbox.example.com"]
+      script-src: ['https://plausible.io']
+      connect-src: ['https://api.anthropic.com']
+      frame-src: ['https://my-sandbox.example.com']
 
     # (2) REPLACE a directive wholesale — escape hatch, rare.
     # Setting a directive here wipes both defaults AND extras for that key.
     override:
-      img-src: ["'self'", "data:"]
+      img-src: ["'self'", 'data:']
 
     # (3) Reporting + debug toggles.
-    report_uri: "/api/csp-report"   # daemon mounts a handler here
-    report_only: false              # true = emit Content-Security-Policy-Report-Only
-    disabled: false                 # dev/debug only, emits loud warning
+    report_uri: '/api/csp-report' # daemon mounts a handler here
+    report_only: false # true = emit Content-Security-Policy-Report-Only
+    disabled: false # dev/debug only, emits loud warning
 ```
 
 **Why the split?** Every operator we've asked about CSP wanted "keep what
@@ -61,7 +61,7 @@ dropping the defaults and breaking unrelated features.
 
 **Empty override is meaningful.** `override: { "script-src": [] }` emits
 `script-src` with no sources — i.e. blocks that directive entirely. This is
-distinct from *omitting* the key, which means "use defaults+extras." If you
+distinct from _omitting_ the key, which means "use defaults+extras." If you
 find yourself reaching for this, double-check it's really what you meant.
 
 ### CORS: mode-based
@@ -69,27 +69,54 @@ find yourself reaching for this, double-check it's really what you meant.
 ```yaml
 security:
   cors:
-    mode: list                              # list | wildcard | reflect | null-origin
-    origins: ["https://agor.mydomain.com"]  # used when mode=list
-    credentials: true                       # default true; forced false in wildcard/reflect
-    methods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
-    allowed_headers: ["Authorization", "Content-Type", "X-MCP-Token"]
+    mode: list # list | wildcard | reflect | null-origin
+    origins: ['https://agor.mydomain.com'] # used when mode=list
+    credentials: true # default true; forced false in wildcard/reflect
+    methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS']
+    allowed_headers: ['Authorization', 'Content-Type', 'X-MCP-Token']
     max_age_seconds: 600
-    allow_sandpack: true                    # include *.codesandbox.io (default true)
+    allow_sandpack: true # include *.codesandbox.io (default true)
 ```
 
 **Mode semantics:**
 
-| Mode          | Behaviour                                                         | Credentials |
-| ------------- | ----------------------------------------------------------------- | ----------- |
-| `list`        | Only origins in `origins[]` + built-ins (localhost, Sandpack)     | Allowed (default) |
-| `wildcard`    | Accept any origin (returns `Access-Control-Allow-Origin: *`)      | Forced off  |
-| `reflect`     | Echo the request's `Origin` header back                           | Forced off  |
-| `null-origin` | Accept `Origin: null` (sandboxed iframes, `file://` docs) plus no-origin non-browser clients (curl, server-to-server) | Allowed     |
+| Mode          | Behaviour                                                                                                             | Credentials       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `list`        | Only origins in `origins[]` + built-ins (localhost, Sandpack)                                                         | Allowed (default) |
+| `wildcard`    | Accept any origin (returns `Access-Control-Allow-Origin: *`)                                                          | Forced off        |
+| `reflect`     | Echo the request's `Origin` header back                                                                               | Forced off        |
+| `null-origin` | Accept `Origin: null` (sandboxed iframes, `file://` docs) plus no-origin non-browser clients (curl, server-to-server) | Allowed           |
 
 `credentials: true` + `mode: wildcard` (or `reflect`) is rejected at config
 load with a clear error — the CORS spec explicitly forbids this combination
 because it would allow credentialed requests from any origin.
+
+### Sandpack, localhost, and Chrome Private Network Access
+
+Local artifacts commonly render inside the hosted Sandpack iframe
+(`https://*.codesandbox.io`) while the daemon listens on
+`http://localhost:<port>`. Chromium treats that as a public HTTPS origin trying
+to reach a loopback/private HTTP address. Depending on Chrome version and flags,
+the browser may enforce Private Network Access / Local Network Access before the
+artifact's `fetch()` reaches Agor at all.
+
+This failure often surfaces only as `TypeError: Failed to fetch` inside the
+artifact. Quick triage:
+
+1. Try the same artifact in Firefox. If Firefox works and Chrome/Edge fail, it
+   is likely Chrome local-network enforcement, not CSP or an Agor token bug.
+2. In Chrome, allow local network access for the Agor/Sandpack page if that site
+   permission is shown.
+3. For local development, Chrome versions that expose the flag can disable the
+   check at `chrome://flags/#local-network-access-check` and then restart
+   Chrome. Older builds may expose the related preflight flag at
+   `chrome://flags/#private-network-access-respect-preflight-results`.
+
+Agor still keeps Sandpack on the non-credentialed side of CORS: browser cookies
+must not be sent to the multi-tenant hosted bundler. Artifacts should use
+explicit Bearer-token grants or configured `/proxies/<vendor>` URLs. The proxy
+feature solves third-party API CORS gaps (for example Shortcut), but it does not
+by itself bypass Chrome's hosted-Sandpack → localhost protection.
 
 ---
 
@@ -123,7 +150,7 @@ ships no Handlebars and never calls `new Function` / `eval`.
 The Sandpack origins (`https://*.codesandbox.io` + `blob:` for workers) are
 the load-bearing piece — without them the hosted bundler iframe renders but
 its workers fail to spawn and artifacts never mount. Setting
-`security.cors.allow_sandpack: false` removes them from *both* the CSP and
+`security.cors.allow_sandpack: false` removes them from _both_ the CSP and
 the CORS allow-list (the two need to stay in sync or you get weird
 half-broken states).
 
@@ -137,8 +164,8 @@ half-broken states).
 security:
   csp:
     extras:
-      script-src: ["https://plausible.io"]
-      connect-src: ["https://plausible.io"]
+      script-src: ['https://plausible.io']
+      connect-src: ['https://plausible.io']
 ```
 
 ### I want to embed an external iframe
@@ -147,7 +174,7 @@ security:
 security:
   csp:
     extras:
-      frame-src: ["https://my-embed.example.com"]
+      frame-src: ['https://my-embed.example.com']
 ```
 
 ### I want to relax CORS for a specific origin
@@ -155,7 +182,7 @@ security:
 ```yaml
 security:
   cors:
-    origins: ["https://dashboard.internal.example.com"]
+    origins: ['https://dashboard.internal.example.com']
 ```
 
 Regex patterns are supported inside `/slashes/`:
@@ -164,7 +191,7 @@ Regex patterns are supported inside `/slashes/`:
 security:
   cors:
     origins:
-      - "https://dashboard.example.com"
+      - 'https://dashboard.example.com'
       - "/\\.internal\\.example\\.com$/"
 ```
 
@@ -174,7 +201,7 @@ security:
 security:
   csp:
     report_only: true
-    report_uri: "/api/csp-report"
+    report_uri: '/api/csp-report'
 ```
 
 The daemon mounts a rate-limited handler at `report_uri` that logs incoming


### PR DESCRIPTION
## Summary
- Switch PR #1497 to a docs-only fix for issue #1496.
- Document that local hosted-Sandpack artifacts can fail in Chrome/Edge because of Private Network Access / Local Network Access before requests reach Agor.
- Add concrete debugging/workaround guidance: try Firefox to confirm, allow local network access in Chrome, use chrome://flags/#local-network-access-check when needed, note older PNA flag, use self-hosted Sandpack or public HTTPS Agor.
- Clarify that Agor API proxies solve upstream API CORS (for example Shortcut), but do not by themselves bypass Chrome's hosted-Sandpack-to-localhost block.

Fixes #1496.

## Security
- No CORS/CSP behavior changes.
- No broadening of Sandpack/CodeSandbox cookie credentials.
- Keeps the fix informational because Chrome may block local network access independently of daemon headers.

## Checks
- pnpm i
- pnpm check
- pnpm --filter @agor/daemon test -- src/setup/cors.test.ts