### PR TITLE
fix: persist multi-tab user settings edits

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1,0 +1,340 @@
+import type { User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { UserSettingsModal } from './UserSettingsModal';
+
+vi.mock('antd', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  type FormInstance = {
+    setFieldsValue: (values: Record<string, unknown>) => void;
+    getFieldsValue: () => Record<string, unknown>;
+    validateFields: () => Promise<Record<string, unknown>>;
+    resetFields: () => void;
+    setFieldValue: (name: string, value: unknown) => void;
+  };
+  type FormContextValue = {
+    form: FormInstance;
+    onValuesChange?: (changed: Record<string, unknown>, all: Record<string, unknown>) => void;
+  };
+
+  const FormContext = React.createContext<FormContextValue | null>(null);
+  const createForm = (): FormInstance => {
+    const store: Record<string, unknown> = {};
+    return {
+      setFieldsValue: (values) => Object.assign(store, values),
+      getFieldsValue: () => ({ ...store }),
+      validateFields: async () => ({ ...store }),
+      resetFields: () => {
+        for (const key of Object.keys(store)) delete store[key];
+      },
+      setFieldValue: (name, value) => {
+        store[name] = value;
+      },
+    };
+  };
+
+  const Form = ({
+    children,
+    component,
+    form,
+    onValuesChange,
+  }: {
+    children?: React.ReactNode;
+    component?: false;
+    form: FormInstance;
+    onValuesChange?: FormContextValue['onValuesChange'];
+  }) => {
+    if (component === false) return null;
+    return React.createElement(
+      FormContext.Provider,
+      { value: { form, onValuesChange } },
+      React.createElement('form', {}, children)
+    );
+  };
+  Form.useForm = () => [React.useState(createForm)[0]];
+  Form.Item = ({
+    children,
+    name,
+    valuePropName,
+    label,
+  }: {
+    children?: React.ReactNode;
+    name?: string;
+    valuePropName?: string;
+    label?: React.ReactNode;
+  }) => {
+    const context = React.useContext(FormContext);
+    const child = React.Children.only(children) as React.ReactElement | undefined;
+    if (!name || !context || !React.isValidElement(child)) {
+      return React.createElement('div', {}, label, children);
+    }
+    const allValues = context.form.getFieldsValue();
+    const value = allValues[name];
+    const propName = valuePropName === 'checked' ? 'checked' : 'value';
+    return React.createElement(
+      'label',
+      {},
+      label,
+      React.cloneElement(child, {
+        [propName]: valuePropName === 'checked' ? !!value : (value ?? ''),
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+          const nextValue = valuePropName === 'checked' ? event.target.checked : event.target.value;
+          context.form.setFieldValue(name, nextValue);
+          context.onValuesChange?.({ [name]: nextValue }, context.form.getFieldsValue());
+          child.props.onChange?.(event);
+        },
+      })
+    );
+  };
+
+  const Input = (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement('input', props);
+  Input.Password = Input;
+
+  const passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement('div', {}, children);
+  const Button = ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) =>
+    React.createElement('button', { type: 'button', onClick }, children);
+  const Checkbox = (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement('input', { ...props, type: 'checkbox' });
+  const Switch = (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement('input', { ...props, type: 'checkbox' });
+  const Select = (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement('input', props);
+  const Modal = ({
+    open,
+    children,
+    footer,
+  }: {
+    open?: boolean;
+    children?: React.ReactNode;
+    footer?: React.ReactNode;
+  }) => (open ? React.createElement('div', { role: 'dialog' }, children, footer) : null);
+  const Layout = Object.assign(passthrough, { Sider: passthrough, Content: passthrough });
+  const Menu = ({
+    items = [],
+    onClick,
+  }: {
+    items?: Array<{
+      key: string;
+      label?: React.ReactNode;
+      children?: Array<{ key: string; label?: React.ReactNode }>;
+    }>;
+    onClick?: ({ key }: { key: string }) => void;
+  }) =>
+    React.createElement(
+      'div',
+      { role: 'menu' },
+      items.flatMap((item) =>
+        item.children
+          ? item.children.map((child) =>
+              React.createElement(
+                'button',
+                {
+                  key: child.key,
+                  type: 'button',
+                  role: 'menuitem',
+                  onClick: () => onClick?.({ key: child.key }),
+                },
+                child.label
+              )
+            )
+          : []
+      )
+    );
+  const Tabs = ({
+    items = [],
+    defaultActiveKey,
+    activeKey,
+    onChange,
+  }: {
+    items?: Array<{ key: string; label: React.ReactNode; children: React.ReactNode }>;
+    defaultActiveKey?: string;
+    activeKey?: string;
+    onChange?: (key: string) => void;
+  }) => {
+    const [internalActive, setInternalActive] = React.useState(defaultActiveKey ?? items[0]?.key);
+    const selected = activeKey ?? internalActive;
+    const activeItem = items.find((item) => item.key === selected) ?? items[0];
+    return React.createElement(
+      'div',
+      {},
+      items.map((item) =>
+        React.createElement(
+          'button',
+          {
+            key: item.key,
+            type: 'button',
+            role: 'tab',
+            onClick: () => {
+              setInternalActive(item.key);
+              onChange?.(item.key);
+            },
+          },
+          item.label
+        )
+      ),
+      activeItem?.children
+    );
+  };
+  const Typography = { Title: passthrough, Paragraph: passthrough };
+  const theme = { useToken: () => ({ token: {} }) };
+
+  return {
+    Alert: passthrough,
+    Button,
+    Checkbox,
+    Flex: passthrough,
+    Form,
+    Input,
+    Layout,
+    Menu,
+    Modal,
+    Popconfirm: passthrough,
+    Select,
+    Space: passthrough,
+    Switch,
+    Tabs,
+    Tag: passthrough,
+    Typography,
+    theme,
+  };
+});
+
+vi.mock('../AgenticToolConfigForm', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const { Form, Input } = await import('antd');
+
+  return {
+    AgenticToolConfigForm: ({ agenticTool }: { agenticTool: string }) =>
+      React.createElement(
+        Form.Item,
+        { name: 'permissionMode', label: `${agenticTool} permission` },
+        React.createElement(Input, { 'aria-label': `${agenticTool} permission` })
+      ),
+    buildConfigFromFormValues: (_tool: string, values: { permissionMode?: string }) => ({
+      permissionMode: values.permissionMode,
+    }),
+    getClearedFormValues: () => ({ permissionMode: 'cleared' }),
+    getFormValuesFromConfig: (_tool: string, config?: { permissionMode?: string }) => ({
+      permissionMode: config?.permissionMode ?? 'default',
+    }),
+  };
+});
+
+vi.mock('../ApiKeyFields', () => ({
+  ApiKeyFields: () => null,
+  TOOL_FIELD_CONFIGS: {
+    'claude-code': [{ field: 'ANTHROPIC_API_KEY' }],
+    'claude-code-cli': [{ field: 'ANTHROPIC_API_KEY' }],
+    codex: [{ field: 'OPENAI_API_KEY' }],
+    gemini: [{ field: 'GEMINI_API_KEY' }],
+    opencode: [],
+    copilot: [{ field: 'COPILOT_GITHUB_TOKEN' }],
+    cursor: [{ field: 'CURSOR_API_KEY' }],
+  },
+}));
+
+vi.mock('../EmojiPickerInput', () => ({
+  FormEmojiPickerInput: () => null,
+}));
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    user_id: 'user-1' as User['user_id'],
+    email: 'me@example.com',
+    name: 'Test User',
+    role: 'admin',
+    onboarding_completed: true,
+    must_change_password: false,
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    default_agentic_config: {
+      'claude-code': { permissionMode: 'claude-original' },
+      codex: { permissionMode: 'codex-original' },
+    },
+    ...overrides,
+  } as User;
+}
+
+function clickToolDefaults(label: string) {
+  fireEvent.click(screen.getByRole('menuitem', { name: label }));
+  fireEvent.click(screen.getByRole('tab', { name: 'Defaults' }));
+}
+
+describe('UserSettingsModal', () => {
+  it('saves dirty default settings from multiple agentic tool tabs', async () => {
+    const onUpdate = vi.fn(async () => undefined);
+    const onClose = vi.fn();
+    const user = makeUser();
+
+    render(
+      <UserSettingsModal
+        open
+        onClose={onClose}
+        user={user}
+        currentUser={user}
+        mcpServerById={new Map()}
+        client={null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    clickToolDefaults('Claude Code');
+    fireEvent.change(screen.getByLabelText('claude-code permission'), {
+      target: { value: 'claude-updated' },
+    });
+
+    clickToolDefaults('Codex');
+    fireEvent.change(screen.getByLabelText('codex permission'), {
+      target: { value: 'codex-updated' },
+    });
+
+    clickToolDefaults('Claude Code');
+    expect(screen.getByLabelText('claude-code permission')).toHaveValue('claude-updated');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate).toHaveBeenCalledWith('user-1', {
+      default_agentic_config: {
+        'claude-code': { permissionMode: 'claude-updated' },
+        codex: { permissionMode: 'codex-updated' },
+      },
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('still saves a single active agentic tool tab and preserves untouched tool defaults', async () => {
+    const onUpdate = vi.fn(async () => undefined);
+    const onClose = vi.fn();
+    const user = makeUser();
+
+    render(
+      <UserSettingsModal
+        open
+        onClose={onClose}
+        user={user}
+        currentUser={user}
+        mcpServerById={new Map()}
+        client={null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    clickToolDefaults('Claude Code');
+    fireEvent.change(screen.getByLabelText('claude-code permission'), {
+      target: { value: 'claude-only-updated' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate).toHaveBeenCalledWith('user-1', {
+      default_agentic_config: {
+        'claude-code': { permissionMode: 'claude-only-updated' },
+        codex: { permissionMode: 'codex-original' },
+      },
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -1,6 +1,7 @@
 import type {
   AgenticToolName,
   AgorClient,
+  DefaultAgenticConfig,
   EnvVarMetadata,
   EnvVarScope,
   Group,
@@ -43,6 +44,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
 import { searchableSelectProps, toGroupSelectOption } from '../../utils/selectSearch';
 import {
+  type AgenticFormValues,
   AgenticToolConfigForm,
   buildConfigFromFormValues,
   getClearedFormValues,
@@ -155,6 +157,19 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     copilot: false,
     cursor: false,
   });
+  const [hydratedAgenticTools, setHydratedAgenticTools] = useState<Set<AgenticToolName>>(
+    () => new Set()
+  );
+  const [dirtyAgenticTools, setDirtyAgenticTools] = useState<Set<AgenticToolName>>(() => new Set());
+
+  const markAgenticToolDirty = useCallback((tool: AgenticToolName) => {
+    setDirtyAgenticTools((prev) => {
+      if (prev.has(tool)) return prev;
+      const next = new Set(prev);
+      next.add(tool);
+      return next;
+    });
+  }, []);
 
   // Initialize forms when user changes or modal opens
   const initializeForms = useCallback(
@@ -176,7 +191,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   );
 
   const loadUserGroups = useCallback(async () => {
-    if (!client || !user || !isAdmin) {
+    const userId = user?.user_id;
+    if (!client || !userId || !isAdmin) {
       setAvailableGroups([]);
       setUserGroupIds([]);
       setGroupsLoaded(false);
@@ -189,7 +205,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     try {
       const [groups, memberships] = await Promise.all([
         client.service('groups').findAll({ query: { archived: false } }),
-        client.service('group-memberships').findAll({ query: { user_id: user.user_id } }),
+        client.service('group-memberships').findAll({ query: { user_id: userId } }),
       ]);
       const nextGroupIds = (memberships as GroupMembership[]).map(
         (membership) => membership.group_id
@@ -203,15 +219,18 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     } finally {
       setLoadingGroups(false);
     }
-  }, [client, form, isAdmin, user]);
+  }, [client, form, isAdmin, user?.user_id]);
 
   // Initialize when modal opens with user data
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Reinitialize only when the modal opens or the user id changes; same-user DTO refreshes must not wipe unsaved tab edits.
   useEffect(() => {
     if (open && user) {
       initializeForms(user);
+      setHydratedAgenticTools(new Set());
+      setDirtyAgenticTools(new Set());
       void loadUserGroups();
     }
-  }, [open, user, initializeForms, loadUserGroups]);
+  }, [open, user?.user_id, initializeForms, loadUserGroups]);
 
   // Hydrate tab-specific forms only after that tab has rendered its
   // corresponding <Form>. Calling setFieldsValue on never-mounted form
@@ -220,9 +239,17 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     if (!open || !user) return;
 
     if (isAgenticToolTab(activeTab)) {
-      agenticFormByTool[activeTab].setFieldsValue(
-        getFormValuesFromConfig(activeTab, user.default_agentic_config?.[activeTab])
-      );
+      if (!hydratedAgenticTools.has(activeTab)) {
+        agenticFormByTool[activeTab].setFieldsValue(
+          getFormValuesFromConfig(activeTab, user.default_agentic_config?.[activeTab])
+        );
+        setHydratedAgenticTools((prev) => {
+          if (prev.has(activeTab)) return prev;
+          const next = new Set(prev);
+          next.add(activeTab);
+          return next;
+        });
+      }
       return;
     }
 
@@ -236,7 +263,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           audioPrefs?.minDurationSeconds ?? DEFAULT_AUDIO_PREFERENCES.minDurationSeconds,
       });
     }
-  }, [activeTab, audioForm, agenticFormByTool, open, user]);
+  }, [activeTab, audioForm, agenticFormByTool, hydratedAgenticTools, open, user]);
 
   // Rehydrate per-tool credential presence and env-var metadata from the
   // server every time the modal opens, so flags reflect the latest patch.
@@ -285,43 +312,114 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     setUserGroupIds(nextGroupIds);
   };
 
-  const handleUpdate = () => {
+  const buildAgenticConfigSavePlan = useCallback(
+    (extraTools: AgenticToolName[] = []) => {
+      if (!user) return null;
+
+      const extraToolSet = new Set(extraTools);
+      const tools = AGENTIC_TOOL_TABS.filter(
+        (tool) =>
+          (dirtyAgenticTools.has(tool) || extraToolSet.has(tool)) &&
+          (hydratedAgenticTools.has(tool) || extraToolSet.has(tool))
+      );
+
+      if (tools.length === 0) return null;
+
+      const defaultAgenticConfig: DefaultAgenticConfig = {
+        ...user.default_agentic_config,
+      };
+
+      for (const tool of tools) {
+        const values = agenticFormByTool[tool].getFieldsValue() as AgenticFormValues;
+        defaultAgenticConfig[tool] = buildConfigFromFormValues(tool, values);
+      }
+
+      return { tools, defaultAgenticConfig };
+    },
+    [agenticFormByTool, dirtyAgenticTools, hydratedAgenticTools, user]
+  );
+
+  const markAgenticConfigSaved = useCallback((tools: readonly AgenticToolName[]) => {
+    setDirtyAgenticTools((prev) => {
+      if (tools.every((tool) => !prev.has(tool))) return prev;
+      const next = new Set(prev);
+      for (const tool of tools) {
+        next.delete(tool);
+      }
+      return next;
+    });
+  }, []);
+
+  const persistAgenticConfigChanges = async (extraTools: AgenticToolName[] = []) => {
+    if (!user) return null;
+
+    const plan = buildAgenticConfigSavePlan(extraTools);
+    if (!plan) return null;
+
+    try {
+      setSavingAgenticConfig((prev) => {
+        const next = { ...prev };
+        for (const tool of plan.tools) {
+          next[tool] = true;
+        }
+        return next;
+      });
+
+      await onUpdate?.(user.user_id, {
+        default_agentic_config: plan.defaultAgenticConfig,
+      });
+      markAgenticConfigSaved(plan.tools);
+      return plan;
+    } finally {
+      setSavingAgenticConfig((prev) => {
+        const next = { ...prev };
+        for (const tool of plan.tools) {
+          next[tool] = false;
+        }
+        return next;
+      });
+    }
+  };
+
+  const handleUpdate = async () => {
     if (!user) return;
 
-    form
-      .validateFields(['email', 'name', 'emoji', 'role', 'unix_username'])
-      .then(async () => {
-        const values = form.getFieldsValue();
-        const updates: UpdateUserInput = {
-          email: values.email,
-          name: values.name,
-          emoji: values.emoji,
-          role: values.role,
-          unix_username: values.unix_username,
-          preferences: {
-            ...user.preferences,
-            eventStream: {
-              enabled: values.eventStreamEnabled ?? true,
-            },
+    try {
+      await form.validateFields(['email', 'name', 'emoji', 'role', 'unix_username']);
+      const values = form.getFieldsValue();
+      const agenticConfigPlan = buildAgenticConfigSavePlan();
+      const updates: UpdateUserInput = {
+        email: values.email,
+        name: values.name,
+        emoji: values.emoji,
+        role: values.role,
+        unix_username: values.unix_username,
+        preferences: {
+          ...user.preferences,
+          eventStream: {
+            enabled: values.eventStreamEnabled ?? true,
           },
-        };
-        if (values.password?.trim()) {
-          updates.password = values.password;
-        }
-        // Only admins can set must_change_password, and only for other users
-        if (
-          hasMinimumRole(currentUser?.role, ROLES.ADMIN) &&
-          user.user_id !== currentUser?.user_id
-        ) {
-          updates.must_change_password = values.must_change_password;
-        }
-        await onUpdate?.(user.user_id, updates);
-        await syncUserGroups(values.groupIds || []);
-        handleClose();
-      })
-      .catch((err) => {
-        console.error('Validation failed:', err);
-      });
+        },
+      };
+      if (agenticConfigPlan) {
+        updates.default_agentic_config = agenticConfigPlan.defaultAgenticConfig;
+      }
+      if (values.password?.trim()) {
+        updates.password = values.password;
+      }
+      // Only admins can set must_change_password, and only for other users
+      if (hasMinimumRole(currentUser?.role, ROLES.ADMIN) && user.user_id !== currentUser?.user_id) {
+        updates.must_change_password = values.must_change_password;
+      }
+      await onUpdate?.(user.user_id, updates);
+      if (agenticConfigPlan) {
+        markAgenticConfigSaved(agenticConfigPlan.tools);
+      }
+      await syncUserGroups(values.groupIds || []);
+      handleClose();
+    } catch (err) {
+      console.error('Validation failed:', err);
+    }
   };
 
   // Persist a per-tool credential field. Patch is shaped as
@@ -444,36 +542,22 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   };
 
   // Handle agentic tool config save
-  const handleAgenticConfigSave = async (tool: AgenticToolName) => {
+  const handleAgenticConfigSave = async (tool?: AgenticToolName) => {
     if (!user) return;
 
     try {
-      setSavingAgenticConfig((prev) => ({ ...prev, [tool]: true }));
-
-      const values = agenticFormByTool[tool].getFieldsValue() as Parameters<
-        typeof buildConfigFromFormValues
-      >[1];
-      const newConfig = {
-        ...user.default_agentic_config,
-        [tool]: buildConfigFromFormValues(tool, values),
-      };
-
-      await onUpdate?.(user.user_id, {
-        default_agentic_config: newConfig,
-      });
-
+      await persistAgenticConfigChanges(tool ? [tool] : []);
       handleClose();
     } catch (err) {
-      console.error(`Failed to save ${tool} config:`, err);
+      console.error(`Failed to save ${tool ? `${tool} config` : 'agentic tool configs'}:`, err);
       throw err;
-    } finally {
-      setSavingAgenticConfig((prev) => ({ ...prev, [tool]: false }));
     }
   };
 
   // Handle agentic tool config clear
   const handleAgenticConfigClear = (tool: AgenticToolName) => {
     agenticFormByTool[tool].setFieldsValue(getClearedFormValues(tool));
+    markAgenticToolDirty(tool);
   };
 
   const handleAudioSave = async () => {
@@ -481,6 +565,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
     try {
       const values = audioForm.getFieldsValue();
+      const agenticConfigPlan = buildAgenticConfigSavePlan();
       const updatedPreferences = {
         ...user.preferences,
         audio: {
@@ -491,9 +576,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         },
       };
 
-      onUpdate(user.user_id, {
+      await onUpdate(user.user_id, {
         preferences: updatedPreferences,
+        ...(agenticConfigPlan
+          ? { default_agentic_config: agenticConfigPlan.defaultAgenticConfig }
+          : {}),
       });
+      if (agenticConfigPlan) {
+        markAgenticConfigSaved(agenticConfigPlan.tools);
+      }
 
       handleClose();
     } catch (error) {
@@ -507,14 +598,16 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
     switch (activeTab) {
       case 'general':
-        handleUpdate();
+        await handleUpdate();
         break;
       case 'env-vars':
       case 'personal-api-keys':
         // These tabs save individually, just close
+        await persistAgenticConfigChanges();
         handleClose();
         break;
       case 'groups':
+        await persistAgenticConfigChanges();
         await syncUserGroups(form.getFieldValue('groupIds') || []);
         handleClose();
         break;
@@ -852,7 +945,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
               Configure default settings for {displayNames[toolName]}. These will prepopulate
               session creation forms.
             </Typography.Paragraph>
-            <Form form={currentForm} layout="vertical">
+            <Form
+              form={currentForm}
+              layout="vertical"
+              onValuesChange={() => markAgenticToolDirty(toolName)}
+            >
               <AgenticToolConfigForm
                 agenticTool={toolName}
                 mcpServerById={mcpServerById}


### PR DESCRIPTION
## Summary

Updates User Settings so saving after editing defaults across multiple Agentic Tools tabs persists all modified tab values in one update, instead of only the currently visible tab.

## Root cause

The modal save path only read the active tool form before closing, so dirty hidden tool forms were omitted from the `default_agentic_config` payload.

## Changes

- Track hydrated and dirty agentic tool default forms for the current modal session.
- Hydrate each tool defaults form once per open modal session so tab switches do not overwrite unsaved edits.
- Build a save payload from all dirty tool forms while preserving untouched existing defaults.
- Add focused regression coverage for multi-tab save and single-tab preservation.

## Validation

- `pnpm --filter agor-ui test -- src/components/SettingsModal/UserSettingsModal.test.tsx`
- `pnpm exec biome check apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx`

Runtime browser validation was not captured because the branch environment health check remained blocked by the recorded GID collision during container build. The focused component test covers the affected save path directly.

Related to #351.
