### PR TITLE
Normalize branch session title weight

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionPeekSection.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionPeekSection.tsx
@@ -50,7 +50,7 @@ export const BranchSessionPeekSection = React.memo<BranchSessionPeekSectionProps
               >
                 <Space size={6} align="center" style={{ minWidth: 0 }}>
                   <ToolIcon tool={session.agentic_tool} size={16} />
-                  <Typography.Text strong ellipsis style={{ maxWidth: 480, fontSize: 12 }}>
+                  <Typography.Text ellipsis style={{ maxWidth: 480, fontSize: 12 }}>
                     {getSessionDisplayTitle(session, { includeAgentFallback: true })}
                   </Typography.Text>
                 </Space>

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -413,7 +413,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             <SessionRelationshipIcon session={session} size={10} />
             <div style={{ flex: 1, minWidth: 0 }}>
-              {renderSessionTitle(session, { strong: true, query })}
+              {renderSessionTitle(session, { query })}
               {(sourceLabel || toolMatches) && (
                 <Typography.Text
                   type="secondary"
@@ -482,7 +482,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             <SessionRelationshipIcon session={session} size={10} />
-            {renderSessionTitle(session, { strong: true })}
+            {renderSessionTitle(session)}
             <BranchBoardLocatorIcon branch={branch} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Use default font weight for session titles in branch card session rows
- Use default font weight for peeked session titles
- Keep section headings, status indicators, selected/ready outlines, and pills unchanged

## Checks
- pnpm exec biome check apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx apps/agor-ui/src/components/BranchCard/BranchSessionPeekSection.tsx