### PR TITLE
chore(agor-ui): rephrase temporal comments in lazy wrappers to timeless WHY

### DIFF
--- a/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminalLazy.tsx
+++ b/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminalLazy.tsx
@@ -2,11 +2,10 @@
  * Lazy-loaded wrapper around the xterm-backed EmbeddedTerminal.
  *
  * `EmbeddedTerminal.tsx` statically imports `@xterm/xterm` and its addons
- * (~300KB, shared with TerminalModal). It used to be imported eagerly by
- * SessionPanelContent, pulling xterm into the always-loaded session panel
- * chunk even though only `claude-code-cli` sessions ever render it. Wrapping
- * it in React.lazy defers the xterm import to the first render of an embedded
- * terminal. The public API matches EmbeddedTerminal exactly.
+ * (~300KB, shared with TerminalModal). Wrapping it in React.lazy keeps xterm
+ * off the always-loaded session panel chunk and defers its import to the first
+ * render of an embedded terminal, which only `claude-code-cli` sessions ever
+ * trigger. The public API matches EmbeddedTerminal exactly.
  */
 import { lazy, Suspense } from 'react';
 import type { EmbeddedTerminalProps } from './EmbeddedTerminal';

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/AppNodeLazy.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/AppNodeLazy.tsx
@@ -1,10 +1,10 @@
 /**
  * Lazy-loaded wrapper around AppNode (a React Flow node type).
  *
- * AppNode statically imports `@codesandbox/sandpack-react` (~200KB). It used
- * to be imported eagerly by SessionCanvas, so Sandpack landed in the board
- * chunk even for boards that have no app nodes. Wrapping it in React.lazy
- * means Sandpack is fetched only when a board actually renders an app node.
+ * AppNode statically imports `@codesandbox/sandpack-react` (~200KB). Wrapping
+ * it in React.lazy keeps Sandpack off the board chunk so it is fetched only
+ * when a board actually renders an app node, rather than for every board
+ * regardless of whether it has app nodes.
  *
  * The fallback is a small neutral placeholder sized to fill the node so the
  * canvas doesn't jump while the Sandpack chunk downloads. The exported

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNodeLazy.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNodeLazy.tsx
@@ -2,10 +2,9 @@
  * Lazy-loaded wrapper around ArtifactNode (a React Flow node type).
  *
  * ArtifactNode statically imports `@codesandbox/sandpack-react` (~200KB,
- * shared with AppNode). It used to be imported eagerly by SessionCanvas, so
- * Sandpack landed in the board chunk even for boards with no artifact nodes.
- * Wrapping it in React.lazy means Sandpack is fetched only when a board
- * actually renders an artifact node.
+ * shared with AppNode). Wrapping it in React.lazy keeps Sandpack off the board
+ * chunk so it is fetched only when a board actually renders an artifact node,
+ * rather than for every board regardless of whether it has artifact nodes.
  *
  * The exported component keeps ArtifactNode's signature so the `nodeTypes`
  * map stays stable; the fallback fills the node box to avoid layout jank.

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModalLazy.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModalLazy.tsx
@@ -2,16 +2,15 @@
  * Lazy-loaded wrapper around the xterm-backed TerminalModal.
  *
  * The real modal (`TerminalModal.tsx`) statically imports `@xterm/xterm` and
- * its addons (~300KB). It used to be imported eagerly by the app shell, so
- * xterm landed in the initial bundle even though most sessions never open a
- * terminal. This wrapper defers the import until the modal is first opened:
+ * its addons (~300KB). Wrapping it in React.lazy keeps xterm off the initial
+ * bundle, which most sessions never need since they never open a terminal.
+ * This wrapper defers the import until the modal is first opened:
  *
  *  - Until `open` first becomes true we render nothing (a closed modal has no
  *    visible output anyway), so the xterm chunk is never fetched.
  *  - On first open we mount the React.lazy inner inside a Suspense boundary.
  *    Once mounted it stays mounted across subsequent open/close cycles, which
- *    matches the previous always-mounted behaviour (and preserves the close
- *    animation).
+ *    keeps the modal always-mounted (and preserves the close animation).
  */
 import { lazy, Suspense, useEffect, useState } from 'react';
 import type { TerminalModalProps } from './TerminalModal';

--- a/apps/agor-ui/src/hooks/useEmojiAutocomplete.ts
+++ b/apps/agor-ui/src/hooks/useEmojiAutocomplete.ts
@@ -22,11 +22,11 @@ type ShortcodeMap = Record<string, string | string[]>;
 
 /**
  * Module-level cache shared by every hook instance. The emojibase data
- * (`emojibase-data/en/compact.json` + shortcodes, ~1.2MB raw) used to be a
- * static import that landed in the initial bundle and was parsed on first
- * render of the always-mounted AutocompleteTextarea. We now pull it in via a
- * dynamic `import()` gated on first need (idle warm-up or first `:` trigger),
- * memoizing the built option list so it's parsed at most once.
+ * (`emojibase-data/en/compact.json` + shortcodes, ~1.2MB raw) is heavy, so we
+ * keep it off the initial bundle and out of the always-mounted
+ * AutocompleteTextarea's first render by pulling it in via a dynamic `import()`
+ * gated on first need (idle warm-up or first `:` trigger), memoizing the built
+ * option list so it's parsed at most once.
  */
 let emojiOptionsCache: EmojiOption[] | null = null;
 let emojiOptionsPromise: Promise<EmojiOption[]> | null = null;


### PR DESCRIPTION
Comment-only cleanup per the no-narration-comments convention. Rephrases the temporal "used to be imported eagerly" framing in the lazy-loading wrappers to a timeless WHY (heavy dep, kept off the initial/board chunk, loaded on first use). No behavior change.

typecheck + lint green.