### PR TITLE
[codex] fix socket reauth after password-change login

### DIFF
--- a/apps/agor-ui/src/hooks/useAgorClient.ts
+++ b/apps/agor-ui/src/hooks/useAgorClient.ts
@@ -443,13 +443,14 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
 
     connect();
 
-    // In-place reauth on token refresh. When singleFlightRefresh rotates
-    // the access token, it dispatches TOKENS_REFRESHED_EVENT. Instead of
-    // rebuilding the entire socket (which would flicker the UI and reset
-    // every real-time subscription), we just call client.authenticate with
-    // the new token on the existing socket. If the socket happens to be
-    // disconnected at the moment of refresh, skip — the connect handler
-    // will pick up the fresh token from the ref when the socket reconnects.
+    // In-place reauth on token replacement. When refresh, local login, or
+    // launch sign-in stores a fresh access token, it dispatches
+    // TOKENS_REFRESHED_EVENT. Instead of rebuilding the entire socket (which
+    // would flicker the UI and reset every real-time subscription), we just
+    // call client.authenticate with the new token on the existing socket. If
+    // the socket happens to be disconnected at the moment of replacement, skip
+    // — the connect handler will pick up the fresh token from the ref when the
+    // socket reconnects.
     const handleTokensRefreshed = (event: Event) => {
       if (!mounted) return;
       const detail = (event as CustomEvent<RefreshResult>).detail;
@@ -463,12 +464,11 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
           // refresh attempt fails transiently (network half-restored, daemon
           // briefly 5xxs, etc.) — see the `setConnecting(true); return;`
           // branch above. Without this `setConnected(true)`, a later
-          // successful refresh from any source (proactive timer, around-hook
-          // on a user click, visibility-change handler) re-authenticates the
+          // successful token replacement from any source re-authenticates the
           // socket but the navbar stays stuck on "Reconnecting" until page
           // refresh. We're safe to publish here because (a) `client.io.connected`
-          // was true at entry, (b) `authenticate()` just resolved, so the
-          // socket is connected AND authenticated.
+          // was true at entry, (b) `authenticate()` just resolved, so the socket
+          // is connected AND authenticated.
           if (!mounted) return;
           setConnected(true);
           setConnecting(false);
@@ -478,7 +478,7 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
           // Best-effort — if this fails, the next service call will 401
           // and the around-hook will take the standard refresh-and-retry
           // path. Log so the cause isn't invisible.
-          console.error('In-place re-authentication failed after token refresh:', err);
+          console.error('In-place re-authentication failed after token replacement:', err);
         });
     };
     window.addEventListener(TOKENS_REFRESHED_EVENT, handleTokensRefreshed);
@@ -505,8 +505,8 @@ export function useAgorClient(options: UseAgorClientOptions = {}): UseAgorClient
     };
     // The dep list deliberately uses `hasToken` (presence), not the token
     // value itself: see the accessTokenRef comment above. Rebuilds happen
