### PR TITLE
Fix archived branch route rehydration

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -862,12 +862,21 @@ export const App: React.FC<AppProps> = ({
   const selectedSessionBranch = selectedSession ? branchById.get(selectedSession.branch_id) : null;
 
   // Sync the actual state when a session disappears (for URL, localStorage, etc.).
-  // The rendering already uses effectiveSelectedSessionId so this is cosmetic.
+  // The rendering already uses effectiveSelectedSessionId so this is mostly
+  // cosmetic, but URL cleanup is load-bearing: if the address bar remains on
+  // `/s/<id>/` after archiving the selected branch/session, the direct
+  // archived-session fallback treats that stale URL like an explicit deep link
+  // and can rehydrate the archived session into local state. Replace the route
+  // with the current board before clearing selection so archive/delete closes
+  // the drawer and does not resurrect the card.
   useEffect(() => {
     if (selectedSessionId && !sessionById.has(selectedSessionId)) {
+      if (routeParams.sessionShortId && currentBoardId) {
+        navigation.goToBoard(currentBoardId, { replace: true });
+      }
       setSelectedSessionId(null);
     }
-  }, [selectedSessionId, sessionById]);
+  }, [currentBoardId, navigation, routeParams.sessionShortId, selectedSessionId, sessionById]);
 
   const sessionSettingsSession = sessionSettingsId ? sessionById.get(sessionSettingsId) : null;
   const primaryAssistantId = currentBoard?.primary_assistant_id ?? null;

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -130,7 +130,7 @@ async function waitForInitialLoad(result: { current: ReturnType<typeof useAgorDa
 }
 
 describe('useAgorData — socket-event bailouts', () => {
-  it('hydrates a direct archived session and its archived branch by id without broadening active lists', async () => {
+  it('hydrates a direct archived session by id without broadening active board lists', async () => {
     const archivedSession = makeSession({
       session_id: 's-archived-full',
       branch_id: 'b-archived',
@@ -157,13 +157,8 @@ describe('useAgorData — socket-event bailouts', () => {
       archived: true,
       branch_id: 'b-archived',
     });
-    expect(result.current.sessionsByBranch.get('b-archived')?.map((s) => s.session_id)).toEqual([
-      's-archived-full',
-    ]);
-    expect(result.current.branchById.get('b-archived')).toMatchObject({
-      archived: true,
-      board_id: 'board-archived',
-    });
+    expect(result.current.sessionsByBranch.has('b-archived')).toBe(false);
+    expect(result.current.branchById.has('b-archived')).toBe(false);
   });
 
   it('drops a duplicate `sessions.patched` (content-equal) without changing byId references', async () => {

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -20,7 +20,7 @@ import type {
   Session,
   User,
 } from '@agor-live/client';
-import { PAGINATION } from '@agor-live/client';
+import { findByShortIdPrefix, PAGINATION } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createInitialLoadDebugTimer, isInitialLoadDebugEnabled } from '../utils/initialLoadDebug';
 import { shallowEqualEntity } from '../utils/shallowEqual';
@@ -262,6 +262,19 @@ function removeBoardObjectFromMaps(prev: DataMaps, boardObject: BoardEntityObjec
     boardObjectByBranchId,
     boardObjectByCardId,
   };
+}
+
+function hasIdMatchingPrefix<T>(
+  prefix: string,
+  entries: Iterable<T>,
+  getId: (entry: T) => string
+): boolean {
+  return (
+    findByShortIdPrefix(
+      prefix,
+      Array.from(entries, (entry) => ({ id: getId(entry) }))
+    ).length > 0
+  );
 }
 
 /**
@@ -512,10 +525,12 @@ export function useAgorData(
 
         // Direct /s/<id>/ opens should work for archived sessions without broadening
         // the default active-session list. If the active query missed the URL target,
-        // fetch just that session (and its branch if necessary) by ID/short ID.
+        // fetch just that session by ID/short ID. Its branch is only hydrated when
+        // it is still active; adding archived branches to `branchById` would make
+        // board-object joins render archived cards back onto active boards.
         if (
           directSessionId &&
-          !sessionsList.some((s) => s.session_id.startsWith(directSessionId))
+          !hasIdMatchingPrefix(directSessionId, sessionsList, (s) => s.session_id)
         ) {
           try {
             const directSession = (await client
@@ -525,6 +540,7 @@ export function useAgorData(
               sessionsList.push(directSession);
             }
             if (
+              !directSession.archived &&
               directSession.branch_id &&
               !branchesList.some((branch) => branch.branch_id === directSession.branch_id)
             ) {
@@ -532,7 +548,9 @@ export function useAgorData(
                 const directBranch = (await client
                   .service('branches')
                   .get(directSession.branch_id)) as Branch;
-                branchesList.push(directBranch);
+                if (!directBranch.archived) {
+                  branchesList.push(directBranch);
+                }
               } catch {
                 // The session can still open; it just won't be able to switch/recenter
                 // if the branch is inaccessible or gone.
@@ -570,7 +588,11 @@ export function useAgorData(
           // sessionById: O(1) ID lookups
           sessionsById.set(session.session_id, session);
 
-          // sessionsByBranch: O(1) branch-scoped filtering
+          // sessionsByBranch: O(1) branch-scoped filtering. Keep this as the
+          // active board/session list: a direct archived-session URL may add
+          // the archived session to sessionById so the drawer can open, but it
+          // must not reappear in branch cards or board assistants.
+          if (session.archived) continue;
           const branchId = session.branch_id;
           if (!sessionsByBranchId.has(branchId)) {
             sessionsByBranchId.set(branchId, []);
@@ -741,7 +763,7 @@ export function useAgorData(
   useEffect(() => {
     if (!client || !enabled || !hasInitiallyFetched || !directSessionId) return;
     if (maps.sessionById.has(directSessionId)) return;
-    if ([...maps.sessionById.values()].some((s) => s.session_id.startsWith(directSessionId))) {
+    if (hasIdMatchingPrefix(directSessionId, maps.sessionById.values(), (s) => s.session_id)) {
       return;
     }
 
@@ -757,21 +779,28 @@ export function useAgorData(
           next.set(directSession.session_id, directSession);
           return next;
         });
-        setSessionsByBranch((prev) => {
-          const branchSessions = prev.get(directSession.branch_id) || [];
-          if (branchSessions.some((s) => s.session_id === directSession.session_id)) return prev;
-          const next = new Map(prev);
-          next.set(directSession.branch_id, [...branchSessions, directSession]);
-          return next;
-        });
+        if (!directSession.archived) {
+          setSessionsByBranch((prev) => {
+            const branchSessions = prev.get(directSession.branch_id) || [];
+            if (branchSessions.some((s) => s.session_id === directSession.session_id)) return prev;
+            const next = new Map(prev);
+            next.set(directSession.branch_id, [...branchSessions, directSession]);
+            return next;
+          });
+        }
 
-        if (directSession.branch_id && !maps.branchById.has(directSession.branch_id)) {
+        if (
+          !directSession.archived &&
+          directSession.branch_id &&
+          !maps.branchById.has(directSession.branch_id)
+        ) {
           try {
             const directBranch = (await client
               .service('branches')
               .get(directSession.branch_id)) as Branch;
             if (cancelled) return;
             setBranchById((prev) => {
+              if (directBranch.archived) return prev;
               if (prev.has(directBranch.branch_id)) return prev;
               const next = new Map(prev);
               next.set(directBranch.branch_id, directBranch);

--- a/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
+++ b/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
@@ -138,6 +138,26 @@ describe('useUrlState — deferred session resolution', () => {
     expect(pathRef.current).toBe(`/s/${SESSION_SHORT}/`);
   });
 
+  it('opens a direct session URL even when the session branch is not in active branchById', () => {
+    const onSessionChange = vi.fn();
+    const onBoardChange = vi.fn();
+    const session = { session_id: SESSION_ID, branch_id: BRANCH_ID, archived: true } as Session;
+
+    const { pathRef } = renderAt(
+      `/s/${SESSION_SHORT}/`,
+      baseOptions({
+        sessionById: new Map([[session.session_id, session]]),
+        branchById: new Map(),
+        onSessionChange,
+        onBoardChange,
+      })
+    );
+
+    expect(onSessionChange).toHaveBeenCalledWith(SESSION_ID);
+    expect(onBoardChange).not.toHaveBeenCalled();
+    expect(pathRef.current).toBe(`/s/${SESSION_SHORT}/`);
+  });
+
   it('explicit session URLs win over an already-selected/restored session', () => {
     const onSessionChange = vi.fn();
     const onBoardChange = vi.fn();

--- a/apps/agor-ui/src/hooks/useUrlState.ts
+++ b/apps/agor-ui/src/hooks/useUrlState.ts
@@ -317,7 +317,12 @@ export function useUrlState(options: UseUrlStateOptions) {
 
     // Wait for required data to load before resolving
     if (urlBoardParam && boardById.size === 0) return;
-    if (urlSessionShortId && (sessionById.size === 0 || branchById.size === 0)) return;
+    // Session URLs only require the session itself to resolve. The branch is
+    // best-effort metadata for board switching/recentering; direct links to
+    // archived sessions intentionally do not hydrate archived branches into
+    // the active `branchById` map, otherwise archived cards would reappear on
+    // boards via board-object joins.
+    if (urlSessionShortId && sessionById.size === 0) return;
     if (urlBranchShortId && branchById.size === 0) return;
     if (urlArtifactShortId && artifactById.size === 0) return;
 
@@ -331,6 +336,8 @@ export function useUrlState(options: UseUrlStateOptions) {
     if (urlBoardParam) {
       resolvedBoardId = resolveBoardFromUrl(urlBoardParam);
       if (resolvedBoardId) urlParamsResolvedRef.current.board = true;
+    } else {
+      urlParamsResolvedRef.current.board = true;
     }
 
     if (urlSessionShortId) {


### PR DESCRIPTION
## Summary
- replace stale /s/<id>/ routes with the current board route when the selected session disappears after branch/session archive or delete
- keep direct archived-session hydration out of active branch/session board maps so archived cards are not resurrected
- allow direct archived session URLs to open without hydrating archived branches into active board state

## Tests
- pnpm --filter agor-ui exec biome check src/hooks/useAgorData.ts src/hooks/useAgorData.test.tsx src/hooks/useUrlState.ts src/hooks/useUrlState.integration.test.tsx src/components/App/App.tsx
- pnpm --filter agor-ui test -- src/hooks/useAgorData.test.tsx src/hooks/useUrlState.integration.test.tsx