### PR TITLE
Improve login error handling copy

### DIFF
--- a/apps/agor-docs/pages/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/pages/guide/one-time-launch-auth.mdx
@@ -65,7 +65,7 @@ one-time code from the URL and shows a clear failure message.
 If `external_launch.login_redirect_url` is configured, the unauthenticated
 screen makes **Return to workspace** the primary action so the user can open a
 fresh launch link from the external workspace. The button appends a `return_to`
-query parameter containing the current Agor URL, allowing the launcher to
+query parameter containing the current Agor path, allowing the launcher to
 preserve deep links such as `/ui/s/<session>/` when it issues a fresh
 `launch_code`. Local username/password login is still available as a secondary
 fallback.

--- a/apps/agor-docs/pages/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/pages/guide/one-time-launch-auth.mdx
@@ -64,8 +64,11 @@ one-time code from the URL and shows a clear failure message.
 
 If `external_launch.login_redirect_url` is configured, the unauthenticated
 screen makes **Return to workspace** the primary action so the user can open a
-fresh launch link from the external workspace. Local username/password login is
-still available as a secondary fallback.
+fresh launch link from the external workspace. The button appends a `return_to`
+query parameter containing the current Agor URL, allowing the launcher to
+preserve deep links such as `/ui/s/<session>/` when it issues a fresh
+`launch_code`. Local username/password login is still available as a secondary
+fallback.
 
 If `login_redirect_url` is omitted, the normal local login screen is unchanged.
 

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -62,6 +62,21 @@ describe('LoginPage external launch redirect', () => {
     );
   });
 