-    // only on login/logout and url changes; token refreshes are absorbed
-    // in-place by the handler above.
+    // only on login/logout and url changes; in-session token replacements are
+    // absorbed in-place by the handler above.
   }, [url, hasToken]);
 
   /**

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -644,8 +644,8 @@ export function useAgorData(
 
   // Tracks whether the most recent silent refetch failed. Set by the silent
   // catch branch in `fetchData`, cleared on success. Read by the
-  // TOKENS_REFRESHED_EVENT listener below so a token refresh that lands AFTER
-  // a failed reconnect refetch (auth race during socket re-auth) gets to
+  // TOKENS_REFRESHED_EVENT listener below so a token replacement that lands
+  // AFTER a failed reconnect refetch (auth race during socket re-auth) gets to
   // retry — without this, the byId maps would stay stale until the next
   // physical reconnect or page refresh. We use a ref rather than state since
   // we only consume it in event handlers, never in render.
@@ -711,7 +711,7 @@ export function useAgorData(
   // reconnect-time 401 (auth race with the re-auth handler in useAgorClient)
   // bubbled up. Silent failures are logged for observability; the UI continues
   // to render whatever byId state was last successfully fetched, and the next
-  // reconnect or token refresh gets another shot.
+  // reconnect or token replacement gets another shot.
   const fetchData = useCallback(
     async ({ silent = false }: { silent?: boolean } = {}) => {
       if (!client || !enabled) {
@@ -2264,10 +2264,10 @@ export function useAgorData(
 
     // If the prior reconnect refetch failed silently — typical scenario: the
     // socket reconnected, the around-hook hadn't refreshed the access token
-    // yet, fetchData hit a 401 that bubbled up — retry once a token refresh
-    // lands. Without this, byId state stays stale until the next physical
-    // reconnect or a page refresh. We gate on the latch so we don't refetch
-    // 14 services on every routine token rotation.
+    // yet, fetchData hit a 401 that bubbled up — retry once a token
+    // replacement lands. Without this, byId state stays stale until the next
+    // physical reconnect or a page refresh. We gate on the latch so we don't
+    // refetch 14 services on every routine token rotation.
     const handleTokensRefreshed = () => {
       if (!lastSilentFetchFailedRef.current) return;
       void refetchSilently();

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 import { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from '../utils/tokenRefresh';
 import { useAuth } from './useAuth';
 
@@ -88,6 +89,39 @@ describe('useAuth launch-code fallback', () => {
     expect(result.current.error).toContain('unexpected response');
     expect(result.current.error).toContain('daemon URL');
     expect(result.current.error).not.toContain('JSON parsing error');
+  });
+
+  it('notifies socket clients when local login replaces invalidated password-change tokens', async () => {
+    window.history.replaceState({}, '', '/ui/');
+    authenticate.mockResolvedValue({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+      user: { user_id: 'u1', email: 'person@example.test' },
+    });
+
+    const listener = vi.fn();
+    window.addEventListener(TOKENS_REFRESHED_EVENT, listener);
+
+    try {
+      const { result } = renderHook(() => useAuth());
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await expect(result.current.login('person@example.test', 'password-123')).resolves.toBe(
+          true
+        );
+      });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect((listener.mock.calls[0][0] as CustomEvent).detail).toMatchObject({
+        accessToken: 'new-access',
+        refreshToken: 'new-refresh',
+        user: { user_id: 'u1', email: 'person@example.test' },
+      });
+    } finally {
+      window.removeEventListener(TOKENS_REFRESHED_EVENT, listener);
+    }
   });
 
   it('preserves stored tokens when stored-session auth gets a non-auth transport response', async () => {

--- a/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
+++ b/apps/agor-ui/src/hooks/useAuth.launch.test.tsx
@@ -40,6 +40,34 @@ describe('useAuth launch-code fallback', () => {
     window.history.replaceState({}, '', '/ui/');
   });
 
+  it('notifies socket clients when launch sign-in stores fresh tokens', async () => {
+    launchCreate.mockResolvedValue({
+      accessToken: 'launch-access',
+      refreshToken: 'launch-refresh',
+      user: { user_id: 'u1', email: 'person@example.test' },
+    });
+
+    const listener = vi.fn();
+    window.addEventListener(TOKENS_REFRESHED_EVENT, listener);
+
+    try {
+      const { result } = renderHook(() => useAuth());
+
+      await waitFor(() => expect(result.current.authenticated).toBe(true));
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect((listener.mock.calls[0][0] as CustomEvent).detail).toMatchObject({
+        accessToken: 'launch-access',
+        refreshToken: 'launch-refresh',
+        user: { user_id: 'u1', email: 'person@example.test' },
+      });
+      expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('launch-access');
+      expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('launch-refresh');
+    } finally {
+      window.removeEventListener(TOKENS_REFRESHED_EVENT, listener);
+    }
+  });
+
   it('preserves stored tokens and restores the normal session when launch sign-in fails', async () => {
     localStorage.setItem(ACCESS_TOKEN_KEY, 'stored-access');
     localStorage.setItem(REFRESH_TOKEN_KEY, 'stored-refresh');

--- a/apps/agor-ui/src/hooks/useAuth.ts
+++ b/apps/agor-ui/src/hooks/useAuth.ts
@@ -17,6 +17,7 @@ import {
   removeLaunchCodeFromCurrentUrl,
 } from '../utils/launchAuth';
 import {
+  dispatchTokensRefreshed,
   RefreshUnrecoverableError,
   refreshTokensSingleFlight,
   resetRefreshFailureState,
@@ -172,6 +173,7 @@ export function useAuth(): UseAuthReturn {
             loading: false,
             error: null,
           });
+          dispatchTokensRefreshed(result);
 
           return;
         } catch (launchError) {
@@ -473,6 +475,7 @@ export function useAuth(): UseAuthReturn {
         loading: false,
         error: null,
       });
+      dispatchTokensRefreshed(result);
 
       return true;
     } catch (error) {

--- a/apps/agor-ui/src/hooks/useSharedReactiveSession.ts
+++ b/apps/agor-ui/src/hooks/useSharedReactiveSession.ts
@@ -61,13 +61,13 @@ export function useSharedReactiveSession(
   // be stale. The reactive session itself only resyncs on socket `connect`
   // events — but auth-recovery happens on other channels too:
   //
-  // - The proactive token-refresh timer in useAuth fires `TOKENS_REFRESHED_EVENT`
-  //   after a successful refresh that the panel didn't trigger.
+  // - Auth recovery in useAuth fires `TOKENS_REFRESHED_EVENT` after a
+  //   successful token replacement that the panel didn't trigger.
   // - When a tab regains focus after a long background, useAuth's
   //   visibilitychange handler may have refreshed tokens silently.
   //
   // Without these listeners, a transient 401 surfaced during a previous
-  // `resync()` (e.g. socket reconnected before the access-token refresh
+  // `resync()` (e.g. socket reconnected before access-token replacement
   // landed) leaves the panel stuck on a "jwt expired" banner indefinitely.
   //
   // We retry while `state.error` is set but skip `state.terminal` errors —

--- a/apps/agor-ui/src/utils/singleFlightRefresh.ts
+++ b/apps/agor-ui/src/utils/singleFlightRefresh.ts
@@ -43,6 +43,16 @@ import { getStoredRefreshToken, type RefreshResult, refreshAndStoreTokens } from
 export const TOKENS_REFRESHED_EVENT = 'agor:tokens-refreshed';
 
 /**
+ * Notify long-lived clients and React listeners that the browser has fresh
+ * auth tokens. Use this for every successful auth path that stores or rotates
+ * tokens while the page may already have socket/service clients alive.
+ */
+export function dispatchTokensRefreshed(result: RefreshResult): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<RefreshResult>(TOKENS_REFRESHED_EVENT, { detail: result }));
+}
+
+/**
  * Custom DOM event fired when the refresh endpoint returned a definite auth
  * failure. Listeners (useAuth) should treat this as "session is dead" and
  * clear tokens + bounce to login.
@@ -118,12 +128,9 @@ export function refreshTokensSingleFlight(
       // the user logged out and back in, or a transient failure was
       // misclassified, resume normal operation.
       unrecoverable = false;
-      // Notify listeners (useAuth) that tokens have rotated.
-      if (typeof window !== 'undefined') {
-        window.dispatchEvent(
-          new CustomEvent<RefreshResult>(TOKENS_REFRESHED_EVENT, { detail: result })
-        );
-      }
+      // Notify listeners (useAuth, socket clients, data hooks) that tokens
+      // have rotated.
+      dispatchTokensRefreshed(result);
       return result;
     })
     .catch((err) => {

--- a/apps/agor-ui/src/utils/singleFlightRefresh.ts
+++ b/apps/agor-ui/src/utils/singleFlightRefresh.ts
@@ -27,12 +27,13 @@
  *    reconnect fallback in useAgorClient and the 401-retry hook on the
  *    same client. Extracted here so the two paths stay in lockstep.
  *
- * The single-flight helper also emits a `TOKENS_REFRESHED_EVENT` on `window`
- * after a successful refresh so that React state (useAuth) can sync even when
- * the refresh was initiated by a non-React code path (e.g. the Feathers hook).
- * On unrecoverable failure it emits `TOKENS_REFRESH_UNRECOVERABLE_EVENT` so
- * useAuth can clear tokens and bounce the user to login exactly once,
- * instead of every call site duplicating that cleanup.
+ * Successful token replacement emits `TOKENS_REFRESHED_EVENT` on `window` so
+ * React state (useAuth), socket clients, and data hooks can sync even when the
+ * token replacement was initiated by a non-React code path (e.g. the Feathers
+ * hook). Refresh failures that make the session unrecoverable emit
+ * `TOKENS_REFRESH_UNRECOVERABLE_EVENT` so useAuth can clear tokens and bounce
+ * the user to login exactly once, instead of every call site duplicating that
+ * cleanup.
  */
 
 import type { AgorClient } from '@agor-live/client';


