### PR TITLE
fix(executor): stabilize gateway MCP startup

### DIFF
--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -206,6 +206,45 @@ describe('setupQuery - Local Settings Support', () => {
     expect(mcpServers.oauthRemote.alwaysLoad).toBeUndefined();
   });
 
+  it('does not block gateway startup on remote Bearer or JWT servers without resolved auth', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      mcp_token: 'test-token',
+      custom_context: { gateway_source: { channel_id: 'channel-1' } },
+    } as any);
+    deps.sessionMCPRepo = {} as any;
+    deps.mcpServerRepo = {} as any;
+    vi.mocked(resolveMCPAuthHeaders).mockResolvedValue(undefined);
+    vi.mocked(getMcpServersForSession).mockResolvedValue([
+      {
+        server: {
+          name: 'bearerRemote',
+          transport: 'http',
+          url: 'https://bearer.example.com/mcp',
+          auth: { type: 'bearer' },
+        },
+      } as any,
+      {
+        server: {
+          name: 'jwtRemote',
+          transport: 'http',
+          url: 'https://jwt.example.com/mcp',
+          auth: { type: 'jwt' },
+        },
+      } as any,
+    ]);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    const mcpServers = callArgs.options.mcpServers as Record<string, Record<string, unknown>>;
+    expect(mcpServers.agor).toMatchObject({ alwaysLoad: true });
+    expect(mcpServers.bearerRemote.alwaysLoad).toBeUndefined();
+    expect(mcpServers.jwtRemote.alwaysLoad).toBeUndefined();
+  });
+
   it('passes session advisorModel through the --advisor CLI flag, NOT settings', async () => {
     const deps = createMockDeps();
     vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -40,6 +40,8 @@ vi.mock('./permissions/permission-hooks.js', () => ({
 }));
 
 import { Claude } from '@agor/core/sdk';
+import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
+import { getMcpServersForSession } from '../base/mcp-scoping.js';
 import { CLAUDE_CODE_DISALLOWED_TOOLS } from './constants.js';
 import { formatListForLog, type QuerySetupDeps, setupQuery } from './query-builder.js';
 
@@ -53,6 +55,7 @@ describe('MCP logging helpers', () => {
 describe('setupQuery - Local Settings Support', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getMcpServersForSession).mockResolvedValue([]);
     vi.mocked(Claude.query).mockReturnValue({
       [Symbol.asyncIterator]: () => ({ next: () => Promise.resolve({ done: true }) }),
       interrupt: () => Promise.resolve(),
@@ -112,6 +115,95 @@ describe('setupQuery - Local Settings Support', () => {
 
     const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
     expect(callArgs.options.disallowedTools).toEqual([...CLAUDE_CODE_DISALLOWED_TOOLS]);
+  });
+
+  it('blocks on MCP startup for gateway sessions', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      mcp_token: 'test-token',
+      custom_context: { gateway_source: { channel_id: 'channel-1' } },
+    } as any);
+    deps.sessionMCPRepo = {} as any;
+    deps.mcpServerRepo = {} as any;
+    vi.mocked(getMcpServersForSession).mockResolvedValue([
+      {
+        server: {
+          name: 'remote',
+          transport: 'http',
+          url: 'https://example.com/mcp',
+        },
+      } as any,
+    ]);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    const mcpServers = callArgs.options.mcpServers as Record<string, Record<string, unknown>>;
+    expect(mcpServers.agor).toMatchObject({ alwaysLoad: true });
+    expect(mcpServers.remote).toMatchObject({ alwaysLoad: true });
+  });
+
+  it('keeps MCP startup lazy for non-gateway sessions', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      mcp_token: 'test-token',
+    } as any);
+    deps.sessionMCPRepo = {} as any;
+    deps.mcpServerRepo = {} as any;
+    vi.mocked(getMcpServersForSession).mockResolvedValue([
+      {
+        server: {
+          name: 'remote',
+          transport: 'http',
+          url: 'https://example.com/mcp',
+        },
+      } as any,
+    ]);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    const mcpServers = callArgs.options.mcpServers as Record<string, Record<string, unknown>>;
+    expect(mcpServers.agor.alwaysLoad).toBeUndefined();
+    expect(mcpServers.remote.alwaysLoad).toBeUndefined();
+  });
+
+  it('does not block gateway startup on unauthenticated OAuth servers with custom headers', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({
+      session_id: 'test-session' as SessionID,
+      branch_id: 'test-branch' as BranchID,
+      mcp_token: 'test-token',
+      custom_context: { gateway_source: { channel_id: 'channel-1' } },
+    } as any);
+    deps.sessionMCPRepo = {} as any;
+    deps.mcpServerRepo = {} as any;
+    vi.mocked(resolveMCPAuthHeaders).mockResolvedValue(undefined);
+    vi.mocked(getMcpServersForSession).mockResolvedValue([
+      {
+        server: {
+          name: 'oauthRemote',
+          transport: 'http',
+          url: 'https://example.com/mcp',
+          auth: { type: 'oauth' },
+          headers: { 'X-Tenant': 'tenant-1' },
+        },
+      } as any,
+    ]);
+
+    await setupQuery('test-session' as SessionID, 'test prompt', deps);
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    const mcpServers = callArgs.options.mcpServers as Record<string, Record<string, unknown>>;
+    expect(mcpServers.agor).toMatchObject({ alwaysLoad: true });
+    expect(mcpServers.oauthRemote).toMatchObject({
+      headers: { 'X-Tenant': 'tenant-1' },
+    });
+    expect(mcpServers.oauthRemote.alwaysLoad).toBeUndefined();
   });
 
   it('passes session advisorModel through the --advisor CLI flag, NOT settings', async () => {

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -573,7 +573,7 @@ export async function setupQuery(
         let remoteServerCount = 0;
         let stdioServerCount = 0;
         let serversWithHeaders = 0;
-        const missingOAuthServers: string[] = [];
+        const missingAuthServers: string[] = [];
         const unresolvedAuthServers: string[] = [];
 
         for (const { server } of serversWithSource) {
@@ -604,16 +604,19 @@ export async function setupQuery(
           try {
             // Pass mcpUrl for OAuth token cache lookup
             const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
-            const missingOAuthAuth =
-              server.auth?.type === 'oauth' && transport !== 'stdio' && !authHeaders?.Authorization;
+            const missingRequiredAuth =
+              !!server.auth &&
+              server.auth.type !== 'none' &&
+              transport !== 'stdio' &&
+              !authHeaders?.Authorization;
             const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
             if (headers && transport !== 'stdio') {
               serverConfig.headers = headers;
               serversWithHeaders += 1;
             }
-            if (missingOAuthAuth) {
-              // OAuth server but no token. Track for one concise per-query summary below.
-              missingOAuthServers.push(server.name);
+            if (missingRequiredAuth) {
+              // Auth-backed remote server but no usable token. Track one concise summary below.
+              missingAuthServers.push(server.name);
               canAlwaysLoad = false;
             }
           } catch (error) {
@@ -644,13 +647,13 @@ export async function setupQuery(
         // Log one safe summary line. Env/header values may contain secrets after template resolution.
         console.log(
           `   🔧 MCP servers configured: total=${serversWithSource.length} remote=${remoteServerCount} ` +
-            `stdio=${stdioServerCount} headers=${serversWithHeaders} missing_oauth=${missingOAuthServers.length} ` +
+            `stdio=${stdioServerCount} headers=${serversWithHeaders} missing_auth=${missingAuthServers.length} ` +
             `auth_errors=${unresolvedAuthServers.length}`
         );
-        if (missingOAuthServers.length > 0) {
+        if (missingAuthServers.length > 0) {
           console.warn(
-            `   ⚠️  ${missingOAuthServers.length} OAuth MCP server(s) have no valid token: ` +
-              `${formatListForLog(missingOAuthServers)}. Authenticate in Settings → MCP Servers.`
+            `   ⚠️  ${missingAuthServers.length} MCP server(s) have configured auth but no valid token: ` +
+              `${formatListForLog(missingAuthServers)}. Check Settings → MCP Servers.`
           );
         }
         if (unresolvedAuthServers.length > 0) {

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -12,6 +12,7 @@ import { Claude } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
+import { isGatewaySession } from '@agor/core/types';
 
 const { query } = Claude;
 type PermissionMode = Claude.PermissionMode;
@@ -175,6 +176,7 @@ export async function setupQuery(
   if (!session) {
     throw new Error(`Session not found: ${sessionId}`);
   }
+  const shouldBlockOnMcpStartup = isGatewaySession(session);
 
   // Determine which user's context to use for environment variables and API
   // keys: the task creator (prompter) when known, else the session owner.
@@ -542,6 +544,7 @@ export async function setupQuery(
           headers: {
             Authorization: `Bearer ${mcpToken}`,
           },
+          ...(shouldBlockOnMcpStartup ? { alwaysLoad: true } : {}),
         },
       };
       queryOptions.mcpServers = mcpConfig;
@@ -587,6 +590,7 @@ export async function setupQuery(
             type: transport,
             env: server.env,
           };
+          let canAlwaysLoad = shouldBlockOnMcpStartup;
 
           // Add transport-specific fields
           if (transport === 'stdio') {
@@ -600,17 +604,26 @@ export async function setupQuery(
           try {
             // Pass mcpUrl for OAuth token cache lookup
             const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
+            const missingOAuthAuth =
+              server.auth?.type === 'oauth' && transport !== 'stdio' && !authHeaders?.Authorization;
             const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
             if (headers && transport !== 'stdio') {
               serverConfig.headers = headers;
               serversWithHeaders += 1;
-            } else if (server.auth?.type === 'oauth' && transport !== 'stdio') {
+            }
+            if (missingOAuthAuth) {
               // OAuth server but no token. Track for one concise per-query summary below.
               missingOAuthServers.push(server.name);
+              canAlwaysLoad = false;
             }
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             unresolvedAuthServers.push(`${server.name}: ${message}`);
+            canAlwaysLoad = false;
+          }
+
+          if (canAlwaysLoad) {
+            serverConfig.alwaysLoad = true;
           }
 
           mcpConfig[server.name] = serverConfig;

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -383,6 +383,75 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       threadId: 'mock-thread-id',
     });
   });
+
+  it('requires MCP startup from gateway session metadata in the prompt path', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-gateway.md');
+
+    configMocks.getDaemonUrl.mockResolvedValue('http://localhost:3030');
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'remote',
+          transport: 'http',
+          url: 'https://example.com/mcp',
+        },
+      },
+    ]);
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-gateway',
+      branch_id: 'branch-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+      custom_context: { gateway_source: { channel_id: 'channel-1' } },
+    });
+    mockSessionsRepo.update.mockResolvedValue(undefined);
+    mockBranchesRepo.findById.mockResolvedValue({
+      branch_id: 'branch-1',
+      path: process.cwd(),
+    });
+
+    mockStreamEvents = [
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ];
+
+    for await (const _event of service.promptSessionStreaming('session-gateway' as any, 'review')) {
+      // Drain stream to force client setup.
+    }
+
+    expect(mockInstanceConfigs.at(-1)).toMatchObject({
+      model_instructions_file: '/tmp/agor-codex-instructions-gateway.md',
+      mcp_servers: {
+        agor: {
+          required: true,
+          startup_timeout_ms: 30_000,
+        },
+        remote: {
+          required: true,
+          startup_timeout_ms: 30_000,
+        },
+      },
+    });
+  });
 });
 
 describe('CodexPromptService - forked sessions', () => {
@@ -1031,5 +1100,87 @@ describe('CodexPromptService - buildMcpServersConfig', () => {
         default_tools_approval_mode: 'approve',
       });
     }
+  });
+
+  it('marks built-in Agor MCP required for gateway sessions', async () => {
+    const service = makeService();
+    const { servers, total } = await (service as any).buildMcpServersConfig(
+      '019e3700-aaaa-bbbb-cccc-dddddddddddd',
+      'agor-bearer-token',
+      undefined,
+      true
+    );
+
+    expect(total).toBe(1);
+    expect(servers.agor).toMatchObject({
+      default_tools_approval_mode: 'approve',
+      required: true,
+      startup_timeout_ms: 30_000,
+    });
+  });
+
+  it('marks attached MCP servers required for gateway sessions', async () => {
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'github',
+          transport: 'stdio',
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-github'],
+        },
+      },
+      {
+        server: {
+          name: 'linear',
+          transport: 'http',
+          url: 'https://mcp.linear.app/sse',
+        },
+      },
+    ]);
+
+    const service = makeService();
+    const { servers, total } = await (service as any).buildMcpServersConfig(
+      '019e3700-aaaa-bbbb-cccc-dddddddddddd',
+      'agor-bearer-token',
+      undefined,
+      true
+    );
+
+    expect(total).toBe(3);
+    for (const name of ['agor', 'github', 'linear']) {
+      expect(servers[name], `server "${name}" missing startup guard`).toMatchObject({
+        required: true,
+        startup_timeout_ms: 30_000,
+      });
+    }
+  });
+
+  it('does not require unauthenticated OAuth MCP servers for gateway sessions', async () => {
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'oauthRemote',
+          transport: 'http',
+          url: 'https://example.com/mcp',
+          auth: { type: 'oauth' },
+        },
+      },
+    ]);
+    mcpAuthMocks.resolveMCPAuthHeaders.mockResolvedValue(null);
+
+    const service = makeService();
+    const { servers, total } = await (service as any).buildMcpServersConfig(
+      '019e3700-aaaa-bbbb-cccc-dddddddddddd',
+      undefined,
+      undefined,
+      true
+    );
+
+    expect(total).toBe(1);
+    expect(servers.oauthremote).toMatchObject({
+      default_tools_approval_mode: 'approve',
+    });
+    expect(servers.oauthremote.required).toBeUndefined();
+    expect(servers.oauthremote.startup_timeout_ms).toBeUndefined();
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1183,4 +1183,43 @@ describe('CodexPromptService - buildMcpServersConfig', () => {
     expect(servers.oauthremote.required).toBeUndefined();
     expect(servers.oauthremote.startup_timeout_ms).toBeUndefined();
   });
