### PR TITLE
perf(agor-ui): SessionPanel reads entity state via store selectors + React.memo

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.rerender.test.tsx
@@ -1,0 +1,310 @@
+import type { Branch, Session, User } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { App as AntdApp } from 'antd';
+import { type ReactNode, useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppActionsProvider } from '../../contexts/AppActionsContext';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { sessionPatched } from '../../store/agorRealtimeActions';
+import { agorStore } from '../../store/agorStore';
+import { SessionPanel } from './index';
+
+// ── Render counter ───────────────────────────────────────────────────────────
+// ToolIcon is rendered inline in SessionPanel's header on every SessionPanel
+// render, so mocking it to bump a counter is a faithful proxy for "did
+// SessionPanel re-render?". The heavy children (content, footer controls,
+// modals) are mocked to no-ops so the test isolates the memo + selector
+// boundary rather than exercising the full conversation subtree.
+let sessionPanelRenders = 0;
+
+vi.mock('../ToolIcon', () => ({
+  __esModule: true,
+  ToolIcon: () => {
+    sessionPanelRenders += 1;
+    return <div data-testid="tool-icon" />;
+  },
+}));
+
+// SessionPanelContent is independently memo'd and pulls in ConversationView /
+// EmbeddedTerminal; stub it so the panel renders without that subtree.
+vi.mock('./SessionPanelContent', () => ({
+  __esModule: true,
+  SessionPanelContent: () => <div data-testid="session-panel-content" />,
+}));
+
+// Footer + modal children that need wider context / a live client. None are
+// under test here; stub them to keep the harness focused on SessionPanel.
+vi.mock('./SessionAttachmentsDropdown', () => ({
+  __esModule: true,
+  SessionAttachmentsDropdown: () => null,
+}));
+vi.mock('./SessionMcpFooterControl', () => ({
+  __esModule: true,
+  SessionMcpFooterControl: () => null,
+}));
+vi.mock('./SessionRunSettingsPopover', () => ({
+  __esModule: true,
+  SessionRunSettingsPopover: () => null,
+}));
+vi.mock('../AutocompleteTextarea', () => ({
+  __esModule: true,
+  AutocompleteTextarea: () => null,
+}));
+vi.mock('../ForkSpawnModal/ForkSpawnModal', () => ({
+  __esModule: true,
+  ForkSpawnModal: () => null,
+}));
+vi.mock('../FileUpload', () => ({
+  __esModule: true,
+  FileUpload: () => null,
+  FileUploadButton: () => null,
+}));
+vi.mock('../SessionIds', () => ({
+  __esModule: true,
+  SessionIdsButton: () => null,
+}));
+vi.mock('../MCPServer', () => ({
+  __esModule: true,
+  MCPServerPill: () => null,
+}));
+vi.mock('../metadata', () => ({
+  __esModule: true,
+  CreatedByTag: () => null,
+}));
+
+const SESSION_ID = 'sA';
+const OTHER_SESSION_ID = 'sB';
+const USER_ID = 'user-1';
+
+const makeSession = (id: string, status: string): Session =>
+  ({
+    session_id: id,
+    branch_id: 'A',
+    status,
+    agentic_tool: 'claude-code',
+    archived: false,
+    created_at: '2026-06-24T00:00:00.000Z',
+    last_updated: '2026-06-24T00:00:00.000Z',
+  }) as unknown as Session;
+
+const sessionA = makeSession(SESSION_ID, 'running');
+const branch = { branch_id: 'A', repo_id: 'repo-1', name: 'A' } as unknown as Branch;
+const user = { user_id: USER_ID, name: 'User' } as unknown as User;
+
+// Stable references for the parent-re-render guard. React.memo only bails when
+// EVERY prop kept its identity, so these are module-level constants — a fresh
+// inline value per render would itself defeat memo and mask whether prop
+// stabilization is what protects the panel.
+const EMPTY_MCP_IDS: string[] = [];
+const CONNECTION_VALUE = {
+  connected: true,
+  connecting: false,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+const APP_ACTIONS = {};
+
+function seedStore() {
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    userById: new Map([[USER_ID, user]]),
+    sessionById: new Map([
+      [SESSION_ID, sessionA],
+      [OTHER_SESSION_ID, makeSession(OTHER_SESSION_ID, 'running')],
+    ]),
+  });
+}
+
+function renderPanel(ui: ReactNode) {
+  return render(
+    <AntdApp>
+      <ConnectionProvider value={CONNECTION_VALUE}>
+        <AppActionsProvider value={APP_ACTIONS}>{ui}</AppActionsProvider>
+      </ConnectionProvider>
+    </AntdApp>
+  );
+}
+
+describe('SessionPanel store-selector re-render isolation', () => {
+  beforeEach(() => {
+    sessionPanelRenders = 0;
+    agorStore.setState({ ...EMPTY_MAPS });
+    seedStore();
+  });
+
+  it('a session:patched for an unrelated session does not re-render the panel', async () => {
+    renderPanel(
+      <SessionPanel
+        client={null}
+        session={sessionA}
+        branch={branch}
+        currentUserId={USER_ID}
+        sessionMcpServerIds={EMPTY_MCP_IDS}
+        open={true}
+        onClose={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(sessionPanelRenders).toBeGreaterThanOrEqual(1));
+    const baseline = sessionPanelRenders;
+
+    // Patch a DIFFERENT session. SessionPanel doesn't subscribe to `sessionById`
+    // at all (session arrives as a prop), so this store change leaves every
+    // selected slice's reference untouched — the subscriptions stay quiet.
+    act(() => {
+      sessionPatched(makeSession(OTHER_SESSION_ID, 'completed'));
+    });
+
+    expect(sessionPanelRenders).toBe(baseline);
+  });
+
+  it('a patch to a slice SessionPanel DOES select (userById) re-renders it', async () => {
+    renderPanel(
+      <SessionPanel
+        client={null}
+        session={sessionA}
+        branch={branch}
+        currentUserId={USER_ID}
+        sessionMcpServerIds={EMPTY_MCP_IDS}
+        open={true}
+        onClose={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(sessionPanelRenders).toBeGreaterThanOrEqual(1));
+    const baseline = sessionPanelRenders;
+
+    // Contrast case: SessionPanel subscribes to `userById`, so replacing that
+    // map's reference must wake its selector subscription. This proves the
+    // selector is genuinely wired (and that the isolation above is real, not a
+    // dead subscription).
+    act(() => {
+      agorStore.setState({
+        userById: new Map<string, User>([[USER_ID, { ...user, name: 'Renamed' } as User]]),
+      });
+    });
+
+    await waitFor(() => expect(sessionPanelRenders).toBeGreaterThan(baseline));
+  });
+
+  it('a patch to an unrelated slice (mcpServerById churn aside) leaves the panel quiet', async () => {
+    renderPanel(
+      <SessionPanel
+        client={null}
+        session={sessionA}
+        branch={branch}
+        currentUserId={USER_ID}
+        sessionMcpServerIds={EMPTY_MCP_IDS}
+        open={true}
+        onClose={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(sessionPanelRenders).toBeGreaterThanOrEqual(1));
+    const baseline = sessionPanelRenders;
+
+    // Patch a slice SessionPanel never selects (branchById). zustand notifies
+    // every subscriber, but the panel's selector slices keep their references,
+    // so it does not re-render.
+    act(() => {
+      agorStore.setState({
+        branchById: new Map<string, Branch>([['A', { ...branch, name: 'A2' } as Branch]]),
+      });
+    });
+
+    expect(sessionPanelRenders).toBe(baseline);
+  });
+});
+
+// Mirror of AppContent's `useStableCallback`: freeze a handler's identity across
+// renders while delegating to the latest impl via a ref. This is the exact
+// mechanism AppContent uses to keep SessionPanel's `onClose` stable, so
+// reproducing it here exercises the real prop-stabilization contract.
+function useStableCallback<TFn extends (...args: never[]) => unknown>(
+  callback: TFn | undefined
+): TFn | undefined {
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+  const stable = useCallback(((...args: never[]) => callbackRef.current?.(...args)) as TFn, []);
+  return callback ? stable : undefined;
+}
+
+// Lets a test trigger a parent re-render without touching SessionPanel's props.
+let triggerParentRerender: () => void = () => {};
+
+// Parent harness that renders the REAL memo'd SessionPanel the way AppContent
+// does: the close handler flows through `useStableCallback` so its identity is
+// frozen. A `useState` bump (driven from the test) re-renders THIS parent; the
+// `stabilize` flag toggles whether the handler is stabilized so the same harness
+// proves both halves of the guard.
+function ParentHarness({ stabilize }: { stabilize: boolean }) {
+  const [, setTick] = useState(0);
+  triggerParentRerender = () => setTick((tick) => tick + 1);
+
+  // Fresh identity on every parent render (mirrors AppContent's plain-const
+  // handlers). When `stabilize` is true we freeze it through useStableCallback;
+  // when false we pass it straight through so memo sees a new prop each render.
+  const closeImpl = () => {};
+  const stableClose = useStableCallback(closeImpl);
+  const onClose = stabilize ? stableClose! : closeImpl;
+
+  return (
+    <SessionPanel
+      client={null}
+      session={sessionA}
+      branch={branch}
+      currentUserId={USER_ID}
+      sessionMcpServerIds={EMPTY_MCP_IDS}
+      open={true}
+      onClose={onClose}
+    />
+  );
+}
+
+describe('SessionPanel memo + handler-stabilization re-render bailout', () => {
+  beforeEach(() => {
+    sessionPanelRenders = 0;
+    triggerParentRerender = () => {};
+    agorStore.setState({ ...EMPTY_MAPS });
+    seedStore();
+  });
+
+  it('a parent re-render does not re-render the memo’d SessionPanel when handlers are stabilized', async () => {
+    renderPanel(<ParentHarness stabilize={true} />);
+
+    await waitFor(() => expect(sessionPanelRenders).toBeGreaterThanOrEqual(1));
+    const baseline = sessionPanelRenders;
+
+    // Re-render the PARENT. Every SessionPanel prop kept its identity (session,
+    // branch, the stabilized close handler, EMPTY_MCP_IDS), so React.memo bails
+    // out and the panel stays put.
+    act(() => {
+      triggerParentRerender();
+    });
+
+    // Regression guard: FAILS if `React.memo(SessionPanel)` is removed (parent
+    // re-render always re-renders the panel) OR if the close handler is
+    // destabilized (a fresh prop identity defeats the shallow memo).
+    expect(sessionPanelRenders).toBe(baseline);
+  });
+
+  it('a parent re-render DOES re-render the panel when a handler identity is not stabilized', async () => {
+    // Contrast case proving the guard above is meaningful: the same parent,
+    // passing a fresh-identity close handler each render, breaks the memo
+    // shallow compare — so the bailout genuinely depends on stabilization.
+    renderPanel(<ParentHarness stabilize={false} />);
+
+    await waitFor(() => expect(sessionPanelRenders).toBeGreaterThanOrEqual(1));
+    const baseline = sessionPanelRenders;
+
+    act(() => {
+      triggerParentRerender();
+    });
+
+    await waitFor(() => expect(sessionPanelRenders).toBeGreaterThan(baseline));
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -36,11 +36,16 @@ import { Alert, App, Badge, Button, Dropdown, Space, Spin, Tooltip, Typography, 
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
-import { useAppMcpData, useAppUserData } from '../../contexts/AppDataContext';
 import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectMcpServerById,
+  selectUserAuthenticatedMcpServerIds,
+  selectUserById,
+} from '../../store/selectors';
 import { getContextWindowGradient } from '../../utils/contextWindow';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
@@ -245,12 +250,14 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const connectionDisabled = useConnectionDisabled();
   const recenterMap = useRecenterMap();
 
-  // Subscribe only to the entity families this panel needs. SessionPanel
-  // intentionally does NOT subscribe to live (sessions / branches / boards)
-  // data here, so streaming session patches don't trigger re-renders through
-  // context; user and MCP updates are also isolated from repo edits.
-  const { userById } = useAppUserData();
-  const { mcpServerById, userAuthenticatedMcpServerIds } = useAppMcpData();
+  // Subscribe only to the entity families this panel needs via narrow store
+  // selectors. SessionPanel intentionally does NOT subscribe to live (sessions
+  // / branches / boards) slices here, so streaming session patches don't
+  // re-render it; each whole-map selector is a stable module-level reference, so
+  // user and MCP updates are isolated from each other and from repo edits.
+  const userById = useAgorStore(selectUserById);
+  const mcpServerById = useAgorStore(selectMcpServerById);
+  const userAuthenticatedMcpServerIds = useAgorStore(selectUserAuthenticatedMcpServerIds);
 
   // Get actions from context
   const { onSendPrompt, onFork, onBtwFork, onOpenSettings, onUpdateSession, onOpenTerminal } =

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -12,7 +12,8 @@ import {
 import { Button, Divider, Space, Tabs, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
-import { useAppMcpData, useAppRepoData, useAppUserData } from '../../contexts/AppDataContext';
+import { useAgorStore } from '../../store/agorStore';
+import { selectMcpServerById, selectRepoById, selectUserById } from '../../store/selectors';
 import { copyToClipboard } from '../../utils/clipboard';
 import { useThemedMessage } from '../../utils/message';
 import { BranchHeaderPill } from '../BranchHeaderPill';
@@ -69,12 +70,15 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     const { token } = theme.useToken();
     const { showSuccess, showError } = useThemedMessage();
 
-    // Subscribe only to the entity families this panel needs. This keeps the
-    // panel insulated from session/branch/board patches and avoids unrelated
-    // entity churn (e.g. repo edits invalidating user/MCP consumers).
-    const { userById } = useAppUserData();
-    const { repoById } = useAppRepoData();
-    const { mcpServerById } = useAppMcpData();
+    // Subscribe only to the entity families this panel needs via narrow store
+    // selectors. This keeps the panel insulated from session/branch/board
+    // patches and avoids unrelated entity churn (e.g. repo edits invalidating
+    // user/MCP consumers): each whole-map selector is a stable module-level
+    // reference, so a slice only re-renders this content when its own reference
+    // changes.
+    const userById = useAgorStore(selectUserById);
+    const repoById = useAgorStore(selectRepoById);
+    const mcpServerById = useAgorStore(selectMcpServerById);
     // Get actions from context
     const {
       onOpenBranch,

--- a/apps/agor-ui/src/store/selectors.ts
+++ b/apps/agor-ui/src/store/selectors.ts
@@ -21,6 +21,8 @@ export const selectCommentById = (s: AgorState) => s.commentById;
 export const selectCardById = (s: AgorState) => s.cardById;
 export const selectUserById = (s: AgorState) => s.userById;
 export const selectMcpServerById = (s: AgorState) => s.mcpServerById;
+export const selectUserAuthenticatedMcpServerIds = (s: AgorState) =>
+  s.userAuthenticatedMcpServerIds;
 
 /**
  * Select a single board's board-object array. Curried so callers can memoize


### PR DESCRIPTION
Applies the PR3 (#1628, SessionCanvas) selector + `React.memo` + stable-props pattern to **SessionPanel + SessionPanelContent**. Behavior is identical — this swaps the data **source** (split AppData context → zustand store selectors), not what's delivered or when.

Stacked on #1628 (base = `zustand-sessioncanvas-selectors`, **not** main).

## What was peeled
- **SessionPanel**: `useAppUserData()` / `useAppMcpData()` → `useAgorStore(selectUserById)` / `useAgorStore(selectMcpServerById)` / `useAgorStore(selectUserAuthenticatedMcpServerIds)`.
- **SessionPanelContent**: `useAppUserData()` / `useAppRepoData()` / `useAppMcpData()` → `useAgorStore(selectUserById / selectRepoById / selectMcpServerById)`.
- **selectors.ts**: added `selectUserAuthenticatedMcpServerIds` (the other four selectors already existed from PR3).

`useAppActions` stays on context (actions, not entity data). The split AppData providers stay (EventStreamPanel still consumes them), so no App.tsx wiring changes.

## Memo + stable props
Both components were already `React.memo`'d. Their props from App are already referentially stable (`session`/`branch` are `.get()` lookups preserved by the store's `Object.is` short-circuit; `onClose` is a `useStableCallback`; `sessionMcpServerIds` falls back to a frozen `EMPTY_STRING_ARRAY`), so no prop stabilization was needed — moving the reads off `useContext` onto narrow store selectors is what gives the granularity (`React.memo` does not stop `useContext`-driven re-renders).

## Guard test
`SessionPanel.rerender.test.tsx` mirrors `SessionCanvas.rerender.test.tsx`:
- A `session:patched` for an **unrelated** session does **not** re-render the panel; a patch to `userById` (a slice it selects) **does** — proving the selector is live, not dead.
- A patch to an unselected slice (`branchById`) leaves the panel quiet.
- A parent re-render with stabilized props bails out of the memo; an unstabilized `onClose` contrast re-renders it.

Verified the memo guard **FAILS** when `React.memo(SessionPanel)` is removed (parent-re-render bailout test: 2 ≠ 1).

## Constraints honored
- Zero behavior change; hot paths (streaming `useSharedReactiveSession`, presence, drag) stay out of the store.
- `useAgorData.test.tsx` untouched.

## Gate (CI-mirror, inside apps/agor-ui)
Fresh `pnpm install` + `turbo run build --filter='agor-ui^...'`, then: typecheck ✓ · lint (`biome check .`, 568 files) ✓ · test (`vitest run`, 542 passed) ✓ · build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)