### PR TITLE
Improve BranchModal schedules list layout

### DIFF
--- a/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.test.tsx
@@ -1,0 +1,105 @@
+import type { AgorClient, Branch, Schedule } from '@agor-live/client';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { makeBranch, renderWithApp } from '../testUtils';
+import { ScheduleTab } from './ScheduleTab';
+
+vi.mock('../../ScheduleModal', () => ({
+  ScheduleModal: () => null,
+}));
+
+vi.mock('../../ScheduleRunsPanel', () => ({
+  ScheduleRunsPanel: () => null,
+}));
+
+const makeSchedule = (overrides: Partial<Schedule> = {}): Schedule =>
+  ({
+    schedule_id: '018f0000-0000-7000-8000-000000000001',
+    branch_id: 'branch-1',
+    name: 'Very long customer escalation heartbeat title that should not stretch the modal',
+    description: 'Long description that should stay tucked into the title cell and tooltip.',
+    cron_expression: '0 8,12,16 * * 1-5',
+    timezone_mode: 'local',
+    timezone: 'America/Los_Angeles',
+    prompt: 'Summarize the branch status.',
+    agentic_tool_config: { agentic_tool: 'claude-code' },
+    enabled: true,
+    allow_concurrent_runs: false,
+    retention: 5,
+    last_run_at: 1_780_527_200_000,
+    last_run_session_id: '018f0000-0000-7000-8000-0000000000aa',
+    next_run_at: 1_780_530_800_000,
+    created_at: '2026-06-04T00:00:00.000Z',
+    updated_at: '2026-06-04T00:00:00.000Z',
+    created_by: '018f0000-0000-7000-8000-0000000000bb',
+    ...overrides,
+  }) as Schedule;
+
+const makeScheduleClient = (schedules: Schedule[]): AgorClient =>
+  ({
+    service(path: string) {
+      return {
+        async find() {
+          if (path === 'schedules') return { data: schedules };
+          return [];
+        },
+        async patch() {
+          return {};
+        },
+        async remove() {
+          return {};
+        },
+        async create() {
+          return {};
+        },
+        on() {},
+        off() {},
+      };
+    },
+  }) as unknown as AgorClient;
+
+function renderScheduleTab({
+  branch = makeBranch(),
+  schedules = [makeSchedule()],
+  onOpenSession = vi.fn(),
+}: {
+  branch?: Branch;
+  schedules?: Schedule[];
+  onOpenSession?: (sessionId: string) => void;
+} = {}) {
+  renderWithApp(
+    <ScheduleTab
+      branch={branch}
+      client={makeScheduleClient(schedules)}
+      onOpenSession={onOpenSession}
+    />
+  );
+  return { onOpenSession };
+}
+
+describe('ScheduleTab compact list', () => {
+  it('keeps secondary schedule details out of full-width columns', async () => {
+    renderScheduleTab();
+
+    expect(await screen.findByRole('columnheader', { name: 'Title' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Schedule' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Next' })).toBeInTheDocument();
+
+    expect(screen.queryByRole('columnheader', { name: /last run/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('columnheader', { name: /scheduled by/i })).not.toBeInTheDocument();
+
+    const title = screen.getByLabelText(/schedule title:/i);
+    expect(title).toHaveStyle({ textOverflow: 'ellipsis', overflow: 'hidden' });
+  });
+
+  it('opens the last run from a row action', async () => {
+    const { onOpenSession } = renderScheduleTab();
+
+    const lastRunButton = await screen.findByRole('button', { name: /view last run/i });
+    fireEvent.click(lastRunButton);
+
+    await waitFor(() => {
+      expect(onOpenSession).toHaveBeenCalledWith('018f0000-0000-7000-8000-0000000000aa');
+    });
+  });
+});

--- a/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
@@ -74,17 +74,23 @@ const CompactTooltipText: React.FC<{
   </Tooltip>
 );
 
-const userLabel = (userId: string | null | undefined, userById: Map<string, User>) => {
+const userLabel = (
+  userId: string | null | undefined,
+  userById: Map<string, User>,
+  currentUser?: User | null
+) => {
   if (!userId) return '—';
   const user = userById.get(userId);
-  return user?.email ?? user?.name ?? shortId(userId);
+  const label = user?.email ?? user?.name ?? shortId(userId);
+  return currentUser?.user_id === userId ? `${label} (you)` : label;
 };
 
 const ScheduleDetails: React.FC<{
   schedule: Schedule;
   humanizedCron: string;
   userById: Map<string, User>;
-}> = ({ schedule, humanizedCron, userById }) => (
+  currentUser?: User | null;
+}> = ({ schedule, humanizedCron, userById, currentUser }) => (
   <Space direction="vertical" size={2} style={{ maxWidth: 360 }}>
     <Text strong>{schedule.name || 'Untitled schedule'}</Text>
     {schedule.description ? <Text>{schedule.description}</Text> : null}
@@ -105,7 +111,7 @@ const ScheduleDetails: React.FC<{
       <Text strong>Last:</Text> {formatTimestamp(schedule.last_run_at)}
     </Text>
     <Text>
-      <Text strong>Runs as:</Text> {userLabel(schedule.created_by, userById)}
+      <Text strong>Runs as:</Text> {userLabel(schedule.created_by, userById, currentUser)}
     </Text>
   </Space>
 );
@@ -114,6 +120,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
   branch,
   client,
   mcpServerById = new Map(),
+  currentUser,
   userById = new Map(),
   onOpenSession,
 }) => {
@@ -217,6 +224,18 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
     }
   };
 
+  const renderScheduleDetails = useCallback(
+    (schedule: Schedule, humanizedCron: string) => (
+      <ScheduleDetails
+        schedule={schedule}
+        humanizedCron={humanizedCron}
+        userById={userById}
+        currentUser={currentUser}
+      />
+    ),
+    [currentUser, userById]
+  );
+
   const columns: TableColumnsType<Schedule> = [
     {
       title: 'On',
@@ -239,9 +258,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
       width: 220,
       render: (_, s) => {
         const humanizedCron = formatHumanizedCron(s.cron_expression);
-        const tooltip = (
-          <ScheduleDetails schedule={s} humanizedCron={humanizedCron} userById={userById} />
-        );
+        const tooltip = renderScheduleDetails(s, humanizedCron);
         return (
           <Space direction="vertical" size={0} style={{ display: 'flex', minWidth: 0 }}>
             <CompactTooltipText title={tooltip} ariaLabel={`Schedule title: ${s.name}`}>
@@ -262,9 +279,7 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
       width: 240,
       render: (_, s) => {
         const humanizedCron = formatHumanizedCron(s.cron_expression);
-        const tooltip = (
-          <ScheduleDetails schedule={s} humanizedCron={humanizedCron} userById={userById} />
-        );
+        const tooltip = renderScheduleDetails(s, humanizedCron);
         return (
           <Space direction="vertical" size={0} style={{ display: 'flex', minWidth: 0 }}>
             <CompactTooltipText title={tooltip}>{humanizedCron}</CompactTooltipText>
@@ -302,14 +317,12 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
       render: (_, s) => {
         const humanizedCron = formatHumanizedCron(s.cron_expression);
         return (
-          <Tooltip
-            title={
-              <ScheduleDetails schedule={s} humanizedCron={humanizedCron} userById={userById} />
-            }
-          >
-            <InfoCircleOutlined
+          <Tooltip title={renderScheduleDetails(s, humanizedCron)}>
+            <Button
+              type="text"
+              size="small"
+              icon={<InfoCircleOutlined />}
               aria-label={`Details for schedule ${s.name}`}
-              style={{ color: 'var(--ant-color-text-secondary)' }}
             />
           </Tooltip>
         );

--- a/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx
@@ -10,14 +10,17 @@ import { humanizeCron, shortId } from '@agor-live/client';
 import {
   DeleteOutlined,
   EditOutlined,
+  HistoryOutlined,
+  InfoCircleOutlined,
   PlayCircleOutlined,
   PlusOutlined,
   UnorderedListOutlined,
 } from '@ant-design/icons';
-import { Button, Empty, Popconfirm, Space, Spin, Switch, Table, Typography } from 'antd';
+import type { TableColumnsType } from 'antd';
+import { Button, Empty, Popconfirm, Space, Spin, Switch, Table, Tooltip, Typography } from 'antd';
+import type { ReactNode } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
-import { UserAvatar } from '../../metadata/UserAvatar';
 import { ScheduleModal } from '../../ScheduleModal';
 import { ScheduleRunsPanel } from '../../ScheduleRunsPanel';
 
@@ -43,11 +46,74 @@ const formatHumanizedCron = (cron: string): string => {
   }
 };
 
+const ellipsisStyle = {
+  display: 'block',
+  maxWidth: '100%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+} as const;
+
+const CompactTooltipText: React.FC<{
+  children: ReactNode;
+  title: ReactNode;
+  type?: 'secondary';
+  code?: boolean;
+  ariaLabel?: string;
+}> = ({ children, title, type, code, ariaLabel }) => (
+  <Tooltip title={title} mouseEnterDelay={0.4}>
+    <Text
+      aria-label={ariaLabel}
+      code={code}
+      type={type}
+      style={ellipsisStyle}
+      title={typeof children === 'string' ? children : undefined}
+    >
+      {children}
+    </Text>
+  </Tooltip>
+);
+
+const userLabel = (userId: string | null | undefined, userById: Map<string, User>) => {
+  if (!userId) return '—';
+  const user = userById.get(userId);
+  return user?.email ?? user?.name ?? shortId(userId);
+};
+
+const ScheduleDetails: React.FC<{
+  schedule: Schedule;
+  humanizedCron: string;
+  userById: Map<string, User>;
+}> = ({ schedule, humanizedCron, userById }) => (
+  <Space direction="vertical" size={2} style={{ maxWidth: 360 }}>
+    <Text strong>{schedule.name || 'Untitled schedule'}</Text>
+    {schedule.description ? <Text>{schedule.description}</Text> : null}
+    <Text>
+      <Text strong>Schedule:</Text> {humanizedCron}
+    </Text>
+    <Text>
+      <Text strong>Cron:</Text> <Text code>{schedule.cron_expression}</Text>
+    </Text>
+    <Text>
+      <Text strong>Timezone:</Text>{' '}
+      {schedule.timezone_mode === 'utc' ? 'UTC' : schedule.timezone || 'local'}
+    </Text>
+    <Text>
+      <Text strong>Next:</Text> {formatTimestamp(schedule.next_run_at)}
+    </Text>
+    <Text>
+      <Text strong>Last:</Text> {formatTimestamp(schedule.last_run_at)}
+    </Text>
+    <Text>
+      <Text strong>Runs as:</Text> {userLabel(schedule.created_by, userById)}
+    </Text>
+  </Space>
+);
+
 export const ScheduleTab: React.FC<ScheduleTabProps> = ({
   branch,
   client,
   mcpServerById = new Map(),
-  currentUser,
   userById = new Map(),
   onOpenSession,
 }) => {
@@ -151,86 +217,150 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
     }
   };
 
-  const columns = [
+  const columns: TableColumnsType<Schedule> = [
     {
       title: 'On',
       key: 'enabled',
-      width: 60,
-      render: (s: Schedule) => (
-        <Switch checked={s.enabled} onChange={(v) => handleToggleEnabled(s, v)} size="small" />
+      width: 50,
+      render: (_, s) => (
+        <Tooltip title={s.enabled ? 'Disable schedule' : 'Enable schedule'}>
+          <Switch
+            aria-label={`${s.enabled ? 'Disable' : 'Enable'} schedule ${s.name}`}
+            checked={s.enabled}
+            onChange={(v) => handleToggleEnabled(s, v)}
+            size="small"
+          />
+        </Tooltip>
       ),
     },
     {
-      title: 'Name',
+      title: 'Title',
       key: 'name',
-      render: (s: Schedule) => (
-        <Button type="link" onClick={() => setRunsPanelSchedule(s)} style={{ padding: 0 }}>
-          {s.name}
-        </Button>
-      ),
-    },
-    {
-      title: 'When',
-      key: 'cron',
-      render: (s: Schedule) => <Text>{formatHumanizedCron(s.cron_expression)}</Text>,
-    },
-    {
-      title: 'Scheduled by / run as',
-      key: 'created_by',
-      render: (s: Schedule) => {
-        const user = userById.get(s.created_by);
-        if (user) {
-          return (
-            <Space size={4}>
-              <UserAvatar user={user} showName size="small" />
-              {currentUser?.user_id === s.created_by && <Text type="secondary">(you)</Text>}
-            </Space>
-          );
-        }
-        return <Text type="secondary">{s.created_by ? shortId(s.created_by) : '—'}</Text>;
+      width: 220,
+      render: (_, s) => {
+        const humanizedCron = formatHumanizedCron(s.cron_expression);
+        const tooltip = (
+          <ScheduleDetails schedule={s} humanizedCron={humanizedCron} userById={userById} />
+        );
+        return (
+          <Space direction="vertical" size={0} style={{ display: 'flex', minWidth: 0 }}>
+            <CompactTooltipText title={tooltip} ariaLabel={`Schedule title: ${s.name}`}>
+              {s.name || 'Untitled schedule'}
+            </CompactTooltipText>
+            {s.description ? (
+              <CompactTooltipText title={tooltip} type="secondary">
+                {s.description}
+              </CompactTooltipText>
+            ) : null}
+          </Space>
+        );
       },
     },
     {
-      title: 'Last run',
-      key: 'last_run_at',
-      render: (s: Schedule) =>
-        s.last_run_session_id && onOpenSession ? (
-          <Button type="link" size="small" onClick={() => onOpenSession(s.last_run_session_id!)}>
-            {formatTimestamp(s.last_run_at)}
-          </Button>
-        ) : (
-          formatTimestamp(s.last_run_at)
-        ),
+      title: 'Schedule',
+      key: 'cron',
+      width: 240,
+      render: (_, s) => {
+        const humanizedCron = formatHumanizedCron(s.cron_expression);
+        const tooltip = (
+          <ScheduleDetails schedule={s} humanizedCron={humanizedCron} userById={userById} />
+        );
+        return (
+          <Space direction="vertical" size={0} style={{ display: 'flex', minWidth: 0 }}>
+            <CompactTooltipText title={tooltip}>{humanizedCron}</CompactTooltipText>
+            <CompactTooltipText title={tooltip} type="secondary" code>
+              {s.cron_expression}
+            </CompactTooltipText>
+          </Space>
+        );
+      },
+    },
+    {
+      title: 'Next',
+      key: 'next_run_at',
+      width: 130,
+      render: (_, s) => (
+        <CompactTooltipText
+          title={
+            <Space direction="vertical" size={2}>
+              <Text strong>Next run</Text>
+              <Text>{formatTimestamp(s.next_run_at)}</Text>
+              <Text type="secondary">
+                {s.timezone_mode === 'utc' ? 'UTC' : s.timezone || 'local'}
+              </Text>
+            </Space>
+          }
+        >
+          {formatTimestamp(s.next_run_at)}
+        </CompactTooltipText>
+      ),
+    },
+    {
+      title: '',
+      key: 'details',
+      width: 32,
+      render: (_, s) => {
+        const humanizedCron = formatHumanizedCron(s.cron_expression);
+        return (
+          <Tooltip
+            title={
+              <ScheduleDetails schedule={s} humanizedCron={humanizedCron} userById={userById} />
+            }
+          >
+            <InfoCircleOutlined
+              aria-label={`Details for schedule ${s.name}`}
+              style={{ color: 'var(--ant-color-text-secondary)' }}
+            />
+          </Tooltip>
+        );
+      },
     },
     {
       title: 'Actions',
       key: 'actions',
-      width: 160,
-      render: (s: Schedule) => (
-        <Space size="small">
-          <Button
-            type="text"
-            size="small"
-            icon={<PlayCircleOutlined />}
-            loading={runningId === s.schedule_id}
-            disabled={runningId === s.schedule_id}
-            onClick={() => handleRunNow(s)}
-            title="Run now"
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<UnorderedListOutlined />}
-            onClick={() => setRunsPanelSchedule(s)}
-            title="View runs"
-          />
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => handleEdit(s)}
-            title="Edit"
-          />
+      width: 150,
+      render: (_, s) => (
+        <Space size={2} wrap={false}>
+          <Tooltip title="Run now">
+            <Button
+              type="text"
+              size="small"
+              icon={<PlayCircleOutlined />}
+              loading={runningId === s.schedule_id}
+              disabled={runningId === s.schedule_id}
+              onClick={() => handleRunNow(s)}
+              aria-label={`Run schedule ${s.name} now`}
+            />
+          </Tooltip>
+          {s.last_run_session_id && onOpenSession ? (
+            <Tooltip title={`View last run — ${formatTimestamp(s.last_run_at)}`}>
+              <Button
+                type="text"
+                size="small"
+                icon={<HistoryOutlined />}
+                onClick={() => onOpenSession(s.last_run_session_id!)}
+                aria-label={`View last run for schedule ${s.name}`}
+              />
+            </Tooltip>
+          ) : null}
+          <Tooltip title="View runs">
+            <Button
+              type="text"
+              size="small"
+              icon={<UnorderedListOutlined />}
+              onClick={() => setRunsPanelSchedule(s)}
+              aria-label={`View runs for schedule ${s.name}`}
+            />
+          </Tooltip>
+          <Tooltip title="Edit">
+            <Button
+              type="text"
+              size="small"
+              icon={<EditOutlined />}
+              onClick={() => handleEdit(s)}
+              aria-label={`Edit schedule ${s.name}`}
+            />
+          </Tooltip>
           <Popconfirm
             title="Delete schedule?"
             description={`Are you sure you want to delete "${s.name}"?`}
@@ -239,7 +369,15 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
             cancelText="Cancel"
             okButtonProps={{ danger: true }}
           >
-            <Button type="text" size="small" icon={<DeleteOutlined />} danger title="Delete" />
+            <Tooltip title="Delete">
+              <Button
+                type="text"
+                size="small"
+                icon={<DeleteOutlined />}
+                danger
+                aria-label={`Delete schedule ${s.name}`}
+              />
+            </Tooltip>
           </Popconfirm>
         </Space>
       ),
@@ -247,10 +385,28 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
   ];
 
   return (
-    <div style={{ padding: 16 }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 12 }}>
-        <Text strong>Schedules for {branch.name}</Text>
-        <Button type="primary" icon={<PlusOutlined />} onClick={handleNew}>
+    <div style={{ padding: 16, minWidth: 0 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 12,
+          marginBottom: 12,
+          minWidth: 0,
+        }}
+      >
+        <CompactTooltipText
+          title={`Schedules for ${branch.name}`}
+          ariaLabel={`Schedules for ${branch.name}`}
+        >
+          Schedules for {branch.name}
+        </CompactTooltipText>
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={handleNew}
+          style={{ flex: '0 0 auto' }}
+        >
           New
         </Button>
       </div>
@@ -270,12 +426,14 @@ export const ScheduleTab: React.FC<ScheduleTabProps> = ({
           </Button>
         </Empty>
       ) : (
-        <Table
+        <Table<Schedule>
           rowKey="schedule_id"
           dataSource={schedules}
           columns={columns}
           pagination={false}
           size="small"
+          tableLayout="fixed"
+          style={{ width: '100%' }}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Compact the BranchModal schedules table to prevent modal overflow
- Truncate long titles, descriptions, cron descriptions, and timestamps with tooltip details
- Move last-run navigation into row actions while preserving run-now, runs, edit, and delete actions
- Add focused tests for the compact column set and last-run action

## Checks
- pnpm --filter agor-ui test -- src/components/BranchModal/tabs/ScheduleTab.test.tsx
- pnpm exec biome check apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.tsx apps/agor-ui/src/components/BranchModal/tabs/ScheduleTab.test.tsx

Note: pnpm --filter agor-ui typecheck was attempted but the local workspace lacks built @agor-live/client/@agor core dist artifacts after dependency install, so it failed before reaching this change with module-resolution errors.