### PR TITLE
fix(ui): use primary color for session links

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -1,6 +1,6 @@
 import { GithubOutlined, GlobalOutlined, LinkOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Badge, Button, Dropdown, Tooltip } from 'antd';
+import { Badge, Button, Dropdown, Tooltip, theme } from 'antd';
 import type React from 'react';
 
 export interface SessionAttachmentItem {
@@ -24,6 +24,8 @@ function getIcon(url: string): React.ReactNode {
 }
 
 export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
+  const { token } = theme.useToken();
+
   if (items.length === 0) return null;
 
   const menuItems: MenuProps['items'] = items.map((item) => ({
@@ -50,8 +52,8 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
   return (
     <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
       <Tooltip title="Attachments">
-        <Badge count={items.length} size="small" offset={[-4, 4]}>
-          <Button type="text" icon={<LinkOutlined />} />
+        <Badge count={items.length} color={token.colorPrimary} size="small" offset={[-4, 4]}>
+          <Button type="text" icon={<LinkOutlined style={{ color: token.colorPrimary }} />} />
         </Badge>
       </Tooltip>
     </Dropdown>


### PR DESCRIPTION
## Summary\n- Use the primary color token for the session header links affordance instead of the error/red affordance.\n\n## Checks\n- pnpm dlx @biomejs/biome@2.4.16 check apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx