### PR TITLE
Polish Settings artifact and action lists

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
@@ -15,13 +15,16 @@ import {
   Tag,
   Tooltip,
   Typography,
+  theme,
 } from 'antd';
+import type { CSSProperties } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { mapToArray, mapToSortedArray } from '@/utils/mapHelpers';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { uiRouteHref } from '@/utils/uiRoutes';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { HighlightMatch } from '../HighlightMatch';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 interface ArtifactsTableProps {
   artifactById: Map<string, Artifact>;
@@ -41,6 +44,11 @@ const templateColors: Record<string, string> = {
   'vanilla-ts': 'geekblue',
 };
 
+const artifactTextStyle: CSSProperties = {
+  display: 'block',
+  maxWidth: '100%',
+};
+
 export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
   artifactById,
   branchById,
@@ -53,6 +61,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
   const [editingArtifact, setEditingArtifact] = useState<Artifact | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
+  const { token } = theme.useToken();
 
   // Reuses the `artifactById` prop so we don't read the same data via
   // both props and context. Only goToArtifact is used from this table.
@@ -116,36 +125,35 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
-      render: (name: string, artifact: Artifact) => (
-        <Space orientation="vertical" size={0}>
-          <Typography.Text strong>
-            <HighlightMatch text={name} query={searchTerm} />
-          </Typography.Text>
-          {artifact.description && (
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              <HighlightMatch text={artifact.description} query={searchTerm} />
+      width: '38%',
+      render: (name: string, artifact: Artifact) => {
+        const displayName = name || shortId(artifact.artifact_id);
+        return (
+          <Space orientation="vertical" size={0} style={{ width: '100%' }}>
+            <Typography.Text strong ellipsis={{ tooltip: displayName }} style={artifactTextStyle}>
+              <HighlightMatch text={displayName} query={searchTerm} />
             </Typography.Text>
-          )}
-        </Space>
-      ),
+            {artifact.description && (
+              <Typography.Text
+                type="secondary"
+                ellipsis={{ tooltip: artifact.description }}
+                style={{ ...artifactTextStyle, fontSize: token.fontSizeSM }}
+              >
+                <HighlightMatch text={artifact.description} query={searchTerm} />
+              </Typography.Text>
+            )}
+            <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              Created {new Date(artifact.created_at).toLocaleDateString()}
+            </Typography.Text>
+          </Space>
+        );
+      },
     },
     {
-      title: 'Template',
-      dataIndex: 'template',
-      key: 'template',
-      width: 120,
-      render: (template: string) => (
-        <Tag color={templateColors[template] || 'default'}>
-          <HighlightMatch text={template} query={searchTerm} />
-        </Tag>
-      ),
-    },
-    {
-      title: 'Build',
-      dataIndex: 'build_status',
-      key: 'build_status',
-      width: 110,
-      render: (status: Artifact['build_status']) => {
+      title: 'Status',
+      key: 'status',
+      width: 150,
+      render: (_: unknown, artifact: Artifact) => {
         const map: Record<
           string,
           { status: 'success' | 'error' | 'processing' | 'default'; text: string }
@@ -155,55 +163,57 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
           checking: { status: 'processing', text: 'Checking' },
           unknown: { status: 'default', text: 'Unknown' },
         };
-        const info = map[status] || map.unknown;
-        return <Badge status={info.status} text={info.text} />;
-      },
-    },
-    {
-      title: 'Branch',
-      dataIndex: 'branch_id',
-      key: 'branch_id',
-      width: 160,
-      render: (branchId: string | null) => {
-        if (!branchId) return <Typography.Text type="secondary">—</Typography.Text>;
-        const branch = branchById.get(branchId);
+        const info = map[artifact.build_status] || map.unknown;
         return (
-          <Typography.Text type="secondary">
-            <HighlightMatch text={branch?.name || shortId(branchId)} query={searchTerm} />
-          </Typography.Text>
+          <Space orientation="vertical" size={0}>
+            <Badge status={info.status} text={info.text} />
+            <Tag
+              color={templateColors[artifact.template] || 'default'}
+              style={{ marginInlineEnd: 0 }}
+            >
+              <HighlightMatch text={artifact.template} query={searchTerm} />
+            </Tag>
+          </Space>
         );
       },
     },
     {
-      title: 'Board',
-      dataIndex: 'board_id',
-      key: 'board_id',
-      width: 160,
-      render: (boardId: string) => {
-        const board = boardById.get(boardId);
+      title: 'Location',
+      key: 'location',
+      width: '32%',
+      render: (_: unknown, artifact: Artifact) => {
+        const branch = artifact.branch_id ? branchById.get(artifact.branch_id) : undefined;
+        const branchText = artifact.branch_id ? branch?.name || shortId(artifact.branch_id) : '—';
+        const board = boardById.get(artifact.board_id);
+        const boardText = board
+          ? `${board.icon || ''} ${board.name}`.trim()
+          : shortId(artifact.board_id);
         return (
-          <Typography.Text type="secondary">
-            <HighlightMatch
-              text={board ? `${board.icon || ''} ${board.name}`.trim() : shortId(boardId)}
-              query={searchTerm}
-            />
-          </Typography.Text>
+          <Space orientation="vertical" size={0} style={{ width: '100%' }}>
+            <Typography.Text
+              type="secondary"
+              ellipsis={{ tooltip: `Board: ${boardText}` }}
+              style={artifactTextStyle}
+            >
+              Board: <HighlightMatch text={boardText} query={searchTerm} />
+            </Typography.Text>
+            <Typography.Text
+              type="secondary"
+              ellipsis={{ tooltip: `Branch: ${branchText}` }}
+              style={artifactTextStyle}
+            >
+              Branch: <HighlightMatch text={branchText} query={searchTerm} />
+            </Typography.Text>
+          </Space>
         );
       },
-    },
-    {
-      title: 'Created',
-      dataIndex: 'created_at',
-      key: 'created_at',
-      width: 110,
-      render: (date: string) => new Date(date).toLocaleDateString(),
     },
     {
       title: 'Actions',
       key: 'actions',
-      width: 150,
+      width: 124,
       render: (_: unknown, artifact: Artifact) => (
-        <Space size="small">
+        <SettingsActionGroup>
           {artifact.board_id && (
             <Tooltip title="Center map on artifact">
               <Button
@@ -248,7 +258,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
               <Button type="text" size="small" icon={<DeleteOutlined />} danger />
             </Tooltip>
           </Popconfirm>
-        </Space>
+        </SettingsActionGroup>
       ),
     },
   ];
@@ -319,6 +329,8 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
           rowKey="artifact_id"
           pagination={false}
           size="small"
+          tableLayout="fixed"
+          scroll={{ x: 760 }}
         />
       )}
 

