### PR TITLE
fix: Show zone toolbar on top of other zones

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1408,15 +1408,24 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
         const selectChanges = changes.filter((c: any) => c.type === 'select');
         if (selectChanges.length > 0) {
-          setNodes((currentNodes) =>
-            currentNodes.map((n) => {
+          setNodes((currentNodes) => {
+            // onNodesChange is hot (fires on drag, resize, selection). Guard against
+            // re-renders when no zone is involved: `map` always allocates a new array,
+            // so returning currentNodes unchanged lets React bail out.
+            // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
+            const zoneIds = new Set(selectChanges.map((c: any) => c.id));
+            const hasZoneChange = currentNodes.some(
+              (n) => n.type === 'zone' && zoneIds.has(n.id)
+            );
+            if (!hasZoneChange) return currentNodes;
+            return currentNodes.map((n) => {
               if (n.type !== 'zone') return n;
               // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
               const change = selectChanges.find((c: any) => c.id === n.id);
               if (change) return { ...n, zIndex: change.selected ? 101 : 100 };
               return n;
-            })
-          );
+            });
+          });
         }
 
         // Detect resize by checking for dimensions changes

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1258,7 +1258,13 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           .filter((n) => n.type === 'zone' && !deletedObjectsRef.current.has(n.id))
           .map((newZone) => {
             const existingZone = currentNodes.find((n) => n.id === newZone.id);
-            return { ...newZone, selected: existingZone?.selected };
+            return {
+              ...newZone,
+              selected: existingZone?.selected,
+              // Preserve runtime zIndex (e.g. 101 when selected) so board data
+              // updates don't reset it to the base value of 100.
+              zIndex: existingZone?.zIndex ?? newZone.zIndex,
+            };
           });
 
         const markdown = boardObjectNodes
