### PR TITLE
fix(ui): restore board card drag handles

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -1,0 +1,47 @@
+import type { Branch, Repo } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import {
+  REACT_FLOW_DRAG_HANDLE_SELECTOR,
+  REACT_FLOW_NO_DRAG_CLASS,
+} from '../../utils/reactFlowDragClasses';
+import BranchCard from './BranchCard';
+
+const connected = {
+  connected: true,
+  connecting: false,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+
+describe('BranchCard drag handle', () => {
+  it('lets the branch title participate in the header drag handle', () => {
+    render(
+      <ConnectionProvider value={connected}>
+        <BranchCard
+          branch={
+            {
+              branch_id: 'branch-1',
+              name: 'feature/canvas-drag',
+              repo_id: 'repo-1',
+              path: '/tmp/feature-canvas-drag',
+              filesystem_status: 'ready',
+              archived: false,
+            } as unknown as Branch
+          }
+          repo={{ repo_id: 'repo-1', slug: 'preset-io/agor' } as unknown as Repo}
+          sessions={[]}
+          userById={new Map()}
+          client={null}
+        />
+      </ConnectionProvider>
+    );
+
+    const title = screen.getByText('feature/canvas-drag');
+
+    expect(title.closest(REACT_FLOW_DRAG_HANDLE_SELECTOR)).not.toBeNull();
+    expect(title.closest(`.${REACT_FLOW_NO_DRAG_CLASS}`)).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -13,6 +13,10 @@ import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
+import {
+  REACT_FLOW_DRAG_HANDLE_CLASS,
+  REACT_FLOW_NO_DRAG_CLASS,
+} from '../../utils/reactFlowDragClasses';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { ArchiveActionButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
@@ -320,13 +324,14 @@ const BranchCardComponent = ({
     >
       {/* Branch header */}
       <div
-        className={!inPopover && !panelMode ? 'drag-handle' : undefined}
+        className={!inPopover && !panelMode ? REACT_FLOW_DRAG_HANDLE_CLASS : undefined}
         style={{
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
           marginBottom: 12,
           gap: 8,
+          cursor: !inPopover && !panelMode ? 'grab' : undefined,
         }}
       >
         <div
@@ -340,7 +345,7 @@ const BranchCardComponent = ({
         >
           {!inPopover && (
             <div
-              className="drag-handle"
+              className={REACT_FLOW_DRAG_HANDLE_CLASS}
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -380,7 +385,6 @@ const BranchCardComponent = ({
               // available in the branch settings modal for power users.
               <Typography.Title
                 level={4}
-                className="nodrag"
                 style={{ margin: 0, fontWeight: 600 }}
                 ellipsis={{ tooltip: assistantConfig?.displayName ?? branch.name }}
               >
@@ -388,7 +392,7 @@ const BranchCardComponent = ({
               </Typography.Title>
             ) : (
               <>
-                <Typography.Text strong className="nodrag" ellipsis={{ tooltip: branch.name }}>
+                <Typography.Text strong ellipsis={{ tooltip: branch.name }}>
                   {branch.name}
                 </Typography.Text>
                 <Typography.Text
@@ -420,7 +424,7 @@ const BranchCardComponent = ({
                   e.stopPropagation();
                   onUnpin?.(branch.branch_id);
                 }}
-                className="nodrag"
+                className={REACT_FLOW_NO_DRAG_CLASS}
               />
             </Tooltip>
           )}
@@ -428,12 +432,12 @@ const BranchCardComponent = ({
             <Button
               type="text"
               icon={<DragOutlined style={{ fontSize: 16 }} />}
-              className="drag-handle"
+              className={REACT_FLOW_DRAG_HANDLE_CLASS}
               title="Drag to reposition"
               style={{ cursor: 'grab', padding: '4px 8px' }}
             />
           )}
-          <div className="nodrag">
+          <div className={REACT_FLOW_NO_DRAG_CLASS}>
             {onOpenTerminal && (
               <Button
                 type="text"
@@ -478,7 +482,7 @@ const BranchCardComponent = ({
       </div>
 
       {/* Branch metadata - all pills on one row with wrapping */}
-      <div className="nodrag" style={{ marginBottom: 8 }}>
+      <div className={REACT_FLOW_NO_DRAG_CLASS} style={{ marginBottom: 8 }}>
         <Space size={4} wrap>
           {branch.created_by && (
             <CreatedByTag
@@ -508,7 +512,7 @@ const BranchCardComponent = ({
 
       {/* Notes */}
       {branch.notes && (
-        <div className="nodrag" style={{ marginBottom: 8 }}>
+        <div className={REACT_FLOW_NO_DRAG_CLASS} style={{ marginBottom: 8 }}>
           <div
             className="markdown-compact"
             style={{
@@ -546,7 +550,7 @@ const BranchCardComponent = ({
       )}
 
       {/* Sessions & Scheduled Runs - composable content shared with the assistant panel */}
-      <div className="nodrag">
+      <div className={REACT_FLOW_NO_DRAG_CLASS}>
         <BranchSessionSections
           branch={branch}
           sessions={sessions}

--- a/apps/agor-ui/src/components/CardNode/CardNode.drag.test.tsx
+++ b/apps/agor-ui/src/components/CardNode/CardNode.drag.test.tsx
@@ -1,0 +1,31 @@
+import type { CardWithType } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  REACT_FLOW_DRAG_HANDLE_SELECTOR,
+  REACT_FLOW_NO_DRAG_CLASS,
+} from '../../utils/reactFlowDragClasses';
+import CardNode from './CardNode';
+
+describe('CardNode drag handle', () => {
+  it('makes the card header, not just the small drag icon, a drag handle', () => {
+    render(
+      <CardNode
+        data={{
+          card: {
+            card_id: 'card-1',
+            title: 'Planning card',
+            effective_color: '#1677ff',
+            effective_emoji: '📝',
+            archived: false,
+          } as unknown as CardWithType,
+        }}
+      />
+    );
+
+    const title = screen.getByText('Planning card');
+
+    expect(title.closest(REACT_FLOW_DRAG_HANDLE_SELECTOR)).not.toBeNull();
+    expect(title.closest(`.${REACT_FLOW_NO_DRAG_CLASS}`)).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/CardNode/CardNode.tsx
+++ b/apps/agor-ui/src/components/CardNode/CardNode.tsx
@@ -24,6 +24,10 @@ function isSafeUrl(url: string): boolean {
 }
 
 import React, { useMemo, useState } from 'react';
+import {
+  REACT_FLOW_DRAG_HANDLE_CLASS,
+  REACT_FLOW_NO_DRAG_CLASS,
+} from '../../utils/reactFlowDragClasses';
 import { ensureColorVisible } from '../../utils/theme';
 
 const DESCRIPTION_MAX_CHARS = 100;
@@ -83,11 +87,13 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
     >
       {/* Header: emoji + title + link + pin + drag */}
       <div
+        className={REACT_FLOW_DRAG_HANDLE_CLASS}
         style={{
           display: 'flex',
           alignItems: 'center',
           gap: 8,
           padding: '10px 12px',
+          cursor: 'grab',
           borderBottom:
             card.description || card.note ? `1px solid ${token.colorBorderSecondary}` : 'none',
         }}
@@ -114,7 +120,7 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className="nodrag"
+            className={REACT_FLOW_NO_DRAG_CLASS}
             style={{ color: token.colorTextSecondary, flexShrink: 0 }}
           >
             <LinkOutlined style={{ fontSize: 12 }} />
@@ -134,7 +140,7 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
                 e.stopPropagation();
                 onUnpin?.(card.card_id);
               }}
-              className="nodrag"
+              className={REACT_FLOW_NO_DRAG_CLASS}
               style={{ flexShrink: 0, width: 24, height: 24, padding: 0 }}
             />
           </Tooltip>
@@ -143,7 +149,7 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
           type="text"
           size="small"
           icon={<DragOutlined />}
-          className="drag-handle"
+          className={REACT_FLOW_DRAG_HANDLE_CLASS}
           style={{ cursor: 'grab', flexShrink: 0, width: 24, height: 24, padding: 0 }}
         />
       </div>
@@ -151,7 +157,7 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
       {/* Description (collapsed) */}
       {card.description && (
         <div
-          className="nodrag"
+          className={REACT_FLOW_NO_DRAG_CLASS}
           style={{
             padding: '8px 12px',
             borderBottom: card.note ? `1px solid ${token.colorBorderSecondary}` : 'none',

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -63,6 +63,7 @@ import {
 import { useMutationGate } from '../../contexts/ConnectionContext';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
 import type { AgenticToolOption } from '../../types';
+import { REACT_FLOW_DRAG_HANDLE_SELECTOR } from '../../utils/reactFlowDragClasses';
 import { sanitizeBoardCss } from '../../utils/sanitizeCss';
 import { isDarkTheme } from '../../utils/theme';
 import { AutocompleteTextarea } from '../AutocompleteTextarea/AutocompleteTextarea';
@@ -726,7 +727,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         nodes.push({
           id: branch.branch_id,
           type: 'branchNode',
-          dragHandle: '.drag-handle',
+          dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
           position, // When pinned (parentId set), this is relative to zone; otherwise absolute
           // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
           zIndex: 500, // Above zones, below comments
@@ -868,7 +869,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         nodes.push({
           id: `card-${cardId}`,
           type: 'cardNode',
-          dragHandle: '.drag-handle',
+          dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
           position,
           // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
           zIndex: 500, // Same level as branches

--- a/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
+++ b/apps/agor-ui/src/components/SessionCard/SessionCard.tsx
@@ -13,6 +13,10 @@ import {
 import { App, Button, Card, Collapse, Space, Typography } from 'antd';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { parseGitStateSha } from '../../utils/gitState';
+import {
+  REACT_FLOW_DRAG_HANDLE_CLASS,
+  REACT_FLOW_NO_DRAG_CLASS,
+} from '../../utils/reactFlowDragClasses';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { CreatedByTag } from '../metadata';
 import { Tag } from '../Tag';
@@ -134,7 +138,7 @@ const SessionCard = ({
     >
       {/* Session header — full-width drag handle */}
       <div
-        className="drag-handle"
+        className={REACT_FLOW_DRAG_HANDLE_CLASS}
         style={{
           display: 'flex',
           justifyContent: 'space-between',
@@ -143,17 +147,18 @@ const SessionCard = ({
         }}
       >
         <Space size={8} align="center">
-          <div className="drag-handle" style={{ display: 'flex', alignItems: 'center' }}>
+          <div
+            className={REACT_FLOW_DRAG_HANDLE_CLASS}
+            style={{ display: 'flex', alignItems: 'center' }}
+          >
             <ToolIcon tool={session.agentic_tool} size={32} />
           </div>
-          <Typography.Text strong className="nodrag">
-            {session.agentic_tool}
-          </Typography.Text>
+          <Typography.Text strong>{session.agentic_tool}</Typography.Text>
           <TaskStatusIcon status={session.status} size={16} />
         </Space>
 
         <Space size={4}>
-          <div className="nodrag">
+          <div className={REACT_FLOW_NO_DRAG_CLASS}>
             {isForked && session.fork_origin === 'btw' ? (
               <Tag icon={<ForkOutlined />} color="orange">
                 BTW
@@ -186,11 +191,11 @@ const SessionCard = ({
           <Button
             type="text"
             icon={<DragOutlined style={{ fontSize: 16 }} />}
-            className="drag-handle"
+            className={REACT_FLOW_DRAG_HANDLE_CLASS}
             title="Drag to reposition"
             style={{ cursor: 'grab', padding: '4px 8px' }}
           />
-          <div className="nodrag">
+          <div className={REACT_FLOW_NO_DRAG_CLASS}>
             {onSessionClick && (
               <Button
                 type="text"
@@ -234,7 +239,7 @@ const SessionCard = ({
       </div>
 
       {/* Session metadata */}
-      <div className="nodrag">
+      <div className={REACT_FLOW_NO_DRAG_CLASS}>
         {/* Title/Description */}
         {(session.title || session.description) && (
           <Typography.Text
@@ -291,7 +296,7 @@ const SessionCard = ({
       </div>
 
       {/* Tasks - collapsible */}
-      <div className="nodrag">
+      <div className={REACT_FLOW_NO_DRAG_CLASS}>
         <Collapse
           defaultActiveKey={defaultExpanded ? ['tasks'] : []}
           items={[

--- a/apps/agor-ui/src/utils/reactFlowDragClasses.ts
+++ b/apps/agor-ui/src/utils/reactFlowDragClasses.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared React Flow class contract.
+ *
+ * React Flow starts a node drag only when the event target is inside
+ * `dragHandle`, and refuses drags from elements with its `nodrag` class.
+ * Keep the selector and class names in one place so card renderers, canvas
+ * node configuration, and tests don't drift.
+ */
+export const REACT_FLOW_DRAG_HANDLE_CLASS = 'drag-handle';
+export const REACT_FLOW_DRAG_HANDLE_SELECTOR = `.${REACT_FLOW_DRAG_HANDLE_CLASS}`;
+export const REACT_FLOW_NO_DRAG_CLASS = 'nodrag';


### PR DESCRIPTION
## Summary
- restore usable drag targets for branch/session card headers by letting non-interactive titles participate in the React Flow drag handle
- make custom board card headers a drag handle instead of requiring the tiny drag icon
- add regression tests for branch cards and custom card nodes so titles remain inside a drag handle and outside nodrag

Fixes #1473

## Checks
- pnpm --filter agor-ui test -- BranchCard.drag.test.tsx CardNode.drag.test.tsx
- pnpm --filter agor-ui lint

## Notes
- pnpm --filter agor-ui typecheck was attempted, but this clean worktree is missing built @agor-live/client/@agor/core dist type artifacts, so TypeScript reported workspace package resolution errors before reaching this change.