### PR TITLE
fix: route branch terminals by branch identity

### DIFF
--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import type { BranchID, BranchName } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
@@ -10,11 +12,13 @@ const mocks = vi.hoisted(() => {
   };
   return {
     branch,
+    branchesById: new Map<string, typeof branch>([[branch.branch_id, branch]]),
     execSync: vi.fn((cmd: string) => {
       if (cmd === 'which zellij') return Buffer.from('/usr/bin/zellij\n');
       throw new Error('not found');
     }),
     spawnExecutorFireAndForget: vi.fn(),
+    resolveUnixUserForImpersonation: vi.fn(() => ({ unixUser: null })),
     resolveUserEnvironment: vi.fn(async () => ({})),
     createUserProcessEnvironment: vi.fn(async () => ({})),
     loadConfig: vi.fn(async () => ({ daemon: { port: 3030 }, execution: { branch_rbac: false } })),
@@ -33,8 +37,8 @@ vi.mock('@agor/core/config', () => ({
 
 vi.mock('@agor/core/db', () => ({
   BranchRepository: class {
-    async findById() {
-      return mocks.branch;
+    async findById(branchId: string) {
+      return mocks.branchesById.get(branchId) ?? null;
     }
     async isOwner() {
       return true;
@@ -43,15 +47,17 @@ vi.mock('@agor/core/db', () => ({
   SessionRepository: class {},
   UsersRepository: class {
     async findById() {
-      return null;
+      return { unix_username: 'alice' };
     }
   },
-  shortId: () => 'short-user',
+  shortId: (id: string) => id.slice(0, 8),
 }));
 
 vi.mock('@agor/core/unix', () => ({
   UnixUserNotFoundError: class UnixUserNotFoundError extends Error {},
-  resolveUnixUserForImpersonation: () => ({ unixUser: null }),
+  getBranchSymlinkPath: (username: string, branchName: string) =>
+    `/home/${username}/agor/worktrees/${branchName}`,
+  resolveUnixUserForImpersonation: mocks.resolveUnixUserForImpersonation,
   validateResolvedUnixUser: () => undefined,
 }));
 
@@ -74,11 +80,12 @@ vi.mock('./claude-cli-integration.js', () => ({
   writeClaudeCliMcpConfigForSession: vi.fn(async () => undefined),
 }));
 
-import { TerminalsService } from './terminals';
+import { buildBranchShellTabName, TerminalsService } from './terminals';
 
 function makeApp() {
   const emit = vi.fn();
   return {
+    emit,
     io: {
       to: vi.fn(() => ({ emit })),
     },
@@ -95,10 +102,14 @@ describe('TerminalsService cold-start concurrency', () => {
     vi.clearAllMocks();
     mocks.execSync.mockImplementation((cmd: string) => {
       if (cmd === 'which zellij') return Buffer.from('/usr/bin/zellij\n');
+      if (cmd.startsWith('sudo -n chown ')) return Buffer.from('');
       throw new Error('not found');
     });
+    mocks.resolveUnixUserForImpersonation.mockReturnValue({ unixUser: null });
     mocks.resolveUserEnvironment.mockResolvedValue({});
     mocks.createUserProcessEnvironment.mockResolvedValue({});
+    mocks.branchesById.clear();
+    mocks.branchesById.set(mocks.branch.branch_id, mocks.branch);
     mocks.loadConfig.mockResolvedValue({
       daemon: { port: 3030 },
       execution: { branch_rbac: false },
@@ -129,5 +140,169 @@ describe('TerminalsService cold-start concurrency', () => {
     expect(firstResult.isNew).toBe(true);
     expect(secondResult.isNew).toBe(false);
     expect(firstResult.sessionName).toBe(secondResult.sessionName);
+  });
+});
+
+describe('TerminalsService branch shell tabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.execSync.mockImplementation((cmd: string) => {
+      if (cmd === 'which zellij') return Buffer.from('/usr/bin/zellij\n');
+      if (cmd.startsWith('sudo -n chown ')) return Buffer.from('');
+      throw new Error('not found');
+    });
+    mocks.resolveUnixUserForImpersonation.mockReturnValue({ unixUser: null });
+    mocks.resolveUserEnvironment.mockResolvedValue({});
+    mocks.createUserProcessEnvironment.mockResolvedValue({});
+    mocks.loadConfig.mockResolvedValue({
+      daemon: { port: 3030 },
+      execution: { branch_rbac: false },
+    });
+    mocks.branchesById.clear();
+  });
+
+  it('includes branch identity in shell tab names even when branch names match', () => {
+    const first = {
+      branch_id: '11111111-1111-7111-8111-111111111111' as BranchID,
+      name: 'same-name' as BranchName,
+    };
+    const second = {
+      branch_id: '22222222-2222-7222-8222-222222222222' as BranchID,
+      name: 'same-name' as BranchName,
+    };
+
+    expect(buildBranchShellTabName(first)).toBe('same-name · 11111111');
+    expect(buildBranchShellTabName(second)).toBe('same-name · 22222222');
+    expect(buildBranchShellTabName(first)).not.toBe(buildBranchShellTabName(second));
+  });
+
+  it('uses identity-safe tab names for cold-start and warm branch shell routing', async () => {
+    const firstBranch = {
+      ...mocks.branch,
+      branch_id: '11111111-1111-7111-8111-111111111111' as BranchID,
+      name: 'same-name',
+      path: '/tmp/repo-a/same-name',
+    };
+    const secondBranch = {
+      ...mocks.branch,
+      branch_id: '22222222-2222-7222-8222-222222222222' as BranchID,
+      name: 'same-name',
+      path: '/tmp/repo-b/same-name',
+    };
+    mocks.branchesById.set(firstBranch.branch_id, firstBranch);
+    mocks.branchesById.set(secondBranch.branch_id, secondBranch);
+
+    const app = makeApp();
+    const service = new TerminalsService(app as never, {} as never);
+
+    const first = await service.create(
+      { branchId: firstBranch.branch_id, rows: 24, cols: 80 },
+      params as never
+    );
+
+    expect(first).toMatchObject({
+      isNew: true,
+      branchName: 'same-name',
+    });
+    expect(mocks.spawnExecutorFireAndForget).toHaveBeenCalledTimes(1);
+    expect(mocks.spawnExecutorFireAndForget.mock.calls[0]?.[0]).toMatchObject({
+      command: 'zellij.attach',
+      params: {
+        cwd: firstBranch.path,
+        tabName: 'same-name · 11111111',
+      },
+    });
+
+    const second = await service.create(
+      { branchId: secondBranch.branch_id, rows: 24, cols: 80 },
+      params as never
+    );
+
+    expect(second).toMatchObject({
+      isNew: false,
+      branchName: 'same-name',
+    });
+    expect(app.emit).toHaveBeenCalledWith('terminal:tab', {
+      userId: params.user.user_id,
+      action: 'create',
+      tabName: 'same-name · 22222222',
+      cwd: secondBranch.path,
+    });
+  });
+
+  it('falls back to branch.path when an impersonated same-name symlink resolves elsewhere', async () => {
+    const staleSymlinkPath = '/home/alice/agor/worktrees/same-name';
+    const requestedBranch = {
+      ...mocks.branch,
+      branch_id: '11111111-1111-7111-8111-111111111111' as BranchID,
+      name: 'same-name',
+      path: '/tmp/repo-a/same-name',
+    };
+    mocks.branchesById.set(requestedBranch.branch_id, requestedBranch);
+    mocks.resolveUnixUserForImpersonation.mockReturnValue({ unixUser: 'alice' });
+    const realpathSpy = vi.spyOn(fs, 'realpathSync').mockImplementation((pathToResolve) => {
+      const pathString = String(pathToResolve);
+      if (pathString === staleSymlinkPath) return '/tmp/repo-b/same-name';
+      if (pathString === requestedBranch.path) return requestedBranch.path;
+      throw new Error(`Unexpected realpath: ${pathString}`);
+    });
+
+    try {
+      const service = new TerminalsService(makeApp() as never, {} as never);
+
+      await service.create(
+        { branchId: requestedBranch.branch_id, rows: 24, cols: 80 },
+        params as never
+      );
+
+      expect(mocks.spawnExecutorFireAndForget).toHaveBeenCalledTimes(1);
+      expect(mocks.spawnExecutorFireAndForget.mock.calls[0]?.[0]).toMatchObject({
+        command: 'zellij.attach',
+        params: {
+          cwd: requestedBranch.path,
+          tabName: 'same-name · 11111111',
+        },
+      });
+    } finally {
+      realpathSpy.mockRestore();
+    }
+  });
+
+  it('uses the impersonated symlink when it resolves to the requested branch path', async () => {
+    const matchingSymlinkPath = '/home/alice/agor/worktrees/same-name';
+    const requestedBranch = {
+      ...mocks.branch,
+      branch_id: '11111111-1111-7111-8111-111111111111' as BranchID,
+      name: 'same-name',
+      path: '/tmp/repo-a/same-name',
+    };
+    mocks.branchesById.set(requestedBranch.branch_id, requestedBranch);
+    mocks.resolveUnixUserForImpersonation.mockReturnValue({ unixUser: 'alice' });
+    const realpathSpy = vi.spyOn(fs, 'realpathSync').mockImplementation((pathToResolve) => {
+      const pathString = String(pathToResolve);
+      if (pathString === matchingSymlinkPath) return requestedBranch.path;
+      if (pathString === requestedBranch.path) return requestedBranch.path;
+      throw new Error(`Unexpected realpath: ${pathString}`);
+    });
+
+    try {
+      const service = new TerminalsService(makeApp() as never, {} as never);
+
+      await service.create(
+        { branchId: requestedBranch.branch_id, rows: 24, cols: 80 },
+        params as never
+      );
+
+      expect(mocks.spawnExecutorFireAndForget).toHaveBeenCalledTimes(1);
+      expect(mocks.spawnExecutorFireAndForget.mock.calls[0]?.[0]).toMatchObject({
+        command: 'zellij.attach',
+        params: {
+          cwd: matchingSymlinkPath,
+          tabName: 'same-name · 11111111',
+        },
+      });
+    } finally {
+      realpathSpy.mockRestore();
+    }
   });
 });

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -37,8 +37,9 @@ import {
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { Forbidden } from '@agor/core/feathers';
-import type { AuthenticatedParams, BranchID, UserID } from '@agor/core/types';
+import type { AuthenticatedParams, Branch, BranchID, UserID } from '@agor/core/types';
 import {
+  getBranchSymlinkPath,
   resolveUnixUserForImpersonation,
   type UnixUserMode,
   UnixUserNotFoundError,
@@ -85,6 +86,50 @@ interface CreateTerminalData {
    * deterministically from the session id.
    */
   ensureCliSessionId?: string;
+}
+
+/**
+ * Build the Zellij tab identity for a branch shell.
+ *
+ * Zellij tab operations are keyed only by tab title. A user has one shared
+ * Zellij session, so plain `branch.name` collides when two branches with the
+ * same display name exist on different boards or repos. Keep the title readable
+ * while making the operational identity stable by branch id.
+ */
+export function buildBranchShellTabName(branch: Pick<Branch, 'branch_id' | 'name'>): string {
+  return `${branch.name} · ${shortId(branch.branch_id)}`;
+}
+
+function safeRealpath(pathToResolve: string): string | null {
+  try {
+    return fs.realpathSync(pathToResolve);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the cwd for a branch shell.
+ *
+ * In Unix impersonation modes users get convenience symlinks under
+ * ~/agor/worktrees/<branch-name>. Those links are name-keyed, so same-name
+ * branches can collide. Only use the symlink when canonical resolution proves
+ * it targets the requested branch path; otherwise fall back to branch.path.
+ */
+export function resolveBranchShellCwd(
+  branch: Pick<Branch, 'name' | 'path'>,
+  finalUnixUser: string | null
+): string {
+  if (!finalUnixUser) return branch.path;
+
+  const symlinkPath = getBranchSymlinkPath(finalUnixUser, branch.name);
+  const symlinkRealpath = safeRealpath(symlinkPath);
+  if (!symlinkRealpath) return branch.path;
+
+  const branchRealpath = safeRealpath(branch.path);
+  if (!branchRealpath) return branch.path;
+
+  return symlinkRealpath === branchRealpath ? symlinkPath : branch.path;
 }
 
 /**
@@ -591,11 +636,12 @@ export class TerminalsService {
         const branchRepo = new BranchRepository(this.db);
         const branch = await branchRepo.findById(data.branchId);
         if (branch) {
+          const branchTabName = buildBranchShellTabName(branch);
           // Emit tab command via channel - executor will handle it
           this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
             userId,
             action: 'create',
-            tabName: branch.name,
+            tabName: branchTabName,
             cwd: branch.path,
           });
 
@@ -616,7 +662,7 @@ export class TerminalsService {
           //
           // Falls back to the old plain-focus behavior when the caller
           // provided a `focusTabName` without an `ensureCliSessionId`.
-          if (data.cliEnsure && data.cliEnsure.tabName !== branch.name) {
+          if (data.cliEnsure && data.cliEnsure.tabName !== branchTabName) {
             const ensure = data.cliEnsure;
             const alive = await isClaudeRunningFor(
               ensure.sessionId as unknown as import('@agor/core/types').SessionID
@@ -640,7 +686,7 @@ export class TerminalsService {
                 });
               }
             }, 300);
-          } else if (data.focusTabName && data.focusTabName !== branch.name) {
+          } else if (data.focusTabName && data.focusTabName !== branchTabName) {
             setTimeout(() => {
               this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
                 userId,
@@ -731,18 +777,15 @@ export class TerminalsService {
       // Determine cwd and branch info
       let cwd = os.homedir();
       let branchName: string | undefined;
+      let branchTabName: string | undefined;
 
       if (data.branchId) {
         const branchRepo = new BranchRepository(this.db);
         const branch = await branchRepo.findById(data.branchId);
         if (branch) {
           branchName = branch.name;
-          if (finalUnixUser) {
-            const symlinkPath = `/home/${finalUnixUser}/agor/worktrees/${branch.name}`;
-            cwd = fs.existsSync(symlinkPath) ? symlinkPath : branch.path;
-          } else {
-            cwd = branch.path;
-          }
+          branchTabName = buildBranchShellTabName(branch);
+          cwd = resolveBranchShellCwd(branch, finalUnixUser);
         }
       }
 
@@ -777,7 +820,7 @@ export class TerminalsService {
             userId,
             sessionName,
             cwd,
-            tabName: branchName,
+            tabName: branchTabName,
             cols: data.cols || 160,
             rows: data.rows || 40,
             envFile, // Pass env file path for shell to source

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -1,6 +1,6 @@
 import type { Branch, Repo } from '@agor-live/client';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import {
   REACT_FLOW_DRAG_HANDLE_SELECTOR,
@@ -43,5 +43,34 @@ describe('BranchCard drag handle', () => {
 
     expect(title.closest(REACT_FLOW_DRAG_HANDLE_SELECTOR)).not.toBeNull();
     expect(title.closest(`.${REACT_FLOW_NO_DRAG_CLASS}`)).toBeNull();
+  });
+
+  it('opens terminals with structured branch id routing instead of raw cd input', () => {
+    const onOpenTerminal = vi.fn();
+    render(
+      <ConnectionProvider value={connected}>
+        <BranchCard
+          branch={
+            {
+              branch_id: 'branch-1',
+              name: 'feature/canvas-drag',
+              repo_id: 'repo-1',
+              path: '/tmp/feature-canvas-drag',
+              filesystem_status: 'ready',
+              archived: false,
+            } as unknown as Branch
+          }
+          repo={{ repo_id: 'repo-1', slug: 'preset-io/agor' } as unknown as Repo}
+          sessions={[]}
+          userById={new Map()}
+          client={null}
+          onOpenTerminal={onOpenTerminal}
+        />
+      </ConnectionProvider>
+    );
+
+    fireEvent.click(screen.getByTitle('Open terminal in branch directory'));
+
+    expect(onOpenTerminal).toHaveBeenCalledWith([], 'branch-1');
   });
 });

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -445,7 +445,7 @@ const BranchCardComponent = ({
                 icon={<CodeOutlined />}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onOpenTerminal([`cd ${branch.path}`], branch.branch_id);
+                  onOpenTerminal([], branch.branch_id);
                 }}
                 title="Open terminal in branch directory"
               />

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -1,0 +1,125 @@
+import type { Branch, Session } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { AppActionsProvider } from '../../contexts/AppActionsContext';
+import { AppEntityDataProvider } from '../../contexts/AppDataContext';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import SessionPanel from './SessionPanel';
+
+vi.mock('../AutocompleteTextarea', () => ({
+  AutocompleteTextarea: () => <textarea aria-label="Prompt" />,
+}));
+
+vi.mock('../FileUpload', () => ({
+  FileUpload: () => null,
+  FileUploadButton: (props: { onClick?: () => void; disabled?: boolean }) => (
+    <button type="button" disabled={props.disabled} onClick={props.onClick}>
+      Upload Files
+    </button>
+  ),
+}));
+
+vi.mock('../ForkSpawnModal/ForkSpawnModal', () => ({
+  ForkSpawnModal: () => null,
+}));
+
+vi.mock('../MCPServer', () => ({
+  MCPServerPill: () => <span>MCP server</span>,
+}));
+
+vi.mock('../metadata', () => ({
+  CreatedByTag: () => <span>Created by test user</span>,
+}));
+
+vi.mock('../Pill', () => ({
+  ContextWindowPill: () => <span>Context window</span>,
+  TimerPill: () => <span>Timer</span>,
+  TokenCountPill: () => <span>Tokens</span>,
+}));
+
+vi.mock('../SessionIds', () => ({
+  SessionIdsButton: () => <span>Session IDs</span>,
+}));
+
+vi.mock('../ToolIcon', () => ({
+  ToolIcon: () => <span>Tool icon</span>,
+}));
+
+vi.mock('./SessionAttachmentsDropdown', () => ({
+  SessionAttachmentsDropdown: () => null,
+}));
+
+vi.mock('./SessionMcpFooterControl', () => ({
+  SessionMcpFooterControl: () => null,
+}));
+
+vi.mock('./SessionPanelContent', () => ({
+  SessionPanelContent: () => <div>Session content</div>,
+}));
+
+vi.mock('./SessionRunSettingsPopover', () => ({
+  SessionRunSettingsPopover: () => null,
+}));
+
+const connected = {
+  connected: true,
+  connecting: false,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+
+const session = {
+  session_id: 'session-1',
+  branch_id: 'branch-1',
+  title: 'Terminal routing session',
+  agentic_tool: 'claude-code-cli',
+  status: 'idle',
+  archived: false,
+  created_at: '2026-06-24T00:00:00.000Z',
+  last_updated: '2026-06-24T00:00:00.000Z',
+} as unknown as Session;
+
+const branch = {
+  branch_id: 'branch-1',
+  board_id: 'board-1',
+  name: 'feature/same-name',
+  path: '/tmp/feature-same-name',
+  filesystem_status: 'ready',
+  archived: false,
+} as unknown as Branch;
+
+function renderPanel(onOpenTerminal = vi.fn()) {
+  render(
+    <ConnectionProvider value={connected}>
+      <AppEntityDataProvider
+        value={{
+          repoById: new Map(),
+          userById: new Map(),
+          mcpServerById: new Map(),
+          userAuthenticatedMcpServerIds: new Set(),
+        }}
+      >
+        <AppActionsProvider value={{ onOpenTerminal }}>
+          <AntApp>
+            <SessionPanel client={null} session={session} branch={branch} open onClose={vi.fn()} />
+          </AntApp>
+        </AppActionsProvider>
+      </AppEntityDataProvider>
+    </ConnectionProvider>
+  );
+  return { onOpenTerminal };
+}
+
+describe('SessionPanel terminal actions', () => {
+  it('opens branch terminals with structured branch id routing instead of raw cd input', async () => {
+    const { onOpenTerminal } = renderPanel();
+
+    fireEvent.click(screen.getByRole('img', { name: 'ellipsis' }).closest('button')!);
+    fireEvent.click(await screen.findByText('Open terminal'));
+
+    expect(onOpenTerminal).toHaveBeenCalledWith([], 'branch-1');
+    expect(onOpenTerminal.mock.calls[0][0]).not.toContain(branch.path);
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -580,7 +580,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             key: 'terminal',
             icon: <CodeOutlined />,
             label: 'Open terminal',
-            onClick: () => onOpenTerminal([`cd ${branch.path}`], branch.branch_id),
+            onClick: () => onOpenTerminal([], branch.branch_id),
           },
         ]
       : []),


### PR DESCRIPTION
## Summary
- Route branch terminal tabs by branch identity instead of display name.
- Open branch terminals through structured branch ids instead of raw `cd` input.
- Guard impersonated cold-start cwd resolution so stale same-name symlinks cannot route to another branch.

Fixes #1589.

## Root cause
A user's shared terminal session keyed branch shell tabs by branch display name. Same-name branches across repos or boards could therefore focus an existing tab for another branch, and impersonated cold starts could also choose a stale name-keyed symlink.

## Validation
- `pnpm --filter @agor/daemon test -- src/services/terminals.test.ts`
- `pnpm --filter agor-ui test -- src/components/BranchCard/BranchCard.drag.test.tsx src/components/SessionPanel/SessionPanel.test.tsx`
- `pnpm exec biome check apps/agor-daemon/src/services/terminals.ts apps/agor-daemon/src/services/terminals.test.ts apps/agor-ui/src/components/BranchCard/BranchCard.tsx apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx`
- `git diff --check`
