### PR TITLE
fix(mcp): reject cross-branch zone trigger targets

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -346,6 +346,159 @@ describe('agor_branches_set_zone', () => {
     ).rejects.toThrow(/cannot be used when zoneId is null/i);
     expect(findByBranchId).not.toHaveBeenCalled();
   });
+
+  it('triggers a show_picker zone prompt when the target session belongs to the moved branch', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+    };
+    const branch = {
+      branch_id: 'branch-1',
+      board_id: 'board-1',
+      name: 'Branch 1',
+    };
+    const targetSession = {
+      session_id: 'session-1',
+      branch_id: 'branch-1',
+      description: 'Existing branch session',
+      custom_context: {},
+    };
+    const zone = {
+      type: 'zone',
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 200,
+      label: 'Evidence/QA',
+      trigger: {
+        behavior: 'show_picker',
+        template: 'Run {{branch.name}} in {{zone.label}}',
+      },
+    };
+    const branchesGet = vi.fn(async () => branch);
+    const sessionsGet = vi.fn(async () => targetSession);
+    const boardsGet = vi.fn(async () => ({
+      board_id: 'board-1',
+      objects: {
+        'zone-validate': zone,
+      },
+    }));
+    const findByBranchId = vi.fn(async () => ({
+      object_id: 'obj-branch-1',
+      branch_id: 'branch-1',
+    }));
+    const boardObjectsPatch = vi.fn(async () => ({
+      object_id: 'obj-branch-1',
+      branch_id: 'branch-1',
+      zone_id: 'zone-validate',
+    }));
+    const promptCreate = vi.fn(async () => ({
+      task_id: 'task-1',
+      status: 'running',
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: branchesGet };
+        if (name === 'sessions') return { get: sessionsGet };
+        if (name === 'boards') return { get: boardsGet };
+        if (name === 'board-objects') {
+          return {
+            findByBranchId,
+            patch: boardObjectsPatch,
+          };
+        }
+        if (name === '/sessions/:id/prompt') return { create: promptCreate };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const setZone = registerAndCaptureHandler('agor_branches_set_zone', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await setZone({
+      branchId: 'branch-1',
+      zoneId: 'zone-validate',
+      triggerTemplate: true,
+      targetSessionId: 'session-1',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(sessionsGet).toHaveBeenCalledWith('session-1', baseServiceParams);
+    expect(boardObjectsPatch).toHaveBeenCalledWith(
+      'obj-branch-1',
+      expect.objectContaining({ zone_id: 'zone-validate' }),
+      baseServiceParams
+    );
+    expect(promptCreate).toHaveBeenCalledWith(
+      { prompt: 'Run Branch 1 in Evidence/QA', stream: true },
+      { ...baseServiceParams, route: { id: 'session-1' } }
+    );
+    expect(parsed.trigger.sessionId).toBe('session-1');
+  });
+
+  it('rejects show_picker zone triggers when the target session belongs to another branch', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+    };
+    const branch = {
+      branch_id: 'branch-1',
+      board_id: 'board-1',
+      name: 'Branch 1',
+    };
+    const targetSession = {
+      session_id: 'session-2',
+      branch_id: 'branch-2',
+      description: 'Other branch session',
+      custom_context: {},
+    };
+    const branchesGet = vi.fn(async () => branch);
+    const sessionsGet = vi.fn(async () => targetSession);
+    const boardsGet = vi.fn();
+    const findByBranchId = vi.fn();
+    const boardObjectsPatch = vi.fn();
+    const promptCreate = vi.fn();
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: branchesGet };
+        if (name === 'sessions') return { get: sessionsGet };
+        if (name === 'boards') return { get: boardsGet };
+        if (name === 'board-objects') {
+          return {
+            findByBranchId,
+            patch: boardObjectsPatch,
+          };
+        }
+        if (name === '/sessions/:id/prompt') return { create: promptCreate };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const setZone = registerAndCaptureHandler('agor_branches_set_zone', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    await expect(
+      setZone({
+        branchId: 'branch-1',
+        zoneId: 'zone-validate',
+        triggerTemplate: true,
+        targetSessionId: 'session-2',
+      })
+    ).rejects.toThrow(/belongs to branch branch2.*moving branch branch1/i);
+
+    expect(boardsGet).not.toHaveBeenCalled();
+    expect(findByBranchId).not.toHaveBeenCalled();
+    expect(boardObjectsPatch).not.toHaveBeenCalled();
+    expect(promptCreate).not.toHaveBeenCalled();
+  });
 });
 
 describe('agor_branches_list', () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1,7 +1,15 @@
 import { existsSync } from 'node:fs';
 import { isBranchRbacEnabled, loadConfig } from '@agor/core/config';
 import { BranchRepository, shortId } from '@agor/core/db';
-import type { BoardID, Branch, BranchID, Repo, UUID, ZoneBoardObject } from '@agor/core/types';
+import type {
+  BoardID,
+  Branch,
+  BranchID,
+  Repo,
+  Session,
+  UUID,
+  ZoneBoardObject,
+} from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS, getAssistantConfig, isAssistant } from '@agor/core/types';
 import { computeZoneRelativePosition } from '@agor/core/utils/board-placement';
 import { normalizeOptionalHttpUrl } from '@agor/core/utils/url';
