### PR TITLE
Fix Codex MCP client lifecycle churn

### DIFF
--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -173,5 +173,5 @@ describe('OnboardingWizard', () => {
     fireEvent.click(await screen.findByText('Cursor SDK (Beta)'));
 
     expect(await screen.findByText('Cursor SDK is configured')).toBeInTheDocument();
-  });
+  }, 30_000);
 });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -142,7 +142,7 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     expect(mockInstanceCount).toBe(initialCount);
   });
 
-  it('should reuse the same Codex instance when API key and session config have not changed', () => {
+  it('should reuse the same Codex instance when API key and session config have not changed', async () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -159,17 +159,17 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     // Access private methods via type assertion for testing
     const serviceWithPrivate = service as any;
     serviceWithPrivate.refreshClient('test-api-key');
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     serviceWithPrivate.refreshClient('test-api-key');
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     serviceWithPrivate.refreshClient('test-api-key');
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
 
     // Should create only the lazily-initialized configured instance
     expect(mockInstanceCount).toBe(countAfterInit + 1);
   });
 
-  it('should create a new Codex instance only when API key changes', () => {
+  it('should create a new Codex instance only when API key changes', async () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -183,27 +183,27 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     const countAfterInit = mockInstanceCount;
 
     const serviceWithPrivate = service as any;
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 1);
 
     // Call with same API key - should NOT create new instance
     serviceWithPrivate.refreshClient('initial-key');
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 1);
 
     // Call with different API key - next configured ensure SHOULD create new instance
     serviceWithPrivate.refreshClient('new-api-key');
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 2);
     expect(mockClosedInstanceIds).toContain(1);
 
     // Call with same new key again - should NOT create another instance
     serviceWithPrivate.refreshClient('new-api-key');
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 2);
   });
 
-  it('should handle empty/undefined API keys correctly', () => {
+  it('should handle empty/undefined API keys correctly', async () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -222,12 +222,12 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     serviceWithPrivate.refreshClient('');
     expect(mockInstanceCount).toBe(countAfterInit);
 
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 1);
 
     // Call with actual key - should create new instance on next ensure
     serviceWithPrivate.refreshClient('new-key');
-    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 2);
   });
 });
