### PR TITLE
Expose branch attention updates through MCP

### DIFF
--- a/apps/agor-daemon/src/mcp/routes.test.ts
+++ b/apps/agor-daemon/src/mcp/routes.test.ts
@@ -395,25 +395,38 @@ describeIntegration('MCP Tools - Branch Tools', () => {
     const branch = branches.data[0];
     const branchId = branch.branch_id;
 
-    const updated = await callMCPTool('agor_branches_update', {
-      branchId,
-      issueUrl: 'https://example.com/issues/123',
-      pullRequestUrl: null,
-      notes: 'Updated via MCP test',
-    });
+    try {
+      const updated = await callMCPTool('agor_branches_update', {
+        branchId,
+        issueUrl: 'https://example.com/issues/123',
+        pullRequestUrl: null,
+        notes: 'Updated via MCP test',
+        needsAttention: false,
+      });
 
-    expect(updated.branch.branch_id).toBe(branchId);
-    expect(updated.branch.issue_url).toBe('https://example.com/issues/123');
-    expect(updated.branch.pull_request_url).toBeNull();
-    expect(updated.branch.notes).toBe('Updated via MCP test');
+      expect(updated.branch.branch_id).toBe(branchId);
+      expect(updated.branch.issue_url).toBe('https://example.com/issues/123');
+      expect(updated.branch.pull_request_url).toBeNull();
+      expect(updated.branch.notes).toBe('Updated via MCP test');
+      expect(updated.branch.needs_attention).toBe(false);
 
-    // Restore original state
-    await callMCPTool('agor_branches_update', {
-      branchId,
-      issueUrl: branch.issue_url ?? null,
-      pullRequestUrl: branch.pull_request_url ?? null,
-      notes: branch.notes ?? null,
-    });
+      const attentionUpdated = await callMCPTool('agor_branches_update', {
+        branchId,
+        needsAttention: true,
+      });
+
+      expect(attentionUpdated.branch.branch_id).toBe(branchId);
+      expect(attentionUpdated.branch.needs_attention).toBe(true);
+    } finally {
+      // Restore original state
+      await callMCPTool('agor_branches_update', {
+        branchId,
+        issueUrl: branch.issue_url ?? null,
+        pullRequestUrl: branch.pull_request_url ?? null,
+        notes: branch.notes ?? null,
+        needsAttention: branch.needs_attention,
+      });
+    }
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -145,6 +145,48 @@ describe('agor_branches_update', () => {
     expect(branchesPatch).toHaveBeenCalledWith('branch-1', { notes: 'updated' }, baseServiceParams);
   });
 
+  it('clears branch attention state through branch metadata updates', async () => {
+    const branchesGet = vi.fn(async () => ({ branch_id: 'branch-1' }));
+    const branchesPatch = vi.fn(async () => ({
+      branch_id: 'branch-1',
+      needs_attention: false,
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: branchesGet, patch: branchesPatch };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const update = registerAndCaptureUpdate({ app, userId: 'user-1' });
+
+    await update({ branchId: 'branch-1', needsAttention: false });
+
+    expect(branchesGet).toHaveBeenCalledWith('branch-1', {});
+    expect(branchesPatch).toHaveBeenCalledWith('branch-1', { needs_attention: false }, {});
+  });
+
+  it('marks branch attention state through branch metadata updates', async () => {
+    const branchesGet = vi.fn(async () => ({ branch_id: 'branch-1' }));
+    const branchesPatch = vi.fn(async () => ({
+      branch_id: 'branch-1',
+      needs_attention: true,
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: branchesGet, patch: branchesPatch };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const update = registerAndCaptureUpdate({ app, userId: 'user-1' });
+
+    await update({ branchId: 'branch-1', needsAttention: true });
+
+    expect(branchesGet).toHaveBeenCalledWith('branch-1', {});
+    expect(branchesPatch).toHaveBeenCalledWith('branch-1', { needs_attention: true }, {});
+  });
+
   it('returns an actionable error when branchId is omitted without session context', async () => {
     const sessionsGet = vi.fn();
     const app = {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -257,6 +257,23 @@ describe('agor_branches_create', () => {
 });
 
 describe('branch MCP input schemas', () => {
+  it('accepts boolean branch attention updates and rejects non-booleans', () => {
+    const config = registerAndCaptureConfig('agor_branches_update', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    expect(
+      config.inputSchema?.safeParse({ branchId: 'branch-1', needsAttention: false }).success
+    ).toBe(true);
+    expect(
+      config.inputSchema?.safeParse({ branchId: 'branch-1', needsAttention: true }).success
+    ).toBe(true);
+    expect(
+      config.inputSchema?.safeParse({ branchId: 'branch-1', needsAttention: 'false' }).success
+    ).toBe(false);
+  });
+
   it('rejects empty required IDs/names with field-specific messages', () => {
     const config = registerAndCaptureConfig('agor_branches_create', {
       app: {},

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -622,7 +622,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     'agor_branches_update',
     {
       description:
-        'Update metadata for an existing branch (issue/PR URLs, notes, board placement, custom context, RBAC permissions, owners)',
+        'Update metadata for an existing branch (issue/PR URLs, notes, board placement, attention state, custom context, RBAC permissions, owners)',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
         branchId: mcpOptionalId(
@@ -667,6 +667,12 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           .optional()
           .describe(
             'Default MCP server IDs for new sessions in this branch. Sessions inherit these unless they explicitly specify their own. Pass null to clear.'
+          ),
+        needsAttention: z
+          .boolean({ error: 'needsAttention must be a boolean when provided.' })
+          .optional()
+          .describe(
+            'Branch/card attention highlight state. Pass true to mark the branch as needing attention, or false to clear it.'
           ),
         // RBAC fields (optional, safe to ignore for single-user setups)
         othersCan: z
@@ -765,6 +771,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           args.mcpServerIds === null
             ? []
             : await Promise.all(args.mcpServerIds.map((id) => resolveMcpServerId(ctx, id)));
+      }
+      if (args.needsAttention !== undefined) {
+        fieldsProvided++;
+        updates.needs_attention = args.needsAttention;
       }
       if (args.othersCan !== undefined) {
         fieldsProvided++;

--- a/apps/agor-docs/pages/guide/architecture.mdx
+++ b/apps/agor-docs/pages/guide/architecture.mdx
@@ -382,7 +382,7 @@ $ agor session list | grep running | wc -l
 | `agor_branches_get` | Get branch details | `{ branchId: '...' }` |
 | `agor_branches_list` | List branches, including zone metadata and optional zone filtering | `{ limit: 10, zoneId: 'zone-review' }` |
 | `agor_branches_create` | Create a branch with optional issue/PR links | `{ repoId: '019a...', branchName: 'feat-x', issueUrl: 'https://...' }` |
-| `agor_branches_update` | Update branch metadata (issue/PR URLs, notes) | `{ branchId: '019a...', pullRequestUrl: 'https://...', notes: 'Ready for review' }` |
+| `agor_branches_update` | Update branch metadata (issue/PR URLs, notes, attention state) | `{ branchId: '019a...', pullRequestUrl: 'https://...', notes: 'Ready for review', needsAttention: false }` |
 | `agor_branches_set_zone` | Pin a branch to a board zone, or clear its zone pin with `zoneId: null` | `{ branchId: '019a...', zoneId: null }` |
 
 **Board Tools:**


### PR DESCRIPTION
## Summary

- Exposes the existing branch `needs_attention` flag through `agor_branches_update` as `needsAttention`.
- Maps both `true` and `false` explicitly to the branch service patch payload.
- Updates MCP docs and regression coverage for setting and clearing attention.

Closes #1619.

## Validation

- `pnpm --filter @agor/daemon test -- src/mcp/tools/branches.test.ts src/mcp/routes.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm exec biome check apps/agor-daemon/src/mcp/tools/branches.ts apps/agor-daemon/src/mcp/tools/branches.test.ts apps/agor-daemon/src/mcp/routes.test.ts apps/agor-docs/pages/guide/architecture.mdx`
- `git diff --check -- apps/agor-daemon/src/mcp/tools/branches.ts apps/agor-daemon/src/mcp/tools/branches.test.ts apps/agor-daemon/src/mcp/routes.test.ts apps/agor-docs/pages/guide/architecture.mdx`

Note: the route test file is configured to skip integration tests in this local environment; the focused branch tool unit tests executed and passed.