@@ -15,7 +23,6 @@ import {
   resolveBranchId,
   resolveMcpServerId,
   resolveRepoId,
-  resolveSessionId,
 } from '../resolve-ids.js';
 import {
   mcpLimit,
@@ -892,9 +899,15 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         );
       }
 
-      const targetSessionId = rawTargetSessionId
-        ? await resolveSessionId(ctx, rawTargetSessionId)
+      const targetSession = rawTargetSessionId
+        ? ((await ctx.app
+            .service('sessions')
+            .get(rawTargetSessionId, ctx.baseServiceParams)) as Pick<
+            Session,
+            'session_id' | 'branch_id' | 'description' | 'custom_context'
+          >)
         : undefined;
+      const targetSessionId = targetSession?.session_id;
 
       console.log(
         zoneId === null
@@ -904,6 +917,16 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
 
       // Get branch to find its board
       const branch = await ctx.app.service('branches').get(branchId, ctx.baseServiceParams);
+
+      if (triggerTemplate && targetSession && targetSession.branch_id !== branch.branch_id) {
+        throw new Error(
+          `targetSessionId ${shortId(targetSession.session_id)} belongs to branch ${shortId(
+            targetSession.branch_id
+          )}, but agor_branches_set_zone is moving branch ${shortId(
+            branch.branch_id
+          )}. Use a session in the moved branch or create a branch-local session first.`
+        );
+      }
 
       // Find or create board object for this branch
       const boardObjectsService = ctx.app.service('board-objects') as unknown as {
@@ -1021,18 +1044,6 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         // Pull the target session into the render context so templates can
         // reference `{{session.description}}` / `{{session.context.foo}}` —
         // matches what the UI's reuse-existing preview path does.
-        let targetSession:
-          | { description?: string; custom_context?: Record<string, unknown> }
-          | undefined;
-        try {
-          targetSession = await ctx.app
-            .service('sessions')
-            .get(targetSessionId, ctx.baseServiceParams);
-        } catch {
-          // Session lookup is best-effort; render context defaults are safe.
-          targetSession = undefined;
-        }
-
         const templateContext = buildZoneTriggerContext({
           branch,
           board,


### PR DESCRIPTION
## Summary

- reject `agor_branches_set_zone(triggerTemplate: true)` when `targetSessionId` belongs to a different branch
- reuse the resolved target session for zone template context
- add same-branch success and cross-branch rejection coverage

Closes #1618.

## Validation

- `pnpm --filter @agor/daemon test -- src/mcp/tools/branches.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm exec biome check apps/agor-daemon/src/mcp/tools/branches.ts apps/agor-daemon/src/mcp/tools/branches.test.ts`
- `git diff --check -- apps/agor-daemon/src/mcp/tools/branches.ts apps/agor-daemon/src/mcp/tools/branches.test.ts`