### PR TITLE
fix(ui): remove child sessions section from session chat panel

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -20,7 +20,6 @@ import { ConversationView } from '../ConversationView';
 import { EmbeddedTerminal } from '../EmbeddedTerminal/EmbeddedTerminal';
 import { ForkSpawnModal } from '../ForkSpawnModal';
 import { IssuePill, PullRequestPill } from '../Pill';
-import { ChildSessionsSection } from './ChildSessionsSection';
 
 export interface SessionPanelContentProps {
   client: AgorClient | null;
@@ -307,9 +306,6 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             }
           />
         </div>
-
-        {/* Child Sessions - sessions spawned or forked from this session */}
-        <ChildSessionsSection session={session} />
 
         {/* Queued Tasks Drawer - Above Footer.
             Reads tasks (status='queued') instead of messages now that the queue


### PR DESCRIPTION
## Summary
- Removes the `ChildSessionsSection` component from `SessionPanelContent.tsx` so child sessions no longer appear in the right-side chat panel
- Child sessions remain visible in the left-panel genealogy tree
- `ChildSessionsSection.tsx` file is untouched

## Test plan
- [ ] Open a session that has child/spawned sessions
- [ ] Confirm the "Child sessions" section no longer appears in the right chat panel
- [ ] Confirm child sessions still show in the left panel tree