### PR TITLE
Improve executor crash diagnostics and reconnect auth

### DIFF
--- a/apps/agor-daemon/src/register-services.executor-exit.test.ts
+++ b/apps/agor-daemon/src/register-services.executor-exit.test.ts
@@ -34,8 +34,19 @@ describe('executor exit safety net helpers', () => {
       task_id: 'task-1',
       status: TaskStatus.RUNNING,
     } as Task;
+    const failedTask = {
+      ...activeTask,
+      status: TaskStatus.FAILED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+      error_message: 'placeholder',
+    } as Task;
     const get = vi.fn().mockResolvedValue(activeTask);
-    const patch = vi.fn().mockResolvedValue({ ...activeTask, status: TaskStatus.FAILED });
+    const patch = vi.fn().mockImplementation((_id, data) =>
+      Promise.resolve({
+        ...failedTask,
+        ...data,
+      })
+    );
     const service = vi.fn((name: string) => {
       if (name !== 'tasks') throw new Error(`Unexpected service: ${name}`);
       return { get, patch };
@@ -56,7 +67,14 @@ describe('executor exit safety net helpers', () => {
       suppressTerminalSideEffects: true,
     });
 
-    expect(result).toEqual({ patched: true, task: activeTask });
+    expect(result).toMatchObject({
+      patched: true,
+      task: {
+        task_id: 'task-1',
+        status: TaskStatus.FAILED,
+        error_message: expect.stringContaining('raw stderr'),
+      },
+    });
     expect(get).toHaveBeenCalledWith('task-1', params);
     expect(patch).toHaveBeenCalledWith(
       'task-1',
@@ -71,6 +89,27 @@ describe('executor exit safety net helpers', () => {
         suppressTerminalQueueProcessing: true,
       })
     );
+  });
+
+  it('reports patched=false when the terminal rewrite guard keeps the existing task', async () => {
+    const timedOutTask = {
+      task_id: 'task-1',
+      status: TaskStatus.TIMED_OUT,
+      completed_at: '2026-01-01T00:00:04.000Z',
+    } as Task;
+    const get = vi.fn().mockResolvedValue(timedOutTask);
+    const patch = vi.fn().mockResolvedValue(timedOutTask);
+    const service = vi.fn(() => ({ get, patch }));
+    const app = { service } as Parameters<typeof markActiveTaskFailedForExecutorExit>[0]['app'];
+
+    const result = await markActiveTaskFailedForExecutorExit({
+      app,
+      params: {},
+      taskId: 'task-1',
+      code: 1,
+    });
+
+    expect(result).toEqual({ patched: false, task: timedOutTask });
   });
 
   it('does not patch already-terminal tasks', async () => {

--- a/apps/agor-daemon/src/register-services.executor-exit.test.ts
+++ b/apps/agor-daemon/src/register-services.executor-exit.test.ts
@@ -1,0 +1,96 @@
+import { type Task, TaskStatus } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  formatExecutorExitError,
+  isTaskStillActiveForExecutorExit,
+  markActiveTaskFailedForExecutorExit,
+} from './utils/executor-exit-safety-net.js';
+
+describe('executor exit safety net helpers', () => {
+  it('centralizes task statuses that should still be repaired on executor exit', () => {
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.RUNNING })).toBe(true);
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.AWAITING_PERMISSION })).toBe(true);
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.AWAITING_INPUT })).toBe(true);
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.STOPPING })).toBe(true);
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.TIMED_OUT })).toBe(true);
+
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.COMPLETED })).toBe(false);
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.FAILED })).toBe(false);
+    expect(isTaskStillActiveForExecutorExit({ status: TaskStatus.STOPPED })).toBe(false);
+  });
+
+  it('formats executor exit errors with stderr preferred over combined output', () => {
+    expect(
+      formatExecutorExitError(1, {
+        stderrTail: 'stderr says why',
+        combinedTail: 'stdout says less',
+      })
+    ).toContain('stderr says why');
+    expect(formatExecutorExitError(null)).toBe('Executor exited unexpectedly with code unknown.');
+  });
+
+  it('marks non-latest active tasks failed while suppressing session/queue side effects', async () => {
+    const activeTask = {
+      task_id: 'task-1',
+      status: TaskStatus.RUNNING,
+    } as Task;
+    const get = vi.fn().mockResolvedValue(activeTask);
+    const patch = vi.fn().mockResolvedValue({ ...activeTask, status: TaskStatus.FAILED });
+    const service = vi.fn((name: string) => {
+      if (name !== 'tasks') throw new Error(`Unexpected service: ${name}`);
+      return { get, patch };
+    });
+    const app = { service } as Parameters<typeof markActiveTaskFailedForExecutorExit>[0]['app'];
+    const params = { user: { user_id: 'user-1' } };
+
+    const result = await markActiveTaskFailedForExecutorExit({
+      app,
+      params,
+      taskId: 'task-1',
+      code: 1,
+      output: {
+        stdoutTail: 'out',
+        stderrTail: 'raw stderr',
+        combinedTail: 'combined',
+      },
+      suppressTerminalSideEffects: true,
+    });
+
+    expect(result).toEqual({ patched: true, task: activeTask });
+    expect(get).toHaveBeenCalledWith('task-1', params);
+    expect(patch).toHaveBeenCalledWith(
+      'task-1',
+      expect.objectContaining({
+        status: TaskStatus.FAILED,
+        completed_at: expect.any(String),
+        error_message: expect.stringContaining('raw stderr'),
+      }),
+      expect.objectContaining({
+        user: { user_id: 'user-1' },
+        suppressTerminalSessionIdle: true,
+        suppressTerminalQueueProcessing: true,
+      })
+    );
+  });
+
+  it('does not patch already-terminal tasks', async () => {
+    const terminalTask = {
+      task_id: 'task-1',
+      status: TaskStatus.COMPLETED,
+    } as Task;
+    const get = vi.fn().mockResolvedValue(terminalTask);
+    const patch = vi.fn();
+    const service = vi.fn(() => ({ get, patch }));
+    const app = { service } as Parameters<typeof markActiveTaskFailedForExecutorExit>[0]['app'];
+
+    const result = await markActiveTaskFailedForExecutorExit({
+      app,
+      params: {},
+      taskId: 'task-1',
+      code: 1,
+    });
+
+    expect(result).toEqual({ patched: false, task: terminalTask });
+    expect(patch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -37,7 +37,7 @@ import type {
   SessionID,
   UserID,
 } from '@agor/core/types';
-import { AGENTIC_TOOL_CAPABILITIES, SessionStatus, TaskStatus } from '@agor/core/types';
+import { AGENTIC_TOOL_CAPABILITIES, SessionStatus } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
 import type express from 'express';
 import type {
@@ -105,6 +105,7 @@ import { createThreadSessionMapService } from './services/thread-session-map.js'
 import { createUsersService } from './services/users.js';
 import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
+import { markActiveTaskFailedForExecutorExit } from './utils/executor-exit-safety-net.js';
 import { escapeHtml } from './utils/html.js';
 import {
   shouldExposeMCPServerSecrets,
@@ -869,18 +870,6 @@ function createExecuteHandler(
 
     const logPrefix = `[Executor ${shortId(sessionId)}]`;
 
-    const formatExecutorExitError = (
-      code: number | null,
-      output?: { stderrTail?: string; combinedTail?: string }
-    ): string => {
-      const codeText = code ?? 'unknown';
-      const rawTail = (output?.stderrTail?.trim() || output?.combinedTail?.trim() || '').trim();
-      const tail = rawTail.length > 4000 ? rawTail.slice(rawTail.length - 4000) : rawTail;
-      return tail
-        ? `Executor exited unexpectedly with code ${codeText}.\n\nLast executor stderr/output:\n${tail}`
-        : `Executor exited unexpectedly with code ${codeText}.`;
-    };
-
     spawnExecutor(executorPayload, {
       cwd,
       asUser: executorUnixUser || undefined,
@@ -912,28 +901,16 @@ function createExecuteHandler(
               `ℹ️ [Executor] Task ${shortId(taskId)} is not the latest (latest: ${shortId(latestTaskId)}); checking task-local safety net only`
             );
             try {
-              const currentTask = await app.service('tasks').get(taskId, params);
-              const isTaskStillActive =
-                currentTask.status === TaskStatus.RUNNING ||
-                currentTask.status === 'awaiting_permission' ||
-                currentTask.status === 'awaiting_input' ||
-                currentTask.status === 'stopping' ||
-                currentTask.status === 'timed_out';
+              const { patched } = await markActiveTaskFailedForExecutorExit({
+                app,
+                params,
+                taskId,
+                code,
+                output,
+                suppressTerminalSideEffects: true,
+              });
 
-              if (isTaskStillActive) {
-                await app.service('tasks').patch(
-                  taskId,
-                  {
-                    status: TaskStatus.FAILED,
-                    completed_at: new Date().toISOString(),
-                    error_message: formatExecutorExitError(code, output),
-                  },
-                  {
-                    ...params,
-                    suppressTerminalSessionIdle: true,
-                    suppressTerminalQueueProcessing: true,
-                  }
-                );
+              if (patched) {
                 console.log(
                   `✅ [Executor] Non-latest task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
                 );
@@ -952,30 +929,21 @@ function createExecuteHandler(
             currentSession.status === SessionStatus.TIMED_OUT
           ) {
             try {
-              const currentTask = await app.service('tasks').get(taskId, params);
-              const isTaskStillActive =
-                currentTask.status === TaskStatus.RUNNING ||
-                currentTask.status === 'awaiting_permission' ||
-                currentTask.status === 'awaiting_input' ||
-                currentTask.status === 'stopping' ||
-                currentTask.status === 'timed_out';
+              const { patched, task: currentTask } = await markActiveTaskFailedForExecutorExit({
+                app,
+                params,
+                taskId,
+                code,
+                output,
+              });
 
-              if (isTaskStillActive) {
-                await app.service('tasks').patch(
-                  taskId,
-                  {
-                    status: TaskStatus.FAILED,
-                    completed_at: new Date().toISOString(),
-                    error_message: formatExecutorExitError(code, output),
-                  },
-                  params
-                );
+              if (patched) {
                 console.log(
                   `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
                 );
               } else {
                 console.log(
-                  `⚠️  [Executor] Task ${shortId(taskId)} already ${currentTask.status}, but session still ${currentSession.status} — repairing session state`
+                  `⚠️  [Executor] Task ${shortId(taskId)} already ${currentTask?.status}, but session still ${currentSession.status} — repairing session state`
                 );
                 await app
                   .service('sessions')

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -869,11 +869,24 @@ function createExecuteHandler(
 
     const logPrefix = `[Executor ${shortId(sessionId)}]`;
 
+    const formatExecutorExitError = (
+      code: number | null,
+      output?: { stderrTail?: string; combinedTail?: string }
+    ): string => {
+      const codeText = code ?? 'unknown';
+      const rawTail = (output?.stderrTail?.trim() || output?.combinedTail?.trim() || '').trim();
+      const tail = rawTail.length > 4000 ? rawTail.slice(rawTail.length - 4000) : rawTail;
+      return tail
+        ? `Executor exited unexpectedly with code ${codeText}.\n\nLast executor stderr/output:\n${tail}`
+        : `Executor exited unexpectedly with code ${codeText}.`;
+    };
+
     spawnExecutor(executorPayload, {
       cwd,
       asUser: executorUnixUser || undefined,
       preparedEnv: executorEnv,
       logPrefix,
+      captureOutput: true,
       templateVariables: {
         session_id: sessionId,
         task_id: taskId,
@@ -885,7 +898,7 @@ function createExecuteHandler(
           console.log(`${logPrefix} PID: ${child.pid}`);
         }
       },
-      onExit: async (code) => {
+      onExit: async (code, output) => {
         console.log(`${logPrefix} Exited with code ${code}`);
         untrackExecutorProcess(sessionId);
 
@@ -896,8 +909,41 @@ function createExecuteHandler(
 
           if (latestTaskId && latestTaskId !== taskId) {
             console.log(
-              `⏭️ [Executor] Task ${shortId(taskId)} is not the latest (latest: ${shortId(latestTaskId)}), skipping safety net`
+              `ℹ️ [Executor] Task ${shortId(taskId)} is not the latest (latest: ${shortId(latestTaskId)}); checking task-local safety net only`
             );
+            try {
+              const currentTask = await app.service('tasks').get(taskId, params);
+              const isTaskStillActive =
+                currentTask.status === TaskStatus.RUNNING ||
+                currentTask.status === 'awaiting_permission' ||
+                currentTask.status === 'awaiting_input' ||
+                currentTask.status === 'stopping' ||
+                currentTask.status === 'timed_out';
+
+              if (isTaskStillActive) {
+                await app.service('tasks').patch(
+                  taskId,
+                  {
+                    status: TaskStatus.FAILED,
+                    completed_at: new Date().toISOString(),
+                    error_message: formatExecutorExitError(code, output),
+                  },
+                  {
+                    ...params,
+                    suppressTerminalSessionIdle: true,
+                    suppressTerminalQueueProcessing: true,
+                  }
+                );
+                console.log(
+                  `✅ [Executor] Non-latest task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
+                );
+              }
+            } catch (taskError) {
+              console.error(
+                `⚠️  [Executor] Failed task-local safety net for non-latest task ${shortId(taskId)}:`,
+                taskError
+              );
+            }
           } else if (
             currentSession.status === SessionStatus.RUNNING ||
             currentSession.status === SessionStatus.AWAITING_PERMISSION ||
@@ -919,7 +965,8 @@ function createExecuteHandler(
                   taskId,
                   {
                     status: TaskStatus.FAILED,
-                    error_message: `Executor exited unexpectedly with code ${code ?? 'unknown'}.`,
+                    completed_at: new Date().toISOString(),
+                    error_message: formatExecutorExitError(code, output),
                   },
                   params
                 );

--- a/apps/agor-daemon/src/utils/executor-exit-safety-net.ts
+++ b/apps/agor-daemon/src/utils/executor-exit-safety-net.ts
@@ -1,0 +1,61 @@
+import type { Application } from '@agor/core/feathers';
+import type { Params, Task } from '@agor/core/types';
+import { isActiveExecutorTaskStatus, TaskStatus } from '@agor/core/types';
+import type { CapturedExecutorOutput } from './spawn-executor.js';
+
+export function formatExecutorExitError(
+  code: number | null,
+  output?: Pick<CapturedExecutorOutput, 'stderrTail' | 'combinedTail'>
+): string {
+  const codeText = code ?? 'unknown';
+  const rawTail = (output?.stderrTail?.trim() || output?.combinedTail?.trim() || '').trim();
+  const tail = rawTail.length > 4000 ? rawTail.slice(rawTail.length - 4000) : rawTail;
+  return tail
+    ? `Executor exited unexpectedly with code ${codeText}.\n\nLast executor stderr/output:\n${tail}`
+    : `Executor exited unexpectedly with code ${codeText}.`;
+}
+
+export function isTaskStillActiveForExecutorExit(task: Pick<Task, 'status'>): boolean {
+  return isActiveExecutorTaskStatus(task.status);
+}
+
+export async function markActiveTaskFailedForExecutorExit({
+  app,
+  params,
+  taskId,
+  code,
+  output,
+  suppressTerminalSideEffects = false,
+}: {
+  app: Application;
+  params: Params;
+  taskId: string;
+  code: number | null;
+  output?: CapturedExecutorOutput;
+  suppressTerminalSideEffects?: boolean;
+}): Promise<{ patched: boolean; task?: Task }> {
+  const currentTask = await app.service('tasks').get(taskId, params);
+  if (!isTaskStillActiveForExecutorExit(currentTask)) {
+    return { patched: false, task: currentTask };
+  }
+
+  const patchParams = suppressTerminalSideEffects
+    ? {
+        ...params,
+        suppressTerminalSessionIdle: true,
+        suppressTerminalQueueProcessing: true,
+      }
+    : params;
+
+  await app.service('tasks').patch(
+    taskId,
+    {
+      status: TaskStatus.FAILED,
+      completed_at: new Date().toISOString(),
+      error_message: formatExecutorExitError(code, output),
+    },
+    patchParams
+  );
+
+  return { patched: true, task: currentTask };
+}

--- a/apps/agor-daemon/src/utils/executor-exit-safety-net.ts
+++ b/apps/agor-daemon/src/utils/executor-exit-safety-net.ts
@@ -47,15 +47,24 @@ export async function markActiveTaskFailedForExecutorExit({
       }
     : params;
 
-  await app.service('tasks').patch(
+  const completedAt = new Date().toISOString();
+  const errorMessage = formatExecutorExitError(code, output);
+  const patchedTask = await app.service('tasks').patch(
     taskId,
     {
       status: TaskStatus.FAILED,
-      completed_at: new Date().toISOString(),
-      error_message: formatExecutorExitError(code, output),
+      completed_at: completedAt,
+      error_message: errorMessage,
     },
     patchParams
   );
 
-  return { patched: true, task: currentTask };
+  return {
+    patched:
+      !Array.isArray(patchedTask) &&
+      patchedTask.status === TaskStatus.FAILED &&
+      patchedTask.error_message === errorMessage &&
+      patchedTask.completed_at === completedAt,
+    task: Array.isArray(patchedTask) ? currentTask : patchedTask,
+  };
 }

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -125,6 +125,35 @@ describe('configured executor spawning', () => {
     expect(onExit).toHaveBeenCalledWith(17);
   });
 
+  it('captures bounded stdout/stderr tails for onExit diagnostics', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const onExit = vi.fn();
+    const { spawnExecutor } = await import('./spawn-executor');
+
+    spawnExecutor(
+      { command: 'prompt' },
+      {
+        captureOutput: true,
+        outputTailMaxBytes: 8,
+        onExit,
+        logPrefix: '[test]',
+      }
+    );
+
+    proc.stdout.emit('data', Buffer.from('stdout-before\n'));
+    proc.stderr.emit('data', Buffer.from('stderr-before\n'));
+    proc.stdout.emit('data', Buffer.from('stdout-after'));
+    proc.stderr.emit('data', Buffer.from('stderr-after'));
+    proc.emit('exit', 1);
+
+    expect(onExit).toHaveBeenCalledWith(1, {
+      stdoutTail: 'ut-after',
+      stderrTail: 'rr-after',
+      combinedTail: 'rr-after',
+    });
+  });
+
   it('keeps createConfiguredSpawner isolated from module-level defaults', async () => {
     const proc = createMockProcess();
     spawnMock.mockReturnValue(proc);

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -101,13 +101,27 @@ export interface SpawnExecutorOptions {
   /** When set, uses template substitution instead of local subprocess. */
   executorCommandTemplate?: string | null;
   templateVariables?: ExecutorTemplateVariables;
-  onExit?: (code: number | null) => void;
+  onExit?: (code: number | null, output?: CapturedExecutorOutput) => void;
   /** Fired after spawn, before stdin is written. Works for both local and templated paths. */
   onSpawn?: (child: ChildProcess) => void;
   /** Caller-assembled env; bypasses internal curation. Ignored by templated path. */
   preparedEnv?: Record<string, string>;
   /** Pre-written 0600 env file; bypasses prepareImpersonationEnv(). Only with asUser. */
   preparedEnvFilePath?: string;
+  /**
+   * Capture a bounded tail of executor stdout/stderr while still teeing output
+   * into daemon logs. Useful for surfacing the real crash reason in task
+   * records when a prompt executor exits before it can patch its own task.
+   */
+  captureOutput?: boolean;
+  /** Max bytes retained for each stdout/stderr/combined tail. */
+  outputTailMaxBytes?: number;
+}
+
+export interface CapturedExecutorOutput {
+  stdoutTail: string;
+  stderrTail: string;
+  combinedTail: string;
 }
 
 export interface ExecutorCommandResult {
@@ -194,6 +208,62 @@ export function findExecutorPath(): string {
   return executorPath;
 }
 
+const DEFAULT_OUTPUT_TAIL_MAX_BYTES = 32 * 1024;
+
+function appendTail(existing: string, chunk: string, maxBytes: number): string {
+  const next = `${existing}${chunk}`;
+  if (Buffer.byteLength(next, 'utf8') <= maxBytes) return next;
+
+  // Slice by characters first (fast/common path), then trim by bytes if the
+  // string contains multi-byte code points. This is diagnostic output, so a
+  // small amount of leading context loss is expected once the cap is reached.
+  let trimmed = next.slice(Math.max(0, next.length - maxBytes));
+  while (Buffer.byteLength(trimmed, 'utf8') > maxBytes && trimmed.length > 0) {
+    trimmed = trimmed.slice(1);
+  }
+  return trimmed;
+}
+
+function createExecutorOutputCapture(maxBytes?: number): {
+  append(stream: 'stdout' | 'stderr', chunk: Buffer): void;
+  snapshot(): CapturedExecutorOutput;
+} {
+  const limit =
+    typeof maxBytes === 'number' && Number.isFinite(maxBytes) && maxBytes > 0
+      ? Math.floor(maxBytes)
+      : DEFAULT_OUTPUT_TAIL_MAX_BYTES;
+  let stdoutTail = '';
+  let stderrTail = '';
+  let combinedTail = '';
+
+  return {
+    append(stream, chunk) {
+      const text = chunk.toString();
+      if (stream === 'stdout') {
+        stdoutTail = appendTail(stdoutTail, text, limit);
+      } else {
+        stderrTail = appendTail(stderrTail, text, limit);
+      }
+      combinedTail = appendTail(combinedTail, text, limit);
+    },
+    snapshot() {
+      return { stdoutTail, stderrTail, combinedTail };
+    },
+  };
+}
+
+function teeExecutorOutput(prefix: string, stream: 'stdout' | 'stderr', chunk: Buffer): void {
+  const text = chunk.toString();
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    if (stream === 'stdout') {
+      console.log(`${prefix} ${line}`);
+    } else {
+      console.error(`${prefix} ${line}`);
+    }
+  }
+}
+
 /**
  * Spawn executor process with JSON payload via stdin (fire-and-forget)
  *
@@ -247,7 +317,9 @@ export function spawnExecutor(
 
 /**
  * Spawn executor as a local subprocess.
- * stdout/stderr are inherited so logs appear in daemon output.
+ * stdout/stderr are inherited by default so logs appear in daemon output.
+ * When captureOutput is enabled, stdout/stderr are piped, tee'd to daemon
+ * output, and retained as bounded tails for failure diagnostics.
  */
 function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExecutorOptions): void {
   const executorPath = findExecutorPath();
@@ -265,6 +337,8 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     onSpawn,
     preparedEnv,
     preparedEnvFilePath,
+    captureOutput = false,
+    outputTailMaxBytes,
   } = options;
   const asUser = rawAsUser || undefined;
 
@@ -350,12 +424,25 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     return;
   }
 
+  const outputCapture = captureOutput ? createExecutorOutputCapture(outputTailMaxBytes) : undefined;
+
   const executorProcess = spawn(cmd, args, {
     cwd,
     env: asUser ? undefined : { ...envWithDaemonUrl }, // When impersonating, env is in the command; otherwise pass to spawn
-    stdio: ['pipe', 'inherit', 'inherit'], // stdin: pipe, stdout/stderr: inherit (show in daemon logs)
+    stdio: captureOutput ? ['pipe', 'pipe', 'pipe'] : ['pipe', 'inherit', 'inherit'],
     detached: false, // Don't detach - let daemon manage lifecycle
   });
+
+  if (outputCapture) {
+    executorProcess.stdout?.on('data', (chunk: Buffer) => {
+      outputCapture.append('stdout', chunk);
+      teeExecutorOutput(logPrefix, 'stdout', chunk);
+    });
+    executorProcess.stderr?.on('data', (chunk: Buffer) => {
+      outputCapture.append('stderr', chunk);
+      teeExecutorOutput(logPrefix, 'stderr', chunk);
+    });
+  }
 
   // Best-effort safety-net cleanup: the inner bash script `rm -f`s the env
   // file before exec, but if sudo/bash failed to launch — or `set -eu`
@@ -375,7 +462,12 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     } else {
       console.error(`${logPrefix} Executor exited with code ${code}`);
     }
-    options.onExit?.(code);
+    const capturedOutput = outputCapture?.snapshot();
+    if (capturedOutput) {
+      options.onExit?.(code, capturedOutput);
+    } else {
+      options.onExit?.(code);
+    }
   });
 
   executorProcess.stdin?.write(JSON.stringify(payload));
@@ -391,6 +483,9 @@ function spawnExecutorWithTemplate(
 ): void {
   const { executorCommandTemplate, templateVariables, logPrefix = '[Executor]' } = options;
   const logLevel = templateVariables.log_level ?? getCurrentLogLevel();
+  const outputCapture = options.captureOutput
+    ? createExecutorOutputCapture(options.outputTailMaxBytes)
+    : undefined;
 
   const command = substituteTemplateVariables(executorCommandTemplate, templateVariables);
 
@@ -407,10 +502,12 @@ function spawnExecutorWithTemplate(
   options.onSpawn?.(executorProcess);
 
   executorProcess.stdout?.on('data', (data) => {
+    outputCapture?.append('stdout', data);
     console.log(`${logPrefix} ${data.toString().trim()}`);
   });
 
   executorProcess.stderr?.on('data', (data) => {
+    outputCapture?.append('stderr', data);
     console.error(`${logPrefix} ${data.toString().trim()}`);
   });
 
@@ -428,7 +525,12 @@ function spawnExecutorWithTemplate(
         `${logPrefix} Executor exited with code ${code} (task: ${templateVariables.task_id})`
       );
     }
-    options.onExit?.(code);
+    const capturedOutput = outputCapture?.snapshot();
+    if (capturedOutput) {
+      options.onExit?.(code, capturedOutput);
+    } else {
+      options.onExit?.(code);
+    }
   });
 
   executorProcess.stdin?.write(JSON.stringify(payload));

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -350,6 +350,22 @@ describe('createClient', () => {
       expect(authMock).toHaveBeenCalledWith({ storage: undefined });
     });
 
+    it('should pass explicit authStorage into the initial authentication configuration', () => {
+      delete (globalThis as any).localStorage;
+
+      const authStorage = {
+        getItem: vi.fn(),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      };
+      const authMock = authClient as unknown as MockedFunction<any>;
+
+      createClient('http://localhost:3030', false, { authStorage });
+
+      expect(authMock).toHaveBeenCalledTimes(1);
+      expect(authMock).toHaveBeenCalledWith({ storage: authStorage });
+    });
+
     it('should handle globalThis without localStorage gracefully', () => {
       const _globalThisBackup = globalThis;
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -52,6 +52,13 @@ import { DAEMON } from '../config/constants';
  */
 const DEFAULT_DAEMON_URL = `http://${DAEMON.DEFAULT_HOST}:${DAEMON.DEFAULT_PORT}`;
 
+type AuthStorageLike = {
+  getItem(key: string): unknown;
+  // biome-ignore lint/suspicious/noExplicitAny: matches Feathers auth storage shape
+  setItem?(key: string, value: any): unknown;
+  removeItem?(key: string): unknown;
+};
+
 /**
  * Symbol used to mark the boards service after custom helpers have been attached.
  * Using a symbol avoids clashing with existing service properties.
@@ -976,6 +983,14 @@ export function createClient(
     verbose?: boolean;
     /** Limit reconnection attempts (useful for CLI to avoid hanging) */
     reconnectionAttempts?: number;
+    /**
+     * Authentication storage override. Executor processes use this to provide
+     * in-memory JWT storage before the Feathers auth client installs its
+     * socket reconnect hooks; configuring auth twice leaves the first hook
+     * bound to empty Node storage and can crash long-running executors on
+     * reconnect.
+     */
+    authStorage?: AuthStorageLike;
   }
 ): AgorClient {
   // Detect if running in browser vs Node.js (CLI)
@@ -1035,7 +1050,12 @@ export function createClient(
   const _ls = (globalThis as { localStorage?: unknown }).localStorage as
     | (Storage & { setItem?: unknown })
     | undefined;
-  const storage = _ls && typeof _ls.setItem === 'function' ? (_ls as Storage) : undefined;
+  const storage =
+    options && 'authStorage' in options
+      ? options.authStorage
+      : _ls && typeof _ls.setItem === 'function'
+        ? (_ls as Storage)
+        : undefined;
 
   client.configure(authentication({ storage }));
   client.io = socket;

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -87,6 +87,21 @@ export function isTerminalTaskStatus(status: TaskStatus | undefined): boolean {
   return status !== undefined && TERMINAL_TASK_STATUSES.has(status);
 }
 
+export const ACTIVE_EXECUTOR_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
+  TaskStatus.RUNNING,
+  TaskStatus.AWAITING_PERMISSION,
+  TaskStatus.AWAITING_INPUT,
+  TaskStatus.STOPPING,
+  // Historical executor-exit safety-net behavior also repairs timed-out tasks
+  // that never completed their terminal hooks. Keep this explicit instead of
+  // inferring from non-terminal status because TIMED_OUT is terminal.
+  TaskStatus.TIMED_OUT,
+]);
+
+export function isActiveExecutorTaskStatus(status: TaskStatus | undefined): boolean {
+  return status !== undefined && ACTIVE_EXECUTOR_TASK_STATUSES.has(status);
+}
+
 /**
  * Authoritative context-window snapshot captured at task completion.
  *

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -58,13 +58,8 @@ export async function createExecutorClient(
   const client = createClient(daemonUrl, false, {
     verbose: DEBUG_FEATHERS_CLIENT, // Log connection status for debugging
     reconnectionAttempts: 5, // Allow more retries for transient network hiccups during long-running tasks
+    authStorage: storage,
   });
-
-  // Re-configure authentication with memory storage
-  // This overrides the default `storage: undefined` for Node.js environments
-  // Import authentication client from @agor/core (re-exported from @feathersjs/authentication-client)
-  const { authenticationClient } = await import('@agor/core/api');
-  client.configure(authenticationClient({ storage }));
 
   // Connect the socket
   client.io.connect();


### PR DESCRIPTION
## Summary

This PR improves diagnostics and robustness for Codex executor deaths that were surfacing as generic `Executor heartbeat lost` failures.

The exported daemon logs showed the concrete failure path was not OOM and not Codex subscription auth. Instead, prompt executors were exiting after an Agor Feathers auth reconnect failure:

```text
[executor] Unhandled rejection: NotAuthenticated: No accessToken found in storage
[executor] Socket reconnected (attempt 1), re-authenticating...
[executor] Failed to update task status: NotAuthenticated: Not authenticated
```

Because the daemon exit safety net skipped some non-latest tasks, those tasks were later marked failed by the heartbeat supervisor, hiding the original executor exit reason.

## Changes

- Capture bounded executor stdout/stderr tails for prompt executors while still teeing output to daemon logs.
- Include the captured stderr/output tail in task `error_message` when a prompt executor exits unexpectedly.
- Apply a task-local safety net for non-latest tasks so executor exits are recorded instead of being hidden until heartbeat stale detection.
- Add `authStorage` support to the shared Feathers client factory.
- Pass executor in-memory auth storage during initial client creation, avoiding duplicate Feathers auth setup with empty Node storage.

## Notes

Heartbeat loss should remain a fallback liveness signal, not the primary classification when the daemon observes an executor exit. A stale heartbeat can mean crash/exit, a wedged event loop, lost daemon socket/auth, or daemon restart/lost process tracking.

The known startup trust-race example remains separate:

- session `019ee281-3002-7e60-820b-351940e5dd2d`
- task `019ee281-3042-7783-8b60-10140611c33a`
- error: `Not inside a trusted directory and --skip-git-repo-check was not specified`

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/utils/spawn-executor.configured.test.ts src/services/executor-heartbeat-supervisor.test.ts src/services/tasks.executor-heartbeat.test.ts`
- `pnpm --filter @agor/core test -- src/api/index.test.ts`
- `pnpm --filter @agor/executor test -- src/executor-heartbeat.test.ts`
