### PR TITLE
Improve Slack gateway progress UX

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -23,7 +23,7 @@ environment:
     full:
       start: >-
         UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
-        branch.unique_id}} AGOR_RBAC_ENABLED=true AGOR_UNIX_USER_MODE=strict docker compose -f
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} AGOR_RBAC_ENABLED=true AGOR_UNIX_USER_MODE=strict docker compose -f
         docker-compose.yml -f docker-compose.override.postgres.yml -p agor-{{branch.name}}
         --profile postgres up -d --build
       stop: >-
@@ -40,7 +40,7 @@ environment:
     sqlite:
       start: >-
         UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
-        branch.unique_id}} SEED=true docker compose -p agor-{{branch.name}} up -d --build
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} SEED=true docker compose -p agor-{{branch.name}} up -d --build
       stop: docker compose -p agor-{{branch.name}} down
       description: Single-user dev with SQLite. No RBAC. Fastest to boot.
       nuke: docker compose -p agor-{{branch.name}} down -v
@@ -50,7 +50,7 @@ environment:
     postgres:
       start: >-
         UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
-        branch.unique_id}} SEED=true docker compose -f docker-compose.yml -f
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} SEED=true docker compose -f docker-compose.yml -f
         docker-compose.override.postgres.yml -p agor-{{branch.name}} --profile postgres up -d
         --build
       stop: >-

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -49,6 +49,24 @@ function extractLatestToolUse(content: Message['content']): GatewayToolUse | nul
   return null;
 }
 