+  it('replaces an existing return_to on the external launcher URL', () => {
+    window.history.replaceState({}, '', '/ui/w/branch123/');
+
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        externalLaunchLoginRedirectUrl="https://workspace.example.com/open?return_to=https%3A%2F%2Fevil.example%2F"
+      />
+    );
+
+    const returnLink = screen.getByRole('link', { name: 'Return to workspace' });
+    const href = new URL(returnLink.getAttribute('href') ?? '');
+    expect(href.searchParams.getAll('return_to')).toEqual([currentPath()]);
+  });
+
   it('offers local login as a secondary fallback for configured deployments', () => {
     render(
       <LoginPage

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LoginPage } from './LoginPage';
 
 vi.mock('./ParticleBackground', () => ({
@@ -7,6 +7,9 @@ vi.mock('./ParticleBackground', () => ({
 }));
 
 describe('LoginPage external launch redirect', () => {
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
   it('keeps the local login form as the default when no redirect is configured', () => {
     render(<LoginPage onLogin={vi.fn()} />);
 
@@ -24,7 +27,10 @@ describe('LoginPage external launch redirect', () => {
     );
 
     const returnLink = screen.getByRole('link', { name: 'Return to workspace' });
-    expect(returnLink).toHaveAttribute('href', 'https://workspace.example.com/open');
+    expect(returnLink).toHaveAttribute(
+      'href',
+      `https://workspace.example.com/open?return_to=${encodeURIComponent(window.location.href)}`
+    );
     expect(screen.queryByPlaceholderText('Email address')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Sign In' })).not.toBeInTheDocument();
   });
@@ -34,6 +40,25 @@ describe('LoginPage external launch redirect', () => {
 
     expect(screen.queryByText(/First-time server setup/)).not.toBeInTheDocument();
     expect(screen.queryByText('agor user create-admin')).not.toBeInTheDocument();
+  });
+
+  it('passes the current deep link to the external launcher as return_to', () => {
+    window.history.replaceState({}, '', '/ui/s/session123/?panel=right#msg-1');
+
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        externalLaunchLoginRedirectUrl="https://workspace.example.com/open?source=agor"
+      />
+    );
+
+    const returnLink = screen.getByRole('link', { name: 'Return to workspace' });
+    const href = returnLink.getAttribute('href');
+    expect(href).toBe(
+      `https://workspace.example.com/open?source=agor&return_to=${encodeURIComponent(
+        window.location.href
+      )}`
+    );
   });
 
   it('offers local login as a secondary fallback for configured deployments', () => {
@@ -62,7 +87,7 @@ describe('LoginPage external launch redirect', () => {
     expect(screen.getByText('Launch sign-in failed')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Return to workspace' })).toHaveAttribute(
       'href',
-      'https://workspace.example.com/open'
+      `https://workspace.example.com/open?return_to=${encodeURIComponent(window.location.href)}`
     );
   });
 

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -29,13 +29,11 @@ describe('LoginPage external launch redirect', () => {
     expect(screen.queryByRole('button', { name: 'Sign In' })).not.toBeInTheDocument();
   });
 
-  it('shows concise first-time admin setup guidance on the local login form', () => {
+  it('does not show first-time admin setup guidance on the local login form', () => {
     render(<LoginPage onLogin={vi.fn()} />);
 
-    expect(screen.getByText(/First-time server setup/)).toBeInTheDocument();
-    expect(screen.getByText('agor user create-admin')).toBeInTheDocument();
-    expect(screen.queryByText(/New user/)).not.toBeInTheDocument();
-    expect(screen.queryByText(/💡/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/First-time server setup/)).not.toBeInTheDocument();
+    expect(screen.queryByText('agor user create-admin')).not.toBeInTheDocument();
   });
 
   it('offers local login as a secondary fallback for configured deployments', () => {
@@ -79,7 +77,7 @@ describe('LoginPage external launch redirect', () => {
 
     expect(screen.getByText('Login Failed')).toBeInTheDocument();
     expect(screen.queryByText('Launch sign-in failed')).not.toBeInTheDocument();
-    expect(screen.getByText(/First-time server setup/)).toBeInTheDocument();
-    expect(screen.getByText('agor user create-admin')).toBeInTheDocument();
+    expect(screen.queryByText(/First-time server setup/)).not.toBeInTheDocument();
+    expect(screen.queryByText('agor user create-admin')).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx
@@ -7,6 +7,9 @@ vi.mock('./ParticleBackground', () => ({
 }));
 
 describe('LoginPage external launch redirect', () => {
+  const currentPath = () =>
+    `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
   afterEach(() => {
     window.history.replaceState({}, '', '/');
   });
@@ -29,7 +32,7 @@ describe('LoginPage external launch redirect', () => {
     const returnLink = screen.getByRole('link', { name: 'Return to workspace' });
     expect(returnLink).toHaveAttribute(
       'href',
-      `https://workspace.example.com/open?return_to=${encodeURIComponent(window.location.href)}`
+      `https://workspace.example.com/open?return_to=${encodeURIComponent(currentPath())}`
     );
     expect(screen.queryByPlaceholderText('Email address')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Sign In' })).not.toBeInTheDocument();
@@ -55,9 +58,7 @@ describe('LoginPage external launch redirect', () => {
     const returnLink = screen.getByRole('link', { name: 'Return to workspace' });
     const href = returnLink.getAttribute('href');
     expect(href).toBe(
-      `https://workspace.example.com/open?source=agor&return_to=${encodeURIComponent(
-        window.location.href
-      )}`
+      `https://workspace.example.com/open?source=agor&return_to=${encodeURIComponent(currentPath())}`
     );
   });
 
@@ -87,7 +88,7 @@ describe('LoginPage external launch redirect', () => {
     expect(screen.getByText('Launch sign-in failed')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Return to workspace' })).toHaveAttribute(
       'href',
-      `https://workspace.example.com/open?return_to=${encodeURIComponent(window.location.href)}`
+      `https://workspace.example.com/open?return_to=${encodeURIComponent(currentPath())}`
     );
   });
 

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -6,7 +6,7 @@
 
 import { LockOutlined, MailOutlined } from '@ant-design/icons';
 import { Alert, Button, Card, Divider, Form, Input, Space, Typography, theme } from 'antd';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { BRAND, brandMarkHref } from '../../branding/brand';
 import { BrandLogo } from '../BrandLogo';
 import { ParticleBackground } from './ParticleBackground';
@@ -54,11 +54,9 @@ export function LoginPage({
   const [showLocalLogin, setShowLocalLogin] = useState(false);
   const { token } = theme.useToken();
   const useExternalLaunch = !!externalLaunchLoginRedirectUrl;
-  const externalLaunchHref = useMemo(
-    () =>
-      externalLaunchLoginRedirectUrl ? addReturnToParam(externalLaunchLoginRedirectUrl) : undefined,
-    [externalLaunchLoginRedirectUrl]
-  );
+  const externalLaunchHref = externalLaunchLoginRedirectUrl
+    ? addReturnToParam(externalLaunchLoginRedirectUrl)
+    : undefined;
   const showLoginForm = !useExternalLaunch || showLocalLogin;
   const isLaunchError = error?.startsWith('Launch sign-in failed') ?? false;
 

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -6,12 +6,24 @@
 
 import { LockOutlined, MailOutlined } from '@ant-design/icons';
 import { Alert, Button, Card, Divider, Form, Input, Space, Typography, theme } from 'antd';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { BRAND, brandMarkHref } from '../../branding/brand';
 import { BrandLogo } from '../BrandLogo';
 import { ParticleBackground } from './ParticleBackground';
 
 const { Text } = Typography;
+
+function addReturnToParam(loginRedirectUrl: string): string {
+  if (typeof window === 'undefined') return loginRedirectUrl;
+
+  try {
+    const url = new URL(loginRedirectUrl);
+    url.searchParams.set('return_to', window.location.href);
+    return url.toString();
+  } catch {
+    return loginRedirectUrl;
+  }
+}
 
 interface LoginPageProps {
   onLogin: (email: string, password: string) => Promise<boolean>;
@@ -31,6 +43,11 @@ export function LoginPage({
   const [showLocalLogin, setShowLocalLogin] = useState(false);
   const { token } = theme.useToken();
   const useExternalLaunch = !!externalLaunchLoginRedirectUrl;
+  const externalLaunchHref = useMemo(
+    () =>
+      externalLaunchLoginRedirectUrl ? addReturnToParam(externalLaunchLoginRedirectUrl) : undefined,
+    [externalLaunchLoginRedirectUrl]
+  );
   const showLoginForm = !useExternalLaunch || showLocalLogin;
   const isLaunchError = error?.startsWith('Launch sign-in failed') ?? false;
 
@@ -147,7 +164,7 @@ export function LoginPage({
             )}
             <Button
               type="primary"
-              href={externalLaunchLoginRedirectUrl}
+              href={externalLaunchHref}
               block
               data-testid="external-launch-return"
             >

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -13,33 +13,6 @@ import { ParticleBackground } from './ParticleBackground';
 
 const { Text } = Typography;
 
-const ADMIN_SETUP_COMMAND = 'agor user create-admin';
-
-function AdminSetupHint() {
-  const { token } = theme.useToken();
-
-  return (
-    <Space orientation="vertical" size={4} style={{ width: '100%' }}>
-      <Text type="secondary" style={{ fontSize: 12 }}>
-        First-time server setup? Create the initial admin account:
-      </Text>
-      <Text
-        code
-        copyable={{ text: ADMIN_SETUP_COMMAND }}
-        style={{
-          fontSize: 12,
-          background: token.colorFillTertiary,
-          border: `1px solid ${token.colorBorderSecondary}`,
-          borderRadius: token.borderRadiusSM,
-          padding: '2px 6px',
-        }}
-      >
-        {ADMIN_SETUP_COMMAND}
-      </Text>
-    </Space>
-  );
-}
-
 interface LoginPageProps {
   onLogin: (email: string, password: string) => Promise<boolean>;
   loading?: boolean;
@@ -155,22 +128,7 @@ export function LoginPage({
           <Alert
             type="error"
             title={isLaunchError ? 'Launch sign-in failed' : 'Login Failed'}
-            description={
-              <Space orientation="vertical" size="small" style={{ width: '100%' }}>
-                <div>{error}</div>
-                {!isLaunchError && (
-                  <div
-                    style={{
-                      marginTop: 8,
-                      paddingTop: 8,
-                      borderTop: `1px solid ${token.colorBorderSecondary}`,
-                    }}
-                  >
-                    <AdminSetupHint />
-                  </div>
-                )}
-              </Space>
-            }
+            description={error}
             showIcon
             closable
             style={{ marginBottom: 24 }}
@@ -246,13 +204,6 @@ export function LoginPage({
               </Form.Item>
             </Form>
           </>
-        )}
-
-        {/* Footer */}
-        {showLoginForm && !error && (
-          <div style={{ textAlign: 'center', marginTop: 24 }}>
-            <AdminSetupHint />
-          </div>
         )}
       </Card>
     </div>

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -13,12 +13,23 @@ import { ParticleBackground } from './ParticleBackground';
 
 const { Text } = Typography;
 
+function currentReturnToPath(): string | null {
+  if (typeof window === 'undefined') return null;
+
+  // Send only a relative Agor route to the external launcher. Avoiding an
+  // absolute URL keeps this from becoming an open-redirect primitive if the
+  // launcher blindly follows `return_to`.
+  const pathname = window.location.pathname.startsWith('//') ? '/' : window.location.pathname;
+  return `${pathname}${window.location.search}${window.location.hash}`;
+}
+
 function addReturnToParam(loginRedirectUrl: string): string {
-  if (typeof window === 'undefined') return loginRedirectUrl;
+  const returnTo = currentReturnToPath();
+  if (!returnTo) return loginRedirectUrl;
 
   try {
     const url = new URL(loginRedirectUrl);
-    url.searchParams.set('return_to', window.location.href);
+    url.searchParams.set('return_to', returnTo);
     return url.toString();
   } catch {
     return loginRedirectUrl;

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '../utils/tokenRefresh';
 import { useAuth } from './useAuth';
@@ -26,6 +26,7 @@ describe('useAuth launch-code fallback', () => {
     authenticate.mockReset();
     launchCreate.mockReset();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     window.history.replaceState({}, '', '/ui/?launch_code=stale-code');
   });
 
@@ -66,5 +67,23 @@ describe('useAuth launch-code fallback', () => {
     expect(result.current.authenticated).toBe(false);
     expect(result.current.error).toContain('Launch sign-in failed');
     expect(window.location.search).toBe('');
+  });
+
+  it('replaces REST JSON parse failures during local login with a helpful message', async () => {
+    authenticate.mockRejectedValue(new Error('JSON parsing error'));
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.login('person@example.test', 'password-123');
+    });
+
+    expect(ok).toBe(false);
+    expect(result.current.error).toContain('unexpected response');
+    expect(result.current.error).toContain('daemon URL');
+    expect(result.current.error).not.toContain('JSON parsing error');
   });
 });

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -45,6 +45,28 @@ interface UseAuthReturn extends AuthState {
   reAuthenticate: () => Promise<void>;
 }
 
+const UNEXPECTED_LOGIN_RESPONSE_MESSAGE =
+  'The Agor server returned an unexpected response while signing in. Check that the daemon URL is correct and the server is reachable, then try again.';
+
+function isJsonParseFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const message =
+    error instanceof Error ? error.message : String((error as { message?: unknown }).message ?? '');
+  return /json parsing error/i.test(message) || /unexpected token.*json/i.test(message);
+}
+
+function loginErrorMessage(error: unknown): string {
+  if (isJsonParseFailure(error)) {
+    return UNEXPECTED_LOGIN_RESPONSE_MESSAGE;
+  }
+
+  if (isTransientConnectionError(error)) {
+    return 'Unable to reach the Agor server. Check your connection and try again.';
+  }
+
+  return error instanceof Error ? error.message : 'Login failed';
+}
+
 /**
  * Authentication hook
  */
@@ -437,12 +459,13 @@ export function useAuth(): UseAuthReturn {
       return true;
     } catch (error) {
       console.error('❌ Login failed:', error);
-      const errorMessage = error instanceof Error ? error.message : 'Login failed';
-      console.error('❌ Error message:', errorMessage);
+      const userFacingMessage = loginErrorMessage(error);
+      const rawMessage = error instanceof Error ? error.message : 'Login failed';
+      console.error('❌ Error message:', rawMessage);
       setState((prev) => ({
         ...prev,
         loading: false,
-        error: errorMessage,
+        error: userFacingMessage,
       }));
       return false;
     }

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -15,8 +15,11 @@ If the launch code is missing, expired, already used, invalid, or the daemon
 cannot complete a non-transient exchange, the UI shows a clear failure message.
 When `external_launch.login_redirect_url` is configured, the unauthenticated
 screen makes that URL the primary action so users can return to the external
-workspace and open a fresh launch link. If the field is omitted, the normal
-local username/password login screen remains unchanged.
+workspace and open a fresh launch link. The UI appends a `return_to` query
+parameter containing the current Agor URL, so launch providers can preserve
+deep links such as `/ui/s/<session>/` when issuing a fresh launch code. If the
+field is omitted, the normal local username/password login screen remains
+unchanged.
 
 ## Configuration
 

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -16,7 +16,7 @@ cannot complete a non-transient exchange, the UI shows a clear failure message.
 When `external_launch.login_redirect_url` is configured, the unauthenticated
 screen makes that URL the primary action so users can return to the external
 workspace and open a fresh launch link. The UI appends a `return_to` query
-parameter containing the current Agor URL, so launch providers can preserve
+parameter containing the current Agor path, so launch providers can preserve
 deep links such as `/ui/s/<session>/` when issuing a fresh launch code. If the
 field is omitted, the normal local username/password login screen remains
 unchanged.


### PR DESCRIPTION
## Summary

- Replace raw Feathers REST `JSON parsing error` messages during local login with actionable user-facing copy for unexpected/non-JSON server responses.
- Keep raw login failures in the browser console for diagnostics.
- Remove the first-time setup/admin CLI hint from the login page.
- Preserve deep links through external-launch fallback by appending a relative `return_to=<current Agor path>` to the configured workspace login URL.
- Update login page/auth tests and one-time launch docs.

## Root cause

The Feathers REST fetch transport throws `JSON parsing error` when an error response body cannot be parsed as JSON, which can happen if `/authentication` receives an HTML/text proxy, network, or server error response. `useAuth.login` displayed that transport-level message directly in the login alert.

While investigating deep links, local login from `/ui/s/<session>/` appears to preserve the route, but the external-launch fallback used only the static `external_launch.login_redirect_url`. That gave the external workspace no target context when a user arrived unauthenticated from a session/branch link.

## Security note

`return_to` is intentionally a relative Agor path (`/ui/s/...` plus query/hash), not an absolute URL. This avoids making the parameter an open-redirect primitive if the external launcher mishandles it.

## Checks

- `pnpm i`
- `pnpm check`
- `pnpm --dir apps/agor-ui test src/components/LoginPage/LoginPage.test.tsx src/hooks/useAuth.launch.test.tsx`
- `pnpm exec biome check apps/agor-ui/src/components/LoginPage/LoginPage.tsx apps/agor-ui/src/components/LoginPage/LoginPage.test.tsx apps/agor-ui/src/hooks/useAuth.ts apps/agor-ui/src/hooks/useAuth.launch.test.tsx apps/agor-docs/pages/guide/one-time-launch-auth.mdx`