+
+  it('does not require remote Bearer or JWT MCP servers without resolved auth', async () => {
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'bearerRemote',
+          transport: 'http',
+          url: 'https://bearer.example.com/mcp',
+          auth: { type: 'bearer' },
+        },
+      },
+      {
+        server: {
+          name: 'jwtRemote',
+          transport: 'http',
+          url: 'https://jwt.example.com/mcp',
+          auth: { type: 'jwt' },
+        },
+      },
+    ]);
+    mcpAuthMocks.resolveMCPAuthHeaders.mockResolvedValue(null);
+
+    const service = makeService();
+    const { servers, total } = await (service as any).buildMcpServersConfig(
+      '019e3700-aaaa-bbbb-cccc-dddddddddddd',
+      undefined,
+      undefined,
+      true
+    );
+
+    expect(total).toBe(2);
+    for (const name of ['bearerremote', 'jwtremote']) {
+      expect(servers[name], `server "${name}" should remain optional`).toMatchObject({
+        default_tools_approval_mode: 'approve',
+      });
+      expect(servers[name].required).toBeUndefined();
+      expect(servers[name].startup_timeout_ms).toBeUndefined();
+    }
+  });
 });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -33,6 +33,7 @@ import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { CodexSandboxMode, ContextUsageSnapshot, EffortLevel } from '@agor/core/types';
