### PR TITLE
Fix MCP acting-user attribution

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -146,6 +146,55 @@ describe('agor_branches_update', () => {
   });
 });
 
+describe('agor_branches_create', () => {
+  it('passes acting MCP user params through to branch creation so ownership resolves to the prompter', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-b', role: 'member' },
+    };
+    const createBranch = vi.fn(async (_repoId: string, data: unknown, params: unknown) => {
+      expect(params).toBe(baseServiceParams);
+      return {
+        branch_id: 'branch-new',
+        created_by: 'user-b',
+        ...(data as Record<string, unknown>),
+      };
+    });
+    const reposGet = vi.fn(async (_repoId: string) => ({
+      repo_id: 'repo-1',
+      default_branch: 'main',
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch };
+        if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-b',
+      sessionId: 'sess-owned-by-a',
+      baseServiceParams,
+    });
+
+    await create({
+      repoId: 'repo-1',
+      branchName: 'user-b-feature',
+      boardId: 'board-1',
+      autoSuffix: false,
+    });
+
+    expect(createBranch).toHaveBeenCalledWith(
+      'repo-1',
+      expect.objectContaining({ name: 'user-b-feature', boardId: 'board-1' }),
+      baseServiceParams
+    );
+  });
+});
+
 describe('branch MCP input schemas', () => {
   it('rejects empty required IDs/names with field-specific messages', () => {
     const config = registerAndCaptureConfig('agor_branches_create', {

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -98,6 +98,7 @@ async function registerAndCaptureTools(
     app: unknown;
     userId: string;
     sessionId?: string;
+    baseServiceParams?: Record<string, unknown>;
   },
   toolNames: string[]
 ): Promise<Record<string, CapturedTool>> {
@@ -117,7 +118,7 @@ async function registerAndCaptureTools(
     userId: ctx.userId as any,
     sessionId: ctx.sessionId as any,
     authenticatedUser: { user_id: ctx.userId, role: 'member' } as any,
-    baseServiceParams: {},
+    baseServiceParams: (ctx.baseServiceParams ?? {}) as any,
   });
 
   for (const name of toolNames) {
@@ -127,7 +128,12 @@ async function registerAndCaptureTools(
 }
 
 async function registerAndCaptureHandlers(
-  ctx: { app: unknown; userId: string; sessionId?: string },
+  ctx: {
+    app: unknown;
+    userId: string;
+    sessionId?: string;
+    baseServiceParams?: Record<string, unknown>;
+  },
   toolNames: string[]
 ): Promise<Record<string, ToolHandler>> {
   const tools = await registerAndCaptureTools(ctx, toolNames);
@@ -391,6 +397,76 @@ describe('agor_sessions_create', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.session).not.toHaveProperty('mcp_token');
+  });
+
+  it("attributes sessions created from another user's session context to the acting MCP user and uses their defaults", async () => {
+    const sessionCreates: unknown[] = [];
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-b', role: 'member' },
+    };
+    const actingUser = {
+      user_id: 'user-b',
+      unix_username: 'bob',
+      default_agentic_config: {
+        'claude-code': {
+          permissionMode: 'acceptEdits',
+          modelConfig: { model: 'claude-sonnet-4-6', mode: 'alias', effort: 'high' },
+        },
+      },
+    };
+    const app = makeFakeApp({
+      users: {
+        get: vi.fn(async (id: string) => {
+          expect(id).toBe('user-b');
+          return actingUser;
+        }),
+      },
+      branches: {
+        get: vi.fn(async (_id: string, params: unknown) => {
+          expect(params).toBe(baseServiceParams);
+          return { ...baseBranch, branch_id: 'wt-1', mcp_server_ids: [] };
+        }),
+      },
+      sessions: {
+        create: vi.fn(async (data: unknown, params: unknown) => {
+          expect(params).toBe(baseServiceParams);
+          sessionCreates.push(data);
+          return { session_id: 'sess-new', ...(data as Record<string, unknown>) };
+        }),
+        get: vi.fn(async (id: string, params: unknown) => {
+          expect(params).toBe(baseServiceParams);
+          return {
+            session_id: id,
+            branch_id: 'wt-1',
+            created_by: 'user-a',
+            unix_username: 'alice',
+            model_config: { model: 'claude-parent' },
+            permission_config: { mode: 'ask' },
+            genealogy: { children: [] },
+          };
+        }),
+        patch: vi.fn(async () => ({})),
+      },
+      '/sessions/:id/mcp-servers': { create: vi.fn(async () => ({})) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-b', sessionId: 'sess-owned-by-a', baseServiceParams },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({ branchId: 'wt-1', agenticTool: 'claude-code' });
+
+    expect(sessionCreates).toHaveLength(1);
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.created_by).toBe('user-b');
+    expect(created.unix_username).toBe('bob');
+    expect(created.permission_config.mode).toBe('acceptEdits');
+    expect(created.model_config.model).toBe('claude-sonnet-4-6');
+    expect(created.model_config.effort).toBe('high');
+    expect(created.model_config.model).not.toBe('claude-parent');
   });
 
   it('falls back to user default modelConfig when none is explicitly provided', async () => {

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -250,10 +250,10 @@ describe('canReceiveMcpTokenForSession', () => {
   const CREATOR = 'user-creator';
   const OTHER = 'user-other';
 
-  it('allows the session creator (matching user_id)', () => {
+  it('allows any authenticated member+ caller to receive a caller-scoped MCP token', () => {
     expect(
       canReceiveMcpTokenForSession({
-        callerUserId: CREATOR,
+        callerUserId: OTHER,
         callerRole: 'member',
         sessionCreatedBy: CREATOR,
       })
@@ -271,8 +271,6 @@ describe('canReceiveMcpTokenForSession', () => {
   });
 
   it('allows the executor service identity (role=service)', () => {
-    // role 'service' is not in ROLE_RANK, so hasMinimumRole returns false for
-    // it — the predicate must match it explicitly.
     expect(
       canReceiveMcpTokenForSession({
         callerUserId: 'executor-service',
@@ -282,29 +280,7 @@ describe('canReceiveMcpTokenForSession', () => {
     ).toBe(true);
   });
 
-  it('denies a member+ viewer who is NOT the creator (the bypass we fixed)', () => {
-    expect(
-      canReceiveMcpTokenForSession({
-        callerUserId: OTHER,
-        callerRole: 'member',
-        sessionCreatedBy: CREATOR,
-      })
-    ).toBe(false);
-  });
-
-  it('denies a plain admin who is NOT the creator (only superadmin gets through)', () => {
-    expect(
-      canReceiveMcpTokenForSession({
-        callerUserId: OTHER,
-        callerRole: 'admin',
-        sessionCreatedBy: CREATOR,
-      })
-    ).toBe(false);
-  });
-
   it('denies a creator who has been demoted to viewer', () => {
-    // Viewers never receive MCP tokens per docs — the creator match alone
-    // isn't enough, they must also be at least a member.
     expect(
       canReceiveMcpTokenForSession({
         callerUserId: CREATOR,
@@ -324,19 +300,7 @@ describe('canReceiveMcpTokenForSession', () => {
     ).toBe(false);
   });
 
-  it('denies when session has no created_by and caller is not privileged', () => {
-    expect(
-      canReceiveMcpTokenForSession({
-        callerUserId: OTHER,
-        callerRole: 'member',
-        sessionCreatedBy: null,
-      })
-    ).toBe(false);
-  });
-
-  it('does NOT match empty-string caller user_id against empty-string created_by', () => {
-    // Empty-string coincidence must not count as "creator match" — this is
-    // why the predicate guards with `!!callerUserId` before comparing.
+  it('denies empty-string caller user_id even with member role', () => {
     expect(
       canReceiveMcpTokenForSession({
         callerUserId: '',

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -255,7 +255,6 @@ describe('canReceiveMcpTokenForSession', () => {
       canReceiveMcpTokenForSession({
         callerUserId: OTHER,
         callerRole: 'member',
-        sessionCreatedBy: CREATOR,
       })
     ).toBe(true);
   });
@@ -265,7 +264,6 @@ describe('canReceiveMcpTokenForSession', () => {
       canReceiveMcpTokenForSession({
         callerUserId: OTHER,
         callerRole: 'superadmin',
-        sessionCreatedBy: CREATOR,
       })
     ).toBe(true);
   });
@@ -275,7 +273,6 @@ describe('canReceiveMcpTokenForSession', () => {
       canReceiveMcpTokenForSession({
         callerUserId: 'executor-service',
         callerRole: 'service',
-        sessionCreatedBy: CREATOR,
       })
     ).toBe(true);
   });
@@ -285,7 +282,6 @@ describe('canReceiveMcpTokenForSession', () => {
       canReceiveMcpTokenForSession({
         callerUserId: CREATOR,
         callerRole: 'viewer',
-        sessionCreatedBy: CREATOR,
       })
     ).toBe(false);
   });
@@ -295,7 +291,6 @@ describe('canReceiveMcpTokenForSession', () => {
       canReceiveMcpTokenForSession({
         callerUserId: undefined,
         callerRole: undefined,
-        sessionCreatedBy: CREATOR,
       })
     ).toBe(false);
   });
@@ -305,7 +300,6 @@ describe('canReceiveMcpTokenForSession', () => {
       canReceiveMcpTokenForSession({
         callerUserId: '',
         callerRole: 'member',
-        sessionCreatedBy: '',
       })
     ).toBe(false);
   });

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -295,6 +295,15 @@ describe('canReceiveMcpTokenForSession', () => {
     ).toBe(false);
   });
 
+  it('denies callers with user_id but no explicit role', () => {
+    expect(
+      canReceiveMcpTokenForSession({
+        callerUserId: CREATOR,
+        callerRole: undefined,
+      })
+    ).toBe(false);
+  });
+
   it('denies empty-string caller user_id even with member role', () => {
     expect(
       canReceiveMcpTokenForSession({

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2396,7 +2396,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             !canReceiveMcpTokenForSession({
               callerUserId: callerUser?.user_id,
               callerRole: callerUser?.role,
-              sessionCreatedBy: session.created_by,
             })
           ) {
             return context;
@@ -2470,10 +2469,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             return context;
           }
 
-          // Gate MCP token issuance on member+ role (see `after: get` note).
+          // Gate MCP token issuance through the same caller-scoped policy as `after:get`.
           const callerUser = (context.params as AuthenticatedParams).user;
-          const callerRole = callerUser?.role;
-          if (!hasMinimumRole(callerRole, ROLES.MEMBER)) {
+          if (
+            !canReceiveMcpTokenForSession({
+              callerUserId: callerUser?.user_id,
+              callerRole: callerUser?.role,
+            })
+          ) {
             return context;
           }
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2403,7 +2403,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           }
 
           const { generateSessionToken } = await import('./mcp/tokens.js');
-          const userId = session.created_by || 'unknown';
+          const userId = callerUser?.user_id;
+          if (!userId) {
+            return context;
+          }
 
           const jwtSecret = app.settings.authentication?.secret;
           if (!jwtSecret) {
@@ -2468,15 +2471,20 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           }
 
           // Gate MCP token issuance on member+ role (see `after: get` note).
-          const callerRole = (context.params as AuthenticatedParams).user?.role;
+          const callerUser = (context.params as AuthenticatedParams).user;
+          const callerRole = callerUser?.role;
           if (!hasMinimumRole(callerRole, ROLES.MEMBER)) {
             return context;
           }
 
           // Resolve MCP token for this session (cached/reused when still valid).
+          // Mint it for the active caller, not for an inherited/parent creator.
           const { generateSessionToken } = await import('./mcp/tokens.js');
           const session = context.result as Session;
-          const userId = session.created_by || 'unknown';
+          const userId = callerUser?.user_id;
+          if (!userId) {
+            return context;
+          }
 
           // Get JWT secret from app settings
           const jwtSecret = app.settings.authentication?.secret;

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -1252,7 +1252,7 @@ export async function writeClaudeCliMcpConfigForSession(
     })
   ) {
     console.warn(
-      `[claude-cli-integration] not writing owner-scoped MCP config for session ${shortId(session.session_id)}: caller ${opts.actor.user_id ?? 'anonymous'} cannot receive session creator token`
+      `[claude-cli-integration] not writing owner-scoped MCP config for session ${shortId(session.session_id)}: caller ${opts.actor.user_id ?? 'anonymous'} is not allowed to control the owner-scoped CLI MCP config`
     );
     return undefined;
   }

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -75,7 +75,7 @@ import {
 } from '@agor/core/unix';
 import { DrizzleService } from '../adapters/drizzle';
 import { buildInitialUserMessage } from '../utils/build-initial-user-message.js';
-import { canReceiveMcpTokenForSession } from '../utils/mcp-token-authorization.js';
+import { canControlCliSession } from '../utils/mcp-token-authorization.js';
 import { getDaemonUrl } from '../utils/spawn-executor.js';
 import {
   ClaudeCliWatcherRegistry,
@@ -1245,7 +1245,7 @@ export async function writeClaudeCliMcpConfigForSession(
 
   if (
     opts.actor &&
-    !canReceiveMcpTokenForSession({
+    !canControlCliSession({
       callerUserId: opts.actor.user_id,
       callerRole: opts.actor.role,
       sessionCreatedBy: session.created_by,

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
@@ -4,54 +4,40 @@ import { canControlCliSession, canReceiveMcpTokenForSession } from './mcp-token-
 const creatorId = 'user-creator';
 
 describe('session actor authorization', () => {
-  it('allows the creator when they are a member or higher', () => {
+  it('allows a member caller to receive an MCP token as the acting user', () => {
     const params = {
-      callerUserId: creatorId,
+      callerUserId: 'user-collaborator',
       callerRole: 'member',
       sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(true);
-    expect(canControlCliSession(params)).toBe(true);
   });
 
-  it('denies the creator if they are not a member', () => {
+  it('denies MCP tokens to viewers even when they created the session', () => {
     const params = {
       callerUserId: creatorId,
       callerRole: 'viewer',
       sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(false);
-    expect(canControlCliSession(params)).toBe(false);
   });
 
-  it('denies other members even when they can access the branch', () => {
-    const params = {
-      callerUserId: 'user-collaborator',
-      callerRole: 'member',
-      sessionCreatedBy: creatorId,
-    };
-    expect(canReceiveMcpTokenForSession(params)).toBe(false);
-    expect(canControlCliSession(params)).toBe(false);
-  });
-
-  it('allows superadmins to receive tokens and control CLI sessions', () => {
+  it('allows superadmins to receive caller-scoped MCP tokens', () => {
     const params = {
       callerUserId: 'user-admin',
       callerRole: 'superadmin',
       sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(true);
-    expect(canControlCliSession(params)).toBe(true);
   });
 
-  it('allows the internal service identity', () => {
+  it('allows the internal service identity to receive MCP tokens', () => {
     const params = {
       callerUserId: undefined,
       callerRole: 'service',
       sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(true);
-    expect(canControlCliSession(params)).toBe(true);
   });
 
   it('denies unauthenticated or role-less callers', () => {
@@ -61,6 +47,36 @@ describe('session actor authorization', () => {
       sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(false);
-    expect(canControlCliSession(params)).toBe(false);
+  });
+
+  it('keeps CLI control limited to the creator, superadmin, or service identity', () => {
+    expect(
+      canControlCliSession({
+        callerUserId: creatorId,
+        callerRole: 'member',
+        sessionCreatedBy: creatorId,
+      })
+    ).toBe(true);
+    expect(
+      canControlCliSession({
+        callerUserId: 'user-collaborator',
+        callerRole: 'member',
+        sessionCreatedBy: creatorId,
+      })
+    ).toBe(false);
+    expect(
+      canControlCliSession({
+        callerUserId: 'user-admin',
+        callerRole: 'superadmin',
+        sessionCreatedBy: creatorId,
+      })
+    ).toBe(true);
+    expect(
+      canControlCliSession({
+        callerUserId: undefined,
+        callerRole: 'service',
+        sessionCreatedBy: creatorId,
+      })
+    ).toBe(true);
   });
 });

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
@@ -44,6 +44,15 @@ describe('session actor authorization', () => {
     expect(canReceiveMcpTokenForSession(params)).toBe(false);
   });
 
+  it('denies MCP tokens when a caller id is present but role is missing', () => {
+    expect(
+      canReceiveMcpTokenForSession({
+        callerUserId: creatorId,
+        callerRole: undefined,
+      })
+    ).toBe(false);
+  });
+
   it('keeps CLI control limited to the creator, superadmin, or service identity', () => {
     expect(
       canControlCliSession({
@@ -73,5 +82,12 @@ describe('session actor authorization', () => {
         sessionCreatedBy: creatorId,
       })
     ).toBe(true);
+    expect(
+      canControlCliSession({
+        callerUserId: creatorId,
+        callerRole: undefined,
+        sessionCreatedBy: creatorId,
+      })
+    ).toBe(false);
   });
 });

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.test.ts
@@ -8,7 +8,6 @@ describe('session actor authorization', () => {
     const params = {
       callerUserId: 'user-collaborator',
       callerRole: 'member',
-      sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(true);
   });
@@ -17,7 +16,6 @@ describe('session actor authorization', () => {
     const params = {
       callerUserId: creatorId,
       callerRole: 'viewer',
-      sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(false);
   });
@@ -26,7 +24,6 @@ describe('session actor authorization', () => {
     const params = {
       callerUserId: 'user-admin',
       callerRole: 'superadmin',
-      sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(true);
   });
@@ -35,7 +32,6 @@ describe('session actor authorization', () => {
     const params = {
       callerUserId: undefined,
       callerRole: 'service',
-      sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(true);
   });
@@ -44,7 +40,6 @@ describe('session actor authorization', () => {
     const params = {
       callerUserId: undefined,
       callerRole: undefined,
-      sessionCreatedBy: creatorId,
     };
     expect(canReceiveMcpTokenForSession(params)).toBe(false);
   });

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.ts
@@ -7,20 +7,21 @@ export interface SessionActorAuthorizationParams {
 }
 
 /**
- * Authorization predicate for handing a session-scoped MCP token to a caller.
+ * Authorization predicate for handing an Agor MCP token to a caller.
  *
- * The token binds `uid = session.created_by` and lets the bearer act as the
- * session creator on the MCP channel. It must therefore only be returned to
- * callers who are already allowed to act as that creator: the creator (member+),
- * a superadmin, or the executor/service identity.
+ * The token is minted for the *current authenticated caller* (not necessarily
+ * `session.created_by`) and is bound to the requested session context. Normal
+ * session/branch RBAC has already run before the after-hook calls this helper;
+ * this gate only prevents anonymous/viewer contexts from receiving a bearer
+ * credential. Returning caller-scoped tokens is important for gateway/aligned
+ * user prompts: a collaborator prompting someone else's session must execute
+ * MCP tools as themselves, not as the original session creator.
  */
 export function canReceiveMcpTokenForSession(params: SessionActorAuthorizationParams): boolean {
-  const { callerUserId, callerRole, sessionCreatedBy } = params;
-  const isSuperadmin = hasMinimumRole(callerRole, ROLES.SUPERADMIN);
+  const { callerUserId, callerRole } = params;
   const isServiceExecutor = callerRole === 'service';
-  const isCreatorMember =
-    !!callerUserId && callerUserId === sessionCreatedBy && hasMinimumRole(callerRole, ROLES.MEMBER);
-  return isCreatorMember || isSuperadmin || isServiceExecutor;
+  const isAuthenticatedMember = !!callerUserId && hasMinimumRole(callerRole, ROLES.MEMBER);
+  return isAuthenticatedMember || isServiceExecutor;
 }
 
 /**
@@ -34,5 +35,10 @@ export function canReceiveMcpTokenForSession(params: SessionActorAuthorizationPa
  * delivery unless the CLI ownership model is redesigned explicitly.
  */
 export function canControlCliSession(params: SessionActorAuthorizationParams): boolean {
-  return canReceiveMcpTokenForSession(params);
+  const { callerUserId, callerRole, sessionCreatedBy } = params;
+  const isSuperadmin = hasMinimumRole(callerRole, ROLES.SUPERADMIN);
+  const isServiceExecutor = callerRole === 'service';
+  const isCreatorMember =
+    !!callerUserId && callerUserId === sessionCreatedBy && hasMinimumRole(callerRole, ROLES.MEMBER);
+  return isCreatorMember || isSuperadmin || isServiceExecutor;
 }

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.ts
@@ -1,8 +1,11 @@
 import { hasMinimumRole, ROLES } from '@agor/core/types';
 
-export interface SessionActorAuthorizationParams {
+export interface McpTokenAuthorizationParams {
   callerUserId: string | undefined;
   callerRole: string | undefined;
+}
+
+export interface CliSessionControlParams extends McpTokenAuthorizationParams {
   sessionCreatedBy: string | null | undefined;
 }
 
@@ -17,7 +20,7 @@ export interface SessionActorAuthorizationParams {
  * user prompts: a collaborator prompting someone else's session must execute
  * MCP tools as themselves, not as the original session creator.
  */
-export function canReceiveMcpTokenForSession(params: SessionActorAuthorizationParams): boolean {
+export function canReceiveMcpTokenForSession(params: McpTokenAuthorizationParams): boolean {
   const { callerUserId, callerRole } = params;
   const isServiceExecutor = callerRole === 'service';
   const isAuthenticatedMember = !!callerUserId && hasMinimumRole(callerRole, ROLES.MEMBER);
@@ -28,13 +31,13 @@ export function canReceiveMcpTokenForSession(params: SessionActorAuthorizationPa
  * Authorization predicate for controlling a Claude CLI process bound to a
  * session (ensure/focus cold-start tab, restart/kill/re-spawn).
  *
- * CLI control is as sensitive as receiving the MCP token: in simple Unix mode
- * the process may run from the creator's shared home/session state, and even in
- * stricter modes resuming someone else's CLI session can execute with that
- * session's credentials/context. Keep this boundary aligned with MCP token
- * delivery unless the CLI ownership model is redesigned explicitly.
+ * CLI control is intentionally stricter than caller-scoped Agor MCP token
+ * delivery. In simple Unix mode the process may run from the creator's shared
+ * home/session state, and even in stricter modes resuming someone else's CLI
+ * session can execute with that session's credentials/context. Only the creator,
+ * a superadmin, or the service identity may control that process boundary.
  */
-export function canControlCliSession(params: SessionActorAuthorizationParams): boolean {
+export function canControlCliSession(params: CliSessionControlParams): boolean {
   const { callerUserId, callerRole, sessionCreatedBy } = params;
   const isSuperadmin = hasMinimumRole(callerRole, ROLES.SUPERADMIN);
   const isServiceExecutor = callerRole === 'service';

--- a/apps/agor-daemon/src/utils/mcp-token-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-token-authorization.ts
@@ -9,6 +9,21 @@ export interface CliSessionControlParams extends McpTokenAuthorizationParams {
   sessionCreatedBy: string | null | undefined;
 }
 
+function hasExplicitMinimumRole(
+  userRole: string | undefined,
+  minimumRole: typeof ROLES.MEMBER
+): boolean;
+function hasExplicitMinimumRole(
+  userRole: string | undefined,
+  minimumRole: typeof ROLES.SUPERADMIN
+): boolean;
+function hasExplicitMinimumRole(
+  userRole: string | undefined,
+  minimumRole: typeof ROLES.MEMBER | typeof ROLES.SUPERADMIN
+): boolean {
+  return !!userRole && hasMinimumRole(userRole, minimumRole);
+}
+
 /**
  * Authorization predicate for handing an Agor MCP token to a caller.
  *
@@ -23,7 +38,7 @@ export interface CliSessionControlParams extends McpTokenAuthorizationParams {
 export function canReceiveMcpTokenForSession(params: McpTokenAuthorizationParams): boolean {
   const { callerUserId, callerRole } = params;
   const isServiceExecutor = callerRole === 'service';
-  const isAuthenticatedMember = !!callerUserId && hasMinimumRole(callerRole, ROLES.MEMBER);
+  const isAuthenticatedMember = !!callerUserId && hasExplicitMinimumRole(callerRole, ROLES.MEMBER);
   return isAuthenticatedMember || isServiceExecutor;
 }
 
@@ -39,9 +54,11 @@ export function canReceiveMcpTokenForSession(params: McpTokenAuthorizationParams
  */
 export function canControlCliSession(params: CliSessionControlParams): boolean {
   const { callerUserId, callerRole, sessionCreatedBy } = params;
-  const isSuperadmin = hasMinimumRole(callerRole, ROLES.SUPERADMIN);
+  const isSuperadmin = hasExplicitMinimumRole(callerRole, ROLES.SUPERADMIN);
   const isServiceExecutor = callerRole === 'service';
   const isCreatorMember =
-    !!callerUserId && callerUserId === sessionCreatedBy && hasMinimumRole(callerRole, ROLES.MEMBER);
+    !!callerUserId &&
+    callerUserId === sessionCreatedBy &&
+    hasExplicitMinimumRole(callerRole, ROLES.MEMBER);
   return isCreatorMember || isSuperadmin || isServiceExecutor;
 }


### PR DESCRIPTION
## Summary
- Mint Agor MCP tokens for the active authenticated caller instead of the parent/session creator, so MCP tool calls from gateway/aligned prompts execute as the prompter.
- Keep Claude CLI control restricted to the session creator/superadmin/service while allowing caller-scoped MCP tokens for member+ session access.
- Split MCP-token vs CLI-control authorization params and require explicit caller roles for bearer-token gates.
- Add regressions for `agor_sessions_create` and `agor_branches_create` when user B acts from user A's session context, plus token-gate coverage.

Fixes #1612.

## Validation
- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/utils/mcp-token-authorization.test.ts src/mcp/tools/sessions.test.ts src/mcp/tools/branches.test.ts` (59 tests)

## AI review
- Reviewed by Codex / GPT-5.5 via Agor subsession.
- Follow-up feedback addressed.
- Final verdict: merge-ready, no substantive issues remaining.