### PR TITLE
fix: save all modified user settings tabs

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -61,7 +61,13 @@ function makeUser(overrides: Partial<User> = {}): User {
   } as User;
 }
 
-describe('UserSettingsModal', () => {
+// This renders the full settings modal plus Ant Form/Menu/Modal plumbing so we
+// can prove dirty defaults survive real tab switches. That is intentionally
+// heavier than a pure unit test and can exceed Vitest's 15s package default on
+// the GitHub runner when the full UI suite is running in parallel.
+const ASYNC = { timeout: 10_000 };
+
+describe('UserSettingsModal', { timeout: 60_000 }, () => {
   it('saves dirty agentic defaults across tabs with the active tab', async () => {
     const user = makeUser({
       default_agentic_config: {
@@ -69,7 +75,7 @@ describe('UserSettingsModal', () => {
         codex: { permissionMode: 'ask', mcpServerIds: [] },
       },
     });
-    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onUpdate = vi.fn();
     const onClose = vi.fn();
 
     renderWithApp(
@@ -87,7 +93,7 @@ describe('UserSettingsModal', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: /claude code/i }));
     await waitFor(() => {
       expect(screen.getByLabelText('claude-code default')).toBeChecked();
-    });
+    }, ASYNC);
     fireEvent.click(screen.getByLabelText('claude-code acceptEdits'));
 
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }));
@@ -103,7 +109,7 @@ describe('UserSettingsModal', () => {
           codex: { permissionMode: 'allow-all', mcpServerIds: [] },
         },
       });
-    });
+    }, ASYNC);
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1,0 +1,109 @@
+import type { AgenticToolName, AgorClient, User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { UserSettingsModal } from './UserSettingsModal';
+
+vi.mock('../ApiKeyFields', () => ({
+  ApiKeyFields: () => null,
+  TOOL_FIELD_CONFIGS: Object.fromEntries(
+    ['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'].map(
+      (tool) => [tool, []]
+    )
+  ),
+}));
+
+vi.mock('../AgenticToolConfigForm', async () => {
+  const { Form, Radio } = await import('antd');
+
+  return {
+    AgenticToolConfigForm: ({ agenticTool }: { agenticTool: AgenticToolName }) => (
+      <Form.Item name="permissionMode" label="Permission Mode">
+        <Radio.Group>
+          <Radio value="default">{agenticTool} default</Radio>
+          <Radio value="acceptEdits">{agenticTool} acceptEdits</Radio>
+          <Radio value="ask">{agenticTool} ask</Radio>
+          <Radio value="allow-all">{agenticTool} allow-all</Radio>
+        </Radio.Group>
+      </Form.Item>
+    ),
+    buildConfigFromFormValues: (
+      _tool: AgenticToolName,
+      values: { permissionMode?: string; mcpServerIds?: string[] }
+    ) => ({
+      permissionMode: values.permissionMode,
+      mcpServerIds: values.mcpServerIds ?? [],
+    }),
+    getClearedFormValues: () => ({ permissionMode: 'default', mcpServerIds: [] }),
+    getFormValuesFromConfig: (
+      _tool: AgenticToolName,
+      config?: { permissionMode?: string; mcpServerIds?: string[] }
+    ) => ({
+      permissionMode: config?.permissionMode ?? 'default',
+      mcpServerIds: config?.mcpServerIds ?? [],
+    }),
+  };
+});
+
+function renderWithApp(children: ReactNode) {
+  return render(<AntApp>{children}</AntApp>);
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    user_id: 'user-1',
+    email: 'admin@agor.live',
+    name: 'Admin',
+    role: 'member',
+    default_agentic_config: {},
+    ...overrides,
+  } as User;
+}
+
+describe('UserSettingsModal', () => {
+  it('saves dirty agentic defaults across tabs with the active tab', async () => {
+    const user = makeUser({
+      default_agentic_config: {
+        'claude-code': { permissionMode: 'default', mcpServerIds: [] },
+        codex: { permissionMode: 'ask', mcpServerIds: [] },
+      },
+    });
+    const onUpdate = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={onClose}
+        user={user}
+        currentUser={user}
+        client={null as AgorClient | null}
+        mcpServerById={new Map()}
+        onUpdate={onUpdate}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /claude code/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText('claude-code default')).toBeChecked();
+    });
+    fireEvent.click(screen.getByLabelText('claude-code acceptEdits'));
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }));
+    await screen.findByRole('heading', { name: 'Codex' });
+    fireEvent.click(screen.getByLabelText('codex allow-all'));
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith('user-1', {
+        default_agentic_config: {
+          'claude-code': { permissionMode: 'acceptEdits', mcpServerIds: [] },
+          codex: { permissionMode: 'allow-all', mcpServerIds: [] },
+        },
+      });
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -322,7 +322,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     };
 
     for (const tool of tools) {
-      const values = agenticConfigDraftByTool[tool] ?? agenticFormByTool[tool].getFieldsValue();
+      const values: AgenticConfigFormValues =
+        agenticConfigDraftByTool[tool] ??
+        (agenticFormByTool[tool].getFieldsValue() as AgenticConfigFormValues);
       nextConfig[tool] = buildConfigFromFormValues(tool, values);
     }
 

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -67,6 +67,8 @@ const AGENTIC_TOOL_TABS = [
   'cursor',
 ] as const satisfies readonly AgenticToolName[];
 
