### PR TITLE
fix: disable backdrop dismiss on Create Session and Create New modals

### DIFF
--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -329,7 +329,7 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
       destroyOnHidden
       width={720}
       closable={!isSubmitting}
-      maskClosable={!isSubmitting}
+      maskClosable={false}
       keyboard={!isSubmitting}
       footer={[
         <Button key="cancel" onClick={handleCancel} disabled={isSubmitting}>

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -194,6 +194,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
       okText="Create Session"
       cancelText="Cancel"
       width={700}
+      maskClosable={false}
       okButtonProps={{
         disabled: !isFormValid || isCreating,
         loading: isCreating,


### PR DESCRIPTION
## Summary

- `NewSessionModal`: adds `maskClosable={false}` — clicking the backdrop no longer closes the Create New Session modal
- `CreateDialog`: changes `maskClosable={!isSubmitting}` → `maskClosable={false}` — the Create New... dialog (opened via the + button) can no longer be dismissed by clicking the backdrop at any point, not just during submission
- In both cases the X button and Cancel button continue to close the modal as expected

## Test plan

- [ ] Open the **Create New Session** modal (from a branch card)
  - [ ] Fill in some fields, click outside — should **not** close
  - [ ] Click X / Cancel — closes normally
- [ ] Open the **Create New...** dialog (via the + button)
  - [ ] Fill in some fields, click outside — should **not** close
  - [ ] Click X / Cancel — closes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)