@@ -1393,6 +1399,26 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const onNodesChange = useCallback(
       // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
       (changes: any) => {
+        // Raise/lower a zone's zIndex when it becomes selected/deselected so its
+        // toolbar clears neighboring zone nodes. zIndex 101 beats sibling zones
+        // (100) while staying below notes (300), artifacts (400), and branches (500).
+        // We do this in the external nodes state (not via useReactFlow().setNodes)
+        // so the board sync effect's currentNodes snapshot reflects the change and
+        // doesn't overwrite it on the next board data update.
+        // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
+        const selectChanges = changes.filter((c: any) => c.type === 'select');
+        if (selectChanges.length > 0) {
+          setNodes((currentNodes) =>
+            currentNodes.map((n) => {
+              if (n.type !== 'zone') return n;
+              // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
+              const change = selectChanges.find((c: any) => c.id === n.id);
+              if (change) return { ...n, zIndex: change.selected ? 101 : 100 };
+              return n;
+            })
+          );
+        }
+
         // Detect resize by checking for dimensions changes
         // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
         changes.forEach((change: any) => {
@@ -1466,7 +1492,7 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         // Call the original handler
         onNodesChangeInternal(changes);
       },
-      [board, client, onNodesChangeInternal]
+      [board, client, onNodesChangeInternal, setNodes]
     );
 
     // Handle node drag start

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1399,24 +1399,13 @@ const SessionCanvas = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const onNodesChange = useCallback(
       // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
       (changes: any) => {
-        // Raise/lower a zone's zIndex when it becomes selected/deselected so its
-        // toolbar clears neighboring zone nodes. zIndex 101 beats sibling zones
-        // (100) while staying below notes (300), artifacts (400), and branches (500).
-        // We do this in the external nodes state (not via useReactFlow().setNodes)
-        // so the board sync effect's currentNodes snapshot reflects the change and
-        // doesn't overwrite it on the next board data update.
         // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
         const selectChanges = changes.filter((c: any) => c.type === 'select');
         if (selectChanges.length > 0) {
           setNodes((currentNodes) => {
-            // onNodesChange is hot (fires on drag, resize, selection). Guard against
-            // re-renders when no zone is involved: `map` always allocates a new array,
-            // so returning currentNodes unchanged lets React bail out.
             // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
             const zoneIds = new Set(selectChanges.map((c: any) => c.id));
-            const hasZoneChange = currentNodes.some(
-              (n) => n.type === 'zone' && zoneIds.has(n.id)
-            );
+            const hasZoneChange = currentNodes.some((n) => n.type === 'zone' && zoneIds.has(n.id));
             if (!hasZoneChange) return currentNodes;
             return currentNodes.map((n) => {
               if (n.type !== 'zone') return n;

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -307,57 +307,57 @@ describe('SessionCanvas zoom shortcuts', () => {
       expect(getNode).toHaveBeenCalledWith('missing-node');
       expect(patch).not.toHaveBeenCalled();
     });
-  });
 
-  describe('onNodesChange zone select zIndex', () => {
-    // The setNodes wrapper in SessionCanvas calls setNodesUnsafe with a
-    // functional updater. We capture that updater and call it with mock nodes
-    // to assert what the zIndex transition produces.
-    function getLastSetNodesUpdater() {
-      const calls = setNodesUnsafeSpy.mock.calls;
-      const last = calls.at(-1);
-      return last?.[0] as ((nodes: unknown[]) => unknown[]) | undefined;
-    }
+    describe('zone select zIndex', () => {
+      // The setNodes wrapper in SessionCanvas calls setNodesUnsafe with a
+      // functional updater. We capture that updater and call it with mock nodes
+      // to assert what the zIndex transition produces.
+      function getLastSetNodesUpdater() {
+        const calls = setNodesUnsafeSpy.mock.calls;
+        const last = calls.at(-1);
+        return last?.[0] as ((nodes: unknown[]) => unknown[]) | undefined;
+      }
 
-    it('raises zone zIndex to 101 when the zone is selected', () => {
-      const { onNodesChange } = renderCanvas(null);
-      setNodesUnsafeSpy.mockClear();
+      it('raises zone zIndex to 101 when the zone is selected', () => {
+        const { onNodesChange } = renderCanvas(null);
+        setNodesUnsafeSpy.mockClear();
 
-      act(() => onNodesChange([{ type: 'select', id: 'zone-1', selected: true }]));
+        act(() => onNodesChange([{ type: 'select', id: 'zone-1', selected: true }]));
 
-      const updater = getLastSetNodesUpdater();
-      expect(updater).toBeDefined();
-      const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 100 }];
-      const result = updater!(mockNodes) as typeof mockNodes;
-      expect(result[0].zIndex).toBe(101);
-    });
+        const updater = getLastSetNodesUpdater();
+        expect(updater).toBeDefined();
+        const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 100 }];
+        const result = updater!(mockNodes) as typeof mockNodes;
+        expect(result[0].zIndex).toBe(101);
+      });
 
-    it('restores zone zIndex to 100 when the zone is deselected', () => {
-      const { onNodesChange } = renderCanvas(null);
-      setNodesUnsafeSpy.mockClear();
+      it('restores zone zIndex to 100 when the zone is deselected', () => {
+        const { onNodesChange } = renderCanvas(null);
+        setNodesUnsafeSpy.mockClear();
 
-      act(() => onNodesChange([{ type: 'select', id: 'zone-1', selected: false }]));
+        act(() => onNodesChange([{ type: 'select', id: 'zone-1', selected: false }]));
 
-      const updater = getLastSetNodesUpdater();
-      expect(updater).toBeDefined();
-      const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 101 }];
-      const result = updater!(mockNodes) as typeof mockNodes;
-      expect(result[0].zIndex).toBe(100);
-    });
+        const updater = getLastSetNodesUpdater();
+        expect(updater).toBeDefined();
+        const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 101 }];
+        const result = updater!(mockNodes) as typeof mockNodes;
+        expect(result[0].zIndex).toBe(100);
+      });
 
-    it('returns the same node array reference when no zone is in the select changes', () => {
-      const { onNodesChange } = renderCanvas(null);
-      setNodesUnsafeSpy.mockClear();
+      it('returns the same node array reference when no zone is in the select changes', () => {
+        const { onNodesChange } = renderCanvas(null);
+        setNodesUnsafeSpy.mockClear();
 
-      // Select a non-zone node (e.g. a branch) — zone-1 is untouched
-      act(() => onNodesChange([{ type: 'select', id: 'branch-999', selected: true }]));
+        // Select a non-zone node (e.g. a branch) — zone-1 is untouched
+        act(() => onNodesChange([{ type: 'select', id: 'branch-999', selected: true }]));
 
-      const updater = getLastSetNodesUpdater();
-      expect(updater).toBeDefined();
-      const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 100 }];
-      const result = updater!(mockNodes);
-      // Guard returns currentNodes unchanged so React can bail out on re-render
-      expect(result).toBe(mockNodes);
+        const updater = getLastSetNodesUpdater();
+        expect(updater).toBeDefined();
+        const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 100 }];
+        const result = updater!(mockNodes);
+        // Guard returns currentNodes unchanged so React can bail out on re-render
+        expect(result).toBe(mockNodes);
+      });
     });
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -9,6 +9,9 @@ let reactFlowProps: Record<string, unknown> | null = null;
 // Stable spy for the `useNodesState` setter (onNodesChangeInternal). Lets tests
 // assert that onNodesChange forwards changes to React Flow's internal handler.
 const onNodesChangeInternalSpy = vi.fn();