### PR DESCRIPTION
## Summary

Fixes the stale socket-auth path after a forced password change. Local login now emits the same token-rotation event used by refresh, so existing socket clients re-authenticate in place with the fresh access token instead of continuing with an invalidated JWT.

Fixes #1624.

## Root Cause

Password changes correctly invalidate previously-issued browser tokens. The forced-password-change flow then signs the user back in and stores fresh tokens, but `useAgorClient` deliberately does not rebuild the socket when the token value changes. It only re-authenticates the existing socket on `TOKENS_REFRESHED_EVENT`, and local login did not emit that event.

## Changes

- Added a shared `dispatchTokensRefreshed` helper for token replacement notifications.
- Emitted the notification after successful local login and launch-code sign-in.
- Kept refresh token rotation on the same helper.
- Added regression tests covering successful local login after invalidated password-change tokens and launch-code token replacement.

## Validation
- Live browser check against an isolated daemon/UI: forced password change emitted one `agor:tokens-refreshed` event, the existing socket re-authenticated with the new access token, and an authenticated `users.find` call succeeded afterward.
- `pnpm --filter agor-ui test -- src/hooks/useAuth.launch.test.tsx src/utils/singleFlightRefresh.test.ts src/utils/launchAuth.test.ts src/utils/forcePasswordChange.test.ts src/components/ConnectionStatus/ConnectionStatus.test.tsx`
- `pnpm --filter agor-ui typecheck`
- `pnpm exec biome check apps/agor-ui/src/hooks/useAuth.ts apps/agor-ui/src/utils/singleFlightRefresh.ts apps/agor-ui/src/hooks/useAuth.launch.test.tsx`
