### PR TITLE
Fix assistant bootstrap template rendering

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1452,6 +1452,13 @@ export const App: React.FC<AppProps> = ({
               artifactById={artifactById}
               onUpdateArtifact={onUpdateArtifact}
               onDeleteArtifact={onDeleteArtifact}
+              onCreateAssistant={() => {
+                closeSettings();
+                onSettingsClose?.();
+                setNewBranchDefaultPosition(null);
+                setCreateDialogDefaultTab('assistant');
+                setCreateDialogOpen(true);
+              }}
               branchStorageConfig={branchStorageConfig}
             />
             {sessionSettingsSession && (

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.test.tsx
@@ -1,0 +1,41 @@
+import type { Board, Branch, Repo, Session, User } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { AssistantsTable } from './AssistantsTable';
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repo_id: 'repo-1',
+    slug: 'preset-io/agor-assistant',
+    name: 'agor-assistant',
+    default_branch: 'main',
+    ...overrides,
+  } as Repo;
+}
+
+describe('AssistantsTable', () => {
+  it('delegates assistant creation to the shared create flow', () => {
+    const onCreateAssistant = vi.fn();
+    const repo = makeRepo();
+
+    renderWithProviders(
+      <AssistantsTable
+        branchById={new Map<string, Branch>()}
+        repoById={new Map([[repo.repo_id, repo]])}
+        boardById={new Map<string, Board>()}
+        sessionsByBranch={new Map<string, Session[]>()}
+        userById={new Map<string, User>()}
+        onCreateAssistant={onCreateAssistant}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Create Assistant/i }));
+
+    expect(onCreateAssistant).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -1,37 +1,11 @@
-import type {
-  AgorClient,
-  Board,
-  Branch,
-  CreateRepoRequest,
-  Repo,
-  Session,
-  User,
-} from '@agor-live/client';
+import type { Board, Branch, Repo, Session, User } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import { AimOutlined, EditOutlined, PlusOutlined, RobotOutlined } from '@ant-design/icons';
-import {
-  Button,
-  Empty,
-  Form,
-  Input,
-  Modal,
-  Popover,
-  Space,
-  Table,
-  Tooltip,
-  Typography,
-  theme,
-} from 'antd';
+import { Button, Empty, Input, Popover, Space, Table, Tooltip, Typography, theme } from 'antd';
 import { useCallback, useMemo, useState } from 'react';
-import { useAssistantForm } from '@/hooks/useAssistantForm';
-import { useEnsureFrameworkRepo } from '@/hooks/useEnsureFrameworkRepo';
-import { createAssistantBranch } from '@/utils/assistantCreation';
-import { mapToArray } from '@/utils/mapHelpers';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { ArchiveActionButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
-import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
-import { AssistantFormFields } from '../forms/AssistantFormFields';
 import { HighlightMatch } from '../HighlightMatch';
 import { MarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
 import { UserAvatar } from '../metadata/UserAvatar';
@@ -42,7 +16,6 @@ interface AssistantsTableProps {
   boardById: Map<string, Board>;
   sessionsByBranch: Map<string, Session[]>;
   userById: Map<string, User>;
-  client: AgorClient | null;
   onArchiveOrDelete?: (
     branchId: string,
     options: {
@@ -51,19 +24,7 @@ interface AssistantsTableProps {
     }
   ) => void;
   onRowClick?: (branch: Branch) => void;
-  onCreateBranch?: (
-    repoId: string,
-    data: {
-      name: string;
-      ref: string;
-      createBranch: boolean;
-      sourceBranch: string;
-      pullLatest: boolean;
-      boardId?: string;
-    }
-  ) => Promise<Branch | null>;
-  onUpdateBranch?: (branchId: string, updates: BranchUpdate) => void;
-  onCreateRepo?: (data: CreateRepoRequest) => void | Promise<void>;
+  onCreateAssistant?: () => void;
   /** Close the parent Settings modal so the canvas isn't obscured by
    *  it after recenter. Wired by SettingsModal. */
   onClose?: () => void;
@@ -75,16 +36,11 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
   boardById,
   sessionsByBranch,
   userById,
-  client,
   onArchiveOrDelete,
   onRowClick,
-  onCreateBranch,
-  onUpdateBranch,
-  onCreateRepo,
+  onCreateAssistant,
   onClose,
 }) => {
-  const repos = mapToArray(repoById);
-
   // Assistants ARE branches (just branches flagged via
   // `custom_context.assistant`), so navigation reuses the `/w/<short>/`
   // URL via `goToBranch` — no separate `/assistant/<short>/` route.
@@ -104,82 +60,10 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
   );
   const { token } = theme.useToken();
 
-  const [createModalOpen, setCreateModalOpen] = useState(false);
-
-  // Only auto-clone the framework repo when the create modal is open,
-  // so merely visiting the Assistants settings tab doesn't trigger a clone.
-  const { frameworkRepo, isCloning } = useEnsureFrameworkRepo(repos, onCreateRepo, {
-    enabled: createModalOpen,
-  });
-  const {
-    form,
-    isFormValid,
-    customRepoSelected,
-    setCustomRepoSelected,
-    validateForm,
-    handleDisplayNameChange,
-    resetForm,
-  } = useAssistantForm(frameworkRepo);
-  const [creating, setCreating] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
 
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
   const [selectedBranch, setSelectedBranch] = useState<Branch | null>(null);
-
-  const handleCreate = async () => {
-    try {
-      const values = await form.validateFields();
-      setCreating(true);
-
-      const repoId = values.repoId || frameworkRepo?.repo_id;
-      if (!repoId) {
-        form.setFields([
-          {
-            name: 'repoId',
-            errors: [
-              'Framework repository is still being registered. Please wait a moment and try again.',
-            ],
-          },
-        ]);
-        return;
-      }
-
-      if (!onCreateBranch || !onUpdateBranch) return;
-
-      const branch = await createAssistantBranch(
-        {
-          displayName: values.displayName.trim(),
-          description: values.description || undefined,
-          emoji: values.emoji || undefined,
-          repoId,
-          branchName: values.name || undefined,
-          sourceBranch: values.sourceBranch || undefined,
-        },
-        { client, repoById, onCreateBranch, onUpdateBranch }
-      );
-
-      setCreateModalOpen(false);
-      resetForm();
-
-      // Match the recenter-from-row behavior: close the Settings modal
-      // so the canvas isn't obscured, then push `/w/<short>/`. Cross-
-      // board switching (when the assistant landed on a freshly created
-      // board) is handled by useUrlState's URL→state effect.
-      if (branch) {
-        onClose?.();
-        navigation.goToBranch(branch.branch_id);
-      }
-    } catch (error) {
-      console.error('Assistant creation failed:', error);
-    } finally {
-      setCreating(false);
-    }
-  };
-
-  const handleCancel = () => {
-    setCreateModalOpen(false);
-    resetForm();
-  };
 
   const assistants = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
@@ -363,8 +247,8 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
           <Button
             type="primary"
             icon={<PlusOutlined />}
-            onClick={() => setCreateModalOpen(true)}
-            disabled={!frameworkRepo && repos.length === 0}
+            onClick={onCreateAssistant}
+            disabled={!onCreateAssistant}
           >
             Create Assistant
           </Button>
@@ -404,33 +288,6 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
           })}
         />
       )}
-
-      {/* Create Assistant Modal */}
-      <Modal
-        title="Create Assistant"
-        open={createModalOpen}
-        onOk={handleCreate}
-        onCancel={handleCancel}
-        okText="Create"
-        okButtonProps={{ disabled: !isFormValid, loading: creating }}
-      >
-        <Form
-          form={form}
-          layout="vertical"
-          onFieldsChange={validateForm}
-          initialValues={{ sourceBranch: 'main' }}
-        >
-          <AssistantFormFields
-            form={form}
-            repos={repos}
-            frameworkRepo={frameworkRepo}
-            isCloning={isCloning}
-            onDisplayNameChange={handleDisplayNameChange}
-            customRepoSelected={customRepoSelected}
-            onCustomRepoChange={setCustomRepoSelected}
-          />
-        </Form>
-      </Modal>
 
       {/* Archive/Delete Modal */}
       {selectedBranch && (

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -118,6 +118,7 @@ export interface SettingsModalProps {
   artifactById?: Map<string, Artifact>;
   onUpdateArtifact?: (artifactId: string, updates: Partial<Artifact>) => void;
   onDeleteArtifact?: (artifactId: string) => void;
+  onCreateAssistant?: () => void;
   branchStorageConfig?: BranchStorageConfig;
 }
 
@@ -164,6 +165,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   artifactById = new Map(),
   onUpdateArtifact,
   onDeleteArtifact,
+  onCreateAssistant,
   branchStorageConfig,
 }) => {
   const [selectedBranch, setSelectedBranch] = useState<Branch | null>(null);
@@ -401,12 +403,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             boardById={boardById}
             sessionsByBranch={sessionsByBranch}
             userById={userById}
-            client={client}
             onArchiveOrDelete={onArchiveOrDeleteBranch}
             onRowClick={handleBranchRowClick}
-            onCreateBranch={onCreateBranch}
-            onUpdateBranch={onUpdateBranch}
-            onCreateRepo={onCreateRepo}
+            onCreateAssistant={onCreateAssistant}
             onClose={onClose}
           />
         );

--- a/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/AssistantFormFields.tsx
@@ -17,8 +17,7 @@ export interface AssistantFormFieldsProps {
 }
 
 /**
- * Shared assistant form fields used in both the CreateDialog AssistantTab
- * and the SettingsModal AssistantsTable create modal.
+ * Shared assistant form fields used by the CreateDialog Assistant tab.
  *
  * Renders: Name + icon, assistant board advice Alert, Advanced collapse
  * (Framework Repository, Branch Name, Source Branch).

--- a/apps/agor-ui/src/hooks/useAssistantForm.ts
+++ b/apps/agor-ui/src/hooks/useAssistantForm.ts
@@ -4,8 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { slugify } from '@/utils/repoSlug';
 
 /**
- * Shared assistant form logic used by both CreateDialog's AssistantTab
- * and SettingsModal's AssistantsTable create modal.
+ * Shared assistant form logic used by CreateDialog's Assistant tab.
  *
  * Encapsulates: form instance, validation, display-name-to-branch-name
  * auto-generation, framework repo auto-select, and custom repo tracking.

--- a/apps/agor-ui/src/hooks/useFrameworkRepo.ts
+++ b/apps/agor-ui/src/hooks/useFrameworkRepo.ts
@@ -42,7 +42,7 @@ function findBestFrameworkRepo(repos: Repo[]): Repo | undefined {
 /**
  * Detects the framework repository from a list of repos.
  * Prefers agor-assistant-private over the public repo.
- * Used by AssistantTab, AssistantsTable, and OnboardingWizard.
+ * Used by AssistantTab and OnboardingWizard.
  */
 export function useFrameworkRepo(repos: Repo[]): Repo | undefined {
   return useMemo(() => findBestFrameworkRepo(repos), [repos]);

--- a/apps/agor-ui/src/utils/assistantBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/assistantBootstrapPrompt.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-  ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE,
   buildAssistantBootstrapPrompt,
   buildAssistantBootstrapPromptContext,
 } from './assistantBootstrapPrompt';
 
 describe('buildAssistantBootstrapPrompt', () => {
-  it('renders the shared Handlebars template with assistant identity params', () => {
+  it('formats assistant identity params without browser-side Handlebars rendering', () => {
     const prompt = buildAssistantBootstrapPrompt({
       displayName: 'PR Reviewer',
       emoji: '🧐',
@@ -15,7 +14,6 @@ describe('buildAssistantBootstrapPrompt', () => {
       userEmail: 'max@example.com',
     });
 
-    expect(ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE).toContain('{{assistant.displayName}}');
     expect(prompt).toContain('### First boot instructions for Agor Assistant');
     expect(prompt).toContain('- Assistant: PR Reviewer 🧐');
     expect(prompt).toContain('- Assistant description: Reviews pull requests');
@@ -23,9 +21,10 @@ describe('buildAssistantBootstrapPrompt', () => {
     expect(prompt).toContain('- User: Max <max@example.com>\n\nRead BOOTSTRAP.md');
     expect(prompt).toContain('ask only the next useful questions');
     expect(prompt).not.toContain("don't re-ask");
+    expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
   });
 
-  it('normalizes fallback identity values in the template context', () => {
+  it('normalizes fallback identity values in the prompt context', () => {
     const context = buildAssistantBootstrapPromptContext({ displayName: '  ', emoji: null });
 
     expect(context).toEqual({
@@ -35,5 +34,15 @@ describe('buildAssistantBootstrapPrompt', () => {
       },
       firstSession: true,
     });
+  });
+
+  it('omits optional user and description lines when absent', () => {
+    const prompt = buildAssistantBootstrapPrompt({ displayName: 'Board Bot', emoji: '🧭' });
+
+    expect(prompt).toContain('- Assistant: Board Bot 🧭');
+    expect(prompt).not.toContain('Assistant description:');
+    expect(prompt).not.toContain('- User:');
+    expect(prompt).not.toContain('- User email:');
+    expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
   });
 });

--- a/apps/agor-ui/src/utils/assistantBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/assistantBootstrapPrompt.ts
@@ -1,5 +1,3 @@
-import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
-
 export interface AssistantBootstrapPromptInput {
   displayName: string;
   emoji?: string | null;
@@ -21,15 +19,33 @@ export interface AssistantBootstrapPromptContext {
   firstSession: true;
 }
 
-export const ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE = `### First boot instructions for Agor Assistant
+function formatAssistantBootstrapPrompt(context: AssistantBootstrapPromptContext): string {
+  const lines = [
+    '### First boot instructions for Agor Assistant',
+    '',
+    'Context:',
+    `- Assistant: ${context.assistant.displayName} ${context.assistant.emoji}`,
+  ];
 
-Context:
-- Assistant: {{assistant.displayName}} {{assistant.emoji}}
-{{#if assistant.description}}- Assistant description: {{assistant.description}}
-{{/if}}{{#if user.name}}- User: {{user.name}}{{#if user.email}} <{{user.email}}>{{/if}}
-{{else}}{{#if user.email}}- User email: {{user.email}}
-{{/if}}{{/if}}
-Read BOOTSTRAP.md, then say hello and ask only the next useful questions to shape this assistant.`;
+  if (context.assistant.description) {
+    lines.push(`- Assistant description: ${context.assistant.description}`);
+  }
+
+  if (context.user?.name) {
+    lines.push(
+      `- User: ${context.user.name}${context.user.email ? ` <${context.user.email}>` : ''}`
+    );
+  } else if (context.user?.email) {
+    lines.push(`- User email: ${context.user.email}`);
+  }
+
+  lines.push('');
+  lines.push(
+    'Read BOOTSTRAP.md, then say hello and ask only the next useful questions to shape this assistant.'
+  );
+
+  return lines.join('\n');
+}
 
 export function buildAssistantBootstrapPromptContext({
   displayName,
@@ -62,14 +78,12 @@ export function buildAssistantBootstrapPromptContext({
 /**
  * First prompt for a newly-created Assistant branch.
  *
- * Shared by onboarding and the board plus-button creation flow. The prompt is
- * intentionally a Handlebars template so both flows pass the same assistant
- * identity params through one rendering path.
+ * Shared by onboarding, the board plus-button creation flow, and Settings →
+ * Assistants creation. Keep this deterministic in the browser instead of
+ * using the shared Handlebars renderer: browser-side Handlebars compilation
+ * relies on `new Function`, which can violate CSP. Rich user-authored
+ * template rendering should go through the daemon `/templates` service.
  */
 export function buildAssistantBootstrapPrompt(input: AssistantBootstrapPromptInput): string {
-  return renderTemplate(
-    ASSISTANT_BOOTSTRAP_PROMPT_TEMPLATE,
-    buildAssistantBootstrapPromptContext(input) as unknown as Record<string, unknown>,
-    { onError: 'raw' }
-  );
+  return formatAssistantBootstrapPrompt(buildAssistantBootstrapPromptContext(input));
 }

--- a/apps/agor-ui/src/utils/assistantCreation.ts
+++ b/apps/agor-ui/src/utils/assistantCreation.ts
@@ -34,8 +34,7 @@ export interface AssistantCreationDeps {
 }
 
 /**
- * Shared assistant creation logic used by both the CreateDialog (via App.tsx)
- * and the SettingsModal AssistantsTable.
+ * Shared assistant creation logic used by CreateDialog (via App.tsx).
  *
  * Flow: resolve repo → create board → create branch → tag branch with
  * assistant metadata → designate the branch as the board primary.


### PR DESCRIPTION
## Summary
- Render assistant bootstrap prompts through a shared deterministic formatter so board `+` assistant creation cannot leak raw `{{assistant...}}`/`{{user...}}` placeholders.
- Keep browser bootstrap formatting CSP-safe by avoiding browser-side Handlebars imports; user-authored template rendering remains behind the daemon template boundary.
- Reuse the shared `CreateDialog` Assistant tab for Settings → Assistants creation, removing the duplicated Settings-only create modal.
- Add focused tests for the bootstrap prompt and Settings assistant create entrypoint.

## Checks
- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- assistantBootstrapPrompt.test.ts AssistantsTable.test.tsx CreateDialog.test.tsx`
- `pnpm exec biome check apps/agor-ui/src/utils/assistantBootstrapPrompt.ts apps/agor-ui/src/utils/assistantBootstrapPrompt.test.ts apps/agor-ui/src/components/forms/AssistantFormFields.tsx apps/agor-ui/src/hooks/useAssistantForm.ts apps/agor-ui/src/utils/assistantCreation.ts apps/agor-ui/src/hooks/useFrameworkRepo.ts`