+import { isGatewaySession } from '@agor/core/types';
 import { getDefaultCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
 import { getDaemonUrl } from '../../config.js';
 import type {
@@ -89,6 +90,7 @@ type CodexConfigValue = CodexConfigObject[string];
  * clears the prompt.
  */
 const MCP_AUTO_APPROVE: CodexConfigObject = { default_tools_approval_mode: 'approve' };
+const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 
 const DEBUG_CODEX = process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex');
 
@@ -96,6 +98,12 @@ function codexDebug(...args: unknown[]): void {
   if (DEBUG_CODEX) {
     console.debug(...args);
   }
+}
+
+function applyGatewayMcpStartupGuard(config: CodexConfigObject, requireMcpServers: boolean): void {
+  if (!requireMcpServers) return;
+  config.required = true;
+  config.startup_timeout_ms = GATEWAY_MCP_STARTUP_TIMEOUT_MS;
 }
 
 export interface CodexPromptResult {
@@ -563,7 +571,8 @@ export class CodexPromptService {
   private async buildMcpServersConfig(
     sessionId: SessionID,
     mcpToken: string | undefined,
-    forUserId: UserID | undefined
+    forUserId: UserID | undefined,
+    requireMcpServers = false
   ): Promise<{ servers: CodexConfigObject; total: number }> {
     codexDebug(`🔍 [Codex MCP] Fetching MCP servers for session ${shortId(sessionId)}...`);
     codexDebug(`   [Codex MCP] forUserId: ${forUserId || 'NOT SET'}`);
@@ -602,9 +611,9 @@ export class CodexPromptService {
       result.agor = {
         url: `${daemonUrl}/mcp`,
         bearer_token_env_var: agorBearerEnvVar,
-        required: false,
         ...MCP_AUTO_APPROVE,
       };
+      applyGatewayMcpStartupGuard(result.agor as CodexConfigObject, requireMcpServers);
       codexDebug(
         `   📝 [Codex MCP] Configuring built-in Agor MCP server (HTTP) at ${daemonUrl}/mcp`
       );
@@ -618,6 +627,7 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
+      applyGatewayMcpStartupGuard(serverConfig, requireMcpServers);
       codexDebug(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
       if (server.command) {
         serverConfig.command = server.command;
@@ -643,6 +653,7 @@ export class CodexPromptService {
       );
 
       const serverConfig: CodexConfigObject = { ...MCP_AUTO_APPROVE };
+      let canRequireServer = requireMcpServers;
       codexDebug(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
       if (server.url) {
         serverConfig.url = server.url;
@@ -673,11 +684,13 @@ export class CodexPromptService {
             serverConfig.bearer_token_env_var = envVarName;
             codexDebug(`      auth: ${server.auth?.type ?? 'bearer'} token via ${envVarName}`);
           } else {
+            canRequireServer = false;
             console.warn(
               `      ⚠️  auth: resolved Authorization header for "${server.name}" is not a Bearer scheme (Codex CLI only supports bearer); skipping injection`
             );
           }
         } else if (server.auth?.type === 'oauth') {
+          canRequireServer = false;
           console.warn(
             `   ⚠️  [Codex MCP] Server "${server.name}" requires OAuth but no valid token found.`
           );
@@ -690,8 +703,10 @@ export class CodexPromptService {
           `   ⚠️  [Codex MCP] Failed to resolve auth headers for "${server.name}":`,
           error instanceof Error ? error.message : String(error)
         );
+        canRequireServer = false;
       }
 
+      applyGatewayMcpStartupGuard(serverConfig, canRequireServer);
       result[serverName] = serverConfig;
     }
 
@@ -961,10 +976,12 @@ export class CodexPromptService {
       taskId,
       tasksService: this.tasksService,
     });
+    const requireMcpServers = isGatewaySession(session);
     const { servers: mcpServersConfig, total: mcpServerCount } = await this.buildMcpServersConfig(
       sessionId,
       mcpToken,
-      forUserId
+      forUserId,
+      requireMcpServers
     );
 
     const codexConfigPayload: CodexConfigObject = {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -670,6 +670,7 @@ export class CodexPromptService {
         const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
         const headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
         const authHeader = headers?.Authorization;
+        const missingRequiredAuth = !!server.auth && server.auth.type !== 'none' && !authHeader;
         const customHeaders = headers ? { ...headers } : undefined;
         if (customHeaders) delete customHeaders.Authorization;
         if (customHeaders && Object.keys(customHeaders).length > 0) {
@@ -689,14 +690,16 @@ export class CodexPromptService {
               `      ⚠️  auth: resolved Authorization header for "${server.name}" is not a Bearer scheme (Codex CLI only supports bearer); skipping injection`
             );
           }
-        } else if (server.auth?.type === 'oauth') {
+        } else if (missingRequiredAuth) {
           canRequireServer = false;
           console.warn(
-            `   ⚠️  [Codex MCP] Server "${server.name}" requires OAuth but no valid token found.`
+            `   ⚠️  [Codex MCP] Server "${server.name}" has configured auth but no valid token found.`
           );
-          console.warn(
-            `      💡 Go to Settings → MCP Servers → ${server.name} → Start OAuth Flow to authenticate.`
-          );
+          const action =
+            server.auth?.type === 'oauth'
+              ? `Start OAuth Flow for ${server.name}`
+              : `check credentials for ${server.name}`;
+          console.warn(`      💡 Go to Settings → MCP Servers → ${action}.`);
         }
       } catch (error) {
         console.warn(


### PR DESCRIPTION
## Summary

Fixes gateway-driven sessions so MCP servers are ready before each agent turn can observe them as unavailable.

Closes #1524.

## Problem

Gateway sessions can span multiple turns while each turn still runs through a fresh executor startup path. That means MCP clients may reconnect around turn boundaries. In practice, several unrelated MCP servers appeared to disconnect/reconnect together, and tools were intermittently unavailable when the agent tried to use them.

The servers themselves were not necessarily unhealthy. The fragile part was the turn startup boundary: gateway turns need MCP availability to be established before the agent starts acting, otherwise tool discovery can race the reconnect window.

## How This Works

Gateway sessions are detected through the canonical `isGatewaySession()` helper from `@agor/core/types`, which checks for `session.custom_context.gateway_source`.

When a session is gateway-driven:

- The built-in Agor MCP server is forced to load at startup.
- Attached MCP servers are also forced to load at startup when they are usable.
- Auth-backed remote MCP servers without usable auth are intentionally left optional, so a missing token does not block the whole session.
- The Codex path uses `required: true` plus a bounded `startup_timeout_ms` so startup waits for MCP readiness without hanging indefinitely.
- The Claude path uses `alwaysLoad: true` for the same gateway-only startup-readiness behavior.

This keeps the fix generic to executor/MCP startup behavior. It does not encode board-specific or workflow-specific behavior.

## What Changed

- Reuse `isGatewaySession()` instead of duplicating gateway detection locally.
- For Claude gateway sessions:
  - mark built-in Agor MCP and attached usable MCP servers with `alwaysLoad: true`
  - do not force `alwaysLoad` for unauthenticated OAuth/Bearer/JWT remotes
- For Codex gateway sessions:
  - mark built-in Agor MCP and attached usable MCP servers as `required`
  - add `startup_timeout_ms: 30000`
  - keep unauthenticated OAuth/Bearer/JWT remotes non-required

## Validation

Automated validation:

- `pnpm --filter @agor/core build`
- `pnpm --filter @agor/executor test -- src/sdk-handlers/claude/query-builder.test.ts src/sdk-handlers/codex/prompt-service.test.ts`
- `pnpm exec biome check packages/executor/src/sdk-handlers/claude/query-builder.ts packages/executor/src/sdk-handlers/claude/query-builder.test.ts packages/executor/src/sdk-handlers/codex/prompt-service.ts packages/executor/src/sdk-handlers/codex/prompt-service.test.ts`
- `git diff --check`
- `pnpm --filter @agor/executor typecheck`

Live smoke validation:

- Ran the daemon from this PR branch.
- Created a disposable gateway-style Codex session with `custom_context.gateway_source`.
- Prompted the session through the normal daemon -> executor path.
- Inspected the actual spawned Codex command line.
- Confirmed the command included:
  - `mcp_servers.agor.required=true`
  - `mcp_servers.agor.startup_timeout_ms=30000`
- Confirmed attached browser MCPs also received the gateway startup guard:
  - `mcp_servers.chrome-devtools.required=true`
  - `mcp_servers.playwright.required=true`
- Let the disposable task complete successfully and removed the smoke session afterward.

## Notes

The live smoke validates that the fix is applied through the real daemon -> executor -> agent launch path, not only through unit tests. Remaining risk is limited to genuinely broken required MCP servers: for gateway sessions, usable attached MCPs now intentionally block startup until ready or until the bounded timeout expires.
