### PR TITLE
Show failed task state on branch session rows

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -22,6 +22,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isPromptFlowPatchOnly,
   PROMPT_FLOW_PATCH_FIELDS,
+  shouldRunSessionPostTurnHooks,
   shouldValidateRepoEnvironmentPayload,
 } from './register-hooks';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization';
@@ -35,6 +36,25 @@ describe('shouldValidateRepoEnvironmentPayload', () => {
   it('validates present repo environment payloads', () => {
     expect(shouldValidateRepoEnvironmentPayload({})).toBe(true);
     expect(shouldValidateRepoEnvironmentPayload('invalid shape')).toBe(true);
+  });
+});
+
+describe('shouldRunSessionPostTurnHooks', () => {
+  it('runs for idle sessions, preserving stop-route gateway finalization behavior', () => {
+    expect(shouldRunSessionPostTurnHooks({ status: 'idle', ready_for_prompt: false })).toBe(true);
+  });
+
+  it('runs for failed sessions only once they are promptable', () => {
+    expect(shouldRunSessionPostTurnHooks({ status: 'failed', ready_for_prompt: true })).toBe(true);
+    expect(shouldRunSessionPostTurnHooks({ status: 'failed', ready_for_prompt: false })).toBe(
+      false
+    );
+  });
+
+  it('does not run for busy sessions', () => {
+    expect(shouldRunSessionPostTurnHooks({ status: 'running', ready_for_prompt: false })).toBe(
+      false
+    );
   });
 });
 

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -22,6 +22,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isPromptFlowPatchOnly,
   PROMPT_FLOW_PATCH_FIELDS,
+  shouldDrainQueueAfterSessionPostTurnPatch,
   shouldRunSessionPostTurnHooks,
   shouldValidateRepoEnvironmentPayload,
 } from './register-hooks';
@@ -55,6 +56,32 @@ describe('shouldRunSessionPostTurnHooks', () => {
     expect(shouldRunSessionPostTurnHooks({ status: 'running', ready_for_prompt: false })).toBe(
       false
     );
+  });
+});
+
+describe('shouldDrainQueueAfterSessionPostTurnPatch', () => {
+  it('drains for promptable ready sessions by default', () => {
+    expect(
+      shouldDrainQueueAfterSessionPostTurnPatch({ status: 'failed', ready_for_prompt: true })
+    ).toBe(true);
+    expect(
+      shouldDrainQueueAfterSessionPostTurnPatch({ status: 'idle', ready_for_prompt: true })
+    ).toBe(true);
+  });
+
+  it('does not drain when terminal queue processing is explicitly suppressed', () => {
+    expect(
+      shouldDrainQueueAfterSessionPostTurnPatch(
+        { status: 'failed', ready_for_prompt: true },
+        { suppressTerminalQueueProcessing: true }
+      )
+    ).toBe(false);
+  });
+
+  it('does not drain for promptable-but-not-ready acknowledgement states', () => {
+    expect(
+      shouldDrainQueueAfterSessionPostTurnPatch({ status: 'idle', ready_for_prompt: false })
+    ).toBe(false);
   });
 });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -125,6 +125,7 @@ import {
   recomputeNextRunAt,
   validateScheduleConfig,
 } from './utils/schedule-hooks.js';
