### PR TITLE
feat(ui): open ForkSpawnModal when Fork button clicked with empty textarea

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -47,6 +47,7 @@ import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { FileUpload, FileUploadButton } from '../FileUpload';
+import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
 import { MCPServerPill } from '../MCPServer';
 import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
@@ -341,6 +342,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [scrollToBottom, setScrollToBottom] = React.useState<(() => void) | null>(null);
   const [scrollToTop, setScrollToTop] = React.useState<(() => void) | null>(null);
   const [queuedTasks, setQueuedTasks] = React.useState<Task[]>([]);
+  const [forkModalOpen, setForkModalOpen] = React.useState(false);
   const [spawnModalOpen, setSpawnModalOpen] = React.useState(false);
   const [uploadModalOpen, setUploadModalOpen] = React.useState(false);
   const [droppedFiles, setDroppedFiles] = React.useState<File[]>([]);
@@ -647,7 +649,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     if (!session) return;
     const value = promptRef.current?.getValue() ?? '';
     const promptToSend = value.trim();
-    if (!promptToSend) return;
+    if (!promptToSend) {
+      setForkModalOpen(true);
+      return;
+    }
     try {
       await onFork?.(session.session_id, promptToSend);
       // Only clear the compose box + draft on success, so a failed fork
@@ -656,6 +661,13 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     } catch (error) {
       console.error('Fork failed — keeping prompt in compose box:', error);
     }
+  };
+
+  const handleForkModalConfirm = async (config: string | Partial<SpawnConfig>) => {
+    if (!session) return;
+    const prompt = typeof config === 'string' ? config : (config.prompt ?? '');
+    if (!prompt) return;
+    await onFork?.(session.session_id, prompt);
   };
 
   const handleBtwSend = async () => {
@@ -1154,6 +1166,18 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             the user is typing into the REPL directly). */}
         {!(session.agentic_tool === 'claude-code-cli' && cliViewMode === 'terminal') &&
           footerControls}
+
+        {/* Fork modal — opened when Fork button is clicked with an empty textarea */}
+        <ForkSpawnModal
+          open={forkModalOpen}
+          action="fork"
+          session={session}
+          currentUser={currentUserId ? (userById.get(currentUserId) ?? null) : null}
+          onConfirm={handleForkModalConfirm}
+          onCancel={() => setForkModalOpen(false)}
+          client={client}
+          userById={userById}
+        />
 
         {/* File upload modal */}
         {session && (


### PR DESCRIPTION
## Summary

- When the Fork button is clicked with an **empty** compose textarea, a modal now opens (reusing the existing `ForkSpawnModal` with `action="fork"`)
- When the textarea **has text**, the existing fast-path direct fork runs unchanged
- The fork modal shows only the prompt input (callbacks, agent grid, and MCP/env var sections are already hidden by `ForkSpawnModal` when `action="fork"`)
- On success the modal resets and closes; on failure it stays open so the typed prompt is preserved

## Changes

`apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx`:
- Added `forkModalOpen` state
- `handleFork`: returns early with `setForkModalOpen(true)` instead of silently returning when textarea is empty
- Added `handleForkModalConfirm` that calls the existing `onFork` context action
- Imported and rendered `ForkSpawnModal` with `action="fork"` alongside the file-upload modal

No changes to `ForkSpawnModal` itself — `action="fork"` already hides the spawn-only sections.

## Test plan

- [ ] Click Fork button with empty textarea → modal opens titled "Fork Session: {session title}"
- [ ] Enter a prompt in the modal and confirm → fork runs, modal closes
- [ ] Confirm failure case: if fork API fails, modal stays open with prompt intact
- [ ] Click Fork button with text in textarea → direct fork as before (no modal)
- [ ] Cancel modal → modal closes, nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)