### PR TITLE
Fix board permission propagation to aligned branches

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -411,12 +411,28 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     const alignedBranches = await branchRepository.findBoardAlignedBranches(boardId as BoardID);
     if (alignedBranches.length === 0) return;
     console.log(
-      `[Unix Integration] Syncing ${alignedBranches.length} board-aligned branch(es) for board ${shortId(boardId)}`
+      `[Unix Integration] Queueing board permission sync for ${alignedBranches.length} board-aligned branch(es) on board ${shortId(boardId)}`
     );
     for (const branch of alignedBranches) {
-      syncBranchUnixAccess(branch.branch_id as BranchID, logPrefix);
       await invalidateRealtimeBranchAccess(branch.branch_id);
     }
+
+    const serviceToken = createServiceToken(jwtSecret, undefined, {
+      board_id: boardId,
+      command: 'unix.sync-board',
+    });
+    spawnExecutorFireAndForget(
+      {
+        command: 'unix.sync-board',
+        sessionToken: serviceToken,
+        daemonUrl: getDaemonUrl(),
+        params: {
+          boardId,
+          daemonUser: config.daemon?.unix_user,
+        },
+      },
+      { logPrefix }
+    );
   };
 
   const syncUnixAccessForBoardFromRoute = async (

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -50,7 +50,9 @@ import {
 import type {
   AuthenticatedParams,
   Board,
+  BoardID,
   Branch,
+  BranchID,
   HookContext,
   MCPServer,
   Paginated,
@@ -378,6 +380,63 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   const invalidateRealtimeBranchFromRoute = async (context: HookContext): Promise<HookContext> => {
     await invalidateRealtimeBranchAccess(context.params.route?.id);
+    return context;
+  };
+
+  const syncBranchUnixAccess = (branchId: BranchID, logPrefix: string): void => {
+    if (!jwtSecret) return;
+    const serviceToken = createServiceToken(jwtSecret, undefined, {
+      branch_id: branchId,
+      command: 'unix.sync-branch',
+    });
+    spawnExecutorFireAndForget(
+      {
+        command: 'unix.sync-branch',
+        sessionToken: serviceToken,
+        daemonUrl: getDaemonUrl(),
+        params: {
+          branchId,
+          daemonUser: config.daemon?.unix_user,
+        },
+      },
+      { logPrefix }
+    );
+  };
+
+  const syncUnixAccessForBoardAlignedBranches = async (
+    boardId: unknown,
+    logPrefix: string
+  ): Promise<void> => {
+    if (!jwtSecret || typeof boardId !== 'string' || boardId.length === 0) return;
+    const alignedBranches = await branchRepository.findBoardAlignedBranches(boardId as BoardID);
+    if (alignedBranches.length === 0) return;
+    console.log(
+      `[Unix Integration] Syncing ${alignedBranches.length} board-aligned branch(es) for board ${shortId(boardId)}`
+    );
+    for (const branch of alignedBranches) {
+      syncBranchUnixAccess(branch.branch_id as BranchID, logPrefix);
+      await invalidateRealtimeBranchAccess(branch.branch_id);
+    }
+  };
+
+  const syncUnixAccessForBoardFromRoute = async (
+    context: HookContext,
+    logPrefix: string
+  ): Promise<HookContext> => {
+    await syncUnixAccessForBoardAlignedBranches(context.params.route?.id, logPrefix);
+    return context;
+  };
+
+  const syncUnixAccessForAllBranches = async (
+    context: HookContext,
+    logPrefix: string
+  ): Promise<HookContext> => {
+    if (!jwtSecret) return context;
+    const branches = await branchRepository.findAll({ includeArchived: false });
+    for (const branch of branches) {
+      syncBranchUnixAccess(branch.branch_id as BranchID, logPrefix);
+      await invalidateRealtimeBranchAccess(branch.branch_id);
+    }
     return context;
   };
 
@@ -1709,8 +1768,16 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('group-memberships')?.hooks(groupMembershipsHooks);
   safeService('group-memberships')?.hooks({
     after: {
-      create: [clearRealtimeBranchVisibility],
-      remove: [clearRealtimeBranchVisibility],
+      create: [
+        clearRealtimeBranchVisibility,
+        (context: HookContext) =>
+          syncUnixAccessForAllBranches(context, '[Executor/group-memberships.create]'),
+      ],
+      remove: [
+        clearRealtimeBranchVisibility,
+        (context: HookContext) =>
+          syncUnixAccessForAllBranches(context, '[Executor/group-memberships.remove]'),
+      ],
     },
   });
   safeService('branches/:id/owners')?.hooks({
@@ -1721,22 +1788,69 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   });
   safeService('branches/:id/group-grants')?.hooks({
     after: {
-      create: [invalidateRealtimeBranchFromRoute],
-      patch: [invalidateRealtimeBranchFromRoute],
-      remove: [invalidateRealtimeBranchFromRoute],
+      create: [
+        invalidateRealtimeBranchFromRoute,
+        (context: HookContext) => {
+          const branchId = context.params.route?.id;
+          if (typeof branchId === 'string') {
+            syncBranchUnixAccess(branchId as BranchID, '[Executor/branch-group-grants.create]');
+          }
+          return context;
+        },
+      ],
+      patch: [
+        invalidateRealtimeBranchFromRoute,
+        (context: HookContext) => {
+          const branchId = context.params.route?.id;
+          if (typeof branchId === 'string') {
+            syncBranchUnixAccess(branchId as BranchID, '[Executor/branch-group-grants.patch]');
+          }
+          return context;
+        },
+      ],
+      remove: [
+        invalidateRealtimeBranchFromRoute,
+        (context: HookContext) => {
+          const branchId = context.params.route?.id;
+          if (typeof branchId === 'string') {
+            syncBranchUnixAccess(branchId as BranchID, '[Executor/branch-group-grants.remove]');
+          }
+          return context;
+        },
+      ],
     },
   });
   safeService('boards/:id/owners')?.hooks({
     after: {
-      create: [clearRealtimeBranchVisibility],
-      remove: [clearRealtimeBranchVisibility],
+      create: [
+        clearRealtimeBranchVisibility,
+        (context: HookContext) =>
+          syncUnixAccessForBoardFromRoute(context, '[Executor/board-owners.create]'),
+      ],
+      remove: [
+        clearRealtimeBranchVisibility,
+        (context: HookContext) =>
+          syncUnixAccessForBoardFromRoute(context, '[Executor/board-owners.remove]'),
+      ],
     },
   });
   safeService('boards/:id/group-grants')?.hooks({
     after: {
-      create: [clearRealtimeBranchVisibility],
-      patch: [clearRealtimeBranchVisibility],
-      remove: [clearRealtimeBranchVisibility],
+      create: [
+        clearRealtimeBranchVisibility,
+        (context: HookContext) =>
+          syncUnixAccessForBoardFromRoute(context, '[Executor/board-group-grants.create]'),
+      ],
+      patch: [
+        clearRealtimeBranchVisibility,
+        (context: HookContext) =>
+          syncUnixAccessForBoardFromRoute(context, '[Executor/board-group-grants.patch]'),
+      ],
+      remove: [
+        clearRealtimeBranchVisibility,
+        (context: HookContext) =>
+          syncUnixAccessForBoardFromRoute(context, '[Executor/board-group-grants.remove]'),
+      ],
     },
   });
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -78,6 +78,7 @@ import {
   createGroupsService,
   setupBoardGroupGrantsService,
   setupBranchEffectiveAccessService,
+  setupBranchFsAccessUsersService,
   setupBranchGroupGrantsService,
 } from './services/groups.js';
 import { createKnowledgeDocumentEditsService } from './services/knowledge-document-edits.js';
@@ -368,6 +369,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     methods: ['find', 'create', 'remove'],
   });
   setupBranchEffectiveAccessService(app, new BranchRepository(db));
+  setupBranchFsAccessUsersService(app, new BranchRepository(db));
   if (branchRbacEnabled) {
     setupBoardOwnersService(app, new BoardRepository(db));
     setupBoardGroupGrantsService(app, db);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -76,6 +76,7 @@ import { registerGitHubAppSetupRoutes } from './services/github-app-setup.js';
 import {
   createGroupMembershipsService,
   createGroupsService,
+  setupBoardAlignedBranchesService,
   setupBoardGroupGrantsService,
   setupBranchEffectiveAccessService,
   setupBranchFsAccessUsersService,
@@ -369,6 +370,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     methods: ['find', 'create', 'remove'],
   });
   setupBranchEffectiveAccessService(app, new BranchRepository(db));
+  setupBoardAlignedBranchesService(app, new BranchRepository(db));
   setupBranchFsAccessUsersService(app, new BranchRepository(db));
   if (branchRbacEnabled) {
     setupBoardOwnersService(app, new BoardRepository(db));

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -17,6 +17,7 @@ import type {
   GroupMembership,
   HookContext,
   Params,
+  User,
   UserID,
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, hasMinimumRole, ROLES } from '@agor/core/types';
@@ -402,6 +403,46 @@ export function setupBranchEffectiveAccessService(
         }
 
         return effective;
+      },
+    },
+    { methods: ['find'] }
+  );
+}
+
+export function setupBranchFsAccessUsersService(
+  app: import('@agor/core/feathers').Application,
+  branchRepo: BranchRepository
+) {
+  app.use(
+    'branches/:id/fs-access-users',
+    {
+      async find(params?: Params): Promise<User[]> {
+        const authParams = params as
+          | (Params & { user?: { user_id: string; role: string; _isServiceAccount?: boolean } })
+          | undefined;
+        if (authParams?.provider && !authParams.user?._isServiceAccount) {
+          const user = authParams.user;
+          if (!user) throw new NotAuthenticated('Authentication required');
+          if (!hasMinimumRole(user.role, ROLES.ADMIN)) {
+            throw new Forbidden('Only admins can list branch filesystem access users');
+          }
+        }
+
+        const branchId = paramsRoute(params)?.id;
+        if (!branchId) throw new BadRequest('Branch ID is required');
+        const userIds = await branchRepo.findExplicitFsAccessUserIds(branchId as BranchID);
+        const usersService = app.service('users');
+        const users = await Promise.all(
+          userIds.map(async (userId): Promise<User | null> => {
+            try {
+              return (await usersService.get(userId)) as User;
+            } catch (error) {
+              console.error(`Failed to fetch branch filesystem access user ${userId}:`, error);
+              return null;
+            }
+          })
+        );
+        return users.filter((user): user is User => user !== null);
       },
     },
     { methods: ['find'] }

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -9,6 +9,8 @@ import { BoardRepository, type Database, GroupRepository } from '@agor/core/db';
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   BoardGroupGrantWithGroup,
+  BoardID,
+  Branch,
   BranchGroupGrantWithGroup,
   BranchID,
   BranchPermissionLevel,
@@ -403,6 +405,34 @@ export function setupBranchEffectiveAccessService(
         }
 
         return effective;
+      },
+    },
+    { methods: ['find'] }
+  );
+}
+
+export function setupBoardAlignedBranchesService(
+  app: import('@agor/core/feathers').Application,
+  branchRepo: BranchRepository
+) {
+  app.use(
+    'boards/:id/aligned-branches',
+    {
+      async find(params?: Params): Promise<Branch[]> {
+        const authParams = params as
+          | (Params & { user?: { user_id: string; role: string; _isServiceAccount?: boolean } })
+          | undefined;
+        if (authParams?.provider && !authParams.user?._isServiceAccount) {
+          const user = authParams.user;
+          if (!user) throw new NotAuthenticated('Authentication required');
+          if (!hasMinimumRole(user.role, ROLES.ADMIN)) {
+            throw new Forbidden('Only admins can list board-aligned branches');
+          }
+        }
+
+        const boardId = paramsRoute(params)?.id;
+        if (!boardId) throw new BadRequest('Board ID is required');
+        return branchRepo.findBoardAlignedBranches(boardId as BoardID);
       },
     },
     { methods: ['find'] }

--- a/context/guides/rbac-and-unix-isolation.md
+++ b/context/guides/rbac-and-unix-isolation.md
@@ -301,7 +301,9 @@ execution:
   - `view` permission → added to group with read-only access (via ACLs if supported)
   - Board-level user/group grants are expanded only for branches aligned to the
     board's permission source. Branches marked as overrides/not aligned do not
-    inherit board grants and must be granted directly.
+    inherit board grants and must be granted directly. Board permission changes
+    enqueue one `unix.sync-board` operation, which syncs the board's aligned
+    branches in a single executor process.
 - Agents still run as daemon user (or `executor_unix_user`)
 - **Great for**: Teams wanting filesystem isolation without complex process impersonation
 

--- a/context/guides/rbac-and-unix-isolation.md
+++ b/context/guides/rbac-and-unix-isolation.md
@@ -299,6 +299,9 @@ execution:
   - `all` permission → added to group (full access)
   - `prompt` permission → NOT in group (API access only)
   - `view` permission → added to group with read-only access (via ACLs if supported)
+  - Board-level user/group grants are expanded only for branches aligned to the
+    board's permission source. Branches marked as overrides/not aligned do not
+    inherit board grants and must be granted directly.
 - Agents still run as daemon user (or `executor_unix_user`)
 - **Great for**: Teams wanting filesystem isolation without complex process impersonation
 

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -920,3 +920,112 @@ describe('BranchRepository resolveUserAccess', () => {
     }
   );
 });