+import { sessionCanStartTask } from './utils/session-task-state.js';
 import {
   createServiceToken,
   getDaemonUrl,
@@ -287,6 +288,12 @@ export function isPromptFlowPatchOnly(data: unknown): boolean {
   const keys = Object.keys(data);
   if (keys.length === 0) return false;
   return keys.every((key) => PROMPT_FLOW_PATCH_FIELDS.includes(key));
+}
+
+export function shouldRunSessionPostTurnHooks(
+  session: Pick<Session, 'status' | 'ready_for_prompt'>
+): boolean {
+  return sessionCanStartTask(session.status, session.ready_for_prompt);
 }
 
 /**
@@ -2379,11 +2386,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       patch: [
         async (context) => {
-          // Automatically process queued tasks when session becomes IDLE
-          // This ensures queued tasks are processed regardless of how the session became IDLE
+          // Automatically run post-turn side effects when a session becomes promptable.
+          // Historically that meant IDLE; failed terminal tasks are now promptable too
+          // (status=failed, ready_for_prompt=true) so the UI can surface the failure
+          // without blocking queue draining or gateway finalization.
           const session = Array.isArray(context.result) ? context.result[0] : context.result;
 
-          if (session && session.status === 'idle') {
+          if (session && shouldRunSessionPostTurnHooks(session)) {
             // Flush GitHub message buffer (fire-and-forget).
             // When a GitHub-connected session finishes its turn, post the last
             // buffered message as a PR/issue comment. Must happen before queue
@@ -2409,7 +2418,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               setImmediate(async () => {
                 try {
                   console.log(
-                    `🔄 [SessionsService.after.patch] Session ${shortId(session.session_id)} became IDLE, checking for queued tasks...`
+                    `🔄 [SessionsService.after.patch] Session ${shortId(session.session_id)} became promptable (${session.status}), checking for queued tasks...`
                   );
 
                   await sessionsService.triggerQueueProcessing(session.session_id, context.params);

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -296,6 +296,17 @@ export function shouldRunSessionPostTurnHooks(
   return sessionCanStartTask(session.status, session.ready_for_prompt);
 }
 
+export function shouldDrainQueueAfterSessionPostTurnPatch(
+  session: Pick<Session, 'status' | 'ready_for_prompt'>,
+  params?: Params
+): boolean {
+  return (
+    shouldRunSessionPostTurnHooks(session) &&
+    session.ready_for_prompt === true &&
+    params?.suppressTerminalQueueProcessing !== true
+  );
+}
+
 /**
  * Extended Params with route ID parameter (needed by artifact routes in hooks).
  */
@@ -2413,7 +2424,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               }
             });
 