+function extractLatestToolUseFromMessage(message: Message): GatewayToolUse | null {
+  const fromContent = extractLatestToolUse(message.content);
+  if (fromContent) return fromContent;
+
+  const toolUses = message.tool_uses;
+  if (!Array.isArray(toolUses) || toolUses.length === 0) return null;
+
+  const latest = toolUses[toolUses.length - 1];
+  if (!latest || typeof latest.name !== 'string') return null;
+  return {
+    name: latest.name,
+    input:
+      latest.input && typeof latest.input === 'object' && !Array.isArray(latest.input)
+        ? latest.input
+        : {},
+  };
+}
+
 /**
  * After hook that routes messages through the gateway.
  * Routes:
@@ -64,7 +82,7 @@ export const gatewayRouteHook = async (context: HookContext) => {
   // Determine if message should be routed to gateway
   let shouldRoute = false;
   let messageText = extractText(message.content);
-  const latestToolUse = extractLatestToolUse(message.content);
+  const latestToolUse = extractLatestToolUseFromMessage(message);
 
   // Tool calls are valuable for the mutable Slack status row: current tool +
   // TodoWrite plan. Some agent SDKs include text and tool_use blocks in the

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -111,6 +111,9 @@ export const gatewayRouteHook = async (context: HookContext) => {
   }
 
   if (message.role === 'assistant') {
+    if (gatewayService.wasMessageStreamedToSlack?.(message.message_id)) {
+      return context;
+    }
     // Always route assistant messages
     shouldRoute = true;
   } else if (message.role === 'user') {

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -83,6 +83,10 @@ export const gatewayRouteHook = async (context: HookContext) => {
     return context;
   }
 
+  if (!messageText && message.role === 'assistant' && typeof message.content_preview === 'string') {
+    messageText = message.content_preview;
+  }
+
   if (message.role === 'assistant') {
     // Always route assistant messages
     shouldRoute = true;

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -111,7 +111,10 @@ export const gatewayRouteHook = async (context: HookContext) => {
   }
 
   if (message.role === 'assistant') {
-    if (gatewayService.wasMessageStreamedToSlack?.(message.message_id)) {
+    if (
+      gatewayService.wasMessageStreamedToSlack?.(message.message_id) ||
+      gatewayService.wasTaskStreamedToSlack?.(message.task_id)
+    ) {
       return context;
     }
     // Always route assistant messages

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -9,6 +9,11 @@
 import type { ContentBlock, HookContext, Message } from '@agor/core/types';
 import type { GatewayService } from '../services/gateway';
 
+interface GatewayToolUse {
+  name: string;
+  input: Record<string, unknown>;
+}
+
 /**
  * Extract readable text from message content.
  * Handles string content, ContentBlock[] arrays, and other shapes gracefully.
@@ -27,6 +32,23 @@ function extractText(content: Message['content']): string {
   return '';
 }
 
+function extractLatestToolUse(content: Message['content']): GatewayToolUse | null {
+  if (!Array.isArray(content)) return null;
+
+  for (let i = content.length - 1; i >= 0; i--) {
+    const block = content[i] as Record<string, unknown>;
+    if (block.type !== 'tool_use') continue;
+    if (typeof block.name !== 'string') continue;
+    const input =
+      block.input && typeof block.input === 'object' && !Array.isArray(block.input)
+        ? (block.input as Record<string, unknown>)
+        : {};
+    return { name: block.name, input };
+  }
+
+  return null;
+}
+
 /**
  * After hook that routes messages through the gateway.
  * Routes:
@@ -37,10 +59,29 @@ function extractText(content: Message['content']): string {
  */
 export const gatewayRouteHook = async (context: HookContext) => {
   const message = context.result as Message;
+  const gatewayService = context.app.service('gateway') as unknown as GatewayService;
 
   // Determine if message should be routed to gateway
   let shouldRoute = false;
   let messageText = extractText(message.content);
+  const latestToolUse = extractLatestToolUse(message.content);
+
+  // Tool-only rows should not be posted as normal chat messages, but they are
+  // valuable for the mutable Slack status row: current tool + TodoWrite plan.
+  if (!messageText && latestToolUse) {
+    try {
+      void gatewayService.updateProgress({
+        session_id: message.session_id,
+        state: 'working',
+        task_id: message.task_id,
+        tool_name: latestToolUse.name,
+        tool_input: latestToolUse.input,
+      });
+    } catch (error) {
+      console.warn('[gateway-route] Failed to route tool progress:', error);
+    }
+    return context;
+  }
 
   if (message.role === 'assistant') {
     // Always route assistant messages
@@ -84,10 +125,12 @@ export const gatewayRouteHook = async (context: HookContext) => {
     return context; // No text to route (tool-only messages, etc.)
   }
 
+  if (message.message_id && gatewayService.wasSlackMessageStreamed(message.message_id)) {
+    return context;
+  }
+
   // Fire-and-forget: route message through gateway
   try {
-    const gatewayService = context.app.service('gateway') as unknown as GatewayService;
-
     // Don't await — fire and forget
     gatewayService
       .routeMessage({

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -125,10 +125,6 @@ export const gatewayRouteHook = async (context: HookContext) => {
     return context; // No text to route (tool-only messages, etc.)
   }
 
-  if (message.message_id && gatewayService.wasSlackMessageStreamed(message.message_id)) {
-    return context;
-  }
-
   // Fire-and-forget: route message through gateway
   try {
     // Don't await — fire and forget

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -66,9 +66,11 @@ export const gatewayRouteHook = async (context: HookContext) => {
   let messageText = extractText(message.content);
   const latestToolUse = extractLatestToolUse(message.content);
 
-  // Tool-only rows should not be posted as normal chat messages, but they are
-  // valuable for the mutable Slack status row: current tool + TodoWrite plan.
-  if (!messageText && latestToolUse) {
+  // Tool calls are valuable for the mutable Slack status row: current tool +
+  // TodoWrite plan. Some agent SDKs include text and tool_use blocks in the
+  // same assistant message, so update progress whenever we see a tool call,
+  // not only for tool-only rows.
+  if (latestToolUse) {
     try {
       void gatewayService.updateProgress({
         session_id: message.session_id,
@@ -80,7 +82,10 @@ export const gatewayRouteHook = async (context: HookContext) => {
     } catch (error) {
       console.warn('[gateway-route] Failed to route tool progress:', error);
     }
-    return context;
+    // Tool-only rows should not be posted as normal chat messages.
+    if (!messageText) {
+      return context;
+    }
   }
 
   if (!messageText && message.role === 'assistant' && typeof message.content_preview === 'string') {

--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -32,6 +32,10 @@ function extractText(content: Message['content']): string {
   return '';
 }
 
+function isGatewayThinkingPlaceholder(text: string): boolean {
+  return /^thinking\s*\.{3}$/i.test(text.trim());
+}
+
 function extractLatestToolUse(content: Message['content']): GatewayToolUse | null {
   if (!Array.isArray(content)) return null;
 
@@ -84,8 +88,8 @@ export const gatewayRouteHook = async (context: HookContext) => {
   let messageText = extractText(message.content);
   const latestToolUse = extractLatestToolUseFromMessage(message);
 
-  // Tool calls are valuable for the mutable Slack status row: current tool +
-  // TodoWrite plan. Some agent SDKs include text and tool_use blocks in the
+  // Tool calls are valuable for Slack's native assistant status/stream: current
+  // tool + TodoWrite plan. Some agent SDKs include text and tool_use blocks in the
   // same assistant message, so update progress whenever we see a tool call,
   // not only for tool-only rows.
   if (latestToolUse) {
@@ -108,6 +112,10 @@ export const gatewayRouteHook = async (context: HookContext) => {
 
   if (!messageText && message.role === 'assistant' && typeof message.content_preview === 'string') {
     messageText = message.content_preview;
+  }
+
+  if (message.role === 'assistant' && messageText && isGatewayThinkingPlaceholder(messageText)) {
+    return context;
   }
 
   if (message.role === 'assistant') {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2392,9 +2392,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               try {
                 const gatewayService = context.app.service('gateway') as unknown as GatewayService;
                 await gatewayService.flushGitHubBuffer(session.session_id);
+                await gatewayService.updateProgress({
+                  session_id: session.session_id,
+                  state: 'done',
+                });
               } catch (error) {
                 console.warn(
-                  `[gateway] Failed to flush GitHub buffer for session ${shortId(session.session_id)}:`,
+                  `[gateway] Failed to flush gateway buffers/status for session ${shortId(session.session_id)}:`,
                   error
                 );
               }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -84,6 +84,7 @@ import type {
   TasksServiceImpl,
 } from './declarations.js';
 import { killExecutorProcess } from './executor-tracking.js';
+import type { GatewayService } from './services/gateway.js';
 import {
   ScheduleBusyError,
   ScheduleNotReadyError,
@@ -652,6 +653,17 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         params: RouteParams
       ) {
         app.service('messages').emit(data.event, data.data);
+        if (
+          data.event === 'streaming:start' ||
+          data.event === 'streaming:chunk' ||
+          data.event === 'streaming:end' ||
+          data.event === 'streaming:error'
+        ) {
+          void (app.service('gateway') as unknown as GatewayService).handleMessageStreamingEvent(
+            data.event,
+            data.data
+          );
+        }
         return { success: true };
       },
     },
@@ -674,6 +686,20 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       ) {
         const _ = params;
         app.service('tasks').emit(data.event, data.data);
+        if (data.event === 'tool:start') {
+          const sessionId =
+            typeof data.data.session_id === 'string' ? data.data.session_id : undefined;
+          const toolName =
+            typeof data.data.tool_name === 'string' ? data.data.tool_name : undefined;
+          if (sessionId) {
+            void (app.service('gateway') as unknown as GatewayService).updateProgress({
+              session_id: sessionId,
+              state: 'working',
+              task_id: typeof data.data.task_id === 'string' ? data.data.task_id : undefined,
+              tool_name: toolName,
+            });
+          }
+        }
         return { success: true };
       },
     },

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -170,6 +170,10 @@ interface RouteParams extends Params {
   user?: User;
 }
 
+function isServiceAccountRoute(params: RouteParams): boolean {
+  return (params.user as { _isServiceAccount?: boolean } | undefined)?._isServiceAccount === true;
+}
+
 /**
  * Type guard to check if result is paginated
  */
@@ -654,10 +658,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       ) {
         app.service('messages').emit(data.event, data.data);
         if (
-          data.event === 'streaming:start' ||
-          data.event === 'streaming:chunk' ||
-          data.event === 'streaming:end' ||
-          data.event === 'streaming:error'
+          isServiceAccountRoute(params) &&
+          (data.event === 'streaming:start' ||
+            data.event === 'streaming:chunk' ||
+            data.event === 'streaming:end' ||
+            data.event === 'streaming:error')
         ) {
           void (app.service('gateway') as unknown as GatewayService).handleMessageStreamingEvent(
             data.event,
@@ -684,9 +689,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         },
         params: RouteParams
       ) {
-        const _ = params;
         app.service('tasks').emit(data.event, data.data);
-        if (data.event === 'tool:start') {
+        if (isServiceAccountRoute(params) && data.event === 'tool:start') {
           const sessionId =
             typeof data.data.session_id === 'string' ? data.data.session_id : undefined;
           const toolName =

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -514,6 +514,51 @@ export class GatewayService {
     return [`*Plan*`, ...lines].join('\n');
   }
 
+  private buildSlackPlanBlock(todos: GatewayTodoItem[]): unknown {
+    const statusForSlack = (status: GatewayTodoItem['status']) => {
+      switch (status) {
+        case 'completed':
+          return 'complete';
+        case 'in_progress':
+          return 'in_progress';
+        case 'stopped':
+        case 'unknown':
+          return 'error';
+        default:
+          return 'pending';
+      }
+    };
+
+    const richText = (text: string) => ({
+      type: 'rich_text',
+      elements: [
+        {
+          type: 'rich_text_section',
+          elements: [{ type: 'text', text }],
+        },
+      ],
+    });
+
+    return {
+      type: 'plan',
+      title: { type: 'plain_text', text: 'Plan' },
+      tasks: todos.slice(0, 12).map((todo, index) => {
+        const activeForm =
+          todo.status === 'in_progress' &&
+          todo.activeForm &&
+          todo.activeForm.trim() !== todo.content.trim()
+            ? this.truncateSlackInline(todo.activeForm, 120)
+            : undefined;
+        return {
+          task_id: `todo_${index + 1}`,
+          title: this.truncateSlackInline(todo.content, 140),
+          status: statusForSlack(todo.status),
+          ...(activeForm ? { details: richText(activeForm) } : {}),
+        };
+      }),
+    };
+  }
+
   private buildSlackProgressText(
     data: GatewayProgressData,
     existingMetadata: Record<string, unknown>
@@ -585,9 +630,12 @@ export class GatewayService {
     const lastLine = lines.at(-1)?.trim();
     const progressLine = lastLine?.startsWith('⏳') ? lines.pop() : undefined;
     const detailText = lines.join('\n').trim();
+    const todos = this.parseGatewayTodos(metadata.slack_status_todos);
     const blocks: unknown[] = [];
 
-    if (detailText) {
+    if (todos.length > 0) {
+      blocks.push(this.buildSlackPlanBlock(todos));
+    } else if (detailText) {
       blocks.push({
         type: 'section',
         text: {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -497,33 +497,27 @@ export class GatewayService {
     };
 
     const lines = todos.slice(0, 12).map((todo) => {
-      const label =
-        todo.status === 'in_progress' && todo.activeForm ? todo.activeForm : todo.content;
-      return `${iconForStatus(todo.status)} ${this.truncateSlackInline(label, 120)}`;
+      const content = this.truncateSlackInline(todo.content, 90);
+      const activeForm =
+        todo.status === 'in_progress' &&
+        todo.activeForm &&
+        todo.activeForm.trim() !== todo.content.trim()
+          ? ` — ${this.truncateSlackInline(todo.activeForm, 50)}`
+          : '';
+      return `${iconForStatus(todo.status)} ${content}${activeForm}`;
     });
 
     if (todos.length > lines.length) {
       lines.push(`… ${todos.length - lines.length} more`);
     }
 
-    return [``, `*Plan*`, ...lines].join('\n');
+    return [`*Plan*`, ...lines].join('\n');
   }
 
   private buildSlackProgressText(
     data: GatewayProgressData,
     existingMetadata: Record<string, unknown>
   ): string {
-    const now = Date.now();
-    const startedAt =
-      typeof existingMetadata.slack_status_started_at === 'string'
-        ? Date.parse(existingMetadata.slack_status_started_at)
-        : now;
-    const elapsedSeconds = Math.max(0, Math.floor((now - startedAt) / 1000));
-    const elapsed =
-      elapsedSeconds < 60
-        ? `${elapsedSeconds}s`
-        : `${Math.floor(elapsedSeconds / 60)}m ${elapsedSeconds % 60}s`;
-
     if (data.state === 'queued') {
       const position =
         typeof data.queue_position === 'number' ? ` at position ${data.queue_position}` : '';
@@ -533,7 +527,7 @@ export class GatewayService {
     if (data.state === 'done') {
       const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
       const plan = this.formatSlackTodoPlan(todos);
-      return `✅ Done.${plan}`;
+      return plan;
     }
 
     if (data.state === 'failed') {
@@ -555,7 +549,8 @@ export class GatewayService {
 
     const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
     const plan = this.formatSlackTodoPlan(todos);
-    return `⏳ Still working (${elapsed}) · ${latestToolSummary}${plan}`;
+    const progress = `⏳ Still working · ${latestToolSummary}`;
+    return plan ? `${plan}\n${progress}` : progress;
   }
 
   private stripSlackProgressMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
@@ -586,19 +581,11 @@ export class GatewayService {
       );
     }
 
-    const [headline, ...details] = statusText.split('\n');
-    const detailText = details.join('\n').trim();
-    const blocks: unknown[] = [
-      {
-        type: 'context',
-        elements: [
-          {
-            type: 'mrkdwn',
-            text: markdownToMrkdwn(headline),
-          },
-        ],
-      },
-    ];
+    const lines = statusText.split('\n');
+    const lastLine = lines.at(-1)?.trim();
+    const progressLine = lastLine?.startsWith('⏳') ? lines.pop() : undefined;
+    const detailText = lines.join('\n').trim();
+    const blocks: unknown[] = [];
 
     if (detailText) {
       blocks.push({
@@ -607,6 +594,30 @@ export class GatewayService {
           type: 'mrkdwn',
           text: markdownToMrkdwn(detailText),
         },
+      });
+    }
+
+    if (progressLine) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: markdownToMrkdwn(progressLine),
+          },
+        ],
+      });
+    }
+
+    if (blocks.length === 0) {
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: markdownToMrkdwn(statusText || 'Done.'),
+          },
+        ],
       });
     }
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -929,6 +929,7 @@ export class GatewayService {
           hasContent: true,
           taskId: taskId ?? this.slackStreamTaskByMessage.get(messageId),
         });
+        this.markTaskStreamedToSlack(taskId ?? this.slackStreamTaskByMessage.get(messageId));
         return;
       }
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -798,22 +798,29 @@ export class GatewayService {
         }
       }
 
+      if (!isTerminal && data.state === 'working') {
+        try {
+          await this.ensureSlackTaskStream({
+            taskId: data.task_id,
+            threadId: mapping.thread_id,
+            connector,
+            metadata: metadataWithStart,
+          });
+        } catch (error) {
+          console.warn('[gateway] Failed to start Slack task stream:', error);
+        }
+      }
+
+      await this.threadMapRepo.updateMetadata(
+        mapping.id,
+        isTerminal
+          ? this.stripSlackProgressMetadata(metadataWithStart)
+          : this.stripSlackProgressMessageMetadata(metadataWithStart)
+      );
+
       if (!connector.setThreadStatus) return;
 
       try {
-        if (!isTerminal && data.state === 'working') {
-          try {
-            await this.ensureSlackTaskStream({
-              taskId: data.task_id,
-              threadId: mapping.thread_id,
-              connector,
-              metadata: metadataWithStart,
-            });
-          } catch (error) {
-            console.warn('[gateway] Failed to start Slack task stream:', error);
-          }
-        }
-
         const loadingMessage = this.buildSlackAssistantLoadingMessage(data, metadataWithStart);
         await connector.setThreadStatus({
           threadId: mapping.thread_id,
@@ -821,13 +828,6 @@ export class GatewayService {
           loadingMessages: loadingMessage ? [loadingMessage] : undefined,
           iconEmoji: ':hourglass_flowing_sand:',
         });
-
-        await this.threadMapRepo.updateMetadata(
-          mapping.id,
-          isTerminal
-            ? this.stripSlackProgressMetadata(metadataWithStart)
-            : this.stripSlackProgressMessageMetadata(metadataWithStart)
-        );
       } catch (error) {
         console.warn('[gateway] Failed to set Slack assistant status:', error);
       }

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -38,6 +38,7 @@ import type {
   Session,
   SessionID,
   Task,
+  ThreadSessionMap,
   User,
   UserID,
 } from '@agor/core/types';
@@ -315,7 +316,7 @@ export class GatewayService {
   private slackStreamedTaskIds = new Set<string>();
   private slackStreamTaskByMessage = new Map<string, string>();
   private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
-  private static SLACK_STREAM_STATUS_REFRESH_MS = 1000;
+  private static SLACK_STREAM_STATUS_REFRESH_MS = 300;
   private static SLACK_STREAMED_MESSAGE_CACHE_MAX = 500;
 
   constructor(db: Database, app: Application) {
@@ -379,6 +380,89 @@ export class GatewayService {
     const singleLine = value.replace(/\s+/g, ' ').trim();
     if (singleLine.length <= maxChars) return singleLine;
     return `${singleLine.slice(0, Math.max(0, maxChars - 1))}…`;
+  }
+
+  private formatSlackLoadingMessage(text: string): string {
+    // Slack validates loading_messages entries as strictly < 51 chars.
+    return this.truncateSlackInline(text, 50);
+  }
+
+  private makeSlackThreadIdForMessage(rootThreadId: string, messageTs: string): string | null {
+    const lastHyphen = rootThreadId.lastIndexOf('-');
+    if (lastHyphen === -1) return null;
+    const channelId = rootThreadId.slice(0, lastHyphen);
+    if (!channelId || !messageTs) return null;
+    return `${channelId}-${messageTs}`;
+  }
+
+  private async addSlackThreadAlias(
+    mapping: ThreadSessionMap,
+    messageTs: string,
+    reason: string
+  ): Promise<void> {
+    const aliasThreadId = this.makeSlackThreadIdForMessage(mapping.thread_id, messageTs);
+    if (!aliasThreadId || aliasThreadId === mapping.thread_id) return;
+
+    // Merge against fresh metadata so alias writes do not clobber platform
+    // context/active-thread fields written by the inbound path moments earlier.
+    const freshMapping = await this.threadMapRepo.findById(mapping.id);
+    const metadata = (((freshMapping ?? mapping).metadata as Record<string, unknown>) ??
+      {}) as Record<string, unknown>;
+    const aliases = Array.isArray(metadata.slack_thread_aliases)
+      ? metadata.slack_thread_aliases.filter((alias): alias is string => typeof alias === 'string')
+      : [];
+    if (aliases.includes(aliasThreadId)) return;
+
+    await this.threadMapRepo.updateMetadata(mapping.id, {
+      ...metadata,
+      slack_thread_aliases: [...aliases, aliasThreadId].slice(-50),
+      slack_thread_alias_last_reason: reason,
+    });
+  }
+
+  private getActiveSlackThreadId(mapping: ThreadSessionMap): string {
+    const metadata = ((mapping.metadata as Record<string, unknown>) ?? {}) as Record<
+      string,
+      unknown
+    >;
+    return typeof metadata.slack_active_thread_id === 'string'
+      ? metadata.slack_active_thread_id
+      : mapping.thread_id;
+  }
+
+  private pickSlackRoutingMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+    return {
+      ...(typeof metadata.slack_active_thread_id === 'string'
+        ? { slack_active_thread_id: metadata.slack_active_thread_id }
+        : {}),
+      ...(Array.isArray(metadata.slack_thread_aliases)
+        ? { slack_thread_aliases: metadata.slack_thread_aliases }
+        : {}),
+      ...(typeof metadata.slack_thread_alias_last_reason === 'string'
+        ? { slack_thread_alias_last_reason: metadata.slack_thread_alias_last_reason }
+        : {}),
+    };
+  }
+
+  private async findSlackThreadAliasMapping(
+    channelId: string | undefined,
+    threadId: string
+  ): Promise<ThreadSessionMap | null> {
+    const mappings = channelId
+      ? await this.threadMapRepo.findByChannel(channelId, 'active')
+      : (await this.threadMapRepo.findAll()).filter((mapping) => mapping.status === 'active');
+    return (
+      mappings.find((mapping) => {
+        const metadata = ((mapping.metadata as Record<string, unknown>) ?? {}) as Record<
+          string,
+          unknown
+        >;
+        return (
+          Array.isArray(metadata.slack_thread_aliases) &&
+          metadata.slack_thread_aliases.includes(threadId)
+        );
+      }) ?? null
+    );
   }
 
   private parseGatewayTodos(raw: unknown): GatewayTodoItem[] {
@@ -518,8 +602,8 @@ export class GatewayService {
     existingMetadata: Record<string, unknown>
   ): string | undefined {
     if (data.state === 'done') return undefined;
-    if (data.state === 'failed') return 'Agor ran into an error.';
-    if (data.state === 'queued') return 'Queued in Agor…';
+    if (data.state === 'failed') return this.formatSlackLoadingMessage('Agor ran into an error.');
+    if (data.state === 'queued') return this.formatSlackLoadingMessage('Queued in Agor…');
 
     const latestToolSummary =
       data.tool_name || data.tool_input
@@ -529,7 +613,7 @@ export class GatewayService {
           : undefined;
 
     if (latestToolSummary) {
-      return `Using ${this.truncateSlackInline(latestToolSummary.replace(/`/g, ''), 80)}…`;
+      return this.formatSlackLoadingMessage(`Using ${latestToolSummary.replace(/`/g, '')}…`);
     }
 
     const latestToolName =
@@ -539,10 +623,10 @@ export class GatewayService {
         : undefined);
 
     if (latestToolName) {
-      return `Using ${this.truncateSlackInline(latestToolName, 60)}…`;
+      return this.formatSlackLoadingMessage(`Using ${latestToolName}…`);
     }
 
-    return 'Working in Agor…';
+    return this.formatSlackLoadingMessage('Working in Agor…');
   }
 
   private stripSlackProgressMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
@@ -580,7 +664,8 @@ export class GatewayService {
       ...(taskId ? { task_id: taskId } : {}),
     };
     const loadingMessage =
-      this.buildSlackAssistantLoadingMessage(progress, metadata) ?? 'Writing response…';
+      this.buildSlackAssistantLoadingMessage(progress, metadata) ??
+      this.formatSlackLoadingMessage('Writing response…');
     await connector.setThreadStatus({
       threadId,
       status: this.buildSlackAssistantStatus(progress, metadata),
@@ -657,43 +742,6 @@ export class GatewayService {
       const oldest = this.slackStreamedTaskIds.values().next().value;
       if (oldest) this.slackStreamedTaskIds.delete(oldest);
     }
-  }
-
-  private async ensureSlackTaskStream(req: {
-    taskId: string | undefined;
-    threadId: string;
-    connector: GatewayConnector;
-    metadata: Record<string, unknown>;
-  }): Promise<void> {
-    if (!req.taskId || this.slackStreamsByTask.has(req.taskId)) return;
-
-    const streamConnector = req.connector as GatewayConnector & {
-      startStream?: (startReq: {
-        threadId: string;
-        text?: string;
-        recipientUserId?: string;
-        recipientTeamId?: string;
-      }) => Promise<string>;
-    };
-    if (!streamConnector.startStream) return;
-
-    const recipientUserId =
-      typeof req.metadata.slack_user_id === 'string' ? req.metadata.slack_user_id : undefined;
-    const recipientTeamId =
-      typeof req.metadata.slack_team_id === 'string' ? req.metadata.slack_team_id : undefined;
-
-    const ts = await streamConnector.startStream({
-      threadId: req.threadId,
-      text: ' ',
-      recipientUserId,
-      recipientTeamId,
-    });
-    this.slackStreamsByTask.set(req.taskId, {
-      threadId: req.threadId,
-      ts,
-      hasContent: false,
-      taskId: req.taskId,
-    });
   }
 
   private async stopSlackTaskStream(
@@ -798,32 +846,30 @@ export class GatewayService {
         }
       }
 
-      if (!isTerminal && data.state === 'working') {
-        try {
-          await this.ensureSlackTaskStream({
-            taskId: data.task_id,
-            threadId: mapping.thread_id,
-            connector,
-            metadata: metadataWithStart,
-          });
-        } catch (error) {
-          console.warn('[gateway] Failed to start Slack task stream:', error);
-        }
-      }
-
-      await this.threadMapRepo.updateMetadata(
-        mapping.id,
-        isTerminal
+      const freshMapping = await this.threadMapRepo.findById(mapping.id);
+      const freshMetadata = ((freshMapping?.metadata as Record<string, unknown>) ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const metadataForWrite = {
+        ...(isTerminal
           ? this.stripSlackProgressMetadata(metadataWithStart)
-          : this.stripSlackProgressMessageMetadata(metadataWithStart)
-      );
+          : this.stripSlackProgressMessageMetadata(metadataWithStart)),
+        ...this.pickSlackRoutingMetadata(freshMetadata),
+      };
+      const slackThreadId =
+        typeof metadataForWrite.slack_active_thread_id === 'string'
+          ? metadataForWrite.slack_active_thread_id
+          : mapping.thread_id;
+
+      await this.threadMapRepo.updateMetadata(mapping.id, metadataForWrite);
 
       if (!connector.setThreadStatus) return;
 
       try {
         const loadingMessage = this.buildSlackAssistantLoadingMessage(data, metadataWithStart);
         await connector.setThreadStatus({
-          threadId: mapping.thread_id,
+          threadId: slackThreadId,
           status: this.buildSlackAssistantStatus(data, metadataWithStart),
           loadingMessages: loadingMessage ? [loadingMessage] : undefined,
           iconEmoji: ':hourglass_flowing_sand:',
@@ -886,6 +932,7 @@ export class GatewayService {
         string,
         unknown
       >;
+      const slackThreadId = this.getActiveSlackThreadId(mapping);
       const recipientUserId =
         typeof metadata.slack_user_id === 'string' ? metadata.slack_user_id : undefined;
       const recipientTeamId =
@@ -901,21 +948,22 @@ export class GatewayService {
         const existing = this.slackStreamsByTask.get(taskKey);
         if (!existing) {
           const ts = await streamConnector.startStream({
-            threadId: mapping.thread_id,
+            threadId: slackThreadId,
             text: chunk,
             recipientUserId,
             recipientTeamId,
           });
           this.slackStreamsByTask.set(taskKey, {
-            threadId: mapping.thread_id,
+            threadId: slackThreadId,
             ts,
             hasContent: true,
             taskId: taskKey,
             lastMessageId: messageId,
           });
+          await this.addSlackThreadAlias(mapping, ts, 'stream');
           try {
             await this.refreshSlackAssistantStatusAfterStreamStart(
-              mapping.thread_id,
+              slackThreadId,
               connector,
               sessionId,
               taskKey,
@@ -940,7 +988,7 @@ export class GatewayService {
         });
         try {
           await this.refreshSlackAssistantStatusAfterStreamAppend(
-            mapping.thread_id,
+            existing.threadId,
             connector,
             sessionId,
             taskKey,
@@ -1023,17 +1071,40 @@ export class GatewayService {
     }
 
     // 2. Look up existing thread mapping
-    const existingMapping = await this.threadMapRepo.findByChannelAndThread(
+    let existingMapping = await this.threadMapRepo.findByChannelAndThread(
       channel.id,
       data.thread_id
     );
+    if (!existingMapping && channel.channel_type === 'slack') {
+      existingMapping = await this.findSlackThreadAliasMapping(channel.id, data.thread_id);
+      if (existingMapping) {
+        console.log(
+          `[gateway] Found Slack thread alias: ${data.thread_id} → ${existingMapping.thread_id}`
+        );
+      }
+    }
+    if (existingMapping && channel.channel_type === 'slack') {
+      console.log(
+        `[gateway] Slack inbound thread ${data.thread_id} → session ${shortId(existingMapping.session_id)} (root ${existingMapping.thread_id})`
+      );
+    }
 
     // 3. Cross-channel ownership check (MUST happen before any sendSystemMessage calls).
     // If this thread is owned by a DIFFERENT gateway channel on the same daemon,
     // silently drop the message — we must not interfere with another gateway's thread.
     // This covers all rejection paths: unmapped thread replies, user alignment failures, etc.
     if (!existingMapping) {
-      const otherChannelMapping = await this.threadMapRepo.findByThread(data.thread_id);
+      const exactThreadMapping = await this.threadMapRepo.findByThread(data.thread_id);
+      const aliasThreadMapping =
+        channel.channel_type === 'slack'
+          ? await this.findSlackThreadAliasMapping(undefined, data.thread_id)
+          : null;
+      const otherChannelMapping =
+        exactThreadMapping && exactThreadMapping.channel_id !== channel.id
+          ? exactThreadMapping
+          : aliasThreadMapping && aliasThreadMapping.channel_id !== channel.id
+            ? aliasThreadMapping
+            : null;
       if (otherChannelMapping) {
         console.log(
           `[gateway] IGNORED: Thread ${data.thread_id} owned by channel ${shortId(otherChannelMapping.channel_id)}, not ours (${shortId(channel.id)}). Silently dropping.`
@@ -1275,22 +1346,26 @@ export class GatewayService {
       // follow-up @mention creates a new "Processing..." comment and the flush
       // needs the latest comment ID. For Slack streaming, chat.startStream
       // requires the recipient user/team IDs for channel threads.
-      if (data.metadata) {
-        const existingMetadata = ((existingMapping.metadata as Record<string, unknown>) ?? {}) as
-          | Record<string, unknown>
-          | undefined;
-        await this.threadMapRepo.updateMetadata(existingMapping.id, {
-          ...existingMetadata,
-          ...(data.metadata.processing_comment_id
-            ? { processing_comment_id: data.metadata.processing_comment_id }
-            : {}),
-          ...(typeof data.metadata.slack_user_id === 'string'
-            ? { slack_user_id: data.metadata.slack_user_id }
-            : {}),
-          ...(typeof data.metadata.slack_team_id === 'string'
-            ? { slack_team_id: data.metadata.slack_team_id }
-            : {}),
-        });
+      const existingMetadata = ((existingMapping.metadata as Record<string, unknown>) ?? {}) as
+        | Record<string, unknown>
+        | undefined;
+      await this.threadMapRepo.updateMetadata(existingMapping.id, {
+        ...existingMetadata,
+        ...(data.metadata?.processing_comment_id
+          ? { processing_comment_id: data.metadata.processing_comment_id }
+          : {}),
+        ...(typeof data.metadata?.slack_user_id === 'string'
+          ? { slack_user_id: data.metadata.slack_user_id }
+          : {}),
+        ...(typeof data.metadata?.slack_team_id === 'string'
+          ? { slack_team_id: data.metadata.slack_team_id }
+          : {}),
+        ...(channel.channel_type === 'slack' ? { slack_active_thread_id: data.thread_id } : {}),
+      });
+      if (channel.channel_type === 'slack') {
+        console.log(
+          `[gateway] Slack active outbound thread for session ${shortId(sessionId)} set to ${data.thread_id}`
+        );
       }
 
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
@@ -1415,7 +1490,10 @@ export class GatewayService {
         session_id: session.session_id,
         branch_id: channel.target_branch_id,
         status: 'active',
-        metadata: data.metadata ?? null,
+        metadata:
+          channel.channel_type === 'slack'
+            ? { ...(data.metadata ?? {}), slack_active_thread_id: data.thread_id }
+            : (data.metadata ?? null),
       });
 
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
@@ -1599,17 +1677,20 @@ export class GatewayService {
       const { text, blocks } = normalizeOutbound(
         connector.formatMessage ? connector.formatMessage(data.message) : data.message
       );
+      const threadId =
+        channel.channel_type === 'slack' ? this.getActiveSlackThreadId(mapping) : mapping.thread_id;
 
-      await connector.sendMessage({
-        threadId: mapping.thread_id,
+      const sentTs = await connector.sendMessage({
+        threadId,
         text,
         blocks,
         metadata: data.metadata,
       });
+      if (channel.channel_type === 'slack') {
+        await this.addSlackThreadAlias(mapping, sentTs, 'message');
+      }
 
-      console.log(
-        `[gateway] Routed message to ${channel.channel_type} thread ${mapping.thread_id}`
-      );
+      console.log(`[gateway] Routed message to ${channel.channel_type} thread ${threadId}`);
     } catch (error) {
       console.error(`[gateway] Failed to route message to ${channel.channel_type}:`, error);
       return { routed: false, channelType: channel.channel_type };

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -303,11 +303,12 @@ export class GatewayService {
   private githubMessageBuffer = new Map<string, string>();
 
   /**
-   * Slack status updates use chat.update; keep a small in-memory throttle so
-   * rapid tool events don't trip Slack rate limits or create distracting UI
-   * flicker. Terminal states always bypass this throttle.
+   * Slack status updates are serialized and lightly throttled so concurrent
+   * tool/message hooks do not race while deleting/reposting the transient row.
+   * Terminal states always bypass this throttle.
    */
   private slackProgressLastUpdate = new Map<string, number>();
+  private slackProgressQueues = new Map<string, Promise<void>>();
   private slackStreamsByMessage = new Map<string, SlackStreamState>();
   private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
 
@@ -633,6 +634,20 @@ export class GatewayService {
    * transcript; Slack receives only a compact truncated preview.
    */
   async updateProgress(data: GatewayProgressData): Promise<void> {
+    const previous = this.slackProgressQueues.get(data.session_id) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(() => this.updateProgressNow(data));
+    this.slackProgressQueues.set(data.session_id, next);
+
+    try {
+      await next;
+    } finally {
+      if (this.slackProgressQueues.get(data.session_id) === next) {
+        this.slackProgressQueues.delete(data.session_id);
+      }
+    }
+  }
+
+  private async updateProgressNow(data: GatewayProgressData): Promise<void> {
     if (!this.hasActiveChannels) return;
 
     const mapping = await this.threadMapRepo.findBySession(data.session_id);

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -514,51 +514,6 @@ export class GatewayService {
     return [`*Plan*`, ...lines].join('\n');
   }
 
-  private buildSlackPlanBlock(todos: GatewayTodoItem[]): unknown {
-    const statusForSlack = (status: GatewayTodoItem['status']) => {
-      switch (status) {
-        case 'completed':
-          return 'complete';
-        case 'in_progress':
-          return 'in_progress';
-        case 'stopped':
-        case 'unknown':
-          return 'error';
-        default:
-          return 'pending';
-      }
-    };
-
-    const richText = (text: string) => ({
-      type: 'rich_text',
-      elements: [
-        {
-          type: 'rich_text_section',
-          elements: [{ type: 'text', text }],
-        },
-      ],
-    });
-
-    return {
-      type: 'plan',
-      title: { type: 'plain_text', text: 'Plan' },
-      tasks: todos.slice(0, 12).map((todo, index) => {
-        const activeForm =
-          todo.status === 'in_progress' &&
-          todo.activeForm &&
-          todo.activeForm.trim() !== todo.content.trim()
-            ? this.truncateSlackInline(todo.activeForm, 120)
-            : undefined;
-        return {
-          task_id: `todo_${index + 1}`,
-          title: this.truncateSlackInline(todo.content, 140),
-          status: statusForSlack(todo.status),
-          ...(activeForm ? { details: richText(activeForm) } : {}),
-        };
-      }),
-    };
-  }
-
   private buildSlackProgressText(
     data: GatewayProgressData,
     existingMetadata: Record<string, unknown>
@@ -630,12 +585,9 @@ export class GatewayService {
     const lastLine = lines.at(-1)?.trim();
     const progressLine = lastLine?.startsWith('⏳') ? lines.pop() : undefined;
     const detailText = lines.join('\n').trim();
-    const todos = this.parseGatewayTodos(metadata.slack_status_todos);
     const blocks: unknown[] = [];
 
-    if (todos.length > 0) {
-      blocks.push(this.buildSlackPlanBlock(todos));
-    } else if (detailText) {
+    if (detailText) {
       blocks.push({
         type: 'section',
         text: {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -345,11 +345,18 @@ export class GatewayService {
    * Send a debug/system message to the platform thread (fire-and-forget).
    * Useful for giving the user visibility into what's happening.
    */
-  private sendDebugMessage(channel: GatewayChannel, threadId: string, text: string): void {
-    // Skip debug messages for GitHub and Slack channels. GitHub has its
-    // editable Processing comment; Slack now uses native assistant status and
-    // stream chrome, so extra content rows make the thread noisy.
-    if (channel.channel_type === 'github' || channel.channel_type === 'slack') return;
+  private sendDebugMessage(
+    channel: GatewayChannel,
+    threadId: string,
+    text: string,
+    opts?: { forceSlack?: boolean }
+  ): void {
+    // Skip routine debug messages for GitHub and Slack channels. GitHub has
+    // its editable Processing comment; Slack now uses native assistant status
+    // and stream chrome, so extra lifecycle rows make the thread noisy.
+    // Slack rejection/config errors may opt in with forceSlack.
+    if (channel.channel_type === 'github') return;
+    if (channel.channel_type === 'slack' && !opts?.forceSlack) return;
 
     if (!hasConnector(channel.channel_type as ChannelType)) return;
     try {
@@ -864,6 +871,15 @@ export class GatewayService {
     if (!taskId) return;
     const stream = this.slackStreamsByTask.get(taskId);
     if (!stream) return;
+    if (!stream.hasContent && !stream.lastTodoSignature && connector.deleteMessage) {
+      await connector.deleteMessage({
+        threadId: stream.threadId,
+        messageId: stream.ts,
+      });
+      this.slackStreamsByTask.delete(taskId);
+      return;
+    }
+
     const streamConnector = connector as GatewayConnector & {
       stopStream?: (req: { threadId: string; ts: string; text?: string }) => Promise<void>;
     };
@@ -1312,7 +1328,7 @@ export class GatewayService {
         console.error(
           `[gateway] Channel "${channel.name}" has no agor_user_id and alignment is OFF. Cannot process message.`
         );
-        this.sendDebugMessage(channel, data.thread_id, errMsg);
+        this.sendDebugMessage(channel, data.thread_id, errMsg, { forceSlack: true });
         // For GitHub: edit the Processing comment with the error
         if (channel.channel_type === 'github' && data.metadata?.processing_comment_id) {
           try {
@@ -1351,7 +1367,8 @@ export class GatewayService {
           this.sendDebugMessage(
             channel,
             data.thread_id,
-            `User ${email} doesn't have an Agor account. Ask an admin to create an account with this email, or disable user alignment.`
+            `User ${email} doesn't have an Agor account. Ask an admin to create an account with this email, or disable user alignment.`,
+            { forceSlack: true }
           );
           return {
             success: false,
@@ -1369,7 +1386,8 @@ export class GatewayService {
         this.sendDebugMessage(
           channel,
           data.thread_id,
-          "Couldn't resolve your Slack identity. The bot may be missing the `users:read.email` scope, or your Slack profile has no email. Ask an admin to check the bot's scopes."
+          "Couldn't resolve your Slack identity. The bot may be missing the `users:read.email` scope, or your Slack profile has no email. Ask an admin to check the bot's scopes.",
+          { forceSlack: true }
         );
         return {
           success: false,
@@ -1740,7 +1758,9 @@ export class GatewayService {
       }
     } catch (error) {
       console.error('[gateway] Failed to send prompt to session:', error);
-      this.sendDebugMessage(channel, data.thread_id, `Error sending prompt: ${error}`);
+      this.sendDebugMessage(channel, data.thread_id, `Error sending prompt: ${error}`, {
+        forceSlack: true,
+      });
       void this.updateProgress({
         session_id: sessionId,
         state: 'failed',

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -799,10 +799,6 @@ export class GatewayService {
           await connector.setThreadStatus({
             threadId: mapping.thread_id,
             status: this.buildSlackAssistantStatus(data, metadataWithStart),
-            loadingMessages:
-              data.state === 'working' && (isNewTask || isRestartingAfterTerminal)
-                ? ['Reading context…', 'Using tools…', 'Writing the response…']
-                : undefined,
             iconEmoji: ':hourglass_flowing_sand:',
           });
 
@@ -898,7 +894,10 @@ export class GatewayService {
     if (!sessionId || !messageId) return;
 
     if (event === 'streaming:start') {
-      if (taskId) this.slackStreamTaskByMessage.set(messageId, taskId);
+      if (taskId) {
+        this.slackStreamTaskByMessage.set(messageId, taskId);
+        this.markTaskStreamedToSlack(taskId);
+      }
       return;
     }
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -102,6 +102,7 @@ interface GatewayTodoItem {
 interface SlackStreamState {
   threadId: string;
   ts: string;
+  hasContent: boolean;
 }
 
 /**
@@ -683,29 +684,24 @@ export class GatewayService {
 
     try {
       if (event === 'streaming:start') {
-        if (this.slackStreamsByMessage.has(messageId)) return;
-        const ts = await streamConnector.startStream({
-          threadId: mapping.thread_id,
-          text: '',
-        });
-        this.slackStreamsByMessage.set(messageId, {
-          threadId: mapping.thread_id,
-          ts,
-        });
         return;
       }
 
       const existing = this.slackStreamsByMessage.get(messageId);
       if (!existing) {
         if (event !== 'streaming:chunk') return;
+        const chunk = typeof data.chunk === 'string' ? data.chunk : '';
+        if (!chunk) return;
         const ts = await streamConnector.startStream({
           threadId: mapping.thread_id,
-          text: '',
+          text: chunk,
         });
         this.slackStreamsByMessage.set(messageId, {
           threadId: mapping.thread_id,
           ts,
+          hasContent: true,
         });
+        return;
       }
 
       const stream = this.slackStreamsByMessage.get(messageId);
@@ -719,6 +715,7 @@ export class GatewayService {
           ts: stream.ts,
           text: chunk,
         });
+        stream.hasContent = true;
         return;
       }
 
@@ -728,7 +725,7 @@ export class GatewayService {
           ts: stream.ts,
         });
         this.slackStreamsByMessage.delete(messageId);
-        if (event === 'streaming:end') {
+        if (event === 'streaming:end' && stream.hasContent) {
           this.slackStreamedMessageIds.set(
             messageId,
             Date.now() + GatewayService.SLACK_STREAMED_MESSAGE_TTL_MS
@@ -1048,11 +1045,13 @@ export class GatewayService {
       }
 
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
-      this.sendDebugMessage(
-        channel,
-        data.thread_id,
-        formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl)
-      );
+      if (sessionUrl) {
+        this.sendDebugMessage(
+          channel,
+          data.thread_id,
+          formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl)
+        );
+      }
     } else {
       // New thread → create session via FeathersJS service
       const sessionsService = this.app.service('sessions') as unknown as {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -111,6 +111,7 @@ interface SlackStreamState {
   hasContent: boolean;
   taskId?: string;
   lastMessageId?: string;
+  lastTodoSignature?: string;
 }
 
 /**
@@ -628,6 +629,86 @@ export class GatewayService {
     return rest;
   }
 
+  private stripSlackProgressMessageMetadata(
+    metadata: Record<string, unknown>
+  ): Record<string, unknown> {
+    const { slack_status_message_ts: _statusTs, ...rest } = metadata;
+    return rest;
+  }
+
+  private slackTodoStatus(
+    status: GatewayTodoItem['status']
+  ): 'pending' | 'in_progress' | 'completed' | 'error' {
+    if (status === 'completed') return 'completed';
+    if (status === 'in_progress') return 'in_progress';
+    if (status === 'stopped') return 'error';
+    return 'pending';
+  }
+
+  private buildSlackTodoTaskUpdates(todos: GatewayTodoItem[]): unknown[] {
+    return todos.slice(0, 12).map((todo, index) => ({
+      type: 'task_update',
+      task: {
+        task_id: `agor_todo_${index + 1}`,
+        title: this.truncateSlackInline(todo.content, 90),
+        status: this.slackTodoStatus(todo.status),
+      },
+    }));
+  }
+
+  private async appendSlackTodoPlanToStream(
+    taskId: string | undefined,
+    connector: GatewayConnector,
+    todos: GatewayTodoItem[]
+  ): Promise<void> {
+    if (!taskId || todos.length === 0) return;
+    const stream = this.slackStreamsByTask.get(taskId);
+    if (!stream) return;
+    const signature = JSON.stringify(
+      todos.map((todo) => [todo.content, todo.activeForm ?? '', todo.status])
+    );
+    if (stream.lastTodoSignature === signature) return;
+
+    const streamConnector = connector as GatewayConnector & {
+      appendStreamPayload?: (req: {
+        threadId: string;
+        ts: string;
+        chunks: unknown[];
+      }) => Promise<void>;
+    };
+    if (!streamConnector.appendStreamPayload) return;
+
+    await streamConnector.appendStreamPayload({
+      threadId: stream.threadId,
+      ts: stream.ts,
+      chunks: this.buildSlackTodoTaskUpdates(todos),
+    });
+    stream.lastTodoSignature = signature;
+  }
+
+  private async refreshSlackAssistantStatusAfterStreamStart(
+    threadId: string,
+    connector: GatewayConnector,
+    sessionId: string,
+    taskId: string | undefined,
+    metadata: Record<string, unknown>
+  ): Promise<void> {
+    if (!connector.setThreadStatus) return;
+    const progress: GatewayProgressData = {
+      session_id: sessionId,
+      state: 'working',
+      ...(taskId ? { task_id: taskId } : {}),
+    };
+    const loadingMessage =
+      this.buildSlackAssistantLoadingMessage(progress, metadata) ?? 'Writing response…';
+    await connector.setThreadStatus({
+      threadId,
+      status: this.buildSlackAssistantStatus(progress, metadata),
+      loadingMessages: [loadingMessage],
+      iconEmoji: ':hourglass_flowing_sand:',
+    });
+  }
+
   private buildSlackProgressOutbound(
     data: GatewayProgressData,
     metadata: Record<string, unknown>,
@@ -843,9 +924,19 @@ export class GatewayService {
             });
           }
 
+          if (!isTerminal && toolTodos.length > 0) {
+            try {
+              await this.appendSlackTodoPlanToStream(data.task_id, connector, toolTodos);
+            } catch (error) {
+              console.warn('[gateway] Failed to append Slack todo plan to stream:', error);
+            }
+          }
+
           await this.threadMapRepo.updateMetadata(
             mapping.id,
-            this.stripSlackProgressMetadata(metadataWithStart)
+            isTerminal
+              ? this.stripSlackProgressMetadata(metadataWithStart)
+              : this.stripSlackProgressMessageMetadata(metadataWithStart)
           );
           return;
         } catch (error) {
@@ -953,6 +1044,7 @@ export class GatewayService {
         text?: string;
         recipientUserId?: string;
         recipientTeamId?: string;
+        taskDisplayMode?: 'plan' | 'timeline' | 'dense';
       }) => Promise<string>;
       appendStream?: (req: { threadId: string; ts: string; text: string }) => Promise<void>;
       stopStream?: (req: { threadId: string; ts: string; text?: string }) => Promise<void>;
@@ -978,11 +1070,13 @@ export class GatewayService {
 
         const existing = this.slackStreamsByTask.get(taskKey);
         if (!existing) {
+          const todos = this.parseGatewayTodos(metadata.slack_status_todos);
           const ts = await streamConnector.startStream({
             threadId: mapping.thread_id,
             text: chunk,
             recipientUserId,
             recipientTeamId,
+            ...(todos.length > 0 ? { taskDisplayMode: 'plan' as const } : {}),
           });
           this.slackStreamsByTask.set(taskKey, {
             threadId: mapping.thread_id,
@@ -991,6 +1085,20 @@ export class GatewayService {
             taskId: taskKey,
             lastMessageId: messageId,
           });
+          if (todos.length > 0) {
+            await this.appendSlackTodoPlanToStream(taskKey, connector, todos);
+          }
+          try {
+            await this.refreshSlackAssistantStatusAfterStreamStart(
+              mapping.thread_id,
+              connector,
+              sessionId,
+              taskKey,
+              metadata
+            );
+          } catch (error) {
+            console.warn('[gateway] Failed to refresh Slack status after stream start:', error);
+          }
           this.markMessageStreamedToSlack(messageId);
           this.markTaskStreamedToSlack(taskKey);
           return;

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -79,6 +79,29 @@ interface RouteMessageResult {
   channelType?: string;
 }
 
+export type GatewayProgressState = 'queued' | 'working' | 'done' | 'failed';
+
+export interface GatewayProgressData {
+  session_id: string;
+  state: GatewayProgressState;
+  task_id?: string;
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  queue_position?: number;
+  error_message?: string;
+}
+
+interface GatewayTodoItem {
+  content: string;
+  activeForm?: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'stopped' | 'unknown';
+}
+
+interface SlackStreamState {
+  threadId: string;
+  ts: string;
+}
+
 /**
  * Check if a channel has the required config for its connector to listen.
  * Slack requires `app_token` (Socket Mode); GitHub requires `app_id` + `private_key` + `installation_id` (polling).
@@ -270,6 +293,17 @@ export class GatewayService {
    */
   private githubMessageBuffer = new Map<string, string>();
 
+  /**
+   * Slack status updates use chat.update; keep a small in-memory throttle so
+   * rapid tool events don't trip Slack rate limits or create distracting UI
+   * flicker. Terminal states always bypass this throttle.
+   */
+  private slackProgressLastUpdate = new Map<string, number>();
+  private slackStreamsByMessage = new Map<string, SlackStreamState>();
+  private slackStreamedMessageIds = new Map<string, number>();
+  private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
+  private static SLACK_STREAMED_MESSAGE_TTL_MS = 5 * 60 * 1000;
+
   constructor(db: Database, app: Application) {
     this.channelRepo = new GatewayChannelRepository(db);
     this.threadMapRepo = new ThreadSessionMapRepository(db);
@@ -318,6 +352,380 @@ export class GatewayService {
         .catch((err) => console.warn('[gateway] Debug message failed:', err));
     } catch {
       // Ignore — debug messages are best-effort
+    }
+  }
+
+  private truncateSlackInline(value: string, maxChars = 160): string {
+    const singleLine = value.replace(/\s+/g, ' ').trim();
+    if (singleLine.length <= maxChars) return singleLine;
+    return `${singleLine.slice(0, Math.max(0, maxChars - 1))}…`;
+  }
+
+  private parseGatewayTodos(raw: unknown): GatewayTodoItem[] {
+    const candidate =
+      typeof raw === 'string'
+        ? (() => {
+            try {
+              return JSON.parse(raw);
+            } catch {
+              return null;
+            }
+          })()
+        : raw;
+
+    if (!Array.isArray(candidate)) return [];
+
+    return candidate
+      .map((item): GatewayTodoItem | null => {
+        if (!item || typeof item !== 'object') return null;
+        const record = item as Record<string, unknown>;
+        const content =
+          typeof record.content === 'string'
+            ? record.content
+            : typeof record.activeForm === 'string'
+              ? record.activeForm
+              : null;
+        if (!content) return null;
+        const status = record.status;
+        if (
+          status !== 'pending' &&
+          status !== 'in_progress' &&
+          status !== 'completed' &&
+          status !== 'stopped' &&
+          status !== 'unknown'
+        ) {
+          return { content, status: 'pending' };
+        }
+        return {
+          content,
+          ...(typeof record.activeForm === 'string' ? { activeForm: record.activeForm } : {}),
+          status,
+        };
+      })
+      .filter((item): item is GatewayTodoItem => item !== null);
+  }
+
+  private formatSlackToolSummary(toolName?: string, input?: Record<string, unknown>): string {
+    if (!toolName) return 'Waiting for the agent...';
+
+    // Keep this deliberately generic: always show the latest tool, but only
+    // append a short one-line hint when a common scalar preview exists.
+    const previewKeys = [
+      'description',
+      'command',
+      'file_path',
+      'path',
+      'query',
+      'url',
+      'pattern',
+      'name',
+    ];
+    const previewValue = previewKeys
+      .map((key) => input?.[key])
+      .find((value) => typeof value === 'string' && value.trim().length > 0);
+
+    if (typeof previewValue === 'string') {
+      return `\`${toolName}\`: ${this.truncateSlackInline(previewValue)}`;
+    }
+
+    const changes = input?.changes;
+    if (Array.isArray(changes) && changes.length > 0) {
+      return `\`${toolName}\`: ${changes.length} file change${changes.length === 1 ? '' : 's'}`;
+    }
+
+    return `\`${toolName}\``;
+  }
+
+  private formatSlackTodoPlan(todos: GatewayTodoItem[]): string {
+    if (todos.length === 0) return '';
+
+    const iconForStatus = (status: GatewayTodoItem['status']) => {
+      switch (status) {
+        case 'completed':
+          return '✓';
+        case 'in_progress':
+          return '◌';
+        case 'stopped':
+          return '■';
+        case 'unknown':
+          return '?';
+        default:
+          return '○';
+      }
+    };
+
+    const lines = todos.slice(0, 12).map((todo) => {
+      const label =
+        todo.status === 'in_progress' && todo.activeForm ? todo.activeForm : todo.content;
+      return `${iconForStatus(todo.status)} ${this.truncateSlackInline(label, 120)}`;
+    });
+
+    if (todos.length > lines.length) {
+      lines.push(`… ${todos.length - lines.length} more`);
+    }
+
+    return [``, `*Plan*`, ...lines].join('\n');
+  }
+
+  private buildSlackProgressText(
+    data: GatewayProgressData,
+    existingMetadata: Record<string, unknown>,
+    sessionUrl?: string | null
+  ): string {
+    const now = Date.now();
+    const startedAt =
+      typeof existingMetadata.slack_status_started_at === 'string'
+        ? Date.parse(existingMetadata.slack_status_started_at)
+        : now;
+    const elapsedSeconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+    const elapsed =
+      elapsedSeconds < 60
+        ? `${elapsedSeconds}s`
+        : `${Math.floor(elapsedSeconds / 60)}m ${elapsedSeconds % 60}s`;
+
+    const sessionLabel = sessionUrl
+      ? `<${sessionUrl}|session ${shortId(data.session_id)}>`
+      : `session \`${shortId(data.session_id)}\``;
+
+    if (data.state === 'queued') {
+      const position =
+        typeof data.queue_position === 'number' ? ` at position ${data.queue_position}` : '';
+      return `⏳ Agor queued your message${position} in ${sessionLabel}.`;
+    }
+
+    if (data.state === 'done') {
+      return `✅ Agor finished in ${sessionLabel}.`;
+    }
+
+    if (data.state === 'failed') {
+      const suffix = data.error_message ? `\n>${data.error_message}` : '';
+      return `⚠️ Agor stopped with an error in ${sessionLabel}.${suffix}`;
+    }
+
+    const latestToolName =
+      data.tool_name ??
+      (typeof existingMetadata.slack_status_tool_name === 'string'
+        ? existingMetadata.slack_status_tool_name
+        : undefined);
+    const latestToolSummary =
+      data.tool_name || data.tool_input
+        ? this.formatSlackToolSummary(data.tool_name, data.tool_input)
+        : typeof existingMetadata.slack_status_tool_summary === 'string'
+          ? existingMetadata.slack_status_tool_summary
+          : this.formatSlackToolSummary(latestToolName);
+
+    const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
+    const plan = this.formatSlackTodoPlan(todos);
+    const toolLine = `\nCurrent tool: ${latestToolSummary}`;
+    return `⏳ Agor is still working in ${sessionLabel} (${elapsed}).${toolLine}${plan}`;
+  }
+
+  /**
+   * Create or update a single mutable Slack status row in the gateway thread.
+   *
+   * We expose a short, Slack-safe tool summary and TodoWrite plan state, never
+   * raw JSON args/results. Raw tool inputs are already persisted in Agor's
+   * transcript; Slack receives only a compact truncated preview.
+   */
+  async updateProgress(data: GatewayProgressData): Promise<void> {
+    if (!this.hasActiveChannels) return;
+
+    const mapping = await this.threadMapRepo.findBySession(data.session_id);
+    if (!mapping) return;
+
+    const channel = await this.channelRepo.findById(mapping.channel_id);
+    if (!channel?.enabled || channel.channel_type !== 'slack') return;
+
+    const now = Date.now();
+    const isTerminal = data.state === 'done' || data.state === 'failed';
+    const lastUpdate = this.slackProgressLastUpdate.get(data.session_id) ?? 0;
+    if (
+      !isTerminal &&
+      !data.tool_name &&
+      now - lastUpdate < GatewayService.SLACK_PROGRESS_MIN_UPDATE_MS
+    ) {
+      return;
+    }
+    this.slackProgressLastUpdate.set(data.session_id, now);
+
+    const metadata = ((mapping.metadata as Record<string, unknown>) ?? {}) as Record<
+      string,
+      unknown
+    >;
+    const statusStartedAt =
+      typeof metadata.slack_status_started_at === 'string'
+        ? metadata.slack_status_started_at
+        : new Date(now).toISOString();
+    const toolTodos =
+      data.tool_name === 'TodoWrite' ? this.parseGatewayTodos(data.tool_input?.todos) : [];
+    const toolSummary =
+      data.tool_name || data.tool_input
+        ? this.formatSlackToolSummary(data.tool_name, data.tool_input)
+        : undefined;
+    const metadataWithStart = {
+      ...metadata,
+      slack_status_started_at: statusStartedAt,
+      ...(data.tool_name ? { slack_status_tool_name: data.tool_name } : {}),
+      ...(toolSummary ? { slack_status_tool_summary: toolSummary } : {}),
+      ...(toolTodos.length > 0 ? { slack_status_todos: toolTodos } : {}),
+    };
+
+    const usersService = this.app.service('users') as {
+      get: (id: string) => Promise<User>;
+    };
+    const sessionsService = this.app.service('sessions') as {
+      get: (id: string, params?: { user: User }) => Promise<Session & { url?: string | null }>;
+    };
+
+    let sessionUrl: string | null = null;
+    try {
+      const session = await sessionsService.get(data.session_id);
+      const user = await usersService.get(session.created_by);
+      sessionUrl = (await sessionsService.get(data.session_id, { user })).url || null;
+    } catch {
+      // Best-effort only; the status message can still identify the short ID.
+    }
+
+    const connector =
+      this.activeListeners.get(channel.id) ??
+      getConnector(channel.channel_type as ChannelType, channel.config);
+    const statusText = this.buildSlackProgressText(data, metadataWithStart, sessionUrl);
+    const { text, blocks } = normalizeOutbound(
+      connector.formatMessage ? connector.formatMessage(statusText) : statusText
+    );
+
+    const existingTs =
+      typeof metadata.slack_status_message_ts === 'string'
+        ? metadata.slack_status_message_ts
+        : undefined;
+
+    try {
+      const ts = await connector.sendMessage({
+        threadId: mapping.thread_id,
+        text,
+        blocks,
+        metadata: existingTs ? { slack_update_ts: existingTs } : undefined,
+      });
+
+      if (
+        !existingTs ||
+        metadataWithStart.slack_status_started_at !== metadata.slack_status_started_at ||
+        data.tool_name ||
+        data.tool_input
+      ) {
+        await this.threadMapRepo.updateMetadata(mapping.id, {
+          ...metadataWithStart,
+          slack_status_message_ts: ts,
+        });
+      }
+    } catch (error) {
+      console.warn('[gateway] Failed to update Slack progress status:', error);
+    }
+  }
+
+  private cleanupSlackStreamedMessageIds(): void {
+    const now = Date.now();
+    for (const [messageId, expiresAt] of this.slackStreamedMessageIds) {
+      if (expiresAt <= now) this.slackStreamedMessageIds.delete(messageId);
+    }
+  }
+
+  wasSlackMessageStreamed(messageId: string): boolean {
+    this.cleanupSlackStreamedMessageIds();
+    return this.slackStreamedMessageIds.has(messageId);
+  }
+
+  async handleMessageStreamingEvent(
+    event: 'streaming:start' | 'streaming:chunk' | 'streaming:end' | 'streaming:error',
+    data: Record<string, unknown>
+  ): Promise<void> {
+    if (!this.hasActiveChannels) return;
+
+    const sessionId = typeof data.session_id === 'string' ? data.session_id : undefined;
+    const messageId = typeof data.message_id === 'string' ? data.message_id : undefined;
+    if (!sessionId || !messageId) return;
+
+    const mapping = await this.threadMapRepo.findBySession(sessionId);
+    if (!mapping) return;
+
+    const channel = await this.channelRepo.findById(mapping.channel_id);
+    if (!channel?.enabled || channel.channel_type !== 'slack') return;
+
+    const connector =
+      this.activeListeners.get(channel.id) ??
+      getConnector(channel.channel_type as ChannelType, channel.config);
+
+    const streamConnector = connector as GatewayConnector & {
+      startStream?: (req: { threadId: string; text?: string }) => Promise<string>;
+      appendStream?: (req: { threadId: string; ts: string; text: string }) => Promise<void>;
+      stopStream?: (req: { threadId: string; ts: string; text?: string }) => Promise<void>;
+    };
+
+    if (
+      !streamConnector.startStream ||
+      !streamConnector.appendStream ||
+      !streamConnector.stopStream
+    ) {
+      return;
+    }
+
+    try {
+      if (event === 'streaming:start') {
+        if (this.slackStreamsByMessage.has(messageId)) return;
+        const ts = await streamConnector.startStream({
+          threadId: mapping.thread_id,
+          text: '',
+        });
+        this.slackStreamsByMessage.set(messageId, {
+          threadId: mapping.thread_id,
+          ts,
+        });
+        return;
+      }
+
+      const existing = this.slackStreamsByMessage.get(messageId);
+      if (!existing) {
+        if (event !== 'streaming:chunk') return;
+        const ts = await streamConnector.startStream({
+          threadId: mapping.thread_id,
+          text: '',
+        });
+        this.slackStreamsByMessage.set(messageId, {
+          threadId: mapping.thread_id,
+          ts,
+        });
+      }
+
+      const stream = this.slackStreamsByMessage.get(messageId);
+      if (!stream) return;
+
+      if (event === 'streaming:chunk') {
+        const chunk = typeof data.chunk === 'string' ? data.chunk : '';
+        if (!chunk) return;
+        await streamConnector.appendStream({
+          threadId: stream.threadId,
+          ts: stream.ts,
+          text: chunk,
+        });
+        return;
+      }
+
+      if (event === 'streaming:end' || event === 'streaming:error') {
+        await streamConnector.stopStream({
+          threadId: stream.threadId,
+          ts: stream.ts,
+        });
+        this.slackStreamsByMessage.delete(messageId);
+        if (event === 'streaming:end') {
+          this.slackStreamedMessageIds.set(
+            messageId,
+            Date.now() + GatewayService.SLACK_STREAMED_MESSAGE_TTL_MS
+          );
+        }
+      }
+    } catch (error) {
+      this.slackStreamsByMessage.delete(messageId);
+      console.warn('[gateway] Failed to mirror message stream to Slack:', error);
     }
   }
 
@@ -821,14 +1229,30 @@ export class GatewayService {
           data.thread_id,
           `Session is busy, message queued at position ${task.queue_position}`
         );
+        void this.updateProgress({
+          session_id: sessionId,
+          state: 'queued',
+          task_id: task.task_id,
+          queue_position: task.queue_position,
+        });
       } else {
         console.log(
           `[gateway] Prompt sent to session ${shortId(sessionId)} via /sessions/:id/prompt`
         );
+        void this.updateProgress({
+          session_id: sessionId,
+          state: 'working',
+          task_id: task.task_id,
+        });
       }
     } catch (error) {
       console.error('[gateway] Failed to send prompt to session:', error);
       this.sendDebugMessage(channel, data.thread_id, `Error sending prompt: ${error}`);
+      void this.updateProgress({
+        session_id: sessionId,
+        state: 'failed',
+        error_message: error instanceof Error ? error.message : String(error),
+      });
     }
 
     return {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -561,6 +561,7 @@ export class GatewayService {
       slack_status_tool_summary: _toolSummary,
       slack_status_todos: _todos,
       slack_status_state: _state,
+      slack_status_task_id: _taskId,
       ...rest
     } = metadata;
     return rest;
@@ -642,23 +643,29 @@ export class GatewayService {
 
     const now = Date.now();
     const isTerminal = data.state === 'done' || data.state === 'failed';
+    const metadata = ((mapping.metadata as Record<string, unknown>) ?? {}) as Record<
+      string,
+      unknown
+    >;
+    const isNewTask =
+      typeof data.task_id === 'string' && data.task_id !== metadata.slack_status_task_id;
+    const isRestartingAfterTerminal =
+      (data.state === 'queued' || data.state === 'working') &&
+      (metadata.slack_status_state === 'done' || metadata.slack_status_state === 'failed');
     const lastUpdate = this.slackProgressLastUpdate.get(data.session_id) ?? 0;
     if (
       !isTerminal &&
       !data.tool_name &&
+      !isNewTask &&
+      !isRestartingAfterTerminal &&
       now - lastUpdate < GatewayService.SLACK_PROGRESS_MIN_UPDATE_MS
     ) {
       return;
     }
     this.slackProgressLastUpdate.set(data.session_id, now);
 
-    const metadata = ((mapping.metadata as Record<string, unknown>) ?? {}) as Record<
-      string,
-      unknown
-    >;
     const statusStartedAt =
-      (data.state === 'queued' || data.state === 'working') &&
-      (metadata.slack_status_state === 'done' || metadata.slack_status_state === 'failed')
+      isNewTask || isRestartingAfterTerminal
         ? new Date(now).toISOString()
         : typeof metadata.slack_status_started_at === 'string'
           ? metadata.slack_status_started_at
@@ -673,6 +680,7 @@ export class GatewayService {
       ...metadata,
       slack_status_started_at: statusStartedAt,
       slack_status_state: data.state,
+      ...(data.task_id ? { slack_status_task_id: data.task_id } : {}),
       ...(data.tool_name ? { slack_status_tool_name: data.tool_name } : {}),
       ...(toolSummary ? { slack_status_tool_summary: toolSummary } : {}),
       ...(toolTodos.length > 0 ? { slack_status_todos: toolTodos } : {}),
@@ -719,6 +727,7 @@ export class GatewayService {
       if (
         !existingTs ||
         metadataWithStart.slack_status_started_at !== metadata.slack_status_started_at ||
+        metadataWithStart.slack_status_task_id !== metadata.slack_status_task_id ||
         isTerminal ||
         data.tool_name ||
         data.tool_input

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -17,7 +17,12 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { GatewayConnector, GatewayContext, InboundMessage } from '@agor/core/gateway';
+import type {
+  GatewayConnector,
+  GatewayContext,
+  InboundMessage,
+  OutboundPayload,
+} from '@agor/core/gateway';
 import {
   formatGatewayContext,
   formatGatewayFollowUpRoutingMessage,
@@ -25,6 +30,7 @@ import {
   formatGatewaySystemMessage,
   getConnector,
   hasConnector,
+  markdownToMrkdwn,
   normalizeOutbound,
   parseGitHubThreadId,
 } from '@agor/core/gateway';
@@ -530,6 +536,48 @@ export class GatewayService {
     return rest;
   }
 
+  private buildSlackProgressOutbound(
+    data: GatewayProgressData,
+    metadata: Record<string, unknown>,
+    connector: GatewayConnector
+  ): OutboundPayload {
+    const statusText = this.buildSlackProgressText(data, metadata);
+
+    // Failures should remain visually prominent. Transient progress/queued
+    // state is UI chrome, so render it in Slack's smaller context style.
+    if (data.state === 'failed') {
+      return normalizeOutbound(
+        connector.formatMessage ? connector.formatMessage(statusText) : statusText
+      );
+    }
+
+    const [headline, ...details] = statusText.split('\n');
+    const detailText = details.join('\n').trim();
+    const blocks: unknown[] = [
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: markdownToMrkdwn(headline),
+          },
+        ],
+      },
+    ];
+
+    if (detailText) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: markdownToMrkdwn(detailText),
+        },
+      });
+    }
+
+    return { text: statusText, blocks };
+  }
+
   /**
    * Create or update a single mutable Slack status row in the gateway thread.
    *
@@ -609,10 +657,7 @@ export class GatewayService {
         return;
       }
 
-      const statusText = this.buildSlackProgressText(data, metadataWithStart);
-      const { text, blocks } = normalizeOutbound(
-        connector.formatMessage ? connector.formatMessage(statusText) : statusText
-      );
+      const { text, blocks } = this.buildSlackProgressOutbound(data, metadataWithStart, connector);
       const ts = await connector.sendMessage({
         threadId: mapping.thread_id,
         text,

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -1021,7 +1021,6 @@ export class GatewayService {
     if (event === 'streaming:start') {
       if (taskId) {
         this.slackStreamTaskByMessage.set(messageId, taskId);
-        this.markTaskStreamedToSlack(taskId);
       }
       return;
     }

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -17,12 +17,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type {
-  GatewayConnector,
-  GatewayContext,
-  InboundMessage,
-  OutboundPayload,
-} from '@agor/core/gateway';
+import type { GatewayConnector, GatewayContext, InboundMessage } from '@agor/core/gateway';
 import {
   formatGatewayContext,
   formatGatewayFollowUpRoutingMessage,
@@ -30,7 +25,6 @@ import {
   formatGatewaySystemPayload,
   getConnector,
   hasConnector,
-  markdownToMrkdwn,
   normalizeOutbound,
   parseGitHubThreadId,
 } from '@agor/core/gateway';
@@ -111,7 +105,6 @@ interface SlackStreamState {
   hasContent: boolean;
   taskId?: string;
   lastMessageId?: string;
-  lastTodoSignature?: string;
 }
 
 /**
@@ -135,6 +128,10 @@ function hasListeningConfig(channel: GatewayChannel): boolean {
     default:
       return false;
   }
+}
+
+function isSlackThinkingPlaceholder(text: string): boolean {
+  return /^thinking\s*\.{3}$/i.test(text.trim());
 }
 
 /**
@@ -313,10 +310,12 @@ export class GatewayService {
   private slackProgressLastUpdate = new Map<string, number>();
   private slackProgressQueues = new Map<string, Promise<void>>();
   private slackStreamsByTask = new Map<string, SlackStreamState>();
+  private slackStreamStatusRefreshLast = new Map<string, number>();
   private slackStreamedMessageIds = new Set<string>();
   private slackStreamedTaskIds = new Set<string>();
   private slackStreamTaskByMessage = new Map<string, string>();
   private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
+  private static SLACK_STREAM_STATUS_REFRESH_MS = 1000;
   private static SLACK_STREAMED_MESSAGE_CACHE_MAX = 500;
 
   constructor(db: Database, app: Application) {
@@ -342,21 +341,20 @@ export class GatewayService {
   }
 
   /**
-   * Send a debug/system message to the platform thread (fire-and-forget).
+   * Send a system message to the platform thread (fire-and-forget).
    * Useful for giving the user visibility into what's happening.
    */
-  private sendDebugMessage(
+  private sendSystemMessage(
     channel: GatewayChannel,
     threadId: string,
     text: string,
-    opts?: { forceSlack?: boolean }
+    opts?: { suppressSlack?: boolean }
   ): void {
-    // Skip routine debug messages for GitHub and Slack channels. GitHub has
-    // its editable Processing comment; Slack now uses native assistant status
-    // and stream chrome, so extra lifecycle rows make the thread noisy.
-    // Slack rejection/config errors may opt in with forceSlack.
+    // GitHub has its editable Processing comment. Slack keeps durable routing
+    // messages (session links/errors) but suppresses transient lifecycle noise
+    // like "creating session" and queued/status rows via suppressSlack.
     if (channel.channel_type === 'github') return;
-    if (channel.channel_type === 'slack' && !opts?.forceSlack) return;
+    if (channel.channel_type === 'slack' && opts?.suppressSlack) return;
 
     if (!hasConnector(channel.channel_type as ChannelType)) return;
     try {
@@ -493,81 +491,6 @@ export class GatewayService {
     return `\`${toolName}\``;
   }
 
-  private formatSlackTodoPlan(todos: GatewayTodoItem[]): string {
-    if (todos.length === 0) return '';
-
-    const iconForStatus = (status: GatewayTodoItem['status']) => {
-      switch (status) {
-        case 'completed':
-          return '✓';
-        case 'in_progress':
-          return '◌';
-        case 'stopped':
-          return '■';
-        case 'unknown':
-          return '?';
-        default:
-          return '○';
-      }
-    };
-
-    const lines = todos.slice(0, 12).map((todo) => {
-      const content = this.truncateSlackInline(todo.content, 90);
-      const activeForm =
-        todo.status === 'in_progress' &&
-        todo.activeForm &&
-        todo.activeForm.trim() !== todo.content.trim()
-          ? ` — ${this.truncateSlackInline(todo.activeForm, 50)}`
-          : '';
-      return `${iconForStatus(todo.status)} ${content}${activeForm}`;
-    });
-
-    if (todos.length > lines.length) {
-      lines.push(`… ${todos.length - lines.length} more`);
-    }
-
-    return [`*Plan*`, ...lines].join('\n');
-  }
-
-  private buildSlackProgressText(
-    data: GatewayProgressData,
-    existingMetadata: Record<string, unknown>
-  ): string {
-    if (data.state === 'queued') {
-      const position =
-        typeof data.queue_position === 'number' ? ` at position ${data.queue_position}` : '';
-      return `⏳ Queued your message${position}.`;
-    }
-
-    if (data.state === 'done') {
-      const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
-      const plan = this.formatSlackTodoPlan(todos);
-      return plan;
-    }
-
-    if (data.state === 'failed') {
-      const suffix = data.error_message ? `\n>${data.error_message}` : '';
-      return `⚠️ Agor stopped with an error.${suffix}`;
-    }
-
-    const latestToolName =
-      data.tool_name ??
-      (typeof existingMetadata.slack_status_tool_name === 'string'
-        ? existingMetadata.slack_status_tool_name
-        : undefined);
-    const latestToolSummary =
-      data.tool_name || data.tool_input
-        ? this.formatSlackToolSummary(data.tool_name, data.tool_input)
-        : typeof existingMetadata.slack_status_tool_summary === 'string'
-          ? existingMetadata.slack_status_tool_summary
-          : this.formatSlackToolSummary(latestToolName);
-
-    const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
-    const plan = this.formatSlackTodoPlan(todos);
-    const progress = `⏳ Still working · ${latestToolSummary}`;
-    return plan ? `${plan}\n${progress}` : progress;
-  }
-
   private buildSlackAssistantStatus(
     data: GatewayProgressData,
     existingMetadata: Record<string, unknown>
@@ -643,56 +566,6 @@ export class GatewayService {
     return rest;
   }
 
-  private slackTodoStatus(
-    status: GatewayTodoItem['status']
-  ): 'pending' | 'in_progress' | 'completed' | 'error' {
-    if (status === 'completed') return 'completed';
-    if (status === 'in_progress') return 'in_progress';
-    if (status === 'stopped') return 'error';
-    return 'pending';
-  }
-
-  private buildSlackTodoTaskUpdates(todos: GatewayTodoItem[]): unknown[] {
-    return todos.slice(0, 12).map((todo, index) => ({
-      type: 'task_update',
-      task: {
-        task_id: `agor_todo_${index + 1}`,
-        title: this.truncateSlackInline(todo.content, 90),
-        status: this.slackTodoStatus(todo.status),
-      },
-    }));
-  }
-
-  private async appendSlackTodoPlanToStream(
-    taskId: string | undefined,
-    connector: GatewayConnector,
-    todos: GatewayTodoItem[]
-  ): Promise<void> {
-    if (!taskId || todos.length === 0) return;
-    const stream = this.slackStreamsByTask.get(taskId);
-    if (!stream) return;
-    const signature = JSON.stringify(
-      todos.map((todo) => [todo.content, todo.activeForm ?? '', todo.status])
-    );
-    if (stream.lastTodoSignature === signature) return;
-
-    const streamConnector = connector as GatewayConnector & {
-      appendStreamPayload?: (req: {
-        threadId: string;
-        ts: string;
-        chunks: unknown[];
-      }) => Promise<void>;
-    };
-    if (!streamConnector.appendStreamPayload) return;
-
-    await streamConnector.appendStreamPayload({
-      threadId: stream.threadId,
-      ts: stream.ts,
-      chunks: this.buildSlackTodoTaskUpdates(todos),
-    });
-    stream.lastTodoSignature = signature;
-  }
-
   private async refreshSlackAssistantStatusAfterStreamStart(
     threadId: string,
     connector: GatewayConnector,
@@ -714,68 +587,34 @@ export class GatewayService {
       loadingMessages: [loadingMessage],
       iconEmoji: ':hourglass_flowing_sand:',
     });
+    if (taskId) {
+      this.slackStreamStatusRefreshLast.set(taskId, Date.now());
+    }
   }
 
-  private buildSlackProgressOutbound(
-    data: GatewayProgressData,
-    metadata: Record<string, unknown>,
-    connector: GatewayConnector
-  ): OutboundPayload {
-    const statusText = this.buildSlackProgressText(data, metadata);
-
-    // Failures should remain visually prominent. Transient progress/queued
-    // state is UI chrome, so render it in Slack's smaller context style.
-    if (data.state === 'failed') {
-      return normalizeOutbound(
-        connector.formatMessage ? connector.formatMessage(statusText) : statusText
-      );
-    }
-
-    const lines = statusText.split('\n');
-    const lastLine = lines.at(-1)?.trim();
-    const progressLine = lastLine?.startsWith('⏳') ? lines.pop() : undefined;
-    const detailText = lines.join('\n').trim();
-    const blocks: unknown[] = [];
-
-    if (detailText) {
-      blocks.push({
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: markdownToMrkdwn(detailText),
-        },
-      });
-    }
-
-    if (progressLine) {
-      blocks.push({
-        type: 'context',
-        elements: [
-          {
-            type: 'mrkdwn',
-            text: markdownToMrkdwn(progressLine),
-          },
-        ],
-      });
-    }
-
-    if (blocks.length === 0) {
-      blocks.push({
-        type: 'context',
-        elements: [
-          {
-            type: 'mrkdwn',
-            text: markdownToMrkdwn(statusText || 'Done.'),
-          },
-        ],
-      });
-    }
-
-    return { text: statusText, blocks };
+  private async refreshSlackAssistantStatusAfterStreamAppend(
+    threadId: string,
+    connector: GatewayConnector,
+    sessionId: string,
+    taskId: string | undefined,
+    metadata: Record<string, unknown>
+  ): Promise<void> {
+    if (!taskId) return;
+    const now = Date.now();
+    const lastRefresh = this.slackStreamStatusRefreshLast.get(taskId) ?? 0;
+    if (now - lastRefresh < GatewayService.SLACK_STREAM_STATUS_REFRESH_MS) return;
+    this.slackStreamStatusRefreshLast.set(taskId, now);
+    await this.refreshSlackAssistantStatusAfterStreamStart(
+      threadId,
+      connector,
+      sessionId,
+      taskId,
+      metadata
+    );
   }
 
   /**
-   * Create or update a single mutable Slack status row in the gateway thread.
+   * Update Slack's native assistant status/stream chrome for a gateway thread.
    *
    * We expose a short, Slack-safe tool summary and TodoWrite plan state, never
    * raw JSON args/results. Raw tool inputs are already persisted in Agor's
@@ -834,7 +673,6 @@ export class GatewayService {
         text?: string;
         recipientUserId?: string;
         recipientTeamId?: string;
-        taskDisplayMode?: 'plan' | 'timeline' | 'dense';
       }) => Promise<string>;
     };
     if (!streamConnector.startStream) return;
@@ -849,7 +687,6 @@ export class GatewayService {
       text: ' ',
       recipientUserId,
       recipientTeamId,
-      taskDisplayMode: 'plan',
     });
     this.slackStreamsByTask.set(req.taskId, {
       threadId: req.threadId,
@@ -857,11 +694,6 @@ export class GatewayService {
       hasContent: false,
       taskId: req.taskId,
     });
-
-    const todos = this.parseGatewayTodos(req.metadata.slack_status_todos);
-    if (todos.length > 0) {
-      await this.appendSlackTodoPlanToStream(req.taskId, req.connector, todos);
-    }
   }
 
   private async stopSlackTaskStream(
@@ -871,12 +703,13 @@ export class GatewayService {
     if (!taskId) return;
     const stream = this.slackStreamsByTask.get(taskId);
     if (!stream) return;
-    if (!stream.hasContent && !stream.lastTodoSignature && connector.deleteMessage) {
+    if (!stream.hasContent && connector.deleteMessage) {
       await connector.deleteMessage({
         threadId: stream.threadId,
         messageId: stream.ts,
       });
       this.slackStreamsByTask.delete(taskId);
+      this.slackStreamStatusRefreshLast.delete(taskId);
       return;
     }
 
@@ -889,6 +722,7 @@ export class GatewayService {
       ts: stream.ts,
     });
     this.slackStreamsByTask.delete(taskId);
+    this.slackStreamStatusRefreshLast.delete(taskId);
   }
 
   private async updateProgressNow(data: GatewayProgressData): Promise<void> {
@@ -929,6 +763,8 @@ export class GatewayService {
         : typeof metadata.slack_status_started_at === 'string'
           ? metadata.slack_status_started_at
           : new Date(now).toISOString();
+    // Keep TodoWrite parsing for compact status text. Slack task_update/plan
+    // rendering is intentionally deferred until a follow-up PR verifies it.
     const toolTodos =
       data.tool_name === 'TodoWrite' ? this.parseGatewayTodos(data.tool_input?.todos) : [];
     const toolSummary =
@@ -950,11 +786,6 @@ export class GatewayService {
     const connector =
       this.activeListeners.get(channel.id) ??
       getConnector(channel.channel_type as ChannelType, channel.config);
-    const existingTs =
-      typeof metadata.slack_status_message_ts === 'string'
-        ? metadata.slack_status_message_ts
-        : undefined;
-    let updateTs = existingTs;
     const activeTaskId =
       typeof metadata.slack_status_task_id === 'string' ? metadata.slack_status_task_id : undefined;
 
@@ -967,113 +798,38 @@ export class GatewayService {
         }
       }
 
-      if (connector.setThreadStatus) {
-        try {
-          if (!isTerminal && data.state === 'working') {
-            try {
-              await this.ensureSlackTaskStream({
-                taskId: data.task_id,
-                threadId: mapping.thread_id,
-                connector,
-                metadata: metadataWithStart,
-              });
-            } catch (error) {
-              console.warn('[gateway] Failed to start Slack task stream:', error);
-            }
-          }
+      if (!connector.setThreadStatus) return;
 
-          const loadingMessage = this.buildSlackAssistantLoadingMessage(data, metadataWithStart);
-          await connector.setThreadStatus({
-            threadId: mapping.thread_id,
-            status: this.buildSlackAssistantStatus(data, metadataWithStart),
-            loadingMessages: loadingMessage ? [loadingMessage] : undefined,
-            iconEmoji: ':hourglass_flowing_sand:',
-          });
-
-          if (existingTs && connector.deleteMessage) {
-            await connector.deleteMessage({
-              threadId: mapping.thread_id,
-              messageId: existingTs,
-            });
-          }
-
-          if (!isTerminal && toolTodos.length > 0) {
-            try {
-              await this.appendSlackTodoPlanToStream(data.task_id, connector, toolTodos);
-            } catch (error) {
-              console.warn('[gateway] Failed to append Slack todo plan to stream:', error);
-            }
-          }
-
-          await this.threadMapRepo.updateMetadata(
-            mapping.id,
-            isTerminal
-              ? this.stripSlackProgressMetadata(metadataWithStart)
-              : this.stripSlackProgressMessageMetadata(metadataWithStart)
-          );
-          return;
-        } catch (error) {
-          console.warn(
-            '[gateway] Failed to set Slack assistant status; falling back to status row:',
-            error
-          );
-        }
-      }
-
-      if (!isTerminal && isNewTask && existingTs) {
-        if (connector.deleteMessage) {
+      try {
+        if (!isTerminal && data.state === 'working') {
           try {
-            await connector.deleteMessage({
+            await this.ensureSlackTaskStream({
+              taskId: data.task_id,
               threadId: mapping.thread_id,
-              messageId: existingTs,
+              connector,
+              metadata: metadataWithStart,
             });
           } catch (error) {
-            console.warn('[gateway] Failed to delete stale Slack progress status:', error);
+            console.warn('[gateway] Failed to start Slack task stream:', error);
           }
         }
-        updateTs = undefined;
-      }
 
-      if (data.state === 'done' && existingTs && connector.deleteMessage) {
-        try {
-          await connector.deleteMessage({
-            threadId: mapping.thread_id,
-            messageId: existingTs,
-          });
-          await this.threadMapRepo.updateMetadata(
-            mapping.id,
-            this.stripSlackProgressMetadata(metadataWithStart)
-          );
-          return;
-        } catch (error) {
-          console.warn('[gateway] Failed to delete Slack progress status; marking done:', error);
-        }
-      }
-
-      if (data.state === 'done' && !existingTs) {
-        return;
-      }
-
-      const { text, blocks } = this.buildSlackProgressOutbound(data, metadataWithStart, connector);
-      const ts = await connector.sendMessage({
-        threadId: mapping.thread_id,
-        text,
-        blocks,
-        metadata: updateTs ? { slack_update_ts: updateTs } : undefined,
-      });
-
-      if (
-        !existingTs ||
-        metadataWithStart.slack_status_started_at !== metadata.slack_status_started_at ||
-        metadataWithStart.slack_status_task_id !== metadata.slack_status_task_id ||
-        isTerminal ||
-        data.tool_name ||
-        data.tool_input
-      ) {
-        await this.threadMapRepo.updateMetadata(mapping.id, {
-          ...metadataWithStart,
-          slack_status_message_ts: ts,
+        const loadingMessage = this.buildSlackAssistantLoadingMessage(data, metadataWithStart);
+        await connector.setThreadStatus({
+          threadId: mapping.thread_id,
+          status: this.buildSlackAssistantStatus(data, metadataWithStart),
+          loadingMessages: loadingMessage ? [loadingMessage] : undefined,
+          iconEmoji: ':hourglass_flowing_sand:',
         });
+
+        await this.threadMapRepo.updateMetadata(
+          mapping.id,
+          isTerminal
+            ? this.stripSlackProgressMetadata(metadataWithStart)
+            : this.stripSlackProgressMessageMetadata(metadataWithStart)
+        );
+      } catch (error) {
+        console.warn('[gateway] Failed to set Slack assistant status:', error);
       }
     } catch (error) {
       console.warn('[gateway] Failed to update Slack progress status:', error);
@@ -1116,7 +872,6 @@ export class GatewayService {
         text?: string;
         recipientUserId?: string;
         recipientTeamId?: string;
-        taskDisplayMode?: 'plan' | 'timeline' | 'dense';
       }) => Promise<string>;
       appendStream?: (req: { threadId: string; ts: string; text: string }) => Promise<void>;
       stopStream?: (req: { threadId: string; ts: string; text?: string }) => Promise<void>;
@@ -1139,16 +894,17 @@ export class GatewayService {
       if (event === 'streaming:chunk') {
         const chunk = typeof data.chunk === 'string' ? data.chunk : '';
         if (!chunk) return;
+        if (isSlackThinkingPlaceholder(chunk)) {
+          return;
+        }
 
         const existing = this.slackStreamsByTask.get(taskKey);
         if (!existing) {
-          const todos = this.parseGatewayTodos(metadata.slack_status_todos);
           const ts = await streamConnector.startStream({
             threadId: mapping.thread_id,
             text: chunk,
             recipientUserId,
             recipientTeamId,
-            taskDisplayMode: 'plan',
           });
           this.slackStreamsByTask.set(taskKey, {
             threadId: mapping.thread_id,
@@ -1157,9 +913,6 @@ export class GatewayService {
             taskId: taskKey,
             lastMessageId: messageId,
           });
-          if (todos.length > 0) {
-            await this.appendSlackTodoPlanToStream(taskKey, connector, todos);
-          }
           try {
             await this.refreshSlackAssistantStatusAfterStreamStart(
               mapping.thread_id,
@@ -1185,6 +938,17 @@ export class GatewayService {
           ts: existing.ts,
           text,
         });
+        try {
+          await this.refreshSlackAssistantStatusAfterStreamAppend(
+            mapping.thread_id,
+            connector,
+            sessionId,
+            taskKey,
+            metadata
+          );
+        } catch (error) {
+          console.warn('[gateway] Failed to refresh Slack status after stream append:', error);
+        }
         existing.hasContent = true;
         existing.lastMessageId = messageId;
         this.markMessageStreamedToSlack(messageId);
@@ -1264,7 +1028,7 @@ export class GatewayService {
       data.thread_id
     );
 
-    // 3. Cross-channel ownership check (MUST happen before any sendDebugMessage calls).
+    // 3. Cross-channel ownership check (MUST happen before any sendSystemMessage calls).
     // If this thread is owned by a DIFFERENT gateway channel on the same daemon,
     // silently drop the message — we must not interfere with another gateway's thread.
     // This covers all rejection paths: unmapped thread replies, user alignment failures, etc.
@@ -1328,7 +1092,7 @@ export class GatewayService {
         console.error(
           `[gateway] Channel "${channel.name}" has no agor_user_id and alignment is OFF. Cannot process message.`
         );
-        this.sendDebugMessage(channel, data.thread_id, errMsg, { forceSlack: true });
+        this.sendSystemMessage(channel, data.thread_id, errMsg);
         // For GitHub: edit the Processing comment with the error
         if (channel.channel_type === 'github' && data.metadata?.processing_comment_id) {
           try {
@@ -1364,11 +1128,10 @@ export class GatewayService {
           user = await usersService.get(matchedUser.user_id);
         } else {
           console.log(`[gateway] Slack user alignment failed: no Agor user with email ${email}`);
-          this.sendDebugMessage(
+          this.sendSystemMessage(
             channel,
             data.thread_id,
-            `User ${email} doesn't have an Agor account. Ask an admin to create an account with this email, or disable user alignment.`,
-            { forceSlack: true }
+            `User ${email} doesn't have an Agor account. Ask an admin to create an account with this email, or disable user alignment.`
           );
           return {
             success: false,
@@ -1383,11 +1146,10 @@ export class GatewayService {
         console.log(
           `[gateway] Slack user alignment failed: could not resolve email for Slack user ${data.user_name ?? 'unknown'} (thread=${data.thread_id})`
         );
-        this.sendDebugMessage(
+        this.sendSystemMessage(
           channel,
           data.thread_id,
-          "Couldn't resolve your Slack identity. The bot may be missing the `users:read.email` scope, or your Slack profile has no email. Ask an admin to check the bot's scopes.",
-          { forceSlack: true }
+          "Couldn't resolve your Slack identity. The bot may be missing the `users:read.email` scope, or your Slack profile has no email. Ask an admin to check the bot's scopes."
         );
         return {
           success: false,
@@ -1533,7 +1295,7 @@ export class GatewayService {
 
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
       if (sessionUrl) {
-        this.sendDebugMessage(
+        this.sendSystemMessage(
           channel,
           data.thread_id,
           formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl)
@@ -1546,10 +1308,11 @@ export class GatewayService {
         setMCPServers: (sessionId: SessionID, serverIds: string[], label: string) => Promise<void>;
       };
 
-      this.sendDebugMessage(
+      this.sendSystemMessage(
         channel,
         data.thread_id,
-        `Creating new ${agenticTool} session (${permissionMode} mode)...`
+        `Creating new ${agenticTool} session (${permissionMode} mode)...`,
+        { suppressSlack: true }
       );
 
       // Build custom_context with gateway metadata + platform-specific fields
@@ -1658,7 +1421,7 @@ export class GatewayService {
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
 
       if (sessionUrl) {
-        this.sendDebugMessage(
+        this.sendSystemMessage(
           channel,
           data.thread_id,
           formatGatewaySessionCreatedMessage(sessionId, sessionUrl)
@@ -1735,10 +1498,11 @@ export class GatewayService {
         console.log(
           `[gateway] Message queued for session ${shortId(sessionId)} at position ${task.queue_position}`
         );
-        this.sendDebugMessage(
+        this.sendSystemMessage(
           channel,
           data.thread_id,
-          `Session is busy, message queued at position ${task.queue_position}`
+          `Session is busy, message queued at position ${task.queue_position}`,
+          { suppressSlack: true }
         );
         void this.updateProgress({
           session_id: sessionId,
@@ -1758,9 +1522,7 @@ export class GatewayService {
       }
     } catch (error) {
       console.error('[gateway] Failed to send prompt to session:', error);
-      this.sendDebugMessage(channel, data.thread_id, `Error sending prompt: ${error}`, {
-        forceSlack: true,
-      });
+      this.sendSystemMessage(channel, data.thread_id, `Error sending prompt: ${error}`);
       void this.updateProgress({
         session_id: sessionId,
         state: 'failed',

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -27,7 +27,7 @@ import {
   formatGatewayContext,
   formatGatewayFollowUpRoutingMessage,
   formatGatewaySessionCreatedMessage,
-  formatGatewaySystemMessage,
+  formatGatewaySystemPayload,
   getConnector,
   hasConnector,
   markdownToMrkdwn,
@@ -354,7 +354,7 @@ export class GatewayService {
       connector
         .sendMessage({
           threadId,
-          text: formatGatewaySystemMessage(channel.channel_type as ChannelType, text),
+          ...formatGatewaySystemPayload(channel.channel_type as ChannelType, text),
         })
         .catch((err) => console.warn('[gateway] Debug message failed:', err));
     } catch {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -110,6 +110,7 @@ interface SlackStreamState {
   ts: string;
   hasContent: boolean;
   taskId?: string;
+  lastMessageId?: string;
 }
 
 /**
@@ -310,7 +311,7 @@ export class GatewayService {
    */
   private slackProgressLastUpdate = new Map<string, number>();
   private slackProgressQueues = new Map<string, Promise<void>>();
-  private slackStreamsByMessage = new Map<string, SlackStreamState>();
+  private slackStreamsByTask = new Map<string, SlackStreamState>();
   private slackStreamedMessageIds = new Set<string>();
   private slackStreamedTaskIds = new Set<string>();
   private slackStreamTaskByMessage = new Map<string, string>();
@@ -699,6 +700,24 @@ export class GatewayService {
     }
   }
 
+  private async stopSlackTaskStream(
+    taskId: string | undefined,
+    connector: GatewayConnector
+  ): Promise<void> {
+    if (!taskId) return;
+    const stream = this.slackStreamsByTask.get(taskId);
+    if (!stream) return;
+    const streamConnector = connector as GatewayConnector & {
+      stopStream?: (req: { threadId: string; ts: string; text?: string }) => Promise<void>;
+    };
+    if (!streamConnector.stopStream) return;
+    await streamConnector.stopStream({
+      threadId: stream.threadId,
+      ts: stream.ts,
+    });
+    this.slackStreamsByTask.delete(taskId);
+  }
+
   private async updateProgressNow(data: GatewayProgressData): Promise<void> {
     if (!this.hasActiveChannels) return;
 
@@ -763,8 +782,18 @@ export class GatewayService {
         ? metadata.slack_status_message_ts
         : undefined;
     let updateTs = existingTs;
+    const activeTaskId =
+      typeof metadata.slack_status_task_id === 'string' ? metadata.slack_status_task_id : undefined;
 
     try {
+      if (isTerminal) {
+        try {
+          await this.stopSlackTaskStream(activeTaskId, connector);
+        } catch (error) {
+          console.warn('[gateway] Failed to stop Slack task stream:', error);
+        }
+      }
+
       if (connector.setThreadStatus) {
         try {
           await connector.setThreadStatus({
@@ -868,6 +897,13 @@ export class GatewayService {
     const taskId = typeof data.task_id === 'string' ? data.task_id : undefined;
     if (!sessionId || !messageId) return;
 
+    if (event === 'streaming:start') {
+      if (taskId) this.slackStreamTaskByMessage.set(messageId, taskId);
+      return;
+    }
+
+    const taskKey = taskId ?? this.slackStreamTaskByMessage.get(messageId) ?? messageId;
+
     const mapping = await this.threadMapRepo.findBySession(sessionId);
     if (!mapping) return;
 
@@ -889,11 +925,7 @@ export class GatewayService {
       stopStream?: (req: { threadId: string; ts: string; text?: string }) => Promise<void>;
     };
 
-    if (
-      !streamConnector.startStream ||
-      !streamConnector.appendStream ||
-      !streamConnector.stopStream
-    ) {
+    if (!streamConnector.startStream || !streamConnector.appendStream) {
       return;
     }
 
@@ -907,63 +939,61 @@ export class GatewayService {
       const recipientTeamId =
         typeof metadata.slack_team_id === 'string' ? metadata.slack_team_id : undefined;
 
-      if (event === 'streaming:start') {
-        if (taskId) this.slackStreamTaskByMessage.set(messageId, taskId);
-        return;
-      }
-
-      const existing = this.slackStreamsByMessage.get(messageId);
-      if (!existing) {
-        if (event !== 'streaming:chunk') return;
-        const chunk = typeof data.chunk === 'string' ? data.chunk : '';
-        if (!chunk) return;
-        const ts = await streamConnector.startStream({
-          threadId: mapping.thread_id,
-          text: chunk,
-          recipientUserId,
-          recipientTeamId,
-        });
-        this.slackStreamsByMessage.set(messageId, {
-          threadId: mapping.thread_id,
-          ts,
-          hasContent: true,
-          taskId: taskId ?? this.slackStreamTaskByMessage.get(messageId),
-        });
-        this.markTaskStreamedToSlack(taskId ?? this.slackStreamTaskByMessage.get(messageId));
-        return;
-      }
-
-      const stream = this.slackStreamsByMessage.get(messageId);
-      if (!stream) return;
-
       if (event === 'streaming:chunk') {
         const chunk = typeof data.chunk === 'string' ? data.chunk : '';
         if (!chunk) return;
+
+        const existing = this.slackStreamsByTask.get(taskKey);
+        if (!existing) {
+          const ts = await streamConnector.startStream({
+            threadId: mapping.thread_id,
+            text: chunk,
+            recipientUserId,
+            recipientTeamId,
+          });
+          this.slackStreamsByTask.set(taskKey, {
+            threadId: mapping.thread_id,
+            ts,
+            hasContent: true,
+            taskId: taskKey,
+            lastMessageId: messageId,
+          });
+          this.markMessageStreamedToSlack(messageId);
+          this.markTaskStreamedToSlack(taskKey);
+          return;
+        }
+
+        const text =
+          existing.hasContent && existing.lastMessageId && existing.lastMessageId !== messageId
+            ? `\n\n${chunk}`
+            : chunk;
         await streamConnector.appendStream({
-          threadId: stream.threadId,
-          ts: stream.ts,
-          text: chunk,
+          threadId: existing.threadId,
+          ts: existing.ts,
+          text,
         });
-        stream.hasContent = true;
+        existing.hasContent = true;
+        existing.lastMessageId = messageId;
+        this.markMessageStreamedToSlack(messageId);
+        this.markTaskStreamedToSlack(taskKey);
         return;
       }
 
-      if (event === 'streaming:end' || event === 'streaming:error') {
-        await streamConnector.stopStream({
-          threadId: stream.threadId,
-          ts: stream.ts,
-        });
-        if (event === 'streaming:end' && stream.hasContent) {
+      if (event === 'streaming:end') {
+        const existing = this.slackStreamsByTask.get(taskKey);
+        if (existing?.hasContent) {
           this.markMessageStreamedToSlack(messageId);
-          this.markTaskStreamedToSlack(
-            stream.taskId ?? this.slackStreamTaskByMessage.get(messageId)
-          );
+          this.markTaskStreamedToSlack(taskKey);
         }
-        this.slackStreamsByMessage.delete(messageId);
+        this.slackStreamTaskByMessage.delete(messageId);
+        return;
+      }
+
+      if (event === 'streaming:error') {
         this.slackStreamTaskByMessage.delete(messageId);
       }
     } catch (error) {
-      this.slackStreamsByMessage.delete(messageId);
+      this.slackStreamsByTask.delete(taskKey);
       this.slackStreamTaskByMessage.delete(messageId);
       console.warn('[gateway] Failed to mirror message stream to Slack:', error);
     }

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -6,6 +6,7 @@
  * since it orchestrates across multiple repositories and services.
  */
 
+import { PublicBaseUrlNotConfiguredError, requirePublicBaseUrl } from '@agor/core/config';
 import {
   type Database,
   GatewayChannelRepository,
@@ -41,6 +42,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
+import { getSessionUrl } from '@agor/core/utils/url';
 
 /**
  * Inbound message data (platform → session)
@@ -744,11 +746,24 @@ export class GatewayService {
     user: User
   ): Promise<string | null> {
     try {
+      const baseUrl = await requirePublicBaseUrl();
+      return getSessionUrl(sessionId, baseUrl);
+    } catch (error) {
+      if (!(error instanceof PublicBaseUrlNotConfiguredError)) {
+        console.warn('[gateway] Failed to build public session URL:', error);
+      }
+    }
+
+    try {
       const sessionsService = this.app.service('sessions') as {
         get: (id: string, params?: { user: User }) => Promise<Session & { url?: string | null }>;
       };
       const sessionWithUrl = await sessionsService.get(sessionId, { user });
-      return sessionWithUrl.url || null;
+      const sessionUrl = sessionWithUrl.url || null;
+      if (!sessionUrl) return null;
+      const hostname = new URL(sessionUrl).hostname;
+      if (hostname === '0.0.0.0') return null;
+      return sessionUrl;
     } catch (error) {
       console.warn('[gateway] Failed to fetch session URL:', error);
       return null;
@@ -1154,10 +1169,7 @@ export class GatewayService {
         metadata: data.metadata ?? null,
       });
 
-      // The create path already returns a Session from SessionRepository.create(),
-      // which populates url when the branch is attached to a board. Avoid an
-      // immediate get() round trip here; only follow-ups need to fetch.
-      const sessionUrl = session.url ?? null;
+      const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
 
       // Send debug message with session URL
       const message = formatGatewaySessionCreatedMessage(sessionId, sessionUrl);

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -109,6 +109,7 @@ interface SlackStreamState {
   threadId: string;
   ts: string;
   hasContent: boolean;
+  taskId?: string;
 }
 
 /**
@@ -311,6 +312,8 @@ export class GatewayService {
   private slackProgressQueues = new Map<string, Promise<void>>();
   private slackStreamsByMessage = new Map<string, SlackStreamState>();
   private slackStreamedMessageIds = new Set<string>();
+  private slackStreamedTaskIds = new Set<string>();
+  private slackStreamTaskByMessage = new Map<string, string>();
   private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
   private static SLACK_STREAMED_MESSAGE_CACHE_MAX = 500;
 
@@ -675,11 +678,24 @@ export class GatewayService {
     return this.slackStreamedMessageIds.has(messageId);
   }
 
+  wasTaskStreamedToSlack(taskId?: string): boolean {
+    return !!taskId && this.slackStreamedTaskIds.has(taskId);
+  }
+
   private markMessageStreamedToSlack(messageId: string): void {
     this.slackStreamedMessageIds.add(messageId);
     if (this.slackStreamedMessageIds.size > GatewayService.SLACK_STREAMED_MESSAGE_CACHE_MAX) {
       const oldest = this.slackStreamedMessageIds.values().next().value;
       if (oldest) this.slackStreamedMessageIds.delete(oldest);
+    }
+  }
+
+  private markTaskStreamedToSlack(taskId?: string): void {
+    if (!taskId) return;
+    this.slackStreamedTaskIds.add(taskId);
+    if (this.slackStreamedTaskIds.size > GatewayService.SLACK_STREAMED_MESSAGE_CACHE_MAX) {
+      const oldest = this.slackStreamedTaskIds.values().next().value;
+      if (oldest) this.slackStreamedTaskIds.delete(oldest);
     }
   }
 
@@ -755,7 +771,7 @@ export class GatewayService {
             threadId: mapping.thread_id,
             status: this.buildSlackAssistantStatus(data, metadataWithStart),
             loadingMessages:
-              data.state === 'working'
+              data.state === 'working' && (isNewTask || isRestartingAfterTerminal)
                 ? ['Reading context…', 'Using tools…', 'Writing the response…']
                 : undefined,
             iconEmoji: ':hourglass_flowing_sand:',
@@ -849,6 +865,7 @@ export class GatewayService {
 
     const sessionId = typeof data.session_id === 'string' ? data.session_id : undefined;
     const messageId = typeof data.message_id === 'string' ? data.message_id : undefined;
+    const taskId = typeof data.task_id === 'string' ? data.task_id : undefined;
     if (!sessionId || !messageId) return;
 
     const mapping = await this.threadMapRepo.findBySession(sessionId);
@@ -891,6 +908,7 @@ export class GatewayService {
         typeof metadata.slack_team_id === 'string' ? metadata.slack_team_id : undefined;
 
       if (event === 'streaming:start') {
+        if (taskId) this.slackStreamTaskByMessage.set(messageId, taskId);
         return;
       }
 
@@ -909,6 +927,7 @@ export class GatewayService {
           threadId: mapping.thread_id,
           ts,
           hasContent: true,
+          taskId: taskId ?? this.slackStreamTaskByMessage.get(messageId),
         });
         return;
       }
@@ -935,11 +954,16 @@ export class GatewayService {
         });
         if (event === 'streaming:end' && stream.hasContent) {
           this.markMessageStreamedToSlack(messageId);
+          this.markTaskStreamedToSlack(
+            stream.taskId ?? this.slackStreamTaskByMessage.get(messageId)
+          );
         }
         this.slackStreamsByMessage.delete(messageId);
+        this.slackStreamTaskByMessage.delete(messageId);
       }
     } catch (error) {
       this.slackStreamsByMessage.delete(messageId);
+      this.slackStreamTaskByMessage.delete(messageId);
       console.warn('[gateway] Failed to mirror message stream to Slack:', error);
     }
   }

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -708,10 +708,9 @@ export class GatewayService {
       typeof metadata.slack_status_message_ts === 'string'
         ? metadata.slack_status_message_ts
         : undefined;
-    const hasTodoPlan = this.parseGatewayTodos(metadataWithStart.slack_status_todos).length > 0;
 
     try {
-      if (data.state === 'done' && existingTs && connector.deleteMessage && !hasTodoPlan) {
+      if (data.state === 'done' && existingTs && connector.deleteMessage) {
         try {
           await connector.deleteMessage({
             threadId: mapping.thread_id,
@@ -732,30 +731,11 @@ export class GatewayService {
       }
 
       const { text, blocks } = this.buildSlackProgressOutbound(data, metadataWithStart, connector);
-      let updateTs = existingTs;
-
-      // Slack `chat.update` edits in place; it does not move the message to the
-      // bottom of the thread. For in-flight progress, keep the visible status
-      // as the last reply by deleting the previous transient row and posting a
-      // replacement. Terminal states can update/delete in place because they
-      // are no longer trying to indicate "currently running".
-      if (!isTerminal && existingTs && connector.deleteMessage) {
-        try {
-          await connector.deleteMessage({
-            threadId: mapping.thread_id,
-            messageId: existingTs,
-          });
-          updateTs = undefined;
-        } catch (error) {
-          console.warn('[gateway] Failed to bump Slack progress status; updating in place:', error);
-        }
-      }
-
       const ts = await connector.sendMessage({
         threadId: mapping.thread_id,
         text,
         blocks,
-        metadata: updateTs ? { slack_update_ts: updateTs } : undefined,
+        metadata: existingTs ? { slack_update_ts: existingTs } : undefined,
       });
 
       if (

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -691,8 +691,10 @@ export class GatewayService {
       data.tool_name || data.tool_input
         ? this.formatSlackToolSummary(data.tool_name, data.tool_input)
         : undefined;
+    const baseMetadata =
+      isNewTask || isRestartingAfterTerminal ? this.stripSlackProgressMetadata(metadata) : metadata;
     const metadataWithStart = {
-      ...metadata,
+      ...baseMetadata,
       slack_status_started_at: statusStartedAt,
       slack_status_state: data.state,
       ...(data.task_id ? { slack_status_task_id: data.task_id } : {}),
@@ -708,8 +710,23 @@ export class GatewayService {
       typeof metadata.slack_status_message_ts === 'string'
         ? metadata.slack_status_message_ts
         : undefined;
+    let updateTs = existingTs;
 
     try {
+      if (!isTerminal && isNewTask && existingTs) {
+        if (connector.deleteMessage) {
+          try {
+            await connector.deleteMessage({
+              threadId: mapping.thread_id,
+              messageId: existingTs,
+            });
+          } catch (error) {
+            console.warn('[gateway] Failed to delete stale Slack progress status:', error);
+          }
+        }
+        updateTs = undefined;
+      }
+
       if (data.state === 'done' && existingTs && connector.deleteMessage) {
         try {
           await connector.deleteMessage({
@@ -735,7 +752,7 @@ export class GatewayService {
         threadId: mapping.thread_id,
         text,
         blocks,
-        metadata: existingTs ? { slack_update_ts: existingTs } : undefined,
+        metadata: updateTs ? { slack_update_ts: updateTs } : undefined,
       });
 
       if (

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -582,6 +582,38 @@ export class GatewayService {
       : 'is working on your request.';
   }
 
+  private buildSlackAssistantLoadingMessage(
+    data: GatewayProgressData,
+    existingMetadata: Record<string, unknown>
+  ): string | undefined {
+    if (data.state === 'done') return undefined;
+    if (data.state === 'failed') return 'Agor ran into an error.';
+    if (data.state === 'queued') return 'Queued in Agor…';
+
+    const latestToolSummary =
+      data.tool_name || data.tool_input
+        ? this.formatSlackToolSummary(data.tool_name, data.tool_input)
+        : typeof existingMetadata.slack_status_tool_summary === 'string'
+          ? existingMetadata.slack_status_tool_summary
+          : undefined;
+
+    if (latestToolSummary) {
+      return `Using ${this.truncateSlackInline(latestToolSummary.replace(/`/g, ''), 80)}…`;
+    }
+
+    const latestToolName =
+      data.tool_name ??
+      (typeof existingMetadata.slack_status_tool_name === 'string'
+        ? existingMetadata.slack_status_tool_name
+        : undefined);
+
+    if (latestToolName) {
+      return `Using ${this.truncateSlackInline(latestToolName, 60)}…`;
+    }
+
+    return 'Working in Agor…';
+  }
+
   private stripSlackProgressMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
     const {
       slack_status_message_ts: _statusTs,
@@ -796,9 +828,11 @@ export class GatewayService {
 
       if (connector.setThreadStatus) {
         try {
+          const loadingMessage = this.buildSlackAssistantLoadingMessage(data, metadataWithStart);
           await connector.setThreadStatus({
             threadId: mapping.thread_id,
             status: this.buildSlackAssistantStatus(data, metadataWithStart),
+            loadingMessages: loadingMessage ? [loadingMessage] : undefined,
             iconEmoji: ':hourglass_flowing_sand:',
           });
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -794,7 +794,12 @@ export class GatewayService {
       getConnector(channel.channel_type as ChannelType, channel.config);
 
     const streamConnector = connector as GatewayConnector & {
-      startStream?: (req: { threadId: string; text?: string }) => Promise<string>;
+      startStream?: (req: {
+        threadId: string;
+        text?: string;
+        recipientUserId?: string;
+        recipientTeamId?: string;
+      }) => Promise<string>;
       appendStream?: (req: { threadId: string; ts: string; text: string }) => Promise<void>;
       stopStream?: (req: { threadId: string; ts: string; text?: string }) => Promise<void>;
     };
@@ -808,6 +813,15 @@ export class GatewayService {
     }
 
     try {
+      const metadata = ((mapping.metadata as Record<string, unknown>) ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const recipientUserId =
+        typeof metadata.slack_user_id === 'string' ? metadata.slack_user_id : undefined;
+      const recipientTeamId =
+        typeof metadata.slack_team_id === 'string' ? metadata.slack_team_id : undefined;
+
       if (event === 'streaming:start') {
         return;
       }
@@ -820,6 +834,8 @@ export class GatewayService {
         const ts = await streamConnector.startStream({
           threadId: mapping.thread_id,
           text: chunk,
+          recipientUserId,
+          recipientTeamId,
         });
         this.slackStreamsByMessage.set(messageId, {
           threadId: mapping.thread_id,
@@ -1152,15 +1168,26 @@ export class GatewayService {
       // Touch timestamps
       await this.threadMapRepo.updateLastMessage(existingMapping.id);
 
-      // Update mapping metadata with new processing_comment_id if present.
-      // Each follow-up @mention creates a new "Processing..." comment, and
-      // the flush needs the latest comment ID to edit the right one.
-      if (data.metadata?.processing_comment_id) {
-        const updatedMetadata = {
-          ...((existingMapping.metadata as Record<string, unknown>) ?? {}),
-          processing_comment_id: data.metadata.processing_comment_id,
-        };
-        await this.threadMapRepo.updateMetadata(existingMapping.id, updatedMetadata);
+      // Update mapping metadata with fresh platform context. For GitHub, each
+      // follow-up @mention creates a new "Processing..." comment and the flush
+      // needs the latest comment ID. For Slack streaming, chat.startStream
+      // requires the recipient user/team IDs for channel threads.
+      if (data.metadata) {
+        const existingMetadata = ((existingMapping.metadata as Record<string, unknown>) ?? {}) as
+          | Record<string, unknown>
+          | undefined;
+        await this.threadMapRepo.updateMetadata(existingMapping.id, {
+          ...existingMetadata,
+          ...(data.metadata.processing_comment_id
+            ? { processing_comment_id: data.metadata.processing_comment_id }
+            : {}),
+          ...(typeof data.metadata.slack_user_id === 'string'
+            ? { slack_user_id: data.metadata.slack_user_id }
+            : {}),
+          ...(typeof data.metadata.slack_team_id === 'string'
+            ? { slack_team_id: data.metadata.slack_team_id }
+            : {}),
+        });
       }
 
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -717,11 +717,30 @@ export class GatewayService {
       }
 
       const { text, blocks } = this.buildSlackProgressOutbound(data, metadataWithStart, connector);
+      let updateTs = existingTs;
+
+      // Slack `chat.update` edits in place; it does not move the message to the
+      // bottom of the thread. For in-flight progress, keep the visible status
+      // as the last reply by deleting the previous transient row and posting a
+      // replacement. Terminal states can update/delete in place because they
+      // are no longer trying to indicate "currently running".
+      if (!isTerminal && existingTs && connector.deleteMessage) {
+        try {
+          await connector.deleteMessage({
+            threadId: mapping.thread_id,
+            messageId: existingTs,
+          });
+          updateTs = undefined;
+        } catch (error) {
+          console.warn('[gateway] Failed to bump Slack progress status; updating in place:', error);
+        }
+      }
+
       const ts = await connector.sendMessage({
         threadId: mapping.thread_id,
         text,
         blocks,
-        metadata: existingTs ? { slack_update_ts: existingTs } : undefined,
+        metadata: updateTs ? { slack_update_ts: updateTs } : undefined,
       });
 
       if (

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -554,6 +554,28 @@ export class GatewayService {
     return plan ? `${plan}\n${progress}` : progress;
   }
 
+  private buildSlackAssistantStatus(
+    data: GatewayProgressData,
+    existingMetadata: Record<string, unknown>
+  ): string {
+    if (data.state === 'done') return '';
+    if (data.state === 'failed') return 'ran into an error.';
+    if (data.state === 'queued') {
+      const position =
+        typeof data.queue_position === 'number' ? ` at position ${data.queue_position}` : '';
+      return `is queued${position}.`;
+    }
+
+    const latestToolName =
+      data.tool_name ??
+      (typeof existingMetadata.slack_status_tool_name === 'string'
+        ? existingMetadata.slack_status_tool_name
+        : undefined);
+    return latestToolName
+      ? `is using ${this.truncateSlackInline(latestToolName, 40)}.`
+      : 'is working on your request.';
+  }
+
   private stripSlackProgressMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
     const {
       slack_status_message_ts: _statusTs,
@@ -713,6 +735,38 @@ export class GatewayService {
     let updateTs = existingTs;
 
     try {
+      if (connector.setThreadStatus) {
+        try {
+          await connector.setThreadStatus({
+            threadId: mapping.thread_id,
+            status: this.buildSlackAssistantStatus(data, metadataWithStart),
+            loadingMessages:
+              data.state === 'working'
+                ? ['Reading context…', 'Using tools…', 'Writing the response…']
+                : undefined,
+            iconEmoji: ':hourglass_flowing_sand:',
+          });
+
+          if (existingTs && connector.deleteMessage) {
+            await connector.deleteMessage({
+              threadId: mapping.thread_id,
+              messageId: existingTs,
+            });
+          }
+
+          await this.threadMapRepo.updateMetadata(
+            mapping.id,
+            this.stripSlackProgressMetadata(metadataWithStart)
+          );
+          return;
+        } catch (error) {
+          console.warn(
+            '[gateway] Failed to set Slack assistant status; falling back to status row:',
+            error
+          );
+        }
+      }
+
       if (!isTerminal && isNewTask && existingTs) {
         if (connector.deleteMessage) {
           try {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -469,8 +469,7 @@ export class GatewayService {
 
   private buildSlackProgressText(
     data: GatewayProgressData,
-    existingMetadata: Record<string, unknown>,
-    sessionUrl?: string | null
+    existingMetadata: Record<string, unknown>
   ): string {
     const now = Date.now();
     const startedAt =
@@ -483,23 +482,19 @@ export class GatewayService {
         ? `${elapsedSeconds}s`
         : `${Math.floor(elapsedSeconds / 60)}m ${elapsedSeconds % 60}s`;
 
-    const sessionLabel = sessionUrl
-      ? `<${sessionUrl}|session ${shortId(data.session_id)}>`
-      : `session \`${shortId(data.session_id)}\``;
-
     if (data.state === 'queued') {
       const position =
         typeof data.queue_position === 'number' ? ` at position ${data.queue_position}` : '';
-      return `⏳ Agor queued your message${position} in ${sessionLabel}.`;
+      return `⏳ Queued your message${position}.`;
     }
 
     if (data.state === 'done') {
-      return `✅ Agor finished in ${sessionLabel}.`;
+      return `✅ Done.`;
     }
 
     if (data.state === 'failed') {
       const suffix = data.error_message ? `\n>${data.error_message}` : '';
-      return `⚠️ Agor stopped with an error in ${sessionLabel}.${suffix}`;
+      return `⚠️ Agor stopped with an error.${suffix}`;
     }
 
     const latestToolName =
@@ -517,7 +512,19 @@ export class GatewayService {
     const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
     const plan = this.formatSlackTodoPlan(todos);
     const toolLine = `\nCurrent tool: ${latestToolSummary}`;
-    return `⏳ Agor is still working in ${sessionLabel} (${elapsed}).${toolLine}${plan}`;
+    return `⏳ Still working (${elapsed}).${toolLine}${plan}`;
+  }
+
+  private stripSlackProgressMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+    const {
+      slack_status_message_ts: _statusTs,
+      slack_status_started_at: _startedAt,
+      slack_status_tool_name: _toolName,
+      slack_status_tool_summary: _toolSummary,
+      slack_status_todos: _todos,
+      ...rest
+    } = metadata;
+    return rest;
   }
 
   /**
@@ -570,36 +577,39 @@ export class GatewayService {
       ...(toolTodos.length > 0 ? { slack_status_todos: toolTodos } : {}),
     };
 
-    const usersService = this.app.service('users') as {
-      get: (id: string) => Promise<User>;
-    };
-    const sessionsService = this.app.service('sessions') as {
-      get: (id: string, params?: { user: User }) => Promise<Session & { url?: string | null }>;
-    };
-
-    let sessionUrl: string | null = null;
-    try {
-      const session = await sessionsService.get(data.session_id);
-      const user = await usersService.get(session.created_by);
-      sessionUrl = (await sessionsService.get(data.session_id, { user })).url || null;
-    } catch {
-      // Best-effort only; the status message can still identify the short ID.
-    }
-
     const connector =
       this.activeListeners.get(channel.id) ??
       getConnector(channel.channel_type as ChannelType, channel.config);
-    const statusText = this.buildSlackProgressText(data, metadataWithStart, sessionUrl);
-    const { text, blocks } = normalizeOutbound(
-      connector.formatMessage ? connector.formatMessage(statusText) : statusText
-    );
-
     const existingTs =
       typeof metadata.slack_status_message_ts === 'string'
         ? metadata.slack_status_message_ts
         : undefined;
 
     try {
+      if (data.state === 'done' && existingTs && connector.deleteMessage) {
+        try {
+          await connector.deleteMessage({
+            threadId: mapping.thread_id,
+            messageId: existingTs,
+          });
+          await this.threadMapRepo.updateMetadata(
+            mapping.id,
+            this.stripSlackProgressMetadata(metadataWithStart)
+          );
+          return;
+        } catch (error) {
+          console.warn('[gateway] Failed to delete Slack progress status; marking done:', error);
+        }
+      }
+
+      if (data.state === 'done' && !existingTs) {
+        return;
+      }
+
+      const statusText = this.buildSlackProgressText(data, metadataWithStart);
+      const { text, blocks } = normalizeOutbound(
+        connector.formatMessage ? connector.formatMessage(statusText) : statusText
+      );
       const ts = await connector.sendMessage({
         threadId: mapping.thread_id,
         text,

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -346,10 +346,10 @@ export class GatewayService {
    * Useful for giving the user visibility into what's happening.
    */
   private sendDebugMessage(channel: GatewayChannel, threadId: string, text: string): void {
-    // Skip debug messages for GitHub channels — the "Processing..." comment
-    // already serves as the status indicator and gets edited with the final response.
-    // Posting debug messages as separate comments clutters the issue thread.
-    if (channel.channel_type === 'github') return;
+    // Skip debug messages for GitHub and Slack channels. GitHub has its
+    // editable Processing comment; Slack now uses native assistant status and
+    // stream chrome, so extra content rows make the thread noisy.
+    if (channel.channel_type === 'github' || channel.channel_type === 'slack') return;
 
     if (!hasConnector(channel.channel_type as ChannelType)) return;
     try {
@@ -813,6 +813,50 @@ export class GatewayService {
     }
   }
 
+  private async ensureSlackTaskStream(req: {
+    taskId: string | undefined;
+    threadId: string;
+    connector: GatewayConnector;
+    metadata: Record<string, unknown>;
+  }): Promise<void> {
+    if (!req.taskId || this.slackStreamsByTask.has(req.taskId)) return;
+
+    const streamConnector = req.connector as GatewayConnector & {
+      startStream?: (startReq: {
+        threadId: string;
+        text?: string;
+        recipientUserId?: string;
+        recipientTeamId?: string;
+        taskDisplayMode?: 'plan' | 'timeline' | 'dense';
+      }) => Promise<string>;
+    };
+    if (!streamConnector.startStream) return;
+
+    const recipientUserId =
+      typeof req.metadata.slack_user_id === 'string' ? req.metadata.slack_user_id : undefined;
+    const recipientTeamId =
+      typeof req.metadata.slack_team_id === 'string' ? req.metadata.slack_team_id : undefined;
+
+    const ts = await streamConnector.startStream({
+      threadId: req.threadId,
+      text: ' ',
+      recipientUserId,
+      recipientTeamId,
+      taskDisplayMode: 'plan',
+    });
+    this.slackStreamsByTask.set(req.taskId, {
+      threadId: req.threadId,
+      ts,
+      hasContent: false,
+      taskId: req.taskId,
+    });
+
+    const todos = this.parseGatewayTodos(req.metadata.slack_status_todos);
+    if (todos.length > 0) {
+      await this.appendSlackTodoPlanToStream(req.taskId, req.connector, todos);
+    }
+  }
+
   private async stopSlackTaskStream(
     taskId: string | undefined,
     connector: GatewayConnector
@@ -909,6 +953,19 @@ export class GatewayService {
 
       if (connector.setThreadStatus) {
         try {
+          if (!isTerminal && data.state === 'working') {
+            try {
+              await this.ensureSlackTaskStream({
+                taskId: data.task_id,
+                threadId: mapping.thread_id,
+                connector,
+                metadata: metadataWithStart,
+              });
+            } catch (error) {
+              console.warn('[gateway] Failed to start Slack task stream:', error);
+            }
+          }
+
           const loadingMessage = this.buildSlackAssistantLoadingMessage(data, metadataWithStart);
           await connector.setThreadStatus({
             threadId: mapping.thread_id,
@@ -1075,7 +1132,7 @@ export class GatewayService {
             text: chunk,
             recipientUserId,
             recipientTeamId,
-            ...(todos.length > 0 ? { taskDisplayMode: 'plan' as const } : {}),
+            taskDisplayMode: 'plan',
           });
           this.slackStreamsByTask.set(taskKey, {
             threadId: mapping.thread_id,

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -362,7 +362,7 @@ export class GatewayService {
     }
   }
 
-  private truncateSlackInline(value: string, maxChars = 160): string {
+  private truncateSlackInline(value: string, maxChars = 70): string {
     const singleLine = value.replace(/\s+/g, ' ').trim();
     if (singleLine.length <= maxChars) return singleLine;
     return `${singleLine.slice(0, Math.max(0, maxChars - 1))}…`;
@@ -415,29 +415,64 @@ export class GatewayService {
   private formatSlackToolSummary(toolName?: string, input?: Record<string, unknown>): string {
     if (!toolName) return 'Waiting for the agent...';
 
-    // Keep this deliberately generic: always show the latest tool, but only
-    // append a short one-line hint when a common scalar preview exists.
-    const previewKeys = [
-      'description',
-      'command',
-      'file_path',
-      'path',
-      'query',
-      'url',
-      'pattern',
-      'name',
-    ];
-    const previewValue = previewKeys
-      .map((key) => input?.[key])
-      .find((value) => typeof value === 'string' && value.trim().length > 0);
+    const str = (value: unknown): string | undefined =>
+      typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+    const preview = (value: unknown, maxChars = 70): string | undefined => {
+      const text = str(value);
+      return text ? this.truncateSlackInline(text, maxChars) : undefined;
+    };
+    const withPreview = (value?: string): string =>
+      value ? `\`${toolName}\` ${value}` : `\`${toolName}\``;
 
-    if (typeof previewValue === 'string') {
-      return `\`${toolName}\`: ${this.truncateSlackInline(previewValue)}`;
+    if (toolName === 'TodoWrite') {
+      const todos = this.parseGatewayTodos(input?.todos);
+      if (todos.length > 0) {
+        const completed = todos.filter((todo) => todo.status === 'completed').length;
+        const inProgress = todos.filter((todo) => todo.status === 'in_progress').length;
+        const parts = [`${completed}/${todos.length} done`];
+        if (inProgress > 0) parts.push(`${inProgress} in progress`);
+        return withPreview(parts.join(', '));
+      }
     }
 
-    const changes = input?.changes;
-    if (Array.isArray(changes) && changes.length > 0) {
-      return `\`${toolName}\`: ${changes.length} file change${changes.length === 1 ? '' : 's'}`;
+    switch (toolName) {
+      case 'Read':
+      case 'Write':
+      case 'Edit':
+      case 'NotebookEdit':
+        return withPreview(preview(input?.file_path));
+      case 'Bash':
+      case 'exec_command':
+        return withPreview(preview(input?.description) ?? preview(input?.command));
+      case 'Grep':
+      case 'Glob':
+        return withPreview(preview(input?.pattern));
+      case 'ToolSearch':
+      case 'WebSearch':
+      case 'web_search':
+        return withPreview(preview(input?.query));
+      case 'WebFetch':
+        return withPreview(preview(input?.url));
+      case 'Agent':
+        return withPreview(preview(input?.description));
+      case 'Skill':
+      case 'SlashCommand':
+        return withPreview(preview(input?.skill) ?? preview(input?.name));
+      case 'Task':
+        return withPreview(preview(str(input?.prompt)?.split('\n')[0], 100));
+      case 'edit_files': {
+        const changes = input?.changes;
+        if (Array.isArray(changes) && changes.length > 0) {
+          if (changes.length === 1) {
+            const change = changes[0] as Record<string, unknown>;
+            const kind = str(change.kind) ?? 'update';
+            const path = str(change.path) ?? '';
+            return withPreview(this.truncateSlackInline(`${kind} ${path}`.trim(), 70));
+          }
+          return withPreview(`${changes.length} files`);
+        }
+        break;
+      }
     }
 
     return `\`${toolName}\``;
@@ -496,7 +531,9 @@ export class GatewayService {
     }
 
     if (data.state === 'done') {
-      return `✅ Done.`;
+      const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
+      const plan = this.formatSlackTodoPlan(todos);
+      return `✅ Done.${plan}`;
     }
 
     if (data.state === 'failed') {
@@ -528,6 +565,7 @@ export class GatewayService {
       slack_status_tool_name: _toolName,
       slack_status_tool_summary: _toolSummary,
       slack_status_todos: _todos,
+      slack_status_state: _state,
       ...rest
     } = metadata;
     return rest;
@@ -608,9 +646,12 @@ export class GatewayService {
       unknown
     >;
     const statusStartedAt =
-      typeof metadata.slack_status_started_at === 'string'
-        ? metadata.slack_status_started_at
-        : new Date(now).toISOString();
+      (data.state === 'queued' || data.state === 'working') &&
+      (metadata.slack_status_state === 'done' || metadata.slack_status_state === 'failed')
+        ? new Date(now).toISOString()
+        : typeof metadata.slack_status_started_at === 'string'
+          ? metadata.slack_status_started_at
+          : new Date(now).toISOString();
     const toolTodos =
       data.tool_name === 'TodoWrite' ? this.parseGatewayTodos(data.tool_input?.todos) : [];
     const toolSummary =
@@ -620,6 +661,7 @@ export class GatewayService {
     const metadataWithStart = {
       ...metadata,
       slack_status_started_at: statusStartedAt,
+      slack_status_state: data.state,
       ...(data.tool_name ? { slack_status_tool_name: data.tool_name } : {}),
       ...(toolSummary ? { slack_status_tool_summary: toolSummary } : {}),
       ...(toolTodos.length > 0 ? { slack_status_todos: toolTodos } : {}),
@@ -632,9 +674,10 @@ export class GatewayService {
       typeof metadata.slack_status_message_ts === 'string'
         ? metadata.slack_status_message_ts
         : undefined;
+    const hasTodoPlan = this.parseGatewayTodos(metadataWithStart.slack_status_todos).length > 0;
 
     try {
-      if (data.state === 'done' && existingTs && connector.deleteMessage) {
+      if (data.state === 'done' && existingTs && connector.deleteMessage && !hasTodoPlan) {
         try {
           await connector.deleteMessage({
             threadId: mapping.thread_id,
@@ -665,6 +708,7 @@ export class GatewayService {
       if (
         !existingTs ||
         metadataWithStart.slack_status_started_at !== metadata.slack_status_started_at ||
+        isTerminal ||
         data.tool_name ||
         data.tool_input
       ) {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -310,7 +310,9 @@ export class GatewayService {
   private slackProgressLastUpdate = new Map<string, number>();
   private slackProgressQueues = new Map<string, Promise<void>>();
   private slackStreamsByMessage = new Map<string, SlackStreamState>();
+  private slackStreamedMessageIds = new Set<string>();
   private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
+  private static SLACK_STREAMED_MESSAGE_CACHE_MAX = 500;
 
   constructor(db: Database, app: Application) {
     this.channelRepo = new GatewayChannelRepository(db);
@@ -669,6 +671,18 @@ export class GatewayService {
     }
   }
 
+  wasMessageStreamedToSlack(messageId: string): boolean {
+    return this.slackStreamedMessageIds.has(messageId);
+  }
+
+  private markMessageStreamedToSlack(messageId: string): void {
+    this.slackStreamedMessageIds.add(messageId);
+    if (this.slackStreamedMessageIds.size > GatewayService.SLACK_STREAMED_MESSAGE_CACHE_MAX) {
+      const oldest = this.slackStreamedMessageIds.values().next().value;
+      if (oldest) this.slackStreamedMessageIds.delete(oldest);
+    }
+  }
+
   private async updateProgressNow(data: GatewayProgressData): Promise<void> {
     if (!this.hasActiveChannels) return;
 
@@ -919,6 +933,9 @@ export class GatewayService {
           threadId: stream.threadId,
           ts: stream.ts,
         });
+        if (event === 'streaming:end' && stream.hasContent) {
+          this.markMessageStreamedToSlack(messageId);
+        }
         this.slackStreamsByMessage.delete(messageId);
       }
     } catch (error) {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -309,9 +309,7 @@ export class GatewayService {
    */
   private slackProgressLastUpdate = new Map<string, number>();
   private slackStreamsByMessage = new Map<string, SlackStreamState>();
-  private slackStreamedMessageIds = new Map<string, number>();
   private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
-  private static SLACK_STREAMED_MESSAGE_TTL_MS = 5 * 60 * 1000;
 
   constructor(db: Database, app: Application) {
     this.channelRepo = new GatewayChannelRepository(db);
@@ -520,8 +518,7 @@ export class GatewayService {
 
     const todos = this.parseGatewayTodos(existingMetadata.slack_status_todos);
     const plan = this.formatSlackTodoPlan(todos);
-    const toolLine = `\nCurrent tool: ${latestToolSummary}`;
-    return `⏳ Still working (${elapsed}).${toolLine}${plan}`;
+    return `⏳ Still working (${elapsed}) · ${latestToolSummary}${plan}`;
   }
 
   private stripSlackProgressMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
@@ -681,18 +678,6 @@ export class GatewayService {
     }
   }
 
-  private cleanupSlackStreamedMessageIds(): void {
-    const now = Date.now();
-    for (const [messageId, expiresAt] of this.slackStreamedMessageIds) {
-      if (expiresAt <= now) this.slackStreamedMessageIds.delete(messageId);
-    }
-  }
-
-  wasSlackMessageStreamed(messageId: string): boolean {
-    this.cleanupSlackStreamedMessageIds();
-    return this.slackStreamedMessageIds.has(messageId);
-  }
-
   async handleMessageStreamingEvent(
     event: 'streaming:start' | 'streaming:chunk' | 'streaming:end' | 'streaming:error',
     data: Record<string, unknown>
@@ -770,12 +755,6 @@ export class GatewayService {
           ts: stream.ts,
         });
         this.slackStreamsByMessage.delete(messageId);
-        if (event === 'streaming:end' && stream.hasContent) {
-          this.slackStreamedMessageIds.set(
-            messageId,
-            Date.now() + GatewayService.SLACK_STREAMED_MESSAGE_TTL_MS
-          );
-        }
       }
     } catch (error) {
       this.slackStreamsByMessage.delete(messageId);
@@ -1215,10 +1194,13 @@ export class GatewayService {
 
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
 
-      // Send debug message with session URL
-      const message = formatGatewaySessionCreatedMessage(sessionId, sessionUrl);
-
-      this.sendDebugMessage(channel, data.thread_id, message);
+      if (sessionUrl) {
+        this.sendDebugMessage(
+          channel,
+          data.thread_id,
+          formatGatewaySessionCreatedMessage(sessionId, sessionUrl)
+        );
+      }
 
       // For GitHub channels: edit the "Processing..." comment to include the session link.
       // The processing_comment_id was stored in inbound metadata by the GitHub connector.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,8 @@ services:
       - UI_PORT=${UI_PORT:-5173}
       # UI connects to daemon via localhost (inside container)
       - VITE_DAEMON_PORT=${DAEMON_PORT:-3030}
+      # Public, browser-facing base URL used in Slack/GitHub/email links.
+      - AGOR_BASE_URL=${AGOR_BASE_URL:-}
 
       # Database configuration
       # AUTO-DETECT: If postgres container is running, use PostgreSQL; otherwise SQLite

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -439,6 +439,18 @@ describe('requirePublicBaseUrl', () => {
     await expect(requirePublicBaseUrl()).resolves.toBe('https://agor.sandbox.example.com');
   });
 
+  it('returns ui.base_url from legacy config when daemon.base_url is unset', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agorDir, 'config.yaml'),
+      yaml.dump({ ui: { base_url: 'https://agor-ui.sandbox.example.com' } }),
+      'utf-8'
+    );
+
+    await expect(requirePublicBaseUrl()).resolves.toBe('https://agor-ui.sandbox.example.com');
+  });
+
   it('throws PublicBaseUrlNotConfiguredError when neither env nor config is set', async () => {
     await expect(requirePublicBaseUrl()).rejects.toBeInstanceOf(PublicBaseUrlNotConfiguredError);
   });

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -562,7 +562,12 @@ export async function getBaseUrl(): Promise<string> {
     return validateBaseUrl(config.daemon.base_url);
   }
 
-  // 3. Default: construct from daemon port (no validation needed for default)
+  // 3. Backward-compatible UI public URL used by older configs.
+  if (config.ui?.base_url) {
+    return validateBaseUrl(config.ui.base_url);
+  }
+
+  // 4. Default: construct from daemon port (no validation needed for default)
   const defaults = getDefaultConfig();
   const envPort = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : undefined;
   const port = envPort || config.daemon?.port || defaults.daemon?.port || DAEMON.DEFAULT_PORT;
@@ -617,9 +622,14 @@ export async function requirePublicBaseUrl(): Promise<string> {
     return validateBaseUrl(config.daemon.base_url);
   }
 
+  if (config.ui?.base_url) {
+    return validateBaseUrl(config.ui.base_url);
+  }
+
   throw new PublicBaseUrlNotConfiguredError(
     'No public base URL configured. Set the AGOR_BASE_URL environment variable ' +
-      "or `daemon.base_url` in ~/.agor/config.yaml to the daemon's " +
+      'or `daemon.base_url` (preferred) / `ui.base_url` (legacy) in ~/.agor/config.yaml ' +
+      "to the daemon's " +
       'browser-reachable URL (e.g. https://agor.example.com). This is required ' +
       'so OAuth providers can redirect users back to a URL their browser can reach — ' +
       'the localhost fallback only works for browsers on the daemon machine.'

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -166,6 +166,15 @@ export interface AgorDaemonSettings {
  * UI settings
  */
 export interface AgorUISettings {
+  /**
+   * Public user-facing base URL for the UI.
+   *
+   * Legacy/compatibility alias for daemon.base_url in older configs. New
+   * installs should prefer daemon.base_url so all external link builders share
+   * one setting.
+   */
+  base_url?: string;
+
   /** UI dev server port (default: 5173) */
   port?: number;
 

--- a/packages/core/src/gateway/connector.ts
+++ b/packages/core/src/gateway/connector.ts
@@ -73,6 +73,19 @@ export interface GatewayConnector {
   deleteMessage?(req: { threadId: string; messageId: string }): Promise<void>;
 
   /**
+   * Set platform-native thread status when supported.
+   *
+   * Slack exposes this via assistant.threads.setStatus; unlike a mutable chat
+   * message, the status is rendered by Slack as assistant chrome.
+   */
+  setThreadStatus?(req: {
+    threadId: string;
+    status: string;
+    loadingMessages?: string[];
+    iconEmoji?: string;
+  }): Promise<void>;
+
+  /**
    * Start listening for inbound messages (e.g., via Socket Mode or webhooks)
    */
   startListening?(callback: (msg: InboundMessage) => void): Promise<void>;

--- a/packages/core/src/gateway/connector.ts
+++ b/packages/core/src/gateway/connector.ts
@@ -65,6 +65,14 @@ export interface GatewayConnector {
   }): Promise<string>;
 
   /**
+   * Delete a previously sent platform message when supported.
+   *
+   * Used for temporary UX affordances (for example, Slack progress rows) that
+   * should disappear once the durable assistant response has arrived.
+   */
+  deleteMessage?(req: { threadId: string; messageId: string }): Promise<void>;
+
+  /**
    * Start listening for inbound messages (e.g., via Socket Mode or webhooks)
    */
   startListening?(callback: (msg: InboundMessage) => void): Promise<void>;

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -566,64 +566,6 @@ describe('SlackConnector.sendMessage', () => {
     ]);
   });
 
-  it('supports Slack stream plan mode and task update chunks', async () => {
-    const calls: Array<{ method: string; args: unknown }> = [];
-    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
-    (connector as unknown as { web: unknown }).web = {
-      chat: {
-        startStream: async (args: unknown) => {
-          calls.push({ method: 'startStream', args });
-          return { ok: true, ts: '1700000000.000006' };
-        },
-        appendStream: async (args: unknown) => {
-          calls.push({ method: 'appendStream', args });
-          return { ok: true };
-        },
-      },
-    };
-
-    const ts = await connector.startStream({
-      threadId: 'C123-1700000000.000000',
-      text: 'hello',
-      taskDisplayMode: 'plan',
-    });
-    await connector.appendStreamPayload({
-      threadId: 'C123-1700000000.000000',
-      ts,
-      chunks: [
-        {
-          type: 'task_update',
-          task: { task_id: 'agor_todo_1', title: 'Read context', status: 'completed' },
-        },
-      ],
-    });
-
-    expect(calls).toEqual([
-      {
-        method: 'startStream',
-        args: {
-          channel: 'C123',
-          thread_ts: '1700000000.000000',
-          markdown_text: 'hello',
-          task_display_mode: 'plan',
-        },
-      },
-      {
-        method: 'appendStream',
-        args: {
-          channel: 'C123',
-          ts: '1700000000.000006',
-          chunks: [
-            {
-              type: 'task_update',
-              task: { task_id: 'agor_todo_1', title: 'Read context', status: 'completed' },
-            },
-          ],
-        },
-      },
-    ]);
-  });
-
   it('passes Slack stream recipient ids when provided', async () => {
     const calls: unknown[] = [];
     const connector = new SlackConnector({ bot_token: 'xoxb-test' });

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -596,6 +596,38 @@ describe('SlackConnector.sendMessage', () => {
     ]);
   });
 
+  it('sets Slack assistant thread status', async () => {
+    const calls: unknown[] = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      assistant: {
+        threads: {
+          setStatus: async (args: unknown) => {
+            calls.push(args);
+            return { ok: true };
+          },
+        },
+      },
+    };
+
+    await connector.setThreadStatus?.({
+      threadId: 'C123-1700000000.000000',
+      status: 'is working on your request.',
+      loadingMessages: ['Reading context…'],
+      iconEmoji: ':hourglass_flowing_sand:',
+    });
+
+    expect(calls).toEqual([
+      {
+        channel_id: 'C123',
+        thread_ts: '1700000000.000000',
+        status: 'is working on your request.',
+        loading_messages: ['Reading context…'],
+        icon_emoji: ':hourglass_flowing_sand:',
+      },
+    ]);
+  });
+
   it('deletes a previously sent Slack message', async () => {
     const calls: unknown[] = [];
     const connector = new SlackConnector({ bot_token: 'xoxb-test' });

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -566,6 +566,64 @@ describe('SlackConnector.sendMessage', () => {
     ]);
   });
 
+  it('supports Slack stream plan mode and task update chunks', async () => {
+    const calls: Array<{ method: string; args: unknown }> = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      chat: {
+        startStream: async (args: unknown) => {
+          calls.push({ method: 'startStream', args });
+          return { ok: true, ts: '1700000000.000006' };
+        },
+        appendStream: async (args: unknown) => {
+          calls.push({ method: 'appendStream', args });
+          return { ok: true };
+        },
+      },
+    };
+
+    const ts = await connector.startStream({
+      threadId: 'C123-1700000000.000000',
+      text: 'hello',
+      taskDisplayMode: 'plan',
+    });
+    await connector.appendStreamPayload({
+      threadId: 'C123-1700000000.000000',
+      ts,
+      chunks: [
+        {
+          type: 'task_update',
+          task: { task_id: 'agor_todo_1', title: 'Read context', status: 'completed' },
+        },
+      ],
+    });
+
+    expect(calls).toEqual([
+      {
+        method: 'startStream',
+        args: {
+          channel: 'C123',
+          thread_ts: '1700000000.000000',
+          markdown_text: 'hello',
+          task_display_mode: 'plan',
+        },
+      },
+      {
+        method: 'appendStream',
+        args: {
+          channel: 'C123',
+          ts: '1700000000.000006',
+          chunks: [
+            {
+              type: 'task_update',
+              task: { task_id: 'agor_todo_1', title: 'Read context', status: 'completed' },
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
   it('passes Slack stream recipient ids when provided', async () => {
     const calls: unknown[] = [];
     const connector = new SlackConnector({ bot_token: 'xoxb-test' });

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -543,4 +543,29 @@ describe('SlackConnector.sendMessage', () => {
       },
     ]);
   });
+
+  it('deletes a previously sent Slack message', async () => {
+    const calls: unknown[] = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      chat: {
+        delete: async (args: unknown) => {
+          calls.push(args);
+          return { ok: true };
+        },
+      },
+    };
+
+    await connector.deleteMessage({
+      threadId: 'C123-1700000000.000000',
+      messageId: '1700000000.000003',
+    });
+
+    expect(calls).toEqual([
+      {
+        channel: 'C123',
+        ts: '1700000000.000003',
+      },
+    ]);
+  });
 });

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -327,17 +327,10 @@ describe('markdownToSlackPayload', () => {
     expect(section.text.text).toContain('```');
   });
 
-  it('renders only the first table natively when a message contains multiple tables', () => {
+  it('uses Slack native markdown block when a message contains multiple tables', () => {
     const md = '| A | B |\n|---|---|\n| 1 | 2 |\n\nText\n\n| C | D |\n|---|---|\n| 3 | 4 |';
     const payload = markdownToSlackPayload(md);
-    const tables = payload.blocks!.filter((b) => (b as { type: string }).type === 'table');
-    expect(tables).toHaveLength(1);
-    // The second table is rendered as a monospace section
-    const sections = payload.blocks!.filter((b) => (b as { type: string }).type === 'section');
-    const monospaceSections = sections.filter((s) =>
-      ((s as { text: { text: string } }).text.text ?? '').includes('```')
-    );
-    expect(monospaceSections.length).toBeGreaterThan(0);
+    expect(payload.blocks).toEqual([{ type: 'markdown', text: md }]);
   });
 
   it('preserves intro/outro prose as section blocks around a table', () => {
@@ -351,6 +344,13 @@ describe('markdownToSlackPayload', () => {
       | { text: { text: string } }
       | undefined;
     expect(firstSection?.text.text).toContain('Before');
+  });
+
+  it('uses Slack native markdown block for a table with markdown inside cells', () => {
+    const md = '| Item | Notes |\n|---|---|\n| API cleanup | **Keep compatibility** |';
+    const payload = markdownToSlackPayload(md);
+    expect(payload.blocks).toEqual([{ type: 'markdown', text: md }]);
+    expect(payload.text).toContain('```');
   });
 
   it('handles empty input', () => {
@@ -369,19 +369,14 @@ describe('markdownToSlackPayload', () => {
     expect(payload.text).toContain('| Col1 | Col2 |');
   });
 
-  it('renders only the first of three tables natively (one-table-per-message)', () => {
+  it('uses Slack native markdown block for three tables', () => {
     const md = [
       '| A | B |\n|---|---|\n| 1 | 2 |',
       '| C | D |\n|---|---|\n| 3 | 4 |',
       '| E | F |\n|---|---|\n| 5 | 6 |',
     ].join('\n\nText\n\n');
     const payload = markdownToSlackPayload(md);
-    const tables = payload.blocks!.filter((b) => (b as { type: string }).type === 'table');
-    expect(tables).toHaveLength(1);
-    const monospaceSections = payload
-      .blocks!.filter((b) => (b as { type: string }).type === 'section')
-      .filter((s) => ((s as { text: { text: string } }).text.text ?? '').includes('```'));
-    expect(monospaceSections).toHaveLength(2);
+    expect(payload.blocks).toEqual([{ type: 'markdown', text: md }]);
   });
 
   it('drops blocks entirely (text-only) when an oversize table would not fit even monospace', () => {

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -484,6 +484,33 @@ describe('SlackConnector.sendMessage', () => {
     ]);
   });
 
+  it('falls back to text when Slack rejects newer block types', async () => {
+    const calls: unknown[] = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      chat: {
+        postMessage: async (args: unknown) => {
+          calls.push(args);
+          if ((args as { blocks?: unknown[] }).blocks) {
+            return { ok: false, error: 'unsupported_block_type' };
+          }
+          return { ok: true, ts: '1700000000.000004' };
+        },
+      },
+    };
+
+    const ts = await connector.sendMessage({
+      threadId: 'C123-1700000000.000000',
+      text: '*Plan*\n○ Test\n⏳ Still working',
+      blocks: [{ type: 'plan', tasks: [] }],
+    });
+
+    expect(ts).toBe('1700000000.000004');
+    expect(calls).toHaveLength(2);
+    expect((calls[0] as { blocks?: unknown[] }).blocks).toBeDefined();
+    expect((calls[1] as { blocks?: unknown[] }).blocks).toBeUndefined();
+  });
+
   it('mirrors message streams with Slack chat stream methods', async () => {
     const calls: Array<{ method: string; args: unknown }> = [];
     const connector = new SlackConnector({ bot_token: 'xoxb-test' });

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { markdownToMrkdwn, markdownToSlackPayload, wrapTablesInCodeBlocks } from './slack';
+import {
+  markdownToMrkdwn,
+  markdownToSlackPayload,
+  SlackConnector,
+  wrapTablesInCodeBlocks,
+} from './slack';
 
 /**
  * slackify-markdown uses zero-width spaces (\u200B) around inline formatting
@@ -449,3 +454,93 @@ describe('markdownToSlackPayload', () => {
 // Mirrors SECTION_MAX_CHARS in slack.ts; kept in the test as a lower-bound
 // sanity check (we expect the legacy mrkdwn fallback to carry more than this).
 const SECTION_MAX_CHARS_TEST = 3000;
+
+describe('SlackConnector.sendMessage', () => {
+  it('updates an existing Slack message when slack_update_ts metadata is present', async () => {
+    const calls: unknown[] = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      chat: {
+        update: async (args: unknown) => {
+          calls.push(args);
+          return { ok: true, ts: '1700000000.000001' };
+        },
+        postMessage: async () => {
+          throw new Error('postMessage should not be called for status updates');
+        },
+      },
+    };
+
+    const ts = await connector.sendMessage({
+      threadId: 'C123-1700000000.000000',
+      text: 'still working',
+      metadata: { slack_update_ts: '1700000000.000001' },
+    });
+
+    expect(ts).toBe('1700000000.000001');
+    expect(calls).toEqual([
+      {
+        channel: 'C123',
+        ts: '1700000000.000001',
+        text: 'still working',
+        unfurl_links: false,
+        unfurl_media: false,
+      },
+    ]);
+  });
+
+  it('mirrors message streams with Slack chat stream methods', async () => {
+    const calls: Array<{ method: string; args: unknown }> = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      chat: {
+        startStream: async (args: unknown) => {
+          calls.push({ method: 'startStream', args });
+          return { ok: true, ts: '1700000000.000002' };
+        },
+        appendStream: async (args: unknown) => {
+          calls.push({ method: 'appendStream', args });
+          return { ok: true };
+        },
+        stopStream: async (args: unknown) => {
+          calls.push({ method: 'stopStream', args });
+          return { ok: true };
+        },
+      },
+    };
+
+    const ts = await connector.startStream({ threadId: 'C123-1700000000.000000' });
+    await connector.appendStream({
+      threadId: 'C123-1700000000.000000',
+      ts,
+      text: 'hello',
+    });
+    await connector.stopStream({ threadId: 'C123-1700000000.000000', ts });
+
+    expect(calls).toEqual([
+      {
+        method: 'startStream',
+        args: {
+          channel: 'C123',
+          thread_ts: '1700000000.000000',
+          markdown_text: ' ',
+        },
+      },
+      {
+        method: 'appendStream',
+        args: {
+          channel: 'C123',
+          ts: '1700000000.000002',
+          markdown_text: 'hello',
+        },
+      },
+      {
+        method: 'stopStream',
+        args: {
+          channel: 'C123',
+          ts: '1700000000.000002',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -566,6 +566,36 @@ describe('SlackConnector.sendMessage', () => {
     ]);
   });
 
+  it('passes Slack stream recipient ids when provided', async () => {
+    const calls: unknown[] = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      chat: {
+        startStream: async (args: unknown) => {
+          calls.push(args);
+          return { ok: true, ts: '1700000000.000005' };
+        },
+      },
+    };
+
+    await connector.startStream({
+      threadId: 'C123-1700000000.000000',
+      text: 'hello',
+      recipientUserId: 'U123',
+      recipientTeamId: 'T123',
+    });
+
+    expect(calls).toEqual([
+      {
+        channel: 'C123',
+        thread_ts: '1700000000.000000',
+        markdown_text: 'hello',
+        recipient_user_id: 'U123',
+        recipient_team_id: 'T123',
+      },
+    ]);
+  });
+
   it('deletes a previously sent Slack message', async () => {
     const calls: unknown[] = [];
     const connector = new SlackConnector({ bot_token: 'xoxb-test' });

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -37,6 +37,8 @@ const TABLE_MAX_COLS = 20;
 // either path. Beyond this we drop to monospace, then text-only.
 const TABLE_MAX_CELL_CHARS = 3000;
 const SECTION_MAX_CHARS = 3000;
+// Slack's native markdown block currently caps cumulative markdown text at 12k chars.
+const MARKDOWN_BLOCK_MAX_CHARS = 12000;
 // Slack rejects messages with more than one `table` block.
 const MAX_TABLES_PER_MESSAGE = 1;
 // Slack rejects `chat.postMessage` with more than 50 blocks; if we'd exceed
@@ -56,6 +58,11 @@ const FENCE_LINE_RE = /^(`{3,}|~{3,})/;
 const PIPE_LINE_RE = /^\s*\|/;
 const TABLE_SEPARATOR_LINE_RE = /^\s*\|[\s:]*-[\s:-]*\|/;
 const TABLE_SEPARATOR_BLOCK_RE = /^\|[\s:]*-[\s:-]*\|/m;
+
+interface SlackMarkdownBlock {
+  type: 'markdown';
+  text: string;
+}
 
 interface SlackConfig {
   bot_token: string;
@@ -368,10 +375,32 @@ function monospaceFallbackBlock(tableLines: string[]): SectionBlock | null {
   };
 }
 
+function buildMarkdownBlock(markdown: string): SlackMarkdownBlock | null {
+  const trimmed = markdown.trim();
+  if (trimmed.length === 0 || trimmed.length > MARKDOWN_BLOCK_MAX_CHARS) return null;
+  return { type: 'markdown', text: markdown };
+}
+
+function tableHasRichMarkdown(tableLines: string[]): boolean {
+  return tableLines.some((line) =>
+    /(\*\*|__|~~|`|\[[^\]]+\]\([^)]*\)|<br\s*\/?\s*>|_[^_|]+_|(^|\|)\s*[-*+]\s+)/i.test(line)
+  );
+}
+
+function shouldUseNativeMarkdownBlock(markdown: string, segments: Segment[]): boolean {
+  if (!buildMarkdownBlock(markdown)) return false;
+
+  const tableSegments = segments.filter((segment) => segment.kind === 'table');
+  if (tableSegments.length > 1) return true;
+  return tableSegments.some((segment) => tableHasRichMarkdown(segment.lines));
+}
+
 /**
  * Build a Slack outbound payload from GitHub-flavored markdown.
  *
- * If the message contains GFM tables, emits a `blocks` array that uses
+ * If the message contains rich or multiple GFM tables and fits Slack's native
+ * markdown block budget, emits a `markdown` block so Slack can preserve richer
+ * table Markdown. Otherwise emits a `blocks` array that uses
  * Block Kit's native `table` block (Aug 2025) for the first qualifying
  * table and falls back to a monospace code block for any table that
  * exceeds Slack's caps (>{@link TABLE_MAX_ROWS} rows, >{@link TABLE_MAX_COLS}
@@ -391,8 +420,16 @@ export function markdownToSlackPayload(markdown: string): OutboundPayload {
   const text = markdownToMrkdwn(markdown);
 
   const segments = segmentMarkdown(markdown);
-  if (!segments.some((s) => s.kind === 'table')) {
+  const hasTable = segments.some((s) => s.kind === 'table');
+  if (!hasTable) {
     return { text };
+  }
+
+  if (shouldUseNativeMarkdownBlock(markdown, segments)) {
+    const markdownBlock = buildMarkdownBlock(markdown);
+    if (markdownBlock) {
+      return { text, blocks: [markdownBlock] };
+    }
   }
 
   const blocks: KnownBlock[] = [];
@@ -1113,8 +1150,8 @@ export class SlackConnector implements GatewayConnector {
    *
    * Returns `{ text, blocks? }`. `text` is the mrkdwn fallback used for
    * notifications and clients that don't render Block Kit; `blocks` is set
-   * when the message contains a GFM table that we can emit as a native
-   * Block Kit `table` block (or a monospace section fallback alongside one).
+   * when the message contains tables that can benefit from Slack's native
+   * markdown/table blocks.
    */
   formatMessage(markdown: string): OutboundPayload {
     return markdownToSlackPayload(markdown);

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -49,7 +49,10 @@ const MAX_BLOCKS_PER_MESSAGE = 50;
 const BLOCK_PAYLOAD_ERRORS = new Set([
   'invalid_blocks',
   'invalid_blocks_format',
+  'invalid_block_type',
   'message_blocks_too_long',
+  'unknown_block_type',
+  'unsupported_block_type',
 ]);
 
 // GFM scanner regexes — hoisted so both `segmentMarkdown` and helpers share

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -813,6 +813,7 @@ export class SlackConnector implements GatewayConnector {
     text?: string;
     recipientUserId?: string;
     recipientTeamId?: string;
+    taskDisplayMode?: 'plan' | 'timeline' | 'dense';
   }): Promise<string> {
     const { channel, thread_ts } = parseThreadId(req.threadId);
     const chat = this.web.chat as unknown as {
@@ -824,6 +825,7 @@ export class SlackConnector implements GatewayConnector {
       channel,
       thread_ts,
       markdown_text: req.text?.trim() ? req.text : ' ',
+      ...(req.taskDisplayMode ? { task_display_mode: req.taskDisplayMode } : {}),
       ...(req.recipientUserId ? { recipient_user_id: req.recipientUserId } : {}),
       ...(req.recipientTeamId ? { recipient_team_id: req.recipientTeamId } : {}),
     });
@@ -834,6 +836,19 @@ export class SlackConnector implements GatewayConnector {
   }
 
   async appendStream(req: { threadId: string; ts: string; text: string }): Promise<void> {
+    await this.appendStreamPayload({
+      threadId: req.threadId,
+      ts: req.ts,
+      markdownText: req.text,
+    });
+  }
+
+  async appendStreamPayload(req: {
+    threadId: string;
+    ts: string;
+    markdownText?: string;
+    chunks?: unknown[];
+  }): Promise<void> {
     const { channel } = parseThreadId(req.threadId);
     const chat = this.web.chat as unknown as {
       appendStream: (args: Record<string, unknown>) => Promise<{ ok?: boolean; error?: string }>;
@@ -841,7 +856,8 @@ export class SlackConnector implements GatewayConnector {
     const result = await chat.appendStream({
       channel,
       ts: req.ts,
-      markdown_text: req.text,
+      ...(req.markdownText !== undefined ? { markdown_text: req.markdownText } : {}),
+      ...(req.chunks ? { chunks: req.chunks } : {}),
     });
     if (!result.ok) {
       throw new Error(`Slack stream append error: ${result.error ?? 'unknown error'}`);

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -874,6 +874,39 @@ export class SlackConnector implements GatewayConnector {
     }
   }
 
+  async setThreadStatus(req: {
+    threadId: string;
+    status: string;
+    loadingMessages?: string[];
+    iconEmoji?: string;
+  }): Promise<void> {
+    const { channel, thread_ts } = parseThreadId(req.threadId);
+    const web = this.web as unknown as {
+      assistant?: {
+        threads?: {
+          setStatus?: (args: Record<string, unknown>) => Promise<{ ok?: boolean; error?: string }>;
+        };
+      };
+      apiCall?: (
+        method: string,
+        args: Record<string, unknown>
+      ) => Promise<{ ok?: boolean; error?: string }>;
+    };
+    const args = {
+      channel_id: channel,
+      thread_ts,
+      status: req.status,
+      ...(req.loadingMessages?.length ? { loading_messages: req.loadingMessages } : {}),
+      ...(req.iconEmoji ? { icon_emoji: req.iconEmoji } : {}),
+    };
+    const result = web.assistant?.threads?.setStatus
+      ? await web.assistant.threads.setStatus(args)
+      : await web.apiCall?.('assistant.threads.setStatus', args);
+    if (!result?.ok) {
+      throw new Error(`Slack assistant status error: ${result?.error ?? 'unknown error'}`);
+    }
+  }
+
   /**
    * Start listening for inbound messages via Socket Mode
    *

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -816,6 +816,17 @@ export class SlackConnector implements GatewayConnector {
     }
   }
 
+  async deleteMessage(req: { threadId: string; messageId: string }): Promise<void> {
+    const { channel } = parseThreadId(req.threadId);
+    const result = await this.web.chat.delete({
+      channel,
+      ts: req.messageId,
+    });
+    if (!result.ok) {
+      throw new Error(`Slack delete error: ${result.error ?? 'unknown error'}`);
+    }
+  }
+
   /**
    * Start listening for inbound messages via Socket Mode
    *

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -813,7 +813,6 @@ export class SlackConnector implements GatewayConnector {
     text?: string;
     recipientUserId?: string;
     recipientTeamId?: string;
-    taskDisplayMode?: 'plan' | 'timeline' | 'dense';
   }): Promise<string> {
     const { channel, thread_ts } = parseThreadId(req.threadId);
     const chat = this.web.chat as unknown as {
@@ -825,7 +824,6 @@ export class SlackConnector implements GatewayConnector {
       channel,
       thread_ts,
       markdown_text: req.text?.trim() ? req.text : ' ',
-      ...(req.taskDisplayMode ? { task_display_mode: req.taskDisplayMode } : {}),
       ...(req.recipientUserId ? { recipient_user_id: req.recipientUserId } : {}),
       ...(req.recipientTeamId ? { recipient_team_id: req.recipientTeamId } : {}),
     });
@@ -836,19 +834,6 @@ export class SlackConnector implements GatewayConnector {
   }
 
   async appendStream(req: { threadId: string; ts: string; text: string }): Promise<void> {
-    await this.appendStreamPayload({
-      threadId: req.threadId,
-      ts: req.ts,
-      markdownText: req.text,
-    });
-  }
-
-  async appendStreamPayload(req: {
-    threadId: string;
-    ts: string;
-    markdownText?: string;
-    chunks?: unknown[];
-  }): Promise<void> {
     const { channel } = parseThreadId(req.threadId);
     const chat = this.web.chat as unknown as {
       appendStream: (args: Record<string, unknown>) => Promise<{ ok?: boolean; error?: string }>;
@@ -856,8 +841,7 @@ export class SlackConnector implements GatewayConnector {
     const result = await chat.appendStream({
       channel,
       ts: req.ts,
-      ...(req.markdownText !== undefined ? { markdown_text: req.markdownText } : {}),
-      ...(req.chunks ? { chunks: req.chunks } : {}),
+      markdown_text: req.text,
     });
     if (!result.ok) {
       throw new Error(`Slack stream append error: ${result.error ?? 'unknown error'}`);

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -713,25 +713,39 @@ export class SlackConnector implements GatewayConnector {
   }): Promise<string> {
     const { channel, thread_ts } = parseThreadId(req.threadId);
     const blocks = req.blocks && req.blocks.length > 0 ? (req.blocks as KnownBlock[]) : undefined;
+    const updateTs =
+      typeof req.metadata?.slack_update_ts === 'string' ? req.metadata.slack_update_ts : undefined;
 
-    const post = (withBlocks: boolean) =>
-      this.web.chat.postMessage({
+    const send = (withBlocks: boolean) => {
+      const base = {
         channel,
-        thread_ts,
         text: req.text,
         ...(withBlocks && blocks ? { blocks } : {}),
         unfurl_links: false,
         unfurl_media: false,
-      });
+      };
 
-    let result: Awaited<ReturnType<typeof post>>;
+      if (updateTs) {
+        return this.web.chat.update({
+          ...base,
+          ts: updateTs,
+        });
+      }
+
+      return this.web.chat.postMessage({
+        ...base,
+        thread_ts,
+      });
+    };
+
+    let result: Awaited<ReturnType<typeof send>>;
     try {
-      result = await post(true);
+      result = await send(true);
     } catch (err) {
       const code = extractSlackErrorCode(err);
       if (blocks && code && BLOCK_PAYLOAD_ERRORS.has(code)) {
         console.warn(`[slack] Block payload rejected (${code}); retrying as text-only`);
-        result = await post(false);
+        result = await send(false);
       } else {
         throw err;
       }
@@ -741,7 +755,7 @@ export class SlackConnector implements GatewayConnector {
       const code = extractSlackErrorCode(result);
       if (blocks && code && BLOCK_PAYLOAD_ERRORS.has(code)) {
         console.warn(`[slack] Block payload rejected (${code}); retrying as text-only`);
-        const retry = await post(false);
+        const retry = await send(false);
         if (!retry.ok || !retry.ts) {
           throw new Error(`Slack API error: ${retry.error ?? 'unknown error'}`);
         }
@@ -752,6 +766,54 @@ export class SlackConnector implements GatewayConnector {
     }
 
     return result.ts;
+  }
+
+  async startStream(req: { threadId: string; text?: string }): Promise<string> {
+    const { channel, thread_ts } = parseThreadId(req.threadId);
+    const chat = this.web.chat as unknown as {
+      startStream: (
+        args: Record<string, unknown>
+      ) => Promise<{ ok?: boolean; ts?: string; error?: string }>;
+    };
+    const result = await chat.startStream({
+      channel,
+      thread_ts,
+      markdown_text: req.text?.trim() ? req.text : ' ',
+    });
+    if (!result.ok || !result.ts) {
+      throw new Error(`Slack stream start error: ${result.error ?? 'unknown error'}`);
+    }
+    return result.ts;
+  }
+
+  async appendStream(req: { threadId: string; ts: string; text: string }): Promise<void> {
+    const { channel } = parseThreadId(req.threadId);
+    const chat = this.web.chat as unknown as {
+      appendStream: (args: Record<string, unknown>) => Promise<{ ok?: boolean; error?: string }>;
+    };
+    const result = await chat.appendStream({
+      channel,
+      ts: req.ts,
+      markdown_text: req.text,
+    });
+    if (!result.ok) {
+      throw new Error(`Slack stream append error: ${result.error ?? 'unknown error'}`);
+    }
+  }
+
+  async stopStream(req: { threadId: string; ts: string; text?: string }): Promise<void> {
+    const { channel } = parseThreadId(req.threadId);
+    const chat = this.web.chat as unknown as {
+      stopStream: (args: Record<string, unknown>) => Promise<{ ok?: boolean; error?: string }>;
+    };
+    const result = await chat.stopStream({
+      channel,
+      ts: req.ts,
+      ...(req.text ? { markdown_text: req.text } : {}),
+    });
+    if (!result.ok) {
+      throw new Error(`Slack stream stop error: ${result.error ?? 'unknown error'}`);
+    }
   }
 
   /**

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -492,11 +492,13 @@ export class SlackConnector implements GatewayConnector {
     string,
     { email: string | null; displayName: string | null; expiresAt: number }
   >();
+  private inboundEventDedup = new Map<string, number>();
 
   /** Cache: Slack channel ID → channel name */
   private channelNameCache = new Map<string, { name: string | null; expiresAt: number }>();
   private static USER_CACHE_TTL_MS = 15 * 60 * 1000; // 15 min for successful lookups
   private static USER_CACHE_ERROR_TTL_MS = 60 * 1000; // 1 min for errors (transient recovery)
+  private static INBOUND_EVENT_DEDUP_TTL_MS = 5 * 60 * 1000; // Slack may send message + app_mention for one user action
 
   /**
    * Cache: Slack channel ID → channel type string (channel/group/mpim/im).
@@ -631,6 +633,75 @@ export class SlackConnector implements GatewayConnector {
       });
       return null;
     }
+  }
+
+  private async lookupLatestThreadReply(
+    event: Record<string, unknown>
+  ): Promise<Record<string, unknown> | null> {
+    const channel = typeof event.channel === 'string' ? event.channel : undefined;
+    const message =
+      typeof event.message === 'object' && event.message !== null
+        ? (event.message as Record<string, unknown>)
+        : undefined;
+    const threadTs =
+      (typeof message?.thread_ts === 'string' ? message.thread_ts : undefined) ??
+      (typeof message?.ts === 'string' ? message.ts : undefined) ??
+      (typeof event.thread_ts === 'string' ? event.thread_ts : undefined);
+    const replies = Array.isArray(message?.replies)
+      ? message.replies.filter((reply): reply is Record<string, unknown> => {
+          return typeof reply === 'object' && reply !== null;
+        })
+      : [];
+    const latestReplyTs =
+      (typeof message?.latest_reply === 'string' ? message.latest_reply : undefined) ??
+      (typeof event.latest_reply === 'string' ? event.latest_reply : undefined) ??
+      [...replies]
+        .reverse()
+        .map((reply) => (typeof reply.ts === 'string' ? reply.ts : undefined))
+        .find(Boolean);
+
+    if (!channel || !threadTs || !latestReplyTs) return null;
+
+    try {
+      const result = await this.web.conversations.replies({
+        channel,
+        ts: threadTs,
+        oldest: latestReplyTs,
+        inclusive: true,
+        limit: 1,
+      });
+      const reply =
+        result.messages?.find((candidate) => candidate.ts === latestReplyTs) ??
+        result.messages?.[0] ??
+        null;
+      if (!reply) return null;
+      return {
+        ...reply,
+        channel,
+        thread_ts: typeof reply.thread_ts === 'string' ? reply.thread_ts : threadTs,
+        team: event.team,
+      };
+    } catch (error) {
+      console.warn('[slack] Failed to fetch latest thread reply for message_replied event:', error);
+      return null;
+    }
+  }
+
+  private shouldProcessInboundEventOnce(
+    channel: string | undefined,
+    ts: string | undefined
+  ): boolean {
+    if (!channel || !ts) return true;
+
+    const now = Date.now();
+    for (const [key, expiresAt] of this.inboundEventDedup) {
+      if (expiresAt <= now) this.inboundEventDedup.delete(key);
+    }
+
+    const key = `${channel}:${ts}`;
+    if (this.inboundEventDedup.has(key)) return false;
+    this.inboundEventDedup.set(key, now + SlackConnector.INBOUND_EVENT_DEDUP_TTL_MS);
+    return true;
   }
 
   /**
@@ -989,7 +1060,7 @@ export class SlackConnector implements GatewayConnector {
       }
 
       await ack();
-      const event = body.event;
+      let event = body.event;
       const slackTeamId =
         typeof event.team === 'string'
           ? event.team
@@ -1011,6 +1082,35 @@ export class SlackConnector implements GatewayConnector {
       // Skip message edits, deletes, and other subtypes — only handle new messages
       // Note: app_mention events don't have subtypes
       if (eventType === 'message' && event.subtype) {
+        if (event.subtype === 'message_replied') {
+          const replyEvent = await this.lookupLatestThreadReply(event);
+          if (!replyEvent) {
+            console.log(
+              `[slack] Skipping message_replied event without fetchable latest reply channel=${event.channel ?? '(none)'} ts=${event.ts ?? '(none)'}`
+            );
+            return;
+          }
+          event = {
+            ...replyEvent,
+            type: 'message',
+            channel_type: event.channel_type,
+          };
+          console.log(
+            `[slack] Resolved message_replied event to latest reply thread_ts=${event.thread_ts ?? '(none)'} ts=${event.ts ?? '(none)'}`
+          );
+        } else {
+          console.debug(
+            `[slack] Skipping message subtype=${event.subtype} user=${event.user ?? '(none)'} thread_ts=${event.thread_ts ?? '(none)'} ts=${event.ts ?? '(none)'}`
+          );
+          return;
+        }
+      }
+
+      // Skip bot replies resolved from message_replied events to avoid loops.
+      if (event.bot_id || event.subtype === 'bot_message') {
+        console.debug(
+          `[slack] Skipping resolved bot message subtype=${event.subtype ?? '(none)'} thread_ts=${event.thread_ts ?? '(none)'} ts=${event.ts ?? '(none)'}`
+        );
         return;
       }
 
@@ -1027,11 +1127,13 @@ export class SlackConnector implements GatewayConnector {
       // This happens for top-level messages AND thread replies.
       //
       // Strategy:
-      // - Use 'app_mention' for active mentions outside code blocks
-      // - Use 'message' for DMs, non-mention messages, and code-block-only mentions
-      // - Skip 'message' events that have active mentions (to avoid duplicates)
-      // - Skip 'app_mention' events where the mention is only inside code blocks
-      //   (those are not "real" mentions and should be handled as plain messages)
+      // - Process whichever event arrives first for an active mention (`message`
+      //   or `app_mention`) and dedupe by channel+ts. Relying only on
+      //   `app_mention` makes Socket Mode multi-connection/lost-event behavior
+      //   look like missed prompts.
+      // - Use `message` for DMs, non-mention messages, and code-block-only mentions.
+      // - Skip `app_mention` events where the mention is only inside code blocks
+      //   (those are not "real" mentions and should be handled as plain messages).
       const isThreadReply = !!event.thread_ts;
       const isChannelMessage = channelType === 'channel' || channelType === 'group';
 
@@ -1052,12 +1154,6 @@ export class SlackConnector implements GatewayConnector {
 
       if (isChannelMessage && botMentionPattern) {
         const mentionOutsideCodeBlock = hasActiveMention(event.text ?? '', botMentionPattern);
-
-        if (eventType === 'message' && mentionOutsideCodeBlock) {
-          // Active (non-code-block) mention detected in a message event.
-          // Skip — the parallel app_mention event will handle it.
-          return;
-        }
 
         if (eventType === 'app_mention' && !mentionOutsideCodeBlock) {
           // app_mention fired but the mention is only inside a code block.
@@ -1141,6 +1237,13 @@ export class SlackConnector implements GatewayConnector {
             messageText = messageText.replace(botMentionReplacePattern, '').trim();
           }
         }
+      }
+
+      if (!this.shouldProcessInboundEventOnce(event.channel, event.ts)) {
+        console.log(
+          `[slack] Skipping duplicate inbound event type=${eventType} channel=${event.channel} ts=${event.ts}`
+        );
+        return;
       }
 
       const threadId = event.thread_ts

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -808,7 +808,12 @@ export class SlackConnector implements GatewayConnector {
     return result.ts;
   }
 
-  async startStream(req: { threadId: string; text?: string }): Promise<string> {
+  async startStream(req: {
+    threadId: string;
+    text?: string;
+    recipientUserId?: string;
+    recipientTeamId?: string;
+  }): Promise<string> {
     const { channel, thread_ts } = parseThreadId(req.threadId);
     const chat = this.web.chat as unknown as {
       startStream: (
@@ -819,6 +824,8 @@ export class SlackConnector implements GatewayConnector {
       channel,
       thread_ts,
       markdown_text: req.text?.trim() ? req.text : ' ',
+      ...(req.recipientUserId ? { recipient_user_id: req.recipientUserId } : {}),
+      ...(req.recipientTeamId ? { recipient_team_id: req.recipientTeamId } : {}),
     });
     if (!result.ok || !result.ts) {
       throw new Error(`Slack stream start error: ${result.error ?? 'unknown error'}`);
@@ -950,6 +957,19 @@ export class SlackConnector implements GatewayConnector {
 
       await ack();
       const event = body.event;
+      const slackTeamId =
+        typeof event.team === 'string'
+          ? event.team
+          : typeof body.team_id === 'string'
+            ? body.team_id
+            : Array.isArray(body.authorizations) &&
+                typeof body.authorizations[0]?.team_id === 'string'
+              ? body.authorizations[0].team_id
+              : undefined;
+      console.log(
+        `[slack] Processing ${eventType} event - channel: ${event.channel}, channel_type: ${event.channel_type}`
+      );
+
       // Skip bot messages to avoid loops
       if (event.bot_id || event.subtype === 'bot_message') {
         return;
@@ -1123,6 +1143,8 @@ export class SlackConnector implements GatewayConnector {
         metadata: {
           channel: event.channel,
           channel_type: channelType,
+          ...(event.user ? { slack_user_id: event.user } : {}),
+          ...(slackTeamId ? { slack_team_id: slackTeamId } : {}),
           requires_mapping_verification: allowedViaThreadReplyException,
           ...(slackUserEmail ? { slack_user_email: slackUserEmail } : {}),
           ...(slackUserDisplayName ? { slack_user_name: slackUserDisplayName } : {}),

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -9,7 +9,7 @@ export type { GatewayConnector, InboundMessage, OutboundPayload } from './connec
 export { normalizeOutbound } from './connector';
 export { getConnector, hasConnector, registerConnector } from './connector-registry';
 export { GitHubConnector, parseThreadId as parseGitHubThreadId } from './connectors/github';
-export { SlackConnector } from './connectors/slack';
+export { markdownToMrkdwn, SlackConnector } from './connectors/slack';
 export {
   extractQuotedReplyText,
   parseThreadId as parseTeamsThreadId,

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -22,4 +22,5 @@ export {
   formatGatewayMarkdownSessionReference,
   formatGatewaySessionCreatedMessage,
   formatGatewaySystemMessage,
+  formatGatewaySystemPayload,
 } from './system-message';

--- a/packages/core/src/gateway/system-message.test.ts
+++ b/packages/core/src/gateway/system-message.test.ts
@@ -31,9 +31,9 @@ describe('formatGatewaySystemMessage', () => {
   it('formats Slack follow-up routing messages with a clickable session link', () => {
     const text = formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl);
 
-    expect(text).toBe(`Follow-up received — routing to [session](${sessionUrl})…`);
+    expect(text).toBe(`Follow-up received — routing to [session](${sessionUrl}) ...`);
     expect(formatGatewaySystemMessage('slack', text)).toBe(
-      `Agor: Follow-up received — routing to <${sessionUrl}|session>…`
+      `Agor: Follow-up received — routing to <${sessionUrl}|session> ...`
     );
   });
 
@@ -54,7 +54,7 @@ describe('formatGatewaySystemMessage', () => {
       `session ${sessionShortId}`
     );
     expect(formatGatewayFollowUpRoutingMessage(sessionId, null)).toBe(
-      `Follow-up received — routing to session ${sessionShortId}…`
+      `Follow-up received — routing to session ${sessionShortId} ...`
     );
   });
 

--- a/packages/core/src/gateway/system-message.test.ts
+++ b/packages/core/src/gateway/system-message.test.ts
@@ -30,11 +30,9 @@ describe('formatGatewaySystemMessage', () => {
   it('formats Slack follow-up routing messages with a clickable session link', () => {
     const text = formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl);
 
-    expect(text).toBe(
-      `Follow-up received — routing to [session ${sessionShortId}](${sessionUrl})...`
-    );
+    expect(text).toBe(`Follow-up received — routing to [the Agor session](${sessionUrl})...`);
     expect(formatGatewaySystemMessage('slack', text)).toBe(
-      `Agor: Follow-up received — routing to <${sessionUrl}|session ${sessionShortId}>...`
+      `Agor: Follow-up received — routing to <${sessionUrl}|the Agor session>...`
     );
   });
 

--- a/packages/core/src/gateway/system-message.test.ts
+++ b/packages/core/src/gateway/system-message.test.ts
@@ -31,9 +31,9 @@ describe('formatGatewaySystemMessage', () => {
   it('formats Slack follow-up routing messages with a clickable session link', () => {
     const text = formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl);
 
-    expect(text).toBe(`Follow-up received — routing to [Open session](${sessionUrl})...`);
+    expect(text).toBe(`Follow-up received — routing to [session](${sessionUrl})…`);
     expect(formatGatewaySystemMessage('slack', text)).toBe(
-      `Agor: Follow-up received — routing to <${sessionUrl}|Open session>...`
+      `Agor: Follow-up received — routing to <${sessionUrl}|session>…`
     );
   });
 
@@ -54,7 +54,7 @@ describe('formatGatewaySystemMessage', () => {
       `session ${sessionShortId}`
     );
     expect(formatGatewayFollowUpRoutingMessage(sessionId, null)).toBe(
-      `Follow-up received — routing to session ${sessionShortId}...`
+      `Follow-up received — routing to session ${sessionShortId}…`
     );
   });
 

--- a/packages/core/src/gateway/system-message.test.ts
+++ b/packages/core/src/gateway/system-message.test.ts
@@ -30,9 +30,9 @@ describe('formatGatewaySystemMessage', () => {
   it('formats Slack follow-up routing messages with a clickable session link', () => {
     const text = formatGatewayFollowUpRoutingMessage(sessionId, sessionUrl);
 
-    expect(text).toBe(`Follow-up received — routing to [the Agor session](${sessionUrl})...`);
+    expect(text).toBe(`Follow-up received — routing to [Open session](${sessionUrl})...`);
     expect(formatGatewaySystemMessage('slack', text)).toBe(
-      `Agor: Follow-up received — routing to <${sessionUrl}|the Agor session>...`
+      `Agor: Follow-up received — routing to <${sessionUrl}|Open session>...`
     );
   });
 

--- a/packages/core/src/gateway/system-message.test.ts
+++ b/packages/core/src/gateway/system-message.test.ts
@@ -4,6 +4,7 @@ import {
   formatGatewayMarkdownSessionReference,
   formatGatewaySessionCreatedMessage,
   formatGatewaySystemMessage,
+  formatGatewaySystemPayload,
 } from './system-message';
 
 const sessionId = '019e6fca-0000-7000-8000-000000000000';
@@ -36,6 +37,18 @@ describe('formatGatewaySystemMessage', () => {
     );
   });
 
+  it('formats Slack system messages as muted context-block payloads', () => {
+    expect(formatGatewaySystemPayload('slack', 'Creating new codex session...')).toEqual({
+      text: 'Agor: Creating new codex session...',
+      blocks: [
+        {
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: 'Agor: Creating new codex session...' }],
+        },
+      ],
+    });
+  });
+
   it('falls back to a short session ID when no session URL is available', () => {
     expect(formatGatewayMarkdownSessionReference(sessionId, null)).toBe(
       `session ${sessionShortId}`
@@ -58,5 +71,11 @@ describe('formatGatewaySystemMessage', () => {
     expect(formatGatewaySystemMessage('github', `Session created: ${sessionUrl}`)).toBe(
       `Agor: Session created: ${sessionUrl}`
     );
+  });
+
+  it('keeps non-Slack system payloads text-only', () => {
+    expect(formatGatewaySystemPayload('github', `Session created: ${sessionUrl}`)).toEqual({
+      text: `Agor: Session created: ${sessionUrl}`,
+    });
   });
 });

--- a/packages/core/src/gateway/system-message.ts
+++ b/packages/core/src/gateway/system-message.ts
@@ -18,7 +18,7 @@ export function formatGatewayMarkdownSessionReference(
   sessionId: SessionID | string,
   sessionUrl?: string | null
 ): string {
-  return sessionUrl ? `[Open session](${sessionUrl})` : `session ${shortId(sessionId)}`;
+  return sessionUrl ? `[session](${sessionUrl})` : `session ${shortId(sessionId)}`;
 }
 
 export function formatGatewaySessionCreatedMessage(
@@ -34,7 +34,7 @@ export function formatGatewayFollowUpRoutingMessage(
   sessionId: SessionID | string,
   sessionUrl?: string | null
 ): string {
-  return `Follow-up received — routing to ${formatGatewayMarkdownSessionReference(sessionId, sessionUrl)}...`;
+  return `Follow-up received — routing to ${formatGatewayMarkdownSessionReference(sessionId, sessionUrl)}…`;
 }
 
 /**

--- a/packages/core/src/gateway/system-message.ts
+++ b/packages/core/src/gateway/system-message.ts
@@ -1,6 +1,7 @@
 import type { ChannelType } from '../types/gateway';
 import type { SessionID } from '../types/id';
 import { shortId } from '../types/id';
+import type { OutboundPayload } from './connector';
 import { markdownToMrkdwn } from './connectors/slack';
 
 const GATEWAY_SYSTEM_PREFIX = 'Agor:';
@@ -56,4 +57,37 @@ export function formatGatewaySystemMessage(channelType: ChannelType, text: strin
   }
 
   return `${GATEWAY_SYSTEM_PREFIX} ${text}`;
+}
+
+/**
+ * Format gateway lifecycle/debug messages as an outbound payload.
+ *
+ * Slack renders these as a muted `context` block so transient lifecycle
+ * notices match the bottom progress/status row instead of competing with the
+ * user's prompt or the agent's final answer.
+ */
+export function formatGatewaySystemPayload(
+  channelType: ChannelType,
+  text: string
+): OutboundPayload {
+  const formatted = formatGatewaySystemMessage(channelType, text);
+
+  if (channelType !== 'slack') {
+    return { text: formatted };
+  }
+
+  return {
+    text: formatted,
+    blocks: [
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: formatted,
+          },
+        ],
+      },
+    ],
+  };
 }

--- a/packages/core/src/gateway/system-message.ts
+++ b/packages/core/src/gateway/system-message.ts
@@ -17,7 +17,7 @@ export function formatGatewayMarkdownSessionReference(
   sessionId: SessionID | string,
   sessionUrl?: string | null
 ): string {
-  return sessionUrl ? `[the Agor session](${sessionUrl})` : `session ${shortId(sessionId)}`;
+  return sessionUrl ? `[Open session](${sessionUrl})` : `session ${shortId(sessionId)}`;
 }
 
 export function formatGatewaySessionCreatedMessage(

--- a/packages/core/src/gateway/system-message.ts
+++ b/packages/core/src/gateway/system-message.ts
@@ -34,7 +34,7 @@ export function formatGatewayFollowUpRoutingMessage(
   sessionId: SessionID | string,
   sessionUrl?: string | null
 ): string {
-  return `Follow-up received — routing to ${formatGatewayMarkdownSessionReference(sessionId, sessionUrl)}…`;
+  return `Follow-up received — routing to ${formatGatewayMarkdownSessionReference(sessionId, sessionUrl)} ...`;
 }
 
 /**

--- a/packages/core/src/gateway/system-message.ts
+++ b/packages/core/src/gateway/system-message.ts
@@ -17,8 +17,7 @@ export function formatGatewayMarkdownSessionReference(
   sessionId: SessionID | string,
   sessionUrl?: string | null
 ): string {
-  const label = `session ${shortId(sessionId)}`;
-  return sessionUrl ? `[${label}](${sessionUrl})` : label;
+  return sessionUrl ? `[the Agor session](${sessionUrl})` : `session ${shortId(sessionId)}`;
 }
 
 export function formatGatewaySessionCreatedMessage(


### PR DESCRIPTION
## Summary

- Add a single mutable Slack progress/status row for gateway sessions using `chat.update`.
- Delete that temporary Slack progress row on successful completion so the final thread stays clean.
- Mirror Agor assistant message streaming events to Slack `chat.startStream` / `chat.appendStream` / `chat.stopStream` when available.
- Surface the latest tool call in the Slack status row with compact, truncated, Slack-safe previews.
- Surface `TodoWrite` plan state in the status row when available, without mapping every agent/tool implementation in gateway code.
- Suppress duplicate final Slack messages when a message has already been delivered through Slack streaming.

## UX notes

- Slack threads get a stable status message that moves through queued → working, then disappears when the durable assistant response is done.
- Failed runs keep a concise error status row.
- The working status says `Still working (...)` and shows the current tool/plan without noisy Agor session URLs.
- Raw tool arguments/results are not posted to Slack; only the tool name plus a short scalar preview or file-count summary is shown.
- Streaming support is opportunistic: if Slack stream calls fail or are unavailable, Agor falls back to the existing final-message route.

## Validation

- `pnpm i`
- `pnpm --filter @agor-live/client build`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/gateway/connectors/slack.test.ts`
- `pnpm --filter @agor/core typecheck`
- `pnpm --filter @agor/daemon typecheck`
- `git diff --check`
