### PR TITLE
Add Knowledge heading anchors

### DIFF
--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
@@ -73,3 +73,41 @@
   max-width: 100%;
   max-height: 150px;
 }
+
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+  scroll-margin-top: 24px;
+}
+
+.markdown-heading-anchor {
+  margin-left: 0.35em;
+  color: inherit;
+  font-size: 0.82em;
+  opacity: 0;
+  text-decoration: none;
+  transition: opacity 120ms ease;
+}
+
+.markdown-content h1:hover .markdown-heading-anchor,
+.markdown-content h2:hover .markdown-heading-anchor,
+.markdown-content h3:hover .markdown-heading-anchor,
+.markdown-content h4:hover .markdown-heading-anchor,
+.markdown-content h5:hover .markdown-heading-anchor,
+.markdown-content h6:hover .markdown-heading-anchor,
+.markdown-heading-anchor:focus {
+  opacity: 0.55;
+}
+
+.markdown-content h1 .markdown-heading-anchor:hover,
+.markdown-content h2 .markdown-heading-anchor:hover,
+.markdown-content h3 .markdown-heading-anchor:hover,
+.markdown-content h4 .markdown-heading-anchor:hover,
+.markdown-content h5 .markdown-heading-anchor:hover,
+.markdown-content h6 .markdown-heading-anchor:hover {
+  opacity: 0.85;
+  text-decoration: none;
+}

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -19,4 +19,13 @@ describe('MarkdownRenderer', () => {
       screen.queryByText('Add semantic and hybrid search once embeddings are configured.')
     ).not.toBeInTheDocument();
   });
