### PR TITLE
Add team helper blog post to index

### DIFF
--- a/apps/agor-docs/lib/blogPosts.ts
+++ b/apps/agor-docs/lib/blogPosts.ts
@@ -9,6 +9,14 @@ export interface BlogPost {
 /** Blog posts ordered newest-first. Keep in sync with pages/blog/*.mdx frontmatter. */
 export const blogPosts: BlogPost[] = [
   {
+    slug: 'raise-team-helper-agent',
+    title: 'Raise a Team Helper Agent in an Afternoon',
+    description:
+      'A practical recipe for turning an Agor Assistant into a PM-style teammate that remembers context, coordinates work, reports progress, and keeps a team aligned.',
+    date: '2026-06-17',
+    image: '/images/blog/raise-team-helper-agent.png',
+  },
+  {
     slug: 'agent-modeling-101',
     title: 'Agent Modeling 101: Designing Long-Lived Agents for Teams',
     description:

--- a/apps/agor-docs/scripts/validate-social-metadata.ts
+++ b/apps/agor-docs/scripts/validate-social-metadata.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { blogPosts } from '../lib/blogPosts';
 import {
   DEFAULT_SOCIAL_IMAGE,
   FAVICON_PATH,
@@ -57,6 +58,37 @@ function parseFrontMatter(filePath: string): FrontMatterLike {
   return frontMatter;
 }
 
+function assertBlogPostsMatchPages(pages: PageMetadata[], errors: string[]): void {
+  const blogPages = pages.filter(
+    (page) => page.filePath.startsWith('pages/blog/') && page.filePath.endsWith('.mdx')
+  );
+  const pageSlugs = new Set(
+    blogPages.map((page) => path.basename(page.filePath, path.extname(page.filePath)))
+  );
+  const listedSlugs = new Set(blogPosts.map((post) => post.slug));
+
+  for (const slug of pageSlugs) {
+    if (!listedSlugs.has(slug)) {
+      errors.push(`pages/blog/${slug}.mdx: missing entry in lib/blogPosts.ts`);
+    }
+  }
+
+  for (const post of blogPosts) {
+    if (!pageSlugs.has(post.slug)) {
+      errors.push(`lib/blogPosts.ts: entry has no matching pages/blog/${post.slug}.mdx`);
+    }
+  }
+
+  const sortedPosts = [...blogPosts].sort((a, b) => b.date.localeCompare(a.date));
+
+  for (const [index, post] of blogPosts.entries()) {
+    if (post.slug !== sortedPosts[index]?.slug) {
+      errors.push('lib/blogPosts.ts: blog posts should be ordered newest-first by date');
+      break;
+    }
+  }
+}
+
 function assertLocalPublicImageExists(value: string, filePath: string, errors: string[]): void {
   if (!value || isAbsoluteUrl(value)) {
     return;
@@ -86,6 +118,7 @@ const errors: string[] = [];
 assertLocalPublicImageExists(DEFAULT_SOCIAL_IMAGE, 'default social image', errors);
 assertLocalPublicImageExists(FAVICON_PATH, 'favicon (siteMetadata.FAVICON_PATH)', errors);
 assertLocalPublicImageExists(LOGO_PATH, 'logo (siteMetadata.LOGO_PATH)', errors);
+assertBlogPostsMatchPages(pages, errors);
 
 for (const page of pages) {
   const socialImage = getSocialImage(page.frontMatter);


### PR DESCRIPTION
## Summary\n- add the raise-team-helper-agent post to the manual blog index\n- extend social metadata validation to catch blog MDX posts missing from the index and enforce newest-first order\n\n## Checks\n- pnpm --filter @agor/docs validate:social-metadata\n- pnpm --filter @agor/docs typecheck\n- pnpm exec biome check apps/agor-docs/lib/blogPosts.ts apps/agor-docs/scripts/validate-social-metadata.ts