### PR TITLE
feat(agor-ui): zustand+immer store scaffold (Phase 4 PR1 — no wiring)

### DIFF
--- a/apps/agor-ui/package.json
+++ b/apps/agor-ui/package.json
@@ -41,6 +41,7 @@
     "emoji-picker-react": "^4.19.1",
     "emojibase": "^17.0.0",
     "emojibase-data": "^17.0.0",
+    "immer": "^11.1.8",
     "lz-string": "1.5.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
@@ -50,7 +51,8 @@
     "react-syntax-highlighter": "^16.1.1",
     "reactflow": "^11.11.4",
     "streamdown": "^1.5.1",
-    "use-stick-to-bottom": "^1.1.6"
+    "use-stick-to-bottom": "^1.1.6",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -125,7 +125,7 @@ export type InitialLoadingStage = 'idle' | 'fetching' | 'indexing';
  * Adding a new map here + to EMPTY_MAPS is all that's required —
  * `setMaps(EMPTY_MAPS)` in the reset effect covers every field automatically.
  */
-type DataMaps = {
+export type DataMaps = {
   sessionById: Map<string, Session>;
   sessionsByBranch: Map<string, Session[]>;
   boardById: Map<string, Board>;
@@ -151,7 +151,7 @@ type DataMaps = {
   userAuthenticatedMcpServerIds: Set<string>;
 };
 
-const EMPTY_MAPS: DataMaps = {
+export const EMPTY_MAPS: DataMaps = {
   sessionById: new Map(),
   sessionsByBranch: new Map(),
   boardById: new Map(),

--- a/apps/agor-ui/src/store/agorStore.test.ts
+++ b/apps/agor-ui/src/store/agorStore.test.ts
@@ -1,0 +1,90 @@
+import type { Session } from '@agor-live/client';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { EMPTY_MAPS } from '../hooks/useAgorData';
+import { agorStore } from './agorStore';
+
+// Reset the singleton before each test so cases don't bleed into each other.
+beforeEach(() => {
+  agorStore.getState().reset();
+});
+
+describe('agorStore scaffold', () => {
+  it('initializes with empty maps and the loading defaults', () => {
+    const state = agorStore.getState();
+
+    // Every data map starts empty (matching EMPTY_MAPS), and the meta fields
+    // match useAgorData's useState defaults.
+    for (const key of Object.keys(EMPTY_MAPS) as (keyof typeof EMPTY_MAPS)[]) {
+      expect(state[key]).toEqual(EMPTY_MAPS[key]);
+    }
+    expect(state.loading).toBe(true);
+    expect(state.loadingStage).toBe('idle');
+    expect(state.error).toBeNull();
+    expect(state.itemCounts).toEqual({});
+  });
+
+  it('reset() restores empty maps and initial meta after mutation', () => {
+    const populated = new Map<string, Session>([['s1', { session_id: 's1' } as Session]]);
+    agorStore.getState().setMap('sessionById', populated);
+    agorStore.getState().setLoading(false);
+    agorStore.getState().setError('boom');
+
+    agorStore.getState().reset();
+
+    const state = agorStore.getState();
+    expect(state.sessionById.size).toBe(0);
+    expect(state.loading).toBe(true);
+    expect(state.loadingStage).toBe('idle');
+    expect(state.error).toBeNull();
+    expect(state.itemCounts).toEqual({});
+  });
+
+  it('setLoading / setMap update their fields', () => {
+    agorStore.getState().setLoading(false);
+    expect(agorStore.getState().loading).toBe(false);
+
+    const next = new Map<string, Session>([['s1', { session_id: 's1' } as Session]]);
+    agorStore.getState().setMap('sessionById', next);
+    expect(agorStore.getState().sessionById).toBe(next);
+
+    // Functional-updater form mirrors setMapSlice's signature.
+    agorStore.getState().setMap('sessionById', (prev) => {
+      const copy = new Map(prev);
+      copy.set('s2', { session_id: 's2' } as Session);
+      return copy;
+    });
+    expect(agorStore.getState().sessionById.size).toBe(2);
+  });
+
+  it('no-op setMap (same reference) preserves the outer state reference', () => {
+    const before = agorStore.getState();
+    // Writing back the identical map reference must short-circuit (Object.is),
+    // leaving the whole state object untouched so no subscriber is notified.
+    agorStore.getState().setMap('sessionById', before.sessionById);
+    expect(agorStore.getState()).toBe(before);
+
+    // A genuine change DOES allocate a new state object.
+    agorStore.getState().setMap('sessionById', new Map());
+    expect(agorStore.getState()).not.toBe(before);
+  });
+
+  it('replaceMaps writes changed slices and skips unchanged ones', () => {
+    const sessions = new Map<string, Session>([['s1', { session_id: 's1' } as Session]]);
+    const before = agorStore.getState();
+
+    // boardById is written back as its current (unchanged) reference, so only
+    // sessionById should actually change.
+    agorStore.getState().replaceMaps({
+      sessionById: sessions,
+      boardById: before.boardById,
+    });
+
+    expect(agorStore.getState().sessionById).toBe(sessions);
+    expect(agorStore.getState().boardById).toBe(before.boardById);
+
+    // An all-no-op replaceMaps preserves the outer state reference.
+    const stable = agorStore.getState();
+    agorStore.getState().replaceMaps({ sessionById: sessions });
+    expect(agorStore.getState()).toBe(stable);
+  });
+});

--- a/apps/agor-ui/src/store/agorStore.ts
+++ b/apps/agor-ui/src/store/agorStore.ts
@@ -1,0 +1,129 @@
+/**
+ * Zustand store scaffold for the Agor frontend state layer (Phase 4, PR1).
+ *
+ * This file is intentionally INERT: it creates and types the store, but nothing
+ * consumes it yet. `useAgorData` remains the single source of truth for the
+ * running app. PR2 moves ownership into this store while keeping the
+ * `useAgorData` return signature identical; later PRs peel consumers onto
+ * narrow selector subscriptions. See `~/.claude/plans/zustand-migration.md`.
+ *
+ * Design notes:
+ * - State shape reuses the canonical `DataMaps` type (17 maps + 1 set) imported
+ *   from `useAgorData` — never redefined here — plus load/meta fields.
+ * - A VANILLA `createStore` (not React `create`) so the hook keeps owning
+ *   lifecycle; React binds via `useStore`.
+ * - The `immer` middleware is installed (and `enableMapSet()` called) so PR2's
+ *   cascade/multi-map actions can mutate `draft` imperatively. The foundational
+ *   actions below deliberately use object-form `set` / early-return, mirroring
+ *   today's `setMapSlice` `Object.is` short-circuit so idempotent writes don't
+ *   allocate a fresh state object (and don't notify subscribers).
+ */
+import { enableMapSet } from 'immer';
+import { useStore } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createStore } from 'zustand/vanilla';
+import {
+  type DataMaps,
+  EMPTY_MAPS,
+  type InitialLoadItemKey,
+  type InitialLoadingStage,
+} from '../hooks/useAgorData';
+
+// Immer needs this to draft Map/Set state. Called once at module load; the
+// store's state is entirely Maps and one Set.
+enableMapSet();
+
+/** Per-item counts captured at fetch-resolution time. Mirrors `useAgorData`. */
+export type ItemCounts = Partial<Record<InitialLoadItemKey, number>>;
+
+/** Load/meta fields that ride alongside the data maps. */
+interface AgorMeta {
+  loading: boolean;
+  loadingStage: InitialLoadingStage;
+  error: string | null;
+  itemCounts: ItemCounts;
+}
+
+/** Foundational actions. PR2 adds entity/realtime/hydration actions. */
+interface AgorActions {
+  /** Reset every data map to empty and meta to its initial (loading) values. */
+  reset: () => void;
+  setLoading: (loading: boolean) => void;
+  setLoadingStage: (loadingStage: InitialLoadingStage) => void;
+  setError: (error: string | null) => void;
+  setItemCounts: (itemCounts: ItemCounts) => void;
+  /**
+   * Replace a single data map. Mirrors `useAgorData`'s `setMapSlice`: accepts a
+   * value or a functional updater, and short-circuits on `Object.is` equality so
+   * a no-op write preserves the outer state reference (no subscriber notify).
+   */
+  setMap: <K extends keyof DataMaps>(
+    key: K,
+    value: DataMaps[K] | ((prev: DataMaps[K]) => DataMaps[K])
+  ) => void;
+  /** Replace several data maps at once; each key honours the `Object.is` guard. */
+  replaceMaps: (partial: Partial<DataMaps>) => void;
+}
+
+export type AgorState = DataMaps & AgorMeta & AgorActions;
+
+/** Initial meta values — identical to `useAgorData`'s `useState` defaults. */
+const INITIAL_META: AgorMeta = {
+  loading: true,
+  loadingStage: 'idle',
+  error: null,
+  itemCounts: {},
+};
+
+export const agorStore = createStore<AgorState>()(
+  immer((set, get) => ({
+    ...EMPTY_MAPS,
+    ...INITIAL_META,
+
+    reset: () => set({ ...EMPTY_MAPS, ...INITIAL_META }),
+
+    setLoading: (loading) => set({ loading }),
+    setLoadingStage: (loadingStage) => set({ loadingStage }),
+    setError: (error) => set({ error }),
+    setItemCounts: (itemCounts) => set({ itemCounts }),
+
+    setMap: (key, value) => {
+      const prev = get()[key];
+      const next =
+        typeof value === 'function'
+          ? (value as (p: DataMaps[typeof key]) => DataMaps[typeof key])(prev)
+          : value;
+      // No-op short-circuit: skip the set entirely so the outer state object
+      // (and every other slice's reference) is preserved.
+      if (Object.is(next, prev)) return;
+      set({ [key]: next } as Partial<AgorState>);
+    },
+
+    replaceMaps: (partial) => {
+      const state = get();
+      const changed: Partial<DataMaps> = {};
+      for (const k of Object.keys(partial) as (keyof DataMaps)[]) {
+        const next = partial[k];
+        if (next !== undefined && !Object.is(next, state[k])) {
+          // biome-ignore lint/suspicious/noExplicitAny: heterogeneous map union; per-key types are sound at the call site.
+          changed[k] = next as any;
+        }
+      }
+      if (Object.keys(changed).length === 0) return;
+      set(changed as Partial<AgorState>);
+    },
+  }))
+);
+
+/**
+ * React binding for the vanilla store. The store's lifecycle stays owned by the
+ * hook layer (PR2); this just subscribes a component to a selected slice.
+ */
+export function useAgorStore<T>(selector: (state: AgorState) => T): T {
+  return useStore(agorStore, selector);
+}
+
+// Re-exported for future multi-field selectors (BY-ID / derived reads) that
+// need a custom equality function — see plan §4 "Selectors/equality".
+export { shallow } from 'zustand/shallow';
+export { useStoreWithEqualityFn } from 'zustand/traditional';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
       emojibase-data:
         specifier: ^17.0.0
         version: 17.0.0(emojibase@17.0.0)
+      immer:
+        specifier: ^11.1.8
+        version: 11.1.8
       lz-string:
         specifier: 1.5.0
         version: 1.5.0
@@ -414,13 +417,16 @@ importers:
         version: 16.1.1(react@19.2.7)
       reactflow:
         specifier: ^11.11.4
-        version: 11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       streamdown:
         specifier: ^1.5.1
         version: 1.5.1(@types/mdast@4.0.4)(@types/react@19.2.17)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.7)(unified@11.0.5)
       use-stick-to-bottom:
         specifier: ^1.1.6
         version: 1.1.6(react@19.2.7)
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -6495,6 +6501,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-in-the-middle@2.0.6:
     resolution: {integrity: sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==}
 
@@ -9417,6 +9426,24 @@ packages:
       immer:
         optional: true
       react:
+        optional: true
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
         optional: true
 
   zwitch@2.0.4:
@@ -12675,29 +12702,29 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  '@reactflow/background@11.3.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@reactflow/background@11.3.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/core': 11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       classcat: 5.0.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/controls@11.2.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@reactflow/controls@11.2.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/core': 11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       classcat: 5.0.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/core@11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@reactflow/core@11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@types/d3': 7.4.3
       '@types/d3-drag': 3.0.7
@@ -12709,14 +12736,14 @@ snapshots:
       d3-zoom: 3.0.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/minimap@11.7.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@reactflow/minimap@11.7.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/core': 11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/d3-selection': 3.0.11
       '@types/d3-zoom': 3.0.8
       classcat: 5.0.5
@@ -12724,31 +12751,31 @@ snapshots:
       d3-zoom: 3.0.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/node-resizer@2.2.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@reactflow/node-resizer@2.2.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/core': 11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       classcat: 5.0.5
       d3-drag: 3.0.0
       d3-selection: 3.0.0
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/core': 11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       classcat: 5.0.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      zustand: 4.5.7(@types/react@19.2.17)(react@19.2.7)
+      zustand: 4.5.7(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -16184,6 +16211,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@11.1.8: {}
+
   import-in-the-middle@2.0.6:
     dependencies:
       acorn: 8.15.0
@@ -18165,14 +18194,14 @@ snapshots:
 
   react@19.2.7: {}
 
-  reactflow@11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  reactflow@11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@reactflow/background': 11.3.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@reactflow/controls': 11.2.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@reactflow/core': 11.11.4(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@reactflow/minimap': 11.7.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/background': 11.3.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/controls': 11.2.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/core': 11.11.4(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/minimap': 11.7.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -19773,11 +19802,19 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@4.5.7(@types/react@19.2.17)(react@19.2.7):
+  zustand@4.5.7(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7):
     dependencies:
       use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
+      immer: 11.1.8
       react: 19.2.7
+
+  zustand@5.0.14(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      immer: 11.1.8
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Phase 4 PR1 — store scaffold only, **zero behavior change**

Lays the foundation for the `apps/agor-ui` state-layer migration to Zustand (+ selective Immer). This PR is **scaffold-only**: the store is created, typed, and unit-tested, but **nothing consumes it yet**. `useAgorData` remains the single source of truth, so the running app — including home / initial-board load — behaves exactly as before. **PR2 wires the store into `useAgorData`.**

### What's here
- **Deps:** add `zustand@^5.0.14` + `immer@^11.1.8` to `agor-ui`.
- **`src/store/agorStore.ts`:**
  - **Vanilla** `createStore` (from `zustand/vanilla`, not React `create`) so the hook keeps owning lifecycle.
  - State = the existing **`DataMaps`** (17 maps + 1 set, imported — not redefined) + load/meta (`loading`/`loadingStage`/`error`/`itemCounts`).
  - `immer` middleware installed + `enableMapSet()` once at module load (state is all `Map`/`Set`), ready for PR2's cascade/multi-map actions.
  - Foundational actions only: `reset()`, `setLoading`/`setLoadingStage`/`setError`/`setItemCounts`, generic `setMap(key, value)` and `replaceMaps(partial)` — both mirror today's `setMapSlice` `Object.is` short-circuit (idempotent writes preserve the outer state reference, no subscriber notify).
  - Exports: `useAgorStore` (React binding via `useStore`), the vanilla `agorStore`, plus re-exported `shallow` + `useStoreWithEqualityFn` for future multi-field selectors.
- **`src/hooks/useAgorData.ts`:** the **only** change is `export`-ing the existing `DataMaps` type and `EMPTY_MAPS` const so the store reuses them. No logic change.
- **`src/store/agorStore.test.ts`:** init defaults (EMPTY_MAPS + `loading:true`/`idle`/`null`/`{}`), `reset()`, `setLoading`/`setMap` updates (incl. functional-updater form), no-op `setMap`/`replaceMaps` preserving the outer-state ref.

### Nothing is wired
No consumer imports the store. `App.tsx` / the prop-drilling chain / context providers are untouched. App behavior is unchanged.

### Checks (CI mirror, run inside `apps/agor-ui`)
- ✅ typecheck (`tsc -b`)
- ✅ lint (`biome check`)
- ✅ test (`vitest run`) — 516 passed / 90 files
- ✅ build (`tsc -b && vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)