### PR TITLE
fix: prevent stale Codex model aliases

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1212,6 +1212,13 @@ describe('agor_models_list', () => {
       displayName: expect.any(String),
       description: expect.any(String),
     });
+    expect(parsed.codex.note).toContain('omit modelConfig');
+
+    const codexIds = parsed.codex.models.map((m: { id: string }) => m.id);
+    expect(codexIds).toContain('gpt-5.5');
+    expect(codexIds).toContain('gpt-5.4-mini');
+    expect(codexIds).not.toContain('gpt-5.4');
+    expect(codexIds).not.toContain('gpt-5-codex');
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1680,6 +1680,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         codex: {
           default: DEFAULT_CODEX_MODEL,
           models: codexModels,
+          note: 'Codex defaults to gpt-5.5; omit modelConfig unless a specific model is required. Use gpt-5.4-mini for lighter subagents. Legacy Codex aliases are intentionally omitted from this selectable list.',
         },
         copilot: {
           default: DEFAULT_COPILOT_MODEL,

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -16,8 +16,13 @@ import {
   type SessionWithLastMessage,
   UsersRepository,
 } from '@agor/core/db';
-import { type Application, Forbidden } from '@agor/core/feathers';
-import { formatModelToolMismatchWarning, lintModelToolMatch } from '@agor/core/models';
+import { type Application, BadRequest, Forbidden } from '@agor/core/feathers';
+import {
+  formatModelToolMismatchWarning,
+  formatUnsupportedAgorCodexModelMessage,
+  isUnsupportedAgorCodexModel,
+  lintModelToolMatch,
+} from '@agor/core/models';
 import { resolveChildSessionConfig } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
@@ -124,6 +129,19 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   private sessionEnvSelectionRepo: SessionEnvSelectionRepository;
   private usersRepo: UsersRepository;
   private branchRepo: BranchRepository;
+
+  private assertSupportedModelConfig(
+    agenticTool: Session['agentic_tool'],
+    modelConfig: Session['model_config'] | undefined
+  ): void {
+    if (
+      agenticTool === 'codex' &&
+      modelConfig?.model &&
+      isUnsupportedAgorCodexModel(modelConfig.model)
+    ) {
+      throw new BadRequest(formatUnsupportedAgorCodexModelMessage(modelConfig.model));
+    }
+  }
 
   constructor(db: Database, app: Application) {
     const sessionRepo = new SessionRepository(db);
@@ -347,6 +365,8 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     // parent owner. Legacy parent-inheriting "identity borrowing" is preserved
     // only when the branch opts in via dangerously_allow_session_sharing.
     const { created_by, unix_username } = await this.resolveChildIdentity(parent, params);
+    const inheritableConfig = getInheritableConfig(parent);
+    this.assertSupportedModelConfig(parent.agentic_tool, inheritableConfig.model_config);
 
     const forkedSession = await this.create(
       {
@@ -367,7 +387,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
           children: [],
         },
         contextFiles: [...(parent.contextFiles || [])],
-        ...getInheritableConfig(parent),
+        ...inheritableConfig,
         tasks: [],
         // Don't copy sdk_session_id - fork will get its own via forkSession:true
       },
@@ -495,6 +515,8 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     if (lintWarning) {
       console.warn(`[SessionsService.spawn] ${lintWarning}`);
     }
+
+    this.assertSupportedModelConfig(targetTool, modelConfig);
 
     // callback_session_id is the single source of truth for where to deliver
     // callbacks. Default to parent session when callbacks are enabled (which

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.test.ts
@@ -89,6 +89,23 @@ describe('applySessionConfigDefaults', () => {
     );
   });
 
+  it('rejects an explicit unsupported Codex model before create', async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: {
+        agentic_tool: 'codex',
+        created_by: ALICE,
+        permission_config: { mode: 'acceptEdits' },
+        model_config: { mode: 'alias', model: 'gpt-5-codex', updated_at: 'now' },
+      },
+      users: { [ALICE]: { user_id: ALICE } },
+    });
+
+    await expect(hook(ctx)).rejects.toThrow('gpt-5-codex');
+  });
+
   it("fills missing model_config from the user's default", async () => {
     const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
     const ctx = makeContext({
@@ -108,6 +125,25 @@ describe('applySessionConfigDefaults', () => {
     expect((ctx.data as { model_config: { model: string } }).model_config.model).toBe(
       'claude-opus-4-6'
     );
+  });
+
+  it("rejects an unsupported Codex model from the user's default", async () => {
+    const hook = applySessionConfigDefaults({ warnOnExternalDefaultFill: false });
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: ALICE },
+      data: { agentic_tool: 'codex', created_by: ALICE },
+      users: {
+        [ALICE]: {
+          user_id: ALICE,
+          default_agentic_config: {
+            codex: { modelConfig: { model: 'gpt-5-codex' } },
+          },
+        },
+      },
+    });
+
+    await expect(hook(ctx)).rejects.toThrow('gpt-5-codex');
   });
 
   it("fills missing advisorModel from the user's model default", async () => {

--- a/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
+++ b/apps/agor-daemon/src/utils/apply-session-config-defaults.ts
@@ -38,6 +38,11 @@
  *    reachable via REST/MCP/UI).
  */
 
+import { BadRequest } from '@agor/core/feathers';
+import {
+  formatUnsupportedAgorCodexModelMessage,
+  isUnsupportedAgorCodexModel,
+} from '@agor/core/models';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import type { AgenticToolName, HookContext, Session, User } from '@agor/core/types';
 
@@ -68,10 +73,19 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
 
     const hasPermission = data.permission_config != null;
     const hasModel = !!data.model_config?.model;
-    if (hasPermission && hasModel) return context; // nothing to fill
 
     const agenticTool = data.agentic_tool as AgenticToolName | undefined;
     if (!agenticTool) return context; // can't resolve defaults without a tool
+
+    if (
+      agenticTool === 'codex' &&
+      data.model_config?.model &&
+      isUnsupportedAgorCodexModel(data.model_config.model)
+    ) {
+      throw new BadRequest(formatUnsupportedAgorCodexModelMessage(data.model_config.model));
+    }
+
+    if (hasPermission && hasModel) return context; // nothing to fill
 
     // Identify the user whose defaults to apply. External calls go through
     // injectCreatedBy() first, which stamps `data.created_by` from
@@ -101,6 +115,13 @@ export function applySessionConfigDefaults(opts: ApplySessionConfigDefaultsOpts 
       user,
       overrides: { modelConfig: data.model_config ?? undefined },
     });
+    if (
+      resolved.model_config?.model &&
+      agenticTool === 'codex' &&
+      isUnsupportedAgorCodexModel(resolved.model_config.model)
+    ) {
+      throw new BadRequest(formatUnsupportedAgorCodexModelMessage(resolved.model_config.model));
+    }
 
     if (!hasPermission) {
       data.permission_config = resolved.permission_config;

--- a/packages/core/src/models/codex.test.ts
+++ b/packages/core/src/models/codex.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CODEX_MINI_MODEL,
+  CODEX_MODEL_METADATA,
+  CODEX_MODEL_REGISTRY,
+  DEFAULT_CODEX_MODEL,
+  formatUnsupportedAgorCodexModelMessage,
+  getCodexModelLifecycle,
+  isUnsupportedAgorCodexModel,
+} from './codex.js';
+
+describe('Codex model registry', () => {
+  it('keeps current defaults on supported Codex models', () => {
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.5');
+    expect(CODEX_MINI_MODEL).toBe('gpt-5.4-mini');
+  });
+
+  it('surfaces only selectable models to callers', () => {
+    const selectableIds = Object.keys(CODEX_MODEL_METADATA);
+
+    expect(selectableIds).toContain('gpt-5.5');
+    expect(selectableIds).toContain('gpt-5.4-mini');
+    expect(selectableIds).not.toContain('gpt-5.4');
+    expect(selectableIds).not.toContain('gpt-5-codex');
+  });
+
+  it('keeps legacy aliases in the lifecycle registry for diagnostics', () => {
+    expect(CODEX_MODEL_REGISTRY['gpt-5-codex']).toMatchObject({
+      selectable: false,
+      availability: 'unsupported',
+      replacement: 'gpt-5.5',
+    });
+  });
+
+  it('matches exact and dated legacy aliases', () => {
+    expect(getCodexModelLifecycle('gpt-5-codex')).toBe(CODEX_MODEL_REGISTRY['gpt-5-codex']);
+    expect(getCodexModelLifecycle('gpt-5-codex-2026-01-01')).toBe(
+      CODEX_MODEL_REGISTRY['gpt-5-codex']
+    );
+    expect(getCodexModelLifecycle('gpt-5-codex-mini-2026-01-01')).toBe(
+      CODEX_MODEL_REGISTRY['gpt-5-codex-mini']
+    );
+    expect(getCodexModelLifecycle('gpt-5.4-mini-2026-01-01')).toBe(
+      CODEX_MODEL_REGISTRY['gpt-5.4-mini']
+    );
+  });
+
+  it('flags only known unsupported Agor Codex aliases', () => {
+    expect(isUnsupportedAgorCodexModel('gpt-5-codex')).toBe(true);
+    expect(isUnsupportedAgorCodexModel('gpt-5-codex-mini')).toBe(true);
+    expect(isUnsupportedAgorCodexModel('gpt-5.5')).toBe(false);
+    expect(isUnsupportedAgorCodexModel('internal-model-v1')).toBe(false);
+  });
+
+  it('formats a user-actionable unsupported-model message', () => {
+    const message = formatUnsupportedAgorCodexModelMessage('gpt-5-codex');
+
+    expect(message).toContain('gpt-5-codex');
+    expect(message).toContain('gpt-5.5');
+    expect(message).toContain('user defaults');
+    expect(message).toContain('omit modelConfig');
+  });
+});

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -7,126 +7,263 @@
 /** Default Codex model */
 export const DEFAULT_CODEX_MODEL = 'gpt-5.5';
 
-/** Codex Mini model (GPT-5-Codex-Mini for cost-effective usage) */
-export const CODEX_MINI_MODEL = 'gpt-5-codex-mini';
+/** Codex Mini model for cost-effective usage */
+export const CODEX_MINI_MODEL = 'gpt-5.4-mini';
+
+export type CodexModelStatus = 'current' | 'known';
+export type CodexModelAvailability = 'supported' | 'not-selectable' | 'unsupported';
+
+export type CodexModelLifecycleMetadata = {
+  name: string;
+  description: string;
+  status: CodexModelStatus;
+  selectable: boolean;
+  availability: CodexModelAvailability;
+  replacement?: string;
+};
 
 /**
- * Model metadata for UI display (single source of truth).
+ * Lifecycle-aware model registry (single source of truth).
  *
- * Order matters — the UI dropdown renders models in this order.
+ * Order matters — selectable entries are surfaced in this order.
  *
  * Uses `as const satisfies` to preserve literal key types for CodexModel.
  */
-const _CODEX_MODEL_METADATA = {
+const _CODEX_MODEL_REGISTRY = {
   // GPT-5.5 models (newest frontier model)
   'gpt-5.5': {
     name: 'GPT-5.5 (Recommended)',
     description:
       "OpenAI's newest frontier model for complex coding, computer use, knowledge work, and research workflows in Codex.",
+    status: 'current',
+    selectable: true,
+    availability: 'supported',
   },
   'gpt-5.5-pro': {
     name: 'GPT-5.5 Pro',
     description: 'Higher-compute GPT-5.5 variant for the toughest professional work',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   // GPT-5.4 models
   'gpt-5.4': {
     name: 'GPT-5.4',
     description: 'Frontier model for professional work with strong coding and agentic workflows',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.4-pro': {
     name: 'GPT-5.4 Pro',
     description: 'Higher-compute GPT-5.4 variant for difficult reasoning tasks',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.4-mini': {
     name: 'GPT-5.4 Mini',
     description: 'Fast, efficient model for responsive coding tasks and subagents',
+    status: 'current',
+    selectable: true,
+    availability: 'supported',
   },
   'gpt-5.4-nano': {
     name: 'GPT-5.4 Nano',
     description: 'Lowest-cost GPT-5.4-class model for simple high-volume tasks and subagents',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: CODEX_MINI_MODEL,
   },
   // GPT-5.3 models
   'gpt-5.3-codex': {
     name: 'GPT-5.3 Codex',
-    description: 'Strong agentic coding model - stronger reasoning, 25% faster',
+    description: 'Previous Codex coding model.',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.3-codex-spark': {
     name: 'GPT-5.3 Codex Spark',
     description: 'Real-time coding model, 1000+ tokens/sec (Pro users)',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: CODEX_MINI_MODEL,
   },
   // GPT-5.2 models
   'gpt-5.2-codex': {
     name: 'GPT-5.2 Codex',
-    description: 'Deprecated coding model optimized for agentic tasks - 400k context',
+    description: 'Previous coding model optimized for agentic tasks - 400k context',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.2': {
     name: 'GPT-5.2',
     description: 'Previous frontier model for complex tasks - 400k context, thinking mode',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.2-pro': {
     name: 'GPT-5.2 Pro',
     description: 'Highest accuracy, xhigh reasoning for difficult problems',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.2-instant': {
     name: 'GPT-5.2 Instant',
     description: 'Faster model for writing and information seeking',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: CODEX_MINI_MODEL,
   },
   // GPT-5.1 models
   'gpt-5.1-codex-max': {
     name: 'GPT-5.1 Codex Max',
-    description: 'Deprecated model optimized for long-horizon agentic coding',
+    description: 'Previous model optimized for long-horizon agentic coding',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.1-codex': {
     name: 'GPT-5.1 Codex',
-    description: 'Deprecated model optimized for agentic coding tasks',
+    description: 'Previous model optimized for agentic coding tasks',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5.1-codex-mini': {
     name: 'GPT-5.1 Codex Mini',
-    description: 'Deprecated cost-effective Codex variant',
+    description: 'Previous cost-effective Codex variant',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: CODEX_MINI_MODEL,
   },
   'gpt-5.1': {
     name: 'GPT-5.1',
     description: 'General purpose GPT-5.1 model',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   // GPT-5 models (legacy)
   'gpt-5-codex': {
     name: 'GPT-5 Codex',
     description: 'Legacy model for software engineering',
+    status: 'known',
+    selectable: false,
+    availability: 'unsupported',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-5-codex-mini': {
     name: 'GPT-5 Codex Mini',
     description: 'Legacy faster, lighter model',
+    status: 'known',
+    selectable: false,
+    availability: 'unsupported',
+    replacement: CODEX_MINI_MODEL,
   },
   'gpt-5': {
     name: 'GPT-5',
     description: 'Legacy general purpose model',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   // GPT-4o models
   'gpt-4o': {
     name: 'GPT-4o',
     description: 'General purpose model',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: DEFAULT_CODEX_MODEL,
   },
   'gpt-4o-mini': {
     name: 'GPT-4o Mini',
     description: 'Smaller, faster model',
+    status: 'known',
+    selectable: false,
+    availability: 'not-selectable',
+    replacement: CODEX_MINI_MODEL,
   },
-} as const satisfies Record<string, { name: string; description: string }>;
+} as const satisfies Record<string, CodexModelLifecycleMetadata>;
 
-export const CODEX_MODEL_METADATA = _CODEX_MODEL_METADATA;
+export const CODEX_MODEL_REGISTRY = _CODEX_MODEL_REGISTRY;
+
+export const CODEX_MODEL_METADATA = Object.fromEntries(
+  Object.entries(CODEX_MODEL_REGISTRY)
+    .filter(([, meta]) => meta.selectable)
+    .map(([id, meta]) => [id, { name: meta.name, description: meta.description }])
+) as PickSelectableCodexModelMetadata<typeof CODEX_MODEL_REGISTRY>;
+
+type PickSelectableCodexModelMetadata<T extends Record<string, CodexModelLifecycleMetadata>> = {
+  [K in keyof T as T[K]['selectable'] extends true ? K : never]: {
+    name: T[K]['name'];
+    description: T[K]['description'];
+  };
+};
 
 /** All known Codex model IDs (literal union) */
-export type CodexModel = keyof typeof _CODEX_MODEL_METADATA;
+export type CodexModel = keyof typeof _CODEX_MODEL_REGISTRY;
 
-/** Model aliases for Codex (derived from metadata) */
+/** Selectable model aliases for Codex (derived from metadata) */
 export const CODEX_MODELS = Object.fromEntries(
   Object.keys(CODEX_MODEL_METADATA).map((id) => [id, id])
-) as Record<CodexModel, CodexModel>;
+) as Record<keyof typeof CODEX_MODEL_METADATA, keyof typeof CODEX_MODEL_METADATA>;
+
+export function getCodexModelLifecycle(model?: string): CodexModelLifecycleMetadata | undefined {
+  if (!model) return undefined;
+
+  const normalized = model.toLowerCase();
+  if (CODEX_MODEL_REGISTRY[normalized as CodexModel]) {
+    return CODEX_MODEL_REGISTRY[normalized as CodexModel];
+  }
+
+  const longestFirstEntries = Object.entries(CODEX_MODEL_REGISTRY).sort(
+    ([a], [b]) => b.length - a.length
+  );
+  for (const [id, meta] of longestFirstEntries) {
+    if (normalized.startsWith(`${id}-`)) {
+      return meta;
+    }
+  }
+
+  return undefined;
+}
+
+export function isUnsupportedAgorCodexModel(model?: string): boolean {
+  return getCodexModelLifecycle(model)?.availability === 'unsupported';
+}
+
+export function formatUnsupportedAgorCodexModelMessage(model: string): string {
+  const lifecycle = getCodexModelLifecycle(model);
+  const replacement = lifecycle?.replacement ?? DEFAULT_CODEX_MODEL;
+  return `Codex model "${model}" is a legacy alias that is not supported for Agor Codex sessions. Remove it from the request, parent session, or user defaults; omit modelConfig to use the default (${DEFAULT_CODEX_MODEL}) or use "${replacement}".`;
+}
 
 const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
 
 /**
- * Approximate context window limits for Codex-compatible OpenAI models.
- * Values mirror OpenAI's public docs (May 2026) and fall back to 200k if unknown.
+ * Best-effort limits for known Codex-compatible OpenAI models.
+ * Unknown models fall back to 200k.
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
   // GPT-5.5 models


### PR DESCRIPTION
## Summary

- centralize Codex model lifecycle metadata in `@agor/core`
- expose only documented broad Codex choices through UI/MCP model discovery: `gpt-5.5` and `gpt-5.4-mini`
- keep older/less-certain model IDs known for diagnostics and context-window lookup without advertising them as selectable
- fail fast when a new Codex session, fork, or spawn would use the stale `gpt-5-codex` / `gpt-5-codex-mini` aliases
- add regression coverage for model discovery, suffix matching, and stale default rejection

## Why

A child session failed because an agent pinned a stale Codex model alias. Agor created the child session, then Codex failed later when the executor tried to start it.

This PR moves the decision into Agor before session state is created:

- agents and UI should discover Codex choices from `agor_models_list` / `CODEX_MODEL_METADATA` instead of guessing aliases
- `CODEX_MODEL_REGISTRY` remains broader than the selectable list so Agor can still recognize older IDs, explain failures, and preserve context-limit accounting
- only aliases marked `availability: "unsupported"` are hard-blocked; known-but-not-selectable models are not advertised but are not rejected by this guard

The fix intentionally avoids live entitlement probing or executor-side model discovery. It is a small guardrail around the model strings Agor itself advertises and the stale aliases known to fail this path.

Fixes #1578

## Validation

- `pnpm exec biome ci --no-errors-on-unmatched --files-ignore-unknown=true packages/core/src/models/codex.ts packages/core/src/models/codex.test.ts apps/agor-daemon/src/services/sessions.ts apps/agor-daemon/src/utils/apply-session-config-defaults.ts`
- `pnpm --filter @agor/core test -- src/models/codex.test.ts src/models/lint-model-tool-match.test.ts`
- `pnpm --filter @agor/daemon test -- src/utils/apply-session-config-defaults.test.ts src/mcp/tools/sessions.test.ts`
- `pnpm --filter @agor/executor test -- src/sdk-handlers/codex/models.test.ts`
- `pnpm --filter @agor/core typecheck`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm --filter @agor/executor typecheck`
