### PR TITLE
Invalidate auth tokens after password changes

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -3,9 +3,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgorConfig } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
-import { createDatabase, eq, initializeDatabase, select, users } from '@agor/core/db';
+import { createDatabase, eq, initializeDatabase, select, update, users } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
-import type { User, UserID } from '@agor/core/types';
+import type { InternalUser, User, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createLaunchAuthService, resolvePublicLaunchAuthSettings } from './launch-auth.js';
@@ -64,7 +64,7 @@ async function makeDb(): Promise<{ db: Database; cleanup: () => void }> {
 
 function makeUsersService(db: Database) {
   return {
-    async get(id: UserID): Promise<User> {
+    async get(id: UserID): Promise<InternalUser> {
       const row = await select(db).from(users).where(eq(users.user_id, id)).one();
       if (!row) throw new Error('missing user');
       return {
@@ -75,6 +75,7 @@ function makeUsersService(db: Database) {
         role: row.role as User['role'],
         onboarding_completed: row.onboarding_completed,
         must_change_password: row.must_change_password,
+        tokens_valid_after: row.tokens_valid_after ? new Date(row.tokens_valid_after) : undefined,
         created_at: row.created_at,
         updated_at: row.updated_at ?? undefined,
         avatar: (row.data as { avatar?: string }).avatar,
@@ -200,6 +201,7 @@ describe('one-time launch auth service', () => {
       })
     );
     expect(result.user.email).toBe('person@example.test');
+    expect(result.user).not.toHaveProperty('tokens_valid_after');
     expect(result.refreshToken).toBeTruthy();
 
     const decoded = jwt.verify(result.accessToken, RUNTIME_JWT_SECRET, {
@@ -235,6 +237,26 @@ describe('one-time launch auth service', () => {
 
     expect(second.user.user_id).toBe(first.user.user_id);
     expect(second.user.name).toBe('Updated Name');
+  });
+
+  it('uses token invalidation metadata for launch tokens without returning it', async () => {
+    mockExchange(signClaims());
+    const first = await service().create({ launchCode: 'first' });
+    const marker = new Date(Date.now() + 1_000);
+    await update(db, users)
+      .set({ tokens_valid_after: marker })
+      .where(eq(users.user_id, first.user.user_id))
+      .run();
+
+    mockExchange(signClaims({ name: 'Updated Name' }));
+    const second = await service().create({ launchCode: 'second' });
+
+    expect(second.user).not.toHaveProperty('tokens_valid_after');
+    const decoded = jwt.verify(second.accessToken, RUNTIME_JWT_SECRET, {
+      issuer: 'agor',
+      audience: 'https://agor.dev',
+    }) as jwt.JwtPayload;
+    expect(decoded.auth_time_ms).toBe(marker.getTime() + 1);
   });
 
   it('does not merge a new external identity by email alone', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -7,6 +7,8 @@ import type { Params, User, UserExternalIdentity, UserID, UserRole } from '@agor
 import { normalizeRole, ROLES } from '@agor/core/types';
 import jwt, { type JwtHeader, type JwtPayload, type SignOptions } from 'jsonwebtoken';
 import { issueRuntimeTokenPair } from './runtime-tokens.js';
+import { authTokenIssuedAtClaim } from './token-invalidation.js';
+import { redactUserAuthMetadata } from './user-redaction.js';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_SERVICE_TOKEN_ENV = 'AGOR_EXTERNAL_LAUNCH_SERVICE_TOKEN';
@@ -441,12 +443,18 @@ function issueRuntimeTokens(
   accessTokenTtl: SignOptions['expiresIn'],
   refreshTokenTtl: SignOptions['expiresIn']
 ): LaunchAuthResult {
-  const tokens = issueRuntimeTokenPair(user, jwtSecret, accessTokenTtl, refreshTokenTtl);
+  const tokens = issueRuntimeTokenPair(
+    user,
+    jwtSecret,
+    accessTokenTtl,
+    refreshTokenTtl,
+    authTokenIssuedAtClaim(Date.now(), user)
+  );
 
   return {
     ...tokens,
     authentication: { strategy: 'launch' },
-    user,
+    user: redactUserAuthMetadata(user),
   };
 }
 

--- a/apps/agor-daemon/src/auth/refresh-token-service.ts
+++ b/apps/agor-daemon/src/auth/refresh-token-service.ts
@@ -1,0 +1,63 @@
+import { NotAuthenticated } from '@agor/core/feathers';
+import type { Params, User, UserID } from '@agor/core/types';
+import jwt, { type SignOptions } from 'jsonwebtoken';
+import {
+  issueRuntimeTokenPair,
+  RUNTIME_JWT_AUDIENCE,
+  RUNTIME_JWT_ISSUER,
+} from './runtime-tokens.js';
+import {
+  assertUserTokenNotInvalidated,
+  authTokenIssuedAtClaim,
+  type UserAuthTokenPayload,
+} from './token-invalidation.js';
+import { redactUserAuthMetadata } from './user-redaction.js';
+
+interface RefreshTokenServiceOptions {
+  jwtSecret: string;
+  accessTokenTtl: SignOptions['expiresIn'];
+  refreshTokenTtl: SignOptions['expiresIn'];
+  usersService: {
+    get(id: UserID, params?: Params): Promise<User>;
+  };
+}
+
+export function createRefreshTokenService(options: RefreshTokenServiceOptions) {
+  return {
+    async create(data: { refreshToken: string }, _params?: Params) {
+      try {
+        const decoded = jwt.verify(data.refreshToken, options.jwtSecret, {
+          issuer: RUNTIME_JWT_ISSUER,
+          audience: RUNTIME_JWT_AUDIENCE,
+        }) as UserAuthTokenPayload;
+
+        if (decoded.type !== 'refresh') {
+          throw new Error('Invalid token type');
+        }
+
+        const user = await options.usersService.get(decoded.sub as UserID);
+        assertUserTokenNotInvalidated(user, decoded);
+
+        // Use the same access-token TTL as the auth-service config. Refresh tokens
+        // get the standard long TTL and both new tokens carry millisecond issue
+        // time so fresh sign-ins immediately after a password change remain usable.
+        const tokens = issueRuntimeTokenPair(
+          user,
+          options.jwtSecret,
+          options.accessTokenTtl,
+          options.refreshTokenTtl,
+          authTokenIssuedAtClaim(Date.now(), user)
+        );
+
+        // Return the full safe user object, matching POST /authentication.
+        return {
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          user: redactUserAuthMetadata(user),
+        };
+      } catch (_error) {
+        throw new NotAuthenticated('Invalid or expired refresh token');
+      }
+    },
+  };
+}

--- a/apps/agor-daemon/src/auth/runtime-tokens.ts
+++ b/apps/agor-daemon/src/auth/runtime-tokens.ts
@@ -35,16 +35,17 @@ export function issueRuntimeTokenPair(
   user: Pick<User, 'user_id'>,
   jwtSecret: string,
   accessTokenTtl: SignOptions['expiresIn'],
-  refreshTokenTtl: SignOptions['expiresIn']
+  refreshTokenTtl: SignOptions['expiresIn'],
+  extraClaims: Record<string, unknown> = {}
 ): RuntimeTokenPair {
   return {
     accessToken: issueRuntimeToken(
-      { sub: user.user_id, type: 'access' },
+      { sub: user.user_id, type: 'access', ...extraClaims },
       jwtSecret,
       accessTokenTtl
     ),
     refreshToken: issueRuntimeToken(
-      { sub: user.user_id, type: 'refresh' },
+      { sub: user.user_id, type: 'refresh', ...extraClaims },
       jwtSecret,
       refreshTokenTtl
     ),

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -11,8 +11,10 @@
  */
 
 import { JWTStrategy } from '@agor/core/feathers';
-import type { Params } from '@agor/core/types';
+import type { Params, UserAuthMetadata } from '@agor/core/types';
 import type { SessionTokenService } from '../services/session-token-service.js';
+import { markAuthenticationUserLookup } from '../services/users.js';
+import { assertUserTokenNotInvalidated, type UserAuthTokenPayload } from './token-invalidation.js';
 
 /**
  * Extended JWT Strategy that handles service tokens
@@ -43,7 +45,8 @@ export class ServiceJWTStrategy extends JWTStrategy {
       };
     }
 
-    // Regular user token - use standard lookup
+    // Regular user token validation needs backend-only auth metadata.
+    markAuthenticationUserLookup(params);
     return super.getEntity(id, params);
   }
 
@@ -56,19 +59,22 @@ export class ServiceJWTStrategy extends JWTStrategy {
   // biome-ignore lint/suspicious/noExplicitAny: Feathers type compatibility
   async authenticate(authentication: any, params: any): Promise<any> {
     // Call parent to verify JWT signature and get payload
-    const result = await super.authenticate(authentication, params);
+    const result = (await super.authenticate(authentication, params)) as {
+      accessToken?: string;
+      authentication?: { payload?: unknown };
+      user?: UserAuthMetadata;
+      [key: string]: unknown;
+    };
 
     // Check if this is a service token by looking at the decoded payload
     const payload = result.authentication?.payload as
-      | {
-          sub?: string;
-          type?: string;
+      | (UserAuthTokenPayload & {
           session_id?: string;
           sessionId?: string;
           task_id?: string;
           branch_id?: string;
           purpose?: string;
-        }
+        })
       | undefined;
 
     if (payload?.type === 'service' && payload?.sub === 'executor-service') {
@@ -117,6 +123,10 @@ export class ServiceJWTStrategy extends JWTStrategy {
       !['access', 'service', 'executor-session'].includes(payload.type)
     ) {
       throw new Error('JWT type is not valid for daemon API authentication');
+    }
+
+    if (result.user) {
+      assertUserTokenNotInvalidated(result.user, payload);
     }
 
     return result;

--- a/apps/agor-daemon/src/auth/token-invalidation.test.ts
+++ b/apps/agor-daemon/src/auth/token-invalidation.test.ts
@@ -1,0 +1,299 @@
+import { AuthenticationService, feathers } from '@agor/core/feathers';
+import type { User, UserID } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
+import { expect, test } from 'vitest';
+import { eq, update, users } from '../../../../packages/core/src/db';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { AgorLocalStrategy } from '../register-routes';
+import { createUsersService, type UsersService } from '../services/users';
+import { createRefreshTokenService } from './refresh-token-service';
+import {
+  issueRuntimeToken,
+  issueRuntimeTokenPair,
+  RUNTIME_JWT_AUDIENCE,
+  RUNTIME_JWT_ISSUER,
+} from './runtime-tokens';
+import { ServiceJWTStrategy } from './service-jwt-strategy';
+import {
+  AUTH_TOKEN_ISSUED_AT_MS_CLAIM,
+  assertUserTokenNotInvalidated,
+  authTokenIssuedAtClaim,
+} from './token-invalidation';
+import { redactUserAuthMetadata } from './user-redaction';
+
+const JWT_SECRET = 'password-token-invalidation-test-secret';
+const ACCESS_TOKEN_TTL = '15m';
+const REFRESH_TOKEN_TTL = '30d';
+
+function authTime(ms: number) {
+  return { [AUTH_TOKEN_ISSUED_AT_MS_CLAIM]: ms };
+}
+
+function expectNoTokenMarker(value: unknown): void {
+  expect(value).not.toHaveProperty('tokens_valid_after');
+}
+
+function expectTokenMarker(value: unknown): void {
+  expect(value).toHaveProperty('tokens_valid_after', expect.any(Date));
+}
+
+test('treats tokens issued at the invalidation boundary as stale', () => {
+  const user = { tokens_valid_after: new Date(1_000) };
+
+  expect(() =>
+    assertUserTokenNotInvalidated(user, { sub: 'user-1', type: 'access', ...authTime(1_000) })
+  ).toThrow(/Session expired/);
+  expect(authTokenIssuedAtClaim(1_000, user)[AUTH_TOKEN_ISSUED_AT_MS_CLAIM]).toBe(1_001);
+});
+
+function createAuthApp(db: Parameters<typeof createUsersService>[0]) {
+  const app = feathers();
+  app.set('authentication', {
+    secret: JWT_SECRET,
+    entity: 'user',
+    entityId: 'user_id',
+    service: 'users',
+    authStrategies: ['jwt', 'local'],
+    jwtOptions: {
+      header: { typ: 'access' },
+      audience: RUNTIME_JWT_AUDIENCE,
+      issuer: RUNTIME_JWT_ISSUER,
+      algorithm: 'HS256',
+      expiresIn: ACCESS_TOKEN_TTL,
+    },
+    local: {
+      usernameField: 'email',
+      passwordField: 'password',
+    },
+  });
+
+  const usersService = createUsersService(db);
+  app.use('users', usersService);
+
+  const authentication = new AuthenticationService(app);
+  authentication.register('jwt', new ServiceJWTStrategy());
+  authentication.register('local', new AgorLocalStrategy());
+  app.use('authentication', authentication);
+
+  const authService = app.service('authentication') as {
+    hooks(hooks: {
+      after: {
+        create: Array<
+          (context: {
+            result?: { user?: User; accessToken?: string; refreshToken?: string };
+          }) => Promise<unknown> | unknown
+        >;
+      };
+    }): void;
+  };
+  authService.hooks({
+    after: {
+      create: [
+        async (context) => {
+          if (context.result?.user) {
+            const tokens = issueRuntimeTokenPair(
+              context.result.user,
+              JWT_SECRET,
+              ACCESS_TOKEN_TTL,
+              REFRESH_TOKEN_TTL,
+              authTokenIssuedAtClaim(Date.now(), context.result.user)
+            );
+            context.result.accessToken = tokens.accessToken;
+            context.result.refreshToken = tokens.refreshToken;
+            context.result.user = redactUserAuthMetadata(context.result.user);
+          }
+          return context;
+        },
+      ],
+    },
+  });
+
+  return { app, usersService };
+}
+
+async function createUser(service: UsersService, email: string): Promise<User> {
+  return service.create({ email, password: 'old-password-1234', role: ROLES.MEMBER });
+}
+
+dbTest('redacts token invalidation marker from external user service responses', async ({ db }) => {
+  const usersService = createUsersService(db);
+  const user = await createUser(usersService, 'redacted-users@example.test');
+
+  const createResult = await usersService.create(
+    { email: 'redacted-create@example.test', password: 'password-1234', role: ROLES.MEMBER },
+    { provider: 'rest' }
+  );
+  expectNoTokenMarker(createResult);
+
+  const patchResult = await usersService.patch(
+    user.user_id,
+    { password: 'new-password-1234' },
+    { provider: 'rest' }
+  );
+  expectNoTokenMarker(patchResult);
+
+  const internalUser = await usersService.get(user.user_id);
+  expectTokenMarker(internalUser);
+
+  const getResult = await usersService.get(user.user_id, { provider: 'rest' });
+  expectNoTokenMarker(getResult);
+
+  const findResult = await usersService.find({ provider: 'rest' });
+  expect(findResult.data).toHaveLength(2);
+  for (const publicUser of findResult.data) {
+    expectNoTokenMarker(publicUser);
+  }
+});
+
+dbTest(
+  'rejects a browser access token issued before the password change marker',
+  async ({ db }) => {
+    const { app, usersService } = createAuthApp(db);
+    const user = await createUser(usersService, 'stale-access@example.test');
+    const issuedBefore = Date.now() - 10_000;
+    const oldAccessToken = issueRuntimeToken(
+      { sub: user.user_id, type: 'access', ...authTime(issuedBefore) },
+      JWT_SECRET,
+      ACCESS_TOKEN_TTL
+    );
+
+    await usersService.patch(user.user_id, { password: 'new-password-1234' });
+
+    await expect(
+      app
+        .service('authentication')
+        .create({ strategy: 'jwt', accessToken: oldAccessToken }, { provider: 'rest' })
+    ).rejects.toThrow(/Session expired|not authenticated|Invalid/);
+  }
+);
+
+dbTest('rejects a refresh token issued before the password change marker', async ({ db }) => {
+  const usersService = createUsersService(db);
+  const refreshService = createRefreshTokenService({
+    jwtSecret: JWT_SECRET,
+    accessTokenTtl: ACCESS_TOKEN_TTL,
+    refreshTokenTtl: REFRESH_TOKEN_TTL,
+    usersService,
+  });
+  const user = await createUser(usersService, 'stale-refresh@example.test');
+  const issuedBefore = Date.now() - 10_000;
+  const oldRefreshToken = issueRuntimeToken(
+    { sub: user.user_id, type: 'refresh', ...authTime(issuedBefore) },
+    JWT_SECRET,
+    REFRESH_TOKEN_TTL
+  );
+
+  await usersService.patch(user.user_id, { password: 'new-password-1234' });
+
+  await expect(refreshService.create({ refreshToken: oldRefreshToken })).rejects.toThrow(
+    /Invalid or expired refresh token/
+  );
+});
+
+dbTest(
+  'admin password reset invalidates the target user access and refresh tokens',
+  async ({ db }) => {
+    const { app, usersService } = createAuthApp(db);
+    const refreshService = createRefreshTokenService({
+      jwtSecret: JWT_SECRET,
+      accessTokenTtl: ACCESS_TOKEN_TTL,
+      refreshTokenTtl: REFRESH_TOKEN_TTL,
+      usersService,
+    });
+    const target = await createUser(usersService, 'admin-reset-target@example.test');
+    const issuedBefore = Date.now() - 10_000;
+    const oldTokens = issueRuntimeTokenPair(
+      target,
+      JWT_SECRET,
+      ACCESS_TOKEN_TTL,
+      REFRESH_TOKEN_TTL,
+      authTime(issuedBefore)
+    );
+
+    await usersService.patch(
+      target.user_id,
+      { password: 'admin-reset-password-1234' },
+      {
+        provider: 'rest',
+        authenticated: true,
+        user: { user_id: 'admin-user' as UserID, email: 'admin@example.test', role: ROLES.ADMIN },
+      }
+    );
+
+    await expect(
+      app
+        .service('authentication')
+        .create({ strategy: 'jwt', accessToken: oldTokens.accessToken }, { provider: 'rest' })
+    ).rejects.toThrow();
+    await expect(refreshService.create({ refreshToken: oldTokens.refreshToken })).rejects.toThrow(
+      /Invalid or expired refresh token/
+    );
+  }
+);
+
+dbTest('fresh login after forced password change gets usable tokens', async ({ db }) => {
+  const { app, usersService } = createAuthApp(db);
+  const user = await createUser(usersService, 'fresh-login@example.test');
+
+  await usersService.patch(user.user_id, { password: 'new-password-1234' });
+
+  const loginResult = await app
+    .service('authentication')
+    .create(
+      { strategy: 'local', email: user.email, password: 'new-password-1234' },
+      { provider: 'rest' }
+    );
+  expect(loginResult.user.email).toBe(user.email);
+  expectNoTokenMarker(loginResult.user);
+
+  const accessResult = await app
+    .service('authentication')
+    .create({ strategy: 'jwt', accessToken: loginResult.accessToken }, { provider: 'rest' });
+  expect(accessResult.user.email).toBe(user.email);
+  expectNoTokenMarker(accessResult.user);
+
+  const refreshResult = await createRefreshTokenService({
+    jwtSecret: JWT_SECRET,
+    accessTokenTtl: ACCESS_TOKEN_TTL,
+    refreshTokenTtl: REFRESH_TOKEN_TTL,
+    usersService,
+  }).create({ refreshToken: loginResult.refreshToken });
+  expect(refreshResult.user.email).toBe(user.email);
+  expectNoTokenMarker(refreshResult.user);
+
+  const decoded = jwt.verify(refreshResult.accessToken, JWT_SECRET) as jwt.JwtPayload;
+  expect(decoded[AUTH_TOKEN_ISSUED_AT_MS_CLAIM]).toEqual(expect.any(Number));
+});
+
+dbTest(
+  'local login uses auth metadata when issuing tokens at the invalidation boundary',
+  async ({ db }) => {
+    const { app, usersService } = createAuthApp(db);
+    const user = await createUser(usersService, 'local-boundary@example.test');
+    const marker = new Date(Date.now() + 1_000);
+    await update(db, users)
+      .set({ tokens_valid_after: marker })
+      .where(eq(users.user_id, user.user_id))
+      .run();
+
+    const loginResult = await app.service('authentication').create(
+      {
+        strategy: 'local',
+        email: user.email,
+        password: 'old-password-1234',
+      },
+      { provider: 'rest' }
+    );
+
+    expectNoTokenMarker(loginResult.user);
+    const decoded = jwt.verify(loginResult.accessToken, JWT_SECRET) as jwt.JwtPayload;
+    expect(decoded[AUTH_TOKEN_ISSUED_AT_MS_CLAIM]).toBe(marker.getTime() + 1);
+
+    const accessResult = await app
+      .service('authentication')
+      .create({ strategy: 'jwt', accessToken: loginResult.accessToken }, { provider: 'rest' });
+    expect(accessResult.user.email).toBe(user.email);
+    expectNoTokenMarker(accessResult.user);
+  }
+);

--- a/apps/agor-daemon/src/auth/token-invalidation.ts
+++ b/apps/agor-daemon/src/auth/token-invalidation.ts
@@ -1,0 +1,53 @@
+import { NotAuthenticated } from '@agor/core/feathers';
+import type { UserAuthMetadata } from '@agor/core/types';
+import type { JwtPayload } from 'jsonwebtoken';
+
+export const AUTH_TOKEN_ISSUED_AT_MS_CLAIM = 'auth_time_ms';
+
+export type UserAuthTokenPayload = JwtPayload & {
+  type?: string;
+  [AUTH_TOKEN_ISSUED_AT_MS_CLAIM]?: unknown;
+};
+
+function dateToMillis(value: Date | string | number | undefined): number | null {
+  if (value === undefined) return null;
+  const millis = value instanceof Date ? value.getTime() : new Date(value).getTime();
+  return Number.isFinite(millis) ? millis : null;
+}
+
+export function getAuthTokenIssuedAtMs(payload: UserAuthTokenPayload | undefined): number | null {
+  const authTimeMs = payload?.[AUTH_TOKEN_ISSUED_AT_MS_CLAIM];
+  if (typeof authTimeMs === 'number' && Number.isFinite(authTimeMs)) {
+    return authTimeMs;
+  }
+  if (typeof authTimeMs === 'string') {
+    const parsed = Number(authTimeMs);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+
+  return typeof payload?.iat === 'number' && Number.isFinite(payload.iat)
+    ? payload.iat * 1000
+    : null;
+}
+
+export function assertUserTokenNotInvalidated(
+  user: UserAuthMetadata,
+  payload: UserAuthTokenPayload | undefined
+): void {
+  const validAfterMs = dateToMillis(user.tokens_valid_after);
+  if (validAfterMs === null) return;
+
+  const issuedAtMs = getAuthTokenIssuedAtMs(payload);
+  if (issuedAtMs === null || issuedAtMs <= validAfterMs) {
+    throw new NotAuthenticated('Session expired, please login again');
+  }
+}
+
+export function authTokenIssuedAtClaim(
+  now = Date.now(),
+  user?: UserAuthMetadata
+): Record<typeof AUTH_TOKEN_ISSUED_AT_MS_CLAIM, number> {
+  const validAfterMs = dateToMillis(user?.tokens_valid_after);
+  const issuedAtMs = validAfterMs !== null && now <= validAfterMs ? validAfterMs + 1 : now;
+  return { [AUTH_TOKEN_ISSUED_AT_MS_CLAIM]: issuedAtMs };
+}

--- a/apps/agor-daemon/src/auth/user-redaction.ts
+++ b/apps/agor-daemon/src/auth/user-redaction.ts
@@ -1,0 +1,14 @@
+import type { User } from '@agor/core/types';
+
+type UserWithBackendFields = User & {
+  tokens_valid_after?: unknown;
+  password?: unknown;
+};
+
+/**
+ * Remove backend-only auth metadata before returning a user object to browser clients.
+ */
+export function redactUserAuthMetadata(user: UserWithBackendFields): User {
+  const { tokens_valid_after: _tokensValidAfter, password: _password, ...publicUser } = user;
+  return publicUser;
+}

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -67,14 +67,16 @@ import {
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
-import jwt from 'jsonwebtoken';
 import { createLaunchAuthService, resolvePublicLaunchAuthSettings } from './auth/launch-auth.js';
+import { createRefreshTokenService } from './auth/refresh-token-service.js';
 import {
   issueRuntimeToken,
   issueRuntimeTokenPair,
   RUNTIME_JWT_AUDIENCE,
   RUNTIME_JWT_ISSUER,
 } from './auth/runtime-tokens.js';
+import { authTokenIssuedAtClaim } from './auth/token-invalidation.js';
+import { redactUserAuthMetadata } from './auth/user-redaction.js';
 import type {
   BoardsServiceImpl,
   BranchesServiceImpl,
@@ -92,7 +94,7 @@ import {
 } from './services/scheduler.js';
 import type { TerminalsService } from './services/terminals.js';
 import { createUserApiKeysService } from './services/user-api-keys.js';
-import { markLocalAuthenticationLookup } from './services/users.js';
+import { markAuthenticationUserLookup, markLocalAuthenticationLookup } from './services/users.js';
 import { registerProxies } from './setup/proxies.js';
 import { applyTierHooks } from './setup/service-tiers.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
@@ -154,6 +156,14 @@ export class AgorLocalStrategy extends LocalStrategy {
   async findEntity(username: string, params: Params) {
     markLocalAuthenticationLookup(params);
     return super.findEntity(username, params);
+  }
+
+  async getEntity(result: unknown, params: Params) {
+    // Local login's final entity lookup also needs backend-only auth metadata
+    // so freshly issued tokens can be bumped past a just-written invalidation
+    // marker. The authentication hook redacts the metadata before returning.
+    markAuthenticationUserLookup(params);
+    return super.getEntity(result, params);
   }
 }
 
@@ -389,7 +399,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     security: [],
   };
 
-  // Hook: Add refresh token to authentication response.
+  // Hook: Issue browser access + refresh tokens with millisecond issue time.
   // Rate limiting is enforced by express-rate-limit middleware mounted on
   // `/authentication` above — by the time we reach this hook the limiter
   // has already 429'd any over-quota request.
@@ -406,11 +416,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           });
 
           if (context.result?.user) {
-            context.result.refreshToken = issueRuntimeToken(
-              { sub: context.result.user.user_id, type: 'refresh' },
+            const tokens = issueRuntimeTokenPair(
+              context.result.user,
               jwtSecret,
-              REFRESH_TOKEN_TTL
+              ACCESS_TOKEN_TTL,
+              REFRESH_TOKEN_TTL,
+              authTokenIssuedAtClaim(Date.now(), context.result.user)
             );
+            context.result.accessToken = tokens.accessToken;
+            context.result.refreshToken = tokens.refreshToken;
+            context.result.user = redactUserAuthMetadata(context.result.user);
           }
           return context;
         },
@@ -447,51 +462,15 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Refresh token endpoint
   // ============================================================================
 
-  app.use('/authentication/refresh', {
-    async create(data: { refreshToken: string }, _params?: Params) {
-      // Rate limiting handled by express-rate-limit at the
-      // /authentication mount point (path-prefix match catches /refresh).
-      try {
-        const decoded = jwt.verify(data.refreshToken, jwtSecret, {
-          issuer: RUNTIME_JWT_ISSUER,
-          audience: RUNTIME_JWT_AUDIENCE,
-        }) as { sub: string; type: string };
-
-        if (decoded.type !== 'refresh') {
-          throw new Error('Invalid token type');
-        }
-
-        const user = await usersService.get(decoded.sub as import('@agor/core/types').UUID);
-
-        // Use the SAME ACCESS_TOKEN_TTL as the auth-service config above —
-        // otherwise this endpoint silently downgrades the access-token
-        // hardening. Refresh tokens get the standard 30-day TTL.
-        const tokens = issueRuntimeTokenPair(user, jwtSecret, ACCESS_TOKEN_TTL, REFRESH_TOKEN_TTL);
-
-        // Return the full user object — matches what POST /authentication
-        // returns via the FeathersJS auth service. Stripping fields here
-        // (previously: only user_id/email/name/emoji/role) silently dropped
-        // `must_change_password` after every token refresh, breaking the
-        // forced-password-change UI guard in App.tsx and showing the user a
-        // black page with "Failed to load data — Password change required."
-        // instead of the change-password modal. `usersService.get` already
-        // omits secrets (password hash, raw API keys, raw env var values)
-        // via rowToUser — see services/users.ts.
-        return {
-          accessToken: tokens.accessToken,
-          refreshToken: tokens.refreshToken,
-          user,
-        };
-      } catch (_error) {
-        // Must throw NotAuthenticated (not plain Error) so the UI's
-        // isDefiniteAuthFailure classifier (apps/agor-ui/src/utils/authErrors.ts)
-        // recognizes a dead refresh token as a 401-class failure and clears
-        // session state. A plain Error has no status/name and gets treated as
-        // transient, leading the single-flight refresh loop to keep retrying.
-        throw new NotAuthenticated('Invalid or expired refresh token');
-      }
-    },
-  });
+  app.use(
+    '/authentication/refresh',
+    createRefreshTokenService({
+      jwtSecret,
+      accessTokenTtl: ACCESS_TOKEN_TTL,
+      refreshTokenTtl: REFRESH_TOKEN_TTL,
+      usersService,
+    })
+  );
 
   // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
   const refreshService = app.service('authentication/refresh') as any;
@@ -569,6 +548,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           impersonated_by: caller.user_id,
           is_impersonated: true,
           jti,
+          ...authTokenIssuedAtClaim(Date.now(), targetUser),
         },
         jwtSecret,
         Math.ceil(expiryMs / 1000)

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -37,6 +37,7 @@ import type {
   AuthenticatedParams,
   EnvVarMetadata,
   EnvVarScope,
+  InternalUser,
   Paginated,
   Params,
   StoredAgenticTools,
@@ -66,19 +67,36 @@ function queryString(value: unknown): string | undefined {
 }
 
 export const LOCAL_AUTH_LOOKUP_PARAM = Symbol('agor.users.local-auth-lookup');
+export const AUTH_INTERNAL_USER_LOOKUP_PARAM = Symbol('agor.users.auth-internal-lookup');
 
 export interface LocalAuthenticationLookupParams extends Params {
   [LOCAL_AUTH_LOOKUP_PARAM]?: true;
+  [AUTH_INTERNAL_USER_LOOKUP_PARAM]?: true;
 }
 
 export function markLocalAuthenticationLookup(params: Params): void {
   (params as LocalAuthenticationLookupParams)[LOCAL_AUTH_LOOKUP_PARAM] = true;
 }
 
+export function markAuthenticationUserLookup(params: Params): void {
+  (params as LocalAuthenticationLookupParams)[AUTH_INTERNAL_USER_LOOKUP_PARAM] = true;
+}
+
 export function isLocalAuthenticationLookup(params: Params | undefined): boolean {
   return (
     (params as LocalAuthenticationLookupParams | undefined)?.[LOCAL_AUTH_LOOKUP_PARAM] === true
   );
+}
+
+export function isAuthenticationUserLookup(params: Params | undefined): boolean {
+  return (
+    (params as LocalAuthenticationLookupParams | undefined)?.[AUTH_INTERNAL_USER_LOOKUP_PARAM] ===
+    true
+  );
+}
+
+function shouldIncludeAuthMetadata(params: Params | undefined, includePassword = false): boolean {
+  return includePassword || !params?.provider || isAuthenticationUserLookup(params);
 }
 
 function isServiceAccount(params: Params | undefined): boolean {
@@ -263,7 +281,10 @@ export class UsersService {
     const pageRows =
       limit === undefined ? rows.slice(skip) : rows.slice(skip, skip + Math.max(limit, 0));
 
-    const results = pageRows.map((row) => this.rowToUser(row, includePassword, requesterId));
+    const includeAuthMetadata = shouldIncludeAuthMetadata(params, includePassword);
+    const results = pageRows.map((row) =>
+      this.rowToUser(row, includePassword, requesterId, includeAuthMetadata)
+    );
 
     return {
       total,
@@ -286,13 +307,13 @@ export class UsersService {
     const requesterId = (params as AuthenticatedParams | undefined)?.user?.user_id as
       | UserID
       | undefined;
-    return this.rowToUser(row, false, requesterId);
+    return this.rowToUser(row, false, requesterId, shouldIncludeAuthMetadata(params));
   }
 
   /**
    * Create new user
    */
-  async create(data: CreateUserData, _params?: Params): Promise<User> {
+  async create(data: CreateUserData, params?: Params): Promise<User> {
     // Check if email already exists
     const existing = await select(this.db).from(users).where(eq(users.email, data.email)).one();
 
@@ -329,7 +350,7 @@ export class UsersService {
       .returning()
       .one();
 
-    return this.rowToUser(row);
+    return this.rowToUser(row, false, undefined, shouldIncludeAuthMetadata(params));
   }
 
   /**
@@ -342,6 +363,9 @@ export class UsersService {
     // Handle password separately (needs hashing)
     if (data.password) {
       updates.password = await hash(data.password, 10);
+      // Any password change requires fresh browser authentication; previously
+      // issued access and refresh tokens are rejected after this marker.
+      updates.tokens_valid_after = now;
       // Auto-clear must_change_password when password is changed,
       // UNLESS explicitly set in the same request (admin reset + force change scenario)
       // e.g., `user update --password newpass --force-password-change` should keep flag true
@@ -483,14 +507,14 @@ export class UsersService {
     const requesterId = (params as AuthenticatedParams | undefined)?.user?.user_id as
       | UserID
       | undefined;
-    return this.rowToUser(row, false, requesterId);
+    return this.rowToUser(row, false, requesterId, shouldIncludeAuthMetadata(params));
   }
 
   /**
    * Delete user
    */
-  async remove(id: UserID, _params?: Params): Promise<User> {
-    const user = await this.get(id);
+  async remove(id: UserID, params?: Params): Promise<User> {
+    const user = await this.get(id, params);
 
     await deleteFrom(this.db, users).where(eq(users.user_id, id)).run();
 
@@ -650,8 +674,9 @@ export class UsersService {
   private rowToUser(
     row: typeof users.$inferSelect,
     includePassword = false,
-    requesterId?: UserID
-  ): User & { password?: string } {
+    requesterId?: UserID,
+    includeAuthMetadata = true
+  ): (User | InternalUser) & { password?: string } {
     const data = row.data as {
       avatar?: string;
       preferences?: Record<string, unknown>;
@@ -671,7 +696,7 @@ export class UsersService {
           )
         : undefined;
 
-    const user: User & { password?: string } = {
+    const user: (User | InternalUser) & { password?: string } = {
       user_id: row.user_id as UserID,
       email: row.email,
       name: row.name ?? undefined,
@@ -699,6 +724,10 @@ export class UsersService {
       default_agentic_config: data.default_agentic_config,
     };
 
+    if (includeAuthMetadata && row.tokens_valid_after) {
+      (user as InternalUser).tokens_valid_after = new Date(row.tokens_valid_after);
+    }
+
     // Include password for authentication (FeathersJS LocalStrategy needs this)
     if (includePassword) {
       user.password = row.password;
@@ -712,7 +741,7 @@ export class UsersService {
  * User service with password field for authentication
  * This version includes the password field for FeathersJS local strategy
  */
-interface UserWithPassword extends User {
+interface UserWithPassword extends InternalUser {
   password: string;
 }
 
@@ -760,6 +789,7 @@ class UsersServiceWithAuth extends UsersService {
       preferences: data.preferences,
       onboarding_completed: !!row.onboarding_completed,
       must_change_password: !!row.must_change_password,
+      tokens_valid_after: row.tokens_valid_after ? new Date(row.tokens_valid_after) : undefined,
       created_at: row.created_at,
       updated_at: row.updated_at ?? undefined,
       agentic_tools: toAgenticToolsStatus(data.agentic_tools),

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -58,6 +58,7 @@ import {
 } from './surfaces/surfaceRegistry';
 import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLifecycle';
 import { isMobileDevice } from './utils/deviceDetection';
+import { completeForcedPasswordChange } from './utils/forcePasswordChange';
 import { useThemedMessage } from './utils/message';
 import { updateSessionMcpServers } from './utils/sessionMcpServers';
 import { getRouterBasename } from './utils/uiRoutes';
@@ -873,12 +874,22 @@ function AppContent() {
   // Handle forced password change (from ForcePasswordChangeModal)
   const handleForcePasswordChange = async (userId: string, newPassword: string) => {
     if (!client) throw new Error('Not connected');
-    // This will auto-clear must_change_password flag on the backend
-    await client.service('users').patch(userId, { password: newPassword } as Partial<User>);
-    showSuccess('Password changed successfully!');
-    // Re-authenticate to refresh user state with must_change_password: false
-    // This will dismiss the modal and allow the user to continue
-    await reAuthenticate();
+    if (!currentUser?.email) throw new Error('Current user is unavailable');
+
+    const signedIn = await completeForcedPasswordChange({
+      client,
+      userId,
+      email: currentUser.email,
+      newPassword,
+      login,
+      logout,
+    });
+
+    showSuccess(
+      signedIn
+        ? 'Password changed successfully!'
+        : 'Password changed successfully. Please sign in again.'
+    );
   };
 
   // Handle board CRUD

--- a/apps/agor-ui/src/utils/forcePasswordChange.test.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { completeForcedPasswordChange } from './forcePasswordChange';
+
+function makeClient(patch = vi.fn().mockResolvedValue({})) {
+  return {
+    service: vi.fn((name: string) => {
+      if (name !== 'users') throw new Error(`unexpected service: ${name}`);
+      return { patch };
+    }),
+  } as unknown as Parameters<typeof completeForcedPasswordChange>[0]['client'];
+}
+
+describe('completeForcedPasswordChange', () => {
+  it('patches the password then signs in with the new password', async () => {
+    const patch = vi.fn().mockResolvedValue({});
+    const login = vi.fn().mockResolvedValue(true);
+    const logout = vi.fn().mockResolvedValue(undefined);
+
+    const result = await completeForcedPasswordChange({
+      client: makeClient(patch),
+      userId: 'user-1',
+      email: 'person@example.test',
+      newPassword: 'new-password-1234',
+      login,
+      logout,
+    });
+
+    expect(result).toBe(true);
+    expect(patch).toHaveBeenCalledWith('user-1', { password: 'new-password-1234' });
+    expect(login).toHaveBeenCalledWith('person@example.test', 'new-password-1234');
+    expect(logout).not.toHaveBeenCalled();
+  });
+
+  it('clears stale local state when the fresh sign-in fails', async () => {
+    const login = vi.fn().mockResolvedValue(false);
+    const logout = vi.fn().mockResolvedValue(undefined);
+
+    const result = await completeForcedPasswordChange({
+      client: makeClient(),
+      userId: 'user-1',
+      email: 'person@example.test',
+      newPassword: 'new-password-1234',
+      login,
+      logout,
+    });
+
+    expect(result).toBe(false);
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/utils/forcePasswordChange.ts
+++ b/apps/agor-ui/src/utils/forcePasswordChange.ts
@@ -1,0 +1,36 @@
+import type { AgorClient, User } from '@agor-live/client';
+
+interface CompleteForcedPasswordChangeOptions {
+  client: AgorClient;
+  userId: string;
+  email: string;
+  newPassword: string;
+  login: (email: string, password: string) => Promise<boolean>;
+  logout: () => Promise<void>;
+}
+
+/**
+ * Completes the forced-password-change flow.
+ *
+ * The password patch intentionally invalidates all existing browser tokens. To
+ * keep the initiating user from getting stuck with now-stale tokens, immediately
+ * sign in with the new password. If that fresh sign-in fails, clear the stale
+ * local session so the user lands on the login screen.
+ */
+export async function completeForcedPasswordChange({
+  client,
+  userId,
+  email,
+  newPassword,
+  login,
+  logout,
+}: CompleteForcedPasswordChangeOptions): Promise<boolean> {
+  await client.service('users').patch(userId, { password: newPassword } as Partial<User>);
+
+  const signedIn = await login(email, newPassword);
+  if (!signedIn) {
+    await logout();
+  }
+
+  return signedIn;
+}

--- a/packages/core/drizzle/postgres/0053_user_token_invalidation.sql
+++ b/packages/core/drizzle/postgres/0053_user_token_invalidation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "tokens_valid_after" timestamp with time zone;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1781800000000,
       "tag": "0052_gateway_outbound_messages",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1781900000000,
+      "tag": "0053_user_token_invalidation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0062_user_token_invalidation.sql
+++ b/packages/core/drizzle/sqlite/0062_user_token_invalidation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `tokens_valid_after` integer;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1781800000000,
       "tag": "0061_gateway_outbound_messages",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "6",
+      "when": 1781900000000,
+      "tag": "0062_user_token_invalidation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -10,6 +10,7 @@ import type {
   AgenticToolName,
   AgenticToolsConfig,
   EnvVarMetadata,
+  InternalUser,
   StoredAgenticTools,
   User,
   UUID,
@@ -33,7 +34,7 @@ import {
 /**
  * Users repository implementation
  */
-export class UsersRepository implements BaseRepository<User, Partial<User>> {
+export class UsersRepository implements BaseRepository<InternalUser, Partial<InternalUser>> {
   constructor(private db: Database) {}
 
   /**
@@ -41,7 +42,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
    * Converts the encrypted `agentic_tools` blob to a boolean presence DTO so
    * decrypted credentials never leave this repository.
    */
-  private rowToUser(row: UserRow): User {
+  private rowToUser(row: UserRow): InternalUser {
     return {
       user_id: row.user_id as UUID,
       created_at: new Date(row.created_at),
@@ -53,6 +54,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
       unix_username: row.unix_username ?? undefined,
       onboarding_completed: row.onboarding_completed,
       must_change_password: row.must_change_password,
+      tokens_valid_after: row.tokens_valid_after ? new Date(row.tokens_valid_after) : undefined,
       avatar: row.data.avatar,
       preferences: row.data.preferences as User['preferences'],
       // Convert encrypted per-tool credential blobs into boolean presence flags.
@@ -81,7 +83,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
    * For updates, this accepts the current user data from the database row
    */
   private userToInsert(
-    user: Partial<User> & {
+    user: Partial<InternalUser> & {
       password?: string;
       agentic_tools_raw?: StoredAgenticTools;
       env_vars_raw?: SchemaUserInsert['data']['env_vars'];
@@ -105,6 +107,8 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
       role: user.role ?? 'member',
       unix_username: user.unix_username ?? null,
       onboarding_completed: user.onboarding_completed ?? false,
+      must_change_password: user.must_change_password ?? false,
+      tokens_valid_after: user.tokens_valid_after ? new Date(user.tokens_valid_after) : null,
       data: {
         avatar: user.avatar,
         preferences: user.preferences,
@@ -165,7 +169,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
   /**
    * Create a new user
    */
-  async create(data: Partial<User>): Promise<User> {
+  async create(data: Partial<InternalUser>): Promise<InternalUser> {
     // Validate unix_username uniqueness if provided
     if (data.unix_username) {
       const isTaken = await this.isUnixUsernameTaken(data.unix_username);
@@ -195,7 +199,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
   /**
    * Find user by ID (supports short ID resolution)
    */
-  async findById(id: string): Promise<User | null> {
+  async findById(id: string): Promise<InternalUser | null> {
     try {
       const fullId = await this.resolveId(id);
 
@@ -217,7 +221,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
   /**
    * Find user by email
    */
-  async findByEmail(email: string): Promise<User | null> {
+  async findByEmail(email: string): Promise<InternalUser | null> {
     const result = await select(this.db).from(users).where(eq(users.email, email)).one();
 
     if (!result) {
@@ -237,7 +241,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
    * match. Prefer an exact match when present; otherwise return a
    * case-insensitive match only when it is unambiguous.
    */
-  async findByEmailForAlignment(email: string): Promise<User | null> {
+  async findByEmailForAlignment(email: string): Promise<InternalUser | null> {
     const normalizedEmail = email.trim().toLowerCase();
     if (!normalizedEmail) return null;
 
@@ -269,7 +273,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
   /**
    * Find all users
    */
-  async findAll(): Promise<User[]> {
+  async findAll(): Promise<InternalUser[]> {
     const results = await select(this.db).from(users).all();
 
     return results.map((row: UserRow) => this.rowToUser(row));
@@ -278,7 +282,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
   /**
    * Update user by ID
    */
-  async update(id: string, updates: Partial<User>): Promise<User> {
+  async update(id: string, updates: Partial<InternalUser>): Promise<InternalUser> {
     const fullId = await this.resolveId(id);
 
     // Get current user
@@ -302,7 +306,7 @@ export class UsersRepository implements BaseRepository<User, Partial<User>> {
     // doesn't nuke stored credentials — the boolean projection on `current`
     // can't round-trip back to encrypted bytes.
     const rawRow = await this.getRawRow(fullId);
-    const merged = { ...current, ...updates } as Partial<User> & {
+    const merged = { ...current, ...updates } as Partial<InternalUser> & {
       agentic_tools_raw?: StoredAgenticTools;
       env_vars_raw?: SchemaUserInsert['data']['env_vars'];
     };

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -893,6 +893,10 @@ export const users = pgTable(
     // Force password change flag (admin-settable, auto-cleared on password change)
     must_change_password: t.bool('must_change_password').notNull().default(false),
 
+    // Auth invalidation marker. Password changes set this timestamp so any
+    // previously issued browser access or refresh token is rejected.
+    tokens_valid_after: t.timestamp('tokens_valid_after'),
+
     // JSON blob for profile/preferences
     data: t
       .json<unknown>('data')

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -912,6 +912,10 @@ export const users = sqliteTable(
     // Force password change flag (admin-settable, auto-cleared on password change)
     must_change_password: t.bool('must_change_password').notNull().default(false),
 
+    // Auth invalidation marker. Password changes set this timestamp so any
+    // previously issued browser access or refresh token is rejected.
+    tokens_valid_after: t.timestamp('tokens_valid_after'),
+
     // JSON blob for profile/preferences
     data: t
       .json<unknown>('data')

--- a/packages/core/src/db/user-utils.ts
+++ b/packages/core/src/db/user-utils.ts
@@ -7,7 +7,7 @@
 import bcrypt from 'bcryptjs';
 import { eq } from 'drizzle-orm';
 import { generateId } from '../lib/ids';
-import type { User, UserID } from '../types';
+import type { InternalUser, User, UserID } from '../types';
 import { normalizeRole } from '../types/user';
 import type { Database } from './client';
 import { insert, select } from './database-wrapper';
@@ -36,7 +36,7 @@ export interface CreateUserData {
  * come from `row.data`, role goes through `normalizeRole`, and nullable DB
  * columns become `undefined` rather than `null`.
  */
-export function userRowToUser(row: UserRow): User {
+export function userRowToUser(row: UserRow): InternalUser {
   const userData = (row.data ?? {}) as {
     avatar?: string;
     preferences?: Record<string, unknown>;
@@ -52,6 +52,7 @@ export function userRowToUser(row: UserRow): User {
     preferences: userData.preferences,
     onboarding_completed: !!row.onboarding_completed,
     must_change_password: !!row.must_change_password,
+    tokens_valid_after: row.tokens_valid_after ? new Date(row.tokens_valid_after) : undefined,
     created_at: row.created_at,
     updated_at: row.updated_at ?? undefined,
   };

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -450,6 +450,19 @@ export interface User extends BaseUserFields {
 }
 
 /**
+ * Backend/internal user shape with auth invalidation metadata.
+ *
+ * Public user DTOs returned to browser clients intentionally omit this marker;
+ * auth services use it while validating or issuing browser tokens.
+ */
+export type UserAuthMetadata = object & {
+  /** Tokens issued at or before this timestamp are no longer valid. */
+  tokens_valid_after?: Date;
+};
+
+export type InternalUser = User & UserAuthMetadata;
+
+/**
  * Env var scope values.
  *
  * v0.5 only validates 'global' and 'session'. Other values (repo, mcp_server,


### PR DESCRIPTION
## Why

Changing a user's password updated the stored password, but browser tokens that were already issued could continue to authenticate until they expired or refreshed. This PR makes password changes an explicit auth boundary: old browser access tokens are rejected, old refresh tokens cannot mint new tokens, and the user who just changed their password can continue with fresh auth instead of getting stuck in a stale session.

## What changed

### Token invalidation
- Added `users.tokens_valid_after` to the SQLite/Postgres schemas and migrations.
- Set `tokens_valid_after` whenever a user's password changes.
- Added shared invalidation helpers in `apps/agor-daemon/src/auth/token-invalidation.ts`.
- Reject browser JWTs issued at or before the marker.
- Reject refresh tokens issued at or before the marker.

### Fresh-token boundary handling
- Browser tokens now carry an `auth_time_ms` claim in addition to normal JWT `iat` seconds.
- Fresh token issuance is bumped just past the marker when password change + immediate reauth happen in the same second/millisecond boundary.
- Covered local login, refresh, launch auth, and impersonation token issuance paths.

### Public response redaction
- Kept `tokens_valid_after` available internally for auth decisions.
- Redacted it from browser-visible user/auth response payloads so the marker remains backend auth metadata.

### Forced-password-change UI
- After the modal patches the password, the UI signs in with the new password.
- If fresh sign-in fails, stale local auth state is cleared so the user lands cleanly at login.

## Reviewer guide

Suggested review order:
1. `apps/agor-daemon/src/auth/token-invalidation.ts`
2. `apps/agor-daemon/src/auth/service-jwt-strategy.ts`
3. `apps/agor-daemon/src/auth/refresh-token-service.ts`
4. `apps/agor-daemon/src/services/users.ts`
5. `apps/agor-daemon/src/auth/user-redaction.ts`
6. `apps/agor-ui/src/utils/forcePasswordChange.ts`
7. Migration files under `packages/core/drizzle/*/*user_token_invalidation.sql`
8. Focused tests in `token-invalidation.test.ts`, `launch-auth.test.ts`, and `forcePasswordChange.test.ts`

Key behavior to verify:
- Password change invalidates the target user's old browser access/refresh tokens.
- Admin password reset invalidates the target user's old browser tokens.
- Immediate fresh login after password change gets usable tokens.
- `tokens_valid_after` is not exposed in public user/auth payloads.

## Validation

Build/typecheck:
- `pnpm --filter @agor/core build`
- `pnpm --filter @agor-live/client build`
- `pnpm --filter @agor/daemon build`
- `pnpm --filter agor-ui build`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm --filter agor-ui typecheck`
- `pnpm --filter @agor/core typecheck`

Tests:
- `pnpm --filter @agor/daemon test -- src/auth/token-invalidation.test.ts src/auth/launch-auth.test.ts`
- `pnpm --filter agor-ui test -- src/utils/forcePasswordChange.test.ts`
- `pnpm --filter agor-ui test`
- `pnpm --filter @agor/core test`
- `TMPDIR=/private/tmp pnpm --filter @agor/daemon test`

Migration / hygiene:
- Temp SQLite migration apply via `AGOR_DB_PATH=file:<tmp> pnpm agor db migrate --yes`
- Targeted Biome checks
- `git diff --check`

Live validation:
- Stale access token rejected after self password change.
- Stale refresh token rejected after self password change.
- Fresh login with new password succeeds.
- Forced-password-change browser flow completes.
- Admin reset invalidates target user's old access/refresh tokens.
- Same-second immediate fresh-token boundary works.
- Unchanged/null-marker user auth and refresh still work.
- Public response/generated-artifact boundaries checked.

## Notes

- Drizzle generation currently stops on an unrelated historical `app_variables` create-vs-rename prompt, so the migration SQL/journal entries were added and verified manually.
- API-key revocation is intentionally not changed here; this covers browser access and refresh tokens.