--- a/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx
@@ -9,6 +9,7 @@ import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import { HighlightMatch } from '../HighlightMatch';
 import { MarkdownRenderer } from '../MarkdownRenderer/MarkdownRenderer';
 import { UserAvatar } from '../metadata/UserAvatar';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 interface AssistantsTableProps {
   branchById: Map<string, Branch>;
@@ -186,9 +187,9 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: 130,
+      width: 104,
       render: (_: unknown, record: Branch) => (
-        <Space size="small">
+        <SettingsActionGroup>
           {record.board_id && (
             <Tooltip title="Center map on assistant">
               <Button
@@ -220,7 +221,7 @@ export const AssistantsTable: React.FC<AssistantsTableProps> = ({
               setArchiveDeleteModalOpen(true);
             }}
           />
-        </Space>
+        </SettingsActionGroup>
       ),
     },
   ];

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -39,6 +39,7 @@ import { ArchiveToggleButton } from '../ArchiveButton';
 import { BoardFormFields, extractBoardFormValues, isCustomCSS } from '../forms/BoardFormFields';
 import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 interface BoardsTableProps {
   client: AgorClient | null;
@@ -394,9 +395,9 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: 280,
+      width: 184,
       render: (_: unknown, board: Board) => (
-        <Space size="small">
+        <SettingsActionGroup>
           <ArchiveToggleButton
             archived={Boolean(board.archived)}
             tooltip={board.archived ? 'Archived • Click to unarchive' : 'Archive board'}
@@ -445,7 +446,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
               <Button type="text" size="small" icon={<DeleteOutlined />} danger />
             </Tooltip>
           </Popconfirm>
-        </Space>
+        </SettingsActionGroup>
       ),
     },
   ];

