### PR TITLE
Fix branch dev deep-link auth routing

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -23,7 +23,6 @@ import {
   ENTITY_PATH_SEGMENTS,
   getRepoReferenceOptions,
   sessionPath,
-  UI_MOUNT_PATH,
 } from '@agor-live/client';
 import { Alert, App as AntApp, ConfigProvider } from 'antd';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
@@ -61,6 +60,7 @@ import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLife
 import { isMobileDevice } from './utils/deviceDetection';
 import { useThemedMessage } from './utils/message';
 import { updateSessionMcpServers } from './utils/sessionMcpServers';
+import { getRouterBasename } from './utils/uiRoutes';
 
 type RouteModuleKey = RouteSurfaceId | 'mobile';
 
@@ -1793,11 +1793,9 @@ function AppWrapper() {
 }
 
 function App() {
-  // Determine base path: UI_MOUNT_PATH ('/ui') in production (served by
-  // daemon at that prefix), '' in dev mode (vite serves at /). Pulled
-  // from the shared core constant so this stays consistent with the
-  // daemon's static-serving block and the server-side URL builders.
-  const basename = import.meta.env.BASE_URL === `${UI_MOUNT_PATH}/` ? UI_MOUNT_PATH : '';
+  // Determine base path: '/ui' in production (served by daemon at that prefix)
+  // and for branch-dev direct canonical links; '' for normal root-mounted Vite.
+  const basename = getRouterBasename();
 
   return (
     <BrowserRouter basename={basename}>

--- a/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AboutTab.tsx
@@ -6,6 +6,7 @@ import type { AgorClient, UnixUserMode } from '@agor-live/client';
 import { Button, Card, Descriptions, Space, Tag, Tooltip, Typography } from 'antd';
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../../config/daemon';
+import { resolveUiRuntime } from '../../config/urlRuntime';
 import { useConnectionState } from '../../contexts/ConnectionContext';
 import { isOutOfSync } from '../../hooks/useServerVersion';
 
@@ -87,6 +88,10 @@ export const AboutTab: React.FC<AboutTabProps> = ({
   isAdmin = false,
 }) => {
   const daemonUrl = getDaemonUrl();
+  const uiRuntime = resolveUiRuntime({
+    baseUrl: import.meta.env.BASE_URL,
+    pathname: typeof window === 'undefined' ? '/' : window.location.pathname,
+  });
   const [detectionMethod, setDetectionMethod] = useState<string>('');
   const [healthInfo, setHealthInfo] = useState<HealthInfo | null>(null);
   // Admin-only crash-test toggle: flipping this true makes <CrashTestBomb />
@@ -102,8 +107,10 @@ export const AboutTab: React.FC<AboutTabProps> = ({
       setDetectionMethod('Runtime injection (window.AGOR_DAEMON_URL)');
     } else if (import.meta.env.VITE_DAEMON_URL) {
       setDetectionMethod('Build-time env var (VITE_DAEMON_URL)');
-    } else if (typeof window !== 'undefined' && window.location.pathname.startsWith('/ui')) {
-      setDetectionMethod('Same-host detection (served from /ui)');
+    } else if (uiRuntime.mode === 'bundled-daemon-ui') {
+      setDetectionMethod('Bundled UI (same-origin daemon)');
+    } else if (uiRuntime.mode === 'canonical-dev-deeplink') {
+      setDetectionMethod('Dev canonical /ui deep link (daemon port)');
     } else {
       setDetectionMethod('Dev mode (explicit port)');
     }
@@ -120,7 +127,7 @@ export const AboutTab: React.FC<AboutTabProps> = ({
         })
         .catch((err) => console.error('Failed to fetch health info:', err));
     }
-  }, [client]);
+  }, [client, uiRuntime.mode]);
 
   return (
     <div style={{ position: 'relative', minHeight: 500, padding: '24px 0' }}>
@@ -358,11 +365,14 @@ export const AboutTab: React.FC<AboutTabProps> = ({
               >
                 <Descriptions column={1} bordered size="small">
                   <Descriptions.Item label="Mode">
-                    {window.location.pathname.startsWith('/ui') ? (
+                    {uiRuntime.mode === 'bundled-daemon-ui' ? (
                       <span>npm package (agor-live)</span>
                     ) : (
                       <span>Source code (dev)</span>
                     )}
+                  </Descriptions.Item>
+                  <Descriptions.Item label="URL Runtime">
+                    <code>{uiRuntime.mode}</code>
                   </Descriptions.Item>
                   <Descriptions.Item label="UI Location">
                     <code>{window.location.href}</code>

--- a/apps/agor-ui/src/config/daemon.ts
+++ b/apps/agor-ui/src/config/daemon.ts
@@ -5,6 +5,7 @@
  */
 
 import { DAEMON } from '@agor-live/client';
+import { daemonUrlForRuntime, resolveUiRuntime } from './urlRuntime';
 
 /**
  * Get daemon URL for UI connections
@@ -32,16 +33,11 @@ export function getDaemonUrl(): string {
   const daemonPort = import.meta.env.VITE_DAEMON_PORT || String(DAEMON.DEFAULT_PORT);
 
   if (typeof window !== 'undefined') {
-    // If served from /ui path, we're on the same host as daemon
-    // Use origin directly (handles forwarded URLs correctly)
-    if (window.location.pathname.startsWith('/ui')) {
-      return window.location.origin;
-    }
-
-    // Dev mode: construct URL with explicit port
-    const origin = window.location.origin;
-    const url = new URL(origin);
-    return `${url.protocol}//${url.hostname}:${daemonPort}`;
+    const runtime = resolveUiRuntime({
+      baseUrl: import.meta.env.BASE_URL,
+      pathname: window.location.pathname,
+    });
+    return daemonUrlForRuntime(runtime, window.location.origin, daemonPort);
   }
 
   // 3. Server-side fallback

--- a/apps/agor-ui/src/config/urlRuntime.test.ts
+++ b/apps/agor-ui/src/config/urlRuntime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  daemonUrlForRuntime,
+  resolveUiRuntime,
+  routerBasenameForRuntime,
+  usesSameOriginDaemon,
+} from './urlRuntime';
+
+describe('UI URL runtime resolution', () => {
+  it('models bundled daemon UI as /ui basename and same-origin API', () => {
+    const runtime = resolveUiRuntime({ baseUrl: '/ui/', pathname: '/ui/kb/global/readme.md' });
+
+    expect(runtime.mode).toBe('bundled-daemon-ui');
+    expect(routerBasenameForRuntime(runtime)).toBe('/ui');
+    expect(usesSameOriginDaemon(runtime)).toBe(true);
+    expect(daemonUrlForRuntime(runtime, 'https://agor.example.com', '3030')).toBe(
+      'https://agor.example.com'
+    );
+  });
+
+  it('models root Vite dev as root basename and daemon-port API', () => {
+    const runtime = resolveUiRuntime({ baseUrl: '/', pathname: '/kb/global/readme.md' });
+
+    expect(runtime.mode).toBe('root-vite-dev');
+    expect(routerBasenameForRuntime(runtime)).toBe('');
+    expect(usesSameOriginDaemon(runtime)).toBe(false);
+    expect(daemonUrlForRuntime(runtime, 'http://localhost:5173', '3030')).toBe(
+      'http://localhost:3030'
+    );
+  });
+
+  it('models canonical /ui deep links in Vite dev as /ui basename but daemon-port API', () => {
+    const runtime = resolveUiRuntime({ baseUrl: '/', pathname: '/ui/kb/global/readme.md' });
+
+    expect(runtime.mode).toBe('canonical-dev-deeplink');
+    expect(routerBasenameForRuntime(runtime)).toBe('/ui');
+    expect(usesSameOriginDaemon(runtime)).toBe(false);
+    expect(daemonUrlForRuntime(runtime, 'http://10.33.92.175:14082', '12082')).toBe(
+      'http://10.33.92.175:12082'
+    );
+  });
+});

--- a/apps/agor-ui/src/config/urlRuntime.ts
+++ b/apps/agor-ui/src/config/urlRuntime.ts
@@ -1,0 +1,71 @@
+import { UI_MOUNT_PATH } from '@agor-live/client';
+
+export type UiRuntimeMode = 'bundled-daemon-ui' | 'root-vite-dev' | 'canonical-dev-deeplink';
+
+export interface UiRuntime {
+  mode: UiRuntimeMode;
+  baseUrl: string;
+  pathname: string;
+  uiMountPath: string;
+}
+
+export interface ResolveUiRuntimeOptions {
+  /**
+   * Vite's compile-time asset/router base. Production/bundled installs build
+   * with `/ui/`; branch/dev Vite serves at `/`.
+   */
+  baseUrl: string;
+  /** The browser location pathname at initial load. */
+  pathname: string;
+  /** Shared daemon UI mount path. Defaults to Agor's canonical `/ui`. */
+  uiMountPath?: string;
+}
+
+function isUnderMountPath(pathname: string, uiMountPath: string): boolean {
+  return pathname === uiMountPath || pathname.startsWith(`${uiMountPath}/`);
+}
+
+/**
+ * Resolve the UI's URL runtime mode.
+ *
+ * Keep these concepts intentionally separate:
+ * - canonical external app links include `/ui/...`;
+ * - bundled installs serve both UI and API from the daemon origin;
+ * - branch/dev Vite serves UI at `/` while API stays on the daemon port.
+ */
+export function resolveUiRuntime({
+  baseUrl,
+  pathname,
+  uiMountPath = UI_MOUNT_PATH,
+}: ResolveUiRuntimeOptions): UiRuntime {
+  if (baseUrl === `${uiMountPath}/`) {
+    return { mode: 'bundled-daemon-ui', baseUrl, pathname, uiMountPath };
+  }
+
+  if (baseUrl === '/' && isUnderMountPath(pathname, uiMountPath)) {
+    return { mode: 'canonical-dev-deeplink', baseUrl, pathname, uiMountPath };
+  }
+
+  return { mode: 'root-vite-dev', baseUrl, pathname, uiMountPath };
+}
+
+export function routerBasenameForRuntime(runtime: UiRuntime): string {
+  return runtime.mode === 'bundled-daemon-ui' || runtime.mode === 'canonical-dev-deeplink'
+    ? runtime.uiMountPath
+    : '';
+}
+
+export function usesSameOriginDaemon(runtime: UiRuntime): boolean {
+  return runtime.mode === 'bundled-daemon-ui';
+}
+
+export function daemonUrlForRuntime(
+  runtime: UiRuntime,
+  origin: string,
+  daemonPort: string
+): string {
+  if (usesSameOriginDaemon(runtime)) return origin;
+
+  const url = new URL(origin);
+  return `${url.protocol}//${url.hostname}:${daemonPort}`;
+}

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -5,6 +5,7 @@ import { useAuth } from './useAuth';
 
 const authenticate = vi.fn();
 const launchCreate = vi.fn();
+const refreshCreate = vi.fn();
 
 vi.mock('@agor-live/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agor-live/client')>();
@@ -14,6 +15,7 @@ vi.mock('@agor-live/client', async (importOriginal) => {
       authenticate,
       service: vi.fn((name: string) => {
         if (name === 'auth/launch') return { create: launchCreate };
+        if (name === 'authentication/refresh') return { create: refreshCreate };
         throw new Error(`unexpected service: ${name}`);
       }),
     })),
@@ -25,6 +27,7 @@ describe('useAuth launch-code fallback', () => {
     localStorage.clear();
     authenticate.mockReset();
     launchCreate.mockReset();
+    refreshCreate.mockReset();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     window.history.replaceState({}, '', '/ui/?launch_code=stale-code');
@@ -85,5 +88,38 @@ describe('useAuth launch-code fallback', () => {
     expect(result.current.error).toContain('unexpected response');
     expect(result.current.error).toContain('daemon URL');
     expect(result.current.error).not.toContain('JSON parsing error');
+  });
+
+  it('preserves stored tokens when stored-session auth gets a non-auth transport response', async () => {
+    window.history.replaceState({}, '', '/ui/');
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'stored-access');
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'stored-refresh');
+    authenticate.mockRejectedValue(new Error('JSON parsing error'));
+    refreshCreate.mockRejectedValue(new Error('JSON parsing error'));
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.authenticated).toBe(false);
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('stored-access');
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('stored-refresh');
+  });
+
+  it('preserves stored tokens when launch fallback auth gets a non-auth transport response', async () => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'stored-access');
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'stored-refresh');
+    launchCreate.mockRejectedValue(new Error('launch code consumed'));
+    authenticate.mockRejectedValue(new Error('JSON parsing error'));
+    refreshCreate.mockRejectedValue(new Error('JSON parsing error'));
+
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.authenticated).toBe(false);
+    expect(result.current.error).toContain('Launch sign-in failed');
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('stored-access');
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('stored-refresh');
   });
 });

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -9,7 +9,7 @@ import type { User } from '@agor-live/client';
 import { createRestClient } from '@agor-live/client';
 import { useCallback, useEffect, useState } from 'react';
 import { getDaemonUrl } from '../config/daemon';
