### PR TITLE
perf(agor): bound first-paint sessions+branches, hydrate full sets (Phase 1.5)

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -102,7 +102,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   /**
    * Apply filters to data array (client-side filtering)
    */
-  private filterData(data: T[], query: Query): T[] {
+  protected filterData(data: T[], query: Query): T[] {
     let filtered = [...data];
 
     // Filter by field values
@@ -147,7 +147,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   /**
    * Sort data array
    */
-  private sortData(data: T[], sortSpec?: Record<string, 1 | -1>): T[] {
+  protected sortData(data: T[], sortSpec?: Record<string, 1 | -1>): T[] {
     if (!sortSpec) return data;
 
     const sorted = [...data];
@@ -171,7 +171,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   /**
    * Select specific fields from data
    */
-  private selectFields(data: T[], fields?: string[]): Partial<T>[] {
+  protected selectFields(data: T[], fields?: string[]): Partial<T>[] {
     if (!fields || fields.length === 0) return data;
 
     // biome-ignore lint/suspicious/noExplicitAny: Field selection requires dynamic property access
@@ -190,7 +190,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   /**
    * Apply pagination to data
    */
-  private paginateData(data: T[], query: Query, total: number): Paginated<T> | T[] {
+  protected paginateData(data: T[], query: Query, total: number): Paginated<T> | T[] {
     const limit = query.$limit ?? this.paginate?.default ?? data.length;
     const skip = query.$skip ?? 0;
 

--- a/apps/agor-daemon/src/services/sessions.find.test.ts
+++ b/apps/agor-daemon/src/services/sessions.find.test.ts
@@ -86,6 +86,12 @@ function ids(result: Awaited<ReturnType<SessionsService['find']>>): string[] {
   return data.map((s) => s.session_id).sort();
 }
 
+// Like `ids` but preserves result order — for asserting $sort behaviour.
+function orderedIds(result: Awaited<ReturnType<SessionsService['find']>>): string[] {
+  const data = Array.isArray(result) ? result : result.data;
+  return data.map((s) => s.session_id);
+}
+
 describe('SessionsService.find — board_id pushdown', () => {
   dbTest('returns only sessions whose branch is on the requested board', async ({ db }) => {
     const service = new SessionsService(db, STUB_APP);
@@ -151,5 +157,87 @@ describe('SessionsService.find — board_id pushdown', () => {
     const paged = await service.find({ query: { board_id: boardA, $limit: 1, $skip: 1 } });
     expect(Array.isArray(paged) ? paged.length : paged.data.length).toBe(1);
     expect(Array.isArray(paged) ? 3 : paged.total).toBe(3);
+  });
+});
+
+describe('SessionsService.find — recency sort + pagination (SQL pushdown)', () => {
+  // oldest → newest by updated_at (driven via `last_updated`, which the repo
+  // persists to the `updated_at` column).
+  const T_OLD = '2026-01-01T00:00:00.000Z';
+  const T_MID = '2026-02-01T00:00:00.000Z';
+  const T_NEW = '2026-03-01T00:00:00.000Z';
+
+  dbTest('orders board-scoped sessions by updated_at desc', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const boardA = await createBoard(db);
+    const branchA = await createBranchOnBoard(db, boardA);
+
+    const old = await createSession(db, branchA, { last_updated: T_OLD });
+    const mid = await createSession(db, branchA, { last_updated: T_MID });
+    const recent = await createSession(db, branchA, { last_updated: T_NEW });
+
+    const result = await service.find({
+      query: { board_id: boardA, $sort: { updated_at: -1 }, $limit: 100 },
+    });
+    // Most-recent first — would be a no-op (insertion order) without SQL sort.
+    expect(orderedIds(result)).toEqual([recent, mid, old]);
+  });
+
+  dbTest('recency sort composes with $limit/$skip (board-scoped)', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const boardA = await createBoard(db);
+    const branchA = await createBranchOnBoard(db, boardA);
+
+    const old = await createSession(db, branchA, { last_updated: T_OLD });
+    const mid = await createSession(db, branchA, { last_updated: T_MID });
+    const recent = await createSession(db, branchA, { last_updated: T_NEW });
+
+    // The first page is the single most-recent session…
+    const page1 = await service.find({
+      query: { board_id: boardA, $sort: { updated_at: -1 }, $limit: 1 },
+    });
+    expect(orderedIds(page1)).toEqual([recent]);
+    expect(Array.isArray(page1) ? 3 : page1.total).toBe(3);
+
+    // …and skipping it yields the next two in recency order.
+    const page2 = await service.find({
+      query: { board_id: boardA, $sort: { updated_at: -1 }, $limit: 2, $skip: 1 },
+    });
+    expect(orderedIds(page2)).toEqual([mid, old]);
+  });
+
+  dbTest('orders the global recent-N slice by updated_at desc across boards', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const boardA = await createBoard(db);
+    const boardB = await createBoard(db);
+    const branchA = await createBranchOnBoard(db, boardA);
+    const branchB = await createBranchOnBoard(db, boardB);
+
+    await createSession(db, branchA, { last_updated: T_OLD });
+    const mid = await createSession(db, branchB, { last_updated: T_MID });
+    const recent = await createSession(db, branchA, { last_updated: T_NEW });
+
+    // Bounded recent-N (no board filter) — must be the genuinely most recent.
+    const result = await service.find({
+      query: { archived: false, $sort: { updated_at: -1 }, $limit: 2 },
+    });
+    expect(orderedIds(result)).toEqual([recent, mid]);
+  });
+
+  dbTest('board_id composes with the $in operator (generic pipeline)', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const boardA = await createBoard(db);
+    const branchA = await createBranchOnBoard(db, boardA);
+
+    const s1 = await createSession(db, branchA);
+    await createSession(db, branchA);
+    const s3 = await createSession(db, branchA);
+
+    // board_id + $in routes through the operator-capable fallback (not the
+    // strict-equality client paginator), so $in must actually filter.
+    const result = await service.find({
+      query: { board_id: boardA, session_id: { $in: [s1, s3] }, $limit: 100 },
+    });
+    expect(ids(result)).toEqual([s1, s3].sort());
   });
 });

--- a/apps/agor-daemon/src/services/sessions.find.test.ts
+++ b/apps/agor-daemon/src/services/sessions.find.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for `SessionsService.find` board_id pushdown (non-RBAC path).
+ *
+ * A session relates to a board through its branch (session.branch_id →
+ * branch.board_id). The `sessions.board_id` column is never populated, so the
+ * filter MUST go through the branch join — both in the indexed repository query
+ * (`findByBoard`) and in the service's non-RBAC find override. These tests pin
+ * that behaviour down end-to-end against a real database, and confirm the other
+ * Feathers query filters (archived, $sort, $limit/$skip) keep working alongside
+ * board_id.
+ */
+import {
+  BoardRepository,
+  BranchRepository,
+  generateId,
+  RepoRepository,
+  SessionRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { Session, UUID } from '@agor/core/types';
+import { SessionStatus } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { SessionsService } from './sessions';
+
+// The find() board_id path only touches the session repos built from `db`; the
+// stored `app` is never read. A bare cast keeps the harness minimal.
+const STUB_APP = {} as unknown as Application;
+
+async function createBoard(db: any): Promise<UUID> {
+  const boardRepo = new BoardRepository(db);
+  const board = await boardRepo.create({ name: 'Board', created_by: 'test-user' as UUID });
+  return board.board_id as UUID;
+}
+
+async function createBranchOnBoard(db: any, boardId: UUID | null): Promise<UUID> {
+  const repoRepo = new RepoRepository(db);
+  const branchRepo = new BranchRepository(db);
+  const repo = await repoRepo.create({
+    repo_id: generateId(),
+    slug: `repo-${generateId()}`,
+    name: 'Test Repo',
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: '/tmp/test-repo',
+    default_branch: 'main',
+  });
+  const branch = await branchRepo.create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name: 'feature',
+    ref: 'feature',
+    branch_unique_id: Math.floor(Math.random() * 1_000_000),
+    path: '/tmp/test-repo',
+    base_ref: 'main',
+    new_branch: false,
+    created_by: 'test-user' as UUID,
+    ...(boardId ? { board_id: boardId } : {}),
+  });
+  return branch.branch_id as UUID;
+}
+
+async function createSession(
+  db: any,
+  branchId: UUID,
+  overrides: Partial<Session> = {}
+): Promise<UUID> {
+  const sessionRepo = new SessionRepository(db);
+  const session = await sessionRepo.create({
+    session_id: generateId(),
+    branch_id: branchId,
+    agentic_tool: 'claude-code',
+    status: SessionStatus.IDLE,
+    created_by: 'test-user' as UUID,
+    git_state: { ref: 'main', base_sha: 'abc', current_sha: 'def' },
+    tasks: [],
+    contextFiles: [],
+    genealogy: { children: [] },
+    ...overrides,
+  });
+  return session.session_id as UUID;
+}
+
+function ids(result: Awaited<ReturnType<SessionsService['find']>>): string[] {
+  const data = Array.isArray(result) ? result : result.data;
+  return data.map((s) => s.session_id).sort();
+}
+
+describe('SessionsService.find — board_id pushdown', () => {
+  dbTest('returns only sessions whose branch is on the requested board', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+
+    const boardA = await createBoard(db);
+    const boardB = await createBoard(db);
+    const branchA = await createBranchOnBoard(db, boardA);
+    const branchB = await createBranchOnBoard(db, boardB);
+
+    const a1 = await createSession(db, branchA);
+    const a2 = await createSession(db, branchA);
+    const b1 = await createSession(db, branchB);
+
+    const onA = await service.find({ query: { board_id: boardA, $limit: 100 } });
+    expect(ids(onA)).toEqual([a1, a2].sort());
+
+    const onB = await service.find({ query: { board_id: boardB, $limit: 100 } });
+    expect(ids(onB)).toEqual([b1]);
+
+    // No board filter → every session across boards.
+    const all = await service.find({ query: { $limit: 100 } });
+    expect(ids(all)).toEqual([a1, a2, b1].sort());
+  });
+
+  dbTest('returns empty for a board with no branches/sessions', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const boardA = await createBoard(db);
+    const emptyBoard = await createBoard(db);
+    const branchA = await createBranchOnBoard(db, boardA);
+    await createSession(db, branchA);
+
+    const result = await service.find({ query: { board_id: emptyBoard, $limit: 100 } });
+    expect(ids(result)).toEqual([]);
+  });
+
+  dbTest('keeps other filters working alongside board_id', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const boardA = await createBoard(db);
+    const branchA = await createBranchOnBoard(db, boardA);
+
+    const active = await createSession(db, branchA, { status: SessionStatus.IDLE });
+    await createSession(db, branchA, { archived: true });
+    await createSession(db, branchA, { status: SessionStatus.RUNNING });
+
+    // archived filter narrows within the board scope.
+    const activeOnly = await service.find({
+      query: { board_id: boardA, archived: false, $limit: 100 },
+    });
+    const activeData = Array.isArray(activeOnly) ? activeOnly : activeOnly.data;
+    expect(activeData.every((s) => !s.archived)).toBe(true);
+    expect(activeData.map((s) => s.session_id)).toContain(active);
+    expect(activeData).toHaveLength(2);
+
+    // status filter narrows within the board scope.
+    const running = await service.find({
+      query: { board_id: boardA, status: SessionStatus.RUNNING, $limit: 100 },
+    });
+    const runningData = Array.isArray(running) ? running : running.data;
+    expect(runningData).toHaveLength(1);
+    expect(runningData[0].status).toBe(SessionStatus.RUNNING);
+
+    // $limit/$skip pagination still applies on the board-scoped set.
+    const paged = await service.find({ query: { board_id: boardA, $limit: 1, $skip: 1 } });
+    expect(Array.isArray(paged) ? paged.length : paged.data.length).toBe(1);
+    expect(Array.isArray(paged) ? 3 : paged.total).toBe(3);
+  });
+});

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -41,6 +41,7 @@ import {
   determineSpawnIdentity,
   isSuperAdmin,
   loadUnixUsernameForUser,
+  paginateClientSide,
   resolveChildUnixUsername,
 } from '../utils/branch-authorization.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
@@ -831,6 +832,21 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    * Note: Last message is NOT included in list operations - only on single GET.
    */
   async find(params?: SessionParams): Promise<Paginated<Session> | Session[]> {
+    // board_id pushdown (non-RBAC path). When RBAC is enabled, scopeSessionQuery
+    // resolves the result in a before-hook and this method never runs; when it's
+    // disabled, this is the only place board_id is honored. We can't lean on
+    // DrizzleService's generic filter: it matches `item.board_id`, but sessions
+    // expose the board as `branch_board_id`, so the generic pass would wipe every
+    // row. Route board_id straight to the indexed branch-join query instead.
+    const boardId = params?.query?.board_id;
+    if (boardId) {
+      const query = params?.query as Record<string, unknown> | undefined;
+      const rows = await this.sessionRepo.findByBoard(boardId);
+      const page = paginateClientSide(rows, query, new Set(['board_id']));
+      const enriched = await this.enrichRemoteRelationships(page.data);
+      return markRemoteRelationshipsEnrichedResult({ ...page, data: enriched });
+    }
+
     const result = await super.find(params);
 
     if (Array.isArray(result)) {

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -36,12 +36,11 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { ROLES, SessionStatus } from '@agor/core/types';
-import { DrizzleService } from '../adapters/drizzle';
+import { DrizzleService, type Query } from '../adapters/drizzle';
 import {
   determineSpawnIdentity,
   isSuperAdmin,
   loadUnixUsernameForUser,
-  paginateClientSide,
   resolveChildUnixUsername,
 } from '../utils/branch-authorization.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
@@ -93,6 +92,37 @@ export type SessionParams = QueryParams<{
     /** Root-level include_last_message flag (bypasses Feathers query filtering, used by internal service calls) */
     _include_last_message?: boolean | 'true' | 'false';
   };
+
+/**
+ * Whether a sessions `find` query should be served by `SessionRepository.findPage`
+ * (SQL board filter + recency sort + limit/offset) rather than the generic
+ * in-memory path. We only divert the loader's bounded list queries — those that
+ * sort by `updated_at` and/or scope to a `board_id` — and only when the rest of
+ * the query is a shape findPage fully models (archived + pagination). Anything
+ * with extra filters, operators, or `$select` falls through to the existing path
+ * so we never silently drop semantics findPage doesn't implement.
+ */
+function shouldSqlPageSessionQuery(query?: Record<string, unknown>): boolean {
+  if (!query) return false;
+
+  const sort = query.$sort as Record<string, unknown> | undefined;
+  const wantsRecency = !!sort && sort.updated_at !== undefined;
+  const wantsBoard = query.board_id !== undefined;
+  if (!wantsRecency && !wantsBoard) return false;
+
+  const allowedKeys = new Set(['archived', 'board_id', '$sort', '$limit', '$skip']);
+  for (const key of Object.keys(query)) {
+    if (!allowedKeys.has(key)) return false;
+  }
+  if (query.archived !== undefined && typeof query.archived !== 'boolean') return false;
+  if (wantsBoard && typeof query.board_id !== 'string') return false;
+  if (sort) {
+    const sortKeys = Object.keys(sort);
+    if (sortKeys.length !== 1 || sortKeys[0] !== 'updated_at') return false;
+    if (sort.updated_at !== 1 && sort.updated_at !== -1) return false;
+  }
+  return true;
+}
 
 const remoteRelationshipsEnrichedResults = new WeakSet<object>();
 
@@ -832,19 +862,59 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    * Note: Last message is NOT included in list operations - only on single GET.
    */
   async find(params?: SessionParams): Promise<Paginated<Session> | Session[]> {
-    // board_id pushdown (non-RBAC path). When RBAC is enabled, scopeSessionQuery
-    // resolves the result in a before-hook and this method never runs; when it's
-    // disabled, this is the only place board_id is honored. We can't lean on
-    // DrizzleService's generic filter: it matches `item.board_id`, but sessions
-    // expose the board as `branch_board_id`, so the generic pass would wipe every
-    // row. Route board_id straight to the indexed branch-join query instead.
+    // SQL-pushdown path for the recency-sorted / board-scoped list queries the
+    // first-paint loader issues. When RBAC is enabled, scopeSessionQuery resolves
+    // the result in a before-hook and this method never runs; when it's disabled,
+    // this is where board_id + `$sort:{updated_at}` are honored.
+    //
+    // We can't lean on DrizzleService's generic path: (1) its filter matches
+    // `item.board_id`, but sessions expose the board as `branch_board_id`, so a
+    // board_id filter would wipe every row; (2) its sort looks up `item.updated_at`
+    // (the field is `last_updated`), so a `$sort:{updated_at}` is a silent no-op
+    // and the bounded slice wouldn't be ordered by recency. findPage does the
+    // filter + recency sort + limit/offset in SQL instead.
+    const query = params?.query as Record<string, unknown> | undefined;
+    if (shouldSqlPageSessionQuery(query)) {
+      const sortSpec = query?.$sort as { updated_at?: 1 | -1 } | undefined;
+      const limit = (query?.$limit as number | undefined) ?? PAGINATION.DEFAULT_LIMIT;
+      const skip = (query?.$skip as number | undefined) ?? 0;
+      const { data, total } = await this.sessionRepo.findPage({
+        boardId: query?.board_id as string | undefined,
+        archived: query?.archived as boolean | undefined,
+        sortUpdatedAt: sortSpec?.updated_at,
+        limit,
+        skip,
+      });
+      const enriched = await this.enrichRemoteRelationships(data);
+      return markRemoteRelationshipsEnrichedResult({ total, limit, skip, data: enriched });
+    }
+
+    // board_id present but with a shape findPage doesn't model (Feathers
+    // operators like $in/$ne/$gt, $select, extra filters): push the board filter
+    // to SQL via the branch join, then run the FULL generic DrizzleService
+    // pipeline on the board-scoped rows so operators / $select / $sort / pagination
+    // all behave exactly as on the unscoped path. (paginateClientSide would only
+    // do strict equality and silently mishandle operators.)
     const boardId = params?.query?.board_id;
     if (boardId) {
-      const query = params?.query as Record<string, unknown> | undefined;
+      const { board_id: _scopedBoardId, ...residualQuery } = (params?.query ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const residual = residualQuery as Query;
       const rows = await this.sessionRepo.findByBoard(boardId);
-      const page = paginateClientSide(rows, query, new Set(['board_id']));
-      const enriched = await this.enrichRemoteRelationships(page.data);
-      return markRemoteRelationshipsEnrichedResult({ ...page, data: enriched });
+      const filtered = this.filterData(rows, residual);
+      const total = filtered.length;
+      const sorted = this.sortData(filtered, residual.$sort);
+      const selected = this.selectFields(sorted, residual.$select);
+      const paged = this.paginateData(selected as Session[], residual, total);
+
+      if (Array.isArray(paged)) {
+        const enriched = await this.enrichRemoteRelationships(paged);
+        return markRemoteRelationshipsEnrichedResult(enriched);
+      }
+      const enrichedData = await this.enrichRemoteRelationships(paged.data);
+      return markRemoteRelationshipsEnrichedResult({ ...paged, data: enrichedData });
     }
 
     const result = await super.find(params);

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -5,6 +5,7 @@
  * Covers the security invariants introduced by the superadmin role feature.
  */
 
+import type { SessionRepository } from '@agor/core/db';
 import type { Branch, BranchPermissionLevel, HookContext, Session } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -18,6 +19,7 @@ import {
   paginateClientSide,
   resolveBranchPermission,
   resolveSessionContext,
+  scopeSessionQuery,
 } from './branch-authorization';
 
 /** Minimal branch fixture for permission tests */
@@ -497,5 +499,76 @@ describe('paginateClientSide', () => {
       expect(result.total).toBe(0);
       expect(result.data).toEqual([]);
     });
+  });
+});
+
+describe('scopeSessionQuery — $sort handling', () => {
+  const SUPERADMIN_USER = {
+    user_id: 'user-super-0001' as import('@agor/core/types').UUID,
+    role: ROLES.SUPERADMIN,
+  };
+
+  function makeSession(id: string, overrides: Partial<Session> = {}): Session {
+    return {
+      session_id: id,
+      branch_id: 'wt-1',
+      status: 'idle',
+      archived: false,
+      created_at: '2026-01-01T00:00:00.000Z',
+      last_updated: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    } as unknown as Session;
+  }
+
+  function makeCtx(query: Record<string, unknown>): HookContext {
+    return {
+      method: 'find',
+      params: { provider: 'socketio', user: SUPERADMIN_USER, query },
+    } as unknown as HookContext;
+  }
+
+  function repoReturning(sessions: Session[]): SessionRepository {
+    return { findAll: vi.fn(async () => sessions) } as unknown as SessionRepository;
+  }
+
+  function resultIds(ctx: HookContext): string[] {
+    const result = ctx.result as { data: Session[] };
+    return result.data.map((s) => s.session_id);
+  }
+
+  it('passes a non-updated_at $sort (created_at) through to the client-side sort', async () => {
+    // REGRESSION GUARD: scopeSessionQuery must NOT strip every $sort — only the
+    // special `updated_at` case it sorts manually. created_at exists on the
+    // Session object, so paginateClientSide can order it.
+    const sessions = [
+      makeSession('s-old', { created_at: '2026-01-01T00:00:00.000Z' }),
+      makeSession('s-new', { created_at: '2026-03-01T00:00:00.000Z' }),
+      makeSession('s-mid', { created_at: '2026-02-01T00:00:00.000Z' }),
+    ];
+    const ctx = makeCtx({ $sort: { created_at: -1 }, $limit: 10 });
+    await scopeSessionQuery(repoReturning(sessions))(ctx);
+    expect(resultIds(ctx)).toEqual(['s-new', 's-mid', 's-old']);
+  });
+
+  it('passes a scheduled_run_at $sort through (ScheduleRunsPanel)', async () => {
+    const sessions = [
+      makeSession('r1', { scheduled_run_at: 100 }),
+      makeSession('r3', { scheduled_run_at: 300 }),
+      makeSession('r2', { scheduled_run_at: 200 }),
+    ];
+    const ctx = makeCtx({ $sort: { scheduled_run_at: -1 }, $limit: 10 });
+    await scopeSessionQuery(repoReturning(sessions))(ctx);
+    expect(resultIds(ctx)).toEqual(['r3', 'r2', 'r1']);
+  });
+
+  it('orders the updated_at $sort on the real last_updated field', async () => {
+    const sessions = [
+      makeSession('u-old', { last_updated: '2026-01-01T00:00:00.000Z' }),
+      makeSession('u-new', { last_updated: '2026-03-01T00:00:00.000Z' }),
+      makeSession('u-mid', { last_updated: '2026-02-01T00:00:00.000Z' }),
+    ];
+    const ctx = makeCtx({ $sort: { updated_at: -1 }, $limit: 10 });
+    await scopeSessionQuery(repoReturning(sessions))(ctx);
+    expect(resultIds(ctx)).toEqual(['u-new', 'u-mid', 'u-old']);
   });
 });

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -644,19 +644,27 @@ export function scopeSessionQuery(
     const userRole = context.params.user?.role as string | undefined;
     const allowSuperadmin = options?.allowSuperadmin ?? true;
 
+    // Push board_id down to SQL via the branch join (session → branch →
+    // board). The client-side pass below CANNOT filter board_id: sessions
+    // expose the board as `branch_board_id`, never `board_id`, so a generic
+    // `item.board_id === value` would wipe every row. We therefore both
+    // push it to SQL here AND skip it in paginateClientSide.
+    const query = context.params.query as Record<string, unknown> | undefined;
+    const boardId = query?.board_id as UUID | undefined;
+
     // Use optimized repository method (single SQL query with JOINs)
     const accessibleSessions = isSuperAdmin(userRole, allowSuperadmin)
-      ? await sessionRepo.findAll()
-      : await sessionRepo.findAccessibleSessions(userId);
+      ? boardId
+        ? await sessionRepo.findByBoard(boardId)
+        : await sessionRepo.findAll()
+      : await sessionRepo.findAccessibleSessions(userId, boardId);
 
     // Apply remaining query filters (branch_id, schedule_id, status, etc.)
     // client-side. Without this pass, `sessions.find({ schedule_id })`
     // silently returns all accessible sessions — which is what the
-    // ScheduleRunsPanel was hitting before this fix.
-    context.result = paginateClientSide(
-      accessibleSessions,
-      context.params.query as Record<string, unknown> | undefined
-    );
+    // ScheduleRunsPanel was hitting before this fix. board_id is already
+    // applied SQL-side above, so it's skipped here.
+    context.result = paginateClientSide(accessibleSessions, query, new Set(['board_id']));
     return context;
   };
 }

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -659,31 +659,41 @@ export function scopeSessionQuery(
         : await sessionRepo.findAll()
       : await sessionRepo.findAccessibleSessions(userId, boardId);
 
-    // Recency sort. Callers sort by the DB column name `updated_at`, but the
-    // Session object exposes that timestamp as `last_updated` — so
-    // paginateClientSide's `$sort` (which reads `item.updated_at`) is a silent
-    // no-op. Sort here on the real field, then strip `$sort` below so
-    // paginateClientSide doesn't reorder (and undo) it.
+    // `updated_at` is the ONE sort key paginateClientSide can't order: the
+    // Session object exposes that timestamp as `last_updated`, so its
+    // `item.updated_at` lookup is undefined → a silent no-op. Handle exactly
+    // that single-key case here on the real field and strip it below. EVERY
+    // OTHER sort (created_at, scheduled_run_at, last_updated, …) maps to a real
+    // Session field, so it MUST pass through to paginateClientSide unchanged —
+    // dropping it here would silently break the ScheduleRunsPanel
+    // (`$sort:{scheduled_run_at:-1}`), branch/session/CLI lists
+    // (`$sort:{created_at:-1}`), and the MCP sessions tool (`$sort:{last_updated:-1}`).
     const sortSpec = query?.$sort as Record<string, 1 | -1> | undefined;
-    const updatedAtDir = sortSpec?.updated_at;
-    if (updatedAtDir === 1 || updatedAtDir === -1) {
+    const sortKeys = sortSpec ? Object.keys(sortSpec) : [];
+    const isUpdatedAtSort = sortKeys.length === 1 && sortKeys[0] === 'updated_at';
+    if (isUpdatedAtSort) {
+      const dir = sortSpec!.updated_at;
       accessibleSessions.sort((a, b) => {
         const av = a.last_updated ?? '';
         const bv = b.last_updated ?? '';
-        if (av < bv) return updatedAtDir === -1 ? 1 : -1;
-        if (av > bv) return updatedAtDir === -1 ? -1 : 1;
+        if (av < bv) return dir === -1 ? 1 : -1;
+        if (av > bv) return dir === -1 ? -1 : 1;
         return 0;
       });
     }
 
-    // Apply remaining query filters (branch_id, schedule_id, status, etc.)
-    // client-side. Without this pass, `sessions.find({ schedule_id })`
-    // silently returns all accessible sessions — which is what the
-    // ScheduleRunsPanel was hitting before this fix. board_id is already
-    // applied SQL-side above; `$sort` is applied above on the real field, so
-    // both are excluded from the client-side pass.
-    const { $sort: _ignoredSort, ...filterQuery } = query ?? {};
-    context.result = paginateClientSide(accessibleSessions, filterQuery, new Set(['board_id']));
+    // Apply remaining query filters (branch_id, schedule_id, status, $sort, …)
+    // client-side. Without this pass, `sessions.find({ schedule_id })` silently
+    // returns all accessible sessions — which is what the ScheduleRunsPanel was
+    // hitting before this fix. board_id is already applied SQL-side above; the
+    // `updated_at`-only sort is applied above on the real field, so it's the
+    // only `$sort` we drop here (every other sort flows through).
+    let paginateQuery: Record<string, unknown> = query ?? {};
+    if (isUpdatedAtSort) {
+      const { $sort: _ignoredUpdatedAtSort, ...rest } = paginateQuery;
+      paginateQuery = rest;
+    }
+    context.result = paginateClientSide(accessibleSessions, paginateQuery, new Set(['board_id']));
     return context;
   };
 }

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -659,12 +659,31 @@ export function scopeSessionQuery(
         : await sessionRepo.findAll()
       : await sessionRepo.findAccessibleSessions(userId, boardId);
 
+    // Recency sort. Callers sort by the DB column name `updated_at`, but the
+    // Session object exposes that timestamp as `last_updated` — so
+    // paginateClientSide's `$sort` (which reads `item.updated_at`) is a silent
+    // no-op. Sort here on the real field, then strip `$sort` below so
+    // paginateClientSide doesn't reorder (and undo) it.
+    const sortSpec = query?.$sort as Record<string, 1 | -1> | undefined;
+    const updatedAtDir = sortSpec?.updated_at;
+    if (updatedAtDir === 1 || updatedAtDir === -1) {
+      accessibleSessions.sort((a, b) => {
+        const av = a.last_updated ?? '';
+        const bv = b.last_updated ?? '';
+        if (av < bv) return updatedAtDir === -1 ? 1 : -1;
+        if (av > bv) return updatedAtDir === -1 ? -1 : 1;
+        return 0;
+      });
+    }
+
     // Apply remaining query filters (branch_id, schedule_id, status, etc.)
     // client-side. Without this pass, `sessions.find({ schedule_id })`
     // silently returns all accessible sessions — which is what the
     // ScheduleRunsPanel was hitting before this fix. board_id is already
-    // applied SQL-side above, so it's skipped here.
-    context.result = paginateClientSide(accessibleSessions, query, new Set(['board_id']));
+    // applied SQL-side above; `$sort` is applied above on the real field, so
+    // both are excluded from the client-side pass.
+    const { $sort: _ignoredSort, ...filterQuery } = query ?? {};
+    context.result = paginateClientSide(accessibleSessions, filterQuery, new Set(['board_id']));
     return context;
   };
 }

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -541,10 +541,12 @@ describe('useAgorData — socket-event bailouts', () => {
  * Background hydration uses a "skip-apply-on-race" rule (see `runHydration` /
  * `liveRevisionsRef` in useAgorData.ts): the full-set snapshot is applied
  * WHOLESALE only when no live write to the target collection raced the fetch.
- * If one did, the snapshot is discarded and refetched — never overlaid — and if
- * the race never settles the apply is skipped entirely. These tests pin that
- * contract (apply-on-quiet, retry-on-race, skip-without-resurrect, and
- * per-collection independence) using `onFetch` to land a live write mid-fetch.
+ * If one did, the snapshot is discarded and refetched — never overlaid — and a
+ * persistent race triggers repeated discard+refetch with capped exponential
+ * backoff until a quiet window allows a wholesale apply: the apply is deferred,
+ * never permanently skipped. These tests pin that contract (apply-on-quiet,
+ * retry-until-quiet, no-resurrect, and per-collection independence) using
+ * `onFetch` to land a live write mid-fetch.
  *
  * jsdom's pathname is `/`, so no board scope resolves: only the sessions+branches
  * (and the always-on mcp/gateway/artifact/oauth) hydrations run, while the gated

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -43,18 +43,26 @@ type Listener = (payload: unknown) => void;
 function makeMockClient(seed: Record<string, unknown[]> = {}) {
   const serviceListeners = new Map<string, Map<string, Listener[]>>();
   const ioListeners = new Map<string, Listener[]>();
-  // Synchronous side effects fired at call time of `service(name)[method]()` —
-  // used by the skip-apply-on-race tests to inject a live write mid-fetch.
-  const fetchHooks = new Map<string, (call: number) => void>();
+  // Side effects fired at call time of `service(name)[method]()` — used by the
+  // skip-apply-on-race tests to inject a live write mid-fetch. If the hook
+  // returns a thenable, `respond` AWAITS it before resolving, which lets a test
+  // hold a fetch in-flight (e.g. to fire a reconnect / logout while a hydration
+  // is pending). The response data is the array reference captured at CALL time
+  // (before the await), so a test can swap `seed[key]` to make a later call see
+  // a different set than an earlier deferred one.
+  const fetchHooks = new Map<string, (call: number) => unknown>();
   const fetchCounts = new Map<string, number>();
 
-  const respond = (name: string, method: 'findAll' | 'find') => {
+  const respond = async (name: string, method: 'findAll' | 'find') => {
     const key = `${name}:${method}`;
     const call = (fetchCounts.get(key) ?? 0) + 1;
     fetchCounts.set(key, call);
-    fetchHooks.get(key)?.(call);
+    const gate = fetchHooks.get(key)?.(call);
     const data = seed[key] ?? seed[name] ?? [];
-    return Promise.resolve(data);
+    if (gate && typeof (gate as { then?: unknown }).then === 'function') {
+      await gate;
+    }
+    return data;
   };
 
   const service = (name: string) => ({
@@ -103,11 +111,16 @@ function makeMockClient(seed: Record<string, unknown[]> = {}) {
     emit: (svc: string, event: string, payload: unknown) => {
       for (const fn of serviceListeners.get(svc)?.get(event) ?? []) fn(payload);
     },
+    // Fire an `io` event (e.g. `connect`) so tests can drive the reconnect
+    // refetch path.
+    emitIo: (event: string) => {
+      for (const fn of ioListeners.get(event) ?? []) fn(undefined);
+    },
     // Register a synchronous side effect that runs every time `service(name)`'s
     // `method` is invoked (receives the 1-based call count). The hook fires
     // BEFORE the returned promise resolves, so emitting a live event here lands
     // a write DURING the fetch window — exactly the race the hydration guards.
-    onFetch: (name: string, method: 'findAll' | 'find', fn: (call: number) => void) =>
+    onFetch: (name: string, method: 'findAll' | 'find', fn: (call: number) => unknown) =>
       fetchHooks.set(`${name}:${method}`, fn),
     fetchCount: (name: string, method: 'findAll' | 'find') =>
       fetchCounts.get(`${name}:${method}`) ?? 0,
@@ -165,6 +178,25 @@ async function waitForInitialLoad(result: { current: ReturnType<typeof useAgorDa
   await act(async () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
   });
+}
+
+// Flush pending microtasks + a macrotask inside `act`, so background hydration
+// retries / applies (and reconnect / reset effects) settle before assertions.
+async function flush() {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+// A promise a test can resolve on demand — returned from an `onFetch` hook to
+// hold a fetch in-flight (so a reconnect / logout can land while a hydration is
+// still pending).
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
 }
 
 describe('useAgorData — socket-event bailouts', () => {
@@ -570,13 +602,37 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     expect(result.current.sessionById.has('s-2')).toBe(true);
   });
 
-  it('skips the apply when the race never settles, so a removed session is not resurrected', async () => {
+  it('retries after races until a quiet window, then applies the fresh snapshot (never gives up)', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
+    const { client, emit, onFetch, fetchCount } = makeMockClient({
+      'sessions:find': [s1],
+      'sessions:findAll': [s1, s2],
+      'branches:findAll': [],
+    });
+    // Race the first two fetches, then go quiet — the third (immediate) retry
+    // sees a clean window and applies. The OLD code would have started skipping
+    // toward a permanent give-up; the new loop converges.
+    onFetch('sessions', 'findAll', (call) => {
+      if (call <= 2) emit('sessions', 'patched', { ...s1, status: `v${call}` });
+    });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    await waitFor(() => expect(result.current.sessionById.has('s-2')).toBe(true), {
+      timeout: 4000,
+    });
+    // Applied on the first quiet window (3rd attempt) — not skipped forever.
+    expect(fetchCount('sessions', 'findAll')).toBe(3);
+  });
+
+  it('keeps retrying past the old bounded cap without resurrecting a removed session (never skips)', async () => {
     const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
     const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
     const { client, emit, onFetch, fetchCount } = makeMockClient({
       'sessions:find': [s1, s2],
-      // The snapshot ALWAYS still contains s-2 (stale backend): if it were ever
-      // applied it would resurrect the removed session.
+      // Stale backend snapshot ALWAYS still contains s-2: if it were ever applied
+      // it would resurrect the removed session.
       'sessions:findAll': [s1, s2],
       'branches:findAll': [],
     });
@@ -588,20 +644,25 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     });
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
-    // Every attempt races → 4 immediate + 2 backoff = 6 fetches, then skip.
-    await waitFor(() => expect(fetchCount('sessions', 'findAll')).toBe(6), { timeout: 4000 });
+    // The OLD code stopped after 6 fetches and skipped forever. The new loop
+    // never gives up — it keeps re-fetching past that cap (proving "retry until
+    // quiet", not "skip after N").
+    await waitFor(() => expect(fetchCount('sessions', 'findAll')).toBeGreaterThanOrEqual(7), {
+      timeout: 5000,
+    });
 
     expect(result.current.sessionById.has('s-1')).toBe(true);
-    // The stale snapshot was never applied, so s-2 stays removed.
+    // The stale snapshot was never applied (it never went quiet), so s-2 stays
+    // removed — a racy snapshot is never force-applied.
     expect(result.current.sessionById.has('s-2')).toBe(false);
   });
 
-  it('hydrates an unrelated collection even while another keeps racing (per-collection revisions)', async () => {
+  it('applies an unrelated collection while another keeps racing (per-collection revisions)', async () => {
     const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
     const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
     const m1 = { mcp_server_id: 'm-1', name: 'one' };
     const m2 = { mcp_server_id: 'm-2', name: 'two' };
-    const { client, emit, onFetch, fetchCount } = makeMockClient({
+    const { client, emit, onFetch } = makeMockClient({
       'sessions:find': [s1],
       'sessions:findAll': [s1, s2],
       'branches:findAll': [],
@@ -613,12 +674,150 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     );
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
-    await waitFor(() => expect(fetchCount('sessions', 'findAll')).toBe(6), { timeout: 4000 });
 
     // …the mcp-servers hydration is independent of `sessions`, so it applied.
-    expect(result.current.mcpServerById.has('m-1')).toBe(true);
+    await waitFor(() => expect(result.current.mcpServerById.has('m-1')).toBe(true));
     expect(result.current.mcpServerById.has('m-2')).toBe(true);
-    // …while the racing sessions hydration was skipped (s-2 never filled in).
+    // …while the still-racing sessions hydration has not applied (s-2 absent).
     expect(result.current.sessionById.has('s-2')).toBe(false);
+  });
+
+  it('decouples per-collection hydration: session churn does not block the branch apply', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
+    const b1 = makeBranch({ branch_id: 'b-1' });
+    const { client, emit, onFetch } = makeMockClient({
+      'sessions:find': [s1],
+      'sessions:findAll': [s1, s2],
+      // Branches are filled ONLY by hydration on Home (the first-paint heavy
+      // batch resolves to [] with no board scope), so this proves the branch
+      // apply does not wait on the sessions quiet window.
+      'branches:findAll': [b1],
+    });
+    // Sessions race forever; branches never race.
+    onFetch('sessions', 'findAll', (call) =>
+      emit('sessions', 'patched', { ...s1, status: `v${call}` })
+    );
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    // Branches hydrated on their own quiet window despite perpetual session churn.
+    await waitFor(() => expect(result.current.branchById.has('b-1')).toBe(true));
+    // Sessions still racing → not applied (coupling would have blocked branches).
+    expect(result.current.sessionById.has('s-2')).toBe(false);
+  });
+
+  it('runs backoff retries with delays preceding attempts (off-by-one)', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
+    const { client, emit, onFetch, fetchCount } = makeMockClient({
+      'sessions:find': [s1],
+      'sessions:findAll': [s1, s2],
+      'branches:findAll': [],
+    });
+    // Race the first five fetches — pushing PAST the immediate-retry phase into
+    // the backoff phase (attempts 5 & 6 are delayed) — then go quiet. The 6th
+    // fetch must still run (its backoff delay PRECEDES it) and apply. If the
+    // off-by-one delayed-after-the-attempt bug were present, the schedule would
+    // be wrong; here the delayed attempts run and converge.
+    onFetch('sessions', 'findAll', (call) => {
+      if (call <= 5) emit('sessions', 'patched', { ...s1, status: `v${call}` });
+    });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    await waitFor(() => expect(result.current.sessionById.has('s-2')).toBe(true), {
+      timeout: 4000,
+    });
+    expect(fetchCount('sessions', 'findAll')).toBe(6);
+  });
+});
+
+/**
+ * Bulk Map replacements that are NOT a `runHydration` apply — the reconnect
+ * resync's wholesale `setMaps`, and the logout reset — MUST bump the
+ * per-collection revisions (and, for the reset, the hydration generations) so an
+ * in-flight hydration whose snapshot predates them cannot clobber the newer
+ * state or repopulate the Maps after teardown. These tests pin BLOCKING-1.
+ */
+describe('useAgorData — bulk-write revision bumps', () => {
+  it('reconnect bulk-replace bumps revisions so an in-flight hydration discards (no clobber)', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const sNew = makeSession({ session_id: 's-new', branch_id: 'b-1' });
+    // Initial hydration sees only the stale set (no s-new); the reconnect sees
+    // the newer set after we swap the seed reference.
+    const seed: Record<string, unknown[]> = {
+      'sessions:find': [s1],
+      'sessions:findAll': [s1],
+      'branches:findAll': [],
+    };
+    const gate = deferred();
+    const { client, onFetch, fetchCount, emitIo } = makeMockClient(seed);
+    // Defer the FIRST sessions hydration fetch so it's still in-flight when the
+    // reconnect lands.
+    onFetch('sessions', 'findAll', (call) => (call === 1 ? gate.promise : undefined));
+
+    const { result } = renderHook(() => useAgorData(client));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(fetchCount('sessions', 'findAll')).toBe(1));
+
+    // Reconnect delivers the NEWER full set: swap the seed so the reconnect's
+    // findAll (call 2) returns it (call 1 already captured the stale reference).
+    seed['sessions:findAll'] = [s1, sNew];
+    seed['sessions:find'] = [s1, sNew];
+    await act(async () => {
+      emitIo('connect');
+      await new Promise<void>((r) => setTimeout(r, 0));
+    });
+    // Reconnect applied the newer snapshot and bumped revisions.
+    expect(result.current.sessionById.has('s-new')).toBe(true);
+
+    // Release the stale in-flight hydration. Its snapshot ([s-1] only) would, if
+    // applied, drop s-new — but the reconnect's revision bump fails its quiet
+    // check, so it discards and re-fetches (now also returning s-new).
+    await act(async () => {
+      gate.resolve();
+      await new Promise<void>((r) => setTimeout(r, 0));
+    });
+    await flush();
+    expect(result.current.sessionById.has('s-new')).toBe(true);
+    expect(result.current.sessionById.has('s-1')).toBe(true);
+  });
+
+  it('logout reset bumps generation/revisions so an in-flight hydration cannot repopulate after logout', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const seed: Record<string, unknown[]> = {
+      'sessions:find': [s1],
+      'sessions:findAll': [s1],
+      'branches:findAll': [],
+    };
+    const gate = deferred();
+    const { client, onFetch, fetchCount } = makeMockClient(seed);
+    onFetch('sessions', 'findAll', (call) => (call === 1 ? gate.promise : undefined));
+
+    const { result, rerender } = renderHook(
+      ({ c }: { c: Parameters<typeof useAgorData>[0] }) => useAgorData(c),
+      { initialProps: { c: client as Parameters<typeof useAgorData>[0] } }
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await waitFor(() => expect(fetchCount('sessions', 'findAll')).toBe(1));
+
+    // Logout: client → null fires the reset (clears Maps, cancels hydrations).
+    await act(async () => {
+      rerender({ c: null });
+      await new Promise<void>((r) => setTimeout(r, 0));
+    });
+    expect(result.current.sessionById.size).toBe(0);
+
+    // Release the in-flight hydration. Its snapshot ([s-1]) must NOT repopulate
+    // the cleared Maps: the reset bumped the generation (cancels the loop) and
+    // the revision (fails the quiet check).
+    await act(async () => {
+      gate.resolve();
+      await new Promise<void>((r) => setTimeout(r, 0));
+    });
+    await flush();
+    expect(result.current.sessionById.size).toBe(0);
+    expect(result.current.sessionById.has('s-1')).toBe(false);
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -33,13 +33,33 @@ import { useAgorData } from './useAgorData';
  */
 type Listener = (payload: unknown) => void;
 
+/**
+ * `seed` is keyed by service name (e.g. `sessions`) and consulted by both
+ * `findAll` and `find`. For the background-hydration tests the gated first-paint
+ * fetch (`find`) and the full hydration fetch (`findAll`) need DIFFERENT data,
+ * so a method-specific key (`sessions:findAll`, `sessions:find`) takes
+ * precedence over the bare name when present. `name:get` seeds `get`.
+ */
 function makeMockClient(seed: Record<string, unknown[]> = {}) {
   const serviceListeners = new Map<string, Map<string, Listener[]>>();
   const ioListeners = new Map<string, Listener[]>();
+  // Synchronous side effects fired at call time of `service(name)[method]()` —
+  // used by the skip-apply-on-race tests to inject a live write mid-fetch.
+  const fetchHooks = new Map<string, (call: number) => void>();
+  const fetchCounts = new Map<string, number>();
+
+  const respond = (name: string, method: 'findAll' | 'find') => {
+    const key = `${name}:${method}`;
+    const call = (fetchCounts.get(key) ?? 0) + 1;
+    fetchCounts.set(key, call);
+    fetchHooks.get(key)?.(call);
+    const data = seed[key] ?? seed[name] ?? [];
+    return Promise.resolve(data);
+  };
 
   const service = (name: string) => ({
-    findAll: vi.fn().mockResolvedValue(seed[name] ?? []),
-    find: vi.fn().mockResolvedValue(seed[name] ?? []),
+    findAll: vi.fn(() => respond(name, 'findAll')),
+    find: vi.fn(() => respond(name, 'find')),
     get: vi.fn().mockResolvedValue(seed[`${name}:get`] ?? null),
     on: (event: string, fn: Listener) => {
       let svc = serviceListeners.get(name);
@@ -83,6 +103,14 @@ function makeMockClient(seed: Record<string, unknown[]> = {}) {
     emit: (svc: string, event: string, payload: unknown) => {
       for (const fn of serviceListeners.get(svc)?.get(event) ?? []) fn(payload);
     },
+    // Register a synchronous side effect that runs every time `service(name)`'s
+    // `method` is invoked (receives the 1-based call count). The hook fires
+    // BEFORE the returned promise resolves, so emitting a live event here lands
+    // a write DURING the fetch window — exactly the race the hydration guards.
+    onFetch: (name: string, method: 'findAll' | 'find', fn: (call: number) => void) =>
+      fetchHooks.set(`${name}:${method}`, fn),
+    fetchCount: (name: string, method: 'findAll' | 'find') =>
+      fetchCounts.get(`${name}:${method}`) ?? 0,
   };
 }
 
@@ -126,6 +154,16 @@ async function waitForInitialLoad(result: { current: ReturnType<typeof useAgorDa
   await waitFor(() => {
     expect(result.current.loading).toBe(false);
     expect(result.current.initialLoadComplete).toBe(true);
+  });
+  // The first paint opens the gate, but the background hydration (sessions +
+  // branches, plus the optional mcp/gateway/artifact/oauth slices) is kicked
+  // off right after and applies a beat later — replacing those map slices
+  // WHOLESALE with the full snapshot, which changes their references even when
+  // content is identical. Flush a macrotask so it settles before tests capture
+  // baseline references or emit events, otherwise reference-stability and
+  // mutation assertions would race the hydration apply.
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
   });
 }
 
@@ -464,5 +502,123 @@ describe('useAgorData — socket-event bailouts', () => {
     expect(result.current.boardObjectsByBoardId.get('board-2')?.[0]?.zone_id).toBe(
       'zone-on-other-board'
     );
+  });
+});
+
+/**
+ * Background hydration uses a "skip-apply-on-race" rule (see `runHydration` /
+ * `liveRevisionsRef` in useAgorData.ts): the full-set snapshot is applied
+ * WHOLESALE only when no live write to the target collection raced the fetch.
+ * If one did, the snapshot is discarded and refetched — never overlaid — and if
+ * the race never settles the apply is skipped entirely. These tests pin that
+ * contract (apply-on-quiet, retry-on-race, skip-without-resurrect, and
+ * per-collection independence) using `onFetch` to land a live write mid-fetch.
+ *
+ * jsdom's pathname is `/`, so no board scope resolves: only the sessions+branches
+ * (and the always-on mcp/gateway/artifact/oauth) hydrations run, while the gated
+ * sessions fetch uses `find` and branches resolve to `[]` — so `sessions.findAll`
+ * / `branches.findAll` are hit ONLY by the hydration, making call counts exact.
+ */
+describe('useAgorData — skip-apply-on-race hydration', () => {
+  it('applies the full snapshot wholesale when no live write races (apply-on-quiet)', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
+    const b1 = makeBranch({ branch_id: 'b-1' });
+    const { client } = makeMockClient({
+      // Gated first paint sees only the recent slice; hydration sees the full set.
+      'sessions:find': [s1],
+      'sessions:findAll': [s1, s2],
+      'branches:findAll': [b1],
+    });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    expect(result.current.sessionById.has('s-1')).toBe(true);
+    // s-2 was absent from first paint and only arrives via the hydration.
+    expect(result.current.sessionById.has('s-2')).toBe(true);
+    expect(result.current.branchById.has('b-1')).toBe(true);
+    expect(
+      result.current.sessionsByBranch
+        .get('b-1')
+        ?.map((s) => s.session_id)
+        .sort()
+    ).toEqual(['s-1', 's-2']);
+  });
+
+  it('discards a racy snapshot, refetches, and applies the fresh one without clobbering the live write', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
+    const s3 = makeSession({ session_id: 's-3', branch_id: 'b-1' });
+    const { client, emit, onFetch, fetchCount } = makeMockClient({
+      'sessions:find': [s1],
+      // Once the race settles, the backend's full set already includes the
+      // racing create (s-3) — models a real refetch reflecting the new row.
+      'sessions:findAll': [s1, s2, s3],
+      'branches:findAll': [],
+    });
+    // A session is created mid-flight on the FIRST hydration fetch only.
+    onFetch('sessions', 'findAll', (call) => {
+      if (call === 1) emit('sessions', 'created', s3);
+    });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    // The first snapshot was discarded (it raced) and a second fetch applied.
+    expect(fetchCount('sessions', 'findAll')).toBe(2);
+    // The racing live create survived AND the hydration filled in s-2.
+    expect(result.current.sessionById.has('s-3')).toBe(true);
+    expect(result.current.sessionById.has('s-2')).toBe(true);
+  });
+
+  it('skips the apply when the race never settles, so a removed session is not resurrected', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
+    const { client, emit, onFetch, fetchCount } = makeMockClient({
+      'sessions:find': [s1, s2],
+      // The snapshot ALWAYS still contains s-2 (stale backend): if it were ever
+      // applied it would resurrect the removed session.
+      'sessions:findAll': [s1, s2],
+      'branches:findAll': [],
+    });
+    onFetch('sessions', 'findAll', (call) => {
+      // Remove s-2 during the first fetch, then bump the sessions revision on
+      // every subsequent attempt so the hydration never sees a quiet window.
+      if (call === 1) emit('sessions', 'removed', s2);
+      else emit('sessions', 'patched', { ...s1, status: `v${call}` });
+    });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+    // Every attempt races → 4 immediate + 2 backoff = 6 fetches, then skip.
+    await waitFor(() => expect(fetchCount('sessions', 'findAll')).toBe(6), { timeout: 4000 });
+
+    expect(result.current.sessionById.has('s-1')).toBe(true);
+    // The stale snapshot was never applied, so s-2 stays removed.
+    expect(result.current.sessionById.has('s-2')).toBe(false);
+  });
+
+  it('hydrates an unrelated collection even while another keeps racing (per-collection revisions)', async () => {
+    const s1 = makeSession({ session_id: 's-1', branch_id: 'b-1' });
+    const s2 = makeSession({ session_id: 's-2', branch_id: 'b-1' });
+    const m1 = { mcp_server_id: 'm-1', name: 'one' };
+    const m2 = { mcp_server_id: 'm-2', name: 'two' };
+    const { client, emit, onFetch, fetchCount } = makeMockClient({
+      'sessions:find': [s1],
+      'sessions:findAll': [s1, s2],
+      'branches:findAll': [],
+      'mcp-servers': [m1, m2],
+    });
+    // Keep the SESSIONS hydration perpetually racing (bumps only `sessions`)…
+    onFetch('sessions', 'findAll', (call) =>
+      emit('sessions', 'patched', { ...s1, status: `v${call}` })
+    );
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+    await waitFor(() => expect(fetchCount('sessions', 'findAll')).toBe(6), { timeout: 4000 });
+
+    // …the mcp-servers hydration is independent of `sessions`, so it applied.
+    expect(result.current.mcpServerById.has('m-1')).toBe(true);
+    expect(result.current.mcpServerById.has('m-2')).toBe(true);
+    // …while the racing sessions hydration was skipped (s-2 never filled in).
+    expect(result.current.sessionById.has('s-2')).toBe(false);
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -628,6 +628,18 @@ export function useAgorData(
   // event handlers, never in render.
   const liveWriteRevisionRef = useRef(0);
 
+  // Entity IDs deleted/archived by a realtime handler. A background hydration
+  // snapshots this set before its fetch and, on apply, drops any ID that was
+  // tombstoned DURING the fetch window from the incoming snapshot — otherwise the
+  // live-wins overlay (which only re-adds create/patch entries) would RESURRECT a
+  // row the snapshot still contains but that was removed mid-flight (the row is
+  // already gone from `prev`, so the overlay can't delete it). "Live wins" must
+  // mean create/patch overlay AND remove suppression. Window-scoped (snapshot the
+  // set at fetch start, diff at apply) so a legitimate later re-create/unarchive
+  // of the same id isn't permanently suppressed. Same ref (not state): only
+  // touched by async fetch code + event handlers.
+  const liveRemovedIdsRef = useRef<Set<string>>(new Set());
+
   // Fetch all data
   //
   // `silent: true` is used by background refetches (e.g. socket reconnect) that
@@ -685,31 +697,47 @@ export function useAgorData(
           return incoming;
         };
 
+        // IDs tombstoned (removed/archived) between `since` and now. The apply
+        // uses this to drop resurrected rows from the snapshot — see
+        // `liveRemovedIdsRef`. Window-scoped: only ids removed DURING this fetch.
+        const removedSince = (since: ReadonlySet<string>): Set<string> => {
+          const out = new Set<string>();
+          for (const id of liveRemovedIdsRef.current) {
+            if (!since.has(id)) out.add(id);
+          }
+          return out;
+        };
+
         // Run a BACKGROUND (non-gated) fetch and apply it clobber-safely.
         // - Silent reconnect refetches are authoritative resyncs → apply once.
         // - Otherwise, if a realtime write to one of these slices landed during
         //   the fetch (liveWriteRevisionRef changed), refetch — bounded — for a
         //   fresh snapshot before applying. The appliers additionally merge live
-        //   entries on top of the snapshot, so an in-flight create/patch is never
-        //   lost even when the retry cap is hit under a continuous write stream.
+        //   entries on top of the snapshot (live wins for create/patch) and drop
+        //   the tombstoned-during-window ids (`removedDuringWindow`, remove wins),
+        //   so neither an in-flight create/patch nor an in-flight remove is lost
+        //   even when the retry cap is hit under a continuous write stream.
         const runBackgroundFetch = async <T>(
           label: string,
           fetchFn: () => Promise<T>,
-          apply: (result: T) => void
+          apply: (result: T, removedDuringWindow: ReadonlySet<string>) => void
         ): Promise<void> => {
           try {
             if (silent) {
-              apply(await fetchFn());
+              const removedBefore = new Set(liveRemovedIdsRef.current);
+              const result = await fetchFn();
+              apply(result, removedSince(removedBefore));
               return;
             }
             for (let attempt = 0; attempt < MAX_BACKGROUND_REFETCH; attempt++) {
               const revBefore = liveWriteRevisionRef.current;
+              const removedBefore = new Set(liveRemovedIdsRef.current);
               const result = await fetchFn();
               if (
                 liveWriteRevisionRef.current === revBefore ||
                 attempt === MAX_BACKGROUND_REFETCH - 1
               ) {
-                apply(result);
+                apply(result, removedSince(removedBefore));
                 return;
               }
               // A realtime write landed mid-fetch; loop to refetch a fresh snapshot.
@@ -837,13 +865,31 @@ export function useAgorData(
         const [sessionsList, boardsList, cardTypesList, reposList, usersList] = await Promise.all([
           track(
             'sessions',
-            client.service('sessions').findAll({
-              query: silent
-                ? // Reconnect resyncs must fully repopulate every board, so they
-                  // stay GLOBAL/full (mirrors the heavy + hydration paths below).
-                  { archived: false, $limit: PAGINATION.DEFAULT_LIMIT, $sort: { updated_at: -1 } }
-                : { archived: false, $limit: RECENT_SESSIONS_LIMIT, $sort: { updated_at: -1 } },
-            })
+            silent
+              ? // Reconnect resyncs must fully repopulate every board, so they stay
+                // GLOBAL/full (mirrors the heavy + hydration paths below).
+                client.service('sessions').findAll({
+                  query: {
+                    archived: false,
+                    $limit: PAGINATION.DEFAULT_LIMIT,
+                    $sort: { updated_at: -1 },
+                  },
+                })
+              : // Bounded recent slice for first paint. Use find() (a SINGLE page),
+                // NOT findAll(): findAll loops until it has `total` rows, so a small
+                // $limit would still walk the whole table and defeat the cap. The
+                // daemon orders by `updated_at` in SQL (findPage), so this is the
+                // genuinely most-recent N. The FULL set is hydrated below.
+                client
+                  .service('sessions')
+                  .find({
+                    query: {
+                      archived: false,
+                      $limit: RECENT_SESSIONS_LIMIT,
+                      $sort: { updated_at: -1 },
+                    },
+                  })
+                  .then((result) => (Array.isArray(result) ? result : result.data))
           ),
           track(
             'boards',
@@ -1131,10 +1177,11 @@ export function useAgorData(
         //
         // Clobber-safety: this runs WHILE the app is interactive, so a realtime
         // create/patch/remove can land during a global fetch. `runBackgroundFetch`
-        // refetches if `liveWriteRevisionRef` changed mid-flight, and each apply
-        // MERGES the live entries on top of the snapshot (live wins) so an
-        // in-flight edit is never reverted by the snapshot. Removes are covered by
-        // the refetch (the fresh snapshot omits them).
+        // refetches if `liveWriteRevisionRef` changed mid-flight; each apply then
+        // MERGES the live entries on top of the snapshot (live wins, so an
+        // in-flight create/patch is never reverted) AND drops ids tombstoned
+        // during the fetch window (`removedDuringWindow`, so an in-flight
+        // remove/archive isn't resurrected by a snapshot taken before it).
 
         // Sessions + branches: now ALWAYS bounded at first paint (recent-N /
         // board-scoped), so hydrate them on every non-silent load (silent
@@ -1156,14 +1203,15 @@ export function useAgorData(
                   .service('branches')
                   .findAll({ query: { archived: false, $limit: PAGINATION.DEFAULT_LIMIT } }),
               ]),
-            ([allSessions, allBranches]) =>
+            ([allSessions, allBranches], removedDuringWindow) =>
               setMaps((prev) => {
-                // Sessions: union the full snapshot with the live sessions we
-                // already hold (live wins) so an in-flight create/patch isn't
-                // reverted, then rebuild both maps (incl. remote surrogates) from
-                // the union so they stay internally consistent.
+                // Sessions: union the full snapshot (minus rows tombstoned during
+                // the fetch — remove wins) with the live sessions we already hold
+                // (live wins for create/patch), then rebuild both maps (incl.
+                // remote surrogates) from the union so they stay consistent.
                 const mergedSessions = new Map<string, Session>();
                 for (const session of allSessions) {
+                  if (removedDuringWindow.has(session.session_id)) continue;
                   mergedSessions.set(session.session_id, session);
                 }
                 for (const [id, session] of prev.sessionById) {
@@ -1172,12 +1220,16 @@ export function useAgorData(
                 const { sessionById, sessionsByBranch } = buildSessionMaps([
                   ...mergedSessions.values(),
                 ]);
+                // Branches: drop tombstoned ids from the snapshot, then live-wins overlay.
+                const branchSnapshot = buildById(
+                  allBranches.filter((branch) => !removedDuringWindow.has(branch.branch_id)),
+                  'branch_id'
+                );
                 return {
                   ...prev,
                   sessionById,
                   sessionsByBranch,
-                  // Branches: live-wins overlay of the full snapshot.
-                  branchById: mergeLiveWins(buildById(allBranches, 'branch_id'), prev.branchById),
+                  branchById: mergeLiveWins(branchSnapshot, prev.branchById),
                 };
               })
           );
@@ -1199,19 +1251,32 @@ export function useAgorData(
                   .service('board-comments')
                   .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
               ]),
-            ([allBoardObjects, allCards, allComments]) =>
+            ([allBoardObjects, allCards, allComments], removedDuringWindow) =>
               setMaps((prev) => {
-                // Start from the global snapshot…
-                const base = buildBoardObjectMaps(allBoardObjects);
+                // Start from the global snapshot, dropping any rows tombstoned
+                // during the fetch window (remove wins — otherwise a board-object/
+                // card/comment removed mid-flight would be resurrected here)…
+                const base = buildBoardObjectMaps(
+                  allBoardObjects.filter((o) => !removedDuringWindow.has(o.object_id))
+                );
                 let next: DataMaps = {
                   ...prev,
                   boardObjectById: base.boardObjectById,
                   boardObjectsByBoardId: base.boardObjectsByBoardId,
                   boardObjectByBranchId: base.boardObjectByBranchId,
                   boardObjectByCardId: base.boardObjectByCardId,
-                  cardById: mergeLiveWins(buildById(allCards, 'card_id'), prev.cardById),
+                  cardById: mergeLiveWins(
+                    buildById(
+                      allCards.filter((c) => !removedDuringWindow.has(c.card_id)),
+                      'card_id'
+                    ),
+                    prev.cardById
+                  ),
                   commentById: mergeLiveWins(
-                    buildById(allComments, 'comment_id'),
+                    buildById(
+                      allComments.filter((c) => !removedDuringWindow.has(c.comment_id)),
+                      'comment_id'
+                    ),
                     prev.commentById
                   ),
                 };
@@ -1391,6 +1456,9 @@ export function useAgorData(
     const handleSessionPatched = (session: Session) => {
       liveWriteRevisionRef.current += 1;
       const isArchived = session.archived === true;
+      // Archive is a removal from the active maps — tombstone it so a background
+      // hydration whose snapshot predates the archive can't resurrect it.
+      if (isArchived) liveRemovedIdsRef.current.add(session.session_id);
       // Track old branch_id for migration detection
       let oldBranchId: string | null = null;
 
@@ -1545,6 +1613,7 @@ export function useAgorData(
     };
     const handleSessionRemoved = (session: Session) => {
       liveWriteRevisionRef.current += 1;
+      liveRemovedIdsRef.current.add(session.session_id);
       // Update sessionById — bail out when the id isn't tracked so the
       // wrapper short-circuit prevents the spurious `maps` update.
       setSessionById((prev) => {
@@ -1617,6 +1686,7 @@ export function useAgorData(
     };
     const handleBoardObjectRemoved = (boardObject: BoardEntityObject) => {
       liveWriteRevisionRef.current += 1;
+      liveRemovedIdsRef.current.add(boardObject.object_id);
       setMaps((prev) => removeBoardObjectFromMaps(prev, boardObject));
     };
 
@@ -1672,6 +1742,10 @@ export function useAgorData(
     // `archived: true` patch path and the hard-delete `removed` path —
     // either way we never want an orphan session card to linger.
     const evictBranchAndSessions = (branchId: string) => {
+      // Tombstone the branch AND every session that lived on it, so a background
+      // sessions/branches hydration whose snapshot predates this eviction can't
+      // resurrect them.
+      liveRemovedIdsRef.current.add(branchId);
       setBranchById((prev) => {
         if (!prev.has(branchId)) return prev;
         const next = new Map(prev);
@@ -1689,6 +1763,7 @@ export function useAgorData(
         const next = new Map(prev);
         for (const [sessionId, session] of prev.entries()) {
           if (session.branch_id === branchId) {
+            liveRemovedIdsRef.current.add(sessionId);
             next.delete(sessionId);
             changed = true;
           }
@@ -1822,6 +1897,7 @@ export function useAgorData(
     };
     const handleCardRemoved = (card: CardWithType) => {
       liveWriteRevisionRef.current += 1;
+      liveRemovedIdsRef.current.add(card.card_id);
       setCardById((prev) => {
         if (!prev.has(card.card_id)) return prev;
         const next = new Map(prev);
@@ -1978,6 +2054,7 @@ export function useAgorData(
     };
     const handleCommentRemoved = (comment: BoardComment) => {
       liveWriteRevisionRef.current += 1;
+      liveRemovedIdsRef.current.add(comment.comment_id);
       setCommentById((prev) => {
         if (!prev.has(comment.comment_id)) return prev; // Doesn't exist, nothing to remove
         const next = new Map(prev);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -61,13 +61,27 @@ export type InitialLoadItemKey = (typeof INITIAL_LOAD_ITEMS)[number]['key'];
 // its full-set snapshot ONLY if no live write to the target collection(s)
 // raced the fetch (proven via the per-collection `liveRevisionsRef` counters);
 // if one did, the snapshot is DISCARDED and refetched from a fresh revision
-// baseline — never overlaid/reconciled. The first few retries are immediate
-// (the race window is ~one fetch RTT), then a couple of backoff retries give a
-// short live-write burst time to settle. If it never goes quiet we skip the
-// apply entirely (leave the collection as-is; live subscriptions + the next
-// reconnect/board-switch reconcile) rather than clobber live state.
+// baseline — never overlaid/reconciled.
+//
+// It retries UNTIL it lands a quiet window, and NEVER gives up: skipping the
+// apply forever would leave Home empty/incomplete indefinitely on a busy
+// workspace, because live subscriptions deliver only CHANGES, not a backfill of
+// existing rows (board switching doesn't refetch, and a reconnect may never
+// fire). The first few retries are immediate (the race window is ~one fetch RTT,
+// so a single transient race converges instantly), then capped exponential
+// backoff lets a sustained live-write burst settle without busy-looping. Each
+// retry RE-snapshots the revision and RE-fetches; a racy snapshot is never
+// force-applied. Per-collection quiet windows are short, so this converges fast
+// (branches almost immediately; sessions once their write churn quiets).
+//
+// Delays PRECEDE the attempt they guard (the delay for attempt N runs before
+// fetch N, not after it). Loops are cancelled — not abandoned mid-flight — via
+// the per-collection generation tokens (`hydrationGenerationRef`): a newer
+// hydration (reconnect) or an unmount/reset supersedes older loops so they stop
+// retrying and never apply a stale snapshot or leak a timer.
 const HYDRATION_IMMEDIATE_RETRIES = 4;
-const HYDRATION_BACKOFF_DELAYS_MS = [100, 400] as const;
+const HYDRATION_BACKOFF_BASE_MS = 200;
+const HYDRATION_BACKOFF_CAP_MS = 5000;
 
 // Hydrated collections that the background hydration replaces wholesale. Each
 // has its own live-write revision counter (`liveRevisionsRef`) so a write to
@@ -668,6 +682,26 @@ export function useAgorData(
     liveRevisionsRef.current[collection] += 1;
   }, []);
 
+  // Per-collection hydration generation tokens. Each `runHydration` call bumps
+  // the generation for the collection(s) it owns and captures it; its retry loop
+  // stops (without applying a snapshot or scheduling another timer) the moment a
+  // newer hydration supersedes it (a reconnect-triggered refetch), the component
+  // unmounts, or a logout reset fires — all of which bump these counters. This
+  // is CANCELLATION, not race reconciliation: clobber-safety still comes entirely
+  // from the quiet-window check against `liveRevisionsRef`.
+  const hydrationGenerationRef = useRef<Record<HydratedCollection, number>>({
+    sessions: 0,
+    branches: 0,
+    boardObjects: 0,
+    cards: 0,
+    comments: 0,
+    mcpServers: 0,
+    sessionMcp: 0,
+    gatewayChannels: 0,
+    artifacts: 0,
+    oauth: 0,
+  });
+
   // Fetch all data
   //
   // `silent: true` is used by background refetches (e.g. socket reconnect) that
@@ -720,44 +754,67 @@ export function useAgorData(
         // collection's revision counter before the fetch and re-checking after.
         // If a write raced, the (potentially stale) snapshot is DISCARDED and
         // refetched from a fresh baseline; we NEVER overlay or reconcile a racy
-        // snapshot. After a few immediate retries we back off briefly to let a
-        // write burst settle; if it still never goes quiet we skip the apply
-        // entirely rather than clobber live state (the collection stays as-is —
-        // first paint already rendered it, and live events + the next
-        // reconnect/board-switch reconcile any cross-board gaps).
+        // snapshot. It retries until it lands a quiet window — a few immediate
+        // retries then capped exponential backoff — and never gives up (skipping
+        // forever could leave Home empty/incomplete indefinitely; live events
+        // only deliver changes, not backfill). The loop is cancelled — not
+        // abandoned — on supersession (reconnect), unmount, or logout reset.
         const runHydration = async <T>(
           label: string,
           collections: readonly HydratedCollection[],
           fetchFn: () => Promise<T>,
           apply: (result: T) => void
         ): Promise<void> => {
-          const totalAttempts = HYDRATION_IMMEDIATE_RETRIES + HYDRATION_BACKOFF_DELAYS_MS.length;
-          for (let attempt = 0; attempt < totalAttempts; attempt++) {
+          // Supersede any older loop for these collections and capture our
+          // generation token. The loop bails the instant a newer hydration
+          // (reconnect), an unmount, or a logout reset bumps the generation — so
+          // it never applies a stale snapshot or schedules another timer after
+          // it's been cancelled.
+          const myGeneration = collections.map((c) => (hydrationGenerationRef.current[c] += 1));
+          const isCurrent = () =>
+            collections.every((c, i) => hydrationGenerationRef.current[c] === myGeneration[i]);
+          // Delay PRECEDING attempt N: the first HYDRATION_IMMEDIATE_RETRIES
+          // attempts fire back-to-back (delay 0) so a single transient race
+          // converges instantly; after that, capped exponential backoff lets a
+          // sustained write burst settle.
+          const delayBeforeAttempt = (attempt: number) =>
+            attempt < HYDRATION_IMMEDIATE_RETRIES
+              ? 0
+              : Math.min(
+                  HYDRATION_BACKOFF_BASE_MS * 2 ** (attempt - HYDRATION_IMMEDIATE_RETRIES),
+                  HYDRATION_BACKOFF_CAP_MS
+                );
+
+          // Retry until a quiet-window apply SUCCEEDS (or the loop is cancelled).
+          // We never force-apply a racy snapshot — we just keep re-snapshotting
+          // and re-fetching until no live write races a fetch.
+          for (let attempt = 0; ; attempt++) {
+            const delayMs = delayBeforeAttempt(attempt);
+            if (delayMs > 0) {
+              await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+              if (!isCurrent()) return; // superseded while waiting
+            }
             const before = collections.map((c) => liveRevisionsRef.current[c]);
             let result: T;
             try {
               result = await fetchFn();
             } catch (err) {
               console.warn(`[useAgorData] background ${label} fetch failed:`, err);
-              return;
+              if (!isCurrent()) return; // superseded while fetching
+              // A failed fetch leaves the collection un-hydrated; retrying (with
+              // backoff) is exactly what keeps Home from staying empty forever.
+              continue;
             }
+            if (!isCurrent()) return; // superseded while fetching
             const raced = collections.some((c, i) => liveRevisionsRef.current[c] !== before[i]);
             if (!raced) {
               apply(result);
               return;
             }
             // A live write to one of these collections raced the fetch — discard
-            // this snapshot and retry from a fresh revision baseline.
-            const backoffIndex = attempt - HYDRATION_IMMEDIATE_RETRIES;
-            const delayMs = backoffIndex >= 0 ? HYDRATION_BACKOFF_DELAYS_MS[backoffIndex] : 0;
-            if (delayMs > 0) {
-              await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
-            }
+            // this snapshot and retry from a fresh revision baseline (the next
+            // iteration's delay precedes its fetch).
           }
-          console.debug(
-            `[useAgorData] ${label} hydration kept racing across ${totalAttempts} attempts; ` +
-              'skipped apply (live state preserved)'
-          );
         };
 
         // ── Background (non-gated) fetches ──────────────────────────────
@@ -1154,6 +1211,17 @@ export function useAgorData(
           branchById: branchesMap,
           userById: usersMap,
         }));
+        // This wholesale replace is NOT a `runHydration` apply, so it must bump
+        // the revisions of every collection it overwrites — exactly like the
+        // per-mutation realtime handlers do. Critical on the SILENT reconnect
+        // resync: an in-flight hydration whose snapshot predates the disconnect
+        // would otherwise pass its quiet check and clobber this newer reconnect
+        // snapshot (resurrecting data that changed while we were disconnected).
+        // The background hydrations kicked off below re-snapshot AFTER this bump,
+        // so they're unaffected.
+        for (const c of ['sessions', 'branches', 'boardObjects', 'cards', 'comments'] as const) {
+          liveRevisionsRef.current[c] += 1;
+        }
         debugTimer?.endIndexing();
         debugFinishStatus = 'success';
 
@@ -1177,31 +1245,29 @@ export function useAgorData(
         // board-scoped), so hydrate them on every non-silent load (silent
         // reconnect already fetched them full above). repos / users / boards /
         // card-types stay global at first paint, so they need no top-up.
+        //
+        // Sessions and branches hydrate on INDEPENDENT loops (separate fetches,
+        // separate revision guards, separate generation tokens). They were
+        // previously coupled in one runHydration, which meant high-frequency
+        // session-write churn (common when agents stream) could starve the
+        // branch apply indefinitely — and on Home, branches start empty and are
+        // filled ONLY by this hydration, so coupling could leave the board empty
+        // forever. Decoupled, branches apply on their own quiet window (almost
+        // immediately) regardless of session churn.
         if (!silent) {
           void runHydration(
-            'sessions+branches',
-            ['sessions', 'branches'],
+            'sessions',
+            ['sessions'],
             () =>
-              Promise.all([
-                client.service('sessions').findAll({
-                  query: {
-                    archived: false,
-                    $limit: PAGINATION.DEFAULT_LIMIT,
-                    $sort: { updated_at: -1 },
-                  },
-                }),
-                client
-                  .service('branches')
-                  .findAll({ query: { archived: false, $limit: PAGINATION.DEFAULT_LIMIT } }),
-              ]),
-            ([allSessions, allBranches]) =>
+              client.service('sessions').findAll({
+                query: {
+                  archived: false,
+                  $limit: PAGINATION.DEFAULT_LIMIT,
+                  $sort: { updated_at: -1 },
+                },
+              }),
+            (allSessions) =>
               setMaps((prev) => {
-                // Quiet window proven by runHydration → apply wholesale. Branches
-                // are active-only (the snapshot query is archived:false and the
-                // handlers never keep an archived branch), so a wholesale replace
-                // is complete.
-                const branchById = buildById(allBranches, 'branch_id');
-
                 // The hydration fetches active sessions only. Deep-link-healed
                 // archived sessions (added to `sessionById` so a direct /s/<id>
                 // archived link can open the drawer) are OUT of that query's
@@ -1215,34 +1281,43 @@ export function useAgorData(
                   if (session.archived && !sessions.has(id)) sessions.set(id, session);
                 }
                 const { sessionById, sessionsByBranch } = buildSessionMaps([...sessions.values()]);
-                return { ...prev, sessionById, sessionsByBranch, branchById };
+                return { ...prev, sessionById, sessionsByBranch };
               })
+          );
+          void runHydration(
+            'branches',
+            ['branches'],
+            () =>
+              client
+                .service('branches')
+                .findAll({ query: { archived: false, $limit: PAGINATION.DEFAULT_LIMIT } }),
+            (allBranches) =>
+              // Quiet window proven by runHydration → apply wholesale. Branches
+              // are active-only (the snapshot query is archived:false and the
+              // handlers never keep an archived branch), so a wholesale replace
+              // is complete.
+              setMaps((prev) => ({ ...prev, branchById: buildById(allBranches, 'branch_id') }))
           );
         }
 
         // Board objects / cards / comments: only board-scoped at first paint when
         // a board was resolved (`boardScope` set, non-silent only — silent
         // reconnect already refetches everything global). Top up to the global set.
+        //
+        // Board objects / cards / comments also hydrate on INDEPENDENT loops so
+        // churn in one (e.g. rapid card moves) can't starve another's apply. Each
+        // global snapshot is a superset of its board-scoped first-paint slice, so
+        // no overlay is needed; the quiet-window guard prevents clobber/resurrect.
         if (boardScope) {
           void runHydration(
-            'board-objects+cards+comments',
-            ['boardObjects', 'cards', 'comments'],
+            'board-objects',
+            ['boardObjects'],
             () =>
-              Promise.all([
-                client
-                  .service('board-objects')
-                  .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-                client.service('cards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-                client
-                  .service('board-comments')
-                  .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-              ]),
-            ([allBoardObjects, allCards, allComments]) =>
+              client
+                .service('board-objects')
+                .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+            (allBoardObjects) =>
               setMaps((prev) => {
-                // Quiet window proven by runHydration → apply the global snapshot
-                // wholesale. It is a superset of the board-scoped first-paint
-                // slice, so no overlay is needed; nothing live raced, so nothing
-                // is clobbered or resurrected.
                 const base = buildBoardObjectMaps(allBoardObjects);
                 return {
                   ...prev,
@@ -1250,10 +1325,24 @@ export function useAgorData(
                   boardObjectsByBoardId: base.boardObjectsByBoardId,
                   boardObjectByBranchId: base.boardObjectByBranchId,
                   boardObjectByCardId: base.boardObjectByCardId,
-                  cardById: buildById(allCards, 'card_id'),
-                  commentById: buildById(allComments, 'comment_id'),
                 };
               })
+          );
+          void runHydration(
+            'cards',
+            ['cards'],
+            () => client.service('cards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+            (allCards) => setMaps((prev) => ({ ...prev, cardById: buildById(allCards, 'card_id') }))
+          );
+          void runHydration(
+            'board-comments',
+            ['comments'],
+            () =>
+              client
+                .service('board-comments')
+                .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
+            (allComments) =>
+              setMaps((prev) => ({ ...prev, commentById: buildById(allComments, 'comment_id') }))
           );
         }
 
@@ -1303,9 +1392,32 @@ export function useAgorData(
   // includes it here without any extra code.
   useEffect(() => {
     if (client) return;
+    // Cancel every in-flight hydration loop (bump generations) AND fail any
+    // quiet check it might still reach (bump revisions) so an unresolved
+    // hydration can't repopulate the Maps AFTER logout (post-logout data leak).
+    // Bumping the generation is the real stop — without it, a revision bump alone
+    // would only make the loop discard-and-RE-FETCH from the stale client and
+    // eventually apply into freshly-cleared Maps. Same lynchpin as the
+    // per-mutation revision bumps.
+    for (const c of Object.keys(liveRevisionsRef.current) as HydratedCollection[]) {
+      hydrationGenerationRef.current[c] += 1;
+      liveRevisionsRef.current[c] += 1;
+    }
     setMaps(EMPTY_MAPS);
     setHasInitiallyFetched(false);
   }, [client]);
+
+  // On unmount, supersede every in-flight per-collection hydration loop so it
+  // stops retrying and never applies a snapshot (or schedules another timer)
+  // after teardown. Generation bump = cancellation; see `runHydration`.
+  useEffect(() => {
+    const generations = hydrationGenerationRef.current;
+    return () => {
+      for (const c of Object.keys(generations) as HydratedCollection[]) {
+        generations[c] += 1;
+      }
+    };
+  }, []);
 
   // If the user navigates to /s/<id>/ after the initial active-session fetch,
   // load that one session by ID as well. This keeps direct links to archived

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -57,10 +57,32 @@ const INITIAL_LOAD_ITEMS = [
 
 export type InitialLoadItemKey = (typeof INITIAL_LOAD_ITEMS)[number]['key'];
 
-// Max times a background fetch refetches when a realtime write races its
-// in-flight request before falling back to a live-wins merge apply. Small: the
-// race window is one fetch RTT and a startup write storm is rare.
-const MAX_BACKGROUND_REFETCH = 3;
+// Skip-apply-on-race background hydration retry schedule. A hydration applies
+// its full-set snapshot ONLY if no live write to the target collection(s)
+// raced the fetch (proven via the per-collection `liveRevisionsRef` counters);
+// if one did, the snapshot is DISCARDED and refetched from a fresh revision
+// baseline — never overlaid/reconciled. The first few retries are immediate
+// (the race window is ~one fetch RTT), then a couple of backoff retries give a
+// short live-write burst time to settle. If it never goes quiet we skip the
+// apply entirely (leave the collection as-is; live subscriptions + the next
+// reconnect/board-switch reconcile) rather than clobber live state.
+const HYDRATION_IMMEDIATE_RETRIES = 4;
+const HYDRATION_BACKOFF_DELAYS_MS = [100, 400] as const;
+
+// Hydrated collections that the background hydration replaces wholesale. Each
+// has its own live-write revision counter (`liveRevisionsRef`) so a write to
+// one collection never blocks another's hydration from applying.
+type HydratedCollection =
+  | 'sessions'
+  | 'branches'
+  | 'boardObjects'
+  | 'cards'
+  | 'comments'
+  | 'mcpServers'
+  | 'sessionMcp'
+  | 'gatewayChannels'
+  | 'artifacts'
+  | 'oauth';
 
 // First-paint bound for the global (non-board-scoped) sessions slice. Covers
 // Home's "My Sessions" + "Team activity" feeds (both show only recent items)
@@ -615,40 +637,36 @@ export function useAgorData(
   // we only consume it in event handlers, never in render.
   const lastSilentFetchFailedRef = useRef(false);
 
-  // Monotonic counter bumped by every realtime handler that mutates a slice a
-  // BACKGROUND fetch later replaces wholesale (board-objects / cards / comments
-  // for full hydration, plus the optional mcp / gateway / artifact / session-mcp
-  // / oauth slices). A background apply snapshots this before its fetch; if it
-  // changed by the time the fetch resolves, a live create/patch/remove landed
-  // mid-flight and the snapshot is potentially stale — so we refetch for a
-  // consistent snapshot rather than clobbering the live write. As a final
-  // backstop the apply merges live entries on top of the snapshot (live wins),
-  // so an in-flight create/patch is never lost even at the retry cap. We use a
-  // ref (not state) since it's only read/written from async fetch code and
-  // event handlers, never in render.
-  const liveWriteRevisionRef = useRef(0);
-
-  // Entity IDs deleted/archived by a realtime handler. A background hydration
-  // snapshots this set before its fetch and, on apply, drops any ID that was
-  // tombstoned DURING the fetch window from the incoming snapshot — otherwise the
-  // live-wins overlay (which only re-adds create/patch entries) would RESURRECT a
-  // row the snapshot still contains but that was removed mid-flight (the row is
-  // already gone from `prev`, so the overlay can't delete it). "Live wins" must
-  // mean create/patch overlay AND remove suppression. Window-scoped (snapshot the
-  // set at fetch start, diff at apply) so a legitimate later re-create/unarchive
-  // of the same id isn't permanently suppressed. Same ref (not state): only
-  // touched by async fetch code + event handlers.
-  const liveRemovedIdsRef = useRef<Set<string>>(new Set());
-
-  // Subset of `liveRemovedIdsRef`: session IDs tombstoned because their BRANCH
-  // was evicted (archived/removed), not because the session itself was removed.
-  // The sessions+branches hydration suppresses these only while the branch is
-  // STILL gone at apply time — if the branch is unarchived/recreated during the
-  // same hydration window it's overlaid back from `prev`, but its child sessions
-  // were dropped from `prev`, so we must keep them from the snapshot rather than
-  // suppress them. Direct session removes are NOT added here, so they stay
-  // unconditionally suppressed.
-  const liveBranchEvictedSessionIdsRef = useRef<Set<string>>(new Set());
+  // Per-collection live-write revision counters — the core of the
+  // skip-apply-on-race background hydration. EVERY realtime handler that
+  // mutates one of these collection Maps bumps the matching counter
+  // (created / patched / removed, INCLUDING cascade removes such as branch
+  // eviction dropping its sessions, the deep-link-healing effect, and
+  // reconnect-driven writes). A background hydration snapshots the counters for
+  // the collections it replaces, fetches the full set, then applies the
+  // snapshot WHOLESALE only if those counters are unchanged when the fetch
+  // resolves — proving no live write raced. If any raced, the snapshot is
+  // discarded and refetched (never overlaid/reconciled). This makes a wholesale
+  // apply provably unable to clobber a live write OR resurrect a removed entity:
+  // a remove would have bumped the counter, so no apply happens. A ref (not
+  // state): only touched by async fetch code + event handlers, never in render.
+  const liveRevisionsRef = useRef<Record<HydratedCollection, number>>({
+    sessions: 0,
+    branches: 0,
+    boardObjects: 0,
+    cards: 0,
+    comments: 0,
+    mcpServers: 0,
+    sessionMcp: 0,
+    gatewayChannels: 0,
+    artifacts: 0,
+    oauth: 0,
+  });
+  // Stable bump helper (identity never changes — only mutates the ref) so it's
+  // safe to reference from the subscribe effect's handlers without churning deps.
+  const bumpRevision = useCallback((collection: HydratedCollection) => {
+    liveRevisionsRef.current[collection] += 1;
+  }, []);
 
   // Fetch all data
   //
@@ -696,65 +714,50 @@ export function useAgorData(
           });
         };
 
-        // Merge fetched snapshot entries with live ones, LIVE WINS: prevMap
-        // entries (delivered by realtime while the fetch was in flight)
-        // overwrite the snapshot. Mutates and returns `incoming`.
-        const mergeLiveWins = <V>(
-          incoming: Map<string, V>,
-          prevMap: Map<string, V>
-        ): Map<string, V> => {
-          for (const [key, value] of prevMap) incoming.set(key, value);
-          return incoming;
-        };
-
-        // IDs tombstoned (removed/archived) between `since` and now. The apply
-        // uses this to drop resurrected rows from the snapshot — see
-        // `liveRemovedIdsRef`. Window-scoped: only ids removed DURING this fetch.
-        const removedSince = (since: ReadonlySet<string>): Set<string> => {
-          const out = new Set<string>();
-          for (const id of liveRemovedIdsRef.current) {
-            if (!since.has(id)) out.add(id);
-          }
-          return out;
-        };
-
-        // Run a BACKGROUND (non-gated) fetch and apply it clobber-safely.
-        // - Silent reconnect refetches are authoritative resyncs → apply once.
-        // - Otherwise, if a realtime write to one of these slices landed during
-        //   the fetch (liveWriteRevisionRef changed), refetch — bounded — for a
-        //   fresh snapshot before applying. The appliers additionally merge live
-        //   entries on top of the snapshot (live wins for create/patch) and drop
-        //   the tombstoned-during-window ids (`removedDuringWindow`, remove wins),
-        //   so neither an in-flight create/patch nor an in-flight remove is lost
-        //   even when the retry cap is hit under a continuous write stream.
-        const runBackgroundFetch = async <T>(
+        // Run a BACKGROUND (non-gated) hydration with skip-apply-on-race. The
+        // fetched full-set snapshot is applied WHOLESALE only if no live write
+        // to any of `collections` raced the fetch — proven by snapshotting each
+        // collection's revision counter before the fetch and re-checking after.
+        // If a write raced, the (potentially stale) snapshot is DISCARDED and
+        // refetched from a fresh baseline; we NEVER overlay or reconcile a racy
+        // snapshot. After a few immediate retries we back off briefly to let a
+        // write burst settle; if it still never goes quiet we skip the apply
+        // entirely rather than clobber live state (the collection stays as-is —
+        // first paint already rendered it, and live events + the next
+        // reconnect/board-switch reconcile any cross-board gaps).
+        const runHydration = async <T>(
           label: string,
+          collections: readonly HydratedCollection[],
           fetchFn: () => Promise<T>,
-          apply: (result: T, removedDuringWindow: ReadonlySet<string>) => void
+          apply: (result: T) => void
         ): Promise<void> => {
-          try {
-            if (silent) {
-              const removedBefore = new Set(liveRemovedIdsRef.current);
-              const result = await fetchFn();
-              apply(result, removedSince(removedBefore));
+          const totalAttempts = HYDRATION_IMMEDIATE_RETRIES + HYDRATION_BACKOFF_DELAYS_MS.length;
+          for (let attempt = 0; attempt < totalAttempts; attempt++) {
+            const before = collections.map((c) => liveRevisionsRef.current[c]);
+            let result: T;
+            try {
+              result = await fetchFn();
+            } catch (err) {
+              console.warn(`[useAgorData] background ${label} fetch failed:`, err);
               return;
             }
-            for (let attempt = 0; attempt < MAX_BACKGROUND_REFETCH; attempt++) {
-              const revBefore = liveWriteRevisionRef.current;
-              const removedBefore = new Set(liveRemovedIdsRef.current);
-              const result = await fetchFn();
-              if (
-                liveWriteRevisionRef.current === revBefore ||
-                attempt === MAX_BACKGROUND_REFETCH - 1
-              ) {
-                apply(result, removedSince(removedBefore));
-                return;
-              }
-              // A realtime write landed mid-fetch; loop to refetch a fresh snapshot.
+            const raced = collections.some((c, i) => liveRevisionsRef.current[c] !== before[i]);
+            if (!raced) {
+              apply(result);
+              return;
             }
-          } catch (err) {
-            console.warn(`[useAgorData] background ${label} fetch failed:`, err);
+            // A live write to one of these collections raced the fetch — discard
+            // this snapshot and retry from a fresh revision baseline.
+            const backoffIndex = attempt - HYDRATION_IMMEDIATE_RETRIES;
+            const delayMs = backoffIndex >= 0 ? HYDRATION_BACKOFF_DELAYS_MS[backoffIndex] : 0;
+            if (delayMs > 0) {
+              await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+            }
           }
+          console.debug(
+            `[useAgorData] ${label} hydration kept racing across ${totalAttempts} attempts; ` +
+              'skipped apply (live state preserved)'
+          );
         };
 
         // ── Background (non-gated) fetches ──────────────────────────────
@@ -762,54 +765,42 @@ export function useAgorData(
         // never block the first-paint gate. Fire-and-forget: each populates its
         // own map slice on resolve. Their realtime subscriptions are attached in
         // the subscribe effect BEFORE this fetch runs, so live events land even
-        // while these fetches are in flight — and `runBackgroundFetch` keeps the
-        // apply from clobbering them. We deliberately do NOT `track()` them —
-        // they're absent from INITIAL_LOAD_ITEMS, so the loading checklist /
-        // `initialLoadComplete` gate ignores them. We merge through the stable
-        // `setMaps` (not the per-render setMapSlice setters, which would
-        // destabilize this useCallback's deps and re-fire the subscribe effect).
-        void runBackgroundFetch(
+        // while these fetches are in flight — and `runHydration` only applies a
+        // snapshot when no live write to that collection raced (else it refetches
+        // a fresh one). We deliberately do NOT `track()` them — they're absent
+        // from INITIAL_LOAD_ITEMS, so the loading checklist / `initialLoadComplete`
+        // gate ignores them. We apply through the stable `setMaps` (not the
+        // per-render setMapSlice setters, which would destabilize this
+        // useCallback's deps and re-fire the subscribe effect).
+        void runHydration(
           'mcp-servers',
+          ['mcpServers'],
           () =>
             client.service('mcp-servers').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
           (list) =>
-            setMaps((prev) => ({
-              ...prev,
-              mcpServerById: silent
-                ? buildById(list, 'mcp_server_id')
-                : mergeLiveWins(buildById(list, 'mcp_server_id'), prev.mcpServerById),
-            }))
+            setMaps((prev) => ({ ...prev, mcpServerById: buildById(list, 'mcp_server_id') }))
         );
-        void runBackgroundFetch(
+        void runHydration(
           'session-mcp-servers',
+          ['sessionMcp'],
           () =>
             client
               .service('session-mcp-servers')
               .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-          (list) =>
-            setMaps((prev) => ({
-              ...prev,
-              sessionMcpServerIds: silent
-                ? buildSessionMcpMap(list)
-                : mergeLiveWins(buildSessionMcpMap(list), prev.sessionMcpServerIds),
-            }))
+          (list) => setMaps((prev) => ({ ...prev, sessionMcpServerIds: buildSessionMcpMap(list) }))
         );
-        void runBackgroundFetch(
+        void runHydration(
           'gateway-channels',
+          ['gatewayChannels'],
           () =>
             client
               .service('gateway-channels')
               .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
-          (list) =>
-            setMaps((prev) => ({
-              ...prev,
-              gatewayChannelById: silent
-                ? buildById(list, 'id')
-                : mergeLiveWins(buildById(list, 'id'), prev.gatewayChannelById),
-            }))
+          (list) => setMaps((prev) => ({ ...prev, gatewayChannelById: buildById(list, 'id') }))
         );
-        void runBackgroundFetch(
+        void runHydration(
           'artifacts',
+          ['artifacts'],
           () =>
             client.service('artifacts').findAll({
               query: {
@@ -837,28 +828,16 @@ export function useAgorData(
                 ],
               },
             }),
-          (list) =>
-            setMaps((prev) => ({
-              ...prev,
-              artifactById: silent
-                ? buildById(list, 'artifact_id')
-                : mergeLiveWins(buildById(list, 'artifact_id'), prev.artifactById),
-            }))
+          (list) => setMaps((prev) => ({ ...prev, artifactById: buildById(list, 'artifact_id') }))
         );
-        void runBackgroundFetch(
+        void runHydration(
           'oauth-status',
+          ['oauth'],
           () => client.service('mcp-servers/oauth-status').find(),
           (res) => {
             const ids =
               (res as { authenticated_server_ids?: string[] })?.authenticated_server_ids ?? [];
-            setMaps((prev) => ({
-              ...prev,
-              // Non-silent: union snapshot with live additions so an OAuth
-              // completion that landed mid-fetch isn't dropped. Silent: replace.
-              userAuthenticatedMcpServerIds: silent
-                ? new Set(ids)
-                : new Set([...ids, ...prev.userAuthenticatedMcpServerIds]),
-            }));
+            setMaps((prev) => ({ ...prev, userAuthenticatedMcpServerIds: new Set(ids) }));
           }
         );
 
@@ -1178,28 +1157,30 @@ export function useAgorData(
         debugTimer?.endIndexing();
         debugFinishStatus = 'success';
 
-        // ── Background full hydration ───────────────────────────────────
+        // ── Background full hydration (skip-apply-on-race) ──────────────
         // First paint is now open with ONLY the recent sessions + the displayed
         // board's branches/sessions/objects/cards/comments. Pull the FULL sets so
         // per-board counts, the board switcher, GlobalSearch, the branch-list
         // drawer, facepiles and session genealogy (which can span boards) see
         // everything a beat later.
         //
-        // Clobber-safety: this runs WHILE the app is interactive, so a realtime
-        // create/patch/remove can land during a global fetch. `runBackgroundFetch`
-        // refetches if `liveWriteRevisionRef` changed mid-flight; each apply then
-        // MERGES the live entries on top of the snapshot (live wins, so an
-        // in-flight create/patch is never reverted) AND drops ids tombstoned
-        // during the fetch window (`removedDuringWindow`, so an in-flight
-        // remove/archive isn't resurrected by a snapshot taken before it).
+        // Correctness: this runs WHILE the app is interactive, so a realtime
+        // create/patch/remove can land during a global fetch. `runHydration`
+        // applies the fetched snapshot WHOLESALE only when no live write to the
+        // listed collection(s) raced the fetch (revision counters unchanged) —
+        // a wholesale apply of a quiet snapshot can neither clobber a live
+        // create/patch (none happened) nor resurrect a live remove (a remove
+        // would have bumped the counter → no apply). If a write raced, the
+        // snapshot is discarded and refetched; we never overlay a racy snapshot.
 
         // Sessions + branches: now ALWAYS bounded at first paint (recent-N /
         // board-scoped), so hydrate them on every non-silent load (silent
         // reconnect already fetched them full above). repos / users / boards /
         // card-types stay global at first paint, so they need no top-up.
         if (!silent) {
-          void runBackgroundFetch(
-            'sessions+branches hydration',
+          void runHydration(
+            'sessions+branches',
+            ['sessions', 'branches'],
             () =>
               Promise.all([
                 client.service('sessions').findAll({
@@ -1213,49 +1194,28 @@ export function useAgorData(
                   .service('branches')
                   .findAll({ query: { archived: false, $limit: PAGINATION.DEFAULT_LIMIT } }),
               ]),
-            ([allSessions, allBranches], removedDuringWindow) =>
+            ([allSessions, allBranches]) =>
               setMaps((prev) => {
-                // Branches first (the session pass below checks branch presence):
-                // drop ids tombstoned during the window from the snapshot, then
-                // live-wins overlay so an unarchive/recreate that landed mid-fetch
-                // (present in `prev`) is restored even though it's filtered here.
-                const branchSnapshot = buildById(
-                  allBranches.filter((branch) => !removedDuringWindow.has(branch.branch_id)),
-                  'branch_id'
-                );
-                const branchById = mergeLiveWins(branchSnapshot, prev.branchById);
+                // Quiet window proven by runHydration → apply wholesale. Branches
+                // are active-only (the snapshot query is archived:false and the
+                // handlers never keep an archived branch), so a wholesale replace
+                // is complete.
+                const branchById = buildById(allBranches, 'branch_id');
 
-                // Sessions: union the snapshot (minus rows tombstoned during the
-                // fetch — remove wins) with the live sessions we already hold
-                // (live wins for create/patch), then rebuild both maps (incl.
-                // remote surrogates) from the union so they stay consistent.
-                const mergedSessions = new Map<string, Session>();
-                for (const session of allSessions) {
-                  if (removedDuringWindow.has(session.session_id)) {
-                    // Branch-eviction tombstones are conditional: if the branch is
-                    // back in `branchById` (unarchived/recreated this window), keep
-                    // the session — it was dropped from `prev` so the live overlay
-                    // can't re-add it. Direct session removes (not tagged) stay
-                    // unconditionally suppressed.
-                    const fromBranchEviction = liveBranchEvictedSessionIdsRef.current.has(
-                      session.session_id
-                    );
-                    if (!fromBranchEviction || !branchById.has(session.branch_id)) continue;
-                  }
-                  mergedSessions.set(session.session_id, session);
-                }
+                // The hydration fetches active sessions only. Deep-link-healed
+                // archived sessions (added to `sessionById` so a direct /s/<id>
+                // archived link can open the drawer) are OUT of that query's
+                // domain — never in branch buckets, so they don't affect board
+                // rendering — so carry them over rather than dropping them. This
+                // is domain-completion, NOT race reconciliation: the race
+                // correctness comes entirely from the quiet-window guarantee.
+                const sessions = new Map<string, Session>();
+                for (const session of allSessions) sessions.set(session.session_id, session);
                 for (const [id, session] of prev.sessionById) {
-                  mergedSessions.set(id, session);
+                  if (session.archived && !sessions.has(id)) sessions.set(id, session);
                 }
-                const { sessionById, sessionsByBranch } = buildSessionMaps([
-                  ...mergedSessions.values(),
-                ]);
-                return {
-                  ...prev,
-                  sessionById,
-                  sessionsByBranch,
-                  branchById,
-                };
+                const { sessionById, sessionsByBranch } = buildSessionMaps([...sessions.values()]);
+                return { ...prev, sessionById, sessionsByBranch, branchById };
               })
           );
         }
@@ -1264,8 +1224,9 @@ export function useAgorData(
         // a board was resolved (`boardScope` set, non-silent only — silent
         // reconnect already refetches everything global). Top up to the global set.
         if (boardScope) {
-          void runBackgroundFetch(
-            'full hydration',
+          void runHydration(
+            'board-objects+cards+comments',
+            ['boardObjects', 'cards', 'comments'],
             () =>
               Promise.all([
                 client
@@ -1276,42 +1237,22 @@ export function useAgorData(
                   .service('board-comments')
                   .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
               ]),
-            ([allBoardObjects, allCards, allComments], removedDuringWindow) =>
+            ([allBoardObjects, allCards, allComments]) =>
               setMaps((prev) => {
-                // Start from the global snapshot, dropping any rows tombstoned
-                // during the fetch window (remove wins — otherwise a board-object/
-                // card/comment removed mid-flight would be resurrected here)…
-                const base = buildBoardObjectMaps(
-                  allBoardObjects.filter((o) => !removedDuringWindow.has(o.object_id))
-                );
-                let next: DataMaps = {
+                // Quiet window proven by runHydration → apply the global snapshot
+                // wholesale. It is a superset of the board-scoped first-paint
+                // slice, so no overlay is needed; nothing live raced, so nothing
+                // is clobbered or resurrected.
+                const base = buildBoardObjectMaps(allBoardObjects);
+                return {
                   ...prev,
                   boardObjectById: base.boardObjectById,
                   boardObjectsByBoardId: base.boardObjectsByBoardId,
                   boardObjectByBranchId: base.boardObjectByBranchId,
                   boardObjectByCardId: base.boardObjectByCardId,
-                  cardById: mergeLiveWins(
-                    buildById(
-                      allCards.filter((c) => !removedDuringWindow.has(c.card_id)),
-                      'card_id'
-                    ),
-                    prev.cardById
-                  ),
-                  commentById: mergeLiveWins(
-                    buildById(
-                      allComments.filter((c) => !removedDuringWindow.has(c.comment_id)),
-                      'comment_id'
-                    ),
-                    prev.commentById
-                  ),
+                  cardById: buildById(allCards, 'card_id'),
+                  commentById: buildById(allComments, 'comment_id'),
                 };
-                // …then overlay every live board-object (current-board first-paint
-                // rows + any realtime edits) so live state wins over the snapshot
-                // across all four derived board-object maps.
-                for (const boardObject of prev.boardObjectById.values()) {
-                  next = upsertBoardObjectInMaps(next, boardObject, 'patch');
-                }
-                return next;
               })
           );
         }
@@ -1382,6 +1323,10 @@ export function useAgorData(
         const directSession = (await client.service('sessions').get(directSessionId)) as Session;
         if (cancelled) return;
 
+        // This is a live write to the sessions maps — bump so a sessions
+        // hydration in flight discards its (session-missing) snapshot rather
+        // than clobbering this deep-link heal.
+        bumpRevision('sessions');
         setSessionById((prev) => {
           if (prev.has(directSession.session_id)) return prev;
           const next = new Map(prev);
@@ -1408,6 +1353,7 @@ export function useAgorData(
               .service('branches')
               .get(directSession.branch_id)) as Branch;
             if (cancelled) return;
+            bumpRevision('branches');
             setBranchById((prev) => {
               if (directBranch.archived) return prev;
               if (prev.has(directBranch.branch_id)) return prev;
@@ -1429,6 +1375,7 @@ export function useAgorData(
       cancelled = true;
     };
   }, [
+    bumpRevision,
     client,
     directSessionId,
     enabled,
@@ -1453,10 +1400,9 @@ export function useAgorData(
     // Subscribe to session events
     const sessionsService = client.service('sessions');
     const handleSessionCreated = (session: Session) => {
-      // Signal liveness so the background sessions+branches hydration refetches
-      // (or live-wins-merges) instead of clobbering this write — same contract
-      // as the board-object/card/comment handlers.
-      liveWriteRevisionRef.current += 1;
+      // Bump the sessions revision so an in-flight sessions hydration discards
+      // its snapshot and refetches instead of clobbering this write.
+      bumpRevision('sessions');
       if (session.archived) return;
 
       // Update sessionById - only create new Map if session doesn't exist
@@ -1479,11 +1425,11 @@ export function useAgorData(
       });
     };
     const handleSessionPatched = (session: Session) => {
-      liveWriteRevisionRef.current += 1;
+      // Patch (incl. archive, which removes the session from the active maps)
+      // counts as a live write — bump so an in-flight sessions hydration can't
+      // clobber it or resurrect an archive with a pre-archive snapshot.
+      bumpRevision('sessions');
       const isArchived = session.archived === true;
-      // Archive is a removal from the active maps — tombstone it so a background
-      // hydration whose snapshot predates the archive can't resurrect it.
-      if (isArchived) liveRemovedIdsRef.current.add(session.session_id);
       // Track old branch_id for migration detection
       let oldBranchId: string | null = null;
 
@@ -1637,8 +1583,7 @@ export function useAgorData(
       });
     };
     const handleSessionRemoved = (session: Session) => {
-      liveWriteRevisionRef.current += 1;
-      liveRemovedIdsRef.current.add(session.session_id);
+      bumpRevision('sessions');
       // Update sessionById — bail out when the id isn't tracked so the
       // wrapper short-circuit prevents the spurious `maps` update.
       setSessionById((prev) => {
@@ -1702,16 +1647,15 @@ export function useAgorData(
     // Subscribe to board object events
     const boardObjectsService = client.service('board-objects');
     const handleBoardObjectCreated = (boardObject: BoardEntityObject) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('boardObjects');
       setMaps((prev) => upsertBoardObjectInMaps(prev, boardObject, 'create'));
     };
     const handleBoardObjectPatched = (boardObject: BoardEntityObject) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('boardObjects');
       setMaps((prev) => upsertBoardObjectInMaps(prev, boardObject, 'patch'));
     };
     const handleBoardObjectRemoved = (boardObject: BoardEntityObject) => {
-      liveWriteRevisionRef.current += 1;
-      liveRemovedIdsRef.current.add(boardObject.object_id);
+      bumpRevision('boardObjects');
       setMaps((prev) => removeBoardObjectFromMaps(prev, boardObject));
     };
 
@@ -1750,9 +1694,9 @@ export function useAgorData(
     // Subscribe to branch events
     const branchesService = client.service('branches');
     const handleBranchCreated = (branch: Branch) => {
-      // Signal liveness for the background sessions+branches hydration (mirrors
-      // the session handlers): refetch / live-wins-merge instead of clobbering.
-      liveWriteRevisionRef.current += 1;
+      // Bump the branches revision so an in-flight branches hydration can't
+      // clobber this write (mirrors the session handlers).
+      bumpRevision('branches');
       if (branch.archived) return;
 
       setBranchById((prev) => {
@@ -1767,10 +1711,11 @@ export function useAgorData(
     // `archived: true` patch path and the hard-delete `removed` path —
     // either way we never want an orphan session card to linger.
     const evictBranchAndSessions = (branchId: string) => {
-      // Tombstone the branch AND every session that lived on it, so a background
-      // sessions/branches hydration whose snapshot predates this eviction can't
-      // resurrect them.
-      liveRemovedIdsRef.current.add(branchId);
+      // This cascade mutates BOTH the branches map (caller already bumped) and
+      // the sessions maps, so bump the sessions revision too — otherwise a
+      // sessions hydration in flight could resurrect the evicted sessions with a
+      // pre-eviction snapshot.
+      bumpRevision('sessions');
       setBranchById((prev) => {
         if (!prev.has(branchId)) return prev;
         const next = new Map(prev);
@@ -1788,10 +1733,6 @@ export function useAgorData(
         const next = new Map(prev);
         for (const [sessionId, session] of prev.entries()) {
           if (session.branch_id === branchId) {
-            liveRemovedIdsRef.current.add(sessionId);
-            // Tag as branch-eviction (not a direct session remove) so hydration
-            // can un-suppress it if the branch comes back during the window.
-            liveBranchEvictedSessionIdsRef.current.add(sessionId);
             next.delete(sessionId);
             changed = true;
           }
@@ -1801,7 +1742,7 @@ export function useAgorData(
     };
 
     const handleBranchPatched = (branch: Branch) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('branches');
       if (branch.archived) {
         evictBranchAndSessions(branch.branch_id);
         return;
@@ -1810,7 +1751,7 @@ export function useAgorData(
       setBranchById((prev) => replaceIfChanged(prev, branch.branch_id, branch));
     };
     const handleBranchRemoved = (branch: Branch) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('branches');
       // Mirror the archive path: a hard delete should also evict any
       // sessions we still track on that branch.
       evictBranchAndSessions(branch.branch_id);
@@ -1851,7 +1792,7 @@ export function useAgorData(
     // Subscribe to MCP server events
     const mcpServersService = client.service('mcp-servers');
     const handleMCPServerCreated = (server: MCPServer) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('mcpServers');
       setMcpServerById((prev) => {
         if (prev.has(server.mcp_server_id)) return prev; // Already exists, shouldn't happen
         const next = new Map(prev);
@@ -1860,11 +1801,11 @@ export function useAgorData(
       });
     };
     const handleMCPServerPatched = (server: MCPServer) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('mcpServers');
       setMcpServerById((prev) => replaceIfChanged(prev, server.mcp_server_id, server));
     };
     const handleMCPServerRemoved = (server: MCPServer) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('mcpServers');
       setMcpServerById((prev) => {
         if (!prev.has(server.mcp_server_id)) return prev; // Doesn't exist, nothing to remove
         const next = new Map(prev);
@@ -1881,7 +1822,7 @@ export function useAgorData(
     // Subscribe to gateway channel events
     const gatewayChannelsService = client.service('gateway-channels');
     const handleGatewayChannelCreated = (channel: GatewayChannel) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('gatewayChannels');
       setGatewayChannelById((prev) => {
         if (prev.has(channel.id)) return prev;
         const next = new Map(prev);
@@ -1890,11 +1831,11 @@ export function useAgorData(
       });
     };
     const handleGatewayChannelPatched = (channel: GatewayChannel) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('gatewayChannels');
       setGatewayChannelById((prev) => replaceIfChanged(prev, channel.id, channel));
     };
     const handleGatewayChannelRemoved = (channel: GatewayChannel) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('gatewayChannels');
       setGatewayChannelById((prev) => {
         if (!prev.has(channel.id)) return prev;
         const next = new Map(prev);
@@ -1911,7 +1852,7 @@ export function useAgorData(
     // Subscribe to card events
     const cardsService = client.service('cards');
     const handleCardCreated = (card: CardWithType) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('cards');
       setCardById((prev) => {
         if (prev.has(card.card_id)) return prev; // Duplicate event — bail.
         const next = new Map(prev);
@@ -1920,12 +1861,11 @@ export function useAgorData(
       });
     };
     const handleCardPatched = (card: CardWithType) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('cards');
       setCardById((prev) => replaceIfChanged(prev, card.card_id, card));
     };
     const handleCardRemoved = (card: CardWithType) => {
-      liveWriteRevisionRef.current += 1;
-      liveRemovedIdsRef.current.add(card.card_id);
+      bumpRevision('cards');
       setCardById((prev) => {
         if (!prev.has(card.card_id)) return prev;
         const next = new Map(prev);
@@ -1969,7 +1909,7 @@ export function useAgorData(
     // Subscribe to artifact events
     const artifactsService = client.service('artifacts');
     const handleArtifactCreated = (artifact: Artifact) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('artifacts');
       setArtifactById((prev) => {
         if (prev.has(artifact.artifact_id)) return prev;
         const next = new Map(prev);
@@ -1978,7 +1918,7 @@ export function useAgorData(
       });
     };
     const handleArtifactPatched = (artifact: Artifact) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('artifacts');
       setArtifactById((prev) => replaceIfChanged(prev, artifact.artifact_id, artifact));
       // Notify ArtifactNode components that payload may have changed. The
       // consumer (apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx)
@@ -1993,7 +1933,7 @@ export function useAgorData(
       );
     };
     const handleArtifactRemoved = (artifact: Artifact) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('artifacts');
       setArtifactById((prev) => {
         if (!prev.has(artifact.artifact_id)) return prev;
         const next = new Map(prev);
@@ -2028,7 +1968,7 @@ export function useAgorData(
       session_id: string;
       mcp_server_id: string;
     }) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('sessionMcp');
       setSessionMcpServerIds((prev) => {
         const sessionMcpIds = prev.get(relationship.session_id) || [];
         // Check if relationship already exists (duplicate event)
@@ -2043,7 +1983,7 @@ export function useAgorData(
       session_id: string;
       mcp_server_id: string;
     }) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('sessionMcp');
       setSessionMcpServerIds((prev) => {
         const sessionMcpIds = prev.get(relationship.session_id) || [];
         const filtered = sessionMcpIds.filter((id) => id !== relationship.mcp_server_id);
@@ -2068,7 +2008,7 @@ export function useAgorData(
     // Subscribe to board comment events
     const commentsService = client.service('board-comments');
     const handleCommentCreated = (comment: BoardComment) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('comments');
       setCommentById((prev) => {
         if (prev.has(comment.comment_id)) return prev; // Already exists, shouldn't happen
         const next = new Map(prev);
@@ -2077,12 +2017,11 @@ export function useAgorData(
       });
     };
     const handleCommentPatched = (comment: BoardComment) => {
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('comments');
       setCommentById((prev) => replaceIfChanged(prev, comment.comment_id, comment));
     };
     const handleCommentRemoved = (comment: BoardComment) => {
-      liveWriteRevisionRef.current += 1;
-      liveRemovedIdsRef.current.add(comment.comment_id);
+      bumpRevision('comments');
       setCommentById((prev) => {
         if (!prev.has(comment.comment_id)) return prev; // Doesn't exist, nothing to remove
         const next = new Map(prev);
@@ -2110,7 +2049,7 @@ export function useAgorData(
       oauth_mode?: string;
     }) => {
       if (!event.success || !event.mcp_server_id) return;
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('oauth');
       const mode = event.oauth_mode || 'per_user';
       if (mode === 'per_user') {
         setUserAuthenticatedMcpServerIds((prev) => {
@@ -2130,6 +2069,7 @@ export function useAgorData(
       // `apps/agor-daemon/src/register-hooks.ts`), so a single `get` is enough.
       try {
         const fresh = (await client.service('mcp-servers').get(event.mcp_server_id)) as MCPServer;
+        bumpRevision('mcpServers');
         setMcpServerById((prev) => replaceIfChanged(prev, fresh.mcp_server_id, fresh));
       } catch (err) {
         console.warn('[OAuth] Failed to refetch MCP server after re-auth:', err);
@@ -2143,7 +2083,8 @@ export function useAgorData(
     // reload.
     const handleOAuthDisconnected = async (event: { mcp_server_id: string }) => {
       if (!event.mcp_server_id) return;
-      liveWriteRevisionRef.current += 1;
+      bumpRevision('oauth');
+      bumpRevision('mcpServers');
       setUserAuthenticatedMcpServerIds((prev) => {
         if (!prev.has(event.mcp_server_id)) return prev;
         const next = new Set(prev);
@@ -2224,8 +2165,8 @@ export function useAgorData(
     // Initial fetch (only once — WebSocket events keep us synced after that).
     // Kicked off AFTER every `.on()` above is attached so realtime
     // created/patched/removed events that fire while fetchData's requests are
-    // in flight are captured (and bump liveWriteRevisionRef) instead of being
-    // dropped in the gap between fetch-start and listener-attach.
+    // in flight are captured (and bump the per-collection revision counters)
+    // instead of being dropped in the gap between fetch-start and listener-attach.
     if (!hasInitiallyFetched) {
       fetchData().then(() => setHasInitiallyFetched(true));
     }

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -62,6 +62,15 @@ export type InitialLoadItemKey = (typeof INITIAL_LOAD_ITEMS)[number]['key'];
 // race window is one fetch RTT and a startup write storm is rare.
 const MAX_BACKGROUND_REFETCH = 3;
 
+// First-paint bound for the global (non-board-scoped) sessions slice. Covers
+// Home's "My Sessions" + "Team activity" feeds (both show only recent items)
+// and seeds enough of `sessionById` to resolve `/s/<id>` deep links. The FULL
+// session set is background-hydrated a beat later (see `fetchData`), so
+// genealogy / GlobalSearch / per-board counts converge without blocking the
+// gate. Sessions are the unbounded-with-activity collection, so this is the
+// single most important cap for first-paint latency on a busy workspace.
+const RECENT_SESSIONS_LIMIT = 50;
+
 // One row in the loading checklist. `count` is captured atomically with
 // `done` when each tracked fetch resolves — readers never see a green row
 // with a stale 0.
@@ -209,6 +218,55 @@ function buildBoardObjectMaps(list: readonly BoardEntityObject[]): {
   return { boardObjectById, boardObjectsByBoardId, boardObjectByBranchId, boardObjectByCardId };
 }
 
+// Build the session lookups (`sessionById` + branch-bucketed `sessionsByBranch`)
+// from a flat session list. Shared by the bounded first-paint build and the
+// background full-hydration pass so the two can't diverge. Mirrors the realtime
+// handlers: archived sessions stay in `sessionById` (so a direct archived-link
+// can open the drawer) but are kept OUT of the branch buckets (so they never
+// reappear as branch/board cards). Cross-branch remote-created sessions are
+// projected as muted surrogate children under the creating session's branch.
+function buildSessionMaps(sessionsList: readonly Session[]): {
+  sessionById: Map<string, Session>;
+  sessionsByBranch: Map<string, Session[]>;
+} {
+  const sessionsById = new Map<string, Session>();
+  const sessionsByBranchId = new Map<string, Session[]>();
+
+  for (const session of sessionsList) {
+    sessionsById.set(session.session_id, session);
+    if (session.archived) continue;
+    const branchId = session.branch_id;
+    if (!sessionsByBranchId.has(branchId)) sessionsByBranchId.set(branchId, []);
+    sessionsByBranchId.get(branchId)!.push(session);
+  }
+
+  for (const sourceSession of sessionsList) {
+    if (sourceSession.archived) continue;
+    for (const relationship of sourceSession.remote_relationships?.as_source ?? []) {
+      if (relationship.relationship_type !== 'remote_create') continue;
+
+      const targetSession = sessionsById.get(relationship.target_session_id);
+      if (!targetSession) continue;
+
+      const sourceBranchSessions = sessionsByBranchId.get(sourceSession.branch_id) ?? [];
+      if (sourceBranchSessions.some((session) => session.session_id === targetSession.session_id)) {
+        continue;
+      }
+
+      const remoteSurrogate = createRemoteSurrogateSession(
+        sourceSession,
+        targetSession,
+        relationship
+      );
+      if (!remoteSurrogate) continue;
+
+      sessionsByBranchId.set(sourceSession.branch_id, [...sourceBranchSessions, remoteSurrogate]);
+    }
+  }
+
+  return { sessionById: sessionsById, sessionsByBranch: sessionsByBranchId };
+}
+
 // Parse the leading entity segment out of the current pathname, e.g.
 // `/ui/b/my-board/` → { kind: 'board', token: 'my-board' }. The regex is
 // built from ENTITY_PATH_SEGMENTS so it stays in lockstep with the route
@@ -246,7 +304,10 @@ function resolveDisplayedBoardId(
   pathname: string,
   boardById: Map<string, { board_id: string; slug?: string }>,
   branchById: Map<string, { branch_id: string; board_id?: string | null }>,
-  sessionById: Map<string, { session_id: string; branch_id?: string }>
+  sessionById: Map<
+    string,
+    { session_id: string; branch_id?: string; branch_board_id?: string | null }
+  >
 ): string | null {
   const parsed = parseEntityPath(pathname);
   if (!parsed) return null;
@@ -257,7 +318,15 @@ function resolveDisplayedBoardId(
     case 'session': {
       const sessionId = resolveSessionFromShortIdPure(parsed.token, sessionById);
       if (!sessionId) return null;
-      const branchId = sessionById.get(sessionId)?.branch_id;
+      const session = sessionById.get(sessionId);
+      if (!session) return null;
+      // Prefer the board id carried on the session itself (`branch_board_id`,
+      // populated from the branch join server-side). First-paint only holds a
+      // bounded `branchById`, so the session's branch may not be present yet —
+      // but the session row always knows its board. Fall back to the branch
+      // lookup for older payloads that predate the field.
+      if (session.branch_board_id) return session.branch_board_id;
+      const branchId = session.branch_id;
       return branchId ? (branchById.get(branchId)?.board_id ?? null) : null;
     }
     case 'branch': {
@@ -756,51 +825,55 @@ export function useAgorData(
         );
 
         // ── Essential gated fetches — LIGHT batch ───────────────────────
-        // Lightweight global collections needed to (a) paint branch cards and
-        // (b) resolve which board the URL targets. Awaited first so we can pick
-        // the first-paint board scope BEFORE issuing the heavy fetches below.
+        // Tiny global collections (boards / users / repos / card-types stay
+        // global — bounded and small) plus a BOUNDED recent slice of sessions.
+        // Awaited first so we can resolve the first-paint board scope BEFORE the
+        // board-scoped heavy batch. Sessions and branches are the two that scale
+        // (sessions unbounded with activity; hundreds of branches on a real
+        // workspace), so they are NOT fetched in full here: sessions are capped
+        // at recent-N, branches are deferred to the board-scoped heavy batch, and
+        // BOTH full sets are background-hydrated after the gate opens.
         debugTimer?.startFetchPhase();
-        const [sessionsList, boardsList, cardTypesList, reposList, branchesList, usersList] =
-          await Promise.all([
-            track(
-              'sessions',
-              client.service('sessions').findAll({
-                query: {
-                  archived: false,
-                  $limit: PAGINATION.DEFAULT_LIMIT,
-                  $sort: { updated_at: -1 },
-                },
-              })
-            ),
-            track(
-              'boards',
-              client.service('boards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
-            ),
-            track(
-              'card-types',
-              client.service('card-types').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
-            ),
-            track(
-              'repos',
-              client.service('repos').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
-            ),
-            track(
-              'branches',
-              client
-                .service('branches')
-                .findAll({ query: { archived: false, $limit: PAGINATION.DEFAULT_LIMIT } })
-            ),
-            track(
-              'users',
-              client.service('users').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
-            ),
-          ]);
+        const [sessionsList, boardsList, cardTypesList, reposList, usersList] = await Promise.all([
+          track(
+            'sessions',
+            client.service('sessions').findAll({
+              query: silent
+                ? // Reconnect resyncs must fully repopulate every board, so they
+                  // stay GLOBAL/full (mirrors the heavy + hydration paths below).
+                  { archived: false, $limit: PAGINATION.DEFAULT_LIMIT, $sort: { updated_at: -1 } }
+                : { archived: false, $limit: RECENT_SESSIONS_LIMIT, $sort: { updated_at: -1 } },
+            })
+          ),
+          track(
+            'boards',
+            client.service('boards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
+          ),
+          track(
+            'card-types',
+            client.service('card-types').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
+          ),
+          track(
+            'repos',
+            client.service('repos').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
+          ),
+          track(
+            'users',
+            client.service('users').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } })
+          ),
+        ]);
+
+        // Branches healed into first paint by a direct deep link — the URL
+        // session's branch, or a `/w/<id>` branch link. They seed `branchById`
+        // ahead of the board-scoped branch fetch so the displayed board can be
+        // resolved and its target card paints immediately.
+        const healedBranches: Branch[] = [];
 
         // Direct /s/<id>/ opens should work for archived sessions without broadening
-        // the default active-session list. If the active query missed the URL target,
-        // fetch just that session by ID/short ID. Its branch is only hydrated when
-        // it is still active; adding archived branches to `branchById` would make
-        // board-object joins render archived cards back onto active boards.
+        // the recent-session slice. If it missed the URL target, fetch just that
+        // session by ID/short ID. Its branch is only hydrated when it is still
+        // active; adding archived branches to `branchById` would make board-object
+        // joins render archived cards back onto active boards.
         if (
           directSessionId &&
           !hasIdMatchingPrefix(directSessionId, sessionsList, (s) => s.session_id)
@@ -812,17 +885,13 @@ export function useAgorData(
             if (!sessionsList.some((s) => s.session_id === directSession.session_id)) {
               sessionsList.push(directSession);
             }
-            if (
-              !directSession.archived &&
-              directSession.branch_id &&
-              !branchesList.some((branch) => branch.branch_id === directSession.branch_id)
-            ) {
+            if (!directSession.archived && directSession.branch_id) {
               try {
                 const directBranch = (await client
                   .service('branches')
                   .get(directSession.branch_id)) as Branch;
                 if (!directBranch.archived) {
-                  branchesList.push(directBranch);
+                  healedBranches.push(directBranch);
                 }
               } catch {
                 // The session can still open; it just won't be able to switch/recenter
@@ -834,75 +903,42 @@ export function useAgorData(
           }
         }
 
-        // Build session Maps for efficient lookups
-        const sessionsById = new Map<string, Session>();
-        const sessionsByBranchId = new Map<string, Session[]>();
+        // The board the app will ACTUALLY display, resolved from the current URL
+        // with the same slug/short-id resolvers `useUrlState` uses (NOT
+        // localStorage — the displayed board can differ from the stored one, e.g.
+        // a `/b/<other>/` deep link). undefined → GLOBAL (unscoped) first paint,
+        // always correct: Home, `/a/` artifact links, or any unresolvable target.
+        // Silent reconnect refetches always go GLOBAL so they fully resync.
+        const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
 
-        for (const session of sessionsList) {
-          // sessionById: O(1) ID lookups
-          sessionsById.set(session.session_id, session);
-
-          // sessionsByBranch: O(1) branch-scoped filtering. Keep this as the
-          // active board/session list: a direct archived-session URL may add
-          // the archived session to sessionById so the drawer can open, but it
-          // must not reappear in branch cards or board assistants.
-          if (session.archived) continue;
-          const branchId = session.branch_id;
-          if (!sessionsByBranchId.has(branchId)) {
-            sessionsByBranchId.set(branchId, []);
-          }
-          sessionsByBranchId.get(branchId)!.push(session);
-        }
-
-        // Cross-branch remote-created sessions are canonical in their target
-        // branch, but should also appear as muted/surrogate children under
-        // the creating session's branch for track-record and navigation.
-        //
-        // Keep this as a UI projection only: the cloned session preserves the
-        // real session_id (so clicks open the real remote session) while using
-        // the source branch + source session as its local tree placement.
-        for (const sourceSession of sessionsList) {
-          if (sourceSession.archived) continue;
-
-          for (const relationship of sourceSession.remote_relationships?.as_source ?? []) {
-            if (relationship.relationship_type !== 'remote_create') continue;
-
-            const targetSession = sessionsById.get(relationship.target_session_id);
-            if (!targetSession) continue;
-
-            const sourceBranchSessions = sessionsByBranchId.get(sourceSession.branch_id) ?? [];
-            if (
-              sourceBranchSessions.some(
-                (session) => session.session_id === targetSession.session_id
-              )
-            ) {
-              continue;
+        // Direct /w/<id>/ branch opens: heal that branch so the board chains
+        // through it (branch → board_id). Sessions carry `branch_board_id` so
+        // session links resolve without this, but a branch link has nothing else
+        // to chain from until the board-scoped branch fetch (which needs the board
+        // we're trying to resolve — hence the targeted get here).
+        if (!silent) {
+          const parsedPath = parseEntityPath(pathname);
+          if (
+            parsedPath?.kind === 'branch' &&
+            !hasIdMatchingPrefix(parsedPath.token, healedBranches, (b) => b.branch_id)
+          ) {
+            try {
+              const directBranch = (await client
+                .service('branches')
+                .get(parsedPath.token)) as Branch;
+              if (!directBranch.archived) healedBranches.push(directBranch);
+            } catch {
+              // Unresolvable branch link → fall back to a GLOBAL first paint.
             }
-
-            const remoteSurrogate = createRemoteSurrogateSession(
-              sourceSession,
-              targetSession,
-              relationship
-            );
-            if (!remoteSurrogate) continue;
-
-            sessionsByBranchId.set(sourceSession.branch_id, [
-              ...sourceBranchSessions,
-              remoteSurrogate,
-            ]);
           }
         }
 
-        // Build board / branch / repo / user / card-type Maps (the light global
-        // collections). Built before the heavy batch so we can resolve the URL
-        // target board.
+        // Build the light global Maps + interim session/branch lookups used to
+        // resolve the board scope. `interimBranchById` holds only healed branches;
+        // the board-scoped set lands in the heavy batch below.
         const boardsMap = new Map<string, Board>();
         for (const board of boardsList) {
           boardsMap.set(board.board_id, board);
-        }
-        const branchesMap = new Map<string, Branch>();
-        for (const branch of branchesList) {
-          branchesMap.set(branch.branch_id, branch);
         }
         const cardTypesMap = new Map<string, CardType>();
         for (const cardType of cardTypesList) {
@@ -917,54 +953,83 @@ export function useAgorData(
           usersMap.set(user.user_id, user);
         }
 
-        // ── First-paint board scope (URL-resolved) ──────────────────────
-        // Scope the heavy collections to the board the app will ACTUALLY
-        // display, resolved from the current URL with the same slug/short-id
-        // resolvers `useUrlState` uses (NOT localStorage — the displayed board
-        // can differ from the stored one, e.g. a `/b/<other>/` deep link).
-        // Returns undefined → GLOBAL (unscoped) first paint, always correct:
-        // Home, `/a/` artifact links, or any unresolvable target. Silent
-        // reconnect refetches always go GLOBAL so they fully resync every board.
-        const pathname = typeof window !== 'undefined' ? window.location.pathname : '';
+        const interimBranchById = new Map<string, Branch>();
+        for (const branch of healedBranches) {
+          interimBranchById.set(branch.branch_id, branch);
+        }
+        const interimSessionById = buildSessionMaps(sessionsList).sessionById;
+
         const boardScope = silent
           ? undefined
-          : (resolveDisplayedBoardId(pathname, boardsMap, branchesMap, sessionsById) ?? undefined);
+          : (resolveDisplayedBoardId(pathname, boardsMap, interimBranchById, interimSessionById) ??
+            undefined);
 
-        // ── Essential gated fetches — HEAVY batch ───────────────────────
-        // The heavy collections, scoped to the first-paint board when resolved
-        // (board-objects / board-comments push board_id to SQL; cards filter it
+        // ── Essential gated fetches — HEAVY + board-scoped batch ────────
+        // Scoped to the first-paint board when resolved (board_id pushes to SQL
+        // for sessions / board-objects / board-comments; cards filter it
         // server-side). On a real workspace this trims thousands of rows to one
-        // board's. Awaited as part of the gate so the displayed board paints
-        // fully; the background hydration below then fills every other board.
-        const [boardObjectsList, commentsList, cardsList] = await Promise.all([
-          track(
-            'board-objects',
-            client.service('board-objects').findAll({
-              query: {
-                $limit: PAGINATION.DEFAULT_LIMIT,
-                ...(boardScope ? { board_id: boardScope } : {}),
-              },
-            })
-          ),
-          track(
-            'board-comments',
-            client.service('board-comments').findAll({
-              query: {
-                $limit: PAGINATION.DEFAULT_LIMIT,
-                ...(boardScope ? { board_id: boardScope } : {}),
-              },
-            })
-          ),
-          track(
-            'cards',
-            client.service('cards').findAll({
-              query: {
-                $limit: PAGINATION.DEFAULT_LIMIT,
-                ...(boardScope ? { board_id: boardScope } : {}),
-              },
-            })
-          ),
-        ]);
+        // board's. Silent reconnect (boardScope undefined) fetches branches
+        // GLOBAL/full to resync; sessions were already fetched full in the silent
+        // light batch above, so the extra board-session fetch is skipped there.
+        const [branchesList, boardSessionsList, boardObjectsList, commentsList, cardsList] =
+          await Promise.all([
+            track(
+              'branches',
+              silent
+                ? client.service('branches').findAll({
+                    query: { archived: false, $limit: PAGINATION.DEFAULT_LIMIT },
+                  })
+                : boardScope
+                  ? client.service('branches').findAll({
+                      query: {
+                        archived: false,
+                        board_id: boardScope,
+                        $limit: PAGINATION.DEFAULT_LIMIT,
+                      },
+                    })
+                  : Promise.resolve([] as Branch[])
+            ),
+            // Board-scoped sessions: only when a board is displayed and we didn't
+            // already fetch the full set (silent path). Merged with the recent
+            // slice below. Not tracked — not part of the loading checklist.
+            !silent && boardScope
+              ? client.service('sessions').findAll({
+                  query: {
+                    archived: false,
+                    board_id: boardScope,
+                    $limit: PAGINATION.DEFAULT_LIMIT,
+                    $sort: { updated_at: -1 },
+                  },
+                })
+              : Promise.resolve([] as Session[]),
+            track(
+              'board-objects',
+              client.service('board-objects').findAll({
+                query: {
+                  $limit: PAGINATION.DEFAULT_LIMIT,
+                  ...(boardScope ? { board_id: boardScope } : {}),
+                },
+              })
+            ),
+            track(
+              'board-comments',
+              client.service('board-comments').findAll({
+                query: {
+                  $limit: PAGINATION.DEFAULT_LIMIT,
+                  ...(boardScope ? { board_id: boardScope } : {}),
+                },
+              })
+            ),
+            track(
+              'cards',
+              client.service('cards').findAll({
+                query: {
+                  $limit: PAGINATION.DEFAULT_LIMIT,
+                  ...(boardScope ? { board_id: boardScope } : {}),
+                },
+              })
+            ),
+          ]);
         debugTimer?.endFetchPhase();
 
         if (!silent) {
@@ -1005,6 +1070,33 @@ export function useAgorData(
           cardsMap.set(card.card_id, card);
         }
 
+        // Merge the recent session slice with the board-scoped sessions (dedup by
+        // id) for first paint, then build both session lookups (incl. remote
+        // surrogates). The FULL session set is background-hydrated below.
+        const firstPaintSessions = new Map<string, Session>();
+        for (const session of sessionsList) {
+          firstPaintSessions.set(session.session_id, session);
+        }
+        for (const session of boardSessionsList) {
+          if (!firstPaintSessions.has(session.session_id)) {
+            firstPaintSessions.set(session.session_id, session);
+          }
+        }
+        const { sessionById: sessionsById, sessionsByBranch: sessionsByBranchId } =
+          buildSessionMaps([...firstPaintSessions.values()]);
+
+        // Branch map for first paint: the board-scoped (or silent-global) set,
+        // plus any deep-link-healed branches. The FULL set is hydrated below.
+        const branchesMap = new Map<string, Branch>();
+        for (const branch of branchesList) {
+          branchesMap.set(branch.branch_id, branch);
+        }
+        for (const branch of healedBranches) {
+          if (!branchesMap.has(branch.branch_id)) {
+            branchesMap.set(branch.branch_id, branch);
+          }
+        }
+
         // Merge the essential slices in one atomic update. We spread `prev`
         // (rather than replacing the whole object) so the BACKGROUND-managed
         // slices — mcpServerById / gatewayChannelById / artifactById /
@@ -1031,21 +1123,69 @@ export function useAgorData(
         debugFinishStatus = 'success';
 
         // ── Background full hydration ───────────────────────────────────
-        // First paint is now open with ONLY the current board's heavy
-        // collections. Pull the global set so cross-board nav, GlobalSearch,
-        // BoardSwitcher, branch-list drawer, facepiles and session genealogy
-        // see every board's objects/cards/comments.
+        // First paint is now open with ONLY the recent sessions + the displayed
+        // board's branches/sessions/objects/cards/comments. Pull the FULL sets so
+        // per-board counts, the board switcher, GlobalSearch, the branch-list
+        // drawer, facepiles and session genealogy (which can span boards) see
+        // everything a beat later.
         //
         // Clobber-safety: this runs WHILE the app is interactive, so a realtime
-        // create/patch/remove can land during the global fetch. `runBackgroundFetch`
-        // refetches if `liveWriteRevisionRef` changed mid-flight, and the apply
-        // below MERGES the live slices on top of the global snapshot (live wins)
-        // so an in-flight edit (e.g. a card the user just moved) is never reverted
-        // by the snapshot. Removes are covered by the refetch (the fresh snapshot
-        // omits them). Sessions/branches/repos/users/boards/card-types are already
-        // global above, so only the board-scoped collections need topping up.
-        // Only runs when first paint was actually scoped (`boardScope` set), which
-        // is non-silent only — silent reconnect already refetches everything global.
+        // create/patch/remove can land during a global fetch. `runBackgroundFetch`
+        // refetches if `liveWriteRevisionRef` changed mid-flight, and each apply
+        // MERGES the live entries on top of the snapshot (live wins) so an
+        // in-flight edit is never reverted by the snapshot. Removes are covered by
+        // the refetch (the fresh snapshot omits them).
+
+        // Sessions + branches: now ALWAYS bounded at first paint (recent-N /
+        // board-scoped), so hydrate them on every non-silent load (silent
+        // reconnect already fetched them full above). repos / users / boards /
+        // card-types stay global at first paint, so they need no top-up.
+        if (!silent) {
+          void runBackgroundFetch(
+            'sessions+branches hydration',
+            () =>
+              Promise.all([
+                client.service('sessions').findAll({
+                  query: {
+                    archived: false,
+                    $limit: PAGINATION.DEFAULT_LIMIT,
+                    $sort: { updated_at: -1 },
+                  },
+                }),
+                client
+                  .service('branches')
+                  .findAll({ query: { archived: false, $limit: PAGINATION.DEFAULT_LIMIT } }),
+              ]),
+            ([allSessions, allBranches]) =>
+              setMaps((prev) => {
+                // Sessions: union the full snapshot with the live sessions we
+                // already hold (live wins) so an in-flight create/patch isn't
+                // reverted, then rebuild both maps (incl. remote surrogates) from
+                // the union so they stay internally consistent.
+                const mergedSessions = new Map<string, Session>();
+                for (const session of allSessions) {
+                  mergedSessions.set(session.session_id, session);
+                }
+                for (const [id, session] of prev.sessionById) {
+                  mergedSessions.set(id, session);
+                }
+                const { sessionById, sessionsByBranch } = buildSessionMaps([
+                  ...mergedSessions.values(),
+                ]);
+                return {
+                  ...prev,
+                  sessionById,
+                  sessionsByBranch,
+                  // Branches: live-wins overlay of the full snapshot.
+                  branchById: mergeLiveWins(buildById(allBranches, 'branch_id'), prev.branchById),
+                };
+              })
+          );
+        }
+
+        // Board objects / cards / comments: only board-scoped at first paint when
+        // a board was resolved (`boardScope` set, non-silent only — silent
+        // reconnect already refetches everything global). Top up to the global set.
         if (boardScope) {
           void runBackgroundFetch(
             'full hydration',
@@ -1223,6 +1363,10 @@ export function useAgorData(
     // Subscribe to session events
     const sessionsService = client.service('sessions');
     const handleSessionCreated = (session: Session) => {
+      // Signal liveness so the background sessions+branches hydration refetches
+      // (or live-wins-merges) instead of clobbering this write — same contract
+      // as the board-object/card/comment handlers.
+      liveWriteRevisionRef.current += 1;
       if (session.archived) return;
 
       // Update sessionById - only create new Map if session doesn't exist
@@ -1245,6 +1389,7 @@ export function useAgorData(
       });
     };
     const handleSessionPatched = (session: Session) => {
+      liveWriteRevisionRef.current += 1;
       const isArchived = session.archived === true;
       // Track old branch_id for migration detection
       let oldBranchId: string | null = null;
@@ -1399,6 +1544,7 @@ export function useAgorData(
       });
     };
     const handleSessionRemoved = (session: Session) => {
+      liveWriteRevisionRef.current += 1;
       // Update sessionById — bail out when the id isn't tracked so the
       // wrapper short-circuit prevents the spurious `maps` update.
       setSessionById((prev) => {
@@ -1509,6 +1655,9 @@ export function useAgorData(
     // Subscribe to branch events
     const branchesService = client.service('branches');
     const handleBranchCreated = (branch: Branch) => {
+      // Signal liveness for the background sessions+branches hydration (mirrors
+      // the session handlers): refetch / live-wins-merge instead of clobbering.
+      liveWriteRevisionRef.current += 1;
       if (branch.archived) return;
 
       setBranchById((prev) => {
@@ -1549,6 +1698,7 @@ export function useAgorData(
     };
 
     const handleBranchPatched = (branch: Branch) => {
+      liveWriteRevisionRef.current += 1;
       if (branch.archived) {
         evictBranchAndSessions(branch.branch_id);
         return;
@@ -1557,6 +1707,7 @@ export function useAgorData(
       setBranchById((prev) => replaceIfChanged(prev, branch.branch_id, branch));
     };
     const handleBranchRemoved = (branch: Branch) => {
+      liveWriteRevisionRef.current += 1;
       // Mirror the archive path: a hard delete should also evict any
       // sessions we still track on that branch.
       evictBranchAndSessions(branch.branch_id);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -640,6 +640,16 @@ export function useAgorData(
   // touched by async fetch code + event handlers.
   const liveRemovedIdsRef = useRef<Set<string>>(new Set());
 
+  // Subset of `liveRemovedIdsRef`: session IDs tombstoned because their BRANCH
+  // was evicted (archived/removed), not because the session itself was removed.
+  // The sessions+branches hydration suppresses these only while the branch is
+  // STILL gone at apply time — if the branch is unarchived/recreated during the
+  // same hydration window it's overlaid back from `prev`, but its child sessions
+  // were dropped from `prev`, so we must keep them from the snapshot rather than
+  // suppress them. Direct session removes are NOT added here, so they stay
+  // unconditionally suppressed.
+  const liveBranchEvictedSessionIdsRef = useRef<Set<string>>(new Set());
+
   // Fetch all data
   //
   // `silent: true` is used by background refetches (e.g. socket reconnect) that
@@ -1205,13 +1215,33 @@ export function useAgorData(
               ]),
             ([allSessions, allBranches], removedDuringWindow) =>
               setMaps((prev) => {
-                // Sessions: union the full snapshot (minus rows tombstoned during
-                // the fetch — remove wins) with the live sessions we already hold
+                // Branches first (the session pass below checks branch presence):
+                // drop ids tombstoned during the window from the snapshot, then
+                // live-wins overlay so an unarchive/recreate that landed mid-fetch
+                // (present in `prev`) is restored even though it's filtered here.
+                const branchSnapshot = buildById(
+                  allBranches.filter((branch) => !removedDuringWindow.has(branch.branch_id)),
+                  'branch_id'
+                );
+                const branchById = mergeLiveWins(branchSnapshot, prev.branchById);
+
+                // Sessions: union the snapshot (minus rows tombstoned during the
+                // fetch — remove wins) with the live sessions we already hold
                 // (live wins for create/patch), then rebuild both maps (incl.
                 // remote surrogates) from the union so they stay consistent.
                 const mergedSessions = new Map<string, Session>();
                 for (const session of allSessions) {
-                  if (removedDuringWindow.has(session.session_id)) continue;
+                  if (removedDuringWindow.has(session.session_id)) {
+                    // Branch-eviction tombstones are conditional: if the branch is
+                    // back in `branchById` (unarchived/recreated this window), keep
+                    // the session — it was dropped from `prev` so the live overlay
+                    // can't re-add it. Direct session removes (not tagged) stay
+                    // unconditionally suppressed.
+                    const fromBranchEviction = liveBranchEvictedSessionIdsRef.current.has(
+                      session.session_id
+                    );
+                    if (!fromBranchEviction || !branchById.has(session.branch_id)) continue;
+                  }
                   mergedSessions.set(session.session_id, session);
                 }
                 for (const [id, session] of prev.sessionById) {
@@ -1220,16 +1250,11 @@ export function useAgorData(
                 const { sessionById, sessionsByBranch } = buildSessionMaps([
                   ...mergedSessions.values(),
                 ]);
-                // Branches: drop tombstoned ids from the snapshot, then live-wins overlay.
-                const branchSnapshot = buildById(
-                  allBranches.filter((branch) => !removedDuringWindow.has(branch.branch_id)),
-                  'branch_id'
-                );
                 return {
                   ...prev,
                   sessionById,
                   sessionsByBranch,
-                  branchById: mergeLiveWins(branchSnapshot, prev.branchById),
+                  branchById,
                 };
               })
           );
@@ -1764,6 +1789,9 @@ export function useAgorData(
         for (const [sessionId, session] of prev.entries()) {
           if (session.branch_id === branchId) {
             liveRemovedIdsRef.current.add(sessionId);
+            // Tag as branch-eviction (not a direct session remove) so hydration
+            // can un-suppress it if the branch comes back during the window.
+            liveBranchEvictedSessionIdsRef.current.add(sessionId);
             next.delete(sessionId);
             changed = true;
           }

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -397,6 +397,75 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   }
 
   /**
+   * Paginated session listing with SQL-side filtering, recency sort, and
+   * limit/offset. Powers the bounded first-paint slices (recent-N and the
+   * board-scoped set) so the cap, the recency ordering, and the board filter all
+   * run in SQL.
+   *
+   * Why SQL and not the generic in-memory path: the Session object exposes its
+   * last-updated time as `last_updated`, but callers sort by the DB column name
+   * `updated_at`. `DrizzleService.sortData` / `paginateClientSide` would look up
+   * `item.updated_at` (undefined) and no-op the sort, then slice an arbitrary
+   * page. Ordering here on the real `sessions.updated_at` column makes the
+   * recent-N slice actually recent. board_id is matched via the branches JOIN
+   * (`sessions.board_id` is never populated — see `sessionToInsert`).
+   *
+   * @returns `{ data, total }` where `total` is the full match count (so Feathers
+   *          pagination and the client `findAll` loop behave correctly).
+   */
+  async findPage(opts: {
+    boardId?: string;
+    archived?: boolean;
+    sortUpdatedAt?: 1 | -1;
+    limit?: number;
+    skip?: number;
+  }): Promise<{ data: Session[]; total: number }> {
+    try {
+      const baseUrl = await getBaseUrl();
+
+      const conditions = [];
+      if (opts.boardId !== undefined) conditions.push(eq(branches.board_id, opts.boardId));
+      if (opts.archived !== undefined) conditions.push(eq(sessions.archived, opts.archived));
+      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      // Total matching rows — drives Feathers pagination + the findAll loop.
+      const countQuery = select(this.db, { count: sql<number>`count(*)` })
+        .from(sessions)
+        .leftJoin(branches, eq(sessions.branch_id, branches.branch_id));
+      const countRow = await (whereClause ? countQuery.where(whereClause) : countQuery).one();
+      const total = Number(countRow?.count ?? 0);
+
+      // Page of rows, recency-sorted in SQL on the real `updated_at` column.
+      let dataQuery = select(this.db)
+        .from(sessions)
+        .leftJoin(branches, eq(sessions.branch_id, branches.branch_id));
+      if (whereClause) dataQuery = dataQuery.where(whereClause);
+      if (opts.sortUpdatedAt !== undefined) {
+        dataQuery = dataQuery.orderBy(
+          opts.sortUpdatedAt === -1 ? desc(sessions.updated_at) : sessions.updated_at
+        );
+      }
+      if (opts.limit !== undefined) dataQuery = dataQuery.limit(opts.limit);
+      if (opts.skip) dataQuery = dataQuery.offset(opts.skip);
+
+      const results = await dataQuery.all();
+      const data = results.map(
+        (result: { sessions: SessionRow; branches?: { board_id?: string } | null }) => {
+          const boardId = (result.branches?.board_id ?? null) as UUID | null;
+          return this.rowToSession(result.sessions, boardId, baseUrl);
+        }
+      );
+
+      return { data, total };
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find sessions page: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Find child sessions (forked or spawned from this session)
    *
    * LEFT JOINs with branches to populate board_id and url.

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -358,18 +358,22 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   /**
    * Find sessions by board ID
    *
-   * Uses materialized board_id column for O(1) indexed lookup.
-   * LEFT JOINs with branches to populate url (board_id already known from filter).
+   * A session relates to a board through its branch (session.branch_id →
+   * branch.board_id), so we filter on the JOINed `branches.board_id`. The
+   * `sessions.board_id` column is intentionally never populated (see
+   * `sessionToInsert`), so filtering on it would always return zero rows —
+   * the branch join is the authoritative source. This still pushes the
+   * filter down to SQL (one indexed JOIN), not an in-memory scan.
    */
   async findByBoard(boardId: string): Promise<Session[]> {
     try {
       const baseUrl = await getBaseUrl();
 
-      // Use materialized board_id column for indexed lookup
+      // Filter on the branch's board_id via the JOIN (sessions.board_id is dead).
       const results = await select(this.db)
         .from(sessions)
-        .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
-        .where(eq(sessions.board_id, boardId))
+        .innerJoin(branches, eq(sessions.branch_id, branches.branch_id))
+        .where(eq(branches.board_id, boardId))
         .all();
 
       return results.map(
@@ -773,13 +777,20 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
    * (which returns all sessions without filtering).
    *
    * @param userId - User ID to check access for
+   * @param boardId - Optional board filter, pushed down to SQL via the branch
+   *                  join (session → branch → board). Lets callers scope to a
+   *                  single board without an in-memory pass.
    * @returns Array of accessible sessions with urls populated
    */
-  async findAccessibleSessions(userId: UUID): Promise<Session[]> {
+  async findAccessibleSessions(userId: UUID, boardId?: UUID): Promise<Session[]> {
     const baseUrl = await getBaseUrl();
 
     // Join branches for board_id (exposed as Session.branch_board_id).
     // No boards join needed — flat `/s/<short>/` URLs don't carry a slug.
+    const accessCondition = visibleBranchAccessCondition(this.db, userId);
+    const whereCondition = boardId
+      ? and(accessCondition, eq(branches.board_id, boardId))
+      : accessCondition;
     const results = await select(this.db)
       .from(sessions)
       .innerJoin(branches, eq(sessions.branch_id, branches.branch_id))
@@ -787,7 +798,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         branchOwners,
         and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
       )
-      .where(visibleBranchAccessCondition(this.db, userId))
+      .where(whereCondition)
       .all();
 
     const seen = new Set<string>();


### PR DESCRIPTION
## Phase 1.5 — bound the two collections that scale

**Stacked on #1560 (`perf-initial-load`, Phase 1).** Base is `perf-initial-load` so this diff shows only Phase 1.5. **Rebase onto `main` after #1560 merges.**

Phase 1 board-scoped the heavy board collections (board-objects/cards/comments) for first paint and background-hydrated them globally. But the gate still **awaited the full `sessions` and full `branches` collections** — the two that scale with activity (sessions unbounded; ~469 branches on the real workspace). This extends Phase 1's exact pattern to them.

### Frontend (`apps/agor-ui/src/hooks/useAgorData.ts`)
- **Light batch** now awaits only a **bounded recent slice of sessions** (`$sort: { updated_at: -1 }, $limit: 50`) — covers Home's *My Sessions* + *Team activity* and seeds enough of `sessionById` to resolve `/s/<id>` links.
- **Branches** deferred to the board-scoped heavy batch: when the URL resolves a board, await only that board's **branches + sessions** (`{ board_id }`); on Home, await none and rely on hydration.
- **boardScope resolution** no longer depends on full branches: session URLs resolve the board via `session.branch_board_id`; `/w/<id>` branch links heal the single branch by id (mirrors the existing direct-session healing).
- **Background hydration** of the FULL `sessions` + `branches` sets after the gate opens — clobber-safe via the existing `liveWriteRevisionRef` machinery (now bumped by the session/branch realtime handlers) + a live-wins overlay, exactly like Phase 1b. Reuses an extracted `buildSessionMaps` so first-paint and hydration build identical maps (incl. remote surrogates).
- `boards` / `users` / `repos` / `card-types` stay global+awaited. Reconnect (`silent`) path stays **global/full**. Empty/unknown board → global fallback.

### Backend (`apps/agor-daemon` + `packages/core`) — the unblocker
Adds **`board_id` SQL pushdown** to `sessions.find` (Phase 1 noted it was in-memory). A session relates to a board through its branch (`session.branch_id → branch.board_id`); the **materialized `sessions.board_id` column is never populated** (`sessionToInsert` always writes `null`), so the authoritative source is the branch join. Therefore:
- `SessionRepository.findByBoard` now filters on `branches.board_id` via the JOIN (was filtering the dead `sessions.board_id` → always empty), `findAccessibleSessions(userId, boardId?)` gains an optional board filter.
- Wired into **both** paths: `scopeSessionQuery` (RBAC) and `SessionsService.find` (non-RBAC), each skipping `board_id` in the client-side equality filter (sessions expose `branch_board_id`, not `board_id`, so the generic pass would wipe every row).
- All existing session filters (status, archived, schedule_id, `$sort`/`$limit`/`$skip`) keep working.
- New DB-backed daemon test: `apps/agor-daemon/src/services/sessions.find.test.ts`.

### Acceptance criteria — reasoning
- **Home counts + feeds**: board cards derive branch/session counts from `branchById` + `sessionsByBranch` → correct once hydration lands (acceptable). *My Sessions* + *Team activity* render from the recent-50 slice immediately.
- **Board view `/b/:id`**: boardScope resolves from global boards → that board's branches + sessions awaited in the gate → render immediately.
- **Board switcher per-board counts / GlobalSearch / genealogy (cross-board) / facepiles**: full data after the sessions+branches hydration.
- **`/s/<id>` & `/w/<id>` deep links**: healed before boardScope resolution; session board resolved via `branch_board_id`.
- **Empty workspace / reconnect**: empty loads cleanly; silent reconnect resyncs full/global (no hydration needed).
- **No realtime clobbering**: session/branch handlers bump `liveWriteRevisionRef`; hydration refetches on mid-flight writes and live-wins-merges otherwise.

### Checks (CI-mirror; not `pnpm check` — pre-existing unrelated `check:shortid`)
- `pnpm typecheck` — 9/9 ✅
- `pnpm lint` — 0 errors (8 pre-existing warnings, none from changed files) ✅
- `pnpm --filter agor-ui test` — 508 passed ✅
- `pnpm --filter @agor/daemon test` — 1207 passed / 31 skipped ✅
- `pnpm --filter agor-ui build` — built in 2.18s ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)