+
+  it('adds stable ids and self-links when heading anchors are enabled', async () => {
+    const { container } = render(<MarkdownRenderer content={'## Foo\n\n## Foo!'} headingAnchors />);
+
+    const headings = await screen.findAllByRole('heading', { level: 2 });
+    expect(headings.map((heading) => heading.id)).toEqual(['foo', 'foo-1']);
+    expect(container.querySelector('a.markdown-heading-anchor[href="#foo"]')).toBeInTheDocument();
+    expect(container.querySelector('a.markdown-heading-anchor[href="#foo-1"]')).toBeInTheDocument();
+  });
 });

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -25,7 +25,9 @@ describe('MarkdownRenderer', () => {
 
     const headings = await screen.findAllByRole('heading', { level: 2 });
     expect(headings.map((heading) => heading.id)).toEqual(['foo', 'foo-1']);
-    expect(container.querySelector('a.markdown-heading-anchor[href="#foo"]')).toBeInTheDocument();
+    const firstAnchor = container.querySelector('a.markdown-heading-anchor[href="#foo"]');
+    expect(firstAnchor).toBeInTheDocument();
+    expect(firstAnchor).not.toHaveAttribute('target', '_blank');
     expect(container.querySelector('a.markdown-heading-anchor[href="#foo-1"]')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -116,7 +116,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   return (
     <Typography style={mergedStyles} className={compact ? 'markdown-compact' : undefined}>
       <Streamdown
-        key={isStreaming ? undefined : markdownContentKey(rawText)}
+        key={isStreaming ? undefined : markdownContentKey(rawText, { headingAnchors })}
         parseIncompleteMarkdown={isStreaming} // Parse incomplete syntax only while streaming
         className={inline ? 'inline-markdown' : 'markdown-content'}
         isAnimating={isStreaming} // Disable buttons during streaming
@@ -138,7 +138,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
 export const MarkdownRenderer = React.memo(MarkdownRendererInner);
 MarkdownRenderer.displayName = 'MarkdownRenderer';
 
-function markdownContentKey(text: string): string {
+function markdownContentKey(text: string, options: { headingAnchors?: boolean } = {}): string {
   // Streamdown memoizes several rendered markdown node components by AST
   // position. Container positions (for example a `<ul>` spanning multiple
   // bullets) do not change when text changes inside an earlier child line, so
@@ -150,7 +150,9 @@ function markdownContentKey(text: string): string {
     hash ^= text.charCodeAt(i);
     hash = Math.imul(hash, 0x01000193);
   }
-  return `${text.length}:${(hash >>> 0).toString(36)}`;
+  return `${options.headingAnchors ? 'anchors' : 'plain'}:${text.length}:${(hash >>> 0).toString(
+    36
+  )}`;
 }
 
 const parseMarkdownAsSingleBlock = (markdown: string) => [markdown];

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -103,6 +103,10 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
       headingAnchors ? [...Object.values(defaultRehypePlugins), rehypeHeadingAnchors] : undefined,
     [headingAnchors]
   );
+  const components = useMemo(
+    () => (headingAnchors ? { a: MarkdownAnchor } : undefined),
+    [headingAnchors]
+  );
 
   // Use default dual theme [light, dark] - Streamdown handles CSS-based switching
   // Note: This may render both themes in the DOM, controlled by CSS media queries
@@ -118,7 +122,10 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
         isAnimating={isStreaming} // Disable buttons during streaming
         controls={showControls} // Show/hide controls based on context
         mermaidConfig={mermaidConfig} // Set Mermaid theme based on current theme mode
+        components={components}
         rehypePlugins={rehypePlugins}
+        // Keep anchored documents in one Streamdown block so the heading slugger
+        // sees the whole document and duplicate headings are deduped globally.
         parseMarkdownIntoBlocksFn={headingAnchors ? parseMarkdownAsSingleBlock : undefined}
         // Use default ['github-light', 'github-dark'] for automatic theme switching
       >
@@ -147,3 +154,32 @@ function markdownContentKey(text: string): string {
 }
 
 const parseMarkdownAsSingleBlock = (markdown: string) => [markdown];
+
+type MarkdownAnchorProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  node?: unknown;
+};
+
+function MarkdownAnchor({ children, className, href, node: _node, ...props }: MarkdownAnchorProps) {
+  if (className?.split(/\s+/).includes('markdown-heading-anchor') && href?.startsWith('#')) {
+    return (
+      <a className={className} href={href} {...props}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <a
+      className={['wrap-anywhere font-medium text-primary underline', className]
+        .filter(Boolean)
+        .join(' ')}
+      data-streamdown="link"
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -12,8 +12,9 @@
  */
 
 import { Typography, theme } from 'antd';
-import React from 'react';
-import { Streamdown } from 'streamdown';
+import React, { useMemo } from 'react';
+import { defaultRehypePlugins, Streamdown } from 'streamdown';
+import { rehypeHeadingAnchors } from '../../utils/headingAnchors';
 import { highlightMentionsInMarkdown } from '../../utils/highlightMentions';
 import { isDarkTheme } from '../../utils/theme';
 import './MarkdownRenderer.css';
@@ -46,6 +47,11 @@ interface MarkdownRendererProps {
    * Useful for compact contexts where controls add clutter
    */
   showControls?: boolean;
+  /**
+   * If true, rendered headings receive stable ids and visible self-links.
+   * Intended for non-streaming document views such as Knowledge Base pages.
+   */
+  headingAnchors?: boolean;
 }
 
 // Memoized: Streamdown does meaningful per-render work (syntax highlighting,
@@ -62,6 +68,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   isStreaming = false,
   compact = false,
   showControls = true,
+  headingAnchors = false,
 }) => {
   const { token } = theme.useToken();
 
@@ -91,6 +98,11 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
     : {};
 
   const mergedStyles = { ...style, ...compactStyles };
+  const rehypePlugins = useMemo(
+    () =>
+      headingAnchors ? [...Object.values(defaultRehypePlugins), rehypeHeadingAnchors] : undefined,
+    [headingAnchors]
+  );
 
   // Use default dual theme [light, dark] - Streamdown handles CSS-based switching
   // Note: This may render both themes in the DOM, controlled by CSS media queries
@@ -106,6 +118,8 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
         isAnimating={isStreaming} // Disable buttons during streaming
         controls={showControls} // Show/hide controls based on context
         mermaidConfig={mermaidConfig} // Set Mermaid theme based on current theme mode
+        rehypePlugins={rehypePlugins}
+        parseMarkdownIntoBlocksFn={headingAnchors ? parseMarkdownAsSingleBlock : undefined}
         // Use default ['github-light', 'github-dark'] for automatic theme switching
       >
         {text}
@@ -131,3 +145,5 @@ function markdownContentKey(text: string): string {
   }
   return `${text.length}:${(hash >>> 0).toString(36)}`;
 }
+
+const parseMarkdownAsSingleBlock = (markdown: string) => [markdown];

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -1888,13 +1888,15 @@ export function KnowledgePage({
       documentPath: activeDoc.path,
       currentSearch: location.search,
     });
-    const currentUrl = `${location.pathname}${location.search}`;
-    if (targetUrl !== currentUrl) navigate(targetUrl, { replace: true });
+    const targetUrlWithHash = `${targetUrl}${location.hash}`;
+    const currentUrl = `${location.pathname}${location.search}${location.hash}`;
+    if (targetUrlWithHash !== currentUrl) navigate(targetUrlWithHash, { replace: true });
   }, [
     activeDoc,
     activeDocId,
     documents,
     draftDocument,
+    location.hash,
     location.pathname,
     location.search,
     namespaceSlugForDocument,
@@ -2849,6 +2851,29 @@ export function KnowledgePage({
     Boolean(activeDoc && (!activeDocMatchesRoute || !activeDocContentReady));
   const fillMain = isEditing || showGraph || showDocumentLoading || showRouteDocumentFailure;
 
+  useEffect(() => {
+    if (!location.hash || isEditing || showDocumentLoading || !activeDocMatchesRoute) return;
+
+    const hash = location.hash.slice(1);
+    const targetId = safeDecodeURIComponent(hash);
+    let cancelled = false;
+    const scrollToHeading = () => {
+      if (cancelled) return;
+      const target =
+        document.getElementById(targetId) ||
+        (targetId !== hash ? document.getElementById(hash) : null);
+      target?.scrollIntoView({ block: 'start' });
+    };
+
+    const frame = window.requestAnimationFrame(scrollToHeading);
+    const timeout = window.setTimeout(scrollToHeading, 80);
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timeout);
+    };
+  }, [activeDocMatchesRoute, isEditing, location.hash, showDocumentLoading]);
+
   return (
     <Layout style={{ height: '100vh', overflow: 'hidden', background: token.colorBgLayout }}>
       <Header
@@ -3458,7 +3483,10 @@ export function KnowledgePage({
                               background: token.colorBgContainer,
                             }}
                           >
-                            <MarkdownRenderer content={hydrateKbLinks(markdownDraft)} />
+                            <MarkdownRenderer
+                              content={hydrateKbLinks(markdownDraft)}
+                              headingAnchors
+                            />
                           </div>
                         </div>
                       </Flex>
@@ -3477,6 +3505,7 @@ export function KnowledgePage({
                               ? stripFirstMarkdownTitleLine(markdownDraft)
                               : markdownDraft
                           )}
+                          headingAnchors
                         />
                       </div>
                     )}
@@ -3666,6 +3695,7 @@ export function KnowledgePage({
                     </Space>
                     <MarkdownRenderer
                       content={hydrateKbLinks(selectedVersion.content_text ?? '')}
+                      headingAnchors
                     />
                   </Space>
                 </div>

--- a/apps/agor-ui/src/utils/headingAnchors.test.ts
+++ b/apps/agor-ui/src/utils/headingAnchors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { createHeadingSlugger, extractHastText, slugifyHeadingText } from './headingAnchors';
+
+describe('heading anchor helpers', () => {
+  it('creates stable slugs from heading text', () => {
+    expect(slugifyHeadingText('Hello, World!')).toBe('hello-world');
+    expect(slugifyHeadingText(' Crème brûlée & API_v2 ')).toBe('creme-brulee-api-v2');
+    expect(slugifyHeadingText('!!!')).toBe('heading');
+  });
+
+  it('deduplicates duplicate headings in source order', () => {
+    const slug = createHeadingSlugger();
+    expect([slug('Foo'), slug('Foo!'), slug('Foo')]).toEqual(['foo', 'foo-1', 'foo-2']);
+  });
+
+  it('extracts nested heading text from hast nodes', () => {
+    expect(
+      extractHastText({
+        type: 'element',
+        tagName: 'h2',
+        children: [
+          { type: 'text', value: 'Use ' },
+          { type: 'element', tagName: 'code', children: [{ type: 'text', value: 'agor' }] },
+        ],
+      })
+    ).toBe('Use agor');
+  });
+});

--- a/apps/agor-ui/src/utils/headingAnchors.ts
+++ b/apps/agor-ui/src/utils/headingAnchors.ts
@@ -1,0 +1,83 @@
+const HEADING_TAG_RE = /^h[1-6]$/;
+
+interface HeadingSluggerState {
+  seen: Map<string, number>;
+}
+
+interface HastNode {
+  type?: string;
+  tagName?: string;
+  value?: unknown;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+}
+
+export function slugifyHeadingText(text: string): string {
+  const slug = text
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{Letter}\p{Number}\s_-]/gu, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  return slug || 'heading';
+}
+
+export function createHeadingSlugger() {
+  const state: HeadingSluggerState = { seen: new Map() };
+
+  return (text: string): string => {
+    const base = slugifyHeadingText(text);
+    const count = state.seen.get(base) ?? 0;
+    state.seen.set(base, count + 1);
+    return count === 0 ? base : `${base}-${count}`;
+  };
+}
+
+export function extractHastText(node: HastNode | undefined): string {
+  if (!node) return '';
+  if (node.type === 'text' || node.type === 'inlineCode') {
+    return typeof node.value === 'string' ? node.value : '';
+  }
+  return (node.children ?? []).map(extractHastText).join('');
+}
+
+function visit(node: HastNode, visitor: (node: HastNode) => void) {
+  visitor(node);
+  for (const child of node.children ?? []) visit(child, visitor);
+}
+
+/**
+ * Rehype plugin that assigns deterministic GitHub-like ids to headings and adds
+ * a small self-link. The slugger is per rendered markdown document, so duplicate
+ * headings become `foo`, `foo-1`, `foo-2` in source order.
+ */
+export function rehypeHeadingAnchors() {
+  return (tree: HastNode) => {
+    const slug = createHeadingSlugger();
+
+    visit(tree, (node) => {
+      if (node.type !== 'element' || !node.tagName || !HEADING_TAG_RE.test(node.tagName)) return;
+
+      const text = extractHastText(node);
+      const id = slug(text);
+      node.properties = { ...(node.properties ?? {}), id };
+      node.children = [
+        ...(node.children ?? []),
+        {
+          type: 'element',
+          tagName: 'a',
+          properties: {
+            className: ['markdown-heading-anchor'],
+            href: `#${id}`,
+            ariaLabel: `Link to ${text || 'heading'}`,
+          },
+          children: [{ type: 'text', value: '#' }],
+        },
+      ];
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- add a scoped `MarkdownRenderer` heading-anchor mode for Knowledge Base pages
- generate stable duplicate-safe heading ids and hover/focus self-links
- preserve URL fragments during Knowledge route mirroring and scroll to headings after content loads

## Notes
- Existing `agor://kb/document/<id>` hydration continues to work; fragments on those hydrated links are preserved.
- Path-style raw `agor://kb/<namespace>/<path>#heading` links are left for a follow-up.

## Checks
- `pnpm i`
- `pnpm check`
- `pnpm --dir apps/agor-ui test -- headingAnchors MarkdownRenderer KnowledgePage.routing --run`