+
+describe('BranchRepository findExplicitFsAccessUserIds', () => {
+  dbTest(
+    'expands board owners and board groups only for board-aligned branches',
+    async ({ db }) => {
+      const repoRepo = new RepoRepository(db);
+      const boardRepo = new BoardRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const groupRepo = new GroupRepository(db);
+      const usersRepo = new UsersRepository(db);
+      const repo = await repoRepo.create(createRepoData({ slug: 'board-fs-users-repo' }));
+      const creatorId = generateId() as UUID;
+      const boardOwnerId = generateId() as UUID;
+      const groupMemberId = generateId() as UUID;
+
+      await usersRepo.create({ user_id: creatorId, email: 'creator-board-fs@example.com' });
+      await usersRepo.create({ user_id: boardOwnerId, email: 'owner-board-fs@example.com' });
+      await usersRepo.create({ user_id: groupMemberId, email: 'member-board-fs@example.com' });
+
+      const board = await boardRepo.create({
+        board_id: generateId(),
+        name: 'Board FS Users',
+        created_by: creatorId,
+        access_mode: 'shared',
+      });
+      await boardRepo.addOwner(board.board_id, boardOwnerId);
+      const group = await groupRepo.create({ name: 'Board FS Group', created_by: creatorId });
+      await groupRepo.addMember(group.group_id, groupMemberId, creatorId);
+      await groupRepo.upsertBoardGrant({
+        board_id: board.board_id,
+        group_id: group.group_id,
+        can: 'session',
+        fs_access: 'write',
+        created_by: creatorId,
+      });
+
+      const aligned = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          name: 'board-fs-aligned',
+          branch_unique_id: 9301,
+          created_by: creatorId,
+          permission_source: 'board',
+        })
+      );
+      const notAligned = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          name: 'board-fs-override',
+          branch_unique_id: 9302,
+          created_by: creatorId,
+          permission_source: 'override',
+        })
+      );
+
+      expect(await branchRepo.findExplicitFsAccessUserIds(aligned.branch_id)).toEqual(
+        expect.arrayContaining([boardOwnerId, groupMemberId])
+      );
+      expect(await branchRepo.findExplicitFsAccessUserIds(notAligned.branch_id)).not.toEqual(
+        expect.arrayContaining([boardOwnerId, groupMemberId])
+      );
+    }
+  );
+
+  dbTest('excludes board group grants with filesystem access none', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const boardRepo = new BoardRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const groupRepo = new GroupRepository(db);
+    const usersRepo = new UsersRepository(db);
+    const repo = await repoRepo.create(createRepoData({ slug: 'board-fs-none-repo' }));
+    const creatorId = generateId() as UUID;
+    const groupMemberId = generateId() as UUID;
+
+    await usersRepo.create({ user_id: creatorId, email: 'creator-fs-none@example.com' });
+    await usersRepo.create({ user_id: groupMemberId, email: 'member-fs-none@example.com' });
+    const board = await boardRepo.create({
+      board_id: generateId(),
+      name: 'Board FS None',
+      created_by: creatorId,
+      access_mode: 'shared',
+    });
+    const group = await groupRepo.create({ name: 'Board No FS Group', created_by: creatorId });
+    await groupRepo.addMember(group.group_id, groupMemberId, creatorId);
+    await groupRepo.upsertBoardGrant({
+      board_id: board.board_id,
+      group_id: group.group_id,
+      can: 'prompt',
+      fs_access: 'none',
+      created_by: creatorId,
+    });
+    const branch = await branchRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        board_id: board.board_id,
+        name: 'board-fs-none',
+        branch_unique_id: 9303,
+        created_by: creatorId,
+        permission_source: 'board',
+      })
+    );
+
+    expect(await branchRepo.findExplicitFsAccessUserIds(branch.branch_id)).not.toContain(
+      groupMemberId
+    );
+  });
+});

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -1028,4 +1028,44 @@ describe('BranchRepository findExplicitFsAccessUserIds', () => {
       groupMemberId
     );
   });
