### PR TITLE
fix(agor-ui): widen resize hit-area for zones, artifacts & apps + fix dead eraser cursor selector (#1547)

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -81,19 +81,30 @@
   cursor: auto;
 }
 
-/* #1547: widen the zone resize hit-area so the resize cursor is easy to grab.
-   reactflow centers each line control on the zone edge (translate(-50%/-50%)),
-   so widening the box keeps it centered. The visible 2px zone border is drawn
-   separately by the inner div and is unaffected. border-width:0 keeps these
-   grab strips invisible. Scoped to zones only — does NOT affect card/artifact/app resize. */
-.react-flow__node-zone .react-flow__resize-control.line {
+/* Widen the resize hit-area on board items (zones, artifacts, apps) so the
+   resize cursor is easy to grab (#1547). reactflow centers each line control
+   on the node edge (translate(-50%/-50%)), so widening the box keeps it
+   centered. Each node's visible 2px border is drawn separately by its own
+   container and is unaffected; border-width:0 keeps these grab strips invisible.
+   Scoped to these node types — other nodes' resize handles are untouched. */
+.react-flow__node-zone .react-flow__resize-control.line,
+.react-flow__node-artifactNode .react-flow__resize-control.line,
+.react-flow__node-appNode .react-flow__resize-control.line {
   border-width: 0;
 }
 .react-flow__node-zone .react-flow__resize-control.line.left,
-.react-flow__node-zone .react-flow__resize-control.line.right {
+.react-flow__node-zone .react-flow__resize-control.line.right,
+.react-flow__node-artifactNode .react-flow__resize-control.line.left,
+.react-flow__node-artifactNode .react-flow__resize-control.line.right,
+.react-flow__node-appNode .react-flow__resize-control.line.left,
+.react-flow__node-appNode .react-flow__resize-control.line.right {
   width: 12px;
 }
 .react-flow__node-zone .react-flow__resize-control.line.top,
-.react-flow__node-zone .react-flow__resize-control.line.bottom {
+.react-flow__node-zone .react-flow__resize-control.line.bottom,
+.react-flow__node-artifactNode .react-flow__resize-control.line.top,
+.react-flow__node-artifactNode .react-flow__resize-control.line.bottom,
+.react-flow__node-appNode .react-flow__resize-control.line.top,
+.react-flow__node-appNode .react-flow__resize-control.line.bottom {
   height: 12px;
 }

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -80,3 +80,20 @@
 .nodrag * {
   cursor: auto;
 }
+
+/* #1547: widen the zone resize hit-area so the resize cursor is easy to grab.
+   reactflow centers each line control on the zone edge (translate(-50%/-50%)),
+   so widening the box keeps it centered. The visible 2px zone border is drawn
+   separately by the inner div and is unaffected. border-width:0 keeps these
+   grab strips invisible. Scoped to zones only — does NOT affect card/artifact/app resize. */
+.react-flow__node-zone .react-flow__resize-control.line {
+  border-width: 0;
+}
+.react-flow__node-zone .react-flow__resize-control.line.left,
+.react-flow__node-zone .react-flow__resize-control.line.right {
+  width: 12px;
+}
+.react-flow__node-zone .react-flow__resize-control.line.top,
+.react-flow__node-zone .react-flow__resize-control.line.bottom {
+  height: 12px;
+}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.css
@@ -60,7 +60,7 @@
   cursor: pointer;
 }
 
-.react-flow.tool-mode-eraser .react-flow__node.zone {
+.react-flow.tool-mode-eraser .react-flow__node-zone {
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Problem
Resizing board items is fiddly — the resize hit-area around the border is ~1px, so you have to be pixel-perfect for the resize cursor to appear. Reported for zones in #1547; artifacts and apps have the same issue.

## Fix
Widen the resize `.line` controls into a ~12px invisible grab strip for zone, artifact, and app nodes. reactflow centers each line control on the node edge via `transform: translate(-50%/-50%)`, so widening the box keeps it centered — the visible 2px border (drawn separately by each node's own container) is unchanged, and corner handles are left as-is. Scoped to those three `react-flow__node-<type>` wrapper classes; other node types are unaffected.

## Also (drive-by, same file + same root cause)
Fixed a pre-existing dead selector: eraser-mode's zone cursor rule used `.react-flow__node.zone` (dot), which never matches reactflow v11's `react-flow__node-zone` wrapper class. One-character fix.

## Testing
- biome lint clean on the changed CSS
- SessionCanvas vitest suite green
- Zone behavior verified live by the maintainer; artifacts/apps mirror the identical mechanism

Fixes #1547