### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## Linked issue
+
+<!-- Use one when applicable: Fixes #123, Closes #123, Refs #123, Blocks #123, Related: #123. -->
+
+<!-- Example: Fixes #123 -->
+
+## Summary
+
+<!-- What changed? Prefer concise bullets. Example:
+- Change 1
+- Change 2
+- Change 3
+-->
+
+## Why / context
+
+<!-- What problem does this solve? Include user impact, root cause, or design context when useful. -->
+
+## Implementation notes
+
+<!-- Call out important decisions, boundaries, migrations, deployment behavior, or review focus areas. Delete if not needed. -->
+
+## Validation / test plan
+
+<!-- List commands run, manual checks, screenshots, or intentionally unchecked follow-ups. Example:
+- [x] pnpm test
+- [x] pnpm typecheck
+- [ ] Manual validation pending: ...
+-->
+
+## Screenshots / demos
+
+<!-- Add screenshots, recordings, rendered docs, or URLs for UI/docs/deployment changes. Delete if not applicable. -->
+
+## Risks / rollout / rollback
+
+<!-- Note operational risks, compatibility concerns, config/env changes, and rollback plan. Delete if not applicable. -->
+
+## Out of scope / follow-ups
+
+<!-- Link deferred work or explicitly state what this PR does not cover. Delete if not applicable. -->

--- a/apps/agor-docs/components/LandingPage.tsx
+++ b/apps/agor-docs/components/LandingPage.tsx
@@ -1,11 +1,7 @@
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef } from 'react';
-import {
-  AGOR_CLOUD_DEMO_URL,
-  DISCORD_INVITE_URL,
-  GITHUB_REPO_URL,
-} from '../lib/links';
+import { AGOR_CLOUD_DEMO_URL, DISCORD_INVITE_URL, GITHUB_REPO_URL } from '../lib/links';
 import { BRAND_NAME, LOGO_PATH } from '../lib/siteMetadata';
 import styles from './LandingPage.module.css';
 


### PR DESCRIPTION
## Summary

- Add `.github/pull_request_template.md` so new Agor PRs open with a consistent review checklist.
- Keep optional sections deletable while prompting for linked issues, context, validation, rollout risk, and follow-ups.

## Implementation notes

The template intentionally uses Markdown comments for guidance so authors can keep the rendered PR body focused on relevant content.

## Validation / test plan

- [x] Verified this repo did not already have a PR template.
- [x] Ran `git diff --check`.

## Screenshots / demos

Not applicable.

## Risks / rollout / rollback

Low risk. This only affects the default body shown when opening future PRs; it does not change runtime behavior or CI.

## Out of scope / follow-ups

No issue templates or multiple PR template variants are added in this PR.
