### PR TITLE
Fix User Settings env var ordering and tab retention

### DIFF
--- a/apps/agor-ui/src/components/EnvVarEditor.test.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { EnvVarEditor } from './EnvVarEditor';
+
+function renderEditor(envVars: ComponentProps<typeof EnvVarEditor>['envVars']) {
+  const props = {
+    envVars,
+    onSave: vi.fn(async () => {}),
+    onDelete: vi.fn(async () => {}),
+  };
+
+  return render(
+    <AntApp>
+      <EnvVarEditor {...props} />
+    </AntApp>
+  );
+}
+
+describe('EnvVarEditor', () => {
+  it('sorts existing environment variables alphabetically by key without mutating props', () => {
+    const envVars = {
+      Z_TOKEN: { set: true, scope: 'global' },
+      alpha_TOKEN: { set: true, scope: 'session' },
+      BETA_TOKEN: true,
+    } satisfies ComponentProps<typeof EnvVarEditor>['envVars'];
+    const originalKeys = Object.keys(envVars);
+
+    renderEditor(envVars);
+
+    const renderedKeys = screen.getAllByText(/_TOKEN$/).map((node) => node.textContent);
+    expect(renderedKeys).toEqual(['alpha_TOKEN', 'BETA_TOKEN', 'Z_TOKEN']);
+    expect(Object.keys(envVars)).toEqual(originalKeys);
+  });
+});

--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -1,7 +1,7 @@
 import { ENV_VAR_SCOPES_V05, type EnvVarMetadata, type EnvVarScope } from '@agor-live/client';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { Button, Input, Select, Space, Table, Tooltip, Typography } from 'antd';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Tag } from './Tag';
 
 const { Text } = Typography;
@@ -232,14 +232,20 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
     },
   ];
 
-  const dataSource: Row[] = Object.entries(envVars).map(([key, entry]) => {
-    const meta = entryToMetadata(entry);
-    return {
-      key,
-      isSet: meta.set,
-      scope: meta.scope,
-    };
-  });
+  const dataSource: Row[] = useMemo(
+    () =>
+      Object.entries(envVars)
+        .map(([key, entry]) => {
+          const meta = entryToMetadata(entry);
+          return {
+            key,
+            isSet: meta.set,
+            scope: meta.scope,
+          };
+        })
+        .sort((a, b) => a.key.localeCompare(b.key, undefined, { sensitivity: 'base' })),
+    [envVars]
+  );
 
   return (
     <Space orientation="vertical" size="middle" style={{ width: '100%' }}>

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -1,7 +1,7 @@
 import type { AgenticToolName, AgorClient, User } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { UserSettingsModal } from './UserSettingsModal';
 
@@ -110,6 +110,79 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
         },
       });
     }, ASYNC);
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Codex' })).toBeInTheDocument();
+  });
+
+  it('keeps the Env Vars section selected after saving and receiving updated user props', async () => {
+    const initialUser = makeUser({
+      env_vars: {
+        Z_TOKEN: { set: true, scope: 'global', resource_id: null },
+      },
+    });
+    const onClose = vi.fn();
+    const updateSpy = vi.fn();
+
+    function Harness() {
+      const [user, setUser] = useState(initialUser);
+      return (
+        <UserSettingsModal
+          open
+          onClose={onClose}
+          user={user}
+          currentUser={user}
+          client={null as AgorClient | null}
+          mcpServerById={new Map()}
+          onUpdate={async (userId, updates) => {
+            updateSpy(userId, updates);
+            if (updates.env_vars) {
+              setUser((prev) => ({
+                ...prev,
+                env_vars: {
+                  ...(prev.env_vars ?? {}),
+                  ...Object.fromEntries(
+                    Object.entries(updates.env_vars ?? {}).flatMap(([key, value]) =>
+                      value === null
+                        ? []
+                        : [
+                            [
+                              key,
+                              {
+                                set: true,
+                                scope: updates.env_var_scopes?.[key] ?? 'global',
+                                resource_id: null,
+                              },
+                            ],
+                          ]
+                    )
+                  ),
+                },
+              }));
+            }
+          }}
+        />
+      );
+    }
+
+    renderWithApp(<Harness />);
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /env vars/i }));
+    await screen.findByRole('heading', { name: 'Environment Variables' });
+
+    fireEvent.change(screen.getByPlaceholderText(/variable name/i), {
+      target: { value: 'ALPHA_TOKEN' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Value'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith('user-1', {
+        env_vars: { ALPHA_TOKEN: 'secret' },
+        env_var_scopes: { ALPHA_TOKEN: 'global' },
+      });
+    }, ASYNC);
+
+    expect(screen.getByRole('heading', { name: 'Environment Variables' })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -114,6 +114,45 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(screen.getByRole('heading', { name: 'Codex' })).toBeInTheDocument();
   });
 
