### PR TITLE
fix(agor): dev-env browser login — point split-port UI at the daemon

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -23,7 +23,7 @@ environment:
     full:
       start: >-
         UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
-        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} AGOR_RBAC_ENABLED=true AGOR_UNIX_USER_MODE=strict docker compose -f
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} AGOR_RBAC_ENABLED=true AGOR_UNIX_USER_MODE=strict docker compose -f
         docker-compose.yml -f docker-compose.override.postgres.yml -p agor-{{branch.name}}
         --profile postgres up -d --build
       stop: >-
@@ -40,7 +40,7 @@ environment:
     sqlite:
       start: >-
         UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
-        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} SEED=true docker compose -p agor-{{branch.name}} up -d --build
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true docker compose -p agor-{{branch.name}} up -d --build
       stop: docker compose -p agor-{{branch.name}} down
       description: Single-user dev with SQLite. No RBAC. Fastest to boot.
       nuke: docker compose -p agor-{{branch.name}} down -v
@@ -50,7 +50,7 @@ environment:
     postgres:
       start: >-
         UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
-        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} SEED=true docker compose -f docker-compose.yml -f
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true docker compose -f docker-compose.yml -f
         docker-compose.override.postgres.yml -p agor-{{branch.name}} --profile postgres up -d
         --build
       stop: >-

