### PR TITLE
fix(ui): pin conversation auto-scroll with use-stick-to-bottom (#111)

### DIFF
--- a/apps/agor-ui/package.json
+++ b/apps/agor-ui/package.json
@@ -49,7 +49,8 @@
     "react-router-dom": "^7.18.0",
     "react-syntax-highlighter": "^16.1.1",
     "reactflow": "^11.11.4",
-    "streamdown": "^1.5.1"
+    "streamdown": "^1.5.1",
+    "use-stick-to-bottom": "^1.1.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
@@ -21,6 +21,36 @@ vi.mock('@agor-live/client', () => ({
   shortId: () => 'short-id',
 }));
 
+// use-stick-to-bottom owns the actual scroll physics (persistent
+// ResizeObserver, spring animation). jsdom has no real layout, so we don't
+// unit-test the library here — instead we mock it and assert OUR integration
+// wiring: onScrollRef exposes the hook's scrollToBottom + a working
+// scrollToTop, the open/session-switch effect calls scrollToBottom, and the
+// new-task expand logic honors the hook's isAtBottom.
+let mockIsAtBottom = true;
+const mockScrollToBottom = vi.fn();
+type CallbackRef = ((el: HTMLElement | null) => void) & { current: HTMLElement | null };
+
+function makeCallbackRef(): CallbackRef {
+  const ref = ((el: HTMLElement | null) => {
+    ref.current = el;
+  }) as CallbackRef;
+  ref.current = null;
+  return ref;
+}
+
+let mockScrollRef: CallbackRef;
+let mockContentRef: CallbackRef;
+
+vi.mock('use-stick-to-bottom', () => ({
+  useStickToBottom: () => ({
+    scrollRef: mockScrollRef,
+    contentRef: mockContentRef,
+    scrollToBottom: mockScrollToBottom,
+    isAtBottom: mockIsAtBottom,
+  }),
+}));
+
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { ConversationView } from './ConversationView';
 
@@ -41,66 +71,6 @@ vi.mock('../TaskBlock', () => ({
 }));
 
 const mockUseSharedReactiveSession = vi.mocked(useSharedReactiveSession);
-
-interface RafEntry {
-  id: number;
-  callback: FrameRequestCallback;
-}
-
-let rafCallbacks: RafEntry[] = [];
-let rafId = 0;
-const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
-const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
-const originalResizeObserver = globalThis.ResizeObserver;
-
-const resizeObserverInstances: MockResizeObserver[] = [];
-
-class MockResizeObserver implements ResizeObserver {
-  callback: ResizeObserverCallback;
-  disconnected = false;
-
-  constructor(callback: ResizeObserverCallback) {
-    this.callback = callback;
-    resizeObserverInstances.push(this);
-  }
-
-  observe = vi.fn();
-  unobserve = vi.fn();
-  disconnect = vi.fn(() => {
-    this.disconnected = true;
-  });
-
-  trigger() {
-    this.callback([] as unknown as ResizeObserverEntry[], this);
-  }
-}
-
-function flushRaf() {
-  const callbacks = rafCallbacks;
-  rafCallbacks = [];
-  act(() => {
-    for (const { callback } of callbacks) {
-      callback(performance.now());
-    }
-  });
-}
-
-function flushAllRaf(maxFrames = 20) {
-  for (let i = 0; i < maxFrames && rafCallbacks.length > 0; i += 1) {
-    flushRaf();
-  }
-}
-
-function setScrollMetrics(element: HTMLElement, scrollHeight: number, clientHeight: number) {
-  Object.defineProperty(element, 'scrollHeight', {
-    configurable: true,
-    value: scrollHeight,
-  });
-  Object.defineProperty(element, 'clientHeight', {
-    configurable: true,
-    value: clientHeight,
-  });
-}
 
 function makeTask(id: string, prompt: string): any {
   return {
@@ -149,370 +119,90 @@ function makeState(overrides: Record<string, unknown>): any {
   };
 }
 
-describe('ConversationView initial auto-scroll', () => {
+describe('ConversationView auto-scroll integration', () => {
   beforeEach(() => {
-    rafCallbacks = [];
-    rafId = 0;
-    resizeObserverInstances.length = 0;
-    globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
-      rafId += 1;
-      rafCallbacks.push({ id: rafId, callback });
-      return rafId;
-    });
-    globalThis.cancelAnimationFrame = vi.fn((id: number) => {
-      rafCallbacks = rafCallbacks.filter((entry) => entry.id !== id);
-    });
-    globalThis.ResizeObserver = MockResizeObserver;
+    mockIsAtBottom = true;
+    mockScrollToBottom.mockClear();
+    mockScrollRef = makeCallbackRef();
+    mockContentRef = makeCallbackRef();
   });
 
   afterEach(() => {
     mockUseSharedReactiveSession.mockReset();
-    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
-    globalThis.ResizeObserver = originalResizeObserver;
   });
 
-  it('scrolls to the bottom after the initial task list finishes loading', () => {
-    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
-    let state = makeState({ loading: true, tasks: [] });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="initial" />
-    );
-
-    state = makeState({ loading: false, tasks });
-    rerender(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
-    );
-
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 1200, 300);
-    expect(scroller.scrollTop).toBe(0);
-
-    flushRaf();
-
-    expect(scroller.scrollTop).toBe(1200);
-  });
-
-  it('scrolls again when the latest task messages finish loading', () => {
-    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
-    let state = makeState({ loading: false, tasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushRaf();
-    expect(scroller.scrollTop).toBe(900);
-
-    state = makeState({
-      loading: false,
-      tasks,
-      loadedTaskIds: new Set(['task-2']),
-      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
-    });
-    rerender(
-      <ConversationView
-        client={null}
-        sessionId={'session-1' as any}
-        sessionModel="messages-loaded"
-      />
-    );
-    setScrollMetrics(scroller, 1600, 300);
-
-    flushRaf();
-
-    expect(scroller.scrollTop).toBe(1600);
-  });
-
-  it('ignores stale reactive session state during a session switch', () => {
-    const sessionOneTasks = [makeTask('task-1', 'session one task')];
-    const sessionTwoTasks = [makeTask('task-2', 'session two latest')];
-    let state = makeState({ sessionId: 'session-1', loading: false, tasks: sessionOneTasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="session-1" />
-    );
-    const firstScroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(firstScroller, 900, 300);
-    flushAllRaf();
-    expect(firstScroller.scrollTop).toBe(900);
-
-    // useSharedReactiveSession can return the previous session's state for one
-    // render after sessionId changes. That stale render must not complete the
-    // new session's initial task-list scroll phase.
-    rerender(
-      <ConversationView client={null} sessionId={'session-2' as any} sessionModel="stale-state" />
-    );
-    expect(screen.queryByTestId('conversation-scroll-container')).not.toBeInTheDocument();
-
-    state = makeState({ sessionId: 'session-2', loading: false, tasks: sessionTwoTasks });
-    rerender(
-      <ConversationView client={null} sessionId={'session-2' as any} sessionModel="session-2" />
-    );
-
-    const secondScroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(secondScroller, 1400, 300);
-    flushAllRaf();
-
-    expect(secondScroller.scrollTop).toBe(1400);
-  });
-
-  it('does not treat task-list layout growth as a manual scroll-away before messages load', () => {
-    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
-    let state = makeState({ loading: false, tasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushRaf();
-    expect(scroller.scrollTop).toBe(900);
-
-    // Simulate late task-list layout growth before the latest task messages
-    // finish loading. This may fire a scroll event, but without an explicit user
-    // scroll input it must not suppress the phase-2 latest-message scroll.
-    setScrollMetrics(scroller, 1600, 300);
-    fireEvent.scroll(scroller);
-
-    state = makeState({
-      loading: false,
-      tasks,
-      loadedTaskIds: new Set(['task-2']),
-      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
-    });
-    rerender(
-      <ConversationView
-        client={null}
-        sessionId={'session-1' as any}
-        sessionModel="messages-loaded"
-      />
-    );
-    setScrollMetrics(scroller, 2400, 300);
-    flushRaf();
-
-    expect(scroller.scrollTop).toBe(2400);
-  });
-
-  it('keeps initial message-load auto-scroll active until large content layout stabilizes', () => {
-    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
-    let state = makeState({ loading: false, tasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushAllRaf();
-    expect(scroller.scrollTop).toBe(900);
-
-    state = makeState({
-      loading: false,
-      tasks,
-      loadedTaskIds: new Set(['task-2']),
-      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
-    });
-    rerender(
-      <ConversationView
-        client={null}
-        sessionId={'session-1' as any}
-        sessionModel="messages-loaded"
-      />
-    );
-
-    setScrollMetrics(scroller, 1600, 300);
-    flushRaf();
-    expect(scroller.scrollTop).toBe(1600);
-
-    setScrollMetrics(scroller, 3200, 300);
-    resizeObserverInstances.at(-1)?.trigger();
-    flushRaf();
-
-    expect(scroller.scrollTop).toBe(3200);
-  });
-
-  it('stops layout-stabilizing initial auto-scroll when the user scrolls away', () => {
-    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
-    let state = makeState({ loading: false, tasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushAllRaf();
-    expect(scroller.scrollTop).toBe(900);
-
-    state = makeState({
-      loading: false,
-      tasks,
-      loadedTaskIds: new Set(['task-2']),
-      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
-    });
-    rerender(
-      <ConversationView
-        client={null}
-        sessionId={'session-1' as any}
-        sessionModel="messages-loaded"
-      />
-    );
-
-    setScrollMetrics(scroller, 1600, 300);
-    flushRaf();
-    expect(scroller.scrollTop).toBe(1600);
-
-    fireEvent.wheel(scroller);
-    scroller.scrollTop = 1000;
-    fireEvent.scroll(scroller);
-    setScrollMetrics(scroller, 3200, 300);
-    resizeObserverInstances.at(-1)?.trigger();
-    flushRaf();
-
-    expect(scroller.scrollTop).toBe(1000);
-  });
-
-  it('lets a manual scroll before the new-task RAF win', () => {
-    let tasks = [makeTask('task-1', 'first task')];
-    let state = makeState({ loading: false, tasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="one-task" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushRaf();
-    expect(scroller.scrollTop).toBe(900);
-
-    tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'new task')];
-    state = makeState({ loading: false, tasks });
-    rerender(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="two-tasks" />
-    );
-    setScrollMetrics(scroller, 1400, 300);
-
-    fireEvent.wheel(scroller);
-    scroller.scrollTop = 100;
-    fireEvent.scroll(scroller);
-    flushRaf();
-
-    expect(scroller.scrollTop).toBe(100);
-  });
-
-  it('treats explicit task expand/collapse as reading intent before a new task arrives', () => {
-    let tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
-    let state = makeState({ loading: false, tasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="two-tasks" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushAllRaf();
-
-    fireEvent.click(screen.getByRole('button', { name: 'toggle task-1' }));
-    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
-
-    tasks = [
-      makeTask('task-1', 'first task'),
-      makeTask('task-2', 'previous latest task'),
-      makeTask('task-3', 'new latest task'),
-    ];
-    state = makeState({ loading: false, tasks });
-    rerender(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="three-tasks" />
-    );
-    setScrollMetrics(scroller, 1500, 300);
-    flushAllRaf();
-
-    expect(scroller.scrollTop).toBe(900);
-    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
-    expect(screen.getByTestId('task-task-3')).toHaveAttribute('data-expanded', 'true');
-  });
-
-  it('keeps streaming locked to the bottom while the user is still at bottom', () => {
-    const tasks = [makeTask('task-1', 'latest task')];
-    let state = makeState({ loading: false, tasks, loadedTaskIds: new Set(['task-1']) });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="loaded" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 1000, 300);
-    flushAllRaf();
-    expect(scroller.scrollTop).toBe(1000);
-
-    state = makeState({
-      loading: false,
-      tasks,
-      loadedTaskIds: new Set(['task-1']),
-      streamingMessages: new Map([['stream-1', makeMessage('task-1')]]),
-    });
-    setScrollMetrics(scroller, 1400, 300);
-    rerender(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="streaming" />
-    );
-
-    expect(scroller.scrollTop).toBe(1400);
-  });
-
-  it('does not scroll when latest task messages load after the latest task was collapsed', () => {
-    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
-    let state = makeState({ loading: false, tasks });
-    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
-
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushRaf();
-    expect(scroller.scrollTop).toBe(900);
-
-    fireEvent.click(screen.getByRole('button', { name: 'toggle task-2' }));
-    expect(screen.getByTestId('task-task-2')).toHaveAttribute('data-expanded', 'false');
-
-    state = makeState({
-      loading: false,
-      tasks,
-      loadedTaskIds: new Set(['task-2']),
-      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
-    });
-    rerender(
-      <ConversationView
-        client={null}
-        sessionId={'session-1' as any}
-        sessionModel="messages-loaded"
-      />
-    );
-    setScrollMetrics(scroller, 1600, 300);
-    flushRaf();
-
-    expect(scroller.scrollTop).toBe(900);
-  });
-
-  it('cancels pending initial auto-scroll when the view becomes inactive', () => {
+  it('exposes a working scrollToBottom and scrollToTop via onScrollRef', () => {
     const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
     const state = makeState({ loading: false, tasks });
     mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
 
-    const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="active" />
-    );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
+    let exposedScrollToBottom: (() => void) | null = null;
+    let exposedScrollToTop: (() => void) | null = null;
+    const onScrollRef = (scrollToBottom: () => void, scrollToTop: () => void) => {
+      exposedScrollToBottom = scrollToBottom;
+      exposedScrollToTop = scrollToTop;
+    };
 
-    rerender(
+    render(
+      <ConversationView
+        client={null}
+        sessionId={'session-1' as any}
+        sessionModel="loaded"
+        onScrollRef={onScrollRef}
+      />
+    );
+
+    expect(exposedScrollToBottom).toBeTypeOf('function');
+    expect(exposedScrollToTop).toBeTypeOf('function');
+
+    // The mount effect already engaged the bottom lock once; clear so we only
+    // assert the explicit button-driven call below.
+    mockScrollToBottom.mockClear();
+    act(() => exposedScrollToBottom?.());
+    expect(mockScrollToBottom).toHaveBeenCalledTimes(1);
+
+    // scrollToTop drives the real scroll container to the top.
+    const scroller = screen.getByTestId('conversation-scroll-container');
+    scroller.scrollTop = 500;
+    act(() => exposedScrollToTop?.());
+    expect(scroller.scrollTop).toBe(0);
+  });
+
+  it('scrolls to the bottom on initial open (active + session present)', () => {
+    const tasks = [makeTask('task-1', 'latest task')];
+    const state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    render(<ConversationView client={null} sessionId={'session-1' as any} sessionModel="loaded" />);
+
+    expect(mockScrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-engages the bottom lock when the session switches', () => {
+    let state = makeState({
+      sessionId: 'session-1',
+      loading: false,
+      tasks: [makeTask('task-1', 'a')],
+    });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="one" />
+    );
+    expect(mockScrollToBottom).toHaveBeenCalledTimes(1);
+
+    mockScrollToBottom.mockClear();
+    state = makeState({ sessionId: 'session-2', loading: false, tasks: [makeTask('task-2', 'b')] });
+    rerender(<ConversationView client={null} sessionId={'session-2' as any} sessionModel="two" />);
+
+    expect(mockScrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not scroll to the bottom while the view is inactive', () => {
+    const state = makeState({ loading: false, tasks: [makeTask('task-1', 'a')] });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    render(
       <ConversationView
         client={null}
         sessionId={'session-1' as any}
@@ -520,44 +210,84 @@ describe('ConversationView initial auto-scroll', () => {
         isActive={false}
       />
     );
-    flushRaf();
 
-    expect(scroller.scrollTop).toBe(0);
-    expect(globalThis.cancelAnimationFrame).toHaveBeenCalled();
+    expect(mockScrollToBottom).not.toHaveBeenCalled();
   });
 
-  it('does not fight the user after they manually scroll away during initial loading', () => {
-    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+  it('collapses older tasks and focuses the new one when the user is at bottom', () => {
+    mockIsAtBottom = true;
+    let tasks = [makeTask('task-1', 'first task')];
     let state = makeState({ loading: false, tasks });
     mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
 
     const { rerender } = render(
-      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="tasks-loaded" />
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="one-task" />
     );
-    const scroller = screen.getByTestId('conversation-scroll-container');
-    setScrollMetrics(scroller, 900, 300);
-    flushRaf();
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
 
-    fireEvent.wheel(scroller);
-    scroller.scrollTop = 100;
-    fireEvent.scroll(scroller);
+    tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'new task')];
+    state = makeState({ loading: false, tasks });
+    rerender(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="two-tasks" />
+    );
 
-    state = makeState({
+    // At bottom → only the latest task stays expanded.
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'false');
+    expect(screen.getByTestId('task-task-2')).toHaveAttribute('data-expanded', 'true');
+  });
+
+  it('keeps older tasks expanded when the user has scrolled away', () => {
+    mockIsAtBottom = false;
+    let tasks = [makeTask('task-1', 'first task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="one-task" />
+    );
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
+
+    tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'new task')];
+    state = makeState({ loading: false, tasks });
+    rerender(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="two-tasks" />
+    );
+
+    // Scrolled away → new task is expanded but the old one is preserved.
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
+    expect(screen.getByTestId('task-task-2')).toHaveAttribute('data-expanded', 'true');
+  });
+
+  it('toggles task expansion on user click without forcing a scroll', () => {
+    const tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'latest task')];
+    const state = makeState({ loading: false, tasks, loadedTaskIds: new Set(['task-2']) });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    render(<ConversationView client={null} sessionId={'session-1' as any} sessionModel="loaded" />);
+
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'false');
+    mockScrollToBottom.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle task-1' }));
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
+    // Manual expand/collapse must not trigger an auto-scroll.
+    expect(mockScrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it('renders streaming task messages without throwing', () => {
+    const tasks = [makeTask('task-1', 'latest task')];
+    const state = makeState({
       loading: false,
       tasks,
-      loadedTaskIds: new Set(['task-2']),
-      messagesByTask: new Map([['task-2', [makeMessage('task-2')]]]),
+      loadedTaskIds: new Set(['task-1']),
+      streamingMessages: new Map([['stream-1', makeMessage('task-1')]]),
     });
-    rerender(
-      <ConversationView
-        client={null}
-        sessionId={'session-1' as any}
-        sessionModel="messages-loaded"
-      />
-    );
-    setScrollMetrics(scroller, 1600, 300);
-    flushRaf();
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
 
-    expect(scroller.scrollTop).toBe(100);
+    render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="streaming" />
+    );
+
+    expect(screen.getByTestId('task-task-1')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.test.tsx
@@ -26,9 +26,15 @@ vi.mock('@agor-live/client', () => ({
 // unit-test the library here — instead we mock it and assert OUR integration
 // wiring: onScrollRef exposes the hook's scrollToBottom + a working
 // scrollToTop, the open/session-switch effect calls scrollToBottom, and the
-// new-task expand logic honors the hook's isAtBottom.
-let mockIsAtBottom = true;
+// new-task expand logic honors the hook's SYNCHRONOUS live `state`
+// (`state.escapedFromLock`), not the lagging returned `isAtBottom`.
+//
+// `mockState` is a mutable object mirroring the library's live `state`: the
+// real hook mutates `state.escapedFromLock`/`state.isAtBottom` synchronously,
+// so tests flip these fields to drive the expand logic deterministically.
+let mockState: { escapedFromLock: boolean; isAtBottom: boolean };
 const mockScrollToBottom = vi.fn();
+const mockStopScroll = vi.fn();
 type CallbackRef = ((el: HTMLElement | null) => void) & { current: HTMLElement | null };
 
 function makeCallbackRef(): CallbackRef {
@@ -47,7 +53,8 @@ vi.mock('use-stick-to-bottom', () => ({
     scrollRef: mockScrollRef,
     contentRef: mockContentRef,
     scrollToBottom: mockScrollToBottom,
-    isAtBottom: mockIsAtBottom,
+    stopScroll: mockStopScroll,
+    state: mockState,
   }),
 }));
 
@@ -121,8 +128,9 @@ function makeState(overrides: Record<string, unknown>): any {
 
 describe('ConversationView auto-scroll integration', () => {
   beforeEach(() => {
-    mockIsAtBottom = true;
+    mockState = { escapedFromLock: false, isAtBottom: true };
     mockScrollToBottom.mockClear();
+    mockStopScroll.mockClear();
     mockScrollRef = makeCallbackRef();
     mockContentRef = makeCallbackRef();
   });
@@ -215,7 +223,7 @@ describe('ConversationView auto-scroll integration', () => {
   });
 
   it('collapses older tasks and focuses the new one when the user is at bottom', () => {
-    mockIsAtBottom = true;
+    mockState.escapedFromLock = false;
     let tasks = [makeTask('task-1', 'first task')];
     let state = makeState({ loading: false, tasks });
     mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
@@ -237,7 +245,7 @@ describe('ConversationView auto-scroll integration', () => {
   });
 
   it('keeps older tasks expanded when the user has scrolled away', () => {
-    mockIsAtBottom = false;
+    mockState.escapedFromLock = true;
     let tasks = [makeTask('task-1', 'first task')];
     let state = makeState({ loading: false, tasks });
     mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
@@ -256,6 +264,48 @@ describe('ConversationView auto-scroll integration', () => {
     // Scrolled away → new task is expanded but the old one is preserved.
     expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
     expect(screen.getByTestId('task-task-2')).toHaveAttribute('data-expanded', 'true');
+  });
+
+  // Behavior 2 regression: a user who deliberately scrolled up (escaped the
+  // bottom lock) must NOT be yanked back when a new task arrives. The expand
+  // logic reads the SYNCHRONOUS `state.escapedFromLock`, so even if the
+  // returned/async `isAtBottom` were still stale-true, the escaped flag wins:
+  // older tasks stay expanded and no auto-scroll fires.
+  it('does not collapse expanded tasks or scroll when an escaped user gets a new task', () => {
+    // Escaped from the lock, but the async/near-bottom value still reads true —
+    // exactly the race the synchronous read defends against.
+    mockState.escapedFromLock = true;
+    mockState.isAtBottom = true;
+
+    let tasks = [makeTask('task-1', 'first task'), makeTask('task-2', 'second task')];
+    let state = makeState({ loading: false, tasks });
+    mockUseSharedReactiveSession.mockImplementation(() => ({ handle: null, state }));
+
+    const { rerender } = render(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="two-tasks" />
+    );
+
+    // Expand an older task to simulate what the user is reading, then clear the
+    // mount-time scroll so we only assert on the new-task arrival below.
+    fireEvent.click(screen.getByRole('button', { name: 'toggle task-1' }));
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
+    mockScrollToBottom.mockClear();
+
+    tasks = [
+      makeTask('task-1', 'first task'),
+      makeTask('task-2', 'second task'),
+      makeTask('task-3', 'new task'),
+    ];
+    state = makeState({ loading: false, tasks });
+    rerender(
+      <ConversationView client={null} sessionId={'session-1' as any} sessionModel="three-tasks" />
+    );
+
+    // Escaped → the new task expands but nothing the user was reading collapses,
+    // and there is NO yank back to the bottom.
+    expect(screen.getByTestId('task-task-1')).toHaveAttribute('data-expanded', 'true');
+    expect(screen.getByTestId('task-task-3')).toHaveAttribute('data-expanded', 'true');
+    expect(mockScrollToBottom).not.toHaveBeenCalled();
   });
 
   it('toggles task expansion on user click without forcing a scroll', () => {

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -147,7 +147,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     // user scrolls up. `scrollRef` goes on the scroll container, `contentRef`
     // on the inner content wrapper. `initial`/`resize: 'instant'` avoids
     // smooth-scroll animation jank on first paint and on layout growth.
-    const { scrollRef, contentRef, scrollToBottom, isAtBottom } = useStickToBottom({
+    const { scrollRef, contentRef, scrollToBottom, stopScroll, state } = useStickToBottom({
       initial: 'instant',
       resize: 'instant',
     });
@@ -159,14 +159,17 @@ export const ConversationView = React.memo<ConversationViewProps>(
       scrollToBottom();
     }, [scrollToBottom]);
 
-    // Scroll to top. The library's persistent observer stops following once the
-    // viewport leaves the bottom, so a plain scrollTop = 0 is enough — no manual
-    // intent flag needed.
+    // Scroll to top. While content is still streaming/growing, the library's
+    // persistent observer can re-pin to the bottom before our scrollTop write
+    // takes effect, snapping the user right back down. `stopScroll()`
+    // synchronously releases the bottom lock (and cancels any in-flight scroll
+    // animation) so the scrollTop = 0 sticks.
     const scrollToTop = useCallback(() => {
+      stopScroll();
       if (scrollRef.current) {
         scrollRef.current.scrollTop = 0;
       }
-    }, [scrollRef]);
+    }, [scrollRef, stopScroll]);
 
     // Expose scroll functions to parent
     useEffect(() => {
@@ -247,9 +250,17 @@ export const ConversationView = React.memo<ConversationViewProps>(
     const lastTaskId = tasks.length > 0 ? tasks[tasks.length - 1].task_id : null;
     useEffect(() => {
       if (!isActive || !lastTaskId) return;
+      // Read the library's SYNCHRONOUS live state, not the returned `isAtBottom`
+      // React value. The returned value lags a render and also counts
+      // "near bottom" as pinned — both would mis-classify a user who just
+      // scrolled up moments before a task arrives, collapsing the tasks they're
+      // reading. `state.escapedFromLock` is mutated synchronously the instant
+      // the user scrolls away from the bottom lock, restoring the old
+      // `userScrolledUpRef` semantics exactly.
+      const userScrolledUp = state.escapedFromLock;
       setExpandedTaskIds((prev) => {
         if (prev.has(lastTaskId)) return prev;
-        if (!isAtBottom) {
+        if (userScrolledUp) {
           // User has scrolled away — just expand the new task, keep older ones
           // visible so we don't disturb what they're reading.
           const next = new Set(prev);
@@ -259,7 +270,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
         // At bottom — collapse older tasks and focus the new one.
         return new Set([lastTaskId]);
       });
-    }, [isActive, lastTaskId, isAtBottom]);
+    }, [isActive, lastTaskId, state]);
 
     // Handle task expand/collapse. Single stable callback shared by every
     // TaskBlock — the callback takes `taskId` so we don't need to mint a

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -14,7 +14,8 @@ import type { AgorClient, Message, PermissionScope, SessionID, User } from '@ago
 import { shortId, TaskStatus } from '@agor-live/client';
 import { BranchesOutlined, CopyOutlined, ForkOutlined } from '@ant-design/icons';
 import { Alert, Button, Spin, Typography, theme } from 'antd';
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useStickToBottom } from 'use-stick-to-bottom';
 import { BRAND, brandMarkHref } from '../../branding/brand';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { useStreamingMessagesByTask } from '../../hooks/useStreamingMessagesByTask';
@@ -27,8 +28,6 @@ const EMPTY_STREAMING_MESSAGES = new Map();
 // reference for tasks whose messages haven't been loaded — otherwise `|| []`
 // would mint a fresh array on every render and thrash TaskBlock's React.memo.
 const EMPTY_MESSAGES: Message[] = [];
-const INITIAL_AUTO_SCROLL_STABLE_FRAMES = 3;
-const INITIAL_AUTO_SCROLL_MAX_FRAMES = 90;
 
 export interface ConversationViewProps {
   /**
@@ -138,150 +137,43 @@ export const ConversationView = React.memo<ConversationViewProps>(
     genealogy,
     assistantEmoji,
   }) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-    const contentRef = useRef<HTMLDivElement>(null);
     const { token } = theme.useToken();
     const [copied, copy] = useCopyToClipboard();
 
-    // true when the user has intentionally scrolled away from the bottom;
-    // auto-scroll is suppressed while this is set. We only set it after an
-    // explicit scroll interaction, not merely because layout growth made the
-    // viewport no longer be near the bottom.
-    const userScrolledUpRef = useRef(false);
-    const userScrollIntentRef = useRef(false);
-    const initialTasksScrollDoneRef = useRef(false);
-    const initialMessagesScrollDoneForTaskRef = useRef<string | null>(null);
-    const scrollLifecycleKeyRef = useRef<string | null>(null);
-    const pendingAutoScrollRafRef = useRef<number | null>(null);
-    const pendingAutoScrollResizeObserverRef = useRef<ResizeObserver | null>(null);
+    // use-stick-to-bottom owns the entire auto-scroll lifecycle. It keeps a
+    // PERSISTENT ResizeObserver on the content element, so any late content
+    // growth (images, lazy markdown/code, fonts, async tool output) keeps the
+    // viewport pinned while the user is at bottom — and stops the moment the
+    // user scrolls up. `scrollRef` goes on the scroll container, `contentRef`
+    // on the inner content wrapper. `initial`/`resize: 'instant'` avoids
+    // smooth-scroll animation jank on first paint and on layout growth.
+    const { scrollRef, contentRef, scrollToBottom, isAtBottom } = useStickToBottom({
+      initial: 'instant',
+      resize: 'instant',
+    });
 
-    // Within 20px of the end counts as "at the bottom". Tight enough that a
-    // mid-swipe scroll won't accidentally keep auto-scroll on, but loose enough
-    // to handle sub-pixel rounding.
-    const isNearBottom = useCallback(() => {
-      if (!containerRef.current) return true;
-      const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
-      return scrollHeight - scrollTop - clientHeight < 20;
-    }, []);
+    // Public scroll-to-bottom exposed via onScrollRef (button clicks) and the
+    // resume-on-send wiring in SessionPanel. Wrap to a plain `() => void` so we
+    // don't leak the library's optional ScrollToBottom options to callers.
+    const handleScrollToBottom = useCallback(() => {
+      scrollToBottom();
+    }, [scrollToBottom]);
 
-    // Internal scroll used by auto-scroll effects. Does NOT reset user intent.
-    const doAutoScroll = useCallback(() => {
-      if (containerRef.current) {
-        containerRef.current.scrollTop = containerRef.current.scrollHeight;
-      }
-    }, []);
-
-    const cancelPendingAutoScroll = useCallback(() => {
-      if (pendingAutoScrollRafRef.current !== null) {
-        cancelAnimationFrame(pendingAutoScrollRafRef.current);
-        pendingAutoScrollRafRef.current = null;
-      }
-      if (pendingAutoScrollResizeObserverRef.current) {
-        pendingAutoScrollResizeObserverRef.current.disconnect();
-        pendingAutoScrollResizeObserverRef.current = null;
-      }
-    }, []);
-
-    const scheduleGuardedAutoScroll = useCallback(
-      ({ waitForStableLayout = false }: { waitForStableLayout?: boolean } = {}) => {
-        cancelPendingAutoScroll();
-        const lifecycleKey = scrollLifecycleKeyRef.current;
-        const contentElement = contentRef.current;
-        let lastScrollHeight = -1;
-        let stableFrameCount = 0;
-        let totalFrameCount = 0;
-
-        const isAutoScrollStillAllowed = () =>
-          scrollLifecycleKeyRef.current === lifecycleKey &&
-          !userScrolledUpRef.current &&
-          !!containerRef.current;
-
-        const disconnectResizeObserver = () => {
-          if (pendingAutoScrollResizeObserverRef.current) {
-            pendingAutoScrollResizeObserverRef.current.disconnect();
-            pendingAutoScrollResizeObserverRef.current = null;
-          }
-        };
-
-        function scheduleNextFrame() {
-          if (pendingAutoScrollRafRef.current !== null) return;
-          pendingAutoScrollRafRef.current = requestAnimationFrame(runAutoScrollFrame);
-        }
-
-        function runAutoScrollFrame() {
-          pendingAutoScrollRafRef.current = null;
-
-          if (!isAutoScrollStillAllowed()) {
-            disconnectResizeObserver();
-            return;
-          }
-
-          doAutoScroll();
-
-          if (!waitForStableLayout || !containerRef.current) {
-            disconnectResizeObserver();
-            return;
-          }
-
-          const currentScrollHeight = containerRef.current.scrollHeight;
-          totalFrameCount += 1;
-
-          if (currentScrollHeight === lastScrollHeight) {
-            stableFrameCount += 1;
-          } else {
-            lastScrollHeight = currentScrollHeight;
-            stableFrameCount = 0;
-          }
-
-          if (
-            stableFrameCount >= INITIAL_AUTO_SCROLL_STABLE_FRAMES ||
-            totalFrameCount >= INITIAL_AUTO_SCROLL_MAX_FRAMES
-          ) {
-            disconnectResizeObserver();
-            return;
-          }
-
-          scheduleNextFrame();
-        }
-
-        if (waitForStableLayout && contentElement && typeof ResizeObserver !== 'undefined') {
-          pendingAutoScrollResizeObserverRef.current = new ResizeObserver(() => {
-            stableFrameCount = 0;
-            scheduleNextFrame();
-          });
-          pendingAutoScrollResizeObserverRef.current.observe(contentElement);
-        }
-
-        scheduleNextFrame();
-      },
-      [cancelPendingAutoScroll, doAutoScroll]
-    );
-
-    // Public scroll-to-bottom exposed via onScrollRef (button clicks). Resets
-    // user intent so auto-scroll resumes after an explicit "go to bottom".
-    const scrollToBottom = useCallback(() => {
-      userScrolledUpRef.current = false;
-      userScrollIntentRef.current = false;
-      if (containerRef.current) {
-        containerRef.current.scrollTop = containerRef.current.scrollHeight;
-      }
-    }, []);
-
-    // Scroll to top: mark user as reading so auto-scroll doesn't yank them back.
+    // Scroll to top. The library's persistent observer stops following once the
+    // viewport leaves the bottom, so a plain scrollTop = 0 is enough — no manual
+    // intent flag needed.
     const scrollToTop = useCallback(() => {
-      userScrolledUpRef.current = true;
-      userScrollIntentRef.current = true;
-      if (containerRef.current) {
-        containerRef.current.scrollTop = 0;
+      if (scrollRef.current) {
+        scrollRef.current.scrollTop = 0;
       }
-    }, []);
+    }, [scrollRef]);
 
     // Expose scroll functions to parent
     useEffect(() => {
       if (onScrollRef) {
-        onScrollRef(scrollToBottom, scrollToTop);
+        onScrollRef(handleScrollToBottom, scrollToTop);
       }
-    }, [onScrollRef, scrollToBottom, scrollToTop]);
+    }, [onScrollRef, handleScrollToBottom, scrollToTop]);
 
     const { handle: reactiveSession, state: reactiveState } = useSharedReactiveSession(
       client,
@@ -293,19 +185,20 @@ export const ConversationView = React.memo<ConversationViewProps>(
     );
     const currentReactiveState = reactiveState?.sessionId === sessionId ? reactiveState : null;
 
-    useLayoutEffect(() => {
-      const lifecycleKey = isActive && sessionId ? `${sessionId}:active` : null;
-      if (scrollLifecycleKeyRef.current === lifecycleKey) return;
-
-      scrollLifecycleKeyRef.current = lifecycleKey;
-      cancelPendingAutoScroll();
-      initialTasksScrollDoneRef.current = false;
-      initialMessagesScrollDoneForTaskRef.current = null;
-      userScrolledUpRef.current = false;
-      userScrollIntentRef.current = false;
-    }, [cancelPendingAutoScroll, isActive, sessionId]);
-
-    useEffect(() => cancelPendingAutoScroll, [cancelPendingAutoScroll]);
+    // Land at the bottom on panel open / session switch.
+    //
+    // ConversationView stays MOUNTED while the panel is closed (SessionPanel
+    // renders it with display:none), so the library's `initial` scroll fires
+    // once at mount while the view is hidden (0 height ⇒ no-op) and does NOT
+    // re-run when the panel later opens. This effect re-engages the bottom lock
+    // whenever the view becomes active or the session changes; the library's
+    // persistent observer then follows lazy task/message growth from there
+    // (covers behaviors 1, 2, 4).
+    useEffect(() => {
+      if (isActive && sessionId) {
+        scrollToBottom();
+      }
+    }, [isActive, sessionId, scrollToBottom]);
 
     // Queued tasks belong to the queue drawer, not the conversation. They
     // haven't run yet — there's no message_range, no user-message row, no
@@ -338,9 +231,12 @@ export const ConversationView = React.memo<ConversationViewProps>(
     });
 
     // When a new task arrives (i.e. the *last* task id changes), expand it.
-    // If the user is still at the bottom, collapse older tasks and follow the new one;
-    // if the user has scrolled away, preserve what they were reading. We deliberately depend on
-    // `lastTaskId` rather than `tasks` so that:
+    // If the user is still at the bottom, collapse older tasks and follow the
+    // new one; if the user has scrolled away, preserve what they were reading.
+    // Following is handled by the library's persistent observer — a new last
+    // task while `isAtBottom` re-pins automatically, so we only need to manage
+    // the expand state here. We deliberately depend on `lastTaskId` rather than
+    // `tasks` so that:
     //   1. unrelated re-renders don't fire this effect (`tasks` still gets
     //      a new reference whenever any task patch lands — the useMemo bails
     //      out only when the *upstream* `reactiveState.tasks` array is
@@ -353,52 +249,33 @@ export const ConversationView = React.memo<ConversationViewProps>(
       if (!isActive || !lastTaskId) return;
       setExpandedTaskIds((prev) => {
         if (prev.has(lastTaskId)) return prev;
-        if (userScrolledUpRef.current) {
+        if (!isAtBottom) {
+          // User has scrolled away — just expand the new task, keep older ones
+          // visible so we don't disturb what they're reading.
           const next = new Set(prev);
           next.add(lastTaskId);
           return next;
         }
-        scheduleGuardedAutoScroll();
+        // At bottom — collapse older tasks and focus the new one.
         return new Set([lastTaskId]);
       });
-    }, [isActive, lastTaskId, scheduleGuardedAutoScroll]);
-
-    // Initial-open scroll phase 1: once the task list bootstrap has completed
-    // and the task DOM is present, land near the latest task. This is separate
-    // from streaming auto-scroll and only runs once per opened session.
-    useEffect(() => {
-      if (initialTasksScrollDoneRef.current) return;
-      if (!isActive || loading || tasks.length === 0) return;
-
-      initialTasksScrollDoneRef.current = true;
-      scheduleGuardedAutoScroll({ waitForStableLayout: true });
-    }, [isActive, loading, tasks.length, scheduleGuardedAutoScroll]);
+    }, [isActive, lastTaskId, isAtBottom]);
 
     // Handle task expand/collapse. Single stable callback shared by every
     // TaskBlock — the callback takes `taskId` so we don't need to mint a
     // per-task closure (which previously rebuilt on every render and broke
     // TaskBlock's React.memo for the entire task list).
-    const handleTaskExpandChange = useCallback(
-      (taskId: string, expanded: boolean) => {
-        // Treat explicit task expand/collapse as user intent. In particular,
-        // stop any initial-load layout stabilization loop so a large task
-        // finishing render does not yank the viewport after the user has begun
-        // interacting with the conversation.
-        userScrolledUpRef.current = true;
-        userScrollIntentRef.current = true;
-        cancelPendingAutoScroll();
-        setExpandedTaskIds((prev) => {
-          const next = new Set(prev);
-          if (expanded) {
-            next.add(taskId);
-          } else {
-            next.delete(taskId);
-          }
-          return next;
-        });
-      },
-      [cancelPendingAutoScroll]
-    );
+    const handleTaskExpandChange = useCallback((taskId: string, expanded: boolean) => {
+      setExpandedTaskIds((prev) => {
+        const next = new Set(prev);
+        if (expanded) {
+          next.add(taskId);
+        } else {
+          next.delete(taskId);
+        }
+        return next;
+      });
+    }, []);
 
     // Stable load/unload callbacks. The previous inline arrows were minted on
     // every ConversationView render → every TaskBlock saw new `onLoadTaskMessages`
@@ -420,83 +297,9 @@ export const ConversationView = React.memo<ConversationViewProps>(
       [reactiveSession]
     );
 
-    // Track user scroll intent separately from scroll position. The scroll event
-    // also fires for programmatic scrolls and browser/layout adjustments while a
-    // large conversation is still rendering; treating every non-bottom scroll as
-    // user intent can suppress the second initial-load scroll before latest
-    // messages finish loading. Only explicit scroll inputs are allowed to break
-    // the bottom lock.
-    const hasConversation = tasks.length > 0;
-    // biome-ignore lint/correctness/useExhaustiveDependencies: hasConversation re-triggers when the container mounts
-    useEffect(() => {
-      const container = containerRef.current;
-      if (!container) return;
-
-      const markUserScrollIntent = () => {
-        userScrollIntentRef.current = true;
-      };
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (
-          event.key === 'ArrowUp' ||
-          event.key === 'ArrowDown' ||
-          event.key === 'PageUp' ||
-          event.key === 'PageDown' ||
-          event.key === 'Home' ||
-          event.key === 'End' ||
-          event.key === ' '
-        ) {
-          markUserScrollIntent();
-        }
-      };
-      const handleScroll = () => {
-        if (isNearBottom()) {
-          userScrolledUpRef.current = false;
-          userScrollIntentRef.current = false;
-          return;
-        }
-
-        if (userScrollIntentRef.current) {
-          userScrolledUpRef.current = true;
-        }
-      };
-
-      container.addEventListener('wheel', markUserScrollIntent, { passive: true });
-      container.addEventListener('touchstart', markUserScrollIntent, { passive: true });
-      container.addEventListener('pointerdown', markUserScrollIntent);
-      container.addEventListener('keydown', handleKeyDown);
-      container.addEventListener('scroll', handleScroll, { passive: true });
-      return () => {
-        container.removeEventListener('wheel', markUserScrollIntent);
-        container.removeEventListener('touchstart', markUserScrollIntent);
-        container.removeEventListener('pointerdown', markUserScrollIntent);
-        container.removeEventListener('keydown', handleKeyDown);
-        container.removeEventListener('scroll', handleScroll);
-      };
-    }, [isNearBottom, hasConversation]);
-
-    // Auto-scroll during streaming — only if the user has not scrolled away.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: We want to scroll on streaming change
-    useEffect(() => {
-      if (isActive && !userScrolledUpRef.current) {
-        doAutoScroll();
-      }
-    }, [allStreamingMessages, isActive]);
-
-    const latestTaskExpanded = !!lastTaskId && expandedTaskIds.has(lastTaskId);
-    const latestTaskMessagesLoaded =
-      !!lastTaskId && latestTaskExpanded && !!currentReactiveState?.loadedTaskIds.has(lastTaskId);
-
-    // Initial-open scroll phase 2: when the latest expanded task's lazy message
-    // load finishes, scroll again so the newest message is visible. The
-    // userScrolledUpRef guard is checked in the RAF callback so a manual scroll
-    // between load completion and paint still wins.
-    useEffect(() => {
-      if (!isActive || !lastTaskId || !latestTaskMessagesLoaded) return;
-      if (initialMessagesScrollDoneForTaskRef.current === lastTaskId) return;
-
-      initialMessagesScrollDoneForTaskRef.current = lastTaskId;
-      scheduleGuardedAutoScroll({ waitForStableLayout: true });
-    }, [isActive, lastTaskId, latestTaskMessagesLoaded, scheduleGuardedAutoScroll]);
+    // Streaming auto-scroll, manual scroll-away detection, and lazy-content
+    // re-pinning are all handled by use-stick-to-bottom's persistent
+    // ResizeObserver — no manual scroll listeners or streaming effect needed.
 
     if (error) {
       // Deterministic escape hatch when auto-recovery (socket-reconnect resync,
@@ -637,7 +440,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
 
     return (
       <div
-        ref={containerRef}
+        ref={scrollRef}
         data-testid="conversation-scroll-container"
         style={{
           flex: 1,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -617,6 +617,11 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     // WebSocket event populates the queue panel for queued prompts.
     promptRef.current?.clear();
     onSendPrompt?.(session.session_id, promptToSend, permissionMode);
+
+    // Re-engage the bottom lock so a scrolled-up user follows their just-sent
+    // message and the streaming reply (behavior 3). `scrollToBottom` is the
+    // function ConversationView exposed via onScrollRef.
+    scrollToBottom?.();
   };
 
   const handleStop = async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       streamdown:
         specifier: ^1.5.1
         version: 1.5.1(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.7)(unified@11.0.5)
+      use-stick-to-bottom:
+        specifier: ^1.1.6
+        version: 1.1.6(react@19.2.7)
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -8977,6 +8980,11 @@ packages:
 
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
+  use-stick-to-bottom@1.1.6:
+    resolution: {integrity: sha512-z3Up8jYQGTkUCsGBnwg6/wj70KgXoW5Kz1AAc1j8MtQuYMBo6ZsdhrIXoegxa7gaMMilgQYyTohTrt3p94jHog==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -19470,6 +19478,10 @@ snapshots:
       tslib: 2.8.1
 
   url-template@2.0.8: {}
+
+  use-stick-to-bottom@1.1.6(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:


### PR DESCRIPTION
## Problem

Opening the conversation drawer (and several streaming scenarios) often left the viewport short of the bottom — the latest message wasn't visible. Fixes #111.

### Root cause

`ConversationView` auto-scrolled with a hand-rolled `requestAnimationFrame` loop plus a **transient** `ResizeObserver` (`scheduleGuardedAutoScroll`) that disconnected once layout "stabilized" (`INITIAL_AUTO_SCROLL_STABLE_FRAMES = 3` / `MAX_FRAMES = 90`). Any content that grew **after** the observer disconnected — images, lazy-rendered markdown/code, web fonts, async tool output — landed the viewport above the bottom. This class of bug had already been patched four times.

## Fix

Replace the entire hand-rolled mechanism with [`use-stick-to-bottom`](https://github.com/stackblitz/use-stick-to-bottom) (v1.1.6, React 19 compatible), which keeps a **persistent** observer and re-pins to the bottom while the user is at bottom — fixing the class at the root.

- `useStickToBottom({ initial: 'instant', resize: 'instant' })`; `scrollRef` on the scroll container, `contentRef` on the inner content wrapper.
- Deleted: `isNearBottom`, `doAutoScroll`, `scheduleGuardedAutoScroll`, all the scroll-lifecycle/user-intent refs, the `INITIAL_AUTO_SCROLL_*` constants, the wheel/touch/pointer/keydown listener effect, both two-phase initial-scroll effects, and the streaming auto-scroll effect.
- `onScrollRef` still exposes a `scrollToBottom`/`scrollToTop` pair (now backed by the hook).
- Expand-on-new-task logic now keys off the hook's `isAtBottom` instead of the old manual ref.

### The four required behaviors

1. **Streaming follows new content** — persistent observer re-pins while at bottom.
2. **Scroll up → auto-scroll stops and holds** — a new task / streaming chunk no longer yanks the user down (gated on `isAtBottom`).
3. **Scrolled-up user sends a prompt → auto-scroll resumes** — `SessionPanel.handleSendPrompt` calls `scrollToBottom()` after `onSendPrompt`.
4. **Open panel / switch session → lands at bottom** — `ConversationView` stays mounted (`display:none`) while the panel is closed, so the library's one-shot `initial` scroll fires while hidden (0 height → no-op). An explicit `useEffect(() => { if (isActive && sessionId) scrollToBottom(); }, [isActive, sessionId, scrollToBottom])` re-engages the lock on open/switch; the persistent observer follows lazy task/message growth from there.

## Tests

The old suite asserted the deleted physics (manual `scrollHeight` metrics, rAF flushing) and can't be reproduced in jsdom (no real layout / ResizeObserver). Rewrote `ConversationView.test.tsx` to mock `use-stick-to-bottom` and cover **our** integration: `onScrollRef` exposes a working `scrollToBottom`/`scrollToTop`, the open/session-switch effect calls `scrollToBottom`, inactive views don't, and the `isAtBottom`-driven expand logic behaves.

## Verification

- `pnpm --filter agor-ui typecheck` ✅
- `pnpm --filter agor-ui test` ✅ (491 tests, incl. the rewritten `ConversationView.test.tsx`)
- `pnpm lint` ✅ (only pre-existing warnings in untouched files)
- `biome check` on touched files ✅

The mobile `SessionPage` also renders `ConversationView` (without `onScrollRef`/`isActive`); props are optional and it still typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
