### PR TITLE
Instrument executor startup latency

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1016,7 +1016,19 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     },
     params: RouteParams
   ): Promise<Task> {
+    const startupStartedAt = Date.now();
     const session = await sessionsService.get(task.session_id, params);
+    const logStartupTiming = (
+      phase: string,
+      extra?: Record<string, unknown>
+    ) => {
+      const message =
+        `[executor-startup] session=${shortId(task.session_id)} task=${shortId(task.task_id)} ` +
+        `phase=${phase} elapsed_ms=${Date.now() - startupStartedAt}`;
+      if (extra) console.log(message, extra);
+      else console.log(message);
+    };
+    logStartupTiming('spawn_task_executor_start');
 
     // Recompute message_range.start_index against the live message count.
     const messageStartIndex = await sessionsRepository.countMessages(task.session_id);
@@ -1049,6 +1061,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       },
       params
     )) as Task;
+    logStartupTiming('task_marked_running');
 
     // Alt D — write the user-message row before spawning. Gated by kill switch.
     // The executor's createUserMessage has a skip-if-exists guard so a duplicate
@@ -1080,6 +1093,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           metadata: Object.keys(messageMetadata).length > 0 ? messageMetadata : undefined,
         });
         await app.service('messages').create(userMessage, params);
+        logStartupTiming('initial_user_message_written');
       } catch (msgErr) {
         // Don't fail the spawn — the executor's createUserMessage fallback
         // (with skip-if-exists) will write the row when it connects.
@@ -1109,6 +1123,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       },
       params
     );
+    logStartupTiming('session_marked_running');
 
     // Tag the bytes shipped to the executor with `[Prompted by: ...]` when a
     // non-owner is prompting. The prompter identity comes from `task.created_by`