--- a/apps/agor-ui/src/config/daemon.test.ts
+++ b/apps/agor-ui/src/config/daemon.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * getDaemonUrl() resolution order matters for the split-port branch dev env
+ * (issue #1576): vite-dev serves the UI on UI_PORT while the daemon API lives
+ * on DAEMON_PORT, so the SPA must POST /authentication to the daemon — not to
+ * its own origin. These tests lock in that an explicit VITE_DAEMON_URL wins
+ * before any same-origin assumption, while production (bundled UI under /ui)
+ * keeps talking to its own origin.
+ */
+
+const originalLocation = window.location;
+
+function setLocation(href: string): void {
+  Object.defineProperty(window, 'location', {
+    value: new URL(href),
+    writable: true,
+    configurable: true,
+  });
+}
+
+// DEFAULT_DAEMON_URL is computed at module import, so each case re-imports the
+// module after stubbing env + location.
+async function loadGetDaemonUrl(): Promise<() => string> {
+  vi.resetModules();
+  const mod = await import('./daemon');
+  return mod.getDaemonUrl;
+}
+
+describe('getDaemonUrl', () => {
+  beforeEach(() => {
+    // Ensure a clean slate; individual tests stub what they need.
+    vi.stubEnv('VITE_DAEMON_URL', '');
+    vi.stubEnv('VITE_DAEMON_PORT', '3030');
+    vi.stubEnv('BASE_URL', '/');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('prefers an explicit VITE_DAEMON_URL in the split-port dev env', async () => {
+    // UI on :14069, daemon on :12069 — the dev variant injects VITE_DAEMON_URL.
+    vi.stubEnv('VITE_DAEMON_URL', 'http://10.33.92.175:12069');
+    setLocation('http://10.33.92.175:14069/');
+
+    const getDaemonUrl = await loadGetDaemonUrl();
+    expect(getDaemonUrl()).toBe('http://10.33.92.175:12069');
+  });
+
+  it('keeps the same-origin daemon for the bundled production UI (/ui base)', async () => {
+    // Production: daemon serves UI + API on one origin; base is /ui/.
+    vi.stubEnv('BASE_URL', '/ui/');
+    setLocation('https://agor.example.com/ui/login');
+
+    const getDaemonUrl = await loadGetDaemonUrl();
+    expect(getDaemonUrl()).toBe('https://agor.example.com');
+  });
+
+  it('derives the daemon port for root vite-dev when no explicit URL is set', async () => {
+    // Fallback path: no VITE_DAEMON_URL, root base — swap UI port for daemon port.
+    vi.stubEnv('VITE_DAEMON_PORT', '12069');
+    setLocation('http://10.33.92.175:14069/');
+
+    const getDaemonUrl = await loadGetDaemonUrl();
+    expect(getDaemonUrl()).toBe('http://10.33.92.175:12069');
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,8 +106,16 @@ services:
 
       # UI configuration
       - UI_PORT=${UI_PORT:-5173}
-      # UI connects to daemon via localhost (inside container)
+      # Daemon port the browser-side SPA derives its API origin from when no
+      # explicit VITE_DAEMON_URL is given (root-vite-dev resolution).
       - VITE_DAEMON_PORT=${DAEMON_PORT:-3030}
+      # Browser-facing daemon URL. In a split-port branch env the UI is served
+      # by vite-dev on UI_PORT while the daemon API listens on DAEMON_PORT, so
+      # the SPA must POST /authentication to the daemon — not its own origin.
+      # When set (see .agor.yml dev variants) getDaemonUrl() returns this
+      # verbatim, short-circuiting the same-origin assumption. Left empty for
+      # production, which serves UI + API from one origin under /ui.
+      - VITE_DAEMON_URL=${VITE_DAEMON_URL:-}
       # Public, browser-facing base URL used in Slack/GitHub/email links.
       - AGOR_BASE_URL=${AGOR_BASE_URL:-}
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -252,8 +252,12 @@ DAEMON_PID=$!
 sleep 3
 
 # Start UI in foreground (this keeps container alive)
+# VITE_DAEMON_URL (when set by the .agor.yml dev variant) points the browser
+# SPA at the daemon's host:DAEMON_PORT in this split-port env, where vite-dev
+# serves the UI on a different port than the daemon API. Forwarded explicitly
+# so vite exposes it as import.meta.env.VITE_DAEMON_URL.
 echo "🎨 Starting UI on port ${UI_PORT:-5173}..."
-VITE_DAEMON_PORT="${DAEMON_PORT:-3030}" pnpm --filter agor-ui dev --host 0.0.0.0 --port "${UI_PORT:-5173}"
+VITE_DAEMON_PORT="${DAEMON_PORT:-3030}" VITE_DAEMON_URL="${VITE_DAEMON_URL:-}" pnpm --filter agor-ui dev --host 0.0.0.0 --port "${UI_PORT:-5173}"
 
 # If UI exits, kill daemon, executor watch, and core watch
 kill $DAEMON_PID 2>/dev/null || true


### PR DESCRIPTION
## The bug (#1576)

Spinning up a branch **dev environment** (`agor_environment_start`; sqlite/full/postgres variants) breaks **browser login**, blocking the standard "spin env → manually test a PR" flow.

The `agor-dev` container runs the UI as **vite-dev on `UI_PORT`** (e.g. `14069`) and the **daemon API on `DAEMON_PORT`** (e.g. `12069`) — two different ports. The SPA must POST `/authentication` to the daemon, but without an explicit daemon URL `getDaemonUrl()` falls back to the **same-origin** assumption (`window.location.origin`). That's correct in production — where the daemon serves the built UI **and** the API on one origin under `/ui` — but here it sends auth to the **UI** port → `404 (Not Found)` → *"Login Failed — the server returned an unexpected response…"*.

The daemon itself is healthy: `curl -X POST http://<host>:<DAEMON_PORT>/authentication …` returns `201` + an access token.

## The fix

Have the dev variants advertise the daemon explicitly and plumb it through to the vite dev server:

- **`.agor.yml`** — the `sqlite`, `full`, and `postgres` `start` commands now export `VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}}` (the daemon's host:`DAEMON_PORT`).
- **`docker-compose.yml`** — pass `VITE_DAEMON_URL=${VITE_DAEMON_URL:-}` into the `agor-dev` service environment.
- **`docker/docker-entrypoint.sh`** — forward `VITE_DAEMON_URL` explicitly onto the `vite dev` invocation (mirrors the existing `VITE_DAEMON_PORT` handoff) so vite exposes it as `import.meta.env.VITE_DAEMON_URL`.

`getDaemonUrl()` already honors `VITE_DAEMON_URL` (and `window.AGOR_DAEMON_URL`) **before** any same-origin / `/ui` reasoning, so login now resolves straight to the daemon. No app code change is required.

## Why production is unaffected

Production **never sets** `VITE_DAEMON_URL` (it's only injected by the `.agor.yml` dev variants; the compose default is empty). With it unset, `getDaemonUrl()` falls through to the existing resolution and keeps the same-origin behavior for the bundled `/ui` UI. The change is dev-variant-specific and opt-in by construction.

## Testing

- Added `apps/agor-ui/src/config/daemon.test.ts`:
  - explicit `VITE_DAEMON_URL` wins in the split-port dev env (UI `:14069` → daemon `:12069`);
  - bundled production UI (`/ui` base) keeps the same-origin daemon (`window.location.origin`);
  - root vite-dev fallback (no explicit URL) still derives `host:DAEMON_PORT`.
- CI-mirror checks all green locally: `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm --filter agor-ui test` (508 passed), `pnpm --filter agor-ui build`.

Closes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)