### PR TITLE
Track cross-branch session relationships

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -328,6 +328,8 @@ describe('agor_sessions_create', () => {
             ...(data as Record<string, unknown>),
           };
         },
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': { create: async () => ({}) },
     });
@@ -366,6 +368,8 @@ describe('agor_sessions_create', () => {
           sessionCreates.push(data);
           return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
         },
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': { create: async () => ({}) },
     });
@@ -401,6 +405,8 @@ describe('agor_sessions_create', () => {
           session_id: 'sess-new',
           ...(data as Record<string, unknown>),
         }),
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
         create: async (data: unknown, params: unknown) => {
@@ -437,6 +443,8 @@ describe('agor_sessions_create', () => {
       branches: { get: async () => baseBranch },
       sessions: {
         create: async () => ({ session_id: 'sess-new' }),
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
         create: async () => {
@@ -472,6 +480,8 @@ describe('agor_sessions_create', () => {
       branches: { get: async () => branchWithMcps },
       sessions: {
         create: async () => ({ session_id: 'sess-new' }),
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
         create: async () => {
@@ -493,6 +503,162 @@ describe('agor_sessions_create', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.mcpAttachFailures).toBeUndefined();
+  });
+
+  it('auto-links to calling session when ctx.sessionId is set', async () => {
+    const patchCalls: Array<{ id: unknown; data: unknown }> = [];
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          genealogy: { children: ['existing-child'] },
+        }),
+        patch: async (id: unknown, data: unknown) => {
+          patchCalls.push({ id, data });
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+    });
+
+    // New session genealogy should reference the calling session as parent
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBe('sess-caller');
+
+    // Parent's children list should be updated to include the new session
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0].id).toBe('sess-caller');
+    const patchData = patchCalls[0].data as Record<string, any>;
+    expect(patchData.genealogy.children).toContain('sess-new');
+    expect(patchData.genealogy.children).toContain('existing-child');
+
+    // Note in response should mention the parent link
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.note).toContain('sess-caller');
+  });
+
+  it('does not set parent_session_id when called without session context', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        patch: async (id: unknown, data: unknown) => {
+          patchCalls.push({ id, data });
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1' }, // no sessionId
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBeUndefined();
+    expect(patchCalls).toHaveLength(0);
+  });
+
+  it('respects explicit parentSessionId when provided', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: Array<{ id: unknown; data: unknown }> = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        patch: async (id: unknown, data: unknown) => {
+          patchCalls.push({ id, data });
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+      parentSessionId: 'sess-explicit-parent',
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    // Explicit value overrides ctx.sessionId
+    expect(created.genealogy.parent_session_id).toBe('sess-explicit-parent');
+    expect(patchCalls[0].id).toBe('sess-explicit-parent');
+  });
+
+  it('creates root session (no parent) when parentSessionId: null is passed', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        patch: async (...args: unknown[]) => {
+          patchCalls.push(args);
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+      parentSessionId: null,
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBeUndefined();
+    // No patch to update a parent's children list
+    expect(patchCalls).toHaveLength(0);
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -35,6 +35,30 @@ vi.mock('@agor/core/db', () => ({
       ...data,
       created_at: new Date(0).toISOString(),
     }));
+    get = vi.fn(async (relationshipId: string) => ({
+      relationship_id: relationshipId,
+      source_session_id: 'sess-source',
+      target_session_id: 'sess-target',
+      relationship_type: 'remote_create',
+      created_by: 'user-1',
+      created_at: new Date(0).toISOString(),
+      updated_at: new Date(0).toISOString(),
+      callback_enabled: false,
+      callback_session_id: null,
+      data: null,
+    }));
+    setCallbackEnabled = vi.fn(async (relationshipId: string, callbackEnabled: boolean) => ({
+      relationship_id: relationshipId,
+      source_session_id: 'sess-source',
+      target_session_id: 'sess-target',
+      relationship_type: 'remote_create',
+      created_by: 'user-1',
+      created_at: new Date(0).toISOString(),
+      updated_at: new Date(0).toISOString(),
+      callback_enabled: callbackEnabled,
+      callback_session_id: null,
+      data: null,
+    }));
   },
   UserApiKeysRepository: class FakeUserApiKeysRepository {},
   shortId: (id: string) => id,
@@ -738,7 +762,54 @@ describe('agor_sessions_create', () => {
       target_session_id: 'sess-new',
       relationship_type: 'remote_create',
       callback_enabled: false,
+      callback_session_id: 'sess-caller',
     });
+  });
+
+  it('enables remote relationship callbacks using the source session as fallback target', async () => {
+    const patchCalls: unknown[] = [];
+    const getCalls: string[] = [];
+    const app = makeFakeApp({
+      sessions: {
+        get: async (id: string) => {
+          getCalls.push(id);
+          return {
+            session_id: id,
+            branch_id: id === 'sess-source' ? 'wt-source' : 'wt-target',
+            callback_config: {},
+          };
+        },
+        patch: async (...args: unknown[]) => {
+          patchCalls.push(args);
+          return {};
+        },
+      },
+    });
+
+    const { agor_session_relationships_set_callback } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_session_relationships_set_callback']
+    );
+
+    await agor_session_relationships_set_callback({
+      relationshipId: 'rel-1',
+      callbackEnabled: true,
+    });
+
+    expect(getCalls).toEqual(['sess-source', 'sess-target']);
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]).toMatchObject([
+      'sess-target',
+      {
+        callback_config: {
+          enabled: true,
+          callback_session_id: 'sess-source',
+        },
+      },
+      {
+        _skipRelationshipCallbackSync: true,
+      },
+    ]);
   });
 
   it('rejects explicit parentSessionId from a different branch', async () => {

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -750,7 +750,6 @@ describe('agor_sessions_create', () => {
     const result = await agor_sessions_create({
       branchId: 'wt-target',
       agenticTool: 'claude-code',
-      enableCallback: false,
     });
 
     const created = sessionCreates[0] as Record<string, any>;

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -637,6 +637,7 @@ describe('agor_sessions_create', () => {
 
     const created = sessionCreates[0] as Record<string, any>;
     expect(created.genealogy.parent_session_id).toBeUndefined();
+    expect(created.callback_config).toBeUndefined();
     expect(patchCalls).toHaveLength(0);
   });
 
@@ -749,10 +750,16 @@ describe('agor_sessions_create', () => {
     const result = await agor_sessions_create({
       branchId: 'wt-target',
       agenticTool: 'claude-code',
+      enableCallback: false,
     });
 
     const created = sessionCreates[0] as Record<string, any>;
     expect(created.genealogy.parent_session_id).toBeUndefined();
+    expect(created.callback_config).toMatchObject({
+      enabled: false,
+      callback_session_id: 'sess-caller',
+      callback_created_by: 'user-1',
+    });
     expect(patchCalls).toHaveLength(0);
 
     const parsed = JSON.parse(result.content[0].text);

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -29,6 +29,13 @@ vi.mock('../../utils/branch-authorization.js', () => ({
 
 vi.mock('@agor/core/db', () => ({
   BranchRepository: class FakeBranchRepository {},
+  SessionRelationshipRepository: class FakeSessionRelationshipRepository {
+    create = vi.fn(async (data: Record<string, unknown>) => ({
+      relationship_id: 'rel-1',
+      ...data,
+      created_at: new Date(0).toISOString(),
+    }));
+  },
   UserApiKeysRepository: class FakeUserApiKeysRepository {},
   shortId: (id: string) => id,
 }));
@@ -328,7 +335,11 @@ describe('agor_sessions_create', () => {
             ...(data as Record<string, unknown>),
           };
         },
-        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
         patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': { create: async () => ({}) },
@@ -368,7 +379,11 @@ describe('agor_sessions_create', () => {
           sessionCreates.push(data);
           return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
         },
-        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
         patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': { create: async () => ({}) },
@@ -405,7 +420,11 @@ describe('agor_sessions_create', () => {
           session_id: 'sess-new',
           ...(data as Record<string, unknown>),
         }),
-        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
         patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
@@ -443,7 +462,11 @@ describe('agor_sessions_create', () => {
       branches: { get: async () => baseBranch },
       sessions: {
         create: async () => ({ session_id: 'sess-new' }),
-        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
         patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
@@ -480,7 +503,11 @@ describe('agor_sessions_create', () => {
       branches: { get: async () => branchWithMcps },
       sessions: {
         create: async () => ({ session_id: 'sess-new' }),
-        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
         patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': {
@@ -518,6 +545,7 @@ describe('agor_sessions_create', () => {
         },
         get: async (id: string) => ({
           session_id: id,
+          branch_id: 'wt-1',
           genealogy: { children: ['existing-child'] },
         }),
         patch: async (id: unknown, data: unknown) => {
@@ -599,7 +627,11 @@ describe('agor_sessions_create', () => {
           sessionCreates.push(data);
           return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
         },
-        get: async (id: string) => ({ session_id: id, genealogy: { children: [] } }),
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
         patch: async (id: unknown, data: unknown) => {
           patchCalls.push({ id, data });
           return {};
@@ -659,6 +691,89 @@ describe('agor_sessions_create', () => {
     expect(created.genealogy.parent_session_id).toBeUndefined();
     // No patch to update a parent's children list
     expect(patchCalls).toHaveLength(0);
+  });
+
+  it('does not auto-link to the calling session when creating in a different branch', async () => {
+    const sessionCreates: unknown[] = [];
+    const patchCalls: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => ({ ...baseBranch, branch_id: 'wt-target' }) },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-caller',
+          genealogy: { children: ['existing-child'] },
+        }),
+        patch: async (...args: unknown[]) => {
+          patchCalls.push(args);
+          return {};
+        },
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    const result = await agor_sessions_create({
+      branchId: 'wt-target',
+      agenticTool: 'claude-code',
+    });
+
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.genealogy.parent_session_id).toBeUndefined();
+    expect(patchCalls).toHaveLength(0);
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.note).toContain('target branch differs');
+    expect(parsed.remoteRelationship).toMatchObject({
+      source_session_id: 'sess-caller',
+      target_session_id: 'sess-new',
+      relationship_type: 'remote_create',
+      callback_enabled: false,
+    });
+  });
+
+  it('rejects explicit parentSessionId from a different branch', async () => {
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => ({ ...baseBranch, branch_id: 'wt-target' }) },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-other',
+          genealogy: { children: [] },
+        }),
+        patch: async () => ({}),
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await expect(
+      agor_sessions_create({
+        branchId: 'wt-target',
+        agenticTool: 'claude-code',
+        parentSessionId: 'sess-explicit-parent',
+      })
+    ).rejects.toThrow(/target branch/i);
+    expect(sessionCreates).toHaveLength(0);
   });
 });
 
@@ -935,6 +1050,12 @@ describe('modelConfig schema (string shorthand coercion)', () => {
           sessionCreates.push(data);
           return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
         },
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
+        patch: async () => ({}),
       },
       '/sessions/:id/mcp-servers': { create: async () => ({}) },
     });

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -860,26 +860,30 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const repo = new SessionRelationshipRepository(ctx.db);
-      const relationship = await repo.setCallbackEnabled(
-        args.relationshipId as import('@agor/core/types').SessionRelationshipID,
-        args.callbackEnabled
-      );
+      const relationshipId =
+        args.relationshipId as import('@agor/core/types').SessionRelationshipID;
+      const existingRelationship = await repo.get(relationshipId);
 
-      // Keep the existing callback_config execution switch in sync. The
-      // relationship is durable provenance; callback_config.enabled controls
-      // whether TasksService actually queues completion callbacks today.
+      // Authorize visibility/access before mutating the durable relationship.
+      // Reading both sides through the sessions service keeps this tool aligned
+      // with normal session RBAC instead of treating relationship IDs as ambient
+      // authority.
+      await ctx.app
+        .service('sessions')
+        .get(existingRelationship.source_session_id, ctx.baseServiceParams);
       const targetSession = await ctx.app
         .service('sessions')
-        .get(relationship.target_session_id, ctx.baseServiceParams);
+        .get(existingRelationship.target_session_id, ctx.baseServiceParams);
+
+      const relationship = await repo.setCallbackEnabled(relationshipId, args.callbackEnabled);
+      const callbackSessionId = relationship.callback_session_id ?? relationship.source_session_id;
       await ctx.app.service('sessions').patch(
         relationship.target_session_id,
         {
           callback_config: {
             ...(targetSession.callback_config ?? {}),
             enabled: args.callbackEnabled,
-            ...(relationship.callback_session_id
-              ? { callback_session_id: relationship.callback_session_id }
-              : {}),
+            callback_session_id: callbackSessionId,
           },
         },
         {
@@ -1117,7 +1121,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             relationship_type: 'remote_create',
             created_by: ctx.userId,
             callback_enabled: Boolean(wantsCallback),
-            callback_session_id: wantsCallback
+            // Keep the durable relationship target even when callbacks are
+            // muted. callback_enabled/callback_config.enabled are the delivery
+            // switches; callback_session_id is the stable endpoint to re-enable.
+            callback_session_id: effectiveCallbackSessionId
               ? (effectiveCallbackSessionId as Session['session_id'])
               : null,
             data: {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1088,6 +1088,15 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         }
       }
 
+      if (remoteRelationshipSourceSessionId && effectiveCallbackSessionId) {
+        // For remote-created sessions, keep the callback endpoint durable even
+        // when delivery is muted. `enabled` / relationship.callback_enabled are
+        // the switches; callback_session_id is needed for generic session
+        // settings/update paths to re-enable callbacks later.
+        callbackConfig.callback_session_id ??= effectiveCallbackSessionId;
+        callbackConfig.callback_created_by ??= ctx.userId;
+      }
+
       const sessionData: Record<string, unknown> = {
         branch_id: branch.branch_id,
         agentic_tool: agenticTool,

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1127,6 +1127,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           })
         : null;
 
+      if (remoteRelationship && remoteRelationshipSourceSessionId) {
+        const sourceSession = await ctx.app
+          .service('sessions')
+          .get(remoteRelationshipSourceSessionId, ctx.baseServiceParams);
+        ctx.app.service('sessions').emit?.('patched', sourceSession, ctx.baseServiceParams);
+      }
+
       // Update the parent session's children list to include the new session.
       if (resolvedParentSessionId && parentSessionForPatch) {
         await ctx.app.service('sessions').patch(

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1093,6 +1093,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         // when delivery is muted. `enabled` / relationship.callback_enabled are
         // the switches; callback_session_id is needed for generic session
         // settings/update paths to re-enable callbacks later.
+        callbackConfig.enabled ??= Boolean(wantsCallback);
         callbackConfig.callback_session_id ??= effectiveCallbackSessionId;
         callbackConfig.callback_created_by ??= ctx.userId;
       }

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -813,7 +813,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_create',
     {
       description:
-        'Create a new session in an existing branch. Use for starting fresh work on a new task in the same codebase (e.g., new feature branch, separate investigation). Unlike spawn, this creates an independent session with no parent-child relationship. MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, advisorModel, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
+        'Create a new session in an existing branch. When called from an MCP session context (the default for orchestrator agents), the new session is automatically linked to the calling session as its parent — pass `parentSessionId: null` to create an unlinked root session instead. Use for starting work on a new task in the same codebase (e.g., new feature branch, separate investigation). MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, advisorModel, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
       inputSchema: z.object({
         branchId: mcpRequiredId(
           'branchId',
@@ -859,6 +859,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .optional()
           .describe(
             'Callback firing mode: "once" (default) fires on first completion then auto-disables, "persistent" fires on every completion'
+          ),
+        parentSessionId: z
+          .string()
+          .min(1, 'parentSessionId cannot be empty when provided.')
+          .nullish()
+          .describe(
+            'Parent session ID to link this session to in the genealogy tree. When omitted and called from a session MCP context, automatically defaults to the calling session. Pass null to explicitly create a root session with no parent.'
           ),
         mcpServerIds: z
           .array(mcpRequiredId('mcpServerIds[]', 'MCP server'))
@@ -948,6 +955,17 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         callbackConfig.callback_mode = args.callbackMode ?? 'once';
       }
 
+      // Determine the parent session to link to in the genealogy:
+      // - explicit string: resolve (supports short IDs) and use
+      // - explicit null: opt out — create a root session with no parent
+      // - undefined (omitted): auto-link to the calling session when available
+      const resolvedParentSessionId =
+        args.parentSessionId !== undefined
+          ? args.parentSessionId !== null
+            ? await resolveSessionId(ctx, args.parentSessionId)
+            : undefined
+          : ctx.sessionId;
+
       const sessionData: Record<string, unknown> = {
         branch_id: branch.branch_id,
         agentic_tool: agenticTool,
@@ -965,11 +983,31 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           base_sha: currentSha,
           current_sha: currentSha,
         },
-        genealogy: { children: [] },
+        genealogy: {
+          ...(resolvedParentSessionId && { parent_session_id: resolvedParentSessionId }),
+          children: [],
+        },
         tasks: [],
       };
 
       const session = await ctx.app.service('sessions').create(sessionData, ctx.baseServiceParams);
+
+      // Update the parent session's children list to include the new session.
+      if (resolvedParentSessionId) {
+        const parentSession = await ctx.app
+          .service('sessions')
+          .get(resolvedParentSessionId, ctx.baseServiceParams);
+        await ctx.app.service('sessions').patch(
+          resolvedParentSessionId,
+          {
+            genealogy: {
+              ...parentSession.genealogy,
+              children: [...(parentSession.genealogy?.children ?? []), session.session_id],
+            },
+          },
+          ctx.baseServiceParams
+        );
+      }
 
       // Attach MCP servers (inherited from branch or user defaults, or
       // explicitly requested via args.mcpServerIds). Explicit failures are
@@ -1018,6 +1056,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         ? ` Callback will be sent to session ${shortId(callbackConfig.callback_session_id as string)} on completion.`
         : '';
 
+      const parentNote = resolvedParentSessionId
+        ? ` Linked to parent session ${shortId(resolvedParentSessionId)}.`
+        : '';
+
       const mcpFailureNote =
         mcpAttachFailures.length > 0
           ? ` Warning: ${mcpAttachFailures.length} requested MCP server(s) failed to attach — see mcpAttachFailures.`
@@ -1027,8 +1069,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         session: redactSessionForMcp(session),
         taskId: initialTask?.task_id,
         note: args.initialPrompt
-          ? `Session created and initial prompt execution started.${callbackNote}${mcpFailureNote}`
-          : `Session created successfully.${callbackNote}${mcpFailureNote}`,
+          ? `Session created and initial prompt execution started.${parentNote}${callbackNote}${mcpFailureNote}`
+          : `Session created successfully.${parentNote}${callbackNote}${mcpFailureNote}`,
         ...(mcpAttachFailures.length > 0 && { mcpAttachFailures }),
       });
     }

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1,4 +1,9 @@
-import { BranchRepository, type BranchWithZoneAndSessions, shortId } from '@agor/core/db';
+import {
+  BranchRepository,
+  type BranchWithZoneAndSessions,
+  SessionRelationshipRepository,
+  shortId,
+} from '@agor/core/db';
 import {
   AVAILABLE_CLAUDE_MODEL_ALIASES,
   CODEX_MODEL_METADATA,
@@ -808,12 +813,91 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     }
   );
 
+  // Tool 5b: agor_session_relationships_list
+  server.registerTool(
+    'agor_session_relationships_list',
+    {
+      description:
+        'List durable non-genealogy relationships for a session, including cross-branch remote-created child/parent links. Defaults to the current session.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        sessionId: mcpOptionalId(
+          'sessionId',
+          'Session',
+          'Session ID to inspect (defaults to current session)'
+        ),
+      }),
+    },
+    async (args) => {
+      const sessionId = args.sessionId
+        ? await resolveSessionId(ctx, args.sessionId)
+        : ctx.sessionId;
+      if (!sessionId) return sessionContextRequiredResult();
+
+      // Validate normal session access/RBAC before returning links.
+      await ctx.app.service('sessions').get(sessionId, ctx.baseServiceParams);
+
+      const relationships = await new SessionRelationshipRepository(ctx.db).findForSession(
+        sessionId
+      );
+      return textResult({ relationships });
+    }
+  );
+
+  // Tool 5c: agor_session_relationships_set_callback
+  server.registerTool(
+    'agor_session_relationships_set_callback',
+    {
+      description:
+        'Enable or disable callback/report-back delivery for a durable session relationship without deleting the relationship itself.',
+      inputSchema: z.object({
+        relationshipId: mcpRequiredString(
+          'relationshipId',
+          'Session relationship ID returned by agor_session_relationships_list'
+        ),
+        callbackEnabled: z.boolean().describe('Whether the remote child should report back.'),
+      }),
+    },
+    async (args) => {
+      const repo = new SessionRelationshipRepository(ctx.db);
+      const relationship = await repo.setCallbackEnabled(
+        args.relationshipId as import('@agor/core/types').SessionRelationshipID,
+        args.callbackEnabled
+      );
+
+      // Keep the existing callback_config execution switch in sync. The
+      // relationship is durable provenance; callback_config.enabled controls
+      // whether TasksService actually queues completion callbacks today.
+      const targetSession = await ctx.app
+        .service('sessions')
+        .get(relationship.target_session_id, ctx.baseServiceParams);
+      await ctx.app.service('sessions').patch(
+        relationship.target_session_id,
+        {
+          callback_config: {
+            ...(targetSession.callback_config ?? {}),
+            enabled: args.callbackEnabled,
+            ...(relationship.callback_session_id
+              ? { callback_session_id: relationship.callback_session_id }
+              : {}),
+          },
+        },
+        {
+          ...ctx.baseServiceParams,
+          _skipRelationshipCallbackSync: true,
+        } as typeof ctx.baseServiceParams
+      );
+
+      return textResult({ relationship });
+    }
+  );
+
   // Tool 6: agor_sessions_create
   server.registerTool(
     'agor_sessions_create',
     {
       description:
-        'Create a new session in an existing branch. When called from an MCP session context (the default for orchestrator agents), the new session is automatically linked to the calling session as its parent — pass `parentSessionId: null` to create an unlinked root session instead. Use for starting work on a new task in the same codebase (e.g., new feature branch, separate investigation). MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, advisorModel, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
+        'Create a new session in an existing branch. When called from an MCP session context in the same target branch (the default for branch-local orchestrator agents), the new session is automatically linked to the calling session as its parent — pass `parentSessionId: null` to create an unlinked root session instead. Cross-branch sessions are not genealogy-linked automatically; use callbacks for remote completion routing. Use for starting work on a new task in the same codebase (e.g., new feature branch, separate investigation). MCP servers are inherited from the branch (if configured) or user defaults, or can be overridden via `mcpServerIds`. Model selection falls back to user defaults and can be overridden via `modelConfig` (accepts either a model ID string like "claude-opus-4-6" or a full {mode, model, effort, advisorModel, provider} object — call `agor_models_list` to discover valid model IDs per agenticTool). Supports optional callbacks to notify the creating session when the new session completes.',
       inputSchema: z.object({
         branchId: mcpRequiredId(
           'branchId',
@@ -865,7 +949,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .min(1, 'parentSessionId cannot be empty when provided.')
           .nullish()
           .describe(
-            'Parent session ID to link this session to in the genealogy tree. When omitted and called from a session MCP context, automatically defaults to the calling session. Pass null to explicitly create a root session with no parent.'
+            'Parent session ID to link this session to in the branch-local genealogy tree. Must be in the target branch. When omitted and called from a session MCP context in the same branch, automatically defaults to the calling session. Pass null to explicitly create a root session with no parent; use callbackSessionId for cross-branch routing.'
           ),
         mcpServerIds: z
           .array(mcpRequiredId('mcpServerIds[]', 'MCP server'))
@@ -955,16 +1039,50 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         callbackConfig.callback_mode = args.callbackMode ?? 'once';
       }
 
-      // Determine the parent session to link to in the genealogy:
-      // - explicit string: resolve (supports short IDs) and use
+      // Determine the parent session to link to in the genealogy.
+      //
+      // `parent_session_id` is the canonical branch-local session tree used by
+      // fork/spawn UI and recursive delete semantics. A session created in a
+      // different target branch is remote provenance/callback state, not a
+      // tree child of the caller. Keep the implicit convenience branch-local:
+      // - explicit string: resolve (supports short IDs), require same branch, and use
       // - explicit null: opt out — create a root session with no parent
-      // - undefined (omitted): auto-link to the calling session when available
-      const resolvedParentSessionId =
-        args.parentSessionId !== undefined
-          ? args.parentSessionId !== null
-            ? await resolveSessionId(ctx, args.parentSessionId)
-            : undefined
-          : ctx.sessionId;
+      // - undefined (omitted): auto-link to the calling session only when the
+      //   calling session lives in the same branch as the new session
+      let resolvedParentSessionId: string | undefined;
+      let parentSessionForPatch: Session | undefined;
+      let skippedAutoParentDueToBranchMismatch = false;
+      let remoteRelationshipSourceSessionId: string | undefined;
+      let remoteRelationshipSourceBranchId: string | undefined;
+
+      if (args.parentSessionId !== undefined) {
+        if (args.parentSessionId !== null) {
+          resolvedParentSessionId = await resolveSessionId(ctx, args.parentSessionId);
+          parentSessionForPatch = (await ctx.app
+            .service('sessions')
+            .get(resolvedParentSessionId, ctx.baseServiceParams)) as Session;
+
+          if (parentSessionForPatch.branch_id !== branch.branch_id) {
+            throw new Error(
+              `parentSessionId must reference a session in the target branch (${shortId(branch.branch_id)}). ` +
+                'For cross-branch completion routing, use enableCallback/callbackSessionId instead of genealogy.'
+            );
+          }
+        }
+      } else if (ctx.sessionId) {
+        const callingSession = (await ctx.app
+          .service('sessions')
+          .get(ctx.sessionId, ctx.baseServiceParams)) as Session;
+
+        if (callingSession.branch_id === branch.branch_id) {
+          resolvedParentSessionId = callingSession.session_id;
+          parentSessionForPatch = callingSession;
+        } else {
+          skippedAutoParentDueToBranchMismatch = true;
+          remoteRelationshipSourceSessionId = callingSession.session_id;
+          remoteRelationshipSourceBranchId = callingSession.branch_id;
+        }
+      }
 
       const sessionData: Record<string, unknown> = {
         branch_id: branch.branch_id,
@@ -992,17 +1110,31 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
       const session = await ctx.app.service('sessions').create(sessionData, ctx.baseServiceParams);
 
+      const remoteRelationship = remoteRelationshipSourceSessionId
+        ? await new SessionRelationshipRepository(ctx.db).create({
+            source_session_id: remoteRelationshipSourceSessionId as Session['session_id'],
+            target_session_id: session.session_id,
+            relationship_type: 'remote_create',
+            created_by: ctx.userId,
+            callback_enabled: Boolean(wantsCallback),
+            callback_session_id: wantsCallback
+              ? (effectiveCallbackSessionId as Session['session_id'])
+              : null,
+            data: {
+              source_branch_id: remoteRelationshipSourceBranchId,
+              target_branch_id: branch.branch_id,
+            },
+          })
+        : null;
+
       // Update the parent session's children list to include the new session.
-      if (resolvedParentSessionId) {
-        const parentSession = await ctx.app
-          .service('sessions')
-          .get(resolvedParentSessionId, ctx.baseServiceParams);
+      if (resolvedParentSessionId && parentSessionForPatch) {
         await ctx.app.service('sessions').patch(
           resolvedParentSessionId,
           {
             genealogy: {
-              ...parentSession.genealogy,
-              children: [...(parentSession.genealogy?.children ?? []), session.session_id],
+              ...parentSessionForPatch.genealogy,
+              children: [...(parentSessionForPatch.genealogy?.children ?? []), session.session_id],
             },
           },
           ctx.baseServiceParams
@@ -1058,7 +1190,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
       const parentNote = resolvedParentSessionId
         ? ` Linked to parent session ${shortId(resolvedParentSessionId)}.`
-        : '';
+        : skippedAutoParentDueToBranchMismatch
+          ? ' Not genealogy-linked because the target branch differs from the calling session branch.'
+          : '';
 
       const mcpFailureNote =
         mcpAttachFailures.length > 0
@@ -1071,6 +1205,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         note: args.initialPrompt
           ? `Session created and initial prompt execution started.${parentNote}${callbackNote}${mcpFailureNote}`
           : `Session created successfully.${parentNote}${callbackNote}${mcpFailureNote}`,
+        ...(remoteRelationship && { remoteRelationship }),
         ...(mcpAttachFailures.length > 0 && { mcpAttachFailures }),
       });
     }

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -11,6 +11,7 @@ import {
   type Database,
   SessionEnvSelectionRepository,
   SessionMCPServerRepository,
+  SessionRelationshipRepository,
   SessionRepository,
   type SessionWithLastMessage,
   UsersRepository,
@@ -106,6 +107,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   private sessionRepo: SessionRepository;
   private app: Application;
   private sessionMCPRepo: SessionMCPServerRepository;
+  private sessionRelationshipRepo: SessionRelationshipRepository;
   private sessionEnvSelectionRepo: SessionEnvSelectionRepository;
   private usersRepo: UsersRepository;
   private branchRepo: BranchRepository;
@@ -125,6 +127,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     this.sessionRepo = sessionRepo;
     this.app = app;
     this.sessionMCPRepo = new SessionMCPServerRepository(db);
+    this.sessionRelationshipRepo = new SessionRelationshipRepository(db);
     this.sessionEnvSelectionRepo = new SessionEnvSelectionRepository(db);
     this.branchRepo = new BranchRepository(db);
     // Used by resolveChildIdentity to stamp unix_username on fork/spawn children
@@ -695,6 +698,35 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     this.emit?.('removed', session, params);
 
     return session;
+  }
+
+  /**
+   * Override patch to keep durable relationship callback state synchronized
+   * with the existing callback_config.enabled execution switch.
+   */
+  async patch(
+    id: import('@agor/core/types').NullableId,
+    data: Partial<Session>,
+    params?: SessionParams
+  ): Promise<Session | Session[]> {
+    const result = (await super.patch(id, data, params)) as Session | Session[];
+
+    const callbackEnabled = data.callback_config?.enabled;
+    if (
+      typeof callbackEnabled === 'boolean' &&
+      !(params as (SessionParams & { _skipRelationshipCallbackSync?: boolean }) | undefined)
+        ?._skipRelationshipCallbackSync
+    ) {
+      const sessionsToSync = Array.isArray(result) ? result : [result];
+      for (const session of sessionsToSync) {
+        await this.sessionRelationshipRepo.setCallbackEnabledForTargetSession(
+          session.session_id as SessionID,
+          callbackEnabled
+        );
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -136,6 +136,36 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     this.usersRepo = new UsersRepository(db);
   }
 
+  private async enrichRemoteRelationships(sessionList: Session[]): Promise<Session[]> {
+    const sessionIds = sessionList.map((session) => session.session_id);
+    if (sessionIds.length === 0) return sessionList;
+
+    const relationships = await this.sessionRelationshipRepo.findForSessions(sessionIds);
+    if (relationships.length === 0) return sessionList;
+
+    const bySessionId = new Map<SessionID, NonNullable<Session['remote_relationships']>>();
+
+    for (const relationship of relationships) {
+      const sourceBucket =
+        bySessionId.get(relationship.source_session_id) ??
+        ({ as_source: [], as_target: [] } satisfies NonNullable<Session['remote_relationships']>);
+      sourceBucket.as_source?.push(relationship);
+      bySessionId.set(relationship.source_session_id, sourceBucket);
+
+      const targetBucket =
+        bySessionId.get(relationship.target_session_id) ??
+        ({ as_source: [], as_target: [] } satisfies NonNullable<Session['remote_relationships']>);
+      targetBucket.as_target?.push(relationship);
+      bySessionId.set(relationship.target_session_id, targetBucket);
+    }
+
+    return sessionList.map((session) => {
+      const remoteRelationships = bySessionId.get(session.session_id);
+      if (!remoteRelationships) return session;
+      return { ...session, remote_relationships: remoteRelationships };
+    });
+  }
+
   /**
    * Attach explicit MCP server IDs to a session.
    * Emits WebSocket events so the UI updates in real-time.
@@ -741,6 +771,8 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     const includeLastMessage = includeLastMessageRoot ?? includeLastMessageQuery;
 
     const session = await super.get(id, params);
+    const [enrichedSession] = await this.enrichRemoteRelationships([session]);
+    const sessionWithRelationships = enrichedSession ?? session;
 
     // Only enrich with last message if explicitly requested
     if (includeLastMessage === true || includeLastMessage === 'true') {
@@ -750,23 +782,30 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         truncationLengthRoot ?? truncationLengthQuery
       );
       const result = await this.sessionRepo.enrichWithLastMessage(
-        session as Session,
+        sessionWithRelationships as Session,
         truncationLength
       );
       return result;
     }
 
-    return session as SessionWithLastMessage;
+    return sessionWithRelationships as SessionWithLastMessage;
   }
 
   /**
-   * Override find - no custom logic, just use default find
-   *
-   * Note: Last message is NOT included in list operations - only on single GET
+   * Override find to include durable remote relationships in list results.
+   * Note: Last message is NOT included in list operations - only on single GET.
    */
   async find(params?: SessionParams): Promise<Paginated<Session> | Session[]> {
-    // Use default find to ensure all hooks and scoping are applied
-    return super.find(params);
+    const result = await super.find(params);
+
+    if (Array.isArray(result)) {
+      return this.enrichRemoteRelationships(result);
+    }
+
+    return {
+      ...result,
+      data: await this.enrichRemoteRelationships(result.data),
+    };
   }
 }
 

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -45,7 +45,6 @@ import {
 } from '../../utils/sessionSearch';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { ArchiveActionButton } from '../ArchiveButton';
-import { BranchBoardLocatorIcon } from '../BranchBoardLocatorIcon';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { HighlightMatch } from '../HighlightMatch';
 import { ChannelPill } from '../Pill';
@@ -621,7 +620,6 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 </Typography.Text>
               )}
             </div>
-            <BranchBoardLocatorIcon branch={branch} />
           </div>
         </div>
       </SessionItemWithActions>
@@ -678,7 +676,6 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
               <SessionRelationshipIcon session={session} size={10} />
             )}
             {renderSessionTitle(session)}
-            {!isRemoteSurrogate && <BranchBoardLocatorIcon branch={branch} />}
           </div>
         </div>
       </SessionItemWithActions>

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -5,6 +5,7 @@ import {
 } from '@agor-live/client';
 import {
   ClockCircleOutlined,
+  ExportOutlined,
   EyeOutlined,
   MessageOutlined,
   PlusOutlined,
@@ -339,17 +340,25 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
   const sessionRowStyle = (session: Session): React.CSSProperties => {
     const isSessionSelected = session.session_id === selectedSessionId;
+    const isRemoteSurrogate = Boolean(session.remote_surrogate);
     return {
       border: session.ready_for_prompt
         ? `1px solid ${token.colorPrimary}`
-        : `1px solid ${isPanel ? token.colorBorderSecondary : 'rgba(255, 255, 255, 0.1)'}`,
+        : isRemoteSurrogate
+          ? `1px dashed ${token.colorBorderSecondary}`
+          : `1px solid ${isPanel ? token.colorBorderSecondary : 'rgba(255, 255, 255, 0.1)'}`,
       borderRadius: isPanel ? 6 : 4,
       padding: isPanel ? 10 : 8,
-      background: isPanel ? token.colorBgContainer : 'transparent',
+      background: isRemoteSurrogate
+        ? token.colorFillQuaternary
+        : isPanel
+          ? token.colorBgContainer
+          : 'transparent',
       display: 'flex',
       alignItems: 'center',
       cursor: 'pointer',
       marginBottom: 4,
+      opacity: isRemoteSurrogate ? 0.78 : undefined,
       boxShadow: session.ready_for_prompt ? `0 0 12px ${token.colorPrimary}30` : undefined,
       ...(isSessionSelected
         ? { outline: `1px dashed ${token.colorTextBase}`, outlineOffset: -2 }
@@ -453,6 +462,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const renderSessionNode = (node: SessionTreeNode) => {
     const session = node.session;
     const isActive = session.status === 'running' || session.status === 'stopping';
+    const isRemoteSurrogate = node.relationshipType === 'remote';
 
     return (
       <SessionItemWithActions
@@ -481,9 +491,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
-            <SessionRelationshipIcon session={session} size={10} />
+            {isRemoteSurrogate ? (
+              <Tooltip title="Remote session created from this session. Click to open it in its own branch.">
+                <ExportOutlined style={{ fontSize: 11, color: token.colorTextTertiary }} />
+              </Tooltip>
+            ) : (
+              <SessionRelationshipIcon session={session} size={10} />
+            )}
             {renderSessionTitle(session)}
-            <BranchBoardLocatorIcon branch={branch} />
+            {!isRemoteSurrogate && <BranchBoardLocatorIcon branch={branch} />}
           </div>
         </div>
       </SessionItemWithActions>

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -308,8 +308,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     (session: Session): string | undefined => {
       const relationship = getCallbackRelationship(session);
       return (
-        relationship?.callback_session_id ??
         session.callback_config?.callback_session_id ??
+        relationship?.callback_session_id ??
         session.genealogy?.parent_session_id ??
         session.remote_surrogate?.source_session_id
       );
@@ -323,10 +323,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       if (!targetId) return null;
 
       const relationship = getCallbackRelationship(session);
-      const enabled =
-        session.callback_config?.enabled !== undefined
-          ? session.callback_config.enabled !== false
-          : (relationship?.callback_enabled ?? true);
+      const enabled = session.callback_config?.enabled ?? relationship?.callback_enabled ?? true;
 
       return {
         enabled,

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -5,9 +5,11 @@ import {
 } from '@agor-live/client';
 import {
   ClockCircleOutlined,
+  DisconnectOutlined,
   ExportOutlined,
   EyeOutlined,
   MessageOutlined,
+  PhoneOutlined,
   PlusOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -83,6 +85,12 @@ const SessionItemWithActions: React.FC<{
   onArchive: (sessionId: string, e: React.MouseEvent) => void;
   onSettings?: (sessionId: string, e: React.MouseEvent) => void;
   onTogglePeek?: (sessionId: string, e: React.MouseEvent) => void;
+  onToggleCallback?: (sessionId: string, e: React.MouseEvent) => void;
+  callbackToggle?: {
+    enabled: boolean;
+    disabled?: boolean;
+    tooltip: string;
+  };
   children: React.ReactNode;
 }> = ({
   sessionId,
@@ -91,6 +99,8 @@ const SessionItemWithActions: React.FC<{
   onArchive,
   onSettings,
   onTogglePeek,
+  onToggleCallback,
+  callbackToggle,
   children,
 }) => {
   const [hovered, setHovered] = useState(false);
@@ -157,6 +167,22 @@ const SessionItemWithActions: React.FC<{
             />
           </Tooltip>
         )}
+        {onToggleCallback && callbackToggle && (
+          <Tooltip title={callbackToggle.tooltip}>
+            <Button
+              type="text"
+              size="small"
+              disabled={callbackToggle.disabled}
+              icon={callbackToggle.enabled ? <PhoneOutlined /> : <DisconnectOutlined />}
+              onClick={(e) => onToggleCallback(sessionId, e)}
+              style={{
+                ...buttonStyle,
+                color: callbackToggle.enabled ? token.colorPrimary : token.colorTextTertiary,
+                background: callbackToggle.enabled ? token.colorPrimaryBg : buttonStyle.background,
+              }}
+            />
+          </Tooltip>
+        )}
         <ArchiveActionButton
           tooltip="Archive session"
           loading={isArchiving}
@@ -218,6 +244,82 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       onTogglePeekSession?.(sessionId);
     },
     [onTogglePeekSession]
+  );
+
+  const getCallbackRelationship = useCallback((session: Session) => {
+    return (
+      session.remote_surrogate?.relationship ??
+      session.remote_relationships?.as_target?.find(
+        (relationship) => relationship.relationship_type === 'remote_create'
+      )
+    );
+  }, []);
+
+  const getCallbackTargetId = useCallback(
+    (session: Session): string | undefined => {
+      const relationship = getCallbackRelationship(session);
+      return (
+        relationship?.callback_session_id ??
+        session.callback_config?.callback_session_id ??
+        session.genealogy?.parent_session_id ??
+        session.remote_surrogate?.source_session_id
+      );
+    },
+    [getCallbackRelationship]
+  );
+
+  const getCallbackToggle = useCallback(
+    (session: Session) => {
+      const targetId = getCallbackTargetId(session);
+      if (!targetId) return null;
+
+      const relationship = getCallbackRelationship(session);
+      const enabled =
+        session.callback_config?.enabled !== undefined
+          ? session.callback_config.enabled !== false
+          : (relationship?.callback_enabled ?? true);
+
+      return {
+        enabled,
+        disabled: connectionDisabled || !client,
+        tooltip: enabled
+          ? 'Callbacks linked — click to stop callback notifications while keeping the relationship'
+          : 'Callbacks unlinked — click to resume callback notifications for this relationship',
+      };
+    },
+    [client, connectionDisabled, getCallbackRelationship, getCallbackTargetId]
+  );
+
+  const handleToggleCallback = useCallback(
+    async (sessionId: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!client) return;
+
+      const session = sessions.find((candidate) => candidate.session_id === sessionId);
+      if (!session) return;
+
+      const targetId = getCallbackTargetId(session);
+      if (!targetId) return;
+
+      const toggle = getCallbackToggle(session);
+      const nextEnabled = !(toggle?.enabled ?? false);
+
+      try {
+        await client.service('sessions').patch(session.session_id, {
+          callback_config: {
+            ...(session.callback_config ?? {}),
+            callback_session_id: targetId as SessionID,
+            enabled: nextEnabled,
+          },
+        });
+        showSuccess(nextEnabled ? 'Callbacks linked' : 'Callbacks unlinked');
+      } catch (error) {
+        showError(
+          `Failed to update callbacks: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    },
+    [client, getCallbackTargetId, getCallbackToggle, sessions, showError, showSuccess]
   );
 
   const handleForkSpawnConfirm = async (config: string | Partial<SpawnConfig>) => {
@@ -390,6 +492,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
   const renderFlatSessionRow = (session: Session, query = '') => {
     const isActive = session.status === 'running' || session.status === 'stopping';
+    const callbackToggle = getCallbackToggle(session);
     const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
     const descriptionSnippet =
       query && session.title && session.description
@@ -408,6 +511,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         sessionId={session.session_id}
         isArchiving={archivingSessionIds.has(session.session_id)}
         onArchive={handleArchiveSession}
+        callbackToggle={callbackToggle ?? undefined}
+        onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
         onSettings={
           onOpenSessionSettings
             ? (id, e) => {
@@ -463,6 +568,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     const session = node.session;
     const isActive = session.status === 'running' || session.status === 'stopping';
     const isRemoteSurrogate = node.relationshipType === 'remote';
+    const callbackToggle = getCallbackToggle(session);
 
     return (
       <SessionItemWithActions
@@ -471,6 +577,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         isPeeked={peekedIds.has(session.session_id)}
         onArchive={handleArchiveSession}
         onTogglePeek={onTogglePeekSession ? handleTogglePeekSession : undefined}
+        callbackToggle={callbackToggle ?? undefined}
+        onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
         onSettings={
           onOpenSessionSettings
             ? (id, e) => {
@@ -588,6 +696,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       {scheduledSessions.map((session) => {
         const isActive = session.status === 'running' || session.status === 'stopping';
+        const callbackToggle = getCallbackToggle(session);
         return (
           <SessionItemWithActions
             key={session.session_id}
@@ -596,6 +705,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             isPeeked={peekedIds.has(session.session_id)}
             onArchive={handleArchiveSession}
             onTogglePeek={onTogglePeekSession ? handleTogglePeekSession : undefined}
+            callbackToggle={callbackToggle ?? undefined}
+            onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
             onSettings={
               onOpenSessionSettings
                 ? (id, e) => {
@@ -651,6 +762,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       {gatewaySessions.map((session) => {
         const gatewaySource = getGatewaySource(session);
         const isActive = session.status === 'running' || session.status === 'stopping';
+        const callbackToggle = getCallbackToggle(session);
 
         return (
           <SessionItemWithActions
@@ -660,6 +772,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             isPeeked={peekedIds.has(session.session_id)}
             onArchive={handleArchiveSession}
             onTogglePeek={onTogglePeekSession ? handleTogglePeekSession : undefined}
+            callbackToggle={callbackToggle ?? undefined}
+            onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
             onSettings={
               onOpenSessionSettings
                 ? (id, e) => {

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -278,12 +278,31 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     );
   }, []);
 
-  const getRemoteParentId = useCallback((session: Session): string | undefined => {
-    if (session.remote_surrogate) return undefined;
-    return session.remote_relationships?.as_target?.find(
-      (relationship) => relationship.relationship_type === 'remote_create'
-    )?.source_session_id;
-  }, []);
+  const getRemoteParentId = useCallback(
+    (session: Session): string | undefined => {
+      if (session.remote_surrogate) return undefined;
+
+      const relationshipParentId = session.remote_relationships?.as_target?.find(
+        (relationship) => relationship.relationship_type === 'remote_create'
+      )?.source_session_id;
+      if (relationshipParentId) return relationshipParentId;
+
+      // Defensive fallback for live-patched session rows that may temporarily
+      // lack enriched remote_relationships. A cross-branch callback target is
+      // still local to the already-loaded Agor session store and points at the
+      // same creator/remote-parent session for remote-created children.
+      const callbackTargetId = session.callback_config?.callback_session_id;
+      const callbackTarget = callbackTargetId
+        ? sessions.find((candidate) => candidate.session_id === callbackTargetId)
+        : undefined;
+      if (callbackTarget && callbackTarget.branch_id !== session.branch_id) {
+        return callbackTargetId;
+      }
+
+      return undefined;
+    },
+    [sessions]
+  );
 
   const getCallbackTargetId = useCallback(
     (session: Session): string | undefined => {

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -4,12 +4,13 @@ import {
   isGatewaySession as isGatewaySessionCore,
 } from '@agor-live/client';
 import {
+  ArrowUpOutlined,
   ClockCircleOutlined,
   DisconnectOutlined,
   ExportOutlined,
   EyeOutlined,
+  LinkOutlined,
   MessageOutlined,
-  PhoneOutlined,
   PlusOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -86,8 +87,13 @@ const SessionItemWithActions: React.FC<{
   onSettings?: (sessionId: string, e: React.MouseEvent) => void;
   onTogglePeek?: (sessionId: string, e: React.MouseEvent) => void;
   onToggleCallback?: (sessionId: string, e: React.MouseEvent) => void;
+  onOpenRemoteParent?: (sessionId: string, e: React.MouseEvent) => void;
   callbackToggle?: {
     enabled: boolean;
+    disabled?: boolean;
+    tooltip: string;
+  };
+  remoteParentLink?: {
     disabled?: boolean;
     tooltip: string;
   };
@@ -100,7 +106,9 @@ const SessionItemWithActions: React.FC<{
   onSettings,
   onTogglePeek,
   onToggleCallback,
+  onOpenRemoteParent,
   callbackToggle,
+  remoteParentLink,
   children,
 }) => {
   const [hovered, setHovered] = useState(false);
@@ -167,13 +175,28 @@ const SessionItemWithActions: React.FC<{
             />
           </Tooltip>
         )}
+        {onOpenRemoteParent && remoteParentLink && (
+          <Tooltip title={remoteParentLink.tooltip}>
+            <Button
+              type="text"
+              size="small"
+              disabled={remoteParentLink.disabled}
+              icon={<ArrowUpOutlined />}
+              onClick={(e) => onOpenRemoteParent(sessionId, e)}
+              style={{
+                ...buttonStyle,
+                color: token.colorTextSecondary,
+              }}
+            />
+          </Tooltip>
+        )}
         {onToggleCallback && callbackToggle && (
           <Tooltip title={callbackToggle.tooltip}>
             <Button
               type="text"
               size="small"
               disabled={callbackToggle.disabled}
-              icon={callbackToggle.enabled ? <PhoneOutlined /> : <DisconnectOutlined />}
+              icon={callbackToggle.enabled ? <LinkOutlined /> : <DisconnectOutlined />}
               onClick={(e) => onToggleCallback(sessionId, e)}
               style={{
                 ...buttonStyle,
@@ -255,6 +278,13 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     );
   }, []);
 
+  const getRemoteParentId = useCallback((session: Session): string | undefined => {
+    if (session.remote_surrogate) return undefined;
+    return session.remote_relationships?.as_target?.find(
+      (relationship) => relationship.relationship_type === 'remote_create'
+    )?.source_session_id;
+  }, []);
+
   const getCallbackTargetId = useCallback(
     (session: Session): string | undefined => {
       const relationship = getCallbackRelationship(session);
@@ -320,6 +350,17 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       }
     },
     [client, getCallbackTargetId, getCallbackToggle, sessions, showError, showSuccess]
+  );
+
+  const handleOpenRemoteParent = useCallback(
+    (sessionId: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+      const session = sessions.find((candidate) => candidate.session_id === sessionId);
+      const remoteParentId = session ? getRemoteParentId(session) : undefined;
+      if (!remoteParentId) return;
+      onSessionClick?.(remoteParentId);
+    },
+    [getRemoteParentId, onSessionClick, sessions]
   );
 
   const handleForkSpawnConfirm = async (config: string | Partial<SpawnConfig>) => {
@@ -493,6 +534,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const renderFlatSessionRow = (session: Session, query = '') => {
     const isActive = session.status === 'running' || session.status === 'stopping';
     const callbackToggle = getCallbackToggle(session);
+    const remoteParentId = getRemoteParentId(session);
     const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
     const descriptionSnippet =
       query && session.title && session.description
@@ -513,6 +555,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         onArchive={handleArchiveSession}
         callbackToggle={callbackToggle ?? undefined}
         onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
+        remoteParentLink={
+          remoteParentId
+            ? { tooltip: 'Open remote parent session that created this session' }
+            : undefined
+        }
+        onOpenRemoteParent={remoteParentId ? handleOpenRemoteParent : undefined}
         onSettings={
           onOpenSessionSettings
             ? (id, e) => {
@@ -569,6 +617,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     const isActive = session.status === 'running' || session.status === 'stopping';
     const isRemoteSurrogate = node.relationshipType === 'remote';
     const callbackToggle = getCallbackToggle(session);
+    const remoteParentId = getRemoteParentId(session);
 
     return (
       <SessionItemWithActions
@@ -579,6 +628,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         onTogglePeek={onTogglePeekSession ? handleTogglePeekSession : undefined}
         callbackToggle={callbackToggle ?? undefined}
         onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
+        remoteParentLink={
+          remoteParentId
+            ? { tooltip: 'Open remote parent session that created this session' }
+            : undefined
+        }
+        onOpenRemoteParent={remoteParentId ? handleOpenRemoteParent : undefined}
         onSettings={
           onOpenSessionSettings
             ? (id, e) => {
@@ -697,6 +752,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       {scheduledSessions.map((session) => {
         const isActive = session.status === 'running' || session.status === 'stopping';
         const callbackToggle = getCallbackToggle(session);
+        const remoteParentId = getRemoteParentId(session);
         return (
           <SessionItemWithActions
             key={session.session_id}
@@ -707,6 +763,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             onTogglePeek={onTogglePeekSession ? handleTogglePeekSession : undefined}
             callbackToggle={callbackToggle ?? undefined}
             onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
+            remoteParentLink={
+              remoteParentId
+                ? { tooltip: 'Open remote parent session that created this session' }
+                : undefined
+            }
+            onOpenRemoteParent={remoteParentId ? handleOpenRemoteParent : undefined}
             onSettings={
               onOpenSessionSettings
                 ? (id, e) => {
@@ -763,6 +825,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         const gatewaySource = getGatewaySource(session);
         const isActive = session.status === 'running' || session.status === 'stopping';
         const callbackToggle = getCallbackToggle(session);
+        const remoteParentId = getRemoteParentId(session);
 
         return (
           <SessionItemWithActions
@@ -774,6 +837,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             onTogglePeek={onTogglePeekSession ? handleTogglePeekSession : undefined}
             callbackToggle={callbackToggle ?? undefined}
             onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
+            remoteParentLink={
+              remoteParentId
+                ? { tooltip: 'Open remote parent session that created this session' }
+                : undefined
+            }
+            onOpenRemoteParent={remoteParentId ? handleOpenRemoteParent : undefined}
             onSettings={
               onOpenSessionSettings
                 ? (id, e) => {

--- a/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
+++ b/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
@@ -8,7 +8,7 @@
 import type { Session } from '@agor-live/client';
 import type { DataNode } from 'antd/es/tree';
 
-export type SessionRelationshipType = 'root' | 'spawn' | 'fork';
+export type SessionRelationshipType = 'root' | 'spawn' | 'fork' | 'remote';
 
 export interface SessionTreeNode extends DataNode {
   key: string;
@@ -58,7 +58,9 @@ export function buildSessionTree(sessions: Session[]): SessionTreeNode[] {
 
     // Determine relationship type
     let relationshipType: SessionRelationshipType = 'root';
-    if (!isRoot) {
+    if (session.remote_surrogate) {
+      relationshipType = 'remote';
+    } else if (!isRoot) {
       if (session.genealogy?.parent_session_id) {
         relationshipType = 'spawn';
       } else if (session.genealogy?.forked_from_session_id) {

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
@@ -43,11 +43,13 @@ export const CallbackTargetDisplay: React.FC<CallbackTargetDisplayProps> = ({
   const { onSessionClick } = useAppActions();
   const { sessionById } = useAppLiveData();
 
-  const remoteParentId = session.remote_relationships?.as_target?.find(
+  const remoteRelationship = session.remote_relationships?.as_target?.find(
     (relationship) => relationship.relationship_type === 'remote_create'
-  )?.source_session_id;
+  );
+  const remoteParentId = remoteRelationship?.source_session_id;
   const targetId =
     session.callback_config?.callback_session_id ??
+    remoteRelationship?.callback_session_id ??
     remoteParentId ??
     session.genealogy?.parent_session_id;
 
@@ -56,7 +58,7 @@ export const CallbackTargetDisplay: React.FC<CallbackTargetDisplayProps> = ({
   const target = sessionById.get(targetId);
   // Mirror CallbackToggleButton's resolution: spawned sessions default to
   // enabled unless explicitly disabled.
-  const enabled = session.callback_config?.enabled !== false;
+  const enabled = session.callback_config?.enabled ?? remoteRelationship?.callback_enabled ?? true;
   const archived = target?.archived === true;
 
   const targetTitle = target

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
@@ -1,6 +1,6 @@
 import type { Session } from '@agor-live/client';
 import { shortId } from '@agor-live/client';
-import { LinkOutlined, PhoneOutlined } from '@ant-design/icons';
+import { DisconnectOutlined, LinkOutlined } from '@ant-design/icons';
 import { Badge, Space, Typography, theme } from 'antd';
 import type React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -90,7 +90,11 @@ export const CallbackTargetDisplay: React.FC<CallbackTargetDisplayProps> = ({
       }}
     >
       <Space size={6} wrap>
-        <PhoneOutlined style={{ color: iconColor }} />
+        {enabled ? (
+          <LinkOutlined style={{ color: iconColor }} />
+        ) : (
+          <DisconnectOutlined style={{ color: iconColor }} />
+        )}
         <Typography.Text strong style={{ color: iconColor }}>
           Callbacks {enabled ? 'ON' : 'OFF'}
         </Typography.Text>

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
@@ -43,8 +43,13 @@ export const CallbackTargetDisplay: React.FC<CallbackTargetDisplayProps> = ({
   const { onSessionClick } = useAppActions();
   const { sessionById } = useAppLiveData();
 
+  const remoteParentId = session.remote_relationships?.as_target?.find(
+    (relationship) => relationship.relationship_type === 'remote_create'
+  )?.source_session_id;
   const targetId =
-    session.callback_config?.callback_session_id ?? session.genealogy?.parent_session_id;
+    session.callback_config?.callback_session_id ??
+    remoteParentId ??
+    session.genealogy?.parent_session_id;
 
   if (!targetId) return null;
 

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
@@ -1,6 +1,6 @@
 import type { Session } from '@agor-live/client';
 import { shortId } from '@agor-live/client';
-import { PhoneOutlined } from '@ant-design/icons';
+import { LinkOutlined } from '@ant-design/icons';
 import { Badge, Button, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -85,7 +85,8 @@ export const CallbackToggleButton: React.FC<CallbackToggleButtonProps> = ({ sess
       ) : (
         <strong>{targetTitle}</strong>
       )}{' '}
-      {statusBadge} on completion. Click to disable. Also accessible in session settings.
+      {statusBadge} on completion. Click to unlink callbacks while keeping the relationship. Also
+      accessible in session settings.
     </span>
   );
 
@@ -94,9 +95,9 @@ export const CallbackToggleButton: React.FC<CallbackToggleButtonProps> = ({ sess
       <Button
         size="small"
         type="text"
-        icon={<PhoneOutlined style={{ color: token.colorPrimary }} />}
+        icon={<LinkOutlined style={{ color: token.colorPrimary }} />}
         onClick={handleDisable}
-        aria-label="Callbacks on — click to disable"
+        aria-label="Callbacks linked — click to unlink"
       />
     </Tooltip>
   );

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
@@ -1,6 +1,6 @@
 import type { Session } from '@agor-live/client';
 import { shortId } from '@agor-live/client';
-import { LinkOutlined } from '@ant-design/icons';
+import { ArrowUpOutlined, LinkOutlined } from '@ant-design/icons';
 import { Badge, Button, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -11,8 +11,22 @@ interface CallbackToggleButtonProps {
   session: Session;
 }
 
+function getRemoteParentSessionId(session: Session): string | undefined {
+  return session.remote_relationships?.as_target?.find(
+    (relationship) => relationship.relationship_type === 'remote_create'
+  )?.source_session_id;
+}
+
+function getCallbackTargetSessionId(session: Session): string | undefined {
+  return (
+    session.callback_config?.callback_session_id ??
+    getRemoteParentSessionId(session) ??
+    session.genealogy?.parent_session_id
+  );
+}
+
 /**
- * Phone-icon toggle in the conversation footer that shows ONLY when this
+ * Link-icon toggle in the conversation footer that shows ONLY when this
  * session has callbacks enabled. Clicking disables callbacks (one click,
  * no confirmation — re-enable lives in Session Settings).
  *
@@ -25,8 +39,7 @@ export const CallbackToggleButton: React.FC<CallbackToggleButtonProps> = ({ sess
   const { onUpdateSession, onSessionClick } = useAppActions();
   const { sessionById } = useAppLiveData();
 
-  const targetId =
-    session.callback_config?.callback_session_id ?? session.genealogy?.parent_session_id;
+  const targetId = getCallbackTargetSessionId(session);
   // Default in core: spawned sessions (have parent_session_id) have callbacks
   // implicitly ON unless explicitly disabled. Only treat as enabled if there's
   // an actual target — there's nothing to call back to otherwise.
@@ -98,6 +111,38 @@ export const CallbackToggleButton: React.FC<CallbackToggleButtonProps> = ({ sess
         icon={<LinkOutlined style={{ color: token.colorPrimary }} />}
         onClick={handleDisable}
         aria-label="Callbacks linked — click to unlink"
+      />
+    </Tooltip>
+  );
+};
+
+export const RemoteParentButton: React.FC<CallbackToggleButtonProps> = ({ session }) => {
+  const { token } = theme.useToken();
+  const { onSessionClick } = useAppActions();
+  const { sessionById } = useAppLiveData();
+
+  const remoteParentId = getRemoteParentSessionId(session);
+  if (!remoteParentId || !onSessionClick) return null;
+
+  const remoteParent = sessionById.get(remoteParentId);
+  const remoteParentTitle = remoteParent
+    ? getSessionDisplayTitle(remoteParent, { includeAgentFallback: true, includeIdFallback: true })
+    : shortId(remoteParentId);
+
+  const handleOpenRemoteParent = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onSessionClick(remoteParentId);
+  };
+
+  return (
+    <Tooltip title={`Open remote parent session: ${remoteParentTitle}`}>
+      <Button
+        size="small"
+        type="text"
+        icon={<ArrowUpOutlined style={{ color: token.colorTextSecondary }} />}
+        onClick={handleOpenRemoteParent}
+        aria-label={`Open remote parent session ${remoteParentTitle}`}
       />
     </Tooltip>
   );

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackToggleButton.tsx
@@ -11,17 +11,31 @@ interface CallbackToggleButtonProps {
   session: Session;
 }
 
-function getRemoteParentSessionId(session: Session): string | undefined {
+function getRemoteCreateRelationship(session: Session) {
   return session.remote_relationships?.as_target?.find(
     (relationship) => relationship.relationship_type === 'remote_create'
-  )?.source_session_id;
+  );
+}
+
+function getRemoteParentSessionId(session: Session): string | undefined {
+  return getRemoteCreateRelationship(session)?.source_session_id;
 }
 
 function getCallbackTargetSessionId(session: Session): string | undefined {
+  const relationship = getRemoteCreateRelationship(session);
   return (
     session.callback_config?.callback_session_id ??
+    relationship?.callback_session_id ??
     getRemoteParentSessionId(session) ??
     session.genealogy?.parent_session_id
+  );
+}
+
+function getCallbackEnabled(session: Session): boolean {
+  return (
+    session.callback_config?.enabled ??
+    getRemoteCreateRelationship(session)?.callback_enabled ??
+    true
   );
 }
 
@@ -43,8 +57,7 @@ export const CallbackToggleButton: React.FC<CallbackToggleButtonProps> = ({ sess
   // Default in core: spawned sessions (have parent_session_id) have callbacks
   // implicitly ON unless explicitly disabled. Only treat as enabled if there's
   // an actual target — there's nothing to call back to otherwise.
-  const explicitlyDisabled = session.callback_config?.enabled === false;
-  const enabled = !explicitlyDisabled && !!targetId;
+  const enabled = getCallbackEnabled(session) && !!targetId;
 
   if (!enabled) return null;
 

--- a/apps/agor-ui/src/components/CallbackToggleButton/index.ts
+++ b/apps/agor-ui/src/components/CallbackToggleButton/index.ts
@@ -1,2 +1,2 @@
 export { CallbackTargetDisplay } from './CallbackTargetDisplay';
-export { CallbackToggleButton } from './CallbackToggleButton';
+export { CallbackToggleButton, RemoteParentButton } from './CallbackToggleButton';

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -46,7 +46,6 @@ import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
-import { CallbackToggleButton, RemoteParentButton } from '../CallbackToggleButton';
 import { FileUpload, FileUploadButton } from '../FileUpload';
 import { MCPServerPill } from '../MCPServer';
 import type { ModelConfig } from '../ModelSelector';
@@ -940,8 +939,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           </Space>
           <Space size={4} wrap style={{ marginLeft: 'auto' }}>
             {isRunning && <Spin size="small" />}
-            <RemoteParentButton session={session} />
-            <CallbackToggleButton session={session} />
             <SessionRunSettingsPopover
               client={client}
               session={session}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -46,7 +46,7 @@ import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
-import { CallbackToggleButton } from '../CallbackToggleButton';
+import { CallbackToggleButton, RemoteParentButton } from '../CallbackToggleButton';
 import { FileUpload, FileUploadButton } from '../FileUpload';
 import { MCPServerPill } from '../MCPServer';
 import type { ModelConfig } from '../ModelSelector';
@@ -940,6 +940,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           </Space>
           <Space size={4} wrap style={{ marginLeft: 'auto' }}>
             {isRunning && <Spin size="small" />}
+            <RemoteParentButton session={session} />
             <CallbackToggleButton session={session} />
             <SessionRunSettingsPopover
               client={client}

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -292,10 +292,20 @@ function hasIdMatchingPrefix<T>(
 function preserveSessionRelationshipFields(session: Session, existing?: Session): Session {
   if (!existing) return session;
 
+  const remoteRelationships = session.remote_relationships ?? existing.remote_relationships;
+  const remoteSurrogate = session.remote_surrogate ?? existing.remote_surrogate;
+
+  if (
+    remoteRelationships === session.remote_relationships &&
+    remoteSurrogate === session.remote_surrogate
+  ) {
+    return session;
+  }
+
   return {
     ...session,
-    remote_relationships: session.remote_relationships ?? existing.remote_relationships,
-    remote_surrogate: session.remote_surrogate ?? existing.remote_surrogate,
+    ...(remoteRelationships !== undefined && { remote_relationships: remoteRelationships }),
+    ...(remoteSurrogate !== undefined && { remote_surrogate: remoteSurrogate }),
   };
 }
 

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -969,10 +969,11 @@ export function useAgorData(
         };
 
         if (isArchived) {
-          if (oldBranchId) {
-            removeFromBranch(oldBranchId);
+          for (const [branchId, bucket] of next) {
+            if (bucket.some((item) => item.session_id === session.session_id)) {
+              removeFromBranch(branchId);
+            }
           }
-          removeFromBranch(newBranchId);
           return changed ? next : prev;
         }
 
@@ -1005,6 +1006,30 @@ export function useAgorData(
         const updatedSessions = [...branchSessions];
         updatedSessions[index] = session;
         next.set(newBranchId, updatedSessions);
+
+        // Also update any remote/surrogate projections of this session that
+        // live in source-branch buckets. Preserve their local tree placement
+        // while refreshing status/callback_config/etc. from the canonical row.
+        for (const [branchId, bucket] of next) {
+          if (branchId === newBranchId) continue;
+
+          let bucketChanged = false;
+          const refreshedBucket = bucket.map((item) => {
+            if (item.session_id !== session.session_id) return item;
+            bucketChanged = true;
+            return {
+              ...session,
+              branch_id: item.branch_id,
+              genealogy: item.genealogy,
+              remote_surrogate: item.remote_surrogate,
+            };
+          });
+
+          if (bucketChanged) {
+            next.set(branchId, refreshedBucket);
+          }
+        }
+
         return next;
       });
     };

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -288,6 +288,17 @@ function hasIdMatchingPrefix<T>(
  *                                  active-list query omits it because it is archived, fetch it by ID.
  * @returns Sessions, boards, loading state, and refetch function
  */
+
+function preserveSessionRelationshipFields(session: Session, existing?: Session): Session {
+  if (!existing) return session;
+
+  return {
+    ...session,
+    remote_relationships: session.remote_relationships ?? existing.remote_relationships,
+    remote_surrogate: session.remote_surrogate ?? existing.remote_surrogate,
+  };
+}
+
 export function useAgorData(
   client: AgorClient | null,
   options?: { enabled?: boolean; directSessionId?: string | null }
@@ -937,15 +948,17 @@ export function useAgorData(
           return next;
         }
 
+        const mergedSession = preserveSessionRelationshipFields(session, existing);
+
         // Bail out on no-op patches. Feathers always emits a fresh object so
         // `existing === session` never holds, but the daemon does emit
         // idempotent patches (e.g. callback bookkeeping that lands at the same
         // status). Shallow-equal misses nested fields the daemon reserializes
         // — that's a safe false negative.
-        if (existing && shallowEqualEntity(existing, session)) return prev;
+        if (existing && shallowEqualEntity(existing, mergedSession)) return prev;
 
         const next = new Map(prev);
-        next.set(session.session_id, session);
+        next.set(session.session_id, mergedSession);
         return next;
       });
 
@@ -991,20 +1004,22 @@ export function useAgorData(
           return next;
         }
 
+        const mergedSession = preserveSessionRelationshipFields(session, branchSessions[index]);
+
         // Bail out when the session is content-equal to what we already hold.
         // Mirrors the sessionById bailout above so an idempotent patch doesn't
         // produce a fresh branch-bucket array (which would invalidate
         // `data.sessions === n.sessions` in BranchNode's custom areEqual and
         // re-render every BranchCard on the affected branch).
         if (
-          branchSessions[index] === session ||
-          shallowEqualEntity(branchSessions[index], session)
+          branchSessions[index] === mergedSession ||
+          shallowEqualEntity(branchSessions[index], mergedSession)
         ) {
           return changed ? next : prev;
         }
 
         const updatedSessions = [...branchSessions];
-        updatedSessions[index] = session;
+        updatedSessions[index] = mergedSession;
         next.set(newBranchId, updatedSessions);
 
         // Also update any remote/surrogate projections of this session that
@@ -1018,7 +1033,7 @@ export function useAgorData(
             if (item.session_id !== session.session_id) return item;
             bucketChanged = true;
             return {
-              ...session,
+              ...preserveSessionRelationshipFields(session, item),
               branch_id: item.branch_id,
               genealogy: item.genealogy,
               remote_surrogate: item.remote_surrogate,

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -600,6 +600,54 @@ export function useAgorData(
           sessionsByBranchId.get(branchId)!.push(session);
         }
 
+        // Cross-branch remote-created sessions are canonical in their target
+        // branch, but should also appear as muted/surrogate children under
+        // the creating session's branch for track-record and navigation.
+        //
+        // Keep this as a UI projection only: the cloned session preserves the
+        // real session_id (so clicks open the real remote session) while using
+        // the source branch + source session as its local tree placement.
+        for (const sourceSession of sessionsList) {
+          if (sourceSession.archived) continue;
+
+          for (const relationship of sourceSession.remote_relationships?.as_source ?? []) {
+            if (relationship.relationship_type !== 'remote_create') continue;
+
+            const targetSession = sessionsById.get(relationship.target_session_id);
+            if (!targetSession || targetSession.archived) continue;
+            if (targetSession.branch_id === sourceSession.branch_id) continue;
+
+            const sourceBranchSessions = sessionsByBranchId.get(sourceSession.branch_id) ?? [];
+            if (
+              sourceBranchSessions.some(
+                (session) => session.session_id === targetSession.session_id
+              )
+            ) {
+              continue;
+            }
+
+            const remoteSurrogate: Session = {
+              ...targetSession,
+              branch_id: sourceSession.branch_id,
+              genealogy: {
+                ...(targetSession.genealogy ?? {}),
+                parent_session_id: sourceSession.session_id,
+              },
+              remote_surrogate: {
+                relationship,
+                source_session_id: sourceSession.session_id,
+                source_branch_id: sourceSession.branch_id,
+                target_branch_id: targetSession.branch_id,
+              },
+            };
+
+            sessionsByBranchId.set(sourceSession.branch_id, [
+              ...sourceBranchSessions,
+              remoteSurrogate,
+            ]);
+          }
+        }
+
         // Build board Map for efficient lookups
         const boardsMap = new Map<string, Board>();
         for (const board of boardsList) {

--- a/packages/core/drizzle/postgres/0051_session_relationships.sql
+++ b/packages/core/drizzle/postgres/0051_session_relationships.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "session_relationships" (
+	"relationship_id" varchar(36) PRIMARY KEY NOT NULL,
+	"source_session_id" varchar(36) NOT NULL,
+	"target_session_id" varchar(36) NOT NULL,
+	"relationship_type" text NOT NULL,
+	"created_by" varchar(36) NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone,
+	"callback_enabled" boolean DEFAULT false NOT NULL,
+	"callback_session_id" varchar(36),
+	"data" jsonb
+);
+--> statement-breakpoint
+ALTER TABLE "session_relationships" ADD CONSTRAINT "session_relationships_source_session_id_sessions_session_id_fk" FOREIGN KEY ("source_session_id") REFERENCES "public"."sessions"("session_id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "session_relationships" ADD CONSTRAINT "session_relationships_target_session_id_sessions_session_id_fk" FOREIGN KEY ("target_session_id") REFERENCES "public"."sessions"("session_id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "session_relationships" ADD CONSTRAINT "session_relationships_callback_session_id_sessions_session_id_fk" FOREIGN KEY ("callback_session_id") REFERENCES "public"."sessions"("session_id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "session_relationships_source_idx" ON "session_relationships" USING btree ("source_session_id");
+--> statement-breakpoint
+CREATE INDEX "session_relationships_target_idx" ON "session_relationships" USING btree ("target_session_id");
+--> statement-breakpoint
+CREATE INDEX "session_relationships_callback_idx" ON "session_relationships" USING btree ("callback_session_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "session_relationships_source_target_type_unique" ON "session_relationships" USING btree ("source_session_id","target_session_id","relationship_type");

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1781600000000,
       "tag": "0050_artifact_source_session",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1781700000000,
+      "tag": "0051_session_relationships",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0060_session_relationships.sql
+++ b/packages/core/drizzle/sqlite/0060_session_relationships.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `session_relationships` (
+	`relationship_id` text(36) PRIMARY KEY NOT NULL,
+	`source_session_id` text(36) NOT NULL,
+	`target_session_id` text(36) NOT NULL,
+	`relationship_type` text NOT NULL,
+	`created_by` text(36) NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer,
+	`callback_enabled` integer DEFAULT false NOT NULL,
+	`callback_session_id` text(36),
+	`data` text,
+	FOREIGN KEY (`source_session_id`) REFERENCES `sessions`(`session_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`target_session_id`) REFERENCES `sessions`(`session_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`callback_session_id`) REFERENCES `sessions`(`session_id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `session_relationships_source_idx` ON `session_relationships` (`source_session_id`);
+--> statement-breakpoint
+CREATE INDEX `session_relationships_target_idx` ON `session_relationships` (`target_session_id`);
+--> statement-breakpoint
+CREATE INDEX `session_relationships_callback_idx` ON `session_relationships` (`callback_session_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_relationships_source_target_type_unique` ON `session_relationships` (`source_session_id`,`target_session_id`,`relationship_type`);

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1781600000000,
       "tag": "0059_artifact_source_session",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "6",
+      "when": 1781700000000,
+      "tag": "0060_session_relationships",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -22,6 +22,7 @@ export * from './schedules';
 export * from './serialized-sessions';
 export * from './session-env-selections';
 export * from './session-mcp-servers';
+export * from './session-relationships';
 export * from './sessions';
 export * from './tasks';
 export * from './thread-session-map';

--- a/packages/core/src/db/repositories/session-relationships.ts
+++ b/packages/core/src/db/repositories/session-relationships.ts
@@ -1,0 +1,184 @@
+/**
+ * Session Relationship Repository
+ *
+ * Durable cross-session links that are not necessarily canonical genealogy.
+ */
+
+import type {
+  SessionID,
+  SessionRelationship,
+  SessionRelationshipID,
+  SessionRelationshipType,
+  UserID,
+} from '@agor/core/types';
+import { and, eq, or } from 'drizzle-orm';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { insert, select, update } from '../database-wrapper';
+import {
+  type SessionRelationshipInsert,
+  type SessionRelationshipRow,
+  sessionRelationships,
+} from '../schema';
+import { EntityNotFoundError, RepositoryError } from './base';
+
+export interface CreateSessionRelationshipInput {
+  source_session_id: SessionID;
+  target_session_id: SessionID;
+  relationship_type: SessionRelationshipType;
+  created_by: UserID;
+  callback_enabled?: boolean;
+  callback_session_id?: SessionID | null;
+  data?: Record<string, unknown> | null;
+}
+
+export class SessionRelationshipRepository {
+  constructor(private db: Database) {}
+
+  private rowToRelationship(row: SessionRelationshipRow): SessionRelationship {
+    return {
+      relationship_id: row.relationship_id as SessionRelationshipID,
+      source_session_id: row.source_session_id as SessionID,
+      target_session_id: row.target_session_id as SessionID,
+      relationship_type: row.relationship_type as SessionRelationshipType,
+      created_by: row.created_by as UserID,
+      created_at: new Date(row.created_at).toISOString(),
+      updated_at: row.updated_at ? new Date(row.updated_at).toISOString() : null,
+      callback_enabled: Boolean(row.callback_enabled),
+      callback_session_id: (row.callback_session_id as SessionID | null) ?? null,
+      data: row.data ?? null,
+    };
+  }
+
+  async create(input: CreateSessionRelationshipInput): Promise<SessionRelationship> {
+    try {
+      const now = new Date();
+      const row: SessionRelationshipInsert = {
+        relationship_id: generateId() as SessionRelationshipID,
+        source_session_id: input.source_session_id,
+        target_session_id: input.target_session_id,
+        relationship_type: input.relationship_type,
+        created_by: input.created_by,
+        created_at: now,
+        updated_at: now,
+        callback_enabled: input.callback_enabled ?? false,
+        callback_session_id: input.callback_session_id ?? null,
+        data: input.data ?? null,
+      };
+
+      await insert(this.db, sessionRelationships).values(row).run();
+      return this.rowToRelationship(row as SessionRelationshipRow);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to create session relationship: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async findForSession(sessionId: SessionID): Promise<SessionRelationship[]> {
+    try {
+      const rows = await select(this.db)
+        .from(sessionRelationships)
+        .where(
+          or(
+            eq(sessionRelationships.source_session_id, sessionId),
+            eq(sessionRelationships.target_session_id, sessionId)
+          )
+        )
+        .all();
+      return rows.map((row: SessionRelationshipRow) => this.rowToRelationship(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list session relationships: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async findRemoteChildren(sourceSessionId: SessionID): Promise<SessionRelationship[]> {
+    try {
+      const rows = await select(this.db)
+        .from(sessionRelationships)
+        .where(
+          and(
+            eq(sessionRelationships.source_session_id, sourceSessionId),
+            eq(sessionRelationships.relationship_type, 'remote_create')
+          )
+        )
+        .all();
+      return rows.map((row: SessionRelationshipRow) => this.rowToRelationship(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list remote child relationships: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async findRemoteParents(targetSessionId: SessionID): Promise<SessionRelationship[]> {
+    try {
+      const rows = await select(this.db)
+        .from(sessionRelationships)
+        .where(
+          and(
+            eq(sessionRelationships.target_session_id, targetSessionId),
+            eq(sessionRelationships.relationship_type, 'remote_create')
+          )
+        )
+        .all();
+      return rows.map((row: SessionRelationshipRow) => this.rowToRelationship(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list remote parent relationships: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async setCallbackEnabled(
+    relationshipId: SessionRelationshipID,
+    callbackEnabled: boolean
+  ): Promise<SessionRelationship> {
+    try {
+      const result = await update(this.db, sessionRelationships)
+        .set({ callback_enabled: callbackEnabled, updated_at: new Date() })
+        .where(eq(sessionRelationships.relationship_id, relationshipId))
+        .run();
+
+      if (result.rowsAffected === 0) {
+        throw new EntityNotFoundError('SessionRelationship', relationshipId);
+      }
+
+      const row = await select(this.db)
+        .from(sessionRelationships)
+        .where(eq(sessionRelationships.relationship_id, relationshipId))
+        .one();
+      if (!row) throw new EntityNotFoundError('SessionRelationship', relationshipId);
+      return this.rowToRelationship(row);
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) throw error;
+      throw new RepositoryError(
+        `Failed to update session relationship callback state: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async setCallbackEnabledForTargetSession(
+    targetSessionId: SessionID,
+    callbackEnabled: boolean
+  ): Promise<void> {
+    try {
+      await update(this.db, sessionRelationships)
+        .set({ callback_enabled: callbackEnabled, updated_at: new Date() })
+        .where(eq(sessionRelationships.target_session_id, targetSessionId))
+        .run();
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to update target session relationship callback state: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+}

--- a/packages/core/src/db/repositories/session-relationships.ts
+++ b/packages/core/src/db/repositories/session-relationships.ts
@@ -11,7 +11,7 @@ import type {
   SessionRelationshipType,
   UserID,
 } from '@agor/core/types';
-import { and, eq, or } from 'drizzle-orm';
+import { and, eq, inArray, or } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { insert, select, update } from '../database-wrapper';
@@ -84,6 +84,28 @@ export class SessionRelationshipRepository {
           or(
             eq(sessionRelationships.source_session_id, sessionId),
             eq(sessionRelationships.target_session_id, sessionId)
+          )
+        )
+        .all();
+      return rows.map((row: SessionRelationshipRow) => this.rowToRelationship(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list session relationships: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async findForSessions(sessionIds: SessionID[]): Promise<SessionRelationship[]> {
+    if (sessionIds.length === 0) return [];
+
+    try {
+      const rows = await select(this.db)
+        .from(sessionRelationships)
+        .where(
+          or(
+            inArray(sessionRelationships.source_session_id, sessionIds),
+            inArray(sessionRelationships.target_session_id, sessionIds)
           )
         )
         .all();

--- a/packages/core/src/db/repositories/session-relationships.ts
+++ b/packages/core/src/db/repositories/session-relationships.ts
@@ -76,6 +76,23 @@ export class SessionRelationshipRepository {
     }
   }
 
+  async get(relationshipId: SessionRelationshipID): Promise<SessionRelationship> {
+    try {
+      const row = await select(this.db)
+        .from(sessionRelationships)
+        .where(eq(sessionRelationships.relationship_id, relationshipId))
+        .one();
+      if (!row) throw new EntityNotFoundError('SessionRelationship', relationshipId);
+      return this.rowToRelationship(row);
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) throw error;
+      throw new RepositoryError(
+        `Failed to get session relationship: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
   async findForSession(sessionId: SessionID): Promise<SessionRelationship[]> {
     try {
       const rows = await select(this.db)
@@ -194,7 +211,12 @@ export class SessionRelationshipRepository {
     try {
       await update(this.db, sessionRelationships)
         .set({ callback_enabled: callbackEnabled, updated_at: new Date() })
-        .where(eq(sessionRelationships.target_session_id, targetSessionId))
+        .where(
+          and(
+            eq(sessionRelationships.target_session_id, targetSessionId),
+            eq(sessionRelationships.relationship_type, 'remote_create')
+          )
+        )
         .run();
     } catch (error) {
       throw new RepositoryError(

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -238,6 +238,48 @@ export const sessions = pgTable(
 );
 
 /**
+ * Session Relationships table
+ *
+ * Durable cross-session links that are not necessarily canonical genealogy.
+ * Used for cross-branch remote-create provenance while keeping
+ * sessions.genealogy.parent_session_id branch-local.
+ */
+export const sessionRelationships = pgTable(
+  'session_relationships',
+  {
+    relationship_id: varchar('relationship_id', { length: 36 }).primaryKey(),
+    source_session_id: varchar('source_session_id', { length: 36 })
+      .notNull()
+      .references(() => sessions.session_id, { onDelete: 'cascade' }),
+    target_session_id: varchar('target_session_id', { length: 36 })
+      .notNull()
+      .references(() => sessions.session_id, { onDelete: 'cascade' }),
+    relationship_type: text('relationship_type', { enum: ['remote_create'] }).notNull(),
+    created_by: varchar('created_by', { length: 36 }).notNull(),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at'),
+    callback_enabled: t.bool('callback_enabled').notNull().default(false),
+    callback_session_id: varchar('callback_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    data: t.json<Record<string, unknown>>('data'),
+  },
+  (table) => ({
+    sourceIdx: index('session_relationships_source_idx').on(table.source_session_id),
+    targetIdx: index('session_relationships_target_idx').on(table.target_session_id),
+    callbackIdx: index('session_relationships_callback_idx').on(table.callback_session_id),
+    sourceTargetTypeUnique: uniqueIndex('session_relationships_source_target_type_unique').on(
+      table.source_session_id,
+      table.target_session_id,
+      table.relationship_type
+    ),
+  })
+);
+
+/**
  * Tasks table - Granular work units within sessions
  */
 export const tasks = pgTable(
@@ -2121,6 +2163,8 @@ export const kbGraphEdges = pgTable(
  */
 export type SessionRow = typeof sessions.$inferSelect;
 export type SessionInsert = typeof sessions.$inferInsert;
+export type SessionRelationshipRow = typeof sessionRelationships.$inferSelect;
+export type SessionRelationshipInsert = typeof sessionRelationships.$inferInsert;
 export type TaskRow = typeof tasks.$inferSelect;
 export type TaskInsert = typeof tasks.$inferInsert;
 export type MessageRow = typeof messages.$inferSelect;
@@ -2190,7 +2234,7 @@ export type KBGraphEdgeInsert = typeof kbGraphEdges.$inferInsert;
  * These enable automatic JOINs using db.query.sessions.findFirst({ with: { branch: true } })
  */
 
-export const sessionsRelations = relations(sessions, ({ one }) => ({
+export const sessionsRelations = relations(sessions, ({ one, many }) => ({
   branch: one(branches, {
     fields: [sessions.branch_id],
     references: [branches.branch_id],
@@ -2198,6 +2242,25 @@ export const sessionsRelations = relations(sessions, ({ one }) => ({
   schedule: one(schedules, {
     fields: [sessions.schedule_id],
     references: [schedules.schedule_id],
+  }),
+  outboundRelationships: many(sessionRelationships, { relationName: 'relationshipSource' }),
+  inboundRelationships: many(sessionRelationships, { relationName: 'relationshipTarget' }),
+}));
+
+export const sessionRelationshipsRelations = relations(sessionRelationships, ({ one }) => ({
+  sourceSession: one(sessions, {
+    fields: [sessionRelationships.source_session_id],
+    references: [sessions.session_id],
+    relationName: 'relationshipSource',
+  }),
+  targetSession: one(sessions, {
+    fields: [sessionRelationships.target_session_id],
+    references: [sessions.session_id],
+    relationName: 'relationshipTarget',
+  }),
+  callbackSession: one(sessions, {
+    fields: [sessionRelationships.callback_session_id],
+    references: [sessions.session_id],
   }),
 }));
 

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -245,6 +245,48 @@ export const sessions = sqliteTable(
 );
 
 /**
+ * Session Relationships table
+ *
+ * Durable cross-session links that are not necessarily canonical genealogy.
+ * Used for cross-branch remote-create provenance while keeping
+ * sessions.genealogy.parent_session_id branch-local.
+ */
+export const sessionRelationships = sqliteTable(
+  'session_relationships',
+  {
+    relationship_id: text('relationship_id', { length: 36 }).primaryKey(),
+    source_session_id: text('source_session_id', { length: 36 })
+      .notNull()
+      .references(() => sessions.session_id, { onDelete: 'cascade' }),
+    target_session_id: text('target_session_id', { length: 36 })
+      .notNull()
+      .references(() => sessions.session_id, { onDelete: 'cascade' }),
+    relationship_type: text('relationship_type', { enum: ['remote_create'] }).notNull(),
+    created_by: text('created_by', { length: 36 }).notNull(),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at'),
+    callback_enabled: t.bool('callback_enabled').notNull().default(false),
+    callback_session_id: text('callback_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    data: t.json<Record<string, unknown>>('data'),
+  },
+  (table) => ({
+    sourceIdx: index('session_relationships_source_idx').on(table.source_session_id),
+    targetIdx: index('session_relationships_target_idx').on(table.target_session_id),
+    callbackIdx: index('session_relationships_callback_idx').on(table.callback_session_id),
+    sourceTargetTypeUnique: uniqueIndex('session_relationships_source_target_type_unique').on(
+      table.source_session_id,
+      table.target_session_id,
+      table.relationship_type
+    ),
+  })
+);
+
+/**
  * Tasks table - Granular work units within sessions
  */
 export const tasks = sqliteTable(
@@ -2152,6 +2194,8 @@ export const kbGraphEdges = sqliteTable(
  */
 export type SessionRow = typeof sessions.$inferSelect;
 export type SessionInsert = typeof sessions.$inferInsert;
+export type SessionRelationshipRow = typeof sessionRelationships.$inferSelect;
+export type SessionRelationshipInsert = typeof sessionRelationships.$inferInsert;
 export type TaskRow = typeof tasks.$inferSelect;
 export type TaskInsert = typeof tasks.$inferInsert;
 export type MessageRow = typeof messages.$inferSelect;
@@ -2221,7 +2265,7 @@ export type KBGraphEdgeInsert = typeof kbGraphEdges.$inferInsert;
  * These enable automatic JOINs using db.query.sessions.findFirst({ with: { branch: true } })
  */
 
-export const sessionsRelations = relations(sessions, ({ one }) => ({
+export const sessionsRelations = relations(sessions, ({ one, many }) => ({
   branch: one(branches, {
     fields: [sessions.branch_id],
     references: [branches.branch_id],
@@ -2229,6 +2273,25 @@ export const sessionsRelations = relations(sessions, ({ one }) => ({
   schedule: one(schedules, {
     fields: [sessions.schedule_id],
     references: [schedules.schedule_id],
+  }),
+  outboundRelationships: many(sessionRelationships, { relationName: 'relationshipSource' }),
+  inboundRelationships: many(sessionRelationships, { relationName: 'relationshipTarget' }),
+}));
+
+export const sessionRelationshipsRelations = relations(sessionRelationships, ({ one }) => ({
+  sourceSession: one(sessions, {
+    fields: [sessionRelationships.source_session_id],
+    references: [sessions.session_id],
+    relationName: 'relationshipSource',
+  }),
+  targetSession: one(sessions, {
+    fields: [sessionRelationships.target_session_id],
+    references: [sessions.session_id],
+    relationName: 'relationshipTarget',
+  }),
+  callbackSession: one(sessions, {
+    fields: [sessionRelationships.callback_session_id],
+    references: [sessions.session_id],
   }),
 }));
 

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -42,6 +42,7 @@ export const artifacts = schema.artifacts;
 export const artifactTrustGrants = schema.artifactTrustGrants;
 export const boardObjects = schema.boardObjects;
 export const sessionMcpServers = schema.sessionMcpServers;
+export const sessionRelationships = schema.sessionRelationships;
 export const sessionEnvSelections = schema.sessionEnvSelections;
 export const userMcpOauthTokens = schema.userMcpOauthTokens;
 export const boardComments = schema.boardComments;

--- a/packages/core/src/types/id.ts
+++ b/packages/core/src/types/id.ts
@@ -235,6 +235,7 @@ export function findByShortIdPrefix<T extends { id: AnyShortId }>(
  * const sessionId: SessionID = "01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f";
  */
 export type SessionID = UUID;
+export type SessionRelationshipID = UUID;
 
 /**
  * Task identifier

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -17,7 +17,7 @@ import type {
   OpenCodePermissionMode,
 } from './agentic-tool';
 import type { ContextFilePath } from './context';
-import type { BoardID, BranchID, SessionID, TaskID } from './id';
+import type { BoardID, BranchID, SessionID, SessionRelationshipID, TaskID, UserID } from './id';
 import type { ScheduleID } from './schedule';
 
 export const SessionStatus = {
@@ -481,6 +481,27 @@ export interface Session {
    * - 'btw_completed': Ephemeral btw fork auto-archived after task completion
    */
   archived_reason?: 'branch_archived' | 'manual' | 'btw_completed';
+}
+
+export type SessionRelationshipType = 'remote_create';
+
+/**
+ * Durable links between sessions that are not necessarily canonical
+ * branch-local genealogy. Cross-branch delegation uses this instead of
+ * genealogy.parent_session_id so the local session tree, recursive delete,
+ * and fork/spawn semantics remain branch-local.
+ */
+export interface SessionRelationship {
+  relationship_id: SessionRelationshipID;
+  source_session_id: SessionID;
+  target_session_id: SessionID;
+  relationship_type: SessionRelationshipType;
+  created_by: UserID;
+  created_at: string;
+  updated_at?: string | null;
+  callback_enabled: boolean;
+  callback_session_id?: SessionID | null;
+  data?: Record<string, unknown> | null;
 }
 
 /**

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -481,6 +481,31 @@ export interface Session {
    * - 'btw_completed': Ephemeral btw fork auto-archived after task completion
    */
   archived_reason?: 'branch_archived' | 'manual' | 'btw_completed';
+
+  /**
+   * Durable non-genealogy relationships involving this session.
+   *
+   * These are separate from genealogy.parent_session_id/forked_from_session_id.
+   * For example, a session in branch A can create a remote session in branch B;
+   * branch B keeps its own genealogy shape, while branch A can still render a
+   * muted/surrogate child card for track-record and navigation purposes.
+   */
+  remote_relationships?: {
+    as_source?: SessionRelationship[];
+    as_target?: SessionRelationship[];
+  };
+
+  /**
+   * UI-only marker for a remote-created session rendered as a surrogate in the
+   * source branch tree. The canonical session still lives in `target_branch_id`;
+   * clicking the surrogate should navigate to/open that real session.
+   */
+  remote_surrogate?: {
+    relationship: SessionRelationship;
+    source_session_id: SessionID;
+    source_branch_id: BranchID;
+    target_branch_id: BranchID;
+  };
 }
 
 export type SessionRelationshipType = 'remote_create';


### PR DESCRIPTION
## Summary

- Add a durable `session_relationships` model for cross-branch session provenance.
- Keep `genealogy.parent_session_id` branch-local for canonical in-branch session trees.
- Record cross-branch MCP-created sessions as `remote_create` relationships instead of auto-parenting them into the target branch genealogy.
- Add MCP tools to list session relationships and toggle callback linkage, with callback state synchronized from session patches.

## Test plan

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/mcp/tools/sessions.test.ts src/services/tasks.callbacks.test.ts`
