### PR TITLE
Add gateway channel MCP CRUD tools

### DIFF
--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -36,6 +36,7 @@ import { registerBranchTools } from './tools/branches.js';
 import { registerCardTypeTools } from './tools/card-types.js';
 import { registerCardTools } from './tools/cards.js';
 import { registerEnvironmentTools } from './tools/environment.js';
+import { registerGatewayChannelTools } from './tools/gateway-channels.js';
 import { registerKnowledgeTools } from './tools/knowledge.js';
 import { registerMcpServerTools } from './tools/mcp-servers.js';
 import { registerMessageTools } from './tools/messages.js';
@@ -209,6 +210,7 @@ const DOMAIN_TOOL_REGISTRARS: DomainToolRegistrar[] = [
   { domain: 'users', register: registerUserTools },
   { domain: 'analytics', register: registerAnalyticsTools },
   { domain: 'mcp-servers', register: registerMcpServerTools },
+  { domain: 'gateway', register: registerGatewayChannelTools },
   { domain: 'knowledge', register: registerKnowledgeTools },
   { domain: 'schedules', register: registerScheduleTools },
 ];

--- a/apps/agor-daemon/src/mcp/tool-registry.ts
+++ b/apps/agor-daemon/src/mcp/tool-registry.ts
@@ -52,6 +52,7 @@ export const DOMAIN_DESCRIPTIONS: Record<string, string> = {
   users: 'User accounts, profiles, preferences, and administration',
   analytics: 'Usage and cost tracking leaderboard',
   'mcp-servers': 'External MCP server configuration and OAuth management',
+  gateway: 'Gateway channels for Slack, GitHub, Teams, and other message integrations',
   proxies: 'Configured HTTP proxies for third-party APIs (Shortcut, Linear, Jira, etc.)',
   widgets:
     'In-conversation interactive widgets — agents render small forms/buttons inline in the transcript to capture user input that never enters the LLM context',

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -1,0 +1,261 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+
+type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
+function makeFakeApp(services: Record<string, ServiceStub>) {
+  return {
+    service: (name: string) => {
+      const svc = services[name];
+      if (!svc) throw new Error(`Unexpected service call: ${name}`);
+      return svc;
+    },
+  };
+}
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+async function captureTools(role: 'admin' | 'member' = 'admin', app = makeFakeApp({})) {
+  const { registerGatewayChannelTools } = await import('./gateway-channels.js');
+  const tools: Record<string, { cfg: any; handler: ToolHandler }> = {};
+  const fakeServer = {
+    registerTool: (name: string, cfg: any, cb: ToolHandler) => {
+      tools[name] = { cfg, handler: cb };
+    },
+  } as unknown as McpServer;
+  registerGatewayChannelTools(fakeServer, {
+    app: app as any,
+    db: {} as any,
+    userId: 'user-1' as any,
+    sessionId: 'sess-1' as any,
+    authenticatedUser: { user_id: 'user-1', role } as any,
+    baseServiceParams: { authenticated: true, user: { user_id: 'user-1', role } } as any,
+  });
+  return tools;
+}
+
+describe('agor_gateway_channels MCP tools', () => {
+  it('validates Slack Socket Mode config on create', async () => {
+    const tools = await captureTools();
+    const missingBot = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Eng Slack',
+      targetBranchId: 'branch-1',
+      channelType: 'slack',
+      config: { connection_mode: 'socket', app_token: 'xapp-1' },
+    });
+    expect(missingBot.success).toBe(false);
+    expect(String(missingBot.error)).toContain('config.bot_token is required for Slack');
+
+    const missingApp = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Eng Slack',
+      targetBranchId: 'branch-1',
+      channelType: 'slack',
+      config: { connection_mode: 'socket', bot_token: 'xoxb-1' },
+    });
+    expect(missingApp.success).toBe(false);
+    expect(String(missingApp.error)).toContain(
+      'config.app_token is required for Slack Socket Mode'
+    );
+  });
+
+  it('creates through gateway-channels service and redacts returned secrets', async () => {
+    const createCalls: Array<{ data: Record<string, unknown>; params: unknown }> = [];
+    const app = makeFakeApp({
+      'gateway-channels': {
+        create: async (data: Record<string, unknown>, params: unknown) => {
+          createCalls.push({ data, params });
+          return {
+            id: 'chan-1',
+            created_by: 'admin-1',
+            name: data.name,
+            channel_type: data.channel_type,
+            target_branch_id: data.target_branch_id,
+            agor_user_id: data.agor_user_id,
+            channel_key: 'raw-channel-key',
+            config: { ...(data.config as Record<string, unknown>) },
+            agentic_config: data.agentic_config,
+            enabled: data.enabled,
+            created_at: '2026-06-22T00:00:00.000Z',
+            updated_at: '2026-06-22T00:00:00.000Z',
+            last_message_at: null,
+          };
+        },
+      },
+    });
+
+    const tools = await captureTools('admin', app);
+    const result = await tools.agor_gateway_channels_create.handler({
+      name: 'Eng Slack',
+      channelType: 'slack',
+      targetBranchId: 'branch-1',
+      agorUserId: 'user-runner',
+      config: {
+        bot_token: 'xoxb-secret',
+        app_token: 'xapp-secret',
+        connection_mode: 'socket',
+        enable_channels: true,
+      },
+      agenticConfig: {
+        agent: 'claude-code',
+        envVars: [{ key: 'SERVICE_TOKEN', value: 'raw-env-secret', forceOverride: true }],
+      },
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(createCalls).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'Eng Slack',
+          channel_type: 'slack',
+          target_branch_id: 'branch-1',
+          agor_user_id: 'user-runner',
+          enabled: true,
+          config: expect.objectContaining({ bot_token: 'xoxb-secret' }),
+        }),
+      }),
+    ]);
+    expect(payload.gateway_channel.channel_key).toBe('••••••••');
+    expect(payload.gateway_channel.config.bot_token).toBe('••••••••');
+    expect(payload.gateway_channel.config.app_token).toBe('••••••••');
+    expect(payload.gateway_channel.agentic_config.envVars[0].value).toBe('••••••••');
+    expect(JSON.stringify(payload)).not.toContain('xoxb-secret');
+    expect(JSON.stringify(payload)).not.toContain('raw-channel-key');
+    expect(JSON.stringify(payload)).not.toContain('raw-env-secret');
+  });
+
+  it('lists with filters and redacts Teams app_password', async () => {
+    const app = makeFakeApp({
+      'gateway-channels': {
+        find: async () => ({
+          data: [
+            {
+              id: 'chan-slack',
+              created_by: 'admin-1',
+              name: 'Slack',
+              channel_type: 'slack',
+              target_branch_id: 'branch-1',
+              agor_user_id: 'user-1',
+              channel_key: 'slack-key',
+              config: { bot_token: 'xoxb', app_token: 'xapp' },
+              agentic_config: null,
+              enabled: false,
+              created_at: '2026-06-22T00:00:00.000Z',
+              updated_at: '2026-06-22T00:00:00.000Z',
+              last_message_at: null,
+            },
+            {
+              id: 'chan-teams',
+              created_by: 'admin-1',
+              name: 'Teams',
+              channel_type: 'teams',
+              target_branch_id: 'branch-1',
+              agor_user_id: 'user-1',
+              channel_key: 'teams-key',
+              config: { app_id: 'app', app_password: 'teams-secret' },
+              agentic_config: null,
+              enabled: true,
+              created_at: '2026-06-22T00:00:00.000Z',
+              updated_at: '2026-06-22T00:00:00.000Z',
+              last_message_at: null,
+            },
+          ],
+        }),
+      },
+    });
+
+    const tools = await captureTools('admin', app);
+    const result = await tools.agor_gateway_channels_list.handler({
+      includeDisabled: false,
+      channelType: 'teams',
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.gateway_channels).toHaveLength(1);
+    expect(payload.gateway_channels[0]).toMatchObject({
+      id: 'chan-teams',
+      channel_key: '••••••••',
+      config: { app_id: 'app', app_password: '••••••••' },
+    });
+    expect(JSON.stringify(payload)).not.toContain('teams-secret');
+    expect(payload.summary).toMatchObject({ total: 1, enabled: 1, disabled: 0 });
+  });
+
+  it('updates only provided fields through gateway-channels service', async () => {
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const app = makeFakeApp({
+      'gateway-channels': {
+        patch: async (id: string, data: Record<string, unknown>) => {
+          patchCalls.push({ id, data });
+          return {
+            id,
+            created_by: 'admin-1',
+            name: data.name ?? 'Slack',
+            channel_type: 'slack',
+            target_branch_id: 'branch-1',
+            agor_user_id: 'user-1',
+            channel_key: 'raw-key',
+            config: { bot_token: 'xoxb', ...(data.config as Record<string, unknown>) },
+            agentic_config: null,
+            enabled: data.enabled ?? true,
+            created_at: '2026-06-22T00:00:00.000Z',
+            updated_at: '2026-06-22T00:00:00.000Z',
+            last_message_at: null,
+          };
+        },
+      },
+    });
+
+    const tools = await captureTools('admin', app);
+    const result = await tools.agor_gateway_channels_update.handler({
+      gatewayChannelId: 'chan-1',
+      name: 'Slack renamed',
+      enabled: false,
+      config: { bot_token: '••••••••', require_mention: true },
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(patchCalls).toEqual([
+      {
+        id: 'chan-1',
+        data: {
+          name: 'Slack renamed',
+          enabled: false,
+          config: { bot_token: '••••••••', require_mention: true },
+        },
+      },
+    ]);
+    expect(payload.gateway_channel.config.bot_token).toBe('••••••••');
+  });
+
+  it('denies list/create/update for non-admin users before service calls', async () => {
+    const app = makeFakeApp({
+      'gateway-channels': {
+        find: vi.fn(async () => ({ data: [] })),
+        create: vi.fn(async () => ({})),
+        patch: vi.fn(async () => ({})),
+      },
+    });
+    const services = app.service('gateway-channels') as Record<string, ReturnType<typeof vi.fn>>;
+    const tools = await captureTools('member', app);
+
+    await expect(tools.agor_gateway_channels_list.handler({})).rejects.toThrow(
+      'admin role required'
+    );
+    await expect(
+      tools.agor_gateway_channels_create.handler({
+        name: 'Eng Slack',
+        targetBranchId: 'branch-1',
+        config: { bot_token: 'xoxb' },
+      })
+    ).rejects.toThrow('admin role required');
+    await expect(
+      tools.agor_gateway_channels_update.handler({ gatewayChannelId: 'chan-1', enabled: false })
+    ).rejects.toThrow('admin role required');
+
+    expect(services.find).not.toHaveBeenCalled();
+    expect(services.create).not.toHaveBeenCalled();
+    expect(services.patch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -126,42 +126,34 @@ describe('agor_gateway_channels MCP tools', () => {
   });
 
   it('lists with filters and redacts Teams app_password', async () => {
+    const findCalls: Array<Record<string, unknown> | undefined> = [];
     const app = makeFakeApp({
       'gateway-channels': {
-        find: async () => ({
-          data: [
-            {
-              id: 'chan-slack',
-              created_by: 'admin-1',
-              name: 'Slack',
-              channel_type: 'slack',
-              target_branch_id: 'branch-1',
-              agor_user_id: 'user-1',
-              channel_key: 'slack-key',
-              config: { bot_token: 'xoxb', app_token: 'xapp' },
-              agentic_config: null,
-              enabled: false,
-              created_at: '2026-06-22T00:00:00.000Z',
-              updated_at: '2026-06-22T00:00:00.000Z',
-              last_message_at: null,
-            },
-            {
-              id: 'chan-teams',
-              created_by: 'admin-1',
-              name: 'Teams',
-              channel_type: 'teams',
-              target_branch_id: 'branch-1',
-              agor_user_id: 'user-1',
-              channel_key: 'teams-key',
-              config: { app_id: 'app', app_password: 'teams-secret' },
-              agentic_config: null,
-              enabled: true,
-              created_at: '2026-06-22T00:00:00.000Z',
-              updated_at: '2026-06-22T00:00:00.000Z',
-              last_message_at: null,
-            },
-          ],
-        }),
+        find: async (params: { query?: Record<string, unknown> }) => {
+          findCalls.push(params.query);
+          return {
+            total: 1,
+            limit: params.query?.$limit,
+            skip: params.query?.$skip,
+            data: [
+              {
+                id: 'chan-teams',
+                created_by: 'admin-1',
+                name: 'Teams',
+                channel_type: 'teams',
+                target_branch_id: 'branch-1',
+                agor_user_id: 'user-1',
+                channel_key: 'teams-key',
+                config: { app_id: 'app', app_password: 'teams-secret' },
+                agentic_config: null,
+                enabled: true,
+                created_at: '2026-06-22T00:00:00.000Z',
+                updated_at: '2026-06-22T00:00:00.000Z',
+                last_message_at: null,
+              },
+            ],
+          };
+        },
       },
     });
 
@@ -169,9 +161,17 @@ describe('agor_gateway_channels MCP tools', () => {
     const result = await tools.agor_gateway_channels_list.handler({
       includeDisabled: false,
       channelType: 'teams',
+      limit: 25,
+      skip: 10,
     });
     const payload = JSON.parse(result.content[0].text);
 
+    expect(findCalls[0]).toMatchObject({
+      enabled: true,
+      channel_type: 'teams',
+      $limit: 25,
+      $skip: 10,
+    });
     expect(payload.gateway_channels).toHaveLength(1);
     expect(payload.gateway_channels[0]).toMatchObject({
       id: 'chan-teams',
@@ -179,7 +179,8 @@ describe('agor_gateway_channels MCP tools', () => {
       config: { app_id: 'app', app_password: '••••••••' },
     });
     expect(JSON.stringify(payload)).not.toContain('teams-secret');
-    expect(payload.summary).toMatchObject({ total: 1, enabled: 1, disabled: 0 });
+    expect(payload.pagination).toMatchObject({ total: 1, returned: 1, limit: 25, skip: 10 });
+    expect(payload.summary).toMatchObject({ returned: 1, enabled: 1, disabled: 0 });
   });
 
   it('updates only provided fields through gateway-channels service', async () => {
@@ -227,6 +228,40 @@ describe('agor_gateway_channels MCP tools', () => {
       },
     ]);
     expect(payload.gateway_channel.config.bot_token).toBe('••••••••');
+  });
+
+  it('passes agenticConfig null through so service hooks can clear it', async () => {
+    const patchCalls: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const app = makeFakeApp({
+      'gateway-channels': {
+        patch: async (id: string, data: Record<string, unknown>) => {
+          patchCalls.push({ id, data });
+          return {
+            id,
+            created_by: 'admin-1',
+            name: 'Slack',
+            channel_type: 'slack',
+            target_branch_id: 'branch-1',
+            agor_user_id: 'user-1',
+            channel_key: 'raw-key',
+            config: {},
+            agentic_config: data.agentic_config,
+            enabled: true,
+            created_at: '2026-06-22T00:00:00.000Z',
+            updated_at: '2026-06-22T00:00:00.000Z',
+            last_message_at: null,
+          };
+        },
+      },
+    });
+
+    const tools = await captureTools('admin', app);
+    await tools.agor_gateway_channels_update.handler({
+      gatewayChannelId: 'chan-1',
+      agenticConfig: null,
+    });
+
+    expect(patchCalls).toEqual([{ id: 'chan-1', data: { agentic_config: null } }]);
   });
 
   it('denies list/create/update for non-admin users before service calls', async () => {

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -1,0 +1,350 @@
+import { type GatewayChannel, hasMinimumRole, ROLES } from '@agor/core/types';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  mcpOptionalId,
+  mcpOptionalNonEmptyString,
+  mcpRequiredId,
+  mcpRequiredString,
+} from '../schema.js';
+import type { McpContext } from '../server.js';
+import { textResult } from '../server.js';
+
+const REDACTED_SENTINEL = '••••••••';
+const SENSITIVE_CONFIG_FIELDS = new Set([
+  'bot_token',
+  'app_token',
+  'signing_secret',
+  'private_key',
+  'webhook_secret',
+  'app_password',
+]);
+
+function requireAdmin(ctx: McpContext, action: string): void {
+  if (!hasMinimumRole(ctx.authenticatedUser?.role, ROLES.ADMIN)) {
+    throw new Error(`Access denied: admin role required to ${action}`);
+  }
+}
+
+const configSchema = z
+  .record(z.string(), z.unknown())
+  .describe(
+    'Platform-specific gateway configuration. Secrets are stored encrypted and returned redacted. Prefer env/template references for shared credentials where the connector supports them.'
+  );
+
+const envVarSchema = z.strictObject({
+  key: mcpRequiredString('agenticConfig.envVars[].key', 'Environment variable name'),
+  value: mcpRequiredString(
+    'agenticConfig.envVars[].value',
+    `Environment variable value. Prefer references/templates over raw secrets. Existing redacted values may be passed as '${REDACTED_SENTINEL}' on update to preserve them.`
+  ),
+  forceOverride: z
+    .boolean()
+    .optional()
+    .describe('When true, channel value wins over user env vars. Defaults to false.'),
+});
+
+const agenticConfigSchema = z
+  .strictObject({
+    agent: z
+      .enum(['claude-code', 'claude-code-cli', 'codex', 'gemini', 'opencode', 'copilot', 'cursor'])
+      .describe('Agent used for sessions created from this gateway channel.'),
+    permissionMode: z
+      .enum([
+        'default',
+        'acceptEdits',
+        'bypassPermissions',
+        'plan',
+        'dontAsk',
+        'autoEdit',
+        'yolo',
+        'ask',
+        'auto',
+        'on-failure',
+        'allow-all',
+      ])
+      .optional()
+      .describe('Permission mode for spawned sessions.'),
+    modelConfig: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Agent model configuration.'),
+    mcpServerIds: z
+      .array(z.string().min(1))
+      .optional()
+      .describe('MCP server IDs to attach to gateway-created sessions.'),
+    codexSandboxMode: z
+      .enum(['read-only', 'workspace-write', 'danger-full-access'])
+      .optional()
+      .describe('Codex sandbox mode for Codex gateway sessions.'),
+    codexApprovalPolicy: z
+      .enum(['untrusted', 'on-failure', 'on-request', 'never'])
+      .optional()
+      .describe('Codex approval policy for Codex gateway sessions.'),
+    codexNetworkAccess: z.boolean().optional().describe('Allow Codex network access.'),
+    envVars: z
+      .array(envVarSchema)
+      .optional()
+      .describe('Gateway-level env vars. Values are redacted in responses.'),
+  })
+  .describe('Agent/session defaults for conversations created through this gateway channel.');
+
+const gatewayChannelCreateSchema = z
+  .strictObject({
+    name: mcpRequiredString('name', 'Human-readable channel name, e.g. "Engineering Slack".'),
+    channelType: z
+      .enum(['slack', 'github', 'teams', 'discord', 'whatsapp', 'telegram'])
+      .default('slack')
+      .describe('Gateway platform type. Current active connectors are slack, github, and teams.'),
+    targetBranchId: mcpRequiredId(
+      'targetBranchId',
+      'Branch',
+      'Branch/worktree ID that this gateway channel prompts.'
+    ),
+    agorUserId: mcpOptionalId(
+      'agorUserId',
+      'User',
+      'Agor user ID whose identity is used when platform-user alignment is disabled.'
+    ),
+    enabled: z.boolean().optional().describe('Whether the channel is active. Defaults to true.'),
+    config: configSchema,
+    agenticConfig: agenticConfigSchema.optional(),
+  })
+  .superRefine((value, issue) => {
+    const config = value.config ?? {};
+    if (value.channelType === 'slack') {
+      if (!config.bot_token) {
+        issue.addIssue({
+          code: 'custom',
+          path: ['config', 'bot_token'],
+          message:
+            'config.bot_token is required for Slack. Prefer a bot token stored outside the transcript when possible.',
+        });
+      }
+      if (config.connection_mode === 'socket' && !config.app_token) {
+        issue.addIssue({
+          code: 'custom',
+          path: ['config', 'app_token'],
+          message: 'config.app_token is required for Slack Socket Mode.',
+        });
+      }
+    }
+    if (value.channelType === 'github') {
+      for (const field of ['app_id', 'private_key', 'installation_id', 'watch_repos'] as const) {
+        if (!config[field]) {
+          issue.addIssue({
+            code: 'custom',
+            path: ['config', field],
+            message: `config.${field} is required for GitHub gateway channels.`,
+          });
+        }
+      }
+    }
+    if (value.channelType === 'teams') {
+      for (const field of ['app_id', 'app_password'] as const) {
+        if (!config[field]) {
+          issue.addIssue({
+            code: 'custom',
+            path: ['config', field],
+            message: `config.${field} is required for Teams gateway channels.`,
+          });
+        }
+      }
+    }
+  });
+
+const gatewayChannelUpdateSchema = z.strictObject({
+  gatewayChannelId: mcpRequiredId(
+    'gatewayChannelId',
+    'Gateway channel',
+    'Gateway channel ID (UUIDv7 or short ID)'
+  ),
+  name: mcpOptionalNonEmptyString('name', 'New human-readable channel name.'),
+  channelType: z
+    .enum(['slack', 'github', 'teams', 'discord', 'whatsapp', 'telegram'])
+    .optional()
+    .describe('Gateway platform type. Changing this should include compatible config.'),
+  targetBranchId: mcpOptionalId('targetBranchId', 'Branch', 'New target branch/worktree ID.'),
+  agorUserId: mcpOptionalId('agorUserId', 'User', 'New run-as Agor user ID.'),
+  enabled: z.boolean().optional().describe('Enable/disable the channel.'),
+  config: configSchema
+    .optional()
+    .describe(
+      `Partial platform config to merge. Send '${REDACTED_SENTINEL}' or omit sensitive fields to preserve existing secrets; send a new value to rotate.`
+    ),
+  agenticConfig: agenticConfigSchema
+    .nullable()
+    .optional()
+    .describe('Replace agent/session defaults. null clears the gateway agentic config.'),
+});
+
+type GatewayChannelSummary = Omit<
+  GatewayChannel,
+  'channel_type' | 'target_branch_id' | 'agor_user_id' | 'agentic_config'
+> & {
+  channel_type: GatewayChannel['channel_type'];
+  target_branch_id: string;
+  agor_user_id: string;
+  channel_key: typeof REDACTED_SENTINEL;
+  config: Record<string, unknown>;
+  agentic_config: GatewayChannel['agentic_config'];
+};
+
+function redactGatewayChannel(channel: GatewayChannel): GatewayChannelSummary {
+  const config = { ...(channel.config ?? {}) };
+  for (const field of SENSITIVE_CONFIG_FIELDS) {
+    if (config[field]) config[field] = REDACTED_SENTINEL;
+  }
+
+  let agentic_config = channel.agentic_config;
+  if (agentic_config?.envVars) {
+    agentic_config = {
+      ...agentic_config,
+      envVars: agentic_config.envVars.map((envVar) => ({
+        ...envVar,
+        value: REDACTED_SENTINEL,
+      })),
+    };
+  }
+
+  return {
+    ...channel,
+    target_branch_id: channel.target_branch_id,
+    agor_user_id: channel.agor_user_id,
+    channel_key: REDACTED_SENTINEL,
+    config,
+    agentic_config,
+  };
+}
+
+function toServiceCreateData(args: z.infer<typeof gatewayChannelCreateSchema>) {
+  return {
+    name: args.name,
+    channel_type: args.channelType,
+    target_branch_id: args.targetBranchId,
+    agor_user_id: args.agorUserId ?? '',
+    enabled: args.enabled ?? true,
+    config: args.config,
+    agentic_config: args.agenticConfig
+      ? {
+          ...args.agenticConfig,
+          envVars: args.agenticConfig.envVars?.map((envVar) => ({
+            ...envVar,
+            forceOverride: envVar.forceOverride ?? false,
+          })),
+        }
+      : undefined,
+  };
+}
+
+function toServiceUpdateData(args: z.infer<typeof gatewayChannelUpdateSchema>) {
+  const updates: Partial<GatewayChannel> = {};
+  if (args.name !== undefined) updates.name = args.name;
+  if (args.channelType !== undefined) updates.channel_type = args.channelType;
+  if (args.targetBranchId !== undefined) updates.target_branch_id = args.targetBranchId as never;
+  if (args.agorUserId !== undefined) updates.agor_user_id = args.agorUserId as never;
+  if (args.enabled !== undefined) updates.enabled = args.enabled;
+  if (args.config !== undefined) updates.config = args.config;
+  if (args.agenticConfig !== undefined) {
+    updates.agentic_config = args.agenticConfig
+      ? ({
+          ...args.agenticConfig,
+          envVars: args.agenticConfig.envVars?.map((envVar) => ({
+            ...envVar,
+            forceOverride: envVar.forceOverride ?? false,
+          })),
+        } as never)
+      : null;
+  }
+  return updates;
+}
+
+export function registerGatewayChannelTools(server: McpServer, ctx: McpContext): void {
+  server.registerTool(
+    'agor_gateway_channels_list',
+    {
+      description:
+        'List gateway channel definitions (admin-only). Returns Slack/GitHub/Teams channel metadata with tokens, app passwords, private keys, webhook secrets, env var values, and inbound channel keys redacted. Use this to discover gatewayChannelId values for agor_gateway_channels_update.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.strictObject({
+        includeDisabled: z
+          .boolean()
+          .optional()
+          .describe('Include disabled channels (default: true).'),
+        channelType: z
+          .enum(['slack', 'github', 'teams', 'discord', 'whatsapp', 'telegram'])
+          .optional()
+          .describe('Optional platform filter.'),
+      }),
+    },
+    async (args) => {
+      requireAdmin(ctx, 'list gateway channels');
+      const result = await ctx.app.service('gateway-channels').find({
+        ...ctx.baseServiceParams,
+        query: { $limit: 100 },
+      });
+      let channels = (Array.isArray(result) ? result : result.data) as GatewayChannel[];
+      if (args.includeDisabled === false) channels = channels.filter((channel) => channel.enabled);
+      if (args.channelType) {
+        channels = channels.filter((channel) => channel.channel_type === args.channelType);
+      }
+
+      return textResult({
+        gateway_channels: channels.map(redactGatewayChannel),
+        summary: {
+          total: channels.length,
+          enabled: channels.filter((channel) => channel.enabled).length,
+          disabled: channels.filter((channel) => !channel.enabled).length,
+        },
+      });
+    }
+  );
+
+  server.registerTool(
+    'agor_gateway_channels_create',
+    {
+      description:
+        'Create a gateway channel definition (admin-only) through the same gateway-channels service used by the UI. Current connectors: Slack, GitHub, Teams. Slack example config: { bot_token, app_token, connection_mode:"socket", enable_channels:true, require_mention:true, allowed_channel_ids:["C123"] }. Secrets are encrypted by the service and returned redacted; prefer environment/template references where possible because raw secrets in tool arguments may appear in the MCP transcript.',
+      annotations: { destructiveHint: false, idempotentHint: false },
+      inputSchema: gatewayChannelCreateSchema,
+    },
+    async (args) => {
+      requireAdmin(ctx, 'create gateway channels');
+      const created = (await ctx.app
+        .service('gateway-channels')
+        .create(toServiceCreateData(args), ctx.baseServiceParams)) as GatewayChannel;
+
+      return textResult({
+        gateway_channel: redactGatewayChannel(created),
+        next_steps: [
+          'Verify the channel in Settings > Gateway Channels or with agor_gateway_channels_list.',
+          'Channel credentials, env vars, and inbound channel keys are intentionally redacted from MCP responses.',
+        ],
+      });
+    }
+  );
+
+  server.registerTool(
+    'agor_gateway_channels_update',
+    {
+      description: `Update a gateway channel definition (admin-only) through the gateway-channels service. Provide only fields to change. To preserve an existing secret in config or agenticConfig.envVars, omit it or pass '${REDACTED_SENTINEL}'; to rotate it, pass a new value. Responses always redact secrets and channel_key.`,
+      annotations: { destructiveHint: false, idempotentHint: false },
+      inputSchema: gatewayChannelUpdateSchema,
+    },
+    async (args) => {
+      requireAdmin(ctx, 'update gateway channels');
+      const updated = (await ctx.app
+        .service('gateway-channels')
+        .patch(
+          args.gatewayChannelId,
+          toServiceUpdateData(args),
+          ctx.baseServiceParams
+        )) as GatewayChannel;
+
+      return textResult({
+        gateway_channel: redactGatewayChannel(updated),
+        next_steps: ['Verify with agor_gateway_channels_list.'],
+      });
+    }
+  );
+}

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -1,7 +1,15 @@
-import { type GatewayChannel, hasMinimumRole, ROLES } from '@agor/core/types';
+import {
+  GATEWAY_REDACTED_SENTINEL,
+  GATEWAY_SENSITIVE_CONFIG_FIELDS,
+  type GatewayChannel,
+  hasMinimumRole,
+  ROLES,
+} from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import {
+  mcpLimit,
+  mcpOffset,
   mcpOptionalId,
   mcpOptionalNonEmptyString,
   mcpRequiredId,
@@ -9,16 +17,6 @@ import {
 } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
-
-const REDACTED_SENTINEL = '••••••••';
-const SENSITIVE_CONFIG_FIELDS = new Set([
-  'bot_token',
-  'app_token',
-  'signing_secret',
-  'private_key',
-  'webhook_secret',
-  'app_password',
-]);
 
 function requireAdmin(ctx: McpContext, action: string): void {
   if (!hasMinimumRole(ctx.authenticatedUser?.role, ROLES.ADMIN)) {
@@ -36,7 +34,7 @@ const envVarSchema = z.strictObject({
   key: mcpRequiredString('agenticConfig.envVars[].key', 'Environment variable name'),
   value: mcpRequiredString(
     'agenticConfig.envVars[].value',
-    `Environment variable value. Prefer references/templates over raw secrets. Existing redacted values may be passed as '${REDACTED_SENTINEL}' on update to preserve them.`
+    `Environment variable value. Prefer references/templates over raw secrets. Existing redacted values may be passed as '${GATEWAY_REDACTED_SENTINEL}' on update to preserve them.`
   ),
   forceOverride: z
     .boolean()
@@ -170,7 +168,7 @@ const gatewayChannelUpdateSchema = z.strictObject({
   config: configSchema
     .optional()
     .describe(
-      `Partial platform config to merge. Send '${REDACTED_SENTINEL}' or omit sensitive fields to preserve existing secrets; send a new value to rotate.`
+      `Partial platform config to merge. Send '${GATEWAY_REDACTED_SENTINEL}' or omit sensitive fields to preserve existing secrets; send a new value to rotate.`
     ),
   agenticConfig: agenticConfigSchema
     .nullable()
@@ -185,15 +183,15 @@ type GatewayChannelSummary = Omit<
   channel_type: GatewayChannel['channel_type'];
   target_branch_id: string;
   agor_user_id: string;
-  channel_key: typeof REDACTED_SENTINEL;
+  channel_key: typeof GATEWAY_REDACTED_SENTINEL;
   config: Record<string, unknown>;
   agentic_config: GatewayChannel['agentic_config'];
 };
 
 function redactGatewayChannel(channel: GatewayChannel): GatewayChannelSummary {
   const config = { ...(channel.config ?? {}) };
-  for (const field of SENSITIVE_CONFIG_FIELDS) {
-    if (config[field]) config[field] = REDACTED_SENTINEL;
+  for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
+    if (config[field]) config[field] = GATEWAY_REDACTED_SENTINEL;
   }
 
   let agentic_config = channel.agentic_config;
@@ -202,7 +200,7 @@ function redactGatewayChannel(channel: GatewayChannel): GatewayChannelSummary {
       ...agentic_config,
       envVars: agentic_config.envVars.map((envVar) => ({
         ...envVar,
-        value: REDACTED_SENTINEL,
+        value: GATEWAY_REDACTED_SENTINEL,
       })),
     };
   }
@@ -211,7 +209,7 @@ function redactGatewayChannel(channel: GatewayChannel): GatewayChannelSummary {
     ...channel,
     target_branch_id: channel.target_branch_id,
     agor_user_id: channel.agor_user_id,
-    channel_key: REDACTED_SENTINEL,
+    channel_key: GATEWAY_REDACTED_SENTINEL,
     config,
     agentic_config,
   };
@@ -275,24 +273,34 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
           .enum(['slack', 'github', 'teams', 'discord', 'whatsapp', 'telegram'])
           .optional()
           .describe('Optional platform filter.'),
+        limit: mcpLimit(100),
+        skip: mcpOffset(0),
       }),
     },
     async (args) => {
       requireAdmin(ctx, 'list gateway channels');
       const result = await ctx.app.service('gateway-channels').find({
         ...ctx.baseServiceParams,
-        query: { $limit: 100 },
+        query: {
+          ...(args.includeDisabled === false ? { enabled: true } : {}),
+          ...(args.channelType ? { channel_type: args.channelType } : {}),
+          $limit: args.limit ?? 100,
+          $skip: args.skip ?? 0,
+        },
       });
-      let channels = (Array.isArray(result) ? result : result.data) as GatewayChannel[];
-      if (args.includeDisabled === false) channels = channels.filter((channel) => channel.enabled);
-      if (args.channelType) {
-        channels = channels.filter((channel) => channel.channel_type === args.channelType);
-      }
+      const channels = (Array.isArray(result) ? result : result.data) as GatewayChannel[];
+      const totalAvailable = Array.isArray(result) ? channels.length : result.total;
 
       return textResult({
         gateway_channels: channels.map(redactGatewayChannel),
+        pagination: {
+          total: totalAvailable,
+          returned: channels.length,
+          limit: args.limit ?? 100,
+          skip: args.skip ?? 0,
+        },
         summary: {
-          total: channels.length,
+          returned: channels.length,
           enabled: channels.filter((channel) => channel.enabled).length,
           disabled: channels.filter((channel) => !channel.enabled).length,
         },
@@ -327,7 +335,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
   server.registerTool(
     'agor_gateway_channels_update',
     {
-      description: `Update a gateway channel definition (admin-only) through the gateway-channels service. Provide only fields to change. To preserve an existing secret in config or agenticConfig.envVars, omit it or pass '${REDACTED_SENTINEL}'; to rotate it, pass a new value. Responses always redact secrets and channel_key.`,
+      description: `Update a gateway channel definition (admin-only) through the gateway-channels service. Provide only fields to change. To preserve an existing secret in config or agenticConfig.envVars, omit it or pass '${GATEWAY_REDACTED_SENTINEL}'; to rotate it, pass a new value. Responses always redact secrets and channel_key.`,
       annotations: { destructiveHint: false, idempotentHint: false },
       inputSchema: gatewayChannelUpdateSchema,
     },

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -9,9 +9,9 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import {
   mcpLimit,
-  mcpOffset,
   mcpOptionalId,
   mcpOptionalNonEmptyString,
+  mcpOptionalNonNegativeInt,
   mcpRequiredId,
   mcpRequiredString,
 } from '../schema.js';
@@ -274,7 +274,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
           .optional()
           .describe('Optional platform filter.'),
         limit: mcpLimit(100),
-        skip: mcpOffset(0),
+        skip: mcpOptionalNonNegativeInt('skip', 'Number of gateway channels to skip (default: 0)'),
       }),
     },
     async (args) => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -61,7 +61,12 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
-import { hasMinimumRole, ROLES } from '@agor/core/types';
+import {
+  GATEWAY_REDACTED_SENTINEL,
+  GATEWAY_SENSITIVE_CONFIG_FIELDS,
+  hasMinimumRole,
+  ROLES,
+} from '@agor/core/types';
 import { executorRuntimeScopeGuard } from './auth/executor-runtime-scope.js';
 import type {
   BoardsServiceImpl,
@@ -1600,6 +1605,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           const data = context.data as Record<string, unknown> | undefined;
           if (!data || !context.id) return context;
 
+          // Explicit null means clear all agentic config. Do not resurrect envVars
+          // from the existing row while resolving redacted sentinels.
+          if (data.agentic_config === null) return context;
+
           let ac = data.agentic_config as Record<string, unknown> | undefined;
           const hadAgenticConfigInPatch = ac !== undefined;
           const ensureAc = (): Record<string, unknown> => {
@@ -1610,7 +1619,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             return ac;
           };
 
-          const SENTINEL = '••••••••';
+          const SENTINEL = GATEWAY_REDACTED_SENTINEL;
           const incomingVars = ac?.envVars as
             | { key: string; value: string; forceOverride: boolean }[]
             | undefined;
@@ -1679,16 +1688,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           const redact = (channel: Record<string, unknown>) => {
             if (channel?.config && typeof channel.config === 'object') {
               const config = { ...(channel.config as Record<string, unknown>) };
-              for (const field of [
-                'bot_token',
-                'app_token',
-                'signing_secret',
-                'private_key',
-                'webhook_secret',
-                'app_password',
-              ]) {
+              for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
                 if (config[field]) {
-                  config[field] = '••••••••';
+                  config[field] = GATEWAY_REDACTED_SENTINEL;
                 }
               }
               channel.config = config;
@@ -1699,7 +1701,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               if (Array.isArray(ac.envVars)) {
                 ac.envVars = (
                   ac.envVars as { key: string; value: string; forceOverride: boolean }[]
-                ).map((v) => ({ key: v.key, value: '••••••••', forceOverride: v.forceOverride }));
+                ).map((v) => ({
+                  key: v.key,
+                  value: GATEWAY_REDACTED_SENTINEL,
+                  forceOverride: v.forceOverride,
+                }));
               }
             }
           };

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1685,6 +1685,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 'signing_secret',
                 'private_key',
                 'webhook_secret',
+                'app_password',
               ]) {
                 if (config[field]) {
                   config[field] = '••••••••';

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -13,7 +13,11 @@ import type {
   GatewayEnvVar,
   UUID,
 } from '@agor/core/types';
-import { prefixToLikePattern } from '@agor/core/types';
+import {
+  GATEWAY_REDACTED_SENTINEL,
+  GATEWAY_SENSITIVE_CONFIG_FIELDS,
+  prefixToLikePattern,
+} from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -27,25 +31,12 @@ import {
   RepositoryError,
 } from './base';
 
-/** Sensitive config fields that should be encrypted at rest */
-const SENSITIVE_CONFIG_FIELDS = [
-  'bot_token',
-  'app_token',
-  'signing_secret', // Slack
-  'private_key',
-  'webhook_secret', // GitHub
-  'app_password', // Teams (Azure Bot App Secret)
-];
-
-/** Sentinel value used by the API to redact sensitive fields in responses */
-const REDACTED_SENTINEL = '••••••••';
-
 /**
  * Encrypt sensitive fields within a config object
  */
 function encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
   const encrypted = { ...config };
-  for (const field of SENSITIVE_CONFIG_FIELDS) {
+  for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
     if (typeof encrypted[field] === 'string' && encrypted[field]) {
       encrypted[field] = encryptApiKey(encrypted[field] as string);
     }
@@ -58,7 +49,7 @@ function encryptConfig(config: Record<string, unknown>): Record<string, unknown>
  */
 function decryptConfig(config: Record<string, unknown>): Record<string, unknown> {
   const decrypted = { ...config };
-  for (const field of SENSITIVE_CONFIG_FIELDS) {
+  for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
     if (typeof decrypted[field] === 'string' && decrypted[field]) {
       try {
         decrypted[field] = decryptApiKey(decrypted[field] as string);
@@ -323,9 +314,12 @@ export class GatewayChannelRepository
       // sends that sentinel back it means "no change" — not "set token to bullets".
       if (updates.config) {
         const mergedConfig = { ...current.config, ...updates.config };
-        for (const field of SENSITIVE_CONFIG_FIELDS) {
+        for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
           const updateValue = updates.config[field];
-          if ((!updateValue || updateValue === REDACTED_SENTINEL) && current.config[field]) {
+          if (
+            (!updateValue || updateValue === GATEWAY_REDACTED_SENTINEL) &&
+            current.config[field]
+          ) {
             mergedConfig[field] = current.config[field];
           }
         }

--- a/packages/core/src/types/config-services.ts
+++ b/packages/core/src/types/config-services.ts
@@ -132,6 +132,7 @@ export const SERVICE_GROUP_TO_MCP_DOMAINS: Partial<Record<ServiceGroupName, stri
   cards: ['cards'],
   artifacts: ['artifacts', 'proxies'],
   mcp_servers: ['mcp-servers'],
+  gateway: ['gateway'],
   leaderboard: ['analytics'],
   scheduler: ['schedules'],
   knowledge: ['knowledge'],

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -30,6 +30,19 @@ export type ChannelType = 'slack' | 'discord' | 'whatsapp' | 'telegram' | 'githu
 /** Thread lifecycle status */
 export type ThreadStatus = 'active' | 'archived' | 'paused';
 
+/** Sensitive gateway config fields that must be encrypted at rest and redacted in responses. */
+export const GATEWAY_SENSITIVE_CONFIG_FIELDS = [
+  'bot_token',
+  'app_token',
+  'signing_secret',
+  'private_key',
+  'webhook_secret',
+  'app_password',
+] as const;
+
+/** Sentinel value used by gateway APIs/tools to represent a redacted secret. */
+export const GATEWAY_REDACTED_SENTINEL = '••••••••';
+
 // ============================================================================
 // Agentic Tool Configuration
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add admin-only MCP tools for gateway channel list/create/update.
- Register the new `gateway` MCP domain so the tools are discoverable through tool search and service-tier filtering.
- Redact gateway secrets in MCP responses, including channel keys, platform credentials, Teams app passwords, and gateway env var values.

## Tests

- `pnpm exec biome check apps/agor-daemon/src/mcp/tools/gateway-channels.ts apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts apps/agor-daemon/src/mcp/server.ts apps/agor-daemon/src/mcp/tool-registry.ts packages/core/src/types/config-services.ts apps/agor-daemon/src/register-hooks.ts`
- `pnpm --filter @agor/daemon test -- src/mcp/tools/gateway-channels.test.ts`
- `pnpm --filter @agor/daemon test -- src/mcp/server.test.ts src/mcp/tools/gateway-channels.test.ts`
- `pnpm --filter @agor/core test -- src/types/config-services.test.ts`
- `pnpm --filter @agor/core typecheck`

## Notes

- `pnpm --filter @agor/daemon typecheck` currently fails in this fresh worktree because `@agor/core` package exports point at `packages/core/dist`, which is absent unless core is built; I did not run a build per repo agent instructions.
- Delete tooling is intentionally omitted; this PR stays focused on list/create/update.