-            if (session.ready_for_prompt) {
+            if (shouldDrainQueueAfterSessionPostTurnPatch(session, context.params)) {
               // Use setImmediate to avoid blocking the patch response
               setImmediate(async () => {
                 try {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -125,7 +125,10 @@ import {
   recomputeNextRunAt,
   validateScheduleConfig,
 } from './utils/schedule-hooks.js';
-import { sessionCanStartTask } from './utils/session-task-state.js';
+import {
+  isTerminalQueueProcessingSuppressed,
+  sessionCanStartTask,
+} from './utils/session-task-state.js';
 import {
   createServiceToken,
   getDaemonUrl,
@@ -303,7 +306,7 @@ export function shouldDrainQueueAfterSessionPostTurnPatch(
   return (
     shouldRunSessionPostTurnHooks(session) &&
     session.ready_for_prompt === true &&
-    params?.suppressTerminalQueueProcessing !== true
+    !isTerminalQueueProcessingSuppressed(params)
   );
 }
 

--- a/apps/agor-daemon/src/register-routes.test.ts
+++ b/apps/agor-daemon/src/register-routes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionsServiceImpl } from './declarations';
+import { markStoppedSessionPromptableAndDrainQueue } from './register-routes';
+
+describe('markStoppedSessionPromptableAndDrainQueue', () => {
+  it('marks the session promptable before triggering queue processing', async () => {
+    const calls: string[] = [];
+    const params = { provider: 'rest' };
+    const sessionsService = {
+      patch: vi.fn(async () => {
+        calls.push('patch');
+        return {};
+      }),
+      triggerQueueProcessing: vi.fn(async () => {
+        calls.push('drain');
+      }),
+    } as unknown as Pick<SessionsServiceImpl, 'patch' | 'triggerQueueProcessing'>;
+
+    await markStoppedSessionPromptableAndDrainQueue(sessionsService, 'session-1' as never, params);
+
+    expect(sessionsService.patch).toHaveBeenCalledWith(
+      'session-1',
+      { status: 'idle', ready_for_prompt: true },
+      params
+    );
+    expect(sessionsService.triggerQueueProcessing).toHaveBeenCalledWith('session-1', params);
+    expect(calls).toEqual(['patch', 'drain']);
+  });
+
+  it('does not trigger the queue if the session patch fails', async () => {
+    const sessionsService = {
+      patch: vi.fn(async () => {
+        throw new Error('patch denied');
+      }),
+      triggerQueueProcessing: vi.fn(async () => {}),
+    } as unknown as Pick<SessionsServiceImpl, 'patch' | 'triggerQueueProcessing'>;
+
+    await expect(
+      markStoppedSessionPromptableAndDrainQueue(sessionsService, 'session-1' as never, {})
+    ).rejects.toThrow('patch denied');
+    expect(sessionsService.triggerQueueProcessing).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -170,6 +170,28 @@ interface RouteParams extends Params {
   user?: User;
 }
 
+export async function markStoppedSessionPromptableAndDrainQueue(
+  sessionsService: Pick<SessionsServiceImpl, 'patch' | 'triggerQueueProcessing'>,
+  sessionId: SessionID,
+  params?: Params
+): Promise<void> {
+  await sessionsService.patch(
+    sessionId,
+    {
+      status: SessionStatus.IDLE,
+      ready_for_prompt: true,
+    },
+    params
+  );
+
+  // Do not rely solely on the sessions.after.patch hook here. Stopping is an
+  // explicit "skip current and continue queued work" action, and the STOPPED
+  // task patch observes the old RUNNING session state before this patch lands.
+  // Trigger the drainer after the session is actually promptable so queued
+  // prompts resume even if hook timing/authorization changes regress later.
+  await sessionsService.triggerQueueProcessing(sessionId, params);
+}
+
 function isServiceAccountRoute(params: RouteParams): boolean {
   return (params.user as { _isServiceAccount?: boolean } | undefined)?._isServiceAccount === true;
 }
@@ -2095,17 +2117,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           console.warn(
             `⚠️  [Stop] No active tasks for session ${shortId(id)}, resetting to IDLE${stopReason ? ` (reason: ${stopReason})` : ''}`
           );
-          // ready_for_prompt: true so the post-patch hook drains any QUEUED tasks.
           // Stop is "skip current", not "wipe everything" — queued prompts represent
-          // user intent and should still execute.
-          await app.service('sessions').patch(
-            id,
-            {
-              status: SessionStatus.IDLE,
-              ready_for_prompt: true,
-            },
-            params
-          );
+          // user intent and should still execute. Mark promptable, then explicitly
+          // trigger the drainer instead of depending only on the post-patch hook.
+          await markStoppedSessionPromptableAndDrainQueue(sessionsService, id as SessionID, params);
           return {
             success: true,
             status: SessionStatus.IDLE,
@@ -2136,19 +2151,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
 
         try {
-          // ready_for_prompt: true so the post-patch hook drains any QUEUED tasks.
           // Stop is "skip current", not "wipe everything" — queued prompts represent
-          // user intent and should still execute.
-          await app.service('sessions').patch(
-            id,
-            {
-              status: SessionStatus.IDLE,
-              ready_for_prompt: true,
-            },
-            params
-          );
+          // user intent and should still execute. Mark promptable, then explicitly
+          // trigger the drainer instead of depending only on the post-patch hook.
+          await markStoppedSessionPromptableAndDrainQueue(sessionsService, id as SessionID, params);
         } catch (error) {
-          console.error(`❌ [Stop] Failed to patch session to IDLE:`, error);
+          console.error(`❌ [Stop] Failed to mark session promptable or drain queue:`, error);
         }
 
         return { success: true, status: SessionStatus.IDLE };

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -74,6 +74,7 @@ describe('TasksService executor heartbeat helpers', () => {
       { status: 'failed', ready_for_prompt: true },
       expect.objectContaining({
         user: { user_id: '018f0000-0000-7000-8000-000000000009' },
+        suppressTerminalQueueProcessing: true,
       })
     );
     expect(triggerQueueProcessing).not.toHaveBeenCalled();

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -35,6 +35,7 @@ import {
   ExecutorHeartbeatCallbackRunner,
 } from '../utils/executor-heartbeat-callback.js';
 import { ensureRepoOriginAlignedById } from '../utils/realign-repo-origin';
+import type { TerminalQueueProcessingParams } from '../utils/session-task-state.js';
 import type { SessionsService } from './sessions';
 
 /**
@@ -286,6 +287,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       );
       return failedTask;
     }
+    const sessionPatchParams: TerminalQueueProcessingParams = {
+      ...params,
+      suppressTerminalQueueProcessing: true,
+    };
     await this.app
       .service('sessions')
       .patch(
@@ -294,10 +299,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           status: SessionStatus.FAILED,
           ready_for_prompt: true,
         },
-        {
-          ...params,
-          suppressTerminalQueueProcessing: true,
-        }
+        sessionPatchParams
       )
       .catch((error: unknown) => {
         console.warn(

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -62,7 +62,7 @@ export type TaskParams = QueryParams<{
    * Internal-only: terminal task patches normally transition the owning session
    * back to a promptable terminal state. Heartbeat-loss handling marks the session failed instead.
    */
-  suppressTerminalSessionIdle?: boolean;
+  suppressTerminalSessionStateUpdate?: boolean;
   /**
    * Internal-only: terminal task patches normally drain queued work for the
    * owning session. Heartbeat-loss handling must not auto-start queued prompts.
@@ -270,7 +270,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       },
       {
         ...params,
-        suppressTerminalSessionIdle: true,
+        suppressTerminalSessionStateUpdate: true,
         suppressTerminalQueueProcessing: true,
       }
     );
@@ -294,7 +294,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           status: SessionStatus.FAILED,
           ready_for_prompt: true,
         },
-        params
+        {
+          ...params,
+          suppressTerminalQueueProcessing: true,
+        }
       )
       .catch((error: unknown) => {
         console.warn(
@@ -479,7 +482,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           }
 
           // For STOPPED tasks: The stop endpoint directly patches session → IDLE with
-          // ready_for_prompt=false. Skip the session update here to avoid racing with it.
+          // ready_for_prompt=true and triggers queue processing after that patch.
+          // Skip the session update here to avoid racing with it.
           //
           // For other terminal tasks: Normal completion - set ready_for_prompt=true
           // to allow auto-queue-processing of any pending messages.
@@ -489,7 +493,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             console.log(
               `⏭️ [TasksService] Skipping session terminal-state update for STOPPED task ${shortId(task.task_id)} — stop endpoint handles session state`
             );
-          } else if (params?.suppressTerminalSessionIdle) {
+          } else if (params?.suppressTerminalSessionStateUpdate) {
             console.log(
               `⏭️ [TasksService] Skipping session terminal-state update for task ${shortId(task.task_id)} (${data.status}) due to internal patch params`
             );

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -290,7 +290,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       .service('sessions')
       .patch(
         failedTask.session_id,
-        { status: SessionStatus.FAILED, ready_for_prompt: true },
+        {
+          status: SessionStatus.FAILED,
+          ready_for_prompt: true,
+        },
         params
       )
       .catch((error: unknown) => {
@@ -494,14 +497,15 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             await this.app.service('sessions').patch(
               task.session_id,
               {
-                status: 'idle',
+                status:
+                  data.status === TaskStatus.FAILED ? SessionStatus.FAILED : SessionStatus.IDLE,
                 ready_for_prompt: true,
               },
               params
             );
 
             console.log(
-              `✅ [TasksService] Session ${shortId(task.session_id)} status updated to IDLE (task ${shortId(task.task_id)} ${data.status})`
+              `✅ [TasksService] Session ${shortId(task.session_id)} status updated after terminal task (task ${shortId(task.task_id)} ${data.status})`
             );
           }
 

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -60,7 +60,7 @@ export type TaskParams = QueryParams<{
 }> & {
   /**
    * Internal-only: terminal task patches normally transition the owning session
-   * back to idle. Heartbeat-loss handling marks the session failed instead.
+   * back to a promptable terminal state. Heartbeat-loss handling marks the session failed instead.
    */
   suppressTerminalSessionIdle?: boolean;
   /**
@@ -435,7 +435,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
     // Run completion side effects only for statuses that historically completed
     // executor turns. Timeout paths patch session state separately and should not
-    // enqueue callbacks, mark sessions idle, archive forks, or drain queues here.
+    // enqueue callbacks, mark sessions promptable, archive forks, or drain queues here.
     if (isCompletionSideEffectTransition) {
       // Since tasks are patched one at a time, result is always a single Task (not an array)
       const task = result as Task;
@@ -469,7 +469,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
           if (latestTaskId && latestTaskId !== task.task_id) {
             console.log(
-              `⏭️ [TasksService] Skipping session IDLE update - task ${shortId(task.task_id)} is not the latest (latest: ${shortId(latestTaskId)})`
+              `⏭️ [TasksService] Skipping session terminal-state update - task ${shortId(task.task_id)} is not the latest (latest: ${shortId(latestTaskId)})`
             );
             // Still process completion callbacks (task completed, callback target needs to know).
             // Route through the same centralized/idempotent dispatcher used by the normal
@@ -487,11 +487,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
           if (isUserInitiatedStop) {
             console.log(
-              `⏭️ [TasksService] Skipping session IDLE update for STOPPED task ${shortId(task.task_id)} — stop endpoint handles session state`
+              `⏭️ [TasksService] Skipping session terminal-state update for STOPPED task ${shortId(task.task_id)} — stop endpoint handles session state`
             );
           } else if (params?.suppressTerminalSessionIdle) {
             console.log(
-              `⏭️ [TasksService] Skipping session IDLE update for task ${shortId(task.task_id)} (${data.status}) due to internal patch params`
+              `⏭️ [TasksService] Skipping session terminal-state update for task ${shortId(task.task_id)} (${data.status}) due to internal patch params`
             );
           } else {
             await this.app.service('sessions').patch(
@@ -532,8 +532,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             await this.injectBtwResultMessage(task, session, params);
           }
 
-          // IMPORTANT: Now that session is idle, process any queued tasks (including callbacks)
-          // This handles the case where callbacks were queued while this session was running
+          // IMPORTANT: Now that the terminal task made the session promptable, process any queued tasks
+          // (including callbacks). This handles the case where callbacks were queued while this session was running
           const sessionsService = this.app.service('sessions') as unknown as SessionsService;
           if (!params?.suppressTerminalQueueProcessing && sessionsService.triggerQueueProcessing) {
             await sessionsService.triggerQueueProcessing(task.session_id);
@@ -704,8 +704,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       // CRITICAL: After queuing callback, ALWAYS trigger target's queue processing.
       // The queue processor uses a promise-based lock that will:
       // - If target is busy: wait for current processing, then retry (self-healing)
-      // - If target is idle: immediately process the callback
-      // - If target becomes idle while waiting: the retry will catch it
+      // - If target is promptable: immediately process the callback
+      // - If target becomes promptable while waiting: the retry will catch it
       //
       // DO NOT check target status before triggering - let the queue processor handle it.
       // This ensures callbacks are never missed due to timing issues.

--- a/apps/agor-daemon/src/utils/session-task-state.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.ts
@@ -1,4 +1,4 @@
-import type { Session, Task } from '@agor/core/types';
+import type { Params, Session, Task } from '@agor/core/types';
 import {
   isTerminalTaskStatus,
   SessionStatus,
@@ -11,6 +11,16 @@ export function isTaskBlockingPrompt(task: Task): boolean {
 }
 
 export { sessionCanStartTask };
+
+export type TerminalQueueProcessingParams = Params & {
+  suppressTerminalQueueProcessing?: boolean;
+};
+
+export function isTerminalQueueProcessingSuppressed(params?: Params): boolean {
+  return (
+    (params as TerminalQueueProcessingParams | undefined)?.suppressTerminalQueueProcessing === true
+  );
+}
 
 /**
  * Detects the limbo state where persisted session status says "failed/not ready",

--- a/apps/agor-daemon/src/utils/session-task-state.ts
+++ b/apps/agor-daemon/src/utils/session-task-state.ts
@@ -1,15 +1,16 @@
 import type { Session, Task } from '@agor/core/types';
-import { isTerminalTaskStatus, SessionStatus, TaskStatus } from '@agor/core/types';
+import {
+  isTerminalTaskStatus,
+  SessionStatus,
+  sessionCanStartTask,
+  TaskStatus,
+} from '@agor/core/types';
 
 export function isTaskBlockingPrompt(task: Task): boolean {
   return task.status !== TaskStatus.QUEUED && !isTerminalTaskStatus(task.status);
 }
 
-export function sessionCanStartTask(status: Session['status'], readyForPrompt?: boolean): boolean {
-  return (
-    status === SessionStatus.IDLE || (status === SessionStatus.FAILED && readyForPrompt === true)
-  );
-}
+export { sessionCanStartTask };
 
 /**
  * Detects the limbo state where persisted session status says "failed/not ready",

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -75,6 +75,31 @@ describe('BranchSessionSections', () => {
     expect(screen.getByRole('button', { name: /new session/i })).toBeInTheDocument();
   });
 
+  it('marks a failed session', () => {
+    const failedSession = makeManualSession({
+      session_id: 'session-failed-task',
+      title: 'Investigate crash',
+      status: 'failed',
+    });
+
+    renderSections({ sessions: [failedSession] });
+
+    expect(screen.getByText('Investigate crash')).toBeInTheDocument();
+    expect(screen.getByLabelText('Latest task failed')).toBeInTheDocument();
+  });
+
+  it('does not mark idle sessions as failures', () => {
+    const stoppedSession = makeManualSession({
+      session_id: 'session-stopped-task',
+      title: 'Stopped by user',
+    });
+
+    renderSections({ sessions: [stoppedSession] });
+
+    expect(screen.getByText('Stopped by user')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Latest task failed')).not.toBeInTheDocument();
+  });
+
   it('counts and renders only visible manual sessions when archived ancestors are filtered out', () => {
     const archivedParent = makeManualSession({
       session_id: 'session-archived-parent',

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -2,11 +2,13 @@ import type { AgorClient, Branch, Session, SessionID, SpawnConfig, User } from '
 import {
   getGatewaySource as getGatewaySourceCore,
   isGatewaySession as isGatewaySessionCore,
+  SessionStatus,
 } from '@agor-live/client';
 import {
   ArrowUpOutlined,
   ClockCircleOutlined,
   DisconnectOutlined,
+  ExclamationCircleOutlined,
   ExportOutlined,
   EyeOutlined,
   LinkOutlined,
@@ -481,6 +483,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const isCreating = branch.filesystem_status === 'creating';
   const isFailed = branch.filesystem_status === 'failed';
 
+  const isSessionFailed = (session: Session): boolean => session.status === SessionStatus.FAILED;
+
   useEffect(() => {
     const collectKeysWithChildren = (nodes: SessionTreeNode[]): React.Key[] => {
       const keys: React.Key[] = [];
@@ -529,11 +533,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     options: { strong?: boolean; secondary?: boolean; query?: string } = {}
   ) => {
     const titleText = getSessionDisplayTitle(session, { includeAgentFallback: true });
+    const failed = isSessionFailed(session);
 
     return (
       <Typography.Text
         strong={options.strong}
-        type={options.secondary ? 'secondary' : undefined}
+        type={failed ? 'danger' : options.secondary ? 'secondary' : undefined}
         style={{
           fontSize: isPanel ? 13 : 12,
           flex: 1,
@@ -545,6 +550,29 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       </Typography.Text>
     );
   };
+
+  const renderSessionFailureIcon = (session: Session) => {
+    if (!isSessionFailed(session)) return null;
+
+    return (
+      <Tooltip title="Latest task failed">
+        <ExclamationCircleOutlined
+          aria-label="Latest task failed"
+          style={{ color: token.colorErrorText, fontSize: 12, flex: '0 0 auto' }}
+        />
+      </Tooltip>
+    );
+  };
+
+  const renderSessionTitleWithFailure = (
+    session: Session,
+    options: { strong?: boolean; secondary?: boolean; query?: string } = {}
+  ) => (
+    <>
+      {renderSessionFailureIcon(session)}
+      {renderSessionTitle(session, options)}
+    </>
+  );
 
   const renderFlatSessionRow = (session: Session, query = '') => {
     const isActive = session.status === 'running' || session.status === 'stopping';
@@ -590,7 +618,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             <SessionRelationshipIcon session={session} size={10} />
             <div style={{ flex: 1, minWidth: 0 }}>
-              {renderSessionTitle(session, { query })}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+                {renderSessionTitleWithFailure(session, { query })}
+              </div>
               {(sourceLabel || toolMatches) && (
                 <Typography.Text
                   type="secondary"
@@ -675,7 +705,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             ) : (
               <SessionRelationshipIcon session={session} size={10} />
             )}
-            {renderSessionTitle(session)}
+            {renderSessionTitleWithFailure(session)}
           </div>
         </div>
       </SessionItemWithActions>
@@ -801,7 +831,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 ) : (
                   <ToolIcon tool={session.agentic_tool} size={20} />
                 )}
-                {renderSessionTitle(session, { secondary: true })}
+                {renderSessionTitleWithFailure(session, { secondary: true })}
               </Space>
             </div>
           </SessionItemWithActions>
@@ -878,7 +908,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 <div
                   style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}
                 >
-                  {renderSessionTitle(session)}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+                    {renderSessionTitleWithFailure(session)}
+                  </div>
                   <div style={{ alignSelf: 'flex-start' }}>
                     {gatewaySource ? (
                       <ChannelPill

--- a/packages/core/src/types/session.test.ts
+++ b/packages/core/src/types/session.test.ts
@@ -15,7 +15,28 @@
 
 import { describe, expect, it } from 'vitest';
 import type { AgenticToolName } from './agentic-tool';
-import { getDefaultPermissionMode } from './session';
+import { getDefaultPermissionMode, isSessionPromptable, sessionCanStartTask } from './session';
+
+describe('session promptability helpers', () => {
+  it('treats idle sessions as promptable regardless of the attention flag', () => {
+    expect(sessionCanStartTask('idle', false)).toBe(true);
+    expect(sessionCanStartTask('idle', true)).toBe(true);
+    expect(isSessionPromptable({ status: 'idle', ready_for_prompt: false })).toBe(true);
+  });
+
+  it('treats failed sessions as promptable only after the terminal task made them ready', () => {
+    expect(sessionCanStartTask('failed', true)).toBe(true);
+    expect(sessionCanStartTask('failed', false)).toBe(false);
+    expect(isSessionPromptable({ status: 'failed', ready_for_prompt: true })).toBe(true);
+    expect(isSessionPromptable({ status: 'failed', ready_for_prompt: false })).toBe(false);
+  });
+
+  it('does not confuse ready_for_prompt attention state with promptability', () => {
+    expect(sessionCanStartTask('timed_out', true)).toBe(false);
+    expect(sessionCanStartTask('running', true)).toBe(false);
+    expect(isSessionPromptable({ status: 'timed_out', ready_for_prompt: true })).toBe(false);
+  });
+});
 
 describe('getDefaultPermissionMode', () => {
   it('returns "allow-all" for codex (Agor MCP-heavy default)', () => {

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -508,6 +508,33 @@ export interface Session {
   };
 }
 
+/**
+ * Minimal persisted session state needed to decide whether a new task can
+ * start immediately.
+ *
+ * `ready_for_prompt` is intentionally not equivalent to promptability: the UI
+ * also uses it as an attention/acknowledgement flag (for example timed-out
+ * permission requests can set it true). Use this helper instead of checking
+ * either field directly at task-execution boundaries.
+ */
+export type SessionPromptState = Pick<Session, 'status' | 'ready_for_prompt'>;
+
+export type PromptableSessionState =
+  | { status: typeof SessionStatus.IDLE; ready_for_prompt: boolean }
+  | { status: typeof SessionStatus.FAILED; ready_for_prompt: true };
+
+export function sessionCanStartTask(status: Session['status'], readyForPrompt?: boolean): boolean {
+  return (
+    status === SessionStatus.IDLE || (status === SessionStatus.FAILED && readyForPrompt === true)
+  );
+}
+
+export function isSessionPromptable<T extends SessionPromptState>(
+  session: T
+): session is T & PromptableSessionState {
+  return sessionCanStartTask(session.status, session.ready_for_prompt);
+}
+
 export type SessionRelationshipType = 'remote_create';
 
 /**


### PR DESCRIPTION
## Summary
- use existing persisted session state for failure indication: when the latest/current terminal task fails, `TasksService` now leaves the session in `failed` with `ready_for_prompt: true`
- render a subtle error icon + danger-colored session title for failed sessions on BranchCard/session rows
- add BranchSessionSections coverage for failed vs non-failed rows

## Checks
- `pnpm exec biome check apps/agor-daemon/src/services/tasks.ts apps/agor-daemon/src/services/sessions.ts packages/core/src/db/repositories/sessions.ts packages/core/src/types/session.ts apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx`
- `pnpm --filter @agor/core typecheck`
- `pnpm --filter @agor-live/client typecheck`
- `pnpm --filter agor-ui test -- BranchSessionSections.test.tsx`

Note: `pnpm --filter agor-ui typecheck` currently fails in this worktree because workspace packages such as `@agor-live/client`/`@agor/core` have no built declaration outputs; per AGENTS.md I did not run package builds.
