### PR TITLE
feat(gateway): webhook channel type with HTTP trigger endpoint and post-actions

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2644,12 +2644,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
                   // Gather trigger context stored at session-creation time
                   const triggerContext = {
-                    prompt: typeof gatewaySource.webhook_prompt === 'string'
-                      ? gatewaySource.webhook_prompt
-                      : '',
-                    summary: typeof gatewaySource.webhook_summary === 'string'
-                      ? gatewaySource.webhook_summary
-                      : '',
+                    prompt:
+                      typeof gatewaySource.webhook_prompt === 'string'
+                        ? gatewaySource.webhook_prompt
+                        : '',
+                    summary:
+                      typeof gatewaySource.webhook_summary === 'string'
+                        ? gatewaySource.webhook_summary
+                        : '',
                     metadata:
                       gatewaySource.webhook_metadata &&
                       typeof gatewaySource.webhook_metadata === 'object'

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2614,13 +2614,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                   const gatewayService = context.app.service(
                     'gateway'
                   ) as unknown as GatewayService;
-                  const gatewaySource =
-                    session.custom_context?.gateway_source as Record<string, unknown> | undefined;
-                  if (!gatewaySource || gatewaySource.channel_type !== 'webhook') return;
+                  const gatewaySource = session.custom_context?.gateway_source as
+                    | Record<string, unknown>
+                    | undefined;
+                  if (!gatewaySource) return;
+                  if (gatewaySource.channel_type !== 'webhook') return;
 
-                  const channelId = typeof gatewaySource.channel_id === 'string'
-                    ? gatewaySource.channel_id
-                    : null;
+                  const channelId =
+                    typeof gatewaySource.channel_id === 'string' ? gatewaySource.channel_id : null;
                   if (!channelId) return;
 
                   const channelRepo = new (await import('@agor/core/db')).GatewayChannelRepository(
@@ -2635,8 +2636,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                     | undefined;
                   if (!postActions) return;
 
-                  const outcome =
-                    session.status === SessionStatus.COMPLETED ? 'success' : 'fail';
+                  const outcome = session.status === SessionStatus.COMPLETED ? 'success' : 'fail';
                   const postAction = postActions[outcome] as
                     | { action: string; gateway_channel_id?: string; message_template?: string }
                     | undefined;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -19,11 +19,12 @@ import {
   ArtifactRepository,
   BoardObjectRepository,
   BoardRepository,
-  type BranchRepository,
+  BranchRepository,
   type Database,
   ScheduleRepository,
   type SessionRepository,
   shortId,
+  TaskRepository,
   UserMCPOAuthTokenRepository,
   type UsersRepository,
 } from '@agor/core/db';
@@ -66,6 +67,7 @@ import {
   GATEWAY_SENSITIVE_CONFIG_FIELDS,
   hasMinimumRole,
   ROLES,
+  SessionStatus,
 } from '@agor/core/types';
 import { executorRuntimeScopeGuard } from './auth/executor-runtime-scope.js';
 import type {
@@ -2598,6 +2600,109 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 );
               }
             });
+
+            // Webhook post-action dispatch (fire-and-forget).
+            // Fires when a webhook-sourced session reaches a terminal state.
+            const terminalStatus: readonly string[] = [
+              SessionStatus.COMPLETED,
+              SessionStatus.FAILED,
+              SessionStatus.TIMED_OUT,
+            ];
+            if (terminalStatus.includes(session.status)) {
+              setImmediate(async () => {
+                try {
+                  const gatewayService = context.app.service(
+                    'gateway'
+                  ) as unknown as GatewayService;
+                  const gatewaySource =
+                    session.custom_context?.gateway_source as Record<string, unknown> | undefined;
+                  if (!gatewaySource || gatewaySource.channel_type !== 'webhook') return;
+
+                  const channelId = typeof gatewaySource.channel_id === 'string'
+                    ? gatewaySource.channel_id
+                    : null;
+                  if (!channelId) return;
+
+                  const channelRepo = new (await import('@agor/core/db')).GatewayChannelRepository(
+                    db
+                  );
+                  const channel = await channelRepo.findById(channelId);
+                  if (!channel) return;
+
+                  const channelCfg = channel.config as Record<string, unknown>;
+                  const postActions = channelCfg.post_actions as
+                    | { success?: Record<string, unknown>; fail?: Record<string, unknown> }
+                    | undefined;
+                  if (!postActions) return;
+
+                  const outcome =
+                    session.status === SessionStatus.COMPLETED ? 'success' : 'fail';
+                  const postAction = postActions[outcome] as
+                    | { action: string; gateway_channel_id?: string; message_template?: string }
+                    | undefined;
+                  if (!postAction || postAction.action === 'none') return;
+
+                  // Gather trigger context stored at session-creation time
+                  const triggerContext = {
+                    prompt: typeof gatewaySource.webhook_prompt === 'string'
+                      ? gatewaySource.webhook_prompt
+                      : '',
+                    summary: typeof gatewaySource.webhook_summary === 'string'
+                      ? gatewaySource.webhook_summary
+                      : '',
+                    metadata:
+                      gatewaySource.webhook_metadata &&
+                      typeof gatewaySource.webhook_metadata === 'object'
+                        ? (gatewaySource.webhook_metadata as Record<string, unknown>)
+                        : {},
+                  };
+
+                  // Gather session outcome context
+                  const taskRepo = new TaskRepository(db);
+                  const tasks = await taskRepo.findBySession(session.session_id);
+                  const latestTask = tasks.at(-1);
+                  const errorMsg = latestTask?.error_message ?? undefined;
+                  let durationS: number | undefined;
+                  if (latestTask?.started_at && latestTask?.completed_at) {
+                    durationS = Math.round(
+                      (new Date(latestTask.completed_at).getTime() -
+                        new Date(latestTask.started_at).getTime()) /
+                        1000
+                    );
+                  }
+
+                  // Branch name for template
+                  let branchName: string | undefined;
+                  if (session.branch_id) {
+                    const bRepo = new BranchRepository(db);
+                    const branch = await bRepo.findById(session.branch_id);
+                    branchName = branch?.name;
+                  }
+
+                  await gatewayService.firePostAction({
+                    postAction: {
+                      action: postAction.action as 'none' | 'channel_message',
+                      gateway_channel_id: postAction.gateway_channel_id,
+                      message_template: postAction.message_template,
+                    },
+                    triggerContext,
+                    sessionOutcome: {
+                      id: session.session_id,
+                      status: session.status,
+                      error: errorMsg,
+                      duration_s: durationS,
+                      branch_name: branchName,
+                    },
+                    emittedByUserId: session.created_by,
+                  });
+                } catch (err) {
+                  console.warn(
+                    `[gateway] Webhook post-action failed for session ${shortId(session.session_id)}:`,
+                    err
+                  );
+                }
+              });
+            }
 
             if (shouldDrainQueueAfterSessionPostTurnPatch(session, context.params)) {
               // Use setImmediate to avoid blocking the patch response

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -65,6 +65,7 @@ import {
   TaskStatus,
 } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
+import crypto from 'node:crypto';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
@@ -3756,6 +3757,133 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       }
     }
   }
