### PR TITLE
Implement gateway outbound seeded threads

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -341,9 +341,9 @@ describe('agor_gateway_channels MCP tools', () => {
 
     for (const target of [
       'channel:C123',
-      '#team-data',
-      'channel_name:team-data',
-      'max@example.com',
+      '#project-updates',
+      'channel_name:project-updates',
+      'user@example.com',
     ]) {
       const parsed = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
         gatewayChannelId: 'chan-1',

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -338,6 +338,21 @@ describe('agor_gateway_channels MCP tools', () => {
 
   it('validates outbound target grammar', async () => {
     const tools = await captureTools('member', makeFakeApp({ gateway: { emitMessage: vi.fn() } }));
+
+    for (const target of [
+      'channel:C123',
+      '#team-data',
+      'channel_name:team-data',
+      'max@example.com',
+    ]) {
+      const parsed = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
+        gatewayChannelId: 'chan-1',
+        message: 'Hello',
+        target,
+      });
+      expect(parsed.success).toBe(true);
+    }
+
     const bareChannel = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
       gatewayChannelId: 'chan-1',
       message: 'Hello',

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -293,4 +293,56 @@ describe('agor_gateway_channels MCP tools', () => {
     expect(services.create).not.toHaveBeenCalled();
     expect(services.patch).not.toHaveBeenCalled();
   });
+
+  it('emits outbound messages through the gateway service without returning secrets', async () => {
+    const emitMessage = vi.fn(async () => ({
+      success: true,
+      gateway_outbound_message_id: 'out-1',
+      gateway_channel_id: 'chan-1',
+      channel_type: 'slack',
+      platform_channel_id: 'C123',
+      platform_message_id: '171234.000100',
+      platform_thread_id: 'C123-171234.000100',
+      platform_permalink: 'https://slack.example/archives/C123/p171234000100',
+    }));
+    const app = makeFakeApp({
+      gateway: { emitMessage },
+    });
+
+    const tools = await captureTools('member', app);
+    const result = await tools.agor_gateway_emit_message.handler({
+      gatewayChannelId: 'chan-1',
+      message: 'Hello Slack',
+      target: 'channel:C123',
+      purpose: 'test',
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(emitMessage).toHaveBeenCalledWith({
+      gatewayChannelId: 'chan-1',
+      message: 'Hello Slack',
+      target: 'channel:C123',
+      purpose: 'test',
+      emittedByUserId: 'user-1',
+      emittedBySessionId: 'sess-1',
+      userRole: 'member',
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      gateway_outbound_message_id: 'out-1',
+      platform_thread_id: 'C123-171234.000100',
+    });
+    expect(JSON.stringify(payload)).not.toContain('xoxb');
+    expect(JSON.stringify(payload)).not.toContain('channel_key');
+  });
+
+  it('validates outbound target grammar', async () => {
+    const tools = await captureTools('member', makeFakeApp({ gateway: { emitMessage: vi.fn() } }));
+    const parsed = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
+      gatewayChannelId: 'chan-1',
+      message: 'Hello',
+      target: 'C123',
+    });
+    expect(parsed.success).toBe(false);
+  });
 });

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -338,11 +338,18 @@ describe('agor_gateway_channels MCP tools', () => {
 
   it('validates outbound target grammar', async () => {
     const tools = await captureTools('member', makeFakeApp({ gateway: { emitMessage: vi.fn() } }));
-    const parsed = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
+    const bareChannel = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
       gatewayChannelId: 'chan-1',
       message: 'Hello',
       target: 'C123',
     });
-    expect(parsed.success).toBe(false);
+    expect(bareChannel.success).toBe(false);
+
+    const existingThread = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
+      gatewayChannelId: 'chan-1',
+      message: 'Hello',
+      target: 'thread:C123:171234.000100',
+    });
+    expect(existingThread.success).toBe(false);
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -446,6 +446,9 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         if (!channel.enabled) continue;
         const outbound = getOutboundConfig(channel);
         if (!outbound.outbound_enabled) continue;
+        if (!outbound.default_outbound_target && outbound.allowed_outbound_targets.length === 0) {
+          continue;
+        }
 
         const branch = await branchRepo.findById(channel.target_branch_id);
         if (!branch) continue;

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -52,6 +52,10 @@ async function canUseGatewayOutbound(
   );
 }
 
+function isSlackChannelOutboundTarget(value: unknown): value is string {
+  return typeof value === 'string' && /^channel:[^:\s]+$/.test(value);
+}
+
 function getOutboundConfig(channel: GatewayChannel): {
   outbound_enabled: boolean;
   default_outbound_target?: string;
@@ -60,13 +64,11 @@ function getOutboundConfig(channel: GatewayChannel): {
   const config = channel.config ?? {};
   return {
     outbound_enabled: config.outbound_enabled === true,
-    ...(typeof config.default_outbound_target === 'string'
+    ...(isSlackChannelOutboundTarget(config.default_outbound_target)
       ? { default_outbound_target: config.default_outbound_target }
       : {}),
     allowed_outbound_targets: Array.isArray(config.allowed_outbound_targets)
-      ? config.allowed_outbound_targets.filter(
-          (value): value is string => typeof value === 'string'
-        )
+      ? config.allowed_outbound_targets.filter(isSlackChannelOutboundTarget)
       : [],
   };
 }
@@ -79,8 +81,10 @@ const configSchema = z
 
 const outboundTargetSchema = z
   .string()
-  .regex(/^(channel:[^:\s]+|thread:[^:\s]+:[^:\s]+)$/)
-  .describe('Slack outbound target: channel:C123 or thread:C123:171234.000100');
+  .regex(/^channel:[^:\s]+$/)
+  .describe(
+    'Slack outbound target for v0: channel:C123. Thread targets are intentionally not supported.'
+  );
 
 const envVarSchema = z.strictObject({
   key: mcpRequiredString('agenticConfig.envVars[].key', 'Environment variable name'),
@@ -469,7 +473,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     'agor_gateway_emit_message',
     {
       description:
-        'Send a proactive Slack message through an outbound-enabled gateway channel and persist a seed/audit record. Does not create a thread-session mapping until a human replies.',
+        'Send a proactive Slack message to a configured Slack channel and persist a seed/audit record. v0 intentionally starts a fresh Slack thread for each emit and does not create a thread-session mapping until a human replies.',
       annotations: { destructiveHint: false, idempotentHint: false },
       inputSchema: z.strictObject({
         gatewayChannelId: mcpRequiredId(

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -1,12 +1,20 @@
+import { BranchRepository, GatewayChannelRepository, SessionRepository } from '@agor/core/db';
 import {
+  type Branch,
+  type BranchID,
   GATEWAY_REDACTED_SENTINEL,
   GATEWAY_SENSITIVE_CONFIG_FIELDS,
   type GatewayChannel,
   hasMinimumRole,
   ROLES,
+  type ScheduleID,
+  type UserID,
+  type UUID,
 } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import type { GatewayService } from '../../services/gateway.js';
+import { hasBranchPermission } from '../../utils/branch-authorization.js';
 import {
   mcpLimit,
   mcpOptionalId,
@@ -24,11 +32,55 @@ function requireAdmin(ctx: McpContext, action: string): void {
   }
 }
 
+async function canUseGatewayOutbound(
+  ctx: McpContext,
+  branchRepo: BranchRepository,
+  branch: Branch
+): Promise<boolean> {
+  if (hasMinimumRole(ctx.authenticatedUser?.role, ROLES.ADMIN)) return true;
+  const userId = ctx.userId as UUID;
+  const isOwner = await branchRepo.isOwner(branch.branch_id as BranchID, userId);
+  const effective = await branchRepo.resolveUserPermission(branch, userId);
+  return hasBranchPermission(
+    branch,
+    userId,
+    isOwner,
+    'all',
+    ctx.authenticatedUser?.role,
+    true,
+    effective
+  );
+}
+
+function getOutboundConfig(channel: GatewayChannel): {
+  outbound_enabled: boolean;
+  default_outbound_target?: string;
+  allowed_outbound_targets: string[];
+} {
+  const config = channel.config ?? {};
+  return {
+    outbound_enabled: config.outbound_enabled === true,
+    ...(typeof config.default_outbound_target === 'string'
+      ? { default_outbound_target: config.default_outbound_target }
+      : {}),
+    allowed_outbound_targets: Array.isArray(config.allowed_outbound_targets)
+      ? config.allowed_outbound_targets.filter(
+          (value): value is string => typeof value === 'string'
+        )
+      : [],
+  };
+}
+
 const configSchema = z
   .record(z.string(), z.unknown())
   .describe(
     'Platform-specific gateway configuration. Secrets are stored encrypted and returned redacted. Prefer env/template references for shared credentials where the connector supports them.'
   );
+
+const outboundTargetSchema = z
+  .string()
+  .regex(/^(channel:[^:\s]+|thread:[^:\s]+:[^:\s]+)$/)
+  .describe('Slack outbound target: channel:C123 or thread:C123:171234.000100');
 
 const envVarSchema = z.strictObject({
   key: mcpRequiredString('agenticConfig.envVars[].key', 'Environment variable name'),
@@ -353,6 +405,106 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         gateway_channel: redactGatewayChannel(updated),
         next_steps: ['Verify with agor_gateway_channels_list.'],
       });
+    }
+  );
+
+  server.registerTool(
+    'agor_gateway_outbound_targets_list',
+    {
+      description:
+        'List Slack gateway outbound targets the caller can use. Returns only outbound-enabled channels where the caller has branch all permission or admin access. Secrets and inbound channel keys are never returned.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.strictObject({
+        branchId: mcpOptionalId('branchId', 'Branch', 'Filter by target branch ID.'),
+        gatewayChannelId: mcpOptionalId(
+          'gatewayChannelId',
+          'Gateway channel',
+          'Filter by gateway channel ID.'
+        ),
+        channelType: z.enum(['slack']).optional().describe('Only Slack is supported for v0.'),
+      }),
+    },
+    async (args) => {
+      const channelRepo = new GatewayChannelRepository(ctx.db);
+      const branchRepo = new BranchRepository(ctx.db);
+      const branchFilter = args.branchId ? await branchRepo.findById(args.branchId) : null;
+      const branchFilterId = branchFilter?.branch_id;
+      const allChannels = args.gatewayChannelId
+        ? [await channelRepo.findById(args.gatewayChannelId)]
+        : await channelRepo.findAll();
+
+      const channels = [];
+      for (const channel of allChannels) {
+        if (!channel) continue;
+        if (args.channelType && channel.channel_type !== args.channelType) continue;
+        if (channel.channel_type !== 'slack') continue;
+        if (args.branchId && channel.target_branch_id !== branchFilterId) continue;
+        if (!channel.enabled) continue;
+        const outbound = getOutboundConfig(channel);
+        if (!outbound.outbound_enabled) continue;
+
+        const branch = await branchRepo.findById(channel.target_branch_id);
+        if (!branch) continue;
+        if (!(await canUseGatewayOutbound(ctx, branchRepo, branch))) continue;
+
+        channels.push({
+          gateway_channel_id: channel.id,
+          name: channel.name,
+          channel_type: 'slack' as const,
+          target_branch_id: channel.target_branch_id,
+          target_branch_name: branch.name,
+          outbound_enabled: outbound.outbound_enabled,
+          ...(outbound.default_outbound_target
+            ? { default_outbound_target: outbound.default_outbound_target }
+            : {}),
+          allowed_outbound_targets: outbound.allowed_outbound_targets,
+        });
+      }
+
+      return textResult({ channels });
+    }
+  );
+
+  server.registerTool(
+    'agor_gateway_emit_message',
+    {
+      description:
+        'Send a proactive Slack message through an outbound-enabled gateway channel and persist a seed/audit record. Does not create a thread-session mapping until a human replies.',
+      annotations: { destructiveHint: false, idempotentHint: false },
+      inputSchema: z.strictObject({
+        gatewayChannelId: mcpRequiredId(
+          'gatewayChannelId',
+          'Gateway channel',
+          'Gateway channel ID (UUIDv7 or short ID).'
+        ),
+        message: mcpRequiredString('message', 'Message to send to Slack.'),
+        target: outboundTargetSchema.optional().describe('Omit to use default_outbound_target.'),
+        purpose: mcpOptionalNonEmptyString('purpose', 'Optional audit purpose.'),
+      }),
+    },
+    async (args) => {
+      const gatewayService = ctx.app.service('gateway') as unknown as GatewayService;
+      let emittedByScheduleId: ScheduleID | undefined;
+      if (ctx.sessionId) {
+        try {
+          const session = await new SessionRepository(ctx.db).findById(ctx.sessionId);
+          emittedByScheduleId = session?.schedule_id;
+        } catch {
+          // Best-effort audit enrichment. A missing/stale session context should
+          // not block an otherwise authorized outbound emit.
+        }
+      }
+      const result = await gatewayService.emitMessage({
+        gatewayChannelId: args.gatewayChannelId,
+        message: args.message,
+        ...(args.target ? { target: args.target } : {}),
+        ...(args.purpose ? { purpose: args.purpose } : {}),
+        emittedByUserId: ctx.userId as UserID,
+        ...(ctx.sessionId ? { emittedBySessionId: ctx.sessionId } : {}),
+        ...(emittedByScheduleId ? { emittedByScheduleId } : {}),
+        userRole: ctx.authenticatedUser?.role,
+      });
+      return textResult(result);
     }
   );
 }

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -52,24 +52,16 @@ async function canUseGatewayOutbound(
   );
 }
 
-function isSlackChannelOutboundTarget(value: unknown): value is string {
-  return typeof value === 'string' && /^channel:[^:\s]+$/.test(value);
-}
-
 function getOutboundConfig(channel: GatewayChannel): {
   outbound_enabled: boolean;
   default_outbound_target?: string;
-  allowed_outbound_targets: string[];
 } {
   const config = channel.config ?? {};
   return {
     outbound_enabled: config.outbound_enabled === true,
-    ...(isSlackChannelOutboundTarget(config.default_outbound_target)
+    ...(typeof config.default_outbound_target === 'string' && config.default_outbound_target.trim()
       ? { default_outbound_target: config.default_outbound_target }
       : {}),
-    allowed_outbound_targets: Array.isArray(config.allowed_outbound_targets)
-      ? config.allowed_outbound_targets.filter(isSlackChannelOutboundTarget)
-      : [],
   };
 }
 
@@ -81,9 +73,12 @@ const configSchema = z
 
 const outboundTargetSchema = z
   .string()
-  .regex(/^channel:[^:\s]+$/)
+  .trim()
+  .regex(
+    /^(channel:[^:\s]+|channel_name:[^\s]+|#[^\s]+|(?:email:|user_email:)?[^@\s]+@[^@\s]+\.[^@\s]+)$/
+  )
   .describe(
-    'Slack outbound target for v0: channel:C123. Thread targets are intentionally not supported.'
+    'Slack outbound target for v0: channel:C123, #team-data, channel_name:team-data, or user@example.com. Thread targets are intentionally not supported.'
   );
 
 const envVarSchema = z.strictObject({
@@ -446,9 +441,6 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         if (!channel.enabled) continue;
         const outbound = getOutboundConfig(channel);
         if (!outbound.outbound_enabled) continue;
-        if (!outbound.default_outbound_target && outbound.allowed_outbound_targets.length === 0) {
-          continue;
-        }
 
         const branch = await branchRepo.findById(channel.target_branch_id);
         if (!branch) continue;
@@ -464,7 +456,12 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
           ...(outbound.default_outbound_target
             ? { default_outbound_target: outbound.default_outbound_target }
             : {}),
-          allowed_outbound_targets: outbound.allowed_outbound_targets,
+          accepted_target_formats: [
+            'channel:C123',
+            '#team-data',
+            'channel_name:team-data',
+            'user@example.com',
+          ],
         });
       }
 
@@ -476,7 +473,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     'agor_gateway_emit_message',
     {
       description:
-        'Send a proactive Slack message to a configured Slack channel and persist a seed/audit record. v0 intentionally starts a fresh Slack thread for each emit and does not create a thread-session mapping until a human replies.',
+        'Send a proactive Slack message through an outbound-enabled gateway channel and persist a seed/audit record. Targets may be Slack channel IDs, channel names, or user emails; v0 intentionally starts a fresh Slack thread/DM message for each emit and does not create a thread-session mapping until a human replies.',
       annotations: { destructiveHint: false, idempotentHint: false },
       inputSchema: z.strictObject({
         gatewayChannelId: mcpRequiredId(

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -78,7 +78,7 @@ const outboundTargetSchema = z
     /^(channel:[^:\s]+|channel_name:[^\s]+|#[^\s]+|(?:email:|user_email:)?[^@\s]+@[^@\s]+\.[^@\s]+)$/
   )
   .describe(
-    'Slack outbound target for v0: channel:C123, #team-data, channel_name:team-data, or user@example.com. Thread targets are intentionally not supported.'
+    'Slack outbound target for v0: channel:C123, #project-updates, channel_name:project-updates, or user@example.com. Thread targets are intentionally not supported.'
   );
 
 const envVarSchema = z.strictObject({
@@ -458,8 +458,8 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
             : {}),
           accepted_target_formats: [
             'channel:C123',
-            '#team-data',
-            'channel_name:team-data',
+            '#project-updates',
+            'channel_name:project-updates',
             'user@example.com',
           ],
         });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -460,6 +460,10 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     app.use('/gateway-channels', createGatewayChannelsService(db));
     app.use('/thread-session-map', createThreadSessionMapService(db));
     app.use('/gateway', createGatewayService(db, app), {
+      // Only expose the inbound gateway entrypoint and existing route hook
+      // externally. Proactive outbound emits are intentionally invoked through
+      // the authenticated Agor MCP tool surface; exposing emitMessage here would
+      // bypass the gateway service's normal channel_key auth model.
       methods: ['create', 'routeMessage'],
     });
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -112,9 +112,8 @@ interface EmitGatewayMessageResult {
 }
 
 interface SlackOutboundTarget {
-  kind: 'channel' | 'thread';
+  kind: 'channel';
   channel: string;
-  thread_ts?: string;
 }
 
 interface SlackDirectConnector extends GatewayConnector {
@@ -186,14 +185,7 @@ function parseSlackOutboundTarget(target: string): SlackOutboundTarget {
     return { kind: 'channel', channel: channelMatch[1] };
   }
 
-  const threadMatch = /^thread:([^:\s]+):([^:\s]+)$/.exec(target);
-  if (threadMatch) {
-    return { kind: 'thread', channel: threadMatch[1], thread_ts: threadMatch[2] };
-  }
-
-  throw new Error(
-    'Invalid Slack outbound target. Expected channel:C123 or thread:C123:171234.000100'
-  );
+  throw new Error('Invalid Slack outbound target. Gateway outbound v0 expects channel:C123');
 }
 
 function redactProviderErrorMessage(error: unknown): string {
@@ -1235,7 +1227,6 @@ export class GatewayService {
         channel: parsedTarget.channel,
         text,
         blocks,
-        ...(parsedTarget.thread_ts ? { thread_ts: parsedTarget.thread_ts } : {}),
         metadata: {
           ...(data.purpose ? { purpose: data.purpose } : {}),
           target,

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -112,8 +112,10 @@ interface EmitGatewayMessageResult {
 }
 
 interface SlackOutboundTarget {
-  kind: 'channel';
-  channel: string;
+  kind: 'channel_id' | 'channel_name' | 'email';
+  channel?: string;
+  name?: string;
+  email?: string;
 }
 
 interface SlackDirectConnector extends GatewayConnector {
@@ -124,6 +126,8 @@ interface SlackDirectConnector extends GatewayConnector {
     thread_ts?: string;
     metadata?: Record<string, unknown>;
   }): Promise<{ ts: string; channel: string; thread_ts: string; permalink?: string | null }>;
+  resolveChannelByName?(name: string): Promise<{ channel: string; name: string }>;
+  openDmByEmail?(email: string): Promise<{ channel: string; user_id: string }>;
 }
 
 export type GatewayProgressState = 'queued' | 'working' | 'done' | 'failed';
@@ -180,12 +184,29 @@ function isSlackThinkingPlaceholder(text: string): boolean {
 }
 
 function parseSlackOutboundTarget(target: string): SlackOutboundTarget {
-  const channelMatch = /^channel:([^:\s]+)$/.exec(target);
+  const trimmed = target.trim();
+  const channelMatch = /^channel:([^:\s]+)$/.exec(trimmed);
   if (channelMatch) {
-    return { kind: 'channel', channel: channelMatch[1] };
+    return { kind: 'channel_id', channel: channelMatch[1] };
   }
 
-  throw new Error('Invalid Slack outbound target. Gateway outbound v0 expects channel:C123');
+  const channelNameMatch = /^channel_name:([^\s]+)$/.exec(trimmed);
+  if (channelNameMatch) {
+    return { kind: 'channel_name', name: channelNameMatch[1].replace(/^#/, '') };
+  }
+
+  if (/^#[^\s]+$/.test(trimmed)) {
+    return { kind: 'channel_name', name: trimmed.slice(1) };
+  }
+
+  const emailMatch = /^(?:email:|user_email:)?([^@\s]+@[^@\s]+\.[^@\s]+)$/.exec(trimmed);
+  if (emailMatch) {
+    return { kind: 'email', email: emailMatch[1] };
+  }
+
+  throw new Error(
+    'Invalid Slack outbound target. Expected channel:C123, #channel-name, channel_name:channel-name, or user@example.com'
+  );
 }
 
 function redactProviderErrorMessage(error: unknown): string {
@@ -1199,15 +1220,6 @@ export class GatewayService {
         : undefined);
     if (!target) throw new Error('No usable default outbound target configured');
 
-    const allowedTargets = Array.isArray(config.allowed_outbound_targets)
-      ? config.allowed_outbound_targets.filter(
-          (value): value is string => typeof value === 'string'
-        )
-      : [];
-    if (data.target && !allowedTargets.includes(target)) {
-      throw new Error('Outbound target is not allowlisted for this gateway channel');
-    }
-
     const parsedTarget = parseSlackOutboundTarget(target);
     const connector = getConnector(
       channel.channel_type as ChannelType,
@@ -1221,15 +1233,40 @@ export class GatewayService {
       connector.formatMessage ? connector.formatMessage(data.message) : data.message
     );
 
+    let resolvedChannel: string;
+    const resolvedTargetMetadata: Record<string, unknown> = {
+      target,
+      target_kind: parsedTarget.kind,
+    };
+    if (parsedTarget.kind === 'channel_id') {
+      resolvedChannel = parsedTarget.channel as string;
+    } else if (parsedTarget.kind === 'channel_name') {
+      if (typeof connector.resolveChannelByName !== 'function') {
+        throw new Error('Slack connector does not support channel-name resolution');
+      }
+      const resolved = await connector.resolveChannelByName(parsedTarget.name as string);
+      resolvedChannel = resolved.channel;
+      resolvedTargetMetadata.resolved_channel_id = resolved.channel;
+      resolvedTargetMetadata.resolved_channel_name = resolved.name;
+    } else {
+      if (typeof connector.openDmByEmail !== 'function') {
+        throw new Error('Slack connector does not support email-to-DM resolution');
+      }
+      const resolved = await connector.openDmByEmail(parsedTarget.email as string);
+      resolvedChannel = resolved.channel;
+      resolvedTargetMetadata.resolved_channel_id = resolved.channel;
+      resolvedTargetMetadata.resolved_user_id = resolved.user_id;
+    }
+
     let sent: Awaited<ReturnType<SlackDirectConnector['sendSlackMessage']>>;
     try {
       sent = await connector.sendSlackMessage({
-        channel: parsedTarget.channel,
+        channel: resolvedChannel,
         text,
         blocks,
         metadata: {
           ...(data.purpose ? { purpose: data.purpose } : {}),
-          target,
+          ...resolvedTargetMetadata,
         },
       });
     } catch (error) {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -8,8 +8,10 @@
 
 import { PublicBaseUrlNotConfiguredError, requirePublicBaseUrl } from '@agor/core/config';
 import {
+  BranchRepository,
   type Database,
   GatewayChannelRepository,
+  GatewayOutboundMessageRepository,
   MCPServerRepository,
   shortId,
   ThreadSessionMapRepository,
@@ -31,8 +33,11 @@ import {
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import type {
   AgenticToolName,
+  BranchPermissionLevel,
   ChannelType,
   GatewayChannel,
+  GatewayOutboundMessage,
+  GatewayOutboundMessageID,
   MCPServerID,
   MessageSource,
   Session,
@@ -42,8 +47,9 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
-import { SessionStatus } from '@agor/core/types';
+import { hasMinimumRole, ROLES, SessionStatus } from '@agor/core/types';
 import { getSessionUrl } from '@agor/core/utils/url';
+import { hasBranchPermission } from '../utils/branch-authorization.js';
 
 /**
  * Inbound message data (platform → session)
@@ -80,6 +86,45 @@ interface RouteMessageData {
 interface RouteMessageResult {
   routed: boolean;
   channelType?: string;
+}
+
+interface EmitGatewayMessageData {
+  gatewayChannelId: string;
+  message: string;
+  target?: string;
+  purpose?: string;
+  emittedByUserId: UserID;
+  emittedBySessionId?: SessionID;
+  emittedByTaskId?: string;
+  emittedByScheduleId?: string;
+  userRole?: string;
+}
+
+interface EmitGatewayMessageResult {
+  success: true;
+  gateway_outbound_message_id: string;
+  gateway_channel_id: string;
+  channel_type: 'slack';
+  platform_channel_id: string;
+  platform_message_id: string;
+  platform_thread_id: string;
+  platform_permalink?: string | null;
+}
+
+interface SlackOutboundTarget {
+  kind: 'channel' | 'thread';
+  channel: string;
+  thread_ts?: string;
+}
+
+interface SlackDirectConnector extends GatewayConnector {
+  sendSlackMessage(req: {
+    channel: string;
+    text: string;
+    blocks?: unknown[];
+    thread_ts?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<{ ts: string; channel: string; thread_ts: string; permalink?: string | null }>;
 }
 
 export type GatewayProgressState = 'queued' | 'working' | 'done' | 'failed';
@@ -133,6 +178,88 @@ function hasListeningConfig(channel: GatewayChannel): boolean {
 
 function isSlackThinkingPlaceholder(text: string): boolean {
   return /^thinking\s*\.{3}$/i.test(text.trim());
+}
+
+function parseSlackOutboundTarget(target: string): SlackOutboundTarget {
+  const channelMatch = /^channel:([^:\s]+)$/.exec(target);
+  if (channelMatch) {
+    return { kind: 'channel', channel: channelMatch[1] };
+  }
+
+  const threadMatch = /^thread:([^:\s]+):([^:\s]+)$/.exec(target);
+  if (threadMatch) {
+    return { kind: 'thread', channel: threadMatch[1], thread_ts: threadMatch[2] };
+  }
+
+  throw new Error(
+    'Invalid Slack outbound target. Expected channel:C123 or thread:C123:171234.000100'
+  );
+}
+
+function redactProviderErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replace(/xox[baprs]-[A-Za-z0-9-]+/g, '[redacted-slack-token]')
+    .replace(/xapp-[A-Za-z0-9-]+/g, '[redacted-slack-token]');
+}
+
+function previewText(text: string, maxChars = 500): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function quoteForPrompt(text: string, maxChars = 2000): string {
+  const truncated = text.length <= maxChars ? text : `${text.slice(0, maxChars - 1)}…`;
+  return truncated
+    .split(/\r?\n/)
+    .map((line) => `> ${line}`)
+    .join('\n');
+}
+
+function buildSeededThreadInitialPrompt(args: {
+  seed: GatewayOutboundMessage;
+  channel: GatewayChannel;
+  replyText: string;
+  metadata?: Record<string, unknown>;
+}): string {
+  const slackSenderName =
+    typeof args.metadata?.slack_user_name === 'string' ? args.metadata.slack_user_name : undefined;
+  const slackSenderId =
+    typeof args.metadata?.slack_user_id === 'string' ? args.metadata.slack_user_id : undefined;
+  const slackSenderEmail =
+    typeof args.metadata?.slack_user_email === 'string'
+      ? args.metadata.slack_user_email
+      : undefined;
+  const slackChannelName =
+    typeof args.metadata?.slack_channel_name === 'string'
+      ? args.metadata.slack_channel_name
+      : undefined;
+
+  const lines = [
+    '[Gateway context]',
+    '',
+    'This Slack thread began from a proactive Agor gateway message. Use the provenance below to understand what the human is replying to.',
+    '',
+    `Outbound seed ID: ${args.seed.id}`,
+    `Originating session: ${args.seed.emitted_by_session_id ?? 'none'}`,
+    `Originating task: ${args.seed.emitted_by_task_id ?? 'none'}`,
+    `Originating schedule: ${args.seed.emitted_by_schedule_id ?? 'none'}`,
+    `Emitted by Agor user: ${args.seed.emitted_by_user_id}`,
+    `Gateway channel: ${args.channel.name} (${args.channel.id})`,
+    `Slack thread: ${args.seed.platform_thread_id}`,
+    `Slack channel: ${slackChannelName ?? args.seed.platform_channel_id}`,
+    `Slack sender name: ${slackSenderName ?? 'unknown'}`,
+    `Slack sender ID: ${slackSenderId ?? 'unknown'}`,
+    `Slack sender email: ${slackSenderEmail ?? 'unknown'}`,
+    '',
+    'Original proactive Agor message:',
+    quoteForPrompt(args.seed.message_text),
+    '',
+    'Human Slack reply:',
+    quoteForPrompt(args.replyText),
+  ];
+  return lines.join('\n');
 }
 
 /**
@@ -277,6 +404,8 @@ function buildGatewayContext(channel: GatewayChannel, data: PostMessageData): Ga
 export class GatewayService {
   private channelRepo: GatewayChannelRepository;
   private threadMapRepo: ThreadSessionMapRepository;
+  private outboundRepo: GatewayOutboundMessageRepository;
+  private branchRepo: BranchRepository;
   private usersRepo: UsersRepository;
 
   private mcpServerRepo: MCPServerRepository;
@@ -322,6 +451,8 @@ export class GatewayService {
   constructor(db: Database, app: Application) {
     this.channelRepo = new GatewayChannelRepository(db);
     this.threadMapRepo = new ThreadSessionMapRepository(db);
+    this.outboundRepo = new GatewayOutboundMessageRepository(db);
+    this.branchRepo = new BranchRepository(db);
     this.usersRepo = new UsersRepository(db);
 
     this.mcpServerRepo = new MCPServerRepository(db);
@@ -1024,6 +1155,136 @@ export class GatewayService {
     }
   }
 
+  private async ensureCanEmitFromChannel(
+    channel: GatewayChannel,
+    userId: UserID,
+    userRole?: string
+  ): Promise<void> {
+    if (hasMinimumRole(userRole, ROLES.ADMIN)) return;
+
+    const branch = await this.branchRepo.findById(channel.target_branch_id);
+    if (!branch) {
+      throw new Error(`Branch not found for gateway channel ${shortId(channel.id)}`);
+    }
+
+    const isOwner = await this.branchRepo.isOwner(branch.branch_id, userId);
+    const effectivePermission = await this.branchRepo.resolveUserPermission(branch, userId);
+    const canEmit = hasBranchPermission(
+      branch,
+      userId,
+      isOwner,
+      'all' as BranchPermissionLevel,
+      userRole,
+      true,
+      effectivePermission
+    );
+
+    if (!canEmit) {
+      throw new Error(
+        'Insufficient branch permission: gateway outbound emits require branch all permission or admin access'
+      );
+    }
+  }
+
+  async emitMessage(data: EmitGatewayMessageData): Promise<EmitGatewayMessageResult> {
+    const channel = await this.channelRepo.findById(data.gatewayChannelId);
+    if (!channel) throw new Error('Gateway channel not found');
+    if (!channel.enabled) throw new Error('Gateway channel is disabled');
+    if (channel.channel_type !== 'slack')
+      throw new Error('Gateway outbound v0 only supports Slack channels');
+
+    const config = channel.config as Record<string, unknown>;
+    if (config.outbound_enabled !== true) {
+      throw new Error('Gateway outbound is disabled for this channel');
+    }
+
+    await this.ensureCanEmitFromChannel(channel, data.emittedByUserId, data.userRole);
+
+    const target =
+      data.target ??
+      (typeof config.default_outbound_target === 'string'
+        ? config.default_outbound_target
+        : undefined);
+    if (!target) throw new Error('No usable default outbound target configured');
+
+    const allowedTargets = Array.isArray(config.allowed_outbound_targets)
+      ? config.allowed_outbound_targets.filter(
+          (value): value is string => typeof value === 'string'
+        )
+      : [];
+    if (data.target && !allowedTargets.includes(target)) {
+      throw new Error('Outbound target is not allowlisted for this gateway channel');
+    }
+
+    const parsedTarget = parseSlackOutboundTarget(target);
+    const connector = getConnector(
+      channel.channel_type as ChannelType,
+      channel.config
+    ) as SlackDirectConnector;
+    if (typeof connector.sendSlackMessage !== 'function') {
+      throw new Error('Slack connector does not support direct outbound sends');
+    }
+
+    const { text, blocks } = normalizeOutbound(
+      connector.formatMessage ? connector.formatMessage(data.message) : data.message
+    );
+
+    let sent: Awaited<ReturnType<SlackDirectConnector['sendSlackMessage']>>;
+    try {
+      sent = await connector.sendSlackMessage({
+        channel: parsedTarget.channel,
+        text,
+        blocks,
+        ...(parsedTarget.thread_ts ? { thread_ts: parsedTarget.thread_ts } : {}),
+        metadata: {
+          ...(data.purpose ? { purpose: data.purpose } : {}),
+          target,
+        },
+      });
+    } catch (error) {
+      throw new Error(`Slack API failure: ${redactProviderErrorMessage(error)}`);
+    }
+
+    const platformThreadId = `${sent.channel}-${sent.thread_ts || sent.ts}`;
+    const row = await this.outboundRepo.create({
+      gateway_channel_id: channel.id,
+      channel_type: 'slack',
+      platform_channel_id: sent.channel,
+      platform_message_id: sent.ts,
+      platform_thread_id: platformThreadId,
+      platform_permalink: sent.permalink ?? null,
+      target_branch_id: channel.target_branch_id,
+      emitted_by_user_id: data.emittedByUserId,
+      emitted_by_session_id: data.emittedBySessionId ?? null,
+      emitted_by_task_id:
+        (data.emittedByTaskId as GatewayOutboundMessage['emitted_by_task_id']) ?? null,
+      emitted_by_schedule_id:
+        (data.emittedByScheduleId as GatewayOutboundMessage['emitted_by_schedule_id']) ?? null,
+      message_text: data.message,
+      message_preview: previewText(data.message),
+      metadata: {
+        target,
+        ...(data.purpose ? { purpose: data.purpose } : {}),
+      },
+    });
+
+    await this.channelRepo.updateLastMessage(channel.id);
+    console.log(
+      `[gateway] Proactive Slack outbound ${shortId(row.id)} sent via ${shortId(channel.id)} to ${target}`
+    );
+
+    return {
+      success: true,
+      gateway_outbound_message_id: row.id,
+      gateway_channel_id: channel.id,
+      channel_type: 'slack',
+      platform_channel_id: sent.channel,
+      platform_message_id: sent.ts,
+      platform_thread_id: platformThreadId,
+      ...(sent.permalink ? { platform_permalink: sent.permalink } : {}),
+    };
+  }
+
   private async fetchExistingSessionUrlForGatewayUser(
     sessionId: SessionID,
     user: User
@@ -1089,6 +1350,16 @@ export class GatewayService {
       );
     }
 
+    const outboundSeed =
+      !existingMapping && channel.channel_type === 'slack'
+        ? await this.outboundRepo.findUnconsumedByChannelAndThread(channel.id, data.thread_id)
+        : null;
+    if (outboundSeed) {
+      console.log(
+        `[gateway] Slack inbound thread ${data.thread_id} is replying to outbound seed ${shortId(outboundSeed.id)}`
+      );
+    }
+
     // 3. Cross-channel ownership check (MUST happen before any sendSystemMessage calls).
     // If this thread is owned by a DIFFERENT gateway channel on the same daemon,
     // silently drop the message — we must not interfere with another gateway's thread.
@@ -1124,7 +1395,7 @@ export class GatewayService {
     // IMPORTANT: Silently drop — do NOT send a debug message. These are normal messages
     // in threads that have nothing to do with Agor. Sending a visible rejection would
     // cause the bot to spam every active thread in the channel.
-    if (!existingMapping && data.metadata?.requires_mapping_verification) {
+    if (!existingMapping && !outboundSeed && data.metadata?.requires_mapping_verification) {
       // Use debug level — this fires for every non-Agor thread reply in monitored
       // channels and would create excessive log noise at info level.
       console.debug(
@@ -1398,6 +1669,12 @@ export class GatewayService {
         thread_id: data.thread_id,
       };
 
+      if (outboundSeed) {
+        gatewaySource.outbound_seed_id = outboundSeed.id;
+        gatewaySource.outbound_seed_thread_id = outboundSeed.platform_thread_id;
+        gatewaySource.proactive_seed = true;
+      }
+
       // Add GitHub-specific metadata for richer context
       if (channel.channel_type === 'github') {
         try {
@@ -1492,9 +1769,20 @@ export class GatewayService {
         status: 'active',
         metadata:
           channel.channel_type === 'slack'
-            ? { ...(data.metadata ?? {}), slack_active_thread_id: data.thread_id }
+            ? {
+                ...(data.metadata ?? {}),
+                slack_active_thread_id: data.thread_id,
+                ...(outboundSeed ? { outbound_seed_id: outboundSeed.id } : {}),
+              }
             : (data.metadata ?? null),
       });
+
+      if (outboundSeed) {
+        await this.outboundRepo.markConsumed(
+          outboundSeed.id as GatewayOutboundMessageID,
+          session.session_id as SessionID
+        );
+      }
 
       const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId, user);
 
@@ -1542,7 +1830,14 @@ export class GatewayService {
       // so the agent knows where it's operating. Follow-up messages (existing
       // mapping) are sent as-is since the session already has context.
       let promptText = data.text;
-      if (created && channel.channel_type === 'github') {
+      if (created && outboundSeed) {
+        promptText = buildSeededThreadInitialPrompt({
+          seed: outboundSeed,
+          channel,
+          replyText: data.text,
+          metadata: data.metadata,
+        });
+      } else if (created && channel.channel_type === 'github') {
         promptText = buildGitHubInitialPrompt(data.thread_id, data.text, data.metadata);
       }
 
@@ -1551,7 +1846,7 @@ export class GatewayService {
       // come from a different user in a shared channel.
       // Skip for initial GitHub messages — buildGitHubInitialPrompt() already
       // includes repo/issue/user context and adding both would be redundant.
-      const skipContext = created && channel.channel_type === 'github';
+      const skipContext = created && (channel.channel_type === 'github' || !!outboundSeed);
       if (!skipContext) {
         const gatewayCtx = buildGatewayContext(channel, data);
         const contextPrefix = formatGatewayContext(gatewayCtx);

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -1244,7 +1244,12 @@ export class GatewayService {
       if (typeof connector.resolveChannelByName !== 'function') {
         throw new Error('Slack connector does not support channel-name resolution');
       }
-      const resolved = await connector.resolveChannelByName(parsedTarget.name as string);
+      let resolved: Awaited<ReturnType<NonNullable<SlackDirectConnector['resolveChannelByName']>>>;
+      try {
+        resolved = await connector.resolveChannelByName(parsedTarget.name as string);
+      } catch (error) {
+        throw new Error(`Slack API failure: ${redactProviderErrorMessage(error)}`);
+      }
       resolvedChannel = resolved.channel;
       resolvedTargetMetadata.resolved_channel_id = resolved.channel;
       resolvedTargetMetadata.resolved_channel_name = resolved.name;
@@ -1252,7 +1257,12 @@ export class GatewayService {
       if (typeof connector.openDmByEmail !== 'function') {
         throw new Error('Slack connector does not support email-to-DM resolution');
       }
-      const resolved = await connector.openDmByEmail(parsedTarget.email as string);
+      let resolved: Awaited<ReturnType<NonNullable<SlackDirectConnector['openDmByEmail']>>>;
+      try {
+        resolved = await connector.openDmByEmail(parsedTarget.email as string);
+      } catch (error) {
+        throw new Error(`Slack API failure: ${redactProviderErrorMessage(error)}`);
+      }
       resolvedChannel = resolved.channel;
       resolvedTargetMetadata.resolved_channel_id = resolved.channel;
       resolvedTargetMetadata.resolved_user_id = resolved.user_id;

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -1331,6 +1331,61 @@ const ChannelFormFields: React.FC<{
               ),
             },
 
+            // ── Outbound ──
+            {
+              key: 'outbound',
+              label: (
+                <SectionLabel
+                  icon={<MessageOutlined />}
+                  title="Outbound"
+                  subtitle="proactive sends"
+                />
+              ),
+              children: (
+                <>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                  >
+                    Allow authorized agents to send proactive Slack messages through this gateway.
+                    Targets can be Slack channel IDs, channel names, or Slack user emails.
+                  </Typography.Text>
+
+                  <Form.Item
+                    label="Enable outbound sends"
+                    name="outbound_enabled"
+                    valuePropName="checked"
+                    initialValue={false}
+                    tooltip="When enabled, branch admins/owners with full branch access can send proactive Slack messages through this gateway."
+                  >
+                    <Switch />
+                  </Form.Item>
+
+                  <Form.Item
+                    label="Default outbound target"
+                    name="default_outbound_target"
+                    tooltip="Optional. Used when the agent omits a target. Examples: #team-data, channel:C01ABC123, max@example.com."
+                  >
+                    <Input placeholder="#team-data, channel:C01ABC123, or max@example.com" />
+                  </Form.Item>
+
+                  <Alert
+                    type="info"
+                    showIcon
+                    title="Slack scopes"
+                    description={
+                      <span>
+                        Channel-name targets require <code>channels:read</code> and, for private
+                        channels, <code>groups:read</code>. Email targets require{' '}
+                        <code>users:read.email</code> and open a DM with that Slack user.
+                      </span>
+                    }
+                    style={{ fontSize: 12 }}
+                  />
+                </>
+              ),
+            },
+
             // ── Advanced ──
             {
               key: 'advanced',
@@ -1639,6 +1694,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       config.require_mention = values.require_mention ?? true;
       config.align_slack_users = values.align_slack_users ?? false;
       config.allowed_channel_ids = values.allowed_channel_ids ?? [];
+      config.outbound_enabled = values.outbound_enabled ?? false;
+      config.default_outbound_target = values.default_outbound_target || null;
     }
 
     // Build agentic config from form values
@@ -1751,6 +1808,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       formValues.require_mention = config?.require_mention ?? true;
       formValues.align_slack_users = config?.align_slack_users ?? false;
       formValues.allowed_channel_ids = (config?.allowed_channel_ids as string[]) ?? [];
+      formValues.outbound_enabled = config?.outbound_enabled ?? false;
+      formValues.default_outbound_target = config?.default_outbound_target;
     } else if (channel.channel_type === 'github') {
       formValues.github_app_id = config?.app_id;
       formValues.github_installation_id = config?.installation_id;

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -1364,9 +1364,9 @@ const ChannelFormFields: React.FC<{
                   <Form.Item
                     label="Default outbound target"
                     name="default_outbound_target"
-                    tooltip="Optional. Used when the agent omits a target. Examples: #team-data, channel:C01ABC123, max@example.com."
+                    tooltip="Optional. Used when the agent omits a target. Examples: #project-updates, channel:C01ABC123, user@example.com."
                   >
-                    <Input placeholder="#team-data, channel:C01ABC123, or max@example.com" />
+                    <Input placeholder="#project-updates, channel:C01ABC123, or user@example.com" />
                   </Form.Item>
 
                   <Alert

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -42,6 +42,7 @@ import {
   Radio,
   Result,
   Select,
+  type SelectProps,
   Space,
   Spin,
   Steps,
@@ -140,11 +141,12 @@ const SectionLabel: React.FC<{ icon: React.ReactNode; title: string; subtitle?: 
   </Space>
 );
 
-const UserSelect: React.FC<{ userById: Map<string, User>; placeholder?: string }> = ({
+const UserSelect: React.FC<SelectProps<string> & { userById: Map<string, User> }> = ({
   userById,
   placeholder = 'Select a user',
+  ...selectProps
 }) => (
-  <Select placeholder={placeholder} showSearch optionFilterProp="children">
+  <Select {...selectProps} placeholder={placeholder} showSearch optionFilterProp="children">
     {Array.from(userById.values())
       .sort((a, b) =>
         (a.name || a.email || a.user_id).localeCompare(b.name || b.email || b.user_id)

--- a/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
+++ b/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
@@ -12,7 +12,7 @@ import type {
   Session,
   User,
 } from '@agor-live/client';
-import { SessionStatus } from '@agor-live/client';
+import { SessionStatus, shortId } from '@agor-live/client';
 import { App as AntdApp, ConfigProvider, Layout, theme } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { ReactFlowProvider } from 'reactflow';
@@ -421,7 +421,7 @@ const branches = branchFixtures.map(
       archived: false,
       filesystem_status: 'ready',
       others_can: 'session',
-      url: `/ui/w/${fixture.id.slice(0, 8)}`,
+      url: `/ui/w/${shortId(fixture.id)}`,
     }) as unknown as Branch
 );
 
@@ -448,7 +448,7 @@ const sessions = branchFixtures.flatMap((fixture, branchIndex) =>
         unix_username: null,
         branch_id: fixture.id as BranchID,
         branch_board_id: boardId,
-        url: `/ui/s/${fixture.id.slice(0, 8)}${sessionIndex}`,
+        url: `/ui/s/${shortId(fixture.id)}${sessionIndex}`,
         git_state: {
           ref: fixture.ref,
           base_sha: '4b825dc642cb6eb9a060e54bf8d69288fbee4904',

--- a/packages/core/drizzle/postgres/0052_gateway_outbound_messages.sql
+++ b/packages/core/drizzle/postgres/0052_gateway_outbound_messages.sql
@@ -1,0 +1,45 @@
+CREATE TABLE "gateway_outbound_messages" (
+	"id" varchar(36) PRIMARY KEY NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"gateway_channel_id" varchar(36) NOT NULL,
+	"channel_type" text NOT NULL,
+	"platform_channel_id" text NOT NULL,
+	"platform_message_id" text NOT NULL,
+	"platform_thread_id" text NOT NULL,
+	"platform_permalink" text,
+	"target_branch_id" varchar(36) NOT NULL,
+	"emitted_by_user_id" varchar(36) NOT NULL,
+	"emitted_by_session_id" varchar(36),
+	"emitted_by_task_id" varchar(36),
+	"emitted_by_schedule_id" varchar(36),
+	"message_text" text NOT NULL,
+	"message_preview" text NOT NULL,
+	"metadata" jsonb,
+	"consumed_by_session_id" varchar(36),
+	"consumed_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "gateway_outbound_messages" ADD CONSTRAINT "gateway_outbound_messages_gateway_channel_id_gateway_channels_id_fk" FOREIGN KEY ("gateway_channel_id") REFERENCES "public"."gateway_channels"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gateway_outbound_messages" ADD CONSTRAINT "gateway_outbound_messages_target_branch_id_branches_branch_id_fk" FOREIGN KEY ("target_branch_id") REFERENCES "public"."branches"("branch_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gateway_outbound_messages" ADD CONSTRAINT "gateway_outbound_messages_emitted_by_user_id_users_user_id_fk" FOREIGN KEY ("emitted_by_user_id") REFERENCES "public"."users"("user_id") ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gateway_outbound_messages" ADD CONSTRAINT "gateway_outbound_messages_emitted_by_session_id_sessions_session_id_fk" FOREIGN KEY ("emitted_by_session_id") REFERENCES "public"."sessions"("session_id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gateway_outbound_messages" ADD CONSTRAINT "gateway_outbound_messages_emitted_by_task_id_tasks_task_id_fk" FOREIGN KEY ("emitted_by_task_id") REFERENCES "public"."tasks"("task_id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gateway_outbound_messages" ADD CONSTRAINT "gateway_outbound_messages_emitted_by_schedule_id_schedules_schedule_id_fk" FOREIGN KEY ("emitted_by_schedule_id") REFERENCES "public"."schedules"("schedule_id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "gateway_outbound_messages" ADD CONSTRAINT "gateway_outbound_messages_consumed_by_session_id_sessions_session_id_fk" FOREIGN KEY ("consumed_by_session_id") REFERENCES "public"."sessions"("session_id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uniq_gateway_outbound_channel_thread" ON "gateway_outbound_messages" USING btree ("gateway_channel_id","platform_thread_id");
+--> statement-breakpoint
+CREATE INDEX "idx_gateway_outbound_emitted_session" ON "gateway_outbound_messages" USING btree ("emitted_by_session_id");
+--> statement-breakpoint
+CREATE INDEX "idx_gateway_outbound_emitted_schedule" ON "gateway_outbound_messages" USING btree ("emitted_by_schedule_id");
+--> statement-breakpoint
+CREATE INDEX "idx_gateway_outbound_branch_created" ON "gateway_outbound_messages" USING btree ("target_branch_id","created_at");
+--> statement-breakpoint
+CREATE INDEX "idx_gateway_outbound_consumed" ON "gateway_outbound_messages" USING btree ("consumed_at");

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1781700000000,
       "tag": "0051_session_relationships",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1781800000000,
+      "tag": "0052_gateway_outbound_messages",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0061_gateway_outbound_messages.sql
+++ b/packages/core/drizzle/sqlite/0061_gateway_outbound_messages.sql
@@ -1,0 +1,38 @@
+CREATE TABLE `gateway_outbound_messages` (
+	`id` text(36) PRIMARY KEY NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`gateway_channel_id` text(36) NOT NULL,
+	`channel_type` text NOT NULL,
+	`platform_channel_id` text NOT NULL,
+	`platform_message_id` text NOT NULL,
+	`platform_thread_id` text NOT NULL,
+	`platform_permalink` text,
+	`target_branch_id` text(36) NOT NULL,
+	`emitted_by_user_id` text(36) NOT NULL,
+	`emitted_by_session_id` text(36),
+	`emitted_by_task_id` text(36),
+	`emitted_by_schedule_id` text(36),
+	`message_text` text NOT NULL,
+	`message_preview` text NOT NULL,
+	`metadata` text,
+	`consumed_by_session_id` text(36),
+	`consumed_at` integer,
+	FOREIGN KEY (`gateway_channel_id`) REFERENCES `gateway_channels`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`target_branch_id`) REFERENCES `branches`(`branch_id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`emitted_by_user_id`) REFERENCES `users`(`user_id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`emitted_by_session_id`) REFERENCES `sessions`(`session_id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`emitted_by_task_id`) REFERENCES `tasks`(`task_id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`emitted_by_schedule_id`) REFERENCES `schedules`(`schedule_id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`consumed_by_session_id`) REFERENCES `sessions`(`session_id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uniq_gateway_outbound_channel_thread` ON `gateway_outbound_messages` (`gateway_channel_id`,`platform_thread_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_gateway_outbound_emitted_session` ON `gateway_outbound_messages` (`emitted_by_session_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_gateway_outbound_emitted_schedule` ON `gateway_outbound_messages` (`emitted_by_schedule_id`);
+--> statement-breakpoint
+CREATE INDEX `idx_gateway_outbound_branch_created` ON `gateway_outbound_messages` (`target_branch_id`,`created_at`);
+--> statement-breakpoint
+CREATE INDEX `idx_gateway_outbound_consumed` ON `gateway_outbound_messages` (`consumed_at`);

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1781700000000,
       "tag": "0060_session_relationships",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "6",
+      "when": 1781800000000,
+      "tag": "0061_gateway_outbound_messages",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/gateway-outbound-messages.test.ts
+++ b/packages/core/src/db/repositories/gateway-outbound-messages.test.ts
@@ -1,0 +1,90 @@
+import type { BranchID, UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { BranchRepository } from './branches';
+import { GatewayChannelRepository } from './gateway-channels';
+import { GatewayOutboundMessageRepository } from './gateway-outbound-messages';
+import { RepoRepository } from './repos';
+import { UsersRepository } from './users';
+
+async function seedGateway(db: Database) {
+  const users = new UsersRepository(db);
+  const user = await users.create({
+    user_id: generateId() as UUID,
+    email: 'outbound@example.com',
+    name: 'Outbound User',
+    role: 'member',
+  });
+
+  const repoRepo = new RepoRepository(db);
+  const repo = await repoRepo.create({
+    repo_id: generateId() as UUID,
+    slug: 'test/repo',
+    name: 'test-repo',
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: '/home/user/.agor/repos/test-repo',
+    default_branch: 'main',
+  });
+
+  const branchRepo = new BranchRepository(db);
+  const branch = await branchRepo.create({
+    branch_id: generateId() as BranchID,
+    repo_id: repo.repo_id as UUID,
+    name: 'main',
+    ref: 'refs/heads/main',
+    branch_unique_id: 1,
+    path: '/home/user/.agor/worktrees/test/repo/main',
+    created_by: user.user_id as UUID,
+  });
+
+  const channelRepo = new GatewayChannelRepository(db);
+  const channel = await channelRepo.create({
+    name: 'Slack Outbound',
+    created_by: user.user_id,
+    target_branch_id: branch.branch_id as UUID,
+    agor_user_id: user.user_id,
+    channel_type: 'slack',
+    config: {
+      bot_token: 'xoxb-secret',
+      outbound_enabled: true,
+      default_outbound_target: 'channel:C123',
+      allowed_outbound_targets: ['channel:C123'],
+    },
+  });
+
+  return { user, branch, channel };
+}
+
+describe('GatewayOutboundMessageRepository', () => {
+  dbTest('creates and finds unconsumed seed by channel/thread', async ({ db }) => {
+    const { user, branch, channel } = await seedGateway(db);
+    const repo = new GatewayOutboundMessageRepository(db);
+
+    const seed = await repo.create({
+      gateway_channel_id: channel.id,
+      channel_type: 'slack',
+      platform_channel_id: 'C123',
+      platform_message_id: '171234.000100',
+      platform_thread_id: 'C123-171234.000100',
+      platform_permalink: 'https://slack.example/archives/C123/p171234000100',
+      target_branch_id: branch.branch_id,
+      emitted_by_user_id: user.user_id,
+      message_text: 'Hello from Agor',
+      message_preview: 'Hello from Agor',
+      metadata: { purpose: 'test' },
+    });
+
+    const found = await repo.findUnconsumedByChannelAndThread(channel.id, 'C123-171234.000100');
+    expect(found).toMatchObject({
+      id: seed.id,
+      gateway_channel_id: channel.id,
+      channel_type: 'slack',
+      platform_thread_id: 'C123-171234.000100',
+      consumed_at: null,
+      message_preview: 'Hello from Agor',
+    });
+  });
+});

--- a/packages/core/src/db/repositories/gateway-outbound-messages.ts
+++ b/packages/core/src/db/repositories/gateway-outbound-messages.ts
@@ -1,0 +1,183 @@
+/**
+ * Gateway Outbound Message Repository
+ *
+ * Durable audit/seed rows for proactive gateway outbound messages.
+ */
+
+import type {
+  ChannelType,
+  GatewayChannelID,
+  GatewayOutboundMessage,
+  GatewayOutboundMessageID,
+  SessionID,
+} from '@agor/core/types';
+import { prefixToLikePattern } from '@agor/core/types';
+import { and, eq, isNull, like } from 'drizzle-orm';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { insert, select, update } from '../database-wrapper';
+import {
+  type GatewayOutboundMessageInsert,
+  type GatewayOutboundMessageRow,
+  gatewayOutboundMessages,
+} from '../schema';
+import { AmbiguousIdError, EntityNotFoundError, RepositoryError } from './base';
+
+export class GatewayOutboundMessageRepository {
+  constructor(private db: Database) {}
+
+  private rowToMessage(row: GatewayOutboundMessageRow): GatewayOutboundMessage {
+    return {
+      id: row.id as GatewayOutboundMessageID,
+      gateway_channel_id: row.gateway_channel_id as GatewayChannelID,
+      channel_type: row.channel_type as ChannelType,
+      platform_channel_id: row.platform_channel_id,
+      platform_message_id: row.platform_message_id,
+      platform_thread_id: row.platform_thread_id,
+      platform_permalink: row.platform_permalink ?? null,
+      target_branch_id: row.target_branch_id as GatewayOutboundMessage['target_branch_id'],
+      emitted_by_user_id: row.emitted_by_user_id as GatewayOutboundMessage['emitted_by_user_id'],
+      emitted_by_session_id: (row.emitted_by_session_id as SessionID | null) ?? null,
+      emitted_by_task_id:
+        (row.emitted_by_task_id as GatewayOutboundMessage['emitted_by_task_id']) ?? null,
+      emitted_by_schedule_id:
+        (row.emitted_by_schedule_id as GatewayOutboundMessage['emitted_by_schedule_id']) ?? null,
+      message_text: row.message_text,
+      message_preview: row.message_preview,
+      metadata: (row.metadata as Record<string, unknown> | null) ?? null,
+      consumed_by_session_id: (row.consumed_by_session_id as SessionID | null) ?? null,
+      consumed_at: row.consumed_at ? new Date(row.consumed_at).toISOString() : null,
+      created_at: new Date(row.created_at).toISOString(),
+      updated_at: new Date(row.updated_at).toISOString(),
+    };
+  }
+
+  private toInsert(data: Partial<GatewayOutboundMessage>): GatewayOutboundMessageInsert {
+    const now = Date.now();
+    return {
+      id: data.id ?? generateId(),
+      created_at: new Date(data.created_at ?? now),
+      updated_at: new Date(data.updated_at ?? now),
+      gateway_channel_id: data.gateway_channel_id ?? '',
+      channel_type: data.channel_type ?? 'slack',
+      platform_channel_id: data.platform_channel_id ?? '',
+      platform_message_id: data.platform_message_id ?? '',
+      platform_thread_id: data.platform_thread_id ?? '',
+      platform_permalink: data.platform_permalink ?? null,
+      target_branch_id: data.target_branch_id ?? '',
+      emitted_by_user_id: data.emitted_by_user_id ?? '',
+      emitted_by_session_id: data.emitted_by_session_id ?? null,
+      emitted_by_task_id: data.emitted_by_task_id ?? null,
+      emitted_by_schedule_id: data.emitted_by_schedule_id ?? null,
+      message_text: data.message_text ?? '',
+      message_preview: data.message_preview ?? '',
+      metadata: data.metadata ?? null,
+      consumed_by_session_id: data.consumed_by_session_id ?? null,
+      consumed_at: data.consumed_at ? new Date(data.consumed_at) : null,
+    };
+  }
+
+  private async resolveId(id: string): Promise<string> {
+    if (id.length === 36 && id.includes('-')) return id;
+    const rows = await select(this.db)
+      .from(gatewayOutboundMessages)
+      .where(like(gatewayOutboundMessages.id, prefixToLikePattern(id)))
+      .all();
+    if (rows.length === 0) throw new EntityNotFoundError('GatewayOutboundMessage', id);
+    if (rows.length > 1) {
+      throw new AmbiguousIdError(
+        'GatewayOutboundMessage',
+        id,
+        rows.map((row: { id: string }) => row.id)
+      );
+    }
+    return rows[0].id;
+  }
+
+  async create(data: Partial<GatewayOutboundMessage>): Promise<GatewayOutboundMessage> {
+    try {
+      const insertData = this.toInsert({ ...data, id: data.id ?? generateId() });
+      await insert(this.db, gatewayOutboundMessages).values(insertData).run();
+      const row = await select(this.db)
+        .from(gatewayOutboundMessages)
+        .where(eq(gatewayOutboundMessages.id, insertData.id))
+        .one();
+      if (!row) throw new RepositoryError('Failed to retrieve created gateway outbound message');
+      return this.rowToMessage(row);
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      throw new RepositoryError(
+        `Failed to create gateway outbound message: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async findById(id: string): Promise<GatewayOutboundMessage | null> {
+    try {
+      const fullId = await this.resolveId(id);
+      const row = await select(this.db)
+        .from(gatewayOutboundMessages)
+        .where(eq(gatewayOutboundMessages.id, fullId))
+        .one();
+      return row ? this.rowToMessage(row) : null;
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) return null;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to find gateway outbound message: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async findUnconsumedByChannelAndThread(
+    gatewayChannelId: string,
+    platformThreadId: string
+  ): Promise<GatewayOutboundMessage | null> {
+    try {
+      const row = await select(this.db)
+        .from(gatewayOutboundMessages)
+        .where(
+          and(
+            eq(gatewayOutboundMessages.gateway_channel_id, gatewayChannelId),
+            eq(gatewayOutboundMessages.platform_thread_id, platformThreadId),
+            isNull(gatewayOutboundMessages.consumed_at)
+          )
+        )
+        .one();
+      return row ? this.rowToMessage(row) : null;
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find gateway outbound seed: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async markConsumed(
+    id: GatewayOutboundMessageID,
+    sessionId: SessionID
+  ): Promise<GatewayOutboundMessage> {
+    try {
+      const fullId = await this.resolveId(id);
+      await update(this.db, gatewayOutboundMessages)
+        .set({
+          consumed_by_session_id: sessionId,
+          consumed_at: new Date(),
+          updated_at: new Date(),
+        })
+        .where(eq(gatewayOutboundMessages.id, fullId))
+        .run();
+      const updated = await this.findById(fullId);
+      if (!updated) throw new RepositoryError('Failed to retrieve consumed gateway outbound seed');
+      return updated;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      throw new RepositoryError(
+        `Failed to mark gateway outbound seed consumed: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+}

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -13,6 +13,7 @@ export * from './branches';
 export * from './card-types';
 export * from './cards';
 export * from './gateway-channels';
+export * from './gateway-outbound-messages';
 export * from './groups';
 export * from './knowledge';
 export * from './mcp-servers';

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1735,6 +1735,87 @@ export const threadSessionMap = pgTable(
 );
 
 /**
+ * Gateway Outbound Messages table - Durable audit/seed rows for proactive outbound messages.
+ *
+ * Proactive emits seed external platform threads. They intentionally do NOT create
+ * thread_session_map rows until a human replies, preserving the invariant that one
+ * external conversation maps to one Agor session.
+ */
+export const gatewayOutboundMessages = pgTable(
+  'gateway_outbound_messages',
+  {
+    id: varchar('id', { length: 36 }).primaryKey(),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at').notNull(),
+
+    gateway_channel_id: varchar('gateway_channel_id', { length: 36 })
+      .notNull()
+      .references(() => gatewayChannels.id, { onDelete: 'cascade' }),
+    channel_type: text('channel_type', {
+      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams'],
+    }).notNull(),
+
+    platform_channel_id: text('platform_channel_id').notNull(),
+    platform_message_id: text('platform_message_id').notNull(),
+    platform_thread_id: text('platform_thread_id').notNull(),
+    platform_permalink: text('platform_permalink'),
+
+    target_branch_id: varchar('target_branch_id', { length: 36 })
+      .notNull()
+      .references(() => branches.branch_id),
+    emitted_by_user_id: varchar('emitted_by_user_id', { length: 36 })
+      .notNull()
+      .references(() => users.user_id),
+    emitted_by_session_id: varchar('emitted_by_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    emitted_by_task_id: varchar('emitted_by_task_id', { length: 36 }).references(
+      () => tasks.task_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    emitted_by_schedule_id: varchar('emitted_by_schedule_id', { length: 36 }).references(
+      () => schedules.schedule_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+
+    message_text: text('message_text').notNull(),
+    message_preview: text('message_preview').notNull(),
+    metadata: t.json<Record<string, unknown> | null>('metadata'),
+    consumed_by_session_id: varchar('consumed_by_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    consumed_at: t.timestamp('consumed_at'),
+  },
+  (table) => ({
+    uniqueChannelThread: uniqueIndex('uniq_gateway_outbound_channel_thread').on(
+      table.gateway_channel_id,
+      table.platform_thread_id
+    ),
+    emittedSessionIdx: index('idx_gateway_outbound_emitted_session').on(
+      table.emitted_by_session_id
+    ),
+    emittedScheduleIdx: index('idx_gateway_outbound_emitted_schedule').on(
+      table.emitted_by_schedule_id
+    ),
+    targetBranchCreatedIdx: index('idx_gateway_outbound_branch_created').on(
+      table.target_branch_id,
+      table.created_at
+    ),
+    consumedIdx: index('idx_gateway_outbound_consumed').on(table.consumed_at),
+  })
+);
+
+/**
  * Session Env Selections - Many-to-many between sessions and session-scope env vars.
  *
  * See the matching sqlite definition for full docs.
@@ -2209,6 +2290,8 @@ export type GatewayChannelRow = typeof gatewayChannels.$inferSelect;
 export type GatewayChannelInsert = typeof gatewayChannels.$inferInsert;
 export type ThreadSessionMapRow = typeof threadSessionMap.$inferSelect;
 export type ThreadSessionMapInsert = typeof threadSessionMap.$inferInsert;
+export type GatewayOutboundMessageRow = typeof gatewayOutboundMessages.$inferSelect;
+export type GatewayOutboundMessageInsert = typeof gatewayOutboundMessages.$inferInsert;
 export type SerializedSessionRow = typeof serializedSessions.$inferSelect;
 export type SerializedSessionInsert = typeof serializedSessions.$inferInsert;
 export type KBNamespaceRow = typeof kbNamespaces.$inferSelect;

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1767,6 +1767,84 @@ export const threadSessionMap = sqliteTable(
 );
 
 /**
+ * Gateway Outbound Messages table - Durable audit/seed rows for proactive outbound messages.
+ *
+ * Proactive emits seed external platform threads. They intentionally do NOT create
+ * thread_session_map rows until a human replies, preserving the invariant that one
+ * external conversation maps to one Agor session.
+ */
+export const gatewayOutboundMessages = sqliteTable(
+  'gateway_outbound_messages',
+  {
+    id: text('id', { length: 36 }).primaryKey(),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at').notNull(),
+
+    gateway_channel_id: text('gateway_channel_id', { length: 36 })
+      .notNull()
+      .references(() => gatewayChannels.id, { onDelete: 'cascade' }),
+    channel_type: text('channel_type', {
+      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams'],
+    }).notNull(),
+
+    platform_channel_id: text('platform_channel_id').notNull(),
+    platform_message_id: text('platform_message_id').notNull(),
+    platform_thread_id: text('platform_thread_id').notNull(),
+    platform_permalink: text('platform_permalink'),
+
+    target_branch_id: text('target_branch_id', { length: 36 })
+      .notNull()
+      .references(() => branches.branch_id),
+    emitted_by_user_id: text('emitted_by_user_id', { length: 36 })
+      .notNull()
+      .references(() => users.user_id),
+    emitted_by_session_id: text('emitted_by_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    emitted_by_task_id: text('emitted_by_task_id', { length: 36 }).references(() => tasks.task_id, {
+      onDelete: 'set null',
+    }),
+    emitted_by_schedule_id: text('emitted_by_schedule_id', { length: 36 }).references(
+      () => schedules.schedule_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+
+    message_text: text('message_text').notNull(),
+    message_preview: text('message_preview').notNull(),
+    metadata: t.json<Record<string, unknown> | null>('metadata'),
+    consumed_by_session_id: text('consumed_by_session_id', { length: 36 }).references(
+      () => sessions.session_id,
+      {
+        onDelete: 'set null',
+      }
+    ),
+    consumed_at: t.timestamp('consumed_at'),
+  },
+  (table) => ({
+    uniqueChannelThread: uniqueIndex('uniq_gateway_outbound_channel_thread').on(
+      table.gateway_channel_id,
+      table.platform_thread_id
+    ),
+    emittedSessionIdx: index('idx_gateway_outbound_emitted_session').on(
+      table.emitted_by_session_id
+    ),
+    emittedScheduleIdx: index('idx_gateway_outbound_emitted_schedule').on(
+      table.emitted_by_schedule_id
+    ),
+    targetBranchCreatedIdx: index('idx_gateway_outbound_branch_created').on(
+      table.target_branch_id,
+      table.created_at
+    ),
+    consumedIdx: index('idx_gateway_outbound_consumed').on(table.consumed_at),
+  })
+);
+
+/**
  * Session Env Selections - Many-to-many between sessions and session-scope env vars.
  *
  * Records which of a user's scope='session' env vars are exposed to a given session
@@ -2240,6 +2318,8 @@ export type GatewayChannelRow = typeof gatewayChannels.$inferSelect;
 export type GatewayChannelInsert = typeof gatewayChannels.$inferInsert;
 export type ThreadSessionMapRow = typeof threadSessionMap.$inferSelect;
 export type ThreadSessionMapInsert = typeof threadSessionMap.$inferInsert;
+export type GatewayOutboundMessageRow = typeof gatewayOutboundMessages.$inferSelect;
+export type GatewayOutboundMessageInsert = typeof gatewayOutboundMessages.$inferInsert;
 export type SerializedSessionRow = typeof serializedSessions.$inferSelect;
 export type SerializedSessionInsert = typeof serializedSessions.$inferInsert;
 export type KBNamespaceRow = typeof kbNamespaces.$inferSelect;

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -48,6 +48,7 @@ export const userMcpOauthTokens = schema.userMcpOauthTokens;
 export const boardComments = schema.boardComments;
 export const gatewayChannels = schema.gatewayChannels;
 export const threadSessionMap = schema.threadSessionMap;
+export const gatewayOutboundMessages = schema.gatewayOutboundMessages;
 export const userApiKeys = schema.userApiKeys;
 export const serializedSessions = schema.serializedSessions;
 export const kbNamespaces = schema.kbNamespaces;

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -446,6 +446,60 @@ describe('markdownToSlackPayload', () => {
   });
 });
 
+describe('SlackConnector outbound target resolution', () => {
+  it('resolves channel names via conversations.list', async () => {
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    const calls: unknown[] = [];
+    (connector as unknown as { web: unknown }).web = {
+      conversations: {
+        list: async (args: unknown) => {
+          calls.push(args);
+          return {
+            ok: true,
+            channels: [
+              { id: 'C111', name: 'random' },
+              { id: 'C222', name: 'team-data', name_normalized: 'team-data' },
+            ],
+            response_metadata: {},
+          };
+        },
+      },
+    };
+
+    const resolved = await connector.resolveChannelByName('#team-data');
+
+    expect(resolved).toEqual({ channel: 'C222', name: 'team-data' });
+    expect(calls).toEqual([{ types: 'public_channel,private_channel', limit: 1000 }]);
+  });
+
+  it('opens a DM by Slack user email', async () => {
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    const calls: Array<{ method: string; args: unknown }> = [];
+    (connector as unknown as { web: unknown }).web = {
+      users: {
+        lookupByEmail: async (args: unknown) => {
+          calls.push({ method: 'lookupByEmail', args });
+          return { ok: true, user: { id: 'U123' } };
+        },
+      },
+      conversations: {
+        open: async (args: unknown) => {
+          calls.push({ method: 'open', args });
+          return { ok: true, channel: { id: 'D123' } };
+        },
+      },
+    };
+
+    const resolved = await connector.openDmByEmail('Max@Example.com');
+
+    expect(resolved).toEqual({ channel: 'D123', user_id: 'U123' });
+    expect(calls).toEqual([
+      { method: 'lookupByEmail', args: { email: 'max@example.com' } },
+      { method: 'open', args: { users: 'U123' } },
+    ]);
+  });
+});
+
 // Mirrors SECTION_MAX_CHARS in slack.ts; kept in the test as a lower-bound
 // sanity check (we expect the legacy mrkdwn fallback to carry more than this).
 const SECTION_MAX_CHARS_TEST = 3000;

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -458,7 +458,7 @@ describe('SlackConnector outbound target resolution', () => {
             ok: true,
             channels: [
               { id: 'C111', name: 'random' },
-              { id: 'C222', name: 'team-data', name_normalized: 'team-data' },
+              { id: 'C222', name: 'project-updates', name_normalized: 'project-updates' },
             ],
             response_metadata: {},
           };
@@ -466,9 +466,9 @@ describe('SlackConnector outbound target resolution', () => {
       },
     };
 
-    const resolved = await connector.resolveChannelByName('#team-data');
+    const resolved = await connector.resolveChannelByName('#project-updates');
 
-    expect(resolved).toEqual({ channel: 'C222', name: 'team-data' });
+    expect(resolved).toEqual({ channel: 'C222', name: 'project-updates' });
     expect(calls).toEqual([{ types: 'public_channel,private_channel', limit: 1000 }]);
   });
 
@@ -490,11 +490,11 @@ describe('SlackConnector outbound target resolution', () => {
       },
     };
 
-    const resolved = await connector.openDmByEmail('Max@Example.com');
+    const resolved = await connector.openDmByEmail('User@Example.com');
 
     expect(resolved).toEqual({ channel: 'D123', user_id: 'U123' });
     expect(calls).toEqual([
-      { method: 'lookupByEmail', args: { email: 'max@example.com' } },
+      { method: 'lookupByEmail', args: { email: 'user@example.com' } },
       { method: 'open', args: { users: 'U123' } },
     ]);
   });

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -947,6 +947,61 @@ export class SlackConnector implements GatewayConnector {
     };
   }
 
+  /** Resolve a Slack channel by its human name (with or without #). */
+  async resolveChannelByName(name: string): Promise<{ channel: string; name: string }> {
+    const normalized = name.replace(/^#/, '').trim().toLowerCase();
+    if (!normalized) throw new Error('Slack channel name is required');
+
+    let cursor: string | undefined;
+    do {
+      const result = await this.web.conversations.list({
+        types: 'public_channel,private_channel',
+        limit: 1000,
+        ...(cursor ? { cursor } : {}),
+      });
+
+      if (!result.ok) {
+        throw new Error(`Slack API error: ${result.error ?? 'unknown error'}`);
+      }
+
+      const channels = (result.channels ?? []) as Array<{
+        id?: string;
+        name?: string;
+        name_normalized?: string;
+        is_archived?: boolean;
+      }>;
+      const match = channels.find((channel) => {
+        if (channel.is_archived) return false;
+        return (channel.name_normalized ?? channel.name ?? '').toLowerCase() === normalized;
+      });
+      if (match?.id) {
+        return { channel: match.id, name: match.name ?? normalized };
+      }
+
+      cursor = result.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+
+    throw new Error(`Slack channel not found: #${normalized}`);
+  }
+
+  /** Resolve a Slack user email to a DM channel with that user. */
+  async openDmByEmail(email: string): Promise<{ channel: string; user_id: string }> {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) throw new Error('Slack user email is required');
+
+    const userResult = await this.web.users.lookupByEmail({ email: normalized });
+    if (!userResult.ok || !userResult.user?.id) {
+      throw new Error(`Slack user lookup failed: ${userResult.error ?? 'user_not_found'}`);
+    }
+
+    const dmResult = await this.web.conversations.open({ users: userResult.user.id });
+    if (!dmResult.ok || !dmResult.channel?.id) {
+      throw new Error(`Slack DM open failed: ${dmResult.error ?? 'unknown error'}`);
+    }
+
+    return { channel: dmResult.channel.id, user_id: userResult.user.id };
+  }
+
   async startStream(req: {
     threadId: string;
     text?: string;

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -879,6 +879,74 @@ export class SlackConnector implements GatewayConnector {
     return result.ts;
   }
 
+  /**
+   * Send directly to a Slack channel or thread. Used for proactive outbound
+   * emits where no gateway thread_session_map exists yet.
+   */
+  async sendSlackMessage(req: {
+    channel: string;
+    text: string;
+    blocks?: unknown[];
+    thread_ts?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<{ ts: string; channel: string; thread_ts: string; permalink?: string | null }> {
+    const blocks = req.blocks && req.blocks.length > 0 ? (req.blocks as KnownBlock[]) : undefined;
+    const send = (withBlocks: boolean) =>
+      this.web.chat.postMessage({
+        channel: req.channel,
+        text: req.text,
+        ...(withBlocks && blocks ? { blocks } : {}),
+        ...(req.thread_ts ? { thread_ts: req.thread_ts } : {}),
+        unfurl_links: false,
+        unfurl_media: false,
+      });
+
+    let result: Awaited<ReturnType<typeof send>>;
+    try {
+      result = await send(true);
+    } catch (err) {
+      const code = extractSlackErrorCode(err);
+      if (blocks && code && BLOCK_PAYLOAD_ERRORS.has(code)) {
+        console.warn(`[slack] Block payload rejected (${code}); retrying direct send as text-only`);
+        result = await send(false);
+      } else {
+        throw err;
+      }
+    }
+
+    if (!result.ok || !result.ts) {
+      const code = extractSlackErrorCode(result);
+      if (blocks && code && BLOCK_PAYLOAD_ERRORS.has(code)) {
+        const retry = await send(false);
+        if (!retry.ok || !retry.ts) {
+          throw new Error(`Slack API error: ${retry.error ?? 'unknown error'}`);
+        }
+        result = retry;
+      } else {
+        throw new Error(`Slack API error: ${result.error ?? 'unknown error'}`);
+      }
+    }
+
+    const sentTs = result.ts;
+    if (!sentTs) {
+      throw new Error('Slack API error: missing message timestamp');
+    }
+    let permalink: string | null = null;
+    try {
+      const link = await this.web.chat.getPermalink({ channel: req.channel, message_ts: sentTs });
+      permalink = link.ok ? (link.permalink ?? null) : null;
+    } catch {
+      permalink = null;
+    }
+
+    return {
+      ts: sentTs,
+      channel: req.channel,
+      thread_ts: req.thread_ts ?? sentTs,
+      permalink,
+    };
+  }
+
   async startStream(req: {
     threadId: string;
     text?: string;

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -6,7 +6,8 @@
  */
 
 import type { AgenticToolName, CodexApprovalPolicy, CodexSandboxMode } from './agentic-tool';
-import type { BranchID, SessionID, UserID, UUID } from './id';
+import type { BranchID, SessionID, TaskID, UserID, UUID } from './id';
+import type { ScheduleID } from './schedule';
 import type { PermissionMode } from './session';
 import type { DefaultModelConfig } from './user';
 
@@ -19,6 +20,9 @@ export type GatewayChannelID = UUID;
 
 /** Thread-session mapping identifier */
 export type ThreadSessionMapID = UUID;
+
+/** Gateway outbound seed/audit message identifier */
+export type GatewayOutboundMessageID = UUID;
 
 // ============================================================================
 // Enums
@@ -130,4 +134,36 @@ export interface ThreadSessionMap {
   last_message_at: string;
   status: ThreadStatus;
   metadata: Record<string, unknown> | null;
+}
+
+/**
+ * Gateway outbound message - durable seed/audit record for proactive emits.
+ *
+ * These rows intentionally do not imply a thread-session mapping. The mapping is
+ * created only when a human replies to the seeded external thread.
+ */
+export interface GatewayOutboundMessage {
+  id: GatewayOutboundMessageID;
+  gateway_channel_id: GatewayChannelID;
+  channel_type: ChannelType;
+
+  platform_channel_id: string;
+  platform_message_id: string;
+  platform_thread_id: string;
+  platform_permalink: string | null;
+
+  target_branch_id: BranchID;
+  emitted_by_user_id: UserID;
+  emitted_by_session_id: SessionID | null;
+  emitted_by_task_id: TaskID | null;
+  emitted_by_schedule_id: ScheduleID | null;
+
+  message_text: string;
+  message_preview: string;
+  metadata: Record<string, unknown> | null;
+  consumed_by_session_id: SessionID | null;
+  consumed_at: string | null;
+
+  created_at: string;
+  updated_at: string;
 }


### PR DESCRIPTION
## Summary

- Add durable `gateway_outbound_messages` seed/audit records with repository support and SQLite/Postgres migrations.
- Add Slack outbound channel config fields and direct Slack send support through authenticated MCP tools.
- Consume unclaimed outbound Slack seeds on first human thread reply, creating the gateway session/thread mapping while preserving the one external thread → one Agor session invariant.
- Keep `emitMessage` off exposed Feathers `/gateway` methods and fix an existing short-id guard violation encountered by `pnpm check`.

## Tests

- `pnpm check`
- `pnpm --dir packages/core test -- src/db/repositories/gateway-outbound-messages.test.ts`
- `pnpm --dir apps/agor-daemon test -- src/mcp/tools/gateway-channels.test.ts`
- `pnpm --dir packages/core test -- src/gateway/connectors/slack.test.ts`
