### PR TITLE
fix(agor-ui): preserve artifact/app position on resize

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
@@ -31,11 +31,11 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
   const iframeContainerRef = useRef<HTMLDivElement>(null);
 
   const handleResize = useCallback(
-    (_event: unknown, params: { width: number; height: number }) => {
+    (_event: unknown, params: { x: number; y: number; width: number; height: number }) => {
       const objectData: AppBoardObject = {
         type: 'app',
-        x: 0, // Position managed by React Flow, not relevant for resize
-        y: 0,
+        x: params.x,
+        y: params.y,
         width: Math.max(params.width, MIN_WIDTH),
         height: Math.max(params.height, MIN_HEIGHT),
         title: data.title,

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -212,11 +212,11 @@ export const ArtifactNode = ({
   }, [data.artifactId, fetchPayload]);
 
   const handleResize = useCallback(
-    (_event: unknown, params: { width: number; height: number }) => {
+    (_event: unknown, params: { x: number; y: number; width: number; height: number }) => {
       const objectData: ArtifactBoardObject = {
         type: 'artifact',
-        x: 0,
-        y: 0,
+        x: params.x,
+        y: params.y,
         width: Math.max(params.width, MIN_WIDTH),
         height: Math.max(params.height, MIN_HEIGHT),
         artifact_id: data.artifactId as ArtifactID,


### PR DESCRIPTION
## The bug

On an Agor board, **resizing** an artifact card (and likewise an app card) teleported it to the board origin `(0,0)` instead of leaving it in place.

## Root cause

Board objects persist via a **wholesale replace**, not a field-merge. In `packages/core/src/db/repositories/boards.ts`, `upsertBoardObject` does:

```ts
const updatedObjects = { ...(current.objects || {}), [objectId]: objectData };
```

so whatever payload the resize handler sends *becomes* the stored object verbatim.

Both resize handlers hardcoded `x: 0, y: 0`:

- `apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx` — `handleResize`
- `apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx` — `handleResize`

They destructured only `{ width, height }` from reactflow's `NodeResizer` `onResize` params and threw away the position — so the wholesale replace nuked x/y to the origin → teleport.

## The fix

`NodeResizer`'s `onResize` already hands us the correct position in `params.x` / `params.y`. Dragging a bottom/right handle keeps x/y constant; dragging a **top/left** handle makes NodeResizer shift x/y so the opposite edge stays anchored — and we *want* those shifted coords. So `params.x` / `params.y` are correct in every case. This mirrors the drag/move path (`useBoardObjects.ts` → `batchUpdateObjectPositions`), which already spreads the existing object and overrides x/y.

The handlers now widen the `params` type to include `x`/`y` and persist `params.x` / `params.y` instead of zeros. The `Math.max(..., MIN_*)` clamps and all other fields are preserved. AppNode's misleading `// Position managed by React Flow, not relevant for resize` comment is removed.

## Scope / other nodes checked

Grepped the canvas dir for the same hardcoded-zero pattern and inspected the other `NodeResizer` usage (zone/markdown node in `BoardObjectNodes.tsx`). That `NodeResizer` has **no `onResize` handler** at all, so it does not have this teleport bug. Only ArtifactNode and AppNode were affected.

The backend wholesale-replace in `boards.ts` is intentional and left unchanged.

## Verification

- `pnpm typecheck` (agor-ui) — green
- `biome check` on both touched files — clean
- Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1546