+
+  dbTest(
+    'includes private board owners for board-aligned branch filesystem access',
+    async ({ db }) => {
+      const repoRepo = new RepoRepository(db);
+      const boardRepo = new BoardRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const usersRepo = new UsersRepository(db);
+      const repo = await repoRepo.create(createRepoData({ slug: 'private-board-owner-fs-repo' }));
+      const creatorId = generateId() as UUID;
+      const boardOwnerId = generateId() as UUID;
+
+      await usersRepo.create({ user_id: creatorId, email: 'creator-private-owner-fs@example.com' });
+      await usersRepo.create({
+        user_id: boardOwnerId,
+        email: 'owner-private-owner-fs@example.com',
+      });
+      const board = await boardRepo.create({
+        board_id: generateId(),
+        name: 'Private Board Owner FS',
+        created_by: creatorId,
+        access_mode: 'private',
+      });
+      await boardRepo.addOwner(board.board_id, boardOwnerId);
+      const branch = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          name: 'private-board-owner-fs',
+          branch_unique_id: 9304,
+          created_by: creatorId,
+          permission_source: 'board',
+        })
+      );
+
+      expect(await branchRepo.findExplicitFsAccessUserIds(branch.branch_id)).toContain(
+        boardOwnerId
+      );
+    }
+  );
 });

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -63,6 +63,7 @@ const FS_ACCESS_RANK: Record<BranchFsAccessLevel, number> = {
 };
 const VIEW_OR_BETTER_BRANCH_PERMISSIONS = ['view', 'session', 'prompt', 'all'] as const;
 const BRANCH_PERMISSION_SOURCES = ['board', 'override'] as const;
