### PR TITLE
Streamline onboarding wizard

### DIFF
--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -93,7 +93,8 @@ describe('OnboardingWizard', () => {
     const onUpdateUser = vi.fn(async () => undefined);
     renderWizard({ onUpdateUser });
 
-    expect(screen.getByText(/Name your assistant/i)).toBeInTheDocument();
+    expect(screen.getByText(/Create your assistant/i)).toBeInTheDocument();
+    expect(screen.getByText(/persistent agent for setup and ongoing work/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /emoji picker/i })).toBeInTheDocument();
     expect(screen.getByDisplayValue('My Assistant')).toBeInTheDocument();
     expect(screen.queryByText(/Welcome to Agor/i)).not.toBeInTheDocument();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -193,6 +193,56 @@ describe('OnboardingWizard', () => {
     expect(body).toHaveStyle({ minHeight: '440px', maxHeight: '640px', overflowY: 'auto' });
   });
 
+  it('ignores stale failed framework repo rows when retrying setup', async () => {
+    const repoById = new Map<string, Repo>([
+      [
+        'failed-old',
+        makeRepo({
+          repo_id: 'failed-old',
+          clone_status: 'failed',
+          clone_error: { message: 'old failure', exit_code: 1 },
+        }),
+      ],
+    ]);
+    const onCreateRepo = vi.fn(async () => undefined);
+    const view = renderWizard({ repoById, onCreateRepo });
+
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
+
+    await waitFor(() => expect(onCreateRepo).toHaveBeenCalled());
+    expect(screen.getByText(/Cloning assistant framework/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Setup failed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/old failure/i)).not.toBeInTheDocument();
+
+    const nextRepoById = new Map(repoById);
+    nextRepoById.set(
+      'failed-new',
+      makeRepo({
+        repo_id: 'failed-new',
+        clone_status: 'failed',
+        clone_error: { message: 'new failure', exit_code: 1 },
+      })
+    );
+    view.rerender(<OnboardingWizard {...view.props} repoById={nextRepoById} />);
+
+    expect(await screen.findByText(/Setup failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/new failure/i)).toBeInTheDocument();
+  });
+
+  it('uses an existing ready framework repo without cloning it again', async () => {
+    const repoById = new Map<string, Repo>([['repo-1', makeRepo()]]);
+    const onCreateRepo = vi.fn(async () => undefined);
+    const onCreateBranch = vi.fn(async () => makeBranch());
+    renderWizard({ repoById, onCreateRepo, onCreateBranch });
+
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
+
+    await waitFor(() => expect(onCreateBranch).toHaveBeenCalled());
+    expect(onCreateRepo).not.toHaveBeenCalled();
+  });
+
   it('creates setup resources with the default assistant branch name and preserves model defaults', async () => {
     const repoById = new Map<string, Repo>();
     const onCreateBranch = vi.fn(async () =>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -177,20 +177,20 @@ describe('OnboardingWizard', () => {
     });
   });
 
-  it('uses one fixed modal body for input and loading steps', async () => {
+  it('uses one bounded modal body for input and loading steps', async () => {
     renderWizard();
     const body = document.querySelector('.ant-modal-body') as HTMLElement;
-    expect(body).toHaveStyle({ height: '440px', overflowY: 'auto' });
+    expect(body).toHaveStyle({ minHeight: '440px', maxHeight: '640px', overflowY: 'auto' });
 
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     expect(document.querySelector('.ant-modal-body')).toBe(body);
-    expect(body).toHaveStyle({ height: '440px', overflowY: 'auto' });
+    expect(body).toHaveStyle({ minHeight: '440px', maxHeight: '640px', overflowY: 'auto' });
 
     fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
     expect(await screen.findByText(/Setting up Agor/i)).toBeInTheDocument();
     expect(screen.getByText(/Cloning assistant framework/i)).toBeInTheDocument();
     expect(document.querySelector('.ant-modal-body')).toBe(body);
-    expect(body).toHaveStyle({ height: '440px', overflowY: 'auto' });
+    expect(body).toHaveStyle({ minHeight: '440px', maxHeight: '640px', overflowY: 'auto' });
   });
 
   it('creates setup resources with the default assistant branch name and preserves model defaults', async () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -1,6 +1,7 @@
-import type { User } from '@agor-live/client';
-import { fireEvent, render, screen } from '@testing-library/react';
+import type { Board, Branch, Repo, User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ComponentProps } from 'react';
+import { FRAMEWORK_REPO_SLUG } from '../../hooks/useFrameworkRepo';
 import { OnboardingWizard } from './OnboardingWizard';
 
 vi.mock('../EmojiPickerInput/EmojiPickerInput', () => ({
@@ -9,6 +10,16 @@ vi.mock('../EmojiPickerInput/EmojiPickerInput', () => ({
       {value}
     </button>
   ),
+}));
+
+vi.mock('../../utils/startAssistantBootstrapSession', () => ({
+  startAssistantBootstrapSession: vi.fn(async ({ onCreateSession, sessionConfig, boardId }) => {
+    return (await onCreateSession(sessionConfig, boardId)) || 'session-1';
+  }),
+}));
+
+vi.mock('../../utils/assistantWelcomeNote', () => ({
+  ensureAssistantWelcomeNote: vi.fn(async () => undefined),
 }));
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -25,136 +36,229 @@ function makeUser(overrides: Partial<User> = {}): User {
   } as unknown as User;
 }
 
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    repo_id: 'repo-1',
+    slug: FRAMEWORK_REPO_SLUG,
+    remote_url: 'https://github.com/preset-io/agor-assistant.git',
+    clone_status: 'ready',
+    default_branch: 'main',
+    ...overrides,
+  } as Repo;
+}
+
+function makeBranch(overrides: Partial<Branch> = {}): Branch {
+  return {
+    branch_id: 'branch-1',
+    repo_id: 'repo-1',
+    name: 'private-my-assistant',
+    ref: 'private-my-assistant',
+    created_by: 'user-1',
+    ...overrides,
+  } as Branch;
+}
+
 function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>> = {}) {
+  const boardsService = {
+    create: vi.fn(async () => ({ board_id: 'board-1', created_by: 'user-1' })),
+    setPrimaryAssistant: vi.fn(async () => undefined),
+    ensureAssistantWelcomeNote: vi.fn(async () => undefined),
+  };
   const reposService = { on: vi.fn(), removeListener: vi.fn() };
   const client = {
     io: { on: vi.fn(), off: vi.fn() },
-    service: vi.fn(() => reposService),
+    service: vi.fn((name: string) => (name === 'boards' ? boardsService : reposService)),
   };
+  const props = {
+    open: true,
+    onComplete: vi.fn(),
+    repoById: new Map<string, Repo>(),
+    branchById: new Map<string, Branch>(),
+    boardById: new Map<string, Board>(),
+    user: makeUser(),
+    client,
+    onCreateRepo: vi.fn(async () => undefined),
+    onCreateLocalRepo: vi.fn(),
+    onCreateBranch: vi.fn(async () => makeBranch()),
+    onCreateSession: vi.fn(async () => 'session-1'),
+    onUpdateUser: vi.fn(async () => undefined),
+    ...overrides,
+  } satisfies ComponentProps<typeof OnboardingWizard>;
 
-  return render(
-    <OnboardingWizard
-      open={true}
-      onComplete={vi.fn()}
-      repoById={new Map()}
-      branchById={new Map()}
-      boardById={new Map()}
-      user={makeUser()}
-      client={client}
-      onCreateRepo={vi.fn()}
-      onCreateLocalRepo={vi.fn()}
-      onCreateBranch={vi.fn()}
-      onCreateSession={vi.fn()}
-      onUpdateUser={vi.fn()}
-      {...overrides}
-    />
-  );
+  return { ...render(<OnboardingWizard {...props} />), props, client, boardsService };
 }
 
 describe('OnboardingWizard', () => {
-  it('starts onboarding through assistant creation only', async () => {
-    const onUpdateUser = vi.fn();
+  it('starts on assistant name and emoji only, then advances to LLM setup', async () => {
+    const onUpdateUser = vi.fn(async () => undefined);
     renderWizard({ onUpdateUser });
 
-    expect(screen.getByText(/Welcome to Agor/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /create your assistant/i })).toBeInTheDocument();
-    expect(screen.getByText('Your assistant can help:')).toBeInTheDocument();
-    expect(screen.getByText(/connect tools and credentials/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Agor assistant/i })).toHaveAttribute(
-      'href',
-      'https://agor.live/guide/assistants'
-    );
-    expect(screen.getByRole('link', { name: /getting started guide/i })).toBeInTheDocument();
-    expect(screen.queryByText(/bring your own repository/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Name your assistant/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /emoji picker/i })).toBeInTheDocument();
+    expect(screen.getByDisplayValue('My Assistant')).toBeInTheDocument();
+    expect(screen.queryByText(/Welcome to Agor/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Add Your Repository/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Branch name/i)).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
+    fireEvent.change(screen.getByDisplayValue('My Assistant'), { target: { value: 'Scout' } });
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
 
-    expect(await screen.findByText('Name Your Assistant')).toBeInTheDocument();
+    expect(await screen.findByText(/Choose your LLM/i)).toBeInTheDocument();
+    expect(screen.getByText(/Step 2 of 2/i)).toBeInTheDocument();
     expect(onUpdateUser).toHaveBeenCalledWith(
       'user-1',
       expect.objectContaining({
         preferences: expect.objectContaining({
-          onboarding: expect.objectContaining({ path: 'assistant' }),
+          onboarding: expect.objectContaining({
+            path: 'assistant',
+            assistantDisplayName: 'Scout',
+            assistantEmoji: '🤖',
+          }),
         }),
       })
     );
   });
 
-  it('does not resume legacy own-repo onboarding as an alternate path', async () => {
-    renderWizard({
-      user: makeUser({
-        preferences: { onboarding: { path: 'own-repo' } },
-      } as Partial<User>),
-    });
-
-    expect(await screen.findByText('Name Your Assistant')).toBeInTheDocument();
-    expect(screen.queryByText('Add Your Repository')).not.toBeInTheDocument();
-  });
-
   it('shows recommended provider cards plus a secondary selector', async () => {
     const { baseElement } = renderWizard();
 
-    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
-    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
 
-    expect(await screen.findByText('Choose an LLM Provider')).toBeInTheDocument();
-    expect(screen.getByText(/Pick what powers your assistant/i)).toBeInTheDocument();
+    expect(await screen.findByText('Choose your LLM')).toBeInTheDocument();
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
     expect(screen.getByText('Codex')).toBeInTheDocument();
     expect(screen.getByAltText('claude-code logo')).toBeInTheDocument();
     expect(screen.getByAltText('codex logo')).toBeInTheDocument();
-    expect(screen.getByRole('list', { name: /onboarding progress/i })).toBeInTheDocument();
     const providerOptions = Array.from(
       baseElement.querySelectorAll<HTMLInputElement>('input[name="recommended-agent"]')
     );
     const claudeOption = providerOptions.find((option) => option.value === 'claude-code');
     const codexOption = providerOptions.find((option) => option.value === 'codex');
-    expect(claudeOption).toBeInstanceOf(HTMLInputElement);
     expect(claudeOption).toBeChecked();
     expect(screen.getAllByText(/ANTHROPIC_API_KEY/).length).toBeGreaterThan(0);
+
     fireEvent.click(screen.getByText('Subscription'));
     expect(screen.getByText(/claude setup-token/)).toBeInTheDocument();
-    expect(codexOption).toBeInstanceOf(HTMLInputElement);
-    expect(codexOption).not.toBeChecked();
-    codexOption?.focus();
-    expect(codexOption).toHaveFocus();
 
     fireEvent.click(codexOption as HTMLInputElement);
-
     expect(codexOption).toBeChecked();
     expect(screen.getByRole('checkbox', { name: /use a different provider/i })).toBeInTheDocument();
     expect(screen.queryByText('Other LLM providers')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('checkbox', { name: /use a different provider/i }));
-
     expect(screen.getByText('Other LLM providers')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('checkbox', { name: /use a different provider/i }));
-    expect(codexOption).toBeChecked();
-    expect(screen.queryByText('Configure Your Agent')).not.toBeInTheDocument();
-    expect(screen.getAllByText(/codex login --device-auth/).length).toBeGreaterThan(0);
   });
 
   it('can save a Claude subscription token during onboarding', async () => {
-    const onUpdateUser = vi.fn();
+    const onUpdateUser = vi.fn(async () => undefined);
     renderWizard({ onUpdateUser });
 
-    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
-    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
-
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     fireEvent.click(await screen.findByText('Subscription'));
     fireEvent.change(screen.getByPlaceholderText('sk-ant-oat01-...'), {
       target: { value: 'sk-ant-oat01-test' },
     });
     fireEvent.click(screen.getByRole('button', { name: /save & continue/i }));
 
-    expect(onUpdateUser).toHaveBeenCalledWith(
-      'user-1',
-      expect.objectContaining({
-        agentic_tools: {
-          'claude-code': { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' },
-        },
-      })
+    await waitFor(() => {
+      expect(onUpdateUser).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          agentic_tools: {
+            'claude-code': { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' },
+          },
+        })
+      );
+    });
+  });
+
+  it('uses one fixed modal body for input and loading steps', async () => {
+    renderWizard();
+    const body = document.querySelector('.ant-modal-body') as HTMLElement;
+    expect(body).toHaveStyle({ height: '440px', overflowY: 'auto' });
+
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    expect(document.querySelector('.ant-modal-body')).toBe(body);
+    expect(body).toHaveStyle({ height: '440px', overflowY: 'auto' });
+
+    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
+    expect(await screen.findByText(/Setting up Agor/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cloning assistant framework/i)).toBeInTheDocument();
+    expect(document.querySelector('.ant-modal-body')).toBe(body);
+    expect(body).toHaveStyle({ height: '440px', overflowY: 'auto' });
+  });
+
+  it('creates setup resources with the default assistant branch name and preserves model defaults', async () => {
+    const repoById = new Map<string, Repo>();
+    const onCreateBranch = vi.fn(async () =>
+      makeBranch({ name: 'private-scout', ref: 'private-scout' })
     );
+    const onCreateSession = vi.fn(async () => 'session-1');
+    const onComplete = vi.fn();
+    const user = makeUser({
+      default_agentic_config: {
+        codex: {
+          modelConfig: { model: 'gpt-5', effort: 'high' },
+          permissionMode: 'auto',
+          mcpServerIds: ['mcp-1'],
+          codexSandboxMode: 'workspace-write',
+          codexApprovalPolicy: 'on-request',
+          codexNetworkAccess: true,
+        },
+      },
+    } as Partial<User>);
+
+    const view = renderWizard({ repoById, onCreateBranch, onCreateSession, onComplete, user });
+
+    fireEvent.change(screen.getByDisplayValue('My Assistant'), { target: { value: 'Scout' } });
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    const codexOption = Array.from(
+      view.baseElement.querySelectorAll<HTMLInputElement>('input[name="recommended-agent"]')
+    ).find((option) => option.value === 'codex');
+    fireEvent.click(codexOption as HTMLInputElement);
+    fireEvent.click(await screen.findByRole('button', { name: /continue with codex cli auth/i }));
+
+    expect(await screen.findByText(/Cloning assistant framework/i)).toBeInTheDocument();
+    repoById.set('repo-1', makeRepo());
+    const readyRepoById = new Map(repoById);
+    view.rerender(<OnboardingWizard {...view.props} repoById={readyRepoById} />);
+
+    await waitFor(() => {
+      expect(onCreateBranch).toHaveBeenCalledWith(
+        'repo-1',
+        expect.objectContaining({
+          name: 'private-scout',
+          ref: 'private-scout',
+          sourceBranch: 'main',
+          createBranch: true,
+          pullLatest: true,
+          boardId: 'board-1',
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(onCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branch_id: 'branch-1',
+          agent: 'codex',
+          modelConfig: { model: 'gpt-5', effort: 'high' },
+          effort: 'high',
+          mcpServerIds: ['mcp-1'],
+          permissionMode: 'auto',
+          codexSandboxMode: 'workspace-write',
+          codexApprovalPolicy: 'on-request',
+          codexNetworkAccess: true,
+        }),
+        'board-1'
+      );
+    });
+    expect(onComplete).toHaveBeenCalledWith({
+      branchId: 'branch-1',
+      sessionId: 'session-1',
+      boardId: 'board-1',
+      path: 'assistant',
+    });
   });
 
   it('detects an existing Cursor credential when selecting Cursor', async () => {
@@ -166,8 +270,7 @@ describe('OnboardingWizard', () => {
       } as Partial<User>),
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /create your assistant/i }));
-    fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     fireEvent.click(await screen.findByRole('checkbox', { name: /use a different provider/i }));
     fireEvent.mouseDown(screen.getByRole('combobox'));
     fireEvent.click(await screen.findByText('Cursor SDK (Beta)'));

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -247,7 +247,7 @@ describe('OnboardingWizard', () => {
         expect.objectContaining({
           branch_id: 'branch-1',
           agent: 'codex',
-          modelConfig: { model: 'gpt-5', effort: 'high' },
+          modelConfig: { mode: 'exact', model: 'gpt-5' },
           effort: 'high',
           mcpServerIds: ['mcp-1'],
           permissionMode: 'auto',

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -93,11 +93,15 @@ describe('OnboardingWizard', () => {
     const onUpdateUser = vi.fn(async () => undefined);
     renderWizard({ onUpdateUser });
 
-    expect(screen.getByText(/Create your assistant/i)).toBeInTheDocument();
-    expect(screen.getByText(/persistent agent for setup and ongoing work/i)).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to Agor/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Agor assistant/i })).toHaveAttribute(
+      'href',
+      'https://agor.live/guide/assistants'
+    );
+    expect(screen.getByText('Your assistant can help:')).toBeInTheDocument();
+    expect(screen.getByText(/Connect tools and credentials/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /emoji picker/i })).toBeInTheDocument();
     expect(screen.getByDisplayValue('My Assistant')).toBeInTheDocument();
-    expect(screen.queryByText(/Welcome to Agor/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Add Your Repository/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Branch name/i)).not.toBeInTheDocument();
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -979,7 +979,8 @@ export function OnboardingWizard({
       width={680}
       styles={{
         body: {
-          height: 440,
+          minHeight: 440,
+          maxHeight: 640,
           overflowY: 'auto',
           padding: '28px 36px',
         },

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -586,8 +586,11 @@ export function OnboardingWizard({
 
   const renderIdentity = () => (
     <div>
-      <Title level={4}>Name your assistant</Title>
-      <Paragraph type="secondary">Pick a name and emoji.</Paragraph>
+      <Title level={4}>Create your assistant</Title>
+      <Paragraph>
+        Your assistant is a persistent agent for setup and ongoing work in Agor.
+      </Paragraph>
+      <Paragraph type="secondary">Pick a name and emoji to get started.</Paragraph>
       <Form layout="vertical">
         <Form.Item label="Assistant" required>
           <Space.Compact style={{ display: 'flex' }}>

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -256,6 +256,7 @@ export function OnboardingWizard({
 
   const cloneTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const completingRepoRef = useRef<string | null>(null);
+  const knownFailedRepoIdsRef = useRef<Set<string>>(new Set());
   const effectiveFrameworkUrl = frameworkRepoUrl || FRAMEWORK_REPO_URL;
 
   const defaultBranchName = useMemo(
@@ -491,17 +492,25 @@ export function OnboardingWizard({
     setError(null);
     completingRepoRef.current = null;
 
+    const readyRepo = findReadyFrameworkRepo(repoById);
+    if (readyRepo) {
+      setOperationText('Preparing assistant workspace…');
+      void finishSetupFromRepo(readyRepo[0]);
+      return;
+    }
+
+    knownFailedRepoIdsRef.current = new Set(
+      Array.from(repoById.values())
+        .filter((repo) => repo.clone_status === 'failed')
+        .map((repo) => repo.repo_id)
+    );
+
     try {
       await onCreateRepo({
         url: effectiveFrameworkUrl,
         slug: FRAMEWORK_REPO_SLUG,
         default_branch: 'main',
       });
-      const readyRepo = findReadyFrameworkRepo(repoById);
-      if (readyRepo) {
-        void finishSetupFromRepo(readyRepo[0]);
-        return;
-      }
       cloneTimeoutRef.current = setTimeout(() => {
         setSetupStage('error');
         setError(
@@ -524,6 +533,7 @@ export function OnboardingWizard({
     if (currentStep !== 'loading' || setupStage !== 'cloning') return;
     for (const repo of repoById.values()) {
       if (repo.clone_status !== 'failed') continue;
+      if (knownFailedRepoIdsRef.current.has(repo.repo_id)) continue;
       if (repo.slug !== FRAMEWORK_REPO_SLUG && !repo.remote_url?.includes('agor-assistant'))
         continue;
       setSetupStage('error');

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1,10 +1,10 @@
 /**
- * OnboardingWizard - Multi-step wizard for new user onboarding
+ * OnboardingWizard - streamlined two-input setup for new users.
  *
- * Assistant-first path:
- * - Assistant: identity -> API keys -> clone assistant framework repo -> create board -> create branch/session
- *
- * Replaces GettingStartedPopover entirely.
+ * Flow:
+ * 1. Assistant identity (name + emoji)
+ * 2. LLM/provider configuration
+ * 3. One progress screen while Agor creates the default assistant workspace
  */
 
 import type {
@@ -13,28 +13,22 @@ import type {
   AuthCheckResult,
   Board,
   Branch,
+  CodexApprovalPolicy,
+  CodexSandboxMode,
   CreateLocalRepoRequest,
   CreateRepoRequest,
+  PermissionMode,
   Repo,
   UpdateUserInput,
   User,
   UserPreferences,
 } from '@agor-live/client';
 import {
-  extractSlugFromUrl,
-  isValidSlug,
-  normalizeRepoUrl,
+  getDefaultPermissionMode,
+  mapToCodexPermissionConfig,
   TOOL_API_KEY_NAMES,
 } from '@agor-live/client';
-import {
-  ApiOutlined,
-  ArrowRightOutlined,
-  BranchesOutlined,
-  CheckCircleOutlined,
-  FolderOpenOutlined,
-  KeyOutlined,
-  RobotOutlined,
-} from '@ant-design/icons';
+import { CheckCircleOutlined, KeyOutlined } from '@ant-design/icons';
 import {
   Alert,
   Button,
@@ -43,7 +37,6 @@ import {
   Form,
   Input,
   Modal,
-  Popconfirm,
   Radio,
   Result,
   Select,
@@ -61,7 +54,7 @@ import {
 } from '../../hooks/useFrameworkRepo';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { ensureAssistantWelcomeNote } from '../../utils/assistantWelcomeNote';
-import { extractSlugFromPath, slugify } from '../../utils/repoSlug';
+import { slugify } from '../../utils/repoSlug';
 import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 import type { NewSessionConfig } from '../NewSessionModal/NewSessionModal';
@@ -70,17 +63,12 @@ import { ToolIcon } from '../ToolIcon';
 const { Text, Title, Paragraph } = Typography;
 const { useToken } = theme;
 
-// ─── Constants ──────────────────────────────────────────
-
 const CLONE_TIMEOUT_MS = 120_000;
 
-// ─── Types ──────────────────────────────────────────────
-
-type WizardPath = 'assistant' | 'own-repo';
-
-type WizardStep = 'welcome' | 'identity' | 'add-repo' | 'clone' | 'board' | 'branch' | 'api-keys';
-
+type WizardPath = 'assistant';
+type WizardStep = 'identity' | 'llm' | 'loading';
 type AuthMethod = 'api-key' | 'claude-subscription-token' | 'codex-cli-auth';
+type SetupStage = 'idle' | 'cloning' | 'board' | 'branch' | 'session' | 'done' | 'error';
 
 export interface OnboardingWizardProps {
   open: boolean;
@@ -91,15 +79,13 @@ export interface OnboardingWizardProps {
     path: WizardPath;
   }) => void;
 
-  // Data
   repoById: Map<string, Repo>;
   branchById: Map<string, Branch>;
   boardById: Map<string, Board>;
   user?: User | null;
-  // biome-ignore lint/suspicious/noExplicitAny: AgorClient type varies
+  // biome-ignore lint/suspicious/noExplicitAny: AgorClient type varies across package boundaries in tests/apps.
   client: any;
 
-  // Actions
   onCreateRepo: (data: CreateRepoRequest) => Promise<void>;
   onCreateLocalRepo: (data: CreateLocalRepoRequest) => void | Promise<void>;
   onCreateBranch: (
@@ -122,12 +108,9 @@ export interface OnboardingWizardProps {
   onUpdateBranch?: (branchId: string, updates: Partial<Branch>) => Promise<void>;
   onCheckAuth?: (tool: AgenticToolName, apiKey?: string) => Promise<AuthCheckResult>;
 
-  // Config from health endpoint
   assistantPending?: boolean;
   frameworkRepoUrl?: string;
 }
-
-// ─── Helpers ────────────────────────────────────────────
 
 function sanitizeBranchName(input: string): string {
   return input
@@ -137,133 +120,47 @@ function sanitizeBranchName(input: string): string {
     .replace(/^-|-$/g, '');
 }
 
-function getUsernameSlug(user?: User | null): string {
-  if (!user) return 'user';
-  const name = user.name || user.email.split('@')[0] || 'user';
-  return sanitizeBranchName(name);
+function defaultAssistantBranchName(displayName: string): string {
+  const slug = slugify(displayName.trim() || 'My Assistant') || 'my-assistant';
+  return sanitizeBranchName(`private-${slug}`);
 }
 
-function getStepsForPath(path: WizardPath | null): WizardStep[] {
-  if (path === 'assistant') {
-    return ['welcome', 'identity', 'api-keys', 'clone', 'board', 'branch'];
-  }
-  if (path === 'own-repo') {
-    return ['welcome', 'api-keys', 'add-repo', 'clone', 'board', 'branch'];
-  }
-  return ['welcome'];
-}
-
-function getStepIndex(steps: WizardStep[], step: WizardStep): number {
-  return steps.indexOf(step);
+function findReadyFrameworkRepo(repoById: Map<string, Repo>): [string, Repo] | undefined {
+  return findFrameworkRepo(repoById, { readyOnly: true });
 }
 
 function apiKeyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-key'): string {
   if (agent === 'claude-code' && authMethod === 'claude-subscription-token') {
     return 'CLAUDE_CODE_OAUTH_TOKEN';
   }
-  // opencode has no canonical key of its own; wizard collects an Anthropic key
-  // and routes it to the claude-code bucket (see handleSaveApiKey).
   return TOOL_API_KEY_NAMES[agent] ?? 'ANTHROPIC_API_KEY';
 }
 
 function apiKeyPlaceholder(agent: AgenticToolName, authMethod: AuthMethod = 'api-key'): string {
-  if (agent === 'claude-code' && authMethod === 'claude-subscription-token') {
+  if (agent === 'claude-code' && authMethod === 'claude-subscription-token')
     return 'sk-ant-oat01-...';
-  }
-  switch (agent) {
-    case 'claude-code':
-      return 'sk-ant-...';
-    case 'codex':
-      return 'sk-...';
-    case 'gemini':
-      return 'AIza...';
-    case 'copilot':
-      return 'ghp_...';
-    case 'cursor':
-      return 'key_...';
-    default:
-      return 'sk-ant-...';
-  }
+  if (agent === 'codex') return 'sk-...';
+  if (agent === 'gemini') return 'AIza...';
+  if (agent === 'copilot') return 'ghp_...';
+  if (agent === 'cursor') return 'key_...';
+  return 'sk-ant-...';
 }
 
 const AGENT_LABELS: Record<AgenticToolName, string> = {
   'claude-code': 'Claude Code',
   'claude-code-cli': 'Claude Code CLI',
-  codex: 'Codex (OpenAI)',
+  codex: 'Codex',
   gemini: 'Gemini',
   opencode: 'OpenCode',
   copilot: 'GitHub Copilot',
   cursor: 'Cursor SDK',
 };
 
-/**
- * A repo is "usable" once its clone has actually completed. After PR #1126
- * the daemon pre-creates a placeholder row with `clone_status: 'cloning'`
- * before the executor runs — matching it as if it were finished caused the
- * wizard to auto-advance off the `'clone'` step within ~50ms, which then
- * dropped the subsequent `repo:cloneError` event (its listener filters on
- * `currentStep === 'clone'`). Legacy rows have no `clone_status`; treat
- * those as ready too so existing repos still match.
- */
-function isRepoReady(repo: Repo): boolean {
-  return repo.clone_status === 'ready' || repo.clone_status === undefined;
-}
-
-/**
- * Find the framework repo only when it's actually usable. Uses `readyOnly`
- * so non-ready candidates are excluded **before** priority selection —
- * a stale failed/cloning private fork never hides a ready public repo.
- */
-function findReadyFrameworkRepo(repoById: Map<string, Repo>): [string, Repo] | undefined {
-  return findFrameworkRepo(repoById, { readyOnly: true });
-}
-
-/**
- * Find a repo in the wizard's in-memory map that matches the user's input.
- * Used by both the clone-complete auto-advance effect and the board/branch
- * safety-net effect — centralised here so the match criteria cannot drift
- * between the two.
- *
- * Placeholder rows (`clone_status: 'cloning' | 'failed'`) are skipped — the
- * caller asked "is the clone done yet?", and the answer for a placeholder
- * is no.
- */
-function findMatchingRepoId(
-  repoById: Map<string, Repo>,
-  criteria: { remoteUrl?: string; slug?: string; localPath?: string }
-): string | null {
-  const normalizedInput = criteria.remoteUrl ? normalizeRepoUrl(criteria.remoteUrl) : '';
-  for (const [id, repo] of repoById) {
-    if (!isRepoReady(repo)) continue;
-    if (
-      (normalizedInput &&
-        repo.remote_url &&
-        normalizeRepoUrl(repo.remote_url) === normalizedInput) ||
-      (criteria.slug && repo.slug === criteria.slug) ||
-      (criteria.localPath && repo.local_path === criteria.localPath)
-    ) {
-      return id;
-    }
-  }
-  return null;
-}
-
-const RECOMMENDED_AGENT_OPTIONS: Array<{
-  value: AgenticToolName;
-  title: string;
-  eyebrow: string;
-}> = [
-  {
-    value: 'claude-code',
-    title: 'Claude Code',
-    eyebrow: 'Recommended',
-  },
-  {
-    value: 'codex',
-    title: 'Codex',
-    eyebrow: 'Recommended',
-  },
-];
+const RECOMMENDED_AGENT_OPTIONS: Array<{ value: AgenticToolName; title: string; eyebrow: string }> =
+  [
+    { value: 'claude-code', title: 'Claude Code', eyebrow: 'Recommended' },
+    { value: 'codex', title: 'Codex', eyebrow: 'Recommended' },
+  ];
 
 const OTHER_AGENT_OPTIONS: Array<{ value: AgenticToolName; label: string }> = [
   { value: 'gemini', label: 'Gemini' },
@@ -281,7 +178,6 @@ const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string }
     label: 'platform.claude.com/settings/keys',
     url: 'https://platform.claude.com/settings/keys',
   },
-  // Claude Code CLI uses the same Anthropic credentials.
   'claude-code-cli': {
     label: 'platform.claude.com/settings/keys',
     url: 'https://platform.claude.com/settings/keys',
@@ -300,535 +196,61 @@ function defaultAuthMethodForAgent(agent: AgenticToolName): AuthMethod {
 function authMethodOptionsForAgent(agent: AgenticToolName) {
   if (agent === 'claude-code') {
     return [
-      {
-        value: 'claude-subscription-token' as const,
-        label: 'Subscription',
-      },
-      {
-        value: 'api-key' as const,
-        label: 'API key',
-      },
+      { value: 'claude-subscription-token' as const, label: 'Subscription' },
+      { value: 'api-key' as const, label: 'API key' },
     ];
   }
-
   if (agent === 'codex') {
     return [
-      {
-        value: 'codex-cli-auth' as const,
-        label: 'CLI sign-in',
-      },
-      {
-        value: 'api-key' as const,
-        label: 'API key',
-      },
+      { value: 'codex-cli-auth' as const, label: 'CLI sign-in' },
+      { value: 'api-key' as const, label: 'API key' },
     ];
   }
-
   return null;
 }
-
-// ─── Component ──────────────────────────────────────────
 
 export function OnboardingWizard({
   open,
   onComplete,
   repoById,
-  branchById,
+  branchById: _branchById,
   boardById,
   user,
   client,
   onCreateRepo,
-  onCreateLocalRepo,
   onCreateBranch,
   onCreateSession,
   onUpdateUser,
   onCheckAuth,
-  assistantPending,
   frameworkRepoUrl,
 }: OnboardingWizardProps) {
+  void _branchById;
+
   const { token } = useToken();
-
-  // ─── State ────────────────────────────────────────
-  const [path, setPath] = useState<WizardPath | null>(null);
-  const [currentStep, rawSetCurrentStep] = useState<WizardStep>('welcome');
-
-  // Funnel ALL step transitions through this wrapper. In dev it logs every
-  // transition with caller context (use the browser console to follow the
-  // wizard's path through its steps). This makes step-transition bugs —
-  // historically the biggest source of regressions in this component —
-  // immediately visible.
-  //
-  // Rule of thumb: any time you'd reach for `rawSetCurrentStep`, use this
-  // instead. Auto-advance effects watching WS events also go through here.
-  const setCurrentStep = useCallback((next: WizardStep) => {
-    rawSetCurrentStep((prev) => {
-      if (import.meta.env.DEV && prev !== next) {
-        // eslint-disable-next-line no-console
-        console.debug(`[OnboardingWizard] step: ${prev} → ${next}`);
-      }
-      return next;
-    });
-  }, []);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  // Step-specific state
-  const [repoUrl, setRepoUrl] = useState('');
-  const [repoSlug, setRepoSlug] = useState('');
-  const [localRepoPath, setLocalRepoPath] = useState('');
-  const [repoMode, setRepoMode] = useState<'remote' | 'local'>('remote');
-  const [branchName, setBranchName] = useState('');
+  const [currentStep, setCurrentStep] = useState<WizardStep>('identity');
   const [assistantDisplayName, setAssistantDisplayName] = useState('My Assistant');
   const [assistantEmoji, setAssistantEmoji] = useState('🤖');
-  const [apiKey, setApiKey] = useState('');
-  const [authMethod, setAuthMethod] = useState<AuthMethod>('api-key');
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
   const [lastRecommendedAgent, setLastRecommendedAgent] = useState<AgenticToolName>('claude-code');
   const [useDifferentProvider, setUseDifferentProvider] = useState(false);
-  const [testAuthLoading, setTestAuthLoading] = useState(false);
-  // Inline feedback from the user clicking "Test Connection" on a typed key.
-  // Never flips the panel, never advances, never saves. Wiped on agent
-  // change and on key edit (stale).
-  const [manualTestResult, setManualTestResult] = useState<AuthCheckResult | null>(null);
-  // Lets the user opt out of an already-stored per-user credential and paste
-  // a different key — useful when the stored key is wrong-account or stale.
-  // Resets on agent change and on wizard reset.
+  const [authMethod, setAuthMethod] = useState<AuthMethod>('api-key');
+  const [apiKey, setApiKey] = useState('');
   const [overrideDetectedAuth, setOverrideDetectedAuth] = useState(false);
+  const [manualTestResult, setManualTestResult] = useState<AuthCheckResult | null>(null);
+  const [testAuthLoading, setTestAuthLoading] = useState(false);
+  const [setupStage, setSetupStage] = useState<SetupStage>('idle');
+  const [operationText, setOperationText] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
-  // Created resource IDs
-  const [createdRepoId, setCreatedRepoId] = useState<string | null>(null);
-  const [createdBoardId, setCreatedBoardId] = useState<string | null>(null);
-  const [createdBranchId, setCreatedBranchId] = useState<string | null>(null);
-
-  // Timeout ref for clone
   const cloneTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Elapsed time for clone progress
-  const [cloneElapsedSeconds, setCloneElapsedSeconds] = useState(0);
-  const cloneIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  // Repo IDs that were already failed when the current clone attempt started.
-  // The failure watcher ignores these so a stale row from a prior attempt never
-  // immediately cancels a new retry before the daemon has a chance to replace it.
-  const knownFailedRepoIdsRef = useRef<Set<string>>(new Set());
-
-  // ─── Derived ──────────────────────────────────────
-  const steps = useMemo(() => getStepsForPath(path), [path]);
-  const stepIndex = getStepIndex(steps, currentStep);
-  const usernameSlug = getUsernameSlug(user);
+  const completingRepoRef = useRef<string | null>(null);
   const effectiveFrameworkUrl = frameworkRepoUrl || FRAMEWORK_REPO_URL;
 
-  // Claude Code accepts either an Anthropic API key or a Pro/Max subscription
-  // OAuth token (from `claude setup-token`). Either is a valid credential.
-  // Per-tool credentials live under `agentic_tools[tool][envVarName]` (boolean
-  // presence flags on the public DTO). `env_vars` is also per-user (lives on
-  // the User record).
-  //
-  // Intentionally PER-USER only — we don't consider host-level fallbacks
-  // (config.yaml `credentials.*` or daemon process env vars) when deciding
-  // whether to skip the LLM-auth onboarding step. Sessions still fall back
-  // to host-level creds at run time, but treating them as "this user is
-  // already authenticated" auto-skipped onboarding for brand-new users (they
-  // silently inherited the admin's setup with no chance to configure their
-  // own). Users who want the host fallback can click "Continue without key"
-  // in the form.
-  const claudeFields = user?.agentic_tools?.['claude-code'];
-  const codexFields = user?.agentic_tools?.codex;
-  const geminiFields = user?.agentic_tools?.gemini;
-  const copilotFields = user?.agentic_tools?.copilot;
-  const cursorFields = user?.agentic_tools?.cursor;
-  const hasAnthropicKey = !!(
-    claudeFields?.ANTHROPIC_API_KEY ||
-    claudeFields?.CLAUDE_CODE_OAUTH_TOKEN ||
-    user?.env_vars?.ANTHROPIC_API_KEY
-  );
-  const hasOpenAIKey = !!(codexFields?.OPENAI_API_KEY || user?.env_vars?.OPENAI_API_KEY);
-  const hasGeminiKey = !!(geminiFields?.GEMINI_API_KEY || user?.env_vars?.GEMINI_API_KEY);
-  const hasCopilotToken = !!(
-    copilotFields?.COPILOT_GITHUB_TOKEN || user?.env_vars?.COPILOT_GITHUB_TOKEN
-  );
-  const hasCursorKey = !!(cursorFields?.CURSOR_API_KEY || user?.env_vars?.CURSOR_API_KEY);
-
-  const hasKeyForAgent = (agent: AgenticToolName): boolean => {
-    switch (agent) {
-      case 'claude-code':
-        return hasAnthropicKey;
-      case 'codex':
-        return hasOpenAIKey;
-      case 'gemini':
-        return hasGeminiKey;
-      case 'copilot':
-        return hasCopilotToken;
-      case 'cursor':
-        return hasCursorKey;
-      case 'opencode':
-        return hasAnthropicKey || hasOpenAIKey || hasGeminiKey;
-      default:
-        return false;
-    }
-  };
-
-  const resetProviderAuthState = useCallback(() => {
-    setApiKey('');
-    setError(null);
-    setManualTestResult(null);
-    setOverrideDetectedAuth(false);
-  }, []);
-
-  const selectAgent = useCallback(
-    (agent: AgenticToolName, options: { useDifferentProvider?: boolean } = {}) => {
-      setSelectedAgent(agent);
-      setAuthMethod(defaultAuthMethodForAgent(agent));
-      if (RECOMMENDED_AGENT_VALUES.has(agent)) {
-        setLastRecommendedAgent(agent);
-      }
-      setUseDifferentProvider(options.useDifferentProvider ?? !RECOMMENDED_AGENT_VALUES.has(agent));
-      resetProviderAuthState();
-    },
-    [resetProviderAuthState]
+  const defaultBranchName = useMemo(
+    () => defaultAssistantBranchName(assistantDisplayName),
+    [assistantDisplayName]
   );
 
-  // ─── Resume from prior onboarding state ──────────
-  //
-  // ONE-SHOT: this effect runs exactly once per wizard mount, before any
-  // user interaction. The wizard's own `saveOnboardingProgress` writes the
-  // user-selected path back to `user.preferences.onboarding.path`, which
-  // would otherwise cause this effect to re-fire AFTER the user picks a
-  // path — making a fresh-flow user look like a returning-resumption user
-  // and triggering bogus step jumps (e.g. the assistant-path branch picks
-  // up the SHARED framework repo and skips to "board", silently bypassing
-  // api-keys and clone). resumedRef.current is set unconditionally at the
-  // end so subsequent re-renders are no-ops. Wizard remount on user
-  // change (key={currentUser.user_id} in App.tsx) gives each user a fresh
-  // shot at the resume decision.
-  const resumedRef = useRef(false);
-  useEffect(() => {
-    if (!open || resumedRef.current || !user) return;
-    resumedRef.current = true;
-
-    const onboarding = user.preferences?.onboarding;
-    const mainBoardId = user.preferences?.mainBoardId;
-
-    if (!onboarding?.path) {
-      // No prior state — auto-select assistant path if flag was set (e.g. by existing installs)
-      if (assistantPending && !path) {
-        setPath('assistant');
-      }
-      return;
-    }
-
-    // Only the assistant path remains an active onboarding route. Legacy saved
-    // non-assistant path preferences are allowed to keep their data shape, but
-    // they resume at the assistant flow instead of exposing the old path.
-    const savedPath = onboarding.path === 'persisted-agent' ? 'assistant' : onboarding.path;
-    const canResumeAssistantResources = savedPath === 'assistant';
-
-    // Resource-ownership validation. The resume-step decisions below jump the
-    // wizard past the api-keys / board / repo creation steps based on IDs
-    // stored in user.preferences. If those IDs ever point at resources NOT
-    // created by the current user — whether through a leak, a stale prefs
-    // copy, or an admin viewing a shared resource — the wizard would
-    // wrongly skip steps for a user who hasn't actually completed them.
-    // Only treat the resume IDs as valid when (a) the resource is loaded
-    // AND (b) the current user is its creator. Anything that fails this
-    // check is treated as if the preference were unset; the fallback chain
-    // then routes the user to the right step (typically api-keys).
-    const validBranchId =
-      canResumeAssistantResources &&
-      onboarding.branchId &&
-      branchById.get(onboarding.branchId)?.created_by === user.user_id
-        ? onboarding.branchId
-        : undefined;
-    const validBoardId =
-      canResumeAssistantResources &&
-      mainBoardId &&
-      boardById.get(mainBoardId)?.created_by === user.user_id
-        ? mainBoardId
-        : undefined;
-    // Repos are SHARED resources (no created_by attribution). We require a
-    // saved repoId in the user's own preferences as proof that this user
-    // intentionally adopted this repo — we deliberately do NOT pick up
-    // matching repos from the map otherwise (e.g. via findReadyFrameworkRepo)
-    // as that would let a new user inherit any framework repo cloned by a
-    // prior user and skip the clone step.
-    const validRepoId =
-      canResumeAssistantResources && onboarding.repoId && repoById.has(onboarding.repoId)
-        ? onboarding.repoId
-        : undefined;
-
-    if (
-      onboarding.branchId !== validBranchId ||
-      mainBoardId !== validBoardId ||
-      onboarding.repoId !== validRepoId
-    ) {
-      console.warn('[OnboardingWizard] Dropping resume references not owned by current user', {
-        user_id: user.user_id,
-        claimed: { branchId: onboarding.branchId, mainBoardId, repoId: onboarding.repoId },
-        valid: { branchId: validBranchId, boardId: validBoardId, repoId: validRepoId },
-      });
-    }
-
-    // Map every saved onboarding path to the assistant flow. 'persisted-agent'
-    // is the old assistant path name; 'own-repo' is no longer an onboarding path.
-    const resumedPath: WizardPath = 'assistant';
-    setPath(resumedPath);
-
-    if (resumedPath === 'assistant') {
-      if (typeof onboarding.assistantDisplayName === 'string') {
-        setAssistantDisplayName(onboarding.assistantDisplayName);
-        setBranchName(`private-${slugify(onboarding.assistantDisplayName || 'My Assistant')}`);
-      }
-      if (typeof onboarding.assistantEmoji === 'string') {
-        setAssistantEmoji(onboarding.assistantEmoji);
-      }
-    }
-
-    // Restore created resource IDs (only the validated ones)
-    if (validBoardId) {
-      setCreatedBoardId(validBoardId);
-    }
-
-    // Restore repoId so the branch step doesn't fail "Missing repo or board"
-    // on resume.
-    if (validRepoId) {
-      setCreatedRepoId(validRepoId);
-    }
-
-    if (validBranchId) {
-      setCreatedBranchId(validBranchId);
-    }
-
-    // Figure out which step to resume from
-    if (validBranchId) {
-      // Branch exists AND is owned by current user — stay on the branch
-      // step, which can retry launching the first session inline.
-      setCurrentStep('branch');
-    } else if (validBoardId) {
-      // Board exists AND is owned by current user — go to branch creation
-      setCurrentStep('branch');
-    } else if (validRepoId) {
-      // Repo is registered (already restored above) — go straight to board
-      setCurrentStep('board');
-    } else {
-      // Nothing the user actually created yet — restart from identity for
-      // assistants so naming/emoji stays in the shared form flow.
-      setCurrentStep(resumedPath === 'assistant' ? 'identity' : 'api-keys');
-    }
-  }, [
-    open,
-    user,
-    assistantPending,
-    path,
-    repoById,
-    boardById,
-    branchById, // own-repo with nothing created — restart from api-keys
-    setCurrentStep,
-  ]);
-
-  // Initialize branch name once when user first loads (ref guards against re-init on edit)
-  const branchNameInitRef = useRef(false);
-  useEffect(() => {
-    if (user && !branchNameInitRef.current) {
-      branchNameInitRef.current = true;
-      setBranchName(`private-${usernameSlug}`);
-    }
-  }, [user, usernameSlug]);
-
-  // ─── Auto-advance: Watch repoById for clone completion ──
-  // This is the ONE legitimately async step: clone completion is signalled
-  // by a WebSocket event landing in `repoById`. Every other step transition
-  // in the wizard is owned by its handler (imperative). If you find yourself
-  // adding another effect that calls `setCurrentStep` based on a service map,
-  // think twice — most operations are synchronous from the wizard's POV.
-  useEffect(() => {
-    if (currentStep !== 'clone' || !loading) return;
-
-    if (path === 'assistant') {
-      // Only advance once the framework repo is actually cloned. Matching
-      // the pre-created placeholder (`clone_status: 'cloning'`) would push
-      // us off the clone step before `repo:cloneError` arrives, so a real
-      // failure would never reach `handleCloneError`. See `isRepoReady`.
-      const found = findReadyFrameworkRepo(repoById);
-      if (found) {
-        setCreatedRepoId(found[0]);
-        setLoading(false);
-        setError(null);
-        if (cloneTimeoutRef.current) {
-          clearTimeout(cloneTimeoutRef.current);
-          cloneTimeoutRef.current = null;
-        }
-        setCurrentStep('board');
-        return;
-      }
-    } else if (path === 'own-repo' && (repoUrl || localRepoPath)) {
-      const matchId = findMatchingRepoId(repoById, {
-        remoteUrl: repoUrl,
-        slug: repoSlug,
-        localPath: localRepoPath,
-      });
-      if (matchId) {
-        setCreatedRepoId(matchId);
-        setLoading(false);
-        setError(null);
-        if (cloneTimeoutRef.current) {
-          clearTimeout(cloneTimeoutRef.current);
-          cloneTimeoutRef.current = null;
-        }
-        setCurrentStep('board');
-        return;
-      }
-    }
-  }, [currentStep, loading, path, repoById, repoUrl, repoSlug, localRepoPath, setCurrentStep]);
-
-  // ─── Safety net: ensure createdRepoId is set when reaching board/branch ──
-  useEffect(() => {
-    if (createdRepoId || (currentStep !== 'board' && currentStep !== 'branch')) return;
-    const matchId = findMatchingRepoId(repoById, {
-      remoteUrl: repoUrl,
-      slug: repoSlug,
-      localPath: localRepoPath,
-    });
-    if (matchId) {
-      setCreatedRepoId(matchId);
-      return;
-    }
-    // For assistant path, find framework repo (placeholders excluded —
-    // `createdRepoId` should point at a real, cloned repo).
-    if (path === 'assistant') {
-      const found = findReadyFrameworkRepo(repoById);
-      if (found) {
-        setCreatedRepoId(found[0]);
-      }
-    }
-  }, [currentStep, createdRepoId, repoById, repoUrl, repoSlug, localRepoPath, path]);
-
-  // No auto-advance for board or branch creation: handleCreateBoard and
-  // handleCreateBranch own their success/failure transitions explicitly
-  // because both are synchronous from the wizard's perspective (the daemon
-  // returns the created row from the create call). Prior effects watching
-  // boardById / branchById raced the handlers — see git history.
-
-  // ─── Watch repoById for clone failure (state-driven, race-free) ──
-  // Events can arrive while the listener closure still has `loading=false`
-  // (between handleStartClone() setting loading=true and the next React render
-  // re-registering the effect). Reading from authoritative repoById covers that
-  // race without relying on event delivery. Pre-existing failed rows (stale from
-  // prior attempts) are excluded via knownFailedRepoIdsRef — see handleStartClone.
-  // Logic mirrors the auto-advance effect above, but for clone_status: 'failed'.
-  useEffect(() => {
-    if (currentStep !== 'clone' || !loading) return;
-
-    let failedRepo: Repo | undefined;
-    for (const [, repo] of repoById) {
-      if (repo.clone_status !== 'failed') continue;
-      // Skip rows that were already failed when this attempt started — those are
-      // stale from a prior attempt and will be replaced by the daemon shortly.
-      if (knownFailedRepoIdsRef.current.has(repo.repo_id)) continue;
-      if (
-        (path === 'assistant' &&
-          (repo.slug === FRAMEWORK_REPO_SLUG || repo.remote_url?.includes('agor-assistant'))) ||
-        (path === 'own-repo' &&
-          ((repoUrl &&
-            repo.remote_url &&
-            normalizeRepoUrl(repo.remote_url) === normalizeRepoUrl(repoUrl)) ||
-            (repoSlug && repo.slug === repoSlug) ||
-            (localRepoPath && repo.local_path === localRepoPath)))
-      ) {
-        failedRepo = repo;
-        break;
-      }
-    }
-
-    if (!failedRepo) return;
-    const message =
-      failedRepo.clone_error?.message ??
-      `Clone failed (exit ${failedRepo.clone_error?.exit_code ?? '?'}).`;
-    setLoading(false);
-    setError(message);
-    if (cloneTimeoutRef.current) {
-      clearTimeout(cloneTimeoutRef.current);
-      cloneTimeoutRef.current = null;
-    }
-  }, [currentStep, loading, path, repoById, repoUrl, repoSlug, localRepoPath]);
-
-  // ─── Listen for clone error events from backend ──
-  // Two redundant channels because event ordering is not guaranteed and we
-  // want whichever lands first to break the spinner:
-  //
-  //  1. `repo:cloneError` (WebSocket broadcast from `cloneRepository`'s
-  //     onExit safety net) — fires only when the executor exits non-zero
-  //     and carries a generic, branch-aware message.
-  //  2. `repos.patched` (Feathers service event) — fires whenever the
-  //     placeholder row transitions to `clone_status: 'failed'`. The patch
-  //     payload includes `clone_error.message` (the first line of git's
-  //     stderr) which is far more useful than the generic WS message —
-  //     e.g. "configuring core.sshCommand is not permitted…" surfaces
-  //     verbatim instead of being swallowed into "Clone failed (exit 1)".
-  useEffect(() => {
-    if (!client?.io) return;
-
-    const isOurCloneByIdentity = (slug: string | undefined, url: string | undefined) =>
-      (path === 'assistant' && slug === FRAMEWORK_REPO_SLUG) ||
-      (path === 'own-repo' && ((url && url === repoUrl) || (slug && slug === repoSlug)));
-
-    const surfaceError = (message: string) => {
-      // Only handle if we're on the clone step and loading. If the user has
-      // moved on (or the wizard never reached `'clone'`), don't yank state.
-      if (currentStep !== 'clone' || !loading) return;
-      setLoading(false);
-      setError(message);
-      if (cloneTimeoutRef.current) {
-        clearTimeout(cloneTimeoutRef.current);
-        cloneTimeoutRef.current = null;
-      }
-    };
-
-    const handleCloneError = (data: { slug: string; url: string; error: string }) => {
-      if (!isOurCloneByIdentity(data.slug, data.url)) return;
-      surfaceError(data.error);
-    };
-
-    const handleRepoPatched = (repo: Repo) => {
-      if (repo.clone_status !== 'failed') return;
-      if (!isOurCloneByIdentity(repo.slug, repo.remote_url)) return;
-      // Prefer the row's specific error; fall back to a generic message.
-      const message =
-        repo.clone_error?.message ?? `Clone failed (exit ${repo.clone_error?.exit_code ?? '?'}).`;
-      surfaceError(message);
-    };
-
-    const reposService = client.service('repos');
-    client.io.on('repo:cloneError', handleCloneError);
-    reposService.on('patched', handleRepoPatched);
-    return () => {
-      client.io.off('repo:cloneError', handleCloneError);
-      reposService.removeListener('patched', handleRepoPatched);
-    };
-  }, [client, currentStep, loading, path, repoUrl, repoSlug]);
-
-  // Stop elapsed timer when loading stops
-  useEffect(() => {
-    if (!loading && cloneIntervalRef.current) {
-      clearInterval(cloneIntervalRef.current);
-      cloneIntervalRef.current = null;
-    }
-  }, [loading]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (cloneTimeoutRef.current) {
-        clearTimeout(cloneTimeoutRef.current);
-      }
-      if (cloneIntervalRef.current) {
-        clearInterval(cloneIntervalRef.current);
-      }
-    };
-  }, []);
-
-  // ─── Step Handlers ────────────────────────────────
-
-  // Persist onboarding progress to user preferences so restarts can resume.
-  // ⚠️  Declared in the handlers section because effects above (notably the
-  // createdRepoId-persist effect below) reference it — moving this further
-  // down re-introduces a TDZ ReferenceError on mount.
   const saveOnboardingProgress = useCallback(
     (updates: {
       path?: WizardPath;
@@ -844,395 +266,311 @@ export function OnboardingWizard({
         ...user.preferences,
         onboarding: { ...current, ...updates },
       };
-      if (updates.boardId) {
-        prefs.mainBoardId = updates.boardId;
-      }
+      if (updates.boardId) prefs.mainBoardId = updates.boardId;
       onUpdateUser(user.user_id, { preferences: prefs as UserPreferences });
     },
-    [user, onUpdateUser]
+    [onUpdateUser, user]
   );
+
+  useEffect(() => {
+    if (!open || !user) return;
+    const onboarding = user.preferences?.onboarding;
+    if (typeof onboarding?.assistantDisplayName === 'string') {
+      setAssistantDisplayName(onboarding.assistantDisplayName || 'My Assistant');
+    }
+    if (typeof onboarding?.assistantEmoji === 'string') {
+      setAssistantEmoji(onboarding.assistantEmoji || '🤖');
+    }
+  }, [open, user]);
+
+  useEffect(() => {
+    return () => {
+      if (cloneTimeoutRef.current) clearTimeout(cloneTimeoutRef.current);
+    };
+  }, []);
+
+  const hasKeyForAgent = useCallback(
+    (agent: AgenticToolName): boolean => {
+      const claudeFields = user?.agentic_tools?.['claude-code'];
+      const codexFields = user?.agentic_tools?.codex;
+      const geminiFields = user?.agentic_tools?.gemini;
+      const copilotFields = user?.agentic_tools?.copilot;
+      const cursorFields = user?.agentic_tools?.cursor;
+      const hasAnthropicKey = !!(
+        claudeFields?.ANTHROPIC_API_KEY ||
+        claudeFields?.CLAUDE_CODE_OAUTH_TOKEN ||
+        user?.env_vars?.ANTHROPIC_API_KEY
+      );
+      const hasOpenAIKey = !!(codexFields?.OPENAI_API_KEY || user?.env_vars?.OPENAI_API_KEY);
+      const hasGeminiKey = !!(geminiFields?.GEMINI_API_KEY || user?.env_vars?.GEMINI_API_KEY);
+      const hasCopilotToken = !!(
+        copilotFields?.COPILOT_GITHUB_TOKEN || user?.env_vars?.COPILOT_GITHUB_TOKEN
+      );
+      const hasCursorKey = !!(cursorFields?.CURSOR_API_KEY || user?.env_vars?.CURSOR_API_KEY);
+
+      if (agent === 'claude-code') return hasAnthropicKey;
+      if (agent === 'codex') return hasOpenAIKey;
+      if (agent === 'gemini') return hasGeminiKey;
+      if (agent === 'copilot') return hasCopilotToken;
+      if (agent === 'cursor') return hasCursorKey;
+      if (agent === 'opencode') return hasAnthropicKey || hasOpenAIKey || hasGeminiKey;
+      return false;
+    },
+    [user]
+  );
+
+  const resetProviderAuthState = useCallback(() => {
+    setApiKey('');
+    setError(null);
+    setManualTestResult(null);
+    setOverrideDetectedAuth(false);
+  }, []);
+
+  const selectAgent = useCallback(
+    (agent: AgenticToolName, options: { useDifferentProvider?: boolean } = {}) => {
+      setSelectedAgent(agent);
+      setAuthMethod(defaultAuthMethodForAgent(agent));
+      if (RECOMMENDED_AGENT_VALUES.has(agent)) setLastRecommendedAgent(agent);
+      setUseDifferentProvider(options.useDifferentProvider ?? !RECOMMENDED_AGENT_VALUES.has(agent));
+      resetProviderAuthState();
+    },
+    [resetProviderAuthState]
+  );
+
+  const buildSessionConfig = useCallback(
+    (branchId: string): NewSessionConfig => {
+      const agentDefaults = user?.default_agentic_config?.[selectedAgent];
+      const permissionMode: PermissionMode =
+        agentDefaults?.permissionMode ?? getDefaultPermissionMode(selectedAgent);
+      const sessionConfig: NewSessionConfig = {
+        branch_id: branchId,
+        agent: selectedAgent,
+        initialPrompt: buildAssistantBootstrapPrompt({
+          displayName: assistantDisplayName.trim() || 'My Assistant',
+          emoji: assistantEmoji || '🤖',
+          userName: user?.name,
+          userEmail: user?.email,
+        }),
+        modelConfig: agentDefaults?.modelConfig,
+        effort: agentDefaults?.modelConfig?.effort,
+        mcpServerIds: agentDefaults?.mcpServerIds,
+        permissionMode,
+      };
+
+      if (selectedAgent === 'codex') {
+        const codexDefaults = mapToCodexPermissionConfig(permissionMode);
+        sessionConfig.codexSandboxMode =
+          (agentDefaults?.codexSandboxMode as CodexSandboxMode | undefined) ??
+          codexDefaults.sandboxMode;
+        sessionConfig.codexApprovalPolicy =
+          (agentDefaults?.codexApprovalPolicy as CodexApprovalPolicy | undefined) ??
+          codexDefaults.approvalPolicy;
+        sessionConfig.codexNetworkAccess =
+          agentDefaults?.codexNetworkAccess ?? codexDefaults.networkAccess;
+      }
+
+      return sessionConfig;
+    },
+    [assistantDisplayName, assistantEmoji, selectedAgent, user]
+  );
+
+  const finishSetupFromRepo = useCallback(
+    async (repoId: string) => {
+      if (completingRepoRef.current === repoId) return;
+      completingRepoRef.current = repoId;
+      if (cloneTimeoutRef.current) {
+        clearTimeout(cloneTimeoutRef.current);
+        cloneTimeoutRef.current = null;
+      }
+
+      try {
+        setError(null);
+        saveOnboardingProgress({ repoId });
+
+        setSetupStage('board');
+        setOperationText('Creating your assistant board…');
+        const existingBoardId = user?.preferences?.mainBoardId;
+        let boardId =
+          existingBoardId && user && boardById.get(existingBoardId)?.created_by === user.user_id
+            ? existingBoardId
+            : null;
+
+        if (!boardId) {
+          const board = await client?.service('boards').create({
+            name: `${assistantDisplayName.trim() || 'My Assistant'}'s Board`,
+            icon: assistantEmoji || '🤖',
+          });
+          boardId = board?.board_id ?? null;
+        }
+        if (!boardId) throw new Error('Failed to create assistant board.');
+        saveOnboardingProgress({ boardId });
+        await ensureAssistantWelcomeNote({
+          client,
+          boardId,
+          assistantName: assistantDisplayName.trim() || 'My Assistant',
+          assistantEmoji,
+        });
+
+        setSetupStage('branch');
+        setOperationText('Creating the default assistant branch…');
+        const sourceBranch = repoById.get(repoId)?.default_branch || 'main';
+        const assistantConfig: AssistantConfig = {
+          kind: 'assistant',
+          displayName: assistantDisplayName.trim() || 'My Assistant',
+          emoji: assistantEmoji || undefined,
+          frameworkRepo: FRAMEWORK_REPO_SLUG,
+          createdViaOnboarding: true,
+        };
+        const branch = await onCreateBranch(repoId, {
+          name: defaultBranchName,
+          ref: defaultBranchName,
+          createBranch: true,
+          sourceBranch,
+          pullLatest: true,
+          boardId,
+          custom_context: { assistant: assistantConfig },
+        });
+        if (!branch?.branch_id) throw new Error('Failed to create assistant branch.');
+        saveOnboardingProgress({ branchId: branch.branch_id });
+        await client
+          ?.service('boards')
+          .setPrimaryAssistant({ boardId, branchId: branch.branch_id });
+
+        setSetupStage('session');
+        setOperationText('Starting your assistant…');
+        const sessionId = await startAssistantBootstrapSession({
+          client,
+          branchId: branch.branch_id,
+          boardId,
+          sessionConfig: buildSessionConfig(branch.branch_id),
+          onCreateSession,
+          onStatusChange: setOperationText,
+        });
+
+        setSetupStage('done');
+        setOperationText('Opening your assistant…');
+        onComplete({ branchId: branch.branch_id, sessionId, boardId, path: 'assistant' });
+      } catch (err) {
+        completingRepoRef.current = null;
+        setSetupStage('error');
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [
+      assistantDisplayName,
+      assistantEmoji,
+      boardById,
+      buildSessionConfig,
+      client,
+      defaultBranchName,
+      onComplete,
+      onCreateBranch,
+      onCreateSession,
+      repoById,
+      saveOnboardingProgress,
+      user,
+    ]
+  );
+
+  const startSetup = useCallback(async () => {
+    setCurrentStep('loading');
+    setSetupStage('cloning');
+    setOperationText('Cloning assistant framework…');
+    setError(null);
+    completingRepoRef.current = null;
+
+    try {
+      await onCreateRepo({
+        url: effectiveFrameworkUrl,
+        slug: FRAMEWORK_REPO_SLUG,
+        default_branch: 'main',
+      });
+      const readyRepo = findReadyFrameworkRepo(repoById);
+      if (readyRepo) {
+        void finishSetupFromRepo(readyRepo[0]);
+        return;
+      }
+      cloneTimeoutRef.current = setTimeout(() => {
+        setSetupStage('error');
+        setError(
+          'Clone is taking longer than expected. Please check the repository connection and try again.'
+        );
+      }, CLONE_TIMEOUT_MS);
+    } catch (err) {
+      setSetupStage('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [effectiveFrameworkUrl, finishSetupFromRepo, onCreateRepo, repoById]);
+
+  useEffect(() => {
+    if (currentStep !== 'loading' || setupStage !== 'cloning') return;
+    const readyRepo = findReadyFrameworkRepo(repoById);
+    if (readyRepo) void finishSetupFromRepo(readyRepo[0]);
+  }, [currentStep, finishSetupFromRepo, repoById, setupStage]);
+
+  useEffect(() => {
+    if (currentStep !== 'loading' || setupStage !== 'cloning') return;
+    for (const repo of repoById.values()) {
+      if (repo.clone_status !== 'failed') continue;
+      if (repo.slug !== FRAMEWORK_REPO_SLUG && !repo.remote_url?.includes('agor-assistant'))
+        continue;
+      setSetupStage('error');
+      setError(
+        repo.clone_error?.message ?? `Clone failed (exit ${repo.clone_error?.exit_code ?? '?'}).`
+      );
+      if (cloneTimeoutRef.current) {
+        clearTimeout(cloneTimeoutRef.current);
+        cloneTimeoutRef.current = null;
+      }
+      return;
+    }
+  }, [currentStep, repoById, setupStage]);
+
+  useEffect(() => {
+    if (!client?.io) return;
+    const handleCloneError = (data: { slug?: string; url?: string; error: string }) => {
+      if (currentStep !== 'loading' || setupStage !== 'cloning') return;
+      if (data.slug !== FRAMEWORK_REPO_SLUG && !data.url?.includes('agor-assistant')) return;
+      setSetupStage('error');
+      setError(data.error);
+      if (cloneTimeoutRef.current) {
+        clearTimeout(cloneTimeoutRef.current);
+        cloneTimeoutRef.current = null;
+      }
+    };
+    client.io.on('repo:cloneError', handleCloneError);
+    return () => client.io.off('repo:cloneError', handleCloneError);
+  }, [client, currentStep, setupStage]);
 
   const handleAssistantIdentityContinue = useCallback(() => {
     const trimmedName = assistantDisplayName.trim() || 'My Assistant';
     setAssistantDisplayName(trimmedName);
-    setBranchName(`private-${slugify(trimmedName)}`);
     saveOnboardingProgress({
+      path: 'assistant',
       assistantDisplayName: trimmedName,
       assistantEmoji: assistantEmoji || '🤖',
     });
     setError(null);
-    setCurrentStep('api-keys');
-  }, [assistantDisplayName, assistantEmoji, saveOnboardingProgress, setCurrentStep]);
-
-  // Persist createdRepoId so a refresh / reset-then-resume of the wizard
-  // lands back on the branch step with the repo still wired up. Without
-  // this, handleCreateBranch throws "Missing repo or board" on resume
-  // because repoId is only kept in local state.
-  useEffect(() => {
-    if (!createdRepoId) return;
-    if (user?.preferences?.onboarding?.repoId === createdRepoId) return;
-    saveOnboardingProgress({ repoId: createdRepoId });
-  }, [createdRepoId, user, saveOnboardingProgress]);
-
-  const handleSelectPath = useCallback(
-    (selectedPath: WizardPath) => {
-      setPath(selectedPath);
-      setError(null);
-
-      // Persist chosen path immediately
-      saveOnboardingProgress({ path: selectedPath });
-
-      // Assistant path first captures assistant identity (name + emoji) in
-      // form territory. Other paths advance to api-keys after selection.
-      //
-      // Previously the assistant branch did `findReadyFrameworkRepo(repoById)`
-      // and skipped to "board" if any framework repo was found anywhere in
-      // the daemon. The framework repo is a SHARED resource (no per-user
-      // attribution), so as soon as one admin or earlier user had cloned it,
-      // every subsequent user picking the assistant path would silently
-      // bypass the api-keys + clone steps and land on board creation. That
-      // matches the reported bug: brand-new user picks "Assistant", wizard
-      // skips past LLM auth and clone, lands at board / branch creation.
-      //
-      // The assistant clone step is now reached via the api-keys path like
-      // every other tool; handleStartClone deduplicates against the shared
-      // framework repo at the daemon level (so re-cloning is a no-op).
-      setCurrentStep(selectedPath === 'assistant' ? 'identity' : 'api-keys');
-    },
-    [saveOnboardingProgress, setCurrentStep]
-  );
-
-  const handleStartClone = useCallback(async () => {
-    // Snapshot which repos are already failed before this attempt starts.
-    // The repoById failure watcher ignores these IDs so a stale row from a
-    // previous attempt never immediately cancels the new clone.
-    const snapshot = new Set<string>();
-    for (const [id, repo] of repoById) {
-      if (repo.clone_status === 'failed') snapshot.add(id);
-    }
-    knownFailedRepoIdsRef.current = snapshot;
-
-    setError(null);
-    setLoading(true);
-    setCloneElapsedSeconds(0);
-    // Start elapsed timer
-    if (cloneIntervalRef.current) clearInterval(cloneIntervalRef.current);
-    cloneIntervalRef.current = setInterval(() => {
-      setCloneElapsedSeconds((s) => s + 1);
-    }, 1000);
-
-    try {
-      if (path === 'assistant') {
-        await onCreateRepo({
-          url: effectiveFrameworkUrl,
-          slug: FRAMEWORK_REPO_SLUG,
-          default_branch: 'main',
-        });
-      } else {
-        // If the user typed a local filesystem path into the URL field (starts with
-        // / or ~), treat it as a local repo regardless of which mode toggle is active.
-        const looksLikeLocalPath = repoUrl.startsWith('/') || repoUrl.startsWith('~');
-        const effectiveMode = looksLikeLocalPath ? 'local' : repoMode;
-
-        if (effectiveMode === 'remote') {
-          await onCreateRepo({
-            url: repoUrl,
-            slug: repoSlug || '',
-            default_branch: 'main',
-          });
-        } else {
-          // Local repos are registered synchronously — no clone needed.
-          await onCreateLocalRepo({
-            path: looksLikeLocalPath ? repoUrl : localRepoPath,
-            slug: repoSlug || undefined,
-          });
-        }
-      }
-    } catch (err) {
-      setLoading(false);
-      setError(err instanceof Error ? err.message : String(err));
-      return;
-    }
-
-    // Decide whether this operation is async (clone) or synchronous (local registration).
-    const looksLikeLocalPath = repoUrl.startsWith('/') || repoUrl.startsWith('~');
-    const effectiveMode = path === 'own-repo' && looksLikeLocalPath ? 'local' : repoMode;
-    const isAsyncClone =
-      path === 'assistant' || (path === 'own-repo' && effectiveMode === 'remote');
-
-    // Transition to the clone step so the auto-advance effect can detect
-    // the newly-created repo in repoById and move to the board step.
-    // For assistant path, we're already on 'clone' (auto-triggered).
-    // For local repos, registration is synchronous — skip the clone step entirely.
-    if (path === 'own-repo') {
-      if (isAsyncClone) {
-        setCurrentStep('clone');
-      } else {
-        if (cloneIntervalRef.current) {
-          clearInterval(cloneIntervalRef.current);
-          cloneIntervalRef.current = null;
-        }
-        setLoading(false);
-        setCurrentStep('board');
-      }
-    }
-
-    // Set timeout for async clone completion only.
-    if (isAsyncClone) {
-      cloneTimeoutRef.current = setTimeout(() => {
-        setLoading(false);
-        setError(
-          'Clone is taking too long. This could be due to network issues, an unreachable repository, or a missing GITHUB_TOKEN for private repos. Please check and try again.'
-        );
-      }, CLONE_TIMEOUT_MS);
-    }
-  }, [
-    path,
-    effectiveFrameworkUrl,
-    repoMode,
-    repoUrl,
-    repoSlug,
-    localRepoPath,
-    repoById,
-    onCreateRepo,
-    onCreateLocalRepo,
-    setCurrentStep,
-  ]);
-
-  const handleCreateBoard = useCallback(async () => {
-    // If we already have a board from a prior run, skip creation —
-    // but only if it's actually OWNED by the current user. A leaked
-    // mainBoardId pointing at someone else's board must not let us
-    // short-circuit the create step.
-    const existingBoardId = user?.preferences?.mainBoardId;
-    if (existingBoardId && user && boardById.get(existingBoardId)?.created_by === user.user_id) {
-      setCreatedBoardId(existingBoardId);
-      if (path === 'assistant') {
-        await ensureAssistantWelcomeNote({
-          client,
-          boardId: existingBoardId,
-          assistantName: assistantDisplayName.trim() || 'My Assistant',
-          assistantEmoji,
-        });
-      }
-      setLoading(false);
-      setCurrentStep('branch');
-      return;
-    }
-
-    setError(null);
-    setLoading(true);
-
-    const userDisplayName = user?.name || user?.email?.split('@')[0] || 'My';
-    const boardName =
-      path === 'assistant'
-        ? `${assistantDisplayName.trim() || 'My Assistant'}'s Board`
-        : `${userDisplayName}'s Board`;
-    const boardIcon = path === 'assistant' ? assistantEmoji || '🤖' : '\u{1F3E0}';
-    try {
-      if (!client) throw new Error('Not connected');
-      const board = await client.service('boards').create({
-        name: boardName,
-        icon: boardIcon,
-      });
-      if (board?.board_id) {
-        setCreatedBoardId(board.board_id);
-        // Persist board ID immediately so restarts don't re-create it
-        saveOnboardingProgress({ boardId: board.board_id });
-        if (path === 'assistant') {
-          await ensureAssistantWelcomeNote({
-            client,
-            boardId: board.board_id,
-            assistantName: assistantDisplayName.trim() || 'My Assistant',
-            assistantEmoji,
-          });
-        }
-        setLoading(false);
-        setCurrentStep('branch');
-      }
-    } catch (err) {
-      setLoading(false);
-      setError(`Failed to create board: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }, [
-    client,
-    user,
-    boardById,
-    saveOnboardingProgress,
-    setCurrentStep,
-    path,
-    assistantDisplayName,
-    assistantEmoji,
-  ]);
-
-  const launchSessionForBranch = useCallback(
-    async (branchId: string, boardId: string) => {
-      if (!path) {
-        setError('Missing onboarding path.');
-        setLoading(false);
-        return;
-      }
-
-      setError(null);
-      setLoading(true);
-
-      try {
-        const sessionConfig: NewSessionConfig = {
-          branch_id: branchId,
-          agent: selectedAgent,
-          ...(path === 'assistant' && {
-            initialPrompt: buildAssistantBootstrapPrompt({
-              displayName: assistantDisplayName,
-              emoji: assistantEmoji,
-              userName: user?.name,
-              userEmail: user?.email,
-            }),
-          }),
-        };
-        const sessionId =
-          path === 'assistant'
-            ? await startAssistantBootstrapSession({
-                client,
-                branchId,
-                boardId,
-                sessionConfig,
-                onCreateSession,
-              })
-            : await onCreateSession(sessionConfig, boardId);
-
-        if (sessionId) {
-          setLoading(false);
-          onComplete({ branchId, sessionId, boardId, path });
-        } else {
-          setLoading(false);
-          setError('Branch created, but failed to create the first session. Please try again.');
-        }
-      } catch (err) {
-        setLoading(false);
-        setError(
-          `Branch created, but failed to create the first session: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-    },
-    [
-      path,
-      selectedAgent,
-      assistantDisplayName,
-      assistantEmoji,
-      user?.name,
-      user?.email,
-      onCreateSession,
-      onComplete,
-      client,
-    ]
-  );
-
-  const handleCreateBranch = useCallback(async () => {
-    if (!createdRepoId || !createdBoardId) {
-      setError('Missing repo or board. Please go back and try again.');
-      return;
-    }
-
-    setError(null);
-    setLoading(true);
-
-    // Branch name and ref are unified into a single input — they're almost
-    // always the same for first-time users, and the underlying form elsewhere
-    // exposes the same shortcut.
-    const sanitized = sanitizeBranchName(branchName);
-    // Fork from the repo's actual default branch (e.g. 'master' on older
-    // repos), falling back to 'main' for legacy rows missing the field.
-    const sourceBranch = repoById.get(createdRepoId)?.default_branch || 'main';
-
-    try {
-      const assistantConfig: AssistantConfig | null =
-        path === 'assistant'
-          ? {
-              kind: 'assistant',
-              displayName: assistantDisplayName.trim() || 'My Assistant',
-              emoji: assistantEmoji || undefined,
-              frameworkRepo: FRAMEWORK_REPO_SLUG,
-              createdViaOnboarding: true,
-            }
-          : null;
-
-      const branch = await onCreateBranch(createdRepoId, {
-        name: sanitized,
-        ref: sanitized,
-        createBranch: true,
-        sourceBranch,
-        pullLatest: true,
-        boardId: createdBoardId,
-        ...(assistantConfig ? { custom_context: { assistant: assistantConfig } } : {}),
-      });
-
-      if (branch) {
-        setCreatedBranchId(branch.branch_id);
-        // Persist branch ID so restarts don't re-create it
-        saveOnboardingProgress({ branchId: branch.branch_id });
-
-        if (path === 'assistant') {
-          await client
-            ?.service('boards')
-            .setPrimaryAssistant({ boardId: createdBoardId, branchId: branch.branch_id });
-        }
-
-        await launchSessionForBranch(branch.branch_id, createdBoardId);
-      } else {
-        setLoading(false);
-        setError('Failed to create branch. Please try again.');
-      }
-    } catch (err) {
-      setLoading(false);
-      setError(`Failed to create branch: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }, [
-    createdRepoId,
-    createdBoardId,
-    path,
-    branchName,
-    assistantDisplayName,
-    assistantEmoji,
-    repoById,
-    onCreateBranch,
-    client,
-    saveOnboardingProgress,
-    launchSessionForBranch,
-  ]);
+    setCurrentStep('llm');
+  }, [assistantDisplayName, assistantEmoji, saveOnboardingProgress]);
 
   const handleSaveApiKey = useCallback(async () => {
     if (!user || !apiKey.trim()) return;
-
     setError(null);
-    setLoading(true);
-
+    const keyName = apiKeyNameForAgent(selectedAgent, authMethod);
+    const targetTool: AgenticToolName =
+      selectedAgent === 'opencode' ? 'claude-code' : selectedAgent;
     try {
-      // Persist into the per-tool credential bucket. Field name = env var name
-      // = ANTHROPIC_API_KEY / OPENAI_API_KEY / etc., as `apiKeyNameForAgent`
-      // returns. The `selectedAgent` IS the bucket — except for `opencode`,
-      // which is a multi-provider tool with no canonical credential of its
-      // own (`OpencodeConfig` has no fields). The onboarding fallback for
-      // opencode collects an Anthropic key, so we route it to claude-code's
-      // bucket where it's modeled, surfaced in settings, and resolvable.
-      const keyName = apiKeyNameForAgent(selectedAgent, authMethod);
-      const targetTool: AgenticToolName =
-        selectedAgent === 'opencode' ? 'claude-code' : selectedAgent;
       await onUpdateUser(user.user_id, {
         agentic_tools: {
           [targetTool]: { [keyName]: apiKey.trim() },
         } as UpdateUserInput['agentic_tools'],
       });
-      setLoading(false);
-      setCurrentStep(path === 'own-repo' ? 'add-repo' : 'clone');
+      await startSetup();
     } catch (err) {
-      setLoading(false);
       setError(`Failed to save API key: ${err instanceof Error ? err.message : String(err)}`);
     }
-  }, [user, apiKey, authMethod, selectedAgent, path, onUpdateUser, setCurrentStep]);
-
-  const handleAdvanceFromApiKeys = useCallback(() => {
-    setCurrentStep(path === 'own-repo' ? 'add-repo' : 'clone');
-  }, [path, setCurrentStep]);
+  }, [apiKey, authMethod, onUpdateUser, selectedAgent, startSetup, user]);
 
   const handleTestAuth = useCallback(async () => {
     if (!onCheckAuth) return;
@@ -1244,97 +582,14 @@ export function OnboardingWizard({
     );
     setTestAuthLoading(false);
     setManualTestResult(result);
-  }, [onCheckAuth, selectedAgent, apiKey, authMethod]);
+  }, [apiKey, authMethod, onCheckAuth, selectedAgent]);
 
-  const handleSkip = useCallback(() => {
-    if (!user) return;
-    // onComplete sets onboarding_completed; updating it here too would double-PATCH.
-    onComplete({
-      branchId: '',
-      sessionId: '',
-      boardId: '',
-      path: 'assistant',
-    });
-  }, [user, onComplete]);
-
-  const handleBack = useCallback(() => {
-    setError(null);
-    const idx = stepIndex;
-    if (idx > 0) {
-      setCurrentStep(steps[idx - 1]);
-    }
-  }, [stepIndex, steps, setCurrentStep]);
-
-  // ─── Render Helpers ───────────────────────────────
-
-  const renderWelcome = () => (
-    <div style={{ padding: '8px 0' }}>
-      <Title level={3} style={{ marginBottom: 8 }}>
-        Welcome to Agor ✨
-      </Title>
-      <Paragraph style={{ marginBottom: 14, fontSize: 15 }}>
-        Start by creating your{' '}
-        <Typography.Link
-          strong
-          href="https://agor.live/guide/assistants"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Agor assistant
-        </Typography.Link>
-        : a persistent agent that can help you set up the workspace and keep things moving.
-      </Paragraph>
-
-      <div
-        style={{
-          background: token.colorPrimaryBg,
-          border: `1px solid ${token.colorPrimaryBorder}`,
-          borderRadius: 8,
-          padding: '14px 16px',
-          marginBottom: 16,
-        }}
-      >
-        <Text strong>Your assistant can help:</Text>
-        <ul style={{ margin: '10px 0 0', paddingLeft: 20, color: token.colorTextSecondary }}>
-          <li>🧰 Connect tools and credentials</li>
-          <li>🗺️ Set up your board and workflow</li>
-          <li>🤝 Coordinate other agents and sessions</li>
-          <li>💬 Show you around and answer questions</li>
-        </ul>
-      </div>
-
-      <Paragraph type="secondary" style={{ marginBottom: 24, fontSize: 14 }}>
-        Want the bigger picture first? Read the{' '}
-        <Typography.Link
-          href="https://agor.live/guide/getting-started"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          getting started guide
-        </Typography.Link>
-        .
-      </Paragraph>
-
-      <Button
-        type="primary"
-        size="large"
-        icon={<RobotOutlined />}
-        onClick={() => handleSelectPath('assistant')}
-      >
-        Create your assistant
-      </Button>
-    </div>
-  );
-
-  const renderAssistantIdentity = () => (
-    <div style={{ padding: '16px 0' }}>
-      <Title level={4}>Name Your Assistant</Title>
-      <Paragraph type="secondary">
-        Pick the name and emoji this assistant will use in its first bootstrap session.
-      </Paragraph>
-
+  const renderIdentity = () => (
+    <div>
+      <Title level={4}>Name your assistant</Title>
+      <Paragraph type="secondary">Pick a name and emoji.</Paragraph>
       <Form layout="vertical">
-        <Form.Item label="Name" required>
+        <Form.Item label="Assistant" required>
           <Space.Compact style={{ display: 'flex' }}>
             <EmojiPickerInput
               value={assistantEmoji}
@@ -1342,16 +597,16 @@ export function OnboardingWizard({
               defaultEmoji="🤖"
             />
             <Input
-              placeholder="e.g. PR Reviewer, Command Center"
+              placeholder="My Assistant"
               value={assistantDisplayName}
-              onChange={(e) => setAssistantDisplayName(e.target.value)}
+              onChange={(event) => setAssistantDisplayName(event.target.value)}
               autoFocus
               style={{ flex: 1 }}
             />
           </Space.Compact>
         </Form.Item>
       </Form>
-
+      {error && <Alert type="error" message={error} showIcon style={{ marginBottom: 16 }} />}
       <Button
         type="primary"
         onClick={handleAssistantIdentityContinue}
@@ -1362,392 +617,91 @@ export function OnboardingWizard({
     </div>
   );
 
-  const renderAddRepo = () => (
-    <div style={{ padding: '16px 0' }}>
-      <Title level={4}>Add Your Repository</Title>
-      <Paragraph type="secondary">
-        Connect a Git repository to get started. You can clone a remote repo or register a local
-        one.
-      </Paragraph>
-
-      <Space style={{ marginBottom: 16 }}>
-        <Button
-          type={repoMode === 'remote' ? 'primary' : 'default'}
-          size="small"
-          onClick={() => setRepoMode('remote')}
-        >
-          Remote URL
-        </Button>
-        <Button
-          type={repoMode === 'local' ? 'primary' : 'default'}
-          size="small"
-          onClick={() => setRepoMode('local')}
-        >
-          Local Path
-        </Button>
-      </Space>
-
-      {repoMode === 'remote' ? (
-        <Form layout="vertical">
-          <Form.Item label="Git URL" required>
-            <Input
-              placeholder="https://github.com/user/repo.git"
-              value={repoUrl}
-              onChange={(e) => {
-                const value = e.target.value;
-                setRepoUrl(value);
-                // Mirror RepoFormFields: auto-fill slug from URL on every keystroke.
-                // `looksLikeLocalPath` covers the case where the user pastes a
-                // filesystem path into the URL field (handled downstream too).
-                if (!value) return;
-                try {
-                  const looksLikeLocalPath = value.startsWith('/') || value.startsWith('~');
-                  const slug = looksLikeLocalPath
-                    ? extractSlugFromPath(value)
-                    : extractSlugFromUrl(value);
-                  if (slug) setRepoSlug(slug);
-                } catch {
-                  // Partial/invalid URL while typing — leave the slug untouched.
-                }
-              }}
-            />
-          </Form.Item>
-          <Form.Item
-            label="Slug (optional)"
-            validateStatus={repoSlug && !isValidSlug(repoSlug) ? 'error' : ''}
-            help={
-              repoSlug && !isValidSlug(repoSlug)
-                ? 'Must be org/name format (e.g. "my-org/my-repo")'
-                : undefined
-            }
-            extra="Auto-detected from URL (editable)"
-          >
-            <Input
-              placeholder="user/repo"
-              value={repoSlug}
-              onChange={(e) => setRepoSlug(e.target.value)}
-            />
-          </Form.Item>
-        </Form>
-      ) : (
-        <Form layout="vertical">
-          <Form.Item label="Local Path" required>
-            <Input
-              placeholder="/path/to/your/repo"
-              value={localRepoPath}
-              onChange={(e) => {
-                const value = e.target.value;
-                setLocalRepoPath(value);
-                if (!value) return;
-                const slug = extractSlugFromPath(value);
-                if (slug) setRepoSlug(slug);
-              }}
-            />
-          </Form.Item>
-          <Form.Item
-            label="Slug (optional)"
-            validateStatus={repoSlug && !isValidSlug(repoSlug) ? 'error' : ''}
-            help={
-              repoSlug && !isValidSlug(repoSlug)
-                ? 'Must be org/name format (e.g. "my-org/my-repo")'
-                : undefined
-            }
-            extra="Auto-detected from path (editable)"
-          >
-            <Input
-              placeholder="local/repo"
-              value={repoSlug}
-              onChange={(e) => setRepoSlug(e.target.value)}
-            />
-          </Form.Item>
-        </Form>
-      )}
-
-      <Button
-        type="primary"
-        onClick={handleStartClone}
-        loading={loading}
-        disabled={repoMode === 'remote' ? !repoUrl.trim() : !localRepoPath.trim()}
-      >
-        {repoMode === 'remote' ? 'Clone Repository' : 'Add Local Repository'}
-      </Button>
-    </div>
-  );
-
-  const renderClone = () => (
-    <div style={{ textAlign: 'center', padding: '32px 0' }}>
-      {loading ? (
-        <>
-          <Spin size="large" />
-          <Paragraph style={{ marginTop: 16 }}>
-            {path === 'assistant'
-              ? 'Cloning assistant framework...'
-              : 'Setting up your repository...'}
-          </Paragraph>
-          <Text type="secondary">
-            {cloneElapsedSeconds < 10
-              ? 'This may take a moment'
-              : cloneElapsedSeconds < 30
-                ? `Cloning in progress... (${cloneElapsedSeconds}s)`
-                : `Still working... large repos can take a while (${cloneElapsedSeconds}s)`}
-          </Text>
-        </>
-      ) : error ? (
-        <>
+  const renderAuthHint = () => {
+    if (selectedAgent === 'claude-code') {
+      if (authMethod === 'claude-subscription-token') {
+        return (
           <Alert
-            type="error"
-            message="Clone failed"
-            description={error}
+            type="info"
             showIcon
             style={{ marginBottom: 16, textAlign: 'left' }}
-          />
-          <Button type="primary" onClick={handleStartClone}>
-            Retry
-          </Button>
-        </>
-      ) : (
-        <>
-          <Result
-            status="success"
-            title="Repository Ready"
-            subTitle={
-              path === 'assistant'
-                ? 'Assistant framework cloned successfully.'
-                : 'Your repository is ready.'
+            description={
+              <span>
+                Run <Text code>claude setup-token</Text>, then paste the token below.
+              </span>
             }
           />
-          <Button type="primary" onClick={() => setCurrentStep('board')}>
-            Continue
-          </Button>
-        </>
-      )}
-    </div>
-  );
-
-  const renderBoard = () => (
-    <div style={{ textAlign: 'center', padding: '32px 0' }}>
-      {error ? (
-        <>
-          <Alert
-            type="error"
-            message={error}
-            showIcon
-            style={{ marginBottom: 16, textAlign: 'left' }}
-          />
-          <Button type="primary" onClick={handleCreateBoard}>
-            Retry
-          </Button>
-        </>
-      ) : (
-        <>
-          <Spin size="large" />
-          <Title level={4} style={{ marginTop: 16 }}>
-            {path === 'assistant' ? "Setting up your assistant's board" : 'Creating your board'}
-          </Title>
-          <Paragraph type="secondary" style={{ marginBottom: 0 }}>
-            {path === 'assistant'
-              ? 'Agor is creating a board where your assistant can organize its work.'
-              : 'Agor is creating a personal board for your work.'}
-          </Paragraph>
-        </>
-      )}
-    </div>
-  );
-
-  const renderBranch = () => {
-    const sourceBranch =
-      (createdRepoId ? repoById.get(createdRepoId)?.default_branch : null) || 'main';
-
-    if (createdBranchId && createdBoardId) {
+        );
+      }
       return (
-        <div style={{ textAlign: 'center', padding: '24px 0' }}>
-          <Result
-            icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
-            title={path === 'assistant' ? 'Assistant Branch Ready' : 'Branch Created'}
-            subTitle={
-              path === 'assistant'
-                ? 'Start your assistant to finish onboarding.'
-                : 'The branch is ready. Create the first session to finish onboarding.'
-            }
-          />
-          {error && (
-            <Alert
-              type="error"
-              message={error}
-              showIcon
-              style={{ marginBottom: 16, textAlign: 'left' }}
-            />
-          )}
-          <Button
-            type="primary"
-            size="large"
-            onClick={() => launchSessionForBranch(createdBranchId, createdBoardId)}
-            loading={loading}
-          >
-            {path === 'assistant' ? 'Start Assistant' : 'Create First Session'}
-          </Button>
-        </div>
+        <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+          Paste an <Text code>ANTHROPIC_API_KEY</Text> from{' '}
+          <Typography.Link href="https://platform.claude.com/settings/keys" target="_blank">
+            Claude Console
+          </Typography.Link>
+          .
+        </Paragraph>
       );
     }
 
-    return (
-      <div style={{ padding: '16px 0' }}>
-        <Title level={4}>
-          {path === 'assistant' ? 'Name Your Assistant Branch' : 'Create Your Branch'}
-        </Title>
-        <Paragraph type="secondary">
-          {path === 'assistant'
-            ? 'Your assistant works from its own branch: a safe place to use tools and keep setup context.'
-            : 'A branch is an isolated workspace backed by its own git branch. Name it whatever you like. We’ll create the first session after the branch is ready.'}
-        </Paragraph>
-
-        <Form layout="vertical">
-          <Form.Item
-            label="Branch name"
-            extra={
-              path === 'assistant' ? undefined : (
-                <>
-                  Used as both the directory name and the new branch name. Forked from{' '}
-                  <Text code>{sourceBranch}</Text>.
-                </>
-              )
+    if (selectedAgent === 'codex') {
+      if (authMethod === 'codex-cli-auth') {
+        return (
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginBottom: 16, textAlign: 'left' }}
+            description={
+              <span>
+                Run <Text code>codex login --device-auth</Text>; Agor will use that local auth.
+              </span>
             }
-          >
-            <Input
-              placeholder={`private-${usernameSlug}`}
-              value={branchName}
-              onChange={(e) => setBranchName(e.target.value)}
-            />
-          </Form.Item>
-        </Form>
+          />
+        );
+      }
+      return (
+        <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+          Paste an <Text code>OPENAI_API_KEY</Text> from{' '}
+          <Typography.Link href="https://platform.openai.com/api-keys" target="_blank">
+            OpenAI Platform
+          </Typography.Link>
+          .
+        </Paragraph>
+      );
+    }
 
-        {error && <Alert type="error" message={error} showIcon style={{ marginBottom: 16 }} />}
-
-        <Button
-          type="primary"
-          onClick={handleCreateBranch}
-          loading={loading}
-          disabled={!branchName.trim()}
-        >
-          {path === 'assistant'
-            ? 'Create Branch & Start Assistant'
-            : 'Create Branch & First Session'}
-        </Button>
-      </div>
+    const consoleInfo = AGENT_KEY_CONSOLES[selectedAgent];
+    if (!consoleInfo) return null;
+    return (
+      <Paragraph type="secondary" style={{ marginBottom: 16 }}>
+        Paste your {apiKeyNameForAgent(selectedAgent, authMethod)} from{' '}
+        <Typography.Link href={consoleInfo.url} target="_blank" rel="noopener noreferrer">
+          {consoleInfo.label}
+        </Typography.Link>
+        .
+      </Paragraph>
     );
   };
 
-  const renderApiKeys = () => {
+  const renderLlm = () => {
     const hasKey = hasKeyForAgent(selectedAgent);
-    // "Already auth'd" covers both stored credentials (agentic_tools / env vars
-    // / system credentials) AND ambient CLI auth detected by onCheckAuth —
-    // e.g. the user already configured Claude/Codex CLI auth outside the wizard.
-    // Auto-flip to "{tool} is configured → Continue" ONLY when the current
-    // user has THEIR OWN stored per-user credential. We intentionally do not
-    // gate on `detectedAuth?.authenticated` here: the ambient probe reads
-    // host-level state (daemon env vars, daemon's ~/.claude or ~/.codex), and
-    // letting it auto-skip the LLM-auth step caused brand-new users to never
-    // see the API-key input — they silently inherited the admin's setup. The
-    // "Test Connection" button writes to manualTestResult (inline ✓/✗) and
-    // is also intentionally absent here so a typed-key test never replaces
-    // the Save step.
-    const isAuthenticated = hasKey;
-
+    const isAuthenticated = hasKey && !overrideDetectedAuth;
     const authMethodOptions = authMethodOptionsForAgent(selectedAgent);
     const usesCodexCliAuth = selectedAgent === 'codex' && authMethod === 'codex-cli-auth';
     const currentKeyName = apiKeyNameForAgent(selectedAgent, authMethod);
 
-    const renderAuthHint = () => {
-      if (selectedAgent === 'claude-code') {
-        if (authMethod === 'claude-subscription-token') {
-          return (
-            <Alert
-              type="info"
-              showIcon
-              style={{ marginBottom: 16, textAlign: 'left' }}
-              description={
-                <span>
-                  Run <Text code>claude setup-token</Text> on the machine Agor runs sessions on,
-                  then paste the printed token below.
-                </span>
-              }
-            />
-          );
-        }
-
-        return (
-          <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste an <Text code>ANTHROPIC_API_KEY</Text> from{' '}
-            <Typography.Link href="https://platform.claude.com/settings/keys" target="_blank">
-              Claude Console
-            </Typography.Link>{' '}
-            for pay-as-you-go API billing.
-          </Paragraph>
-        );
-      }
-
-      if (selectedAgent === 'codex') {
-        if (usesCodexCliAuth) {
-          return (
-            <Alert
-              type="info"
-              showIcon
-              style={{ marginBottom: 16, textAlign: 'left' }}
-              description={
-                <span>
-                  Run <Text code>codex login --device-auth</Text> on the machine Agor runs sessions
-                  on; Agor uses that local auth when no <Text code>OPENAI_API_KEY</Text> is set.
-                </span>
-              }
-            />
-          );
-        }
-
-        return (
-          <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste an <Text code>OPENAI_API_KEY</Text> from{' '}
-            <Typography.Link href="https://platform.openai.com/api-keys" target="_blank">
-              OpenAI Platform
-            </Typography.Link>{' '}
-            for API billing, automation, or team-managed keys.
-          </Paragraph>
-        );
-      }
-
-      if (AGENT_KEY_CONSOLES[selectedAgent]) {
-        return (
-          <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-            Paste your {currentKeyName} below. Get one at{' '}
-            <Typography.Link
-              href={AGENT_KEY_CONSOLES[selectedAgent]?.url}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {AGENT_KEY_CONSOLES[selectedAgent]?.label}
-            </Typography.Link>
-            .
-          </Paragraph>
-        );
-      }
-      return null;
-    };
-
     return (
-      <div style={{ padding: '16px 0' }}>
-        <Title level={4}>Choose an LLM Provider</Title>
+      <div>
+        <Title level={4}>Choose your LLM</Title>
         <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-          Pick what powers your assistant. You can change this later.
+          Pick what powers your assistant.
         </Paragraph>
 
-        <Space direction="vertical" size="middle" style={{ width: '100%', marginBottom: 16 }}>
+        <Space orientation="vertical" size="middle" style={{ width: '100%', marginBottom: 16 }}>
           <div
             role="radiogroup"
             aria-label="Recommended LLM providers"
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
-              gap: 12,
-            }}
+            style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 12 }}
           >
             {RECOMMENDED_AGENT_OPTIONS.map((option) => {
               const selected = selectedAgent === option.value;
@@ -1761,20 +715,11 @@ export function OnboardingWizard({
                   }}
                   styles={{ body: { padding: 0 } }}
                 >
-                  <label
-                    style={{
-                      display: 'block',
-                      width: '100%',
-                      cursor: 'pointer',
-                      padding: 14,
-                    }}
-                  >
+                  <label style={{ display: 'block', cursor: 'pointer', padding: 14 }}>
                     <Space align="center" size={10} style={{ width: '100%' }}>
                       <ToolIcon tool={option.value} size={32} />
                       <div style={{ flex: 1, minWidth: 0 }}>
-                        <div>
-                          <Text strong>{option.title}</Text>
-                        </div>
+                        <Text strong>{option.title}</Text>
                         <div>
                           <Tag color={selected ? 'blue' : 'default'}>{option.eyebrow}</Tag>
                         </div>
@@ -1820,21 +765,18 @@ export function OnboardingWizard({
           )}
         </Space>
 
-        {isAuthenticated && !overrideDetectedAuth ? (
-          <div style={{ textAlign: 'center', padding: '8px 0' }}>
+        {isAuthenticated ? (
+          <div style={{ textAlign: 'center' }}>
             <Result
-              style={{ padding: '16px 0' }}
+              style={{ padding: '8px 0 12px' }}
               icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
               title={`${AGENT_LABELS[selectedAgent]} is configured`}
               subTitle={`You're all set to use ${AGENT_LABELS[selectedAgent]}.`}
             />
-            <Space direction="vertical" size="small">
-              <Button type="primary" onClick={handleAdvanceFromApiKeys}>
+            <Space orientation="vertical" size="small">
+              <Button type="primary" onClick={startSetup}>
                 Continue
               </Button>
-              {/* Escape hatch: stored key may be stale, wrong-account, or
-                  just not what the user wants (e.g. work account on file but
-                  they want to use a personal key for this onboarding). */}
               <Button type="link" onClick={() => setOverrideDetectedAuth(true)}>
                 Use a different API key instead
               </Button>
@@ -1842,20 +784,19 @@ export function OnboardingWizard({
           </div>
         ) : (
           <>
-            {isAuthenticated && overrideDetectedAuth && (
-              <div style={{ marginBottom: 12 }}>
-                <Button
-                  type="link"
-                  onClick={() => {
-                    setOverrideDetectedAuth(false);
-                    setApiKey('');
-                  }}
-                  style={{ padding: 0 }}
-                >
-                  ← Back to detected authentication
-                </Button>
-              </div>
+            {overrideDetectedAuth && (
+              <Button
+                type="link"
+                onClick={() => {
+                  setOverrideDetectedAuth(false);
+                  setApiKey('');
+                }}
+                style={{ padding: 0, marginBottom: 12 }}
+              >
+                ← Back to detected authentication
+              </Button>
             )}
+
             {authMethodOptions && (
               <Radio.Group
                 value={authMethod}
@@ -1873,27 +814,20 @@ export function OnboardingWizard({
                     gap: 8,
                   }}
                 >
-                  {authMethodOptions.map((option) => {
-                    const selected = authMethod === option.value;
-                    return (
-                      <Radio
-                        key={option.value}
-                        value={option.value}
-                        style={{
-                          alignItems: 'center',
-                          border: selected
-                            ? '1px solid var(--ant-color-primary)'
-                            : '1px solid var(--ant-color-border)',
-                          borderRadius: 8,
-                          display: 'flex',
-                          marginInlineEnd: 0,
-                          padding: '8px 12px',
-                        }}
-                      >
-                        <Text strong={selected}>{option.label}</Text>
-                      </Radio>
-                    );
-                  })}
+                  {authMethodOptions.map((option) => (
+                    <Radio
+                      key={option.value}
+                      value={option.value}
+                      style={{
+                        border: `1px solid ${token.colorBorder}`,
+                        borderRadius: 8,
+                        marginInlineEnd: 0,
+                        padding: '8px 12px',
+                      }}
+                    >
+                      <Text strong={authMethod === option.value}>{option.label}</Text>
+                    </Radio>
+                  ))}
                 </div>
               </Radio.Group>
             )}
@@ -1902,8 +836,7 @@ export function OnboardingWizard({
 
             {selectedAgent === 'opencode' && (
               <Paragraph type="secondary" style={{ marginBottom: 16 }}>
-                OpenCode supports 75+ LLM providers. Configure the appropriate API key for your
-                chosen provider below.
+                OpenCode supports many LLM providers. Configure the key for your provider below.
               </Paragraph>
             )}
 
@@ -1913,9 +846,8 @@ export function OnboardingWizard({
                   <Input.Password
                     placeholder={apiKeyPlaceholder(selectedAgent, authMethod)}
                     value={apiKey}
-                    onChange={(e) => {
-                      setApiKey(e.target.value);
-                      // Editing the key invalidates any prior test result.
+                    onChange={(event) => {
+                      setApiKey(event.target.value);
                       setManualTestResult(null);
                     }}
                   />
@@ -1924,41 +856,25 @@ export function OnboardingWizard({
             )}
 
             {error && <Alert type="error" message={error} showIcon style={{ marginBottom: 16 }} />}
-
-            {manualTestResult &&
-              (manualTestResult.authenticated ? (
-                <Alert
-                  type="success"
-                  showIcon
-                  style={{ marginBottom: 16, textAlign: 'left' }}
-                  message="Connection works"
-                  description={
-                    manualTestResult.hint ||
-                    (usesCodexCliAuth
-                      ? 'Click Continue with Codex CLI auth to use this machine login.'
-                      : 'Click Save & Continue to store this key.')
-                  }
-                />
-              ) : (
-                <Alert
-                  type="warning"
-                  showIcon
-                  style={{ marginBottom: 16, textAlign: 'left' }}
-                  message="Not authenticated"
-                  description={manualTestResult.hint}
-                />
-              ))}
+            {manualTestResult && (
+              <Alert
+                type={manualTestResult.authenticated ? 'success' : 'warning'}
+                showIcon
+                style={{ marginBottom: 16, textAlign: 'left' }}
+                message={manualTestResult.authenticated ? 'Connection works' : 'Not authenticated'}
+                description={manualTestResult.hint}
+              />
+            )}
 
             <Space wrap>
               {usesCodexCliAuth ? (
-                <Button type="primary" onClick={handleAdvanceFromApiKeys} disabled={loading}>
+                <Button type="primary" onClick={startSetup}>
                   Continue with Codex CLI auth
                 </Button>
               ) : (
                 <Button
                   type="primary"
                   onClick={handleSaveApiKey}
-                  loading={loading}
                   disabled={!apiKey.trim()}
                   icon={<KeyOutlined />}
                 >
@@ -1966,15 +882,11 @@ export function OnboardingWizard({
                 </Button>
               )}
               {onCheckAuth && (
-                <Button onClick={handleTestAuth} loading={testAuthLoading} disabled={loading}>
+                <Button onClick={handleTestAuth} loading={testAuthLoading}>
                   Test Connection
                 </Button>
               )}
-              {!usesCodexCliAuth && (
-                <Button onClick={handleAdvanceFromApiKeys} disabled={loading}>
-                  Continue without key
-                </Button>
-              )}
+              {!usesCodexCliAuth && <Button onClick={startSetup}>Continue without key</Button>}
             </Space>
           </>
         )}
@@ -1982,202 +894,48 @@ export function OnboardingWizard({
     );
   };
 
-  const renderStepContent = () => {
-    switch (currentStep) {
-      case 'welcome':
-        return renderWelcome();
-      case 'identity':
-        return renderAssistantIdentity();
-      case 'add-repo':
-        return renderAddRepo();
-      case 'clone':
-        return renderClone();
-      case 'board':
-        return renderBoard();
-      case 'branch':
-        return renderBranch();
-      case 'api-keys':
-        return renderApiKeys();
-      default:
-        return null;
-    }
-  };
-
-  // ─── Progress display config ─────────────────────
-
-  const progressItems = useMemo(() => {
-    if (path === 'assistant') {
-      return [
-        { key: 'identity' as const, title: 'Assistant', icon: <RobotOutlined /> },
-        { key: 'api-keys' as const, title: 'LLM Provider', icon: <ApiOutlined /> },
-        { key: 'branch' as const, title: 'Workspace', icon: <BranchesOutlined /> },
-      ];
-    }
-
-    if (path === 'own-repo') {
-      return [
-        { key: 'api-keys' as const, title: 'LLM Provider', icon: <ApiOutlined /> },
-        { key: 'add-repo' as const, title: 'Repo', icon: <FolderOpenOutlined /> },
-        { key: 'branch' as const, title: 'Workspace', icon: <BranchesOutlined /> },
-      ];
-    }
-
-    return [];
-  }, [path]);
-
-  const currentProgressIndex = useMemo(() => {
-    if (!path || currentStep === 'welcome') return -1;
-    if (path === 'assistant') {
-      if (currentStep === 'identity') return 0;
-      if (currentStep === 'api-keys') return 1;
-      return 2;
-    }
-    if (currentStep === 'api-keys') return 0;
-    if (currentStep === 'add-repo' || currentStep === 'clone') return 1;
-    return 2;
-  }, [path, currentStep]);
-
-  const renderProgressIndicator = () => {
-    if (!path || currentStep === 'welcome' || progressItems.length === 0) return null;
-
-    return (
-      <ol
-        aria-label="Onboarding progress"
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: 10,
-          marginBottom: 24,
-          padding: 0,
-          listStyle: 'none',
-        }}
-      >
-        {progressItems.map((item, index) => {
-          const isActive = index === currentProgressIndex;
-          const color = isActive ? token.colorPrimary : token.colorTextDisabled;
-          return (
-            <li
-              key={item.key}
-              aria-current={isActive ? 'step' : undefined}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 10,
-                color,
-              }}
-            >
-              <Space direction="vertical" size={4} align="center">
-                <div
-                  style={{
-                    width: 34,
-                    height: 34,
-                    borderRadius: 999,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    color,
-                    background: isActive ? token.colorPrimaryBg : token.colorFillTertiary,
-                    border: `1px solid ${isActive ? token.colorPrimary : token.colorBorder}`,
-                    opacity: isActive ? 1 : 0.55,
-                  }}
-                >
-                  {item.icon}
-                </div>
-                <Text
-                  style={{
-                    color,
-                    fontSize: 12,
-                    fontWeight: isActive ? 600 : undefined,
-                    opacity: isActive ? 1 : 0.65,
-                  }}
-                >
-                  {item.title}
-                </Text>
-              </Space>
-              {index < progressItems.length - 1 && (
-                <ArrowRightOutlined
-                  style={{ color: token.colorTextDisabled, opacity: 0.55, fontSize: 12 }}
-                />
-              )}
-            </li>
-          );
-        })}
-      </ol>
-    );
-  };
-
-  // ─── Auto-trigger steps that should auto-start ────
-  useEffect(() => {
-    // Auto-start clone when entering clone step for assistant
-    if (currentStep === 'clone' && path === 'assistant' && !loading && !error && !createdRepoId) {
-      handleStartClone();
-    }
-  }, [currentStep, path, loading, error, createdRepoId, handleStartClone]);
-
-  // Auto-start board creation
-  useEffect(() => {
-    if (currentStep === 'board' && !loading && !error && !createdBoardId) {
-      handleCreateBoard();
-    }
-  }, [currentStep, loading, error, createdBoardId, handleCreateBoard]);
-
-  // ─── Footer ───────────────────────────────────────
-
-  const footer = (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: '0 8px',
-      }}
-    >
-      {/* Left: Resources */}
-      <Space size="middle">
-        <Typography.Link
-          href="https://agor.live/guide/getting-started"
-          target="_blank"
-          style={{ fontSize: 12 }}
-        >
-          Getting Started Docs
-        </Typography.Link>
-        <Typography.Link
-          href="https://github.com/preset-io/agor"
-          target="_blank"
-          style={{ fontSize: 12 }}
-        >
-          GitHub
-        </Typography.Link>
-      </Space>
-
-      {/* Right: Skip */}
-      <Space size="small">
-        <Popconfirm
-          title="Skip setup?"
-          description={
-            <div style={{ maxWidth: 250 }}>
-              Are you sure? Your assistant has been waiting their whole life to meet you.
-              <br />
-              <br />
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                (You can always come back via Settings)
-              </Text>
-            </div>
-          }
-          okText="Skip anyway"
-          cancelText="Go back"
-          onConfirm={handleSkip}
-        >
-          <Button type="text" size="small" style={{ color: token.colorTextTertiary }}>
-            Skip setup
+  const renderLoading = () => (
+    <div style={{ textAlign: 'center', padding: '48px 0' }}>
+      {setupStage === 'error' ? (
+        <>
+          <Alert
+            type="error"
+            message="Setup failed"
+            description={error}
+            showIcon
+            style={{ marginBottom: 16, textAlign: 'left' }}
+          />
+          <Button type="primary" onClick={startSetup}>
+            Retry
           </Button>
-        </Popconfirm>
-      </Space>
+        </>
+      ) : (
+        <>
+          <Spin size="large" />
+          <Title level={4} style={{ marginTop: 20, marginBottom: 8 }}>
+            Setting up Agor
+          </Title>
+          <Paragraph type="secondary" style={{ marginBottom: 0 }}>
+            {operationText}
+          </Paragraph>
+        </>
+      )}
     </div>
   );
 
-  // ─── Render ───────────────────────────────────────
+  const footer =
+    currentStep === 'loading' ? null : (
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Text type="secondary" style={{ fontSize: 12 }}>
+          Step {currentStep === 'identity' ? '1' : '2'} of 2
+        </Text>
+        {currentStep === 'llm' && (
+          <Button type="link" onClick={() => setCurrentStep('identity')}>
+            ← Back
+          </Button>
+        )}
+      </div>
+    );
 
   return (
     <Modal
@@ -2186,28 +944,18 @@ export function OnboardingWizard({
       mask={{ closable: false }}
       keyboard={false}
       footer={footer}
-      width={640}
+      width={680}
       styles={{
         body: {
-          minHeight: 360,
-          padding: '24px 32px',
+          height: 440,
+          overflowY: 'auto',
+          padding: '28px 36px',
         },
       }}
     >
-      {/* Progress indicator (only when path is chosen) */}
-      {renderProgressIndicator()}
-
-      {/* Step content */}
-      {renderStepContent()}
-
-      {/* Back button (where appropriate) */}
-      {currentStep !== 'welcome' && stepIndex > 1 && !loading && (
-        <div style={{ marginTop: 16 }}>
-          <Button type="link" onClick={handleBack} style={{ padding: 0 }}>
-            &larr; Back
-          </Button>
-        </div>
-      )}
+      {currentStep === 'identity' && renderIdentity()}
+      {currentStep === 'llm' && renderLlm()}
+      {currentStep === 'loading' && renderLoading()}
     </Modal>
   );
 }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -586,13 +586,42 @@ export function OnboardingWizard({
 
   const renderIdentity = () => (
     <div>
-      <Title level={4}>Create your assistant</Title>
-      <Paragraph>
-        Your assistant is a persistent agent for setup and ongoing work in Agor.
+      <Title level={4} style={{ marginBottom: 8 }}>
+        Welcome to Agor ✨
+      </Title>
+      <Paragraph style={{ marginBottom: 14 }}>
+        Start by creating your{' '}
+        <Typography.Link
+          strong
+          href="https://agor.live/guide/assistants"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Agor assistant
+        </Typography.Link>
+        : a persistent agent that can help set up your workspace and keep things moving.
       </Paragraph>
-      <Paragraph type="secondary">Pick a name and emoji to get started.</Paragraph>
+
+      <div
+        style={{
+          background: token.colorPrimaryBg,
+          border: `1px solid ${token.colorPrimaryBorder}`,
+          borderRadius: 8,
+          padding: '12px 14px',
+          marginBottom: 16,
+        }}
+      >
+        <Text strong>Your assistant can help:</Text>
+        <ul style={{ margin: '8px 0 0', paddingLeft: 20, color: token.colorTextSecondary }}>
+          <li>🧰 Connect tools and credentials</li>
+          <li>🗺️ Set up your board and workflow</li>
+          <li>🤝 Coordinate agents and sessions</li>
+          <li>💬 Show you around and answer questions</li>
+        </ul>
+      </div>
+
       <Form layout="vertical">
-        <Form.Item label="Assistant" required>
+        <Form.Item label="Name and emoji" required>
           <Space.Compact style={{ display: 'flex' }}>
             <EmojiPickerInput
               value={assistantEmoji}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -17,6 +17,7 @@ import type {
   CodexSandboxMode,
   CreateLocalRepoRequest,
   CreateRepoRequest,
+  DefaultModelConfig,
   PermissionMode,
   Repo,
   UpdateUserInput,
@@ -193,6 +194,17 @@ function defaultAuthMethodForAgent(agent: AgenticToolName): AuthMethod {
   return agent === 'codex' ? 'codex-cli-auth' : 'api-key';
 }
 
+function toSessionModelConfig(
+  config?: DefaultModelConfig
+): NewSessionConfig['modelConfig'] | undefined {
+  if (!config?.model) return undefined;
+  return {
+    mode: config.mode ?? 'exact',
+    model: config.model,
+    ...(config.advisorModel ? { advisorModel: config.advisorModel } : {}),
+  };
+}
+
 function authMethodOptionsForAgent(agent: AgenticToolName) {
   if (agent === 'claude-code') {
     return [
@@ -351,7 +363,7 @@ export function OnboardingWizard({
           userName: user?.name,
           userEmail: user?.email,
         }),
-        modelConfig: agentDefaults?.modelConfig,
+        modelConfig: toSessionModelConfig(agentDefaults?.modelConfig),
         effort: agentDefaults?.modelConfig?.effort,
         mcpServerIds: agentDefaults?.mcpServerIds,
         permissionMode,


### PR DESCRIPTION
## Summary
- Reduce onboarding to two input screens: assistant orientation/name/emoji and LLM/provider configuration.
- Replace repo, board, and branch input screens with a bounded setup progress screen that shows the current operation.
- Use sensible defaults for setup, including the generated default assistant branch name instead of asking for a branch name.
- Preserve selected agent credentials and user default session/model config when starting the assistant bootstrap session.
- Keep modal sizing bounded/dynamic so the LLM form has room without returning to large step-to-step jumps.

## Checks
- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- OnboardingWizard.test.tsx`