@@ -1225,6 +1240,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // response should not block on the executor process being live.
     setImmediate(async () => {
       try {
+        logStartupTiming('execute_task_dispatch_start', { agenticTool: session.agentic_tool });
         console.log(
           `🚀 [Daemon] Routing ${session.agentic_tool} to Feathers/WebSocket executor (task ${shortId(taskId)})`
         );
@@ -1244,6 +1260,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         console.log(
           `✅ [Daemon] Executor spawned for session ${shortId(sessionId)}, waiting for task completion`
         );
+        logStartupTiming('execute_task_dispatch_returned');
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -641,6 +641,19 @@ function createExecuteHandler(
   sessionTokenService: import('./services/session-token-service.js').SessionTokenService
 ) {
   const { db, app, config, daemonUrl } = ctx;
+  const logStartupTiming = (
+    sessionId: string,
+    taskId: string,
+    startedAtMs: number,
+    phase: string,
+    extra?: Record<string, unknown>
+  ) => {
+    const message =
+      `[executor-startup] session=${shortId(sessionId)} task=${shortId(taskId)} ` +
+      `phase=${phase} elapsed_ms=${Date.now() - startedAtMs}`;
+    if (extra) console.log(message, extra);
+    else console.log(message);
+  };
 
   return async (
     sessionId: string,
@@ -654,10 +667,14 @@ function createExecuteHandler(
     // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type varies by context
     params: any
   ) => {
+    const startupStartedAt = Date.now();
+    const taskId = data.taskId;
+    logStartupTiming(sessionId, taskId, startupStartedAt, 'execute_handler_start');
     const session = await sessionsService.get(sessionId, params);
     if (!session) {
       throw new Error(`Session ${sessionId} not found`);
     }
+    logStartupTiming(sessionId, taskId, startupStartedAt, 'session_loaded');
 
     // Validate stateless_fs_mode compatibility with agentic tool
     if (config.execution?.stateless_fs_mode) {
@@ -697,8 +714,7 @@ function createExecuteHandler(
         maxUses: -1,
       }
     );
-
-    const taskId = data.taskId;
+    logStartupTiming(sessionId, taskId, startupStartedAt, 'session_token_generated');
 
     // Get branch path
     let cwd = process.cwd();
@@ -710,6 +726,7 @@ function createExecuteHandler(
         console.warn(`Could not get branch path for ${session.branch_id}:`, error);
       }
     }
+    logStartupTiming(sessionId, taskId, startupStartedAt, 'branch_path_resolved', { cwd });
 
     // Determine Unix user for executor
     const {
@@ -791,6 +808,9 @@ function createExecuteHandler(
       sessionId as SessionID,
       session.agentic_tool
     );
+    logStartupTiming(sessionId, taskId, startupStartedAt, 'executor_env_resolved', {
+      envKeyCount: Object.keys(executorEnv).length,
+    });
 
     // Validate required user environment variables
     const requiredUserEnvVars = config.execution?.required_user_env_vars;
@@ -866,9 +886,14 @@ function createExecuteHandler(
         // Don't block the executor — proceed with potentially stale/missing session file
       }
     }
+    logStartupTiming(sessionId, taskId, startupStartedAt, 'stateless_fs_restore_checked');
 
     const logPrefix = `[Executor ${shortId(sessionId)}]`;
 
+    logStartupTiming(sessionId, taskId, startupStartedAt, 'spawn_calling', {
+      asUser: executorUnixUser || undefined,
+      cwd,
+    });
     spawnExecutor(executorPayload, {
       cwd,
       asUser: executorUnixUser || undefined,
@@ -880,6 +905,9 @@ function createExecuteHandler(
         unix_user: executorUnixUser || undefined,
       },
       onSpawn: (child) => {
+        logStartupTiming(sessionId, taskId, startupStartedAt, 'process_spawned', {
+          pid: child.pid,
+        });
         if (child.pid) {
           trackExecutorProcess(sessionId, child.pid);
           console.log(`${logPrefix} PID: ${child.pid}`);

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -167,8 +167,7 @@ async function handlePromptPayload(
   }
 
   // Validate tool using registry
-  const { ToolRegistry, initializeToolRegistry } = await import('./handlers/sdk/tool-registry.js');
-  await initializeToolRegistry();
+  const { ToolRegistry } = await import('./handlers/sdk/tool-registry.js');
 
   if (!ToolRegistry.has(payload.params.tool)) {
     console.error(`[executor] Invalid tool: ${payload.params.tool}`);
@@ -226,11 +225,11 @@ async function handleLegacyMode(values: {
   }
 
   // Validate tool using registry
-  const { ToolRegistry, initializeToolRegistry } = await import('./handlers/sdk/tool-registry.js');
-  await initializeToolRegistry();
+  const { ToolRegistry } = await import('./handlers/sdk/tool-registry.js');
+  const tool = values.tool as string;
 
-  if (!ToolRegistry.has(values.tool as string)) {
-    console.error(`Invalid tool: ${values.tool}`);
+  if (!ToolRegistry.has(tool)) {
+    console.error(`Invalid tool: ${tool}`);
     console.error(`Valid tools: ${ToolRegistry.getAll().join(', ')}`);
     process.exit(1);
   }

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -35,6 +35,20 @@ function sdkDebug(...args: unknown[]): void {
   }
 }
 
+function startupTiming(
+  toolName: string,
+  taskId: TaskID,
+  startedAtMs: number,
+  phase: string,
+  extra?: Record<string, unknown>
+): void {
+  const message =
+    `[executor-startup] tool=${toolName} task=${shortId(taskId)} ` +
+    `phase=${phase} elapsed_ms=${Date.now() - startedAtMs}`;
+  if (extra) console.log(message, extra);
+  else console.log(message);
+}
+
 /**
  * Tool interface that all SDK wrappers must implement
  */
@@ -395,26 +409,35 @@ export async function executeToolTask(params: {
 }): Promise<void> {
   const { client, sessionId, taskId, prompt, permissionMode, apiKeyEnvVar, toolName, createTool } =
     params;
+  const startupStartedAt = Date.now();
 
   console.log(`[${toolName}] Executing task ${shortId(taskId)}...`);
+  startupTiming(toolName, taskId, startupStartedAt, 'base_execute_start');
 
   // Ensure plain git commands launched by the agent SDK inherit safe.directory
   // trust for this managed checkout. Without this, Unix-isolated sessions can
   // create and run successfully through executor-mediated git probes while
   // `git status` inside the agent shell still fails with dubious ownership.
   await configureSessionGitSafeDirectories(client, sessionId, `[${toolName} git.safe-directory]`);
+  startupTiming(toolName, taskId, startupStartedAt, 'git_safe_directories_configured');
 
   // Capture and stamp task-start git state inside the executor as early as
   // possible. The daemon transitions the task to RUNNING before spawn, but the
   // authoritative branch git read belongs here with the rest of
   // executor-mediated git work.
   await stampGitStateAtTaskStart(client, sessionId, taskId);
+  startupTiming(toolName, taskId, startupStartedAt, 'git_state_start_stamped');
 
   // Resolve API key with proper precedence (user → config → env → native auth).
   // Pass `toolName` so the daemon scopes the per-user lookup to this tool's
   // credential bucket — prevents cross-SDK leak (e.g. Codex picking up an
   // ANTHROPIC_API_KEY stored under claude-code).
   const resolution = await resolveApiKeyForTask(apiKeyEnvVar, client, taskId, toolName);
+  startupTiming(toolName, taskId, startupStartedAt, 'api_key_resolved', {
+    source: resolution.source,
+    hasApiKey: Boolean(resolution.apiKey),
+    useNativeAuth: resolution.useNativeAuth,
+  });
 
   // Fail fast if stored key can't be decrypted (e.g. master secret changed)
   if (resolution.decryptionFailed) {
@@ -436,10 +459,12 @@ export async function executeToolTask(params: {
 
   // Create execution context
   const ctx = createExecutionContext(client, toolName, sessionId);
+  startupTiming(toolName, taskId, startupStartedAt, 'execution_context_created');
 
   // Create tool instance using factory function
   // Pass the resolved key (or empty string) and useNativeAuth flag
   const tool = createTool(ctx.repos, resolution.apiKey || '', resolution.useNativeAuth);
+  startupTiming(toolName, taskId, startupStartedAt, 'tool_instance_created');
 
   // Wire up abort signal to tool's stopTask method.
   // Triggered by SIGTERM handler calling abortController.abort().
@@ -472,6 +497,7 @@ export async function executeToolTask(params: {
   try {
     // Execute prompt with streaming
     // Pass abortController directly to SDK for proper cancellation support
+    startupTiming(toolName, taskId, startupStartedAt, 'execute_prompt_with_streaming_start');
     const result = await tool.executePromptWithStreaming(
       sessionId,
       prompt,
@@ -481,6 +507,7 @@ export async function executeToolTask(params: {
       params.abortController,
       params.messageSource
     );
+    startupTiming(toolName, taskId, startupStartedAt, 'execute_prompt_with_streaming_done');
 
     console.log(
       `[${toolName}] Execution completed: user=${result.userMessageId}, assistant=${result.assistantMessageIds.length} messages`

--- a/packages/executor/src/handlers/sdk/tool-registry.ts
+++ b/packages/executor/src/handlers/sdk/tool-registry.ts
@@ -15,6 +15,15 @@ import type { AgorClient } from '../../services/feathers-client.js';
  */
 export type Tool = 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'cursor';
 
+export const KNOWN_TOOLS: readonly Tool[] = [
+  'claude-code',
+  'codex',
+  'gemini',
+  'opencode',
+  'copilot',
+  'cursor',
+] as const;
+
 /**
  * Tool runner function - executes via Feathers WebSocket
  */
@@ -69,14 +78,14 @@ export class ToolRegistry {
    * Get all registered tools
    */
   static getAll(): Tool[] {
-    return Array.from(ToolRegistry.tools.keys());
+    return [...KNOWN_TOOLS];
   }
 
   /**
    * Check if tool is registered
    */
   static has(tool: string): tool is Tool {
-    return ToolRegistry.tools.has(tool as Tool);
+    return (KNOWN_TOOLS as readonly string[]).includes(tool);
   }
 
   /**
@@ -117,62 +126,78 @@ export class ToolRegistry {
 /**
  * Initialize tool registry with all available tools
  */
-export async function initializeToolRegistry(): Promise<void> {
-  // Import all tool handlers
-  const [claude, codex, gemini, opencode, copilot, cursor] = await Promise.all([
-    import('./claude.js'),
-    import('./codex.js'),
-    import('./gemini.js'),
-    import('./opencode.js'),
-    import('./copilot.js'),
-    import('./cursor.js'),
-  ]);
+export async function initializeToolRegistry(tool?: Tool): Promise<void> {
+  const registerTool = async (selectedTool: Tool): Promise<void> => {
+    if (ToolRegistry.get(selectedTool)) return;
 
-  // Register Claude Code
-  ToolRegistry.register({
-    tool: 'claude-code',
-    name: 'Claude Code',
-    apiKeyEnvVar: TOOL_API_KEY_NAMES['claude-code']!,
-    runner: claude.executeClaudeCodeTask,
-  });
+    switch (selectedTool) {
+      case 'claude-code': {
+        const claude = await import('./claude.js');
+        ToolRegistry.register({
+          tool: 'claude-code',
+          name: 'Claude Code',
+          apiKeyEnvVar: TOOL_API_KEY_NAMES['claude-code']!,
+          runner: claude.executeClaudeCodeTask,
+        });
+        break;
+      }
+      case 'codex': {
+        const codex = await import('./codex.js');
+        ToolRegistry.register({
+          tool: 'codex',
+          name: 'Codex',
+          apiKeyEnvVar: TOOL_API_KEY_NAMES.codex!,
+          runner: codex.executeCodexTask,
+        });
+        break;
+      }
+      case 'gemini': {
+        const gemini = await import('./gemini.js');
+        ToolRegistry.register({
+          tool: 'gemini',
+          name: 'Gemini',
+          apiKeyEnvVar: TOOL_API_KEY_NAMES.gemini!,
+          runner: gemini.executeGeminiTask,
+        });
+        break;
+      }
+      case 'opencode': {
+        const opencode = await import('./opencode.js');
+        ToolRegistry.register({
+          tool: 'opencode',
+          name: 'OpenCode',
+          apiKeyEnvVar: 'NONE', // OpenCode doesn't need API key
+          runner: opencode.executeOpenCodeTask,
+        });
+        break;
+      }
+      case 'copilot': {
+        const copilot = await import('./copilot.js');
+        ToolRegistry.register({
+          tool: 'copilot',
+          name: 'GitHub Copilot',
+          apiKeyEnvVar: TOOL_API_KEY_NAMES.copilot!, // Note: execution also accepts GH_TOKEN / GITHUB_TOKEN aliases
+          runner: copilot.executeCopilotTask,
+        });
+        break;
+      }
+      case 'cursor': {
+        const cursor = await import('./cursor.js');
+        ToolRegistry.register({
+          tool: 'cursor',
+          name: 'Cursor SDK',
+          apiKeyEnvVar: TOOL_API_KEY_NAMES.cursor!,
+          runner: cursor.executeCursorTask,
+        });
+        break;
+      }
+    }
+  };
 
-  // Register Codex
-  ToolRegistry.register({
-    tool: 'codex',
-    name: 'Codex',
-    apiKeyEnvVar: TOOL_API_KEY_NAMES.codex!,
-    runner: codex.executeCodexTask,
-  });
+  if (tool) {
+    await registerTool(tool);
+    return;
+  }
 
-  // Register Gemini
-  ToolRegistry.register({
-    tool: 'gemini',
-    name: 'Gemini',
-    apiKeyEnvVar: TOOL_API_KEY_NAMES.gemini!,
-    runner: gemini.executeGeminiTask,
-  });
-
-  // Register OpenCode
-  ToolRegistry.register({
-    tool: 'opencode',
-    name: 'OpenCode',
-    apiKeyEnvVar: 'NONE', // OpenCode doesn't need API key
-    runner: opencode.executeOpenCodeTask,
-  });
-
-  // Register Copilot
-  ToolRegistry.register({
-    tool: 'copilot',
-    name: 'GitHub Copilot',
-    apiKeyEnvVar: TOOL_API_KEY_NAMES.copilot!, // Note: execution also accepts GH_TOKEN / GITHUB_TOKEN aliases
-    runner: copilot.executeCopilotTask,
-  });
-
-  // Register Cursor SDK (experimental skeleton; handler intentionally fails until runtime lands)
-  ToolRegistry.register({
-    tool: 'cursor',
-    name: 'Cursor SDK',
-    apiKeyEnvVar: TOOL_API_KEY_NAMES.cursor!,
-    runner: cursor.executeCursorTask,
-  });
+  await Promise.all(KNOWN_TOOLS.map((knownTool) => registerTool(knownTool)));
 }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -35,6 +35,20 @@ function executorDebug(...args: unknown[]): void {
   }
 }
 
+function startupTiming(
+  tool: string,
+  taskId: string,
+  startedAtMs: number,
+  phase: string,
+  extra?: Record<string, unknown>
+): void {
+  const message =
+    `[executor-startup] tool=${tool} task=${shortId(taskId)} ` +
+    `phase=${phase} elapsed_ms=${Date.now() - startedAtMs}`;
+  if (extra) console.log(message, extra);
+  else console.log(message);
+}
+
 export interface ExecutorConfig {
   sessionToken: string;
   sessionId: string;
@@ -75,17 +89,20 @@ export class AgorExecutor {
    * Start the executor process
    */
   async start(): Promise<void> {
+    const startupStartedAt = Date.now();
     const uid = typeof process.getuid === 'function' ? process.getuid() : 'N/A';
     console.log(
       `[executor] Starting ${this.config.tool} task ${shortId(this.config.taskId)} ` +
         `for session ${shortId(this.config.sessionId)} as ${process.env.USER || 'unknown'} (uid: ${uid})`
     );
+    startupTiming(this.config.tool, this.config.taskId, startupStartedAt, 'process_start');
 
     try {
       // Connect to daemon via Feathers/WebSocket
       executorDebug('[executor] Connecting to daemon via Feathers...');
       this.client = await createFeathersClient(this.config.daemonUrl, this.config.sessionToken);
       executorDebug('[executor] Connected to daemon');
+      startupTiming(this.config.tool, this.config.taskId, startupStartedAt, 'daemon_connected');
 
       // Setup event listeners
       this.setupEventListeners();
@@ -94,7 +111,7 @@ export class AgorExecutor {
       this.setupShutdownHandlers();
 
       // Execute the task
-      await this.executeTask();
+      await this.executeTask(startupStartedAt);
 
       // Exit successfully
       console.log('[executor] Task completed, exiting');
@@ -152,7 +169,7 @@ export class AgorExecutor {
   /**
    * Execute the task using the appropriate SDK
    */
-  private async executeTask(): Promise<void> {
+  private async executeTask(startupStartedAt: number): Promise<void> {
     if (!this.client) {
       throw new Error('Feathers client not initialized');
     }
@@ -166,6 +183,7 @@ export class AgorExecutor {
       enabled: heartbeatConfig?.enabled ?? true,
       intervalMs: heartbeatConfig?.interval_ms,
     });
+    startupTiming(this.config.tool, this.config.taskId, startupStartedAt, 'heartbeat_started');
 
     executorDebug(`[executor] Executing task with ${this.config.tool}...`);
 
@@ -174,9 +192,17 @@ export class AgorExecutor {
       const { ToolRegistry, initializeToolRegistry } = await import(
         './handlers/sdk/tool-registry.js'
       );
-      await initializeToolRegistry();
+      startupTiming(
+        this.config.tool,
+        this.config.taskId,
+        startupStartedAt,
+        'tool_registry_imported'
+      );
+      await initializeToolRegistry(this.config.tool);
+      startupTiming(this.config.tool, this.config.taskId, startupStartedAt, 'tool_registered');
 
       // Execute using registry
+      startupTiming(this.config.tool, this.config.taskId, startupStartedAt, 'tool_execute_start');
       await ToolRegistry.execute(this.config.tool, {
         client: this.client,
         sessionId: this.config.sessionId as SessionID,

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -73,6 +73,21 @@ function shouldRefreshEditFilesBaselineAfterTool(toolName: string): boolean {
   return normalized === 'bash' || toolName.includes('.');
 }
 
+function codexStartupTiming(
+  taskId: TaskID | undefined,
+  sessionId: SessionID,
+  startedAtMs: number,
+  phase: string,
+  extra?: Record<string, unknown>
+): void {
+  const taskLabel = taskId ? shortId(taskId) : 'unknown';
+  const message =
+    `[codex-startup] session=${shortId(sessionId)} task=${taskLabel} ` +
+    `phase=${phase} elapsed_ms=${Date.now() - startedAtMs}`;
+  if (extra) console.log(message, extra);
+  else console.log(message);
+}
+
 export class CodexTool implements ITool {
   readonly toolType = 'codex' as const;
   readonly name = 'OpenAI Codex';
@@ -220,6 +235,8 @@ export class CodexTool implements ITool {
     const pendingToolMessageIds = new Map<string, MessageID>();
     const pendingSnapshotToolIds = new Set<string>();
     const snapshotContext = { snapshotScope: sessionId };
+    const startupStartedAt = Date.now();
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'execute_prompt_start');
 
     if (this.sessionsRepo && this.branchesRepo) {
       const session = await this.sessionsRepo.findById(sessionId);
@@ -228,11 +245,26 @@ export class CodexTool implements ITool {
         workingDirectory = branch?.path;
       }
     }
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'working_directory_resolved');
 
-    await registerEditFilesTurnBaseline({
+    let editFilesBaselineLogged = false;
+    const editFilesBaselineReady = registerEditFilesTurnBaseline({
       ...(workingDirectory ? { workingDirectory } : {}),
       ...snapshotContext,
+    }).catch(() => {
+      // registerEditFilesTurnBaseline is already best-effort, but keep the
+      // fire-and-overlap promise non-rejecting so SDK startup is never delayed
+      // by baseline capture.
     });
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'edit_files_baseline_started');
+
+    const awaitEditFilesBaseline = async () => {
+      await editFilesBaselineReady;
+      if (!editFilesBaselineLogged) {
+        editFilesBaselineLogged = true;
+        codexStartupTiming(taskId, sessionId, startupStartedAt, 'edit_files_baseline_ready');
+      }
+    };
 
     try {
       for await (const event of this.promptService.promptSessionStreaming(
@@ -415,6 +447,7 @@ export class CodexTool implements ITool {
           ];
 
           // Best-effort diff enrichment for Edit/Write tool results
+          await awaitEditFilesBaseline();
           enrichContentBlocks(toolContent, {
             ...(workingDirectory ? { workingDirectory } : {}),
             ...snapshotContext,
@@ -562,6 +595,7 @@ export class CodexTool implements ITool {
         }
       }
     } finally {
+      await awaitEditFilesBaseline();
       for (const toolUseId of pendingSnapshotToolIds) {
         clearToolInvocationState(toolUseId, snapshotContext);
       }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -100,6 +100,21 @@ function codexDebug(...args: unknown[]): void {
   }
 }
 
+function codexStartupTiming(
+  taskId: TaskID | undefined,
+  sessionId: SessionID,
+  startedAtMs: number,
+  phase: string,
+  extra?: Record<string, unknown>
+): void {
+  const taskLabel = taskId ? shortId(taskId) : 'unknown';
+  const message =
+    `[codex-startup] session=${shortId(sessionId)} task=${taskLabel} ` +
+    `phase=${phase} elapsed_ms=${Date.now() - startedAtMs}`;
+  if (extra) console.log(message, extra);
+  else console.log(message);
+}
+
 function applyGatewayMcpStartupGuard(config: CodexConfigObject, requireMcpServers: boolean): void {
   if (!requireMcpServers) return;
   config.required = true;
@@ -915,11 +930,14 @@ export class CodexPromptService {
     permissionMode?: PermissionMode,
     abortController?: AbortController
   ): AsyncGenerator<CodexStreamEvent> {
+    const startupStartedAt = Date.now();
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'prompt_service_start');
     // Get session to check for existing thread ID and working directory
     const session = await this.sessionsRepo.findById(sessionId);
     if (!session) {
       throw new Error(`Session ${sessionId} not found`);
     }
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'session_loaded');
 
     // NOTE: API key resolution is already handled by executeToolTask in base-executor
     // The API key was resolved via daemon service and passed to this constructor
@@ -964,6 +982,7 @@ export class CodexPromptService {
     // executor user's $HOME/.codex which already contains auth.json plus any
     // user-authored config.toml.
     const instructionsFile = await this.ensureCodexInstructionsFile(sessionId);
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'instructions_file_ready');
 
     const mcpToken = session.mcp_token;
     if (!mcpToken) {
@@ -986,6 +1005,10 @@ export class CodexPromptService {
       forUserId,
       requireMcpServers
     );
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'mcp_config_ready', {
+      mcpServerCount,
+      requireMcpServers,
+    });
 
     const codexConfigPayload: CodexConfigObject = {
       model_instructions_file: instructionsFile,
@@ -995,6 +1018,7 @@ export class CodexPromptService {
     // Recreate Codex instance only if the per-session config payload (or
     // apiKey/baseUrl) actually changed — issue #133 protection.
     await this.ensureCodexClient(codexConfigPayload);
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'codex_client_ready');
 
     codexDebug(
       `   Configured: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}, ${mcpServerCount} MCP server(s)`
@@ -1005,10 +1029,12 @@ export class CodexPromptService {
     if (!branch) {
       throw new Error(`Branch ${session.branch_id} not found for session ${sessionId}`);
     }
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'branch_loaded');
 
     codexDebug(`   Working directory: ${branch.path}`);
 
     await this.ensureForkedCodexThread(sessionId, session);
+    codexStartupTiming(taskId, sessionId, startupStartedAt, 'fork_state_ready');
 
     // Build thread options. approvalPolicy + networkAccessEnabled flow through
     // here (not config.toml); ThreadOptions override matching `--config` keys.
@@ -1138,7 +1164,9 @@ export class CodexPromptService {
       // The signal is passed to Codex SDK which will throw AbortError when aborted
       codexDebug(`🎬 [Codex] Starting runStreamed() for session ${shortId(sessionId)}`);
       const turnOptions = abortController ? { signal: abortController.signal } : undefined;
+      codexStartupTiming(taskId, sessionId, startupStartedAt, 'run_streamed_calling');
       const { events } = await thread.runStreamed(prompt, turnOptions);
+      codexStartupTiming(taskId, sessionId, startupStartedAt, 'run_streamed_returned');
       codexDebug(`✅ [Codex] runStreamed() returned, starting event iteration`);
 
       const currentMessage: Array<{
@@ -1161,6 +1189,11 @@ export class CodexPromptService {
 
       for await (const event of events) {
         eventCount++;
+        if (eventCount === 1) {
+          codexStartupTiming(taskId, sessionId, startupStartedAt, 'first_sdk_event', {
+            eventType: event.type,
+          });
+        }
         codexDebug(`📨 [Codex] Event ${eventCount}: ${event.type}`);
 
         // Check if stop was requested


### PR DESCRIPTION
## Summary
- Add startup timing logs from task dispatch through executor spawn, executor boot, shared SDK setup, and Codex-specific SDK startup phases.
- Lazily load only the selected SDK handler instead of importing every agent SDK during executor startup.
- Overlap Codex edit-files baseline capture with SDK startup so repository snapshotting no longer blocks the runStreamed call.

## Checks
- git diff --check
- pnpm --filter @agor/executor test -- src/commands/index.test.ts src/handlers/sdk/base-executor.test.ts src/sdk-handlers/codex/prompt-service.test.ts *(fails locally: package node_modules/vitest not installed in this worktree)*