+type AgenticConfigFormValues = Parameters<typeof buildConfigFromFormValues>[1];
+
 const isAgenticToolTab = (value: string): value is AgenticToolName =>
   AGENTIC_TOOL_TABS.includes(value as AgenticToolName);
 
@@ -155,11 +157,28 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     copilot: false,
     cursor: false,
   });
+  const [dirtyAgenticConfigTools, setDirtyAgenticConfigTools] = useState<Set<AgenticToolName>>(
+    () => new Set()
+  );
+  const [agenticConfigDraftByTool, setAgenticConfigDraftByTool] = useState<
+    Partial<Record<AgenticToolName, AgenticConfigFormValues>>
+  >({});
+
+  const markAgenticConfigDirty = useCallback((tool: AgenticToolName) => {
+    setDirtyAgenticConfigTools((prev) => {
+      if (prev.has(tool)) return prev;
+      const next = new Set(prev);
+      next.add(tool);
+      return next;
+    });
+  }, []);
 
   // Initialize forms when user changes or modal opens
   const initializeForms = useCallback(
     (userData: User) => {
       setActiveTab('general');
+      setDirtyAgenticConfigTools(new Set());
+      setAgenticConfigDraftByTool({});
 
       form.setFieldsValue({
         email: userData.email,
@@ -221,7 +240,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
     if (isAgenticToolTab(activeTab)) {
       agenticFormByTool[activeTab].setFieldsValue(
-        getFormValuesFromConfig(activeTab, user.default_agentic_config?.[activeTab])
+        agenticConfigDraftByTool[activeTab] ??
+          getFormValuesFromConfig(activeTab, user.default_agentic_config?.[activeTab])
       );
       return;
     }
@@ -236,7 +256,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           audioPrefs?.minDurationSeconds ?? DEFAULT_AUDIO_PREFERENCES.minDurationSeconds,
       });
     }
-  }, [activeTab, audioForm, agenticFormByTool, open, user]);
+  }, [activeTab, agenticConfigDraftByTool, audioForm, agenticFormByTool, open, user]);
 
   // Rehydrate per-tool credential presence and env-var metadata from the
   // server every time the modal opens, so flags reflect the latest patch.
@@ -275,6 +295,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     setAvailableGroups([]);
     setUserGroupIds([]);
     setGroupsLoaded(false);
+    setDirtyAgenticConfigTools(new Set());
+    setAgenticConfigDraftByTool({});
     setActiveTab('general');
     onClose();
   };
@@ -285,43 +307,83 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     setUserGroupIds(nextGroupIds);
   };
 
