### PR TITLE
perf(agor-ui): BranchCard family reads entity state via store selectors

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.rerender.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.rerender.test.tsx
@@ -1,0 +1,241 @@
+import type { Artifact, Board, BoardEntityObject, Branch, Repo, Session } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { sessionPatched } from '../../store/agorRealtimeActions';
+import { agorStore } from '../../store/agorStore';
+import SessionCanvas from '../SessionCanvas/SessionCanvas';
+
+// ── Render counters ──────────────────────────────────────────────────────────
+// The BranchCard mock counts renders per branch and records the `sessions` prop
+// it last received. This isolates the boundary the peel protects: each branch
+// card now sources its session list from the store via a per-branch selector
+// (read inside SessionCanvas's private `BranchNode` wrapper), so a
+// `session:patched` for one branch must not re-render the other branch's card.
+const branchCardRenders = new Map<string, number>();
+const branchCardSessions = new Map<string, Session[]>();
+
+vi.mock('../SessionCard', () => ({ __esModule: true, default: () => null }));
+vi.mock('../CardNode', () => ({
+  __esModule: true,
+  default: () => <div data-testid="card-node" />,
+}));
+
+vi.mock('../BranchCard', () => ({
+  __esModule: true,
+  default: ({ branch, sessions }: { branch: Branch; sessions: Session[] }) => {
+    branchCardRenders.set(branch.branch_id, (branchCardRenders.get(branch.branch_id) ?? 0) + 1);
+    branchCardSessions.set(branch.branch_id, sessions);
+    return <div data-testid={`branch-card-${branch.branch_id}`} />;
+  },
+}));
+
+// Render real node components through `nodeTypes` so the in-component React.memo
+// boundary (BranchNode's custom areEqual + its per-branch store subscription) is
+// exercised. We pass ONLY `data` (mirroring how React Flow re-renders a node
+// component) so the assertions reflect the store subscription, not node-object
+// churn from the sync effects.
+vi.mock('reactflow', async () => {
+  const React = await import('react');
+  return {
+    Background: () => null,
+    Controls: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    ControlButton: ({ children }: { children?: React.ReactNode }) => (
+      <button type="button">{children}</button>
+    ),
+    MiniMap: () => null,
+    useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+    useNodesState: (initial: unknown[]) => {
+      const [nodes, setNodes] = React.useState(initial);
+      const onNodesChange = React.useCallback(() => {}, []);
+      return [nodes, setNodes, onNodesChange];
+    },
+    useEdgesState: (initial: unknown[]) => {
+      const [edges, setEdges] = React.useState(initial);
+      const onEdgesChange = React.useCallback(() => {}, []);
+      return [edges, setEdges, onEdgesChange];
+    },
+    ReactFlow: (props: {
+      nodes?: Array<{ id: string; type: string; data: unknown }>;
+      nodeTypes?: Record<string, React.ComponentType<{ data: unknown }>>;
+      children?: React.ReactNode;
+    }) => (
+      <div data-testid="react-flow">
+        {props.nodes?.map((node) => {
+          const NodeComponent = props.nodeTypes?.[node.type];
+          return NodeComponent ? <NodeComponent key={node.id} data={node.data} /> : null;
+        })}
+        {props.children}
+      </div>
+    ),
+  };
+});
+
+const BOARD_ID = 'board-1';
+const REPO_ID = 'repo-1';
+
+const board = {
+  board_id: BOARD_ID,
+  name: 'Board',
+  slug: 'board',
+  objects: {},
+  created_at: '2026-06-24T00:00:00.000Z',
+  last_updated: '2026-06-24T00:00:00.000Z',
+  created_by: 'user-1',
+  url: 'http://localhost/ui/b/board/',
+  archived: false,
+} as unknown as Board;
+
+const repo = { repo_id: REPO_ID, name: 'repo', slug: 'repo' } as unknown as Repo;
+
+const makeBranch = (id: string): Branch =>
+  ({
+    branch_id: id,
+    repo_id: REPO_ID,
+    board_id: BOARD_ID,
+    name: id,
+    archived: false,
+    others_can: 'session',
+  }) as unknown as Branch;
+
+const makeSession = (id: string, branchId: string, status: string): Session =>
+  ({
+    session_id: id,
+    branch_id: branchId,
+    status,
+    archived: false,
+    created_at: '2026-06-24T00:00:00.000Z',
+    last_updated: '2026-06-24T00:00:00.000Z',
+  }) as unknown as Session;
+
+const branchA = makeBranch('A');
+const branchB = makeBranch('B');
+const sessionA = makeSession('sA', 'A', 'running');
+const sessionB = makeSession('sB', 'B', 'running');
+
+const boardObjects: BoardEntityObject[] = [
+  {
+    object_id: 'bo-A',
+    board_id: BOARD_ID,
+    branch_id: 'A',
+    entity_type: 'branch',
+    position: { x: 0, y: 0 },
+  } as unknown as BoardEntityObject,
+  {
+    object_id: 'bo-B',
+    board_id: BOARD_ID,
+    branch_id: 'B',
+    entity_type: 'branch',
+    position: { x: 0, y: 600 },
+  } as unknown as BoardEntityObject,
+];
+
+function seedStore() {
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    repoById: new Map([[REPO_ID, repo]]),
+    branchById: new Map([
+      ['A', branchA],
+      ['B', branchB],
+    ]),
+    sessionById: new Map([
+      ['sA', sessionA],
+      ['sB', sessionB],
+    ]),
+    sessionsByBranch: new Map([
+      ['A', [sessionA]],
+      ['B', [sessionB]],
+    ]),
+    boardObjectsByBoardId: new Map([[BOARD_ID, boardObjects]]),
+  });
+}
+
+describe('BranchCard store-selector session isolation', () => {
+  beforeEach(() => {
+    branchCardRenders.clear();
+    branchCardSessions.clear();
+    agorStore.setState({ ...EMPTY_MAPS });
+    seedStore();
+  });
+
+  it('a session:patched for branch A re-renders only branch A’s card with the updated session', async () => {
+    render(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <SessionCanvas board={board} client={null} branches={[branchA, branchB]} />
+      </ConnectionProvider>
+    );
+
+    await waitFor(() => {
+      expect(branchCardRenders.get('A')).toBeGreaterThanOrEqual(1);
+      expect(branchCardRenders.get('B')).toBeGreaterThanOrEqual(1);
+    });
+
+    const branchABaseline = branchCardRenders.get('A') ?? 0;
+    const branchBBaseline = branchCardRenders.get('B') ?? 0;
+    const branchBSessionsBaseline = branchCardSessions.get('B');
+
+    // Patch session A only. `sessionPatched` rebuilds branch A's session bucket
+    // while leaving branch B's array reference untouched.
+    act(() => {
+      sessionPatched(makeSession('sA', 'A', 'completed'));
+    });
+
+    await waitFor(() => {
+      expect(branchCardRenders.get('A') ?? 0).toBeGreaterThan(branchABaseline);
+    });
+
+    // Branch A's card sourced the patched session from the store…
+    expect(branchCardSessions.get('A')?.[0]?.status).toBe('completed');
+    // …and branch B's card — whose per-branch session selector kept the same
+    // array reference across the patch — neither re-rendered nor saw its
+    // `sessions` prop change. This is the win the peel locks in: it FAILS if
+    // BranchNode subscribes to the whole `sessionsByBranch` map (every patch
+    // re-renders every card) or if its `areEqual` is removed.
+    expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
+    expect(branchCardSessions.get('B')).toBe(branchBSessionsBaseline);
+  });
+
+  it('a patch to a slice no branch card reads leaves every card un-rendered', async () => {
+    render(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <SessionCanvas board={board} client={null} branches={[branchA, branchB]} />
+      </ConnectionProvider>
+    );
+
+    await waitFor(() => {
+      expect(branchCardRenders.get('A')).toBeGreaterThanOrEqual(1);
+      expect(branchCardRenders.get('B')).toBeGreaterThanOrEqual(1);
+    });
+
+    const branchABaseline = branchCardRenders.get('A') ?? 0;
+    const branchBBaseline = branchCardRenders.get('B') ?? 0;
+
+    act(() => {
+      agorStore.setState({
+        artifactById: new Map<string, Artifact>([
+          ['artifact-1', { artifact_id: 'artifact-1' } as unknown as Artifact],
+        ]),
+      });
+    });
+
+    expect(branchCardRenders.get('A') ?? 0).toBe(branchABaseline);
+    expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -64,6 +64,7 @@ import { useCursorTracking } from '../../hooks/useCursorTracking';
 import { useAgorStore } from '../../store/agorStore';
 import {
   makeBoardObjectsForBoardSelector,
+  makeSessionsForBranchSelector,
   selectBranchById,
   selectCardById,
   selectCommentById,
@@ -173,10 +174,10 @@ interface SessionNodeData {
   zoneColor?: string;
 }
 
-// Shared empty array for branches that have no sessions. Without this,
-// `sessionsByBranch.get(id) || []` produces a new `[]` on every render,
-// breaking referential equality and forcing memoized children to re-render
-// on every unrelated socket event.
+// Shared empty array for branches that have no sessions. Without this, a
+// per-branch session selector returning `undefined` would fall back to a fresh
+// `[]` on every render, breaking referential equality and forcing memoized
+// children to re-render on every unrelated socket event.
 const EMPTY_SESSIONS: Session[] = [];
 
 // Custom node component that renders SessionCard (memoized to prevent re-renders on unrelated node changes)
@@ -204,7 +205,6 @@ const SessionNode = React.memo(({ data }: { data: SessionNodeData }) => {
 interface BranchNodeData {
   branch: Branch;
   repo: Repo;
-  sessions: Session[];
   userById: Map<string, User>;
   currentUserId?: string;
   onTaskClick?: (taskId: string) => void;
@@ -256,17 +256,29 @@ const CardNodeWrapper = React.memo(({ data }: { data: CardNodeData }) => {
 // — even unrelated ones. We supply a custom areEqual that compares the
 // individual fields of `data` shallowly so unrelated socket events don't
 // invalidate this node. This is the primary fix for board jank during
-// streaming socket traffic. (The empty-sessions array is stabilized in
-// `initialNodes` via EMPTY_SESSIONS so unrelated patches keep
-// `data.sessions` referentially equal too.)
+// streaming socket traffic.
+//
+// This branch's session list — the highest-frequency entity read (a
+// `session:patched` arrives on every streaming token batch) — is sourced
+// directly from the store by branch id rather than carried in `data`. A patch
+// to another branch's sessions leaves this branch's array reference untouched,
+// so this card's subscription stays quiet; a patch to this branch re-renders
+// only this card without rebuilding (and re-allocating) every branch's node
+// `data` in the parent `initialNodes` memo. EMPTY_SESSIONS keeps the prop
+// referentially stable for branches with no sessions.
 const BranchNode = React.memo(
   ({ data }: { data: BranchNodeData }) => {
+    const sessionsSelector = useMemo(
+      () => makeSessionsForBranchSelector(data.branch.branch_id),
+      [data.branch.branch_id]
+    );
+    const sessions = useAgorStore(sessionsSelector) ?? EMPTY_SESSIONS;
     return (
       <div className="branch-node">
         <BranchCard
           branch={data.branch}
           repo={data.repo}
-          sessions={data.sessions}
+          sessions={sessions}
           userById={data.userById}
           currentUserId={data.currentUserId}
           selectedSessionId={data.selectedSessionId}
@@ -305,7 +317,6 @@ const BranchNode = React.memo(
     return (
       p.branch === n.branch &&
       p.repo === n.repo &&
-      p.sessions === n.sessions &&
       p.userById === n.userById &&
       p.currentUserId === n.currentUserId &&
       p.selectedSessionId === n.selectedSessionId &&
@@ -721,11 +732,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             ? zoneObj.borderColor || zoneObj.color // Backwards compat: borderColor first, then fall back to deprecated color
             : undefined;
 
-        // Get sessions for this branch. Use EMPTY_SESSIONS (shared
-        // constant) instead of inline `|| []` so branches without sessions
-        // keep a referentially stable `sessions` prop across renders.
-        const branchSessions = sessionsByBranch.get(branch.branch_id) || EMPTY_SESSIONS;
-
         // Get repo for this branch
         const repo = repoById.get(branch.repo_id);
         if (!repo) {
@@ -750,7 +756,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           data: {
             branch,
             repo,
-            sessions: branchSessions,
             userById,
             currentUserId,
             selectedSessionId,
@@ -786,7 +791,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       primaryAssistantId,
       boardObjectByBranch,
       repoById,
-      sessionsByBranch,
       currentUserId,
       selectedSessionId,
       activeUrlTargetBranchId,

--- a/apps/agor-ui/src/store/agorRealtimeActions.ts
+++ b/apps/agor-ui/src/store/agorRealtimeActions.ts
@@ -169,9 +169,9 @@ export function sessionPatched(session: Session) {
 
       // Bail out when the session is content-equal to what we already hold.
       // Mirrors the sessionById bailout above so an idempotent patch doesn't
-      // produce a fresh branch-bucket array (which would invalidate
-      // `data.sessions === n.sessions` in BranchNode's custom areEqual and
-      // re-render every BranchCard on the affected branch).
+      // produce a fresh branch-bucket array — preserving the reference that
+      // `makeSessionsForBranchSelector(branchId)` returns, so a BranchNode
+      // subscribed to it doesn't re-render on a no-op patch.
       if (
         branchSessions[index] === mergedSession ||
         shallowEqualEntity(branchSessions[index], mergedSession)

--- a/apps/agor-ui/src/store/selectors.ts
+++ b/apps/agor-ui/src/store/selectors.ts
@@ -11,7 +11,7 @@
  * one board's bucket: a patch to another board's objects leaves this board's
  * array reference untouched, so the subscription doesn't fire.
  */
-import type { BoardEntityObject } from '@agor-live/client';
+import type { BoardEntityObject, Session } from '@agor-live/client';
 import type { AgorState } from './agorStore';
 
 export const selectSessionsByBranch = (s: AgorState) => s.sessionsByBranch;
@@ -32,4 +32,17 @@ export function makeBoardObjectsForBoardSelector(
   boardId: string | undefined
 ): (s: AgorState) => BoardEntityObject[] | undefined {
   return (s) => (boardId ? s.boardObjectsByBoardId.get(boardId) : undefined);
+}
+
+/**
+ * Select a single branch's session array by id. Curried so a card can memoize
+ * the selector per `branchId` (stable reference while the branch doesn't
+ * change) — a `session:patched` for another branch leaves THIS branch's array
+ * reference untouched, so the subscription stays quiet and only the affected
+ * card re-renders. Mirrors the canvas's prior `sessionsByBranch.get(id)` read.
+ */
+export function makeSessionsForBranchSelector(
+  branchId: string
+): (s: AgorState) => Session[] | undefined {
+  return (s) => s.sessionsByBranch.get(branchId);
 }


### PR DESCRIPTION
## Data-flow assessment (BranchCard family)

I assessed how each BranchCard-family component (`BranchCard`, `SessionCard`, `BranchSessionSections`, `BranchSessionPeekSection`, `SessionLatestTaskPeek`) gets its entity data:

- **Entity data → 100% via React Flow `node.data` props (category a).** `branch`, `repo`, `sessions`, `userById`, `currentUserId`, `selectedSessionId` all arrive through `SessionCanvas.initialNodes` → `BranchNode.data`. None of the family reads entity data from an AppData context or the store directly.
- **The only context read is `useConnectionDisabled` / `useMutationGate` (`ConnectionContext`)** — connection booleans, **not** entity state and **not** in the zustand store (it's a do-not-touch context per the migration plan, like presence/streaming). So there is **no valid context→store-selector swap** in this family (correcting the initial assumption that these were store-eligible).
- **Per-card isolation is already achieved** by the merged Phase 4 PR3: `SessionCanvas` reads entity maps via reference-stable store selectors and `BranchNode`'s custom `areEqual` shallow-compares `data` fields. `SessionCanvas.rerender.test.tsx` already proves a `session:patched` for branch A doesn't re-render branch B's card.

## What I peeled

The single coherent, low-risk, **highest-frequency** read: each branch's **`sessions`** list (a `session:patched` lands on every streaming token batch). `BranchNode` (SessionCanvas-private wrapper) now subscribes to `makeSessionsForBranchSelector(branchId)` and passes the result down as BranchCard's existing `sessions` prop.

Result: `initialNodes` no longer depends on `sessionsByBranch`, so a session patch no longer re-runs that memo and re-allocates node `data` for every branch; only the affected branch's card re-renders, via its own per-branch subscription. `BranchNode.areEqual` drops the now-unnecessary `sessions` comparison.

- **BranchCard's public `sessions` prop is unchanged** → its other render sites (`EventStreamPanel` popover, `BoardAssistantPanel`) are untouched.
- **Behavior is identical**: same per-branch array references, same `EMPTY_SESSIONS` stability fallback, component logic byte-identical.

## What I deferred (and why)

- **Migrating `branch` / `repo` / `userById` and the rest of the family's data to BY-ID store selectors.** This is the higher-risk path: it changes BranchCard's **public** prop contract across multiple render sites and offers little marginal benefit (these are low-frequency reads already isolated by `areEqual`). `userById` is also still needed by `SessionCanvas.commentNodes`, so moving it wouldn't drop the canvas subscription.
- **Decoupling zone session-counts (`useBoardObjects`) from `sessionsByBranch`.** `getBoardObjectNodes` still consumes the whole map for zone counts, so `SessionCanvas` still re-renders on session patches — out of scope here; the win in this PR is skipping the `initialNodes` rebuild.
- **`useStableCallback` extraction** was not needed (no new callbacks introduced), so it stays a local function in `components/App/App.tsx`.

## Guard test

`BranchCard.rerender.test.tsx` mirrors `SessionCanvas.rerender.test.tsx`:
- a `session:patched` for branch A re-renders **only** A's card (with the updated session, sourced from the store) and leaves B's render count and `sessions` reference untouched;
- a patch to an unread slice (artifacts) re-renders no card.

Verified the guard **fails on revert**: switching `BranchNode` to subscribe to the whole `sessionsByBranch` map makes the "branch B not re-rendered" assertion fail (every patch re-renders every card).

## Gate (CI-mirror)

Fresh `pnpm install` + `turbo run build --filter='agor-ui^...'`, then in `apps/agor-ui`: typecheck ✅, lint (biome) ✅, test ✅ (83 files / 475 tests), build ✅. `useAgorData.test.tsx` unedited.

Independent off `main` (not stacked). Also edits `store/selectors.ts`, so a trivial additive conflict with #1629 is expected/fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)