### PR TITLE
Redesign docs landing page

### DIFF
--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -324,6 +324,24 @@
   top: 92px;
 }
 
+.workspaceScreenshot {
+  margin-top: 28px;
+  overflow: hidden;
+  border: 1px solid var(--landing-line);
+  border-radius: 18px;
+  background: rgba(8, 14, 24, 0.78);
+  box-shadow: 0 22px 58px rgba(0, 0, 0, 0.24);
+}
+
+.workspaceScreenshot img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1.18 / 1;
+  object-fit: cover;
+  object-position: 50% 24%;
+  filter: saturate(1.05) brightness(1.05);
+}
+
 .featureGrid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   margin-top: 0;
@@ -636,6 +654,10 @@
 
   .workspaceCopy {
     position: static;
+  }
+
+  .workspaceScreenshot {
+    max-width: 520px;
   }
 
   .problemGrid,

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -1,0 +1,668 @@
+.landingShell {
+  --landing-ink: #111827;
+  --landing-muted: #5d6878;
+  --landing-line: rgba(17, 24, 39, 0.1);
+  --landing-teal: #2e9a92;
+  --landing-blue: #2388f2;
+  --landing-mint: #d9fb89;
+  --landing-pink: #ffc3df;
+  --landing-sky: #9bdcff;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  margin-top: -4rem;
+  color: var(--landing-ink);
+  background:
+    radial-gradient(circle at 80% 8%, rgba(127, 232, 223, 0.2), transparent 34rem),
+    linear-gradient(180deg, #fbfaf6 0%, #ffffff 28%, #f7fbff 62%, #ffffff 100%);
+  overflow: hidden;
+}
+
+.heroSection,
+.problemSection,
+.workspaceSection,
+.useCaseSection,
+.controlSection,
+.finalCta {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 88px 28px;
+}
+
+.heroSection {
+  padding-top: 112px;
+}
+
+.navAnnouncement {
+  width: fit-content;
+  margin: 0 auto 56px;
+  padding: 9px 16px;
+  border: 1px solid var(--landing-line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.74);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+  color: var(--landing-muted);
+  font-size: 0.86rem;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+  backdrop-filter: blur(14px);
+}
+
+.heroGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.98fr) minmax(430px, 1.02fr);
+  gap: 42px;
+  align-items: center;
+}
+
+.heroCopy {
+  max-width: 610px;
+}
+
+.brandMark {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 28px;
+  color: var(--landing-ink);
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.brandMark img {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  box-shadow: 0 10px 24px rgba(46, 154, 146, 0.22);
+}
+
+.kicker,
+.eyebrow {
+  margin: 0 0 16px;
+  color: var(--landing-teal);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.heroCopy h1,
+.sectionHeader h2,
+.workspaceCopy h2,
+.useCaseSection h2,
+.controlSection h2,
+.finalCta h2 {
+  margin: 0;
+  color: var(--landing-ink);
+  font-weight: 820;
+  letter-spacing: -0.055em;
+  line-height: 0.95;
+}
+
+.heroCopy h1 {
+  max-width: 720px;
+  font-size: clamp(3.7rem, 7.4vw, 6.25rem);
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
+}
+
+.heroDescription {
+  max-width: 590px;
+  margin: 28px 0 0;
+  color: var(--landing-muted);
+  font-size: 1.16rem;
+  line-height: 1.68;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  margin-top: 34px;
+}
+
+.primaryButton,
+.secondaryButton,
+.textButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  border-radius: 999px;
+  font-weight: 750;
+  text-decoration: none;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.landingShell .primaryButton {
+  color: white;
+  background: #168bff;
+  box-shadow: 0 16px 34px rgba(35, 136, 242, 0.24);
+}
+
+.primaryButton:hover,
+.secondaryButton:hover,
+.textButton:hover {
+  transform: translateY(-2px);
+}
+
+.landingShell .primaryButton:hover {
+  color: white;
+  box-shadow: 0 20px 44px rgba(35, 136, 242, 0.32);
+}
+
+.landingShell .secondaryButton {
+  border: 1px solid var(--landing-line);
+  color: var(--landing-ink);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.landingShell .secondaryButton:hover {
+  border-color: rgba(35, 136, 242, 0.35);
+  color: var(--landing-ink);
+}
+
+.landingShell .textButton {
+  border: 0;
+  color: var(--landing-muted);
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.mockup {
+  position: relative;
+  min-height: 560px;
+  padding: 58px 28px 30px;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  border-radius: 34px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.72)),
+    radial-gradient(circle at 50% 0%, rgba(35, 136, 242, 0.17), transparent 24rem);
+  box-shadow: 0 36px 90px rgba(15, 23, 42, 0.14);
+  overflow: hidden;
+}
+
+.mockup::before {
+  position: absolute;
+  inset: 82px -80px -80px;
+  content: "";
+  background-image:
+    linear-gradient(rgba(17, 24, 39, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(17, 24, 39, 0.06) 1px, transparent 1px);
+  background-size: 40px 40px;
+  transform: perspective(520px) rotateX(58deg) rotateZ(-10deg);
+  transform-origin: top center;
+}
+
+.mockupTopbar {
+  position: absolute;
+  top: 20px;
+  left: 24px;
+  display: flex;
+  gap: 8px;
+}
+
+.mockupTopbar span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(17, 24, 39, 0.18);
+}
+
+.boardGrid {
+  position: relative;
+  height: 420px;
+}
+
+.zone {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 18px;
+  min-width: 235px;
+  min-height: 156px;
+  padding: 18px;
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  border-radius: 28px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  transform: rotate(-8deg) skewY(-4deg);
+}
+
+.zone > span {
+  color: rgba(17, 24, 39, 0.58);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.zoneA {
+  top: 118px;
+  left: 22px;
+  background: var(--landing-sky);
+}
+
+.zoneB {
+  top: 54px;
+  right: 48px;
+  background: var(--landing-mint);
+}
+
+.zoneC {
+  right: -4px;
+  bottom: 22px;
+  background: var(--landing-pink);
+}
+
+.branchCard {
+  padding: 14px;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
+  transform: skewY(4deg);
+}
+
+.branchCard strong,
+.branchCard small {
+  display: block;
+}
+
+.branchCard strong {
+  color: var(--landing-ink);
+  font-size: 0.98rem;
+}
+
+.branchCard small {
+  margin-top: 4px;
+  color: var(--landing-muted);
+}
+
+.agentBubble,
+.commandCard {
+  position: absolute;
+  z-index: 2;
+  border: 1px solid rgba(17, 24, 39, 0.1);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(16px);
+}
+
+.agentBubble {
+  top: 86px;
+  left: 72px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  width: min(400px, calc(100% - 92px));
+  padding: 16px;
+  border-radius: 24px;
+}
+
+.agentBubble p {
+  margin: 0;
+  color: var(--landing-muted);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.agentBubble strong {
+  color: var(--landing-ink);
+}
+
+.avatarStack {
+  display: flex;
+  align-items: center;
+}
+
+.avatarStack span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  margin-left: -8px;
+  border: 2px solid white;
+  border-radius: 999px;
+  color: #0b3b38;
+  background: #7fe8df;
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.avatarStack span:first-child {
+  margin-left: 0;
+}
+
+.commandCard {
+  right: 38px;
+  bottom: 78px;
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  padding: 13px 16px;
+  border-radius: 999px;
+  color: var(--landing-ink);
+  font-size: 0.9rem;
+  font-weight: 750;
+}
+
+.statusDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #2e9a92;
+  box-shadow: 0 0 0 6px rgba(46, 154, 146, 0.16);
+}
+
+.assistantStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 22px;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 28px;
+  border-top: 1px solid var(--landing-line);
+  border-bottom: 1px solid var(--landing-line);
+  color: var(--landing-muted);
+}
+
+.assistantStrip > span {
+  font-weight: 750;
+}
+
+.assistantStrip div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.assistantStrip strong {
+  padding: 8px 13px;
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: 999px;
+  color: var(--landing-ink);
+  background: white;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+}
+
+.sectionHeader {
+  max-width: 760px;
+}
+
+.sectionHeader h2,
+.workspaceCopy h2,
+.useCaseSection h2,
+.controlSection h2,
+.finalCta h2 {
+  font-size: clamp(2.8rem, 5vw, 5rem);
+}
+
+.problemGrid,
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 48px;
+}
+
+.problemCard,
+.featureCard {
+  min-height: 220px;
+  padding: 28px;
+  border: 1px solid var(--landing-line);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.74);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.06);
+}
+
+.problemCard h3,
+.featureCard h3 {
+  margin: 0;
+  color: var(--landing-ink);
+  font-size: 1.35rem;
+  letter-spacing: -0.02em;
+}
+
+.problemCard p,
+.featureCard p,
+.workspaceCopy p,
+.controlSection p,
+.finalCta p {
+  margin: 16px 0 0;
+  color: var(--landing-muted);
+  line-height: 1.7;
+}
+
+.workspaceSection {
+  display: grid;
+  grid-template-columns: 0.82fr 1.18fr;
+  gap: 52px;
+  align-items: start;
+}
+
+.workspaceCopy {
+  position: sticky;
+  top: 92px;
+}
+
+.featureGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 0;
+}
+
+.featureCard span {
+  display: inline-flex;
+  margin-bottom: 42px;
+  color: var(--landing-blue);
+  font-weight: 850;
+}
+
+.useCaseSection {
+  text-align: center;
+}
+
+.useCaseGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  max-width: 900px;
+  margin: 38px auto 0;
+}
+
+.useCaseGrid span {
+  padding: 12px 16px;
+  border: 1px solid var(--landing-line);
+  border-radius: 999px;
+  color: var(--landing-muted);
+  background: white;
+  font-weight: 720;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.04);
+}
+
+.controlSection {
+  display: grid;
+  grid-template-columns: 1fr 0.8fr;
+  gap: 42px;
+  align-items: center;
+  margin-top: 40px;
+  padding: 66px 28px;
+  border-radius: 36px;
+  background: #07111f;
+}
+
+.controlSection h2,
+.controlSection p {
+  color: white;
+}
+
+.controlSection p {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.trustList {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.trustList li {
+  padding: 16px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  color: rgba(255, 255, 255, 0.86);
+  background: rgba(255, 255, 255, 0.06);
+  font-weight: 720;
+}
+
+.finalCta {
+  text-align: center;
+}
+
+.finalCta p {
+  max-width: 640px;
+  margin: 20px auto 0;
+}
+
+.finalCta .heroActions {
+  justify-content: center;
+}
+
+:global(.dark) .landingShell {
+  background:
+    radial-gradient(circle at 80% 8%, rgba(46, 154, 146, 0.24), transparent 34rem),
+    linear-gradient(180deg, #f8faf8 0%, #ffffff 30%, #f7fbff 68%, #ffffff 100%);
+}
+
+@media (max-width: 980px) {
+  .heroGrid,
+  .workspaceSection,
+  .controlSection {
+    grid-template-columns: 1fr;
+  }
+
+  .heroGrid {
+    gap: 44px;
+  }
+
+  .mockup {
+    min-height: 500px;
+  }
+
+  .workspaceCopy {
+    position: static;
+  }
+
+  .problemGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .landingShell {
+    margin-top: -2rem;
+  }
+
+  .heroSection,
+  .problemSection,
+  .workspaceSection,
+  .useCaseSection,
+  .finalCta {
+    padding: 64px 18px;
+  }
+
+  .heroSection {
+    padding-top: 104px;
+  }
+
+  .navAnnouncement {
+    margin-bottom: 44px;
+  }
+
+  .heroCopy h1 {
+    font-size: clamp(3.4rem, 16vw, 5.4rem);
+  }
+
+  .heroDescription {
+    font-size: 1.04rem;
+  }
+
+  .heroActions,
+  .assistantStrip,
+  .assistantStrip div {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .primaryButton,
+  .secondaryButton,
+  .textButton {
+    width: 100%;
+  }
+
+  .mockup {
+    min-height: 480px;
+    padding-inline: 16px;
+    border-radius: 26px;
+  }
+
+  .zone {
+    min-width: 205px;
+  }
+
+  .zoneA {
+    left: 0;
+  }
+
+  .zoneB {
+    right: 0;
+  }
+
+  .zoneC {
+    right: -24px;
+  }
+
+  .agentBubble {
+    top: 58px;
+    left: 18px;
+    width: calc(100% - 36px);
+  }
+
+  .commandCard {
+    right: 16px;
+    bottom: 38px;
+  }
+
+  .featureGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .sectionHeader h2,
+  .workspaceCopy h2,
+  .useCaseSection h2,
+  .controlSection h2,
+  .finalCta h2 {
+    font-size: clamp(2.4rem, 12vw, 4rem);
+  }
+
+  .controlSection {
+    margin-inline: 18px;
+    padding: 48px 22px;
+  }
+}

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -4,6 +4,7 @@
   --landing-line: rgba(255, 255, 255, 0.12);
   --landing-teal: #7fe8df;
   --landing-blue: #7fe8df;
+  --landing-gradient: linear-gradient(90deg, #2e9a92 0%, #7fe8df 50%, #a8f5ed 100%);
   --landing-mint: #d9fb89;
   --landing-pink: #ffc3df;
   --landing-sky: #9bdcff;
@@ -53,21 +54,32 @@
   gap: 12px;
   margin-bottom: 34px;
   color: var(--landing-ink);
-  font-size: 1.42rem;
-  font-weight: 800;
+  font-size: 1.58rem;
+  font-weight: 850;
 }
 
 .brandMark img {
-  width: 64px;
-  height: 64px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
   box-shadow: 0 0 34px rgba(127, 232, 223, 0.2);
+}
+
+.brandMark span {
+  background: var(--landing-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .kicker,
 .eyebrow {
   margin: 0 0 16px;
   color: var(--landing-teal);
+  background: var(--landing-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
   font-size: 0.82rem;
   font-weight: 800;
   letter-spacing: 0.13em;
@@ -89,7 +101,7 @@
 
 .heroCopy h1 {
   max-width: 720px;
-  font-size: clamp(3.45rem, 6.65vw, 5.7rem);
+  font-size: clamp(3.25rem, 5.75vw, 5.25rem);
   overflow-wrap: normal;
   word-break: normal;
   hyphens: none;
@@ -306,7 +318,7 @@
 }
 
 .sectionHeader {
-  max-width: 760px;
+  max-width: 920px;
 }
 
 .sectionHeader h2,
@@ -314,7 +326,7 @@
 .useCaseSection h2,
 .controlSection h2,
 .finalCta h2 {
-  font-size: clamp(2.55rem, 4.45vw, 4.45rem);
+  font-size: clamp(2.45rem, 4vw, 4.05rem);
 }
 
 .problemGrid,
@@ -395,10 +407,12 @@
   width: 36px;
   height: 36px;
   margin-bottom: 24px;
-  border: 1px solid rgba(127, 232, 223, 0.18);
+  border: 1px solid transparent;
   border-radius: 999px;
   color: var(--landing-blue);
-  background: rgba(127, 232, 223, 0.08);
+  background:
+    linear-gradient(rgba(9, 17, 30, 0.92), rgba(9, 17, 30, 0.92)) padding-box,
+    var(--landing-gradient) border-box;
   font-weight: 850;
 }
 

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -393,6 +393,10 @@
   object-position: 50% 20%;
 }
 
+.productCard:nth-child(5) img {
+  object-position: 50% 22%;
+}
+
 .productCard div {
   padding: 22px;
 }

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -1,20 +1,22 @@
 .landingShell {
-  --landing-ink: #111827;
-  --landing-muted: #5d6878;
-  --landing-line: rgba(17, 24, 39, 0.1);
-  --landing-teal: #2e9a92;
-  --landing-blue: #2388f2;
+  --landing-ink: #f8fafc;
+  --landing-muted: #aeb9c8;
+  --landing-line: rgba(255, 255, 255, 0.12);
+  --landing-teal: #7fe8df;
+  --landing-blue: #6bb7ff;
   --landing-mint: #d9fb89;
   --landing-pink: #ffc3df;
   --landing-sky: #9bdcff;
+  --hero-scroll: 0;
   width: 100vw;
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
   margin-top: -4rem;
   color: var(--landing-ink);
   background:
-    radial-gradient(circle at 80% 8%, rgba(127, 232, 223, 0.2), transparent 34rem),
-    linear-gradient(180deg, #fbfaf6 0%, #ffffff 28%, #f7fbff 62%, #ffffff 100%);
+    radial-gradient(circle at 18% 12%, rgba(46, 154, 146, 0.22), transparent 30rem),
+    radial-gradient(circle at 82% 8%, rgba(35, 136, 242, 0.16), transparent 34rem),
+    linear-gradient(180deg, #05070b 0%, #09111d 36%, #070b12 72%, #05070b 100%);
   overflow: hidden;
 }
 
@@ -39,13 +41,14 @@
   padding: 9px 16px;
   border: 1px solid var(--landing-line);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.74);
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+  background: rgba(10, 18, 31, 0.72);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.24);
   color: var(--landing-muted);
   font-size: 0.86rem;
   font-weight: 650;
   letter-spacing: 0.01em;
   backdrop-filter: blur(14px);
+  transform: translateY(calc(var(--hero-scroll) * 14px));
 }
 
 .heroGrid {
@@ -73,7 +76,7 @@
   width: 44px;
   height: 44px;
   border-radius: 50%;
-  box-shadow: 0 10px 24px rgba(46, 154, 146, 0.22);
+  box-shadow: 0 0 34px rgba(127, 232, 223, 0.2);
 }
 
 .kicker,
@@ -161,8 +164,8 @@
 .landingShell .secondaryButton {
   border: 1px solid var(--landing-line);
   color: var(--landing-ink);
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
   cursor: pointer;
   font-family: inherit;
 }
@@ -184,14 +187,16 @@
   position: relative;
   min-height: 560px;
   perspective: 1200px;
+  transform: translateY(calc(var(--hero-scroll) * -24px));
+  transition: transform 120ms linear;
 }
 
 .mainScreenshotFrame,
 .floatingScreenshot,
 .screenshotBadge {
-  border: 1px solid rgba(17, 24, 39, 0.12);
-  background: rgba(255, 255, 255, 0.88);
-  box-shadow: 0 36px 90px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(9, 17, 30, 0.86);
+  box-shadow: 0 36px 90px rgba(0, 0, 0, 0.42);
   backdrop-filter: blur(16px);
 }
 
@@ -210,15 +215,15 @@
   align-items: center;
   height: 42px;
   padding: 0 18px;
-  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
-  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(7, 12, 20, 0.92);
 }
 
 .screenshotTopbar span {
   width: 10px;
   height: 10px;
   border-radius: 999px;
-  background: rgba(17, 24, 39, 0.18);
+  background: rgba(255, 255, 255, 0.24);
 }
 
 .mainScreenshotFrame img,
@@ -246,7 +251,7 @@
   bottom: 28px;
   width: min(390px, 58%);
   height: 228px;
-  transform: rotate(2deg);
+  transform: rotate(2deg) translateY(calc(var(--hero-scroll) * 18px));
 }
 
 .floatingSessions {
@@ -254,7 +259,7 @@
   top: 0;
   width: min(295px, 46%);
   height: 292px;
-  transform: rotate(-4deg);
+  transform: rotate(-4deg) translateY(calc(var(--hero-scroll) * -28px));
 }
 
 .screenshotBadge {
@@ -271,6 +276,7 @@
   color: var(--landing-ink);
   font-size: 0.9rem;
   font-weight: 750;
+  transform: translateY(calc(var(--hero-scroll) * -12px));
 }
 
 .statusDot {
@@ -308,11 +314,11 @@
 
 .assistantStrip strong {
   padding: 8px 13px;
-  border: 1px solid rgba(17, 24, 39, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 999px;
   color: var(--landing-ink);
-  background: white;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
 }
 
 .sectionHeader {
@@ -330,9 +336,12 @@
 .problemGrid,
 .featureGrid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
   margin-top: 48px;
+}
+
+.problemGrid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .problemCard,
@@ -341,7 +350,7 @@
   padding: 28px;
   border: 1px solid var(--landing-line);
   border-radius: 28px;
-  background: rgba(255, 255, 255, 0.74);
+  background: rgba(10, 18, 31, 0.72);
   box-shadow: 0 18px 48px rgba(15, 23, 42, 0.06);
 }
 
@@ -405,9 +414,9 @@
   border: 1px solid var(--landing-line);
   border-radius: 999px;
   color: var(--landing-muted);
-  background: white;
+  background: rgba(255, 255, 255, 0.06);
   font-weight: 720;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
 }
 
 .controlSection {
@@ -418,7 +427,8 @@
   margin-top: 40px;
   padding: 66px 28px;
   border-radius: 36px;
-  background: #07111f;
+  background: linear-gradient(135deg, rgba(7, 17, 31, 0.95), rgba(3, 8, 16, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .controlSection h2,
@@ -462,8 +472,26 @@
 
 :global(.dark) .landingShell {
   background:
-    radial-gradient(circle at 80% 8%, rgba(46, 154, 146, 0.24), transparent 34rem),
-    linear-gradient(180deg, #f8faf8 0%, #ffffff 30%, #f7fbff 68%, #ffffff 100%);
+    radial-gradient(circle at 18% 12%, rgba(46, 154, 146, 0.22), transparent 30rem),
+    radial-gradient(circle at 82% 8%, rgba(35, 136, 242, 0.16), transparent 34rem),
+    linear-gradient(180deg, #05070b 0%, #09111d 36%, #070b12 72%, #05070b 100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navAnnouncement,
+  .screenshotCollage,
+  .screenshotBadge {
+    transform: none;
+    transition: none;
+  }
+
+  .floatingConversation {
+    transform: rotate(2deg);
+  }
+
+  .floatingSessions {
+    transform: rotate(-4deg);
+  }
 }
 
 @media (max-width: 980px) {
@@ -490,7 +518,7 @@
   }
 
   .problemGrid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -566,6 +594,7 @@
     border-radius: 22px;
   }
 
+  .problemGrid,
   .featureGrid {
     grid-template-columns: 1fr;
   }

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -205,7 +205,7 @@
   aspect-ratio: 2340 / 1334;
   border-radius: 10px;
   overflow: hidden;
-  transform: rotate(-1.2deg);
+  transform: rotateY(-6deg) rotateX(1.5deg) rotateZ(-2.2deg);
   transform-origin: center;
 }
 
@@ -233,7 +233,7 @@
   top: 398px;
   width: min(340px, 50%);
   height: 190px;
-  transform: rotate(1.8deg) translateY(calc(var(--hero-scroll) * 34px));
+  transform: rotateY(-5deg) rotateZ(4deg) translateY(calc(var(--hero-scroll) * 34px));
 }
 
 .floatingSessions {
@@ -241,7 +241,7 @@
   top: 382px;
   width: min(235px, 36%);
   height: 240px;
-  transform: rotate(-2.4deg) translateY(calc(var(--hero-scroll) * -28px));
+  transform: rotateY(6deg) rotateZ(-5deg) translateY(calc(var(--hero-scroll) * -28px));
 }
 
 .assistantStrip {
@@ -570,11 +570,11 @@
   }
 
   .floatingConversation {
-    transform: rotate(1.8deg);
+    transform: rotateZ(4deg);
   }
 
   .floatingSessions {
-    transform: rotate(-2.4deg);
+    transform: rotateZ(-5deg);
   }
 }
 

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -223,25 +223,34 @@
 
 .floatingScreenshot {
   position: absolute;
-  z-index: 1;
+  z-index: 3;
   overflow: hidden;
   border-radius: 8px;
+  opacity: 0.96;
 }
 
-.floatingConversation {
-  right: -4px;
-  top: 398px;
-  width: min(340px, 50%);
+.floatingParallel {
+  left: 26px;
+  top: 404px;
+  width: min(230px, 34%);
+  height: 224px;
+  transform: rotateY(6deg) rotateZ(-5.2deg) translateY(calc(var(--hero-scroll) * -118px));
+}
+
+.floatingHierarchy {
+  left: 206px;
+  top: 394px;
+  width: min(310px, 46%);
   height: 190px;
-  transform: rotateY(-5deg) rotateZ(4deg) translateY(calc(var(--hero-scroll) * 34px));
+  transform: rotateY(-4deg) rotateZ(2.4deg) translateY(calc(var(--hero-scroll) * -96px));
 }
 
-.floatingSessions {
-  left: 28px;
-  top: 382px;
-  width: min(235px, 36%);
-  height: 240px;
-  transform: rotateY(6deg) rotateZ(-5deg) translateY(calc(var(--hero-scroll) * -28px));
+.floatingReview {
+  right: -8px;
+  top: 386px;
+  width: min(330px, 49%);
+  height: 210px;
+  transform: rotateY(-7deg) rotateZ(4.6deg) translateY(calc(var(--hero-scroll) * -132px));
 }
 
 .assistantStrip {
@@ -569,12 +578,16 @@
     transition: none;
   }
 
-  .floatingConversation {
-    transform: rotateZ(4deg);
+  .floatingParallel {
+    transform: rotateZ(-5.2deg);
   }
 
-  .floatingSessions {
-    transform: rotateZ(-5deg);
+  .floatingHierarchy {
+    transform: rotateZ(2.4deg);
+  }
+
+  .floatingReview {
+    transform: rotateZ(4.6deg);
   }
 }
 
@@ -598,12 +611,16 @@
     width: 100%;
   }
 
-  .floatingConversation {
-    top: 376px;
+  .floatingParallel {
+    top: 370px;
   }
 
-  .floatingSessions {
+  .floatingHierarchy {
     top: 360px;
+  }
+
+  .floatingReview {
+    top: 354px;
   }
 
   .workspaceCopy {
@@ -671,18 +688,25 @@
     object-position: center;
   }
 
-  .floatingSessions {
-    top: 290px;
+  .floatingParallel {
+    top: 294px;
     left: 4px;
     width: 40%;
-    height: 176px;
+    height: 170px;
   }
 
-  .floatingConversation {
-    top: 306px;
+  .floatingHierarchy {
+    top: 286px;
+    left: 31%;
+    width: 48%;
+    height: 130px;
+  }
+
+  .floatingReview {
+    top: 344px;
     right: 0;
     width: 58%;
-    height: 150px;
+    height: 146px;
   }
 
   .problemGrid,

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -23,7 +23,6 @@
 
 .heroSection,
 .workspaceSection,
-.useCaseSection,
 .productShowcase,
 .controlSection,
 .finalCta {
@@ -88,7 +87,6 @@
 .heroCopy h1,
 .sectionHeader h2,
 .workspaceCopy h2,
-.useCaseSection h2,
 .controlSection h2,
 .finalCta h2 {
   margin: 0;
@@ -251,7 +249,6 @@
 
 .sectionHeader h2,
 .workspaceCopy h2,
-.useCaseSection h2,
 .controlSection h2,
 .finalCta h2 {
   font-size: clamp(2.45rem, 4vw, 4.05rem);
@@ -424,36 +421,6 @@
   transform: translateY(-2px);
 }
 
-.useCaseSection {
-  text-align: center;
-}
-
-.useCaseGrid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: center;
-  max-width: 900px;
-  margin: 38px auto 0;
-}
-
-.useCaseGrid a {
-  padding: 12px 16px;
-  border: 1px solid var(--landing-line);
-  border-radius: 999px;
-  color: var(--landing-muted);
-  background: rgba(255, 255, 255, 0.06);
-  font-weight: 720;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
-  text-decoration: none;
-}
-
-.useCaseGrid a:hover {
-  border-color: rgba(127, 232, 223, 0.34);
-  color: var(--landing-ink);
-  background: rgba(127, 232, 223, 0.1);
-}
-
 .controlSection {
   display: grid;
   grid-template-columns: 1fr 0.8fr;
@@ -590,7 +557,6 @@
   .heroSection,
   .workspaceSection,
   .productShowcase,
-  .useCaseSection,
   .finalCta {
     padding: 64px 18px;
   }
@@ -643,7 +609,6 @@
 
   .sectionHeader h2,
   .workspaceCopy h2,
-  .useCaseSection h2,
   .controlSection h2,
   .finalCta h2 {
     font-size: clamp(2.25rem, 10.5vw, 3.65rem);

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -199,28 +199,14 @@
 
 .mainScreenshotFrame {
   position: absolute;
-  inset: 34px 18px 70px 6px;
+  top: 44px;
+  left: -14px;
+  width: min(720px, 124%);
+  aspect-ratio: 2340 / 1334;
   border-radius: 32px;
   overflow: hidden;
-  transform: rotateY(-7deg) rotateX(1.5deg);
+  transform: rotateY(-5deg) rotateX(1deg);
   transform-origin: left center;
-}
-
-.screenshotTopbar {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  height: 42px;
-  padding: 0 18px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(7, 12, 20, 0.92);
-}
-
-.screenshotTopbar span {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.24);
 }
 
 .mainScreenshotFrame img,
@@ -232,8 +218,7 @@
 }
 
 .mainScreenshotFrame img {
-  height: calc(100% - 42px);
-  object-position: 24% 44%;
+  object-position: center;
 }
 
 .floatingScreenshot {
@@ -244,26 +229,26 @@
 }
 
 .floatingConversation {
-  right: -4px;
-  bottom: 16px;
-  width: min(410px, 60%);
-  height: 236px;
+  right: -2px;
+  bottom: 38px;
+  width: min(320px, 46%);
+  height: 176px;
   transform: rotate(2.5deg) translateY(calc(var(--hero-scroll) * 44px));
 }
 
 .floatingSessions {
-  left: -6px;
-  top: 8px;
-  width: min(285px, 42%);
-  height: 260px;
+  left: -2px;
+  top: 0;
+  width: min(195px, 30%);
+  height: 210px;
   transform: rotate(-3deg) translateY(calc(var(--hero-scroll) * -64px));
 }
 
 .screenshotBadge {
   position: absolute;
   z-index: 3;
-  right: 34px;
-  top: 286px;
+  right: 42px;
+  top: 370px;
   display: inline-flex;
   gap: 10px;
   align-items: center;
@@ -636,7 +621,8 @@
   }
 
   .mainScreenshotFrame {
-    inset: 54px 20px 54px 28px;
+    left: 0;
+    width: 100%;
   }
 
   .workspaceCopy {
@@ -693,30 +679,32 @@
   }
 
   .mainScreenshotFrame {
-    inset: 62px 0 42px 0;
+    top: 72px;
+    left: 0;
+    width: 100%;
     border-radius: 26px;
     transform: none;
   }
 
   .mainScreenshotFrame img {
-    object-position: 34% 48%;
+    object-position: center;
   }
 
   .floatingSessions {
     top: 0;
-    width: 52%;
+    width: 42%;
     height: 176px;
   }
 
   .floatingConversation {
     right: 0;
-    bottom: 8px;
-    width: 66%;
-    height: 160px;
+    bottom: 20px;
+    width: 58%;
+    height: 150px;
   }
 
   .screenshotBadge {
-    top: 198px;
+    top: 300px;
     right: 14px;
     left: 14px;
     border-radius: 22px;

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -22,6 +22,7 @@
 }
 
 .heroSection,
+.liveSection,
 .workspaceSection,
 .productShowcase,
 .controlSection,
@@ -86,6 +87,7 @@
 
 .heroCopy h1,
 .sectionHeader h2,
+.liveCopy h2,
 .workspaceCopy h2,
 .controlSection h2,
 .finalCta h2 {
@@ -216,44 +218,12 @@
   object-position: center;
 }
 
-.assistantStrip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 22px;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 1180px;
-  margin: 0 auto;
-  padding: 28px;
-  border-top: 1px solid var(--landing-line);
-  border-bottom: 1px solid var(--landing-line);
-  color: var(--landing-muted);
-}
-
-.assistantStrip > span {
-  font-weight: 750;
-}
-
-.assistantStrip div {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.assistantStrip strong {
-  padding: 8px 13px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 999px;
-  color: var(--landing-ink);
-  background: rgba(255, 255, 255, 0.06);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.2);
-}
-
 .sectionHeader {
   max-width: 920px;
 }
 
 .sectionHeader h2,
+.liveCopy h2,
 .workspaceCopy h2,
 .controlSection h2,
 .finalCta h2 {
@@ -285,6 +255,7 @@
 }
 
 .featureCard p,
+.liveCopy p,
 .workspaceCopy p,
 .controlSection p,
 .finalCta p {
@@ -317,24 +288,6 @@
 .workspaceCopy {
   position: sticky;
   top: 92px;
-}
-
-.workspaceScreenshot {
-  margin-top: 28px;
-  overflow: hidden;
-  border: 1px solid var(--landing-line);
-  border-radius: 18px;
-  background: rgba(8, 14, 24, 0.78);
-  box-shadow: 0 22px 58px rgba(0, 0, 0, 0.24);
-}
-
-.workspaceScreenshot img {
-  display: block;
-  width: 100%;
-  aspect-ratio: 1.18 / 1;
-  object-fit: cover;
-  object-position: 50% 24%;
-  filter: saturate(1.05) brightness(1.05);
 }
 
 .featureGrid {
@@ -452,9 +405,21 @@
 
 .trustList a {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 5px;
   color: rgba(255, 255, 255, 0.86);
   text-decoration: none;
+}
+
+.trustLabel {
+  font-weight: 800;
+}
+
+.trustBody {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.5;
 }
 
 .trustList li:hover {
@@ -473,6 +438,130 @@
 
 .finalCta .heroActions {
   justify-content: center;
+}
+
+.liveSection {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 56px;
+  align-items: center;
+}
+
+.liveCopy {
+  max-width: 600px;
+}
+
+.liveHighlights {
+  display: grid;
+  gap: 20px;
+  margin: 30px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.liveHighlights li {
+  display: grid;
+  gap: 4px;
+  padding-left: 18px;
+  border-left: 2px solid rgba(127, 232, 223, 0.4);
+}
+
+.liveHighlights strong {
+  color: var(--landing-ink);
+  font-size: 1.06rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
+
+.liveHighlights span {
+  color: var(--landing-muted);
+  line-height: 1.6;
+}
+
+.liveCopy .cardLink {
+  margin-top: 30px;
+}
+
+.liveVisual {
+  overflow: hidden;
+  border: 1px solid var(--landing-line);
+  border-radius: 16px;
+  background: rgba(8, 14, 24, 0.78);
+  box-shadow: 0 32px 84px rgba(0, 0, 0, 0.44);
+}
+
+.liveVisual img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: 50% 0;
+  filter: saturate(1.04) brightness(1.04);
+}
+
+.landingFooter {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.3fr);
+  gap: 48px;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 56px 28px 88px;
+  border-top: 1px solid var(--landing-line);
+}
+
+.footerBrand {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.footerBrand img {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+}
+
+.footerBrand strong {
+  display: block;
+  color: var(--landing-ink);
+  font-size: 1.15rem;
+  font-weight: 850;
+}
+
+.footerBrand p {
+  margin: 6px 0 0;
+  max-width: 240px;
+  color: var(--landing-muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.footerLinks {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px;
+}
+
+.footerLinks h4 {
+  margin: 0 0 14px;
+  color: var(--landing-ink);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.footerLinks a {
+  display: block;
+  margin-bottom: 10px;
+  color: var(--landing-muted);
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: color 140ms ease;
+}
+
+.footerLinks a:hover {
+  color: var(--landing-teal);
 }
 
 .landingShell [data-reveal] {
@@ -508,9 +597,20 @@
 
 @media (max-width: 980px) {
   .heroGrid,
+  .liveSection,
   .workspaceSection,
   .controlSection {
     grid-template-columns: 1fr;
+  }
+
+  .liveVisual {
+    max-width: 520px;
+    max-height: none;
+  }
+
+  .landingFooter {
+    grid-template-columns: 1fr;
+    gap: 36px;
   }
 
   .heroGrid {
@@ -530,10 +630,6 @@
     position: static;
   }
 
-  .workspaceScreenshot {
-    max-width: 520px;
-  }
-
   .productGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -545,6 +641,7 @@
   }
 
   .heroSection,
+  .liveSection,
   .workspaceSection,
   .productShowcase,
   .finalCta {
@@ -563,9 +660,7 @@
     font-size: 1.16rem;
   }
 
-  .heroActions,
-  .assistantStrip,
-  .assistantStrip div {
+  .heroActions {
     align-items: stretch;
     flex-direction: column;
   }
@@ -598,6 +693,7 @@
   }
 
   .sectionHeader h2,
+  .liveCopy h2,
   .workspaceCopy h2,
   .controlSection h2,
   .finalCta h2 {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -26,6 +26,7 @@
 .workspaceSection,
 .useCaseSection,
 .productShowcase,
+.capabilitySection,
 .controlSection,
 .finalCta {
   max-width: 1180px;
@@ -409,6 +410,85 @@
   transform: translateY(-2px);
 }
 
+.capabilitySection {
+  padding-top: 40px;
+}
+
+.capabilityGrid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 42px;
+}
+
+.capabilityCard {
+  min-height: 260px;
+  padding: 24px;
+  border: 1px solid var(--landing-line);
+  border-radius: 26px;
+  color: var(--landing-ink);
+  background:
+    radial-gradient(circle at 24% 0%, rgba(127, 232, 223, 0.1), transparent 16rem),
+    rgba(10, 18, 31, 0.72);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.2);
+  text-decoration: none;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.capabilityCard:nth-child(1),
+.capabilityCard:nth-child(2) {
+  grid-column: span 3;
+}
+
+.capabilityCard:nth-child(n + 3) {
+  grid-column: span 2;
+}
+
+.capabilityCard > span {
+  display: inline-flex;
+  margin-bottom: 18px;
+  color: var(--landing-teal);
+  background: var(--landing-eyebrow-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-size: 0.76rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.capabilityCard h3 {
+  max-width: 520px;
+  margin: 0;
+  color: var(--landing-ink);
+  font-size: clamp(1.55rem, 2.2vw, 2.05rem);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+}
+
+.capabilityCard p {
+  margin: 16px 0 24px;
+  color: var(--landing-muted);
+  line-height: 1.65;
+}
+
+.capabilityCard strong {
+  color: var(--landing-teal);
+  font-size: 0.92rem;
+}
+
+.capabilityCard:hover {
+  border-color: rgba(127, 232, 223, 0.32);
+  background:
+    radial-gradient(circle at 24% 0%, rgba(127, 232, 223, 0.15), transparent 16rem),
+    rgba(14, 24, 40, 0.82);
+  transform: translateY(-2px);
+}
+
 .useCaseSection {
   text-align: center;
 }
@@ -562,6 +642,17 @@
   .productGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .capabilityGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .capabilityCard,
+  .capabilityCard:nth-child(1),
+  .capabilityCard:nth-child(2),
+  .capabilityCard:nth-child(n + 3) {
+    grid-column: auto;
+  }
 }
 
 @media (max-width: 720px) {
@@ -573,6 +664,7 @@
   .problemSection,
   .workspaceSection,
   .productShowcase,
+  .capabilitySection,
   .useCaseSection,
   .finalCta {
     padding: 64px 18px;
@@ -621,8 +713,13 @@
 
   .problemGrid,
   .featureGrid,
-  .productGrid {
+  .productGrid,
+  .capabilityGrid {
     grid-template-columns: 1fr;
+  }
+
+  .capabilityCard {
+    min-height: 0;
   }
 
   .sectionHeader h2,

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -48,7 +48,7 @@
   font-weight: 650;
   letter-spacing: 0.01em;
   backdrop-filter: blur(14px);
-  transform: translateY(calc(var(--hero-scroll) * 14px));
+  transform: translateY(calc(var(--hero-scroll) * 30px));
 }
 
 .heroGrid {
@@ -187,8 +187,7 @@
   position: relative;
   min-height: 560px;
   perspective: 1200px;
-  transform: translateY(calc(var(--hero-scroll) * -24px));
-  transition: transform 120ms linear;
+  transform: translateY(calc(var(--hero-scroll) * -80px));
 }
 
 .mainScreenshotFrame,
@@ -251,7 +250,7 @@
   bottom: 28px;
   width: min(390px, 58%);
   height: 228px;
-  transform: rotate(2deg) translateY(calc(var(--hero-scroll) * 18px));
+  transform: rotate(2deg) translateY(calc(var(--hero-scroll) * 44px));
 }
 
 .floatingSessions {
@@ -259,7 +258,7 @@
   top: 0;
   width: min(295px, 46%);
   height: 292px;
-  transform: rotate(-4deg) translateY(calc(var(--hero-scroll) * -28px));
+  transform: rotate(-4deg) translateY(calc(var(--hero-scroll) * -64px));
 }
 
 .screenshotBadge {
@@ -276,7 +275,7 @@
   color: var(--landing-ink);
   font-size: 0.9rem;
   font-weight: 750;
-  transform: translateY(calc(var(--hero-scroll) * -12px));
+  transform: translateY(calc(var(--hero-scroll) * -38px));
 }
 
 .statusDot {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -102,10 +102,20 @@
 
 .heroCopy h1 {
   max-width: 720px;
-  font-size: clamp(3.45rem, 6.5vw, 5.75rem);
+  font-size: clamp(3.15rem, 5.1vw, 4.85rem);
   overflow-wrap: normal;
   word-break: normal;
   hyphens: none;
+}
+
+.heroProvocation {
+  max-width: 560px;
+  margin: 24px 0 0;
+  color: var(--landing-ink);
+  font-size: clamp(1.18rem, 1.8vw, 1.55rem);
+  font-weight: 760;
+  line-height: 1.34;
+  letter-spacing: -0.025em;
 }
 
 .heroDescription {
@@ -698,6 +708,10 @@
 
   .heroCopy h1 {
     font-size: clamp(3.05rem, 14vw, 4.75rem);
+  }
+
+  .heroProvocation {
+    font-size: 1.16rem;
   }
 
   .heroDescription {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -413,12 +413,6 @@
   line-height: 1.55;
 }
 
-.productCard span {
-  color: var(--landing-teal);
-  font-size: 0.9rem;
-  font-weight: 800;
-}
-
 .productCard:hover {
   border-color: rgba(127, 232, 223, 0.3);
   transform: translateY(-2px);

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -179,6 +179,12 @@
   font-family: inherit;
 }
 
+.githubIcon {
+  width: 1.05em;
+  height: 1.05em;
+  margin-right: 0.45em;
+}
+
 .screenshotCollage {
   position: relative;
   min-height: 560px;
@@ -513,7 +519,6 @@
     transform: none;
     transition: none;
   }
-
 }
 
 @media (max-width: 980px) {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -203,7 +203,7 @@
   left: -10px;
   width: min(700px, 120%);
   aspect-ratio: 2340 / 1334;
-  border-radius: 20px;
+  border-radius: 10px;
   overflow: hidden;
   transform: rotate(-1.2deg);
   transform-origin: center;
@@ -225,7 +225,7 @@
   position: absolute;
   z-index: 1;
   overflow: hidden;
-  border-radius: 16px;
+  border-radius: 8px;
 }
 
 .floatingConversation {
@@ -663,7 +663,7 @@
     top: 72px;
     left: 0;
     width: 100%;
-    border-radius: 18px;
+    border-radius: 10px;
     transform: none;
   }
 

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -112,17 +112,9 @@
   margin: 24px 0 0;
   color: var(--landing-ink);
   font-size: clamp(1.18rem, 1.8vw, 1.55rem);
-  font-weight: 760;
-  line-height: 1.34;
+  font-weight: 620;
+  line-height: 1.42;
   letter-spacing: -0.025em;
-}
-
-.heroDescription {
-  max-width: 590px;
-  margin: 28px 0 0;
-  color: var(--landing-muted);
-  font-size: 1.16rem;
-  line-height: 1.68;
 }
 
 .heroActions {
@@ -701,10 +693,6 @@
 
   .heroProvocation {
     font-size: 1.16rem;
-  }
-
-  .heroDescription {
-    font-size: 1.04rem;
   }
 
   .heroActions,

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -645,7 +645,7 @@
   .workspaceSection,
   .productShowcase,
   .finalCta {
-    padding: 64px 18px;
+    padding: 64px 24px;
   }
 
   .heroSection {
@@ -701,7 +701,19 @@
   }
 
   .controlSection {
-    margin-inline: 18px;
-    padding: 48px 22px;
+    margin-inline: 24px;
+    padding: 48px 24px;
+  }
+
+  .landingFooter {
+    padding: 48px 24px 72px;
+  }
+
+  .footerLinks {
+    gap: 18px;
+  }
+
+  .footerLinks h4 {
+    letter-spacing: 0.06em;
   }
 }

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -9,7 +9,6 @@
   --landing-mint: #d9fb89;
   --landing-pink: #ffc3df;
   --landing-sky: #9bdcff;
-  --hero-scroll: 0;
   width: 100vw;
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
@@ -185,83 +184,31 @@
   position: relative;
   min-height: 560px;
   perspective: 1400px;
-  transform: translateY(calc(var(--hero-scroll) * -80px));
-}
-
-.mainScreenshotFrame,
-.floatingScreenshot {
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  background: rgba(9, 17, 30, 0.86);
-  box-shadow: 0 36px 90px rgba(0, 0, 0, 0.42);
-  backdrop-filter: blur(16px);
 }
 
 .mainScreenshotFrame {
   position: absolute;
   z-index: 2;
-  top: 34px;
-  left: -10px;
-  width: min(700px, 120%);
+  top: 70px;
+  left: -18px;
+  width: min(760px, 124%);
   aspect-ratio: 2340 / 1334;
+  border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: 10px;
   overflow: hidden;
-  transform: rotateY(-6deg) rotateX(1.5deg) rotateZ(-2.2deg);
+  background: rgba(9, 17, 30, 0.86);
+  box-shadow: 0 36px 90px rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(16px);
+  transform: rotateY(-4deg) rotateX(1deg) rotateZ(-1.4deg);
   transform-origin: center;
 }
 
-.mainScreenshotFrame img,
-.floatingScreenshot img {
+.mainScreenshotFrame img {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
-}
-
-.mainScreenshotFrame img {
   object-position: center;
-}
-
-.floatingScreenshot {
-  position: absolute;
-  z-index: 3;
-  overflow: hidden;
-  border-radius: 8px;
-  opacity: 0.96;
-}
-
-.floatingParallel {
-  left: 26px;
-  top: 404px;
-  width: min(230px, 34%);
-  height: 224px;
-  transform: rotateY(6deg) rotateZ(-5.2deg) translateY(calc(var(--hero-scroll) * -118px));
-}
-
-.floatingHierarchy {
-  left: 206px;
-  top: 394px;
-  width: min(310px, 46%);
-  height: 190px;
-  transform: rotateY(-4deg) rotateZ(2.4deg) translateY(calc(var(--hero-scroll) * -96px));
-}
-
-.floatingReview {
-  right: -58px;
-  top: 386px;
-  width: min(330px, 49%);
-  height: 210px;
-  transform: rotateY(-7deg) rotateZ(4.6deg) translateY(calc(var(--hero-scroll) * -132px));
-}
-
-
-.floatingParallel img {
-  object-position: 50% 46%;
-  transform: scale(1.08);
-}
-
-.floatingHierarchy img {
-  object-position: 50% 50%;
-  transform: scale(1.12);
 }
 
 .assistantStrip {
@@ -569,10 +516,6 @@
   transform: translateY(0) scale(1);
 }
 
-.landingShell .screenshotCollage {
-  will-change: transform;
-}
-
 :global(.dark) .landingShell {
   background:
     radial-gradient(circle at 18% 12%, rgba(46, 154, 146, 0.22), transparent 30rem),
@@ -589,17 +532,6 @@
     transition: none;
   }
 
-  .floatingParallel {
-    transform: rotateZ(-5.2deg);
-  }
-
-  .floatingHierarchy {
-    transform: rotateZ(2.4deg);
-  }
-
-  .floatingReview {
-    transform: rotateZ(4.6deg);
-  }
 }
 
 @media (max-width: 980px) {
@@ -614,24 +546,12 @@
   }
 
   .screenshotCollage {
-    min-height: 560px;
+    min-height: 500px;
   }
 
   .mainScreenshotFrame {
     left: 0;
     width: 100%;
-  }
-
-  .floatingParallel {
-    top: 370px;
-  }
-
-  .floatingHierarchy {
-    top: 360px;
-  }
-
-  .floatingReview {
-    top: 354px;
   }
 
   .workspaceCopy {
@@ -684,11 +604,11 @@
   }
 
   .screenshotCollage {
-    min-height: 540px;
+    min-height: 360px;
   }
 
   .mainScreenshotFrame {
-    top: 72px;
+    top: 42px;
     left: 0;
     width: 100%;
     border-radius: 10px;
@@ -697,27 +617,6 @@
 
   .mainScreenshotFrame img {
     object-position: center;
-  }
-
-  .floatingParallel {
-    top: 294px;
-    left: 4px;
-    width: 40%;
-    height: 170px;
-  }
-
-  .floatingHierarchy {
-    top: 286px;
-    left: 31%;
-    width: 48%;
-    height: 130px;
-  }
-
-  .floatingReview {
-    top: 344px;
-    right: -22px;
-    width: 58%;
-    height: 146px;
   }
 
   .problemGrid,

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -24,6 +24,7 @@
 .problemSection,
 .workspaceSection,
 .useCaseSection,
+.productShowcase,
 .controlSection,
 .finalCta {
   max-width: 1180px;
@@ -170,7 +171,7 @@
 .screenshotCollage {
   position: relative;
   min-height: 560px;
-  perspective: 1200px;
+  perspective: 1400px;
   transform: translateY(calc(var(--hero-scroll) * -80px));
 }
 
@@ -185,10 +186,10 @@
 
 .mainScreenshotFrame {
   position: absolute;
-  inset: 54px 0 54px 28px;
-  border-radius: 34px;
+  inset: 34px 18px 70px 6px;
+  border-radius: 32px;
   overflow: hidden;
-  transform: rotateY(-10deg) rotateX(2deg);
+  transform: rotateY(-7deg) rotateX(1.5deg);
   transform-origin: left center;
 }
 
@@ -219,7 +220,7 @@
 
 .mainScreenshotFrame img {
   height: calc(100% - 42px);
-  object-position: center top;
+  object-position: 24% 44%;
 }
 
 .floatingScreenshot {
@@ -230,26 +231,26 @@
 }
 
 .floatingConversation {
-  right: -10px;
-  bottom: 28px;
-  width: min(390px, 58%);
-  height: 228px;
-  transform: rotate(2deg) translateY(calc(var(--hero-scroll) * 44px));
+  right: -4px;
+  bottom: 16px;
+  width: min(410px, 60%);
+  height: 236px;
+  transform: rotate(2.5deg) translateY(calc(var(--hero-scroll) * 44px));
 }
 
 .floatingSessions {
-  left: 0;
-  top: 0;
-  width: min(295px, 46%);
-  height: 292px;
-  transform: rotate(-4deg) translateY(calc(var(--hero-scroll) * -64px));
+  left: -6px;
+  top: 8px;
+  width: min(285px, 42%);
+  height: 260px;
+  transform: rotate(-3deg) translateY(calc(var(--hero-scroll) * -64px));
 }
 
 .screenshotBadge {
   position: absolute;
   z-index: 3;
-  right: 42px;
-  top: 94px;
+  right: 34px;
+  top: 286px;
   display: inline-flex;
   gap: 10px;
   align-items: center;
@@ -329,8 +330,10 @@
 
 .problemCard,
 .featureCard {
-  min-height: 220px;
-  padding: 28px;
+  min-height: 236px;
+  padding: 26px;
+  display: flex;
+  flex-direction: column;
   border: 1px solid var(--landing-line);
   border-radius: 28px;
   background: rgba(10, 18, 31, 0.72);
@@ -357,7 +360,8 @@
 
 .cardLink {
   display: inline-flex;
-  margin-top: 22px;
+  margin-top: auto;
+  padding-top: 22px;
   color: var(--landing-teal);
   font-size: 0.92rem;
   font-weight: 800;
@@ -386,10 +390,82 @@
 }
 
 .featureCard span {
-  display: inline-flex;
-  margin-bottom: 42px;
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  margin-bottom: 24px;
+  border: 1px solid rgba(127, 232, 223, 0.18);
+  border-radius: 999px;
   color: var(--landing-blue);
+  background: rgba(127, 232, 223, 0.08);
   font-weight: 850;
+}
+
+.productShowcase {
+  padding-top: 42px;
+}
+
+.productGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+  margin-top: 42px;
+}
+
+.productCard {
+  overflow: hidden;
+  border: 1px solid var(--landing-line);
+  border-radius: 28px;
+  color: var(--landing-ink);
+  background: rgba(255, 255, 255, 0.055);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+  text-decoration: none;
+}
+
+.productCard img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+  object-position: 34% 44%;
+  border-bottom: 1px solid var(--landing-line);
+  filter: saturate(1.08) brightness(1.04);
+}
+
+.productCard:nth-child(2) img {
+  object-position: 72% 45%;
+}
+
+.productCard:nth-child(3) img {
+  object-position: 50% 20%;
+}
+
+.productCard div {
+  padding: 22px;
+}
+
+.productCard h3 {
+  margin: 0;
+  font-size: 1.22rem;
+  letter-spacing: -0.02em;
+}
+
+.productCard p {
+  margin: 10px 0 18px;
+  color: var(--landing-muted);
+  line-height: 1.55;
+}
+
+.productCard span {
+  color: var(--landing-teal);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.productCard:hover {
+  border-color: rgba(127, 232, 223, 0.3);
+  transform: translateY(-2px);
 }
 
 .useCaseSection {
@@ -521,11 +597,11 @@
   }
 
   .floatingConversation {
-    transform: rotate(2deg);
+    transform: rotate(2.5deg);
   }
 
   .floatingSessions {
-    transform: rotate(-4deg);
+    transform: rotate(-3deg);
   }
 }
 
@@ -552,7 +628,8 @@
     position: static;
   }
 
-  .problemGrid {
+  .problemGrid,
+  .productGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -565,6 +642,7 @@
   .heroSection,
   .problemSection,
   .workspaceSection,
+  .productShowcase,
   .useCaseSection,
   .finalCta {
     padding: 64px 18px;
@@ -605,10 +683,14 @@
     transform: none;
   }
 
+  .mainScreenshotFrame img {
+    object-position: 34% 48%;
+  }
+
   .floatingSessions {
     top: 0;
     width: 52%;
-    height: 180px;
+    height: 176px;
   }
 
   .floatingConversation {
@@ -619,14 +701,15 @@
   }
 
   .screenshotBadge {
-    top: 206px;
+    top: 198px;
     right: 14px;
     left: 14px;
     border-radius: 22px;
   }
 
   .problemGrid,
-  .featureGrid {
+  .featureGrid,
+  .productGrid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -108,16 +108,6 @@
   hyphens: none;
 }
 
-.heroProvocation {
-  max-width: 560px;
-  margin: 24px 0 0;
-  color: var(--landing-ink);
-  font-size: clamp(1.18rem, 1.8vw, 1.55rem);
-  font-weight: 760;
-  line-height: 1.34;
-  letter-spacing: -0.025em;
-}
-
 .heroDescription {
   max-width: 590px;
   margin: 28px 0 0;
@@ -708,10 +698,6 @@
 
   .heroCopy h1 {
     font-size: clamp(3.05rem, 14vw, 4.75rem);
-  }
-
-  .heroProvocation {
-    font-size: 1.16rem;
   }
 
   .heroDescription {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -453,6 +453,24 @@
   justify-content: center;
 }
 
+.landingShell [data-reveal] {
+  opacity: 0;
+  transform: translateY(34px) scale(0.985);
+  transition:
+    opacity 700ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms),
+    transform 700ms cubic-bezier(0.22, 1, 0.36, 1) var(--reveal-delay, 0ms);
+  will-change: opacity, transform;
+}
+
+.landingShell .isVisible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.landingShell .screenshotCollage {
+  will-change: transform;
+}
+
 :global(.dark) .landingShell {
   background:
     radial-gradient(circle at 18% 12%, rgba(46, 154, 146, 0.22), transparent 30rem),
@@ -461,8 +479,11 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .landingShell [data-reveal],
+  .landingShell .isVisible,
   .screenshotCollage,
   .screenshotBadge {
+    opacity: 1;
     transform: none;
     transition: none;
   }

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -5,6 +5,7 @@
   --landing-teal: #7fe8df;
   --landing-blue: #7fe8df;
   --landing-gradient: linear-gradient(90deg, #2e9a92 0%, #7fe8df 50%, #a8f5ed 100%);
+  --landing-eyebrow-gradient: linear-gradient(90deg, #a8f5ed 0%, #7fe8df 45%, #2e9a92 100%);
   --landing-mint: #d9fb89;
   --landing-pink: #ffc3df;
   --landing-sky: #9bdcff;
@@ -76,7 +77,7 @@
 .eyebrow {
   margin: 0 0 16px;
   color: var(--landing-teal);
-  background: var(--landing-gradient);
+  background: var(--landing-eyebrow-gradient);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -180,177 +180,92 @@
   font-family: inherit;
 }
 
-.mockup {
+.screenshotCollage {
   position: relative;
   min-height: 560px;
-  padding: 58px 28px 30px;
-  border: 1px solid rgba(17, 24, 39, 0.1);
+  perspective: 1200px;
+}
+
+.mainScreenshotFrame,
+.floatingScreenshot,
+.screenshotBadge {
+  border: 1px solid rgba(17, 24, 39, 0.12);
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 36px 90px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(16px);
+}
+
+.mainScreenshotFrame {
+  position: absolute;
+  inset: 54px 0 54px 28px;
   border-radius: 34px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.72)),
-    radial-gradient(circle at 50% 0%, rgba(35, 136, 242, 0.17), transparent 24rem);
-  box-shadow: 0 36px 90px rgba(15, 23, 42, 0.14);
   overflow: hidden;
+  transform: rotateY(-10deg) rotateX(2deg);
+  transform-origin: left center;
 }
 
-.mockup::before {
-  position: absolute;
-  inset: 82px -80px -80px;
-  content: "";
-  background-image:
-    linear-gradient(rgba(17, 24, 39, 0.06) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(17, 24, 39, 0.06) 1px, transparent 1px);
-  background-size: 40px 40px;
-  transform: perspective(520px) rotateX(58deg) rotateZ(-10deg);
-  transform-origin: top center;
-}
-
-.mockupTopbar {
-  position: absolute;
-  top: 20px;
-  left: 24px;
+.screenshotTopbar {
   display: flex;
   gap: 8px;
+  align-items: center;
+  height: 42px;
+  padding: 0 18px;
+  border-bottom: 1px solid rgba(17, 24, 39, 0.08);
+  background: rgba(255, 255, 255, 0.92);
 }
 
-.mockupTopbar span {
+.screenshotTopbar span {
   width: 10px;
   height: 10px;
   border-radius: 999px;
   background: rgba(17, 24, 39, 0.18);
 }
 
-.boardGrid {
-  position: relative;
-  height: 420px;
-}
-
-.zone {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  gap: 18px;
-  min-width: 235px;
-  min-height: 156px;
-  padding: 18px;
-  border: 1px solid rgba(17, 24, 39, 0.12);
-  border-radius: 28px;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
-  transform: rotate(-8deg) skewY(-4deg);
-}
-
-.zone > span {
-  color: rgba(17, 24, 39, 0.58);
-  font-size: 0.8rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.zoneA {
-  top: 118px;
-  left: 22px;
-  background: var(--landing-sky);
-}
-
-.zoneB {
-  top: 54px;
-  right: 48px;
-  background: var(--landing-mint);
-}
-
-.zoneC {
-  right: -4px;
-  bottom: 22px;
-  background: var(--landing-pink);
-}
-
-.branchCard {
-  padding: 14px;
-  border: 1px solid rgba(17, 24, 39, 0.08);
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.8);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
-  transform: skewY(4deg);
-}
-
-.branchCard strong,
-.branchCard small {
+.mainScreenshotFrame img,
+.floatingScreenshot img {
   display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
-.branchCard strong {
-  color: var(--landing-ink);
-  font-size: 0.98rem;
+.mainScreenshotFrame img {
+  height: calc(100% - 42px);
+  object-position: center top;
 }
 
-.branchCard small {
-  margin-top: 4px;
-  color: var(--landing-muted);
-}
-
-.agentBubble,
-.commandCard {
+.floatingScreenshot {
   position: absolute;
   z-index: 2;
-  border: 1px solid rgba(17, 24, 39, 0.1);
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.16);
-  backdrop-filter: blur(16px);
-}
-
-.agentBubble {
-  top: 86px;
-  left: 72px;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 14px;
-  width: min(400px, calc(100% - 92px));
-  padding: 16px;
+  overflow: hidden;
   border-radius: 24px;
 }
 
-.agentBubble p {
-  margin: 0;
-  color: var(--landing-muted);
-  font-size: 0.95rem;
-  line-height: 1.45;
+.floatingConversation {
+  right: -10px;
+  bottom: 28px;
+  width: min(390px, 58%);
+  height: 228px;
+  transform: rotate(2deg);
 }
 
-.agentBubble strong {
-  color: var(--landing-ink);
+.floatingSessions {
+  left: 0;
+  top: 0;
+  width: min(295px, 46%);
+  height: 292px;
+  transform: rotate(-4deg);
 }
 
-.avatarStack {
-  display: flex;
-  align-items: center;
-}
-
-.avatarStack span {
-  display: grid;
-  place-items: center;
-  width: 34px;
-  height: 34px;
-  margin-left: -8px;
-  border: 2px solid white;
-  border-radius: 999px;
-  color: #0b3b38;
-  background: #7fe8df;
-  font-size: 0.75rem;
-  font-weight: 850;
-}
-
-.avatarStack span:first-child {
-  margin-left: 0;
-}
-
-.commandCard {
-  right: 38px;
-  bottom: 78px;
+.screenshotBadge {
+  position: absolute;
+  z-index: 3;
+  right: 42px;
+  top: 94px;
   display: inline-flex;
   gap: 10px;
   align-items: center;
+  max-width: 360px;
   padding: 13px 16px;
   border-radius: 999px;
   color: var(--landing-ink);
@@ -359,6 +274,7 @@
 }
 
 .statusDot {
+  flex: 0 0 auto;
   width: 9px;
   height: 9px;
   border-radius: 999px;
@@ -561,8 +477,12 @@
     gap: 44px;
   }
 
-  .mockup {
+  .screenshotCollage {
     min-height: 500px;
+  }
+
+  .mainScreenshotFrame {
+    inset: 54px 20px 54px 28px;
   }
 
   .workspaceCopy {
@@ -616,37 +536,34 @@
     width: 100%;
   }
 
-  .mockup {
-    min-height: 480px;
-    padding-inline: 16px;
+  .screenshotCollage {
+    min-height: 500px;
+  }
+
+  .mainScreenshotFrame {
+    inset: 62px 0 42px 0;
     border-radius: 26px;
+    transform: none;
   }
 
-  .zone {
-    min-width: 205px;
+  .floatingSessions {
+    top: 0;
+    width: 52%;
+    height: 180px;
   }
 
-  .zoneA {
-    left: 0;
-  }
-
-  .zoneB {
+  .floatingConversation {
     right: 0;
+    bottom: 8px;
+    width: 66%;
+    height: 160px;
   }
 
-  .zoneC {
-    right: -24px;
-  }
-
-  .agentBubble {
-    top: 58px;
-    left: 18px;
-    width: calc(100% - 36px);
-  }
-
-  .commandCard {
-    right: 16px;
-    bottom: 38px;
+  .screenshotBadge {
+    top: 206px;
+    right: 14px;
+    left: 14px;
+    border-radius: 22px;
   }
 
   .featureGrid {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -108,6 +108,16 @@
   hyphens: none;
 }
 
+.heroProvocation {
+  max-width: 560px;
+  margin: 24px 0 0;
+  color: var(--landing-ink);
+  font-size: clamp(1.18rem, 1.8vw, 1.55rem);
+  font-weight: 760;
+  line-height: 1.34;
+  letter-spacing: -0.025em;
+}
+
 .heroDescription {
   max-width: 590px;
   margin: 28px 0 0;
@@ -698,6 +708,10 @@
 
   .heroCopy h1 {
     font-size: clamp(3.05rem, 14vw, 4.75rem);
+  }
+
+  .heroProvocation {
+    font-size: 1.16rem;
   }
 
   .heroDescription {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -32,23 +32,7 @@
 }
 
 .heroSection {
-  padding-top: 112px;
-}
-
-.navAnnouncement {
-  width: fit-content;
-  margin: 0 auto 56px;
-  padding: 9px 16px;
-  border: 1px solid var(--landing-line);
-  border-radius: 999px;
-  background: rgba(10, 18, 31, 0.72);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.24);
-  color: var(--landing-muted);
-  font-size: 0.86rem;
-  font-weight: 650;
-  letter-spacing: 0.01em;
-  backdrop-filter: blur(14px);
-  transform: translateY(calc(var(--hero-scroll) * 30px));
+  padding-top: 128px;
 }
 
 .heroGrid {
@@ -66,15 +50,15 @@
   display: inline-flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 28px;
+  margin-bottom: 34px;
   color: var(--landing-ink);
-  font-size: 1.1rem;
+  font-size: 1.42rem;
   font-weight: 800;
 }
 
 .brandMark img {
-  width: 44px;
-  height: 44px;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
   box-shadow: 0 0 34px rgba(127, 232, 223, 0.2);
 }
@@ -477,7 +461,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .navAnnouncement,
   .screenshotCollage,
   .screenshotBadge {
     transform: none;
@@ -535,11 +518,7 @@
   }
 
   .heroSection {
-    padding-top: 104px;
-  }
-
-  .navAnnouncement {
-    margin-bottom: 44px;
+    padding-top: 96px;
   }
 
   .heroCopy h1 {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -246,11 +246,22 @@
 }
 
 .floatingReview {
-  right: -8px;
+  right: -58px;
   top: 386px;
   width: min(330px, 49%);
   height: 210px;
   transform: rotateY(-7deg) rotateZ(4.6deg) translateY(calc(var(--hero-scroll) * -132px));
+}
+
+
+.floatingParallel img {
+  object-position: 50% 46%;
+  transform: scale(1.08);
+}
+
+.floatingHierarchy img {
+  object-position: 50% 50%;
+  transform: scale(1.12);
 }
 
 .assistantStrip {
@@ -704,7 +715,7 @@
 
   .floatingReview {
     top: 344px;
-    right: 0;
+    right: -22px;
     width: 58%;
     height: 146px;
   }

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -25,7 +25,6 @@
 .workspaceSection,
 .useCaseSection,
 .productShowcase,
-.capabilitySection,
 .controlSection,
 .finalCta {
   max-width: 1180px;
@@ -421,85 +420,6 @@
   transform: translateY(-2px);
 }
 
-.capabilitySection {
-  padding-top: 40px;
-}
-
-.capabilityGrid {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 18px;
-  margin-top: 42px;
-}
-
-.capabilityCard {
-  min-height: 260px;
-  padding: 24px;
-  border: 1px solid var(--landing-line);
-  border-radius: 26px;
-  color: var(--landing-ink);
-  background:
-    radial-gradient(circle at 24% 0%, rgba(127, 232, 223, 0.1), transparent 16rem),
-    rgba(10, 18, 31, 0.72);
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.2);
-  text-decoration: none;
-  transition:
-    transform 160ms ease,
-    border-color 160ms ease,
-    background 160ms ease;
-}
-
-.capabilityCard:nth-child(1),
-.capabilityCard:nth-child(2) {
-  grid-column: span 3;
-}
-
-.capabilityCard:nth-child(n + 3) {
-  grid-column: span 2;
-}
-
-.capabilityCard > span {
-  display: inline-flex;
-  margin-bottom: 18px;
-  color: var(--landing-teal);
-  background: var(--landing-eyebrow-gradient);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  font-size: 0.76rem;
-  font-weight: 850;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.capabilityCard h3 {
-  max-width: 520px;
-  margin: 0;
-  color: var(--landing-ink);
-  font-size: clamp(1.55rem, 2.2vw, 2.05rem);
-  line-height: 1.08;
-  letter-spacing: -0.035em;
-}
-
-.capabilityCard p {
-  margin: 16px 0 24px;
-  color: var(--landing-muted);
-  line-height: 1.65;
-}
-
-.capabilityCard strong {
-  color: var(--landing-teal);
-  font-size: 0.92rem;
-}
-
-.capabilityCard:hover {
-  border-color: rgba(127, 232, 223, 0.32);
-  background:
-    radial-gradient(circle at 24% 0%, rgba(127, 232, 223, 0.15), transparent 16rem),
-    rgba(14, 24, 40, 0.82);
-  transform: translateY(-2px);
-}
-
 .useCaseSection {
   text-align: center;
 }
@@ -656,17 +576,6 @@
   .productGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-
-  .capabilityGrid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .capabilityCard,
-  .capabilityCard:nth-child(1),
-  .capabilityCard:nth-child(2),
-  .capabilityCard:nth-child(n + 3) {
-    grid-column: auto;
-  }
 }
 
 @media (max-width: 720px) {
@@ -677,7 +586,6 @@
   .heroSection,
   .workspaceSection,
   .productShowcase,
-  .capabilitySection,
   .useCaseSection,
   .finalCta {
     padding: 64px 18px;
@@ -725,13 +633,8 @@
   }
 
   .featureGrid,
-  .productGrid,
-  .capabilityGrid {
+  .productGrid {
     grid-template-columns: 1fr;
-  }
-
-  .capabilityCard {
-    min-height: 0;
   }
 
   .sectionHeader h2,

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -342,21 +342,6 @@
   margin-top: 0;
 }
 
-.featureCard span {
-  display: inline-grid;
-  place-items: center;
-  width: 36px;
-  height: 36px;
-  margin-bottom: 24px;
-  border: 1px solid transparent;
-  border-radius: 999px;
-  color: var(--landing-blue);
-  background:
-    linear-gradient(rgba(9, 17, 30, 0.92), rgba(9, 17, 30, 0.92)) padding-box,
-    var(--landing-gradient) border-box;
-  font-weight: 850;
-}
-
 .productShowcase {
   padding-top: 42px;
 }

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -88,7 +88,7 @@
 
 .heroCopy h1 {
   max-width: 720px;
-  font-size: clamp(3.7rem, 7.4vw, 6.25rem);
+  font-size: clamp(3.45rem, 6.65vw, 5.7rem);
   overflow-wrap: normal;
   word-break: normal;
   hyphens: none;
@@ -313,7 +313,7 @@
 .useCaseSection h2,
 .controlSection h2,
 .finalCta h2 {
-  font-size: clamp(2.8rem, 5vw, 5rem);
+  font-size: clamp(2.55rem, 4.45vw, 4.45rem);
 }
 
 .problemGrid,
@@ -575,7 +575,7 @@
   }
 
   .heroCopy h1 {
-    font-size: clamp(3.4rem, 16vw, 5.4rem);
+    font-size: clamp(3.05rem, 14vw, 4.75rem);
   }
 
   .heroDescription {
@@ -635,7 +635,7 @@
   .useCaseSection h2,
   .controlSection h2,
   .finalCta h2 {
-    font-size: clamp(2.4rem, 12vw, 4rem);
+    font-size: clamp(2.25rem, 10.5vw, 3.65rem);
   }
 
   .controlSection {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -355,6 +355,19 @@
   line-height: 1.7;
 }
 
+.cardLink {
+  display: inline-flex;
+  margin-top: 22px;
+  color: var(--landing-teal);
+  font-size: 0.92rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.cardLink:hover {
+  color: #a8f5ed;
+}
+
 .workspaceSection {
   display: grid;
   grid-template-columns: 0.82fr 1.18fr;
@@ -392,7 +405,7 @@
   margin: 38px auto 0;
 }
 
-.useCaseGrid span {
+.useCaseGrid a {
   padding: 12px 16px;
   border: 1px solid var(--landing-line);
   border-radius: 999px;
@@ -400,6 +413,13 @@
   background: rgba(255, 255, 255, 0.06);
   font-weight: 720;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+  text-decoration: none;
+}
+
+.useCaseGrid a:hover {
+  border-color: rgba(127, 232, 223, 0.34);
+  color: var(--landing-ink);
+  background: rgba(127, 232, 223, 0.1);
 }
 
 .controlSection {
@@ -438,6 +458,18 @@
   color: rgba(255, 255, 255, 0.86);
   background: rgba(255, 255, 255, 0.06);
   font-weight: 720;
+}
+
+.trustList a {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(255, 255, 255, 0.86);
+  text-decoration: none;
+}
+
+.trustList li:hover {
+  border-color: rgba(127, 232, 223, 0.28);
+  background: rgba(127, 232, 223, 0.08);
 }
 
 .finalCta {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -102,7 +102,7 @@
 
 .heroCopy h1 {
   max-width: 720px;
-  font-size: clamp(3.15rem, 5.1vw, 4.85rem);
+  font-size: clamp(3.45rem, 6.5vw, 5.75rem);
   overflow-wrap: normal;
   word-break: normal;
   hyphens: none;

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -3,7 +3,7 @@
   --landing-muted: #aeb9c8;
   --landing-line: rgba(255, 255, 255, 0.12);
   --landing-teal: #7fe8df;
-  --landing-blue: #6bb7ff;
+  --landing-blue: #7fe8df;
   --landing-mint: #d9fb89;
   --landing-pink: #ffc3df;
   --landing-sky: #9bdcff;
@@ -129,9 +129,9 @@
 }
 
 .landingShell .primaryButton {
-  color: white;
-  background: #168bff;
-  box-shadow: 0 16px 34px rgba(35, 136, 242, 0.24);
+  color: #031311;
+  background: linear-gradient(135deg, #2e9a92 0%, #7fe8df 100%);
+  box-shadow: 0 16px 34px rgba(46, 154, 146, 0.3);
 }
 
 .primaryButton:hover,
@@ -141,8 +141,8 @@
 }
 
 .landingShell .primaryButton:hover {
-  color: white;
-  box-shadow: 0 20px 44px rgba(35, 136, 242, 0.32);
+  color: #031311;
+  box-shadow: 0 20px 44px rgba(127, 232, 223, 0.34);
 }
 
 .landingShell .secondaryButton {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -102,7 +102,7 @@
 
 .heroCopy h1 {
   max-width: 720px;
-  font-size: clamp(3.25rem, 5.75vw, 5.25rem);
+  font-size: clamp(3.45rem, 6.5vw, 5.75rem);
   overflow-wrap: normal;
   word-break: normal;
   hyphens: none;

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -189,8 +189,7 @@
 }
 
 .mainScreenshotFrame,
-.floatingScreenshot,
-.screenshotBadge {
+.floatingScreenshot {
   border: 1px solid rgba(255, 255, 255, 0.14);
   background: rgba(9, 17, 30, 0.86);
   box-shadow: 0 36px 90px rgba(0, 0, 0, 0.42);
@@ -199,14 +198,15 @@
 
 .mainScreenshotFrame {
   position: absolute;
-  top: 44px;
-  left: -14px;
-  width: min(720px, 124%);
+  z-index: 2;
+  top: 34px;
+  left: -10px;
+  width: min(700px, 120%);
   aspect-ratio: 2340 / 1334;
   border-radius: 32px;
   overflow: hidden;
-  transform: rotateY(-5deg) rotateX(1deg);
-  transform-origin: left center;
+  transform: rotate(-1.2deg);
+  transform-origin: center;
 }
 
 .mainScreenshotFrame img,
@@ -223,51 +223,25 @@
 
 .floatingScreenshot {
   position: absolute;
-  z-index: 2;
+  z-index: 1;
   overflow: hidden;
   border-radius: 24px;
 }
 
 .floatingConversation {
-  right: -2px;
-  bottom: 38px;
-  width: min(320px, 46%);
-  height: 176px;
-  transform: rotate(2.5deg) translateY(calc(var(--hero-scroll) * 44px));
+  right: -4px;
+  top: 398px;
+  width: min(340px, 50%);
+  height: 190px;
+  transform: rotate(1.8deg) translateY(calc(var(--hero-scroll) * 34px));
 }
 
 .floatingSessions {
-  left: -2px;
-  top: 0;
-  width: min(195px, 30%);
-  height: 210px;
-  transform: rotate(-3deg) translateY(calc(var(--hero-scroll) * -64px));
-}
-
-.screenshotBadge {
-  position: absolute;
-  z-index: 3;
-  right: 42px;
-  top: 370px;
-  display: inline-flex;
-  gap: 10px;
-  align-items: center;
-  max-width: 360px;
-  padding: 13px 16px;
-  border-radius: 999px;
-  color: var(--landing-ink);
-  font-size: 0.9rem;
-  font-weight: 750;
-  transform: translateY(calc(var(--hero-scroll) * -38px));
-}
-
-.statusDot {
-  flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-radius: 999px;
-  background: #2e9a92;
-  box-shadow: 0 0 0 6px rgba(46, 154, 146, 0.16);
+  left: 28px;
+  top: 382px;
+  width: min(235px, 36%);
+  height: 240px;
+  transform: rotate(-2.4deg) translateY(calc(var(--hero-scroll) * -28px));
 }
 
 .assistantStrip {
@@ -589,19 +563,18 @@
 @media (prefers-reduced-motion: reduce) {
   .landingShell [data-reveal],
   .landingShell .isVisible,
-  .screenshotCollage,
-  .screenshotBadge {
+  .screenshotCollage {
     opacity: 1;
     transform: none;
     transition: none;
   }
 
   .floatingConversation {
-    transform: rotate(2.5deg);
+    transform: rotate(1.8deg);
   }
 
   .floatingSessions {
-    transform: rotate(-3deg);
+    transform: rotate(-2.4deg);
   }
 }
 
@@ -617,12 +590,20 @@
   }
 
   .screenshotCollage {
-    min-height: 500px;
+    min-height: 560px;
   }
 
   .mainScreenshotFrame {
     left: 0;
     width: 100%;
+  }
+
+  .floatingConversation {
+    top: 376px;
+  }
+
+  .floatingSessions {
+    top: 360px;
   }
 
   .workspaceCopy {
@@ -675,7 +656,7 @@
   }
 
   .screenshotCollage {
-    min-height: 500px;
+    min-height: 540px;
   }
 
   .mainScreenshotFrame {
@@ -691,23 +672,17 @@
   }
 
   .floatingSessions {
-    top: 0;
-    width: 42%;
+    top: 290px;
+    left: 4px;
+    width: 40%;
     height: 176px;
   }
 
   .floatingConversation {
+    top: 306px;
     right: 0;
-    bottom: 20px;
     width: 58%;
     height: 150px;
-  }
-
-  .screenshotBadge {
-    top: 300px;
-    right: 14px;
-    left: 14px;
-    border-radius: 22px;
   }
 
   .problemGrid,

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -22,7 +22,6 @@
 }
 
 .heroSection,
-.problemSection,
 .workspaceSection,
 .useCaseSection,
 .productShowcase,
@@ -267,18 +266,12 @@
   font-size: clamp(2.45rem, 4vw, 4.05rem);
 }
 
-.problemGrid,
 .featureGrid {
   display: grid;
   gap: 18px;
   margin-top: 48px;
 }
 
-.problemGrid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.problemCard,
 .featureCard {
   min-height: 236px;
   padding: 26px;
@@ -290,7 +283,6 @@
   box-shadow: 0 18px 48px rgba(15, 23, 42, 0.06);
 }
 
-.problemCard h3,
 .featureCard h3 {
   margin: 0;
   color: var(--landing-ink);
@@ -298,7 +290,6 @@
   letter-spacing: -0.02em;
 }
 
-.problemCard p,
 .featureCard p,
 .workspaceCopy p,
 .controlSection p,
@@ -670,7 +661,6 @@
     max-width: 520px;
   }
 
-  .problemGrid,
   .productGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -693,7 +683,6 @@
   }
 
   .heroSection,
-  .problemSection,
   .workspaceSection,
   .productShowcase,
   .capabilitySection,
@@ -747,7 +736,6 @@
     object-position: center;
   }
 
-  .problemGrid,
   .featureGrid,
   .productGrid,
   .capabilityGrid {

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -203,7 +203,7 @@
   left: -10px;
   width: min(700px, 120%);
   aspect-ratio: 2340 / 1334;
-  border-radius: 32px;
+  border-radius: 20px;
   overflow: hidden;
   transform: rotate(-1.2deg);
   transform-origin: center;
@@ -225,7 +225,7 @@
   position: absolute;
   z-index: 1;
   overflow: hidden;
-  border-radius: 24px;
+  border-radius: 16px;
 }
 
 .floatingConversation {
@@ -663,7 +663,7 @@
     top: 72px;
     left: 0;
     width: 100%;
-    border-radius: 26px;
+    border-radius: 18px;
     transform: none;
   }
 

--- a/apps/agor-docs/components/LandingPage.module.css
+++ b/apps/agor-docs/components/LandingPage.module.css
@@ -397,6 +397,12 @@
   object-position: 50% 22%;
 }
 
+.productCard:nth-child(7) img,
+.productCard:nth-child(8) img,
+.productCard:nth-child(9) img {
+  object-position: 50% 24%;
+}
+
 .productCard div {
   padding: 22px;
 }

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -65,48 +65,33 @@ const trustItems = [
 
 function ProductMockup() {
   return (
-    <div className={styles.mockup} role="img" aria-label="Agor product preview">
-      <div className={styles.mockupTopbar}>
-        <span />
-        <span />
-        <span />
+    <div className={styles.screenshotCollage} role="img" aria-label="Agor product screenshots">
+      <div className={styles.mainScreenshotFrame}>
+        <div className={styles.screenshotTopbar}>
+          <span />
+          <span />
+          <span />
+        </div>
+        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+        <img
+          src="/screenshots/board-hero.png"
+          alt="Agor board showing branches on a shared canvas"
+        />
       </div>
-      <div className={styles.boardGrid}>
-        <div className={`${styles.zone} ${styles.zoneA}`}>
-          <span>Review lane</span>
-          <div className={styles.branchCard}>
-            <strong>security-audit</strong>
-            <small>3 assistants running</small>
-          </div>
-        </div>
-        <div className={`${styles.zone} ${styles.zoneB}`}>
-          <span>Launch</span>
-          <div className={styles.branchCard}>
-            <strong>docs-refresh</strong>
-            <small>ready for PR</small>
-          </div>
-        </div>
-        <div className={`${styles.zone} ${styles.zoneC}`}>
-          <span>Research</span>
-          <div className={styles.branchCard}>
-            <strong>pricing-intel</strong>
-            <small>scheduled daily</small>
-          </div>
-        </div>
+
+      <div className={`${styles.floatingScreenshot} ${styles.floatingConversation}`}>
+        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+        <img src="/screenshots/conversation_full_page.png" alt="Agor conversation view" />
       </div>
-      <div className={styles.agentBubble}>
-        <div className={styles.avatarStack}>
-          <span>R</span>
-          <span>L</span>
-          <span>S</span>
-        </div>
-        <p>
-          <strong>Scout</strong> found 6 changes, opened a follow-up, and posted the report.
-        </p>
+
+      <div className={`${styles.floatingScreenshot} ${styles.floatingSessions}`}>
+        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+        <img src="/screenshots/parallel-board-5-sessions.png" alt="Agor parallel session tree" />
       </div>
-      <div className={styles.commandCard}>
+
+      <div className={styles.screenshotBadge}>
         <span className={styles.statusDot} />
-        <span>Schedule · every weekday at 9:00</span>
+        <span>Live branches, sessions, agents, and teammates in one place</span>
       </div>
     </div>
   );

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -195,7 +195,7 @@ export function LandingPage() {
                 Join the private beta
               </Link>
               <Link href="/guide/getting-started" className={styles.secondaryButton}>
-                Install locally in 3 minutes
+                Try locally
               </Link>
               <Link
                 href={GITHUB_REPO_URL}
@@ -329,7 +329,7 @@ export function LandingPage() {
             Book a demo
           </Link>
           <Link href="/guide/getting-started" className={styles.secondaryButton}>
-            Install locally in 3 minutes
+            Try locally
           </Link>
         </div>
       </section>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef, useState } from 'react';
-import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
+import { AGOR_CLOUD_DEMO_URL, AGOR_CLOUD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
 import { HubSpotFormModal } from './HubSpotFormModal';
 import styles from './LandingPage.module.css';
@@ -299,32 +299,27 @@ export function LandingPage() {
 
       <section className={styles.finalCta} data-reveal>
         <h2>Give your team’s AI work a place to live.</h2>
-        <p>
-          Start with the guide, join the community, or reach out if you’re rolling Agor out for a
-          team.
-        </p>
+        <p>Join the private beta, book a demo for Agor Cloud, or self-host Agor today.</p>
         <div className={styles.heroActions}>
-          <Link href="/guide" className={styles.primaryButton}>
-            Read the docs
-          </Link>
-          <Link href="/guide/features-overview" className={styles.secondaryButton}>
-            Feature map
+          <Link
+            href={AGOR_CLOUD_INVITE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.primaryButton}
+          >
+            Join the private beta
           </Link>
           <Link
-            href={DISCORD_INVITE_URL}
+            href={AGOR_CLOUD_DEMO_URL}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.secondaryButton}
           >
-            Join Discord
+            Book a demo
           </Link>
-          <button
-            type="button"
-            className={styles.textButton}
-            onClick={() => setIsContactOpen(true)}
-          >
-            Talk to us →
-          </button>
+          <Link href="/guide/getting-started" className={styles.secondaryButton}>
+            Self-host Agor
+          </Link>
         </div>
       </section>
 

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -10,29 +10,43 @@ const assistants = ['ReviewBot', 'LaunchOps', 'Scout', 'Standup', 'Docs'];
 const featureCards = [
   {
     eyebrow: '01',
-    title: 'Give each assistant a real job',
-    body: 'Define what it’s for, give it memory, and wire it into the systems your team already uses.',
+    title: 'Shared memory',
+    body: 'Each assistant gets a namespace in the knowledge base: semantic-searchable, durable, and shared with the team.',
+    href: '/guide/knowledge',
+    linkLabel: 'Explore Knowledge',
+  },
+  {
+    eyebrow: '02',
+    title: 'Skills + MCP',
+    body: 'Package repeatable workflows as skills and connect assistants to the MCP servers your team already trusts.',
+    href: '/guide/internal-mcp',
+    linkLabel: 'See MCP control',
+  },
+  {
+    eyebrow: '03',
+    title: 'Conversational onboarding',
+    body: 'Teach an assistant by talking to it. The programming language is conversation, and the useful parts become reusable context.',
     href: '/guide/assistants',
     linkLabel: 'Read about Assistants',
   },
   {
-    eyebrow: '02',
-    title: 'Make the learning visible',
-    body: 'The whole team can see what each assistant is doing and lift the prompts that work.',
-    href: '/guide/multiplayer-social',
-    linkLabel: 'See multiplayer',
+    eyebrow: '04',
+    title: 'Where your team works',
+    body: 'Reach assistants from Slack, GitHub, or wherever work already happens through gateway channels.',
+    href: '/guide/message-gateway',
+    linkLabel: 'Open Message Gateway',
   },
   {
-    eyebrow: '03',
-    title: 'Let work happen on schedule',
-    body: 'Run audits, standups, grooming, digests, reviews, and reports instead of waiting to be asked.',
+    eyebrow: '05',
+    title: 'Scheduled agency',
+    body: 'Run heartbeats, daily standups, audits, digests, or longer workflows without waiting for a prompt.',
     href: '/guide/scheduler',
     linkLabel: 'Explore Scheduler',
   },
   {
-    eyebrow: '04',
-    title: 'Keep ownership and control',
-    body: 'Model assistants like team members: scoped on purpose, governed, observable, and owned together.',
+    eyebrow: '06',
+    title: 'Personality + boundaries',
+    body: 'Tune voice, style, and level of agency so every assistant knows how bold to be and when to ask first.',
     href: '/blog/agent-modeling-101',
     linkLabel: 'Agent modeling 101',
   },
@@ -251,10 +265,11 @@ export function LandingPage() {
       <section className={styles.workspaceSection} data-reveal>
         <div className={styles.workspaceCopy}>
           <span className={styles.eyebrow}>The shared workspace</span>
-          <h2>Raise real assistants, not throwaway agents.</h2>
+          <h2>Raise team assistants with memory, skills, and a place to work.</h2>
           <p>
-            Agor gives your team one place to launch assistants, teach them the workflows that
-            matter, coordinate live work, and turn the patterns that work into shared muscle.
+            Give each assistant a durable identity: shared memory, reusable skills, MCP connections,
+            gateway channels, schedules, and a configurable style of agency. Teach them
+            conversationally, then let the useful patterns compound for the whole team.
           </p>
           <div className={styles.workspaceScreenshot}>
             {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -187,10 +187,6 @@ export function LandingPage() {
               <br />
               Bring the team and agents together.
             </p>
-            <p className={styles.heroDescription}>
-              Agor gives every agent run a place to live: branches, sessions, dev environments,
-              prompts, and teammates together on one shared canvas.
-            </p>
             <div className={styles.heroActions}>
               <Link href="/guide" className={styles.primaryButton}>
                 Start with the guide

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -271,6 +271,13 @@ export function LandingPage() {
             Agor gives your team one place to launch assistants, teach them the workflows that
             matter, coordinate live work, and turn the patterns that work into shared muscle.
           </p>
+          <div className={styles.workspaceScreenshot}>
+            {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+            <img
+              src="/screenshots/assistants-list.png"
+              alt="Agor assistants list showing persistent team assistants"
+            />
+          </div>
         </div>
         <div className={styles.featureGrid}>
           {featureCards.map((feature) => (

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -76,6 +76,24 @@ const productPreviews = [
     image: '/images/artifacts-hero.png',
     href: '/guide/artifacts',
   },
+  {
+    title: 'Built-in knowledge base',
+    body: 'Give humans and agents one shared place for decisions, runbooks, prompts, memory, and reusable context.',
+    image: '/images/knowledge-hero.png',
+    href: '/guide/knowledge',
+  },
+  {
+    title: 'Branch environments',
+    body: 'Start, stop, health-check, and inspect logs for every branch environment without port fights.',
+    image: '/screenshots/env_configuration.png',
+    href: '/guide/environment-configuration',
+  },
+  {
+    title: 'MCP-native control',
+    body: 'Anything a user can do in Agor, an agent can do too: spawn peers, move work, schedule runs, and report back.',
+    image: '/screenshots/mcp_environment.png',
+    href: '/guide/internal-mcp',
+  },
 ];
 
 const useCases = [

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,9 +1,8 @@
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { AGOR_CLOUD_DEMO_URL, AGOR_CLOUD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
-import { HubSpotFormModal } from './HubSpotFormModal';
 import styles from './LandingPage.module.css';
 
 const assistants = ['ReviewBot', 'LaunchOps', 'Scout', 'Standup', 'Docs'];
@@ -107,6 +106,14 @@ const trustItems = [
 const revealDelay = (index: number): CSSProperties =>
   ({ '--reveal-delay': `${index * 70}ms` }) as CSSProperties;
 
+function GitHubIcon() {
+  return (
+    <svg className={styles.githubIcon} aria-hidden="true" viewBox="0 0 16 16" fill="currentColor">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 3.86c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
+  );
+}
+
 function ProductMockup() {
   return (
     <div className={styles.screenshotCollage} role="img" aria-label="Agor product screenshots">
@@ -122,7 +129,6 @@ function ProductMockup() {
 }
 
 export function LandingPage() {
-  const [isContactOpen, setIsContactOpen] = useState(false);
   const landingRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -180,23 +186,25 @@ export function LandingPage() {
               Bring the team and agents together.
             </p>
             <div className={styles.heroActions}>
-              <Link href="/guide" className={styles.primaryButton}>
-                Start with the guide
-              </Link>
-              <button
-                type="button"
-                className={styles.secondaryButton}
-                onClick={() => setIsContactOpen(true)}
+              <Link
+                href={AGOR_CLOUD_INVITE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.primaryButton}
               >
-                Contact us
-              </button>
+                Join the private beta
+              </Link>
+              <Link href="/guide/getting-started" className={styles.secondaryButton}>
+                Install locally in 3 minutes
+              </Link>
               <Link
                 href={GITHUB_REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.textButton}
               >
-                View GitHub →
+                <GitHubIcon />
+                View GitHub
               </Link>
             </div>
           </div>
@@ -299,7 +307,10 @@ export function LandingPage() {
 
       <section className={styles.finalCta} data-reveal>
         <h2>Give your team’s AI work a place to live.</h2>
-        <p>Join the private beta, book a demo for Agor Cloud, or self-host Agor today.</p>
+        <p>
+          Join the private beta, book a demo for Agor Cloud, or install the open-source version
+          locally.
+        </p>
         <div className={styles.heroActions}>
           <Link
             href={AGOR_CLOUD_INVITE_URL}
@@ -318,12 +329,10 @@ export function LandingPage() {
             Book a demo
           </Link>
           <Link href="/guide/getting-started" className={styles.secondaryButton}>
-            Self-host Agor
+            Install locally in 3 minutes
           </Link>
         </div>
       </section>
-
-      <HubSpotFormModal isOpen={isContactOpen} onClose={() => setIsContactOpen(false)} />
     </div>
   );
 }

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -199,15 +199,6 @@ export function LandingPage() {
         </div>
       </section>
 
-      <section className={styles.assistantStrip} aria-label="Example assistants" data-reveal>
-        <span>What works for one person finally reaches everyone</span>
-        <div>
-          {assistants.map((assistant) => (
-            <strong key={assistant}>@{assistant}</strong>
-          ))}
-        </div>
-      </section>
-
       <section className={styles.productShowcase} data-reveal>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Product surfaces</span>
@@ -229,6 +220,15 @@ export function LandingPage() {
                 <p>{preview.body}</p>
               </div>
             </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.assistantStrip} aria-label="Example assistants" data-reveal>
+        <span>What works for one person finally reaches everyone</span>
+        <div>
+          {assistants.map((assistant) => (
+            <strong key={assistant}>@{assistant}</strong>
           ))}
         </div>
       </section>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -110,30 +110,6 @@ function ProductMockup() {
           alt="Agor board showing colorful zones and branch cards on a shared canvas"
         />
       </div>
-
-      <div className={`${styles.floatingScreenshot} ${styles.floatingParallel}`}>
-        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
-        <img
-          src="/screenshots/parallel-board-5-sessions.png"
-          alt="Agor branch card with parallel assistant sessions"
-        />
-      </div>
-
-      <div className={`${styles.floatingScreenshot} ${styles.floatingHierarchy}`}>
-        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
-        <img
-          src="/screenshots/subsession-board-hierarchy.png"
-          alt="Agor branch card showing assistant session hierarchy"
-        />
-      </div>
-
-      <div className={`${styles.floatingScreenshot} ${styles.floatingReview}`}>
-        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
-        <img
-          src="/screenshots/subsession-spawn-codex-review.png"
-          alt="Agor conversation delegating a Codex review subsession"
-        />
-      </div>
     </div>
   );
 }
@@ -141,37 +117,6 @@ function ProductMockup() {
 export function LandingPage() {
   const [isContactOpen, setIsContactOpen] = useState(false);
   const landingRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const landing = landingRef.current;
-    if (!landing || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      return;
-    }
-
-    let frame = 0;
-    const updateParallax = () => {
-      frame = 0;
-      const progress = Math.min(window.scrollY / 520, 1).toFixed(3);
-      landing.style.setProperty('--hero-scroll', progress);
-    };
-
-    const onScroll = () => {
-      if (frame) {
-        return;
-      }
-      frame = window.requestAnimationFrame(updateParallax);
-    };
-
-    updateParallax();
-    window.addEventListener('scroll', onScroll, { passive: true });
-
-    return () => {
-      window.removeEventListener('scroll', onScroll);
-      if (frame) {
-        window.cancelAnimationFrame(frame);
-      }
-    };
-  }, []);
 
   useEffect(() => {
     const landing = landingRef.current;

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -58,6 +58,27 @@ const featureCards = [
   },
 ];
 
+const productPreviews = [
+  {
+    title: 'Spatial boards',
+    body: 'Arrange branches, zones, sessions, and teammates on one live canvas.',
+    image: '/screenshots/board-hero.png',
+    href: '/guide/boards',
+  },
+  {
+    title: 'Rich agent sessions',
+    body: 'Watch tool calls, decisions, reports, and handoffs unfold with full context.',
+    image: '/screenshots/conversation_full_page.png',
+    href: '/guide/rich-chat-ux',
+  },
+  {
+    title: 'Persistent assistants',
+    body: 'Give long-lived helpers memory, skills, schedules, and team-wide reach.',
+    image: '/screenshots/assistants-list.png',
+    href: '/guide/assistants',
+  },
+];
+
 const useCases = [
   { label: 'multi-agent code review', href: '/guide/sessions' },
   { label: 'release audits', href: '/guide/scheduler' },
@@ -91,7 +112,7 @@ function ProductMockup() {
         {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
         <img
           src="/screenshots/board-hero.png"
-          alt="Agor board showing branches on a shared canvas"
+          alt="Agor board showing colorful zones and branch cards on a shared canvas"
         />
       </div>
 
@@ -102,12 +123,15 @@ function ProductMockup() {
 
       <div className={`${styles.floatingScreenshot} ${styles.floatingSessions}`}>
         {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
-        <img src="/screenshots/parallel-board-5-sessions.png" alt="Agor parallel session tree" />
+        <img
+          src="/screenshots/branch-card-with-scheduled-sessions.png"
+          alt="Agor branch card with scheduled assistant runs"
+        />
       </div>
 
       <div className={styles.screenshotBadge}>
         <span className={styles.statusDot} />
-        <span>Live branches, sessions, agents, and teammates in one place</span>
+        <span>A living board for assistants, branches, sessions, and teammates</span>
       </div>
     </div>
   );
@@ -282,6 +306,32 @@ export function LandingPage() {
                 {feature.linkLabel} →
               </Link>
             </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.productShowcase} data-reveal>
+        <div className={styles.sectionHeader}>
+          <span className={styles.eyebrow}>Product surfaces</span>
+          <h2>Show the work, not an abstraction.</h2>
+        </div>
+        <div className={styles.productGrid}>
+          {productPreviews.map((preview, index) => (
+            <Link
+              className={styles.productCard}
+              href={preview.href}
+              key={preview.title}
+              data-reveal
+              style={revealDelay(index)}
+            >
+              {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+              <img src={preview.image} alt="" />
+              <div>
+                <h3>{preview.title}</h3>
+                <p>{preview.body}</p>
+                <span>Open guide →</span>
+              </div>
+            </Link>
           ))}
         </div>
       </section>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -96,17 +96,6 @@ const productPreviews = [
   },
 ];
 
-const useCases = [
-  { label: 'multi-agent code review', href: '/guide/sessions' },
-  { label: 'release audits', href: '/guide/scheduler' },
-  { label: 'backlog grooming', href: '/blog/raise-team-helper-agent' },
-  { label: 'security sweeps', href: '/guide/multiplayer-unix-isolation' },
-  { label: 'competitive intel', href: '/guide/assistants' },
-  { label: 'customer digests', href: '/guide/message-gateway' },
-  { label: 'weekly reports', href: '/guide/scheduler' },
-  { label: 'standups', href: '/blog/raise-team-helper-agent' },
-];
-
 const trustItems = [
   { label: 'Agor Cloud is coming', href: '/blog/agor-cloud' },
   { label: 'Open source / self-hosted', href: '/guide/getting-started' },
@@ -286,18 +275,6 @@ export function LandingPage() {
         </div>
       </section>
 
-      <section className={styles.useCaseSection} data-reveal>
-        <span className={styles.eyebrow}>What teams run</span>
-        <h2>From code reviews to customer digests.</h2>
-        <div className={styles.useCaseGrid}>
-          {useCases.map((useCase) => (
-            <Link href={useCase.href} key={useCase.label}>
-              {useCase.label}
-            </Link>
-          ))}
-        </div>
-      </section>
-
       <section className={styles.controlSection} data-reveal>
         <div>
           <span className={styles.eyebrow}>Built for real teams</span>
@@ -307,9 +284,8 @@ export function LandingPage() {
             Now make it compound.
           </h2>
           <p>
-            Self-host Agor and build on the best agent harnesses: Claude Code, Codex, OpenCode,
-            Copilot, Gemini, and whatever comes next. Keep your data yours, pick the right runtime
-            for the job, and avoid locking your team into one frontier.
+            Choose the right agent harness, keep your data yours, and move from solo experiments to
+            team-visible workflows without locking into one frontier.
           </p>
         </div>
         <ul className={styles.trustList}>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -139,9 +139,6 @@ export function LandingPage() {
   return (
     <div ref={landingRef} className={styles.landingShell}>
       <section className={styles.heroSection}>
-        <div className={styles.navAnnouncement}>
-          Shared canvas for assistants, schedules, and live work
-        </div>
         <div className={styles.heroGrid}>
           <div className={styles.heroCopy}>
             <div className={styles.brandMark}>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import type { CSSProperties } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
@@ -66,6 +67,9 @@ const trustItems = [
   'Claude Code · Codex · Gemini',
   'Unix-level isolation when you need it',
 ];
+
+const revealDelay = (index: number): CSSProperties =>
+  ({ '--reveal-delay': `${index * 70}ms` }) as CSSProperties;
 
 function ProductMockup() {
   return (
@@ -136,11 +140,48 @@ export function LandingPage() {
     };
   }, []);
 
+  useEffect(() => {
+    const landing = landingRef.current;
+    if (!landing) {
+      return;
+    }
+
+    const revealItems = Array.from(landing.querySelectorAll<HTMLElement>('[data-reveal]'));
+    if (!revealItems.length) {
+      return;
+    }
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      revealItems.forEach((item) => {
+        item.classList.add(styles.isVisible);
+      });
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add(styles.isVisible);
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: '0px 0px -12% 0px', threshold: 0.14 }
+    );
+
+    revealItems.forEach((item) => {
+      observer.observe(item);
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div ref={landingRef} className={styles.landingShell}>
       <section className={styles.heroSection}>
         <div className={styles.heroGrid}>
-          <div className={styles.heroCopy}>
+          <div className={styles.heroCopy} data-reveal>
             <div className={styles.brandMark}>
               {/* biome-ignore lint/performance/noImgElement: Static docs asset */}
               <img src={LOGO_PATH} alt={`${BRAND_NAME} logo`} />
@@ -174,11 +215,13 @@ export function LandingPage() {
               </Link>
             </div>
           </div>
-          <ProductMockup />
+          <div data-reveal style={revealDelay(1)}>
+            <ProductMockup />
+          </div>
         </div>
       </section>
 
-      <section className={styles.assistantStrip} aria-label="Example assistants">
+      <section className={styles.assistantStrip} aria-label="Example assistants" data-reveal>
         <span>What works for one person finally reaches everyone</span>
         <div>
           {assistants.map((assistant) => (
@@ -187,14 +230,19 @@ export function LandingPage() {
         </div>
       </section>
 
-      <section className={styles.problemSection}>
+      <section className={styles.problemSection} data-reveal>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Why teams need a home for AI work</span>
           <h2>Everyone’s cranking with AI. Now make it compound.</h2>
         </div>
         <div className={styles.problemGrid}>
           {problemCards.map((card) => (
-            <article className={styles.problemCard} key={card.title}>
+            <article
+              className={styles.problemCard}
+              key={card.title}
+              data-reveal
+              style={revealDelay(problemCards.indexOf(card))}
+            >
               <h3>{card.title}</h3>
               <p>{card.body}</p>
             </article>
@@ -202,7 +250,7 @@ export function LandingPage() {
         </div>
       </section>
 
-      <section className={styles.workspaceSection}>
+      <section className={styles.workspaceSection} data-reveal>
         <div className={styles.workspaceCopy}>
           <span className={styles.eyebrow}>The shared workspace</span>
           <h2>Raise real assistants, not throwaway agents.</h2>
@@ -213,7 +261,12 @@ export function LandingPage() {
         </div>
         <div className={styles.featureGrid}>
           {featureCards.map((feature) => (
-            <article className={styles.featureCard} key={feature.title}>
+            <article
+              className={styles.featureCard}
+              key={feature.title}
+              data-reveal
+              style={revealDelay(featureCards.indexOf(feature))}
+            >
               <span>{feature.eyebrow}</span>
               <h3>{feature.title}</h3>
               <p>{feature.body}</p>
@@ -222,7 +275,7 @@ export function LandingPage() {
         </div>
       </section>
 
-      <section className={styles.useCaseSection}>
+      <section className={styles.useCaseSection} data-reveal>
         <span className={styles.eyebrow}>What teams run</span>
         <h2>From code reviews to customer digests.</h2>
         <div className={styles.useCaseGrid}>
@@ -232,7 +285,7 @@ export function LandingPage() {
         </div>
       </section>
 
-      <section className={styles.controlSection}>
+      <section className={styles.controlSection} data-reveal>
         <div>
           <span className={styles.eyebrow}>Built for real teams</span>
           <h2>Your work, your data, your assistants.</h2>
@@ -249,7 +302,7 @@ export function LandingPage() {
         </ul>
       </section>
 
-      <section className={styles.finalCta}>
+      <section className={styles.finalCta} data-reveal>
         <h2>Give your team’s AI work a place to live.</h2>
         <p>
           Start with the guide, join the community, or reach out if you’re rolling Agor out for a

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -314,10 +314,7 @@ export function LandingPage() {
 
       <section className={styles.finalCta} data-reveal>
         <h2>Give your team’s AI work a place to live.</h2>
-        <p>
-          Join the private beta, book a demo for Agor Cloud, or install the open-source version
-          locally.
-        </p>
+        <p>Agor Cloud is opening to teams now. The open-source build is ready when you are.</p>
         <div className={styles.heroActions}>
           <Link
             href={AGOR_CLOUD_INVITE_URL}

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,11 +1,14 @@
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef } from 'react';
-import { AGOR_CLOUD_DEMO_URL, AGOR_CLOUD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
+import {
+  AGOR_CLOUD_DEMO_URL,
+  AGOR_CLOUD_INVITE_URL,
+  DISCORD_INVITE_URL,
+  GITHUB_REPO_URL,
+} from '../lib/links';
 import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
 import styles from './LandingPage.module.css';
-
-const assistants = ['ReviewBot', 'LaunchOps', 'Scout', 'Standup', 'Docs'];
 
 const featureCards = [
   {
@@ -48,8 +51,8 @@ const featureCards = [
 const productPreviews = [
   {
     title: 'Spatial boards',
-    body: 'Arrange branches, zones, sessions, and teammates on one Figma-like canvas for agentic workflows.',
-    image: '/screenshots/board-hero.png',
+    body: 'Arrange branches, zones, sessions, and teammates on one spatial canvas for agentic workflows.',
+    image: '/screenshots/board.png',
     href: '/guide/boards',
   },
   {
@@ -103,11 +106,31 @@ const productPreviews = [
 ];
 
 const trustItems = [
-  { label: 'Agor Cloud is coming', href: '/blog/agor-cloud' },
-  { label: 'Open source / self-hosted', href: '/guide/getting-started' },
-  { label: 'MCP-native', href: '/guide/internal-mcp' },
-  { label: 'Best harnesses, no frontier lock-in', href: '/guide/sdk-comparison' },
-  { label: 'Unix-level isolation when you need it', href: '/guide/multiplayer-unix-isolation' },
+  {
+    label: 'Open source & self-hosted',
+    body: 'Your repos, your database, your infrastructure. BSL 1.1.',
+    href: '/guide/getting-started',
+  },
+  {
+    label: 'No frontier lock-in',
+    body: 'Claude Code, Codex, Gemini, OpenCode — pick the best harness per session.',
+    href: '/guide/sdk-comparison',
+  },
+  {
+    label: 'MCP-native',
+    body: 'Anything you can do, an agent can do too — over Agor’s own MCP server.',
+    href: '/guide/internal-mcp',
+  },
+  {
+    label: 'Unix-level isolation',
+    body: 'Progressive isolation modes for when teams and security demand it.',
+    href: '/guide/multiplayer-unix-isolation',
+  },
+  {
+    label: 'Agor Cloud is coming',
+    body: 'Managed hosting for teams who’d rather not run it themselves.',
+    href: '/blog/agor-cloud',
+  },
 ];
 
 const revealDelay = (index: number): CSSProperties =>
@@ -221,6 +244,51 @@ export function LandingPage() {
         </div>
       </section>
 
+      <section className={styles.liveSection} data-reveal>
+        <div className={styles.liveCopy}>
+          <span className={styles.eyebrow}>Multiplayer by default</span>
+          <h2>Your team’s agents, live on a Figma-like canvas.</h2>
+          <p>
+            Most agent tools are solo. Agor isn’t. Cursors, comments, and a facepile show who’s
+            here. Sessions, dev environments, and branches are shared. One link, one running thing,
+            everyone looking at the same live work.
+          </p>
+          <ul className={styles.liveHighlights}>
+            <li>
+              <strong>Live presence</strong>
+              <span>
+                See teammates’ cursors, comments, and reactions as work happens — not after the
+                fact.
+              </span>
+            </li>
+            <li>
+              <strong>Shared dev environments</strong>
+              <span>
+                Engineers, reviewers, PMs, and QA rally around the same running branch instead of
+                “spin up your own to see it.”
+              </span>
+            </li>
+            <li>
+              <strong>Learn from each other</strong>
+              <span>
+                Watch how teammates prompt, lift the patterns that work, and standardize them as
+                zone triggers.
+              </span>
+            </li>
+          </ul>
+          <Link href="/guide/multiplayer-social" className={styles.cardLink}>
+            Explore multiplayer →
+          </Link>
+        </div>
+        <div className={styles.liveVisual}>
+          {/* biome-ignore lint/performance/noImgElement: Static product screenshot (interim — needs a bespoke presence/cursors shot before launch) */}
+          <img
+            src="/screenshots/cards-hero.png"
+            alt="Agor board with branches and sessions organized in shared zones"
+          />
+        </div>
+      </section>
+
       <section className={styles.productShowcase} data-reveal>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Product surfaces</span>
@@ -246,15 +314,6 @@ export function LandingPage() {
         </div>
       </section>
 
-      <section className={styles.assistantStrip} aria-label="Example assistants" data-reveal>
-        <span>What works for one person finally reaches everyone</span>
-        <div>
-          {assistants.map((assistant) => (
-            <strong key={assistant}>@{assistant}</strong>
-          ))}
-        </div>
-      </section>
-
       <section className={styles.workspaceSection} data-reveal>
         <div className={styles.workspaceCopy}>
           <span className={styles.eyebrow}>The shared workspace</span>
@@ -262,15 +321,8 @@ export function LandingPage() {
           <p>
             One-off prompts don’t compound. In Agor, assistants have durable identities your team
             can teach conversationally, then equip with memory, tools, channels, and schedules as
-            they grow.
+            they grow — so what works for one person finally reaches the whole team.
           </p>
-          <div className={styles.workspaceScreenshot}>
-            {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
-            <img
-              src="/screenshots/assistants-list.png"
-              alt="Agor assistants list showing persistent team assistants"
-            />
-          </div>
         </div>
         <div className={styles.featureGrid}>
           {featureCards.map((feature) => (
@@ -292,7 +344,7 @@ export function LandingPage() {
 
       <section className={styles.controlSection} data-reveal>
         <div>
-          <span className={styles.eyebrow}>Built for real teams</span>
+          <span className={styles.eyebrow}>Built for teams</span>
           <h2>
             Everyone’s cranking with AI.
             <br />
@@ -306,7 +358,10 @@ export function LandingPage() {
         <ul className={styles.trustList}>
           {trustItems.map((item) => (
             <li key={item.label}>
-              <Link href={item.href}>{item.label} →</Link>
+              <Link href={item.href}>
+                <span className={styles.trustLabel}>{item.label} →</span>
+                <span className={styles.trustBody}>{item.body}</span>
+              </Link>
             </li>
           ))}
         </ul>
@@ -337,6 +392,44 @@ export function LandingPage() {
           </Link>
         </div>
       </section>
+
+      <footer className={styles.landingFooter} data-reveal>
+        <div className={styles.footerBrand}>
+          {/* biome-ignore lint/performance/noImgElement: Static docs asset */}
+          <img src={LOGO_PATH} alt={`${BRAND_NAME} logo`} />
+          <div>
+            <strong>agor</strong>
+            <p>Team command center for all things agentic.</p>
+          </div>
+        </div>
+        <div className={styles.footerLinks}>
+          <div>
+            <h4>Product</h4>
+            <Link href="/guide/boards">Boards</Link>
+            <Link href="/guide/sessions">Sessions</Link>
+            <Link href="/guide/assistants">Assistants</Link>
+            <Link href="/guide/internal-mcp">MCP control</Link>
+          </div>
+          <div>
+            <h4>Resources</h4>
+            <Link href="/guide/getting-started">Get started</Link>
+            <Link href="/guide">Documentation</Link>
+            <Link href="/blog/agor-cloud">Agor Cloud</Link>
+          </div>
+          <div>
+            <h4>Community</h4>
+            <Link href={GITHUB_REPO_URL} target="_blank" rel="noopener noreferrer">
+              GitHub
+            </Link>
+            <Link href={DISCORD_INVITE_URL} target="_blank" rel="noopener noreferrer">
+              Discord
+            </Link>
+            <Link href={AGOR_CLOUD_INVITE_URL} target="_blank" rel="noopener noreferrer">
+              Join the private beta
+            </Link>
+          </div>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -104,11 +104,6 @@ function ProductMockup() {
   return (
     <div className={styles.screenshotCollage} role="img" aria-label="Agor product screenshots">
       <div className={styles.mainScreenshotFrame}>
-        <div className={styles.screenshotTopbar}>
-          <span />
-          <span />
-          <span />
-        </div>
         {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
         <img
           src="/screenshots/board-hero.png"

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -365,7 +365,11 @@ export function LandingPage() {
       <section className={styles.controlSection} data-reveal>
         <div>
           <span className={styles.eyebrow}>Built for real teams</span>
-          <h2>Your work, your data, your assistants.</h2>
+          <h2>
+            Everyone’s cranking with AI.
+            <br />
+            Now make it compound.
+          </h2>
           <p>
             Self-host Agor and build on the best agent harnesses: Claude Code, Codex, OpenCode,
             Copilot, Gemini, and whatever comes next. Keep your data yours, pick the right runtime

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -127,7 +127,7 @@ const trustItems = [
   { label: 'Agor Cloud is coming', href: '/blog/agor-cloud' },
   { label: 'Open source / self-hosted', href: '/guide/getting-started' },
   { label: 'MCP-native', href: '/guide/internal-mcp' },
-  { label: 'Claude Code · Codex · Gemini', href: '/guide/sdk-comparison' },
+  { label: 'Best harnesses, no frontier lock-in', href: '/guide/sdk-comparison' },
   { label: 'Unix-level isolation when you need it', href: '/guide/multiplayer-unix-isolation' },
 ];
 
@@ -367,9 +367,9 @@ export function LandingPage() {
           <span className={styles.eyebrow}>Built for real teams</span>
           <h2>Your work, your data, your assistants.</h2>
           <p>
-            Self-host Agor, connect the best models and harnesses, and keep your data yours. As the
-            stakes grow, add governance, observability, and isolation without locking into one
-            vendor.
+            Self-host Agor and build on the best agent harnesses: Claude Code, Codex, OpenCode,
+            Copilot, Gemini, and whatever comes next. Keep your data yours, pick the right runtime
+            for the job, and avoid locking your team into one frontier.
           </p>
         </div>
         <ul className={styles.trustList}>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -168,9 +168,11 @@ export function LandingPage() {
             <p className={styles.kicker}>Team command center for all things agentic.</p>
             <h1>Meet your team of AI assistants.</h1>
             <p className={styles.heroDescription}>
-              Everyone’s cranking with AI, but it’s chaos: scattered sessions, ephemeral context,
-              nothing that compounds. Agor is where your team raises real assistants, wires them
-              into the systems you live in, and watches the work happen in one shared place.
+              Everyone’s cranking with AI.
+              <br />
+              But it’s chaos: scattered sessions, ephemeral context, nothing that compounds. Agor is
+              where your team raises real assistants, wires them into the systems you live in, and
+              watches the work happen in one shared place.
             </p>
             <div className={styles.heroActions}>
               <Link href="/guide" className={styles.primaryButton}>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -41,54 +41,33 @@ const featureCards = [
 
 const productPreviews = [
   {
-    title: 'Spatial boards',
-    body: 'Arrange branches, zones, sessions, and teammates on one live canvas.',
+    title: 'Figma-like canvas for agentic workflows',
+    body: 'Branches become cards, zones become prompts, and teammates can read the state of AI work at a glance.',
     image: '/screenshots/board-hero.png',
     href: '/guide/boards',
   },
   {
-    title: 'Rich agent sessions',
-    body: 'Watch tool calls, decisions, reports, and handoffs unfold with full context.',
-    image: '/screenshots/conversation_full_page.png',
-    href: '/guide/rich-chat-ux',
-  },
-  {
-    title: 'Persistent assistants',
-    body: 'Give long-lived helpers memory, skills, schedules, and team-wide reach.',
-    image: '/screenshots/assistants-list.png',
-    href: '/guide/assistants',
-  },
-];
-
-const workflowHighlights = [
-  {
-    eyebrow: 'Spatial board',
-    title: 'Figma-like canvas for agentic workflows',
-    body: 'Branches become cards, zones become prompts, and teammates can read the state of AI work at a glance.',
-    href: '/guide/boards',
-  },
-  {
-    eyebrow: 'Message gateway',
     title: 'Your agents in Slack, GitHub, and wherever work happens',
     body: 'DM Agor or mention it on a PR. Sessions start on the right branch and route the answer back to the thread.',
+    image: '/screenshots/subsession-spawn-codex-review.png',
     href: '/guide/message-gateway',
   },
   {
-    eyebrow: 'Automation',
     title: 'Schedulers and artifacts for repeatable work',
     body: 'Run standups, audits, and reports on a cadence — or let agents render live dashboards and tools on the board.',
-    href: '/guide/scheduler',
+    image: '/images/artifacts-hero.png',
+    href: '/guide/artifacts',
   },
   {
-    eyebrow: 'Grown-up agent ops',
     title: 'Governance, observability, and MCP-native control',
     body: 'Track sessions, tools, and spend; let agents operate Agor itself; add RBAC and Unix isolation when stakes rise.',
+    image: '/screenshots/context-window-viz.png',
     href: '/guide/internal-mcp',
   },
   {
-    eyebrow: 'Environments',
     title: 'One dev server per branch, without port fights',
     body: 'Start, stop, health-check, and inspect logs for every branch environment from the same shared workspace.',
+    image: '/screenshots/env_configuration.png',
     href: '/guide/environment-configuration',
   },
 ];
@@ -261,7 +240,7 @@ export function LandingPage() {
       <section className={styles.productShowcase} data-reveal>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Product surfaces</span>
-          <h2>Show the work, not an abstraction.</h2>
+          <h2>This product is much bigger than a chat window.</h2>
         </div>
         <div className={styles.productGrid}>
           {productPreviews.map((preview, index) => (
@@ -279,29 +258,6 @@ export function LandingPage() {
                 <p>{preview.body}</p>
                 <span>Open guide →</span>
               </div>
-            </Link>
-          ))}
-        </div>
-      </section>
-
-      <section className={styles.capabilitySection} data-reveal>
-        <div className={styles.sectionHeader}>
-          <span className={styles.eyebrow}>Why it becomes a command center</span>
-          <h2>This product is much bigger than a chat window.</h2>
-        </div>
-        <div className={styles.capabilityGrid}>
-          {workflowHighlights.map((highlight, index) => (
-            <Link
-              className={styles.capabilityCard}
-              href={highlight.href}
-              key={highlight.title}
-              data-reveal
-              style={revealDelay(index)}
-            >
-              <span>{highlight.eyebrow}</span>
-              <h3>{highlight.title}</h3>
-              <p>{highlight.body}</p>
-              <strong>Explore →</strong>
             </Link>
           ))}
         </div>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -111,16 +111,27 @@ function ProductMockup() {
         />
       </div>
 
-      <div className={`${styles.floatingScreenshot} ${styles.floatingConversation}`}>
-        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
-        <img src="/screenshots/conversation_full_page.png" alt="Agor conversation view" />
-      </div>
-
-      <div className={`${styles.floatingScreenshot} ${styles.floatingSessions}`}>
+      <div className={`${styles.floatingScreenshot} ${styles.floatingParallel}`}>
         {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
         <img
-          src="/screenshots/branch-card-with-scheduled-sessions.png"
-          alt="Agor branch card with scheduled assistant runs"
+          src="/screenshots/parallel-board-5-sessions.png"
+          alt="Agor branch card with parallel assistant sessions"
+        />
+      </div>
+
+      <div className={`${styles.floatingScreenshot} ${styles.floatingHierarchy}`}>
+        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+        <img
+          src="/screenshots/subsession-board-hierarchy.png"
+          alt="Agor branch card showing assistant session hierarchy"
+        />
+      </div>
+
+      <div className={`${styles.floatingScreenshot} ${styles.floatingReview}`}>
+        {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+        <img
+          src="/screenshots/subsession-spawn-codex-review.png"
+          alt="Agor conversation delegating a Codex review subsession"
         />
       </div>
     </div>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -227,7 +227,6 @@ export function LandingPage() {
               <div>
                 <h3>{preview.title}</h3>
                 <p>{preview.body}</p>
-                <span>Open guide →</span>
               </div>
             </Link>
           ))}

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -8,25 +8,6 @@ import styles from './LandingPage.module.css';
 
 const assistants = ['ReviewBot', 'LaunchOps', 'Scout', 'Standup', 'Docs'];
 
-const problemCards = [
-  {
-    title: 'My agents are everywhere',
-    body: 'More agents, more models, more tabs. Keeping them straight has become its own job.',
-  },
-  {
-    title: 'I can’t see what anyone else is doing',
-    body: 'Teammates find great ways to use AI, but prompts and patterns get reinvented in private.',
-  },
-  {
-    title: 'AI adoption isn’t stalled',
-    body: 'It’s unevenly distributed: the best agent runs stay hidden on laptops instead of becoming team muscle.',
-  },
-  {
-    title: 'The bots live on someone’s laptop',
-    body: 'Team-critical helpers need ownership, governance, schedules, and observability in one shared place.',
-  },
-];
-
 const featureCards = [
   {
     eyebrow: '01',
@@ -242,26 +223,6 @@ export function LandingPage() {
         <div>
           {assistants.map((assistant) => (
             <strong key={assistant}>@{assistant}</strong>
-          ))}
-        </div>
-      </section>
-
-      <section className={styles.problemSection} data-reveal>
-        <div className={styles.sectionHeader}>
-          <span className={styles.eyebrow}>Why teams need a home for AI work</span>
-          <h2>Everyone’s cranking with AI. Now make it compound.</h2>
-        </div>
-        <div className={styles.problemGrid}>
-          {problemCards.map((card) => (
-            <article
-              className={styles.problemCard}
-              key={card.title}
-              data-reveal
-              style={revealDelay(problemCards.indexOf(card))}
-            >
-              <h3>{card.title}</h3>
-              <p>{card.body}</p>
-            </article>
           ))}
         </div>
       </section>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -123,11 +123,6 @@ function ProductMockup() {
           alt="Agor branch card with scheduled assistant runs"
         />
       </div>
-
-      <div className={styles.screenshotBadge}>
-        <span className={styles.statusDot} />
-        <span>A living board for assistants, branches, sessions, and teammates</span>
-      </div>
     </div>
   );
 }

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -79,6 +79,39 @@ const productPreviews = [
   },
 ];
 
+const workflowHighlights = [
+  {
+    eyebrow: 'Spatial board',
+    title: 'Figma-like canvas for agentic workflows',
+    body: 'Branches become cards, zones become prompts, and teammates can read the state of AI work at a glance.',
+    href: '/guide/boards',
+  },
+  {
+    eyebrow: 'Message gateway',
+    title: 'Your agents in Slack, GitHub, and wherever work happens',
+    body: 'DM Agor or mention it on a PR. Sessions start on the right branch and route the answer back to the thread.',
+    href: '/guide/message-gateway',
+  },
+  {
+    eyebrow: 'Automation',
+    title: 'Schedulers and artifacts for repeatable work',
+    body: 'Run standups, audits, and reports on a cadence — or let agents render live dashboards and tools on the board.',
+    href: '/guide/scheduler',
+  },
+  {
+    eyebrow: 'Grown-up agent ops',
+    title: 'Governance, observability, and MCP-native control',
+    body: 'Track sessions, tools, and spend; let agents operate Agor itself; add RBAC and Unix isolation when stakes rise.',
+    href: '/guide/internal-mcp',
+  },
+  {
+    eyebrow: 'Environments',
+    title: 'One dev server per branch, without port fights',
+    body: 'Start, stop, health-check, and inspect logs for every branch environment from the same shared workspace.',
+    href: '/guide/environment-configuration',
+  },
+];
+
 const useCases = [
   { label: 'multi-agent code review', href: '/guide/sessions' },
   { label: 'release audits', href: '/guide/scheduler' },
@@ -279,6 +312,29 @@ export function LandingPage() {
                 <p>{preview.body}</p>
                 <span>Open guide →</span>
               </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.capabilitySection} data-reveal>
+        <div className={styles.sectionHeader}>
+          <span className={styles.eyebrow}>Why it becomes a command center</span>
+          <h2>The product is bigger than a chat window.</h2>
+        </div>
+        <div className={styles.capabilityGrid}>
+          {workflowHighlights.map((highlight, index) => (
+            <Link
+              className={styles.capabilityCard}
+              href={highlight.href}
+              key={highlight.title}
+              data-reveal
+              style={revealDelay(index)}
+            >
+              <span>{highlight.eyebrow}</span>
+              <h3>{highlight.title}</h3>
+              <p>{highlight.body}</p>
+              <strong>Explore →</strong>
             </Link>
           ))}
         </div>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -32,40 +32,48 @@ const featureCards = [
     eyebrow: '01',
     title: 'Give each assistant a real job',
     body: 'Define what it’s for, give it memory, and wire it into the systems your team already uses.',
+    href: '/guide/assistants',
+    linkLabel: 'Read about Assistants',
   },
   {
     eyebrow: '02',
     title: 'Make the learning visible',
     body: 'The whole team can see what each assistant is doing and lift the prompts that work.',
+    href: '/guide/multiplayer-social',
+    linkLabel: 'See multiplayer',
   },
   {
     eyebrow: '03',
     title: 'Let work happen on schedule',
     body: 'Run audits, standups, grooming, digests, reviews, and reports instead of waiting to be asked.',
+    href: '/guide/scheduler',
+    linkLabel: 'Explore Scheduler',
   },
   {
     eyebrow: '04',
     title: 'Keep ownership and control',
     body: 'Model assistants like team members: scoped on purpose, governed, observable, and owned together.',
+    href: '/blog/agent-modeling-101',
+    linkLabel: 'Agent modeling 101',
   },
 ];
 
 const useCases = [
-  'multi-agent code review',
-  'release audits',
-  'backlog grooming',
-  'security sweeps',
-  'competitive intel',
-  'customer digests',
-  'weekly reports',
-  'standups',
+  { label: 'multi-agent code review', href: '/guide/sessions' },
+  { label: 'release audits', href: '/guide/scheduler' },
+  { label: 'backlog grooming', href: '/blog/raise-team-helper-agent' },
+  { label: 'security sweeps', href: '/guide/multiplayer-unix-isolation' },
+  { label: 'competitive intel', href: '/guide/assistants' },
+  { label: 'customer digests', href: '/guide/message-gateway' },
+  { label: 'weekly reports', href: '/guide/scheduler' },
+  { label: 'standups', href: '/blog/raise-team-helper-agent' },
 ];
 
 const trustItems = [
-  'Self-hosted first',
-  'MCP-native',
-  'Claude Code · Codex · Gemini',
-  'Unix-level isolation when you need it',
+  { label: 'Self-hosted first', href: '/guide/getting-started' },
+  { label: 'MCP-native', href: '/guide/internal-mcp' },
+  { label: 'Claude Code · Codex · Gemini', href: '/guide/sdk-comparison' },
+  { label: 'Unix-level isolation when you need it', href: '/guide/multiplayer-unix-isolation' },
 ];
 
 const revealDelay = (index: number): CSSProperties =>
@@ -270,6 +278,9 @@ export function LandingPage() {
               <span>{feature.eyebrow}</span>
               <h3>{feature.title}</h3>
               <p>{feature.body}</p>
+              <Link href={feature.href} className={styles.cardLink}>
+                {feature.linkLabel} →
+              </Link>
             </article>
           ))}
         </div>
@@ -280,7 +291,9 @@ export function LandingPage() {
         <h2>From code reviews to customer digests.</h2>
         <div className={styles.useCaseGrid}>
           {useCases.map((useCase) => (
-            <span key={useCase}>{useCase}</span>
+            <Link href={useCase.href} key={useCase.label}>
+              {useCase.label}
+            </Link>
           ))}
         </div>
       </section>
@@ -297,7 +310,9 @@ export function LandingPage() {
         </div>
         <ul className={styles.trustList}>
           {trustItems.map((item) => (
-            <li key={item}>{item}</li>
+            <li key={item.label}>
+              <Link href={item.href}>{item.label} →</Link>
+            </li>
           ))}
         </ul>
       </section>
@@ -311,6 +326,9 @@ export function LandingPage() {
         <div className={styles.heroActions}>
           <Link href="/guide" className={styles.primaryButton}>
             Read the docs
+          </Link>
+          <Link href="/guide/features-overview" className={styles.secondaryButton}>
+            Feature map
           </Link>
           <Link
             href={DISCORD_INVITE_URL}

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -195,7 +195,7 @@ export function LandingPage() {
                 Join the private beta
               </Link>
               <Link href="/guide/getting-started" className={styles.secondaryButton}>
-                Try locally
+                Get started
               </Link>
               <Link
                 href={GITHUB_REPO_URL}
@@ -329,7 +329,7 @@ export function LandingPage() {
             Book a demo
           </Link>
           <Link href="/guide/getting-started" className={styles.secondaryButton}>
-            Try locally
+            Get started
           </Link>
         </div>
       </section>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -9,49 +9,42 @@ const assistants = ['ReviewBot', 'LaunchOps', 'Scout', 'Standup', 'Docs'];
 
 const featureCards = [
   {
-    eyebrow: '01',
     title: 'Shared memory',
-    body: 'Each assistant gets a namespace in the knowledge base: semantic-searchable, durable, and shared with the team.',
+    body: 'Each assistant gets a namespace in the knowledge base: semantically searchable, durable, and shared with the team.',
     href: '/guide/knowledge',
     linkLabel: 'Explore Knowledge',
   },
   {
-    eyebrow: '02',
     title: 'Skills + MCP',
     body: 'Package repeatable workflows as skills and connect assistants to the MCP servers your team already trusts.',
     href: '/guide/internal-mcp',
     linkLabel: 'See MCP control',
   },
   {
-    eyebrow: '03',
     title: 'Conversational onboarding',
     body: 'Teach an assistant by talking to it. The programming language is conversation, and the useful parts become reusable context.',
     href: '/guide/assistants',
     linkLabel: 'Read about Assistants',
   },
   {
-    eyebrow: '04',
     title: 'Where your team works',
     body: 'Reach assistants from Slack, GitHub, or wherever work already happens through gateway channels.',
     href: '/guide/message-gateway',
     linkLabel: 'Open Message Gateway',
   },
   {
-    eyebrow: '05',
     title: 'Scheduled agency',
     body: 'Run heartbeats, daily standups, audits, digests, or longer workflows without waiting for a prompt.',
     href: '/guide/scheduler',
     linkLabel: 'Explore Scheduler',
   },
   {
-    eyebrow: '06',
     title: 'Personality + boundaries',
     body: 'Tune voice, style, and level of agency so every assistant knows how bold to be and when to ask first.',
     href: '/blog/agent-modeling-101',
     linkLabel: 'Agent modeling 101',
   },
 ];
-
 const productPreviews = [
   {
     title: 'Spatial boards',
@@ -267,9 +260,9 @@ export function LandingPage() {
           <span className={styles.eyebrow}>The shared workspace</span>
           <h2>Raise team assistants with memory, skills, and a place to work.</h2>
           <p>
-            Give each assistant a durable identity: shared memory, reusable skills, MCP connections,
-            gateway channels, schedules, and a configurable style of agency. Teach them
-            conversationally, then let the useful patterns compound for the whole team.
+            One-off prompts don’t compound. In Agor, assistants have durable identities your team
+            can teach conversationally, then equip with memory, tools, channels, and schedules as
+            they grow.
           </p>
           <div className={styles.workspaceScreenshot}>
             {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
@@ -287,7 +280,6 @@ export function LandingPage() {
               data-reveal
               style={revealDelay(featureCards.indexOf(feature))}
             >
-              <span>{feature.eyebrow}</span>
               <h3>{feature.title}</h3>
               <p>{feature.body}</p>
               <Link href={feature.href} className={styles.cardLink}>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -18,8 +18,8 @@ const problemCards = [
     body: 'Teammates find great ways to use AI, but prompts and patterns get reinvented in private.',
   },
   {
-    title: 'Our AI adoption isn’t going anywhere',
-    body: 'Tools were handed out, but there’s no shared place to build assistants together and make them stick.',
+    title: 'AI adoption isn’t stalled',
+    body: 'It’s unevenly distributed: the best agent runs stay hidden on laptops instead of becoming team muscle.',
   },
   {
     title: 'The bots live on someone’s laptop',
@@ -198,14 +198,21 @@ export function LandingPage() {
               <img src={LOGO_PATH} alt={`${BRAND_NAME} logo`} />
               <span>agor</span>
             </div>
-            <p className={styles.kicker}>Team command center for all things agentic.</p>
-            <h1>Meet your team of AI assistants.</h1>
-            <p className={styles.heroDescription}>
+            <h1>
               Everyone’s cranking with AI.
               <br />
-              But it’s chaos: scattered sessions, ephemeral context, nothing that compounds. Agor is
-              where your team raises real assistants, wires them into the systems you live in, and
-              watches the work happen in one shared place.
+              Now make it compound.
+            </h1>
+            <p className={styles.heroProvocation}>
+              Break out of the terminal.
+              <br />
+              Bring the team and agents together.
+            </p>
+            <p className={styles.heroDescription}>
+              AI adoption isn’t stalled — it’s unevenly distributed. Agent workflows are trapped
+              behind local-environment curtains, so teammates can’t see what worked, reuse prompts,
+              share workflows, or learn from each other. Agor pulls that work onto a shared canvas
+              where agents, branches, dev environments, and the team all meet.
             </p>
             <div className={styles.heroActions}>
               <Link href="/guide" className={styles.primaryButton}>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -41,34 +41,40 @@ const featureCards = [
 
 const productPreviews = [
   {
-    title: 'Figma-like canvas for agentic workflows',
-    body: 'Branches become cards, zones become prompts, and teammates can read the state of AI work at a glance.',
+    title: 'Spatial boards',
+    body: 'Arrange branches, zones, sessions, and teammates on one Figma-like canvas for agentic workflows.',
     image: '/screenshots/board-hero.png',
     href: '/guide/boards',
   },
   {
-    title: 'Your agents in Slack, GitHub, and wherever work happens',
-    body: 'DM Agor or mention it on a PR. Sessions start on the right branch and route the answer back to the thread.',
+    title: 'Rich agent sessions',
+    body: 'Watch tool calls, decisions, session trees, forks, subsessions, and handoffs unfold with full context.',
+    image: '/screenshots/conversation_full_page.png',
+    href: '/guide/rich-chat-ux',
+  },
+  {
+    title: 'Persistent assistants',
+    body: 'Give long-lived helpers memory, skills, schedules, and team-wide reach beyond one-off prompts.',
+    image: '/screenshots/assistants-list.png',
+    href: '/guide/assistants',
+  },
+  {
+    title: 'Message gateway',
+    body: 'Bring agents into Slack, GitHub, and the threads where your team already coordinates work.',
     image: '/screenshots/subsession-spawn-codex-review.png',
     href: '/guide/message-gateway',
   },
   {
-    title: 'Schedulers and artifacts for repeatable work',
-    body: 'Run standups, audits, and reports on a cadence — or let agents render live dashboards and tools on the board.',
+    title: 'Scheduler',
+    body: 'Run standups, audits, digests, reports, and assistant heartbeats without waiting to be asked.',
+    image: '/screenshots/scheduler-modal.png',
+    href: '/guide/scheduler',
+  },
+  {
+    title: 'Artifacts',
+    body: 'Let agents render live dashboards, mockups, calculators, and tools directly on the board.',
     image: '/images/artifacts-hero.png',
     href: '/guide/artifacts',
-  },
-  {
-    title: 'Governance, observability, and MCP-native control',
-    body: 'Track sessions, tools, and spend; let agents operate Agor itself; add RBAC and Unix isolation when stakes rise.',
-    image: '/screenshots/context-window-viz.png',
-    href: '/guide/internal-mcp',
-  },
-  {
-    title: 'One dev server per branch, without port fights',
-    body: 'Start, stop, health-check, and inspect logs for every branch environment from the same shared workspace.',
-    image: '/screenshots/env_configuration.png',
-    href: '/guide/environment-configuration',
   },
 ];
 
@@ -202,6 +208,32 @@ export function LandingPage() {
         </div>
       </section>
 
+      <section className={styles.productShowcase} data-reveal>
+        <div className={styles.sectionHeader}>
+          <span className={styles.eyebrow}>Product surfaces</span>
+          <h2>This product is much bigger than a chat window.</h2>
+        </div>
+        <div className={styles.productGrid}>
+          {productPreviews.map((preview, index) => (
+            <Link
+              className={styles.productCard}
+              href={preview.href}
+              key={preview.title}
+              data-reveal
+              style={revealDelay(index)}
+            >
+              {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
+              <img src={preview.image} alt="" />
+              <div>
+                <h3>{preview.title}</h3>
+                <p>{preview.body}</p>
+                <span>Open guide →</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
       <section className={styles.workspaceSection} data-reveal>
         <div className={styles.workspaceCopy}>
           <span className={styles.eyebrow}>The shared workspace</span>
@@ -233,32 +265,6 @@ export function LandingPage() {
                 {feature.linkLabel} →
               </Link>
             </article>
-          ))}
-        </div>
-      </section>
-
-      <section className={styles.productShowcase} data-reveal>
-        <div className={styles.sectionHeader}>
-          <span className={styles.eyebrow}>Product surfaces</span>
-          <h2>This product is much bigger than a chat window.</h2>
-        </div>
-        <div className={styles.productGrid}>
-          {productPreviews.map((preview, index) => (
-            <Link
-              className={styles.productCard}
-              href={preview.href}
-              key={preview.title}
-              data-reveal
-              style={revealDelay(index)}
-            >
-              {/* biome-ignore lint/performance/noImgElement: Static product screenshot */}
-              <img src={preview.image} alt="" />
-              <div>
-                <h3>{preview.title}</h3>
-                <p>{preview.body}</p>
-                <span>Open guide →</span>
-              </div>
-            </Link>
           ))}
         </div>
       </section>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -124,7 +124,8 @@ const useCases = [
 ];
 
 const trustItems = [
-  { label: 'Self-hosted first', href: '/guide/getting-started' },
+  { label: 'Agor Cloud is coming', href: '/blog/agor-cloud' },
+  { label: 'Open source / self-hosted', href: '/guide/getting-started' },
   { label: 'MCP-native', href: '/guide/internal-mcp' },
   { label: 'Claude Code · Codex · Gemini', href: '/guide/sdk-comparison' },
   { label: 'Unix-level isolation when you need it', href: '/guide/multiplayer-unix-isolation' },

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -198,17 +198,14 @@ export function LandingPage() {
               <img src={LOGO_PATH} alt={`${BRAND_NAME} logo`} />
               <span>agor</span>
             </div>
+            <p className={styles.kicker}>Team command center for all things agentic.</p>
             <h1>Meet your team of AI assistants.</h1>
-            <p className={styles.heroProvocation}>
-              Break out of the terminal.
-              <br />
-              Bring the team and agents together.
-            </p>
             <p className={styles.heroDescription}>
-              AI adoption isn’t stalled — it’s unevenly distributed. Agent workflows are trapped
-              behind local-environment curtains, so teammates can’t see what worked, reuse prompts,
-              share workflows, or learn from each other. Agor pulls that work onto a shared canvas
-              where agents, branches, dev environments, and the team all meet.
+              Everyone’s cranking with AI.
+              <br />
+              But it’s chaos: scattered sessions, ephemeral context, nothing that compounds. Agor is
+              where your team raises real assistants, wires them into the systems you live in, and
+              watches the work happen in one shared place.
             </p>
             <div className={styles.heroActions}>
               <Link href="/guide" className={styles.primaryButton}>
@@ -304,7 +301,11 @@ export function LandingPage() {
       <section className={styles.productShowcase} data-reveal>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Product surfaces</span>
-          <h2>Show the work, not an abstraction.</h2>
+          <h2>
+            Break out of the terminal.
+            <br />
+            Bring the team and agents together.
+          </h2>
         </div>
         <div className={styles.productGrid}>
           {productPreviews.map((preview, index) => (

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -198,11 +198,7 @@ export function LandingPage() {
               <img src={LOGO_PATH} alt={`${BRAND_NAME} logo`} />
               <span>agor</span>
             </div>
-            <h1>
-              Everyone’s cranking with AI.
-              <br />
-              Now make it compound.
-            </h1>
+            <h1>Meet your team of AI assistants.</h1>
             <p className={styles.heroProvocation}>
               Break out of the terminal.
               <br />

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,0 +1,264 @@
+import Link from 'next/link';
+import { useState } from 'react';
+import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
+import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
+import { HubSpotFormModal } from './HubSpotFormModal';
+import styles from './LandingPage.module.css';
+
+const assistants = ['ReviewBot', 'LaunchOps', 'Scout', 'Standup', 'Docs'];
+
+const problemCards = [
+  {
+    title: 'Your agents are everywhere',
+    body: 'More models, more tabs, more terminals. Keeping the work straight becomes its own job.',
+  },
+  {
+    title: 'Learning stays private',
+    body: 'Great prompts and workflows disappear behind individual screens instead of compounding for the team.',
+  },
+  {
+    title: 'Useful bots live on laptops',
+    body: 'PR reviewers, legal helpers, and report writers need ownership, memory, schedules, and visibility.',
+  },
+];
+
+const featureCards = [
+  {
+    eyebrow: '01',
+    title: 'Raise assistants together',
+    body: 'Give each assistant a purpose, memory, skills, and access to the systems your team already uses.',
+  },
+  {
+    eyebrow: '02',
+    title: 'Work on a shared canvas',
+    body: 'See teammates, branches, live environments, prompts, sessions, and progress in one multiplayer space.',
+  },
+  {
+    eyebrow: '03',
+    title: 'Let work happen on schedule',
+    body: 'Run audits, standups, grooming, digests, reviews, and reports without waiting for someone to ask.',
+  },
+  {
+    eyebrow: '04',
+    title: 'Keep the receipts',
+    body: 'Every prompt, tool call, decision, cost, and handoff stays observable and attached to the work.',
+  },
+];
+
+const useCases = [
+  'multi-agent code review',
+  'release audits',
+  'backlog grooming',
+  'security sweeps',
+  'competitive intel',
+  'customer digests',
+  'weekly reports',
+  'standups',
+];
+
+const trustItems = [
+  'Self-hosted first',
+  'MCP-native',
+  'Claude Code · Codex · Gemini',
+  'Unix-level isolation when you need it',
+];
+
+function ProductMockup() {
+  return (
+    <div className={styles.mockup} role="img" aria-label="Agor product preview">
+      <div className={styles.mockupTopbar}>
+        <span />
+        <span />
+        <span />
+      </div>
+      <div className={styles.boardGrid}>
+        <div className={`${styles.zone} ${styles.zoneA}`}>
+          <span>Review lane</span>
+          <div className={styles.branchCard}>
+            <strong>security-audit</strong>
+            <small>3 assistants running</small>
+          </div>
+        </div>
+        <div className={`${styles.zone} ${styles.zoneB}`}>
+          <span>Launch</span>
+          <div className={styles.branchCard}>
+            <strong>docs-refresh</strong>
+            <small>ready for PR</small>
+          </div>
+        </div>
+        <div className={`${styles.zone} ${styles.zoneC}`}>
+          <span>Research</span>
+          <div className={styles.branchCard}>
+            <strong>pricing-intel</strong>
+            <small>scheduled daily</small>
+          </div>
+        </div>
+      </div>
+      <div className={styles.agentBubble}>
+        <div className={styles.avatarStack}>
+          <span>R</span>
+          <span>L</span>
+          <span>S</span>
+        </div>
+        <p>
+          <strong>Scout</strong> found 6 changes, opened a follow-up, and posted the report.
+        </p>
+      </div>
+      <div className={styles.commandCard}>
+        <span className={styles.statusDot} />
+        <span>Schedule · every weekday at 9:00</span>
+      </div>
+    </div>
+  );
+}
+
+export function LandingPage() {
+  const [isContactOpen, setIsContactOpen] = useState(false);
+
+  return (
+    <div className={styles.landingShell}>
+      <section className={styles.heroSection}>
+        <div className={styles.navAnnouncement}>
+          Shared canvas for assistants, schedules, and live work
+        </div>
+        <div className={styles.heroGrid}>
+          <div className={styles.heroCopy}>
+            <div className={styles.brandMark}>
+              {/* biome-ignore lint/performance/noImgElement: Static docs asset */}
+              <img src={LOGO_PATH} alt={`${BRAND_NAME} logo`} />
+              <span>agor</span>
+            </div>
+            <p className={styles.kicker}>Team command center for all things agentic.</p>
+            <h1>Meet your team of AI assistants.</h1>
+            <p className={styles.heroDescription}>
+              Everyone’s cranking with AI, but it’s chaos: scattered sessions, ephemeral context,
+              nothing that compounds. Agor is where your team raises real assistants, wires them
+              into the systems you live in, and watches the work happen in one shared place.
+            </p>
+            <div className={styles.heroActions}>
+              <Link href="/guide" className={styles.primaryButton}>
+                Start with the guide
+              </Link>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={() => setIsContactOpen(true)}
+              >
+                Contact us
+              </button>
+              <Link
+                href={GITHUB_REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.textButton}
+              >
+                View GitHub →
+              </Link>
+            </div>
+          </div>
+          <ProductMockup />
+        </div>
+      </section>
+
+      <section className={styles.assistantStrip} aria-label="Example assistants">
+        <span>Assistants your team can actually share</span>
+        <div>
+          {assistants.map((assistant) => (
+            <strong key={assistant}>@{assistant}</strong>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.problemSection}>
+        <div className={styles.sectionHeader}>
+          <span className={styles.eyebrow}>Why teams need a home for AI work</span>
+          <h2>One agent in a terminal is fine. Five across a team is chaos.</h2>
+        </div>
+        <div className={styles.problemGrid}>
+          {problemCards.map((card) => (
+            <article className={styles.problemCard} key={card.title}>
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.workspaceSection}>
+        <div className={styles.workspaceCopy}>
+          <span className={styles.eyebrow}>The shared workspace</span>
+          <h2>Build assistants that stick around.</h2>
+          <p>
+            Agor gives your team one place to launch assistants, teach them the workflows that
+            matter, coordinate live work, and turn the patterns that work into shared muscle.
+          </p>
+        </div>
+        <div className={styles.featureGrid}>
+          {featureCards.map((feature) => (
+            <article className={styles.featureCard} key={feature.title}>
+              <span>{feature.eyebrow}</span>
+              <h3>{feature.title}</h3>
+              <p>{feature.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.useCaseSection}>
+        <span className={styles.eyebrow}>What teams run</span>
+        <h2>From code reviews to customer digests.</h2>
+        <div className={styles.useCaseGrid}>
+          {useCases.map((useCase) => (
+            <span key={useCase}>{useCase}</span>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.controlSection}>
+        <div>
+          <span className={styles.eyebrow}>Built for real teams</span>
+          <h2>Your work, your data, your assistants.</h2>
+          <p>
+            Self-host Agor, connect the runtimes you already trust, and turn on stronger isolation
+            as the stakes grow. Agents can use Agor over MCP, so the system can help operate itself.
+          </p>
+        </div>
+        <ul className={styles.trustList}>
+          {trustItems.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.finalCta}>
+        <h2>Give your team’s AI work a place to live.</h2>
+        <p>
+          Start with the guide, join the community, or reach out if you’re rolling Agor out for a
+          team.
+        </p>
+        <div className={styles.heroActions}>
+          <Link href="/guide" className={styles.primaryButton}>
+            Read the docs
+          </Link>
+          <Link
+            href={DISCORD_INVITE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.secondaryButton}
+          >
+            Join Discord
+          </Link>
+          <button
+            type="button"
+            className={styles.textButton}
+            onClick={() => setIsContactOpen(true)}
+          >
+            Talk to us →
+          </button>
+        </div>
+      </section>
+
+      <HubSpotFormModal isOpen={isContactOpen} onClose={() => setIsContactOpen(false)} />
+    </div>
+  );
+}

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
 import { HubSpotFormModal } from './HubSpotFormModal';
@@ -9,39 +9,43 @@ const assistants = ['ReviewBot', 'LaunchOps', 'Scout', 'Standup', 'Docs'];
 
 const problemCards = [
   {
-    title: 'Your agents are everywhere',
-    body: 'More models, more tabs, more terminals. Keeping the work straight becomes its own job.',
+    title: 'My agents are everywhere',
+    body: 'More agents, more models, more tabs. Keeping them straight has become its own job.',
   },
   {
-    title: 'Learning stays private',
-    body: 'Great prompts and workflows disappear behind individual screens instead of compounding for the team.',
+    title: 'I can’t see what anyone else is doing',
+    body: 'Teammates find great ways to use AI, but prompts and patterns get reinvented in private.',
   },
   {
-    title: 'Useful bots live on laptops',
-    body: 'PR reviewers, legal helpers, and report writers need ownership, memory, schedules, and visibility.',
+    title: 'Our AI adoption isn’t going anywhere',
+    body: 'Tools were handed out, but there’s no shared place to build assistants together and make them stick.',
+  },
+  {
+    title: 'The bots live on someone’s laptop',
+    body: 'Team-critical helpers need ownership, governance, schedules, and observability in one shared place.',
   },
 ];
 
 const featureCards = [
   {
     eyebrow: '01',
-    title: 'Raise assistants together',
-    body: 'Give each assistant a purpose, memory, skills, and access to the systems your team already uses.',
+    title: 'Give each assistant a real job',
+    body: 'Define what it’s for, give it memory, and wire it into the systems your team already uses.',
   },
   {
     eyebrow: '02',
-    title: 'Work on a shared canvas',
-    body: 'See teammates, branches, live environments, prompts, sessions, and progress in one multiplayer space.',
+    title: 'Make the learning visible',
+    body: 'The whole team can see what each assistant is doing and lift the prompts that work.',
   },
   {
     eyebrow: '03',
     title: 'Let work happen on schedule',
-    body: 'Run audits, standups, grooming, digests, reviews, and reports without waiting for someone to ask.',
+    body: 'Run audits, standups, grooming, digests, reviews, and reports instead of waiting to be asked.',
   },
   {
     eyebrow: '04',
-    title: 'Keep the receipts',
-    body: 'Every prompt, tool call, decision, cost, and handoff stays observable and attached to the work.',
+    title: 'Keep ownership and control',
+    body: 'Model assistants like team members: scoped on purpose, governed, observable, and owned together.',
   },
 ];
 
@@ -99,9 +103,41 @@ function ProductMockup() {
 
 export function LandingPage() {
   const [isContactOpen, setIsContactOpen] = useState(false);
+  const landingRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const landing = landingRef.current;
+    if (!landing || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+
+    let frame = 0;
+    const updateParallax = () => {
+      frame = 0;
+      const progress = Math.min(window.scrollY / 520, 1).toFixed(3);
+      landing.style.setProperty('--hero-scroll', progress);
+    };
+
+    const onScroll = () => {
+      if (frame) {
+        return;
+      }
+      frame = window.requestAnimationFrame(updateParallax);
+    };
+
+    updateParallax();
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      if (frame) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, []);
 
   return (
-    <div className={styles.landingShell}>
+    <div ref={landingRef} className={styles.landingShell}>
       <section className={styles.heroSection}>
         <div className={styles.navAnnouncement}>
           Shared canvas for assistants, schedules, and live work
@@ -146,7 +182,7 @@ export function LandingPage() {
       </section>
 
       <section className={styles.assistantStrip} aria-label="Example assistants">
-        <span>Assistants your team can actually share</span>
+        <span>What works for one person finally reaches everyone</span>
         <div>
           {assistants.map((assistant) => (
             <strong key={assistant}>@{assistant}</strong>
@@ -157,7 +193,7 @@ export function LandingPage() {
       <section className={styles.problemSection}>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Why teams need a home for AI work</span>
-          <h2>One agent in a terminal is fine. Five across a team is chaos.</h2>
+          <h2>Everyone’s cranking with AI. Now make it compound.</h2>
         </div>
         <div className={styles.problemGrid}>
           {problemCards.map((card) => (
@@ -172,7 +208,7 @@ export function LandingPage() {
       <section className={styles.workspaceSection}>
         <div className={styles.workspaceCopy}>
           <span className={styles.eyebrow}>The shared workspace</span>
-          <h2>Build assistants that stick around.</h2>
+          <h2>Raise real assistants, not throwaway agents.</h2>
           <p>
             Agor gives your team one place to launch assistants, teach them the workflows that
             matter, coordinate live work, and turn the patterns that work into shared muscle.
@@ -204,8 +240,9 @@ export function LandingPage() {
           <span className={styles.eyebrow}>Built for real teams</span>
           <h2>Your work, your data, your assistants.</h2>
           <p>
-            Self-host Agor, connect the runtimes you already trust, and turn on stronger isolation
-            as the stakes grow. Agents can use Agor over MCP, so the system can help operate itself.
+            Self-host Agor, connect the best models and harnesses, and keep your data yours. As the
+            stakes grow, add governance, observability, and isolation without locking into one
+            vendor.
           </p>
         </div>
         <ul className={styles.trustList}>

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -201,12 +201,14 @@ export function LandingPage() {
             </div>
             <p className={styles.kicker}>Team command center for all things agentic.</p>
             <h1>Meet your team of AI assistants.</h1>
-            <p className={styles.heroDescription}>
-              Everyone’s cranking with AI.
+            <p className={styles.heroProvocation}>
+              Break out of the terminal.
               <br />
-              But it’s chaos: scattered sessions, ephemeral context, nothing that compounds. Agor is
-              where your team raises real assistants, wires them into the systems you live in, and
-              watches the work happen in one shared place.
+              Bring the team and agents together.
+            </p>
+            <p className={styles.heroDescription}>
+              Agor gives every agent run a place to live: branches, sessions, dev environments,
+              prompts, and teammates together on one shared canvas.
             </p>
             <div className={styles.heroActions}>
               <Link href="/guide" className={styles.primaryButton}>
@@ -302,11 +304,7 @@ export function LandingPage() {
       <section className={styles.productShowcase} data-reveal>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Product surfaces</span>
-          <h2>
-            Break out of the terminal.
-            <br />
-            Bring the team and agents together.
-          </h2>
+          <h2>Show the work, not an abstraction.</h2>
         </div>
         <div className={styles.productGrid}>
           {productPreviews.map((preview, index) => (

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -330,7 +330,7 @@ export function LandingPage() {
       <section className={styles.capabilitySection} data-reveal>
         <div className={styles.sectionHeader}>
           <span className={styles.eyebrow}>Why it becomes a command center</span>
-          <h2>The product is bigger than a chat window.</h2>
+          <h2>This product is much bigger than a chat window.</h2>
         </div>
         <div className={styles.capabilityGrid}>
           {workflowHighlights.map((highlight, index) => (

--- a/apps/agor-docs/components/index.ts
+++ b/apps/agor-docs/components/index.ts
@@ -4,5 +4,6 @@ export { CloudInviteCTA } from './CloudInviteCTA';
 export { DocsBackground } from './DocsBackground';
 export { GifGallery } from './GifGallery';
 export { Hero } from './Hero';
+export { LandingPage } from './LandingPage';
 export { NavbarCloudCTA } from './NavbarCloudCTA';
 export { ParticleBackground } from './ParticleBackground';

--- a/apps/agor-docs/pages/guide/development.mdx
+++ b/apps/agor-docs/pages/guide/development.mdx
@@ -385,7 +385,7 @@ cd apps/agor-daemon && pnpm dev
 
 ## What to Contribute
 
-Browse the **[roadmap issues](https://github.com/preset-io/agor/issues?q=is%3Aissue%20state%3Aopen%20label%3Aroadmap)** for contribution ideas, or propose your own!
+Browse the **[open GitHub issues](https://github.com/preset-io/agor/issues)** for contribution ideas, or propose your own.
 
 ## Getting Help
 

--- a/apps/agor-docs/pages/guide/index.mdx
+++ b/apps/agor-docs/pages/guide/index.mdx
@@ -160,23 +160,11 @@ See the [Architecture Guide](/guide/architecture) for details.
 
 ---
 
-## Roadmap
-
-**[Full roadmap](https://github.com/preset-io/agor/issues?q=is%3Aissue%20state%3Aopen%20label%3Aroadmap)**
-
-Highlights:
-
-- **Match CLI-Native Features** — SDKs are evolving rapidly and exposing more functionality. Our goal is to push integrations deeper to match all key features available in the underlying CLIs, closing the gap between SDK-based orchestration and native tool capabilities
-- **Bring Your Own IDE** — Connect VSCode, Cursor, or any IDE directly to Agor-managed branches via SSH/Remote. Keep your familiar editor and agent while Agor orchestrates sessions, tracks progress, and enables team visibility on the multiplayer board
-- **Unix User Integration** — Enable true multi-tenancy with per-user Unix isolation for secure collaboration. [Read the guide →](/guide/multiplayer-unix-isolation)
-
----
-
 ## Contributing
 
 TypeScript strict mode, branded types, repository pattern with Drizzle ORM.
 
-Read the [Development Guide](/guide/development) for dev workflow and detailed roadmap.
+Read the [Development Guide](/guide/development) for the local development workflow.
 
 ---
 

--- a/apps/agor-docs/pages/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/pages/guide/sdk-comparison.mdx
@@ -868,8 +868,6 @@ OpenCode supports MCP servers via its REST API:
 
 As agent SDKs evolve, Agor will gain new capabilities.
 
-**[See full roadmap on GitHub](https://github.com/preset-io/agor/issues?q=is%3Aissue%20state%3Aopen%20label%3Aroadmap)**
-
 Agent integration priorities:
 
 - **Codex text streaming** - The Codex SDK (`@openai/codex-sdk`) does not support token-level text streaming as of v0.99.0. When OpenAI adds `item.updated` support for `agent_message` items (or a new text delta event), Agor's code is already prepared to handle it

--- a/apps/agor-docs/pages/index.mdx
+++ b/apps/agor-docs/pages/index.mdx
@@ -1,11 +1,8 @@
-import { Hero } from '../components';
+---
+title: agor
+description: Meet your team of AI assistants. Team command center for all things agentic.
+---
 
-{/* Trigger GHA build */}
+import { LandingPage } from '../components';
 
-<Hero
-  title="agor"
-  subtitle="Team command center for all things agentic"
-  description="A shared canvas where coding agents (Claude Code, Codex, Gemini) and long-lived assistants run side-by-side on isolated git branches. Your whole team rallies around the same live work in real time, and the agents themselves drive Agor over MCP."
-  ctaText="Learn More!"
-  ctaLink="/guide"
-/>
+<LandingPage />


### PR DESCRIPTION
## Summary
- Replaces the docs homepage with a polished marketing landing page built around the updated assistant/team command-center positioning.
- Adds a responsive hero with product-style canvas mockup, clearer CTAs, problem framing, benefit cards, use cases, and self-hosted/MCP/runtime trust notes.
- Keeps the root page as a Nextra MDX entry point with metadata while moving the focused landing implementation into reusable docs components.

## Checks
- `pnpm --filter @agor/docs validate:social-metadata`
- `pnpm --filter @agor/docs typecheck`
- `pnpm -w exec biome check apps/agor-docs/components/LandingPage.tsx apps/agor-docs/components/LandingPage.module.css apps/agor-docs/pages/index.mdx apps/agor-docs/components/index.ts`

## Visual validation
- Inspected the updated local docs homepage with Playwright at desktop and mobile viewport sizes.
- Captured viewport and full-page screenshots locally to verify layout rhythm, responsive wrapping, and CTA visibility before removing screenshot artifacts from the branch.