-  const handleUpdate = () => {
+  const getAgenticConfigToolsToSave = (activeTool?: AgenticToolName): AgenticToolName[] => [
+    ...new Set([
+      ...dirtyAgenticConfigTools,
+      ...(activeTool ? [activeTool] : []),
+    ] satisfies AgenticToolName[]),
+  ];
+
+  const saveAgenticConfigs = async (tools: AgenticToolName[]) => {
+    if (!user || tools.length === 0) return;
+
+    const nextConfig: NonNullable<UpdateUserInput['default_agentic_config']> = {
+      ...(user.default_agentic_config ?? {}),
+    };
+
+    for (const tool of tools) {
+      const values = agenticConfigDraftByTool[tool] ?? agenticFormByTool[tool].getFieldsValue();
+      nextConfig[tool] = buildConfigFromFormValues(tool, values);
+    }
+
+    await onUpdate?.(user.user_id, {
+      default_agentic_config: nextConfig,
+    });
+
+    setDirtyAgenticConfigTools((prev) => {
+      if (prev.size === 0) return prev;
+      const next = new Set(prev);
+      for (const tool of tools) {
+        next.delete(tool);
+      }
+      return next;
+    });
+    setAgenticConfigDraftByTool((prev) => {
+      const next = { ...prev };
+      for (const tool of tools) {
+        delete next[tool];
+      }
+      return next;
+    });
+  };
+
+  const saveDirtyAgenticConfigs = async () => {
+    await saveAgenticConfigs(getAgenticConfigToolsToSave());
+  };
+
+  const handleUpdate = async () => {
     if (!user) return;
 
-    form
-      .validateFields(['email', 'name', 'emoji', 'role', 'unix_username'])
-      .then(async () => {
-        const values = form.getFieldsValue();
-        const updates: UpdateUserInput = {
-          email: values.email,
-          name: values.name,
-          emoji: values.emoji,
-          role: values.role,
-          unix_username: values.unix_username,
-          preferences: {
-            ...user.preferences,
-            eventStream: {
-              enabled: values.eventStreamEnabled ?? true,
-            },
+    try {
+      await form.validateFields(['email', 'name', 'emoji', 'role', 'unix_username']);
+      const values = form.getFieldsValue();
+      const updates: UpdateUserInput = {
+        email: values.email,
+        name: values.name,
+        emoji: values.emoji,
+        role: values.role,
+        unix_username: values.unix_username,
+        preferences: {
+          ...user.preferences,
+          eventStream: {
+            enabled: values.eventStreamEnabled ?? true,
           },
-        };
-        if (values.password?.trim()) {
-          updates.password = values.password;
-        }
-        // Only admins can set must_change_password, and only for other users
-        if (
-          hasMinimumRole(currentUser?.role, ROLES.ADMIN) &&
-          user.user_id !== currentUser?.user_id
-        ) {
-          updates.must_change_password = values.must_change_password;
-        }
-        await onUpdate?.(user.user_id, updates);
-        await syncUserGroups(values.groupIds || []);
-        handleClose();
-      })
-      .catch((err) => {
-        console.error('Validation failed:', err);
-      });
+        },
+      };
+      if (values.password?.trim()) {
+        updates.password = values.password;
+      }
+      // Only admins can set must_change_password, and only for other users
+      if (hasMinimumRole(currentUser?.role, ROLES.ADMIN) && user.user_id !== currentUser?.user_id) {
+        updates.must_change_password = values.must_change_password;
+      }
+      await onUpdate?.(user.user_id, updates);
+      await syncUserGroups(values.groupIds || []);
+      await saveDirtyAgenticConfigs();
+      handleClose();
+    } catch (err) {
+      console.error('Validation failed:', err);
+    }
   };
 
   // Persist a per-tool credential field. Patch is shaped as
@@ -447,33 +509,36 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const handleAgenticConfigSave = async (tool: AgenticToolName) => {
     if (!user) return;
 
+    const toolsToSave = getAgenticConfigToolsToSave(tool);
+
     try {
-      setSavingAgenticConfig((prev) => ({ ...prev, [tool]: true }));
-
-      const values = agenticFormByTool[tool].getFieldsValue() as Parameters<
-        typeof buildConfigFromFormValues
-      >[1];
-      const newConfig = {
-        ...user.default_agentic_config,
-        [tool]: buildConfigFromFormValues(tool, values),
-      };
-
-      await onUpdate?.(user.user_id, {
-        default_agentic_config: newConfig,
+      setSavingAgenticConfig((prev) => {
+        const next = { ...prev };
+        for (const toolName of toolsToSave) next[toolName] = true;
+        return next;
       });
+
+      await saveAgenticConfigs(toolsToSave);
 
       handleClose();
     } catch (err) {
       console.error(`Failed to save ${tool} config:`, err);
       throw err;
     } finally {
-      setSavingAgenticConfig((prev) => ({ ...prev, [tool]: false }));
+      setSavingAgenticConfig((prev) => {
+        const next = { ...prev };
+        for (const toolName of toolsToSave) next[toolName] = false;
+        return next;
+      });
     }
   };
 
   // Handle agentic tool config clear
   const handleAgenticConfigClear = (tool: AgenticToolName) => {
-    agenticFormByTool[tool].setFieldsValue(getClearedFormValues(tool));
+    const clearedValues = getClearedFormValues(tool);
+    agenticFormByTool[tool].setFieldsValue(clearedValues);
+    setAgenticConfigDraftByTool((prev) => ({ ...prev, [tool]: clearedValues }));
+    markAgenticConfigDirty(tool);
   };
 
   const handleAudioSave = async () => {
@@ -491,10 +556,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         },
       };
 
-      onUpdate(user.user_id, {
+      await onUpdate(user.user_id, {
         preferences: updatedPreferences,
       });
 
+      await saveDirtyAgenticConfigs();
       handleClose();
     } catch (error) {
       console.error('Failed to save audio settings:', error);
@@ -512,10 +578,12 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       case 'env-vars':
       case 'personal-api-keys':
         // These tabs save individually, just close
+        await saveDirtyAgenticConfigs();
         handleClose();
         break;
       case 'groups':
         await syncUserGroups(form.getFieldValue('groupIds') || []);
+        await saveDirtyAgenticConfigs();
         handleClose();
         break;
       case 'audio':
@@ -852,7 +920,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
               Configure default settings for {displayNames[toolName]}. These will prepopulate
               session creation forms.
             </Typography.Paragraph>
-            <Form form={currentForm} layout="vertical">
+            <Form
+              key={toolName}
+              form={currentForm}
+              layout="vertical"
+              onValuesChange={(_, allValues) => {
+                setAgenticConfigDraftByTool((prev) => ({ ...prev, [toolName]: allValues }));
+                markAgenticConfigDirty(toolName);
+              }}
+            >
               <AgenticToolConfigForm
                 agenticTool={toolName}
                 mcpServerById={mcpServerById}


### PR DESCRIPTION
## Summary

Updates User Settings so saving after editing multiple Agentic Tools default tabs persists every modified tab, not just the currently visible one.

## Root cause

The modal-level save path only read the active tool form before closing, so earlier tab edits were left out of the `default_agentic_config` update.

## Changes

- Track dirty Agentic Tools default tabs and keep per-tool draft values while switching tabs.
- Save all dirty defaults together with the active tab while preserving untouched existing defaults.
- Flush pending agentic default edits when saving from other User Settings sections.
- Add focused regression coverage for saving defaults across multiple tabs.
- Stabilize the full modal regression for the GitHub runner timeout budget.

## Validation

- `pnpm --filter agor-ui typecheck`
- `pnpm --filter agor-ui test -- UserSettingsModal`
- `pnpm --filter agor-ui exec biome check src/components/SettingsModal/UserSettingsModal.tsx src/components/SettingsModal/UserSettingsModal.test.tsx`
- GitHub CI: `Lint, typecheck, build, test` passed on `266e1cda`.
- GitHub smoke test: `Pack + boot + curl` passed on `266e1cda`.
- Browser validation confirmed Claude Code and Codex default edits persisted together after saving from the Codex tab.

Fixes #351.
