### PR TITLE
fix(ui): space Knowledge header icon

### DIFF
--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -2876,7 +2876,7 @@ export function KnowledgePage({
             style={{
               display: 'inline-flex',
               alignItems: 'center',
-              gap: 6,
+              gap: token.sizeUnit,
               fontSize: 15,
               cursor: 'pointer',
             }}


### PR DESCRIPTION
## Summary\n- add a tiny gap between the Knowledge header icon and title\n\n## Checks\n- pnpm dlx @biomejs/biome@2.4.16 check apps/agor-ui/src/pages/KnowledgePage.tsx