@@ -257,50 +257,131 @@ describe('CodexPromptService - OPENAI_BASE_URL handling', () => {
       mockDb
     );
 
-  it('passes OPENAI_BASE_URL into Codex.Codex when session config is ensured', () => {
+  it('passes OPENAI_BASE_URL into Codex.Codex when session config is ensured', async () => {
     process.env.OPENAI_BASE_URL = 'https://gateway.example.com/v1';
     const service = makeService('test-api-key') as any;
-    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceBaseUrls).toEqual(['https://gateway.example.com/v1']);
   });
 
-  it('omits baseUrl when OPENAI_BASE_URL is unset', () => {
+  it('omits baseUrl when OPENAI_BASE_URL is unset', async () => {
     const service = makeService('test-api-key') as any;
-    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceBaseUrls).toEqual([undefined]);
   });
 
-  it('trims whitespace and treats whitespace-only as unset', () => {
+  it('trims whitespace and treats whitespace-only as unset', async () => {
     process.env.OPENAI_BASE_URL = '   ';
     const service = makeService('test-api-key') as any;
-    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceBaseUrls).toEqual([undefined]);
   });
 
-  it('reinitializes Codex when OPENAI_BASE_URL changes between refreshes', () => {
+  it('reinitializes Codex when OPENAI_BASE_URL changes between refreshes', async () => {
     const service = makeService('stable-key') as any;
     const countAfterInit = mockInstanceCount;
-    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 1);
 
     // Same key, base URL appears -> next ensure must recreate.
     process.env.OPENAI_BASE_URL = 'https://gateway.example.com/v1';
     service.refreshClient('stable-key');
-    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 2);
     expect(mockInstanceBaseUrls.at(-1)).toBe('https://gateway.example.com/v1');
 
     // Same key, same URL -> must NOT recreate (issue #133 protection).
     service.refreshClient('stable-key');
-    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 2);
 
     // Same key, URL cleared -> must recreate without baseUrl.
     delete process.env.OPENAI_BASE_URL;
     service.refreshClient('stable-key');
-    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    await service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 3);
     expect(mockInstanceBaseUrls.at(-1)).toBeUndefined();
+  });
+});
+
+describe('CodexPromptService - prompt flow client initialization', () => {
+  beforeEach(() => {
+    mockInstanceCount = 0;
+    mockInstanceBaseUrls = [];
+    mockInstanceConfigs = [];
+    mockClosedInstanceIds = [];
+    mockStreamEvents = [];
+    delete process.env.OPENAI_BASE_URL;
+    vi.clearAllMocks();
+  });
+
+  it('builds session config, initializes the Codex client, and uses the configured accessor', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-flow.md');
+    serviceWithPrivates.buildMcpServersConfig = vi.fn().mockResolvedValue({
+      total: 1,
+      servers: {
+        agor: {
+          url: 'http://localhost:3030/mcp',
+          default_tools_approval_mode: 'approve',
+        },
+      },
+    });
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-flow',
+      branch_id: 'branch-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    });
+    mockSessionsRepo.update.mockResolvedValue(undefined);
+    mockBranchesRepo.findById.mockResolvedValue({
+      branch_id: 'branch-1',
+      path: process.cwd(),
+    });
+
+    mockStreamEvents = [
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-flow' as any, 'review')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    expect(mockInstanceCount).toBe(1);
+    expect(mockInstanceConfigs).toEqual([
+      {
+        model_instructions_file: '/tmp/agor-codex-instructions-flow.md',
+        mcp_servers: {
+          agor: {
+            url: 'http://localhost:3030/mcp',
+            default_tools_approval_mode: 'approve',
+          },
+        },
+      },
+    ]);
+    expect(emitted.find((event) => event.type === 'complete')).toMatchObject({
+      threadId: 'mock-thread-id',
+    });
   });
 });
 
