### PR TITLE
Restore onboarding skip setup action

### DIFF
--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -88,6 +88,15 @@ function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>
   return { ...render(<OnboardingWizard {...props} />), props, client, boardsService };
 }
 
+async function continueWithCodexCliAuth() {
+  const codexOption = Array.from(
+    document.querySelectorAll<HTMLInputElement>('input[name="recommended-agent"]')
+  ).find((option) => option.value === 'codex');
+  if (!codexOption) throw new Error('Codex provider option was not found');
+  fireEvent.click(codexOption);
+  fireEvent.click(await screen.findByRole('button', { name: /continue with codex cli auth/i }));
+}
+
 describe('OnboardingWizard', () => {
   it('starts on assistant name and emoji only, then advances to LLM setup', async () => {
     const onUpdateUser = vi.fn(async () => undefined);
@@ -141,6 +150,7 @@ describe('OnboardingWizard', () => {
     const codexOption = providerOptions.find((option) => option.value === 'codex');
     expect(claudeOption).toBeChecked();
     expect(screen.getAllByText(/ANTHROPIC_API_KEY/).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: /continue without key/i })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Subscription'));
     expect(screen.getByText(/claude setup-token/)).toBeInTheDocument();
@@ -186,7 +196,7 @@ describe('OnboardingWizard', () => {
     expect(document.querySelector('.ant-modal-body')).toBe(body);
     expect(body).toHaveStyle({ minHeight: '440px', maxHeight: '640px', overflowY: 'auto' });
 
-    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
+    await continueWithCodexCliAuth();
     expect(await screen.findByText(/Setting up Agor/i)).toBeInTheDocument();
     expect(screen.getByText(/Cloning assistant framework/i)).toBeInTheDocument();
     expect(document.querySelector('.ant-modal-body')).toBe(body);
@@ -208,7 +218,7 @@ describe('OnboardingWizard', () => {
     const view = renderWizard({ repoById, onCreateRepo });
 
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
-    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
+    await continueWithCodexCliAuth();
 
     await waitFor(() => expect(onCreateRepo).toHaveBeenCalled());
     expect(screen.getByText(/Cloning assistant framework/i)).toBeInTheDocument();
@@ -237,7 +247,7 @@ describe('OnboardingWizard', () => {
     renderWizard({ repoById, onCreateRepo, onCreateBranch });
 
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
-    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
+    await continueWithCodexCliAuth();
 
     await waitFor(() => expect(onCreateBranch).toHaveBeenCalled());
     expect(onCreateRepo).not.toHaveBeenCalled();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -141,6 +141,17 @@ describe('OnboardingWizard', () => {
     expect(onCreateRepo).not.toHaveBeenCalled();
   });
 
+  it('keeps onboarding open when skip confirmation is cancelled', async () => {
+    const onComplete = vi.fn();
+    renderWizard({ onComplete });
+
+    fireEvent.click(screen.getByRole('button', { name: /skip setup/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /go back/i }));
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(screen.getByText(/Welcome to Agor/i)).toBeInTheDocument();
+  });
+
   it('shows recommended provider cards plus a secondary selector', async () => {
     const { baseElement } = renderWizard();
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -88,15 +88,6 @@ function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>
   return { ...render(<OnboardingWizard {...props} />), props, client, boardsService };
 }
 
-async function continueWithCodexCliAuth() {
-  const codexOption = Array.from(
-    document.querySelectorAll<HTMLInputElement>('input[name="recommended-agent"]')
-  ).find((option) => option.value === 'codex');
-  if (!codexOption) throw new Error('Codex provider option was not found');
-  fireEvent.click(codexOption);
-  fireEvent.click(await screen.findByRole('button', { name: /continue with codex cli auth/i }));
-}
-
 describe('OnboardingWizard', () => {
   it('starts on assistant name and emoji only, then advances to LLM setup', async () => {
     const onUpdateUser = vi.fn(async () => undefined);
@@ -133,6 +124,23 @@ describe('OnboardingWizard', () => {
     );
   });
 
+  it('can skip setup after confirmation', async () => {
+    const onComplete = vi.fn();
+    const onCreateRepo = vi.fn(async () => undefined);
+    renderWizard({ onComplete, onCreateRepo });
+
+    fireEvent.click(screen.getByRole('button', { name: /skip setup/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /skip anyway/i }));
+
+    expect(onComplete).toHaveBeenCalledWith({
+      branchId: '',
+      sessionId: '',
+      boardId: '',
+      path: 'assistant',
+    });
+    expect(onCreateRepo).not.toHaveBeenCalled();
+  });
+
   it('shows recommended provider cards plus a secondary selector', async () => {
     const { baseElement } = renderWizard();
 
@@ -150,7 +158,6 @@ describe('OnboardingWizard', () => {
     const codexOption = providerOptions.find((option) => option.value === 'codex');
     expect(claudeOption).toBeChecked();
     expect(screen.getAllByText(/ANTHROPIC_API_KEY/).length).toBeGreaterThan(0);
-    expect(screen.queryByRole('button', { name: /continue without key/i })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Subscription'));
     expect(screen.getByText(/claude setup-token/)).toBeInTheDocument();
@@ -196,7 +203,7 @@ describe('OnboardingWizard', () => {
     expect(document.querySelector('.ant-modal-body')).toBe(body);
     expect(body).toHaveStyle({ minHeight: '440px', maxHeight: '640px', overflowY: 'auto' });
 
-    await continueWithCodexCliAuth();
+    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
     expect(await screen.findByText(/Setting up Agor/i)).toBeInTheDocument();
     expect(screen.getByText(/Cloning assistant framework/i)).toBeInTheDocument();
     expect(document.querySelector('.ant-modal-body')).toBe(body);
@@ -218,7 +225,7 @@ describe('OnboardingWizard', () => {
     const view = renderWizard({ repoById, onCreateRepo });
 
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
-    await continueWithCodexCliAuth();
+    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
 
     await waitFor(() => expect(onCreateRepo).toHaveBeenCalled());
     expect(screen.getByText(/Cloning assistant framework/i)).toBeInTheDocument();
@@ -247,7 +254,7 @@ describe('OnboardingWizard', () => {
     renderWizard({ repoById, onCreateRepo, onCreateBranch });
 
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
-    await continueWithCodexCliAuth();
+    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
 
     await waitFor(() => expect(onCreateBranch).toHaveBeenCalled());
     expect(onCreateRepo).not.toHaveBeenCalled();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -38,6 +38,7 @@ import {
   Form,
   Input,
   Modal,
+  Popconfirm,
   Radio,
   Result,
   Select,
@@ -606,6 +607,11 @@ export function OnboardingWizard({
     setManualTestResult(result);
   }, [apiKey, authMethod, onCheckAuth, selectedAgent]);
 
+  const handleSkip = useCallback(() => {
+    if (!user) return;
+    onComplete({ branchId: '', sessionId: '', boardId: '', path: 'assistant' });
+  }, [onComplete, user]);
+
   const renderIdentity = () => (
     <div>
       <Title level={4} style={{ marginBottom: 8 }}>
@@ -940,6 +946,7 @@ export function OnboardingWizard({
                   Test Connection
                 </Button>
               )}
+              {!usesCodexCliAuth && <Button onClick={startSetup}>Continue without key</Button>}
             </Space>
           </>
         )}
@@ -982,11 +989,33 @@ export function OnboardingWizard({
         <Text type="secondary" style={{ fontSize: 12 }}>
           Step {currentStep === 'identity' ? '1' : '2'} of 2
         </Text>
-        {currentStep === 'llm' && (
-          <Button type="link" onClick={() => setCurrentStep('identity')}>
-            ← Back
-          </Button>
-        )}
+        <Space size="small">
+          {currentStep === 'llm' && (
+            <Button type="link" onClick={() => setCurrentStep('identity')}>
+              ← Back
+            </Button>
+          )}
+          <Popconfirm
+            title="Skip setup?"
+            description={
+              <div style={{ maxWidth: 250 }}>
+                Are you sure? Your assistant has been waiting their whole life to meet you.
+                <br />
+                <br />
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  (You can always come back via Settings)
+                </Text>
+              </div>
+            }
+            okText="Skip anyway"
+            cancelText="Go back"
+            onConfirm={handleSkip}
+          >
+            <Button type="text" size="small" style={{ color: token.colorTextTertiary }}>
+              Skip setup
+            </Button>
+          </Popconfirm>
+        </Space>
       </div>
     );
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -940,7 +940,6 @@ export function OnboardingWizard({
                   Test Connection
                 </Button>
               )}
-              {!usesCodexCliAuth && <Button onClick={startSetup}>Continue without key</Button>}
             </Space>
           </>
         )}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -985,7 +985,15 @@ export function OnboardingWizard({
 
   const footer =
     currentStep === 'loading' ? null : (
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          width: '100%',
+          textAlign: 'left',
+        }}
+      >
         <Text type="secondary" style={{ fontSize: 12 }}>
           Step {currentStep === 'identity' ? '1' : '2'} of 2
         </Text>


### PR DESCRIPTION
## Summary

- Restored the onboarding wizard's current main behavior for continuing without a key.
- Reintroduced the explicit guarded `Skip setup` action from the prior onboarding flow.
- Balanced the onboarding footer so the step indicator occupies the left side and actions stay on the right.
- Added test coverage for confirming and cancelling the skip action while preserving the normal setup flow.

## Checks

- [x] `pnpm --filter agor-ui test -- OnboardingWizard`
- [x] `pnpm check`
- [x] Commit hook (`biome ci` via lint-staged)