### PR TITLE
Add Knowledge mentions to prompt autocomplete

### DIFF
--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { AutocompleteTextarea } from './AutocompleteTextarea';
+import { AutocompleteTextarea, type KbDocMention } from './AutocompleteTextarea';
 
 const renderSlashAutocomplete = () => {
   const Harness = () => {
@@ -78,7 +78,14 @@ const createMockClient = () => {
   return { client, filesFindAll, kbSearchFind, kbDocumentsFind };
 };
 
-const renderMentionAutocomplete = (client: ReturnType<typeof createMockClient>['client']) => {
+const renderMentionAutocomplete = (
+  client: ReturnType<typeof createMockClient>['client'],
+  options: {
+    enableKnowledgeMentions?: boolean;
+    kbLinkTarget?: 'stable-uri' | 'absolute-route';
+    kbDocs?: KbDocMention[];
+  } = {}
+) => {
   const Harness = () => {
     const [value, setValue] = useState('');
 
@@ -90,6 +97,9 @@ const renderMentionAutocomplete = (client: ReturnType<typeof createMockClient>['
         client={client as never}
         sessionId={'0190a000-0000-7000-8000-000000000001' as never}
         userById={new Map()}
+        enableKnowledgeMentions={options.enableKnowledgeMentions}
+        kbLinkTarget={options.kbLinkTarget}
+        kbDocs={options.kbDocs}
       />
     );
   };
@@ -99,9 +109,10 @@ const renderMentionAutocomplete = (client: ReturnType<typeof createMockClient>['
 };
 
 const waitForDebounce = () => new Promise((resolve) => setTimeout(resolve, 350));
+const waitForStateUpdate = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('AutocompleteTextarea', () => {
-  it('navigates autocomplete options with arrow keys and selects the highlighted item', async () => {
+  it('selects the default highlighted autocomplete item with Enter', async () => {
     const textarea = renderSlashAutocomplete();
 
     fireEvent.change(textarea, { target: { value: '/', selectionStart: 1 } });
@@ -109,11 +120,10 @@ describe('AutocompleteTextarea', () => {
     await screen.findByText('alpha');
     expect(screen.getByText('beta')).toBeInTheDocument();
 
-    fireEvent.keyDown(textarea, { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40, which: 40 });
     fireEvent.keyDown(textarea, { key: 'Enter' });
 
     await waitFor(() => {
-      expect(textarea).toHaveValue('/beta ');
+      expect(textarea).toHaveValue('/alpha ');
     });
   });
 
@@ -126,7 +136,11 @@ describe('AutocompleteTextarea', () => {
     expect(screen.getByText('beta')).toBeInTheDocument();
 
     fireEvent.keyDown(textarea, { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40, which: 40 });
+    await waitForStateUpdate();
+    fireEvent.keyDown(textarea, { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40, which: 40 });
+    await waitForStateUpdate();
     fireEvent.keyDown(textarea, { key: 'ArrowUp', code: 'ArrowUp', keyCode: 38, which: 38 });
+    await waitForStateUpdate();
     fireEvent.keyDown(textarea, { key: 'Enter' });
 
     await waitFor(() => {
@@ -136,7 +150,10 @@ describe('AutocompleteTextarea', () => {
 
   it('combines Knowledge and file suggestions for @ queries without changing file search', async () => {
     const { client, filesFindAll, kbSearchFind } = createMockClient();
-    const textarea = renderMentionAutocomplete(client);
+    const textarea = renderMentionAutocomplete(client, {
+      enableKnowledgeMentions: true,
+      kbLinkTarget: 'absolute-route',
+    });
 
     fireEvent.change(textarea, { target: { value: '@arc', selectionStart: 4 } });
     await waitForDebounce();
@@ -146,6 +163,9 @@ describe('AutocompleteTextarea', () => {
     expect(screen.queryByText('guides/architecture.md')).not.toBeInTheDocument();
     expect(screen.getByText('FILES & FOLDERS')).toBeInTheDocument();
     expect(screen.getByText('src/architecture.ts')).toBeInTheDocument();
+    expect(document.body.textContent?.indexOf('FILES & FOLDERS')).toBeLessThan(
+      document.body.textContent?.indexOf('KNOWLEDGE BASE') ?? Number.POSITIVE_INFINITY
+    );
     expect(kbSearchFind).toHaveBeenCalledWith({
       query: { q: 'arc', mode: 'text', limit: 8, include_chunks: false },
     });
@@ -154,9 +174,12 @@ describe('AutocompleteTextarea', () => {
     });
   });
 
-  it('inserts a stable agor:// Knowledge document link when a KB suggestion is selected', async () => {
+  it('inserts a clickable route link for prompt-composer KB selections', async () => {
     const { client } = createMockClient();
-    const textarea = renderMentionAutocomplete(client);
+    const textarea = renderMentionAutocomplete(client, {
+      enableKnowledgeMentions: true,
+      kbLinkTarget: 'absolute-route',
+    });
 
     fireEvent.change(textarea, { target: { value: 'Read @arc', selectionStart: 9 } });
     await waitForDebounce();
@@ -170,15 +193,54 @@ describe('AutocompleteTextarea', () => {
     });
   });
 
-  it('uses the readable document list instead of broad search for empty @ queries', async () => {
+  it('does not search Knowledge unless explicitly enabled', async () => {
     const { client, kbSearchFind, kbDocumentsFind } = createMockClient();
     const textarea = renderMentionAutocomplete(client);
+
+    fireEvent.change(textarea, { target: { value: '@arc', selectionStart: 4 } });
+    await waitForDebounce();
+
+    expect(screen.queryByText('KNOWLEDGE BASE')).not.toBeInTheDocument();
+    expect(kbSearchFind).not.toHaveBeenCalled();
+    expect(kbDocumentsFind).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch broad Knowledge lists for empty @ queries', async () => {
+    const { client, kbSearchFind, kbDocumentsFind } = createMockClient();
+    const textarea = renderMentionAutocomplete(client, { enableKnowledgeMentions: true });
 
     fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
     await waitForDebounce();
 
-    await screen.findByText('Recent Runbook');
-    expect(kbDocumentsFind).toHaveBeenCalledWith({ query: { archived: false } });
+    expect(screen.queryByText('Recent Runbook')).not.toBeInTheDocument();
+    expect(kbDocumentsFind).not.toHaveBeenCalled();
     expect(kbSearchFind).not.toHaveBeenCalled();
+  });
+
+  it('inserts stable agor:// links for provided KB docs, without live KB search', async () => {
+    const { client, kbSearchFind, kbDocumentsFind } = createMockClient();
+    const kbDocs: KbDocMention[] = [
+      {
+        title: 'Architecture Overview',
+        documentId: '0190a000-0000-7000-8000-0000000000aa' as never,
+        path: 'guides/architecture.md',
+        uri: 'agor://kb/global/guides/architecture.md',
+        routePath: '/kb/global/guides/architecture.md',
+      },
+    ];
+    const textarea = renderMentionAutocomplete(client, { kbDocs });
+
+    fireEvent.change(textarea, { target: { value: 'Read @arc', selectionStart: 9 } });
+    await waitForDebounce();
+
+    fireEvent.click(await screen.findByText('Architecture Overview'));
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue(
+        'Read [Architecture Overview](agor://kb/document/0190a000-0000-7000-8000-0000000000aa) '
+      );
+    });
+    expect(kbSearchFind).not.toHaveBeenCalled();
+    expect(kbDocumentsFind).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { AutocompleteTextarea } from './AutocompleteTextarea';
 
 const renderSlashAutocomplete = () => {
@@ -23,6 +23,82 @@ const renderSlashAutocomplete = () => {
   render(<Harness />);
   return screen.getByPlaceholderText('Prompt') as HTMLTextAreaElement;
 };
+
+const createMockClient = () => {
+  const filesFindAll = vi.fn(async () => [{ path: 'src/architecture.ts', type: 'file' }]);
+  const kbSearchFind = vi.fn(async () => [
+    {
+      document: {
+        document_id: '0190a000-0000-7000-8000-0000000000aa',
+        namespace_id: '0190a000-0000-7000-8000-0000000000bb',
+        path: 'guides/architecture.md',
+        uri: 'agor://kb/global/guides/architecture.md',
+        title: 'Architecture Overview',
+        kind: 'doc',
+        visibility: 'public',
+        status: 'published',
+        edit_policy: 'editors',
+        current_version_id: null,
+        metadata: null,
+        created_by: null,
+        created_at: new Date('2026-01-01T00:00:00Z'),
+        updated_by: null,
+        updated_at: new Date('2026-01-02T00:00:00Z'),
+        archived: false,
+        archived_at: null,
+      },
+      namespace: { slug: 'global' },
+      score: 1,
+      mode: 'text',
+      snippet: '',
+      chunks: [],
+    },
+  ]);
+  const kbDocumentsFind = vi.fn(async () => [
+    {
+      document_id: '0190a000-0000-7000-8000-0000000000cc',
+      namespace_id: '0190a000-0000-7000-8000-0000000000bb',
+      path: 'runbooks/recent.md',
+      uri: 'agor://kb/team/runbooks/recent.md',
+      title: 'Recent Runbook',
+      created_at: new Date('2026-01-01T00:00:00Z'),
+      updated_at: new Date('2026-01-03T00:00:00Z'),
+    },
+  ]);
+
+  const client = {
+    service: vi.fn((name: string) => {
+      if (name === 'files') return { findAll: filesFindAll };
+      if (name === 'kb/search') return { find: kbSearchFind };
+      if (name === 'kb/documents') return { find: kbDocumentsFind };
+      throw new Error(`Unexpected service ${name}`);
+    }),
+  };
+
+  return { client, filesFindAll, kbSearchFind, kbDocumentsFind };
+};
+
+const renderMentionAutocomplete = (client: ReturnType<typeof createMockClient>['client']) => {
+  const Harness = () => {
+    const [value, setValue] = useState('');
+
+    return (
+      <AutocompleteTextarea
+        value={value}
+        onChange={setValue}
+        placeholder="Prompt"
+        client={client as never}
+        sessionId={'0190a000-0000-7000-8000-000000000001' as never}
+        userById={new Map()}
+      />
+    );
+  };
+
+  render(<Harness />);
+  return screen.getByPlaceholderText('Prompt') as HTMLTextAreaElement;
+};
+
+const waitForDebounce = () => new Promise((resolve) => setTimeout(resolve, 350));
 
 describe('AutocompleteTextarea', () => {
   it('navigates autocomplete options with arrow keys and selects the highlighted item', async () => {
@@ -56,5 +132,52 @@ describe('AutocompleteTextarea', () => {
     await waitFor(() => {
       expect(textarea).toHaveValue('/alpha ');
     });
+  });
+
+  it('combines Knowledge and file suggestions for @ queries without changing file search', async () => {
+    const { client, filesFindAll, kbSearchFind } = createMockClient();
+    const textarea = renderMentionAutocomplete(client);
+
+    fireEvent.change(textarea, { target: { value: '@arc', selectionStart: 4 } });
+    await waitForDebounce();
+
+    await screen.findByText('KNOWLEDGE BASE');
+    expect(screen.getByText('Architecture Overview')).toBeInTheDocument();
+    expect(screen.getByText('FILES & FOLDERS')).toBeInTheDocument();
+    expect(screen.getByText('src/architecture.ts')).toBeInTheDocument();
+    expect(kbSearchFind).toHaveBeenCalledWith({
+      query: { q: 'arc', mode: 'text', limit: 8, include_chunks: false },
+    });
+    expect(filesFindAll).toHaveBeenCalledWith({
+      query: { sessionId: '0190a000-0000-7000-8000-000000000001', search: 'arc' },
+    });
+  });
+
+  it('inserts a stable agor:// Knowledge document link when a KB suggestion is selected', async () => {
+    const { client } = createMockClient();
+    const textarea = renderMentionAutocomplete(client);
+
+    fireEvent.change(textarea, { target: { value: 'Read @arc', selectionStart: 9 } });
+    await waitForDebounce();
+
+    fireEvent.click(await screen.findByText('Architecture Overview'));
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue(
+        'Read [Architecture Overview](agor://kb/document/0190a000-0000-7000-8000-0000000000aa) '
+      );
+    });
+  });
+
+  it('uses the readable document list instead of broad search for empty @ queries', async () => {
+    const { client, kbSearchFind, kbDocumentsFind } = createMockClient();
+    const textarea = renderMentionAutocomplete(client);
+
+    fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
+    await waitForDebounce();
+
+    await screen.findByText('Recent Runbook');
+    expect(kbDocumentsFind).toHaveBeenCalledWith({ query: { archived: false } });
+    expect(kbSearchFind).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
@@ -143,6 +143,7 @@ describe('AutocompleteTextarea', () => {
 
     await screen.findByText('KNOWLEDGE BASE');
     expect(screen.getByText('Architecture Overview')).toBeInTheDocument();
+    expect(screen.queryByText('guides/architecture.md')).not.toBeInTheDocument();
     expect(screen.getByText('FILES & FOLDERS')).toBeInTheDocument();
     expect(screen.getByText('src/architecture.ts')).toBeInTheDocument();
     expect(kbSearchFind).toHaveBeenCalledWith({
@@ -164,7 +165,7 @@ describe('AutocompleteTextarea', () => {
 
     await waitFor(() => {
       expect(textarea).toHaveValue(
-        'Read [Architecture Overview](agor://kb/document/0190a000-0000-7000-8000-0000000000aa) '
+        `Read [Architecture Overview](${window.location.origin}/kb/global/guides/architecture.md) `
       );
     });
   });

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -8,23 +8,21 @@
  * Highlights @ mentions with a background overlay.
  */
 
-import type {
-  KnowledgeDocument,
-  KnowledgeDocumentID,
-  KnowledgeSearchResult,
-} from '@agor/core/types';
+import type { KnowledgeDocumentID, KnowledgeSearchResult } from '@agor/core/types';
 import type { AgorClient, SessionID, User } from '@agor-live/client';
 import { Input, Popover, Spin, Typography, theme } from 'antd';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useEmojiAutocomplete } from '@/hooks/useEmojiAutocomplete';
-import { buildKnowledgeRoutePath, namespaceSlugFromUri } from '@/utils/knowledgeRoutes';
 import { mapToArray } from '@/utils/mapHelpers';
 import './AutocompleteTextarea.css';
 import {
+  buildKbDocLink,
   buildKbMarkdownLink,
   filterKbDocs,
   type KbDocMention,
+  kbMentionFromDocument,
   MAX_KB_DOC_RESULTS,
+  uniqueKbMentions,
 } from './kbMentions';
 
 export type { KbDocMention } from './kbMentions';
@@ -43,7 +41,6 @@ const AUTOCOMPLETE_POPOVER_MAX_HEIGHT = 300;
 const EMPTY_SLASH_COMMANDS: string[] = [];
 const EMPTY_SKILLS: string[] = [];
 const MIN_KB_SEARCH_QUERY_LENGTH = 2;
-const MAX_KB_PREFETCH_RESULTS = 25;
 
 interface FileResult {
   path: string;
@@ -84,6 +81,8 @@ type AutocompleteResult =
   | KbDocResult
   | { heading: string };
 
+type KbLinkTarget = 'stable-uri' | 'absolute-route';
+
 interface AutocompleteTextareaProps {
   value: string;
   onChange: (value: string) => void;
@@ -101,12 +100,19 @@ interface AutocompleteTextareaProps {
   slashCommands?: string[];
   /** Available skills from the SDK (stored on session.custom_context) */
   skills?: string[];
+  /** Enable live Knowledge Base lookup for `@` references. Disabled by default so shared comment inputs do not search KB. */
+  enableKnowledgeMentions?: boolean;
   /**
-   * Knowledge Base documents available for `@` references. When provided, the
-   * `@` autocomplete includes a "Knowledge Base" section and inserts a markdown
-   * link to the selected doc. Empty/omitted in non-KB contexts.
+   * Knowledge Base documents available for local `@` references. Supplying this
+   * also enables the Knowledge section without live network search (used by the
+   * Knowledge editor).
    */
   kbDocs?: KbDocMention[];
+  /**
+   * Link form inserted for KB selections. `stable-uri` is rename-proof for persisted
+   * Knowledge markdown; prompt composers use `absolute-route` so conversation markdown is clickable.
+   */
+  kbLinkTarget?: KbLinkTarget;
   /** Draw attention to the textarea while it is empty. */
   highlightWhenEmpty?: boolean;
 }
@@ -228,36 +234,6 @@ const quoteIfNeeded = (text: string): string => {
 
 const normalizeFindResult = <T,>(result: T[] | { data?: T[] }): T[] =>
   Array.isArray(result) ? result : (result.data ?? []);
-
-const leafTitleFromPath = (path: string): string => {
-  const leaf = path.split('/').filter(Boolean).pop() ?? path;
-  return leaf.replace(/\.[^.]+$/, '') || 'Untitled';
-};
-
-const kbMentionFromDocument = (doc: KnowledgeDocument): KbDocMention | null => {
-  const path = doc.path?.trim();
-  if (!path) return null;
-  const slug = namespaceSlugFromUri(doc.uri);
-  if (!slug) return null;
-  return {
-    title: doc.title?.trim() || leafTitleFromPath(path),
-    documentId: doc.document_id,
-    path,
-    uri: doc.uri,
-    routePath: buildKnowledgeRoutePath('/kb', slug, path),
-  };
-};
-
-const uniqueKbMentions = (docs: KbDocMention[]): KbDocMention[] => {
-  const seen = new Set<string>();
-  const unique: KbDocMention[] = [];
-  for (const doc of docs) {
-    if (seen.has(doc.documentId)) continue;
-    seen.add(doc.documentId);
-    unique.push(doc);
-  }
-  return unique;
-};
 
 /**
  * Highlight @ mentions in text
@@ -391,7 +367,9 @@ export const AutocompleteTextarea = React.forwardRef<
       onFilesDrop,
       slashCommands = EMPTY_SLASH_COMMANDS,
       skills = EMPTY_SKILLS,
+      enableKnowledgeMentions = false,
       kbDocs,
+      kbLinkTarget = 'stable-uri',
       highlightWhenEmpty = false,
     },
     ref
@@ -422,7 +400,8 @@ export const AutocompleteTextarea = React.forwardRef<
     const [highlightedIndex, setHighlightedIndex] = useState(-1);
 
     const hasProvidedKbDocs = kbDocs !== undefined;
-    const effectiveKbDocs = kbDocs ?? fetchedKbDocs;
+    const shouldSearchKnowledge = enableKnowledgeMentions || hasProvidedKbDocs;
+    const effectiveKbDocs = shouldSearchKnowledge ? (kbDocs ?? fetchedKbDocs) : [];
     const isLoading = isFileLoading || isKbLoading;
 
     // Scroll synchronization state
@@ -546,17 +525,25 @@ export const AutocompleteTextarea = React.forwardRef<
     );
 
     /**
-     * Search readable Knowledge documents for @ references. Query length >= 2
-     * uses kb/search; empty/one-character queries use the list endpoint and
-     * local filtering so @ opens quickly without issuing broad text searches.
-     * Both services enforce Knowledge RBAC server-side.
+     * Search readable Knowledge documents for @ references. Uses kb/search only
+     * for meaningful queries; empty/one-character queries stay local so `@` does
+     * not fan out into broad Knowledge listing. The search service enforces
+     * Knowledge RBAC server-side.
      */
     const searchKnowledgeDocs = useCallback(
       async (searchQuery: string) => {
         const requestId = kbSearchSeqRef.current + 1;
         kbSearchSeqRef.current = requestId;
 
-        if (hasProvidedKbDocs || !client) {
+        if (!shouldSearchKnowledge || hasProvidedKbDocs || !client) {
+          setFetchedKbDocs([]);
+          setKbError(null);
+          setIsKbLoading(false);
+          return;
+        }
+
+        const trimmed = searchQuery.trim();
+        if (trimmed.length < MIN_KB_SEARCH_QUERY_LENGTH) {
           setFetchedKbDocs([]);
           setKbError(null);
           setIsKbLoading(false);
@@ -567,40 +554,19 @@ export const AutocompleteTextarea = React.forwardRef<
         setKbError(null);
 
         try {
-          const trimmed = searchQuery.trim();
-          let mentions: KbDocMention[] = [];
-
-          if (trimmed.length >= MIN_KB_SEARCH_QUERY_LENGTH) {
-            const result = await client.service('kb/search').find({
-              query: {
-                q: trimmed,
-                mode: 'text',
-                limit: MAX_KB_DOC_RESULTS,
-                include_chunks: false,
-              },
-            });
-            mentions = normalizeFindResult<KnowledgeSearchResult>(
-              result as KnowledgeSearchResult[] | { data?: KnowledgeSearchResult[] }
-            )
-              .map((row) => kbMentionFromDocument(row.document))
-              .filter((doc): doc is KbDocMention => Boolean(doc));
-          } else {
-            const result = await client.service('kb/documents').find({
-              query: { archived: false },
-            });
-            const listed = normalizeFindResult<KnowledgeDocument>(
-              result as KnowledgeDocument[] | { data?: KnowledgeDocument[] }
-            )
-              .sort(
-                (a, b) =>
-                  new Date(b.updated_at || b.created_at || 0).getTime() -
-                  new Date(a.updated_at || a.created_at || 0).getTime()
-              )
-              .slice(0, MAX_KB_PREFETCH_RESULTS)
-              .map(kbMentionFromDocument)
-              .filter((doc): doc is KbDocMention => Boolean(doc));
-            mentions = filterKbDocs(listed, trimmed);
-          }
+          const result = await client.service('kb/search').find({
+            query: {
+              q: trimmed,
+              mode: 'text',
+              limit: MAX_KB_DOC_RESULTS,
+              include_chunks: false,
+            },
+          });
+          const mentions = normalizeFindResult<KnowledgeSearchResult>(
+            result as KnowledgeSearchResult[] | { data?: KnowledgeSearchResult[] }
+          )
+            .map((row) => kbMentionFromDocument(row.document))
+            .filter((doc): doc is KbDocMention => Boolean(doc));
 
           if (kbSearchSeqRef.current !== requestId) return;
           setFetchedKbDocs(uniqueKbMentions(mentions).slice(0, MAX_KB_DOC_RESULTS));
@@ -613,7 +579,7 @@ export const AutocompleteTextarea = React.forwardRef<
           if (kbSearchSeqRef.current === requestId) setIsKbLoading(false);
         }
       },
-      [client, hasProvidedKbDocs]
+      [client, hasProvidedKbDocs, shouldSearchKnowledge]
     );
 
     /**
@@ -830,13 +796,13 @@ export const AutocompleteTextarea = React.forwardRef<
           setEmojiResults([]);
           setSlashCommandResults([]);
 
-          // Debounced search for files + Knowledge. Request sequence refs ignore stale in-flight results.
+          // Debounced search for files + optional Knowledge. Request sequence refs ignore stale in-flight results.
           if (debounceTimerRef.current) {
             clearTimeout(debounceTimerRef.current);
           }
           debounceTimerRef.current = setTimeout(() => {
             searchFiles(atTrigger.query);
-            searchKnowledgeDocs(atTrigger.query);
+            if (shouldSearchKnowledge) searchKnowledgeDocs(atTrigger.query);
           }, DEBOUNCE_MS);
 
           setShowPopover(true);
@@ -888,7 +854,15 @@ export const AutocompleteTextarea = React.forwardRef<
         kbSearchSeqRef.current += 1;
         setHighlightedIndex(-1);
       },
-      [onChange, searchFiles, searchKnowledgeDocs, searchEmojis, slashCommands, skills]
+      [
+        onChange,
+        searchFiles,
+        searchKnowledgeDocs,
+        searchEmojis,
+        slashCommands,
+        skills,
+        shouldSearchKnowledge,
+      ]
     );
 
     /**
@@ -906,12 +880,13 @@ export const AutocompleteTextarea = React.forwardRef<
         let addTrailingSpace = true;
 
         if ('kbDocumentId' in item) {
-          // KB doc reference - replace @query with a user-clickable in-app URL.
-          // `agor://` is the internal stable URI, but conversation markdown
-          // intentionally blocks non-http(s) schemes. Use the current origin so
-          // the prompt remains useful and clickable wherever the UI is served.
-          const href = `${window.location.origin}${item.kbRoutePath}`;
-          insertText = buildKbMarkdownLink(item.kbTitle, href);
+          // KB doc reference. Persisted Knowledge markdown should use the stable
+          // document URI; prompt composers opt into absolute in-app URLs so
+          // conversation markdown renders a user-clickable link.
+          insertText =
+            kbLinkTarget === 'absolute-route'
+              ? buildKbMarkdownLink(item.kbTitle, `${window.location.origin}${item.kbRoutePath}`)
+              : buildKbDocLink(item.kbTitle, item.kbDocumentId);
         } else if ('command' in item) {
           // Slash command selection - replace with /command
           insertText = `/${item.command}`;
@@ -954,7 +929,7 @@ export const AutocompleteTextarea = React.forwardRef<
           textareaRef.current.current?.focus();
         }, 0);
       },
-      [triggerIndex, value, onChange]
+      [triggerIndex, value, onChange, kbLinkTarget]
     );
 
     /**

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -20,7 +20,12 @@ import { useEmojiAutocomplete } from '@/hooks/useEmojiAutocomplete';
 import { buildKnowledgeRoutePath, namespaceSlugFromUri } from '@/utils/knowledgeRoutes';
 import { mapToArray } from '@/utils/mapHelpers';
 import './AutocompleteTextarea.css';
-import { buildKbDocLink, filterKbDocs, type KbDocMention, MAX_KB_DOC_RESULTS } from './kbMentions';
+import {
+  buildKbMarkdownLink,
+  filterKbDocs,
+  type KbDocMention,
+  MAX_KB_DOC_RESULTS,
+} from './kbMentions';
 
 export type { KbDocMention } from './kbMentions';
 
@@ -66,7 +71,6 @@ interface SlashCommandResult {
 interface KbDocResult {
   kbTitle: string;
   kbDocumentId: KnowledgeDocumentID;
-  kbPath: string;
   kbUri: string;
   kbRoutePath: string;
   type: 'kb_doc';
@@ -667,7 +671,6 @@ export const AutocompleteTextarea = React.forwardRef<
           const kbResults: KbDocResult[] = docsForOptions.map((doc) => ({
             kbTitle: doc.title,
             kbDocumentId: doc.documentId,
-            kbPath: doc.path,
             kbUri: doc.uri,
             kbRoutePath: doc.routePath,
             type: 'kb_doc' as const,
@@ -903,8 +906,12 @@ export const AutocompleteTextarea = React.forwardRef<
         let addTrailingSpace = true;
 
         if ('kbDocumentId' in item) {
-          // KB doc reference - replace @query with a rename-proof markdown link
-          insertText = buildKbDocLink(item.kbTitle, item.kbDocumentId);
+          // KB doc reference - replace @query with a user-clickable in-app URL.
+          // `agor://` is the internal stable URI, but conversation markdown
+          // intentionally blocks non-http(s) schemes. Use the current origin so
+          // the prompt remains useful and clickable wherever the UI is served.
+          const href = `${window.location.origin}${item.kbRoutePath}`;
+          insertText = buildKbMarkdownLink(item.kbTitle, href);
         } else if ('command' in item) {
           // Slash command selection - replace with /command
           insertText = `/${item.command}`;
@@ -1303,20 +1310,6 @@ export const AutocompleteTextarea = React.forwardRef<
                         : ''
                       : label}
                 </Text>
-                {/* Show namespace/path for KB docs */}
-                {isKbDoc && 'kbPath' in item && (
-                  <Text
-                    style={{
-                      fontSize: token.fontSizeSM - 1,
-                      color: token.colorTextDescription,
-                      flexShrink: 0,
-                      maxWidth: 140,
-                    }}
-                    ellipsis
-                  >
-                    {item.kbPath}
-                  </Text>
-                )}
                 {/* Show source badge for slash commands */}
                 {isCommand && 'source' in item && (
                   <Text

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -8,14 +8,19 @@
  * Highlights @ mentions with a background overlay.
  */
 
-import type { KnowledgeDocumentID } from '@agor/core/types';
+import type {
+  KnowledgeDocument,
+  KnowledgeDocumentID,
+  KnowledgeSearchResult,
+} from '@agor/core/types';
 import type { AgorClient, SessionID, User } from '@agor-live/client';
 import { Input, Popover, Spin, Typography, theme } from 'antd';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { useEmojiAutocomplete } from '@/hooks/useEmojiAutocomplete';
+import { buildKnowledgeRoutePath, namespaceSlugFromUri } from '@/utils/knowledgeRoutes';
 import { mapToArray } from '@/utils/mapHelpers';
 import './AutocompleteTextarea.css';
-import { buildKbDocLink, filterKbDocs, type KbDocMention } from './kbMentions';
+import { buildKbDocLink, filterKbDocs, type KbDocMention, MAX_KB_DOC_RESULTS } from './kbMentions';
 
 export type { KbDocMention } from './kbMentions';
 
@@ -23,7 +28,7 @@ const { TextArea } = Input;
 const { Text } = Typography;
 
 // Constants
-const _MAX_FILE_RESULTS = 10;
+const MAX_FILE_RESULTS = 10;
 const MAX_USER_RESULTS = 5;
 const MAX_EMOJI_RESULTS = 15;
 const DEBOUNCE_MS = 300;
@@ -32,7 +37,8 @@ const AUTOCOMPLETE_POPOVER_WIDTH = 320;
 const AUTOCOMPLETE_POPOVER_MAX_HEIGHT = 300;
 const EMPTY_SLASH_COMMANDS: string[] = [];
 const EMPTY_SKILLS: string[] = [];
-const EMPTY_KB_DOCS: KbDocMention[] = [];
+const MIN_KB_SEARCH_QUERY_LENGTH = 2;
+const MAX_KB_PREFETCH_RESULTS = 25;
 
 interface FileResult {
   path: string;
@@ -216,6 +222,39 @@ const quoteIfNeeded = (text: string): string => {
   return text.includes(' ') ? `"${text}"` : text;
 };
 
+const normalizeFindResult = <T,>(result: T[] | { data?: T[] }): T[] =>
+  Array.isArray(result) ? result : (result.data ?? []);
+
+const leafTitleFromPath = (path: string): string => {
+  const leaf = path.split('/').filter(Boolean).pop() ?? path;
+  return leaf.replace(/\.[^.]+$/, '') || 'Untitled';
+};
+
+const kbMentionFromDocument = (doc: KnowledgeDocument): KbDocMention | null => {
+  const path = doc.path?.trim();
+  if (!path) return null;
+  const slug = namespaceSlugFromUri(doc.uri);
+  if (!slug) return null;
+  return {
+    title: doc.title?.trim() || leafTitleFromPath(path),
+    documentId: doc.document_id,
+    path,
+    uri: doc.uri,
+    routePath: buildKnowledgeRoutePath('/kb', slug, path),
+  };
+};
+
+const uniqueKbMentions = (docs: KbDocMention[]): KbDocMention[] => {
+  const seen = new Set<string>();
+  const unique: KbDocMention[] = [];
+  for (const doc of docs) {
+    if (seen.has(doc.documentId)) continue;
+    seen.add(doc.documentId);
+    unique.push(doc);
+  }
+  return unique;
+};
+
 /**
  * Highlight @ mentions in text
  * Returns JSX with highlighted mentions
@@ -348,7 +387,7 @@ export const AutocompleteTextarea = React.forwardRef<
       onFilesDrop,
       slashCommands = EMPTY_SLASH_COMMANDS,
       skills = EMPTY_SKILLS,
-      kbDocs = EMPTY_KB_DOCS,
+      kbDocs,
       highlightWhenEmpty = false,
     },
     ref
@@ -359,6 +398,8 @@ export const AutocompleteTextarea = React.forwardRef<
     const popoverRef = useRef<React.ElementRef<typeof Popover> | null>(null);
     const popoverContentRef = useRef<HTMLDivElement>(null);
     const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+    const fileSearchSeqRef = useRef(0);
+    const kbSearchSeqRef = useRef(0);
     const [isDragOver, setIsDragOver] = useState(false);
     const { searchEmojis } = useEmojiAutocomplete();
 
@@ -367,11 +408,18 @@ export const AutocompleteTextarea = React.forwardRef<
     const [triggerType, setTriggerType] = useState<'@' | ':' | '/' | null>(null);
     const [triggerIndex, setTriggerIndex] = useState(-1);
     const [query, setQuery] = useState('');
-    const [isLoading, setIsLoading] = useState(false);
+    const [isFileLoading, setIsFileLoading] = useState(false);
+    const [isKbLoading, setIsKbLoading] = useState(false);
+    const [kbError, setKbError] = useState<string | null>(null);
     const [fileResults, setFileResults] = useState<FileResult[]>([]);
     const [emojiResults, setEmojiResults] = useState<EmojiResult[]>([]);
     const [slashCommandResults, setSlashCommandResults] = useState<SlashCommandResult[]>([]);
+    const [fetchedKbDocs, setFetchedKbDocs] = useState<KbDocMention[]>([]);
     const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+    const hasProvidedKbDocs = kbDocs !== undefined;
+    const effectiveKbDocs = kbDocs ?? fetchedKbDocs;
+    const isLoading = isFileLoading || isKbLoading;
 
     // Scroll synchronization state
     const [scrollTop, setScrollTop] = useState(0);
@@ -399,6 +447,14 @@ export const AutocompleteTextarea = React.forwardRef<
       textarea.addEventListener('scroll', handleScroll);
       return () => {
         textarea.removeEventListener('scroll', handleScroll);
+      };
+    }, []);
+
+    React.useEffect(() => {
+      return () => {
+        if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+        fileSearchSeqRef.current += 1;
+        kbSearchSeqRef.current += 1;
       };
     }, []);
 
@@ -456,27 +512,104 @@ export const AutocompleteTextarea = React.forwardRef<
      */
     const searchFiles = useCallback(
       async (searchQuery: string) => {
+        const requestId = fileSearchSeqRef.current + 1;
+        fileSearchSeqRef.current = requestId;
+
         if (!client || !sessionId || !searchQuery.trim()) {
           setFileResults([]);
+          setIsFileLoading(false);
           return;
         }
 
-        setIsLoading(true);
+        setIsFileLoading(true);
 
         try {
           const result = await client.service('files').findAll({
             query: { sessionId, search: searchQuery },
           });
 
-          setFileResults(result as FileResult[]);
+          if (fileSearchSeqRef.current !== requestId) return;
+          setFileResults((result as FileResult[]).slice(0, MAX_FILE_RESULTS));
         } catch (error) {
+          if (fileSearchSeqRef.current !== requestId) return;
           console.error('File search error:', error);
           setFileResults([]);
         } finally {
-          setIsLoading(false);
+          if (fileSearchSeqRef.current === requestId) setIsFileLoading(false);
         }
       },
       [client, sessionId]
+    );
+
+    /**
+     * Search readable Knowledge documents for @ references. Query length >= 2
+     * uses kb/search; empty/one-character queries use the list endpoint and
+     * local filtering so @ opens quickly without issuing broad text searches.
+     * Both services enforce Knowledge RBAC server-side.
+     */
+    const searchKnowledgeDocs = useCallback(
+      async (searchQuery: string) => {
+        const requestId = kbSearchSeqRef.current + 1;
+        kbSearchSeqRef.current = requestId;
+
+        if (hasProvidedKbDocs || !client) {
+          setFetchedKbDocs([]);
+          setKbError(null);
+          setIsKbLoading(false);
+          return;
+        }
+
+        setIsKbLoading(true);
+        setKbError(null);
+
+        try {
+          const trimmed = searchQuery.trim();
+          let mentions: KbDocMention[] = [];
+
+          if (trimmed.length >= MIN_KB_SEARCH_QUERY_LENGTH) {
+            const result = await client.service('kb/search').find({
+              query: {
+                q: trimmed,
+                mode: 'text',
+                limit: MAX_KB_DOC_RESULTS,
+                include_chunks: false,
+              },
+            });
+            mentions = normalizeFindResult<KnowledgeSearchResult>(
+              result as KnowledgeSearchResult[] | { data?: KnowledgeSearchResult[] }
+            )
+              .map((row) => kbMentionFromDocument(row.document))
+              .filter((doc): doc is KbDocMention => Boolean(doc));
+          } else {
+            const result = await client.service('kb/documents').find({
+              query: { archived: false },
+            });
+            const listed = normalizeFindResult<KnowledgeDocument>(
+              result as KnowledgeDocument[] | { data?: KnowledgeDocument[] }
+            )
+              .sort(
+                (a, b) =>
+                  new Date(b.updated_at || b.created_at || 0).getTime() -
+                  new Date(a.updated_at || a.created_at || 0).getTime()
+              )
+              .slice(0, MAX_KB_PREFETCH_RESULTS)
+              .map(kbMentionFromDocument)
+              .filter((doc): doc is KbDocMention => Boolean(doc));
+            mentions = filterKbDocs(listed, trimmed);
+          }
+
+          if (kbSearchSeqRef.current !== requestId) return;
+          setFetchedKbDocs(uniqueKbMentions(mentions).slice(0, MAX_KB_DOC_RESULTS));
+        } catch (error) {
+          if (kbSearchSeqRef.current !== requestId) return;
+          console.error('Knowledge mention search error:', error);
+          setFetchedKbDocs([]);
+          setKbError(error instanceof Error ? error.message : 'Unable to search Knowledge');
+        } finally {
+          if (kbSearchSeqRef.current === requestId) setIsKbLoading(false);
+        }
+      },
+      [client, hasProvidedKbDocs]
     );
 
     /**
@@ -520,9 +653,18 @@ export const AutocompleteTextarea = React.forwardRef<
       const options: AutocompleteResult[] = [];
 
       if (triggerType === '@') {
-        // @ trigger: show KB docs, files, and users
-        if (kbDocs.length > 0) {
-          const kbResults: KbDocResult[] = filterKbDocs(kbDocs, query).map((doc) => ({
+        // @ trigger: keep files first to preserve the existing prompt-composer
+        // muscle memory, then append clearly labeled Knowledge and user groups.
+        if (fileResults.length > 0) {
+          options.push({ heading: 'FILES & FOLDERS' });
+          options.push(...fileResults);
+        }
+
+        if (effectiveKbDocs.length > 0) {
+          const docsForOptions = hasProvidedKbDocs
+            ? filterKbDocs(effectiveKbDocs, query)
+            : effectiveKbDocs;
+          const kbResults: KbDocResult[] = docsForOptions.map((doc) => ({
             kbTitle: doc.title,
             kbDocumentId: doc.documentId,
             kbPath: doc.path,
@@ -534,11 +676,6 @@ export const AutocompleteTextarea = React.forwardRef<
             options.push({ heading: 'KNOWLEDGE BASE' });
             options.push(...kbResults);
           }
-        }
-
-        if (fileResults.length > 0) {
-          options.push({ heading: 'FILES & FOLDERS' });
-          options.push(...fileResults);
         }
 
         const userResults = filterUsers(query);
@@ -561,7 +698,16 @@ export const AutocompleteTextarea = React.forwardRef<
       }
 
       return options;
-    }, [triggerType, fileResults, emojiResults, slashCommandResults, kbDocs, query, filterUsers]);
+    }, [
+      triggerType,
+      fileResults,
+      emojiResults,
+      slashCommandResults,
+      effectiveKbDocs,
+      query,
+      filterUsers,
+      hasProvidedKbDocs,
+    ]);
 
     const popoverAnchorKey = `${popoverPlacement}:${popoverAnchor[0]}:${popoverAnchor[1]}`;
 
@@ -635,9 +781,15 @@ export const AutocompleteTextarea = React.forwardRef<
           setTriggerType('/');
           setQuery(slashTrigger.query);
           setTriggerIndex(slashTrigger.triggerIndex);
+          if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+          fileSearchSeqRef.current += 1;
+          kbSearchSeqRef.current += 1;
           setFileResults([]);
           setEmojiResults([]);
-          setIsLoading(false);
+          setFetchedKbDocs([]);
+          setKbError(null);
+          setIsFileLoading(false);
+          setIsKbLoading(false);
 
           // Filter available commands by query, deduplicating between slashCommands and skills
           const q = slashTrigger.query.toLowerCase();
@@ -675,12 +827,13 @@ export const AutocompleteTextarea = React.forwardRef<
           setEmojiResults([]);
           setSlashCommandResults([]);
 
-          // Debounced search for files
+          // Debounced search for files + Knowledge. Request sequence refs ignore stale in-flight results.
           if (debounceTimerRef.current) {
             clearTimeout(debounceTimerRef.current);
           }
           debounceTimerRef.current = setTimeout(() => {
             searchFiles(atTrigger.query);
+            searchKnowledgeDocs(atTrigger.query);
           }, DEBOUNCE_MS);
 
           setShowPopover(true);
@@ -693,9 +846,15 @@ export const AutocompleteTextarea = React.forwardRef<
           setTriggerType(':');
           setQuery(colonTrigger.query);
           setTriggerIndex(colonTrigger.triggerIndex);
+          if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+          fileSearchSeqRef.current += 1;
+          kbSearchSeqRef.current += 1;
           setFileResults([]);
+          setFetchedKbDocs([]);
+          setKbError(null);
           setSlashCommandResults([]);
-          setIsLoading(false); // Reset loading state when switching to emoji trigger
+          setIsFileLoading(false);
+          setIsKbLoading(false); // Reset loading state when switching to emoji trigger
 
           // Instant emoji search (no debounce needed)
           const emojis = searchEmojis(colonTrigger.query);
@@ -712,14 +871,21 @@ export const AutocompleteTextarea = React.forwardRef<
         }
 
         // No trigger detected
+        if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
         setShowPopover(false);
         setTriggerType(null);
         setFileResults([]);
         setEmojiResults([]);
         setSlashCommandResults([]);
+        setFetchedKbDocs([]);
+        setKbError(null);
+        setIsFileLoading(false);
+        setIsKbLoading(false);
+        fileSearchSeqRef.current += 1;
+        kbSearchSeqRef.current += 1;
         setHighlightedIndex(-1);
       },
-      [onChange, searchFiles, searchEmojis, slashCommands, skills]
+      [onChange, searchFiles, searchKnowledgeDocs, searchEmojis, slashCommands, skills]
     );
 
     /**
@@ -766,6 +932,12 @@ export const AutocompleteTextarea = React.forwardRef<
         setFileResults([]);
         setEmojiResults([]);
         setSlashCommandResults([]);
+        setFetchedKbDocs([]);
+        setKbError(null);
+        setIsFileLoading(false);
+        setIsKbLoading(false);
+        fileSearchSeqRef.current += 1;
+        kbSearchSeqRef.current += 1;
         setHighlightedIndex(-1);
 
         // Move cursor after inserted value
@@ -830,7 +1002,9 @@ export const AutocompleteTextarea = React.forwardRef<
               if (highlightedIndex >= 0) {
                 const item = autocompleteOptions[highlightedIndex];
                 if (!('heading' in item)) {
-                  handleSelect(item as FileResult | UserResult | SlashCommandResult | KbDocResult);
+                  handleSelect(
+                    item as FileResult | UserResult | EmojiResult | SlashCommandResult | KbDocResult
+                  );
                 }
               } else if (autocompleteOptions.length > 0) {
                 // If nothing highlighted, highlight first non-heading item
@@ -860,7 +1034,14 @@ export const AutocompleteTextarea = React.forwardRef<
                 // Nothing highlighted - select first non-heading item (like Slack)
                 const firstItem = autocompleteOptions.find((item) => !('heading' in item));
                 if (firstItem) {
-                  handleSelect(firstItem as FileResult | UserResult | EmojiResult | KbDocResult);
+                  handleSelect(
+                    firstItem as
+                      | FileResult
+                      | UserResult
+                      | EmojiResult
+                      | SlashCommandResult
+                      | KbDocResult
+                  );
                 }
               }
             } else if (!isPopoverOpen && onKeyPress) {
@@ -982,6 +1163,18 @@ export const AutocompleteTextarea = React.forwardRef<
             }}
           >
             <Spin size="small" />
+          </div>
+        )}
+
+        {!isLoading && kbError && (
+          <div
+            style={{
+              padding: `${token.paddingXS}px ${token.paddingSM}px`,
+              color: token.colorError,
+              fontSize: token.fontSizeSM,
+            }}
+          >
+            Unable to search Knowledge
           </div>
         )}
 

--- a/apps/agor-ui/src/components/AutocompleteTextarea/index.ts
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/index.ts
@@ -1,3 +1,3 @@
 export type { KbDocMention } from './AutocompleteTextarea';
 export { AutocompleteTextarea } from './AutocompleteTextarea';
-export { hydrateKbDocLinks } from './kbMentions';
+export { hydrateKbDocLinks, kbMentionFromDocument } from './kbMentions';

--- a/apps/agor-ui/src/components/AutocompleteTextarea/kbMentions.ts
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/kbMentions.ts
@@ -58,14 +58,17 @@ export function filterKbDocs(
 }
 
 /**
- * Build a markdown link to a KB doc. The href is the rename-proof
- * `agor://kb/document/<uuid>` URI (hydrated to a clickable route at render time);
- * the label is the doc title with `[` / `]` escaped so it can't break out of the
- * link syntax.
+ * Build a markdown link with a KB document title as the label. Escapes square
+ * brackets so the title can't break out of link syntax.
  */
-export function buildKbDocLink(title: string, documentId: KnowledgeDocumentID): string {
+export function buildKbMarkdownLink(title: string, href: string): string {
   const label = title.replace(/[[\]]/g, '\\$&').trim() || 'Untitled';
-  return `[${label}](${buildKnowledgeDocumentUri(documentId)})`;
+  return `[${label}](${href})`;
+}
+
+/** Build the internal rename-proof KB document URI form for persisted Knowledge docs. */
+export function buildKbDocLink(title: string, documentId: KnowledgeDocumentID): string {
+  return buildKbMarkdownLink(title, buildKnowledgeDocumentUri(documentId));
 }
 
 const KB_DOC_URI_RE = new RegExp(

--- a/apps/agor-ui/src/components/AutocompleteTextarea/kbMentions.ts
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/kbMentions.ts
@@ -8,8 +8,10 @@
 import {
   buildKnowledgeDocumentUri,
   KNOWLEDGE_DOCUMENT_URI_PREFIX,
+  type KnowledgeDocument,
   type KnowledgeDocumentID,
 } from '@agor/core/types';
+import { buildKnowledgeRoutePath, namespaceSlugFromUri } from '@/utils/knowledgeRoutes';
 
 export interface KbDocMention {
   /** Display title, used as the dropdown label and the markdown link text. */
@@ -26,10 +28,50 @@ export interface KbDocMention {
 
 export const MAX_KB_DOC_RESULTS = 8;
 
+// Non-throwing leaf title used only as a fallback when a doc has no title.
+export const leafTitleFromPath = (path: string): string => {
+  const leaf = path.split('/').filter(Boolean).pop() ?? path;
+  return (
+    leaf
+      .replace(/\.(md|markdown)$/i, '')
+      .replace(/[-_]+/g, ' ')
+      .trim() || path
+  );
+};
+
+/** Convert a readable Knowledge document row into the mention view model. */
+export function kbMentionFromDocument(
+  doc: Pick<KnowledgeDocument, 'document_id' | 'path' | 'uri' | 'title'>,
+  routeBasePath = '/kb'
+): KbDocMention | null {
+  const path = doc.path?.trim();
+  if (!path) return null;
+  const slug = namespaceSlugFromUri(doc.uri);
+  if (!slug) return null;
+  return {
+    title: doc.title?.trim() || leafTitleFromPath(path),
+    documentId: doc.document_id,
+    path,
+    uri: doc.uri,
+    routePath: buildKnowledgeRoutePath(routeBasePath, slug, path),
+  };
+}
+
+export const uniqueKbMentions = (docs: KbDocMention[]): KbDocMention[] => {
+  const seen = new Set<string>();
+  const unique: KbDocMention[] = [];
+  for (const doc of docs) {
+    if (seen.has(doc.documentId)) continue;
+    seen.add(doc.documentId);
+    unique.push(doc);
+  }
+  return unique;
+};
+
 /**
- * Filter and rank KB docs for the typed query. Matches against title and path,
- * preferring title prefix matches. With an empty query, returns the first
- * `limit` docs so the dropdown is useful immediately after typing `@`.
+ * Filter and rank a caller-provided KB doc set for the typed query. Matches
+ * against title and path, preferring title prefix matches. With an empty query,
+ * returns the first `limit` docs from that bounded local set.
  */
 export function filterKbDocs(
   docs: KbDocMention[],

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -233,6 +233,8 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
             client={client}
             sessionId={session?.session_id || null}
             userById={userById}
+            enableKnowledgeMentions
+            kbLinkTarget="absolute-route"
           />
         </Form.Item>
 
@@ -317,6 +319,8 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
                     client={client}
                     sessionId={session?.session_id || null}
                     userById={userById}
+                    enableKnowledgeMentions
+                    kbLinkTarget="absolute-route"
                   />
                 </Form.Item>
               </>

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -245,6 +245,8 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
             client={client}
             sessionId={null}
             userById={userById}
+            enableKnowledgeMentions
+            kbLinkTarget="absolute-route"
           />
         </Form.Item>
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -205,6 +205,8 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
         onFilesDrop={onFilesDrop}
         slashCommands={slashCommands}
         skills={skills}
+        enableKnowledgeMentions
+        kbLinkTarget="absolute-route"
         highlightWhenEmpty
       />
     );

--- a/apps/agor-ui/src/components/mobile/MobilePromptInput.tsx
+++ b/apps/agor-ui/src/components/mobile/MobilePromptInput.tsx
@@ -72,6 +72,8 @@ export const MobilePromptInput: React.FC<MobilePromptInputProps> = ({
           sessionId={sessionId}
           userById={userById}
           autoSize={{ minRows: 1, maxRows: 4 }}
+          enableKnowledgeMentions
+          kbLinkTarget="absolute-route"
         />
       </div>
       <Button

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -90,6 +90,7 @@ import {
   AutocompleteTextarea,
   hydrateKbDocLinks,
   type KbDocMention,
+  kbMentionFromDocument,
 } from '../components/AutocompleteTextarea';
 import { BrandLogo } from '../components/BrandLogo';
 import { AgorEmojiPicker } from '../components/EmojiPickerInput';
@@ -395,17 +396,6 @@ const kindForSegment = (segment: string): KnowledgeDocumentKind | undefined => {
   if (segment === 'Skills') return 'skill';
   if (segment === 'Memories') return 'memory';
   return undefined;
-};
-
-// Non-throwing leaf title used only as a fallback when a doc has no title.
-const leafTitleFromPath = (path: string): string => {
-  const leaf = path.split('/').filter(Boolean).pop() ?? path;
-  return (
-    leaf
-      .replace(/\.(md|markdown)$/i, '')
-      .replace(/[-_]+/g, ' ')
-      .trim() || path
-  );
 };
 
 const normalizeFindResult = <T,>(result: T[] | { data?: T[] }): T[] =>
@@ -1163,20 +1153,9 @@ export function KnowledgePage({
     try {
       const result = await client.service('kb/documents').find({ query: { archived: false } });
       const rows = normalizeFindResult<KnowledgeDocument>(result as KnowledgeDocument[]);
-      const mentions = rows.reduce<KbDocMention[]>((acc, doc) => {
-        const path = doc.path?.trim();
-        if (!path) return acc;
-        const slug = namespaceSlugFromUri(doc.uri);
-        if (!slug) return acc;
-        acc.push({
-          title: doc.title?.trim() || leafTitleFromPath(path),
-          documentId: doc.document_id,
-          path,
-          uri: doc.uri,
-          routePath: buildKnowledgeRoutePath('/kb', slug, path),
-        });
-        return acc;
-      }, []);
+      const mentions = rows
+        .map((doc) => kbMentionFromDocument(doc, '/kb'))
+        .filter((doc): doc is KbDocMention => Boolean(doc));
       setMentionDocs(mentions);
     } catch (err) {
       console.error('Failed to load Knowledge mentions:', err);


### PR DESCRIPTION
## Summary
- extends the shared prompt composer @ autocomplete to fetch readable Knowledge docs via existing kb/search and kb/documents services
- groups suggestions as Files & Folders, Knowledge Base, and Users while keeping files first to preserve existing file-autocomplete behavior
- displays KB autocomplete rows as just the document title (plus the Knowledge group/icon), not the inserted reference/path
- inserts Knowledge selections as same-origin, user-clickable markdown links to `/kb/<namespace>/<path>` so conversation markdown does not render `[blocked]`
- adds coverage for combined file/KB suggestions, KB insertion, and empty-query readable document list behavior

## Notes
- For queries with 2+ characters, Knowledge suggestions use `kb/search` with text mode and server-side RBAC.
- Empty/one-character queries use `kb/documents` and local limiting/filtering to avoid broad search and keep the menu responsive.
- `agor://kb/document/<id>` remains supported for persisted Knowledge docs, but prompt composer insertion now favors the user-visible URL because conversation markdown blocks non-http(s) schemes.

## Tests
- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- AutocompleteTextarea.test.tsx kbMentions.test.ts`
- `pnpm exec biome check apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx apps/agor-ui/src/components/AutocompleteTextarea/kbMentions.ts apps/agor-ui/src/components/AutocompleteTextarea/kbMentions.test.ts`
