### PR TITLE
test: resolve workspace source exports

### DIFF
--- a/apps/agor-cli/vitest.config.ts
+++ b/apps/agor-cli/vitest.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vitest/config';
 
+const workspaceSourceConditions = ['source', 'module', 'node', 'development|production'];
+
 export default defineConfig({
+  ssr: {
+    resolve: {
+      conditions: workspaceSourceConditions,
+    },
+  },
   test: {
     include: ['src/**/*.test.ts'],
   },

--- a/apps/agor-daemon/vitest.config.ts
+++ b/apps/agor-daemon/vitest.config.ts
@@ -1,6 +1,13 @@
 import { configDefaults, defineConfig } from 'vitest/config';
 
+const workspaceSourceConditions = ['source', 'module', 'node', 'development|production'];
+
 export default defineConfig({
+  ssr: {
+    resolve: {
+      conditions: workspaceSourceConditions,
+    },
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/packages/executor/vitest.config.ts
+++ b/packages/executor/vitest.config.ts
@@ -1,6 +1,13 @@
 import { configDefaults, defineConfig } from 'vitest/config';
 
+const workspaceSourceConditions = ['source', 'module', 'node', 'development|production'];
+
 export default defineConfig({
+  ssr: {
+    resolve: {
+      conditions: workspaceSourceConditions,
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

- opts Node test configs into the workspace source export condition
- preserves the default server-side package resolution conditions
- covers daemon, CLI, and executor test consumers

Closes #1530.

## Validation

- pnpm --filter @agor/daemon exec vitest run src/services/branches.test.ts
- pnpm --filter @agor/cli exec vitest run src/lib/check-migrations.test.ts
- pnpm --filter @agor/executor exec vitest run src/payload-types.test.ts