### PR TITLE
Add Slack-backed user avatars

### DIFF
--- a/apps/agor-cli/src/commands/user/list.ts
+++ b/apps/agor-cli/src/commands/user/list.ts
@@ -59,12 +59,17 @@ export default class UserList extends Command {
       // Convert to User type
       const userList: User[] = rows.map((row: unknown) => {
         const userRow = row as UserRow;
-        const data = userRow.data as { avatar?: string; preferences?: Record<string, unknown> };
+        const data = userRow.data as {
+          avatar_url?: string;
+          avatar?: string;
+          preferences?: Record<string, unknown>;
+        };
         return {
           user_id: userRow.user_id as User['user_id'],
           email: userRow.email,
           name: userRow.name ?? undefined,
           role: userRow.role as User['role'],
+          avatar_url: data.avatar_url ?? data.avatar,
           avatar: data.avatar,
           preferences: data.preferences,
           onboarding_completed: !!userRow.onboarding_completed,

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -371,6 +371,26 @@ describe('executorRuntimeScopeGuard', () => {
     expect(context.data).toMatchObject({ taskId: 'task-1' });
   });
 
+  it('uses JWT auth-result scope fields when Socket.io drops the decoded payload', async () => {
+    const context = ctx({
+      path: 'config/resolve-api-key',
+      method: 'create',
+      data: { keyName: 'OPENAI_API_KEY', tool: 'codex' },
+      params: {
+        authentication: { strategy: 'jwt' },
+        task_id: 'task-1',
+        session_id: 'session-1',
+        branch_id: 'branch-1',
+        query: {},
+        provider: 'socketio',
+      } as never,
+    });
+
+    await executorRuntimeScopeGuard()(context);
+
+    expect(context.data).toMatchObject({ taskId: 'task-1' });
+  });
+
   it('rejects API key resolution for another task under executor token auth', async () => {
     const context = ctx({
       path: 'config/resolve-api-key',

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -17,14 +17,32 @@ type Scope = {
 };
 
 function scopedPayload(context: HookContext): ExecutorTokenPayload | null {
-  const payload = (context.params as AuthenticatedParams).authentication?.payload as
-    | ExecutorTokenPayload
-    | undefined;
-  if (payload?.type !== 'executor-session') return null;
-  if (payload.purpose !== 'executor-task') {
-    throw new Forbidden('Executor token is not valid for this request');
+  const params = context.params as AuthenticatedParams & ExecutorTokenPayload;
+  const payload = params.authentication?.payload as ExecutorTokenPayload | undefined;
+  if (payload?.type === 'executor-session') {
+    if (payload.purpose !== 'executor-task') {
+      throw new Forbidden('Executor token is not valid for this request');
+    }
+    return payload;
   }
-  return payload;
+
+  // Socket.io can preserve custom auth-result fields (`task_id`, `session_id`)
+  // on the connection while dropping the decoded JWT payload. Treat those
+  // fields as executor scope only when they came from JWT auth and carry a task
+  // claim; normal user/API-key auth must continue through unscoped.
+  if (params.authentication?.strategy === 'jwt' && params.task_id) {
+    return {
+      type: 'executor-session',
+      purpose: 'executor-task',
+      task_id: params.task_id,
+      session_id: params.session_id,
+      sessionId: params.sessionId,
+      branch_id: params.branch_id,
+    };
+  }
+
+  if (payload?.type !== undefined) return null;
+  return null;
 }
 
 function expectClaim(claim: string | undefined, label: string): string {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -288,7 +288,8 @@ async function upsertLaunchUser(
         updated_at: now,
         data: {
           ...data,
-          avatar: avatar ?? data.avatar,
+          avatar_url: avatar ?? data.avatar_url ?? data.avatar,
+          avatar_source: avatar ? 'launch-auth' : data.avatar_source,
           external_identities: nextIdentities,
         },
       })
@@ -316,7 +317,9 @@ async function upsertLaunchUser(
       onboarding_completed: false,
       must_change_password: false,
       data: {
+        avatar_url: avatar,
         avatar,
+        avatar_source: avatar ? 'launch-auth' : undefined,
         preferences: {},
         external_identities: [identity],
       } as UserDataWithExternalIdentities,

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -16,6 +16,40 @@ import type { SessionTokenService } from '../services/session-token-service.js';
 import { markAuthenticationUserLookup } from '../services/users.js';
 import { assertUserTokenNotInvalidated, type UserAuthTokenPayload } from './token-invalidation.js';
 
+type JwtConnectionState = {
+  authentication?: { strategy?: string; accessToken?: string; payload?: unknown };
+  feathers?: { authentication?: { strategy?: string; accessToken?: string; payload?: unknown } };
+};
+
+function persistExecutorJwtPayloadOnConnection(
+  params: unknown,
+  accessToken: string | undefined,
+  payload: unknown
+): void {
+  const connection = (params as { connection?: JwtConnectionState } | undefined)?.connection;
+  if (!connection) return;
+
+  // For Socket.io, Feathers service params are built from the per-socket
+  // `feathers` connection object on subsequent calls. Depending on the call
+  // path, `params.connection` may be that object directly, or the socket-like
+  // wrapper that owns it. Persist the decoded executor JWT payload in whichever
+  // object will become future `params.authentication`, otherwise the executor
+  // reconnects as the session creator user but loses the task-scoped claims.
+  let target: JwtConnectionState;
+  if ('feathers' in connection) {
+    connection.feathers ??= {};
+    target = connection.feathers;
+  } else {
+    target = connection;
+  }
+  target.authentication = {
+    ...(target.authentication ?? {}),
+    strategy: 'jwt',
+    ...(accessToken ? { accessToken } : {}),
+    payload,
+  };
+}
+
 /**
  * Extended JWT Strategy that handles service tokens
  *
@@ -110,6 +144,7 @@ export class ServiceJWTStrategy extends JWTStrategy {
       if (!sessionInfo) {
         throw new Error('Invalid or expired executor token');
       }
+      persistExecutorJwtPayloadOnConnection(params, token, payload);
       return {
         ...result,
         session_id: sessionInfo.session_id,

--- a/apps/agor-daemon/src/mcp/tools/users.ts
+++ b/apps/agor-daemon/src/mcp/tools/users.ts
@@ -214,7 +214,8 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       inputSchema: z.strictObject({
         name: mcpOptionalString('name', 'Display name'),
         emoji: mcpOptionalString('emoji', 'User emoji (single emoji character)'),
-        avatar: mcpOptionalString('avatar', 'Avatar URL'),
+        avatar_url: mcpOptionalString('avatar_url', 'Avatar URL'),
+        avatar: mcpOptionalString('avatar', 'Legacy avatar URL alias'),
         preferences: z
           .object({})
           .passthrough()
@@ -226,6 +227,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       const updateData: Record<string, unknown> = {};
       if (args.name !== undefined) updateData.name = args.name;
       if (args.emoji !== undefined) updateData.emoji = args.emoji;
+      if (args.avatar_url !== undefined) updateData.avatar_url = args.avatar_url;
       if (args.avatar !== undefined) updateData.avatar = args.avatar;
       if (args.preferences !== undefined) updateData.preferences = args.preferences;
       const updatedUser = await ctx.app
@@ -262,7 +264,8 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
           .optional()
           .describe('Force user to change password on next login (optional)'),
         emoji: mcpOptionalString('emoji', 'User emoji (optional, single emoji character)'),
-        avatar: mcpOptionalString('avatar', 'Avatar URL (optional)'),
+        avatar_url: mcpOptionalString('avatar_url', 'Avatar URL (optional)'),
+        avatar: mcpOptionalString('avatar', 'Legacy avatar URL alias (optional)'),
         preferences: z
           .object({})
           .passthrough()
@@ -280,6 +283,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       if (args.must_change_password !== undefined)
         updateData.must_change_password = args.must_change_password;
       if (args.emoji !== undefined) updateData.emoji = args.emoji;
+      if (args.avatar_url !== undefined) updateData.avatar_url = args.avatar_url;
       if (args.avatar !== undefined) updateData.avatar = args.avatar;
       if (args.preferences !== undefined) updateData.preferences = args.preferences;
 
@@ -308,7 +312,8 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
           'emoji',
           'User emoji for visual identity (optional, single emoji character)'
         ),
-        avatar: mcpOptionalString('avatar', 'Avatar URL (optional)'),
+        avatar_url: mcpOptionalString('avatar_url', 'Avatar URL (optional)'),
+        avatar: mcpOptionalString('avatar', 'Legacy avatar URL alias (optional)'),
         unix_username: mcpOptionalString(
           'unix_username',
           'Unix username for shell access (optional, defaults to email prefix if not specified)'
@@ -332,6 +337,7 @@ export function registerUserTools(server: McpServer, ctx: McpContext): void {
       };
       if (args.name !== undefined) createData.name = args.name;
       if (args.emoji !== undefined) createData.emoji = args.emoji;
+      if (args.avatar_url !== undefined) createData.avatar_url = args.avatar_url;
       if (args.avatar !== undefined) createData.avatar = args.avatar;
       if (args.unix_username !== undefined) createData.unix_username = args.unix_username;
       if (args.must_change_password !== undefined)

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2195,6 +2195,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           if ((context.params as Params & { skipAvatarRefresh?: boolean }).skipAvatarRefresh) {
             return context;
           }
+          const data = context.data as { email?: string; preferences?: unknown } | undefined;
+          if (data?.email === undefined && data?.preferences === undefined) {
+            return context;
+          }
           const user = context.result as User;
           const avatarService = safeService('user-avatars') as
             | { refreshUserFromSettings?: (userId: UserID) => Promise<unknown> }

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1920,6 +1920,15 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     },
   });
 
+  safeService('user-avatars')?.hooks({
+    before: {
+      all: [requireAuth],
+      find: [requireMinimumRole(ROLES.ADMIN, 'view user avatar settings')],
+      create: [requireMinimumRole(ROLES.ADMIN, 'sync user avatars')],
+      patch: [requireMinimumRole(ROLES.ADMIN, 'update user avatar settings')],
+    },
+  });
+
   // ============================================================================
   // Users hooks
   // ============================================================================
@@ -2113,6 +2122,24 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
           return context;
         },
+        async (context: HookContext) => {
+          if ((context.params as Params & { skipAvatarRefresh?: boolean }).skipAvatarRefresh) {
+            return context;
+          }
+          const user = context.result as User;
+          const avatarService = safeService('user-avatars') as
+            | { refreshUserFromSettings?: (userId: UserID) => Promise<unknown> }
+            | undefined;
+          if (avatarService?.refreshUserFromSettings) {
+            avatarService.refreshUserFromSettings(user.user_id).catch((error: unknown) => {
+              console.warn(
+                `[user-avatars] Failed to refresh avatar for new user ${shortId(user.user_id)}:`,
+                error instanceof Error ? error.message : String(error)
+              );
+            });
+          }
+          return context;
+        },
       ],
       patch: [
         async (context: HookContext) => {
@@ -2162,6 +2189,24 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             { logPrefix: '[Executor/user.patch]' }
           );
 
+          return context;
+        },
+        async (context: HookContext) => {
+          if ((context.params as Params & { skipAvatarRefresh?: boolean }).skipAvatarRefresh) {
+            return context;
+          }
+          const user = context.result as User;
+          const avatarService = safeService('user-avatars') as
+            | { refreshUserFromSettings?: (userId: UserID) => Promise<unknown> }
+            | undefined;
+          if (avatarService?.refreshUserFromSettings) {
+            avatarService.refreshUserFromSettings(user.user_id).catch((error: unknown) => {
+              console.warn(
+                `[user-avatars] Failed to refresh avatar for updated user ${shortId(user.user_id)}:`,
+                error instanceof Error ? error.message : String(error)
+              );
+            });
+          }
           return context;
         },
       ],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1920,15 +1920,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     },
   });
 
-  safeService('user-avatars')?.hooks({
-    before: {
-      all: [requireAuth],
-      find: [requireMinimumRole(ROLES.ADMIN, 'view user avatar settings')],
-      create: [requireMinimumRole(ROLES.ADMIN, 'sync user avatars')],
-      patch: [requireMinimumRole(ROLES.ADMIN, 'update user avatar settings')],
-    },
-  });
-
   // ============================================================================
   // Users hooks
   // ============================================================================
@@ -2127,13 +2118,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             return context;
           }
           const user = context.result as User;
-          const avatarService = safeService('user-avatars') as
-            | { refreshUserFromSettings?: (userId: UserID) => Promise<unknown> }
+          const avatarService = safeService('users') as
+            | { refreshAvatarFromSettings?: (userId: UserID) => Promise<unknown> }
             | undefined;
-          if (avatarService?.refreshUserFromSettings) {
-            avatarService.refreshUserFromSettings(user.user_id).catch((error: unknown) => {
+          if (avatarService?.refreshAvatarFromSettings) {
+            avatarService.refreshAvatarFromSettings(user.user_id).catch((error: unknown) => {
               console.warn(
-                `[user-avatars] Failed to refresh avatar for new user ${shortId(user.user_id)}:`,
+                `[users/avatar-sync] Failed to refresh avatar for new user ${shortId(user.user_id)}:`,
                 error instanceof Error ? error.message : String(error)
               );
             });
@@ -2200,13 +2191,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             return context;
           }
           const user = context.result as User;
-          const avatarService = safeService('user-avatars') as
-            | { refreshUserFromSettings?: (userId: UserID) => Promise<unknown> }
+          const avatarService = safeService('users') as
+            | { refreshAvatarFromSettings?: (userId: UserID) => Promise<unknown> }
             | undefined;
-          if (avatarService?.refreshUserFromSettings) {
-            avatarService.refreshUserFromSettings(user.user_id).catch((error: unknown) => {
+          if (avatarService?.refreshAvatarFromSettings) {
+            avatarService.refreshAvatarFromSettings(user.user_id).catch((error: unknown) => {
               console.warn(
-                `[user-avatars] Failed to refresh avatar for updated user ${shortId(user.user_id)}:`,
+                `[users/avatar-sync] Failed to refresh avatar for updated user ${shortId(user.user_id)}:`,
                 error instanceof Error ? error.message : String(error)
               );
             });

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3695,7 +3695,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     core: ['sessions', 'tasks', 'messages'],
     branches: ['branches'],
     repos: ['repos'],
-    users: ['users'],
+    users: ['users', 'user-avatars'],
     boards: ['boards', 'board-objects', 'board-comments'],
     cards: ['cards', 'card-types'],
     artifacts: ['artifacts'],

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3695,7 +3695,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     core: ['sessions', 'tasks', 'messages'],
     branches: ['branches'],
     repos: ['repos'],
-    users: ['users', 'user-avatars'],
+    users: ['users'],
     boards: ['boards', 'board-objects', 'board-comments'],
     cards: ['cards', 'card-types'],
     artifacts: ['artifacts'],

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -110,6 +110,7 @@ import { createTasksService } from './services/tasks.js';
 import { createTemplatesService } from './services/templates.js';
 import { TerminalsService } from './services/terminals.js';
 import { createThreadSessionMapService } from './services/thread-session-map.js';
+import { createUserAvatarsService } from './services/user-avatars.js';
 import { createUsersService } from './services/users.js';
 import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
@@ -619,6 +620,9 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // wiring throw "Can not apply hooks. 'update' is not a function" at startup.
   app.use('/users', usersService, {
     methods: ['find', 'get', 'create', 'patch', 'remove', 'getGitEnvironment'],
+  });
+  app.use('/user-avatars', createUserAvatarsService(db, app), {
+    methods: ['find', 'create', 'patch', 'refreshUserFromSettings'],
   });
 
   // Bootstrap superadmin users

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -110,7 +110,6 @@ import { createTasksService } from './services/tasks.js';
 import { createTemplatesService } from './services/templates.js';
 import { TerminalsService } from './services/terminals.js';
 import { createThreadSessionMapService } from './services/thread-session-map.js';
-import { createUserAvatarsService } from './services/user-avatars.js';
 import { createUsersService } from './services/users.js';
 import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
@@ -614,15 +613,22 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // Users service
   // ============================================================================
 
-  const usersService = createUsersService(db);
+  const usersService = createUsersService(db, app);
   // UsersService implements find/get/create/patch/remove (no `update`), plus
-  // the custom `getGitEnvironment`. Listing `update` here makes Feathers' hook
+  // custom RPCs like `getGitEnvironment` and avatar sync helpers. Listing `update` here makes Feathers' hook
   // wiring throw "Can not apply hooks. 'update' is not a function" at startup.
   app.use('/users', usersService, {
-    methods: ['find', 'get', 'create', 'patch', 'remove', 'getGitEnvironment'],
-  });
-  app.use('/user-avatars', createUserAvatarsService(db, app), {
-    methods: ['find', 'create', 'patch'],
+    methods: [
+      'find',
+      'get',
+      'create',
+      'patch',
+      'remove',
+      'getGitEnvironment',
+      'getAvatarSettings',
+      'updateAvatarSettings',
+      'syncAvatars',
+    ],
   });
 
   // Bootstrap superadmin users

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -622,7 +622,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     methods: ['find', 'get', 'create', 'patch', 'remove', 'getGitEnvironment'],
   });
   app.use('/user-avatars', createUserAvatarsService(db, app), {
-    methods: ['find', 'create', 'patch', 'refreshUserFromSettings'],
+    methods: ['find', 'create', 'patch'],
   });
 
   // Bootstrap superadmin users

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -128,6 +128,65 @@ describe('ConfigService.resolveApiKey', () => {
     });
   });
 
+  it('allows executor runtime tokens passed as explicit session-token proof', async () => {
+    const service = new ConfigService({} as never);
+    service.app = {
+      sessionTokenService: {
+        validateToken: vi.fn(async () => ({ task_id: 'task-1' })),
+      },
+      service(name: string) {
+        if (name === 'tasks') {
+          return { get: vi.fn(async () => ({ created_by: 'creator-1', session_id: 'session-1' })) };
+        }
+        if (name === 'sessions') {
+          return { get: vi.fn(async () => ({ agentic_tool: 'codex' })) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    const result = await service.resolveApiKey(
+      {
+        taskId: 'task-1' as TaskID,
+        keyName: 'OPENAI_API_KEY',
+        tool: 'codex',
+        executorSessionToken: 'executor-jwt',
+      },
+      {
+        provider: 'socketio',
+        user: { user_id: 'creator-1' },
+      } as never
+    );
+
+    expect(result).toMatchObject({ apiKey: 'resolved-test-key', source: 'user' });
+  });
+
+  it('allows executor runtime tokens when Socket.io preserved scope fields without payload', async () => {
+    const service = new ConfigService({} as never);
+    service.app = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return { get: vi.fn(async () => ({ created_by: 'creator-1', session_id: 'session-1' })) };
+        }
+        if (name === 'sessions') {
+          return { get: vi.fn(async () => ({ agentic_tool: 'codex' })) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    const result = await service.resolveApiKey(
+      { taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY', tool: 'codex' },
+      {
+        provider: 'socketio',
+        authentication: { strategy: 'jwt' },
+        task_id: 'task-1',
+      } as never
+    );
+
+    expect(result).toMatchObject({ apiKey: 'resolved-test-key', source: 'user' });
+  });
+
   it('rejects executor runtime tokens for a different API key than the session tool uses', async () => {
     const service = new ConfigService({} as never);
     service.app = {

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -13,8 +13,7 @@ import {
   saveConfig,
 } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
-import type { Application } from '@agor/core/feathers';
-import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
   type AgenticToolName,
   type AuthenticatedParams,
@@ -23,6 +22,7 @@ import {
   TOOL_API_KEY_NAMES,
   type UserID,
 } from '@agor/core/types';
+import type { SessionTokenService } from './session-token-service.js';
 
 const RESOLVABLE_API_KEY_NAMES: Record<ApiKeyName, true> = {
   ANTHROPIC_API_KEY: true,
@@ -45,12 +45,28 @@ type ExecutorTokenPayload = {
 };
 
 function getExecutorTokenPayload(params?: Params): ExecutorTokenPayload | undefined {
-  const payload = (params as AuthenticatedParams | undefined)?.authentication?.payload as
-    | ExecutorTokenPayload
+  const authParams = params as
+    | (AuthenticatedParams & { task_id?: string; authentication?: { strategy?: string } })
     | undefined;
-  return payload?.type === 'executor-session' && payload.purpose === 'executor-task'
-    ? payload
-    : undefined;
+  const payload = authParams?.authentication?.payload as ExecutorTokenPayload | undefined;
+  if (payload?.type === 'executor-session' && payload.purpose === 'executor-task') {
+    return payload;
+  }
+
+  // Socket.io executor logins may preserve auth-result scope fields on the
+  // connection even when the decoded JWT payload is not carried forward into
+  // later service params. Keep the secret resolver restricted to task-scoped
+  // executor JWTs by only accepting this fallback for JWT-authenticated
+  // connections that have a task claim minted by ServiceJWTStrategy.
+  if (authParams?.authentication?.strategy === 'jwt' && authParams.task_id) {
+    return {
+      type: 'executor-session',
+      purpose: 'executor-task',
+      task_id: authParams.task_id,
+    };
+  }
+
+  return undefined;
 }
 
 /**
@@ -140,6 +156,14 @@ export class ConfigService {
        * sweep (legacy behavior preserved for non-SDK callers).
        */
       tool?: AgenticToolName;
+      /**
+       * Explicit task-scoped executor JWT proof. The Socket.io connection can
+       * authenticate as the session creator user while dropping custom JWT
+       * claims from later service params, so executors include the minted token
+       * on this secret-resolution call and the daemon validates it against the
+       * in-memory session-token registry.
+       */
+      executorSessionToken?: string;
     },
     params?: Params
   ): Promise<{
@@ -158,7 +182,24 @@ export class ConfigService {
     // service account or with a task-scoped executor runtime JWT. Normal
     // user/API-key auth may read masked config via /config but must not resolve
     // raw configured keys.
-    const executorPayload = getExecutorTokenPayload(params);
+    let executorPayload = getExecutorTokenPayload(params);
+    if (!executorPayload && params?.provider && data.executorSessionToken) {
+      const sessionTokenService = (
+        this.app as unknown as {
+          sessionTokenService?: SessionTokenService;
+        }
+      )?.sessionTokenService;
+      const sessionInfo = await sessionTokenService?.validateToken(data.executorSessionToken, {
+        taskId,
+      });
+      if (sessionInfo?.task_id === taskId) {
+        executorPayload = {
+          type: 'executor-session',
+          purpose: 'executor-task',
+          task_id: sessionInfo.task_id,
+        };
+      }
+    }
     if (params?.provider) {
       const caller = (params as AuthenticatedParams | undefined)?.user;
       const isServiceAccount = caller?._isServiceAccount === true;

--- a/apps/agor-daemon/src/services/user-avatar-sync.ts
+++ b/apps/agor-daemon/src/services/user-avatar-sync.ts
@@ -56,7 +56,7 @@ function isUsableAvatarUrl(url: string | null | undefined): url is string {
   }
 }
 
-export class UserAvatarsService {
+export class UserAvatarSyncManager {
   private variables: AppVariableRepository;
   private gatewayChannels: GatewayChannelRepository;
   private users: UsersRepository;
@@ -70,14 +70,15 @@ export class UserAvatarsService {
     this.users = new UsersRepository(db);
   }
 
-  async find(_params?: Params): Promise<UserAvatarSettings> {
+  async getSettings(params?: Params): Promise<UserAvatarSettings> {
+    requireAdmin(params);
     const raw = await this.variables.getPlain(NAMESPACE, SETTINGS_KEY);
     return parseSettings(raw);
   }
 
-  async patch(_id: null, data: Partial<UserAvatarSettings>, params?: Params) {
+  async updateSettings(data: Partial<UserAvatarSettings>, params?: Params) {
     requireAdmin(params);
-    const current = await this.find();
+    const current = await this.getSettings();
     const next: UserAvatarSettings = {
       ...current,
       ...data,
@@ -98,9 +99,12 @@ export class UserAvatarsService {
     return next;
   }
 
-  async create(data: UserAvatarSyncRequest = {}, params?: Params): Promise<UserAvatarSyncResult> {
+  async syncAvatars(
+    data: UserAvatarSyncRequest = {},
+    params?: Params
+  ): Promise<UserAvatarSyncResult> {
     requireAdmin(params);
-    const settings = await this.find();
+    const settings = await this.getSettings();
     const gatewayChannelId = data.gateway_channel_id ?? settings.gateway_channel_id;
     const result = data.user_id
       ? await this.refreshSingleUser(data.user_id as UserID, gatewayChannelId, {
@@ -124,7 +128,7 @@ export class UserAvatarsService {
   }
 
   async refreshUserFromSettings(userId: UserID): Promise<UserAvatarSyncResult | null> {
-    const settings = await this.find();
+    const settings = await this.getSettings();
     if (!settings.enabled || settings.provider !== 'slack' || !settings.gateway_channel_id) {
       return null;
     }
@@ -310,8 +314,4 @@ export class UserAvatarsService {
       };
     }
   }
-}
-
-export function createUserAvatarsService(db: Database, app: Application): UserAvatarsService {
-  return new UserAvatarsService(db, app);
 }

--- a/apps/agor-daemon/src/services/user-avatars.ts
+++ b/apps/agor-daemon/src/services/user-avatars.ts
@@ -85,6 +85,9 @@ export class UserAvatarsService {
       gateway_channel_id:
         data.enabled === false ? null : (data.gateway_channel_id ?? current.gateway_channel_id),
     };
+    if (next.enabled && !next.gateway_channel_id) {
+      throw new Error('Select a Slack gateway channel before enabling Slack avatars');
+    }
     await this.saveSettings(
       next,
       (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined

--- a/apps/agor-daemon/src/services/user-avatars.ts
+++ b/apps/agor-daemon/src/services/user-avatars.ts
@@ -1,0 +1,314 @@
+import {
+  AppVariableRepository,
+  type Database,
+  GatewayChannelRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import { type Application, Forbidden } from '@agor/core/feathers';
+import { SlackConnector } from '@agor/core/gateway';
+import type {
+  AuthenticatedParams,
+  GatewayChannel,
+  Params,
+  User,
+  UserAvatarSettings,
+  UserAvatarSyncRequest,
+  UserAvatarSyncResult,
+  UserID,
+} from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+
+const NAMESPACE = 'user_avatars';
+const SETTINGS_KEY = 'settings';
+
+const DEFAULT_SETTINGS: UserAvatarSettings = {
+  enabled: false,
+  provider: null,
+  gateway_channel_id: null,
+};
+
+function isAdmin(params?: Params): boolean {
+  return hasMinimumRole((params as AuthenticatedParams | undefined)?.user?.role, ROLES.ADMIN);
+}
+
+function requireAdmin(params?: Params): void {
+  if (params?.provider && !isAdmin(params)) {
+    throw new Forbidden('Only admins can manage user avatars');
+  }
+}
+
+function parseSettings(raw: string | null): UserAvatarSettings {
+  if (!raw) return DEFAULT_SETTINGS;
+  try {
+    return { ...DEFAULT_SETTINGS, ...(JSON.parse(raw) as Partial<UserAvatarSettings>) };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+function isUsableAvatarUrl(url: string | null | undefined): url is string {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export class UserAvatarsService {
+  private variables: AppVariableRepository;
+  private gatewayChannels: GatewayChannelRepository;
+  private users: UsersRepository;
+
+  constructor(
+    db: Database,
+    private app: Application
+  ) {
+    this.variables = new AppVariableRepository(db);
+    this.gatewayChannels = new GatewayChannelRepository(db);
+    this.users = new UsersRepository(db);
+  }
+
+  async find(_params?: Params): Promise<UserAvatarSettings> {
+    const raw = await this.variables.getPlain(NAMESPACE, SETTINGS_KEY);
+    return parseSettings(raw);
+  }
+
+  async patch(_id: null, data: Partial<UserAvatarSettings>, params?: Params) {
+    requireAdmin(params);
+    const current = await this.find();
+    const next: UserAvatarSettings = {
+      ...current,
+      ...data,
+      provider: data.enabled === false ? null : (data.provider ?? current.provider ?? 'slack'),
+      gateway_channel_id:
+        data.enabled === false ? null : (data.gateway_channel_id ?? current.gateway_channel_id),
+    };
+    await this.saveSettings(
+      next,
+      (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined
+    );
+    if (data.enabled === false) {
+      await this.clearSlackAvatars();
+    }
+    return next;
+  }
+
+  async create(data: UserAvatarSyncRequest = {}, params?: Params): Promise<UserAvatarSyncResult> {
+    requireAdmin(params);
+    const settings = await this.find();
+    const gatewayChannelId = data.gateway_channel_id ?? settings.gateway_channel_id;
+    const result = data.user_id
+      ? await this.refreshSingleUser(data.user_id as UserID, gatewayChannelId, {
+          mode: 'single',
+        })
+      : await this.refreshAllUsers(gatewayChannelId);
+
+    const nextSettings: UserAvatarSettings = {
+      ...settings,
+      enabled: true,
+      provider: 'slack',
+      gateway_channel_id: gatewayChannelId ?? settings.gateway_channel_id,
+      last_sync_at: result.finished_at,
+      last_sync_result: result,
+    };
+    await this.saveSettings(
+      nextSettings,
+      (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined
+    );
+    return result;
+  }
+
+  async refreshUserFromSettings(userId: UserID): Promise<UserAvatarSyncResult | null> {
+    const settings = await this.find();
+    if (!settings.enabled || settings.provider !== 'slack' || !settings.gateway_channel_id) {
+      return null;
+    }
+    return this.refreshSingleUser(userId, settings.gateway_channel_id, {
+      mode: 'single',
+    });
+  }
+
+  private async saveSettings(settings: UserAvatarSettings, updatedBy?: UserID): Promise<void> {
+    await this.variables.set({
+      namespace: NAMESPACE,
+      key: SETTINGS_KEY,
+      value: JSON.stringify(settings),
+      content_type: 'application/json',
+      updated_by: updatedBy ?? null,
+    });
+  }
+
+  private async clearSlackAvatars(): Promise<void> {
+    const allUsers = await this.users.findAll();
+    const slackUsers = allUsers.filter((user) => user.avatar_source === 'slack');
+    await Promise.all(
+      slackUsers.map((user) =>
+        this.app.service('users').patch(
+          user.user_id,
+          {
+            avatar_url: null,
+            avatar: null,
+            avatar_source: null,
+            avatar_source_id: null,
+            avatar_synced_at: null,
+          } as unknown as Partial<User>,
+          {
+            skipAvatarRefresh: true,
+            user: {
+              user_id: 'user-avatars-service',
+              email: 'user-avatars@agor.internal',
+              role: ROLES.ADMIN,
+              _isServiceAccount: true,
+            },
+          } as Params
+        )
+      )
+    );
+  }
+
+  private async getSlackGateway(
+    gatewayChannelId: string | null | undefined
+  ): Promise<GatewayChannel> {
+    if (!gatewayChannelId) throw new Error('Select a Slack gateway channel first');
+    const channel = await this.gatewayChannels.findById(gatewayChannelId);
+    if (!channel) throw new Error(`Gateway channel not found: ${gatewayChannelId}`);
+    if (channel.channel_type !== 'slack') throw new Error('Selected gateway channel is not Slack');
+    if (!channel.config?.bot_token || typeof channel.config.bot_token !== 'string') {
+      throw new Error('Selected Slack gateway is missing a bot token');
+    }
+    return channel;
+  }
+
+  private async refreshAllUsers(gatewayChannelId: string | null | undefined) {
+    const startedAt = new Date().toISOString();
+    const channel = await this.getSlackGateway(gatewayChannelId);
+    const connector = new SlackConnector(channel.config);
+    const allUsers = await this.users.findAll();
+    let matched = 0;
+    let updated = 0;
+    let skipped = 0;
+    let failed = 0;
+    const failures: UserAvatarSyncResult['failures'] = [];
+
+    for (const user of allUsers) {
+      try {
+        const one = await this.refreshUserWithConnector(user, connector);
+        matched += one.matched;
+        updated += one.updated;
+        skipped += one.skipped;
+        failed += one.failed;
+        failures.push(...one.failures);
+      } catch (error) {
+        failed += 1;
+        failures.push({
+          user_id: user.user_id,
+          email: user.email,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return {
+      ok: failed === 0,
+      mode: 'bulk' as const,
+      gateway_channel_id: channel.id,
+      started_at: startedAt,
+      finished_at: new Date().toISOString(),
+      matched,
+      updated,
+      skipped,
+      failed,
+      failures,
+    };
+  }
+
+  private async refreshSingleUser(
+    userId: UserID,
+    gatewayChannelId: string | null | undefined,
+    options: { mode: 'single' }
+  ): Promise<UserAvatarSyncResult> {
+    const startedAt = new Date().toISOString();
+    const channel = await this.getSlackGateway(gatewayChannelId);
+    const connector = new SlackConnector(channel.config);
+    const user = await this.users.findById(userId);
+    if (!user) throw new Error(`User not found: ${userId}`);
+    const one = await this.refreshUserWithConnector(user, connector);
+    return {
+      ok: one.failed === 0,
+      mode: options.mode,
+      gateway_channel_id: channel.id,
+      started_at: startedAt,
+      finished_at: new Date().toISOString(),
+      ...one,
+    };
+  }
+
+  private async refreshUserWithConnector(
+    user: User,
+    connector: SlackConnector
+  ): Promise<
+    Pick<UserAvatarSyncResult, 'matched' | 'updated' | 'skipped' | 'failed' | 'failures'>
+  > {
+    if (!user.email) {
+      return { matched: 0, updated: 0, skipped: 1, failed: 0, failures: [] };
+    }
+    if (user.preferences?.use_slack_avatar === false) {
+      return { matched: 0, updated: 0, skipped: 1, failed: 0, failures: [] };
+    }
+
+    try {
+      const profile = await connector.lookupUserAvatarByEmail(user.email);
+      if (!profile) {
+        return { matched: 0, updated: 0, skipped: 1, failed: 0, failures: [] };
+      }
+      if (!isUsableAvatarUrl(profile.avatarUrl)) {
+        return { matched: 1, updated: 0, skipped: 1, failed: 0, failures: [] };
+      }
+
+      await this.app.service('users').patch(
+        user.user_id,
+        {
+          avatar_url: profile.avatarUrl,
+          avatar_source: 'slack',
+          avatar_source_id: profile.slackUserId,
+          avatar_synced_at: new Date().toISOString(),
+        } as Partial<User>,
+        {
+          skipAvatarRefresh: true,
+          // users.patch has field-level/profile ownership hooks even for
+          // internal calls. Avatar sync is an admin-only service action, so
+          // carry an internal service user through the hook chain rather than
+          // bypassing the users service and losing Feathers events.
+          user: {
+            user_id: 'user-avatars-service',
+            email: 'user-avatars@agor.internal',
+            role: ROLES.ADMIN,
+            _isServiceAccount: true,
+          },
+        } as Params
+      );
+
+      return { matched: 1, updated: 1, skipped: 0, failed: 0, failures: [] };
+    } catch (error) {
+      return {
+        matched: 0,
+        updated: 0,
+        skipped: 0,
+        failed: 1,
+        failures: [
+          {
+            user_id: user.user_id,
+            email: user.email,
+            reason: error instanceof Error ? error.message : String(error),
+          },
+        ],
+      };
+    }
+  }
+}
+
+export function createUserAvatarsService(db: Database, app: Application): UserAvatarsService {
+  return new UserAvatarsService(db, app);
+}

--- a/apps/agor-daemon/src/services/users.security.test.ts
+++ b/apps/agor-daemon/src/services/users.security.test.ts
@@ -81,3 +81,29 @@ describe('UsersService — git token env var hardening', () => {
     ).resolves.toBeDefined();
   });
 });
+
+describe('UsersService — avatar source metadata', () => {
+  dbTest(
+    'marks explicit avatar URL patches as manual and clears Slack metadata',
+    async ({ db }) => {
+      const service = new UsersService(db);
+      const user = await service.create({
+        email: 'avatar-source@test.local',
+        password: 'test-password-1234',
+        avatar_url: 'https://slack.example.com/avatar-512.png',
+        avatar_source: 'slack',
+        avatar_source_id: 'U123',
+        avatar_synced_at: '2026-06-24T00:00:00.000Z',
+      });
+
+      const updated = await service.patch(user.user_id as UserID, {
+        avatar_url: 'https://cdn.example.com/manual.png',
+      });
+
+      expect(updated.avatar_url).toBe('https://cdn.example.com/manual.png');
+      expect(updated.avatar_source).toBe('manual');
+      expect(updated.avatar_source_id).toBeUndefined();
+      expect(updated.avatar_synced_at).toBeUndefined();
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/users.security.test.ts
+++ b/apps/agor-daemon/src/services/users.security.test.ts
@@ -106,4 +106,29 @@ describe('UsersService — avatar source metadata', () => {
       expect(updated.avatar_synced_at).toBeUndefined();
     }
   );
+
+  dbTest(
+    'clears stale Slack metadata when avatar source changes away from Slack',
+    async ({ db }) => {
+      const service = new UsersService(db);
+      const user = await service.create({
+        email: 'avatar-source-change@test.local',
+        password: 'test-password-1234',
+        avatar_url: 'https://slack.example.com/avatar-512.png',
+        avatar_source: 'slack',
+        avatar_source_id: 'U456',
+        avatar_synced_at: '2026-06-24T00:00:00.000Z',
+      });
+
+      const updated = await service.patch(user.user_id as UserID, {
+        avatar_url: 'https://launch.example.com/avatar.png',
+        avatar_source: 'launch-auth',
+      });
+
+      expect(updated.avatar_url).toBe('https://launch.example.com/avatar.png');
+      expect(updated.avatar_source).toBe('launch-auth');
+      expect(updated.avatar_source_id).toBeUndefined();
+      expect(updated.avatar_synced_at).toBeUndefined();
+    }
+  );
 });

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -354,7 +354,8 @@ export class UsersService {
         updated_at: now,
         data: {
           avatar_url: data.avatar_url ?? data.avatar ?? undefined,
-          avatar_source: data.avatar_source ?? undefined,
+          avatar_source:
+            data.avatar_source ?? ((data.avatar_url ?? data.avatar) ? 'manual' : undefined),
           avatar_source_id: data.avatar_source_id ?? undefined,
           avatar_synced_at: data.avatar_synced_at ?? undefined,
           preferences: {},
@@ -506,22 +507,32 @@ export class UsersService {
         }
       }
 
+      const avatarUrlTouched = data.avatar_url !== undefined || data.avatar !== undefined;
+      const avatarCleared = data.avatar_url === null || data.avatar === null;
+      const inferredManualAvatarSource =
+        avatarUrlTouched && !avatarCleared && data.avatar_source === undefined;
+
       updates.data = {
         ...currentData,
-        avatar_url:
-          data.avatar_url === null || data.avatar === null
-            ? undefined
-            : (data.avatar_url ?? data.avatar ?? current.avatar_url),
+        avatar_url: avatarCleared
+          ? undefined
+          : (data.avatar_url ?? data.avatar ?? current.avatar_url),
         // Deprecated legacy alias: read for back-compat, stop writing it on avatar updates.
         avatar: undefined,
         avatar_source:
-          data.avatar_source === null ? undefined : (data.avatar_source ?? current.avatar_source),
+          data.avatar_source === null || avatarCleared
+            ? undefined
+            : data.avatar_source !== undefined
+              ? data.avatar_source
+              : inferredManualAvatarSource
+                ? 'manual'
+                : current.avatar_source,
         avatar_source_id:
-          data.avatar_source_id === null
+          data.avatar_source_id === null || avatarCleared || inferredManualAvatarSource
             ? undefined
             : (data.avatar_source_id ?? current.avatar_source_id),
         avatar_synced_at:
-          data.avatar_synced_at === null
+          data.avatar_synced_at === null || avatarCleared || inferredManualAvatarSource
             ? undefined
             : (data.avatar_synced_at ?? current.avatar_synced_at),
         preferences: data.preferences ?? current.preferences,

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -28,7 +28,7 @@ import {
   update,
   users,
 } from '@agor/core/db';
-import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import { isLikelyGitToken } from '@agor/core/git';
 import type {
   AgenticToolName,
@@ -42,6 +42,9 @@ import type {
   Params,
   StoredAgenticTools,
   User,
+  UserAvatarSettings,
+  UserAvatarSyncRequest,
+  UserAvatarSyncResult,
   UserID,
   UserRole,
 } from '@agor/core/types';
@@ -52,6 +55,7 @@ import {
   ROLES,
   toAgenticToolsStatus,
 } from '@agor/core/types';
+import { UserAvatarSyncManager } from './user-avatar-sync.js';
 
 function optionalNonNegativeInteger(value: unknown): number | undefined {
   if (value === undefined || value === null || value === '') return undefined;
@@ -229,7 +233,23 @@ interface UpdateUserData {
  * Users Service Methods
  */
 export class UsersService {
-  constructor(protected db: Database) {}
+  private avatarSync?: UserAvatarSyncManager;
+
+  constructor(
+    protected db: Database,
+    app?: Application
+  ) {
+    if (app) {
+      this.avatarSync = new UserAvatarSyncManager(db, app);
+    }
+  }
+
+  private requireAvatarSync(): UserAvatarSyncManager {
+    if (!this.avatarSync) {
+      throw new Error('User avatar sync is not available in this service context');
+    }
+    return this.avatarSync;
+  }
 
   /**
    * Find all users.
@@ -717,6 +737,28 @@ export class UsersService {
     return resolveUserEnvironment(userId, this.db);
   }
 
+  async getAvatarSettings(_data?: unknown, params?: Params): Promise<UserAvatarSettings> {
+    return this.requireAvatarSync().getSettings(params);
+  }
+
+  async updateAvatarSettings(
+    data: Partial<UserAvatarSettings>,
+    params?: Params
+  ): Promise<UserAvatarSettings> {
+    return this.requireAvatarSync().updateSettings(data, params);
+  }
+
+  async syncAvatars(
+    data: UserAvatarSyncRequest = {},
+    params?: Params
+  ): Promise<UserAvatarSyncResult> {
+    return this.requireAvatarSync().syncAvatars(data, params);
+  }
+
+  async refreshAvatarFromSettings(userId: UserID): Promise<UserAvatarSyncResult | null> {
+    return this.requireAvatarSync().refreshUserFromSettings(userId);
+  }
+
   /**
    * Convert database row to User type
    *
@@ -875,6 +917,6 @@ class UsersServiceWithAuth extends UsersService {
 /**
  * Create users service
  */
-export function createUsersService(db: Database): UsersServiceWithAuth {
-  return new UsersServiceWithAuth(db);
+export function createUsersService(db: Database, app?: Application): UsersServiceWithAuth {
+  return new UsersServiceWithAuth(db, app);
 }

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -185,6 +185,11 @@ interface CreateUserData {
   role?: UserRole;
   unix_username?: string;
   must_change_password?: boolean;
+  avatar_url?: string | null;
+  avatar?: string | null;
+  avatar_source?: string | null;
+  avatar_source_id?: string | null;
+  avatar_synced_at?: string | null;
 }
 
 /**
@@ -198,7 +203,11 @@ interface UpdateUserData {
   role?: UserRole;
   unix_username?: string;
   must_change_password?: boolean;
-  avatar?: string;
+  avatar_url?: string | null;
+  avatar?: string | null;
+  avatar_source?: string | null;
+  avatar_source_id?: string | null;
+  avatar_synced_at?: string | null;
   preferences?: Record<string, unknown>;
   onboarding_completed?: boolean;
   /**
@@ -344,6 +353,10 @@ export class UsersService {
         created_at: now,
         updated_at: now,
         data: {
+          avatar_url: data.avatar_url ?? data.avatar ?? undefined,
+          avatar_source: data.avatar_source ?? undefined,
+          avatar_source_id: data.avatar_source_id ?? undefined,
+          avatar_synced_at: data.avatar_synced_at ?? undefined,
           preferences: {},
         },
       })
@@ -386,7 +399,11 @@ export class UsersService {
 
     // Update data blob
     if (
-      data.avatar ||
+      data.avatar_url !== undefined ||
+      data.avatar !== undefined ||
+      data.avatar_source !== undefined ||
+      data.avatar_source_id !== undefined ||
+      data.avatar_synced_at !== undefined ||
       data.preferences ||
       data.agentic_tools ||
       data.env_vars ||
@@ -396,7 +413,11 @@ export class UsersService {
       const current = await this.get(id);
       const currentRow = await select(this.db).from(users).where(eq(users.user_id, id)).one();
       const currentData = currentRow?.data as {
+        avatar_url?: string;
         avatar?: string;
+        avatar_source?: string;
+        avatar_source_id?: string;
+        avatar_synced_at?: string;
         preferences?: Record<string, unknown>;
         agentic_tools?: StoredAgenticTools;
         env_vars?: Record<string, string | StoredEnvVar>;
@@ -486,7 +507,23 @@ export class UsersService {
       }
 
       updates.data = {
-        avatar: data.avatar ?? current.avatar,
+        ...currentData,
+        avatar_url:
+          data.avatar_url === null || data.avatar === null
+            ? undefined
+            : (data.avatar_url ?? data.avatar ?? current.avatar_url),
+        // Deprecated legacy alias: read for back-compat, stop writing it on avatar updates.
+        avatar: undefined,
+        avatar_source:
+          data.avatar_source === null ? undefined : (data.avatar_source ?? current.avatar_source),
+        avatar_source_id:
+          data.avatar_source_id === null
+            ? undefined
+            : (data.avatar_source_id ?? current.avatar_source_id),
+        avatar_synced_at:
+          data.avatar_synced_at === null
+            ? undefined
+            : (data.avatar_synced_at ?? current.avatar_synced_at),
         preferences: data.preferences ?? current.preferences,
         agentic_tools: Object.keys(nextAgenticTools).length > 0 ? nextAgenticTools : undefined,
         env_vars: Object.keys(nextEnvVars).length > 0 ? nextEnvVars : undefined,
@@ -678,7 +715,11 @@ export class UsersService {
     includeAuthMetadata = true
   ): (User | InternalUser) & { password?: string } {
     const data = row.data as {
+      avatar_url?: string;
       avatar?: string;
+      avatar_source?: string;
+      avatar_source_id?: string;
+      avatar_synced_at?: string;
       preferences?: Record<string, unknown>;
       agentic_tools?: StoredAgenticTools; // Encrypted per-tool credential blobs
       env_vars?: Record<string, string | StoredEnvVar>; // Encrypted env vars (legacy + v0.5 shape)
@@ -703,7 +744,11 @@ export class UsersService {
       emoji: row.emoji ?? undefined,
       role: normalizeRole(row.role ?? undefined),
       unix_username: row.unix_username ?? undefined,
+      avatar_url: data.avatar_url ?? data.avatar,
       avatar: data.avatar,
+      avatar_source: data.avatar_source,
+      avatar_source_id: data.avatar_source_id,
+      avatar_synced_at: data.avatar_synced_at,
       preferences: data.preferences,
       onboarding_completed: !!row.onboarding_completed,
       must_change_password: !!row.must_change_password,
@@ -761,7 +806,11 @@ class UsersServiceWithAuth extends UsersService {
     }
 
     const data = row.data as {
+      avatar_url?: string;
       avatar?: string;
+      avatar_source?: string;
+      avatar_source_id?: string;
+      avatar_synced_at?: string;
       preferences?: Record<string, unknown>;
       agentic_tools?: StoredAgenticTools;
       env_vars?: Record<string, string | StoredEnvVar>;
@@ -785,7 +834,11 @@ class UsersServiceWithAuth extends UsersService {
       name: row.name ?? undefined,
       emoji: row.emoji ?? undefined,
       role: normalizeRole(row.role ?? undefined),
+      avatar_url: data.avatar_url ?? data.avatar,
       avatar: data.avatar,
+      avatar_source: data.avatar_source,
+      avatar_source_id: data.avatar_source_id,
+      avatar_synced_at: data.avatar_synced_at,
       preferences: data.preferences,
       onboarding_completed: !!row.onboarding_completed,
       must_change_password: !!row.must_change_password,

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -511,6 +511,10 @@ export class UsersService {
       const avatarCleared = data.avatar_url === null || data.avatar === null;
       const inferredManualAvatarSource =
         avatarUrlTouched && !avatarCleared && data.avatar_source === undefined;
+      const avatarSourceChangedAwayFromSlack =
+        data.avatar_source !== undefined &&
+        data.avatar_source !== null &&
+        data.avatar_source !== 'slack';
 
       updates.data = {
         ...currentData,
@@ -528,11 +532,17 @@ export class UsersService {
                 ? 'manual'
                 : current.avatar_source,
         avatar_source_id:
-          data.avatar_source_id === null || avatarCleared || inferredManualAvatarSource
+          data.avatar_source_id === null ||
+          avatarCleared ||
+          inferredManualAvatarSource ||
+          (avatarSourceChangedAwayFromSlack && data.avatar_source_id === undefined)
             ? undefined
             : (data.avatar_source_id ?? current.avatar_source_id),
         avatar_synced_at:
-          data.avatar_synced_at === null || avatarCleared || inferredManualAvatarSource
+          data.avatar_synced_at === null ||
+          avatarCleared ||
+          inferredManualAvatarSource ||
+          (avatarSourceChangedAwayFromSlack && data.avatar_synced_at === undefined)
             ? undefined
             : (data.avatar_synced_at ?? current.avatar_synced_at),
         preferences: data.preferences ?? current.preferences,

--- a/apps/agor-ui/src/components/Facepile/Facepile.tsx
+++ b/apps/agor-ui/src/components/Facepile/Facepile.tsx
@@ -8,9 +8,9 @@
  */
 
 import type { ActiveUser, Board, BoardID } from '@agor-live/client';
-import { Tooltip } from 'antd';
+import { Avatar, Tooltip, theme } from 'antd';
 import type { CSSProperties } from 'react';
-import { AgorAvatar } from '../AgorAvatar';
+import { slackAvatarRadius, UserIdentityAvatar } from '../UserIdentityAvatar';
 import './Facepile.css';
 
 export interface FacepileProps {
@@ -27,7 +27,7 @@ export interface FacepileProps {
 }
 
 /**
- * Facepile component showing active users with emoji avatars
+ * Facepile component showing active users with Slack-style user avatars
  */
 export const Facepile: React.FC<FacepileProps> = ({
   activeUsers,
@@ -36,6 +36,8 @@ export const Facepile: React.FC<FacepileProps> = ({
   boardById,
   style,
 }) => {
+  const { token } = theme.useToken();
+
   // Show first N users, with overflow count
   const visibleUsers = activeUsers.slice(0, maxVisible);
   const overflowUsers = activeUsers.slice(maxVisible);
@@ -73,7 +75,8 @@ export const Facepile: React.FC<FacepileProps> = ({
             }
           >
             <span>
-              <AgorAvatar
+              <UserIdentityAvatar
+                user={user}
                 style={{
                   cursor: canClick ? 'pointer' : 'default',
                 }}
@@ -82,9 +85,7 @@ export const Facepile: React.FC<FacepileProps> = ({
                     onUserClick(user.user_id, boardId, cursor);
                   }
                 }}
-              >
-                {user.emoji || '👤'}
-              </AgorAvatar>
+              />
             </span>
           </Tooltip>
         );
@@ -96,7 +97,7 @@ export const Facepile: React.FC<FacepileProps> = ({
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               {overflowUsers.map(({ user }) => (
                 <div key={user.user_id} style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <span style={{ fontSize: 16 }}>{user.emoji || '👤'}</span>
+                  <UserIdentityAvatar user={user} size={20} fontSize="16px" />
                   <span>{user.name || user.email}</span>
                 </div>
               ))}
@@ -104,9 +105,19 @@ export const Facepile: React.FC<FacepileProps> = ({
           }
         >
           <span>
-            <AgorAvatar fontSize="12px" style={{ fontWeight: 'bold' }}>
+            <Avatar
+              shape="square"
+              size={40}
+              style={{
+                borderRadius: slackAvatarRadius(40),
+                backgroundColor: token.colorPrimaryBg,
+                color: token.colorText,
+                fontSize: 12,
+                fontWeight: 'bold',
+              }}
+            >
               +{overflowCount}
-            </AgorAvatar>
+            </Avatar>
           </span>
         </Tooltip>
       )}

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -46,6 +46,7 @@ import {
 } from '../ToolBlock';
 import { ToolIcon } from '../ToolIcon';
 import { ToolUseRenderer } from '../ToolUseRenderer';
+import { UserIdentityAvatar } from '../UserIdentityAvatar';
 // Side-effect import: registers every built-in widget component with the
 // `WidgetBlock` dispatcher (e.g. `env_vars`).
 import '../Widgets';
@@ -346,7 +347,6 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
 
   // Get current user's emoji
   const currentUser = currentUserId ? userById.get(currentUserId) : undefined;
-  const userEmoji = currentUser?.emoji || '👤';
 
   // Skip rendering if message has no content
   if (!message.content || (typeof message.content === 'string' && message.content.trim() === '')) {
@@ -591,7 +591,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
       {hasTextBefore &&
         (() => {
           const avatar = isUser ? (
-            <AgorAvatar>{userEmoji}</AgorAvatar>
+            <UserIdentityAvatar user={currentUser} />
           ) : (
             getAgentAvatar({ assistantEmoji, agentic_tool, isCallback, token })
           );

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/RemoteCursorLayer.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/RemoteCursorLayer.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useViewport } from 'reactflow';
 import { useBoardPresenceRoom } from '../../../hooks/useBoardPresenceRoom';
 import { usePresence } from '../../../hooks/usePresence';
+import { UserIdentityAvatar } from '../../UserIdentityAvatar';
 
 export interface StaticRemoteCursor {
   userId: string;
@@ -128,7 +129,7 @@ export const RemoteCursorLayer: React.FC<RemoteCursorLayerProps> = ({
                   boxShadow: token.boxShadowSecondary,
                 }}
               >
-                <span style={{ fontSize: '14px' }}>{user.emoji || '👤'}</span>
+                <UserIdentityAvatar user={user} size={18} fontSize="14px" />
                 <span style={{ fontWeight: 500 }}>{user.name || user.email}</span>
               </div>
             </div>

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -462,6 +462,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           <UsersTable
             userById={userById}
             mcpServerById={mcpServerById}
+            gatewayChannelById={gatewayChannelById}
             client={client}
             currentUser={currentUser}
             onCreate={onCreateUser}

--- a/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
@@ -66,6 +66,38 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
     setGatewayId(saved.gateway_channel_id);
   };
 
+  const enableWithCurrentGateway = async (nextEnabled: boolean) => {
+    const previousEnabled = enabled;
+    setEnabled(nextEnabled);
+    if (nextEnabled && !gatewayId) {
+      return;
+    }
+    try {
+      await save(nextEnabled, gatewayId);
+    } catch (error) {
+      setEnabled(previousEnabled);
+      showError(
+        `Failed to update avatar settings: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  };
+
+  const selectGateway = async (nextGatewayId: string) => {
+    const previousGatewayId = gatewayId;
+    setGatewayId(nextGatewayId);
+    if (!enabled) {
+      return;
+    }
+    try {
+      await save(true, nextGatewayId);
+    } catch (error) {
+      setGatewayId(previousGatewayId);
+      showError(
+        `Failed to update avatar settings: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  };
+
   const runSync = async () => {
     if (!client || !gatewayId) return;
     setSyncing(true);
@@ -104,11 +136,7 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
         <Space direction="vertical" size="middle" style={{ width: '100%' }}>
           <Checkbox
             checked={enabled}
-            onChange={async (event) => {
-              const nextEnabled = event.target.checked;
-              setEnabled(nextEnabled);
-              await save(nextEnabled, gatewayId);
-            }}
+            onChange={(event) => enableWithCurrentGateway(event.target.checked)}
           >
             Enable Slack-synced avatars
           </Checkbox>
@@ -123,11 +151,7 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
               style={{ minWidth: 320 }}
               placeholder="Select Slack gateway"
               value={gatewayId ?? undefined}
-              disabled={!enabled}
-              onChange={async (value) => {
-                setGatewayId(value);
-                await save(enabled, value);
-              }}
+              onChange={selectGateway}
               options={slackGateways.map((channel) => ({
                 value: channel.id,
                 label: `${channel.name}${channel.enabled ? '' : ' (disabled)'}`,

--- a/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
@@ -1,0 +1,184 @@
+import type {
+  AgorClient,
+  GatewayChannel,
+  UserAvatarSettings,
+  UserAvatarSyncResult,
+} from '@agor-live/client';
+import { Alert, Button, Card, Checkbox, Flex, Select, Space, Typography } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import { mapToSortedArray } from '@/utils/mapHelpers';
+import { useThemedMessage } from '../../utils/message';
+
+interface UserAvatarsTabProps {
+  client: AgorClient | null;
+  gatewayChannelById: Map<string, GatewayChannel>;
+}
+
+const DEFAULT_SETTINGS: UserAvatarSettings = {
+  enabled: false,
+  provider: null,
+  gateway_channel_id: null,
+};
+
+export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayChannelById }) => {
+  const { showSuccess, showError } = useThemedMessage();
+  const [settings, setSettings] = useState<UserAvatarSettings>(DEFAULT_SETTINGS);
+  const [enabled, setEnabled] = useState(false);
+  const [gatewayId, setGatewayId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [lastResult, setLastResult] = useState<UserAvatarSyncResult | null>(null);
+
+  const slackGateways = useMemo(
+    () =>
+      mapToSortedArray(gatewayChannelById, (a, b) => a.name.localeCompare(b.name)).filter(
+        (channel) => channel.channel_type === 'slack'
+      ),
+    [gatewayChannelById]
+  );
+
+  useEffect(() => {
+    if (!client) return;
+    setLoading(true);
+    client
+      .service('user-avatars')
+      .find()
+      .then((value) => {
+        const next = value as unknown as UserAvatarSettings;
+        setSettings(next);
+        setEnabled(next.enabled);
+        setGatewayId(next.gateway_channel_id);
+        setLastResult(next.last_sync_result ?? null);
+      })
+      .catch((error) => showError(`Failed to load avatar settings: ${error.message}`))
+      .finally(() => setLoading(false));
+  }, [client, showError]);
+
+  const save = async (nextEnabled = enabled, nextGatewayId = gatewayId) => {
+    if (!client) return;
+    const saved = (await client.service('user-avatars').patch(null, {
+      enabled: nextEnabled,
+      provider: nextEnabled ? 'slack' : null,
+      gateway_channel_id: nextEnabled ? nextGatewayId : null,
+    } as Partial<UserAvatarSettings>)) as UserAvatarSettings;
+    setSettings(saved);
+    setEnabled(saved.enabled);
+    setGatewayId(saved.gateway_channel_id);
+  };
+
+  const runSync = async () => {
+    if (!client || !gatewayId) return;
+    setSyncing(true);
+    try {
+      await save(true, gatewayId);
+      const result = (await client.service('user-avatars').create({
+        gateway_channel_id: gatewayId,
+      })) as UserAvatarSyncResult;
+      setLastResult(result);
+      showSuccess(
+        `Synced Slack avatars: ${result.updated} updated, ${result.skipped} skipped, ` +
+          `${result.failed} failed`
+      );
+    } catch (error) {
+      showError(
+        `Slack avatar sync failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  return (
+    <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <div>
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          User Slack avatars
+        </Typography.Title>
+        <Typography.Text type="secondary">
+          Use a Slack gateway bot token to sync Slack profile image URLs onto Agor users by email.
+          Agor prefers avatar_url when present and falls back to each user’s emoji tile.
+        </Typography.Text>
+      </div>
+
+      <Card loading={loading} size="small">
+        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+          <Checkbox
+            checked={enabled}
+            onChange={async (event) => {
+              const nextEnabled = event.target.checked;
+              setEnabled(nextEnabled);
+              await save(nextEnabled, gatewayId);
+            }}
+          >
+            Enable Slack-synced avatars
+          </Checkbox>
+
+          <Typography.Text type="secondary">
+            Disabling this stops Slack avatar refreshes and removes only Slack-synced avatar URLs.
+            Manually/provider-set avatar URLs are preserved.
+          </Typography.Text>
+
+          <Flex gap={12} align="center" wrap="wrap">
+            <Select
+              style={{ minWidth: 320 }}
+              placeholder="Select Slack gateway"
+              value={gatewayId ?? undefined}
+              disabled={!enabled}
+              onChange={async (value) => {
+                setGatewayId(value);
+                await save(enabled, value);
+              }}
+              options={slackGateways.map((channel) => ({
+                value: channel.id,
+                label: `${channel.name}${channel.enabled ? '' : ' (disabled)'}`,
+              }))}
+            />
+            <Button
+              type="primary"
+              disabled={!enabled || !gatewayId}
+              loading={syncing}
+              onClick={runSync}
+            >
+              Sync now
+            </Button>
+          </Flex>
+
+          {lastResult && (
+            <Typography.Text type={lastResult.failed ? 'warning' : 'secondary'}>
+              Last sync: {lastResult.updated} updated, {lastResult.skipped} skipped,{' '}
+              {lastResult.failed} failed at {new Date(lastResult.finished_at).toLocaleString()}.
+            </Typography.Text>
+          )}
+
+          {lastResult?.failures?.length ? (
+            <Alert
+              type="warning"
+              showIcon
+              message="Avatar sync failures"
+              description={
+                <Space direction="vertical" size={4}>
+                  {lastResult.failures.slice(0, 5).map((failure) => (
+                    <Typography.Text key={`${failure.user_id}-${failure.reason}`} type="secondary">
+                      {failure.email || failure.user_id}: {failure.reason}
+                    </Typography.Text>
+                  ))}
+                  {lastResult.failures.length > 5 && (
+                    <Typography.Text type="secondary">
+                      …and {lastResult.failures.length - 5} more.
+                    </Typography.Text>
+                  )}
+                </Space>
+              }
+            />
+          ) : null}
+
+          {settings.last_sync_at && !lastResult && (
+            <Typography.Text type="secondary">
+              Last sync: {new Date(settings.last_sync_at).toLocaleString()}.
+            </Typography.Text>
+          )}
+        </Space>
+      </Card>
+    </Space>
+  );
+};

--- a/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserAvatarsTab.tsx
@@ -14,6 +14,19 @@ interface UserAvatarsTabProps {
   gatewayChannelById: Map<string, GatewayChannel>;
 }
 
+type UsersAvatarClient = {
+  getAvatarSettings(data?: unknown): Promise<UserAvatarSettings>;
+  updateAvatarSettings(data: Partial<UserAvatarSettings>): Promise<UserAvatarSettings>;
+  syncAvatars(data: {
+    gateway_channel_id?: string | null;
+    user_id?: string;
+  }): Promise<UserAvatarSyncResult>;
+};
+
+function usersAvatarClient(client: AgorClient): UsersAvatarClient {
+  return client.service('users') as unknown as UsersAvatarClient;
+}
+
 const DEFAULT_SETTINGS: UserAvatarSettings = {
   enabled: false,
   provider: null,
@@ -40,9 +53,8 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
   useEffect(() => {
     if (!client) return;
     setLoading(true);
-    client
-      .service('user-avatars')
-      .find()
+    usersAvatarClient(client)
+      .getAvatarSettings({})
       .then((value) => {
         const next = value as unknown as UserAvatarSettings;
         setSettings(next);
@@ -56,7 +68,7 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
 
   const save = async (nextEnabled = enabled, nextGatewayId = gatewayId) => {
     if (!client) return;
-    const saved = (await client.service('user-avatars').patch(null, {
+    const saved = (await usersAvatarClient(client).updateAvatarSettings({
       enabled: nextEnabled,
       provider: nextEnabled ? 'slack' : null,
       gateway_channel_id: nextEnabled ? nextGatewayId : null,
@@ -103,7 +115,7 @@ export const UserAvatarsTab: React.FC<UserAvatarsTabProps> = ({ client, gatewayC
     setSyncing(true);
     try {
       await save(true, gatewayId);
-      const result = (await client.service('user-avatars').create({
+      const result = (await usersAvatarClient(client).syncAvatars({
         gateway_channel_id: gatewayId,
       })) as UserAvatarSyncResult;
       setLastResult(result);

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -189,6 +189,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         unix_username: userData.unix_username,
         groupIds: [],
         eventStreamEnabled: userData.preferences?.eventStream?.enabled ?? true,
+        useSlackAvatar: userData.preferences?.use_slack_avatar !== false,
         must_change_password: userData.must_change_password ?? false,
       });
     },
@@ -368,18 +369,25 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     try {
       await form.validateFields(['email', 'name', 'emoji', 'role', 'unix_username']);
       const values = form.getFieldsValue();
+      const nextPreferences: NonNullable<UpdateUserInput['preferences']> = {
+        ...user.preferences,
+        eventStream: {
+          enabled: values.eventStreamEnabled ?? true,
+        },
+      };
+      if (values.useSlackAvatar === false) {
+        nextPreferences.use_slack_avatar = false;
+      } else {
+        delete nextPreferences.use_slack_avatar;
+      }
+
       const updates: UpdateUserInput = {
         email: values.email,
         name: values.name,
         emoji: values.emoji,
         role: values.role,
         unix_username: values.unix_username,
-        preferences: {
-          ...user.preferences,
-          eventStream: {
-            enabled: values.eventStreamEnabled ?? true,
-          },
-        },
+        preferences: nextPreferences,
       };
       if (values.password?.trim()) {
         updates.password = values.password;
@@ -758,6 +766,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                 name="eventStreamEnabled"
                 valuePropName="checked"
                 tooltip="Show/hide the event stream icon in the navbar. When enabled, you can view live WebSocket events for debugging."
+              >
+                <Switch />
+              </Form.Item>
+
+              <Form.Item
+                label="Use Slack avatar when available"
+                name="useSlackAvatar"
+                valuePropName="checked"
+                tooltip="When enabled, Agor shows your Slack-synced profile image. Turn this off to keep using your emoji tile."
               >
                 <Switch />
               </Form.Item>

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -1,6 +1,7 @@
 import type {
   AgorClient,
   CreateUserInput,
+  GatewayChannel,
   Group,
   GroupMembership,
   MCPServer,
@@ -20,6 +21,7 @@ import {
   Select,
   Space,
   Table,
+  Tabs,
   Tag,
   Typography,
 } from 'antd';
@@ -29,12 +31,15 @@ import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { useThemedMessage } from '../../utils/message';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { HighlightMatch } from '../HighlightMatch';
+import { UserIdentityAvatar } from '../UserIdentityAvatar';
 import { SettingsActionGroup } from './SettingsActionGroup';
+import { UserAvatarsTab } from './UserAvatarsTab';
 import { UserSettingsModal } from './UserSettingsModal';
 
 interface UsersTableProps {
   userById: Map<string, User>;
   mcpServerById: Map<string, MCPServer>;
+  gatewayChannelById?: Map<string, GatewayChannel>;
   client: AgorClient | null;
   currentUser?: User | null;
   onCreate?: (data: CreateUserInput) => void;
@@ -45,6 +50,7 @@ interface UsersTableProps {
 export const UsersTable: React.FC<UsersTableProps> = ({
   userById,
   mcpServerById,
+  gatewayChannelById = new Map(),
   client,
   currentUser,
   onCreate,
@@ -161,7 +167,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       key: 'email',
       render: (email: string, user: User) => (
         <Space>
-          <span style={{ fontSize: 20 }}>{user.emoji || '👤'}</span>
+          <UserIdentityAvatar user={user} size={28} fontSize="20px" />
           <span>
             <HighlightMatch text={email} query={searchTerm} />
           </span>
@@ -237,7 +243,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
     },
   ];
 
-  return (
+  const usersTable = (
     <div>
       <div
         style={{
@@ -366,5 +372,25 @@ export const UsersTable: React.FC<UsersTableProps> = ({
         onUpdate={onUpdate}
       />
     </div>
+  );
+
+  return (
+    <Tabs
+      defaultActiveKey="users"
+      items={[
+        { key: 'users', label: 'Users', children: usersTable },
+        ...(isAdmin
+          ? [
+              {
+                key: 'avatars',
+                label: 'Avatars',
+                children: (
+                  <UserAvatarsTab client={client} gatewayChannelById={gatewayChannelById} />
+                ),
+              },
+            ]
+          : []),
+      ]}
+    />
   );
 };

--- a/apps/agor-ui/src/components/UserIdentityAvatar.tsx
+++ b/apps/agor-ui/src/components/UserIdentityAvatar.tsx
@@ -1,0 +1,55 @@
+import type { User } from '@agor-live/client';
+import { Avatar, type AvatarProps, theme } from 'antd';
+import type { CSSProperties } from 'react';
+
+export interface UserIdentityAvatarProps extends Omit<AvatarProps, 'src' | 'style'> {
+  user?: Pick<
+    User,
+    'avatar_url' | 'avatar_source' | 'emoji' | 'name' | 'email' | 'preferences'
+  > | null;
+  size?: number;
+  fontSize?: string;
+  style?: CSSProperties;
+}
+
+export function getUserAvatarUrl(user?: Pick<User, 'avatar_url'> | null): string | undefined {
+  return user?.avatar_url || undefined;
+}
+
+export function slackAvatarRadius(size: number): number {
+  return Math.max(5, Math.round(size * 0.2));
+}
+
+export const UserIdentityAvatar: React.FC<UserIdentityAvatarProps> = ({
+  user,
+  size = 40,
+  fontSize,
+  style,
+  ...props
+}) => {
+  const { token } = theme.useToken();
+  const prefersSlackAvatar = user?.preferences?.use_slack_avatar !== false;
+  const rawAvatarUrl = getUserAvatarUrl(user);
+  const avatarUrl =
+    user?.avatar_source === 'slack' && !prefersSlackAvatar ? undefined : rawAvatarUrl;
+
+  return (
+    <Avatar
+      {...props}
+      src={avatarUrl}
+      shape="square"
+      size={size}
+      style={{
+        borderRadius: slackAvatarRadius(size),
+        backgroundColor: avatarUrl ? token.colorBgContainer : token.colorPrimaryBg,
+        color: token.colorText,
+        fontSize: fontSize ?? `${Math.round(size * 0.6)}px`,
+        lineHeight: `${size}px`,
+        overflow: 'hidden',
+        ...style,
+      }}
+    >
+      {user?.emoji || '👤'}
+    </Avatar>
+  );
+};

--- a/apps/agor-ui/src/components/metadata/UserAvatar.tsx
+++ b/apps/agor-ui/src/components/metadata/UserAvatar.tsx
@@ -1,5 +1,6 @@
 import type { User } from '@agor-live/client';
 import { Space, Tooltip, theme } from 'antd';
+import { UserIdentityAvatar } from '../UserIdentityAvatar';
 
 export interface UserAvatarProps {
   user: User;
@@ -8,9 +9,9 @@ export interface UserAvatarProps {
 }
 
 const sizeMap = {
-  small: 12,
-  default: 14,
-  large: 18,
+  small: { avatar: 18, font: 12 },
+  default: { avatar: 22, font: 14 },
+  large: { avatar: 28, font: 18 },
 };
 
 /**
@@ -23,13 +24,13 @@ export const UserAvatar: React.FC<UserAvatarProps> = ({
   showName = true,
   size = 'default',
 }) => {
-  const fontSize = sizeMap[size];
+  const sizes = sizeMap[size];
   const { token } = theme.useToken();
 
   return (
     <Tooltip title={`${user.name || user.email} (${user.role})`}>
       <Space size={4}>
-        <span style={{ fontSize }}>{user.emoji || '👤'}</span>
+        <UserIdentityAvatar user={user} size={sizes.avatar} fontSize={`${sizes.font}px`} />
         {showName && (
           <span
             style={{

--- a/apps/agor-ui/src/components/mobile/MobileHeader.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileHeader.tsx
@@ -2,6 +2,7 @@ import type { User } from '@agor-live/client';
 import { UnorderedListOutlined } from '@ant-design/icons';
 import { Button, Layout, Space, Typography, theme } from 'antd';
 import { BRAND, brandMarkHref } from '../../branding/brand';
+import { UserIdentityAvatar } from '../UserIdentityAvatar';
 
 const { Header } = Layout;
 const { Title } = Typography;
@@ -65,16 +66,7 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({
       </Space>
 
       <Space size={12} align="center">
-        {user && (
-          <div
-            style={{
-              fontSize: 20,
-              lineHeight: 1,
-            }}
-          >
-            {user.emoji || '👤'}
-          </div>
-        )}
+        {user && <UserIdentityAvatar user={user} size={28} fontSize="20px" />}
 
         {showMenu && (
           <Button

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -588,7 +588,12 @@ describe('createClient', () => {
       const usersService = client.service('users') as unknown as {
         methods: MockedFunction<(...names: string[]) => unknown>;
       };
-      expect(usersService.methods).toHaveBeenCalledWith('getGitEnvironment');
+      expect(usersService.methods).toHaveBeenCalledWith(
+        'getGitEnvironment',
+        'getAvatarSettings',
+        'updateAvatarSettings',
+        'syncAvatars'
+      );
     });
 
     it('registers repos.initializeUnixGroup custom method on client', () => {

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -38,6 +38,8 @@ import type {
   TemplateRenderRequest,
   TemplateRenderResponse,
   User,
+  UserAvatarSettings,
+  UserAvatarSyncResult,
   UUID,
 } from '@agor/core/types';
 import authentication from '@feathersjs/authentication-client';
@@ -178,6 +180,7 @@ export interface ServiceTypes {
   branches: Branch;
   schedules: Schedule;
   users: User;
+  'user-avatars': UserAvatarSettings | UserAvatarSyncResult;
   groups: Group;
   'group-memberships': GroupMembership;
   'boards/:id/owners': User;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -39,6 +39,7 @@ import type {
   TemplateRenderResponse,
   User,
   UserAvatarSettings,
+  UserAvatarSyncRequest,
   UserAvatarSyncResult,
   UUID,
 } from '@agor/core/types';
@@ -180,7 +181,6 @@ export interface ServiceTypes {
   branches: Branch;
   schedules: Schedule;
   users: User;
-  'user-avatars': UserAvatarSettings | UserAvatarSyncResult;
   groups: Group;
   'group-memberships': GroupMembership;
   'boards/:id/owners': User;
@@ -439,6 +439,12 @@ export interface UsersService extends AgorService<User> {
    * regular users may only fetch their own.
    */
   getGitEnvironment(data: { userId: string }, params?: Params): Promise<Record<string, string>>;
+  getAvatarSettings(data?: unknown, params?: Params): Promise<UserAvatarSettings>;
+  updateAvatarSettings(
+    data: Partial<UserAvatarSettings>,
+    params?: Params
+  ): Promise<UserAvatarSettings>;
+  syncAvatars(data?: UserAvatarSyncRequest, params?: Params): Promise<UserAvatarSyncResult>;
 }
 
 /**
@@ -802,7 +808,12 @@ function extendUsersService(client: AgorClient): void {
   };
   if (usersService[USERS_SERVICE_EXTENDED]) return;
   if (typeof usersService.methods === 'function') {
-    usersService.methods('getGitEnvironment');
+    usersService.methods(
+      'getGitEnvironment',
+      'getAvatarSettings',
+      'updateAvatarSettings',
+      'syncAvatars'
+    );
   }
   usersService[USERS_SERVICE_EXTENDED] = true;
 }

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -55,7 +55,11 @@ export class UsersRepository implements BaseRepository<InternalUser, Partial<Int
       onboarding_completed: row.onboarding_completed,
       must_change_password: row.must_change_password,
       tokens_valid_after: row.tokens_valid_after ? new Date(row.tokens_valid_after) : undefined,
+      avatar_url: row.data.avatar_url ?? row.data.avatar,
       avatar: row.data.avatar,
+      avatar_source: row.data.avatar_source,
+      avatar_source_id: row.data.avatar_source_id,
+      avatar_synced_at: row.data.avatar_synced_at,
       preferences: row.data.preferences as User['preferences'],
       // Convert encrypted per-tool credential blobs into boolean presence flags.
       agentic_tools: toAgenticToolsStatus(row.data.agentic_tools as StoredAgenticTools | undefined),
@@ -110,7 +114,11 @@ export class UsersRepository implements BaseRepository<InternalUser, Partial<Int
       must_change_password: user.must_change_password ?? false,
       tokens_valid_after: user.tokens_valid_after ? new Date(user.tokens_valid_after) : null,
       data: {
+        avatar_url: user.avatar_url,
         avatar: user.avatar,
+        avatar_source: user.avatar_source,
+        avatar_source_id: user.avatar_source_id,
+        avatar_synced_at: user.avatar_synced_at,
         preferences: user.preferences,
         // Encrypted per-tool credentials. Only forwarded when caller passes the
         // raw shape (internal credential mutators); regular updates leave it undefined,

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -902,6 +902,10 @@ export const users = pgTable(
       .json<unknown>('data')
       .$type<{
         avatar?: string;
+        avatar_url?: string;
+        avatar_source?: string;
+        avatar_source_id?: string;
+        avatar_synced_at?: string;
         preferences?: Record<string, unknown>;
         // Stable external-auth identity mappings used by generic launch-code auth.
         external_identities?: UserExternalIdentity[];

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -921,6 +921,10 @@ export const users = sqliteTable(
       .json<unknown>('data')
       .$type<{
         avatar?: string;
+        avatar_url?: string;
+        avatar_source?: string;
+        avatar_source_id?: string;
+        avatar_synced_at?: string;
         preferences?: Record<string, unknown>;
         // Stable external-auth identity mappings used by generic launch-code auth.
         external_identities?: UserExternalIdentity[];

--- a/packages/core/src/db/user-utils.ts
+++ b/packages/core/src/db/user-utils.ts
@@ -38,7 +38,11 @@ export interface CreateUserData {
  */
 export function userRowToUser(row: UserRow): InternalUser {
   const userData = (row.data ?? {}) as {
+    avatar_url?: string;
     avatar?: string;
+    avatar_source?: string;
+    avatar_source_id?: string;
+    avatar_synced_at?: string;
     preferences?: Record<string, unknown>;
   };
   return {
@@ -48,7 +52,11 @@ export function userRowToUser(row: UserRow): InternalUser {
     emoji: row.emoji ?? undefined,
     role: normalizeRole(row.role ?? undefined),
     unix_username: row.unix_username ?? undefined,
+    avatar_url: userData.avatar_url ?? userData.avatar,
     avatar: userData.avatar,
+    avatar_source: userData.avatar_source,
+    avatar_source_id: userData.avatar_source_id,
+    avatar_synced_at: userData.avatar_synced_at,
     preferences: userData.preferences,
     onboarding_completed: !!row.onboarding_completed,
     must_change_password: !!row.must_change_password,

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -836,3 +836,20 @@ describe('SlackConnector.sendMessage', () => {
     ]);
   });
 });
+
+describe('SlackConnector.lookupUserAvatarByEmail', () => {
+  it('treats Slack users_not_found platform errors as a skipped lookup', async () => {
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: { users: { lookupByEmail: unknown } } }).web = {
+      users: {
+        lookupByEmail: async () => {
+          const error = new Error('users_not_found') as Error & { data?: { error?: string } };
+          error.data = { error: 'users_not_found' };
+          throw error;
+        },
+      },
+    };
+
+    await expect(connector.lookupUserAvatarByEmail('missing@example.com')).resolves.toBeNull();
+  });
+});

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -648,8 +648,15 @@ export class SlackConnector implements GatewayConnector {
     const normalized = email.trim().toLowerCase();
     if (!normalized) throw new Error('Slack user email is required');
 
-    const result = await this.web.users.lookupByEmail({ email: normalized });
-    if (!result.ok || !result.user?.id) {
+    const result = await this.web.users
+      .lookupByEmail({ email: normalized })
+      .catch((error: unknown) => {
+        if (extractSlackErrorCode(error) === 'users_not_found') {
+          return null;
+        }
+        throw error;
+      });
+    if (!result?.ok || !result.user?.id) {
       return null;
     }
 

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -84,6 +84,13 @@ interface SlackConfig {
   align_slack_users?: boolean;
 }
 
+export interface SlackUserAvatarProfile {
+  slackUserId: string;
+  email: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
 export interface SlackThreadHistoryMessage {
   ts: string;
   iso_time: string;
@@ -629,6 +636,57 @@ export class SlackConnector implements GatewayConnector {
       });
       return { email: null, displayName: null };
     }
+  }
+
+  /**
+   * Look up a Slack user by email and return display metadata including a
+   * high-resolution avatar URL. Used by Agor's admin-triggered user avatar
+   * sync. Prefer image_512 for crisp large/retina rendering, falling back to
+   * smaller Slack-provided variants.
+   */
+  async lookupUserAvatarByEmail(email: string): Promise<SlackUserAvatarProfile | null> {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) throw new Error('Slack user email is required');
+
+    const result = await this.web.users.lookupByEmail({ email: normalized });
+    if (!result.ok || !result.user?.id) {
+      return null;
+    }
+
+    const profile = result.user.profile as
+      | {
+          email?: string;
+          display_name?: string;
+          real_name?: string;
+          image_original?: string;
+          image_1024?: string;
+          image_512?: string;
+          image_192?: string;
+          image_72?: string;
+          image_48?: string;
+        }
+      | undefined;
+
+    const avatarUrl =
+      profile?.image_512 ||
+      profile?.image_original ||
+      profile?.image_1024 ||
+      profile?.image_192 ||
+      profile?.image_72 ||
+      profile?.image_48 ||
+      null;
+
+    return {
+      slackUserId: result.user.id,
+      email: profile?.email ?? normalized,
+      displayName:
+        profile?.display_name ||
+        profile?.real_name ||
+        result.user.real_name ||
+        result.user.name ||
+        null,
+      avatarUrl,
+    };
   }
 
   /**

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -383,6 +383,8 @@ export interface UserPreferences {
   onboarding?: OnboardingState;
   /** The user's personal/main board ID (created during onboarding or later) */
   mainBoardId?: string;
+  /** Whether to render Slack-synced avatar_url when available. Undefined defaults to true. */
+  use_slack_avatar?: boolean;
   // Future preferences can be added here
   [key: string]: unknown;
 }
@@ -417,7 +419,17 @@ export interface BaseUserFields {
  */
 export interface User extends BaseUserFields {
   user_id: UserID;
+  /**
+   * Preferred image avatar URL for this user.
+   *
+   * Stored in `users.data.avatar_url`. `avatar` is retained as a legacy alias
+   * for older launch-auth/MCP callers and should be treated as a fallback.
+   */
+  avatar_url?: string;
   avatar?: string;
+  avatar_source?: 'manual' | 'slack' | 'launch-auth' | string;
+  avatar_source_id?: string;
+  avatar_synced_at?: string;
   preferences?: UserPreferences;
   onboarding_completed: boolean;
   /** Force password change on next login (admin-settable, auto-cleared on password change) */
@@ -504,6 +516,32 @@ export interface UserApiKey {
   last_used_at?: Date;
 }
 
+export interface UserAvatarSettings {
+  enabled: boolean;
+  provider: 'slack' | null;
+  gateway_channel_id: string | null;
+  last_sync_at?: string;
+  last_sync_result?: UserAvatarSyncResult;
+}
+
+export interface UserAvatarSyncResult {
+  ok: boolean;
+  mode: 'bulk' | 'single';
+  gateway_channel_id: string | null;
+  started_at: string;
+  finished_at: string;
+  matched: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  failures: Array<{ user_id?: string; email?: string; reason: string }>;
+}
+
+export interface UserAvatarSyncRequest {
+  gateway_channel_id?: string;
+  user_id?: string;
+}
+
 /**
  * Create user input (password required, not stored in User type)
  */
@@ -512,6 +550,11 @@ export interface CreateUserInput extends Partial<Omit<BaseUserFields, 'role'>> {
   password: string;
   role?: UserRole; // Optional, defaults to 'member' if not provided
   unix_username?: string;
+  avatar_url?: string;
+  avatar?: string;
+  avatar_source?: string;
+  avatar_source_id?: string;
+  avatar_synced_at?: string;
   /** Force user to change password on first login (admin-only) */
   must_change_password?: boolean;
 }
@@ -521,7 +564,11 @@ export interface CreateUserInput extends Partial<Omit<BaseUserFields, 'role'>> {
  */
 export interface UpdateUserInput extends Partial<BaseUserFields> {
   password?: string;
+  avatar_url?: string | null;
   avatar?: string;
+  avatar_source?: string | null;
+  avatar_source_id?: string | null;
+  avatar_synced_at?: string | null;
   preferences?: UserPreferences;
   onboarding_completed?: boolean;
   unix_username?: string;

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -25,9 +25,46 @@ function makeClient(error: unknown) {
   } as never;
 }
 
+function makeSuccessfulClient(capture: { data?: unknown }) {
+  return {
+    executorSessionToken: 'executor-jwt',
+    service(name: string) {
+      if (name !== 'config/resolve-api-key') {
+        throw new Error(`unexpected service ${name}`);
+      }
+      return {
+        create: vi.fn(async (data: unknown) => {
+          capture.data = data;
+          return { apiKey: 'daemon-key', source: 'user', useNativeAuth: false };
+        }),
+      };
+    },
+  } as never;
+}
+
 describe('resolveApiKeyForTask', () => {
   beforeEach(() => {
     vi.mocked(resolveApiKey).mockReset();
+  });
+
+  it('sends the executor session token as explicit task-scoped proof', async () => {
+    const capture: { data?: unknown } = {};
+
+    await expect(
+      resolveApiKeyForTask(
+        'OPENAI_API_KEY',
+        makeSuccessfulClient(capture),
+        'task-1' as never,
+        'codex' as never
+      )
+    ).resolves.toMatchObject({ apiKey: 'daemon-key', source: 'user' });
+
+    expect(capture.data).toMatchObject({
+      taskId: 'task-1',
+      keyName: 'OPENAI_API_KEY',
+      tool: 'codex',
+      executorSessionToken: 'executor-jwt',
+    });
   });
 
   it('does not fall back to local secret resolution after daemon authorization rejection', async () => {

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -354,10 +354,13 @@ export async function resolveApiKeyForTask(
   // `tool` scopes the per-user lookup to the calling SDK's bucket so a Codex spawn
   // never resolves a key stored under `agentic_tools['claude-code']`, and vice versa.
   try {
+    const executorSessionToken = (client as AgorClient & { executorSessionToken?: string })
+      .executorSessionToken;
     const result = (await client.service('config/resolve-api-key').create({
       taskId,
       keyName,
       tool,
+      ...(executorSessionToken ? { executorSessionToken } : {}),
     })) as import('@agor/core/config').KeyResolutionResult;
     sdkDebug(`[API Key Resolution] Resolved ${keyName} via daemon (source: ${result.source})`);
     return result;

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -61,6 +61,11 @@ export async function createExecutorClient(
     authStorage: storage,
   });
 
+  // Keep the executor JWT available for daemon endpoints that need an explicit
+  // task-scoped proof. Socket.io auth can preserve the session creator user
+  // while dropping custom JWT claims from subsequent service params.
+  (client as AgorClient & { executorSessionToken?: string }).executorSessionToken = sessionToken;
+
   // Connect the socket
   client.io.connect();
 


### PR DESCRIPTION
## Summary

- Add admin-configured Slack avatar syncing from a selected Slack channel gateway
- Store canonical `avatar_url` plus Slack source metadata on users, with per-user opt-out in profile preferences
- Render users through a shared Slack-style rounded-square avatar component across facepiles, cursors, messages, mobile header, and settings
- Fix executor API-key resolution over Socket.io by preserving executor JWT scope and sending the executor session token fallback

## Details

### Slack avatars

- New `user-avatars` service for admin-only settings and one-shot sync.
- Settings remember whether Slack avatars are enabled and which gateway channel provides credentials.
- User create/update hooks opportunistically refresh that user's Slack avatar when global Slack avatars are enabled.
- Disabling global Slack avatars stops refreshes and clears only Slack-sourced avatar URLs, preserving any non-Slack/manual avatar URL.
- Users can opt out via profile setting; undefined defaults to opted in so no migration is needed.

### Rendering

- Introduces `UserIdentityAvatar` as the shared renderer.
- Uses `avatar_url` when present and allowed, otherwise falls back to emoji/name initials.
- Keeps emoji and image avatars the same square size with Slack-like rounded corners.
- Updates facepile overflow to match the same form factor.

### Executor regression

- Persists executor JWT payload onto the Socket.io connection state so later service calls retain task-scoped runtime claims.
- Adds executor-session-token fallback to `config/resolve-api-key` for the executor client path.
- Covers the fallback behavior with daemon and executor unit tests.

## Validation

- `pnpm i`
  - Completed successfully. Note: `node-pty` optional/native rebuild logged a missing `make` failure during postinstall, but pnpm exited 0.
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/auth/executor-runtime-scope.test.ts src/services/config.test.ts`
- `pnpm --filter @agor/executor test -- src/handlers/sdk/base-executor.test.ts`
- `pnpm --filter @agor/core test -- src/gateway/connectors/slack.test.ts`