+const FS_ACCESS_BRANCH_PERMISSIONS = ['read', 'write'] as const;
 
 /**
  * Session activity summary for a branch
@@ -751,6 +752,127 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
       userIds.add(row.user_id as UUID);
     }
     return Array.from(userIds);
+  }
+
+  /**
+   * Find users whose explicit branch or aligned-board grants should materialize
+   * into filesystem access for the branch.
+   *
+   * This intentionally excludes ambient "others" access because there is no
+   * bounded user set to expand. Board owners/groups only apply when the branch
+   * is explicitly aligned to board permissions (`permission_source = 'board'`)
+   * and the board is shared; override branches must not inherit board grants.
+   */
+  async findExplicitFsAccessUserIds(branchId: BranchID): Promise<UUID[]> {
+    const branchRow = await select(this.db, {
+      board_id: branches.board_id,
+      permission_source: branches.permission_source,
+    })
+      .from(branches)
+      .where(eq(branches.branch_id, branchId))
+      .one();
+
+    const ownerRows = await select(this.db, { user_id: branchOwners.user_id })
+      .from(branchOwners)
+      .where(eq(branchOwners.branch_id, branchId))
+      .all();
+
+    const groupRows = await select(this.db, { user_id: groupMemberships.user_id })
+      .from(branchGroupGrants)
+      .innerJoin(groupMemberships, eq(groupMemberships.group_id, branchGroupGrants.group_id))
+      .innerJoin(
+        groups,
+        and(eq(groups.group_id, branchGroupGrants.group_id), eq(groups.archived, false))
+      )
+      .where(
+        and(
+          eq(branchGroupGrants.branch_id, branchId),
+          inArray(
+            sql`coalesce(${branchGroupGrants.fs_access}, 'read')`,
+            FS_ACCESS_BRANCH_PERMISSIONS
+          )
+        )
+      )
+      .all();
+
+    const isBoardAligned = branchRow?.permission_source === 'board' && branchRow.board_id;
+    const boardOwnerRows = isBoardAligned
+      ? await select(this.db, { user_id: boardOwners.user_id })
+          .from(boardOwners)
+          .innerJoin(
+            boards,
+            and(
+              eq(boards.board_id, boardOwners.board_id),
+              eq(
+                sql`coalesce(${jsonExtract(this.db, boards.data, 'access_mode')}, 'shared')`,
+                'shared'
+              )
+            )
+          )
+          .where(eq(boardOwners.board_id, branchRow.board_id))
+          .all()
+      : [];
+
+    const boardGroupRows = isBoardAligned
+      ? await select(this.db, { user_id: groupMemberships.user_id })
+          .from(boardGroupGrants)
+          .innerJoin(groupMemberships, eq(groupMemberships.group_id, boardGroupGrants.group_id))
+          .innerJoin(
+            groups,
+            and(eq(groups.group_id, boardGroupGrants.group_id), eq(groups.archived, false))
+          )
+          .innerJoin(
+            boards,
+            and(
+              eq(boards.board_id, boardGroupGrants.board_id),
+              eq(
+                sql`coalesce(${jsonExtract(this.db, boards.data, 'access_mode')}, 'shared')`,
+                'shared'
+              )
+            )
+          )
+          .where(
+            and(
+              eq(boardGroupGrants.board_id, branchRow.board_id),
+              inArray(
+                sql`coalesce(${boardGroupGrants.fs_access}, 'read')`,
+                FS_ACCESS_BRANCH_PERMISSIONS
+              )
+            )
+          )
+          .all()
+      : [];
+
+    const userIds = new Set<UUID>();
+    for (const row of ownerRows as Array<{ user_id: string }>) {
+      userIds.add(row.user_id as UUID);
+    }
+    for (const row of groupRows as Array<{ user_id: string }>) {
+      userIds.add(row.user_id as UUID);
+    }
+    for (const row of boardOwnerRows as Array<{ user_id: string }>) {
+      userIds.add(row.user_id as UUID);
+    }
+    for (const row of boardGroupRows as Array<{ user_id: string }>) {
+      userIds.add(row.user_id as UUID);
+    }
+    return Array.from(userIds);
+  }
+
+  async findBoardAlignedBranches(boardId: BoardID): Promise<Branch[]> {
+    const rows = await select(this.db)
+      .from(branches)
+      .where(
+        and(
+          eq(branches.board_id, boardId),
+          eq(branches.permission_source, 'board'),
+          eq(branches.archived, false)
+        )
+      )
+      .all();
+
+    const baseUrl = await getBaseUrl();
+    return rows.map((row: BranchRow) => this.rowToBranch(row, baseUrl));
   }
 
   /**

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -759,9 +759,10 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
    * into filesystem access for the branch.
    *
    * This intentionally excludes ambient "others" access because there is no
-   * bounded user set to expand. Board owners/groups only apply when the branch
-   * is explicitly aligned to board permissions (`permission_source = 'board'`)
-   * and the board is shared; override branches must not inherit board grants.
+   * bounded user set to expand. Board owners apply whenever the branch is
+   * explicitly aligned to board permissions (`permission_source = 'board'`);
+   * board group grants additionally require a shared board. Override branches
+   * must not inherit board grants.
    */
   async findExplicitFsAccessUserIds(branchId: BranchID): Promise<UUID[]> {
     const branchRow = await select(this.db, {

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -799,16 +799,6 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     const boardOwnerRows = isBoardAligned
       ? await select(this.db, { user_id: boardOwners.user_id })
           .from(boardOwners)
-          .innerJoin(
-            boards,
-            and(
-              eq(boards.board_id, boardOwners.board_id),
-              eq(
-                sql`coalesce(${jsonExtract(this.db, boards.data, 'access_mode')}, 'shared')`,
-                'shared'
-              )
-            )
-          )
           .where(eq(boardOwners.board_id, branchRow.board_id))
           .all()
       : [];

--- a/packages/core/src/unix/unix-integration-service.ts
+++ b/packages/core/src/unix/unix-integration-service.ts
@@ -119,6 +119,37 @@ export class UnixIntegrationService {
     this.repoRepo = new RepoRepository(db);
   }
 
+  private async getUnixUsernamesForUsers(userIds: Iterable<UUID>): Promise<Set<string>> {
+    const unixUsernames = new Set<string>();
+    for (const userId of userIds) {
+      const user = await this.usersRepo.findById(userId as UserID);
+      if (user?.unix_username) {
+        unixUsernames.add(user.unix_username);
+      }
+    }
+    return unixUsernames;
+  }
+
+  private async reconcileUnixGroupMembers(
+    groupName: string,
+    allowedUnixUsernames: Set<string>,
+    options: { label: string }
+  ): Promise<void> {
+    if (this.config.daemonUser) {
+      allowedUnixUsernames.add(this.config.daemonUser);
+    }
+
+    const result = await this.executor.exec(UnixGroupCommands.listGroupMembers(groupName));
+    const currentMembers = result.stdout.trim().split(',').filter(Boolean);
+    for (const unixUsername of currentMembers) {
+      if (allowedUnixUsernames.has(unixUsername)) continue;
+      console.log(
+        `[UnixIntegration] Removing stale ${options.label} group member ${unixUsername} from ${groupName}`
+      );
+      await this.executor.exec(UnixGroupCommands.removeUserFromGroup(unixUsername, groupName));
+    }
+  }
+
   /**
    * Get the configured daemon user
    *
@@ -414,21 +445,29 @@ export class UnixIntegrationService {
   /**
    * Initialize Unix group for an existing branch
    *
-   * Creates group and adds all current owners.
+   * Creates group and adds all users with explicit filesystem access.
    *
    * @param branchId - Branch ID
    */
   async initializeBranchGroup(branchId: BranchID): Promise<void> {
     const groupName = await this.createBranchGroup(branchId);
 
-    const ownerIds = await this.branchRepo.getOwners(branchId);
-    for (const ownerId of ownerIds) {
-      await this.addUserToBranchGroup(branchId, ownerId);
+    const userIds = await this.branchRepo.findExplicitFsAccessUserIds(branchId);
+    for (const userId of userIds) {
+      await this.addUserToBranchGroup(branchId, userId);
     }
+    await this.reconcileUnixGroupMembers(groupName, await this.getUnixUsernamesForUsers(userIds), {
+      label: 'branch',
+    });
 
     console.log(
-      `[UnixIntegration] Initialized group ${groupName} with ${ownerIds.length} owner(s)`
+      `[UnixIntegration] Initialized group ${groupName} with ${userIds.length} explicit filesystem user(s)`
     );
+
+    const branch = await this.branchRepo.findById(branchId);
+    if (branch?.repo_id) {
+      await this.syncRepo(branch.repo_id as RepoID);
+    }
   }
 
   // ============================================================
@@ -712,8 +751,8 @@ export class UnixIntegrationService {
   /**
    * Check if a user should be in a repo's Unix group
    *
-   * A user should be in the repo group if they have ownership
-   * of ANY branch in that repo.
+   * A user should be in the repo group if they have explicit filesystem access
+   * to ANY branch in that repo.
    *
    * @param repoId - Repo ID
    * @param userId - User ID to check
@@ -723,10 +762,9 @@ export class UnixIntegrationService {
     // Get all branches for this repo
     const branches = await this.branchRepo.findAll({ repo_id: repoId });
 
-    // Check if user is owner of any branch in this repo
     for (const wt of branches) {
-      const isOwner = await this.branchRepo.isOwner(wt.branch_id, userId as UserID);
-      if (isOwner) {
+      const userIds = await this.branchRepo.findExplicitFsAccessUserIds(wt.branch_id);
+      if (userIds.includes(userId)) {
         return true;
       }
     }
@@ -737,32 +775,34 @@ export class UnixIntegrationService {
   /**
    * Initialize Unix group for an existing repo
    *
-   * Creates group, sets .git permissions, and adds all users who
-   * own any branch in the repo.
+   * Creates group, sets .git permissions, and adds all users who have explicit
+   * filesystem access to any branch in the repo.
    *
    * @param repoId - Repo ID
    */
   async initializeRepoGroup(repoId: RepoID): Promise<void> {
     const groupName = await this.createRepoGroup(repoId);
 
-    // Find all unique owners across all branches in this repo
     const branches = await this.branchRepo.findAll({ repo_id: repoId });
-    const ownerIds = new Set<string>();
+    const userIds = new Set<UUID>();
 
     for (const wt of branches) {
-      const wtOwners = await this.branchRepo.getOwners(wt.branch_id);
-      for (const ownerId of wtOwners) {
-        ownerIds.add(ownerId);
+      const branchUserIds = await this.branchRepo.findExplicitFsAccessUserIds(wt.branch_id);
+      for (const userId of branchUserIds) {
+        userIds.add(userId);
       }
     }
 
-    // Add each unique owner to the repo group
-    for (const ownerId of ownerIds) {
-      await this.addUserToRepoGroup(repoId, ownerId as UUID);
+    // Add each unique filesystem-access user to the repo group
+    for (const userId of userIds) {
+      await this.addUserToRepoGroup(repoId, userId);
     }
+    await this.reconcileUnixGroupMembers(groupName, await this.getUnixUsernamesForUsers(userIds), {
+      label: 'repo',
+    });
 
     console.log(
-      `[UnixIntegration] Initialized repo group ${groupName} with ${ownerIds.size} unique owner(s)`
+      `[UnixIntegration] Initialized repo group ${groupName} with ${userIds.size} unique filesystem user(s)`
     );
   }
 
@@ -770,7 +810,7 @@ export class UnixIntegrationService {
    * Full sync for a repo
    *
    * Ensures repo group exists, .git permissions are set, and all
-   * branch owners are in the repo group.
+   * branch filesystem-access users are in the repo group.
    *
    * @param repoId - Repo ID
    */
@@ -780,20 +820,27 @@ export class UnixIntegrationService {
     // Ensure repo group exists and .git permissions are set
     await this.createRepoGroup(repoId);
 
-    // Get all unique owners across all branches
     const branches = await this.branchRepo.findAll({ repo_id: repoId });
-    const ownerIds = new Set<string>();
+    const userIds = new Set<UUID>();
 
     for (const wt of branches) {
-      const wtOwners = await this.branchRepo.getOwners(wt.branch_id);
-      for (const ownerId of wtOwners) {
-        ownerIds.add(ownerId);
+      const branchUserIds = await this.branchRepo.findExplicitFsAccessUserIds(wt.branch_id);
+      for (const userId of branchUserIds) {
+        userIds.add(userId);
       }
     }
 
-    // Add each unique owner to repo group
-    for (const ownerId of ownerIds) {
-      await this.addUserToRepoGroup(repoId, ownerId as UUID);
+    // Add each unique filesystem-access user to repo group
+    for (const userId of userIds) {
+      await this.addUserToRepoGroup(repoId, userId);
+    }
+    const repo = await this.repoRepo.findById(repoId);
+    if (repo?.unix_group) {
+      await this.reconcileUnixGroupMembers(
+        repo.unix_group,
+        await this.getUnixUsernamesForUsers(userIds),
+        { label: 'repo' }
+      );
     }
   }
 
@@ -1149,7 +1196,8 @@ export class UnixIntegrationService {
   /**
    * Full sync for a branch
    *
-   * Ensures group exists, all owners are in group, and symlinks are created.
+   * Ensures group exists, all explicit filesystem-access users are in group,
+   * and symlinks are created.
    *
    * @param branchId - Branch ID
    */
@@ -1160,10 +1208,21 @@ export class UnixIntegrationService {
     // Note: createBranchGroup() handles setting directory permissions internally
     await this.createBranchGroup(branchId);
 
-    // Add all owners to group and create symlinks
-    const ownerIds = await this.branchRepo.getOwners(branchId);
-    for (const ownerId of ownerIds) {
-      await this.addUserToBranchGroup(branchId, ownerId);
+    // Add all explicit filesystem-access users to group and create symlinks
+    const userIds = await this.branchRepo.findExplicitFsAccessUserIds(branchId);
+    for (const userId of userIds) {
+      await this.addUserToBranchGroup(branchId, userId);
+    }
+    const branch = await this.branchRepo.findById(branchId);
+    if (branch?.unix_group) {
+      await this.reconcileUnixGroupMembers(
+        branch.unix_group,
+        await this.getUnixUsernamesForUsers(userIds),
+        { label: 'branch' }
+      );
+    }
+    if (branch?.repo_id) {
+      await this.syncRepo(branch.repo_id as RepoID);
     }
   }
 

--- a/packages/executor/src/commands/index.ts
+++ b/packages/executor/src/commands/index.ts
@@ -21,7 +21,12 @@ import {
   handleGitRepoDelete,
   handleGitRepoRealignOrigin,
 } from './git.js';
-import { handleUnixSyncBranch, handleUnixSyncRepo, handleUnixSyncUser } from './unix.js';
+import {
+  handleUnixSyncBoard,
+  handleUnixSyncBranch,
+  handleUnixSyncRepo,
+  handleUnixSyncUser,
+} from './unix.js';
 import { handleZellijAttach, handleZellijTab } from './zellij.js';
 
 export interface CommandOptions {
@@ -166,6 +171,7 @@ registerCommand('git.repo.realign-origin', handleGitRepoRealignOrigin);
 registerCommand('git.repo.delete', handleGitRepoDelete);
 registerCommand('unix.sync-repo', handleUnixSyncRepo);
 registerCommand('unix.sync-branch', handleUnixSyncBranch);
+registerCommand('unix.sync-board', handleUnixSyncBoard);
 registerCommand('unix.sync-user', handleUnixSyncUser);
 registerCommand('zellij.attach', handleZellijAttach);
 registerCommand('zellij.tab', handleZellijTab);

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -34,6 +34,7 @@ import {
 } from '@agor/core/unix';
 import type {
   ExecutorResult,
+  UnixSyncBoardPayload,
   UnixSyncBranchPayload,
   UnixSyncRepoPayload,
   UnixSyncUserPayload,
@@ -665,6 +666,96 @@ export async function handleUnixSyncBranch(
     return {
       success: false,
       error: { code: 'UNIX_SYNC_BRANCH_FAILED', message: errorMessage },
+    };
+  } finally {
+    if (client) {
+      try {
+        client.io.disconnect();
+      } catch {
+        // Ignore
+      }
+    }
+  }
+}
+
+// ============================================================
+// BOARD SYNC OPERATIONS
+// ============================================================
+
+/**
+ * Sync Unix state for every branch currently aligned with a board.
+ *
+ * This keeps board permission propagation in one executor process while
+ * preserving the branch-level sync semantics and no-overgrant alignment gate.
+ */
+export async function handleUnixSyncBoard(
+  payload: UnixSyncBoardPayload,
+  options: CommandOptions
+): Promise<ExecutorResult> {
+  if (options.dryRun) {
+    return {
+      success: true,
+      data: { dryRun: true, command: 'unix.sync-board', boardId: payload.params.boardId },
+    };
+  }
+
+  let client: AgorClient | null = null;
+
+  try {
+    const daemonUrl = payload.daemonUrl || 'http://localhost:3030';
+    client = await createExecutorClient(daemonUrl, payload.sessionToken);
+    console.log('[unix.sync-board] Connected to daemon');
+
+    const boardId = payload.params.boardId;
+    const branchesResult = await client.service(`boards/${boardId}/aligned-branches`).find({});
+    const branches = Array.isArray(branchesResult) ? branchesResult : branchesResult.data || [];
+
+    console.log(
+      `[unix.sync-board] Syncing ${branches.length} board-aligned branch(es) for board ${shortId(boardId)}`
+    );
+
+    // This client was only needed to resolve the board's branch set. Each
+    // branch sync opens its own daemon client through the existing handler,
+    // but all work still runs inside this one executor process.
+    client.io.disconnect();
+    client = null;
+
+    const results: Array<{ branchId: string; success: boolean; error?: unknown }> = [];
+    for (const branch of branches as Array<{ branch_id?: string }>) {
+      if (!branch.branch_id) continue;
+      const result = await handleUnixSyncBranch(
+        {
+          ...payload,
+          command: 'unix.sync-branch',
+          params: {
+            branchId: branch.branch_id,
+            daemonUser: payload.params.daemonUser,
+          },
+        },
+        options
+      );
+      results.push({ branchId: branch.branch_id, success: result.success, error: result.error });
+    }
+
+    const failed = results.filter((result) => !result.success);
+    if (failed.length > 0) {
+      return {
+        success: false,
+        data: { boardId, synced: results.length, failed },
+        error: {
+          code: 'UNIX_SYNC_BOARD_PARTIAL_FAILURE',
+          message: `Failed to sync ${failed.length} of ${results.length} board-aligned branch(es)`,
+        },
+      };
+    }
+
+    return { success: true, data: { boardId, synced: results.length } };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error('[unix.sync-board] Failed:', errorMessage);
+    return {
+      success: false,
+      error: { code: 'UNIX_SYNC_BOARD_FAILED', message: errorMessage },
     };
   } finally {
     if (client) {

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -121,6 +121,39 @@ async function runCommands(commands: string[]): Promise<void> {
   }
 }
 
+function parseGroupMembers(output: string): string[] {
+  return output.trim().split(',').filter(Boolean);
+}
+
+async function addUsersToGroup(usernames: Iterable<string>, groupName: string): Promise<number> {
+  let added = 0;
+  for (const username of usernames) {
+    const inGroup = await checkCommand(UnixGroupCommands.isUserInGroup(username, groupName));
+    if (!inGroup) {
+      await runCommand(UnixGroupCommands.addUserToGroup(username, groupName));
+      added++;
+    }
+  }
+  return added;
+}
+
+async function reconcileGroupMembers(
+  groupName: string,
+  allowedUsernames: Set<string>,
+  logPrefix: string
+): Promise<void> {
+  const currentMembers = parseGroupMembers(
+    await runCommand(UnixGroupCommands.listGroupMembers(groupName))
+  );
+  for (const username of currentMembers) {
+    if (allowedUsernames.has(username)) continue;
+    await runCommand(UnixGroupCommands.removeUserFromGroup(username, groupName), {
+      ignoreErrors: true,
+    });
+    console.log(`${logPrefix} Removed stale group member ${username} from ${groupName}`);
+  }
+}
+
 // ============================================================
 // REPO SYNC OPERATIONS
 // ============================================================
@@ -407,6 +440,28 @@ export async function handleUnixSyncBranch(
       console.log(`[unix.sync-branch] Could not fetch owners, skipping user sync`);
     }
 
+    // Fetch and add all users with explicit filesystem access. This expands
+    // branch groups plus board owners/groups for board-aligned branches.
+    const explicitFsUsernames = new Set(ownerUsernames);
+    let fsAccessUsersAdded = 0;
+    try {
+      const fsUsersResult = await client.service(`branches/${branchId}/fs-access-users`).find({});
+      const fsUsers = Array.isArray(fsUsersResult) ? fsUsersResult : fsUsersResult.data || [];
+      for (const user of fsUsers as Array<{ unix_username?: string | null }>) {
+        if (user.unix_username) {
+          explicitFsUsernames.add(user.unix_username);
+        }
+      }
+      fsAccessUsersAdded = await addUsersToGroup(explicitFsUsernames, groupName);
+      if (fsAccessUsersAdded > 0) {
+        console.log(
+          `[unix.sync-branch] Added ${fsAccessUsersAdded} explicit filesystem access user(s) to branch group`
+        );
+      }
+    } catch (_error) {
+      console.log(`[unix.sync-branch] Could not fetch filesystem access users, skipping`);
+    }
+
     // When others_fs_access is 'write', non-owner session users need branch group
     // membership for full read-write access. For 'read' mode, they rely on ACL "others"
     // bits (o::rX) on the branch directory — adding them to the branch group would
@@ -429,7 +484,7 @@ export async function handleUnixSyncBranch(
         // Collect unique non-owner unix_usernames from sessions
         const sessionUsernames = new Set<string>();
         for (const session of sessions as Array<{ unix_username?: string | null }>) {
-          if (session.unix_username && !ownerUsernames.has(session.unix_username)) {
+          if (session.unix_username && !explicitFsUsernames.has(session.unix_username)) {
             sessionUsernames.add(session.unix_username);
           }
         }
@@ -449,6 +504,27 @@ export async function handleUnixSyncBranch(
       }
     }
 
+    const allowedBranchMembers = new Set(explicitFsUsernames);
+    if (payload.params.daemonUser) allowedBranchMembers.add(payload.params.daemonUser);
+    if (othersAccess === 'write') {
+      try {
+        const sessionsResult = await client.service('sessions').find({
+          query: {
+            branch_id: branchId,
+            $select: ['unix_username'],
+            $limit: 500,
+          },
+        });
+        const sessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data || [];
+        for (const session of sessions as Array<{ unix_username?: string | null }>) {
+          if (session.unix_username) allowedBranchMembers.add(session.unix_username);
+        }
+      } catch {
+        // Best-effort stale-member cleanup only.
+      }
+    }
+    await reconcileGroupMembers(groupName, allowedBranchMembers, '[unix.sync-branch]');
+
     // Also sync repo group (ensure owners and authorized session users have .git/ access)
     if (branch.repo_id) {
       try {
@@ -466,6 +542,9 @@ export async function handleUnixSyncBranch(
               console.log(`[unix.sync-branch] Added daemon user to repo group ${repo.unix_group}`);
             }
           }
+
+          // Add all explicit filesystem access users to repo group (for .git/ access)
+          await addUsersToGroup(explicitFsUsernames, repo.unix_group);
 
           // Add all branch owners to repo group (for .git/ access)
           // This ensures owners can run git commands which need .git/ access
@@ -510,7 +589,7 @@ export async function handleUnixSyncBranch(
 
               const sessionUsernames = new Set<string>();
               for (const session of sessions as Array<{ unix_username?: string | null }>) {
-                if (session.unix_username && !ownerUsernames.has(session.unix_username)) {
+                if (session.unix_username && !explicitFsUsernames.has(session.unix_username)) {
                   sessionUsernames.add(session.unix_username);
                 }
               }
@@ -568,6 +647,7 @@ export async function handleUnixSyncBranch(
         branchId,
         groupName,
         ownersAdded,
+        fsAccessUsersAdded,
         sessionUsersAdded,
       },
     };

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -714,11 +714,12 @@ export async function handleUnixSyncBoard(
       `[unix.sync-board] Syncing ${branches.length} board-aligned branch(es) for board ${shortId(boardId)}`
     );
 
-    // This client was only needed to resolve the board's branch set. Each
-    // branch sync opens its own daemon client through the existing handler,
-    // but all work still runs inside this one executor process.
-    client.io.disconnect();
-    client = null;
+    // Keep this authenticated client open while nested branch syncs run.
+    // Branch syncs currently open their own daemon clients, but all work still
+    // runs inside this one executor process. Disconnecting here can race the
+    // auth client's async re-auth/logout bookkeeping while the nested syncs
+    // start. The finally block below closes the board client after all branch
+    // work finishes.
 
     const results: Array<{ branchId: string; success: boolean; error?: unknown }> = [];
     for (const branch of branches as Array<{ branch_id?: string }>) {

--- a/packages/executor/src/commands/unix.ts
+++ b/packages/executor/src/commands/unix.ts
@@ -444,6 +444,7 @@ export async function handleUnixSyncBranch(
     // branch groups plus board owners/groups for board-aligned branches.
     const explicitFsUsernames = new Set(ownerUsernames);
     let fsAccessUsersAdded = 0;
+    let explicitFsUsersFetched = false;
     try {
       const fsUsersResult = await client.service(`branches/${branchId}/fs-access-users`).find({});
       const fsUsers = Array.isArray(fsUsersResult) ? fsUsersResult : fsUsersResult.data || [];
@@ -452,6 +453,7 @@ export async function handleUnixSyncBranch(
           explicitFsUsernames.add(user.unix_username);
         }
       }
+      explicitFsUsersFetched = true;
       fsAccessUsersAdded = await addUsersToGroup(explicitFsUsernames, groupName);
       if (fsAccessUsersAdded > 0) {
         console.log(
@@ -523,7 +525,13 @@ export async function handleUnixSyncBranch(
         // Best-effort stale-member cleanup only.
       }
     }
-    await reconcileGroupMembers(groupName, allowedBranchMembers, '[unix.sync-branch]');
+    if (explicitFsUsersFetched) {
+      await reconcileGroupMembers(groupName, allowedBranchMembers, '[unix.sync-branch]');
+    } else {
+      console.log(
+        '[unix.sync-branch] Skipping stale branch group member cleanup because explicit filesystem access users could not be fetched'
+      );
+    }
 
     // Also sync repo group (ensure owners and authorized session users have .git/ access)
     if (branch.repo_id) {

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -631,10 +631,11 @@ describe('getSupportedCommands', () => {
     expect(commands).toContain('git.repo.realign-origin');
     expect(commands).toContain('git.repo.delete');
     expect(commands).toContain('unix.sync-branch');
+    expect(commands).toContain('unix.sync-board');
     expect(commands).toContain('unix.sync-repo');
     expect(commands).toContain('unix.sync-user');
     expect(commands).toContain('zellij.attach');
     expect(commands).toContain('zellij.tab');
-    expect(commands.length).toBe(18);
+    expect(commands.length).toBe(19);
   });
 });

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -708,6 +708,29 @@ export const UnixSyncBranchPayloadSchema = BasePayloadSchema.extend({
 export type UnixSyncBranchPayload = z.infer<typeof UnixSyncBranchPayloadSchema>;
 
 /**
+ * Unix sync-board payload - Sync Unix state for every branch aligned with a board.
+ *
+ * The executor resolves board-aligned branches through the daemon, then reuses
+ * unix.sync-branch semantics for each branch in the same executor process.
+ */
+export const UnixSyncBoardPayloadSchema = BasePayloadSchema.extend({
+  command: z.literal('unix.sync-board'),
+
+  /** JWT for Feathers authentication */
+  sessionToken: z.string(),
+
+  params: z.object({
+    /** Board ID whose aligned branches should be synced */
+    boardId: z.string().uuid(),
+
+    /** Daemon Unix user (added to all groups for daemon access) */
+    daemonUser: z.string().optional(),
+  }),
+});
+
+export type UnixSyncBoardPayload = z.infer<typeof UnixSyncBoardPayloadSchema>;
+
+/**
  * Unix sync-repo payload - Sync all Unix state for a repo
  *
  * This handles:
@@ -895,6 +918,7 @@ export const ExecutorPayloadSchema = z.discriminatedUnion('command', [
   GitRepoRealignOriginPayloadSchema,
   GitRepoDeletePayloadSchema,
   UnixSyncBranchPayloadSchema,
+  UnixSyncBoardPayloadSchema,
   UnixSyncRepoPayloadSchema,
   UnixSyncUserPayloadSchema,
   ZellijAttachPayloadSchema,
@@ -959,6 +983,7 @@ export function getSupportedCommands(): string[] {
     'git.repo.realign-origin',
     'git.repo.delete',
     'unix.sync-branch',
+    'unix.sync-board',
     'unix.sync-repo',
     'unix.sync-user',
     'zellij.attach',
@@ -1017,6 +1042,13 @@ export function isUnixSyncBranchPayload(
 /**
  * Type guard for UnixSyncRepoPayload
  */
+/**
+ * Type guard for UnixSyncBoardPayload
+ */
+export function isUnixSyncBoardPayload(payload: ExecutorPayload): payload is UnixSyncBoardPayload {
+  return payload.command === 'unix.sync-board';
+}
+
 export function isUnixSyncRepoPayload(payload: ExecutorPayload): payload is UnixSyncRepoPayload {
   return payload.command === 'unix.sync-repo';
 }

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -1040,15 +1040,15 @@ export function isUnixSyncBranchPayload(
 }
 
 /**
- * Type guard for UnixSyncRepoPayload
- */
-/**
  * Type guard for UnixSyncBoardPayload
  */
 export function isUnixSyncBoardPayload(payload: ExecutorPayload): payload is UnixSyncBoardPayload {
   return payload.command === 'unix.sync-board';
 }
 
+/**
+ * Type guard for UnixSyncRepoPayload
+ */
 export function isUnixSyncRepoPayload(payload: ExecutorPayload): payload is UnixSyncRepoPayload {
   return payload.command === 'unix.sync-repo';
 }


### PR DESCRIPTION
## Summary
- Expand board owner/group grants into explicit filesystem-access users for board-aligned branches
- Trigger Unix sync when board owners/group grants or group memberships change, and resync only branches whose permission source is aligned to that board
- Reconcile branch/repo Unix groups so stale users are removed when grants are revoked
- Document that branches not aligned with a board do not inherit board grants

Fixes preset-io/agor-cloud#35

## Tests
- pnpm --filter @agor/core test -- branches.test.ts
- pnpm --filter @agor/core build
- pnpm --filter @agor/daemon typecheck
- pnpm exec biome check packages/core/src/db/repositories/branches.ts packages/core/src/db/repositories/branches.test.ts packages/core/src/unix/unix-integration-service.ts apps/agor-daemon/src/register-hooks.ts context/guides/rbac-and-unix-isolation.md