--- a/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx
@@ -32,6 +32,7 @@ import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import { BranchFormFields } from '../BranchFormFields';
 import { HighlightMatch } from '../HighlightMatch';
 import { renderEnvCell } from './BranchEnvColumn';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 interface BranchesTableProps {
   client: AgorClient | null;
@@ -317,21 +318,40 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
 
   const columns = [
     {
-      title: 'Name',
+      title: 'Branch',
       dataIndex: 'name',
-      key: 'name',
-      render: (name: string, record: Branch) => (
-        <Space>
-          {isAssistant(record) ? (
-            <RobotOutlined style={{ color: token.colorInfo }} />
-          ) : (
-            <BranchesOutlined />
-          )}
-          <Typography.Text strong>
-            <HighlightMatch text={name} query={searchTerm} />
-          </Typography.Text>
-        </Space>
-      ),
+      key: 'branch',
+      render: (name: string, record: Branch) => {
+        const nameMatchesRef = name === record.ref;
+        return (
+          <Space style={{ minWidth: 0, width: '100%' }}>
+            {isAssistant(record) ? (
+              <RobotOutlined style={{ color: token.colorInfo }} />
+            ) : (
+              <BranchesOutlined />
+            )}
+            <Space orientation="vertical" size={0} style={{ minWidth: 0, flex: 1 }}>
+              <Typography.Text
+                strong
+                ellipsis={{ tooltip: name }}
+                style={{ display: 'block', maxWidth: '100%' }}
+              >
+                <HighlightMatch text={name} query={searchTerm} />
+              </Typography.Text>
+              {!nameMatchesRef && (
+                <Typography.Text
+                  code
+                  type="secondary"
+                  ellipsis={{ tooltip: record.ref }}
+                  style={{ display: 'block', maxWidth: '100%' }}
+                >
+                  <HighlightMatch text={record.ref} query={searchTerm} />
+                </Typography.Text>
+              )}
+            </Space>
+          </Space>
+        );
+      },
     },
     {
       title: 'Env',
@@ -354,16 +374,6 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
             <HighlightMatch text={getRepoName(repoId)} query={searchTerm} />
           </Typography.Text>
         </Space>
-      ),
-    },
-    {
-      title: 'Branch',
-      dataIndex: 'ref',
-      key: 'ref',
-      render: (ref: string) => (
-        <Typography.Text code>
-          <HighlightMatch text={ref} query={searchTerm} />
-        </Typography.Text>
       ),
     },
     {
@@ -396,9 +406,9 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: 160,
+      width: 144,
       render: (_: unknown, record: Branch) => (
-        <Space size="small">
+        <SettingsActionGroup>
           {!record.archived && record.board_id && (
             <Tooltip title="Center map on branch">
               <Button
@@ -467,7 +477,7 @@ export const BranchesTable: React.FC<BranchesTableProps> = ({
               setArchiveDeleteModalOpen(true);
             }}
           />
-        </Space>
+        </SettingsActionGroup>
       ),
     },
   ];

--- a/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
@@ -30,6 +30,7 @@ import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 import { MetaRow } from '../MetaRow';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 const { Sider, Content } = Layout;
 
@@ -397,7 +398,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
                     </Typography.Text>
                   }
                 />
-                <Space size="small" onClick={(e) => e.stopPropagation()}>
+                <SettingsActionGroup onClick={(e) => e.stopPropagation()}>
                   <Button
                     type="text"
                     size="small"
@@ -424,7 +425,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
                       onClick={(e) => e.stopPropagation()}
                     />
                   </Popconfirm>
-                </Space>
+                </SettingsActionGroup>
               </div>
             ))
           )}

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -66,6 +66,7 @@ import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
 import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 import { BranchSelect } from './BranchSelect';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 interface GatewayChannelsTableProps {
   client: AgorClient | null;
@@ -1886,9 +1887,9 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: 140,
+      width: 96,
       render: (_: unknown, channel: GatewayChannel) => (
-        <Space size="small">
+        <SettingsActionGroup>
           <Button
             type="text"
             size="small"
@@ -1912,7 +1913,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
           >
             <Button type="text" size="small" icon={<DeleteOutlined />} danger title="Delete" />
           </Popconfirm>
-        </Space>
+        </SettingsActionGroup>
       ),
     },
   ];

