### PR TITLE
Improve Slack gateway session status messages

### DIFF
--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -19,6 +19,8 @@ import type { Application } from '@agor/core/feathers';
 import type { GatewayConnector, GatewayContext, InboundMessage } from '@agor/core/gateway';
 import {
   formatGatewayContext,
+  formatGatewayFollowUpRoutingMessage,
+  formatGatewaySessionCreatedMessage,
   formatGatewaySystemMessage,
   getConnector,
   hasConnector,
@@ -319,6 +321,22 @@ export class GatewayService {
     }
   }
 
+  private async fetchExistingSessionUrlForGatewayUser(
+    sessionId: SessionID,
+    user: User
+  ): Promise<string | null> {
+    try {
+      const sessionsService = this.app.service('sessions') as {
+        get: (id: string, params?: { user: User }) => Promise<Session & { url?: string | null }>;
+      };
+      const sessionWithUrl = await sessionsService.get(sessionId, { user });
+      return sessionWithUrl.url || null;
+    } catch (error) {
+      console.warn('[gateway] Failed to fetch session URL:', error);
+      return null;
+    }
+  }
+
   /**
    * Inbound routing: platform → session
    *
@@ -547,7 +565,7 @@ export class GatewayService {
       }
     }
 
-    let sessionId: string;
+    let sessionId: SessionID;
     let created = false;
     let mcpAuthWarning: string | undefined;
 
@@ -596,10 +614,11 @@ export class GatewayService {
         await this.threadMapRepo.updateMetadata(existingMapping.id, updatedMetadata);
       }
 
+      const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
       this.sendDebugMessage(
         channel,
         data.thread_id,
-        `Received follow-up, routing to session ${shortId(sessionId)}...`
+        formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl)
       );
     } else {
       // New thread → create session via FeathersJS service
@@ -717,24 +736,13 @@ export class GatewayService {
         metadata: data.metadata ?? null,
       });
 
-      // Get session URL from created session (URL is added by after hook)
-      // Fetch the session to get the URL property
-      let sessionUrl: string | null = null;
-      try {
-        const sessionsService = this.app.service('sessions') as {
-          get: (id: string, params?: { user: User }) => Promise<Session & { url?: string | null }>;
-        };
-        const sessionWithUrl = await sessionsService.get(sessionId, { user });
-        sessionUrl = sessionWithUrl.url || null;
-      } catch (error) {
-        console.warn('[gateway] Failed to fetch session URL:', error);
-      }
+      // The create path already returns a Session from SessionRepository.create(),
+      // which populates url when the branch is attached to a board. Avoid an
+      // immediate get() round trip here; only follow-ups need to fetch.
+      const sessionUrl = session.url ?? null;
 
       // Send debug message with session URL
-      const sessionIdShort = shortId(sessionId);
-      const message = sessionUrl
-        ? `Session created: ${sessionUrl}`
-        : `Session ${sessionIdShort} created, sending prompt to agent...`;
+      const message = formatGatewaySessionCreatedMessage(sessionId, sessionUrl);
 
       this.sendDebugMessage(channel, data.thread_id, message);
 

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -17,4 +17,9 @@ export {
 } from './connectors/teams';
 export type { GatewayContext } from './context';
 export { formatGatewayContext } from './context';
-export { formatGatewaySystemMessage } from './system-message';
+export {
+  formatGatewayFollowUpRoutingMessage,
+  formatGatewayMarkdownSessionReference,
+  formatGatewaySessionCreatedMessage,
+  formatGatewaySystemMessage,
+} from './system-message';

--- a/packages/core/src/gateway/system-message.test.ts
+++ b/packages/core/src/gateway/system-message.test.ts
@@ -1,34 +1,64 @@
 import { describe, expect, it } from 'vitest';
-import { formatGatewaySystemMessage } from './system-message';
+import {
+  formatGatewayFollowUpRoutingMessage,
+  formatGatewayMarkdownSessionReference,
+  formatGatewaySessionCreatedMessage,
+  formatGatewaySystemMessage,
+} from './system-message';
+
+const sessionId = '019e6fca-0000-7000-8000-000000000000';
+const sessionShortId = '019e6fca0000700080000000';
+const sessionUrl = 'https://agor.sandbox.preset.zone/ui/s/019e6fca/';
 
 describe('formatGatewaySystemMessage', () => {
   it('formats Slack session-created messages without markdown emphasis wrappers', () => {
-    expect(
-      formatGatewaySystemMessage(
-        'slack',
-        'Session created: https://agor.sandbox.preset.zone/ui/s/019e6fca/'
-      )
-    ).toBe(
-      '[system] Session created: <https://agor.sandbox.preset.zone/ui/s/019e6fca/|View session>'
+    expect(formatGatewaySystemMessage('slack', `Session created: ${sessionUrl}`)).toBe(
+      `Agor: Session created: <${sessionUrl}|View session>`
     );
   });
 
   it('keeps generic Slack system messages plain', () => {
     expect(formatGatewaySystemMessage('slack', 'Creating new codex session...')).toBe(
-      '[system] Creating new codex session...'
+      'Agor: Creating new codex session...'
     );
   });
 
   it('escapes generic Slack system messages with the shared Slack markdown formatter', () => {
-    expect(formatGatewaySystemMessage('slack', 'A & B < C')).toBe('[system] A &amp; B &lt; C');
+    expect(formatGatewaySystemMessage('slack', 'A & B < C')).toBe('Agor: A &amp; B &lt; C');
+  });
+
+  it('formats Slack follow-up routing messages with a clickable session link', () => {
+    const text = formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl);
+
+    expect(text).toBe(
+      `Follow-up received — routing to [session ${sessionShortId}](${sessionUrl})...`
+    );
+    expect(formatGatewaySystemMessage('slack', text)).toBe(
+      `Agor: Follow-up received — routing to <${sessionUrl}|session ${sessionShortId}>...`
+    );
+  });
+
+  it('falls back to a short session ID when no session URL is available', () => {
+    expect(formatGatewayMarkdownSessionReference(sessionId, null)).toBe(
+      `session ${sessionShortId}`
+    );
+    expect(formatGatewayFollowUpRoutingMessage(sessionId, null)).toBe(
+      `Follow-up received — routing to session ${sessionShortId}...`
+    );
+  });
+
+  it('centralizes created-session fallback wording', () => {
+    expect(formatGatewaySessionCreatedMessage(sessionId, sessionUrl)).toBe(
+      `Session created: ${sessionUrl}`
+    );
+    expect(formatGatewaySessionCreatedMessage(sessionId, null)).toBe(
+      `Session ${sessionShortId} created, sending prompt to agent...`
+    );
   });
 
   it('does not apply Slack link syntax to non-Slack channels', () => {
-    expect(
-      formatGatewaySystemMessage(
-        'github',
-        'Session created: https://agor.sandbox.preset.zone/ui/s/019e6fca/'
-      )
-    ).toBe('[system] Session created: https://agor.sandbox.preset.zone/ui/s/019e6fca/');
+    expect(formatGatewaySystemMessage('github', `Session created: ${sessionUrl}`)).toBe(
+      `Agor: Session created: ${sessionUrl}`
+    );
   });
 });

--- a/packages/core/src/gateway/system-message.ts
+++ b/packages/core/src/gateway/system-message.ts
@@ -1,5 +1,41 @@
 import type { ChannelType } from '../types/gateway';
+import type { SessionID } from '../types/id';
+import { shortId } from '../types/id';
 import { markdownToMrkdwn } from './connectors/slack';
+
+const GATEWAY_SYSTEM_PREFIX = 'Agor:';
+
+/**
+ * Format a session reference for gateway lifecycle messages as markdown.
+ *
+ * When the daemon can resolve an Agor UI URL, the reference is markdown so
+ * channel-specific formatters can turn it into native links (Slack mrkdwn,
+ * GitHub markdown, etc.). Without a URL, fall back to a short ID rather than
+ * exposing a full UUID in external chat surfaces.
+ */
+export function formatGatewayMarkdownSessionReference(
+  sessionId: SessionID | string,
+  sessionUrl?: string | null
+): string {
+  const label = `session ${shortId(sessionId)}`;
+  return sessionUrl ? `[${label}](${sessionUrl})` : label;
+}
+
+export function formatGatewaySessionCreatedMessage(
+  sessionId: SessionID | string,
+  sessionUrl?: string | null
+): string {
+  return sessionUrl
+    ? `Session created: ${sessionUrl}`
+    : `Session ${shortId(sessionId)} created, sending prompt to agent...`;
+}
+
+export function formatGatewayFollowUpRoutingMessage(
+  sessionId: SessionID | string,
+  sessionUrl?: string | null
+): string {
+  return `Follow-up received — routing to ${formatGatewayMarkdownSessionReference(sessionId, sessionUrl)}...`;
+}
 
 /**
  * Format low-volume gateway lifecycle messages for external channels.
@@ -14,11 +50,11 @@ export function formatGatewaySystemMessage(channelType: ChannelType, text: strin
 
   if (channelType === 'slack') {
     const markdown = sessionCreatedMatch
-      ? `[system] Session created: [View session](${sessionCreatedMatch[1]})`
-      : `[system] ${text}`;
+      ? `${GATEWAY_SYSTEM_PREFIX} Session created: [View session](${sessionCreatedMatch[1]})`
+      : `${GATEWAY_SYSTEM_PREFIX} ${text}`;
 
     return markdownToMrkdwn(markdown);
   }
 
-  return `[system] ${text}`;
+  return `${GATEWAY_SYSTEM_PREFIX} ${text}`;
 }


### PR DESCRIPTION
## Summary
- Link Slack follow-up status messages to the existing Agor session when the session URL is available
- Centralize gateway session reference formatting with a short-ID fallback
- Refresh gateway system prefix from `[system]` to `Agor:` and cover link behavior in tests

## Checks
- pnpm --filter @agor/core test -- system-message.test.ts
- pnpm exec biome check packages/core/src/gateway/system-message.ts packages/core/src/gateway/system-message.test.ts packages/core/src/gateway/index.ts apps/agor-daemon/src/services/gateway.ts
- pnpm --filter @agor/core typecheck

## Note
- `pnpm --filter @agor/daemon typecheck` was attempted but this fresh worktree cannot resolve `@agor/core/*` declaration exports without building core first; per agent instructions I did not run a build.