+// Stable spy for the raw setNodes setter (setNodesUnsafe). Lets tests inspect
+// the functional updater passed when zIndex needs to change for zone selection.
+const setNodesUnsafeSpy = vi.fn();
 
 vi.mock('reactflow', () => ({
   Background: () => <div data-testid="react-flow-background" />,
@@ -34,7 +37,7 @@ vi.mock('reactflow', () => ({
   },
   useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
   useEdgesState: (initialEdges: unknown[]) => [initialEdges, vi.fn(), vi.fn()],
-  useNodesState: (initialNodes: unknown[]) => [initialNodes, vi.fn(), onNodesChangeInternalSpy],
+  useNodesState: (initialNodes: unknown[]) => [initialNodes, setNodesUnsafeSpy, onNodesChangeInternalSpy],
 }));
 
 vi.mock('./canvas/AppNode', () => ({
@@ -48,6 +51,7 @@ vi.mock('./canvas/ArtifactNode', () => ({
 beforeEach(() => {
   reactFlowProps = null;
   onNodesChangeInternalSpy.mockClear();
+  setNodesUnsafeSpy.mockClear();
 });
 
 describe('SessionCanvas zoom shortcuts', () => {
@@ -298,6 +302,58 @@ describe('SessionCanvas zoom shortcuts', () => {
 
       expect(getNode).toHaveBeenCalledWith('missing-node');
       expect(patch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onNodesChange zone select zIndex', () => {
+    // The setNodes wrapper in SessionCanvas calls setNodesUnsafe with a
+    // functional updater. We capture that updater and call it with mock nodes
+    // to assert what the zIndex transition produces.
+    function getLastSetNodesUpdater() {
+      const calls = setNodesUnsafeSpy.mock.calls;
+      const last = calls.at(-1);
+      return last?.[0] as ((nodes: unknown[]) => unknown[]) | undefined;
+    }
+
+    it('raises zone zIndex to 101 when the zone is selected', () => {
+      const { onNodesChange } = renderCanvas(null);
+      setNodesUnsafeSpy.mockClear();
+
+      act(() => onNodesChange([{ type: 'select', id: 'zone-1', selected: true }]));
+
+      const updater = getLastSetNodesUpdater();
+      expect(updater).toBeDefined();
+      const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 100 }];
+      const result = updater!(mockNodes) as typeof mockNodes;
+      expect(result[0].zIndex).toBe(101);
+    });
+
+    it('restores zone zIndex to 100 when the zone is deselected', () => {
+      const { onNodesChange } = renderCanvas(null);
+      setNodesUnsafeSpy.mockClear();
+
+      act(() => onNodesChange([{ type: 'select', id: 'zone-1', selected: false }]));
+
+      const updater = getLastSetNodesUpdater();
+      expect(updater).toBeDefined();
+      const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 101 }];
+      const result = updater!(mockNodes) as typeof mockNodes;
+      expect(result[0].zIndex).toBe(100);
+    });
+
+    it('returns the same node array reference when no zone is in the select changes', () => {
+      const { onNodesChange } = renderCanvas(null);
+      setNodesUnsafeSpy.mockClear();
+
+      // Select a non-zone node (e.g. a branch) — zone-1 is untouched
+      act(() => onNodesChange([{ type: 'select', id: 'branch-999', selected: true }]));
+
+      const updater = getLastSetNodesUpdater();
+      expect(updater).toBeDefined();
+      const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 100 }];
+      const result = updater!(mockNodes);
+      // Guard returns currentNodes unchanged so React can bail out on re-render
+      expect(result).toBe(mockNodes);
     });
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -37,7 +37,11 @@ vi.mock('reactflow', () => ({
   },
   useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
   useEdgesState: (initialEdges: unknown[]) => [initialEdges, vi.fn(), vi.fn()],
-  useNodesState: (initialNodes: unknown[]) => [initialNodes, setNodesUnsafeSpy, onNodesChangeInternalSpy],
+  useNodesState: (initialNodes: unknown[]) => [
+    initialNodes,
+    setNodesUnsafeSpy,
+    onNodesChangeInternalSpy,
+  ],
 }));
 
 vi.mock('./canvas/AppNode', () => ({


### PR DESCRIPTION
## Summary

When clicking on a zone, its toolbar would show up behind an overlapping Zone:

<img width="750" height="774" alt="image" src="https://github.com/user-attachments/assets/eb4f53f8-3f27-4f1a-9a3e-9f2734138815" />

This PR fixes the issue:

<img width="900" height="664" alt="image" src="https://github.com/user-attachments/assets/14420c4a-d09b-479e-a04d-ac8e88edb413" />