+  it('clears the password field after saving General settings in place', async () => {
+    const user = makeUser();
+    const onUpdate = vi.fn(async () => {});
+    const onClose = vi.fn();
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={onClose}
+        user={user}
+        currentUser={user}
+        client={null as AgorClient | null}
+        mcpServerById={new Map()}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const passwordInput = screen.getByPlaceholderText('••••••••') as HTMLInputElement;
+    fireEvent.change(passwordInput, { target: { value: 'new-password' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ password: 'new-password' })
+      );
+    }, ASYNC);
+
+    expect(passwordInput).toHaveValue('');
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledTimes(2);
+    }, ASYNC);
+    expect(onUpdate.mock.calls[1][1]).not.toHaveProperty('password');
+  });
+
   it('keeps the Env Vars section selected after saving and receiving updated user props', async () => {
     const initialUser = makeUser({
       env_vars: {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -39,7 +39,7 @@ import {
   Typography,
   theme,
 } from 'antd';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
 import { searchableSelectProps, toGroupSelectOption } from '../../utils/selectSearch';
 import {
@@ -95,6 +95,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 }) => {
   const [form] = Form.useForm();
   const [activeTab, setActiveTab] = useState<string>('general');
+  const initializedUserIdRef = useRef<string | null>(null);
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
 
   // Separate forms for each agentic tool tab
@@ -195,7 +196,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   );
 
   const loadUserGroups = useCallback(async () => {
-    if (!client || !user || !isAdmin) {
+    const userId = user?.user_id;
+    if (!client || !userId || !isAdmin) {
       setAvailableGroups([]);
       setUserGroupIds([]);
       setGroupsLoaded(false);
@@ -208,7 +210,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     try {
       const [groups, memberships] = await Promise.all([
         client.service('groups').findAll({ query: { archived: false } }),
-        client.service('group-memberships').findAll({ query: { user_id: user.user_id } }),
+        client.service('group-memberships').findAll({ query: { user_id: userId } }),
       ]);
       const nextGroupIds = (memberships as GroupMembership[]).map(
         (membership) => membership.group_id
@@ -222,14 +224,21 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     } finally {
       setLoadingGroups(false);
     }
-  }, [client, form, isAdmin, user]);
+  }, [client, form, isAdmin, user?.user_id]);
 
   // Initialize when modal opens with user data
   useEffect(() => {
-    if (open && user) {
-      initializeForms(user);
-      void loadUserGroups();
+    if (!open) {
+      initializedUserIdRef.current = null;
+      return;
     }
+
+    const userId = user?.user_id;
+    if (!user || !userId || initializedUserIdRef.current === userId) return;
+
+    initializedUserIdRef.current = userId;
+    initializeForms(user);
+    void loadUserGroups();
   }, [open, user, initializeForms, loadUserGroups]);
 
   // Hydrate tab-specific forms only after that tab has rendered its
@@ -382,7 +391,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       await onUpdate?.(user.user_id, updates);
       await syncUserGroups(values.groupIds || []);
       await saveDirtyAgenticConfigs();
-      handleClose();
     } catch (err) {
       console.error('Validation failed:', err);
     }
@@ -521,8 +529,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       });
 
       await saveAgenticConfigs(toolsToSave);
-
-      handleClose();
     } catch (err) {
       console.error(`Failed to save ${tool} config:`, err);
       throw err;
@@ -563,7 +569,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       });
 
       await saveDirtyAgenticConfigs();
-      handleClose();
     } catch (error) {
       console.error('Failed to save audio settings:', error);
     }
@@ -575,18 +580,16 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
     switch (activeTab) {
       case 'general':
-        handleUpdate();
+        await handleUpdate();
         break;
       case 'env-vars':
       case 'personal-api-keys':
-        // These tabs save individually, just close
+        // These tabs save inline; keep the user on the current section.
         await saveDirtyAgenticConfigs();
-        handleClose();
         break;
       case 'groups':
         await syncUserGroups(form.getFieldValue('groupIds') || []);
         await saveDirtyAgenticConfigs();
-        handleClose();
         break;
       case 'audio':
         await handleAudioSave();

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -389,9 +389,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         updates.must_change_password = values.must_change_password;
       }
       await onUpdate?.(user.user_id, updates);
+      form.setFieldValue('password', undefined);
       await syncUserGroups(values.groupIds || []);
       await saveDirtyAgenticConfigs();
-      form.setFieldValue('password', undefined);
     } catch (err) {
       console.error('Validation failed:', err);
     }

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -391,6 +391,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       await onUpdate?.(user.user_id, updates);
       await syncUserGroups(values.groupIds || []);
       await saveDirtyAgenticConfigs();
+      form.setFieldValue('password', undefined);
     } catch (err) {
       console.error('Validation failed:', err);
     }

--- a/biome.json
+++ b/biome.json
@@ -1,12 +1,13 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": false
+    "ignoreUnknown": false,
+    "includes": ["**", "!apps/agor-docs/launch-video"]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Sort User Settings environment variables alphabetically by key without mutating incoming env var metadata
- Keep the current User Settings section selected after footer saves and same-user save refreshes
- Add focused tests for env var ordering and tab retention after Env Vars / agentic settings saves

## Checks
- pnpm -C apps/agor-ui exec vitest run src/components/EnvVarEditor.test.tsx src/components/SettingsModal/UserSettingsModal.test.tsx
- pnpm exec biome check apps/agor-ui/src/components/EnvVarEditor.tsx apps/agor-ui/src/components/EnvVarEditor.test.tsx apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
- pnpm -C apps/agor-ui exec tsc --noEmit --pretty false