--- a/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
@@ -21,6 +21,7 @@ import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { useThemedMessage } from '../../utils/message';
 import { HighlightMatch } from '../HighlightMatch';
 import { syncGroupMembersForGroup } from './groupMembershipSync';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 interface GroupsTableProps {
   client: AgorClient | null;
@@ -239,9 +240,9 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
           },
           {
             title: 'Actions',
-            width: 110,
+            width: 76,
             render: (_: unknown, group: Group) => (
-              <Space>
+              <SettingsActionGroup>
                 <Button
                   type="text"
                   size="small"
@@ -256,7 +257,7 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
                 <Popconfirm title="Archive group?" onConfirm={() => archiveGroup(group)}>
                   <Button type="text" size="small" icon={<DeleteOutlined />} danger />
                 </Popconfirm>
-              </Space>
+              </SettingsActionGroup>
             ),
           },
         ]}

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -20,6 +20,7 @@ import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { HighlightMatch } from '../HighlightMatch';
 import { MCPServerEditModal, MCPServerFormFields } from '../MCPServer';
 import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from '../MCPServer/mcp-oauth-utils';
+import { SettingsActionGroup } from './SettingsActionGroup';
 
 interface MCPServersTableProps {
   mcpServerById: Map<string, MCPServer>;
@@ -347,9 +348,9 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: 140,
+      width: 96,
       render: (_: unknown, server: MCPServer) => (
-        <Space size="small">
+        <SettingsActionGroup>
           <Button
             type="text"
             size="small"
@@ -374,7 +375,7 @@ export const MCPServersTable: React.FC<MCPServersTableProps> = ({
           >
             <Button type="text" size="small" icon={<DeleteOutlined />} danger title="Delete" />
           </Popconfirm>
-        </Space>
+        </SettingsActionGroup>
       ),
     },
   ];

--- a/apps/agor-ui/src/components/SettingsModal/SettingsActionGroup.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsActionGroup.tsx
@@ -1,0 +1,15 @@
+import type { SpaceProps } from 'antd';
+import { Space, theme } from 'antd';
+
+/**
+ * Compact-but-clickable spacing for icon-only actions in Settings tables.
+ * Ant's `small` Space is 8px, which gets wide when rows have 4+ icon buttons.
+ */
+export function SettingsActionGroup({ children, size, ...props }: SpaceProps) {
+  const { token } = theme.useToken();
+  return (
+    <Space size={size ?? token.sizeUnit} {...props}>
+      {children}
+    </Space>
+  );
+}

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -29,6 +29,7 @@ import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { useThemedMessage } from '../../utils/message';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { HighlightMatch } from '../HighlightMatch';
+import { SettingsActionGroup } from './SettingsActionGroup';
 import { UserSettingsModal } from './UserSettingsModal';
 
 interface UsersTableProps {
@@ -212,9 +213,9 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     {
       title: 'Actions',
       key: 'actions',
-      width: 120,
+      width: 88,
       render: (_: unknown, user: User) => (
-        <Space size="small">
+        <SettingsActionGroup>
           <Button
             type="text"
             size="small"
@@ -231,7 +232,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
           >
             <Button type="text" size="small" icon={<DeleteOutlined />} danger />
           </Popconfirm>
-        </Space>
+        </SettingsActionGroup>
       ),
     },
   ];


### PR DESCRIPTION
## Summary
- Compact Settings artifact CRUD into fewer columns with truncated name/description/location text and tooltips
- Add a shared compact Settings action group using the Ant Design size token and apply it across Settings list action clusters
- Merge Branches Settings name/ref display so duplicated branch names are not shown twice

## Checks
- pnpm exec biome check apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx apps/agor-ui/src/components/SettingsModal/BranchesTable.tsx apps/agor-ui/src/components/SettingsModal/SettingsActionGroup.tsx apps/agor-ui/src/components/SettingsModal/AssistantsTable.tsx apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx apps/agor-ui/src/components/SettingsModal/CardsTable.tsx apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
- pnpm --filter agor-ui test -- SettingsModal/BranchesTable.test.tsx

Note: pnpm --filter agor-ui typecheck currently fails in this fresh worktree before reaching these changes because @agor-live/client/@agor/core dist type declarations are not present without building workspace packages.