-import { isTransientConnectionError } from '../utils/authErrors';
+import { isDefiniteAuthFailure, isTransientConnectionError } from '../utils/authErrors';
 import { isExpiringSoon, msUntilExpiry } from '../utils/jwtExpiry';
 import {
   exchangeLaunchCode,
@@ -118,8 +118,9 @@ export function useAuth(): UseAuthReturn {
           });
 
           return true;
-        } catch (_accessTokenError) {
+        } catch (accessTokenError) {
           // Access token expired or invalid, try refresh token
+          if (!isDefiniteAuthFailure(accessTokenError)) throw accessTokenError;
         }
       }
 
@@ -137,8 +138,14 @@ export function useAuth(): UseAuthReturn {
           });
 
           return true;
-        } catch (_refreshError) {
+        } catch (refreshError) {
           // Refresh token also expired or invalid
+          if (
+            !isDefiniteAuthFailure(refreshError) &&
+            !(refreshError instanceof RefreshUnrecoverableError)
+          ) {
+            throw refreshError;
+          }
         }
       }
 
@@ -226,14 +233,25 @@ export function useAuth(): UseAuthReturn {
       // IMPORTANT: Don't clear tokens for connection errors or for failed
       // launch-code attempts when stored tokens exist. A stale/consumed URL
       // code must not log out a user with an otherwise valid local session.
-      if (!isConnectionError && !(attemptedLaunch && hasStoredTokens)) {
+      if (
+        isDefiniteAuthFailure(error) &&
+        !isConnectionError &&
+        !(attemptedLaunch && hasStoredTokens)
+      ) {
         console.error('Authentication failure, clearing tokens:', error);
         clearTokens();
       }
 
       if (attemptedLaunch && hasStoredTokens) {
-        const client = await createRestClient(getDaemonUrl());
-        if (await authenticateWithStoredTokens(client)) return;
+        try {
+          const client = await createRestClient(getDaemonUrl());
+          if (await authenticateWithStoredTokens(client)) return;
+        } catch (fallbackError) {
+          console.warn(
+            'Stored-token fallback after launch sign-in failure also failed:',
+            fallbackError
+          );
+        }
       }
 
       setState({

--- a/apps/agor-ui/src/utils/uiRoutes.test.ts
+++ b/apps/agor-ui/src/utils/uiRoutes.test.ts
@@ -11,4 +11,9 @@ describe('uiRoutes', () => {
     expect(getRouterBasename('/')).toBe('');
     expect(uiRouteHref('a/artifact/fullscreen', '/')).toBe('/a/artifact/fullscreen');
   });
+
+  it('accepts canonical /ui deep links in root-mounted dev environments', () => {
+    expect(getRouterBasename('/', '/ui/kb/global/readme.md')).toBe('/ui');
+    expect(getRouterBasename('/', '/')).toBe('');
+  });
 });

--- a/apps/agor-ui/src/utils/uiRoutes.ts
+++ b/apps/agor-ui/src/utils/uiRoutes.ts
@@ -1,7 +1,14 @@
-import { UI_MOUNT_PATH } from '@agor-live/client';
+import { resolveUiRuntime, routerBasenameForRuntime } from '../config/urlRuntime';
 
-export function getRouterBasename(baseUrl = import.meta.env.BASE_URL): string {
-  return baseUrl === `${UI_MOUNT_PATH}/` ? UI_MOUNT_PATH : '';
+function currentPathname(): string {
+  return typeof window === 'undefined' ? '/' : window.location.pathname;
+}
+
+export function getRouterBasename(
+  baseUrl = import.meta.env.BASE_URL,
+  pathname = currentPathname()
+): string {
+  return routerBasenameForRuntime(resolveUiRuntime({ baseUrl, pathname }));
 }
 
 export function uiRouteHref(path: string, baseUrl = import.meta.env.BASE_URL): string {


### PR DESCRIPTION
## Summary

- Add a single `urlRuntime` model for the UI URL matrix:
  - bundled daemon UI: `/ui/...` routes and same-origin daemon API
  - root Vite dev: `/...` routes and daemon-port API
  - canonical branch-dev deep links: `/ui/...` routes but daemon-port API
- Fix branch-dev `/ui/...` deep links so auth requests keep using the configured daemon port instead of treating the Vite UI origin as the daemon.
- Let React Router strip `/ui` for direct canonical deep links in root-mounted dev environments.
- Preserve existing auth tokens when stored-token reauth receives a non-auth transport/parse response, so an unexpected HTML/text response cannot log out other tabs.
- Route Settings → About debug/detection labels through the same runtime model; removed remaining UI runtime `pathname.startsWith('/ui')` checks.
- Fix launch-code + stored-token fallback so secondary fallback failures settle cleanly without clearing tokens or leaving auth loading stuck.

## Evidence

- In the branch environment, `GET /ui/kb/foo/bar.md` on the UI port returns the Vite SPA HTML.
- `POST /authentication` on the UI port is not the daemon auth endpoint, while the daemon port returns JSON auth responses.
- The previous `getDaemonUrl()` path check (`pathname.startsWith('/ui')`) therefore sent deep-link login/reauth requests to Vite in branch dev.

## Checks

```bash
docker compose -p agor-investigate-direct-kb-login-logout exec -T agor-dev pnpm --filter agor-ui test -- src/hooks/useAuth.launch.test.tsx src/utils/uiRoutes.test.ts src/config/urlRuntime.test.ts

docker compose -p agor-investigate-direct-kb-login-logout exec -T agor-dev pnpm exec biome check apps/agor-ui/src/hooks/useAuth.ts apps/agor-ui/src/hooks/useAuth.launch.test.tsx
```

Earlier broader Biome run also covered:

```bash
apps/agor-ui/src/components/SettingsModal/AboutTab.tsx apps/agor-ui/src/config/daemon.ts apps/agor-ui/src/config/urlRuntime.ts apps/agor-ui/src/config/urlRuntime.test.ts apps/agor-ui/src/utils/uiRoutes.ts apps/agor-ui/src/utils/uiRoutes.test.ts apps/agor-ui/src/hooks/useAuth.ts apps/agor-ui/src/hooks/useAuth.launch.test.tsx apps/agor-ui/src/App.tsx
```

## Notes

- `pnpm --filter agor-ui typecheck` in the dev container is currently blocked by existing missing declaration output for `@agor-live/client` (`packages/client/dist/*.js`), unrelated to this change.