+
+  // ============================================================================
+  // Webhook inbound trigger endpoint
+  //
+  // POST /v1/gateway/inbound/:channel_key
+  //
+  // Unauthenticated — the channel_key in the path IS the auth credential.
+  // Optional HMAC-SHA256 verification via X-Agor-Signature: sha256=<hex>.
+  // ============================================================================
+
+  // biome-ignore lint/suspicious/noExplicitAny: Express route method not on FeathersJS Application type
+  (app as any).post('/v1/gateway/inbound/:channel_key', async (req: any, res: any) => {
+    // Mask the channel_key in all logs — only log a short prefix for correlation
+    const rawKey: string = req.params.channel_key ?? '';
+    const keyHint = rawKey.slice(0, 8) || '(empty)';
+
+    if (!rawKey) {
+      return res.status(400).json({ error: 'channel_key is required' });
+    }
+
+    const body = req.body as Record<string, unknown>;
+
+    if (!body || typeof body.prompt !== 'string' || !body.prompt.trim()) {
+      return res.status(400).json({ error: 'prompt (string) is required' });
+    }
+
+    // Look up the channel early so we can verify HMAC before doing more work
+    const channelRepo = new (await import('@agor/core/db')).GatewayChannelRepository(db);
+    const channel = await channelRepo.findByKey(rawKey).catch(() => null);
+
+    if (!channel) {
+      // Return 401 without revealing whether the key exists
+      console.warn(`[webhook-inbound] Unknown channel_key hint=${keyHint}`);
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    if (!channel.enabled) {
+      return res.status(403).json({ error: 'Channel is disabled' });
+    }
+
+    // HMAC-SHA256 verification (optional — only when webhook_secret is configured)
+    const channelConfig = channel.config as Record<string, unknown>;
+    const webhookSecret = typeof channelConfig.webhook_secret === 'string'
+      ? channelConfig.webhook_secret
+      : null;
+
+    if (webhookSecret) {
+      const signatureHeader = req.headers['x-agor-signature'] as string | undefined;
+      if (!signatureHeader?.startsWith('sha256=')) {
+        return res.status(401).json({ error: 'Missing X-Agor-Signature header' });
+      }
+      const providedHex = signatureHeader.slice('sha256='.length);
+
+      // Compute HMAC over the raw request body
+      const rawBody: Buffer = (req as unknown as { rawBody?: Buffer }).rawBody ??
+        Buffer.from(JSON.stringify(body));
+      const expectedHmac = crypto
+        .createHmac('sha256', webhookSecret)
+        .update(rawBody)
+        .digest('hex');
+
+      const expectedBuf = Buffer.from(expectedHmac, 'hex');
+      const providedBuf = Buffer.from(providedHex, 'hex');
+      // timingSafeEqual requires equal lengths — use alloc(32) on mismatch so
+      // the comparison always runs in constant time but returns false.
+      const signatureValid = crypto.timingSafeEqual(
+        providedBuf.length === expectedBuf.length ? providedBuf : Buffer.alloc(32),
+        expectedBuf
+      );
+
+      if (!signatureValid) {
+        console.warn(`[webhook-inbound] HMAC mismatch for channel hint=${keyHint}`);
+        return res.status(401).json({ error: 'Signature mismatch' });
+      }
+    }
+
+    // Auto-generate thread_id if caller did not supply one
+    const threadId: string =
+      typeof body.thread_id === 'string' && body.thread_id.trim()
+        ? body.thread_id.trim()
+        : generateId();
+
+    const prompt = (body.prompt as string).trim();
+    const summary = typeof body.summary === 'string' ? body.summary : undefined;
+    const extraMetadata =
+      body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+        ? (body.metadata as Record<string, unknown>)
+        : {};
+
+    try {
+      const gatewayService = app.service('gateway') as unknown as GatewayService;
+      const result = await gatewayService.create({
+        channel_key: rawKey,
+        thread_id: threadId,
+        text: prompt,
+        metadata: {
+          ...extraMetadata,
+          // Store trigger fields for post-action template resolution
+          webhook_prompt: prompt,
+          ...(summary ? { webhook_summary: summary } : {}),
+          ...(Object.keys(extraMetadata).length > 0 ? { webhook_metadata: extraMetadata } : {}),
+        },
+      });
+
+      if (!result.success) {
+        return res.status(400).json({ error: 'Failed to process inbound message' });
+      }
+
+      const response: Record<string, unknown> = {
+        session_id: result.sessionId,
+        thread_id: threadId,
+        status: result.taskStatus === 'queued' ? 'queued' : 'started',
+      };
+      if (result.taskQueuePosition !== undefined) {
+        response.queue_position = result.taskQueuePosition;
+      }
+
+      console.log(
+        `[webhook-inbound] Processed: hint=${keyHint} session=${shortId(result.sessionId)} status=${response.status}`
+      );
+      return res.status(200).json(response);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[webhook-inbound] Error for hint=${keyHint}: ${message}`);
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
 
   // ============================================================================
   // MCP routes

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -6,6 +6,7 @@
  * Extracted from index.ts for maintainability.
  */
 
+import crypto from 'node:crypto';
 import { type AgorConfig, loadConfig, resolveBranchStorageConfig } from '@agor/core/config';
 import {
   BranchRepository,
@@ -65,7 +66,6 @@ import {
   TaskStatus,
 } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
-import crypto from 'node:crypto';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
@@ -3799,9 +3799,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
     // HMAC-SHA256 verification (optional — only when webhook_secret is configured)
     const channelConfig = channel.config as Record<string, unknown>;
-    const webhookSecret = typeof channelConfig.webhook_secret === 'string'
-      ? channelConfig.webhook_secret
-      : null;
+    const webhookSecret =
+      typeof channelConfig.webhook_secret === 'string' ? channelConfig.webhook_secret : null;
 
     if (webhookSecret) {
       const signatureHeader = req.headers['x-agor-signature'] as string | undefined;
@@ -3811,12 +3810,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       const providedHex = signatureHeader.slice('sha256='.length);
 
       // Compute HMAC over the raw request body
-      const rawBody: Buffer = (req as unknown as { rawBody?: Buffer }).rawBody ??
-        Buffer.from(JSON.stringify(body));
-      const expectedHmac = crypto
-        .createHmac('sha256', webhookSecret)
-        .update(rawBody)
-        .digest('hex');
+      const rawBody: Buffer =
+        (req as unknown as { rawBody?: Buffer }).rawBody ?? Buffer.from(JSON.stringify(body));
+      const expectedHmac = crypto.createHmac('sha256', webhookSecret).update(rawBody).digest('hex');
 
       const expectedBuf = Buffer.from(expectedHmac, 'hex');
       const providedBuf = Buffer.from(providedHex, 'hex');

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -48,9 +48,9 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
-import Handlebars from 'handlebars';
 import { hasMinimumRole, ROLES, SessionStatus } from '@agor/core/types';
 import { getSessionUrl } from '@agor/core/utils/url';
+import Handlebars from 'handlebars';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
 
 /**

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -40,6 +40,7 @@ import type {
   GatewayOutboundMessageID,
   MCPServerID,
   MessageSource,
+  PostActionConfig,
   Session,
   SessionID,
   Task,
@@ -47,6 +48,7 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
+import Handlebars from 'handlebars';
 import { hasMinimumRole, ROLES, SessionStatus } from '@agor/core/types';
 import { getSessionUrl } from '@agor/core/utils/url';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
@@ -69,6 +71,8 @@ interface PostMessageResult {
   success: boolean;
   sessionId: string;
   created: boolean;
+  taskStatus?: 'running' | 'queued';
+  taskQueuePosition?: number;
 }
 
 /**
@@ -401,6 +405,12 @@ function buildGatewayContext(channel: GatewayChannel, data: PostMessageData): Ga
         userEmail: (meta.teams_user_email as string) ?? undefined,
       };
     }
+
+    case 'webhook':
+      return {
+        platform: 'webhook',
+        userName: data.user_name,
+      };
 
     default:
       // Generic fallback for future platforms
@@ -1713,6 +1723,19 @@ export class GatewayService {
         gatewaySource.proactive_seed = true;
       }
 
+      // Add webhook-specific trigger context so post-actions can read it later
+      if (channel.channel_type === 'webhook') {
+        if (data.metadata?.webhook_prompt) {
+          gatewaySource.webhook_prompt = data.metadata.webhook_prompt;
+        }
+        if (data.metadata?.webhook_summary) {
+          gatewaySource.webhook_summary = data.metadata.webhook_summary;
+        }
+        if (data.metadata?.webhook_metadata) {
+          gatewaySource.webhook_metadata = data.metadata.webhook_metadata;
+        }
+      }
+
       // Add GitHub-specific metadata for richer context
       if (channel.channel_type === 'github') {
         try {
@@ -1905,7 +1928,12 @@ export class GatewayService {
         { route: { id: sessionId }, user }
       );
 
+      let taskStatus: PostMessageResult['taskStatus'] = 'running';
+      let taskQueuePosition: number | undefined;
+
       if (task.status === 'queued') {
+        taskStatus = 'queued';
+        taskQueuePosition = task.queue_position;
         console.log(
           `[gateway] Message queued for session ${shortId(sessionId)} at position ${task.queue_position}`
         );
@@ -1931,6 +1959,14 @@ export class GatewayService {
           task_id: task.task_id,
         });
       }
+
+      return {
+        success: true,
+        sessionId,
+        created,
+        taskStatus,
+        taskQueuePosition,
+      };
     } catch (error) {
       console.error('[gateway] Failed to send prompt to session:', error);
       this.sendSystemMessage(channel, data.thread_id, `Error sending prompt: ${error}`);
@@ -2102,6 +2138,84 @@ export class GatewayService {
         `[gateway] Failed to flush GitHub buffer for session ${shortId(sessionId)} (re-queued):`,
         error
       );
+    }
+  }
+
+  /**
+   * Execute a webhook post-action after a session reaches a terminal state.
+   *
+   * Called by the sessions.after.patch hook when a webhook-sourced session
+   * transitions to completed / failed / timed_out. Renders the configured
+   * Handlebars template and dispatches via the target gateway channel.
+   */
+  async firePostAction(opts: {
+    postAction: PostActionConfig;
+    triggerContext: {
+      prompt?: string;
+      summary?: string;
+      metadata?: Record<string, unknown>;
+    };
+    sessionOutcome: {
+      id: string;
+      status: string;
+      error?: string;
+      duration_s?: number;
+      branch_name?: string;
+    };
+    emittedByUserId: UserID;
+  }): Promise<void> {
+    if (opts.postAction.action !== 'channel_message') return;
+    if (!opts.postAction.gateway_channel_id) {
+      console.warn('[gateway] firePostAction: channel_message requires gateway_channel_id');
+      return;
+    }
+    if (!opts.postAction.message_template) {
+      console.warn('[gateway] firePostAction: channel_message requires message_template');
+      return;
+    }
+
+    const targetChannel = await this.channelRepo.findById(opts.postAction.gateway_channel_id);
+    if (!targetChannel?.enabled) {
+      console.warn(
+        `[gateway] firePostAction: target channel ${shortId(opts.postAction.gateway_channel_id)} not found or disabled`
+      );
+      return;
+    }
+
+    let renderedMessage: string;
+    try {
+      const compiledTemplate = Handlebars.compile(opts.postAction.message_template);
+      renderedMessage = compiledTemplate({
+        trigger: {
+          prompt: opts.triggerContext.prompt ?? '',
+          summary: opts.triggerContext.summary ?? '',
+          metadata: opts.triggerContext.metadata ?? {},
+        },
+        session: {
+          id: opts.sessionOutcome.id,
+          status: opts.sessionOutcome.status,
+          error: opts.sessionOutcome.error ?? '',
+          duration_s: opts.sessionOutcome.duration_s ?? 0,
+          branch: { name: opts.sessionOutcome.branch_name ?? '' },
+        },
+      });
+    } catch (err) {
+      console.error('[gateway] firePostAction: Handlebars render failed:', err);
+      return;
+    }
+
+    try {
+      await this.emitMessage({
+        gatewayChannelId: opts.postAction.gateway_channel_id,
+        message: renderedMessage,
+        purpose: 'webhook_post_action',
+        emittedByUserId: opts.emittedByUserId,
+      });
+      console.log(
+        `[gateway] Post-action message dispatched via channel ${shortId(opts.postAction.gateway_channel_id)}`
+      );
+    } catch (err) {
+      console.error('[gateway] firePostAction: Failed to dispatch message:', err);
     }
   }
 

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,11 +1,7 @@
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef } from 'react';
-import {
-  AGOR_CLOUD_DEMO_URL,
-  DISCORD_INVITE_URL,
-  GITHUB_REPO_URL,
-} from '../lib/links';
+import { AGOR_CLOUD_DEMO_URL, DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
 import styles from './LandingPage.module.css';
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -8,15 +8,18 @@ import type {
   GatewayEnvVar,
   MCPServer,
   PermissionMode,
+  PostActionConfig,
   User,
   UUID,
 } from '@agor-live/client';
 import {
+  ApiOutlined,
   CopyOutlined,
   DeleteOutlined,
   EditOutlined,
   GithubOutlined,
   KeyOutlined,
+  LinkOutlined,
   LoadingOutlined,
   LockOutlined,
   MessageOutlined,
@@ -48,6 +51,7 @@ import {
   Steps,
   Switch,
   Table,
+  Tabs,
   Tag,
   Tooltip,
   Typography,
@@ -85,6 +89,7 @@ const CHANNEL_TYPE_OPTIONS: { value: ChannelType; label: string; icon: React.Rea
   { value: 'slack', label: 'Slack', icon: <SlackOutlined /> },
   { value: 'github', label: 'GitHub', icon: <GithubOutlined /> },
   { value: 'teams', label: 'Microsoft Teams', icon: <TeamOutlined /> },
+  { value: 'webhook', label: 'Webhook (HTTP)', icon: <ApiOutlined /> },
   { value: 'discord', label: 'Discord', icon: <MessageOutlined /> },
   { value: 'whatsapp', label: 'WhatsApp', icon: <MessageOutlined /> },
   { value: 'telegram', label: 'Telegram', icon: <MessageOutlined /> },
@@ -98,6 +103,8 @@ function getChannelTypeIcon(type: ChannelType): React.ReactNode {
       return <GithubOutlined />;
     case 'teams':
       return <TeamOutlined />;
+    case 'webhook':
+      return <ApiOutlined />;
     default:
       return <MessageOutlined />;
   }
@@ -111,6 +118,8 @@ function getChannelTypeColor(type: ChannelType): string {
       return 'default';
     case 'teams':
       return 'geekblue';
+    case 'webhook':
+      return 'orange';
     case 'discord':
       return 'blue';
     case 'whatsapp':
@@ -328,6 +337,86 @@ const GatewayEnvVarsEditor: React.FC<{
 };
 
 // ============================================================================
+// Webhook Post-Action Form Fields
+// ============================================================================
+
+const POST_ACTION_OPTIONS = [
+  { value: 'none', label: 'Do nothing' },
+  { value: 'channel_message', label: 'Send via channel' },
+];
+
+const TEMPLATE_HELP = `Available variables:
+{{ trigger.prompt }}   — original webhook prompt
+{{ trigger.summary }}  — optional summary field
+{{ trigger.metadata.* }} — any metadata fields
+{{ session.id }}
+{{ session.status }}
+{{ session.error }}    — error message (on fail)
+{{ session.duration_s }}
+{{ session.branch.name }}`;
+
+const WebhookPostActionFields: React.FC<{
+  prefix: string;
+  form: FormInstance;
+  gatewayChannelById: Map<string, GatewayChannel>;
+}> = ({ prefix, form, gatewayChannelById }) => {
+  const action = Form.useWatch(`${prefix}_action`, form) ?? 'none';
+
+  return (
+    <Space orientation="vertical" style={{ width: '100%' }} size="small">
+      <Form.Item
+        label="Action"
+        name={`${prefix}_action`}
+        initialValue="none"
+      >
+        <Select options={POST_ACTION_OPTIONS} style={{ width: 220 }} />
+      </Form.Item>
+
+      {action === 'channel_message' && (
+        <>
+          <Form.Item
+            label="Target channel"
+            name={`${prefix}_gateway_channel_id`}
+            rules={[{ required: true, message: 'Select a gateway channel' }]}
+            tooltip="Gateway channel to send the notification through (must support outbound)"
+          >
+            <Select placeholder="Select a gateway channel" showSearch optionFilterProp="label">
+              {Array.from(gatewayChannelById.values())
+                .filter((ch) => ch.channel_type !== 'webhook')
+                .map((ch) => (
+                  <Select.Option key={ch.id} value={ch.id} label={ch.name}>
+                    <Space size="small">
+                      {ch.name}
+                      <Tag style={{ fontSize: 10 }}>{ch.channel_type}</Tag>
+                    </Space>
+                  </Select.Option>
+                ))}
+            </Select>
+          </Form.Item>
+
+          <Form.Item
+            label="Message template"
+            name={`${prefix}_message_template`}
+            rules={[{ required: true, message: 'Enter a message template' }]}
+            tooltip={TEMPLATE_HELP}
+          >
+            <Input.TextArea
+              rows={4}
+              placeholder="Session {{ session.id }} finished in {{ session.duration_s }}s"
+              style={{ fontFamily: 'monospace', fontSize: 12 }}
+            />
+          </Form.Item>
+
+          <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+            Handlebars template. Hover the label for available variables.
+          </Typography.Text>
+        </>
+      )}
+    </Space>
+  );
+};
+
+// ============================================================================
 // GitHub App Setup Types & Helpers
 // ============================================================================
 
@@ -353,6 +442,7 @@ const ChannelFormFields: React.FC<{
   branchById: Map<string, Branch>;
   userById: Map<string, User>;
   mcpServerById: Map<string, MCPServer>;
+  gatewayChannelById: Map<string, GatewayChannel>;
   selectedAgent: string;
   onAgentChange: (agent: string) => void;
   editingChannel?: GatewayChannel | null;
@@ -371,6 +461,7 @@ const ChannelFormFields: React.FC<{
   branchById,
   userById,
   mcpServerById,
+  gatewayChannelById,
   selectedAgent,
   onAgentChange,
   editingChannel,
@@ -456,15 +547,18 @@ const ChannelFormFields: React.FC<{
         <Switch />
       </Form.Item>
 
-      {channelType !== 'slack' && channelType !== 'github' && channelType !== 'teams' && (
-        <Alert
-          title={`${channelType.charAt(0).toUpperCase() + channelType.slice(1)} support coming soon`}
-          description="This platform integration is not yet available. Slack, GitHub, and Microsoft Teams are currently supported."
-          type="info"
-          showIcon
-          style={{ marginBottom: 16 }}
-        />
-      )}
+      {channelType !== 'slack' &&
+        channelType !== 'github' &&
+        channelType !== 'teams' &&
+        channelType !== 'webhook' && (
+          <Alert
+            title={`${channelType.charAt(0).toUpperCase() + channelType.slice(1)} support coming soon`}
+            description="This platform integration is not yet available. Slack, GitHub, Microsoft Teams, and Webhook are currently supported."
+            type="info"
+            showIcon
+            style={{ marginBottom: 16 }}
+          />
+        )}
 
       {/* ── GitHub App Setup Wizard ── */}
       {channelType === 'github' && (
@@ -873,6 +967,174 @@ const ChannelFormFields: React.FC<{
             />
           )}
         </>
+      )}
+
+      {/* ── Collapsible sections (Webhook) ── */}
+      {channelType === 'webhook' && (
+        <Collapse
+          ghost
+          destroyOnHidden={false}
+          defaultActiveKey={['webhook-config', 'agentic-tool-config']}
+          style={{ marginLeft: -16, marginRight: -16 }}
+          items={[
+            // ── Webhook URL + Security ──
+            {
+              key: 'webhook-config',
+              label: (
+                <SectionLabel
+                  icon={<LinkOutlined />}
+                  title="Webhook Configuration"
+                  subtitle="endpoint & optional HMAC secret"
+                />
+              ),
+              children: (
+                <>
+                  {mode === 'edit' && editingChannel && (
+                    <Form.Item label="Webhook URL">
+                      <Input.Search
+                        value={`${getDaemonUrl()}/v1/gateway/inbound/${editingChannel.channel_key}`}
+                        readOnly
+                        enterButton={<CopyOutlined />}
+                        onSearch={() =>
+                          onCopyKey?.(
+                            `${getDaemonUrl()}/v1/gateway/inbound/${editingChannel.channel_key}`
+                          )
+                        }
+                        style={{ fontFamily: 'monospace', fontSize: 12 }}
+                      />
+                      <Typography.Text
+                        type="secondary"
+                        style={{ fontSize: 12, marginTop: 4, display: 'block' }}
+                      >
+                        POST to this URL with{' '}
+                        <code>{'{ "prompt": "..." }'}</code> to trigger an agent session.
+                      </Typography.Text>
+                    </Form.Item>
+                  )}
+
+                  <Form.Item
+                    label="Webhook Secret"
+                    name="webhook_secret"
+                    tooltip="Optional HMAC-SHA256 secret. When set, requests must include X-Agor-Signature: sha256=<hmac> header."
+                  >
+                    <Input.Password
+                      placeholder={
+                        mode === 'edit' ? '••••••••' : 'Optional — leave blank to skip verification'
+                      }
+                    />
+                  </Form.Item>
+
+                  <Alert
+                    type="info"
+                    showIcon
+                    message="Request format"
+                    description={
+                      <div style={{ fontSize: 12 }}>
+                        <p style={{ margin: '4px 0' }}>
+                          <strong>Required:</strong> <code>prompt</code> (string)
+                        </p>
+                        <p style={{ margin: '4px 0' }}>
+                          <strong>Optional:</strong> <code>summary</code>, <code>thread_id</code>,{' '}
+                          <code>metadata</code> (object)
+                        </p>
+                        <p style={{ margin: '4px 0' }}>
+                          Reuse the same <code>thread_id</code> to continue an existing session.
+                        </p>
+                      </div>
+                    }
+                  />
+                </>
+              ),
+            },
+
+            // ── Post-actions ──
+            {
+              key: 'post-actions',
+              label: (
+                <SectionLabel
+                  icon={<ThunderboltOutlined />}
+                  title="Post-actions"
+                  subtitle="notify when session completes or fails"
+                />
+              ),
+              children: (
+                <Tabs
+                  defaultActiveKey="success"
+                  items={[
+                    {
+                      key: 'success',
+                      label: 'On success',
+                      children: (
+                        <WebhookPostActionFields
+                          prefix="post_action_success"
+                          form={form}
+                          gatewayChannelById={gatewayChannelById}
+                        />
+                      ),
+                    },
+                    {
+                      key: 'fail',
+                      label: 'On fail',
+                      children: (
+                        <WebhookPostActionFields
+                          prefix="post_action_fail"
+                          form={form}
+                          gatewayChannelById={gatewayChannelById}
+                        />
+                      ),
+                    },
+                  ]}
+                />
+              ),
+            },
+
+            // ── Agent Configuration ──
+            {
+              key: 'agentic-tool-config',
+              label: (
+                <SectionLabel
+                  icon={<ThunderboltOutlined />}
+                  title="Agent Configuration"
+                  subtitle={selectedAgent}
+                />
+              ),
+              children: (
+                <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
+                  <AgentSelectionGrid
+                    agents={AVAILABLE_AGENTS}
+                    selectedAgentId={selectedAgent}
+                    onSelect={onAgentChange}
+                    columns={2}
+                    showHelperText={false}
+                    showComparisonLink={false}
+                  />
+                  <AgenticToolConfigForm
+                    agenticTool={selectedAgent as AgenticToolName}
+                    mcpServerById={mcpServerById}
+                    showHelpText={false}
+                  />
+                </Space>
+              ),
+            },
+
+            // ── Environment Variables ──
+            {
+              key: 'env-vars',
+              label: (
+                <SectionLabel
+                  icon={<LockOutlined />}
+                  title="Environment Variables"
+                  subtitle="channel-level secrets"
+                />
+              ),
+              children: (
+                <Form.Item name="envVars" noStyle>
+                  <GatewayEnvVarsEditor />
+                </Form.Item>
+              ),
+            },
+          ]}
+        />
       )}
 
       {/* ── Collapsible sections (Teams) ── */}
@@ -1675,6 +1937,26 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
           // validateJSON rule handles the error display
         }
       }
+    } else if (values.channel_type === 'webhook') {
+      if (values.webhook_secret) config.webhook_secret = values.webhook_secret;
+      // Build post_actions config
+      const buildPostAction = (prefix: string): PostActionConfig | undefined => {
+        const action = (values[`${prefix}_action`] as string | undefined) ?? 'none';
+        if (action === 'none') return { action: 'none' };
+        return {
+          action: 'channel_message',
+          gateway_channel_id: values[`${prefix}_gateway_channel_id`] as string | undefined,
+          message_template: values[`${prefix}_message_template`] as string | undefined,
+        };
+      };
+      const successAction = buildPostAction('post_action_success');
+      const failAction = buildPostAction('post_action_fail');
+      if (successAction || failAction) {
+        config.post_actions = {
+          ...(successAction ? { success: successAction } : {}),
+          ...(failAction ? { fail: failAction } : {}),
+        };
+      }
     } else if (values.channel_type === 'teams') {
       if (values.teams_app_id) config.app_id = values.teams_app_id;
       if (values.teams_app_password) config.app_password = values.teams_app_password;
@@ -1821,6 +2103,23 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       const userMap = config?.user_map as Record<string, string> | undefined;
       if (userMap && typeof userMap === 'object' && Object.keys(userMap).length > 0) {
         formValues.github_user_map = JSON.stringify(userMap, null, 2);
+      }
+    } else if (channel.channel_type === 'webhook') {
+      // webhook_secret stays blank on edit (server redacts it)
+      const postActions = config?.post_actions as
+        | { success?: PostActionConfig; fail?: PostActionConfig }
+        | undefined;
+      if (postActions?.success) {
+        formValues.post_action_success_action = postActions.success.action ?? 'none';
+        formValues.post_action_success_gateway_channel_id =
+          postActions.success.gateway_channel_id;
+        formValues.post_action_success_message_template =
+          postActions.success.message_template;
+      }
+      if (postActions?.fail) {
+        formValues.post_action_fail_action = postActions.fail.action ?? 'none';
+        formValues.post_action_fail_gateway_channel_id = postActions.fail.gateway_channel_id;
+        formValues.post_action_fail_message_template = postActions.fail.message_template;
       }
     } else if (channel.channel_type === 'teams') {
       formValues.teams_app_id = config?.app_id;
@@ -2100,6 +2399,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             branchById={branchOptionsById}
             userById={userById}
             mcpServerById={mcpServerById}
+            gatewayChannelById={gatewayChannelById}
             selectedAgent={selectedAgent}
             onAgentChange={setSelectedAgent}
             githubStep={githubStep}
@@ -2135,6 +2435,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             branchById={branchOptionsById}
             userById={userById}
             mcpServerById={mcpServerById}
+            gatewayChannelById={gatewayChannelById}
             selectedAgent={selectedAgent}
             onAgentChange={setSelectedAgent}
             editingChannel={editingChannel}
@@ -2173,30 +2474,85 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         <Result
           status="success"
           title="Channel Created"
-          subTitle="Your gateway channel has been created. Use the channel key below to configure your platform integration."
+          subTitle={
+            createdChannelType === 'webhook'
+              ? 'Your webhook channel is ready. Copy the URL below to start receiving triggers.'
+              : 'Your gateway channel has been created. Use the channel key below to configure your platform integration.'
+          }
         />
         {createdChannelKey && createdChannelKey !== 'pending' && (
           <div style={{ padding: '0 24px 16px' }}>
-            <Alert
-              title="Channel Key"
-              description={
-                <Space orientation="vertical" style={{ width: '100%' }}>
-                  <Input.Search
-                    value={createdChannelKey}
-                    readOnly
-                    enterButton={<CopyOutlined />}
-                    onSearch={() => handleCopyKey(createdChannelKey)}
-                    style={{ fontFamily: 'monospace' }}
-                  />
-                  <Typography.Text type="warning" style={{ fontSize: 12 }}>
-                    Keep this key secret — it authenticates messages from the platform to Agor.
-                  </Typography.Text>
-                </Space>
-              }
-              type="warning"
-              showIcon
-              style={{ marginBottom: 16 }}
-            />
+            {createdChannelType === 'webhook' ? (
+              <Alert
+                title="Webhook URL"
+                description={
+                  <Space orientation="vertical" style={{ width: '100%' }}>
+                    <Input.Search
+                      value={`${getDaemonUrl()}/v1/gateway/inbound/${createdChannelKey}`}
+                      readOnly
+                      enterButton={<CopyOutlined />}
+                      onSearch={() =>
+                        handleCopyKey(
+                          `${getDaemonUrl()}/v1/gateway/inbound/${createdChannelKey}`
+                        )
+                      }
+                      style={{ fontFamily: 'monospace', fontSize: 12 }}
+                    />
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      POST with <code>{'{ "prompt": "..." }'}</code> to trigger an agent session.
+                    </Typography.Text>
+                    <Typography.Text type="warning" style={{ fontSize: 12 }}>
+                      Keep this URL secret — the path contains the auth key.
+                    </Typography.Text>
+                  </Space>
+                }
+                type="success"
+                showIcon
+                style={{ marginBottom: 16 }}
+              />
+            ) : (
+              <Alert
+                title="Channel Key"
+                description={
+                  <Space orientation="vertical" style={{ width: '100%' }}>
+                    <Input.Search
+                      value={createdChannelKey}
+                      readOnly
+                      enterButton={<CopyOutlined />}
+                      onSearch={() => handleCopyKey(createdChannelKey)}
+                      style={{ fontFamily: 'monospace' }}
+                    />
+                    <Typography.Text type="warning" style={{ fontSize: 12 }}>
+                      Keep this key secret — it authenticates messages from the platform to Agor.
+                    </Typography.Text>
+                  </Space>
+                }
+                type="warning"
+                showIcon
+                style={{ marginBottom: 16 }}
+              />
+            )}
+            {createdChannelType === 'webhook' && (
+              <Alert
+                title="Webhook Setup"
+                description={
+                  <div style={{ fontSize: 12 }}>
+                    <p style={{ margin: '0 0 4px' }}>
+                      <strong>Required field:</strong> <code>prompt</code> (string)
+                    </p>
+                    <p style={{ margin: '0 0 4px' }}>
+                      <strong>Optional fields:</strong> <code>summary</code>,{' '}
+                      <code>thread_id</code>, <code>metadata</code>
+                    </p>
+                    <p style={{ margin: 0 }}>
+                      Reuse the same <code>thread_id</code> to continue the same session.
+                    </p>
+                  </div>
+                }
+                type="info"
+                showIcon
+              />
+            )}
             {createdChannelType === 'slack' && (
               <Alert
                 title="Slack Setup"

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -364,11 +364,7 @@ const WebhookPostActionFields: React.FC<{
 
   return (
     <Space orientation="vertical" style={{ width: '100%' }} size="small">
-      <Form.Item
-        label="Action"
-        name={`${prefix}_action`}
-        initialValue="none"
-      >
+      <Form.Item label="Action" name={`${prefix}_action`} initialValue="none">
         <Select options={POST_ACTION_OPTIONS} style={{ width: 220 }} />
       </Form.Item>
 
@@ -1006,8 +1002,8 @@ const ChannelFormFields: React.FC<{
                         type="secondary"
                         style={{ fontSize: 12, marginTop: 4, display: 'block' }}
                       >
-                        POST to this URL with{' '}
-                        <code>{'{ "prompt": "..." }'}</code> to trigger an agent session.
+                        POST to this URL with <code>{'{ "prompt": "..." }'}</code> to trigger an
+                        agent session.
                       </Typography.Text>
                     </Form.Item>
                   )}
@@ -2111,10 +2107,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         | undefined;
       if (postActions?.success) {
         formValues.post_action_success_action = postActions.success.action ?? 'none';
-        formValues.post_action_success_gateway_channel_id =
-          postActions.success.gateway_channel_id;
-        formValues.post_action_success_message_template =
-          postActions.success.message_template;
+        formValues.post_action_success_gateway_channel_id = postActions.success.gateway_channel_id;
+        formValues.post_action_success_message_template = postActions.success.message_template;
       }
       if (postActions?.fail) {
         formValues.post_action_fail_action = postActions.fail.action ?? 'none';
@@ -2492,9 +2486,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
                       readOnly
                       enterButton={<CopyOutlined />}
                       onSearch={() =>
-                        handleCopyKey(
-                          `${getDaemonUrl()}/v1/gateway/inbound/${createdChannelKey}`
-                        )
+                        handleCopyKey(`${getDaemonUrl()}/v1/gateway/inbound/${createdChannelKey}`)
                       }
                       style={{ fontFamily: 'monospace', fontSize: 12 }}
                     />
@@ -2541,8 +2533,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
                       <strong>Required field:</strong> <code>prompt</code> (string)
                     </p>
                     <p style={{ margin: '0 0 4px' }}>
-                      <strong>Optional fields:</strong> <code>summary</code>,{' '}
-                      <code>thread_id</code>, <code>metadata</code>
+                      <strong>Optional fields:</strong> <code>summary</code>, <code>thread_id</code>
+                      , <code>metadata</code>
                     </p>
                     <p style={{ margin: 0 }}>
                       Reuse the same <code>thread_id</code> to continue the same session.

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1665,7 +1665,7 @@ export const gatewayChannels = pgTable(
     // Materialized for queries
     name: text('name').notNull(),
     channel_type: text('channel_type', {
-      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams'],
+      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams', 'webhook'],
     }).notNull(),
     target_branch_id: varchar('target_branch_id', { length: 36 })
       .notNull()
@@ -1752,7 +1752,7 @@ export const gatewayOutboundMessages = pgTable(
       .notNull()
       .references(() => gatewayChannels.id, { onDelete: 'cascade' }),
     channel_type: text('channel_type', {
-      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams'],
+      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams', 'webhook'],
     }).notNull(),
 
     platform_channel_id: text('platform_channel_id').notNull(),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1697,7 +1697,7 @@ export const gatewayChannels = sqliteTable(
     // Materialized for queries
     name: text('name').notNull(),
     channel_type: text('channel_type', {
-      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams'],
+      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams', 'webhook'],
     }).notNull(),
     target_branch_id: text('target_branch_id', { length: 36 })
       .notNull()
@@ -1784,7 +1784,7 @@ export const gatewayOutboundMessages = sqliteTable(
       .notNull()
       .references(() => gatewayChannels.id, { onDelete: 'cascade' }),
     channel_type: text('channel_type', {
-      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams'],
+      enum: ['slack', 'discord', 'whatsapp', 'telegram', 'github', 'teams', 'webhook'],
     }).notNull(),
 
     platform_channel_id: text('platform_channel_id').notNull(),

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -29,7 +29,7 @@ export type GatewayOutboundMessageID = UUID;
 // ============================================================================
 
 /** Supported messaging platform types */
-export type ChannelType = 'slack' | 'discord' | 'whatsapp' | 'telegram' | 'github' | 'teams';
+export type ChannelType = 'slack' | 'discord' | 'whatsapp' | 'telegram' | 'github' | 'teams' | 'webhook';
 
 /** Thread lifecycle status */
 export type ThreadStatus = 'active' | 'archived' | 'paused';
@@ -46,6 +46,32 @@ export const GATEWAY_SENSITIVE_CONFIG_FIELDS = [
 
 /** Sentinel value used by gateway APIs/tools to represent a redacted secret. */
 export const GATEWAY_REDACTED_SENTINEL = '••••••••';
+
+// ============================================================================
+// Webhook Post-Action Configuration
+// ============================================================================
+
+/**
+ * What to do after a webhook-triggered session reaches a terminal state.
+ */
+export interface PostActionConfig {
+  action: 'none' | 'channel_message';
+  /** Target gateway channel to send the message through */
+  gateway_channel_id?: string;
+  /** Handlebars template for the outbound message */
+  message_template?: string;
+}
+
+/**
+ * Webhook channel config stored in GatewayChannel.config.
+ */
+export interface WebhookChannelConfig {
+  webhook_secret?: string;
+  post_actions?: {
+    success?: PostActionConfig;
+    fail?: PostActionConfig;
+  };
+}
 
 // ============================================================================
 // Agentic Tool Configuration

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -29,7 +29,14 @@ export type GatewayOutboundMessageID = UUID;
 // ============================================================================
 
 /** Supported messaging platform types */
-export type ChannelType = 'slack' | 'discord' | 'whatsapp' | 'telegram' | 'github' | 'teams' | 'webhook';
+export type ChannelType =
+  | 'slack'
+  | 'discord'
+  | 'whatsapp'
+  | 'telegram'
+  | 'github'
+  | 'teams'
+  | 'webhook';
 
 /** Thread lifecycle status */
 export type ThreadStatus = 'active' | 'archived' | 'paused';


### PR DESCRIPTION
## Summary

Implements webhook-based agent triggers for Agor (phases 1, 2, and 3.0).

- **Phase 1 — HTTP inbound endpoint**: `POST /v1/gateway/inbound/:channel_key` — no additional auth beyond the UUID channel_key. Optional HMAC-SHA256 via `X-Agor-Signature: sha256=<hex>`. Returns `{ session_id, thread_id, status, queue_position? }`. Channel_key is masked to 8-char hint in all logs.
- **Phase 2 — UI**: `webhook` channel type in the channel selector; post-create success modal shows the full webhook URL with a copy button; edit mode shows the URL in a read-only field.
- **Phase 3.0 — Post-actions**: `PostActionConfig` / `WebhookChannelConfig` types in `@agor/core`. `GatewayService.firePostAction()` renders a Handlebars template and dispatches via any outbound channel when a webhook-sourced session reaches COMPLETED / FAILED / TIMED_OUT. Dispatch happens fire-and-forget via `setImmediate` in the `sessions.after.patch` hook. UI exposes On success / On fail sections in a Post-actions tab inside the webhook channel form.

### Handlebars template variables

| Variable | Description |
|---|---|
| `{{ trigger.prompt }}` | The prompt that triggered the session |
| `{{ trigger.summary }}` | Optional caller-supplied summary |
| `{{ trigger.metadata.* }}` | Any extra metadata fields |
| `{{ session.id }}` | Session UUID |
| `{{ session.status }}` | Terminal status (`completed` / `failed` / `timed_out`) |
| `{{ session.error }}` | Error message (if any) |
| `{{ session.duration_s }}` | Wall-clock seconds |
| `{{ session.branch.name }}` | Branch name |

### Out of scope (deferred)

- Rate limiting (v1)
- `partial_success` tier (Phase 3.1)
- `session.last_message` template variable (future)

## Test plan

- [ ] `POST /v1/gateway/inbound/<channel_key>` with `{ "prompt": "..." }` creates a session and returns `{ session_id, thread_id, status: "started" }`
- [ ] Same `thread_id` on a second POST routes to the same session
- [ ] Omitting `prompt` returns 400
- [ ] Wrong channel_key returns 401 without revealing existence
- [ ] With `webhook_secret` configured, missing or wrong `X-Agor-Signature` returns 401
- [ ] Correct HMAC-SHA256 over raw body passes verification
- [ ] Disabled channel returns 403
- [ ] Create a webhook channel in the UI → post-create modal shows the full URL with copy button
- [ ] Edit the webhook channel → URL visible in the Config section
- [ ] Set a post-action (On success: Send via channel) → session completion fires the Handlebars-rendered message
- [ ] `channel_key` never appears in daemon logs (only 8-char hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)