### PR TITLE
fix: allow local repos without environment config

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -19,8 +19,24 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { isPromptFlowPatchOnly, PROMPT_FLOW_PATCH_FIELDS } from './register-hooks';
+import {
+  isPromptFlowPatchOnly,
+  PROMPT_FLOW_PATCH_FIELDS,
+  shouldValidateRepoEnvironmentPayload,
+} from './register-hooks';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization';
+
+describe('shouldValidateRepoEnvironmentPayload', () => {
+  it('skips absent repo environment payloads', () => {
+    expect(shouldValidateRepoEnvironmentPayload(undefined)).toBe(false);
+    expect(shouldValidateRepoEnvironmentPayload(null)).toBe(false);
+  });
+
+  it('validates present repo environment payloads', () => {
+    expect(shouldValidateRepoEnvironmentPayload({})).toBe(true);
+    expect(shouldValidateRepoEnvironmentPayload('invalid shape')).toBe(true);
+  });
+});
 
 describe('isPromptFlowPatchOnly', () => {
   describe('accepts whitelisted-only patches', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -153,6 +153,10 @@ function itemHasAnyField(item: Record<string, unknown>, fields: readonly string[
   return fields.some((field) => Object.hasOwn(item, field));
 }
 
+export function shouldValidateRepoEnvironmentPayload(value: unknown): boolean {
+  return value !== undefined && value !== null;
+}
+
 async function getManagedEnvExecutionMode() {
   const config = await loadConfig();
   return config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT;
@@ -164,7 +168,10 @@ function validateRepoEnvPolicyHook() {
     const items = Array.isArray(context.data) ? context.data : [context.data];
 
     for (const item of items as Array<Record<string, unknown>>) {
-      if (Object.hasOwn(item, 'environment') && item.environment !== null) {
+      if (
+        Object.hasOwn(item, 'environment') &&
+        shouldValidateRepoEnvironmentPayload(item.environment)
+      ) {
         try {
           const env = validateRepoEnvironment(item.environment);
           validateRepoEnvironmentLifecyclePolicy(env, mode);
@@ -173,7 +180,10 @@ function validateRepoEnvPolicyHook() {
         }
       }
 
-      if (Object.hasOwn(item, 'environment_config') && item.environment_config !== null) {
+      if (
+        Object.hasOwn(item, 'environment_config') &&
+        shouldValidateRepoEnvironmentPayload(item.environment_config)
+      ) {
         try {
           const env = wrapV1AsV2(item.environment_config as Parameters<typeof wrapV1AsV2>[0]);
           if (env) validateRepoEnvironmentLifecyclePolicy(env, mode, 'legacy repo environment');


### PR DESCRIPTION
## Summary

Fixes local repository registration when the checkout does not define a `.agor.yml` environment file.

When no `.agor.yml` exists, the local repo add flow passes `environment: undefined`. The repo environment policy hook treated the field's presence as enough reason to validate it, which sent `undefined` into the environment validator and produced `Expected a mapping (object)`.

This change treats `undefined` like an absent environment payload while preserving validation for any present value, including invalid shapes.

Closes #1504.

## Validation

```bash
pnpm --dir apps/agor-daemon test register-hooks.test.ts
```

I also verified the original local repo add flow succeeds after the fix with a checkout that has no `.agor.yml`.
