### PR TITLE
Fix assistant discovery query

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -1,3 +1,5 @@
+import * as configModule from '@agor/core/config';
+import { BranchRepository } from '@agor/core/db';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { registerBranchTools } from './branches.js';
@@ -24,6 +26,12 @@ function registerAndCaptureHandler(
     userId: string;
     sessionId?: string;
     baseServiceParams?: Record<string, unknown>;
+    authenticatedUser?: {
+      user_id: string;
+      role: string;
+      email?: string;
+      _isServiceAccount?: boolean;
+    };
   }
 ): ToolHandler {
   let handler: ToolHandler | undefined;
@@ -38,9 +46,11 @@ function registerAndCaptureHandler(
     db: {} as Parameters<typeof registerBranchTools>[1]['db'],
     userId: ctx.userId as Parameters<typeof registerBranchTools>[1]['userId'],
     sessionId: ctx.sessionId as Parameters<typeof registerBranchTools>[1]['sessionId'],
-    authenticatedUser: { user_id: ctx.userId, role: 'member' } as Parameters<
-      typeof registerBranchTools
-    >[1]['authenticatedUser'],
+    authenticatedUser: (ctx.authenticatedUser ?? {
+      user_id: ctx.userId,
+      email: 'user@example.test',
+      role: 'member',
+    }) as Parameters<typeof registerBranchTools>[1]['authenticatedUser'],
     baseServiceParams: (ctx.baseServiceParams ?? {}) as Parameters<
       typeof registerBranchTools
     >[1]['baseServiceParams'],
@@ -57,6 +67,12 @@ function registerAndCaptureConfig(
     userId: string;
     sessionId?: string;
     baseServiceParams?: Record<string, unknown>;
+    authenticatedUser?: {
+      user_id: string;
+      role: string;
+      email?: string;
+      _isServiceAccount?: boolean;
+    };
   }
 ): ToolConfig {
   let config: ToolConfig | undefined;
@@ -71,9 +87,11 @@ function registerAndCaptureConfig(
     db: {} as Parameters<typeof registerBranchTools>[1]['db'],
     userId: ctx.userId as Parameters<typeof registerBranchTools>[1]['userId'],
     sessionId: ctx.sessionId as Parameters<typeof registerBranchTools>[1]['sessionId'],
-    authenticatedUser: { user_id: ctx.userId, role: 'member' } as Parameters<
-      typeof registerBranchTools
-    >[1]['authenticatedUser'],
+    authenticatedUser: (ctx.authenticatedUser ?? {
+      user_id: ctx.userId,
+      email: 'user@example.test',
+      role: 'member',
+    }) as Parameters<typeof registerBranchTools>[1]['authenticatedUser'],
     baseServiceParams: (ctx.baseServiceParams ?? {}) as Parameters<
       typeof registerBranchTools
     >[1]['baseServiceParams'],
@@ -93,6 +111,7 @@ function registerAndCaptureUpdate(ctx: {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
@@ -782,5 +801,178 @@ describe('agor_branches_cleanup_candidates', () => {
     await expect(cleanupCandidates({ archivedBefore: '2026-06-04T00:00:00.000Z' })).rejects.toThrow(
       /must not be in the future/i
     );
+  });
+});
+
+describe('agor_assistants_list', () => {
+  it('delegates to the targeted assistant repository query instead of paginating branches first', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+    };
+    const hodorLikeBranch = {
+      branch_id: 'assistant-branch-1',
+      repo_id: 'repo-1',
+      name: 'private-hodor-like',
+      board_id: 'board-1',
+      last_used: '2026-06-24T00:00:00.000Z',
+      archived: false,
+      storage_mode: 'clone',
+      custom_context: {
+        assistant: {
+          kind: 'assistant',
+          displayName: 'Hodor-like',
+          emoji: '🚪',
+          kb: {
+            primary_namespace_id: 'namespace-1',
+            primary_namespace_slug: 'team-kb',
+            memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+            default_visibility: 'public',
+            global_access: 'write',
+          },
+        },
+      },
+    };
+    const findAssistantBranches = vi
+      .spyOn(BranchRepository.prototype, 'findAssistantBranches')
+      .mockResolvedValue([hodorLikeBranch] as Awaited<
+        ReturnType<BranchRepository['findAssistantBranches']>
+      >);
+    const app = {
+      service(name: string) {
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const listAssistants = registerAndCaptureHandler('agor_assistants_list', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await listAssistants({ limit: 200 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(findAssistantBranches).toHaveBeenCalledWith({ archived: false, limit: 200 });
+    expect(parsed.total).toBe(1);
+    expect(parsed.assistants).toEqual([
+      expect.objectContaining({
+        branch_id: 'assistant-branch-1',
+        name: 'private-hodor-like',
+        display_name: 'Hodor-like',
+        emoji: '🚪',
+        board_id: 'board-1',
+      }),
+    ]);
+  });
+
+  it('shapes schedule-only legacy assistant backfill rows returned by the repository', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+    };
+    const scheduledLegacyBranch = {
+      branch_id: 'legacy-scheduled-branch',
+      repo_id: 'repo-1',
+      name: 'datagor-like',
+      notes: 'Legacy assistant bootstrapped before custom_context marker backfill.',
+      board_id: 'board-1',
+      last_used: '2026-06-24T00:00:00.000Z',
+      archived: false,
+      storage_mode: 'clone',
+    };
+    vi.spyOn(BranchRepository.prototype, 'findAssistantBranches').mockResolvedValue([
+      scheduledLegacyBranch,
+    ] as Awaited<ReturnType<BranchRepository['findAssistantBranches']>>);
+    const app = {
+      service(name: string) {
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const listAssistants = registerAndCaptureHandler('agor_assistants_list', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await listAssistants({});
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.total).toBe(1);
+    expect(parsed.assistants[0]).toEqual(
+      expect.objectContaining({
+        branch_id: 'legacy-scheduled-branch',
+        name: 'datagor-like',
+        display_name: 'datagor-like',
+        description: 'Legacy assistant bootstrapped before custom_context marker backfill.',
+      })
+    );
+  });
+
+  it('does not scope assistant discovery for superadmins when superadmin bypass is enabled', async () => {
+    vi.spyOn(configModule, 'isBranchRbacEnabled').mockReturnValue(true);
+    vi.spyOn(configModule, 'loadConfig').mockResolvedValue({
+      execution: { allow_superadmin: true },
+    } as Awaited<ReturnType<typeof configModule.loadConfig>>);
+
+    const findAssistantBranches = vi
+      .spyOn(BranchRepository.prototype, 'findAssistantBranches')
+      .mockResolvedValue([]);
+    const app = {
+      service(name: string) {
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const listAssistants = registerAndCaptureHandler('agor_assistants_list', {
+      app,
+      userId: 'superadmin-1',
+      authenticatedUser: {
+        user_id: 'superadmin-1',
+        email: 'superadmin@example.test',
+        role: 'superadmin',
+      },
+    });
+
+    await listAssistants({});
+
+    expect(findAssistantBranches).toHaveBeenCalledWith({ archived: false, limit: 200 });
+  });
+
+  it('scopes assistant discovery for superadmins when superadmin bypass is disabled', async () => {
+    vi.spyOn(configModule, 'isBranchRbacEnabled').mockReturnValue(true);
+    vi.spyOn(configModule, 'loadConfig').mockResolvedValue({
+      execution: { allow_superadmin: false },
+    } as Awaited<ReturnType<typeof configModule.loadConfig>>);
+
+    const findAssistantBranches = vi
+      .spyOn(BranchRepository.prototype, 'findAssistantBranches')
+      .mockResolvedValue([]);
+    const app = {
+      service(name: string) {
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const listAssistants = registerAndCaptureHandler('agor_assistants_list', {
+      app,
+      userId: 'superadmin-1',
+      authenticatedUser: {
+        user_id: 'superadmin-1',
+        email: 'superadmin@example.test',
+        role: 'superadmin',
+      },
+    });
+
+    await listAssistants({});
+
+    expect(findAssistantBranches).toHaveBeenCalledWith({
+      archived: false,
+      userId: 'superadmin-1',
+      limit: 200,
+    });
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { isBranchRbacEnabled } from '@agor/core/config';
+import { isBranchRbacEnabled, loadConfig } from '@agor/core/config';
 import { BranchRepository, shortId } from '@agor/core/db';
 import type { BoardID, Branch, BranchID, Repo, UUID, ZoneBoardObject } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, getAssistantConfig, isAssistant } from '@agor/core/types';
@@ -9,6 +9,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { BranchesServiceImpl, ReposServiceImpl } from '../../declarations.js';
 import type { BranchParams } from '../../services/branches.js';
+import { isSuperAdmin } from '../../utils/branch-authorization.js';
 import {
   resolveBoardId,
   resolveBranchId,
@@ -100,6 +101,15 @@ function notesPreview(notes: string | undefined, maxLength = 200): string | null
   const singleLine = notes.replace(/\s+/g, ' ').trim();
   if (singleLine.length <= maxLength) return singleLine;
   return `${singleLine.slice(0, maxLength - 1)}…`;
+}
+
+async function shouldScopeAssistantDiscoveryToUser(ctx: McpContext): Promise<boolean> {
+  if (!isBranchRbacEnabled()) return false;
+  if (ctx.authenticatedUser?._isServiceAccount) return false;
+
+  const config = await loadConfig();
+  const allowSuperadmin = config.execution?.allow_superadmin === true;
+  return !isSuperAdmin(ctx.authenticatedUser?.role, allowSuperadmin);
 }
 
 async function findAllArchivedBranchesForCleanup(
@@ -1256,16 +1266,16 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const query: Record<string, unknown> = { archived: false, $limit: args.limit || 200 };
-      if (args.repoId) query.repo_id = await resolveRepoId(ctx, args.repoId);
+      const limit = args.limit || 200;
+      const repoId = args.repoId ? await resolveRepoId(ctx, args.repoId) : undefined;
 
-      const result = await ctx.app.service('branches').find({ query, ...ctx.baseServiceParams });
-
-      // Filter to assistants only and shape the response
-      const branches: Branch[] = Array.isArray(result)
-        ? result
-        : (result as { data: Branch[] }).data;
-      const assistants = branches.filter((w) => isAssistant(w));
+      const branchRepo = new BranchRepository(ctx.db);
+      const assistants = await branchRepo.findAssistantBranches({
+        archived: false,
+        ...(repoId ? { repo_id: repoId as UUID } : {}),
+        ...((await shouldScopeAssistantDiscoveryToUser(ctx)) ? { userId: ctx.userId as UUID } : {}),
+        limit,
+      });
 
       // Per-branch schedule fields are now in the first-class `schedules`
       // table; consumers should call `agor_schedules_list({branchId})`

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -15,6 +15,7 @@ import { BoardRepository } from './boards';
 import { BranchRepository } from './branches';
 import { GroupRepository } from './groups';
 import { RepoRepository } from './repos';
+import { ScheduleRepository } from './schedules';
 import { UsersRepository } from './users';
 
 /**
@@ -1068,4 +1069,170 @@ describe('BranchRepository findExplicitFsAccessUserIds', () => {
       );
     }
   );
+});
+
+describe('BranchRepository.findAssistantBranches', () => {
+  dbTest(
+    'finds marker assistants and enabled-schedule legacy assistants without scanning all branches',
+    async ({ db }) => {
+      const users = new UsersRepository(db);
+      const repos = new RepoRepository(db);
+      const branches = new BranchRepository(db);
+      const schedules = new ScheduleRepository(db);
+
+      const user = await users.create({
+        email: `assistant-discovery-${Date.now()}@example.com`,
+        name: 'Assistant Discovery',
+      });
+      const repo = await repos.create(
+        createRepoData({ slug: `assistant-discovery-${Date.now()}` })
+      );
+
+      const markedCloneAssistant = await branches.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          created_by: user.user_id as UUID,
+          branch_unique_id: 1,
+          name: 'private-hodor-like',
+          storage_mode: 'clone',
+          custom_context: {
+            assistant: {
+              kind: 'assistant',
+              displayName: 'Hodor-like',
+              kb: {
+                primary_namespace_id: generateId(),
+                primary_namespace_slug: 'team-kb',
+                memory_path_template: 'memory/{{YYYY-MM-DD}}.md',
+                default_visibility: 'public',
+              },
+            },
+          },
+        })
+      );
+      await schedules.create({
+        schedule_id: generateId(),
+        branch_id: markedCloneAssistant.branch_id,
+        created_by: user.user_id as UUID,
+        name: 'Daily brief',
+        cron_expression: '0 15 * * 1-5',
+        timezone_mode: 'utc',
+        prompt: 'Run the daily brief',
+        agentic_tool_config: { agentic_tool: 'codex' },
+        enabled: true,
+        allow_concurrent_runs: false,
+        retention: 5,
+      });
+
+      const legacyScheduledAssistant = await branches.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          created_by: user.user_id as UUID,
+          branch_unique_id: 2,
+          name: 'datagor-like',
+          storage_mode: 'clone',
+        })
+      );
+      await schedules.create({
+        schedule_id: generateId(),
+        branch_id: legacyScheduledAssistant.branch_id,
+        created_by: user.user_id as UUID,
+        name: 'Heartbeat',
+        cron_expression: '0 * * * *',
+        timezone_mode: 'utc',
+        prompt: 'Heartbeat',
+        agentic_tool_config: { agentic_tool: 'claude-code' },
+        enabled: true,
+        allow_concurrent_runs: false,
+        retention: 5,
+      });
+
+      const disabledScheduledBranch = await branches.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          created_by: user.user_id as UUID,
+          branch_unique_id: 3,
+          name: 'disabled-scheduled-branch',
+          storage_mode: 'clone',
+        })
+      );
+      await schedules.create({
+        schedule_id: generateId(),
+        branch_id: disabledScheduledBranch.branch_id,
+        created_by: user.user_id as UUID,
+        name: 'Disabled heartbeat',
+        cron_expression: '0 * * * *',
+        timezone_mode: 'utc',
+        prompt: 'Heartbeat',
+        agentic_tool_config: { agentic_tool: 'claude-code' },
+        enabled: false,
+        allow_concurrent_runs: false,
+        retention: 5,
+      });
+
+      const result = await branches.findAssistantBranches({
+        archived: false,
+        repo_id: repo.repo_id as UUID,
+        limit: 10,
+      });
+
+      expect(result.map((branch) => branch.branch_id)).toEqual(
+        expect.arrayContaining([markedCloneAssistant.branch_id, legacyScheduledAssistant.branch_id])
+      );
+      expect(result.map((branch) => branch.branch_id)).not.toContain(
+        disabledScheduledBranch.branch_id
+      );
+    }
+  );
+
+  dbTest('applies branch visibility when a userId is provided', async ({ db }) => {
+    const users = new UsersRepository(db);
+    const repos = new RepoRepository(db);
+    const branches = new BranchRepository(db);
+
+    const owner = await users.create({
+      email: `assistant-owner-${Date.now()}@example.com`,
+      name: 'Assistant Owner',
+    });
+    const outsider = await users.create({
+      email: `assistant-outsider-${Date.now()}@example.com`,
+      name: 'Assistant Outsider',
+    });
+    const repo = await repos.create(createRepoData({ slug: `assistant-rbac-${Date.now()}` }));
+
+    const privateAssistant = await branches.create(
+      createBranchData({
+        repo_id: repo.repo_id as UUID,
+        created_by: owner.user_id as UUID,
+        branch_unique_id: 4,
+        name: 'private-assistant',
+        permission_source: 'override',
+        others_can: 'none',
+        custom_context: {
+          assistant: {
+            kind: 'assistant',
+            displayName: 'Private Assistant',
+          },
+        },
+      })
+    );
+    await branches.addOwner(privateAssistant.branch_id, owner.user_id as UUID);
+
+    const ownerResult = await branches.findAssistantBranches({
+      archived: false,
+      repo_id: repo.repo_id as UUID,
+      userId: owner.user_id as UUID,
+      limit: 10,
+    });
+    const outsiderResult = await branches.findAssistantBranches({
+      archived: false,
+      repo_id: repo.repo_id as UUID,
+      userId: outsider.user_id as UUID,
+      limit: 10,
+    });
+
+    expect(ownerResult.map((branch) => branch.branch_id)).toContain(privateAssistant.branch_id);
+    expect(outsiderResult.map((branch) => branch.branch_id)).not.toContain(
+      privateAssistant.branch_id
+    );
+  });
 });

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -15,7 +15,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
-import { and, desc, eq, getTableColumns, inArray, like, sql } from 'drizzle-orm';
+import { and, desc, eq, exists, getTableColumns, inArray, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
 import { getBranchUrl } from '../../utils/url';
@@ -41,6 +41,7 @@ import {
   branchOwners,
   groupMemberships,
   groups,
+  schedules,
 } from '../schema';
 import {
   type BaseRepository,
@@ -358,6 +359,66 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
 
     const baseUrl = await getBaseUrl();
     return rows.map((row: BranchRow) => this.rowToBranch(row, baseUrl));
+  }
+
+  /**
+   * Find active assistant branches without paginating the whole branch list first.
+   *
+   * A branch is discoverable as an assistant when it has the canonical assistant
+   * marker in custom_context (new or legacy key), or as a read-time backfill for
+   * older hand-bootstrapped assistants, when it has at least one enabled
+   * first-class schedule.
+   */
+  async findAssistantBranches(filter?: {
+    repo_id?: UUID;
+    archived?: boolean;
+    userId?: UUID;
+    limit?: number;
+  }): Promise<Branch[]> {
+    const assistantKindConditions = [
+      eq(sql`${jsonExtract(this.db, branches.data, 'custom_context.assistant.kind')}`, 'assistant'),
+      eq(
+        sql`${jsonExtract(this.db, branches.data, 'custom_context.assistant.kind')}`,
+        'persisted-agent'
+      ),
+      eq(sql`${jsonExtract(this.db, branches.data, 'custom_context.agent.kind')}`, 'assistant'),
+      eq(
+        sql`${jsonExtract(this.db, branches.data, 'custom_context.agent.kind')}`,
+        'persisted-agent'
+      ),
+    ];
+
+    const hasEnabledSchedule = exists(
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+      (this.db as any)
+        .select({ _: sql`1` })
+        .from(schedules)
+        .where(and(eq(schedules.branch_id, branches.branch_id), eq(schedules.enabled, true)))
+    );
+
+    const conditions = [or(...assistantKindConditions, hasEnabledSchedule) ?? sql`false`];
+    if (filter?.repo_id) conditions.push(eq(branches.repo_id, filter.repo_id));
+    if (filter?.archived !== undefined) conditions.push(eq(branches.archived, filter.archived));
+    if (filter?.userId) conditions.push(visibleBranchAccessCondition(this.db, filter.userId));
+
+    const baseQuery = select(this.db, getTableColumns(branches)).from(branches);
+    const query = filter?.userId
+      ? baseQuery.leftJoin(
+          branchOwners,
+          and(
+            eq(branchOwners.branch_id, branches.branch_id),
+            eq(branchOwners.user_id, filter.userId)
+          )
+        )
+      : baseQuery;
+
+    const rows = await query
+      .where(and(...conditions))
+      .limit(filter?.limit ?? 200)
+      .all();
+
+    const baseUrl = await getBaseUrl();
+    return (rows as BranchRow[]).map((row) => this.rowToBranch(row, baseUrl));
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #1611 by moving `agor_assistants_list` discovery into a targeted repository query instead of listing the first N branches and filtering assistants in memory.

Root cause: the MCP tool applied the default branch-list limit before `isAssistant()`, so valid assistant branches such as Hodor could be paginated out before the assistant predicate ran.

## Changes

- Added `BranchRepository.findAssistantBranches()` for DB-side assistant discovery:
  - assistant markers in `custom_context.assistant.kind` and legacy `custom_context.agent.kind`
  - enabled schedule fallback for older hand-bootstrapped assistants
  - archived/repo filters
  - optional RBAC visibility scoping
- Updated `agor_assistants_list` to call the targeted repository query and preserve response shaping.
- Preserved superadmin/service-account RBAC bypass semantics before applying direct repository scoping.
- Added MCP and repository regression tests for pagination-independent discovery, schedule-only legacy rows, and RBAC visibility.

## Verification

- `pnpm i`
- `pnpm check` ✅ (passes; existing lint warnings only)
- `pnpm --filter @agor/core test src/db/repositories/branches.test.ts`
- `pnpm --filter @agor/daemon test src/mcp/tools/branches.test.ts`
- `git diff --check`
