### PR TITLE
perf(agor-ui): memoize AppHeader + BoardAssistantPanel boundaries

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1045,6 +1045,39 @@ export const App: React.FC<AppProps> = ({
   const stableOnStopEnvironment = useStableCallback(onStopEnvironment);
   const stableOnNukeEnvironment = useStableCallback(onNukeEnvironment);
 
+  // Header action handlers, frozen so the memoized AppHeader's React.memo bailout
+  // isn't defeated by a fresh inline-arrow identity on every App re-render. Each
+  // delegates to the latest impl via useStableCallback, so they read current
+  // state (selection, panel, board) at call time without re-rendering the header.
+  const handleHomeClick = useStableCallback(() => {
+    setPendingHomeNavigation(true);
+    navigation.goHome();
+  });
+  const handleEventStreamClick = useStableCallback(() => {
+    // If a session is open, close it and reveal the event stream; otherwise
+    // toggle the event stream panel.
+    if (effectiveSelectedSessionId) {
+      if (currentBoardId) navigation.goToBoard(currentBoardId);
+      setEventStreamPanelCollapsed(false);
+    } else {
+      setEventStreamPanelCollapsed(!eventStreamPanelCollapsed);
+    }
+  });
+  const handleOpenSettingsClick = useStableCallback(() => openSettings());
+  const handleOpenUserSettings = useStableCallback(() => setUserSettingsOpen(true));
+  const handleOpenThemeEditor = useStableCallback(() => setThemeEditorOpen(true));
+  const handleHeaderUserClick = useStableCallback(
+    (_userId: string, boardId?: BoardID, _cursor?: { x: number; y: number }) => {
+      // Navigate to the user's board (pushes history, so the back button
+      // returns to the previous board).
+      if (boardId) {
+        navigation.goToBoard(boardId);
+      }
+    }
+  );
+  const stableOnLogout = useStableCallback(onLogout);
+  const stableOnRetryConnection = useStableCallback(onRetryConnection);
+
   return (
     <AppEntityDataProvider value={appEntityDataValue}>
       <AppLiveDataProvider value={appLiveDataValue}>
@@ -1054,27 +1087,17 @@ export const App: React.FC<AppProps> = ({
             <AppHeader
               user={user}
               presenceClient={client}
-              presenceUsers={mapToArray(userById)}
               currentUserId={user?.user_id}
               connected={connected}
               connecting={connecting}
               onMenuClick={handleToggleBoardPanel}
               onCommentsClick={handleOpenCommentsPanel}
-              onEventStreamClick={() => {
-                // If session is open, close it and show event stream
-                if (effectiveSelectedSessionId) {
-                  if (currentBoardId) navigation.goToBoard(currentBoardId);
-                  setEventStreamPanelCollapsed(false);
-                } else {
-                  // Toggle event stream panel
-                  setEventStreamPanelCollapsed(!eventStreamPanelCollapsed);
-                }
-              }}
-              onSettingsClick={() => openSettings()}
-              onUserSettingsClick={() => setUserSettingsOpen(true)}
-              onThemeEditorClick={() => setThemeEditorOpen(true)}
-              onLogout={onLogout}
-              onRetryConnection={onRetryConnection}
+              onEventStreamClick={handleEventStreamClick}
+              onSettingsClick={handleOpenSettingsClick}
+              onUserSettingsClick={handleOpenUserSettings}
+              onThemeEditorClick={handleOpenThemeEditor}
+              onLogout={stableOnLogout}
+              onRetryConnection={stableOnRetryConnection}
               currentBoardName={headerBoard?.name}
               currentBoardIcon={headerBoard?.icon}
               unreadCommentsCount={
@@ -1082,34 +1105,13 @@ export const App: React.FC<AppProps> = ({
               }
               eventStreamEnabled={eventStreamEnabled}
               hasUserMentions={hasUserMentions}
-              boards={mapToArray(boardById)}
               currentBoardId={headerBoardId}
               onBoardChange={navigation.goToBoard}
-              onHomeClick={() => {
-                setPendingHomeNavigation(true);
-                navigation.goHome();
-              }}
-              branchById={branchById}
-              boardById={boardById}
-              onUserClick={(
-                userId: string,
-                boardId?: BoardID,
-                cursor?: { x: number; y: number }
-              ) => {
-                // Navigate to the user's board (pushes history, so back
-                // button returns to the previous board)
-                if (boardId) {
-                  navigation.goToBoard(boardId);
-                  // TODO: If cursor position is provided, we could pan to that position
-                  // This would require exposing a method on SessionCanvasRef
-                }
-              }}
+              onHomeClick={handleHomeClick}
+              onUserClick={handleHeaderUserClick}
               instanceLabel={instanceLabel}
               recentBoards={recentBoards}
               instanceDescription={instanceDescription}
-              sessionById={sessionById}
-              artifactById={artifactById}
-              mcpServerById={mcpServerById}
             />
             <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
               <PanelGroup

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -485,8 +485,10 @@ export const App: React.FC<AppProps> = ({
     true
   );
 
-  // Track recent boards (single instance — passed down to AppHeader as props)
-  const { recentBoards, recentBoardIds, trackBoardVisit } = useRecentBoards(
+  // Recent-board visit tracking + the id list HomePage consumes. AppHeader owns
+  // its own pill derivation from the store (so it isn't fed an unstable array),
+  // and the localStorage-backed recents list keeps both in sync.
+  const { recentBoardIds, trackBoardVisit } = useRecentBoards(
     mapToArray(boardById),
     currentBoardId
   );
@@ -1110,7 +1112,6 @@ export const App: React.FC<AppProps> = ({
               onHomeClick={handleHomeClick}
               onUserClick={handleHeaderUserClick}
               instanceLabel={instanceLabel}
-              recentBoards={recentBoards}
               instanceDescription={instanceDescription}
             />
             <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.rerender.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.rerender.test.tsx
@@ -1,4 +1,4 @@
-import type { Board, Repo } from '@agor-live/client';
+import type { Board, Repo, User } from '@agor-live/client';
 import { act, render, waitFor } from '@testing-library/react';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -128,25 +128,61 @@ function useStableCallback<TFn extends (...args: never[]) => unknown>(
 // Lets a test trigger a parent re-render without touching AppHeader's props.
 let triggerParentRerender: () => void = () => {};
 
-// Parent harness that renders the REAL memo'd AppHeader the way App does: an
-// action handler flows through `useStableCallback` so its identity is frozen. A
-// `useState` bump (driven from the test) re-renders THIS parent; the `stabilize`
-// flag toggles whether the settings handler is stabilized, so the same harness
-// proves both halves of the guard.
+// Stable identities for every NON-flipped AppHeader prop, mirroring App's render
+// site: handlers are frozen (App routes them through useStableCallback) and the
+// scalar props are constants. Module-level so they keep their identity across
+// parent re-renders — the whole point of the guard is that NOTHING AppHeader
+// receives churns, so React.memo can bail out.
+const HARNESS_USER = { user_id: 'u1', name: 'User', email: 'u@example.test' } as unknown as User;
+const noop = () => {};
+
+// The complete prop set App passes, minus the one handler the harness flips. If a
+// future change reintroduces an unstable prop here (e.g. a fresh array), the
+// all-stable assertion below starts failing — that's the regression this guards.
+const STABLE_HEADER_PROPS = {
+  user: HARNESS_USER,
+  presenceClient: null,
+  currentUserId: 'u1',
+  connected: true,
+  connecting: false,
+  onMenuClick: noop,
+  onCommentsClick: noop,
+  onEventStreamClick: noop,
+  onUserSettingsClick: noop,
+  onThemeEditorClick: noop,
+  onLogout: noop,
+  onRetryConnection: noop,
+  currentBoardName: 'Board',
+  currentBoardIcon: '📋',
+  unreadCommentsCount: 0,
+  eventStreamEnabled: true,
+  hasUserMentions: false,
+  currentBoardId: 'board-1',
+  onBoardChange: noop,
+  onHomeClick: noop,
+  onUserClick: noop,
+  instanceLabel: 'Test Instance',
+} as const;
+
+// Parent harness that renders the REAL memo'd AppHeader the way App does, with
+// the FULL prop set. One handler (`onSettingsClick`) flows through
+// `useStableCallback` when `stabilize` is true and is passed as a fresh arrow
+// otherwise — so the same harness proves both halves of the guard while every
+// other prop stays referentially stable. A `useState` bump re-renders THIS
+// parent without touching any prop value.
 function ParentHarness({ stabilize }: { stabilize: boolean }) {
   const [, setTick] = useState(0);
   triggerParentRerender = () => setTick((tick) => tick + 1);
 
-  // Fresh identity on every parent render (mirrors App's plain-const handlers).
-  // When `stabilize` is true we freeze it through useStableCallback; when false
-  // we pass it straight through so memo sees a new prop each render.
+  // Fresh identity on every parent render unless we freeze it via
+  // useStableCallback (mirrors App's plain-const → stabilized handlers).
   const settingsImpl = () => {};
   const stableSettings = useStableCallback(settingsImpl);
   const onSettingsClick = stabilize ? stableSettings : settingsImpl;
 
   return (
     <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
-      <AppHeader onSettingsClick={onSettingsClick} />
+      <AppHeader {...STABLE_HEADER_PROPS} onSettingsClick={onSettingsClick} />
     </MemoryRouter>
   );
 }

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.rerender.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.rerender.test.tsx
@@ -1,0 +1,201 @@
+import type { Board, Repo } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { AppHeader } from './AppHeader';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../contexts/ConnectionContext', () => ({
+  useConnectionDisabled: () => false,
+}));
+
+// AppHeader's own render count. ConnectionStatus is rendered unconditionally on
+// every AppHeader render and is NOT memoized in this mock, so its invocation
+// count is a faithful proxy for how many times the memoized AppHeader rendered.
+let headerRenders = 0;
+
+vi.mock('../BoardSwitcher', () => ({
+  BoardSwitcher: () => <div data-testid="board-switcher" />,
+}));
+vi.mock('../BrandLogo', () => ({
+  BrandLogo: () => <div data-testid="brand-logo" />,
+}));
+vi.mock('../ConnectionStatus', () => ({
+  ConnectionStatus: () => {
+    headerRenders += 1;
+    return null;
+  },
+}));
+vi.mock('../GlobalSearch', () => ({
+  GlobalSearch: () => <div data-testid="global-search" />,
+}));
+vi.mock('../GlobalUserMenu', () => ({
+  GlobalUserMenu: () => <div data-testid="global-user-menu" />,
+}));
+vi.mock('../MarkdownRenderer', () => ({
+  MarkdownRenderer: () => <div data-testid="markdown-renderer" />,
+}));
+vi.mock('../ThemeSwitcher', () => ({
+  ThemeSwitcher: () => <div data-testid="theme-switcher" />,
+}));
+vi.mock('./GlobalPresenceFacepile', () => ({
+  GlobalPresenceFacepile: () => <div data-testid="presence-facepile" />,
+}));
+
+const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as unknown as Board;
+const repo = { repo_id: 'repo-1', name: 'repo', slug: 'repo' } as unknown as Repo;
+
+function renderHeader(node: React.ReactNode) {
+  return render(
+    <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
+      {node}
+    </MemoryRouter>
+  );
+}
+
+describe('AppHeader store-selector re-render isolation', () => {
+  beforeEach(() => {
+    headerRenders = 0;
+    agorStore.setState({ ...EMPTY_MAPS });
+  });
+
+  it('a patch to a slice AppHeader does not select leaves the header un-rendered', async () => {
+    renderHeader(<AppHeader />);
+
+    await waitFor(() => {
+      expect(headerRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = headerRenders;
+
+    // Patch a slice AppHeader never selects (repos). zustand notifies every
+    // subscriber, but each of AppHeader's selector slices keeps its reference,
+    // so its subscriptions stay quiet and it does not re-render.
+    act(() => {
+      agorStore.setState({ repoById: new Map([[repo.repo_id, repo]]) });
+    });
+
+    expect(headerRenders).toBe(baseline);
+  });
+
+  it('a patch to a selected slice (boards) re-renders the header', async () => {
+    renderHeader(<AppHeader />);
+
+    await waitFor(() => {
+      expect(headerRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = headerRenders;
+
+    // Contrast: AppHeader subscribes to boardById (it derives the board list
+    // from it), so a boards patch MUST wake the header — proving the
+    // subscription is live and the isolation above is meaningful.
+    act(() => {
+      agorStore.setState({ boardById: new Map([[board.board_id, board]]) });
+    });
+
+    await waitFor(() => {
+      expect(headerRenders).toBeGreaterThan(baseline);
+    });
+  });
+});
+
+// Mirror of App's `useStableCallback`: freeze a handler's identity across renders
+// while delegating to the latest impl via a ref. This is the exact mechanism App
+// uses to keep AppHeader's action handlers stable, so reproducing it here
+// exercises the real prop-stabilization contract.
+function useStableCallback<TFn extends (...args: never[]) => unknown>(
+  callback: TFn | undefined
+): TFn | undefined {
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+  const stable = useCallback(((...args: never[]) => callbackRef.current?.(...args)) as TFn, []);
+  return callback ? stable : undefined;
+}
+
+// Lets a test trigger a parent re-render without touching AppHeader's props.
+let triggerParentRerender: () => void = () => {};
+
+// Parent harness that renders the REAL memo'd AppHeader the way App does: an
+// action handler flows through `useStableCallback` so its identity is frozen. A
+// `useState` bump (driven from the test) re-renders THIS parent; the `stabilize`
+// flag toggles whether the settings handler is stabilized, so the same harness
+// proves both halves of the guard.
+function ParentHarness({ stabilize }: { stabilize: boolean }) {
+  const [, setTick] = useState(0);
+  triggerParentRerender = () => setTick((tick) => tick + 1);
+
+  // Fresh identity on every parent render (mirrors App's plain-const handlers).
+  // When `stabilize` is true we freeze it through useStableCallback; when false
+  // we pass it straight through so memo sees a new prop each render.
+  const settingsImpl = () => {};
+  const stableSettings = useStableCallback(settingsImpl);
+  const onSettingsClick = stabilize ? stableSettings : settingsImpl;
+
+  return (
+    <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
+      <AppHeader onSettingsClick={onSettingsClick} />
+    </MemoryRouter>
+  );
+}
+
+describe('AppHeader memo + handler-stabilization re-render bailout', () => {
+  beforeEach(() => {
+    headerRenders = 0;
+    triggerParentRerender = () => {};
+    agorStore.setState({ ...EMPTY_MAPS });
+  });
+
+  it('a parent re-render does not re-render the memo’d AppHeader when handlers are stabilized', async () => {
+    render(<ParentHarness stabilize={true} />);
+
+    await waitFor(() => {
+      expect(headerRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = headerRenders;
+
+    // Re-render the PARENT. Every AppHeader prop kept its identity (the
+    // stabilized settings handler), so React.memo bails out and the header
+    // stays put.
+    act(() => {
+      triggerParentRerender();
+    });
+
+    // Regression guard: FAILS if `memo(AppHeaderInner)` is removed (parent
+    // re-render always re-renders the header) OR if the handler is destabilized
+    // (a fresh prop identity defeats the shallow memo).
+    expect(headerRenders).toBe(baseline);
+  });
+
+  it('a parent re-render DOES re-render the header when a handler identity is not stabilized', async () => {
+    // Contrast case: proves the guard above is meaningful. The same parent,
+    // passing a fresh-identity settings handler each render, breaks the memo
+    // shallow compare — so the bailout genuinely depends on stabilization.
+    render(<ParentHarness stabilize={false} />);
+
+    await waitFor(() => {
+      expect(headerRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = headerRenders;
+
+    act(() => {
+      triggerParentRerender();
+    });
+
+    await waitFor(() => {
+      expect(headerRenders).toBeGreaterThan(baseline);
+    });
+  });
+});

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.test.tsx
@@ -45,13 +45,7 @@ vi.mock('./GlobalPresenceFacepile', () => ({
 function renderHeader() {
   return render(
     <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
-      <AppHeader
-        branchById={new Map()}
-        boardById={new Map()}
-        sessionById={new Map()}
-        artifactById={new Map()}
-        mcpServerById={new Map()}
-      />
+      <AppHeader />
     </MemoryRouter>
   );
 }

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,14 +1,4 @@
-import type {
-  ActiveUser,
-  AgorClient,
-  Artifact,
-  Board,
-  BoardID,
-  Branch,
-  MCPServer,
-  Session,
-  User,
-} from '@agor-live/client';
+import type { ActiveUser, AgorClient, Board, BoardID, User } from '@agor-live/client';
 import {
   ApiOutlined,
   BulbOutlined,
@@ -17,9 +7,20 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { Badge, Button, Divider, Layout, Popover, Space, Tag, Tooltip, theme } from 'antd';
+import { memo, useMemo } from 'react';
 import { useHref, useNavigate } from 'react-router-dom';
+import { mapToArray } from '@/utils/mapHelpers';
 import { BRAND, brandMarkHref } from '../../branding/brand';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectArtifactById,
+  selectBoardById,
+  selectBranchById,
+  selectMcpServerById,
+  selectSessionById,
+  selectUserById,
+} from '../../store/selectors';
 import { BoardSwitcher } from '../BoardSwitcher';
 import { BrandLogo } from '../BrandLogo';
 import { ConnectionStatus } from '../ConnectionStatus';
@@ -34,7 +35,6 @@ const { Header } = Layout;
 export interface AppHeaderProps {
   user?: User | null;
   presenceClient?: AgorClient | null;
-  presenceUsers?: User[];
   currentUserId?: string;
   /** Demo/screenshot-only fixture: render static presence while keeping AppHeader chrome. */
   staticActiveUsers?: ActiveUser[];
@@ -55,12 +55,9 @@ export interface AppHeaderProps {
   unreadCommentsCount?: number;
   eventStreamEnabled?: boolean;
   hasUserMentions?: boolean; // True if current user is mentioned in active comments
-  boards?: Board[];
   currentBoardId?: string;
   onBoardChange?: (boardId: string) => void;
   onHomeClick?: () => void;
-  branchById: Map<string, Branch>;
-  boardById: Map<string, Board>; // For looking up board names; required because GlobalSearch hands it to useAppNavigation for slug-aware path building
   onUserClick?: (
     userId: string,
     boardId?: BoardID,
@@ -72,12 +69,6 @@ export interface AppHeaderProps {
   instanceLabel?: string;
   /** Instance description (markdown) shown in popover around the instance label */
   instanceDescription?: string;
-  /** Live entity maps for the global-search dropdown. Passed through from App.tsx.
-   * GlobalSearch calls useAppNavigation directly, so it needs boardById (for
-   * slug-aware path building) on top of the entity maps. */
-  sessionById: Map<string, Session>;
-  artifactById: Map<string, Artifact>;
-  mcpServerById: Map<string, MCPServer>;
 }
 
 const RecentBoardPills: React.FC<{
@@ -118,10 +109,9 @@ const RecentBoardPills: React.FC<{
   );
 };
 
-export const AppHeader: React.FC<AppHeaderProps> = ({
+const AppHeaderInner: React.FC<AppHeaderProps> = ({
   user,
   presenceClient = null,
-  presenceUsers = [],
   currentUserId,
   staticActiveUsers,
   presenceMaxVisible,
@@ -139,23 +129,32 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
   unreadCommentsCount = 0,
   eventStreamEnabled = false,
   hasUserMentions = false,
-  boards = [],
   currentBoardId,
   onBoardChange,
   onHomeClick,
-  branchById,
-  boardById,
   onUserClick,
   recentBoards = [],
   instanceLabel,
   instanceDescription,
-  sessionById,
-  artifactById,
-  mcpServerById,
 }) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
   const knowledgeHref = useHref('/knowledge');
+
+  // Entity state via narrow store subscriptions rather than props. Each
+  // whole-map selector is a stable module-level reference, so the header
+  // re-renders only when a slice it actually reads changes — not on every
+  // top-down App render. The board list and presence directory are derived
+  // here (instead of arriving as fresh `mapToArray(...)` props each render)
+  // so React.memo's bailout isn't defeated by an unstable array identity.
+  const boardById = useAgorStore(selectBoardById);
+  const userById = useAgorStore(selectUserById);
+  const branchById = useAgorStore(selectBranchById);
+  const sessionById = useAgorStore(selectSessionById);
+  const artifactById = useAgorStore(selectArtifactById);
+  const mcpServerById = useAgorStore(selectMcpServerById);
+  const boards = useMemo(() => mapToArray(boardById), [boardById]);
+  const presenceUsers = useMemo(() => mapToArray(userById), [userById]);
   // Single source of truth for "is the daemon usable right now?". Captures
   // disconnected, the 1.5s reconnect grace window, and out-of-sync. Don't
   // gate off raw `connected` — it stays true through the grace window.
@@ -362,3 +361,10 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
     </Header>
   );
 };
+
+// Memoized so the always-mounted header is insulated from App's top-down
+// re-renders: App re-renders on every live store patch, but AppHeader re-renders
+// only when one of its own props actually changes OR one of its `useAgorStore`
+// selector slices fires. The bailout holds only while the parent keeps every
+// prop referentially stable (see the stabilized handlers at the App render site).
+export const AppHeader = memo(AppHeaderInner);

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -12,6 +12,7 @@ import { useHref, useNavigate } from 'react-router-dom';
 import { mapToArray } from '@/utils/mapHelpers';
 import { BRAND, brandMarkHref } from '../../branding/brand';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
+import { useRecentBoards } from '../../hooks/useRecentBoards';
 import { useAgorStore } from '../../store/agorStore';
 import {
   selectArtifactById,
@@ -63,8 +64,6 @@ export interface AppHeaderProps {
     boardId?: BoardID,
     cursorPosition?: { x: number; y: number }
   ) => void; // Navigate to user's board
-  /** Recently visited boards (excluding current) for quick-access pills */
-  recentBoards?: Board[];
   /** Instance label for deployment identification (displayed as a Tag) */
   instanceLabel?: string;
   /** Instance description (markdown) shown in popover around the instance label */
@@ -133,7 +132,6 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   onBoardChange,
   onHomeClick,
   onUserClick,
-  recentBoards = [],
   instanceLabel,
   instanceDescription,
 }) => {
@@ -155,6 +153,11 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   const mcpServerById = useAgorStore(selectMcpServerById);
   const boards = useMemo(() => mapToArray(boardById), [boardById]);
   const presenceUsers = useMemo(() => mapToArray(userById), [userById]);
+  // Derive the recent-board pills here (not as a prop): the source array is the
+  // store-derived `boards`, so unrelated App re-renders can't hand us a fresh
+  // recents array and defeat React.memo. The localStorage-backed recents list is
+  // shared across hook instances, so this stays in sync with App's visit tracker.
+  const { recentBoards } = useRecentBoards(boards, currentBoardId ?? '');
   // Single source of truth for "is the daemon usable right now?". Captures
   // disconnected, the 1.5s reconnect grace window, and out-of-sync. Don't
   // gate off raw `connected` — it stays true through the grace window.

--- a/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
+++ b/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
@@ -7,7 +7,6 @@ import type {
   Branch,
   BranchID,
   CardWithType,
-  MCPServer,
   Repo,
   Session,
   User,
@@ -665,7 +664,6 @@ export const MarketingScreenshotPage = () => {
             <AppHeader
               user={users[0]}
               presenceClient={null}
-              presenceUsers={users}
               currentUserId={users[0].user_id}
               staticActiveUsers={activeUsers}
               connected={true}
@@ -675,14 +673,8 @@ export const MarketingScreenshotPage = () => {
               unreadCommentsCount={comments.length}
               eventStreamEnabled={true}
               hasUserMentions={true}
-              boards={[board]}
               currentBoardId={boardId}
-              branchById={maps.branchById}
-              boardById={maps.boardById}
               recentBoards={[]}
-              sessionById={maps.sessionById}
-              artifactById={new Map()}
-              mcpServerById={new Map<string, MCPServer>()}
             />
             <main className="marketing-product-canvas">
               <ReactFlowProvider>

--- a/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
+++ b/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
@@ -635,6 +635,11 @@ export const MarketingScreenshotPage = () => {
       cardById: maps.cardById,
       userById: maps.userById,
       commentById: maps.commentById,
+      // AppHeader's GlobalSearch reads artifacts + MCP servers from the store;
+      // pin them empty so a previously-populated workspace store can't leak its
+      // entities into this standalone demo regardless of prior state.
+      artifactById: new Map(),
+      mcpServerById: new Map(),
     });
   }, [maps]);
 
@@ -674,7 +679,6 @@ export const MarketingScreenshotPage = () => {
               eventStreamEnabled={true}
               hasUserMentions={true}
               currentBoardId={boardId}
-              recentBoards={[]}
             />
             <main className="marketing-product-canvas">
               <ReactFlowProvider>

--- a/apps/agor-ui/src/store/selectors.ts
+++ b/apps/agor-ui/src/store/selectors.ts
@@ -14,15 +14,18 @@
 import type { BoardEntityObject, Session } from '@agor-live/client';
 import type { AgorState } from './agorStore';
 
+export const selectSessionById = (s: AgorState) => s.sessionById;
 export const selectSessionsByBranch = (s: AgorState) => s.sessionsByBranch;
 export const selectRepoById = (s: AgorState) => s.repoById;
 export const selectBranchById = (s: AgorState) => s.branchById;
+export const selectBoardById = (s: AgorState) => s.boardById;
 export const selectCommentById = (s: AgorState) => s.commentById;
 export const selectCardById = (s: AgorState) => s.cardById;
 export const selectUserById = (s: AgorState) => s.userById;
 export const selectMcpServerById = (s: AgorState) => s.mcpServerById;
 export const selectUserAuthenticatedMcpServerIds = (s: AgorState) =>
   s.userAuthenticatedMcpServerIds;
+export const selectArtifactById = (s: AgorState) => s.artifactById;
 
 /**
  * Select a single board's board-object array. Curried so callers can memoize


### PR DESCRIPTION
## What

Insulate the always-mounted **`AppHeader`** boundary so it (and its entire subtree) stops re-rendering on every store change that re-renders the inner `App`. `App` subscribes to the whole store, so its re-render previously dragged the un-memoized `AppHeader` (fed fresh `mapToArray(boardById)` / `mapToArray(userById)` arrays each render) every time. This is the higher-value of the Phase-4 consumer peels — `AppHeader` is always mounted, so its subtree is insulated on every live patch.

### AppHeader (memoized + peeled)
- **`React.memo`** — split into `AppHeaderInner` + `export const AppHeader = memo(AppHeaderInner)`.
- **Entity reads moved to store selectors** (mirrors `SessionCanvas`): `AppHeader` now subscribes via `useAgorStore` to `boardById`, `userById`, `branchById`, `sessionById`, `artifactById`, `mcpServerById` instead of receiving them as props. The **board list** and **presence directory** are derived internally with `useMemo`, removing the unstable `boards` / `presenceUsers` array props that defeated the memo bailout. Both render sites (`App`, `MarketingScreenshotPage`) already seed the store, so behavior is identical.
- **Every remaining prop stabilized** at the `App` render site — the inline-arrow handlers (`onEventStreamClick`, `onSettingsClick`, `onUserSettingsClick`, `onThemeEditorClick`, `onHomeClick`, `onUserClick`) and the `onLogout` / `onRetryConnection` passthroughs now go through the existing `useStableCallback`. `onBoardChange={navigation.goToBoard}`, `onMenuClick`, `onCommentsClick` were already stable `useCallback`s.

### Selectors (`store/selectors.ts`, additive)
- Added `selectBoardById`, `selectSessionById`, `selectArtifactById` (module-level stable refs, same pattern as the existing selectors).

## Guard test
`AppHeader.rerender.test.tsx` mirrors `SessionCanvas.rerender.test.tsx`'s parent-re-render harness:
- A parent re-render does **not** re-render the memoized header when handlers are stabilized; the contrast case (unstabilized handler) **does** — proving the bailout depends on stabilization.
- An unrelated store-slice patch (`repoById`) leaves the header untouched, while a selected-slice patch (`boardById`) wakes it — proving the subscription is live and the isolation is meaningful.
- **Verified the guard fails if `memo(AppHeaderInner)` is reverted** (header render count goes 1→2).

## Deferred
**`BoardAssistantPanel`** — deferred to a focused follow-up. It is only mounted when the left panel is expanded (conditional, lower-frequency re-render cost than the always-mounted header) and carries ~15 callback props requiring stabilization (several inline arrows + comment handlers + a `mapToArray(commentById).filter(...)` array). A clean small PR beats a risky big one.

## Behavior
Zero behavior change — header renders and behaves identically. Hot paths (cursors/streaming/drag) untouched; home/initial board unaffected.

## Gate (CI-mirror, fresh `pnpm install` + `turbo run build --filter='agor-ui^...'`)
- typecheck ✓ · lint (biome) ✓ · test ✓ (83 files, **475 tests**) · build ✓

## Independence
Independent off `main` (the merged Phase-4 foundation). Additively touches `store/selectors.ts` and the `App.tsx` / `MarketingScreenshotPage.tsx` render sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)