### PR TITLE
feat(seed): add LOAD_FIXTURES demo data switch

### DIFF
--- a/apps/agor-docs/pages/guide/development.mdx
+++ b/apps/agor-docs/pages/guide/development.mdx
@@ -18,16 +18,44 @@ docker compose up
 
 That gives you SQLite, single-user, no RBAC — the fastest path to a running daemon. For Postgres, multiplayer + RBAC, or the docs site, see the variant system below.
 
+## Seeding test data
+
+Two optional, composable env switches pre-populate the database on first boot:
+
+```bash
+# Real runnable branch (clones the agor repo) + a rich set of demo data
+SEED=true LOAD_FIXTURES=true docker compose up
+```
+
+- **`SEED=true`** — clones the real `agor` repo and creates one runnable `test-branch`.
+- **`LOAD_FIXTURES=true`** — inserts hardcoded, `demo-`-prefixed fake data (pure DB
+  inserts, no git/network): 4 loginable users, 2 repos, a board with 4 zones, 5
+  branches, 4 sessions with fork/spawn genealogy + transcripts, kanban cards, and a
+  live Sandpack artifact. Idempotent and **dev-only**. You can also run it manually
+  with `pnpm load:fixtures`.
+
+Both are off by default and can be enabled independently. With `LOAD_FIXTURES`,
+extra demo logins are available (passwords printed in the seed log):
+
+| Email                  | Password              | Role   |
+| ---------------------- | --------------------- | ------ |
+| `demo.alice@agor.live` | `demo-password-alice` | admin  |
+| `demo.bob@agor.live`   | `demo-password-bob`   | member |
+| `demo.carol@agor.live` | `demo-password-carol` | member |
+| `demo.dave@agor.live`  | `demo-password-dave`  | viewer |
+
+See [`packages/core/src/seed/README.md`](https://github.com/preset-io/agor/blob/main/packages/core/src/seed/README.md) for the full inventory.
+
 ## `.agor.yml` — the variant system
 
 Agor's repo ships [`.agor.yml`](https://github.com/preset-io/agor/blob/main/.agor.yml) — a declarative schema describing how to spawn an environment for this codebase. The same schema you'd write for any repo you load into Agor: Agor uses it to develop itself. Each variant is a Handlebars-templated `start` / `stop` / `nuke` / `logs` / `health` / `app` block.
 
-| Variant | What you get | Base ports |
-|---|---|---|
-| **`sqlite`** _(default)_ | SQLite, single-user, no RBAC. Fastest to boot. | daemon: `3000 + branch.unique_id`, UI: `5000 + …` |
-| **`postgres`** | Postgres backend (closer to multi-user prod). RBAC off. **Requires Postgres 13+** (migrations use `gen_random_uuid()` from pg_catalog). | same as `sqlite` |
-| **`full`** | Postgres + branch RBAC + strict Unix-user impersonation. Requires the sudoers config under `docker/sudoers/`. Same PG13+ floor as `postgres`. | same as `sqlite` |
-| **`docs`** | The Nextra docs site (`apps/agor-docs`) in its own self-contained container. Standalone — no daemon, no DB. | `7000 + branch.unique_id` |
+| Variant                  | What you get                                                                                                                                  | Base ports                                        |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| **`sqlite`** _(default)_ | SQLite, single-user, no RBAC. Fastest to boot.                                                                                                | daemon: `3000 + branch.unique_id`, UI: `5000 + …` |
+| **`postgres`**           | Postgres backend (closer to multi-user prod). RBAC off. **Requires Postgres 13+** (migrations use `gen_random_uuid()` from pg_catalog).       | same as `sqlite`                                  |
+| **`full`**               | Postgres + branch RBAC + strict Unix-user impersonation. Requires the sudoers config under `docker/sudoers/`. Same PG13+ floor as `postgres`. | same as `sqlite`                                  |
+| **`docs`**               | The Nextra docs site (`apps/agor-docs`) in its own self-contained container. Standalone — no daemon, no DB.                                   | `7000 + branch.unique_id`                         |
 
 Ports derive from `branch.unique_id` so multiple branches run side-by-side without colliding. The `docs` variant uses `{{host.ip_address}}` in its app URL so the dev server is reachable from your laptop, not just localhost on the daemon host.
 
@@ -42,11 +70,11 @@ sqlite:
     DAEMON_PORT={{add 3000 branch.unique_id}}
     UI_PORT={{add 5000 branch.unique_id}}
     docker compose -p agor-{{branch.name}} up -d
-  stop:   docker compose -p agor-{{branch.name}} down
-  nuke:   docker compose -p agor-{{branch.name}} down -v
-  logs:   docker compose -p agor-{{branch.name}} logs --tail=100
+  stop: docker compose -p agor-{{branch.name}} down
+  nuke: docker compose -p agor-{{branch.name}} down -v
+  logs: docker compose -p agor-{{branch.name}} logs --tail=100
   health: http://localhost:{{add 3000 branch.unique_id}}/health
-  app:    http://localhost:{{add 5000 branch.unique_id}}
+  app: http://localhost:{{add 5000 branch.unique_id}}
 ```
 
 Other variants `extends: sqlite` to inherit the unchanged blocks — the schema enforces single-level extension only (no chains).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,6 +129,12 @@ services:
       # Creates: Agor repo (https://github.com/preset-io/agor.git) + test-branch
       - SEED=${SEED:-false}
 
+      # Load demo fixtures (optional, set LOAD_FIXTURES=true for hardcoded fake
+      # data: users, branches, sessions+transcripts, boards/zones, cards,
+      # artifacts). Pure DB inserts (no git/network). Composes with SEED; the
+      # recommended combo for instant E2E testing is SEED=true LOAD_FIXTURES=true
+      - LOAD_FIXTURES=${LOAD_FIXTURES:-false}
+
       # Pass through API keys from host (if set)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -236,6 +236,21 @@ if [ "$SEED" = "true" ]; then
   fi
 fi
 
+# Load demo fixtures if LOAD_FIXTURES=true (idempotent: skips if demo data
+# exists). Pure DB inserts — no git/network/executor. Orthogonal to SEED and
+# runs AFTER it, so `SEED=true LOAD_FIXTURES=true` yields a real runnable branch
+# plus a rich set of hardcoded fake data for instant end-to-end testing.
+if [ "$LOAD_FIXTURES" = "true" ]; then
+  echo "🎭 Loading demo fixtures..."
+  if [ -n "$ADMIN_USER_ID" ]; then
+    echo "   Using admin user: ${ADMIN_USER_ID}..."
+    pnpm tsx scripts/load-fixtures.ts --skip-if-exists --user-id "$ADMIN_USER_ID"
+  else
+    echo "⚠️  Warning: Could not find admin user, loading demo fixtures without admin owner"
+    pnpm tsx scripts/load-fixtures.ts --skip-if-exists
+  fi
+fi
+
 # Create RBAC test users if enabled (PostgreSQL + RBAC mode)
 if [ "$CREATE_RBAC_TEST_USERS" = "true" ]; then
   echo "👥 Creating RBAC test users and branches..."

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "cli:unlink": "pnpm -C apps/agor-cli unlink --global",
     "agor": "NODE_NO_WARNINGS=1 pnpm --filter @agor/cli exec tsx bin/dev.ts",
     "seed": "tsx scripts/seed.ts",
+    "load:fixtures": "tsx scripts/load-fixtures.ts",
     "sync:agor-live-deps": "node scripts/sync-agor-live-deps.mjs",
     "check:agor-live-deps": "node scripts/sync-agor-live-deps.mjs --check"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -214,6 +214,12 @@
       "import": "./dist/seed/dev-fixtures.js",
       "require": "./dist/seed/dev-fixtures.cjs"
     },
+    "./seed/demo-fixtures": {
+      "source": "./src/seed/demo-fixtures.ts",
+      "types": "./dist/seed/demo-fixtures.d.ts",
+      "import": "./dist/seed/demo-fixtures.js",
+      "require": "./dist/seed/demo-fixtures.cjs"
+    },
     "./callbacks/child-completion-template": {
       "source": "./src/callbacks/child-completion-template.ts",
       "types": "./dist/callbacks/child-completion-template.d.ts",

--- a/packages/core/src/seed/README.md
+++ b/packages/core/src/seed/README.md
@@ -2,6 +2,23 @@
 
 Quick-start your Agor development environment with pre-populated test data.
 
+There are **two independent, composable seeders**, each gated by its own env var:
+
+| Switch               | Seeder             | What it does                                                                                                 |
+| -------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `SEED=true`          | `seedDevFixtures`  | Clones the **real** `agor` repo + creates one real, runnable `test-branch` (does git/network).               |
+| `LOAD_FIXTURES=true` | `loadDemoFixtures` | Inserts a rich set of **hardcoded fake data** (`demo-`-prefixed). Pure DB inserts — no git/network/executor. |
+
+They are orthogonal — enable either or both. The **recommended combo for instant
+end-to-end testing** is:
+
+```bash
+SEED=true LOAD_FIXTURES=true docker compose up
+```
+
+…which gives you a real runnable branch **plus** a fully-populated demo board you
+can log into. See [Demo Fixtures](#demo-fixtures-load_fixtures) below.
+
 ## What Gets Seeded?
 
 The default seed (`seedDevFixtures`) creates:
@@ -50,6 +67,84 @@ const result = await seedDevFixtures({
 console.log(result.repo_id);
 console.log(result.branch_id);
 ```
+
+## Demo Fixtures (`LOAD_FIXTURES`)
+
+`loadDemoFixtures` (gated by `LOAD_FIXTURES=true`) populates a fresh dev/test
+database with a rich set of **hardcoded fake data** so the UI is immediately
+browsable and testable. It performs **pure DB inserts** — no git clone, no
+network, no executor — and runs **inside a single transaction** (all-or-nothing).
+It is **idempotent** (re-running is a no-op) and **dev-only** (never enable in
+production: the demo credentials below are well-known).
+
+Everything it creates is **`demo-`/`demo.`-prefixed**, so it never collides with
+the real `agor` repo (or its `test-branch`) created by `SEED`.
+
+### What gets seeded
+
+- **4 users** — loginable, bcrypt-hashed passwords (see credentials below).
+- **3 card types** — 🐛 Demo Bug / ✨ Demo Feature / ✅ Demo Task.
+- **2 repos** — `demo-webapp` (local) and `demo-api` (remote), placeholder paths.
+- **1 board** — "Demo Board" with 4 **zones**: To Do / In Progress / Review / Done.
+- **5 branches** — placed on the board and pinned into zones (no git ops).
+- **4 sessions** — terminal status, with **genealogy** (one spawned child + one
+  forked sibling of a root session).
+- **4 tasks** + **16 transcript messages** (including a `tool_use`/`tool_result`
+  exchange).
+- **4 kanban cards** — placed into zones.
+- **1 public Sandpack artifact** — a tiny React counter app.
+
+### Usage
+
+```bash
+# Docker — recommended combo (real branch + rich fakes)
+SEED=true LOAD_FIXTURES=true docker compose up
+
+# Just the demo data
+LOAD_FIXTURES=true docker compose up
+
+# Manual (CLI), from repo root
+pnpm load:fixtures
+pnpm load:fixtures --skip-if-exists
+pnpm tsx scripts/load-fixtures.ts --skip-if-exists --user-id <admin-uuid>
+```
+
+The docker entrypoint runs `LOAD_FIXTURES` **after** `SEED`. Passing
+`--user-id <admin-uuid>` (the entrypoint passes the bootstrapped admin) also adds
+that user as an owner of the demo board/branches; otherwise the demo entities are
+owned by the demo users.
+
+```typescript
+import { loadDemoFixtures } from '@agor/core/seed/demo-fixtures';
+
+const result = await loadDemoFixtures({ skipIfExists: true });
+console.log(result.skipped, result.counts);
+```
+
+### Test user credentials (dev-only)
+
+These are printed in the seed log on load. The bootstrap admin (`admin@agor.live`)
+is created by Agor's first-run setup; the `demo.*` users are created by
+`LOAD_FIXTURES`.
+
+| Email                  | Password              | Role       | Source              |
+| ---------------------- | --------------------- | ---------- | ------------------- |
+| `admin@agor.live`      | `admin`               | superadmin | first-run bootstrap |
+| `demo.alice@agor.live` | `demo-password-alice` | admin      | `LOAD_FIXTURES`     |
+| `demo.bob@agor.live`   | `demo-password-bob`   | member     | `LOAD_FIXTURES`     |
+| `demo.carol@agor.live` | `demo-password-carol` | member     | `LOAD_FIXTURES`     |
+| `demo.dave@agor.live`  | `demo-password-dave`  | viewer     | `LOAD_FIXTURES`     |
+
+> The `admin@agor.live` / `admin` default is development-only and refused when
+> `NODE_ENV=production`. Demo users exist only when `LOAD_FIXTURES` is enabled.
+
+### Files
+
+- **`packages/core/src/seed/demo-fixtures.ts`** — `loadDemoFixtures` (uses repositories)
+- **`scripts/load-fixtures.ts`** — CLI wrapper script
+- **`docker/docker-entrypoint.sh`** — Docker integration (checks `LOAD_FIXTURES`)
+- **`docker-compose.yml`** — exposes `LOAD_FIXTURES`
+- **`package.json`** — `pnpm load:fixtures` script
 
 ## Adding Custom Seed Data
 

--- a/packages/core/src/seed/demo-fixtures.test.ts
+++ b/packages/core/src/seed/demo-fixtures.test.ts
@@ -1,0 +1,114 @@
+/**
+ * loadDemoFixtures Tests
+ *
+ * Verifies the LOAD_FIXTURES demo seeder against a fresh in-memory database:
+ * per-entity row counts on first run, and idempotency (no duplicates) when
+ * re-run.
+ */
+
+import { describe, expect } from 'vitest';
+import {
+  ArtifactRepository,
+  BoardObjectRepository,
+  BoardRepository,
+  BranchRepository,
+  CardRepository,
+  CardTypeRepository,
+  MessagesRepository,
+  RepoRepository,
+  SessionRepository,
+  TaskRepository,
+  UsersRepository,
+} from '../db/repositories';
+import { dbTest } from '../db/test-helpers';
+import { loadDemoFixtures } from './demo-fixtures';
+
+describe('loadDemoFixtures', () => {
+  dbTest('inserts the expected demo entities on a fresh database', async ({ db }) => {
+    const result = await loadDemoFixtures({ db, skipIfExists: true });
+
+    expect(result.skipped).toBe(false);
+    expect(result.counts).toEqual({
+      users: 4,
+      card_types: 3,
+      repos: 2,
+      boards: 1,
+      branches: 5,
+      sessions: 4,
+      tasks: 4,
+      messages: 16,
+      cards: 4,
+      artifacts: 1,
+    });
+
+    // Cross-check actual rows landed in the DB.
+    const usersRepo = new UsersRepository(db);
+    const cardTypeRepo = new CardTypeRepository(db);
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const sessionRepo = new SessionRepository(db);
+    const taskRepo = new TaskRepository(db);
+    const messagesRepo = new MessagesRepository(db);
+    const cardRepo = new CardRepository(db);
+    const artifactRepo = new ArtifactRepository(db);
+    const boardRepo = new BoardRepository(db);
+    const boardObjectRepo = new BoardObjectRepository(db);
+
+    const demoUsers = (await usersRepo.findAll()).filter((u) => u.email.startsWith('demo.'));
+    expect(demoUsers).toHaveLength(4);
+
+    const demoTypes = (await cardTypeRepo.findAll()).filter((t) => t.name.startsWith('Demo'));
+    expect(demoTypes).toHaveLength(3);
+
+    const demoRepos = (await repoRepo.findAll()).filter((r) => r.slug.startsWith('demo-'));
+    expect(demoRepos).toHaveLength(2);
+
+    const demoBranches = (await branchRepo.findAll()).filter((b) => b.name.startsWith('demo-'));
+    expect(demoBranches).toHaveLength(5);
+
+    expect(await sessionRepo.findAll()).toHaveLength(4);
+    expect(await taskRepo.findAll()).toHaveLength(4);
+    expect(await messagesRepo.findAll()).toHaveLength(16);
+    expect(await cardRepo.findAll()).toHaveLength(4);
+    expect(await artifactRepo.findAll()).toHaveLength(1);
+
+    // Board with zones.
+    const board = await boardRepo.findBySlug('demo-board');
+    expect(board).not.toBeNull();
+    const objects = board?.objects ?? {};
+    const zones = Object.values(objects).filter((o) => o.type === 'zone');
+    expect(zones).toHaveLength(4);
+    const artifactEntries = Object.values(objects).filter((o) => o.type === 'artifact');
+    expect(artifactEntries).toHaveLength(1);
+
+    // Branch + card placements are board_objects rows (5 branches + 4 cards).
+    const placements = await boardObjectRepo.findByBoardId(board!.board_id);
+    expect(placements).toHaveLength(9);
+
+    // Genealogy: one spawned child + one forked sibling reference the root.
+    const sessions = await sessionRepo.findAll();
+    const withParent = sessions.filter((s) => s.genealogy?.parent_session_id);
+    const withFork = sessions.filter((s) => s.genealogy?.forked_from_session_id);
+    expect(withParent).toHaveLength(1);
+    expect(withFork).toHaveLength(1);
+  });
+
+  dbTest('is idempotent — re-running does not duplicate rows', async ({ db }) => {
+    const first = await loadDemoFixtures({ db, skipIfExists: true });
+    expect(first.skipped).toBe(false);
+
+    const second = await loadDemoFixtures({ db, skipIfExists: true });
+    expect(second.skipped).toBe(true);
+
+    // Run a third time without skipIfExists — still a no-op (sentinel guards it).
+    const third = await loadDemoFixtures({ db });
+    expect(third.skipped).toBe(true);
+
+    const usersRepo = new UsersRepository(db);
+    const demoUsers = (await usersRepo.findAll()).filter((u) => u.email.startsWith('demo.'));
+    expect(demoUsers).toHaveLength(4);
+
+    const messagesRepo = new MessagesRepository(db);
+    expect(await messagesRepo.findAll()).toHaveLength(16);
+  });
+});

--- a/packages/core/src/seed/demo-fixtures.test.ts
+++ b/packages/core/src/seed/demo-fixtures.test.ts
@@ -2,11 +2,15 @@
  * loadDemoFixtures Tests
  *
  * Verifies the LOAD_FIXTURES demo seeder against a fresh in-memory database:
- * per-entity row counts on first run, and idempotency (no duplicates) when
- * re-run.
+ * per-entity row counts, idempotency (no duplicates on re-run), loginable
+ * (bcrypt-hashed) demo users, session/task metadata consistency, genealogy
+ * wiring, and the artifact board-object layout entry shape.
  */
 
+import bcrypt from 'bcryptjs';
+import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
+import { select } from '../db/database-wrapper';
 import {
   ArtifactRepository,
   BoardObjectRepository,
@@ -20,8 +24,9 @@ import {
   TaskRepository,
   UsersRepository,
 } from '../db/repositories';
+import { users } from '../db/schema';
 import { dbTest } from '../db/test-helpers';
-import { loadDemoFixtures } from './demo-fixtures';
+import { DEMO_USER_CREDENTIALS, loadDemoFixtures } from './demo-fixtures';
 
 describe('loadDemoFixtures', () => {
   dbTest('inserts the expected demo entities on a fresh database', async ({ db }) => {
@@ -78,19 +83,100 @@ describe('loadDemoFixtures', () => {
     const objects = board?.objects ?? {};
     const zones = Object.values(objects).filter((o) => o.type === 'zone');
     expect(zones).toHaveLength(4);
-    const artifactEntries = Object.values(objects).filter((o) => o.type === 'artifact');
-    expect(artifactEntries).toHaveLength(1);
 
     // Branch + card placements are board_objects rows (5 branches + 4 cards).
     const placements = await boardObjectRepo.findByBoardId(board!.board_id);
     expect(placements).toHaveLength(9);
+  });
 
-    // Genealogy: one spawned child + one forked sibling reference the root.
+  dbTest('creates loginable demo users with bcrypt-hashed passwords', async ({ db }) => {
+    await loadDemoFixtures({ db, skipIfExists: true });
+
+    for (const cred of DEMO_USER_CREDENTIALS) {
+      // Read the RAW row to inspect the stored password (the public User DTO omits it).
+      const row = await select(db).from(users).where(eq(users.email, cred.email)).one();
+      expect(row).not.toBeNull();
+      const stored = (row as { password: string }).password;
+
+      // Stored value must be a bcrypt hash, not the cleartext.
+      expect(stored).toMatch(/^\$2[aby]\$/);
+      expect(stored).not.toBe(cred.password);
+
+      // ...and the known cleartext must verify against it (i.e. the user can log in).
+      expect(await bcrypt.compare(cred.password, stored)).toBe(true);
+    }
+  });
+
+  dbTest('wires session metadata + genealogy consistently', async ({ db }) => {
+    await loadDemoFixtures({ db, skipIfExists: true });
+
+    const sessionRepo = new SessionRepository(db);
+    const taskRepo = new TaskRepository(db);
     const sessions = await sessionRepo.findAll();
-    const withParent = sessions.filter((s) => s.genealogy?.parent_session_id);
-    const withFork = sessions.filter((s) => s.genealogy?.forked_from_session_id);
-    expect(withParent).toHaveLength(1);
-    expect(withFork).toHaveLength(1);
+    const tasks = await taskRepo.findAll();
+
+    // Each session's data.tasks must exactly match the task rows pointing at it.
+    for (const session of sessions) {
+      const taskIdsForSession = tasks
+        .filter((t) => t.session_id === session.session_id)
+        .map((t) => t.task_id)
+        .sort();
+      expect([...(session.tasks ?? [])].sort()).toEqual(taskIdsForSession);
+      expect(session.tasks).toHaveLength(1);
+    }
+
+    // Root session = the one referenced as parent/fork-source by its children.
+    const root = sessions.find((s) => s.title === 'Implement login form');
+    expect(root).toBeDefined();
+
+    const spawnedChild = sessions.find((s) => s.genealogy?.parent_session_id === root!.session_id);
+    const forkedChild = sessions.find(
+      (s) => s.genealogy?.forked_from_session_id === root!.session_id
+    );
+    expect(spawnedChild).toBeDefined();
+    expect(forkedChild).toBeDefined();
+
+    // Root genealogy.children must include BOTH the spawned and forked child.
+    expect(root!.genealogy?.children).toHaveLength(2);
+    expect(root!.genealogy?.children).toEqual(
+      expect.arrayContaining([spawnedChild!.session_id, forkedChild!.session_id])
+    );
+
+    // fork/spawn point fields live on the CHILDREN only, never on the root.
+    expect(root!.genealogy?.spawn_point_task_id).toBeUndefined();
+    expect(root!.genealogy?.fork_point_task_id).toBeUndefined();
+    expect(spawnedChild!.genealogy?.spawn_point_task_id).toBeDefined();
+    expect(forkedChild!.genealogy?.fork_point_task_id).toBeDefined();
+  });
+
+  dbTest('places a non-empty artifact via a board.data.objects entry', async ({ db }) => {
+    await loadDemoFixtures({ db, skipIfExists: true });
+
+    const artifactRepo = new ArtifactRepository(db);
+    const boardRepo = new BoardRepository(db);
+
+    const artifacts = await artifactRepo.findAll();
+    expect(artifacts).toHaveLength(1);
+    const artifact = artifacts[0];
+
+    // Artifact carries a non-empty Sandpack file map.
+    expect(artifact.files).toBeDefined();
+    expect(Object.keys(artifact.files ?? {}).length).toBeGreaterThan(0);
+
+    // Layout entry lives in board.data.objects, keyed `artifact-<id>`, with the
+    // exact ArtifactBoardObject shape (no board_objects row for artifacts).
+    const board = await boardRepo.findBySlug('demo-board');
+    const entry = board?.objects?.[`artifact-${artifact.artifact_id}`];
+    expect(entry).toBeDefined();
+    expect(entry).toMatchObject({
+      type: 'artifact',
+      artifact_id: artifact.artifact_id,
+    });
+    const layout = entry as { x: number; y: number; width: number; height: number };
+    expect(typeof layout.x).toBe('number');
+    expect(typeof layout.y).toBe('number');
+    expect(layout.width).toBeGreaterThan(0);
+    expect(layout.height).toBeGreaterThan(0);
   });
 
   dbTest('is idempotent — re-running does not duplicate rows', async ({ db }) => {

--- a/packages/core/src/seed/demo-fixtures.ts
+++ b/packages/core/src/seed/demo-fixtures.ts
@@ -1,0 +1,725 @@
+/**
+ * Demo Fixtures
+ *
+ * Lightweight, opt-in seeder that populates the database with a rich set of
+ * hardcoded FAKE data — users, card types, repos, a board with zones, branches,
+ * sessions with conversation transcripts, tasks, cards, and an artifact — so a
+ * fresh dev/test Agor environment is immediately usable for end-to-end testing.
+ *
+ * Unlike {@link seedDevFixtures} (`SEED=true`), this seeder performs PURE DB
+ * inserts: no git clones, no network, no executor. It is gated by the
+ * `LOAD_FIXTURES=true` switch and is orthogonal/composable with `SEED`.
+ *
+ * Everything is prefixed `demo-` / `demo.` so it never collides with the real
+ * `agor` repo (or its `test-branch`) created by {@link seedDevFixtures}. The
+ * seeder is idempotent: a sentinel user (`demo.alice@agor.live`) is checked
+ * first, so re-running is a no-op.
+ *
+ * Usage:
+ *   import { loadDemoFixtures } from '@agor/core/seed/demo-fixtures';
+ *   await loadDemoFixtures({ skipIfExists: true });
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import type {
+  Artifact,
+  BoardID,
+  BoardObject,
+  Branch,
+  Card,
+  CardType,
+  Message,
+  Task,
+  User,
+  UUID,
+} from '@agor/core/types';
+import { MessageRole, SessionStatus, TaskStatus } from '@agor/core/types';
+import type { Database } from '../db/client';
+import {
+  ArtifactRepository,
+  BoardObjectRepository,
+  BoardRepository,
+  BranchRepository,
+  CardRepository,
+  CardTypeRepository,
+  MessagesRepository,
+  RepoRepository,
+  SessionRepository,
+  TaskRepository,
+  UsersRepository,
+} from '../db/repositories';
+import { generateId } from '../lib/ids';
+
+/**
+ * Options for {@link loadDemoFixtures}.
+ *
+ * Mirrors {@link import('./dev-fixtures').SeedOptions} but `userId` is optional:
+ * demo fixtures create and own their own demo users, so no pre-existing admin
+ * is required. When `userId` IS provided (e.g. the bootstrapped admin passed by
+ * the docker entrypoint) that user is added as an owner of the demo board and
+ * branches so they show up immediately for the real operator too.
+ */
+export interface DemoFixturesOptions {
+  /**
+   * Optional real user to also grant ownership of the demo board/branches.
+   * Demo entities are still attributed to the demo users regardless.
+   */
+  userId?: UUID;
+
+  /**
+   * Skip if demo data already exists (idempotent). Re-running is a no-op.
+   */
+  skipIfExists?: boolean;
+
+  /**
+   * Inject a database instance (used by tests). When omitted, the database is
+   * resolved from `DATABASE_URL` / `AGOR_DB_DIALECT` like {@link seedDevFixtures}.
+   */
+  db?: Database;
+}
+
+export interface DemoFixturesResult {
+  skipped: boolean;
+  counts: {
+    users: number;
+    card_types: number;
+    repos: number;
+    boards: number;
+    branches: number;
+    sessions: number;
+    tasks: number;
+    messages: number;
+    cards: number;
+    artifacts: number;
+  };
+}
+
+const SENTINEL_EMAIL = 'demo.alice@agor.live';
+
+/**
+ * Resolve the database the same way {@link seedDevFixtures} does, honoring
+ * `DATABASE_URL` and `AGOR_DB_DIALECT`. Tests inject `options.db` to bypass this.
+ */
+async function resolveDatabase(options: DemoFixturesOptions): Promise<Database> {
+  if (options.db) return options.db;
+
+  let databaseUrl: string;
+  const dialect = process.env.AGOR_DB_DIALECT;
+  if (dialect === 'postgresql') {
+    databaseUrl = process.env.DATABASE_URL || 'postgresql://localhost:5432/agor';
+  } else {
+    const dbPath = path.join(os.homedir(), '.agor', 'agor.db');
+    databaseUrl = process.env.DATABASE_URL || `file:${dbPath}`;
+  }
+
+  const { createDatabase } = await import('../db/client');
+  return createDatabase({ url: databaseUrl });
+}
+
+/**
+ * Load hardcoded demo fixtures into the database.
+ */
+export async function loadDemoFixtures(
+  options: DemoFixturesOptions = {}
+): Promise<DemoFixturesResult> {
+  const db = await resolveDatabase(options);
+
+  const usersRepo = new UsersRepository(db);
+  const cardTypeRepo = new CardTypeRepository(db);
+  const repoRepo = new RepoRepository(db);
+  const boardRepo = new BoardRepository(db);
+  const branchRepo = new BranchRepository(db);
+  const boardObjectRepo = new BoardObjectRepository(db);
+  const sessionRepo = new SessionRepository(db);
+  const taskRepo = new TaskRepository(db);
+  const messagesRepo = new MessagesRepository(db);
+  const cardRepo = new CardRepository(db);
+  const artifactRepo = new ArtifactRepository(db);
+
+  const emptyCounts: DemoFixturesResult['counts'] = {
+    users: 0,
+    card_types: 0,
+    repos: 0,
+    boards: 0,
+    branches: 0,
+    sessions: 0,
+    tasks: 0,
+    messages: 0,
+    cards: 0,
+    artifacts: 0,
+  };
+
+  // Idempotency sentinel: if the demo admin already exists, do nothing.
+  const sentinel = await usersRepo.findByEmail(SENTINEL_EMAIL);
+  if (sentinel) {
+    console.log('✓ Demo fixtures already exist, skipping...');
+    return { skipped: true, counts: emptyCounts };
+  }
+
+  console.log('🎭 Loading demo fixtures (hardcoded fake data, no git/network)...');
+
+  // ── STEP 1: Users ─────────────────────────────────────────────────────────
+  console.log('1️⃣  Creating demo users...');
+  const userSpecs: Array<Partial<User> & { password: string }> = [
+    {
+      email: SENTINEL_EMAIL,
+      name: 'Alice Demo',
+      emoji: '👩‍💻',
+      role: 'admin',
+      password: 'demo-password-alice',
+      onboarding_completed: true,
+    },
+    {
+      email: 'demo.bob@agor.live',
+      name: 'Bob Demo',
+      emoji: '🧑‍🔧',
+      role: 'member',
+      password: 'demo-password-bob',
+      onboarding_completed: true,
+    },
+    {
+      email: 'demo.carol@agor.live',
+      name: 'Carol Demo',
+      emoji: '👩‍🎨',
+      role: 'member',
+      password: 'demo-password-carol',
+      onboarding_completed: true,
+    },
+    {
+      email: 'demo.dave@agor.live',
+      name: 'Dave Demo',
+      emoji: '🧑‍🚀',
+      role: 'viewer',
+      password: 'demo-password-dave',
+      onboarding_completed: true,
+    },
+  ];
+  const users = await Promise.all(userSpecs.map((spec) => usersRepo.create(spec)));
+  const [alice, bob, carol] = users;
+
+  // ── STEP 2: Card types (global) ───────────────────────────────────────────
+  console.log('2️⃣  Creating demo card types...');
+  const cardTypeSpecs: Array<Partial<CardType>> = [
+    { name: 'Demo Bug', emoji: '🐛', color: '#ff4d4f', created_by: alice.user_id },
+    { name: 'Demo Feature', emoji: '✨', color: '#1677ff', created_by: alice.user_id },
+    { name: 'Demo Task', emoji: '✅', color: '#52c41a', created_by: alice.user_id },
+  ];
+  const cardTypes = await Promise.all(cardTypeSpecs.map((spec) => cardTypeRepo.create(spec)));
+  const [bugType, featureType, taskType] = cardTypes;
+
+  // ── STEP 3: Repos (demo-* slugs, placeholder paths, no git) ───────────────
+  console.log('3️⃣  Creating demo repos...');
+  const webappRepo = await repoRepo.create({
+    slug: 'demo-webapp',
+    name: 'Demo Webapp',
+    repo_type: 'local',
+    local_path: '/tmp/demo-fixtures/demo-webapp',
+    default_branch: 'main',
+  });
+  const apiRepo = await repoRepo.create({
+    slug: 'demo-api',
+    name: 'Demo API',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/demo-org/demo-api.git',
+    local_path: '/tmp/demo-fixtures/demo-api',
+    default_branch: 'main',
+  });
+  const repos = [webappRepo, apiRepo];
+
+  // ── STEP 4: Board with zones ──────────────────────────────────────────────
+  console.log('4️⃣  Creating demo board with zones...');
+  // Zones are `type: "zone"` entries in the board's `data.objects` map.
+  const ZONE_W = 420;
+  const ZONE_H = 760;
+  const ZONE_GAP = 40;
+  const zoneIds = {
+    todo: 'demo-zone-todo',
+    inProgress: 'demo-zone-in-progress',
+    review: 'demo-zone-review',
+    done: 'demo-zone-done',
+  };
+  const zoneDefs: Array<{ id: string; label: string; color: string }> = [
+    { id: zoneIds.todo, label: 'To Do', color: '#8c8c8c' },
+    { id: zoneIds.inProgress, label: 'In Progress', color: '#1677ff' },
+    { id: zoneIds.review, label: 'Review', color: '#faad14' },
+    { id: zoneIds.done, label: 'Done', color: '#52c41a' },
+  ];
+  const boardObjects: Record<string, BoardObject> = {};
+  const zoneOrigins: Record<string, { x: number; y: number }> = {};
+  zoneDefs.forEach((zone, i) => {
+    const x = i * (ZONE_W + ZONE_GAP);
+    const y = 0;
+    zoneOrigins[zone.id] = { x, y };
+    boardObjects[zone.id] = {
+      type: 'zone',
+      x,
+      y,
+      width: ZONE_W,
+      height: ZONE_H,
+      label: zone.label,
+      borderColor: zone.color,
+      backgroundColor: `${zone.color}1a`,
+    };
+  });
+
+  const board = await boardRepo.create({
+    name: 'Demo Board',
+    slug: 'demo-board',
+    description: 'Demo board populated by LOAD_FIXTURES',
+    icon: '🎭',
+    color: '#722ed1',
+    created_by: alice.user_id,
+    objects: boardObjects,
+  });
+  const boardId = board.board_id as BoardID;
+  await boardRepo.addOwner(boardId, alice.user_id);
+  if (options.userId) {
+    await boardRepo.addOwner(boardId, options.userId);
+  }
+
+  // ── STEP 5: Branches (no git ops) ─────────────────────────────────────────
+  console.log('5️⃣  Creating demo branches...');
+  // Use a high, fixed branch_unique_id range so port allocation never collides
+  // with the real seeded branch (which uses a random 1..1000 id).
+  const branchSpecs: Array<{
+    name: string;
+    repoId: UUID;
+    creator: UUID;
+    zoneId: string;
+    rel: { x: number; y: number };
+    uniqueId: number;
+  }> = [
+    {
+      name: 'demo-feature-login',
+      repoId: webappRepo.repo_id,
+      creator: alice.user_id,
+      zoneId: zoneIds.inProgress,
+      rel: { x: 20, y: 60 },
+      uniqueId: 9001,
+    },
+    {
+      name: 'demo-fix-navbar',
+      repoId: webappRepo.repo_id,
+      creator: bob.user_id,
+      zoneId: zoneIds.todo,
+      rel: { x: 20, y: 60 },
+      uniqueId: 9002,
+    },
+    {
+      name: 'demo-refactor-api',
+      repoId: apiRepo.repo_id,
+      creator: carol.user_id,
+      zoneId: zoneIds.review,
+      rel: { x: 20, y: 60 },
+      uniqueId: 9003,
+    },
+    {
+      name: 'demo-docs-update',
+      repoId: webappRepo.repo_id,
+      creator: bob.user_id,
+      zoneId: zoneIds.done,
+      rel: { x: 20, y: 60 },
+      uniqueId: 9004,
+    },
+    {
+      name: 'demo-assistant',
+      repoId: webappRepo.repo_id,
+      creator: alice.user_id,
+      zoneId: zoneIds.todo,
+      rel: { x: 20, y: 320 },
+      uniqueId: 9005,
+    },
+  ];
+
+  const branches: Branch[] = [];
+  for (const spec of branchSpecs) {
+    const branch = await branchRepo.create({
+      repo_id: spec.repoId,
+      name: spec.name,
+      ref: spec.name,
+      path: `/tmp/demo-fixtures/worktrees/${spec.name}`,
+      base_ref: 'main',
+      branch_unique_id: spec.uniqueId,
+      created_by: spec.creator,
+      board_id: boardId,
+      needs_attention: false,
+    });
+    await branchRepo.addOwner(branch.branch_id, spec.creator);
+    if (options.userId) {
+      await branchRepo.addOwner(branch.branch_id, options.userId);
+    }
+
+    // ── STEP 6: Branch placement (board_objects row, pinned to a zone) ──────
+    await boardObjectRepo.create({
+      board_id: boardId,
+      branch_id: branch.branch_id,
+      position: spec.rel,
+      zone_id: spec.zoneId,
+    });
+    branches.push(branch);
+  }
+  const branchByName = new Map(branches.map((b) => [b.name, b]));
+  const loginBranch = branchByName.get('demo-feature-login')!;
+  const navbarBranch = branchByName.get('demo-fix-navbar')!;
+  const refactorBranch = branchByName.get('demo-refactor-api')!;
+
+  // ── STEP 7: Sessions (terminal status + genealogy) ────────────────────────
+  console.log('7️⃣  Creating demo sessions with genealogy...');
+  // Pre-generate ids so genealogy (parent/child, fork points) can be wired in a
+  // single pass without re-fetching/updating.
+  const rootSessionId = generateId() as UUID;
+  const spawnedSessionId = generateId() as UUID;
+  const forkedSessionId = generateId() as UUID;
+  const soloSessionId = generateId() as UUID;
+
+  // Pre-generate the root task id so spawn/fork points can reference it.
+  const rootTaskId = generateId() as UUID;
+
+  const now = Date.now();
+  const iso = (offsetMs: number) => new Date(now + offsetMs).toISOString();
+
+  // Root session — completed, has a spawned child and a forked sibling.
+  const rootSession = await sessionRepo.create({
+    session_id: rootSessionId,
+    branch_id: loginBranch.branch_id as UUID,
+    created_by: alice.user_id,
+    status: SessionStatus.COMPLETED,
+    agentic_tool: 'claude-code',
+    title: 'Implement login form',
+    description: 'Add a login form with validation to the demo webapp',
+    tasks: [rootTaskId],
+    genealogy: {
+      children: [spawnedSessionId],
+      spawn_point_task_id: rootTaskId,
+      spawn_point_message_index: 3,
+      fork_point_task_id: rootTaskId,
+      fork_point_message_index: 3,
+    },
+  });
+
+  // Spawned child — fresh context window, child of root.
+  const spawnedSession = await sessionRepo.create({
+    session_id: spawnedSessionId,
+    branch_id: navbarBranch.branch_id as UUID,
+    created_by: alice.user_id,
+    status: SessionStatus.IDLE,
+    agentic_tool: 'claude-code',
+    title: 'Fix navbar layout (spawned)',
+    description: 'Spawned child of the login session',
+    genealogy: {
+      children: [],
+      parent_session_id: rootSessionId,
+      spawn_point_task_id: rootTaskId,
+      spawn_point_message_index: 3,
+    },
+  });
+
+  // Forked sibling — copies parent context at a fork point.
+  const forkedSession = await sessionRepo.create({
+    session_id: forkedSessionId,
+    branch_id: refactorBranch.branch_id as UUID,
+    created_by: carol.user_id,
+    status: SessionStatus.COMPLETED,
+    agentic_tool: 'codex',
+    title: 'Refactor API client (forked)',
+    description: 'Forked sibling of the login session',
+    genealogy: {
+      children: [],
+      forked_from_session_id: rootSessionId,
+      fork_point_task_id: rootTaskId,
+      fork_point_message_index: 3,
+    },
+  });
+
+  // Independent root session on another branch.
+  const soloSession = await sessionRepo.create({
+    session_id: soloSessionId,
+    branch_id: navbarBranch.branch_id as UUID,
+    created_by: bob.user_id,
+    status: SessionStatus.IDLE,
+    agentic_tool: 'gemini',
+    title: 'Update documentation',
+    description: 'Standalone documentation session',
+    genealogy: { children: [] },
+  });
+  const sessions = [rootSession, spawnedSession, forkedSession, soloSession];
+
+  // ── STEP 8: Tasks (1–2 per session) ───────────────────────────────────────
+  console.log('8️⃣  Creating demo tasks...');
+  const taskSpecs: Array<Partial<Task>> = [
+    {
+      task_id: rootTaskId,
+      session_id: rootSessionId,
+      created_by: alice.user_id,
+      status: TaskStatus.COMPLETED,
+      full_prompt: 'Add a login form with email + password validation.',
+      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(0) },
+      git_state: { ref_at_start: 'demo-feature-login', sha_at_start: 'demo000001' },
+      completed_at: iso(60_000),
+      tool_use_count: 1,
+    },
+    {
+      session_id: spawnedSessionId,
+      created_by: alice.user_id,
+      status: TaskStatus.COMPLETED,
+      full_prompt: 'Fix the navbar so it stays pinned on scroll.',
+      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(120_000) },
+      git_state: { ref_at_start: 'demo-fix-navbar', sha_at_start: 'demo000002' },
+      completed_at: iso(180_000),
+      tool_use_count: 1,
+    },
+    {
+      session_id: forkedSessionId,
+      created_by: carol.user_id,
+      status: TaskStatus.COMPLETED,
+      full_prompt: 'Refactor the API client to use async/await.',
+      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(240_000) },
+      git_state: { ref_at_start: 'demo-refactor-api', sha_at_start: 'demo000003' },
+      completed_at: iso(300_000),
+      tool_use_count: 1,
+    },
+    {
+      session_id: soloSessionId,
+      created_by: bob.user_id,
+      status: TaskStatus.COMPLETED,
+      full_prompt: 'Update the README with setup instructions.',
+      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(360_000) },
+      git_state: { ref_at_start: 'demo-docs-update', sha_at_start: 'demo000004' },
+      completed_at: iso(420_000),
+      tool_use_count: 1,
+    },
+  ];
+  const createdTasks = await Promise.all(taskSpecs.map((spec) => taskRepo.create(spec)));
+
+  // ── STEP 9: Messages (readable transcript per session) ────────────────────
+  console.log('9️⃣  Creating demo message transcripts...');
+  const allMessages: Message[] = [];
+  for (const task of createdTasks) {
+    const sessionId = task.session_id as UUID;
+    const taskId = task.task_id as UUID;
+    const toolUseId = `demo-tool-${generateId()}`;
+    const base = new Date(task.message_range?.start_timestamp ?? iso(0)).getTime();
+    const ts = (i: number) => new Date(base + i * 1000).toISOString();
+
+    const transcript: Message[] = [
+      {
+        message_id: generateId() as UUID,
+        session_id: sessionId,
+        task_id: taskId,
+        type: 'user',
+        role: MessageRole.USER,
+        index: 0,
+        timestamp: ts(0),
+        content_preview: task.full_prompt ?? '',
+        content: task.full_prompt ?? '',
+        metadata: { source: 'agor' },
+      },
+      {
+        message_id: generateId() as UUID,
+        session_id: sessionId,
+        task_id: taskId,
+        type: 'assistant',
+        role: MessageRole.ASSISTANT,
+        index: 1,
+        timestamp: ts(1),
+        content_preview: "I'll make that change now.",
+        content: [
+          { type: 'text', text: "Sure — I'll make that change now." },
+          {
+            type: 'tool_use',
+            id: toolUseId,
+            name: 'Write',
+            input: { file_path: 'src/App.tsx', content: '// demo change\n' },
+          },
+        ],
+        tool_uses: [
+          {
+            id: toolUseId,
+            name: 'Write',
+            input: { file_path: 'src/App.tsx', content: '// demo change\n' },
+          },
+        ],
+        metadata: { model: 'claude-demo', tokens: { input: 120, output: 45 } },
+      },
+      {
+        message_id: generateId() as UUID,
+        session_id: sessionId,
+        task_id: taskId,
+        type: 'user',
+        role: MessageRole.USER,
+        index: 2,
+        timestamp: ts(2),
+        content_preview: 'File written successfully.',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content: 'File written successfully (1 file changed).',
+          },
+        ],
+        parent_tool_use_id: toolUseId,
+      },
+      {
+        message_id: generateId() as UUID,
+        session_id: sessionId,
+        task_id: taskId,
+        type: 'assistant',
+        role: MessageRole.ASSISTANT,
+        index: 3,
+        timestamp: ts(3),
+        content_preview: 'Done! The change is in place.',
+        content: 'Done! The change is in place and ready for review.',
+        metadata: { model: 'claude-demo', tokens: { input: 130, output: 30 } },
+      },
+    ];
+    allMessages.push(...transcript);
+  }
+  await messagesRepo.createMany(allMessages);
+
+  // ── STEP 10: Cards (placed via board_objects rows) ────────────────────────
+  console.log('🔟 Creating demo cards...');
+  const cardSpecs: Array<{
+    title: string;
+    type: CardType;
+    description: string;
+    zoneId: string;
+    rel: { x: number; y: number };
+    creator: UUID;
+  }> = [
+    {
+      title: 'Login button misaligned on mobile',
+      type: bugType,
+      description: 'The login button overflows on small viewports.',
+      zoneId: zoneIds.todo,
+      rel: { x: 20, y: 580 },
+      creator: bob.user_id,
+    },
+    {
+      title: 'Add dark mode toggle',
+      type: featureType,
+      description: 'Users want a dark mode switch in settings.',
+      zoneId: zoneIds.inProgress,
+      rel: { x: 20, y: 340 },
+      creator: carol.user_id,
+    },
+    {
+      title: 'Write integration tests',
+      type: taskType,
+      description: 'Cover the checkout flow with integration tests.',
+      zoneId: zoneIds.review,
+      rel: { x: 20, y: 340 },
+      creator: alice.user_id,
+    },
+    {
+      title: 'Ship v1.0 release notes',
+      type: taskType,
+      description: 'Draft and publish the v1.0 release notes.',
+      zoneId: zoneIds.done,
+      rel: { x: 20, y: 340 },
+      creator: alice.user_id,
+    },
+  ];
+  const cards: Card[] = [];
+  for (const spec of cardSpecs) {
+    const card = await cardRepo.create({
+      board_id: boardId,
+      card_type_id: spec.type.card_type_id,
+      title: spec.title,
+      description: spec.description,
+      created_by: spec.creator,
+    });
+    await boardObjectRepo.create({
+      board_id: boardId,
+      card_id: card.card_id as UUID,
+      position: spec.rel,
+      zone_id: spec.zoneId,
+    });
+    cards.push(card);
+  }
+
+  // ── STEP 11: Artifacts (placed via board.data.objects entry) ──────────────
+  console.log('🎨 Creating demo artifact...');
+  // A public, self-owned artifact needs no artifact_trust_grants row.
+  const artifact: Artifact = await artifactRepo.create({
+    board_id: boardId,
+    name: 'Demo Counter App',
+    description: 'A tiny React counter rendered via Sandpack',
+    template: 'react',
+    public: true,
+    created_by: alice.user_id,
+    entry: '/index.js',
+    files: {
+      '/package.json': JSON.stringify(
+        {
+          name: 'demo-counter',
+          version: '1.0.0',
+          dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0' },
+          main: '/index.js',
+        },
+        null,
+        2
+      ),
+      '/index.js': [
+        "import React from 'react';",
+        "import { createRoot } from 'react-dom/client';",
+        "import App from './App';",
+        "createRoot(document.getElementById('root')).render(<App />);",
+        '',
+      ].join('\n'),
+      '/App.js': [
+        "import React, { useState } from 'react';",
+        '',
+        'export default function App() {',
+        '  const [count, setCount] = useState(0);',
+        '  return (',
+        "    <div style={{ fontFamily: 'sans-serif', padding: 24 }}>",
+        '      <h1>Demo Counter</h1>',
+        '      <p>Count: {count}</p>',
+        '      <button onClick={() => setCount((c) => c + 1)}>Increment</button>',
+        '    </div>',
+        '  );',
+        '}',
+        '',
+      ].join('\n'),
+    },
+  });
+
+  // Artifact layout lives as an entry in board.data.objects, keyed
+  // `artifact-<artifactId>`, with type 'artifact' + x/y/width/height + artifact_id.
+  const artifactObjectKey = `artifact-${artifact.artifact_id}`;
+  const artifactsRightEdge = zoneDefs.length * (ZONE_W + ZONE_GAP);
+  await boardRepo.upsertBoardObject(boardId, artifactObjectKey, {
+    type: 'artifact',
+    artifact_id: artifact.artifact_id as UUID,
+    x: artifactsRightEdge,
+    y: 0,
+    width: 600,
+    height: 400,
+  });
+
+  const counts: DemoFixturesResult['counts'] = {
+    users: users.length,
+    card_types: cardTypes.length,
+    repos: repos.length,
+    boards: 1,
+    branches: branches.length,
+    sessions: sessions.length,
+    tasks: createdTasks.length,
+    messages: allMessages.length,
+    cards: cards.length,
+    artifacts: 1,
+  };
+
+  console.log('✅ Demo fixtures loaded successfully!');
+  console.log(`   Users:    ${counts.users}`);
+  console.log(`   Repos:    ${counts.repos}`);
+  console.log(`   Board:    ${board.name} (${board.board_id})`);
+  console.log(`   Branches: ${counts.branches}`);
+  console.log(
+    `   Sessions: ${counts.sessions} (tasks: ${counts.tasks}, messages: ${counts.messages})`
+  );
+  console.log(`   Cards:    ${counts.cards}, Artifacts: ${counts.artifacts}`);
+
+  return { skipped: false, counts };
+}

--- a/packages/core/src/seed/demo-fixtures.ts
+++ b/packages/core/src/seed/demo-fixtures.ts
@@ -280,8 +280,14 @@ export async function loadDemoFixtures(
     console.log('4️⃣  Creating demo board with zones...');
     // Zones are `type: "zone"` entries in the board's `data.objects` map.
     const ZONE_W = 420;
-    const ZONE_H = 760;
+    const ZONE_H = 960;
     const ZONE_GAP = 40;
+    // Vertical layout for items stacked inside a zone. Branch cards render
+    // ~280px tall, so use a generous stride to keep stacked branch/kanban cards
+    // from overlapping. Rows resolve to y = 60, 400, 740 — all within ZONE_H.
+    const ROW_Y0 = 60;
+    const ITEM_STRIDE = 340;
+    const rowY = (row: number) => ROW_Y0 + row * ITEM_STRIDE;
     const zoneIds = {
       todo: 'demo-zone-todo',
       inProgress: 'demo-zone-in-progress',
@@ -340,7 +346,7 @@ export async function loadDemoFixtures(
         repoId: webappRepo.repo_id,
         creator: alice.user_id,
         zoneId: zoneIds.inProgress,
-        rel: { x: 20, y: 60 },
+        rel: { x: 20, y: rowY(0) },
         uniqueId: 9001,
       },
       {
@@ -348,7 +354,7 @@ export async function loadDemoFixtures(
         repoId: webappRepo.repo_id,
         creator: bob.user_id,
         zoneId: zoneIds.todo,
-        rel: { x: 20, y: 60 },
+        rel: { x: 20, y: rowY(0) },
         uniqueId: 9002,
       },
       {
@@ -356,7 +362,7 @@ export async function loadDemoFixtures(
         repoId: apiRepo.repo_id,
         creator: carol.user_id,
         zoneId: zoneIds.review,
-        rel: { x: 20, y: 60 },
+        rel: { x: 20, y: rowY(0) },
         uniqueId: 9003,
       },
       {
@@ -364,7 +370,7 @@ export async function loadDemoFixtures(
         repoId: webappRepo.repo_id,
         creator: bob.user_id,
         zoneId: zoneIds.done,
-        rel: { x: 20, y: 60 },
+        rel: { x: 20, y: rowY(0) },
         uniqueId: 9004,
       },
       {
@@ -372,7 +378,7 @@ export async function loadDemoFixtures(
         repoId: webappRepo.repo_id,
         creator: alice.user_id,
         zoneId: zoneIds.todo,
-        rel: { x: 20, y: 320 },
+        rel: { x: 20, y: rowY(1) },
         uniqueId: 9005,
       },
     ];
@@ -640,7 +646,7 @@ export async function loadDemoFixtures(
         type: bugType,
         description: 'The login button overflows on small viewports.',
         zoneId: zoneIds.todo,
-        rel: { x: 20, y: 580 },
+        rel: { x: 20, y: rowY(2) },
         creator: bob.user_id,
       },
       {
@@ -648,7 +654,7 @@ export async function loadDemoFixtures(
         type: featureType,
         description: 'Users want a dark mode switch in settings.',
         zoneId: zoneIds.inProgress,
-        rel: { x: 20, y: 340 },
+        rel: { x: 20, y: rowY(1) },
         creator: carol.user_id,
       },
       {
@@ -656,7 +662,7 @@ export async function loadDemoFixtures(
         type: taskType,
         description: 'Cover the checkout flow with integration tests.',
         zoneId: zoneIds.review,
-        rel: { x: 20, y: 340 },
+        rel: { x: 20, y: rowY(1) },
         creator: alice.user_id,
       },
       {
@@ -664,7 +670,7 @@ export async function loadDemoFixtures(
         type: taskType,
         description: 'Draft and publish the v1.0 release notes.',
         zoneId: zoneIds.done,
-        rel: { x: 20, y: 340 },
+        rel: { x: 20, y: rowY(1) },
         creator: alice.user_id,
       },
     ];

--- a/packages/core/src/seed/demo-fixtures.ts
+++ b/packages/core/src/seed/demo-fixtures.ts
@@ -11,9 +11,17 @@
  * `LOAD_FIXTURES=true` switch and is orthogonal/composable with `SEED`.
  *
  * Everything is prefixed `demo-` / `demo.` so it never collides with the real
- * `agor` repo (or its `test-branch`) created by {@link seedDevFixtures}. The
- * seeder is idempotent: a sentinel user (`demo.alice@agor.live`) is checked
- * first, so re-running is a no-op.
+ * `agor` repo (or its `test-branch`) created by {@link seedDevFixtures}.
+ *
+ * Idempotency / crash-safety: the entire load runs inside a SINGLE database
+ * transaction, so it is strictly all-or-nothing. A mid-run failure (or kill)
+ * rolls back every insert, leaving the DB exactly as it was. Because of that
+ * atomicity, the demo admin user (`demo.alice@agor.live`) is a valid TERMINAL
+ * sentinel: if it exists, the whole load committed, so re-running is a no-op.
+ *
+ * Demo users are loginable — passwords are bcrypt-hashed via the same path as
+ * real users (see {@link DEMO_USER_CREDENTIALS}); the cleartext is printed in
+ * the seed log so operators can sign in during E2E testing.
  *
  * Usage:
  *   import { loadDemoFixtures } from '@agor/core/seed/demo-fixtures';
@@ -35,7 +43,9 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { MessageRole, SessionStatus, TaskStatus } from '@agor/core/types';
+import bcrypt from 'bcryptjs';
 import type { Database } from '../db/client';
+import { txAsDb } from '../db/database-wrapper';
 import {
   ArtifactRepository,
   BoardObjectRepository,
@@ -95,7 +105,52 @@ export interface DemoFixturesResult {
   };
 }
 
-const SENTINEL_EMAIL = 'demo.alice@agor.live';
+/**
+ * Known cleartext credentials for the demo users (dev-only, LOAD_FIXTURES-gated).
+ * Stored hashed with bcrypt so the users are loginable for E2E testing.
+ */
+export const DEMO_USER_CREDENTIALS: ReadonlyArray<{
+  email: string;
+  password: string;
+  name: string;
+  emoji: string;
+  role: User['role'];
+}> = [
+  {
+    email: 'demo.alice@agor.live',
+    password: 'demo-password-alice',
+    name: 'Alice Demo',
+    emoji: '👩‍💻',
+    role: 'admin',
+  },
+  {
+    email: 'demo.bob@agor.live',
+    password: 'demo-password-bob',
+    name: 'Bob Demo',
+    emoji: '🧑‍🔧',
+    role: 'member',
+  },
+  {
+    email: 'demo.carol@agor.live',
+    password: 'demo-password-carol',
+    name: 'Carol Demo',
+    emoji: '👩‍🎨',
+    role: 'member',
+  },
+  {
+    email: 'demo.dave@agor.live',
+    password: 'demo-password-dave',
+    name: 'Dave Demo',
+    emoji: '🧑‍🚀',
+    role: 'viewer',
+  },
+];
+
+/** Demo admin email — used as the terminal idempotency sentinel (see file docstring). */
+const SENTINEL_EMAIL = DEMO_USER_CREDENTIALS[0].email;
+
+/** bcrypt cost factor — matches `createUser` in db/user-utils.ts. */
+const BCRYPT_ROUNDS = 12;
 
 /**
  * Resolve the database the same way {@link seedDevFixtures} does, honoring
@@ -125,18 +180,6 @@ export async function loadDemoFixtures(
 ): Promise<DemoFixturesResult> {
   const db = await resolveDatabase(options);
 
-  const usersRepo = new UsersRepository(db);
-  const cardTypeRepo = new CardTypeRepository(db);
-  const repoRepo = new RepoRepository(db);
-  const boardRepo = new BoardRepository(db);
-  const branchRepo = new BranchRepository(db);
-  const boardObjectRepo = new BoardObjectRepository(db);
-  const sessionRepo = new SessionRepository(db);
-  const taskRepo = new TaskRepository(db);
-  const messagesRepo = new MessagesRepository(db);
-  const cardRepo = new CardRepository(db);
-  const artifactRepo = new ArtifactRepository(db);
-
   const emptyCounts: DemoFixturesResult['counts'] = {
     users: 0,
     card_types: 0,
@@ -150,576 +193,582 @@ export async function loadDemoFixtures(
     artifacts: 0,
   };
 
-  // Idempotency sentinel: if the demo admin already exists, do nothing.
-  const sentinel = await usersRepo.findByEmail(SENTINEL_EMAIL);
-  if (sentinel) {
+  // Terminal idempotency sentinel. Because the load is atomic (single
+  // transaction below), the demo admin existing means the WHOLE load committed
+  // — so re-running is a safe no-op. A partial/crashed run leaves no sentinel.
+  const sentinelCheck = new UsersRepository(db);
+  if (await sentinelCheck.findByEmail(SENTINEL_EMAIL)) {
     console.log('✓ Demo fixtures already exist, skipping...');
     return { skipped: true, counts: emptyCounts };
   }
 
   console.log('🎭 Loading demo fixtures (hardcoded fake data, no git/network)...');
 
-  // ── STEP 1: Users ─────────────────────────────────────────────────────────
-  console.log('1️⃣  Creating demo users...');
-  const userSpecs: Array<Partial<User> & { password: string }> = [
-    {
-      email: SENTINEL_EMAIL,
-      name: 'Alice Demo',
-      emoji: '👩‍💻',
-      role: 'admin',
-      password: 'demo-password-alice',
-      onboarding_completed: true,
-    },
-    {
-      email: 'demo.bob@agor.live',
-      name: 'Bob Demo',
-      emoji: '🧑‍🔧',
-      role: 'member',
-      password: 'demo-password-bob',
-      onboarding_completed: true,
-    },
-    {
-      email: 'demo.carol@agor.live',
-      name: 'Carol Demo',
-      emoji: '👩‍🎨',
-      role: 'member',
-      password: 'demo-password-carol',
-      onboarding_completed: true,
-    },
-    {
-      email: 'demo.dave@agor.live',
-      name: 'Dave Demo',
-      emoji: '🧑‍🚀',
-      role: 'viewer',
-      password: 'demo-password-dave',
-      onboarding_completed: true,
-    },
-  ];
-  const users = await Promise.all(userSpecs.map((spec) => usersRepo.create(spec)));
-  const [alice, bob, carol] = users;
+  // Pre-hash demo passwords OUTSIDE the transaction (bcrypt is CPU-bound; no
+  // reason to hold the DB transaction open while hashing).
+  const hashedPasswords = await Promise.all(
+    DEMO_USER_CREDENTIALS.map((c) => bcrypt.hash(c.password, BCRYPT_ROUNDS))
+  );
 
-  // ── STEP 2: Card types (global) ───────────────────────────────────────────
-  console.log('2️⃣  Creating demo card types...');
-  const cardTypeSpecs: Array<Partial<CardType>> = [
-    { name: 'Demo Bug', emoji: '🐛', color: '#ff4d4f', created_by: alice.user_id },
-    { name: 'Demo Feature', emoji: '✨', color: '#1677ff', created_by: alice.user_id },
-    { name: 'Demo Task', emoji: '✅', color: '#52c41a', created_by: alice.user_id },
-  ];
-  const cardTypes = await Promise.all(cardTypeSpecs.map((spec) => cardTypeRepo.create(spec)));
-  const [bugType, featureType, taskType] = cardTypes;
+  // Everything below runs in ONE transaction → all-or-nothing. Repos are bound
+  // to the transaction handle via `txAsDb(tx)`. We use pre-generated IDs and
+  // create-only writes (no repo.update calls) so we never open a NESTED
+  // transaction inside this one.
+  const counts = await db.transaction(async (tx) => {
+    const t = txAsDb(tx);
+    const usersRepo = new UsersRepository(t);
+    const cardTypeRepo = new CardTypeRepository(t);
+    const repoRepo = new RepoRepository(t);
+    const boardRepo = new BoardRepository(t);
+    const branchRepo = new BranchRepository(t);
+    const boardObjectRepo = new BoardObjectRepository(t);
+    const sessionRepo = new SessionRepository(t);
+    const taskRepo = new TaskRepository(t);
+    const messagesRepo = new MessagesRepository(t);
+    const cardRepo = new CardRepository(t);
+    const artifactRepo = new ArtifactRepository(t);
 
-  // ── STEP 3: Repos (demo-* slugs, placeholder paths, no git) ───────────────
-  console.log('3️⃣  Creating demo repos...');
-  const webappRepo = await repoRepo.create({
-    slug: 'demo-webapp',
-    name: 'Demo Webapp',
-    repo_type: 'local',
-    local_path: '/tmp/demo-fixtures/demo-webapp',
-    default_branch: 'main',
-  });
-  const apiRepo = await repoRepo.create({
-    slug: 'demo-api',
-    name: 'Demo API',
-    repo_type: 'remote',
-    remote_url: 'https://github.com/demo-org/demo-api.git',
-    local_path: '/tmp/demo-fixtures/demo-api',
-    default_branch: 'main',
-  });
-  const repos = [webappRepo, apiRepo];
+    // ── STEP 1: Users (bcrypt-hashed → loginable) ───────────────────────────
+    console.log('1️⃣  Creating demo users...');
+    const users = await Promise.all(
+      DEMO_USER_CREDENTIALS.map((cred, i) =>
+        usersRepo.create({
+          email: cred.email,
+          name: cred.name,
+          emoji: cred.emoji,
+          role: cred.role,
+          onboarding_completed: true,
+          // usersRepo.create stores `password` verbatim; we pass a bcrypt hash so
+          // the auth layer's bcrypt.compare succeeds. Cast to surface `password`,
+          // which is intentionally absent from the public User type.
+          password: hashedPasswords[i],
+        } as Partial<User>)
+      )
+    );
+    const [alice, bob, carol] = users;
 
-  // ── STEP 4: Board with zones ──────────────────────────────────────────────
-  console.log('4️⃣  Creating demo board with zones...');
-  // Zones are `type: "zone"` entries in the board's `data.objects` map.
-  const ZONE_W = 420;
-  const ZONE_H = 760;
-  const ZONE_GAP = 40;
-  const zoneIds = {
-    todo: 'demo-zone-todo',
-    inProgress: 'demo-zone-in-progress',
-    review: 'demo-zone-review',
-    done: 'demo-zone-done',
-  };
-  const zoneDefs: Array<{ id: string; label: string; color: string }> = [
-    { id: zoneIds.todo, label: 'To Do', color: '#8c8c8c' },
-    { id: zoneIds.inProgress, label: 'In Progress', color: '#1677ff' },
-    { id: zoneIds.review, label: 'Review', color: '#faad14' },
-    { id: zoneIds.done, label: 'Done', color: '#52c41a' },
-  ];
-  const boardObjects: Record<string, BoardObject> = {};
-  const zoneOrigins: Record<string, { x: number; y: number }> = {};
-  zoneDefs.forEach((zone, i) => {
-    const x = i * (ZONE_W + ZONE_GAP);
-    const y = 0;
-    zoneOrigins[zone.id] = { x, y };
-    boardObjects[zone.id] = {
-      type: 'zone',
-      x,
-      y,
-      width: ZONE_W,
-      height: ZONE_H,
-      label: zone.label,
-      borderColor: zone.color,
-      backgroundColor: `${zone.color}1a`,
-    };
-  });
+    // ── STEP 2: Card types (global) ─────────────────────────────────────────
+    console.log('2️⃣  Creating demo card types...');
+    const cardTypeSpecs: Array<Partial<CardType>> = [
+      { name: 'Demo Bug', emoji: '🐛', color: '#ff4d4f', created_by: alice.user_id },
+      { name: 'Demo Feature', emoji: '✨', color: '#1677ff', created_by: alice.user_id },
+      { name: 'Demo Task', emoji: '✅', color: '#52c41a', created_by: alice.user_id },
+    ];
+    const cardTypes = await Promise.all(cardTypeSpecs.map((spec) => cardTypeRepo.create(spec)));
+    const [bugType, featureType, taskType] = cardTypes;
 
-  const board = await boardRepo.create({
-    name: 'Demo Board',
-    slug: 'demo-board',
-    description: 'Demo board populated by LOAD_FIXTURES',
-    icon: '🎭',
-    color: '#722ed1',
-    created_by: alice.user_id,
-    objects: boardObjects,
-  });
-  const boardId = board.board_id as BoardID;
-  await boardRepo.addOwner(boardId, alice.user_id);
-  if (options.userId) {
-    await boardRepo.addOwner(boardId, options.userId);
-  }
-
-  // ── STEP 5: Branches (no git ops) ─────────────────────────────────────────
-  console.log('5️⃣  Creating demo branches...');
-  // Use a high, fixed branch_unique_id range so port allocation never collides
-  // with the real seeded branch (which uses a random 1..1000 id).
-  const branchSpecs: Array<{
-    name: string;
-    repoId: UUID;
-    creator: UUID;
-    zoneId: string;
-    rel: { x: number; y: number };
-    uniqueId: number;
-  }> = [
-    {
-      name: 'demo-feature-login',
-      repoId: webappRepo.repo_id,
-      creator: alice.user_id,
-      zoneId: zoneIds.inProgress,
-      rel: { x: 20, y: 60 },
-      uniqueId: 9001,
-    },
-    {
-      name: 'demo-fix-navbar',
-      repoId: webappRepo.repo_id,
-      creator: bob.user_id,
-      zoneId: zoneIds.todo,
-      rel: { x: 20, y: 60 },
-      uniqueId: 9002,
-    },
-    {
-      name: 'demo-refactor-api',
-      repoId: apiRepo.repo_id,
-      creator: carol.user_id,
-      zoneId: zoneIds.review,
-      rel: { x: 20, y: 60 },
-      uniqueId: 9003,
-    },
-    {
-      name: 'demo-docs-update',
-      repoId: webappRepo.repo_id,
-      creator: bob.user_id,
-      zoneId: zoneIds.done,
-      rel: { x: 20, y: 60 },
-      uniqueId: 9004,
-    },
-    {
-      name: 'demo-assistant',
-      repoId: webappRepo.repo_id,
-      creator: alice.user_id,
-      zoneId: zoneIds.todo,
-      rel: { x: 20, y: 320 },
-      uniqueId: 9005,
-    },
-  ];
-
-  const branches: Branch[] = [];
-  for (const spec of branchSpecs) {
-    const branch = await branchRepo.create({
-      repo_id: spec.repoId,
-      name: spec.name,
-      ref: spec.name,
-      path: `/tmp/demo-fixtures/worktrees/${spec.name}`,
-      base_ref: 'main',
-      branch_unique_id: spec.uniqueId,
-      created_by: spec.creator,
-      board_id: boardId,
-      needs_attention: false,
+    // ── STEP 3: Repos (demo-* slugs, placeholder paths, no git) ─────────────
+    console.log('3️⃣  Creating demo repos...');
+    const webappRepo = await repoRepo.create({
+      slug: 'demo-webapp',
+      name: 'Demo Webapp',
+      repo_type: 'local',
+      local_path: '/tmp/demo-fixtures/demo-webapp',
+      default_branch: 'main',
     });
-    await branchRepo.addOwner(branch.branch_id, spec.creator);
+    const apiRepo = await repoRepo.create({
+      slug: 'demo-api',
+      name: 'Demo API',
+      repo_type: 'remote',
+      remote_url: 'https://github.com/demo-org/demo-api.git',
+      local_path: '/tmp/demo-fixtures/demo-api',
+      default_branch: 'main',
+    });
+    const repos = [webappRepo, apiRepo];
+
+    // ── STEP 4: Board with zones ────────────────────────────────────────────
+    console.log('4️⃣  Creating demo board with zones...');
+    // Zones are `type: "zone"` entries in the board's `data.objects` map.
+    const ZONE_W = 420;
+    const ZONE_H = 760;
+    const ZONE_GAP = 40;
+    const zoneIds = {
+      todo: 'demo-zone-todo',
+      inProgress: 'demo-zone-in-progress',
+      review: 'demo-zone-review',
+      done: 'demo-zone-done',
+    };
+    const zoneDefs: Array<{ id: string; label: string; color: string }> = [
+      { id: zoneIds.todo, label: 'To Do', color: '#8c8c8c' },
+      { id: zoneIds.inProgress, label: 'In Progress', color: '#1677ff' },
+      { id: zoneIds.review, label: 'Review', color: '#faad14' },
+      { id: zoneIds.done, label: 'Done', color: '#52c41a' },
+    ];
+    const initialObjects: Record<string, BoardObject> = {};
+    zoneDefs.forEach((zone, i) => {
+      initialObjects[zone.id] = {
+        type: 'zone',
+        x: i * (ZONE_W + ZONE_GAP),
+        y: 0,
+        width: ZONE_W,
+        height: ZONE_H,
+        label: zone.label,
+        borderColor: zone.color,
+        backgroundColor: `${zone.color}1a`,
+      };
+    });
+
+    const board = await boardRepo.create({
+      name: 'Demo Board',
+      slug: 'demo-board',
+      description: 'Demo board populated by LOAD_FIXTURES',
+      icon: '🎭',
+      color: '#722ed1',
+      created_by: alice.user_id,
+      objects: initialObjects,
+    });
+    const boardId = board.board_id as BoardID;
+    await boardRepo.addOwner(boardId, alice.user_id);
     if (options.userId) {
-      await branchRepo.addOwner(branch.branch_id, options.userId);
+      await boardRepo.addOwner(boardId, options.userId);
     }
 
-    // ── STEP 6: Branch placement (board_objects row, pinned to a zone) ──────
-    await boardObjectRepo.create({
-      board_id: boardId,
-      branch_id: branch.branch_id,
-      position: spec.rel,
-      zone_id: spec.zoneId,
-    });
-    branches.push(branch);
-  }
-  const branchByName = new Map(branches.map((b) => [b.name, b]));
-  const loginBranch = branchByName.get('demo-feature-login')!;
-  const navbarBranch = branchByName.get('demo-fix-navbar')!;
-  const refactorBranch = branchByName.get('demo-refactor-api')!;
-
-  // ── STEP 7: Sessions (terminal status + genealogy) ────────────────────────
-  console.log('7️⃣  Creating demo sessions with genealogy...');
-  // Pre-generate ids so genealogy (parent/child, fork points) can be wired in a
-  // single pass without re-fetching/updating.
-  const rootSessionId = generateId() as UUID;
-  const spawnedSessionId = generateId() as UUID;
-  const forkedSessionId = generateId() as UUID;
-  const soloSessionId = generateId() as UUID;
-
-  // Pre-generate the root task id so spawn/fork points can reference it.
-  const rootTaskId = generateId() as UUID;
-
-  const now = Date.now();
-  const iso = (offsetMs: number) => new Date(now + offsetMs).toISOString();
-
-  // Root session — completed, has a spawned child and a forked sibling.
-  const rootSession = await sessionRepo.create({
-    session_id: rootSessionId,
-    branch_id: loginBranch.branch_id as UUID,
-    created_by: alice.user_id,
-    status: SessionStatus.COMPLETED,
-    agentic_tool: 'claude-code',
-    title: 'Implement login form',
-    description: 'Add a login form with validation to the demo webapp',
-    tasks: [rootTaskId],
-    genealogy: {
-      children: [spawnedSessionId],
-      spawn_point_task_id: rootTaskId,
-      spawn_point_message_index: 3,
-      fork_point_task_id: rootTaskId,
-      fork_point_message_index: 3,
-    },
-  });
-
-  // Spawned child — fresh context window, child of root.
-  const spawnedSession = await sessionRepo.create({
-    session_id: spawnedSessionId,
-    branch_id: navbarBranch.branch_id as UUID,
-    created_by: alice.user_id,
-    status: SessionStatus.IDLE,
-    agentic_tool: 'claude-code',
-    title: 'Fix navbar layout (spawned)',
-    description: 'Spawned child of the login session',
-    genealogy: {
-      children: [],
-      parent_session_id: rootSessionId,
-      spawn_point_task_id: rootTaskId,
-      spawn_point_message_index: 3,
-    },
-  });
-
-  // Forked sibling — copies parent context at a fork point.
-  const forkedSession = await sessionRepo.create({
-    session_id: forkedSessionId,
-    branch_id: refactorBranch.branch_id as UUID,
-    created_by: carol.user_id,
-    status: SessionStatus.COMPLETED,
-    agentic_tool: 'codex',
-    title: 'Refactor API client (forked)',
-    description: 'Forked sibling of the login session',
-    genealogy: {
-      children: [],
-      forked_from_session_id: rootSessionId,
-      fork_point_task_id: rootTaskId,
-      fork_point_message_index: 3,
-    },
-  });
-
-  // Independent root session on another branch.
-  const soloSession = await sessionRepo.create({
-    session_id: soloSessionId,
-    branch_id: navbarBranch.branch_id as UUID,
-    created_by: bob.user_id,
-    status: SessionStatus.IDLE,
-    agentic_tool: 'gemini',
-    title: 'Update documentation',
-    description: 'Standalone documentation session',
-    genealogy: { children: [] },
-  });
-  const sessions = [rootSession, spawnedSession, forkedSession, soloSession];
-
-  // ── STEP 8: Tasks (1–2 per session) ───────────────────────────────────────
-  console.log('8️⃣  Creating demo tasks...');
-  const taskSpecs: Array<Partial<Task>> = [
-    {
-      task_id: rootTaskId,
-      session_id: rootSessionId,
-      created_by: alice.user_id,
-      status: TaskStatus.COMPLETED,
-      full_prompt: 'Add a login form with email + password validation.',
-      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(0) },
-      git_state: { ref_at_start: 'demo-feature-login', sha_at_start: 'demo000001' },
-      completed_at: iso(60_000),
-      tool_use_count: 1,
-    },
-    {
-      session_id: spawnedSessionId,
-      created_by: alice.user_id,
-      status: TaskStatus.COMPLETED,
-      full_prompt: 'Fix the navbar so it stays pinned on scroll.',
-      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(120_000) },
-      git_state: { ref_at_start: 'demo-fix-navbar', sha_at_start: 'demo000002' },
-      completed_at: iso(180_000),
-      tool_use_count: 1,
-    },
-    {
-      session_id: forkedSessionId,
-      created_by: carol.user_id,
-      status: TaskStatus.COMPLETED,
-      full_prompt: 'Refactor the API client to use async/await.',
-      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(240_000) },
-      git_state: { ref_at_start: 'demo-refactor-api', sha_at_start: 'demo000003' },
-      completed_at: iso(300_000),
-      tool_use_count: 1,
-    },
-    {
-      session_id: soloSessionId,
-      created_by: bob.user_id,
-      status: TaskStatus.COMPLETED,
-      full_prompt: 'Update the README with setup instructions.',
-      message_range: { start_index: 0, end_index: 3, start_timestamp: iso(360_000) },
-      git_state: { ref_at_start: 'demo-docs-update', sha_at_start: 'demo000004' },
-      completed_at: iso(420_000),
-      tool_use_count: 1,
-    },
-  ];
-  const createdTasks = await Promise.all(taskSpecs.map((spec) => taskRepo.create(spec)));
-
-  // ── STEP 9: Messages (readable transcript per session) ────────────────────
-  console.log('9️⃣  Creating demo message transcripts...');
-  const allMessages: Message[] = [];
-  for (const task of createdTasks) {
-    const sessionId = task.session_id as UUID;
-    const taskId = task.task_id as UUID;
-    const toolUseId = `demo-tool-${generateId()}`;
-    const base = new Date(task.message_range?.start_timestamp ?? iso(0)).getTime();
-    const ts = (i: number) => new Date(base + i * 1000).toISOString();
-
-    const transcript: Message[] = [
+    // ── STEP 5: Branches (no git ops) ───────────────────────────────────────
+    console.log('5️⃣  Creating demo branches...');
+    // High, fixed branch_unique_id range so port allocation never collides with
+    // the real seeded branch (which uses a random 1..1000 id).
+    const branchSpecs: Array<{
+      name: string;
+      repoId: UUID;
+      creator: UUID;
+      zoneId: string;
+      rel: { x: number; y: number };
+      uniqueId: number;
+    }> = [
       {
-        message_id: generateId() as UUID,
-        session_id: sessionId,
-        task_id: taskId,
-        type: 'user',
-        role: MessageRole.USER,
-        index: 0,
-        timestamp: ts(0),
-        content_preview: task.full_prompt ?? '',
-        content: task.full_prompt ?? '',
-        metadata: { source: 'agor' },
+        name: 'demo-feature-login',
+        repoId: webappRepo.repo_id,
+        creator: alice.user_id,
+        zoneId: zoneIds.inProgress,
+        rel: { x: 20, y: 60 },
+        uniqueId: 9001,
       },
       {
-        message_id: generateId() as UUID,
-        session_id: sessionId,
-        task_id: taskId,
-        type: 'assistant',
-        role: MessageRole.ASSISTANT,
-        index: 1,
-        timestamp: ts(1),
-        content_preview: "I'll make that change now.",
-        content: [
-          { type: 'text', text: "Sure — I'll make that change now." },
-          {
-            type: 'tool_use',
-            id: toolUseId,
-            name: 'Write',
-            input: { file_path: 'src/App.tsx', content: '// demo change\n' },
-          },
-        ],
-        tool_uses: [
-          {
-            id: toolUseId,
-            name: 'Write',
-            input: { file_path: 'src/App.tsx', content: '// demo change\n' },
-          },
-        ],
-        metadata: { model: 'claude-demo', tokens: { input: 120, output: 45 } },
+        name: 'demo-fix-navbar',
+        repoId: webappRepo.repo_id,
+        creator: bob.user_id,
+        zoneId: zoneIds.todo,
+        rel: { x: 20, y: 60 },
+        uniqueId: 9002,
       },
       {
-        message_id: generateId() as UUID,
-        session_id: sessionId,
-        task_id: taskId,
-        type: 'user',
-        role: MessageRole.USER,
-        index: 2,
-        timestamp: ts(2),
-        content_preview: 'File written successfully.',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: toolUseId,
-            content: 'File written successfully (1 file changed).',
-          },
-        ],
-        parent_tool_use_id: toolUseId,
+        name: 'demo-refactor-api',
+        repoId: apiRepo.repo_id,
+        creator: carol.user_id,
+        zoneId: zoneIds.review,
+        rel: { x: 20, y: 60 },
+        uniqueId: 9003,
       },
       {
-        message_id: generateId() as UUID,
-        session_id: sessionId,
-        task_id: taskId,
-        type: 'assistant',
-        role: MessageRole.ASSISTANT,
-        index: 3,
-        timestamp: ts(3),
-        content_preview: 'Done! The change is in place.',
-        content: 'Done! The change is in place and ready for review.',
-        metadata: { model: 'claude-demo', tokens: { input: 130, output: 30 } },
+        name: 'demo-docs-update',
+        repoId: webappRepo.repo_id,
+        creator: bob.user_id,
+        zoneId: zoneIds.done,
+        rel: { x: 20, y: 60 },
+        uniqueId: 9004,
+      },
+      {
+        name: 'demo-assistant',
+        repoId: webappRepo.repo_id,
+        creator: alice.user_id,
+        zoneId: zoneIds.todo,
+        rel: { x: 20, y: 320 },
+        uniqueId: 9005,
       },
     ];
-    allMessages.push(...transcript);
-  }
-  await messagesRepo.createMany(allMessages);
 
-  // ── STEP 10: Cards (placed via board_objects rows) ────────────────────────
-  console.log('🔟 Creating demo cards...');
-  const cardSpecs: Array<{
-    title: string;
-    type: CardType;
-    description: string;
-    zoneId: string;
-    rel: { x: number; y: number };
-    creator: UUID;
-  }> = [
-    {
-      title: 'Login button misaligned on mobile',
-      type: bugType,
-      description: 'The login button overflows on small viewports.',
-      zoneId: zoneIds.todo,
-      rel: { x: 20, y: 580 },
-      creator: bob.user_id,
-    },
-    {
-      title: 'Add dark mode toggle',
-      type: featureType,
-      description: 'Users want a dark mode switch in settings.',
-      zoneId: zoneIds.inProgress,
-      rel: { x: 20, y: 340 },
-      creator: carol.user_id,
-    },
-    {
-      title: 'Write integration tests',
-      type: taskType,
-      description: 'Cover the checkout flow with integration tests.',
-      zoneId: zoneIds.review,
-      rel: { x: 20, y: 340 },
-      creator: alice.user_id,
-    },
-    {
-      title: 'Ship v1.0 release notes',
-      type: taskType,
-      description: 'Draft and publish the v1.0 release notes.',
-      zoneId: zoneIds.done,
-      rel: { x: 20, y: 340 },
-      creator: alice.user_id,
-    },
-  ];
-  const cards: Card[] = [];
-  for (const spec of cardSpecs) {
-    const card = await cardRepo.create({
-      board_id: boardId,
-      card_type_id: spec.type.card_type_id,
-      title: spec.title,
-      description: spec.description,
-      created_by: spec.creator,
-    });
-    await boardObjectRepo.create({
-      board_id: boardId,
-      card_id: card.card_id as UUID,
-      position: spec.rel,
-      zone_id: spec.zoneId,
-    });
-    cards.push(card);
-  }
+    const branches: Branch[] = [];
+    for (const spec of branchSpecs) {
+      const branch = await branchRepo.create({
+        repo_id: spec.repoId,
+        name: spec.name,
+        ref: spec.name,
+        path: `/tmp/demo-fixtures/worktrees/${spec.name}`,
+        base_ref: 'main',
+        branch_unique_id: spec.uniqueId,
+        created_by: spec.creator,
+        board_id: boardId,
+        needs_attention: false,
+      });
+      await branchRepo.addOwner(branch.branch_id, spec.creator);
+      if (options.userId) {
+        await branchRepo.addOwner(branch.branch_id, options.userId);
+      }
 
-  // ── STEP 11: Artifacts (placed via board.data.objects entry) ──────────────
-  console.log('🎨 Creating demo artifact...');
-  // A public, self-owned artifact needs no artifact_trust_grants row.
-  const artifact: Artifact = await artifactRepo.create({
-    board_id: boardId,
-    name: 'Demo Counter App',
-    description: 'A tiny React counter rendered via Sandpack',
-    template: 'react',
-    public: true,
-    created_by: alice.user_id,
-    entry: '/index.js',
-    files: {
-      '/package.json': JSON.stringify(
+      // ── STEP 6: Branch placement (board_objects row, pinned to a zone) ────
+      await boardObjectRepo.create({
+        board_id: boardId,
+        branch_id: branch.branch_id,
+        position: spec.rel,
+        zone_id: spec.zoneId,
+      });
+      branches.push(branch);
+    }
+    const branchByName = new Map(branches.map((b) => [b.name, b]));
+    const loginBranch = branchByName.get('demo-feature-login')!;
+    const navbarBranch = branchByName.get('demo-fix-navbar')!;
+    const refactorBranch = branchByName.get('demo-refactor-api')!;
+    const docsBranch = branchByName.get('demo-docs-update')!;
+
+    // ── STEP 7: Sessions (terminal status + genealogy) ──────────────────────
+    console.log('7️⃣  Creating demo sessions with genealogy...');
+    // Pre-generate session + task IDs so genealogy (parent/child, fork/spawn
+    // points) and each session's `data.tasks` are fully consistent at insert
+    // time — no follow-up updates (which would open a nested transaction).
+    const rootSessionId = generateId() as UUID;
+    const spawnedSessionId = generateId() as UUID;
+    const forkedSessionId = generateId() as UUID;
+    const soloSessionId = generateId() as UUID;
+    const rootTaskId = generateId() as UUID;
+    const spawnedTaskId = generateId() as UUID;
+    const forkedTaskId = generateId() as UUID;
+    const soloTaskId = generateId() as UUID;
+
+    const now = Date.now();
+    const iso = (offsetMs: number) => new Date(now + offsetMs).toISOString();
+
+    // Root — completed; parent of the spawned child AND source of the forked
+    // sibling. fork/spawn point fields live on the CHILDREN, not here.
+    const rootSession = await sessionRepo.create({
+      session_id: rootSessionId,
+      branch_id: loginBranch.branch_id as UUID,
+      created_by: alice.user_id,
+      status: SessionStatus.COMPLETED,
+      agentic_tool: 'claude-code',
+      title: 'Implement login form',
+      description: 'Add a login form with validation to the demo webapp',
+      tasks: [rootTaskId],
+      genealogy: { children: [spawnedSessionId, forkedSessionId] },
+    });
+
+    // Spawned child — fresh context window, child of root.
+    const spawnedSession = await sessionRepo.create({
+      session_id: spawnedSessionId,
+      branch_id: navbarBranch.branch_id as UUID,
+      created_by: alice.user_id,
+      status: SessionStatus.IDLE,
+      agentic_tool: 'claude-code',
+      title: 'Fix navbar layout (spawned)',
+      description: 'Spawned child of the login session',
+      tasks: [spawnedTaskId],
+      genealogy: {
+        children: [],
+        parent_session_id: rootSessionId,
+        spawn_point_task_id: rootTaskId,
+        spawn_point_message_index: 3,
+      },
+    });
+
+    // Forked sibling — copies parent context at a fork point.
+    const forkedSession = await sessionRepo.create({
+      session_id: forkedSessionId,
+      branch_id: refactorBranch.branch_id as UUID,
+      created_by: carol.user_id,
+      status: SessionStatus.COMPLETED,
+      agentic_tool: 'codex',
+      title: 'Refactor API client (forked)',
+      description: 'Forked sibling of the login session',
+      tasks: [forkedTaskId],
+      genealogy: {
+        children: [],
+        forked_from_session_id: rootSessionId,
+        fork_point_task_id: rootTaskId,
+        fork_point_message_index: 3,
+      },
+    });
+
+    // Independent root session on another branch.
+    const soloSession = await sessionRepo.create({
+      session_id: soloSessionId,
+      branch_id: docsBranch.branch_id as UUID,
+      created_by: bob.user_id,
+      status: SessionStatus.IDLE,
+      agentic_tool: 'gemini',
+      title: 'Update documentation',
+      description: 'Standalone documentation session',
+      tasks: [soloTaskId],
+      genealogy: { children: [] },
+    });
+    const sessions = [rootSession, spawnedSession, forkedSession, soloSession];
+
+    // ── STEP 8: Tasks (one per session, matching each session's data.tasks) ──
+    console.log('8️⃣  Creating demo tasks...');
+    const taskSpecs: Array<Partial<Task>> = [
+      {
+        task_id: rootTaskId,
+        session_id: rootSessionId,
+        created_by: alice.user_id,
+        status: TaskStatus.COMPLETED,
+        full_prompt: 'Add a login form with email + password validation.',
+        message_range: { start_index: 0, end_index: 3, start_timestamp: iso(0) },
+        git_state: { ref_at_start: 'demo-feature-login', sha_at_start: 'demo000001' },
+        completed_at: iso(60_000),
+        tool_use_count: 1,
+      },
+      {
+        task_id: spawnedTaskId,
+        session_id: spawnedSessionId,
+        created_by: alice.user_id,
+        status: TaskStatus.COMPLETED,
+        full_prompt: 'Fix the navbar so it stays pinned on scroll.',
+        message_range: { start_index: 0, end_index: 3, start_timestamp: iso(120_000) },
+        git_state: { ref_at_start: 'demo-fix-navbar', sha_at_start: 'demo000002' },
+        completed_at: iso(180_000),
+        tool_use_count: 1,
+      },
+      {
+        task_id: forkedTaskId,
+        session_id: forkedSessionId,
+        created_by: carol.user_id,
+        status: TaskStatus.COMPLETED,
+        full_prompt: 'Refactor the API client to use async/await.',
+        message_range: { start_index: 0, end_index: 3, start_timestamp: iso(240_000) },
+        git_state: { ref_at_start: 'demo-refactor-api', sha_at_start: 'demo000003' },
+        completed_at: iso(300_000),
+        tool_use_count: 1,
+      },
+      {
+        task_id: soloTaskId,
+        session_id: soloSessionId,
+        created_by: bob.user_id,
+        status: TaskStatus.COMPLETED,
+        full_prompt: 'Update the README with setup instructions.',
+        message_range: { start_index: 0, end_index: 3, start_timestamp: iso(360_000) },
+        git_state: { ref_at_start: 'demo-docs-update', sha_at_start: 'demo000004' },
+        completed_at: iso(420_000),
+        tool_use_count: 1,
+      },
+    ];
+    const createdTasks = await Promise.all(taskSpecs.map((spec) => taskRepo.create(spec)));
+
+    // ── STEP 9: Messages (readable transcript per session) ──────────────────
+    console.log('9️⃣  Creating demo message transcripts...');
+    const allMessages: Message[] = [];
+    for (const task of createdTasks) {
+      const sessionId = task.session_id as UUID;
+      const taskId = task.task_id as UUID;
+      const toolUseId = `demo-tool-${generateId()}`;
+      const taskBase = new Date(task.message_range?.start_timestamp ?? iso(0)).getTime();
+      const ts = (i: number) => new Date(taskBase + i * 1000).toISOString();
+
+      allMessages.push(
         {
-          name: 'demo-counter',
-          version: '1.0.0',
-          dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0' },
-          main: '/index.js',
+          message_id: generateId() as UUID,
+          session_id: sessionId,
+          task_id: taskId,
+          type: 'user',
+          role: MessageRole.USER,
+          index: 0,
+          timestamp: ts(0),
+          content_preview: task.full_prompt ?? '',
+          content: task.full_prompt ?? '',
+          metadata: { source: 'agor' },
         },
-        null,
-        2
-      ),
-      '/index.js': [
-        "import React from 'react';",
-        "import { createRoot } from 'react-dom/client';",
-        "import App from './App';",
-        "createRoot(document.getElementById('root')).render(<App />);",
-        '',
-      ].join('\n'),
-      '/App.js': [
-        "import React, { useState } from 'react';",
-        '',
-        'export default function App() {',
-        '  const [count, setCount] = useState(0);',
-        '  return (',
-        "    <div style={{ fontFamily: 'sans-serif', padding: 24 }}>",
-        '      <h1>Demo Counter</h1>',
-        '      <p>Count: {count}</p>',
-        '      <button onClick={() => setCount((c) => c + 1)}>Increment</button>',
-        '    </div>',
-        '  );',
-        '}',
-        '',
-      ].join('\n'),
-    },
+        {
+          message_id: generateId() as UUID,
+          session_id: sessionId,
+          task_id: taskId,
+          type: 'assistant',
+          role: MessageRole.ASSISTANT,
+          index: 1,
+          timestamp: ts(1),
+          content_preview: "I'll make that change now.",
+          content: [
+            { type: 'text', text: "Sure — I'll make that change now." },
+            {
+              type: 'tool_use',
+              id: toolUseId,
+              name: 'Write',
+              input: { file_path: 'src/App.tsx', content: '// demo change\n' },
+            },
+          ],
+          tool_uses: [
+            {
+              id: toolUseId,
+              name: 'Write',
+              input: { file_path: 'src/App.tsx', content: '// demo change\n' },
+            },
+          ],
+          metadata: { model: 'claude-demo', tokens: { input: 120, output: 45 } },
+        },
+        {
+          message_id: generateId() as UUID,
+          session_id: sessionId,
+          task_id: taskId,
+          type: 'user',
+          role: MessageRole.USER,
+          index: 2,
+          timestamp: ts(2),
+          content_preview: 'File written successfully.',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: toolUseId,
+              content: 'File written successfully (1 file changed).',
+            },
+          ],
+          parent_tool_use_id: toolUseId,
+        },
+        {
+          message_id: generateId() as UUID,
+          session_id: sessionId,
+          task_id: taskId,
+          type: 'assistant',
+          role: MessageRole.ASSISTANT,
+          index: 3,
+          timestamp: ts(3),
+          content_preview: 'Done! The change is in place.',
+          content: 'Done! The change is in place and ready for review.',
+          metadata: { model: 'claude-demo', tokens: { input: 130, output: 30 } },
+        }
+      );
+    }
+    await messagesRepo.createMany(allMessages);
+
+    // ── STEP 10: Cards (placed via board_objects rows) ──────────────────────
+    console.log('🔟 Creating demo cards...');
+    const cardSpecs: Array<{
+      title: string;
+      type: CardType;
+      description: string;
+      zoneId: string;
+      rel: { x: number; y: number };
+      creator: UUID;
+    }> = [
+      {
+        title: 'Login button misaligned on mobile',
+        type: bugType,
+        description: 'The login button overflows on small viewports.',
+        zoneId: zoneIds.todo,
+        rel: { x: 20, y: 580 },
+        creator: bob.user_id,
+      },
+      {
+        title: 'Add dark mode toggle',
+        type: featureType,
+        description: 'Users want a dark mode switch in settings.',
+        zoneId: zoneIds.inProgress,
+        rel: { x: 20, y: 340 },
+        creator: carol.user_id,
+      },
+      {
+        title: 'Write integration tests',
+        type: taskType,
+        description: 'Cover the checkout flow with integration tests.',
+        zoneId: zoneIds.review,
+        rel: { x: 20, y: 340 },
+        creator: alice.user_id,
+      },
+      {
+        title: 'Ship v1.0 release notes',
+        type: taskType,
+        description: 'Draft and publish the v1.0 release notes.',
+        zoneId: zoneIds.done,
+        rel: { x: 20, y: 340 },
+        creator: alice.user_id,
+      },
+    ];
+    const cards: Card[] = [];
+    for (const spec of cardSpecs) {
+      const card = await cardRepo.create({
+        board_id: boardId,
+        card_type_id: spec.type.card_type_id,
+        title: spec.title,
+        description: spec.description,
+        created_by: spec.creator,
+      });
+      await boardObjectRepo.create({
+        board_id: boardId,
+        card_id: card.card_id as UUID,
+        position: spec.rel,
+        zone_id: spec.zoneId,
+      });
+      cards.push(card);
+    }
+
+    // ── STEP 11: Artifact (placed via a board.data.objects entry) ───────────
+    console.log('🎨 Creating demo artifact...');
+    // A public, self-owned artifact needs no artifact_trust_grants row.
+    const artifact: Artifact = await artifactRepo.create({
+      board_id: boardId,
+      name: 'Demo Counter App',
+      description: 'A tiny React counter rendered via Sandpack',
+      template: 'react',
+      public: true,
+      created_by: alice.user_id,
+      entry: '/index.js',
+      files: {
+        '/package.json': JSON.stringify(
+          {
+            name: 'demo-counter',
+            version: '1.0.0',
+            dependencies: { react: '^18.0.0', 'react-dom': '^18.0.0' },
+            main: '/index.js',
+          },
+          null,
+          2
+        ),
+        '/index.js': [
+          "import React from 'react';",
+          "import { createRoot } from 'react-dom/client';",
+          "import App from './App';",
+          "createRoot(document.getElementById('root')).render(<App />);",
+          '',
+        ].join('\n'),
+        '/App.js': [
+          "import React, { useState } from 'react';",
+          '',
+          'export default function App() {',
+          '  const [count, setCount] = useState(0);',
+          '  return (',
+          "    <div style={{ fontFamily: 'sans-serif', padding: 24 }}>",
+          '      <h1>Demo Counter</h1>',
+          '      <p>Count: {count}</p>',
+          '      <button onClick={() => setCount((c) => c + 1)}>Increment</button>',
+          '    </div>',
+          '  );',
+          '}',
+          '',
+        ].join('\n'),
+      },
+    });
+
+    // Artifact layout lives as an entry in board.data.objects, keyed
+    // `artifact-<artifactId>`, with type 'artifact' + x/y/width/height + artifact_id.
+    const artifactObjectKey = `artifact-${artifact.artifact_id}`;
+    const artifactsRightEdge = zoneDefs.length * (ZONE_W + ZONE_GAP);
+    await boardRepo.upsertBoardObject(boardId, artifactObjectKey, {
+      type: 'artifact',
+      artifact_id: artifact.artifact_id as UUID,
+      x: artifactsRightEdge,
+      y: 0,
+      width: 600,
+      height: 400,
+    });
+
+    console.log('✅ Demo fixtures loaded successfully!');
+    console.log(`   Board:    ${board.name} (${board.board_id})`);
+    console.log(
+      `   Sessions: ${sessions.length} (tasks: ${createdTasks.length}, messages: ${allMessages.length})`
+    );
+    console.log('   Demo login credentials (dev-only):');
+    for (const cred of DEMO_USER_CREDENTIALS) {
+      console.log(`     • ${cred.email} / ${cred.password}  (${cred.role})`);
+    }
+
+    return {
+      users: users.length,
+      card_types: cardTypes.length,
+      repos: repos.length,
+      boards: 1,
+      branches: branches.length,
+      sessions: sessions.length,
+      tasks: createdTasks.length,
+      messages: allMessages.length,
+      cards: cards.length,
+      artifacts: 1,
+    } satisfies DemoFixturesResult['counts'];
   });
-
-  // Artifact layout lives as an entry in board.data.objects, keyed
-  // `artifact-<artifactId>`, with type 'artifact' + x/y/width/height + artifact_id.
-  const artifactObjectKey = `artifact-${artifact.artifact_id}`;
-  const artifactsRightEdge = zoneDefs.length * (ZONE_W + ZONE_GAP);
-  await boardRepo.upsertBoardObject(boardId, artifactObjectKey, {
-    type: 'artifact',
-    artifact_id: artifact.artifact_id as UUID,
-    x: artifactsRightEdge,
-    y: 0,
-    width: 600,
-    height: 400,
-  });
-
-  const counts: DemoFixturesResult['counts'] = {
-    users: users.length,
-    card_types: cardTypes.length,
-    repos: repos.length,
-    boards: 1,
-    branches: branches.length,
-    sessions: sessions.length,
-    tasks: createdTasks.length,
-    messages: allMessages.length,
-    cards: cards.length,
-    artifacts: 1,
-  };
-
-  console.log('✅ Demo fixtures loaded successfully!');
-  console.log(`   Users:    ${counts.users}`);
-  console.log(`   Repos:    ${counts.repos}`);
-  console.log(`   Board:    ${board.name} (${board.board_id})`);
-  console.log(`   Branches: ${counts.branches}`);
-  console.log(
-    `   Sessions: ${counts.sessions} (tasks: ${counts.tasks}, messages: ${counts.messages})`
-  );
-  console.log(`   Cards:    ${counts.cards}, Artifacts: ${counts.artifacts}`);
 
   return { skipped: false, counts };
 }

--- a/packages/core/src/seed/index.ts
+++ b/packages/core/src/seed/index.ts
@@ -4,4 +4,5 @@
  * Exports seed utilities for development fixtures
  */
 
+export * from './demo-fixtures';
 export * from './dev-fixtures';

--- a/scripts/load-fixtures.ts
+++ b/scripts/load-fixtures.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env tsx
+
+/**
+ * Load Demo Fixtures
+ *
+ * Populates the Agor database with a rich set of HARDCODED FAKE data (users,
+ * branches, sessions + transcripts, boards/zones, cards, artifacts) for instant
+ * end-to-end testing. Pure DB inserts — no git, network, or executor.
+ *
+ * Gated by `LOAD_FIXTURES=true` in the docker entrypoint. Orthogonal to (and
+ * composable with) `SEED=true`. Idempotent: re-running is a no-op.
+ *
+ * Usage:
+ *   pnpm tsx scripts/load-fixtures.ts [--skip-if-exists] [--user-id <uuid>]
+ *   pnpm load:fixtures [--skip-if-exists]
+ */
+
+import { loadDemoFixtures } from '@agor/core/seed';
+import type { UUID } from '@agor/core/types';
+
+async function main() {
+  const skipIfExists = process.argv.includes('--skip-if-exists');
+
+  // Parse --user-id argument (optional — demo fixtures own their own users).
+  const userIdIndex = process.argv.indexOf('--user-id');
+  const userId = userIdIndex !== -1 ? (process.argv[userIdIndex + 1] as UUID) : undefined;
+
+  try {
+    const result = await loadDemoFixtures({ skipIfExists, userId });
+
+    if (result.skipped) {
+      console.log('ℹ️  Demo fixtures skipped (data already exists)');
+      process.exit(0);
+    }
+
+    console.log('✅ Demo fixtures complete!');
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Loading demo fixtures failed:', error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add an opt-in **`LOAD_FIXTURES=true`** switch that populates a fresh dev/test Agor DB with a rich set of **hardcoded fake data** for instant end-to-end testing.
- Pure DB inserts via the repository layer — **no git, network, or executor** — mirroring the existing `SEED` seam (`seedDevFixtures`).
- New `loadDemoFixtures()` (`packages/core/src/seed/demo-fixtures.ts`), `scripts/load-fixtures.ts` (mirrors `scripts/seed.ts`), `pnpm load:fixtures` script, docker-entrypoint hook, and `docker-compose.yml` env var.

Seeded (in dependency order):
- 4 **users** (mixed roles/emojis, **bcrypt-hashed passwords → loginable**), 3 global **card types** (🐛 Bug / ✨ Feature / ✅ Task)
- 2 **repos** (`demo-webapp` local, `demo-api` remote — placeholder paths)
- 1 **board** ("Demo Board") with 4 **zones** (To Do / In Progress / Review / Done)
- 5 **branches** (placed + zone-pinned via `board_objects`, high fixed `branch_unique_id`s so ports never collide)
- 4 **sessions** with terminal status + **genealogy** (one spawned child, one forked sibling)
- 4 **tasks**, 16 transcript **messages** (incl. a `tool_use`/`tool_result` exchange)
- 4 **cards** (placed via `board_objects`), 1 public Sandpack **artifact** (placed via a `board.data.objects` entry)

## Demo login credentials (dev-only, `LOAD_FIXTURES`-gated)

Printed in the seed log on load. All passwords are bcrypt-hashed at rest.

| Email | Password | Role |
| --- | --- | --- |
| `demo.alice@agor.live` | `demo-password-alice` | admin |
| `demo.bob@agor.live` | `demo-password-bob` | member |
| `demo.carol@agor.live` | `demo-password-carol` | member |
| `demo.dave@agor.live` | `demo-password-dave` | viewer |

## Why / context

Spinning up a realistic, browsable, multi-user Agor environment for E2E/manual testing previously required driving the UI/CLI by hand. This gives a one-flag path to a fully-populated board you can actually log into.

## Implementation notes

- **`demo-`/`demo.`-prefixed** slugs/names/emails everywhere → no collision with the real `agor` repo (or its `test-branch`) created by `SEED`.
- **Atomic / crash-safe idempotency.** The entire load runs inside a **single DB transaction** (all-or-nothing): a mid-run failure or kill rolls back every insert. Because of that atomicity, the demo admin (`demo.alice@agor.live`) is a valid **terminal sentinel** — present only when the whole load committed, so reruns are safe no-ops and partial runs self-heal. Uses pre-generated IDs + create-only writes to avoid nested transactions.
- **Loginable users.** Passwords are bcrypt-hashed (12 rounds, same path as `createUser`) before `usersRepo.create`, so the auth layer's `bcrypt.compare` succeeds.
- **Consistent session metadata.** Every session's `data.tasks` matches its task row; root `genealogy.children` includes **both** the spawned and forked child; `fork_point_*` / `spawn_point_*` live on the children only.
- **`LOAD_FIXTURES` and `SEED` are orthogonal/composable.** The entrypoint runs `LOAD_FIXTURES` **after** `SEED`; recommended combo is `SEED=true LOAD_FIXTURES=true`.
- **Placement shapes** (confirmed against the board renderer):
  - branches + cards → `board_objects` rows (`branch_id`/`card_id` + `position` + optional `zone_id`).
  - zones → `type:"zone"` entries in `board.data.objects`.
  - artifact layout → a `board.data.objects` entry keyed **`artifact-<artifactId>`** with `{ type:"artifact", artifact_id, x, y, width, height }` (no `board_objects` row; matches `apps/agor-daemon/src/services/artifacts.ts`). A public, self-owned artifact needs no `artifact_trust_grants` row.
- Added `./seed/demo-fixtures` package export (parity with `./seed/dev-fixtures`).
- `docker-compose.prod.yml` intentionally untouched.

## Validation / test plan

- [x] `packages/core/src/seed/demo-fixtures.test.ts` — 5 passing: per-entity counts; idempotency (rerun → `skipped`, no dupes); **bcrypt hash + `bcrypt.compare` (loginable)**; **per-session `data.tasks` ↔ task-row consistency** + root has both children with points on children only; **artifact layout entry shape + non-empty `files`**.
- [x] Smoke (env-`DATABASE_URL` path, throwaway sqlite): clean first insert, idempotent 2nd run, creds printed, `demo.alice` password stored as `$2a$12$…`. Counts: `users=4, branches=5, sessions=4, tasks=4, messages=16, cards=4, artifacts=1, board_objects=9`.
- [x] `biome check` clean; `tsc --noEmit` (core) clean; `check:shortid` clean; `@agor/core` build succeeds.
- [ ] Full `SEED=true LOAD_FIXTURES=true docker compose up` E2E — deferred to review.

## Risks / rollout / rollback

Off by default (`LOAD_FIXTURES=${LOAD_FIXTURES:-false}`); no behavior change unless explicitly enabled. Atomic, additive DB inserts behind an idempotency sentinel — rollback is simply not setting the flag. Demo credentials are well-known and dev-only; the flag should never be enabled in production.