### PR TITLE
Fix remote child session list enrichment

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -59,6 +59,9 @@ export interface SessionsServiceImpl extends Service<Session, Partial<Session>, 
     ancestors: import('@agor/core/types').Session[];
     children: import('@agor/core/types').Session[];
   }>;
+  enrichRemoteRelationships(
+    sessionList: import('@agor/core/types').Session[]
+  ): Promise<import('@agor/core/types').Session[]>;
   // Callback queue processing
   setQueueProcessor(
     processor: (

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -20,6 +20,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  enrichSessionFindResultWithRemoteRelationships,
   isPromptFlowPatchOnly,
   PROMPT_FLOW_PATCH_FIELDS,
   shouldDrainQueueAfterSessionPostTurnPatch,
@@ -27,6 +28,23 @@ import {
   shouldValidateRepoEnvironmentPayload,
 } from './register-hooks';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization';
+
+const makeSession = (sessionId: string): import('@agor/core/types').Session =>
+  ({
+    session_id: sessionId,
+    branch_id: 'branch-1',
+    status: 'idle',
+    agentic_tool: 'codex',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_updated: '2026-01-01T00:00:00.000Z',
+    tasks: [],
+    genealogy: { children: [] },
+    contextFiles: [],
+    git_state: { ref: 'main', base_sha: 'abc', current_sha: 'abc' },
+    scheduled_from_branch: false,
+    ready_for_prompt: false,
+    archived: false,
+  }) as import('@agor/core/types').Session;
 
 describe('shouldValidateRepoEnvironmentPayload', () => {
   it('skips absent repo environment payloads', () => {
@@ -82,6 +100,64 @@ describe('shouldDrainQueueAfterSessionPostTurnPatch', () => {
     expect(
       shouldDrainQueueAfterSessionPostTurnPatch({ status: 'idle', ready_for_prompt: false })
     ).toBe(false);
+  });
+});
+
+describe('enrichSessionFindResultWithRemoteRelationships', () => {
+  it('enriches paginated results produced by before.find RBAC scoping', async () => {
+    const session = makeSession('session-1');
+    const relationship = {
+      relationship_id: 'relationship-1',
+      source_session_id: 'session-1',
+      target_session_id: 'session-2',
+      relationship_type: 'remote_create',
+      created_by: 'user-1',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      callback_enabled: false,
+      callback_session_id: null,
+      data: null,
+    } as const;
+    let calls = 0;
+    const service = {
+      async enrichRemoteRelationships(sessions: import('@agor/core/types').Session[]) {
+        calls += 1;
+        return sessions.map((item) =>
+          item.session_id === session.session_id
+            ? { ...item, remote_relationships: { as_source: [relationship], as_target: [] } }
+            : item
+        );
+      },
+    };
+
+    const result = await enrichSessionFindResultWithRemoteRelationships(
+      { total: 1, limit: 10, skip: 0, data: [session] },
+      service
+    );
+
+    expect(calls).toBe(1);
+    expect(Array.isArray(result)).toBe(false);
+    expect(Array.isArray(result) ? null : result.data[0].remote_relationships?.as_source?.[0]).toBe(
+      relationship
+    );
+  });
+
+  it('does not enrich a result that the sessions service already enriched', async () => {
+    const session = makeSession('session-1');
+    let calls = 0;
+    const service = {
+      async enrichRemoteRelationships(sessions: import('@agor/core/types').Session[]) {
+        calls += 1;
+        return sessions.map((item) => ({ ...item, title: 'enriched twice' }));
+      },
+    };
+
+    const once = await enrichSessionFindResultWithRemoteRelationships([session], service);
+    const twice = await enrichSessionFindResultWithRemoteRelationships(once, service);
+
+    expect(twice).toBe(once);
+    expect(calls).toBe(1);
+    expect((twice as import('@agor/core/types').Session[])[0].title).toBe('enriched twice');
   });
 });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -71,6 +71,7 @@ import type { ArtifactsService } from './services/artifacts.js';
 import { normalizeBoardObjectFindQuery } from './services/board-objects.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
+import type { SessionParams } from './services/sessions.js';
 import { isLocalAuthenticationLookup } from './services/users.js';
 import { buildSessionCreatedAnalyticsProperties } from './utils/analytics-payloads.js';
 import { applySessionConfigDefaults } from './utils/apply-session-config-defaults.js';
@@ -2209,6 +2210,31 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
     },
     after: {
+      find: [
+        async (context) => {
+          // In RBAC mode, scopeSessionQuery() resolves the paginated result in
+          // before.find for SQL-efficient access control. That intentionally
+          // short-circuits SessionsService.find(), so enrich list payloads here
+          // as a single batched query over the final page.
+          const params = context.params as SessionParams | undefined;
+          if (params?._remote_relationships_enriched) return context;
+
+          const result = context.result as Paginated<Session> | Session[];
+          if (Array.isArray(result)) {
+            context.result = await sessionsService.enrichRemoteRelationships(result);
+            return context;
+          }
+
+          if (result?.data) {
+            context.result = {
+              ...result,
+              data: await sessionsService.enrichRemoteRelationships(result.data),
+            };
+          }
+
+          return context;
+        },
+      ],
       get: [
         async (context) => {
           // Attach an MCP token for fetched session (cached/reused when still valid).

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -71,7 +71,10 @@ import type { ArtifactsService } from './services/artifacts.js';
 import { normalizeBoardObjectFindQuery } from './services/board-objects.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
-import type { SessionParams } from './services/sessions.js';
+import {
+  isRemoteRelationshipsEnrichedResult,
+  markRemoteRelationshipsEnrichedResult,
+} from './services/sessions.js';
 import { isLocalAuthenticationLookup } from './services/users.js';
 import { buildSessionCreatedAnalyticsProperties } from './utils/analytics-payloads.js';
 import { applySessionConfigDefaults } from './utils/apply-session-config-defaults.js';
@@ -309,6 +312,24 @@ export function shouldDrainQueueAfterSessionPostTurnPatch(
     session.ready_for_prompt === true &&
     !isTerminalQueueProcessingSuppressed(params)
   );
+}
+
+export async function enrichSessionFindResultWithRemoteRelationships(
+  result: Paginated<Session> | Session[],
+  sessionsService: Pick<SessionsServiceImpl, 'enrichRemoteRelationships'>
+): Promise<Paginated<Session> | Session[]> {
+  if (isRemoteRelationshipsEnrichedResult(result)) return result;
+
+  if (Array.isArray(result)) {
+    return markRemoteRelationshipsEnrichedResult(
+      await sessionsService.enrichRemoteRelationships(result)
+    );
+  }
+
+  return markRemoteRelationshipsEnrichedResult({
+    ...result,
+    data: await sessionsService.enrichRemoteRelationships(result.data),
+  });
 }
 
 /**
@@ -2216,22 +2237,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           // before.find for SQL-efficient access control. That intentionally
           // short-circuits SessionsService.find(), so enrich list payloads here
           // as a single batched query over the final page.
-          const params = context.params as SessionParams | undefined;
-          if (params?._remote_relationships_enriched) return context;
-
-          const result = context.result as Paginated<Session> | Session[];
-          if (Array.isArray(result)) {
-            context.result = await sessionsService.enrichRemoteRelationships(result);
-            return context;
-          }
-
-          if (result?.data) {
-            context.result = {
-              ...result,
-              data: await sessionsService.enrichRemoteRelationships(result.data),
-            };
-          }
-
+          context.result = await enrichSessionFindResultWithRemoteRelationships(
+            context.result as Paginated<Session> | Session[],
+            sessionsService
+          );
           return context;
         },
       ],

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -86,9 +86,20 @@ export type SessionParams = QueryParams<{
   InternalEnrichmentParams & {
     /** Root-level include_last_message flag (bypasses Feathers query filtering, used by internal service calls) */
     _include_last_message?: boolean | 'true' | 'false';
-    /** Internal marker to avoid enriching the same find result twice in hooks. */
-    _remote_relationships_enriched?: boolean;
   };
+
+const remoteRelationshipsEnrichedResults = new WeakSet<object>();
+
+export function markRemoteRelationshipsEnrichedResult<T extends object>(result: T): T {
+  remoteRelationshipsEnrichedResults.add(result);
+  return result;
+}
+
+export function isRemoteRelationshipsEnrichedResult(result: unknown): boolean {
+  return (
+    typeof result === 'object' && result !== null && remoteRelationshipsEnrichedResults.has(result)
+  );
+}
 
 /**
  * Execute task data payload
@@ -802,16 +813,14 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
 
     if (Array.isArray(result)) {
       const enriched = await this.enrichRemoteRelationships(result);
-      if (params) params._remote_relationships_enriched = true;
-      return enriched;
+      return markRemoteRelationshipsEnrichedResult(enriched);
     }
 
     const enrichedData = await this.enrichRemoteRelationships(result.data);
-    if (params) params._remote_relationships_enriched = true;
-    return {
+    return markRemoteRelationshipsEnrichedResult({
       ...result,
       data: enrichedData,
-    };
+    });
   }
 }
 

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -86,6 +86,8 @@ export type SessionParams = QueryParams<{
   InternalEnrichmentParams & {
     /** Root-level include_last_message flag (bypasses Feathers query filtering, used by internal service calls) */
     _include_last_message?: boolean | 'true' | 'false';
+    /** Internal marker to avoid enriching the same find result twice in hooks. */
+    _remote_relationships_enriched?: boolean;
   };
 
 /**
@@ -136,7 +138,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     this.usersRepo = new UsersRepository(db);
   }
 
-  private async enrichRemoteRelationships(sessionList: Session[]): Promise<Session[]> {
+  async enrichRemoteRelationships(sessionList: Session[]): Promise<Session[]> {
     const sessionIds = sessionList.map((session) => session.session_id);
     if (sessionIds.length === 0) return sessionList;
 
@@ -799,12 +801,16 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     const result = await super.find(params);
 
     if (Array.isArray(result)) {
-      return this.enrichRemoteRelationships(result);
+      const enriched = await this.enrichRemoteRelationships(result);
+      if (params) params._remote_relationships_enriched = true;
+      return enriched;
     }
 
+    const enrichedData = await this.enrichRemoteRelationships(result.data);
+    if (params) params._remote_relationships_enriched = true;
     return {
       ...result,
-      data: await this.enrichRemoteRelationships(result.data),
+      data: enrichedData,
     };
   }
 }

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -309,6 +309,42 @@ function preserveSessionRelationshipFields(session: Session, existing?: Session)
   };
 }
 
+function createRemoteSurrogateSession(
+  sourceSession: Session,
+  targetSession: Session,
+  relationship: NonNullable<NonNullable<Session['remote_relationships']>['as_source']>[number]
+): Session | null {
+  if (relationship.relationship_type !== 'remote_create') return null;
+  if (targetSession.archived) return null;
+  if (targetSession.branch_id === sourceSession.branch_id) return null;
+
+  return {
+    ...targetSession,
+    branch_id: sourceSession.branch_id,
+    genealogy: {
+      ...(targetSession.genealogy ?? {}),
+      parent_session_id: sourceSession.session_id,
+    },
+    remote_surrogate: {
+      relationship,
+      source_session_id: sourceSession.session_id,
+      source_branch_id: sourceSession.branch_id,
+      target_branch_id: targetSession.branch_id,
+    },
+  };
+}
+
+function findSessionInBranchBuckets(
+  sessionsByBranchId: Map<string, Session[]>,
+  sessionId: string
+): Session | undefined {
+  for (const bucket of sessionsByBranchId.values()) {
+    const session = bucket.find((candidate) => candidate.session_id === sessionId);
+    if (session && !session.remote_surrogate) return session;
+  }
+  return undefined;
+}
+
 export function useAgorData(
   client: AgorClient | null,
   options?: { enabled?: boolean; directSessionId?: string | null }
@@ -635,8 +671,7 @@ export function useAgorData(
             if (relationship.relationship_type !== 'remote_create') continue;
 
             const targetSession = sessionsById.get(relationship.target_session_id);
-            if (!targetSession || targetSession.archived) continue;
-            if (targetSession.branch_id === sourceSession.branch_id) continue;
+            if (!targetSession) continue;
 
             const sourceBranchSessions = sessionsByBranchId.get(sourceSession.branch_id) ?? [];
             if (
@@ -647,20 +682,12 @@ export function useAgorData(
               continue;
             }
 
-            const remoteSurrogate: Session = {
-              ...targetSession,
-              branch_id: sourceSession.branch_id,
-              genealogy: {
-                ...(targetSession.genealogy ?? {}),
-                parent_session_id: sourceSession.session_id,
-              },
-              remote_surrogate: {
-                relationship,
-                source_session_id: sourceSession.session_id,
-                source_branch_id: sourceSession.branch_id,
-                target_branch_id: targetSession.branch_id,
-              },
-            };
+            const remoteSurrogate = createRemoteSurrogateSession(
+              sourceSession,
+              targetSession,
+              relationship
+            );
+            if (!remoteSurrogate) continue;
 
             sessionsByBranchId.set(sourceSession.branch_id, [
               ...sourceBranchSessions,
@@ -1053,6 +1080,36 @@ export function useAgorData(
           if (bucketChanged) {
             next.set(branchId, refreshedBucket);
           }
+        }
+
+        // Remote relationships are created after the canonical target session
+        // row. The daemon then emits a patched source session with
+        // remote_relationships.as_source populated. Project that single source
+        // row into muted remote-surrogate children now, instead of doing any
+        // expensive relationship work during render.
+        for (const relationship of mergedSession.remote_relationships?.as_source ?? []) {
+          if (relationship.relationship_type !== 'remote_create') continue;
+
+          const targetSession = findSessionInBranchBuckets(next, relationship.target_session_id);
+          if (!targetSession) continue;
+
+          const sourceBranchSessions = next.get(mergedSession.branch_id) ?? [];
+          if (
+            sourceBranchSessions.some(
+              (candidate) => candidate.session_id === targetSession.session_id
+            )
+          ) {
+            continue;
+          }
+
+          const remoteSurrogate = createRemoteSurrogateSession(
+            mergedSession,
+            targetSession,
+            relationship
+          );
+          if (!remoteSurrogate) continue;
+
+          next.set(mergedSession.branch_id, [...sourceBranchSessions, remoteSurrogate]);
         }
 
         return next;

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -1035,50 +1035,51 @@ export function useAgorData(
 
         const branchSessions = next.get(newBranchId) || [];
         const index = branchSessions.findIndex((s) => s.session_id === session.session_id);
+        let sourceSessionForRemoteProjection = session;
 
         if (index === -1) {
           next.set(newBranchId, [...branchSessions, session]);
-          return next;
-        }
+        } else {
+          const mergedSession = preserveSessionRelationshipFields(session, branchSessions[index]);
+          sourceSessionForRemoteProjection = mergedSession;
 
-        const mergedSession = preserveSessionRelationshipFields(session, branchSessions[index]);
+          // Bail out when the session is content-equal to what we already hold.
+          // Mirrors the sessionById bailout above so an idempotent patch doesn't
+          // produce a fresh branch-bucket array (which would invalidate
+          // `data.sessions === n.sessions` in BranchNode's custom areEqual and
+          // re-render every BranchCard on the affected branch).
+          if (
+            branchSessions[index] === mergedSession ||
+            shallowEqualEntity(branchSessions[index], mergedSession)
+          ) {
+            return changed ? next : prev;
+          }
 
-        // Bail out when the session is content-equal to what we already hold.
-        // Mirrors the sessionById bailout above so an idempotent patch doesn't
-        // produce a fresh branch-bucket array (which would invalidate
-        // `data.sessions === n.sessions` in BranchNode's custom areEqual and
-        // re-render every BranchCard on the affected branch).
-        if (
-          branchSessions[index] === mergedSession ||
-          shallowEqualEntity(branchSessions[index], mergedSession)
-        ) {
-          return changed ? next : prev;
-        }
+          const updatedSessions = [...branchSessions];
+          updatedSessions[index] = mergedSession;
+          next.set(newBranchId, updatedSessions);
 
-        const updatedSessions = [...branchSessions];
-        updatedSessions[index] = mergedSession;
-        next.set(newBranchId, updatedSessions);
+          // Also update any remote/surrogate projections of this session that
+          // live in source-branch buckets. Preserve their local tree placement
+          // while refreshing status/callback_config/etc. from the canonical row.
+          for (const [branchId, bucket] of next) {
+            if (branchId === newBranchId) continue;
 
-        // Also update any remote/surrogate projections of this session that
-        // live in source-branch buckets. Preserve their local tree placement
-        // while refreshing status/callback_config/etc. from the canonical row.
-        for (const [branchId, bucket] of next) {
-          if (branchId === newBranchId) continue;
+            let bucketChanged = false;
+            const refreshedBucket = bucket.map((item) => {
+              if (item.session_id !== session.session_id) return item;
+              bucketChanged = true;
+              return {
+                ...preserveSessionRelationshipFields(session, item),
+                branch_id: item.branch_id,
+                genealogy: item.genealogy,
+                remote_surrogate: item.remote_surrogate,
+              };
+            });
 
-          let bucketChanged = false;
-          const refreshedBucket = bucket.map((item) => {
-            if (item.session_id !== session.session_id) return item;
-            bucketChanged = true;
-            return {
-              ...preserveSessionRelationshipFields(session, item),
-              branch_id: item.branch_id,
-              genealogy: item.genealogy,
-              remote_surrogate: item.remote_surrogate,
-            };
-          });
-
-          if (bucketChanged) {
-            next.set(branchId, refreshedBucket);
+            if (bucketChanged) {
+              next.set(branchId, refreshedBucket);
+            }
           }
         }
 
@@ -1087,13 +1088,14 @@ export function useAgorData(
         // remote_relationships.as_source populated. Project that single source
         // row into muted remote-surrogate children now, instead of doing any
         // expensive relationship work during render.
-        for (const relationship of mergedSession.remote_relationships?.as_source ?? []) {
+        for (const relationship of sourceSessionForRemoteProjection.remote_relationships
+          ?.as_source ?? []) {
           if (relationship.relationship_type !== 'remote_create') continue;
 
           const targetSession = findSessionInBranchBuckets(next, relationship.target_session_id);
           if (!targetSession) continue;
 
-          const sourceBranchSessions = next.get(mergedSession.branch_id) ?? [];
+          const sourceBranchSessions = next.get(sourceSessionForRemoteProjection.branch_id) ?? [];
           if (
             sourceBranchSessions.some(
               (candidate) => candidate.session_id === targetSession.session_id
@@ -1103,13 +1105,16 @@ export function useAgorData(
           }
 
           const remoteSurrogate = createRemoteSurrogateSession(
-            mergedSession,
+            sourceSessionForRemoteProjection,
             targetSession,
             relationship
           );
           if (!remoteSurrogate) continue;
 
-          next.set(mergedSession.branch_id, [...sourceBranchSessions, remoteSurrogate]);
+          next.set(sourceSessionForRemoteProjection.branch_id, [
+            ...sourceBranchSessions,
+            remoteSurrogate,
+          ]);
         }
 
         return next;


### PR DESCRIPTION
## Summary

- Enrich `sessions.find` results with durable remote relationships even when RBAC `scopeSessionQuery` short-circuits the service method.
- Keep relationship enrichment batched over the final result page to avoid N+1 lookups.
- Project remote child surrogate sessions on live source-session patch events so branch cards update without render-time relationship work.

## Root cause

`SessionsService.get()` already enriched `remote_relationships`, and `SessionsService.find()` attempted to do the same. However, when branch RBAC is enabled, the `scopeSessionQuery()` before-hook sets `context.result` directly for efficient access control. That skips the service `find()` method, so `/sessions?...` and `agor_sessions_list` returned sessions without `remote_relationships`.

The UI depends on `sourceSession.remote_relationships?.as_source` from the sessions list to render cross-branch remote child surrogates, so the remote child session did not appear under the source branch.

## Changes

### Backend

- Exposes `SessionsService.enrichRemoteRelationships()` for hook use.
- Adds an `after.find` sessions hook to enrich list payloads after RBAC scoping.
- Marks already-enriched service results to avoid duplicate relationship queries on non-RBAC paths.

### Frontend

- Extracts remote surrogate session construction into a helper.
- Reuses the helper for initial data projection.
- Adds an event-time projection when a patched source session receives `remote_relationships.as_source`, avoiding expensive lookups or RBAC logic during render.

## Verification

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- register-hooks.test.ts mcp/tools/sessions.test.ts`
- `pnpm --filter agor-ui test -- BranchSessionSections.test.tsx`

## Notes

`pnpm i` logged a transient `node-pty@1.0.0` native build failure for the optional/fallback install path (`make` unavailable), but pnpm completed successfully and subsequent checks/tests passed.
