### PR TITLE
Make gateway user alignment email matching case-insensitive

### DIFF
--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -451,7 +451,7 @@ export class GatewayService {
     if (alignSlackUsers) {
       if (data.metadata?.slack_user_email && typeof data.metadata.slack_user_email === 'string') {
         const email = data.metadata.slack_user_email.toLowerCase().trim();
-        const matchedUser = await this.usersRepo.findByEmail(email);
+        const matchedUser = await this.usersRepo.findByEmailForAlignment(email);
 
         if (matchedUser) {
           console.log(
@@ -506,7 +506,7 @@ export class GatewayService {
         githubLogin && userMap?.[githubLogin] ? userMap[githubLogin].toLowerCase().trim() : null;
 
       if (mappedEmail) {
-        const matchedUser = await this.usersRepo.findByEmail(mappedEmail);
+        const matchedUser = await this.usersRepo.findByEmailForAlignment(mappedEmail);
         if (matchedUser) {
           console.log(
             `[gateway] GitHub user aligned via user_map: ${githubLogin} → ${mappedEmail} → Agor user ${shortId(matchedUser.user_id)}`
@@ -528,7 +528,7 @@ export class GatewayService {
             : null;
 
         if (githubEmail) {
-          const matchedUser = await this.usersRepo.findByEmail(githubEmail);
+          const matchedUser = await this.usersRepo.findByEmailForAlignment(githubEmail);
           if (matchedUser) {
             console.log(
               `[gateway] GitHub user aligned via email: ${githubLogin} (${githubEmail}) → Agor user ${shortId(matchedUser.user_id)}`

--- a/packages/core/src/db/repositories/users.test.ts
+++ b/packages/core/src/db/repositories/users.test.ts
@@ -38,6 +38,55 @@ async function makeUser(repo: UsersRepository): Promise<UserID> {
   return u.user_id as UserID;
 }
 
+describe('UsersRepository.findByEmailForAlignment', () => {
+  dbTest('matches external-provider emails case-insensitively', async ({ db }) => {
+    const repo = new UsersRepository(db);
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const created = await repo.create({
+      email: `Mixed.Case-${suffix}@Example.com`,
+      name: 'Mixed Case User',
+    });
+
+    const found = await repo.findByEmailForAlignment(`mixed.case-${suffix}@example.com`);
+
+    expect(found?.user_id).toBe(created.user_id);
+  });
+
+  dbTest('prefers exact lowercase match when case variants exist', async ({ db }) => {
+    const repo = new UsersRepository(db);
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const lower = await repo.create({
+      email: `case-pref-${suffix}@example.com`,
+      name: 'Lowercase User',
+    });
+    await repo.create({
+      email: `CASE-PREF-${suffix}@example.com`,
+      name: 'Uppercase User',
+    });
+
+    const found = await repo.findByEmailForAlignment(`case-pref-${suffix}@example.com`);
+
+    expect(found?.user_id).toBe(lower.user_id);
+  });
+
+  dbTest('does not guess when only ambiguous case variants exist', async ({ db }) => {
+    const repo = new UsersRepository(db);
+    const suffix = `${Date.now()}-${Math.random()}`;
+    await repo.create({
+      email: `Ambiguous-${suffix}@example.com`,
+      name: 'Ambiguous User 1',
+    });
+    await repo.create({
+      email: `AMBIGUOUS-${suffix}@example.com`,
+      name: 'Ambiguous User 2',
+    });
+
+    const found = await repo.findByEmailForAlignment(`ambiguous-${suffix}@example.com`);
+
+    expect(found).toBeNull();
+  });
+});
+
 describe('UsersRepository.setToolConfigField + getToolConfigField', () => {
   dbTest('persists and decrypts a single field', async ({ db }) => {
     const repo = new UsersRepository(db);

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -253,7 +253,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
       if (results.length > 1) {
         console.warn(
           `[users] Ambiguous case-insensitive email alignment for ${normalizedEmail}: ${results
-            .map((row) => {
+            .map((row: unknown) => {
               const userRow = row as UserRow;
               return `${shortId(userRow.user_id)}:${userRow.email}`;
             })

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -15,7 +15,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { toAgenticToolsStatus } from '@agor/core/types';
-import { eq, like } from 'drizzle-orm';
+import { eq, like, sql } from 'drizzle-orm';
 import { normalizeStoredEnvMap, type RawStoredEnvVar } from '../../config/env-vars';
 import { generateId, shortId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -225,6 +225,45 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
     }
 
     return this.rowToUser(result as UserRow);
+  }
+
+  /**
+   * Find user by email for external identity providers.
+   *
+   * Agor intentionally keeps exact/case-sensitive email lookup semantics for
+   * auth paths because the schema historically allowed case-distinct emails.
+   * External providers such as Slack and GitHub treat email addresses as a
+   * canonical identity hint, so their alignment path needs a case-insensitive
+   * match. Prefer an exact match when present; otherwise return a
+   * case-insensitive match only when it is unambiguous.
+   */
+  async findByEmailForAlignment(email: string): Promise<User | null> {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) return null;
+
+    const exact = await this.findByEmail(normalizedEmail);
+    if (exact) return exact;
+
+    const results = await select(this.db)
+      .from(users)
+      .where(sql`LOWER(${users.email}) = ${normalizedEmail}`)
+      .all();
+
+    if (results.length !== 1) {
+      if (results.length > 1) {
+        console.warn(
+          `[users] Ambiguous case-insensitive email alignment for ${normalizedEmail}: ${results
+            .map((row) => {
+              const userRow = row as UserRow;
+              return `${shortId(userRow.user_id)}:${userRow.email}`;
+            })
+            .join(', ')}`
+        );
+      }
+      return null;
+    }
+
+    return this.rowToUser(results[0] as UserRow);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add an explicit `UsersRepository.findByEmailForAlignment()` helper for external identity alignment.
- Use it for Slack and GitHub gateway user alignment instead of exact/case-sensitive `findByEmail()`.
- Keep auth/login lookup semantics unchanged.
- Add regression coverage for case-insensitive alignment, canonical lowercase preference, and ambiguous case-variant safety.

## Context

This came out of investigating a live Slack gateway alignment issue where an existing Agor user was incorrectly rejected as missing. The immediate live issue was operational: the relevant gateway channel had been disabled, and re-enabling it restored routing.

This PR keeps the small hardening fix found during the investigation: gateway alignment should not fail merely because an external provider returns a different email casing than Agor stores.

Why this is scoped narrowly:

- `findByEmail()` remains exact/case-sensitive for existing auth and sync paths.
- Gateway alignment now uses a provider-facing helper that normalizes email casing.
- If only ambiguous case variants exist, alignment returns `null` rather than guessing the wrong user.

## Testing

Not run in this worktree: `node_modules` are missing and `vitest` is unavailable.

Attempted:

```bash
pnpm --filter @agor/core test src/db/repositories/users.test.ts
```

Result:

```text
sh: 1: vitest: not found
WARN Local package.json exists, but node_modules missing
```
