### PR TITLE
fix(ui): format board locator icon changes

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -409,9 +409,18 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         }
       >
         {(hovered) => (
-          <div style={sessionRowStyle(session)} onClick={() => onSessionClick?.(session.session_id)}>
-            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
-              {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+          <div
+            style={sessionRowStyle(session)}
+            onClick={() => onSessionClick?.(session.session_id)}
+          >
+            <div
+              style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}
+            >
+              {isActive ? (
+                <Spin size="small" />
+              ) : (
+                <ToolIcon tool={session.agentic_tool} size={20} />
+              )}
               <SessionRelationshipIcon session={session} size={10} />
               <div style={{ flex: 1, minWidth: 0 }}>
                 {renderSessionTitle(session, { strong: true, query })}
@@ -489,7 +498,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             }}
           >
             <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
-              {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
+              {isActive ? (
+                <Spin size="small" />
+              ) : (
+                <ToolIcon tool={session.agentic_tool} size={20} />
+              )}
               <SessionRelationshipIcon session={session} size={10} />
               {renderSessionTitle(session, { strong: true })}
               <BranchBoardLocatorIcon

--- a/apps/agor-ui/src/components/SessionPanel/ChildSessionsSection.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/ChildSessionsSection.tsx
@@ -6,8 +6,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAppLiveData } from '../../contexts/AppDataContext';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
-import { buildSessionTree, type SessionTreeNode } from '../BranchCard/buildSessionTree';
 import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
+import { buildSessionTree, type SessionTreeNode } from '../BranchCard/buildSessionTree';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import { ToolIcon } from '../ToolIcon';
 


### PR DESCRIPTION
## Summary\n- Apply Biome formatting/import order to the board locator icon changes from PR #1491.\n- No behavior changes; keeps hover-only locator icon and session-panel click behavior intact.\n\n## Checks\n- pnpm exec biome check apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx apps/agor-ui/src/components/SessionPanel/ChildSessionsSection.tsx\n- pnpm lint\n- pnpm check\n- pnpm check:agor-live-deps\n- pnpm turbo run test --filter=agor-ui --filter=@agor/daemon --filter=@agor/core (attempted; local run hit unrelated long-running/failing tests in core/daemon, killed after UI tests had passed)\n\nFixes CI lint failure on #1491.