### PR TITLE
Bump agor-live packages to 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ The reader's first pass is the headline only; sub-bullets are for the curious. K
 
 _No user-visible changes yet._
 
+## 0.22.0 (TBD)
+
+### Chores
+
+- **Prepare the next agor-live minor release** — bumps `agor-live` and `@agor-live/client` to 0.22.0 and keeps the standalone agor-live package lock in sync. ([#1561](https://github.com/preset-io/agor/pull/1561))
+
 ## 0.21.2 (TBD)
 
 ### Features

--- a/packages/agor-live/package-lock.json
+++ b/packages/agor-live/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agor-live",
-  "version": "0.15.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agor-live",
-      "version": "0.15.0",
+      "version": "0.22.0",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `agor-live` and `@agor-live/client` from 0.21.2 to 0.22.0
- Sync the standalone `packages/agor-live/package-lock.json` package version
- Add a 0.22.0 changelog entry

## Tags
- Compared local tags against `origin`; no local-only tags were missing on GitHub, so no tags were pushed

## Checks
- `pnpm check:agor-live-deps`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @agor-live/client typecheck`
- `pnpm exec prettier --check CHANGELOG.md packages/agor-live/package.json packages/agor-live/package-lock.json packages/client/package.json`
