### PR TITLE
feat(session-panel): footer redesign — info bar + split send + overflow menu

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -183,18 +183,19 @@ describe('SessionFooter', () => {
     expect(timerChip.tagName.toLowerCase()).toBe('div');
   });
 
-  it('Tools chip shows "No tools" when no MCP servers are attached', () => {
+  it('MCP chip shows 0 count when no MCP servers are attached', () => {
     render(<SessionFooter {...baseProps} sessionMcpServerIds={[]} />, { wrapper: Wrapper });
-    const chip = screen.getByTestId('tools-chip');
+    const chip = screen.getByTitle(/No MCP servers attached/);
     expect(chip).toBeInTheDocument();
-    expect(chip.textContent).toContain('No tools');
+    expect(chip.textContent).toContain('0');
   });
 
-  it('Tools chip shows the server count when MCP servers are attached', () => {
+  it('MCP chip shows the server count when MCP servers are attached', () => {
     render(<SessionFooter {...baseProps} sessionMcpServerIds={['a', 'b', 'c']} />, {
       wrapper: Wrapper,
     });
-    const chip = screen.getByTestId('tools-chip');
+    // IDs not in mcpServerById are counted as "missing" → "need attention" tooltip
+    const chip = screen.getByTitle(/3 MCP servers need attention/);
     expect(chip).toBeInTheDocument();
     expect(chip.textContent).toContain('3');
   });

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -1,0 +1,192 @@
+import type {
+  CodexApprovalPolicy,
+  CodexSandboxMode,
+  EffortLevel,
+  PermissionMode,
+  Session,
+} from '@agor-live/client';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import { App, ConfigProvider } from 'antd';
+import type React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFooterPreferences } from '../../hooks/useFooterPreferences';
+import { SessionFooter } from './SessionFooter';
+
+// ModelSelector makes async network calls — replace with a stub
+vi.mock('../ModelSelector', () => ({
+  ModelSelector: () => <div data-testid="model-selector-stub" />,
+}));
+
+// TimerPill uses complex internal state not needed for footer layout tests
+vi.mock('../Pill', () => ({
+  TimerPill: () => <span data-testid="timer-pill-stub" />,
+}));
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ConfigProvider>
+    <App>{children}</App>
+  </ConfigProvider>
+);
+
+const baseSession: Session = {
+  session_id: 'test-session-123',
+  status: 'idle' as Session['status'],
+  agentic_tool: 'claude-code',
+  model_config: undefined,
+} as unknown as Session;
+
+const baseTokenBreakdown = {
+  total: 0,
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  cost: 0,
+};
+
+const baseProps = {
+  session: baseSession,
+  footerTimerTask: null,
+  tokenBreakdown: baseTokenBreakdown,
+  latestContextWindow: null,
+  footerGradient: undefined,
+  sessionMcpServerIds: [] as string[],
+  unauthedMcpServers: [],
+  mcpServerById: new Map(),
+  isRunning: false,
+  isStopping: false,
+  stopRequestInFlight: false,
+  hasInput: false,
+  connectionDisabled: false,
+  effortLevel: 'high' as EffortLevel,
+  permissionMode: 'default' as PermissionMode,
+  codexSandboxMode: 'on' as CodexSandboxMode,
+  codexApprovalPolicy: 'auto' as CodexApprovalPolicy,
+  queuedTasks: [],
+  client: null,
+  modelLabel: undefined,
+  modelConfig: undefined,
+  onModelConfigChange: vi.fn(),
+  onOpenSessionSettings: undefined,
+  onSendPrompt: vi.fn(),
+  onStop: vi.fn(),
+  onFork: vi.fn(),
+  onBtwSend: vi.fn(),
+  onSpawnOpen: vi.fn(),
+  onUploadOpen: vi.fn(),
+  onEffortChange: vi.fn(),
+  onPermissionModeChange: vi.fn(),
+  onCodexPermissionChange: vi.fn(),
+  promptInputSlot: <div data-testid="prompt-input">prompt-input</div>,
+};
+
+describe('SessionFooter', () => {
+  it('Send button is disabled when there is no input', () => {
+    render(<SessionFooter {...baseProps} hasInput={false} />, { wrapper: Wrapper });
+    const sendBtn = screen.getByRole('button', { name: /send/i });
+    expect(sendBtn).toBeDisabled();
+  });
+
+  it('Send button is enabled when there is input', () => {
+    render(<SessionFooter {...baseProps} hasInput={true} isRunning={false} />, {
+      wrapper: Wrapper,
+    });
+    const sendBtn = screen.getByRole('button', { name: /send/i });
+    expect(sendBtn).not.toBeDisabled();
+  });
+
+  it('Send button shows "Queue" label when session is running and there is input', () => {
+    render(<SessionFooter {...baseProps} hasInput={true} isRunning={true} />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.getByRole('button', { name: /queue/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^send$/i })).not.toBeInTheDocument();
+  });
+
+  it('Stop button is not rendered when session is not running', () => {
+    render(<SessionFooter {...baseProps} isRunning={false} stopRequestInFlight={false} />, {
+      wrapper: Wrapper,
+    });
+    expect(screen.queryByRole('button', { name: /stop/i })).not.toBeInTheDocument();
+  });
+
+  it('Stop button is rendered when session is running', () => {
+    render(<SessionFooter {...baseProps} isRunning={true} />, { wrapper: Wrapper });
+    expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
+  });
+
+  it('Stats chip is hidden when there is no model and no tokens', () => {
+    render(
+      <SessionFooter
+        {...baseProps}
+        session={{ ...baseSession, model_config: undefined } as unknown as Session}
+        tokenBreakdown={{ ...baseTokenBreakdown, total: 0 }}
+      />,
+      { wrapper: Wrapper }
+    );
+    expect(screen.queryByTestId('stats-chip')).not.toBeInTheDocument();
+  });
+
+  it('Stats chip shows warning styling when context usage is above 80%', () => {
+    render(
+      <SessionFooter
+        {...baseProps}
+        // Need model or tokens so the chip renders
+        session={
+          {
+            ...baseSession,
+            model_config: { model: 'claude-sonnet-4-6', mode: 'alias' },
+          } as unknown as Session
+        }
+        latestContextWindow={{ used: 85_000, limit: 100_000, taskMetadata: {} }}
+      />,
+      { wrapper: Wrapper }
+    );
+    const chip = screen.getByTestId('stats-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip.getAttribute('data-warning')).toBe('true');
+  });
+
+  it('Tools chip is hidden when no MCP servers are attached', () => {
+    render(<SessionFooter {...baseProps} sessionMcpServerIds={[]} />, { wrapper: Wrapper });
+    expect(screen.queryByTestId('tools-chip')).not.toBeInTheDocument();
+  });
+
+  it('Tools chip shows the server count when MCP servers are attached', () => {
+    render(<SessionFooter {...baseProps} sessionMcpServerIds={['a', 'b', 'c']} />, {
+      wrapper: Wrapper,
+    });
+    const chip = screen.getByTestId('tools-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toContain('3');
+  });
+});
+
+describe('useFooterPreferences', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns the default preferences when nothing is stored', () => {
+    const { result } = renderHook(() => useFooterPreferences());
+    const [prefs] = result.current;
+    expect(prefs.showToolsChip).toBe(true);
+    expect(prefs.showStatsChip).toBe(true);
+    expect(prefs.showForkInBar).toBe(true);
+    expect(prefs.showUploadInBar).toBe(true);
+  });
+
+  it('persists updated preferences to localStorage', () => {
+    const { result } = renderHook(() => useFooterPreferences());
+    act(() => {
+      result.current[1]({ showToolsChip: false });
+    });
+    const stored = JSON.parse(localStorage.getItem('agor-footer-prefs') ?? '{}');
+    expect(stored.showToolsChip).toBe(false);
+    // Other prefs remain at their defaults
+    expect(stored.showStatsChip).toBe(true);
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -147,9 +147,11 @@ describe('SessionFooter', () => {
     expect(chip.getAttribute('data-warning')).toBe('true');
   });
 
-  it('Tools chip is hidden when no MCP servers are attached', () => {
+  it('Tools chip shows "No tools" when no MCP servers are attached', () => {
     render(<SessionFooter {...baseProps} sessionMcpServerIds={[]} />, { wrapper: Wrapper });
-    expect(screen.queryByTestId('tools-chip')).not.toBeInTheDocument();
+    const chip = screen.getByTestId('tools-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toContain('No tools');
   });
 
   it('Tools chip shows the server count when MCP servers are attached', () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -81,6 +81,13 @@ const baseProps = {
 };
 
 describe('SessionFooter', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('Send button is disabled when there is no input', () => {
     render(<SessionFooter {...baseProps} hasInput={false} />, { wrapper: Wrapper });
     const sendBtn = screen.getByRole('button', { name: /send/i });
@@ -115,7 +122,7 @@ describe('SessionFooter', () => {
     expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
   });
 
-  it('Stats chip is hidden when there is no model and no tokens', () => {
+  it('Model chip is hidden when no model is present', () => {
     render(
       <SessionFooter
         {...baseProps}
@@ -124,27 +131,56 @@ describe('SessionFooter', () => {
       />,
       { wrapper: Wrapper }
     );
+    expect(screen.queryByTestId('model-chip')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('tokens-chip')).not.toBeInTheDocument();
     expect(screen.queryByTestId('stats-chip')).not.toBeInTheDocument();
   });
 
-  it('Stats chip shows warning styling when context usage is above 80%', () => {
+  it('Context chip shows warning styling when context usage is above 80%', () => {
     render(
       <SessionFooter
         {...baseProps}
-        // Need model or tokens so the chip renders
+        latestContextWindow={{ used: 85_000, limit: 100_000, taskMetadata: {} }}
+      />,
+      { wrapper: Wrapper }
+    );
+    const chip = screen.getByTestId('context-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip.getAttribute('data-warning')).toBe('true');
+  });
+
+  it('Individual model chip renders when model is present', () => {
+    render(
+      <SessionFooter
+        {...baseProps}
         session={
           {
             ...baseSession,
             model_config: { model: 'claude-sonnet-4-6', mode: 'alias' },
           } as unknown as Session
         }
-        latestContextWindow={{ used: 85_000, limit: 100_000, taskMetadata: {} }}
       />,
       { wrapper: Wrapper }
     );
-    const chip = screen.getByTestId('stats-chip');
-    expect(chip).toBeInTheDocument();
-    expect(chip.getAttribute('data-warning')).toBe('true');
+    expect(screen.getByTestId('model-chip')).toBeInTheDocument();
+  });
+
+  it('Timer chip renders as a plain div when footerTimerTask is present', () => {
+    const timerTask = {
+      task_id: 't1',
+      status: 'running',
+      created_at: new Date().toISOString(),
+      message_range: null,
+      duration_ms: null,
+      last_executor_heartbeat_at: null,
+      completed_at: null,
+    };
+    render(<SessionFooter {...baseProps} footerTimerTask={timerTask as never} />, {
+      wrapper: Wrapper,
+    });
+    const timerChip = screen.getByTestId('timer-chip');
+    expect(timerChip).toBeInTheDocument();
+    expect(timerChip.tagName.toLowerCase()).toBe('div');
   });
 
   it('Tools chip shows "No tools" when no MCP servers are attached', () => {
@@ -185,6 +221,12 @@ describe('useFooterPreferences', () => {
     const { result } = renderHook(() => useFooterPreferences());
     const [prefs] = result.current;
     expect(prefs.pinnedItems).toEqual([]);
+  });
+
+  it('defaults include pinnedChips with all chips visible', () => {
+    const { result } = renderHook(() => useFooterPreferences());
+    const [prefs] = result.current;
+    expect(prefs.pinnedChips).toEqual(['timer', 'tools', 'model', 'tokens', 'context']);
   });
 
   it('persists updated preferences to localStorage', () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -217,10 +217,10 @@ describe('useFooterPreferences', () => {
     expect(prefs.showUploadInBar).toBe(true);
   });
 
-  it('defaults include pinnedItems as empty array', () => {
+  it('defaults include pinnedItems with fork and upload pinned', () => {
     const { result } = renderHook(() => useFooterPreferences());
     const [prefs] = result.current;
-    expect(prefs.pinnedItems).toEqual([]);
+    expect(prefs.pinnedItems).toEqual(['fork', 'upload']);
   });
 
   it('defaults include pinnedChips with all chips visible', () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -179,6 +179,12 @@ describe('useFooterPreferences', () => {
     expect(prefs.showUploadInBar).toBe(true);
   });
 
+  it('defaults include pinnedItems as empty array', () => {
+    const { result } = renderHook(() => useFooterPreferences());
+    const [prefs] = result.current;
+    expect(prefs.pinnedItems).toEqual([]);
+  });
+
   it('persists updated preferences to localStorage', () => {
     const { result } = renderHook(() => useFooterPreferences());
     act(() => {
@@ -188,5 +194,29 @@ describe('useFooterPreferences', () => {
     expect(stored.showToolsChip).toBe(false);
     // Other prefs remain at their defaults
     expect(stored.showStatsChip).toBe(true);
+  });
+
+  it('persists pinnedItems to localStorage', () => {
+    const { result } = renderHook(() => useFooterPreferences());
+    act(() => {
+      result.current[1]({ pinnedItems: ['btw-fork'] });
+    });
+    const stored = JSON.parse(localStorage.getItem('agor-footer-prefs') ?? '{}');
+    expect(stored.pinnedItems).toEqual(['btw-fork']);
+  });
+});
+
+describe('SessionFooter pinned items', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows BTW fork button in action bar when pinned', () => {
+    localStorage.setItem('agor-footer-prefs', JSON.stringify({ pinnedItems: ['btw-fork'] }));
+    render(<SessionFooter {...baseProps} hasInput={true} />, { wrapper: Wrapper });
+    expect(screen.getByTestId('btw-fork-bar-btn')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -10,7 +10,6 @@ import type {
 } from '@agor-live/client';
 import {
   BranchesOutlined,
-  CheckCircleFilled,
   ClockCircleOutlined,
   EllipsisOutlined,
   ForkOutlined,
@@ -24,14 +23,13 @@ import {
   QuestionCircleOutlined,
   RobotOutlined,
   SendOutlined,
-  SettingOutlined,
   StopOutlined,
   ToolOutlined,
-  WarningOutlined,
 } from '@ant-design/icons';
 import { Badge, Button, Divider, Popover, Space, Spin, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useFooterPreferences } from '../../hooks/useFooterPreferences';
+import { resolveContextWindowPercentage } from '../../utils/contextWindow';
 import { EffortSelector } from '../EffortSelector';
 import type { ModelConfig } from '../ModelSelector';
 import { ModelSelector } from '../ModelSelector';
@@ -40,6 +38,7 @@ import { TimerPill } from '../Pill';
 import { getModelDisplayName } from '../Pill/modelDisplay';
 import { SessionIdsList } from '../SessionIds';
 import { Tag } from '../Tag';
+import { SessionMcpFooterControl } from './SessionMcpFooterControl';
 
 export interface SessionFooterProps {
   // Session data for chips
@@ -59,6 +58,7 @@ export interface SessionFooterProps {
   sessionMcpServerIds: string[];
   unauthedMcpServers: MCPServer[];
   mcpServerById: Map<string, MCPServer>;
+  userAuthenticatedMcpServerIds: Set<string>;
   // Action state
   isRunning: boolean;
   isStopping: boolean;
@@ -100,6 +100,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
   sessionMcpServerIds,
   unauthedMcpServers,
   mcpServerById,
+  userAuthenticatedMcpServerIds,
   isRunning,
   isStopping,
   stopRequestInFlight,
@@ -155,16 +156,33 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           : session.model_config.model
       )
     : null;
-  const tokensK = tokenBreakdown.total > 0 ? Math.round(tokenBreakdown.total / 1000) : 0;
+  const tokenDisplay =
+    tokenBreakdown.total >= 1000
+      ? `${Math.round(tokenBreakdown.total / 1000)}k`
+      : tokenBreakdown.total > 0
+        ? String(tokenBreakdown.total)
+        : null;
 
-  // Context window usage percentage (for warning styling)
-  const contextPct =
-    latestContextWindow && latestContextWindow.limit > 0
-      ? latestContextWindow.used / latestContextWindow.limit
-      : 0;
+  // Context window usage percentage (for warning styling).
+  // Prefers the executor-supplied snapshot.percentage (0-100) when available
+  // so Codex baseline-adjusted display matches the agent's own indicator.
+  const contextPct = React.useMemo(() => {
+    if (!latestContextWindow) return 0;
+    const meta = latestContextWindow.taskMetadata as {
+      normalized_sdk_response?: {
+        contextUsageSnapshot?: { percentage: number; totalTokens: number; maxTokens: number };
+      };
+    } | null;
+    const snapshot = meta?.normalized_sdk_response?.contextUsageSnapshot;
+    return (
+      resolveContextWindowPercentage(
+        latestContextWindow.used,
+        latestContextWindow.limit,
+        snapshot
+      ) / 100
+    );
+  }, [latestContextWindow]);
   const contextWarning = contextPct > 0.8;
-
-  const hasUnauthedMcp = unauthedMcpServers.length > 0;
 
   const sectionHeaderStyle: React.CSSProperties = {
     padding: '6px 12px 3px',
@@ -183,104 +201,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
     padding: '0 6px 0 12px',
     height: 32,
   };
-
-  // Tools chip popover: list server names
-  const toolsPopoverContent = (
-    <div style={{ width: 260, paddingTop: 6, paddingBottom: 6 }}>
-      <div style={sectionHeaderStyle}>Tools</div>
-
-      {sessionMcpServerIds.length === 0 && (
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: 4,
-            padding: '12px 12px 8px',
-            textAlign: 'center',
-          }}
-        >
-          <ToolOutlined style={{ fontSize: 20, color: token.colorTextTertiary }} />
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            No tools attached
-          </Typography.Text>
-          <Typography.Text
-            type="secondary"
-            style={{ fontSize: 11, color: token.colorTextTertiary }}
-          >
-            Add MCP servers in settings
-          </Typography.Text>
-        </div>
-      )}
-
-      {sessionMcpServerIds.map((id) => {
-        const server = mcpServerById.get(id);
-        const needsAuth = unauthedMcpServers.some((s) => s.mcp_server_id === id);
-        return (
-          <div
-            key={id}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              padding: '0 12px',
-              height: 32,
-            }}
-          >
-            {needsAuth ? (
-              <WarningOutlined style={{ fontSize: 12, color: token.colorWarning, flexShrink: 0 }} />
-            ) : (
-              <CheckCircleFilled
-                style={{ fontSize: 12, color: token.colorSuccess, flexShrink: 0 }}
-              />
-            )}
-            <Typography.Text
-              style={{
-                fontSize: 13,
-                flex: 1,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                minWidth: 0,
-              }}
-            >
-              {server?.name ?? id}
-            </Typography.Text>
-            {needsAuth && (
-              <Typography.Text
-                type="warning"
-                style={{ fontSize: 11, flexShrink: 0, whiteSpace: 'nowrap' }}
-              >
-                needs auth
-              </Typography.Text>
-            )}
-          </div>
-        );
-      })}
-
-      {onOpenSessionSettings && (
-        <>
-          <Divider style={{ margin: '4px 0' }} />
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              padding: '0 6px 0 12px',
-              height: 32,
-              cursor: 'pointer',
-            }}
-            onClick={() => onOpenSessionSettings(session.session_id)}
-          >
-            <SettingOutlined
-              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
-            />
-            <Typography.Text style={{ fontSize: 13, flex: 1 }}>MCP settings</Typography.Text>
-          </div>
-        </>
-      )}
-    </div>
-  );
 
   const moreContent = (
     <div style={{ width: 260, paddingTop: 6, paddingBottom: 6 }}>
@@ -382,7 +302,10 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       <div style={sectionHeaderStyle}>Actions</div>
 
       {/* Upload */}
+      {/* biome-ignore lint/a11y/useSemanticElements: row contains a nested pin <button>; can't use <button> as parent */}
       <div
+        role="button"
+        tabIndex={connectionDisabled ? -1 : 0}
         style={{
           ...overflowRowStyle,
           opacity: connectionDisabled ? 0.4 : 1,
@@ -394,6 +317,17 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             : () => {
                 setMoreOpen(false);
                 onUploadOpen();
+              }
+        }
+        onKeyDown={
+          connectionDisabled
+            ? undefined
+            : (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setMoreOpen(false);
+                  onUploadOpen();
+                }
               }
         }
       >
@@ -462,7 +396,10 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       {/* Fork */}
       {toolCaps?.supportsSessionFork !== false && (
+        // biome-ignore lint/a11y/useSemanticElements: row contains a nested pin <button>; can't use <button> as parent
         <div
+          role="button"
+          tabIndex={connectionDisabled ? -1 : 0}
           style={{
             ...overflowRowStyle,
             opacity: connectionDisabled ? 0.4 : 1,
@@ -474,6 +411,17 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               : () => {
                   setMoreOpen(false);
                   onFork();
+                }
+          }
+          onKeyDown={
+            connectionDisabled
+              ? undefined
+              : (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setMoreOpen(false);
+                    onFork();
+                  }
                 }
           }
         >
@@ -543,7 +491,10 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       {/* BTW fork */}
       {toolCaps?.supportsSessionFork !== false && (
+        // biome-ignore lint/a11y/useSemanticElements: row contains a nested pin <button>; can't use <button> as parent
         <div
+          role="button"
+          tabIndex={connectionDisabled || !hasInput ? -1 : 0}
           style={{
             ...overflowRowStyle,
             opacity: connectionDisabled || !hasInput ? 0.4 : 1,
@@ -555,6 +506,17 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               : () => {
                   setMoreOpen(false);
                   onBtwSend();
+                }
+          }
+          onKeyDown={
+            connectionDisabled || !hasInput
+              ? undefined
+              : (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setMoreOpen(false);
+                    onBtwSend();
+                  }
                 }
           }
         >
@@ -630,7 +592,10 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       {/* Spawn */}
       {toolCaps?.supportsChildSpawn !== false && (
+        // biome-ignore lint/a11y/useSemanticElements: row contains a nested pin <button>; can't use <button> as parent
         <div
+          role="button"
+          tabIndex={connectionDisabled || isRunning ? -1 : 0}
           style={{
             ...overflowRowStyle,
             opacity: connectionDisabled || isRunning ? 0.4 : 1,
@@ -642,6 +607,17 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               : () => {
                   setMoreOpen(false);
                   onSpawnOpen();
+                }
+          }
+          onKeyDown={
+            connectionDisabled || isRunning
+              ? undefined
+              : (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setMoreOpen(false);
+                    onSpawnOpen();
+                  }
                 }
           }
         >
@@ -861,7 +837,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         </div>
       )}
 
-      {tokensK > 0 && (
+      {tokenDisplay !== null && (
         <div style={{ ...overflowRowStyle, cursor: 'default' }}>
           <NumberOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
@@ -981,7 +957,18 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           </div>
         }
       >
-        <div style={{ ...overflowRowStyle, cursor: 'pointer' }}>
+        {/* biome-ignore lint/a11y/useSemanticElements: row contains a nested pin <button>; can't use <button> as parent */}
+        <div
+          role="button"
+          tabIndex={0}
+          style={{ ...overflowRowStyle, cursor: 'pointer' }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              e.currentTarget.click();
+            }
+          }}
+        >
           <IdcardOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
           />
@@ -1086,7 +1073,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         {(pinnedChips.includes('tools') ||
           (footerTimerTask && pinnedChips.includes('timer')) ||
           (modelName && pinnedChips.includes('model')) ||
-          (tokensK > 0 && pinnedChips.includes('tokens')) ||
+          (tokenDisplay !== null && pinnedChips.includes('tokens')) ||
           (latestContextWindow &&
             latestContextWindow.limit > 0 &&
             pinnedChips.includes('context')) ||
@@ -1120,38 +1107,14 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             )}
 
             {pinnedChips.includes('tools') && (
-              <Popover
-                trigger="click"
-                placement="topLeft"
-                content={toolsPopoverContent}
-                title={null}
-              >
-                <Tag
-                  icon={<ToolOutlined />}
-                  color={hasUnauthedMcp ? 'warning' : 'default'}
-                  style={{
-                    cursor: 'pointer',
-                    height: 22,
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    opacity: sessionMcpServerIds.length === 0 ? 0.45 : 1,
-                  }}
-                  data-testid="tools-chip"
-                >
-                  {sessionMcpServerIds.length === 0 ? (
-                    'No tools'
-                  ) : (
-                    <>
-                      Tools&nbsp;·&nbsp;{sessionMcpServerIds.length}
-                      {hasUnauthedMcp && (
-                        <WarningOutlined
-                          style={{ marginLeft: token.sizeUnit, color: token.colorWarning }}
-                        />
-                      )}
-                    </>
-                  )}
-                </Tag>
-              </Popover>
+              <SessionMcpFooterControl
+                client={client}
+                sessionId={session.session_id}
+                sessionMcpServerIds={sessionMcpServerIds}
+                mcpServerById={mcpServerById}
+                userAuthenticatedMcpServerIds={userAuthenticatedMcpServerIds}
+                onOpenSessionSettings={onOpenSessionSettings}
+              />
             )}
 
             {/* Model chip */}
@@ -1199,19 +1162,42 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             )}
 
             {/* Tokens chip */}
-            {tokensK > 0 && pinnedChips.includes('tokens') && (
-              <Tag
-                color="default"
-                style={{
-                  cursor: 'default',
-                  height: 22,
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                }}
-                data-testid="tokens-chip"
+            {tokenDisplay !== null && pinnedChips.includes('tokens') && (
+              <Tooltip
+                title={
+                  tokenBreakdown.total > 0 ? (
+                    <div style={{ fontSize: 12 }}>
+                      <div>Total: {tokenBreakdown.total.toLocaleString()}</div>
+                      {tokenBreakdown.input > 0 && (
+                        <div>Input: {tokenBreakdown.input.toLocaleString()}</div>
+                      )}
+                      {tokenBreakdown.output > 0 && (
+                        <div>Output: {tokenBreakdown.output.toLocaleString()}</div>
+                      )}
+                      {tokenBreakdown.cacheRead > 0 && (
+                        <div>Cache read: {tokenBreakdown.cacheRead.toLocaleString()}</div>
+                      )}
+                      {tokenBreakdown.cost > 0 && (
+                        <div>Est. cost: ${tokenBreakdown.cost.toFixed(4)}</div>
+                      )}
+                    </div>
+                  ) : undefined
+                }
+                placement="top"
               >
-                {tokensK}k tokens
-              </Tag>
+                <Tag
+                  color="default"
+                  style={{
+                    cursor: 'default',
+                    height: 22,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                  }}
+                  data-testid="tokens-chip"
+                >
+                  {tokenDisplay} tokens
+                </Tag>
+              </Tooltip>
             )}
 
             {/* Context % chip */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -233,7 +233,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         <Typography.Text style={{ fontSize: 12, flex: 1, color: token.colorTextSecondary }}>
           Model
         </Typography.Text>
-        <div style={{ maxWidth: 120, flexShrink: 0 }}>
+        <div style={{ maxWidth: 160, flexShrink: 0, display: 'flex', alignItems: 'center' }}>
           <ModelSelector
             value={modelConfig}
             onChange={onModelConfigChange}
@@ -289,10 +289,82 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       <div style={sectionHeaderStyle}>Actions</div>
 
       {/* Upload */}
-      <Tooltip
-        title={connectionDisabled ? 'Disconnected from daemon' : 'Attach files to prompt'}
-        placement="left"
+      <div
+        style={{
+          ...overflowRowStyle,
+          opacity: connectionDisabled ? 0.4 : 1,
+          cursor: connectionDisabled ? 'not-allowed' : 'pointer',
+        }}
+        onClick={
+          connectionDisabled
+            ? undefined
+            : () => {
+                setMoreOpen(false);
+                onUploadOpen();
+              }
+        }
       >
+        <Tooltip
+          title={connectionDisabled ? 'Disconnected from daemon' : 'Attach files to prompt'}
+          placement="left"
+        >
+          <span
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: token.sizeUnit,
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+            }}
+          >
+            <PaperClipOutlined
+              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+            />
+            <Typography.Text
+              style={{
+                fontSize: 13,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Attach files
+            </Typography.Text>
+          </span>
+        </Tooltip>
+        <Tooltip
+          title={pinnedItems.includes('upload') ? 'Unpin from bar' : 'Pin to bar'}
+          placement="right"
+        >
+          <button
+            type="button"
+            aria-label={pinnedItems.includes('upload') ? 'Unpin Upload' : 'Pin Upload'}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: pinnedItems.includes('upload') ? token.colorPrimary : token.colorTextTertiary,
+              lineHeight: 1,
+              padding: 2,
+              flexShrink: 0,
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              togglePin('upload');
+            }}
+          >
+            {pinnedItems.includes('upload') ? (
+              <PushpinFilled style={{ fontSize: 12 }} />
+            ) : (
+              <PushpinOutlined style={{ fontSize: 12 }} />
+            )}
+          </button>
+        </Tooltip>
+      </div>
+
+      {/* Fork */}
+      {toolCaps?.supportsSessionFork !== false && (
         <div
           style={{
             ...overflowRowStyle,
@@ -304,37 +376,132 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               ? undefined
               : () => {
                   setMoreOpen(false);
-                  onUploadOpen();
+                  onFork();
                 }
           }
         >
-          <PaperClipOutlined
-            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
-          />
-          <Typography.Text
-            style={{
-              fontSize: 13,
-              flex: 1,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              minWidth: 0,
-            }}
-          >
-            Attach files
-          </Typography.Text>
           <Tooltip
-            title={pinnedItems.includes('upload') ? 'Unpin from bar' : 'Pin to bar'}
+            title={connectionDisabled ? 'Disconnected from daemon' : 'Fork this session'}
+            placement="left"
+          >
+            <span
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: token.sizeUnit,
+                flex: 1,
+                minWidth: 0,
+                overflow: 'hidden',
+              }}
+            >
+              <ForkOutlined
+                style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+              />
+              <Typography.Text
+                style={{
+                  fontSize: 13,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Fork session
+              </Typography.Text>
+            </span>
+          </Tooltip>
+          <Tooltip
+            title={pinnedItems.includes('fork') ? 'Unpin from bar' : 'Pin to bar'}
             placement="right"
           >
             <button
               type="button"
-              aria-label={pinnedItems.includes('upload') ? 'Unpin Upload' : 'Pin Upload'}
+              aria-label={pinnedItems.includes('fork') ? 'Unpin Fork' : 'Pin Fork'}
               style={{
                 background: 'none',
                 border: 'none',
                 cursor: 'pointer',
-                color: pinnedItems.includes('upload')
+                color: pinnedItems.includes('fork') ? token.colorPrimary : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                togglePin('fork');
+              }}
+            >
+              {pinnedItems.includes('fork') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
+        </div>
+      )}
+
+      {/* BTW fork */}
+      {toolCaps?.supportsSessionFork !== false && (
+        <div
+          style={{
+            ...overflowRowStyle,
+            opacity: connectionDisabled || !hasInput ? 0.4 : 1,
+            cursor: connectionDisabled || !hasInput ? 'not-allowed' : 'pointer',
+          }}
+          onClick={
+            connectionDisabled || !hasInput
+              ? undefined
+              : () => {
+                  setMoreOpen(false);
+                  onBtwSend();
+                }
+          }
+        >
+          <Tooltip
+            title={
+              connectionDisabled || !hasInput
+                ? 'Needs input and a live connection'
+                : 'Ask a side question via an ephemeral fork'
+            }
+            placement="left"
+          >
+            <span
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: token.sizeUnit,
+                flex: 1,
+                minWidth: 0,
+                overflow: 'hidden',
+              }}
+            >
+              <QuestionCircleOutlined
+                style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+              />
+              <Typography.Text
+                style={{
+                  fontSize: 13,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                BTW fork
+              </Typography.Text>
+            </span>
+          </Tooltip>
+          <Tooltip
+            title={pinnedItems.includes('btw-fork') ? 'Unpin from bar' : 'Pin to bar'}
+            placement="right"
+          >
+            <button
+              type="button"
+              aria-label={pinnedItems.includes('btw-fork') ? 'Unpin BTW fork' : 'Pin BTW fork'}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedItems.includes('btw-fork')
                   ? token.colorPrimary
                   : token.colorTextTertiary,
                 lineHeight: 1,
@@ -343,10 +510,10 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               }}
               onClick={(e) => {
                 e.stopPropagation();
-                togglePin('upload');
+                togglePin('btw-fork');
               }}
             >
-              {pinnedItems.includes('upload') ? (
+              {pinnedItems.includes('btw-fork') ? (
                 <PushpinFilled style={{ fontSize: 12 }} />
               ) : (
                 <PushpinOutlined style={{ fontSize: 12 }} />
@@ -354,226 +521,89 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             </button>
           </Tooltip>
         </div>
-      </Tooltip>
-
-      {/* Fork */}
-      {toolCaps?.supportsSessionFork !== false && (
-        <Tooltip
-          title={connectionDisabled ? 'Disconnected from daemon' : 'Fork this session'}
-          placement="left"
-        >
-          <div
-            style={{
-              ...overflowRowStyle,
-              opacity: connectionDisabled ? 0.4 : 1,
-              cursor: connectionDisabled ? 'not-allowed' : 'pointer',
-            }}
-            onClick={
-              connectionDisabled
-                ? undefined
-                : () => {
-                    setMoreOpen(false);
-                    onFork();
-                  }
-            }
-          >
-            <ForkOutlined
-              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
-            />
-            <Typography.Text
-              style={{
-                fontSize: 13,
-                flex: 1,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                minWidth: 0,
-              }}
-            >
-              Fork session
-            </Typography.Text>
-            <Tooltip
-              title={pinnedItems.includes('fork') ? 'Unpin from bar' : 'Pin to bar'}
-              placement="right"
-            >
-              <button
-                type="button"
-                aria-label={pinnedItems.includes('fork') ? 'Unpin Fork' : 'Pin Fork'}
-                style={{
-                  background: 'none',
-                  border: 'none',
-                  cursor: 'pointer',
-                  color: pinnedItems.includes('fork')
-                    ? token.colorPrimary
-                    : token.colorTextTertiary,
-                  lineHeight: 1,
-                  padding: 2,
-                  flexShrink: 0,
-                }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  togglePin('fork');
-                }}
-              >
-                {pinnedItems.includes('fork') ? (
-                  <PushpinFilled style={{ fontSize: 12 }} />
-                ) : (
-                  <PushpinOutlined style={{ fontSize: 12 }} />
-                )}
-              </button>
-            </Tooltip>
-          </div>
-        </Tooltip>
-      )}
-
-      {/* BTW fork */}
-      {toolCaps?.supportsSessionFork !== false && (
-        <Tooltip
-          title={
-            connectionDisabled || !hasInput
-              ? 'Needs input and a live connection'
-              : 'Ask a side question via an ephemeral fork'
-          }
-          placement="left"
-        >
-          <div
-            style={{
-              ...overflowRowStyle,
-              opacity: connectionDisabled || !hasInput ? 0.4 : 1,
-              cursor: connectionDisabled || !hasInput ? 'not-allowed' : 'pointer',
-            }}
-            onClick={
-              connectionDisabled || !hasInput
-                ? undefined
-                : () => {
-                    setMoreOpen(false);
-                    onBtwSend();
-                  }
-            }
-          >
-            <QuestionCircleOutlined
-              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
-            />
-            <Typography.Text
-              style={{
-                fontSize: 13,
-                flex: 1,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                minWidth: 0,
-              }}
-            >
-              BTW fork
-            </Typography.Text>
-            <Tooltip
-              title={pinnedItems.includes('btw-fork') ? 'Unpin from bar' : 'Pin to bar'}
-              placement="right"
-            >
-              <button
-                type="button"
-                aria-label={pinnedItems.includes('btw-fork') ? 'Unpin BTW fork' : 'Pin BTW fork'}
-                style={{
-                  background: 'none',
-                  border: 'none',
-                  cursor: 'pointer',
-                  color: pinnedItems.includes('btw-fork')
-                    ? token.colorPrimary
-                    : token.colorTextTertiary,
-                  lineHeight: 1,
-                  padding: 2,
-                  flexShrink: 0,
-                }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  togglePin('btw-fork');
-                }}
-              >
-                {pinnedItems.includes('btw-fork') ? (
-                  <PushpinFilled style={{ fontSize: 12 }} />
-                ) : (
-                  <PushpinOutlined style={{ fontSize: 12 }} />
-                )}
-              </button>
-            </Tooltip>
-          </div>
-        </Tooltip>
       )}
 
       {/* Spawn */}
       {toolCaps?.supportsChildSpawn !== false && (
-        <Tooltip
-          title={
-            connectionDisabled
-              ? 'Disconnected'
-              : isRunning
-                ? 'Session is running'
-                : 'Spawn a child subsession'
+        <div
+          style={{
+            ...overflowRowStyle,
+            opacity: connectionDisabled || isRunning ? 0.4 : 1,
+            cursor: connectionDisabled || isRunning ? 'not-allowed' : 'pointer',
+          }}
+          onClick={
+            connectionDisabled || isRunning
+              ? undefined
+              : () => {
+                  setMoreOpen(false);
+                  onSpawnOpen();
+                }
           }
-          placement="left"
         >
-          <div
-            style={{
-              ...overflowRowStyle,
-              opacity: connectionDisabled || isRunning ? 0.4 : 1,
-              cursor: connectionDisabled || isRunning ? 'not-allowed' : 'pointer',
-            }}
-            onClick={
-              connectionDisabled || isRunning
-                ? undefined
-                : () => {
-                    setMoreOpen(false);
-                    onSpawnOpen();
-                  }
+          <Tooltip
+            title={
+              connectionDisabled
+                ? 'Disconnected'
+                : isRunning
+                  ? 'Session is running'
+                  : 'Spawn a child subsession'
             }
+            placement="left"
           >
-            <BranchesOutlined
-              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
-            />
-            <Typography.Text
+            <span
               style={{
-                fontSize: 13,
+                display: 'flex',
+                alignItems: 'center',
+                gap: token.sizeUnit,
                 flex: 1,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
                 minWidth: 0,
+                overflow: 'hidden',
               }}
             >
-              Spawn subsession
-            </Typography.Text>
-            <Tooltip
-              title={pinnedItems.includes('spawn') ? 'Unpin from bar' : 'Pin to bar'}
-              placement="right"
-            >
-              <button
-                type="button"
-                aria-label={pinnedItems.includes('spawn') ? 'Unpin Spawn' : 'Pin Spawn'}
+              <BranchesOutlined
+                style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+              />
+              <Typography.Text
                 style={{
-                  background: 'none',
-                  border: 'none',
-                  cursor: 'pointer',
-                  color: pinnedItems.includes('spawn')
-                    ? token.colorPrimary
-                    : token.colorTextTertiary,
-                  lineHeight: 1,
-                  padding: 2,
-                  flexShrink: 0,
-                }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  togglePin('spawn');
+                  fontSize: 13,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
                 }}
               >
-                {pinnedItems.includes('spawn') ? (
-                  <PushpinFilled style={{ fontSize: 12 }} />
-                ) : (
-                  <PushpinOutlined style={{ fontSize: 12 }} />
-                )}
-              </button>
-            </Tooltip>
-          </div>
-        </Tooltip>
+                Spawn subsession
+              </Typography.Text>
+            </span>
+          </Tooltip>
+          <Tooltip
+            title={pinnedItems.includes('spawn') ? 'Unpin from bar' : 'Pin to bar'}
+            placement="right"
+          >
+            <button
+              type="button"
+              aria-label={pinnedItems.includes('spawn') ? 'Unpin Spawn' : 'Pin Spawn'}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedItems.includes('spawn') ? token.colorPrimary : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                togglePin('spawn');
+              }}
+            >
+              {pinnedItems.includes('spawn') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
+        </div>
       )}
 
       <Divider style={{ margin: '6px 0' }} />
@@ -969,7 +999,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 placement="topLeft"
                 title="Model"
                 content={
-                  <div style={{ width: 280 }}>
+                  <div style={{ width: 360 }}>
                     <ModelSelector
                       value={modelConfig}
                       onChange={onModelConfigChange}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -228,12 +228,25 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       <div style={sectionHeaderStyle}>Settings</div>
 
       {/* Model */}
-      <div style={{ ...overflowRowStyle, cursor: 'default' }}>
-        <RobotOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
-        <Typography.Text style={{ fontSize: 12, flex: 1, color: token.colorTextSecondary }}>
+      <div style={{ ...overflowRowStyle, alignItems: 'flex-start', cursor: 'default' }}>
+        <RobotOutlined
+          style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0, paddingTop: 6 }}
+        />
+        <Typography.Text
+          style={{
+            fontSize: 12,
+            color: token.colorTextSecondary,
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+            paddingTop: 6,
+          }}
+        >
           Model
         </Typography.Text>
-        <div style={{ maxWidth: 160, flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+        <div style={{ maxWidth: 160, flexShrink: 0 }}>
           <ModelSelector
             value={modelConfig}
             onChange={onModelConfigChange}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -14,8 +14,11 @@ import {
   DollarOutlined,
   EllipsisOutlined,
   ForkOutlined,
+  LockOutlined,
   PaperClipOutlined,
   PercentageOutlined,
+  PushpinFilled,
+  PushpinOutlined,
   QuestionCircleOutlined,
   RobotOutlined,
   SendOutlined,
@@ -25,6 +28,7 @@ import {
 } from '@ant-design/icons';
 import { Button, Divider, Popover, Space, Spin, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
+import { useFooterPreferences } from '../../hooks/useFooterPreferences';
 import { EffortSelector } from '../EffortSelector';
 import type { ModelConfig } from '../ModelSelector';
 import { ModelSelector } from '../ModelSelector';
@@ -121,6 +125,15 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 }) => {
   const { token } = theme.useToken();
   const [moreOpen, setMoreOpen] = React.useState(false);
+  const [prefs, setPref] = useFooterPreferences();
+  const pinnedItems = prefs.pinnedItems;
+  const togglePin = (id: string) => {
+    setPref({
+      pinnedItems: pinnedItems.includes(id)
+        ? pinnedItems.filter((p) => p !== id)
+        : [...pinnedItems, id],
+    });
+  };
 
   // Stats chip: show when model or tokens are present
   const modelName = session.model_config?.model
@@ -277,121 +290,227 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
     </div>
   );
 
-  // ··· more panel content (Popover with settings + overflow actions)
+  const sectionHeaderStyle: React.CSSProperties = {
+    padding: `4px ${token.sizeUnit * 2}px 2px`,
+    fontSize: 11,
+    fontWeight: 500,
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.5px',
+    color: token.colorTextTertiary,
+    userSelect: 'none',
+  };
+
+  const overflowRowStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: token.sizeUnit,
+    padding: `${token.sizeUnit * 0.5}px ${token.sizeUnit * 2}px`,
+    minHeight: 32,
+  };
+
   const moreContent = (
-    <div style={{ width: 280 }}>
-      <Space direction="vertical" size={8} style={{ width: '100%' }}>
-        {/* Overflow actions */}
-        {(toolCaps?.supportsSessionFork !== false || toolCaps?.supportsChildSpawn !== false) && (
-          <>
-            <Space size={4} wrap>
-              {toolCaps?.supportsSessionFork !== false && (
-                <Tooltip title="Ask a side question via ephemeral BTW fork">
-                  <Button
-                    size="small"
-                    type="default"
-                    icon={<QuestionCircleOutlined />}
-                    disabled={connectionDisabled || !hasInput}
-                    onClick={() => {
-                      setMoreOpen(false);
-                      onBtwSend();
-                    }}
-                  >
-                    BTW fork
-                  </Button>
-                </Tooltip>
-              )}
-              {toolCaps?.supportsChildSpawn !== false && (
+    <div style={{ width: 248 }}>
+      {/* === Section: Actions === */}
+      {(toolCaps?.supportsSessionFork !== false || toolCaps?.supportsChildSpawn !== false) && (
+        <>
+          <div style={sectionHeaderStyle}>Actions</div>
+          {toolCaps?.supportsSessionFork !== false && (
+            <Tooltip
+              title={
+                connectionDisabled || !hasInput
+                  ? 'Needs input and a live connection'
+                  : 'Ask a side question via an ephemeral fork'
+              }
+              placement="left"
+            >
+              <div
+                style={{
+                  ...overflowRowStyle,
+                  opacity: connectionDisabled || !hasInput ? 0.4 : 1,
+                  cursor: connectionDisabled || !hasInput ? 'not-allowed' : 'pointer',
+                }}
+                onClick={
+                  connectionDisabled || !hasInput
+                    ? undefined
+                    : () => {
+                        setMoreOpen(false);
+                        onBtwSend();
+                      }
+                }
+              >
+                <QuestionCircleOutlined
+                  style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+                />
+                <Typography.Text style={{ fontSize: 13, flex: 1 }}>BTW fork</Typography.Text>
                 <Tooltip
-                  title={
-                    connectionDisabled
-                      ? 'Disconnected from daemon'
-                      : isRunning
-                        ? 'Session is running'
-                        : 'Spawn subsession'
-                  }
+                  title={pinnedItems.includes('btw-fork') ? 'Unpin from bar' : 'Pin to bar'}
+                  placement="right"
                 >
-                  <Button
-                    size="small"
-                    type="default"
-                    icon={<BranchesOutlined />}
-                    disabled={connectionDisabled || isRunning}
-                    onClick={() => {
-                      setMoreOpen(false);
-                      onSpawnOpen();
+                  <button
+                    type="button"
+                    aria-label={
+                      pinnedItems.includes('btw-fork') ? 'Unpin BTW fork' : 'Pin BTW fork'
+                    }
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: pinnedItems.includes('btw-fork')
+                        ? token.colorPrimary
+                        : token.colorTextTertiary,
+                      lineHeight: 1,
+                      padding: 2,
+                      flexShrink: 0,
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      togglePin('btw-fork');
                     }}
                   >
-                    Spawn
-                  </Button>
+                    {pinnedItems.includes('btw-fork') ? (
+                      <PushpinFilled style={{ fontSize: 12 }} />
+                    ) : (
+                      <PushpinOutlined style={{ fontSize: 12 }} />
+                    )}
+                  </button>
                 </Tooltip>
-              )}
-            </Space>
-            <Divider style={{ margin: '4px 0' }} />
-          </>
-        )}
+              </div>
+            </Tooltip>
+          )}
+          {toolCaps?.supportsChildSpawn !== false && (
+            <Tooltip
+              title={
+                connectionDisabled
+                  ? 'Disconnected'
+                  : isRunning
+                    ? 'Session is running'
+                    : 'Spawn a child subsession'
+              }
+              placement="left"
+            >
+              <div
+                style={{
+                  ...overflowRowStyle,
+                  opacity: connectionDisabled || isRunning ? 0.4 : 1,
+                  cursor: connectionDisabled || isRunning ? 'not-allowed' : 'pointer',
+                }}
+                onClick={
+                  connectionDisabled || isRunning
+                    ? undefined
+                    : () => {
+                        setMoreOpen(false);
+                        onSpawnOpen();
+                      }
+                }
+              >
+                <BranchesOutlined
+                  style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+                />
+                <Typography.Text style={{ fontSize: 13, flex: 1 }}>
+                  Spawn subsession
+                </Typography.Text>
+                <Tooltip
+                  title={pinnedItems.includes('spawn') ? 'Unpin from bar' : 'Pin to bar'}
+                  placement="right"
+                >
+                  <button
+                    type="button"
+                    aria-label={pinnedItems.includes('spawn') ? 'Unpin Spawn' : 'Pin Spawn'}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      color: pinnedItems.includes('spawn')
+                        ? token.colorPrimary
+                        : token.colorTextTertiary,
+                      lineHeight: 1,
+                      padding: 2,
+                      flexShrink: 0,
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      togglePin('spawn');
+                    }}
+                  >
+                    {pinnedItems.includes('spawn') ? (
+                      <PushpinFilled style={{ fontSize: 12 }} />
+                    ) : (
+                      <PushpinOutlined style={{ fontSize: 12 }} />
+                    )}
+                  </button>
+                </Tooltip>
+              </div>
+            </Tooltip>
+          )}
+          <Divider style={{ margin: '6px 0' }} />
+        </>
+      )}
 
-        {/* Model selector */}
-        <div>
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            Model
-          </Typography.Text>
-          <div style={{ marginTop: token.sizeUnit }}>
-            <ModelSelector
-              value={modelConfig}
-              onChange={onModelConfigChange}
-              agentic_tool={session.agentic_tool}
-              client={client}
-              compact
-            />
-          </div>
+      {/* === Section: Settings === */}
+      <div style={sectionHeaderStyle}>Settings</div>
+
+      {/* Model */}
+      <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+        <RobotOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
+        <Typography.Text style={{ fontSize: 12, flex: 1, color: token.colorTextSecondary }}>
+          Model
+        </Typography.Text>
+        <div style={{ maxWidth: 120, flexShrink: 0 }}>
+          <ModelSelector
+            value={modelConfig}
+            onChange={onModelConfigChange}
+            agentic_tool={session.agentic_tool}
+            client={client}
+            compact
+          />
         </div>
+      </div>
 
-        {/* Effort selector — only for claude-code */}
-        {session.agentic_tool === 'claude-code' && (
-          <div>
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              Reasoning effort
-            </Typography.Text>
-            <div style={{ marginTop: token.sizeUnit }}>
-              <EffortSelector
-                value={effortLevel}
-                onChange={onEffortChange}
-                size="small"
-                compact
-                plain
-                fullWidth
-              />
-            </div>
-          </div>
-        )}
-
-        {/* Permission mode */}
-        <div>
-          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-            Permissions
+      {/* Effort — only for claude-code */}
+      {session.agentic_tool === 'claude-code' && (
+        <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+          <PercentageOutlined
+            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+          />
+          <Typography.Text style={{ fontSize: 12, flex: 1, color: token.colorTextSecondary }}>
+            Effort
           </Typography.Text>
-          <div style={{ marginTop: token.sizeUnit }}>
-            <PermissionModeSelector
-              value={permissionMode}
-              onChange={onPermissionModeChange}
-              agentic_tool={session.agentic_tool}
-              codexSandboxMode={codexSandboxMode}
-              codexApprovalPolicy={codexApprovalPolicy}
-              onCodexChange={onCodexPermissionChange}
-              compact
-              iconOnly={false}
-              plain
-              fullWidth
-              size="small"
-            />
-          </div>
+          <EffortSelector
+            value={effortLevel}
+            onChange={onEffortChange}
+            size="small"
+            compact
+            plain
+          />
         </div>
+      )}
 
-        <Divider style={{ margin: '4px 0' }} />
+      {/* Permissions */}
+      <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+        <LockOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
+        <Typography.Text style={{ fontSize: 12, flex: 1, color: token.colorTextSecondary }}>
+          Permissions
+        </Typography.Text>
+        <PermissionModeSelector
+          value={permissionMode}
+          onChange={onPermissionModeChange}
+          agentic_tool={session.agentic_tool}
+          codexSandboxMode={codexSandboxMode}
+          codexApprovalPolicy={codexApprovalPolicy}
+          onCodexChange={onCodexPermissionChange}
+          compact
+          iconOnly={false}
+          plain
+          size="small"
+        />
+      </div>
 
-        {/* Session IDs */}
+      <Divider style={{ margin: '6px 0' }} />
+
+      {/* Session IDs */}
+      <div style={{ padding: `0 ${token.sizeUnit * 2}px 4px` }}>
         <SessionIdsButton session={session} />
-      </Space>
+      </div>
     </div>
   );
 
@@ -537,6 +656,30 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   icon={<ForkOutlined />}
                   onClick={onFork}
                   disabled={connectionDisabled}
+                />
+              </Tooltip>
+            )}
+            {/* Dynamically pinned items */}
+            {pinnedItems.includes('btw-fork') && toolCaps?.supportsSessionFork !== false && (
+              <Tooltip title="BTW fork">
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<QuestionCircleOutlined />}
+                  onClick={onBtwSend}
+                  disabled={connectionDisabled || !hasInput}
+                  data-testid="btw-fork-bar-btn"
+                />
+              </Tooltip>
+            )}
+            {pinnedItems.includes('spawn') && toolCaps?.supportsChildSpawn !== false && (
+              <Tooltip title="Spawn subsession">
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<BranchesOutlined />}
+                  onClick={onSpawnOpen}
+                  disabled={connectionDisabled || isRunning}
                 />
               </Tooltip>
             )}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -11,10 +11,10 @@ import type {
 import {
   BranchesOutlined,
   ClockCircleOutlined,
-  DollarOutlined,
   EllipsisOutlined,
   ForkOutlined,
   LockOutlined,
+  NumberOutlined,
   PaperClipOutlined,
   PercentageOutlined,
   PushpinFilled,
@@ -134,8 +134,16 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         : [...pinnedItems, id],
     });
   };
+  const pinnedChips = prefs.pinnedChips;
+  const toggleChip = (id: string) => {
+    setPref({
+      pinnedChips: pinnedChips.includes(id)
+        ? pinnedChips.filter((c) => c !== id)
+        : [...pinnedChips, id],
+    });
+  };
 
-  // Stats chip: show when model or tokens are present
+  // Model name + token counts for individual chips
   const modelName = session.model_config?.model
     ? getModelDisplayName(
         session.model_config.provider
@@ -144,7 +152,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       )
     : null;
   const tokensK = tokenBreakdown.total > 0 ? Math.round(tokenBreakdown.total / 1000) : 0;
-  const showStatsChip = !!(modelName || tokenBreakdown.total > 0);
 
   // Context window usage percentage (for warning styling)
   const contextPct =
@@ -153,7 +160,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       : 0;
   const contextWarning = contextPct > 0.8;
 
-  const showToolsChip = true;
   const hasUnauthedMcp = unauthedMcpServers.length > 0;
 
   // Tools chip popover: list server names
@@ -192,79 +198,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               MCP settings
             </Button>
           </>
-        )}
-      </Space>
-    </div>
-  );
-
-  // Stats chip popover: model, tokens, context window, cost, effort, timer
-  const statsPopoverContent = (
-    <div style={{ width: 260 }}>
-      <Space direction="vertical" size={8} style={{ width: '100%' }}>
-        {modelName && (
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Space size={4}>
-              <RobotOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                Model
-              </Typography.Text>
-            </Space>
-            <Typography.Text style={{ fontSize: 12 }}>{modelName}</Typography.Text>
-          </div>
-        )}
-        {tokenBreakdown.total > 0 && (
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              Tokens
-            </Typography.Text>
-            <Typography.Text style={{ fontSize: 12 }}>
-              {tokenBreakdown.total.toLocaleString()}
-            </Typography.Text>
-          </div>
-        )}
-        {latestContextWindow && latestContextWindow.limit > 0 && (
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Space size={4}>
-              <PercentageOutlined
-                style={{
-                  fontSize: 12,
-                  color: contextWarning ? token.colorWarning : token.colorTextSecondary,
-                }}
-              />
-              <Typography.Text
-                type={contextWarning ? 'warning' : 'secondary'}
-                style={{ fontSize: 12 }}
-              >
-                Context
-              </Typography.Text>
-            </Space>
-            <Typography.Text type={contextWarning ? 'warning' : undefined} style={{ fontSize: 12 }}>
-              {Math.round(contextPct * 100)}%
-            </Typography.Text>
-          </div>
-        )}
-        {tokenBreakdown.cost > 0 && (
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Space size={4}>
-              <DollarOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                Est. cost
-              </Typography.Text>
-            </Space>
-            <Typography.Text style={{ fontSize: 12 }}>
-              ${tokenBreakdown.cost.toFixed(4)}
-            </Typography.Text>
-          </div>
-        )}
-        {effortLevel && (
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              Effort
-            </Typography.Text>
-            <Typography.Text style={{ fontSize: 12, textTransform: 'capitalize' }}>
-              {effortLevel}
-            </Typography.Text>
-          </div>
         )}
       </Space>
     </div>
@@ -487,6 +420,150 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       <Divider style={{ margin: '6px 0' }} />
 
+      {/* === Section: Chips === */}
+      <div style={sectionHeaderStyle}>Info bar</div>
+
+      {footerTimerTask && (
+        <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+          <ClockCircleOutlined
+            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+          />
+          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Timer</Typography.Text>
+          <button
+            type="button"
+            aria-label={pinnedChips.includes('timer') ? 'Hide timer' : 'Show timer'}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: pinnedChips.includes('timer') ? token.colorPrimary : token.colorTextTertiary,
+              lineHeight: 1,
+              padding: 2,
+              flexShrink: 0,
+            }}
+            onClick={() => toggleChip('timer')}
+          >
+            {pinnedChips.includes('timer') ? (
+              <PushpinFilled style={{ fontSize: 12 }} />
+            ) : (
+              <PushpinOutlined style={{ fontSize: 12 }} />
+            )}
+          </button>
+        </div>
+      )}
+
+      <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+        <ToolOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
+        <Typography.Text style={{ fontSize: 13, flex: 1 }}>Tools</Typography.Text>
+        <button
+          type="button"
+          aria-label={pinnedChips.includes('tools') ? 'Hide tools' : 'Show tools'}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: pinnedChips.includes('tools') ? token.colorPrimary : token.colorTextTertiary,
+            lineHeight: 1,
+            padding: 2,
+            flexShrink: 0,
+          }}
+          onClick={() => toggleChip('tools')}
+        >
+          {pinnedChips.includes('tools') ? (
+            <PushpinFilled style={{ fontSize: 12 }} />
+          ) : (
+            <PushpinOutlined style={{ fontSize: 12 }} />
+          )}
+        </button>
+      </div>
+
+      {modelName && (
+        <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+          <RobotOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
+          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Model</Typography.Text>
+          <button
+            type="button"
+            aria-label={pinnedChips.includes('model') ? 'Hide model' : 'Show model'}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: pinnedChips.includes('model') ? token.colorPrimary : token.colorTextTertiary,
+              lineHeight: 1,
+              padding: 2,
+              flexShrink: 0,
+            }}
+            onClick={() => toggleChip('model')}
+          >
+            {pinnedChips.includes('model') ? (
+              <PushpinFilled style={{ fontSize: 12 }} />
+            ) : (
+              <PushpinOutlined style={{ fontSize: 12 }} />
+            )}
+          </button>
+        </div>
+      )}
+
+      {tokensK > 0 && (
+        <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+          <NumberOutlined
+            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+          />
+          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Tokens</Typography.Text>
+          <button
+            type="button"
+            aria-label={pinnedChips.includes('tokens') ? 'Hide tokens' : 'Show tokens'}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: pinnedChips.includes('tokens') ? token.colorPrimary : token.colorTextTertiary,
+              lineHeight: 1,
+              padding: 2,
+              flexShrink: 0,
+            }}
+            onClick={() => toggleChip('tokens')}
+          >
+            {pinnedChips.includes('tokens') ? (
+              <PushpinFilled style={{ fontSize: 12 }} />
+            ) : (
+              <PushpinOutlined style={{ fontSize: 12 }} />
+            )}
+          </button>
+        </div>
+      )}
+
+      {latestContextWindow && latestContextWindow.limit > 0 && (
+        <div style={{ ...overflowRowStyle, cursor: 'default' }}>
+          <PercentageOutlined
+            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+          />
+          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Context %</Typography.Text>
+          <button
+            type="button"
+            aria-label={pinnedChips.includes('context') ? 'Hide context' : 'Show context'}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: pinnedChips.includes('context') ? token.colorPrimary : token.colorTextTertiary,
+              lineHeight: 1,
+              padding: 2,
+              flexShrink: 0,
+            }}
+            onClick={() => toggleChip('context')}
+          >
+            {pinnedChips.includes('context') ? (
+              <PushpinFilled style={{ fontSize: 12 }} />
+            ) : (
+              <PushpinOutlined style={{ fontSize: 12 }} />
+            )}
+          </button>
+        </div>
+      )}
+
+      <Divider style={{ margin: '6px 0' }} />
+
       {/* Session IDs */}
       <div style={{ padding: `0 ${token.sizeUnit * 2}px 4px` }}>
         <SessionIdsButton session={session} />
@@ -539,7 +616,13 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       <div style={{ position: 'relative', zIndex: 1 }}>
         {/* Row 1 — Info bar */}
-        {(showToolsChip || showStatsChip || footerTimerTask) && (
+        {(pinnedChips.includes('tools') ||
+          (footerTimerTask && pinnedChips.includes('timer')) ||
+          (modelName && pinnedChips.includes('model')) ||
+          (tokensK > 0 && pinnedChips.includes('tokens')) ||
+          (latestContextWindow &&
+            latestContextWindow.limit > 0 &&
+            pinnedChips.includes('context'))) && (
           <div
             style={{
               display: 'flex',
@@ -549,16 +632,9 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               flexWrap: 'wrap',
             }}
           >
-            {footerTimerTask && (
-              <Tag
-                icon={<ClockCircleOutlined />}
-                color="default"
-                style={{
-                  cursor: 'default',
-                  height: 22,
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                }}
+            {footerTimerTask && pinnedChips.includes('timer') && (
+              <div
+                style={{ display: 'inline-flex', alignItems: 'center', height: 22 }}
                 data-testid="timer-chip"
               >
                 <TimerPill
@@ -572,9 +648,10 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   durationMs={footerTimerTask.duration_ms}
                   lastExecutorHeartbeatAt={footerTimerTask.last_executor_heartbeat_at}
                 />
-              </Tag>
+              </div>
             )}
-            {showToolsChip && (
+
+            {pinnedChips.includes('tools') && (
               <Popover
                 trigger="click"
                 placement="topLeft"
@@ -609,31 +686,62 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               </Popover>
             )}
 
-            {showStatsChip && (
-              <Popover
-                trigger="click"
-                placement="topLeft"
-                content={statsPopoverContent}
-                title={null}
+            {/* Model chip */}
+            {modelName && pinnedChips.includes('model') && (
+              <Tag
+                icon={<RobotOutlined />}
+                color="default"
+                style={{
+                  cursor: 'default',
+                  height: 22,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                }}
+                data-testid="model-chip"
               >
+                {modelName}
+              </Tag>
+            )}
+
+            {/* Tokens chip */}
+            {tokensK > 0 && pinnedChips.includes('tokens') && (
+              <Tag
+                color="default"
+                style={{
+                  cursor: 'default',
+                  height: 22,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                }}
+                data-testid="tokens-chip"
+              >
+                {tokensK}k tokens
+              </Tag>
+            )}
+
+            {/* Context % chip */}
+            {latestContextWindow &&
+              latestContextWindow.limit > 0 &&
+              pinnedChips.includes('context') && (
                 <Tag
-                  icon={<RobotOutlined />}
+                  icon={
+                    <PercentageOutlined
+                      style={{ color: contextWarning ? token.colorWarning : undefined }}
+                    />
+                  }
                   color={contextWarning ? 'warning' : 'default'}
                   style={{
-                    cursor: 'pointer',
+                    cursor: 'default',
                     height: 22,
                     display: 'inline-flex',
                     alignItems: 'center',
                   }}
-                  data-testid="stats-chip"
+                  data-testid="context-chip"
                   data-warning={contextWarning ? 'true' : undefined}
                 >
-                  {modelName && <span>{modelName}</span>}
-                  {modelName && tokensK > 0 && <span>&nbsp;·&nbsp;</span>}
-                  {tokensK > 0 && <span>{tokensK}k</span>}
+                  {Math.round(contextPct * 100)}%
                 </Tag>
-              </Popover>
-            )}
+              )}
           </div>
         )}
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1374,7 +1374,11 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 count={queuedTasks.length > 0 ? queuedTasks.length : 0}
                 size="small"
                 offset={[-2, 2]}
-                style={{ boxShadow: 'none', backgroundColor: token.colorInfo, fontSize: 10 }}
+                style={{
+                  boxShadow: 'none',
+                  backgroundColor: token.colorTextTertiary,
+                  fontSize: 10,
+                }}
               >
                 <Button
                   type="primary"

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -205,32 +205,32 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
   );
 
   const sectionHeaderStyle: React.CSSProperties = {
-    padding: `4px ${token.sizeUnit * 2}px 2px`,
+    padding: '6px 12px 3px',
     fontSize: 11,
-    fontWeight: 500,
+    fontWeight: 600,
     textTransform: 'uppercase' as const,
-    letterSpacing: '0.5px',
+    letterSpacing: '0.4px',
     color: token.colorTextTertiary,
-    userSelect: 'none',
+    userSelect: 'none' as const,
   };
 
   const overflowRowStyle: React.CSSProperties = {
     display: 'flex',
     alignItems: 'center',
-    gap: token.sizeUnit,
-    padding: `${token.sizeUnit * 0.5}px ${token.sizeUnit * 2}px`,
-    minHeight: 32,
+    gap: 8,
+    padding: '0 6px 0 12px',
+    height: 32,
   };
 
   const moreContent = (
-    <div style={{ width: 248 }}>
+    <div style={{ width: 260, paddingTop: 6, paddingBottom: 6 }}>
       {/* === Section: Settings === */}
       <div style={sectionHeaderStyle}>Settings</div>
 
       {/* Model */}
       <div style={{ ...overflowRowStyle, alignItems: 'flex-start', cursor: 'default' }}>
         <RobotOutlined
-          style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0, paddingTop: 6 }}
+          style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0, marginTop: 7 }}
         />
         <Typography.Text
           style={{
@@ -241,7 +241,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             minWidth: 0,
-            paddingTop: 6,
+            marginTop: 7,
           }}
         >
           Model
@@ -263,7 +263,17 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           <PercentageOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
           />
-          <Typography.Text style={{ fontSize: 12, flex: 1, color: token.colorTextSecondary }}>
+          <Typography.Text
+            style={{
+              fontSize: 12,
+              flex: 1,
+              color: token.colorTextSecondary,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
             Effort
           </Typography.Text>
           <EffortSelector
@@ -279,7 +289,17 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       {/* Permissions */}
       <div style={{ ...overflowRowStyle, cursor: 'default' }}>
         <LockOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
-        <Typography.Text style={{ fontSize: 12, flex: 1, color: token.colorTextSecondary }}>
+        <Typography.Text
+          style={{
+            fontSize: 12,
+            flex: 1,
+            color: token.colorTextSecondary,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+          }}
+        >
           Permissions
         </Typography.Text>
         <PermissionModeSelector
@@ -296,7 +316,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         />
       </div>
 
-      <Divider style={{ margin: '6px 0' }} />
+      <Divider style={{ margin: '4px 0' }} />
 
       {/* === Section: Actions === */}
       <div style={sectionHeaderStyle}>Actions</div>
@@ -325,7 +345,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             style={{
               display: 'flex',
               alignItems: 'center',
-              gap: token.sizeUnit,
+              gap: 8,
               flex: 1,
               minWidth: 0,
               overflow: 'hidden',
@@ -359,8 +379,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               cursor: 'pointer',
               color: pinnedItems.includes('upload') ? token.colorPrimary : token.colorTextTertiary,
               lineHeight: 1,
-              padding: 2,
+              padding: '4px',
               flexShrink: 0,
+              borderRadius: token.borderRadiusSM,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
             onClick={(e) => {
               e.stopPropagation();
@@ -401,7 +425,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: token.sizeUnit,
+                gap: 8,
                 flex: 1,
                 minWidth: 0,
                 overflow: 'hidden',
@@ -435,8 +459,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 cursor: 'pointer',
                 color: pinnedItems.includes('fork') ? token.colorPrimary : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={(e) => {
                 e.stopPropagation();
@@ -482,7 +510,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: token.sizeUnit,
+                gap: 8,
                 flex: 1,
                 minWidth: 0,
                 overflow: 'hidden',
@@ -518,8 +546,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   ? token.colorPrimary
                   : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={(e) => {
                 e.stopPropagation();
@@ -567,7 +599,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               style={{
                 display: 'flex',
                 alignItems: 'center',
-                gap: token.sizeUnit,
+                gap: 8,
                 flex: 1,
                 minWidth: 0,
                 overflow: 'hidden',
@@ -601,8 +633,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 cursor: 'pointer',
                 color: pinnedItems.includes('spawn') ? token.colorPrimary : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={(e) => {
                 e.stopPropagation();
@@ -619,7 +655,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         </div>
       )}
 
-      <Divider style={{ margin: '6px 0' }} />
+      <Divider style={{ margin: '4px 0' }} />
 
       {/* === Section: Info bar chips === */}
       <div style={sectionHeaderStyle}>Info bar</div>
@@ -654,8 +690,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 cursor: 'pointer',
                 color: pinnedChips.includes('timer') ? token.colorPrimary : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={() => toggleChip('timer')}
             >
@@ -696,8 +736,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               cursor: 'pointer',
               color: pinnedChips.includes('tools') ? token.colorPrimary : token.colorTextTertiary,
               lineHeight: 1,
-              padding: 2,
+              padding: '4px',
               flexShrink: 0,
+              borderRadius: token.borderRadiusSM,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
             onClick={() => toggleChip('tools')}
           >
@@ -738,8 +782,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 cursor: 'pointer',
                 color: pinnedChips.includes('model') ? token.colorPrimary : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={() => toggleChip('model')}
             >
@@ -785,8 +833,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   ? token.colorPrimary
                   : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={() => toggleChip('tokens')}
             >
@@ -832,8 +884,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   ? token.colorPrimary
                   : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={() => toggleChip('context')}
             >
@@ -847,7 +903,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         </div>
       )}
 
-      <Divider style={{ margin: '6px 0' }} />
+      <Divider style={{ margin: '4px 0' }} />
 
       {/* Session IDs row */}
       <Popover
@@ -898,8 +954,12 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   ? token.colorPrimary
                   : token.colorTextTertiary,
                 lineHeight: 1,
-                padding: 2,
+                padding: '4px',
                 flexShrink: 0,
+                borderRadius: token.borderRadiusSM,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
               }}
               onClick={(e) => {
                 e.stopPropagation();

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@agor-live/client';
 import {
   BranchesOutlined,
+  CheckCircleFilled,
   ClockCircleOutlined,
   EllipsisOutlined,
   ForkOutlined,
@@ -23,6 +24,7 @@ import {
   QuestionCircleOutlined,
   RobotOutlined,
   SendOutlined,
+  SettingOutlined,
   StopOutlined,
   ToolOutlined,
   WarningOutlined,
@@ -163,47 +165,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
   const hasUnauthedMcp = unauthedMcpServers.length > 0;
 
-  // Tools chip popover: list server names
-  const toolsPopoverContent = (
-    <div style={{ maxWidth: 280 }}>
-      <Space direction="vertical" size={6} style={{ width: '100%' }}>
-        <Typography.Text strong style={{ fontSize: 13 }}>
-          Attached MCP servers
-        </Typography.Text>
-        {sessionMcpServerIds.map((id) => {
-          const server = mcpServerById.get(id);
-          const needsAuth = unauthedMcpServers.some((s) => s.mcp_server_id === id);
-          return (
-            <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              {needsAuth && <WarningOutlined style={{ color: token.colorWarning, fontSize: 12 }} />}
-              <Typography.Text style={{ fontSize: 12 }}>
-                {server?.name ?? id}
-                {needsAuth && (
-                  <Typography.Text type="warning" style={{ fontSize: 11, marginLeft: 4 }}>
-                    (needs auth)
-                  </Typography.Text>
-                )}
-              </Typography.Text>
-            </div>
-          );
-        })}
-        {onOpenSessionSettings && (
-          <>
-            <Divider style={{ margin: '4px 0' }} />
-            <Button
-              type="link"
-              size="small"
-              style={{ padding: 0, height: 'auto' }}
-              onClick={() => onOpenSessionSettings(session.session_id)}
-            >
-              MCP settings
-            </Button>
-          </>
-        )}
-      </Space>
-    </div>
-  );
-
   const sectionHeaderStyle: React.CSSProperties = {
     padding: '6px 12px 3px',
     fontSize: 11,
@@ -221,6 +182,104 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
     padding: '0 6px 0 12px',
     height: 32,
   };
+
+  // Tools chip popover: list server names
+  const toolsPopoverContent = (
+    <div style={{ width: 260, paddingTop: 6, paddingBottom: 6 }}>
+      <div style={sectionHeaderStyle}>Tools</div>
+
+      {sessionMcpServerIds.length === 0 && (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 4,
+            padding: '12px 12px 8px',
+            textAlign: 'center',
+          }}
+        >
+          <ToolOutlined style={{ fontSize: 20, color: token.colorTextTertiary }} />
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            No tools attached
+          </Typography.Text>
+          <Typography.Text
+            type="secondary"
+            style={{ fontSize: 11, color: token.colorTextTertiary }}
+          >
+            Add MCP servers in settings
+          </Typography.Text>
+        </div>
+      )}
+
+      {sessionMcpServerIds.map((id) => {
+        const server = mcpServerById.get(id);
+        const needsAuth = unauthedMcpServers.some((s) => s.mcp_server_id === id);
+        return (
+          <div
+            key={id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '0 12px',
+              height: 32,
+            }}
+          >
+            {needsAuth ? (
+              <WarningOutlined style={{ fontSize: 12, color: token.colorWarning, flexShrink: 0 }} />
+            ) : (
+              <CheckCircleFilled
+                style={{ fontSize: 12, color: token.colorSuccess, flexShrink: 0 }}
+              />
+            )}
+            <Typography.Text
+              style={{
+                fontSize: 13,
+                flex: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              {server?.name ?? id}
+            </Typography.Text>
+            {needsAuth && (
+              <Typography.Text
+                type="warning"
+                style={{ fontSize: 11, flexShrink: 0, whiteSpace: 'nowrap' }}
+              >
+                needs auth
+              </Typography.Text>
+            )}
+          </div>
+        );
+      })}
+
+      {onOpenSessionSettings && (
+        <>
+          <Divider style={{ margin: '4px 0' }} />
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '0 6px 0 12px',
+              height: 32,
+              cursor: 'pointer',
+            }}
+            onClick={() => onOpenSessionSettings(session.session_id)}
+          >
+            <SettingOutlined
+              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+            />
+            <Typography.Text style={{ fontSize: 13, flex: 1 }}>MCP settings</Typography.Text>
+          </div>
+        </>
+      )}
+    </div>
+  );
 
   const moreContent = (
     <div style={{ width: 260, paddingTop: 6, paddingBottom: 6 }}>

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1,0 +1,593 @@
+import type {
+  AgorClient,
+  CodexApprovalPolicy,
+  CodexSandboxMode,
+  EffortLevel,
+  MCPServer,
+  PermissionMode,
+  Session,
+  Task,
+} from '@agor-live/client';
+import {
+  BranchesOutlined,
+  ClockCircleOutlined,
+  DollarOutlined,
+  EllipsisOutlined,
+  ForkOutlined,
+  PaperClipOutlined,
+  PercentageOutlined,
+  QuestionCircleOutlined,
+  RobotOutlined,
+  SendOutlined,
+  StopOutlined,
+  ToolOutlined,
+  WarningOutlined,
+} from '@ant-design/icons';
+import { Button, Divider, Popover, Space, Spin, Tooltip, Typography, theme } from 'antd';
+import React from 'react';
+import { EffortSelector } from '../EffortSelector';
+import type { ModelConfig } from '../ModelSelector';
+import { ModelSelector } from '../ModelSelector';
+import { PermissionModeSelector } from '../PermissionModeSelector';
+import { TimerPill } from '../Pill';
+import { getModelDisplayName } from '../Pill/modelDisplay';
+import { SessionIdsButton } from '../SessionIds';
+import { Tag } from '../Tag';
+
+export interface SessionFooterProps {
+  // Session data for chips
+  session: Session;
+  footerTimerTask: Task | null;
+  tokenBreakdown: {
+    total: number;
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheCreation: number;
+    cost: number;
+  };
+  latestContextWindow: { used: number; limit: number; taskMetadata: unknown } | null;
+  footerGradient?: string;
+  // MCP data for Tools chip
+  sessionMcpServerIds: string[];
+  unauthedMcpServers: MCPServer[];
+  mcpServerById: Map<string, MCPServer>;
+  // Action state
+  isRunning: boolean;
+  isStopping: boolean;
+  stopRequestInFlight: boolean;
+  hasInput: boolean;
+  connectionDisabled: boolean;
+  toolCaps?: { supportsSessionFork?: boolean; supportsChildSpawn?: boolean };
+  // Settings state
+  effortLevel: EffortLevel;
+  permissionMode: PermissionMode;
+  codexSandboxMode: CodexSandboxMode;
+  codexApprovalPolicy: CodexApprovalPolicy;
+  queuedTasks: Task[];
+  client: AgorClient | null;
+  modelLabel?: string;
+  modelConfig?: ModelConfig;
+  // Handlers
+  onModelConfigChange: (config: ModelConfig) => void;
+  onOpenSessionSettings?: (sessionId: string) => void;
+  onSendPrompt: () => void;
+  onStop: () => void;
+  onFork: () => void;
+  onBtwSend: () => void;
+  onSpawnOpen: () => void;
+  onUploadOpen: () => void;
+  onEffortChange: (v: EffortLevel) => void;
+  onPermissionModeChange: (v: PermissionMode) => void;
+  onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) => void;
+  // Prompt textarea rendered between the two bars
+  promptInputSlot: React.ReactNode;
+}
+
+export const SessionFooter: React.FC<SessionFooterProps> = ({
+  session,
+  footerTimerTask,
+  tokenBreakdown,
+  latestContextWindow,
+  footerGradient,
+  sessionMcpServerIds,
+  unauthedMcpServers,
+  mcpServerById,
+  isRunning,
+  isStopping,
+  stopRequestInFlight,
+  hasInput,
+  connectionDisabled,
+  toolCaps,
+  effortLevel,
+  permissionMode,
+  codexSandboxMode,
+  codexApprovalPolicy,
+  client,
+  modelLabel,
+  modelConfig,
+  onModelConfigChange,
+  onOpenSessionSettings,
+  onSendPrompt,
+  onStop,
+  onFork,
+  onBtwSend,
+  onSpawnOpen,
+  onUploadOpen,
+  onEffortChange,
+  onPermissionModeChange,
+  onCodexPermissionChange,
+  promptInputSlot,
+}) => {
+  const { token } = theme.useToken();
+  const [moreOpen, setMoreOpen] = React.useState(false);
+
+  // Stats chip: show when model or tokens are present
+  const modelName = session.model_config?.model
+    ? getModelDisplayName(
+        session.model_config.provider
+          ? `${session.model_config.provider}/${session.model_config.model}`
+          : session.model_config.model
+      )
+    : null;
+  const tokensK = tokenBreakdown.total > 0 ? Math.round(tokenBreakdown.total / 1000) : 0;
+  const showStatsChip = !!(modelName || tokenBreakdown.total > 0);
+
+  // Context window usage percentage (for warning styling)
+  const contextPct =
+    latestContextWindow && latestContextWindow.limit > 0
+      ? latestContextWindow.used / latestContextWindow.limit
+      : 0;
+  const contextWarning = contextPct > 0.8;
+
+  // Tools chip: show when MCP servers are attached
+  const showToolsChip = sessionMcpServerIds.length > 0;
+  const hasUnauthedMcp = unauthedMcpServers.length > 0;
+
+  // Tools chip popover: list server names
+  const toolsPopoverContent = (
+    <div style={{ maxWidth: 280 }}>
+      <Space direction="vertical" size={6} style={{ width: '100%' }}>
+        <Typography.Text strong style={{ fontSize: 13 }}>
+          Attached MCP servers
+        </Typography.Text>
+        {sessionMcpServerIds.map((id) => {
+          const server = mcpServerById.get(id);
+          const needsAuth = unauthedMcpServers.some((s) => s.mcp_server_id === id);
+          return (
+            <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              {needsAuth && <WarningOutlined style={{ color: token.colorWarning, fontSize: 12 }} />}
+              <Typography.Text style={{ fontSize: 12 }}>
+                {server?.name ?? id}
+                {needsAuth && (
+                  <Typography.Text type="warning" style={{ fontSize: 11, marginLeft: 4 }}>
+                    (needs auth)
+                  </Typography.Text>
+                )}
+              </Typography.Text>
+            </div>
+          );
+        })}
+        {onOpenSessionSettings && (
+          <>
+            <Divider style={{ margin: '4px 0' }} />
+            <Button
+              type="link"
+              size="small"
+              style={{ padding: 0, height: 'auto' }}
+              onClick={() => onOpenSessionSettings(session.session_id)}
+            >
+              MCP settings
+            </Button>
+          </>
+        )}
+      </Space>
+    </div>
+  );
+
+  // Stats chip popover: model, tokens, context window, cost, effort, timer
+  const statsPopoverContent = (
+    <div style={{ width: 260 }}>
+      <Space direction="vertical" size={8} style={{ width: '100%' }}>
+        {modelName && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Space size={4}>
+              <RobotOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                Model
+              </Typography.Text>
+            </Space>
+            <Typography.Text style={{ fontSize: 12 }}>{modelName}</Typography.Text>
+          </div>
+        )}
+        {tokenBreakdown.total > 0 && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Tokens
+            </Typography.Text>
+            <Typography.Text style={{ fontSize: 12 }}>
+              {tokenBreakdown.total.toLocaleString()}
+            </Typography.Text>
+          </div>
+        )}
+        {latestContextWindow && latestContextWindow.limit > 0 && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Space size={4}>
+              <PercentageOutlined
+                style={{
+                  fontSize: 12,
+                  color: contextWarning ? token.colorWarning : token.colorTextSecondary,
+                }}
+              />
+              <Typography.Text
+                type={contextWarning ? 'warning' : 'secondary'}
+                style={{ fontSize: 12 }}
+              >
+                Context
+              </Typography.Text>
+            </Space>
+            <Typography.Text type={contextWarning ? 'warning' : undefined} style={{ fontSize: 12 }}>
+              {Math.round(contextPct * 100)}%
+            </Typography.Text>
+          </div>
+        )}
+        {tokenBreakdown.cost > 0 && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Space size={4}>
+              <DollarOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                Est. cost
+              </Typography.Text>
+            </Space>
+            <Typography.Text style={{ fontSize: 12 }}>
+              ${tokenBreakdown.cost.toFixed(4)}
+            </Typography.Text>
+          </div>
+        )}
+        {effortLevel && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Effort
+            </Typography.Text>
+            <Typography.Text style={{ fontSize: 12, textTransform: 'capitalize' }}>
+              {effortLevel}
+            </Typography.Text>
+          </div>
+        )}
+        {footerTimerTask && (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Space size={4}>
+              <ClockCircleOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                Elapsed
+              </Typography.Text>
+            </Space>
+            <TimerPill
+              status={footerTimerTask.status}
+              startedAt={
+                footerTimerTask.message_range?.start_timestamp || footerTimerTask.created_at
+              }
+              endedAt={footerTimerTask.message_range?.end_timestamp || footerTimerTask.completed_at}
+              durationMs={footerTimerTask.duration_ms}
+              lastExecutorHeartbeatAt={footerTimerTask.last_executor_heartbeat_at}
+            />
+          </div>
+        )}
+      </Space>
+    </div>
+  );
+
+  // ··· more panel content (Popover with settings + overflow actions)
+  const moreContent = (
+    <div style={{ width: 280 }}>
+      <Space direction="vertical" size={8} style={{ width: '100%' }}>
+        {/* Overflow actions */}
+        {(toolCaps?.supportsSessionFork !== false || toolCaps?.supportsChildSpawn !== false) && (
+          <>
+            <Space size={4} wrap>
+              {toolCaps?.supportsSessionFork !== false && (
+                <Tooltip title="Ask a side question via ephemeral BTW fork">
+                  <Button
+                    size="small"
+                    type="default"
+                    icon={<QuestionCircleOutlined />}
+                    disabled={connectionDisabled || !hasInput}
+                    onClick={() => {
+                      setMoreOpen(false);
+                      onBtwSend();
+                    }}
+                  >
+                    BTW fork
+                  </Button>
+                </Tooltip>
+              )}
+              {toolCaps?.supportsChildSpawn !== false && (
+                <Tooltip
+                  title={
+                    connectionDisabled
+                      ? 'Disconnected from daemon'
+                      : isRunning
+                        ? 'Session is running'
+                        : 'Spawn subsession'
+                  }
+                >
+                  <Button
+                    size="small"
+                    type="default"
+                    icon={<BranchesOutlined />}
+                    disabled={connectionDisabled || isRunning}
+                    onClick={() => {
+                      setMoreOpen(false);
+                      onSpawnOpen();
+                    }}
+                  >
+                    Spawn
+                  </Button>
+                </Tooltip>
+              )}
+            </Space>
+            <Divider style={{ margin: '4px 0' }} />
+          </>
+        )}
+
+        {/* Model selector */}
+        <div>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            Model
+          </Typography.Text>
+          <div style={{ marginTop: token.sizeUnit }}>
+            <ModelSelector
+              value={modelConfig}
+              onChange={onModelConfigChange}
+              agentic_tool={session.agentic_tool}
+              client={client}
+              compact
+            />
+          </div>
+        </div>
+
+        {/* Effort selector — only for claude-code */}
+        {session.agentic_tool === 'claude-code' && (
+          <div>
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              Reasoning effort
+            </Typography.Text>
+            <div style={{ marginTop: token.sizeUnit }}>
+              <EffortSelector
+                value={effortLevel}
+                onChange={onEffortChange}
+                size="small"
+                compact
+                plain
+                fullWidth
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Permission mode */}
+        <div>
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            Permissions
+          </Typography.Text>
+          <div style={{ marginTop: token.sizeUnit }}>
+            <PermissionModeSelector
+              value={permissionMode}
+              onChange={onPermissionModeChange}
+              agentic_tool={session.agentic_tool}
+              codexSandboxMode={codexSandboxMode}
+              codexApprovalPolicy={codexApprovalPolicy}
+              onCodexChange={onCodexPermissionChange}
+              compact
+              iconOnly={false}
+              plain
+              fullWidth
+              size="small"
+            />
+          </div>
+        </div>
+
+        <Divider style={{ margin: '4px 0' }} />
+
+        {/* Session IDs */}
+        <SessionIdsButton session={session} />
+      </Space>
+    </div>
+  );
+
+  const stopTooltip = stopRequestInFlight
+    ? 'Sending stop request...'
+    : isStopping
+      ? 'Stopping... (Click again to retry if stuck)'
+      : 'Stop Execution';
+
+  const showStop = isRunning || stopRequestInFlight;
+
+  const sendLabel = isRunning && hasInput ? 'Queue' : 'Send';
+  const sendTooltip = connectionDisabled
+    ? 'Disconnected from daemon'
+    : isRunning
+      ? 'Queue Message'
+      : 'Send Prompt';
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        flexShrink: 0,
+        background: token.colorBgContainer,
+        borderTop: `1px solid ${token.colorBorder}`,
+        padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 6}px ${token.sizeUnit * 3}px`,
+        marginLeft: -token.sizeUnit * 6,
+        marginRight: -token.sizeUnit * 6,
+      }}
+    >
+      {/* Context window gradient overlay */}
+      {footerGradient && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: footerGradient,
+            pointerEvents: 'none',
+            zIndex: 0,
+          }}
+        />
+      )}
+
+      <div style={{ position: 'relative', zIndex: 1 }}>
+        {/* Row 1 — Info bar */}
+        {(showToolsChip || showStatsChip) && (
+          <div
+            style={{
+              display: 'flex',
+              gap: token.sizeUnit,
+              alignItems: 'center',
+              marginBottom: token.sizeUnit * 2,
+              flexWrap: 'wrap',
+            }}
+          >
+            {showToolsChip && (
+              <Popover
+                trigger="click"
+                placement="topLeft"
+                content={toolsPopoverContent}
+                title={null}
+              >
+                <Tag
+                  icon={<ToolOutlined />}
+                  color={hasUnauthedMcp ? 'warning' : 'default'}
+                  style={{
+                    cursor: 'pointer',
+                    height: 22,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                  }}
+                  data-testid="tools-chip"
+                >
+                  Tools&nbsp;·&nbsp;{sessionMcpServerIds.length}
+                  {hasUnauthedMcp && (
+                    <WarningOutlined
+                      style={{ marginLeft: token.sizeUnit, color: token.colorWarning }}
+                    />
+                  )}
+                </Tag>
+              </Popover>
+            )}
+
+            {showStatsChip && (
+              <Popover
+                trigger="click"
+                placement="topLeft"
+                content={statsPopoverContent}
+                title={null}
+              >
+                <Tag
+                  icon={<RobotOutlined />}
+                  color={contextWarning ? 'warning' : 'default'}
+                  style={{
+                    cursor: 'pointer',
+                    height: 22,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                  }}
+                  data-testid="stats-chip"
+                  data-warning={contextWarning ? 'true' : undefined}
+                >
+                  {modelName && <span>{modelName}</span>}
+                  {modelName && tokensK > 0 && <span>&nbsp;·&nbsp;</span>}
+                  {tokensK > 0 && <span>{tokensK}k</span>}
+                </Tag>
+              </Popover>
+            )}
+          </div>
+        )}
+
+        {/* Row 2 — Prompt textarea */}
+        {promptInputSlot}
+
+        {/* Row 3 — Action bar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: token.sizeUnit,
+            marginTop: token.sizeUnit * 2,
+          }}
+        >
+          {/* Left group */}
+          <Space size={4}>
+            <Tooltip title={connectionDisabled ? 'Disconnected from daemon' : 'Upload Files'}>
+              <Button
+                size="small"
+                type="text"
+                icon={<PaperClipOutlined />}
+                onClick={onUploadOpen}
+                disabled={connectionDisabled}
+              />
+            </Tooltip>
+            {toolCaps?.supportsSessionFork !== false && (
+              <Tooltip title={connectionDisabled ? 'Disconnected from daemon' : 'Fork Session'}>
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<ForkOutlined />}
+                  onClick={onFork}
+                  disabled={connectionDisabled}
+                />
+              </Tooltip>
+            )}
+            <Popover
+              open={moreOpen}
+              onOpenChange={setMoreOpen}
+              trigger="click"
+              placement="topLeft"
+              content={moreContent}
+              title={null}
+            >
+              <Tooltip title="More options">
+                <Button size="small" type="text" icon={<EllipsisOutlined />} />
+              </Tooltip>
+            </Popover>
+          </Space>
+
+          {/* Spacer */}
+          <div style={{ flex: 1 }} />
+
+          {/* Right group */}
+          <Space size={4}>
+            {showStop && (
+              <Tooltip title={stopTooltip}>
+                <Button
+                  danger
+                  size="small"
+                  icon={
+                    isStopping && !stopRequestInFlight ? <Spin size="small" /> : <StopOutlined />
+                  }
+                  onClick={onStop}
+                  disabled={!isRunning || stopRequestInFlight}
+                >
+                  Stop
+                </Button>
+              </Tooltip>
+            )}
+            <Tooltip title={sendTooltip}>
+              <Button
+                type="primary"
+                size="small"
+                icon={<SendOutlined />}
+                onClick={onSendPrompt}
+                disabled={connectionDisabled || !hasInput}
+              >
+                {sendLabel}
+              </Button>
+            </Tooltip>
+          </Space>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -153,8 +153,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       : 0;
   const contextWarning = contextPct > 0.8;
 
-  // Tools chip: show when MCP servers are attached
-  const showToolsChip = sessionMcpServerIds.length > 0;
+  const showToolsChip = true;
   const hasUnauthedMcp = unauthedMcpServers.length > 0;
 
   // Tools chip popover: list server names
@@ -265,25 +264,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             <Typography.Text style={{ fontSize: 12, textTransform: 'capitalize' }}>
               {effortLevel}
             </Typography.Text>
-          </div>
-        )}
-        {footerTimerTask && (
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Space size={4}>
-              <ClockCircleOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />
-              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                Elapsed
-              </Typography.Text>
-            </Space>
-            <TimerPill
-              status={footerTimerTask.status}
-              startedAt={
-                footerTimerTask.message_range?.start_timestamp || footerTimerTask.created_at
-              }
-              endedAt={footerTimerTask.message_range?.end_timestamp || footerTimerTask.completed_at}
-              durationMs={footerTimerTask.duration_ms}
-              lastExecutorHeartbeatAt={footerTimerTask.last_executor_heartbeat_at}
-            />
           </div>
         )}
       </Space>
@@ -559,7 +539,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       <div style={{ position: 'relative', zIndex: 1 }}>
         {/* Row 1 — Info bar */}
-        {(showToolsChip || showStatsChip) && (
+        {(showToolsChip || showStatsChip || footerTimerTask) && (
           <div
             style={{
               display: 'flex',
@@ -569,6 +549,31 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               flexWrap: 'wrap',
             }}
           >
+            {footerTimerTask && (
+              <Tag
+                icon={<ClockCircleOutlined />}
+                color="default"
+                style={{
+                  cursor: 'default',
+                  height: 22,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                }}
+                data-testid="timer-chip"
+              >
+                <TimerPill
+                  status={footerTimerTask.status}
+                  startedAt={
+                    footerTimerTask.message_range?.start_timestamp || footerTimerTask.created_at
+                  }
+                  endedAt={
+                    footerTimerTask.message_range?.end_timestamp || footerTimerTask.completed_at
+                  }
+                  durationMs={footerTimerTask.duration_ms}
+                  lastExecutorHeartbeatAt={footerTimerTask.last_executor_heartbeat_at}
+                />
+              </Tag>
+            )}
             {showToolsChip && (
               <Popover
                 trigger="click"
@@ -584,14 +589,21 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                     height: 22,
                     display: 'inline-flex',
                     alignItems: 'center',
+                    opacity: sessionMcpServerIds.length === 0 ? 0.45 : 1,
                   }}
                   data-testid="tools-chip"
                 >
-                  Tools&nbsp;·&nbsp;{sessionMcpServerIds.length}
-                  {hasUnauthedMcp && (
-                    <WarningOutlined
-                      style={{ marginLeft: token.sizeUnit, color: token.colorWarning }}
-                    />
+                  {sessionMcpServerIds.length === 0 ? (
+                    'No tools'
+                  ) : (
+                    <>
+                      Tools&nbsp;·&nbsp;{sessionMcpServerIds.length}
+                      {hasUnauthedMcp && (
+                        <WarningOutlined
+                          style={{ marginLeft: token.sizeUnit, color: token.colorWarning }}
+                        />
+                      )}
+                    </>
                   )}
                 </Tag>
               </Popover>

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -224,162 +224,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
   const moreContent = (
     <div style={{ width: 248 }}>
-      {/* === Section: Actions === */}
-      {(toolCaps?.supportsSessionFork !== false || toolCaps?.supportsChildSpawn !== false) && (
-        <>
-          <div style={sectionHeaderStyle}>Actions</div>
-          {toolCaps?.supportsSessionFork !== false && (
-            <Tooltip
-              title={
-                connectionDisabled || !hasInput
-                  ? 'Needs input and a live connection'
-                  : 'Ask a side question via an ephemeral fork'
-              }
-              placement="left"
-            >
-              <div
-                style={{
-                  ...overflowRowStyle,
-                  opacity: connectionDisabled || !hasInput ? 0.4 : 1,
-                  cursor: connectionDisabled || !hasInput ? 'not-allowed' : 'pointer',
-                }}
-                onClick={
-                  connectionDisabled || !hasInput
-                    ? undefined
-                    : () => {
-                        setMoreOpen(false);
-                        onBtwSend();
-                      }
-                }
-              >
-                <QuestionCircleOutlined
-                  style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
-                />
-                <Typography.Text
-                  style={{
-                    fontSize: 13,
-                    flex: 1,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    minWidth: 0,
-                  }}
-                >
-                  BTW fork
-                </Typography.Text>
-                <Tooltip
-                  title={pinnedItems.includes('btw-fork') ? 'Unpin from bar' : 'Pin to bar'}
-                  placement="right"
-                >
-                  <button
-                    type="button"
-                    aria-label={
-                      pinnedItems.includes('btw-fork') ? 'Unpin BTW fork' : 'Pin BTW fork'
-                    }
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      cursor: 'pointer',
-                      color: pinnedItems.includes('btw-fork')
-                        ? token.colorPrimary
-                        : token.colorTextTertiary,
-                      lineHeight: 1,
-                      padding: 2,
-                      flexShrink: 0,
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      togglePin('btw-fork');
-                    }}
-                  >
-                    {pinnedItems.includes('btw-fork') ? (
-                      <PushpinFilled style={{ fontSize: 12 }} />
-                    ) : (
-                      <PushpinOutlined style={{ fontSize: 12 }} />
-                    )}
-                  </button>
-                </Tooltip>
-              </div>
-            </Tooltip>
-          )}
-          {toolCaps?.supportsChildSpawn !== false && (
-            <Tooltip
-              title={
-                connectionDisabled
-                  ? 'Disconnected'
-                  : isRunning
-                    ? 'Session is running'
-                    : 'Spawn a child subsession'
-              }
-              placement="left"
-            >
-              <div
-                style={{
-                  ...overflowRowStyle,
-                  opacity: connectionDisabled || isRunning ? 0.4 : 1,
-                  cursor: connectionDisabled || isRunning ? 'not-allowed' : 'pointer',
-                }}
-                onClick={
-                  connectionDisabled || isRunning
-                    ? undefined
-                    : () => {
-                        setMoreOpen(false);
-                        onSpawnOpen();
-                      }
-                }
-              >
-                <BranchesOutlined
-                  style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
-                />
-                <Typography.Text
-                  style={{
-                    fontSize: 13,
-                    flex: 1,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    minWidth: 0,
-                  }}
-                >
-                  Spawn subsession
-                </Typography.Text>
-                <Tooltip
-                  title={pinnedItems.includes('spawn') ? 'Unpin from bar' : 'Pin to bar'}
-                  placement="right"
-                >
-                  <button
-                    type="button"
-                    aria-label={pinnedItems.includes('spawn') ? 'Unpin Spawn' : 'Pin Spawn'}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      cursor: 'pointer',
-                      color: pinnedItems.includes('spawn')
-                        ? token.colorPrimary
-                        : token.colorTextTertiary,
-                      lineHeight: 1,
-                      padding: 2,
-                      flexShrink: 0,
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      togglePin('spawn');
-                    }}
-                  >
-                    {pinnedItems.includes('spawn') ? (
-                      <PushpinFilled style={{ fontSize: 12 }} />
-                    ) : (
-                      <PushpinOutlined style={{ fontSize: 12 }} />
-                    )}
-                  </button>
-                </Tooltip>
-              </div>
-            </Tooltip>
-          )}
-          <Divider style={{ margin: '6px 0' }} />
-        </>
-      )}
-
       {/* === Section: Settings === */}
       <div style={sectionHeaderStyle}>Settings</div>
 
@@ -441,7 +285,300 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       <Divider style={{ margin: '6px 0' }} />
 
-      {/* === Section: Chips === */}
+      {/* === Section: Actions === */}
+      <div style={sectionHeaderStyle}>Actions</div>
+
+      {/* Upload */}
+      <Tooltip
+        title={connectionDisabled ? 'Disconnected from daemon' : 'Attach files to prompt'}
+        placement="left"
+      >
+        <div
+          style={{
+            ...overflowRowStyle,
+            opacity: connectionDisabled ? 0.4 : 1,
+            cursor: connectionDisabled ? 'not-allowed' : 'pointer',
+          }}
+          onClick={
+            connectionDisabled
+              ? undefined
+              : () => {
+                  setMoreOpen(false);
+                  onUploadOpen();
+                }
+          }
+        >
+          <PaperClipOutlined
+            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+          />
+          <Typography.Text
+            style={{
+              fontSize: 13,
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            Attach files
+          </Typography.Text>
+          <Tooltip
+            title={pinnedItems.includes('upload') ? 'Unpin from bar' : 'Pin to bar'}
+            placement="right"
+          >
+            <button
+              type="button"
+              aria-label={pinnedItems.includes('upload') ? 'Unpin Upload' : 'Pin Upload'}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedItems.includes('upload')
+                  ? token.colorPrimary
+                  : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                togglePin('upload');
+              }}
+            >
+              {pinnedItems.includes('upload') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
+        </div>
+      </Tooltip>
+
+      {/* Fork */}
+      {toolCaps?.supportsSessionFork !== false && (
+        <Tooltip
+          title={connectionDisabled ? 'Disconnected from daemon' : 'Fork this session'}
+          placement="left"
+        >
+          <div
+            style={{
+              ...overflowRowStyle,
+              opacity: connectionDisabled ? 0.4 : 1,
+              cursor: connectionDisabled ? 'not-allowed' : 'pointer',
+            }}
+            onClick={
+              connectionDisabled
+                ? undefined
+                : () => {
+                    setMoreOpen(false);
+                    onFork();
+                  }
+            }
+          >
+            <ForkOutlined
+              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+            />
+            <Typography.Text
+              style={{
+                fontSize: 13,
+                flex: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              Fork session
+            </Typography.Text>
+            <Tooltip
+              title={pinnedItems.includes('fork') ? 'Unpin from bar' : 'Pin to bar'}
+              placement="right"
+            >
+              <button
+                type="button"
+                aria-label={pinnedItems.includes('fork') ? 'Unpin Fork' : 'Pin Fork'}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: pinnedItems.includes('fork')
+                    ? token.colorPrimary
+                    : token.colorTextTertiary,
+                  lineHeight: 1,
+                  padding: 2,
+                  flexShrink: 0,
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  togglePin('fork');
+                }}
+              >
+                {pinnedItems.includes('fork') ? (
+                  <PushpinFilled style={{ fontSize: 12 }} />
+                ) : (
+                  <PushpinOutlined style={{ fontSize: 12 }} />
+                )}
+              </button>
+            </Tooltip>
+          </div>
+        </Tooltip>
+      )}
+
+      {/* BTW fork */}
+      {toolCaps?.supportsSessionFork !== false && (
+        <Tooltip
+          title={
+            connectionDisabled || !hasInput
+              ? 'Needs input and a live connection'
+              : 'Ask a side question via an ephemeral fork'
+          }
+          placement="left"
+        >
+          <div
+            style={{
+              ...overflowRowStyle,
+              opacity: connectionDisabled || !hasInput ? 0.4 : 1,
+              cursor: connectionDisabled || !hasInput ? 'not-allowed' : 'pointer',
+            }}
+            onClick={
+              connectionDisabled || !hasInput
+                ? undefined
+                : () => {
+                    setMoreOpen(false);
+                    onBtwSend();
+                  }
+            }
+          >
+            <QuestionCircleOutlined
+              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+            />
+            <Typography.Text
+              style={{
+                fontSize: 13,
+                flex: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              BTW fork
+            </Typography.Text>
+            <Tooltip
+              title={pinnedItems.includes('btw-fork') ? 'Unpin from bar' : 'Pin to bar'}
+              placement="right"
+            >
+              <button
+                type="button"
+                aria-label={pinnedItems.includes('btw-fork') ? 'Unpin BTW fork' : 'Pin BTW fork'}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: pinnedItems.includes('btw-fork')
+                    ? token.colorPrimary
+                    : token.colorTextTertiary,
+                  lineHeight: 1,
+                  padding: 2,
+                  flexShrink: 0,
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  togglePin('btw-fork');
+                }}
+              >
+                {pinnedItems.includes('btw-fork') ? (
+                  <PushpinFilled style={{ fontSize: 12 }} />
+                ) : (
+                  <PushpinOutlined style={{ fontSize: 12 }} />
+                )}
+              </button>
+            </Tooltip>
+          </div>
+        </Tooltip>
+      )}
+
+      {/* Spawn */}
+      {toolCaps?.supportsChildSpawn !== false && (
+        <Tooltip
+          title={
+            connectionDisabled
+              ? 'Disconnected'
+              : isRunning
+                ? 'Session is running'
+                : 'Spawn a child subsession'
+          }
+          placement="left"
+        >
+          <div
+            style={{
+              ...overflowRowStyle,
+              opacity: connectionDisabled || isRunning ? 0.4 : 1,
+              cursor: connectionDisabled || isRunning ? 'not-allowed' : 'pointer',
+            }}
+            onClick={
+              connectionDisabled || isRunning
+                ? undefined
+                : () => {
+                    setMoreOpen(false);
+                    onSpawnOpen();
+                  }
+            }
+          >
+            <BranchesOutlined
+              style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+            />
+            <Typography.Text
+              style={{
+                fontSize: 13,
+                flex: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                minWidth: 0,
+              }}
+            >
+              Spawn subsession
+            </Typography.Text>
+            <Tooltip
+              title={pinnedItems.includes('spawn') ? 'Unpin from bar' : 'Pin to bar'}
+              placement="right"
+            >
+              <button
+                type="button"
+                aria-label={pinnedItems.includes('spawn') ? 'Unpin Spawn' : 'Pin Spawn'}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: pinnedItems.includes('spawn')
+                    ? token.colorPrimary
+                    : token.colorTextTertiary,
+                  lineHeight: 1,
+                  padding: 2,
+                  flexShrink: 0,
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  togglePin('spawn');
+                }}
+              >
+                {pinnedItems.includes('spawn') ? (
+                  <PushpinFilled style={{ fontSize: 12 }} />
+                ) : (
+                  <PushpinOutlined style={{ fontSize: 12 }} />
+                )}
+              </button>
+            </Tooltip>
+          </div>
+        </Tooltip>
+      )}
+
+      <Divider style={{ margin: '6px 0' }} />
+
+      {/* === Section: Info bar chips === */}
       <div style={sectionHeaderStyle}>Info bar</div>
 
       {footerTimerTask && (
@@ -672,6 +809,38 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           >
             Session IDs
           </Typography.Text>
+          <Tooltip
+            title={pinnedChips.includes('session-ids') ? 'Unpin from info bar' : 'Pin to info bar'}
+            placement="right"
+          >
+            <button
+              type="button"
+              aria-label={
+                pinnedChips.includes('session-ids') ? 'Unpin Session IDs' : 'Pin Session IDs'
+              }
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedChips.includes('session-ids')
+                  ? token.colorPrimary
+                  : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggleChip('session-ids');
+              }}
+            >
+              {pinnedChips.includes('session-ids') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
         </div>
       </Popover>
     </div>
@@ -728,7 +897,8 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           (tokensK > 0 && pinnedChips.includes('tokens')) ||
           (latestContextWindow &&
             latestContextWindow.limit > 0 &&
-            pinnedChips.includes('context'))) && (
+            pinnedChips.includes('context')) ||
+          pinnedChips.includes('session-ids')) && (
           <div
             style={{
               display: 'flex',
@@ -794,28 +964,44 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
             {/* Model chip */}
             {modelName && pinnedChips.includes('model') && (
-              <Tag
-                icon={<RobotOutlined />}
-                color="default"
-                style={{
-                  cursor: 'default',
-                  height: 22,
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  maxWidth: 180,
-                }}
-                data-testid="model-chip"
+              <Popover
+                trigger="click"
+                placement="topLeft"
+                title="Model"
+                content={
+                  <div style={{ width: 280 }}>
+                    <ModelSelector
+                      value={modelConfig}
+                      onChange={onModelConfigChange}
+                      agentic_tool={session.agentic_tool}
+                      client={client}
+                    />
+                  </div>
+                }
               >
-                <span
+                <Tag
+                  icon={<RobotOutlined />}
+                  color="default"
                   style={{
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
+                    cursor: 'pointer',
+                    height: 22,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    maxWidth: 180,
                   }}
+                  data-testid="model-chip"
                 >
-                  {modelName}
-                </span>
-              </Tag>
+                  <span
+                    style={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {modelName}
+                  </span>
+                </Tag>
+              </Popover>
             )}
 
             {/* Tokens chip */}
@@ -857,6 +1043,39 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   {Math.round(contextPct * 100)}%
                 </Tag>
               )}
+
+            {/* Session IDs chip */}
+            {pinnedChips.includes('session-ids') && (
+              <Popover
+                trigger="click"
+                placement="topLeft"
+                title={
+                  <span>
+                    <IdcardOutlined style={{ marginRight: 8 }} />
+                    Session IDs
+                  </span>
+                }
+                content={
+                  <div style={{ width: 400, maxWidth: '90vw' }}>
+                    <SessionIdsList session={session} />
+                  </div>
+                }
+              >
+                <Tag
+                  icon={<IdcardOutlined />}
+                  color="default"
+                  style={{
+                    cursor: 'pointer',
+                    height: 22,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                  }}
+                  data-testid="session-ids-chip"
+                >
+                  IDs
+                </Tag>
+              </Popover>
+            )}
           </div>
         )}
 
@@ -874,16 +1093,19 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         >
           {/* Left group */}
           <Space size={4}>
-            <Tooltip title={connectionDisabled ? 'Disconnected from daemon' : 'Upload Files'}>
-              <Button
-                size="small"
-                type="text"
-                icon={<PaperClipOutlined />}
-                onClick={onUploadOpen}
-                disabled={connectionDisabled}
-              />
-            </Tooltip>
-            {toolCaps?.supportsSessionFork !== false && (
+            {pinnedItems.includes('upload') && (
+              <Tooltip title={connectionDisabled ? 'Disconnected from daemon' : 'Upload Files'}>
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<PaperClipOutlined />}
+                  onClick={onUploadOpen}
+                  disabled={connectionDisabled}
+                  data-testid="upload-bar-btn"
+                />
+              </Tooltip>
+            )}
+            {pinnedItems.includes('fork') && toolCaps?.supportsSessionFork !== false && (
               <Tooltip title={connectionDisabled ? 'Disconnected from daemon' : 'Fork Session'}>
                 <Button
                   size="small"
@@ -891,6 +1113,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   icon={<ForkOutlined />}
                   onClick={onFork}
                   disabled={connectionDisabled}
+                  data-testid="fork-bar-btn"
                 />
               </Tooltip>
             )}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -628,26 +628,31 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           >
             Timer
           </Typography.Text>
-          <button
-            type="button"
-            aria-label={pinnedChips.includes('timer') ? 'Hide timer' : 'Show timer'}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: pinnedChips.includes('timer') ? token.colorPrimary : token.colorTextTertiary,
-              lineHeight: 1,
-              padding: 2,
-              flexShrink: 0,
-            }}
-            onClick={() => toggleChip('timer')}
+          <Tooltip
+            title={pinnedChips.includes('timer') ? 'Hide from info bar' : 'Show in info bar'}
+            placement="right"
           >
-            {pinnedChips.includes('timer') ? (
-              <PushpinFilled style={{ fontSize: 12 }} />
-            ) : (
-              <PushpinOutlined style={{ fontSize: 12 }} />
-            )}
-          </button>
+            <button
+              type="button"
+              aria-label={pinnedChips.includes('timer') ? 'Hide timer' : 'Show timer'}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedChips.includes('timer') ? token.colorPrimary : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={() => toggleChip('timer')}
+            >
+              {pinnedChips.includes('timer') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
         </div>
       )}
 
@@ -665,26 +670,31 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
         >
           Tools
         </Typography.Text>
-        <button
-          type="button"
-          aria-label={pinnedChips.includes('tools') ? 'Hide tools' : 'Show tools'}
-          style={{
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            color: pinnedChips.includes('tools') ? token.colorPrimary : token.colorTextTertiary,
-            lineHeight: 1,
-            padding: 2,
-            flexShrink: 0,
-          }}
-          onClick={() => toggleChip('tools')}
+        <Tooltip
+          title={pinnedChips.includes('tools') ? 'Hide from info bar' : 'Show in info bar'}
+          placement="right"
         >
-          {pinnedChips.includes('tools') ? (
-            <PushpinFilled style={{ fontSize: 12 }} />
-          ) : (
-            <PushpinOutlined style={{ fontSize: 12 }} />
-          )}
-        </button>
+          <button
+            type="button"
+            aria-label={pinnedChips.includes('tools') ? 'Hide tools' : 'Show tools'}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: pinnedChips.includes('tools') ? token.colorPrimary : token.colorTextTertiary,
+              lineHeight: 1,
+              padding: 2,
+              flexShrink: 0,
+            }}
+            onClick={() => toggleChip('tools')}
+          >
+            {pinnedChips.includes('tools') ? (
+              <PushpinFilled style={{ fontSize: 12 }} />
+            ) : (
+              <PushpinOutlined style={{ fontSize: 12 }} />
+            )}
+          </button>
+        </Tooltip>
       </div>
 
       {modelName && (
@@ -702,26 +712,31 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           >
             Model
           </Typography.Text>
-          <button
-            type="button"
-            aria-label={pinnedChips.includes('model') ? 'Hide model' : 'Show model'}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: pinnedChips.includes('model') ? token.colorPrimary : token.colorTextTertiary,
-              lineHeight: 1,
-              padding: 2,
-              flexShrink: 0,
-            }}
-            onClick={() => toggleChip('model')}
+          <Tooltip
+            title={pinnedChips.includes('model') ? 'Hide from info bar' : 'Show in info bar'}
+            placement="right"
           >
-            {pinnedChips.includes('model') ? (
-              <PushpinFilled style={{ fontSize: 12 }} />
-            ) : (
-              <PushpinOutlined style={{ fontSize: 12 }} />
-            )}
-          </button>
+            <button
+              type="button"
+              aria-label={pinnedChips.includes('model') ? 'Hide model' : 'Show model'}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedChips.includes('model') ? token.colorPrimary : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={() => toggleChip('model')}
+            >
+              {pinnedChips.includes('model') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
         </div>
       )}
 
@@ -742,26 +757,33 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           >
             Tokens
           </Typography.Text>
-          <button
-            type="button"
-            aria-label={pinnedChips.includes('tokens') ? 'Hide tokens' : 'Show tokens'}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: pinnedChips.includes('tokens') ? token.colorPrimary : token.colorTextTertiary,
-              lineHeight: 1,
-              padding: 2,
-              flexShrink: 0,
-            }}
-            onClick={() => toggleChip('tokens')}
+          <Tooltip
+            title={pinnedChips.includes('tokens') ? 'Hide from info bar' : 'Show in info bar'}
+            placement="right"
           >
-            {pinnedChips.includes('tokens') ? (
-              <PushpinFilled style={{ fontSize: 12 }} />
-            ) : (
-              <PushpinOutlined style={{ fontSize: 12 }} />
-            )}
-          </button>
+            <button
+              type="button"
+              aria-label={pinnedChips.includes('tokens') ? 'Hide tokens' : 'Show tokens'}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedChips.includes('tokens')
+                  ? token.colorPrimary
+                  : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={() => toggleChip('tokens')}
+            >
+              {pinnedChips.includes('tokens') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
         </div>
       )}
 
@@ -782,26 +804,33 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           >
             Context %
           </Typography.Text>
-          <button
-            type="button"
-            aria-label={pinnedChips.includes('context') ? 'Hide context' : 'Show context'}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: pinnedChips.includes('context') ? token.colorPrimary : token.colorTextTertiary,
-              lineHeight: 1,
-              padding: 2,
-              flexShrink: 0,
-            }}
-            onClick={() => toggleChip('context')}
+          <Tooltip
+            title={pinnedChips.includes('context') ? 'Hide from info bar' : 'Show in info bar'}
+            placement="right"
           >
-            {pinnedChips.includes('context') ? (
-              <PushpinFilled style={{ fontSize: 12 }} />
-            ) : (
-              <PushpinOutlined style={{ fontSize: 12 }} />
-            )}
-          </button>
+            <button
+              type="button"
+              aria-label={pinnedChips.includes('context') ? 'Hide context' : 'Show context'}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: pinnedChips.includes('context')
+                  ? token.colorPrimary
+                  : token.colorTextTertiary,
+                lineHeight: 1,
+                padding: 2,
+                flexShrink: 0,
+              }}
+              onClick={() => toggleChip('context')}
+            >
+              {pinnedChips.includes('context') ? (
+                <PushpinFilled style={{ fontSize: 12 }} />
+              ) : (
+                <PushpinOutlined style={{ fontSize: 12 }} />
+              )}
+            </button>
+          </Tooltip>
         </div>
       )}
 
@@ -840,7 +869,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
             Session IDs
           </Typography.Text>
           <Tooltip
-            title={pinnedChips.includes('session-ids') ? 'Unpin from info bar' : 'Pin to info bar'}
+            title={pinnedChips.includes('session-ids') ? 'Hide from info bar' : 'Show in info bar'}
             placement="right"
           >
             <button

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1040,8 +1040,10 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 trigger="click"
                 placement="topLeft"
                 title="Model"
+                overlayStyle={{ maxWidth: 'none' }}
+                overlayInnerStyle={{ padding: 8 }}
                 content={
-                  <div style={{ width: 360 }}>
+                  <div style={{ width: 420 }}>
                     <ModelSelector
                       value={modelConfig}
                       onChange={onModelConfigChange}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1374,7 +1374,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 count={queuedTasks.length > 0 ? queuedTasks.length : 0}
                 size="small"
                 offset={[-2, 2]}
-                style={{ boxShadow: 'none' }}
+                style={{ boxShadow: 'none', backgroundColor: token.colorInfo, fontSize: 10 }}
               >
                 <Button
                   type="primary"

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -13,6 +13,7 @@ import {
   ClockCircleOutlined,
   EllipsisOutlined,
   ForkOutlined,
+  IdcardOutlined,
   LockOutlined,
   NumberOutlined,
   PaperClipOutlined,
@@ -35,7 +36,7 @@ import { ModelSelector } from '../ModelSelector';
 import { PermissionModeSelector } from '../PermissionModeSelector';
 import { TimerPill } from '../Pill';
 import { getModelDisplayName } from '../Pill/modelDisplay';
-import { SessionIdsButton } from '../SessionIds';
+import { SessionIdsList } from '../SessionIds';
 import { Tag } from '../Tag';
 
 export interface SessionFooterProps {
@@ -254,7 +255,18 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 <QuestionCircleOutlined
                   style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
                 />
-                <Typography.Text style={{ fontSize: 13, flex: 1 }}>BTW fork</Typography.Text>
+                <Typography.Text
+                  style={{
+                    fontSize: 13,
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    minWidth: 0,
+                  }}
+                >
+                  BTW fork
+                </Typography.Text>
                 <Tooltip
                   title={pinnedItems.includes('btw-fork') ? 'Unpin from bar' : 'Pin to bar'}
                   placement="right"
@@ -319,7 +331,16 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                 <BranchesOutlined
                   style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
                 />
-                <Typography.Text style={{ fontSize: 13, flex: 1 }}>
+                <Typography.Text
+                  style={{
+                    fontSize: 13,
+                    flex: 1,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    minWidth: 0,
+                  }}
+                >
                   Spawn subsession
                 </Typography.Text>
                 <Tooltip
@@ -428,7 +449,18 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           <ClockCircleOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
           />
-          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Timer</Typography.Text>
+          <Typography.Text
+            style={{
+              fontSize: 13,
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            Timer
+          </Typography.Text>
           <button
             type="button"
             aria-label={pinnedChips.includes('timer') ? 'Hide timer' : 'Show timer'}
@@ -454,7 +486,18 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       <div style={{ ...overflowRowStyle, cursor: 'default' }}>
         <ToolOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
-        <Typography.Text style={{ fontSize: 13, flex: 1 }}>Tools</Typography.Text>
+        <Typography.Text
+          style={{
+            fontSize: 13,
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+          }}
+        >
+          Tools
+        </Typography.Text>
         <button
           type="button"
           aria-label={pinnedChips.includes('tools') ? 'Hide tools' : 'Show tools'}
@@ -480,7 +523,18 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
       {modelName && (
         <div style={{ ...overflowRowStyle, cursor: 'default' }}>
           <RobotOutlined style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }} />
-          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Model</Typography.Text>
+          <Typography.Text
+            style={{
+              fontSize: 13,
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            Model
+          </Typography.Text>
           <button
             type="button"
             aria-label={pinnedChips.includes('model') ? 'Hide model' : 'Show model'}
@@ -509,7 +563,18 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           <NumberOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
           />
-          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Tokens</Typography.Text>
+          <Typography.Text
+            style={{
+              fontSize: 13,
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            Tokens
+          </Typography.Text>
           <button
             type="button"
             aria-label={pinnedChips.includes('tokens') ? 'Hide tokens' : 'Show tokens'}
@@ -538,7 +603,18 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
           <PercentageOutlined
             style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
           />
-          <Typography.Text style={{ fontSize: 13, flex: 1 }}>Context %</Typography.Text>
+          <Typography.Text
+            style={{
+              fontSize: 13,
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            Context %
+          </Typography.Text>
           <button
             type="button"
             aria-label={pinnedChips.includes('context') ? 'Hide context' : 'Show context'}
@@ -564,10 +640,40 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
 
       <Divider style={{ margin: '6px 0' }} />
 
-      {/* Session IDs */}
-      <div style={{ padding: `0 ${token.sizeUnit * 2}px 4px` }}>
-        <SessionIdsButton session={session} />
-      </div>
+      {/* Session IDs row */}
+      <Popover
+        trigger="click"
+        placement="topLeft"
+        title={
+          <span>
+            <IdcardOutlined style={{ marginRight: 8 }} />
+            Session IDs
+          </span>
+        }
+        content={
+          <div style={{ width: 400, maxWidth: '90vw' }}>
+            <SessionIdsList session={session} />
+          </div>
+        }
+      >
+        <div style={{ ...overflowRowStyle, cursor: 'pointer' }}>
+          <IdcardOutlined
+            style={{ fontSize: 14, color: token.colorTextSecondary, flexShrink: 0 }}
+          />
+          <Typography.Text
+            style={{
+              fontSize: 13,
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            Session IDs
+          </Typography.Text>
+        </div>
+      </Popover>
     </div>
   );
 
@@ -696,10 +802,19 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
                   height: 22,
                   display: 'inline-flex',
                   alignItems: 'center',
+                  maxWidth: 180,
                 }}
                 data-testid="model-chip"
               >
-                {modelName}
+                <span
+                  style={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {modelName}
+                </span>
               </Tag>
             )}
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -29,7 +29,7 @@ import {
   ToolOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
-import { Button, Divider, Popover, Space, Spin, Tooltip, Typography, theme } from 'antd';
+import { Badge, Button, Divider, Popover, Space, Spin, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useFooterPreferences } from '../../hooks/useFooterPreferences';
 import { EffortSelector } from '../EffortSelector';
@@ -106,6 +106,7 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
   hasInput,
   connectionDisabled,
   toolCaps,
+  queuedTasks,
   effortLevel,
   permissionMode,
   codexSandboxMode,
@@ -1369,15 +1370,22 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
               </Tooltip>
             )}
             <Tooltip title={sendTooltip}>
-              <Button
-                type="primary"
+              <Badge
+                count={queuedTasks.length > 0 ? queuedTasks.length : 0}
                 size="small"
-                icon={<SendOutlined />}
-                onClick={onSendPrompt}
-                disabled={connectionDisabled || !hasInput}
+                offset={[-2, 2]}
+                style={{ boxShadow: 'none' }}
               >
-                {sendLabel}
-              </Button>
+                <Button
+                  type="primary"
+                  size="small"
+                  icon={<SendOutlined />}
+                  onClick={onSendPrompt}
+                  disabled={connectionDisabled || !hasInput}
+                >
+                  {sendLabel}
+                </Button>
+              </Badge>
             </Tooltip>
           </Space>
         </div>

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -20,19 +20,14 @@ import {
 } from '@agor-live/client';
 import {
   AimOutlined,
-  BranchesOutlined,
   CloseOutlined,
   CodeOutlined,
   EllipsisOutlined,
-  ForkOutlined,
   InboxOutlined,
-  QuestionCircleOutlined,
-  SendOutlined,
   SettingOutlined,
-  StopOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Alert, App, Badge, Button, Dropdown, Space, Spin, Tooltip, Typography, theme } from 'antd';
+import { App, Badge, Button, Dropdown, Space, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -46,20 +41,16 @@ import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
-import { FileUpload, FileUploadButton } from '../FileUpload';
+import { FileUpload } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
-import { MCPServerPill } from '../MCPServer';
 import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
-import { ContextWindowPill, TimerPill, TokenCountPill } from '../Pill';
 import { getUrlDisplayLabel } from '../Pill/url-helpers';
-import { SessionIdsButton } from '../SessionIds';
 import { ToolIcon } from '../ToolIcon';
 import type { SessionAttachmentItem } from './SessionAttachmentsDropdown';
 import { SessionAttachmentsDropdown } from './SessionAttachmentsDropdown';
-import { SessionMcpFooterControl } from './SessionMcpFooterControl';
+import { SessionFooter } from './SessionFooter';
 import { SessionPanelContent } from './SessionPanelContent';
-import { SessionRunSettingsPopover } from './SessionRunSettingsPopover';
 
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
@@ -822,59 +813,42 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       }
     : undefined;
 
-  // Footer controls
-  const footerControls = (
-    <div
-      style={{
-        position: 'relative',
-        flexShrink: 0,
-        background: token.colorBgContainer,
-        borderTop: `1px solid ${token.colorBorder}`,
-        padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 6}px ${token.sizeUnit * 3}px`,
-        marginLeft: -token.sizeUnit * 6,
-        marginRight: -token.sizeUnit * 6,
-      }}
-    >
-      {footerGradient && (
-        <div
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            background: footerGradient,
-            pointerEvents: 'none',
-            zIndex: 0,
-          }}
-        />
-      )}
-      <Space
-        orientation="vertical"
-        style={{ width: '100%', position: 'relative', zIndex: 1 }}
-        size={8}
-      >
-        {unauthedMcpServers.length > 0 && (
-          <Alert
-            type="warning"
-            showIcon
-            title={
-              <span>
-                {unauthedMcpServers.map((server) => (
-                  <MCPServerPill
-                    key={server.mcp_server_id}
-                    server={server}
-                    needsAuth
-                    client={client}
-                  />
-                ))}{' '}
-                not authenticated — click to sign in.
-              </span>
-            }
-            style={{ marginBottom: 0, borderRadius: token.borderRadius }}
-            banner
-          />
-        )}
+  const sessionFooter = (
+    <SessionFooter
+      session={session}
+      footerTimerTask={footerTimerTask}
+      tokenBreakdown={tokenBreakdown}
+      latestContextWindow={latestContextWindow}
+      footerGradient={footerGradient}
+      sessionMcpServerIds={sessionMcpServerIds}
+      unauthedMcpServers={unauthedMcpServers}
+      mcpServerById={mcpServerById}
+      isRunning={isRunning}
+      isStopping={isStopping}
+      stopRequestInFlight={stopRequestInFlight}
+      hasInput={hasInput}
+      connectionDisabled={connectionDisabled}
+      toolCaps={toolCaps}
+      effortLevel={effortLevel}
+      permissionMode={permissionMode}
+      codexSandboxMode={codexSandboxMode}
+      codexApprovalPolicy={codexApprovalPolicy}
+      queuedTasks={queuedTasks}
+      client={client}
+      modelLabel={modelLabel}
+      modelConfig={modelConfig}
+      onModelConfigChange={handleModelConfigChange}
+      onOpenSessionSettings={onOpenSettings}
+      onSendPrompt={handleSendPrompt}
+      onStop={handleStop}
+      onFork={handleFork}
+      onBtwSend={handleBtwSend}
+      onSpawnOpen={() => setSpawnModalOpen(true)}
+      onUploadOpen={() => setUploadModalOpen(true)}
+      onEffortChange={handleEffortChange}
+      onPermissionModeChange={handlePermissionModeChange}
+      onCodexPermissionChange={handleCodexPermissionChange}
+      promptInputSlot={
         <PromptInput
           ref={promptRef}
           sessionId={session.session_id}
@@ -893,7 +867,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           client={client}
           userById={userById}
           onFilesDrop={(files) => {
-            // Store dropped files and open modal
             setDroppedFiles(files);
             setUploadModalOpen(true);
           }}
@@ -906,154 +879,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             return Array.isArray(ctx?.skills) ? ctx.skills : undefined;
           })()}
         />
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: `${token.sizeUnit}px`,
-            alignItems: 'center',
-            justifyContent: 'space-between',
-          }}
-        >
-          <Space size={4} wrap>
-            <SessionMcpFooterControl
-              client={client}
-              sessionId={session.session_id}
-              sessionMcpServerIds={sessionMcpServerIds}
-              mcpServerById={mcpServerById}
-              userAuthenticatedMcpServerIds={userAuthenticatedMcpServerIds}
-              onOpenSessionSettings={onOpenSettings}
-            />
-            {footerTimerTask && (
-              <TimerPill
-                status={footerTimerTask.status}
-                startedAt={
-                  footerTimerTask.message_range?.start_timestamp || footerTimerTask.created_at
-                }
-                endedAt={
-                  footerTimerTask.message_range?.end_timestamp || footerTimerTask.completed_at
-                }
-                durationMs={footerTimerTask.duration_ms}
-                lastExecutorHeartbeatAt={footerTimerTask.last_executor_heartbeat_at}
-              />
-            )}
-            <SessionIdsButton session={session} />
-            {tokenBreakdown.total > 0 && (
-              <TokenCountPill
-                count={tokenBreakdown.total}
-                estimatedCost={tokenBreakdown.cost}
-                inputTokens={tokenBreakdown.input}
-                outputTokens={tokenBreakdown.output}
-                cacheReadTokens={tokenBreakdown.cacheRead}
-                cacheCreationTokens={tokenBreakdown.cacheCreation}
-              />
-            )}
-            {latestContextWindow && (
-              <ContextWindowPill
-                used={latestContextWindow.used}
-                limit={latestContextWindow.limit}
-                taskMetadata={latestContextWindow.taskMetadata}
-              />
-            )}
-          </Space>
-          <Space size={4} wrap style={{ marginLeft: 'auto' }}>
-            {isRunning && <Spin size="small" />}
-            <SessionRunSettingsPopover
-              client={client}
-              session={session}
-              modelLabel={modelLabel}
-              modelConfig={modelConfig}
-              onModelConfigChange={handleModelConfigChange}
-              effortLevel={effortLevel}
-              onEffortChange={handleEffortChange}
-              permissionMode={permissionMode}
-              onPermissionModeChange={handlePermissionModeChange}
-              codexSandboxMode={codexSandboxMode}
-              codexApprovalPolicy={codexApprovalPolicy}
-              onCodexPermissionChange={handleCodexPermissionChange}
-            />
-            <Space.Compact>
-              <Tooltip
-                title={
-                  stopRequestInFlight
-                    ? 'Sending stop request...'
-                    : isStopping
-                      ? 'Stopping... (Click again to retry if stuck)'
-                      : isRunning
-                        ? 'Stop Execution'
-                        : 'No active execution'
-                }
-              >
-                <Button
-                  danger
-                  icon={<StopOutlined />}
-                  onClick={handleStop}
-                  disabled={!isRunning || stopRequestInFlight}
-                  loading={isStopping && !stopRequestInFlight}
-                />
-              </Tooltip>
-              {toolCaps?.supportsSessionFork !== false && (
-                <Tooltip title={connectionDisabled ? 'Disconnected from daemon' : 'Fork Session'}>
-                  <Button
-                    icon={<ForkOutlined />}
-                    onClick={handleFork}
-                    disabled={connectionDisabled}
-                  />
-                </Tooltip>
-              )}
-              {toolCaps?.supportsChildSpawn !== false && (
-                <Tooltip
-                  title={
-                    connectionDisabled
-                      ? 'Disconnected from daemon'
-                      : isRunning
-                        ? 'Session is running...'
-                        : 'Spawn Subsession'
-                  }
-                >
-                  <Button
-                    icon={<BranchesOutlined />}
-                    onClick={() => setSpawnModalOpen(true)}
-                    disabled={connectionDisabled || isRunning}
-                  />
-                </Tooltip>
-              )}
-              {toolCaps?.supportsSessionFork !== false && (
-                <Tooltip title="Ask a side question via ephemeral fork (btw)">
-                  <Button
-                    icon={<QuestionCircleOutlined />}
-                    onClick={handleBtwSend}
-                    disabled={connectionDisabled}
-                  />
-                </Tooltip>
-              )}
-              <Tooltip title={connectionDisabled ? 'Disconnected from daemon' : 'Upload Files'}>
-                <FileUploadButton
-                  onClick={() => setUploadModalOpen(true)}
-                  disabled={connectionDisabled}
-                />
-              </Tooltip>
-              <Tooltip
-                title={
-                  connectionDisabled
-                    ? 'Disconnected from daemon'
-                    : isRunning
-                      ? 'Queue Message'
-                      : 'Send Prompt'
-                }
-              >
-                <Button
-                  type="primary"
-                  icon={<SendOutlined />}
-                  onClick={handleSendPrompt}
-                  disabled={connectionDisabled || !hasInput}
-                />
-              </Tooltip>
-            </Space.Compact>
-          </Space>
-        </div>
-      </Space>
-    </div>
+      }
+    />
   );
 
   return (
@@ -1158,14 +985,14 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           setCliViewMode={setCliViewMode}
         />
 
-        {/* Footer Controls — rendered outside SessionPanelContent so that
+        {/* Footer — rendered outside SessionPanelContent so that
             keystroke-driven re-renders don't propagate to ConversationView.
             Hidden for CLI sessions in 'terminal' view because the embedded
             `claude` REPL has its own input prompt; the Agor textarea is
             redundant (and would inject via PTY anyway, racy with whatever
             the user is typing into the REPL directly). */}
         {!(session.agentic_tool === 'claude-code-cli' && cliViewMode === 'terminal') &&
-          footerControls}
+          sessionFooter}
 
         {/* Fork modal — opened when Fork button is clicked with an empty textarea */}
         <ForkSpawnModal

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -823,6 +823,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       sessionMcpServerIds={sessionMcpServerIds}
       unauthedMcpServers={unauthedMcpServers}
       mcpServerById={mcpServerById}
+      userAuthenticatedMcpServerIds={userAuthenticatedMcpServerIds}
       isRunning={isRunning}
       isStopping={isStopping}
       stopRequestInFlight={stopRequestInFlight}

--- a/apps/agor-ui/src/hooks/useFooterPreferences.ts
+++ b/apps/agor-ui/src/hooks/useFooterPreferences.ts
@@ -19,8 +19,19 @@ export function useFooterPreferences(): [
 ] {
   const [prefs, setPrefs] = React.useState<FooterPreferences>(() => {
     try {
-      const stored = localStorage.getItem(KEY);
-      if (stored) return { ...DEFAULTS, ...JSON.parse(stored) };
+      const stored = JSON.parse(localStorage.getItem(KEY) ?? 'null');
+      if (stored && typeof stored === 'object') {
+        return {
+          ...DEFAULTS,
+          ...stored,
+          pinnedItems: Array.isArray(stored.pinnedItems)
+            ? stored.pinnedItems
+            : DEFAULTS.pinnedItems,
+          pinnedChips: Array.isArray(stored.pinnedChips)
+            ? stored.pinnedChips
+            : DEFAULTS.pinnedChips,
+        };
+      }
     } catch {
       // ignore
     }

--- a/apps/agor-ui/src/hooks/useFooterPreferences.ts
+++ b/apps/agor-ui/src/hooks/useFooterPreferences.ts
@@ -5,6 +5,7 @@ const DEFAULTS = {
   showStatsChip: true,
   showForkInBar: true,
   showUploadInBar: true,
+  pinnedItems: [] as string[],
 };
 
 export type FooterPreferences = typeof DEFAULTS;

--- a/apps/agor-ui/src/hooks/useFooterPreferences.ts
+++ b/apps/agor-ui/src/hooks/useFooterPreferences.ts
@@ -5,7 +5,7 @@ const DEFAULTS = {
   showStatsChip: true,
   showForkInBar: true,
   showUploadInBar: true,
-  pinnedItems: [] as string[],
+  pinnedItems: ['fork', 'upload'] as string[],
   pinnedChips: ['timer', 'tools', 'model', 'tokens', 'context'] as string[],
 };
 

--- a/apps/agor-ui/src/hooks/useFooterPreferences.ts
+++ b/apps/agor-ui/src/hooks/useFooterPreferences.ts
@@ -6,6 +6,7 @@ const DEFAULTS = {
   showForkInBar: true,
   showUploadInBar: true,
   pinnedItems: [] as string[],
+  pinnedChips: ['timer', 'tools', 'model', 'tokens', 'context'] as string[],
 };
 
 export type FooterPreferences = typeof DEFAULTS;

--- a/apps/agor-ui/src/hooks/useFooterPreferences.ts
+++ b/apps/agor-ui/src/hooks/useFooterPreferences.ts
@@ -1,0 +1,41 @@
+import React from 'react';
+
+const DEFAULTS = {
+  showToolsChip: true,
+  showStatsChip: true,
+  showForkInBar: true,
+  showUploadInBar: true,
+};
+
+export type FooterPreferences = typeof DEFAULTS;
+
+const KEY = 'agor-footer-prefs';
+
+export function useFooterPreferences(): [
+  FooterPreferences,
+  (patch: Partial<FooterPreferences>) => void,
+] {
+  const [prefs, setPrefs] = React.useState<FooterPreferences>(() => {
+    try {
+      const stored = localStorage.getItem(KEY);
+      if (stored) return { ...DEFAULTS, ...JSON.parse(stored) };
+    } catch {
+      // ignore
+    }
+    return DEFAULTS;
+  });
+
+  const setPref = React.useCallback((patch: Partial<FooterPreferences>) => {
+    setPrefs((prev) => {
+      const next = { ...prev, ...patch };
+      try {
+        localStorage.setItem(KEY, JSON.stringify(next));
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  return [prefs, setPref];
+}


### PR DESCRIPTION
## Summary

Before
<img width="425" height="177" alt="image" src="https://github.com/user-attachments/assets/80e34646-a06c-47fa-b194-bf394631064f" />

After

https://github.com/user-attachments/assets/608d6a02-23be-4642-a830-8f3987fd1255



- Extracts a new `SessionFooter` component with a three-row layout that gives `Send` clear visual primacy over 10+ secondary controls
- **Row 1 (info bar):** Tools chip (MCP server count + unauth warning) and Stats chip (model · Xk tokens, context window warning at >80%) sit above the textarea — monitoring at a glance, never in the action path
- **Row 2:** Prompt textarea (passed as a React slot, `PromptInput` unchanged)
- **Row 3 (action bar):** Upload + Fork + ··· overflow Popover on the left; Stop (only when running) + Send on the right. Send label becomes "Queue" when the session is already running
- Secondary actions (BTW fork, Spawn, model/effort/permission settings, Session IDs) move into the ··· overflow Popover — still accessible, not competing with Send
- Adds `useFooterPreferences` hook (localStorage key `agor-footer-prefs`) for future per-user layout toggles

## Test plan

- [ ] 11 tests in `SessionFooter.test.tsx` cover: Send disabled/enabled, Queue label when running, Stop visibility, Stats chip hidden/warning, Tools chip hidden/count, hook defaults and persistence
- [ ] `npx vitest run "SessionFooter"` — all 11 pass
- [ ] Full suite `npx vitest run` — 519 tests pass (90 suites)
- [ ] `biome ci` clean on all 4 modified/created files
- [ ] No new TypeScript errors beyond pre-existing `@agor-live/client` declaration gaps in this worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)