@@ -334,7 +415,7 @@ describe('CodexPromptService - forked sessions', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
-    serviceWithPrivates.ensureCodexClient({
+    await serviceWithPrivates.ensureCodexClient({
       model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
     });
     serviceWithPrivates.ensureCodexClient = vi.fn();
@@ -489,7 +570,7 @@ describe('CodexPromptService - Todo normalization', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
-    serviceWithPrivates.ensureCodexClient({
+    await serviceWithPrivates.ensureCodexClient({
       model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
     });
     serviceWithPrivates.ensureCodexClient = vi.fn();
@@ -568,7 +649,7 @@ describe('CodexPromptService - tool payload mapping', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
-    serviceWithPrivates.ensureCodexClient({
+    await serviceWithPrivates.ensureCodexClient({
       model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
     });
     serviceWithPrivates.ensureCodexClient = vi.fn();
@@ -786,7 +867,7 @@ describe('CodexPromptService - tool payload mapping', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
-    serviceWithPrivates.ensureCodexClient({
+    await serviceWithPrivates.ensureCodexClient({
       model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
     });
     serviceWithPrivates.ensureCodexClient = vi.fn();

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -3,11 +3,12 @@
  *
  * Focused test: Verify SDK instance caching to prevent memory leak (issue #133)
  *
- * KNOWN GAP: the `MockCodexClient` below only captures `apiKey` + `baseUrl`,
- * not `config` (model_instructions_file, mcp_servers) or `env` (subscription-
- * mode scrubbing). The streaming tests stub out `ensureCodexInstructionsFile`,
- * `buildMcpServersConfig`, and `ensureCodexClient` outright. So the
- * load-bearing behaviors of the per-session-CODEX_HOME removal —
+ * KNOWN GAP: the `MockCodexClient` below captures `apiKey`, `baseUrl`, and
+ * `config` only shallowly; it still does not emulate Codex CLI process
+ * behavior or subscription-mode env scrubbing. Some streaming tests stub out
+ * `ensureCodexInstructionsFile`, `buildMcpServersConfig`, and
+ * `ensureCodexClient`. So the load-bearing behaviors of the
+ * per-session-CODEX_HOME removal —
  * `model_instructions_file` injection, MCP server flattening, subscription-
  * mode env scrubbing, fingerprint-based cache invalidation on token rotation
  * — are NOT exercised here. End-to-end coverage for those lives in the
@@ -37,9 +38,12 @@ import { CodexPromptService } from './prompt-service.js';
 
 // Track how many Codex instances were created (module-level state)
 let mockInstanceCount = 0;
-// Track the baseUrl each constructed instance saw, in creation order. Lets
-// tests assert that custom OPENAI_BASE_URL values flow into Codex.Codex().
+// Track options each constructed instance saw, in creation order. Lets
+// tests assert that custom OPENAI_BASE_URL values and session config flow into
+// Codex.Codex().
 let mockInstanceBaseUrls: Array<string | undefined> = [];
+let mockInstanceConfigs: Array<unknown> = [];
+let mockClosedInstanceIds: number[] = [];
 let mockStreamEvents: Array<Record<string, unknown>> = [];
 
 async function* streamMockEvents() {
@@ -60,11 +64,16 @@ vi.mock('@agor/core/sdk', () => {
     baseUrl: string | undefined;
     instanceId: number;
 
-    constructor(options: { apiKey?: string; baseUrl?: string }) {
+    constructor(options: { apiKey?: string; baseUrl?: string; config?: unknown }) {
       this.apiKey = options.apiKey || '';
       this.baseUrl = options.baseUrl;
       this.instanceId = ++mockInstanceCount;
       mockInstanceBaseUrls.push(options.baseUrl);
+      mockInstanceConfigs.push(options.config);
+    }
+
+    close() {
+      mockClosedInstanceIds.push(this.instanceId);
     }
 
     startThread() {
@@ -109,13 +118,15 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
   beforeEach(() => {
     mockInstanceCount = 0;
     mockInstanceBaseUrls = [];
+    mockInstanceConfigs = [];
+    mockClosedInstanceIds = [];
     mockStreamEvents = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
     appServerMocks.forkCodexThreadViaAppServer.mockReset();
   });
 
-  it('should create exactly one Codex instance on initialization', () => {
+  it('does not create a Codex instance on initialization before session MCP config is known', () => {
     const initialCount = mockInstanceCount;
 
     new CodexPromptService(
@@ -128,10 +139,10 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
       mockDb
     );
 
-    expect(mockInstanceCount).toBe(initialCount + 1);
+    expect(mockInstanceCount).toBe(initialCount);
   });
 
-  it('should reuse the same Codex instance when API key has not changed', () => {
+  it('should reuse the same Codex instance when API key and session config have not changed', () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -144,15 +155,18 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
 
     const countAfterInit = mockInstanceCount;
 
-    // Simulate multiple calls to refreshClient with the same API key
-    // Access private method via type assertion for testing
+    // Simulate multiple calls with the same API key and same per-session config
+    // Access private methods via type assertion for testing
     const serviceWithPrivate = service as any;
     serviceWithPrivate.refreshClient('test-api-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     serviceWithPrivate.refreshClient('test-api-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     serviceWithPrivate.refreshClient('test-api-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
 
-    // Should NOT create new instances - still same count
-    expect(mockInstanceCount).toBe(countAfterInit);
+    // Should create only the lazily-initialized configured instance
+    expect(mockInstanceCount).toBe(countAfterInit + 1);
   });
 
   it('should create a new Codex instance only when API key changes', () => {
@@ -168,18 +182,25 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
 
     const countAfterInit = mockInstanceCount;
 
-    // Call with same API key - should NOT create new instance
     const serviceWithPrivate = service as any;
-    serviceWithPrivate.refreshClient('initial-key');
-    expect(mockInstanceCount).toBe(countAfterInit);
-
-    // Call with different API key - SHOULD create new instance
-    serviceWithPrivate.refreshClient('new-api-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 1);
+
+    // Call with same API key - should NOT create new instance
+    serviceWithPrivate.refreshClient('initial-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    expect(mockInstanceCount).toBe(countAfterInit + 1);
+
+    // Call with different API key - next configured ensure SHOULD create new instance
+    serviceWithPrivate.refreshClient('new-api-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    expect(mockInstanceCount).toBe(countAfterInit + 2);
+    expect(mockClosedInstanceIds).toContain(1);
 
     // Call with same new key again - should NOT create another instance
     serviceWithPrivate.refreshClient('new-api-key');
-    expect(mockInstanceCount).toBe(countAfterInit + 1);
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    expect(mockInstanceCount).toBe(countAfterInit + 2);
   });
 
   it('should handle empty/undefined API keys correctly', () => {
@@ -195,14 +216,19 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
 
     const countAfterInit = mockInstanceCount;
 
-    // Call with empty string - should not recreate if already empty
+    // Call with empty string - should not instantiate if already empty and no
+    // session config has been ensured yet.
     const serviceWithPrivate = service as any;
     serviceWithPrivate.refreshClient('');
     expect(mockInstanceCount).toBe(countAfterInit);
 
-    // Call with actual key - should create new instance
-    serviceWithPrivate.refreshClient('new-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 1);
+
+    // Call with actual key - should create new instance on next ensure
+    serviceWithPrivate.refreshClient('new-key');
+    serviceWithPrivate.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    expect(mockInstanceCount).toBe(countAfterInit + 2);
   });
 });
 
@@ -214,6 +240,8 @@ describe('CodexPromptService - OPENAI_BASE_URL handling', () => {
   beforeEach(() => {
     mockInstanceCount = 0;
     mockInstanceBaseUrls = [];
+    mockInstanceConfigs = [];
+    mockClosedInstanceIds = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
   });
@@ -229,41 +257,49 @@ describe('CodexPromptService - OPENAI_BASE_URL handling', () => {
       mockDb
     );
 
-  it('passes OPENAI_BASE_URL into Codex.Codex on construction', () => {
+  it('passes OPENAI_BASE_URL into Codex.Codex when session config is ensured', () => {
     process.env.OPENAI_BASE_URL = 'https://gateway.example.com/v1';
-    makeService('test-api-key');
+    const service = makeService('test-api-key') as any;
+    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceBaseUrls).toEqual(['https://gateway.example.com/v1']);
   });
 
   it('omits baseUrl when OPENAI_BASE_URL is unset', () => {
-    makeService('test-api-key');
+    const service = makeService('test-api-key') as any;
+    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceBaseUrls).toEqual([undefined]);
   });
 
   it('trims whitespace and treats whitespace-only as unset', () => {
     process.env.OPENAI_BASE_URL = '   ';
-    makeService('test-api-key');
+    const service = makeService('test-api-key') as any;
+    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceBaseUrls).toEqual([undefined]);
   });
 
   it('reinitializes Codex when OPENAI_BASE_URL changes between refreshes', () => {
-    const service = makeService('stable-key');
+    const service = makeService('stable-key') as any;
     const countAfterInit = mockInstanceCount;
-
-    // Same key, base URL appears -> must recreate.
-    process.env.OPENAI_BASE_URL = 'https://gateway.example.com/v1';
-    (service as any).refreshClient('stable-key');
+    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
     expect(mockInstanceCount).toBe(countAfterInit + 1);
+
+    // Same key, base URL appears -> next ensure must recreate.
+    process.env.OPENAI_BASE_URL = 'https://gateway.example.com/v1';
+    service.refreshClient('stable-key');
+    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    expect(mockInstanceCount).toBe(countAfterInit + 2);
     expect(mockInstanceBaseUrls.at(-1)).toBe('https://gateway.example.com/v1');
 
     // Same key, same URL -> must NOT recreate (issue #133 protection).
-    (service as any).refreshClient('stable-key');
-    expect(mockInstanceCount).toBe(countAfterInit + 1);
+    service.refreshClient('stable-key');
+    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    expect(mockInstanceCount).toBe(countAfterInit + 2);
 
     // Same key, URL cleared -> must recreate without baseUrl.
     delete process.env.OPENAI_BASE_URL;
-    (service as any).refreshClient('stable-key');
-    expect(mockInstanceCount).toBe(countAfterInit + 2);
+    service.refreshClient('stable-key');
+    service.ensureCodexClient({ model_instructions_file: '/tmp/a.md' });
+    expect(mockInstanceCount).toBe(countAfterInit + 3);
     expect(mockInstanceBaseUrls.at(-1)).toBeUndefined();
   });
 });
@@ -272,6 +308,8 @@ describe('CodexPromptService - forked sessions', () => {
   beforeEach(() => {
     mockInstanceCount = 0;
     mockInstanceBaseUrls = [];
+    mockInstanceConfigs = [];
+    mockClosedInstanceIds = [];
     mockStreamEvents = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
@@ -296,6 +334,9 @@ describe('CodexPromptService - forked sessions', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
     serviceWithPrivates.ensureCodexClient = vi.fn();
     serviceWithPrivates.refreshClient = vi.fn();
 
@@ -448,6 +489,9 @@ describe('CodexPromptService - Todo normalization', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
     serviceWithPrivates.ensureCodexClient = vi.fn();
     serviceWithPrivates.refreshClient = vi.fn();
 
@@ -524,6 +568,9 @@ describe('CodexPromptService - tool payload mapping', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
     serviceWithPrivates.ensureCodexClient = vi.fn();
     serviceWithPrivates.refreshClient = vi.fn();
 
@@ -739,6 +786,9 @@ describe('CodexPromptService - tool payload mapping', () => {
     serviceWithPrivates.buildMcpServersConfig = vi
       .fn()
       .mockResolvedValue({ servers: {}, total: 0 });
+    serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
     serviceWithPrivates.ensureCodexClient = vi.fn();
     serviceWithPrivates.refreshClient = vi.fn();
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -404,7 +404,7 @@ export class CodexPromptService {
    * rotated MCP bearer tokens invalidate the cache even when the config
    * shape stays the same — see `snapshotMcpEnvValues()`.
    */
-  private ensureCodexClient(config: CodexConfigObject): void {
+  private async ensureCodexClient(config: CodexConfigObject): Promise<void> {
     const baseUrl = this.resolveBaseUrl();
     const fingerprint = JSON.stringify({
       apiKey: this.apiKey || '',
@@ -421,7 +421,7 @@ export class CodexPromptService {
     codexDebug(
       `🔄 [Codex] Per-session config changed, reinitializing SDK (apiKey=${this.apiKey ? 'set' : 'unset'}, useNativeAuth=${this.useNativeAuth})`
     );
-    this.replaceCodexClient(this.buildCodexOptions(this.apiKey, baseUrl, config));
+    await this.replaceCodexClient(this.buildCodexOptions(this.apiKey, baseUrl, config));
     this.lastApiKey = this.apiKey || null;
     this.lastBaseUrl = baseUrl ?? null;
     this.lastClientFingerprint = fingerprint;
@@ -430,10 +430,12 @@ export class CodexPromptService {
   /**
    * Best-effort close for SDK clients that expose a lifecycle method. The
    * current Codex SDK API has changed over time, so probe common method names
-   * rather than depending on one concrete type. Closing before replacement keeps
-   * abandoned app-server/MCP transports from flapping alongside the new client.
+   * rather than depending on one concrete type. Awaiting close before replacement
+   * keeps abandoned app-server/MCP transports from overlapping the new client.
    */
-  private closeCodexClient(client: InstanceType<typeof Codex.Codex> | undefined): void {
+  private async closeCodexClient(
+    client: InstanceType<typeof Codex.Codex> | undefined
+  ): Promise<void> {
     if (!client) return;
     const candidate = client as unknown as {
       close?: () => void | Promise<void>;
@@ -444,18 +446,19 @@ export class CodexPromptService {
     if (!close) return;
 
     try {
-      void Promise.resolve(close.call(candidate)).catch((error) => {
-        console.warn('⚠️  [Codex] Failed to close previous SDK client:', error);
-      });
+      await Promise.resolve(close.call(candidate));
     } catch (error) {
       console.warn('⚠️  [Codex] Failed to close previous SDK client:', error);
     }
   }
 
-  private replaceCodexClient(options: ConstructorParameters<typeof Codex.Codex>[0]): void {
+  private async replaceCodexClient(
+    options: ConstructorParameters<typeof Codex.Codex>[0]
+  ): Promise<void> {
     const previous = this.codex;
+    this.codex = undefined;
+    await this.closeCodexClient(previous);
     this.codex = new Codex.Codex(options);
-    this.closeCodexClient(previous);
   }
 
   private getCodexClient(): InstanceType<typeof Codex.Codex> {
@@ -971,7 +974,7 @@ export class CodexPromptService {
 
     // Recreate Codex instance only if the per-session config payload (or
     // apiKey/baseUrl) actually changed — issue #133 protection.
-    this.ensureCodexClient(codexConfigPayload);
+    await this.ensureCodexClient(codexConfigPayload);
 
     codexDebug(
       `   Configured: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}, ${mcpServerCount} MCP server(s)`

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -182,7 +182,7 @@ export type CodexStreamEvent =
     };
 
 export class CodexPromptService {
-  private codex: InstanceType<typeof Codex.Codex>;
+  private codex?: InstanceType<typeof Codex.Codex>;
   private lastApiKey: string | null = null;
   private lastBaseUrl: string | null = null;
   private lastClientFingerprint: string | null = null;
@@ -243,10 +243,11 @@ export class CodexPromptService {
       codexDebug(`🔗 [Codex] Using custom OPENAI_BASE_URL`);
     }
 
-    // Bootstrap Codex SDK without per-session config (rebuilt lazily in
-    // promptSessionStreaming once we know the session's instructions file +
-    // MCP servers).
-    this.codex = new Codex.Codex(this.buildCodexOptions(this.apiKey, baseUrl, undefined));
+    // Do not construct the Codex SDK client until promptSessionStreaming has
+    // resolved the session-scoped config (instructions file + MCP servers).
+    // Constructing here with no MCP config and then replacing it moments later
+    // makes the SDK/app-server briefly start with the wrong lifecycle, which is
+    // visible as MCP disconnect/reconnect waves in gateway-driven turns.
     this.lastClientFingerprint = null;
 
     // Best-effort sweep of orphaned per-session instructions files in
@@ -362,16 +363,13 @@ export class CodexPromptService {
     const baseUrlChanged = (this.lastBaseUrl ?? null) !== (currentBaseUrl ?? null);
     if (this.lastApiKey !== currentApiKey || baseUrlChanged) {
       console.log(
-        `🔄 [Codex] ${this.lastApiKey !== currentApiKey ? 'API key' : 'Base URL'} changed, reinitializing SDK...`
-      );
-      this.codex = new Codex.Codex(
-        this.buildCodexOptions(currentApiKey, currentBaseUrl, undefined)
+        `🔄 [Codex] ${this.lastApiKey !== currentApiKey ? 'API key' : 'Base URL'} changed, invalidating SDK client...`
       );
       this.apiKey = currentApiKey;
       this.lastApiKey = currentApiKey;
       this.lastBaseUrl = currentBaseUrl ?? null;
       this.lastClientFingerprint = null;
-      console.log('✅ [Codex] SDK reinitialized');
+      console.log('✅ [Codex] SDK configuration invalidated');
     }
   }
 
@@ -423,10 +421,48 @@ export class CodexPromptService {
     codexDebug(
       `🔄 [Codex] Per-session config changed, reinitializing SDK (apiKey=${this.apiKey ? 'set' : 'unset'}, useNativeAuth=${this.useNativeAuth})`
     );
-    this.codex = new Codex.Codex(this.buildCodexOptions(this.apiKey, baseUrl, config));
+    this.replaceCodexClient(this.buildCodexOptions(this.apiKey, baseUrl, config));
     this.lastApiKey = this.apiKey || null;
     this.lastBaseUrl = baseUrl ?? null;
     this.lastClientFingerprint = fingerprint;
+  }
+
+  /**
+   * Best-effort close for SDK clients that expose a lifecycle method. The
+   * current Codex SDK API has changed over time, so probe common method names
+   * rather than depending on one concrete type. Closing before replacement keeps
+   * abandoned app-server/MCP transports from flapping alongside the new client.
+   */
+  private closeCodexClient(client: InstanceType<typeof Codex.Codex> | undefined): void {
+    if (!client) return;
+    const candidate = client as unknown as {
+      close?: () => void | Promise<void>;
+      dispose?: () => void | Promise<void>;
+      shutdown?: () => void | Promise<void>;
+    };
+    const close = candidate.close ?? candidate.dispose ?? candidate.shutdown;
+    if (!close) return;
+
+    try {
+      void Promise.resolve(close.call(candidate)).catch((error) => {
+        console.warn('⚠️  [Codex] Failed to close previous SDK client:', error);
+      });
+    } catch (error) {
+      console.warn('⚠️  [Codex] Failed to close previous SDK client:', error);
+    }
+  }
+
+  private replaceCodexClient(options: ConstructorParameters<typeof Codex.Codex>[0]): void {
+    const previous = this.codex;
+    this.codex = new Codex.Codex(options);
+    this.closeCodexClient(previous);
+  }
+
+  private getCodexClient(): InstanceType<typeof Codex.Codex> {
+    if (!this.codex) {
+      throw new Error('Codex SDK client was not initialized before use');
+    }
+    return this.codex;
   }
 
   /**
@@ -1024,7 +1060,7 @@ export class CodexPromptService {
     if (session.sdk_session_id) {
       codexDebug(`🔄 [Codex] Resuming thread: ${session.sdk_session_id}`);
 
-      thread = this.codex.resumeThread(session.sdk_session_id, threadOptions);
+      thread = this.getCodexClient().resumeThread(session.sdk_session_id, threadOptions);
 
       // If approval policy changed, send slash command to update thread settings
       if (approvalPolicyChanged) {
@@ -1054,7 +1090,7 @@ export class CodexPromptService {
           `✅ [Codex MCP] New thread will have ${mcpServerCount} MCP server(s) available via --config flags`
         );
       }
-      thread = this.codex.startThread(threadOptions);
+      thread = this.getCodexClient().startThread(threadOptions);
     }
 
     try {


### PR DESCRIPTION
## Summary

Fixes a Codex-specific MCP client lifecycle issue that can contribute to gateway-driven sessions seeing MCP tools disconnect/reconnect around turn boundaries.

Codex prompt handling previously constructed a `Codex` client eagerly in the prompt service constructor before session-scoped MCP config/instructions were available. The first real prompt then rebuilt the client with the correct config, leaving the earlier unconfigured client unclosed. Repeated API/config refreshes could also replace clients without cleanup.

This PR makes Codex client creation lazy and session-configured, and closes replaced SDK clients when possible.

## Root cause

- `CodexPromptService` eagerly created a client with no session MCP config.
- `ensureCodexClient()` later created a second configured client once session MCP/instruction config was known.
- Replaced clients were not disposed, creating avoidable MCP/client lifecycle churn.

## Fix

- Defer Codex client construction until the first configured use.
- Invalidate the cached client fingerprint on API/base URL refresh instead of immediately creating an unconfigured client.
- Centralize client replacement through a helper that best-effort calls `close`, `dispose`, or `shutdown` on the previous client.
- Route prompt execution through a configured `getCodexClient()` accessor.

## Tests / checks

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/executor test -- sdk-handlers/codex/prompt-service.test.ts`

## Notes

This fixes a concrete Codex lifecycle bug. It does not prove all gateway-driven SDK sessions now hold MCP clients persistently for the entire Agor session lifetime. If issue #1524 still reproduces after merging, the next likely follow-up is broader gateway/SDK session-resident MCP client lifecycle work across other agentic tools.

Refs #1524
