### PR TITLE
docs: mention private sandbox hosts for artifact PNA

### DIFF
--- a/apps/agor-docs/pages/guide/api-proxies.mdx
+++ b/apps/agor-docs/pages/guide/api-proxies.mdx
@@ -13,9 +13,10 @@ sees a normal CORS response.
 
 This proxy is for **upstream API CORS** (for example Shortcut's API not allowing
 browser access). It is not a Chrome Private Network Access workaround by itself:
-when running Agor locally with the hosted Sandpack iframe, Chrome may still
-block `https://*.codesandbox.io → http://localhost:<port>` before the request
-reaches `/proxies/...`. See the [artifacts local Chrome note](/guide/artifacts#local-chrome-note-private-network-access) for that browser setting/debug path.
+when using the hosted Sandpack iframe, Chrome may still block
+`https://*.codesandbox.io → <local/private Agor URL>` (localhost, VPN/internal
+hosts, or sandbox hostnames that resolve privately) before the request reaches
+`/proxies/...`. See the [artifacts local Chrome note](/guide/artifacts#local-chrome-note-private-network-access) for that browser setting/debug path.
 
 ## What this is, and is not
 

--- a/apps/agor-docs/pages/guide/artifacts.mdx
+++ b/apps/agor-docs/pages/guide/artifacts.mdx
@@ -239,13 +239,14 @@ if (!apiKey) {
 
 #### Local Chrome note: Private Network Access
 
-When Agor runs locally, `AGOR_API_URL` is usually `http://localhost:3030`, but
-the default Sandpack preview iframe is hosted at `https://*.codesandbox.io`.
-Chrome treats `https://*.codesandbox.io → http://localhost` as a **Private
-Network Access / Local Network Access** request and may block the artifact's
-`fetch()` before the daemon sees it. The common symptom is a generic
-`TypeError: Failed to fetch` in the artifact, even though the URL and token were
-injected correctly.
+When an artifact uses the hosted Sandpack preview iframe
+(`https://*.codesandbox.io`) and calls an Agor URL that Chrome classifies as
+local/private — for example `http://localhost:3030`, or an internal/sandbox
+hostname such as `https://agor.sandbox.preset.zone` when it resolves to a
+private network address — Chrome may treat the request as **Private Network
+Access / Local Network Access** and block the artifact's `fetch()` before the
+daemon sees it. The common symptom is a generic `TypeError: Failed to fetch` in
+the artifact, even though the URL and token were injected correctly.
 
 To confirm this is Chrome-specific, open the same artifact in Firefox. If it
 works there but fails in Chrome or Edge, you're probably hitting Chrome's local
@@ -258,7 +259,7 @@ check for local development, and restart Chrome. Older Chrome builds may expose
 the related preflight flag as
 `chrome://flags/#private-network-access-respect-preflight-results`.
 
-Other ways around the Chrome-only local-network block:
+Other ways around the Chrome-only local/private-network block:
 
 - Build/run with Agor's self-hosted Sandpack bundler so the preview is served
   locally instead of from `https://*.codesandbox.io`.
@@ -267,7 +268,7 @@ Other ways around the Chrome-only local-network block:
 Agor's [API Proxies](/guide/api-proxies) solve a different problem: third-party
 APIs like Shortcut that do not allow browser CORS. They are useful once the
 artifact can reach the daemon, but they do not by themselves bypass Chrome's
-hosted-Sandpack → localhost block.
+hosted-Sandpack → local/private Agor URL block.
 
 ### TOFU consent
 

--- a/context/concepts/security.md
+++ b/context/concepts/security.md
@@ -91,14 +91,17 @@ security:
 load with a clear error — the CORS spec explicitly forbids this combination
 because it would allow credentialed requests from any origin.
 
-### Sandpack, localhost, and Chrome Private Network Access
+### Sandpack, local/private Agor URLs, and Chrome Private Network Access
 
-Local artifacts commonly render inside the hosted Sandpack iframe
-(`https://*.codesandbox.io`) while the daemon listens on
-`http://localhost:<port>`. Chromium treats that as a public HTTPS origin trying
-to reach a loopback/private HTTP address. Depending on Chrome version and flags,
-the browser may enforce Private Network Access / Local Network Access before the
-artifact's `fetch()` reaches Agor at all.
+Artifacts commonly render inside the hosted Sandpack iframe
+(`https://*.codesandbox.io`) while the Agor API URL may point at a loopback,
+internal, VPN, or sandbox host. That includes obvious local URLs like
+`http://localhost:<port>`, but it can also include public-looking names such as
+`https://agor.sandbox.preset.zone` if DNS routes them to a private network
+address. Chromium treats this as a public HTTPS origin trying to reach a
+private/local address space. Depending on Chrome version and flags, the browser
+may enforce Private Network Access / Local Network Access before the artifact's
+`fetch()` reaches Agor at all.
 
 This failure often surfaces only as `TypeError: Failed to fetch` inside the
 artifact. Quick triage:
@@ -116,7 +119,7 @@ Agor still keeps Sandpack on the non-credentialed side of CORS: browser cookies
 must not be sent to the multi-tenant hosted bundler. Artifacts should use
 explicit Bearer-token grants or configured `/proxies/<vendor>` URLs. The proxy
 feature solves third-party API CORS gaps (for example Shortcut), but it does not
-by itself bypass Chrome's hosted-Sandpack → localhost protection.
+by itself bypass Chrome's hosted-Sandpack → local/private Agor URL protection.
 
 ---
 


### PR DESCRIPTION
## Summary
- Follow-up to #1497 after clarifying that the reported failure was on `https://agor.sandbox.preset.zone`, not only `http://localhost`.
- Document that Chrome Private Network Access / Local Network Access can apply to public-looking sandbox/internal hostnames when they resolve to a private network address.
- Keep the debugging/workaround guidance: try Firefox, allow local network access / use `chrome://flags/#local-network-access-check`, self-host Sandpack, or use a public HTTPS Agor URL.
- Clarify that API proxies solve upstream API CORS (for example Shortcut) after an artifact can reach Agor, but do not bypass Chrome's hosted-Sandpack-to-local/private-Agor-URL protection.

Follow-up to #1496 and #1497.

## Checks
- `pnpm check`
