### PR TITLE
feat(gateway): Slack app manifest generator + scope matrix + DM whitelist fix

### DIFF
--- a/packages/core/src/gateway/connectors/slack-manifest.test.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSlackManifest,
+  requiredBotEvents,
+  requiredBotScopes,
+  type SlackWizardOptions,
+} from './slack-manifest';
+
+/**
+ * These assertions pin the scope/event matrix to itself — they guard against
+ * accidental edits to the generator, NOT against drift between the generator
+ * and the live Slack connector. Keeping the matrix aligned with the connector
+ * is a manual review step.
+ */
+const baseOptions: SlackWizardOptions = {
+  appName: 'Agor',
+  publicChannels: false,
+  privateChannels: false,
+  groupDms: false,
+  alignUsers: false,
+  outbound: false,
+};
+
+function withOptions(overrides: Partial<SlackWizardOptions>): SlackWizardOptions {
+  return { ...baseOptions, ...overrides };
+}
+
+describe('requiredBotScopes', () => {
+  it('DM-only baseline', () => {
+    expect(requiredBotScopes(baseOptions)).toEqual([
+      'chat:write',
+      'im:history',
+      'im:read',
+      'users:read',
+    ]);
+  });
+
+  it('adds app_mentions + public channel read/history for public channels', () => {
+    expect(requiredBotScopes(withOptions({ publicChannels: true }))).toEqual([
+      'app_mentions:read',
+      'channels:history',
+      'channels:read',
+      'chat:write',
+      'im:history',
+      'im:read',
+      'users:read',
+    ]);
+  });
+
+  it('adds outbound name-resolution + DM-by-email scopes', () => {
+    expect(requiredBotScopes(withOptions({ outbound: true }))).toEqual([
+      'channels:read',
+      'chat:write',
+      'chat:write.public',
+      'groups:read',
+      'im:history',
+      'im:read',
+      'im:write',
+      'users:read',
+      'users:read.email',
+    ]);
+  });
+
+  it('adds users:read.email for user alignment', () => {
+    expect(requiredBotScopes(withOptions({ alignUsers: true }))).toEqual([
+      'chat:write',
+      'im:history',
+      'im:read',
+      'users:read',
+      'users:read.email',
+    ]);
+  });
+
+  it('all capabilities on — de-duplicated and sorted', () => {
+    const allOn = withOptions({
+      publicChannels: true,
+      privateChannels: true,
+      groupDms: true,
+      alignUsers: true,
+      outbound: true,
+    });
+    expect(requiredBotScopes(allOn)).toEqual([
+      'app_mentions:read',
+      'channels:history',
+      'channels:read',
+      'chat:write',
+      'chat:write.public',
+      'groups:history',
+      'groups:read',
+      'im:history',
+      'im:read',
+      'im:write',
+      'mpim:history',
+      'mpim:read',
+      'users:read',
+      'users:read.email',
+    ]);
+  });
+
+  it('private channels and group DMs each contribute their own read/history scopes', () => {
+    expect(requiredBotScopes(withOptions({ privateChannels: true }))).toEqual([
+      'app_mentions:read',
+      'chat:write',
+      'groups:history',
+      'groups:read',
+      'im:history',
+      'im:read',
+      'users:read',
+    ]);
+    expect(requiredBotScopes(withOptions({ groupDms: true }))).toEqual([
+      'app_mentions:read',
+      'chat:write',
+      'im:history',
+      'im:read',
+      'mpim:history',
+      'mpim:read',
+      'users:read',
+    ]);
+  });
+});
+
+describe('requiredBotEvents', () => {
+  it('DM-only emits only message.im', () => {
+    expect(requiredBotEvents(baseOptions)).toEqual(['message.im']);
+  });
+
+  it('any channel-like surface adds app_mention (and no message.channels/groups/mpim)', () => {
+    expect(requiredBotEvents(withOptions({ publicChannels: true }))).toEqual([
+      'app_mention',
+      'message.im',
+    ]);
+    expect(requiredBotEvents(withOptions({ privateChannels: true }))).toEqual([
+      'app_mention',
+      'message.im',
+    ]);
+    expect(requiredBotEvents(withOptions({ groupDms: true }))).toEqual([
+      'app_mention',
+      'message.im',
+    ]);
+  });
+
+  it('outbound and alignUsers do not add events', () => {
+    expect(requiredBotEvents(withOptions({ outbound: true, alignUsers: true }))).toEqual([
+      'message.im',
+    ]);
+  });
+});
+
+describe('buildSlackManifest', () => {
+  it('uses appName as bot display name when botDisplayName is omitted', () => {
+    expect(buildSlackManifest(baseOptions).features.bot_user.display_name).toBe('Agor');
+  });
+
+  it('honors an explicit botDisplayName', () => {
+    const manifest = buildSlackManifest(withOptions({ botDisplayName: 'Agor Bot' }));
+    expect(manifest.features.bot_user.display_name).toBe('Agor Bot');
+  });
+
+  it('matches the DM-only snapshot', () => {
+    expect(buildSlackManifest(baseOptions)).toMatchInlineSnapshot(`
+      {
+        "display_information": {
+          "name": "Agor",
+        },
+        "features": {
+          "app_home": {
+            "home_tab_enabled": false,
+            "messages_tab_enabled": true,
+            "messages_tab_read_only_enabled": false,
+          },
+          "bot_user": {
+            "always_online": true,
+            "display_name": "Agor",
+          },
+        },
+        "oauth_config": {
+          "scopes": {
+            "bot": [
+              "chat:write",
+              "im:history",
+              "im:read",
+              "users:read",
+            ],
+          },
+        },
+        "settings": {
+          "event_subscriptions": {
+            "bot_events": [
+              "message.im",
+            ],
+          },
+          "interactivity": {
+            "is_enabled": false,
+          },
+          "org_deploy_enabled": false,
+          "socket_mode_enabled": true,
+          "token_rotation_enabled": false,
+        },
+      }
+    `);
+  });
+
+  it('matches the all-channels snapshot', () => {
+    const allChannels = withOptions({
+      publicChannels: true,
+      privateChannels: true,
+      groupDms: true,
+    });
+    expect(buildSlackManifest(allChannels)).toMatchInlineSnapshot(`
+      {
+        "display_information": {
+          "name": "Agor",
+        },
+        "features": {
+          "app_home": {
+            "home_tab_enabled": false,
+            "messages_tab_enabled": true,
+            "messages_tab_read_only_enabled": false,
+          },
+          "bot_user": {
+            "always_online": true,
+            "display_name": "Agor",
+          },
+        },
+        "oauth_config": {
+          "scopes": {
+            "bot": [
+              "app_mentions:read",
+              "channels:history",
+              "channels:read",
+              "chat:write",
+              "groups:history",
+              "groups:read",
+              "im:history",
+              "im:read",
+              "mpim:history",
+              "mpim:read",
+              "users:read",
+            ],
+          },
+        },
+        "settings": {
+          "event_subscriptions": {
+            "bot_events": [
+              "app_mention",
+              "message.im",
+            ],
+          },
+          "interactivity": {
+            "is_enabled": false,
+          },
+          "org_deploy_enabled": false,
+          "socket_mode_enabled": true,
+          "token_rotation_enabled": false,
+        },
+      }
+    `);
+  });
+
+  it('matches the restricted-public + outbound snapshot', () => {
+    // "Restricted" (allowed_channel_ids) is runtime config and does not change
+    // scopes, so this is public + outbound at the manifest level.
+    const restrictedOutbound = withOptions({ publicChannels: true, outbound: true });
+    expect(buildSlackManifest(restrictedOutbound)).toMatchInlineSnapshot(`
+      {
+        "display_information": {
+          "name": "Agor",
+        },
+        "features": {
+          "app_home": {
+            "home_tab_enabled": false,
+            "messages_tab_enabled": true,
+            "messages_tab_read_only_enabled": false,
+          },
+          "bot_user": {
+            "always_online": true,
+            "display_name": "Agor",
+          },
+        },
+        "oauth_config": {
+          "scopes": {
+            "bot": [
+              "app_mentions:read",
+              "channels:history",
+              "channels:read",
+              "chat:write",
+              "chat:write.public",
+              "groups:read",
+              "im:history",
+              "im:read",
+              "im:write",
+              "users:read",
+              "users:read.email",
+            ],
+          },
+        },
+        "settings": {
+          "event_subscriptions": {
+            "bot_events": [
+              "app_mention",
+              "message.im",
+            ],
+          },
+          "interactivity": {
+            "is_enabled": false,
+          },
+          "org_deploy_enabled": false,
+          "socket_mode_enabled": true,
+          "token_rotation_enabled": false,
+        },
+      }
+    `);
+  });
+});

--- a/packages/core/src/gateway/connectors/slack-manifest.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.ts
@@ -131,10 +131,10 @@ export function requiredBotEvents(opts: SlackWizardOptions): string[] {
 /**
  * Build the complete Slack app manifest for the selected capabilities.
  *
- * Socket Mode is enabled (so no request URLs or signing secret are emitted),
- * interactivity is disabled (v1 is a plain App-Home bot), and the assistant
- * view is intentionally omitted because the connector does not handle
- * assistant lifecycle events.
+ * Socket Mode is enabled, so no request URLs or signing secret are emitted.
+ * Interactivity is disabled because the connector uses no interactive components.
+ * The assistant view is omitted because the connector does not handle assistant
+ * lifecycle events.
  */
 export function buildSlackManifest(opts: SlackWizardOptions): SlackAppManifest {
   return {

--- a/packages/core/src/gateway/connectors/slack-manifest.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.ts
@@ -1,0 +1,172 @@
+/**
+ * Slack App Manifest generator
+ *
+ * Pure, dependency-free derivation of the Slack OAuth bot scopes, event
+ * subscriptions, and a complete app manifest from a small set of capability
+ * toggles. The output is the full manifest JSON a user can paste into Slack's
+ * "Create app from manifest" flow — no scope or event needs to be added by
+ * hand. The only manual step left to the user is generating the app-level
+ * token (`connections:write`), which is not a bot scope and therefore never
+ * appears in this manifest.
+ *
+ * The scope/event matrix mirrors what the Slack connector actually calls; see
+ * {@link ./slack.ts}. DMs are always handled, so there is no DM toggle, and
+ * channel-like surfaces trigger exclusively on `app_mention` (verified in the
+ * connector's inbound filter), so no `message.channels`/`groups`/`mpim` events
+ * are requested.
+ */
+
+export interface SlackWizardOptions {
+  appName: string;
+  botDisplayName?: string;
+  /** Listen in public channels (`#channel`). */
+  publicChannels: boolean;
+  /** Listen in private channels (groups). */
+  privateChannels: boolean;
+  /** Listen in group DMs (multi-person IMs). */
+  groupDms: boolean;
+  /** Resolve Slack user email → Agor user (requires reading user emails). */
+  alignUsers: boolean;
+  /** Proactive outbound: post to channels by name and DM users by email. */
+  outbound: boolean;
+}
+
+export interface SlackBotEventSubscriptions {
+  bot_events: string[];
+}
+
+export interface SlackAppManifest {
+  display_information: {
+    name: string;
+  };
+  features: {
+    bot_user: {
+      display_name: string;
+      always_online: boolean;
+    };
+    app_home: {
+      messages_tab_enabled: boolean;
+      messages_tab_read_only_enabled: boolean;
+      home_tab_enabled: boolean;
+    };
+  };
+  oauth_config: {
+    scopes: {
+      bot: string[];
+    };
+  };
+  settings: {
+    event_subscriptions: SlackBotEventSubscriptions;
+    interactivity: {
+      is_enabled: boolean;
+    };
+    org_deploy_enabled: boolean;
+    socket_mode_enabled: boolean;
+    token_rotation_enabled: boolean;
+  };
+}
+
+/** Any channel-like surface (public/private/group-DM) shares the @mention trigger. */
+function hasChannelLikeSurface(opts: SlackWizardOptions): boolean {
+  return opts.publicChannels || opts.privateChannels || opts.groupDms;
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+/**
+ * Bot OAuth scopes required for the selected capabilities, de-duplicated and
+ * stable-sorted. Derived from the connector's Web API usage.
+ */
+export function requiredBotScopes(opts: SlackWizardOptions): string[] {
+  // Baseline: DM handling (always on) + user profile lookups + sending.
+  const scopes = ['chat:write', 'im:history', 'im:read', 'users:read'];
+
+  if (hasChannelLikeSurface(opts)) {
+    scopes.push('app_mentions:read');
+  }
+  if (opts.publicChannels) {
+    scopes.push('channels:history', 'channels:read');
+  }
+  if (opts.privateChannels) {
+    scopes.push('groups:history', 'groups:read');
+  }
+  if (opts.groupDms) {
+    scopes.push('mpim:history', 'mpim:read');
+  }
+  if (opts.alignUsers) {
+    scopes.push('users:read.email');
+  }
+  if (opts.outbound) {
+    // Outbound name resolution lists public+private channels and opens DMs by
+    // email, independent of inbound listening.
+    scopes.push(
+      'chat:write.public',
+      'channels:read',
+      'groups:read',
+      'im:write',
+      'users:read.email'
+    );
+  }
+
+  return sortedUnique(scopes);
+}
+
+/**
+ * Bot event subscriptions required for the selected capabilities,
+ * de-duplicated and stable-sorted. Channel-like surfaces trigger only on
+ * `app_mention`; DMs trigger on `message.im`.
+ */
+export function requiredBotEvents(opts: SlackWizardOptions): string[] {
+  const events = ['message.im'];
+
+  if (hasChannelLikeSurface(opts)) {
+    events.push('app_mention');
+  }
+
+  return sortedUnique(events);
+}
+
+/**
+ * Build the complete Slack app manifest for the selected capabilities.
+ *
+ * Socket Mode is enabled (so no request URLs or signing secret are emitted),
+ * interactivity is disabled (v1 is a plain App-Home bot), and the assistant
+ * view is intentionally omitted because the connector does not handle
+ * assistant lifecycle events.
+ */
+export function buildSlackManifest(opts: SlackWizardOptions): SlackAppManifest {
+  return {
+    display_information: {
+      name: opts.appName,
+    },
+    features: {
+      bot_user: {
+        display_name: opts.botDisplayName ?? opts.appName,
+        always_online: true,
+      },
+      app_home: {
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+        home_tab_enabled: false,
+      },
+    },
+    oauth_config: {
+      scopes: {
+        bot: requiredBotScopes(opts),
+      },
+    },
+    settings: {
+      event_subscriptions: {
+        bot_events: requiredBotEvents(opts),
+      },
+      interactivity: {
+        is_enabled: false,
+      },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isChannelAllowedByWhitelist,
   markdownToMrkdwn,
   markdownToSlackPayload,
   SlackConnector,
@@ -851,5 +852,31 @@ describe('SlackConnector.lookupUserAvatarByEmail', () => {
     };
 
     await expect(connector.lookupUserAvatarByEmail('missing@example.com')).resolves.toBeNull();
+  });
+});
+
+describe('isChannelAllowedByWhitelist', () => {
+  const whitelist = ['C123'];
+
+  it('always accepts DMs even when a channel whitelist is configured', () => {
+    expect(isChannelAllowedByWhitelist('im', 'D999', whitelist)).toBe(true);
+  });
+
+  it('rejects a channel-like surface not in the whitelist', () => {
+    expect(isChannelAllowedByWhitelist('channel', 'C999', whitelist)).toBe(false);
+  });
+
+  it('accepts a channel-like surface that is in the whitelist', () => {
+    expect(isChannelAllowedByWhitelist('channel', 'C123', whitelist)).toBe(true);
+  });
+
+  it('applies the whitelist to private channels and group DMs', () => {
+    expect(isChannelAllowedByWhitelist('group', 'C999', whitelist)).toBe(false);
+    expect(isChannelAllowedByWhitelist('mpim', 'C999', whitelist)).toBe(false);
+  });
+
+  it('accepts everything when no whitelist is configured', () => {
+    expect(isChannelAllowedByWhitelist('channel', 'C999', undefined)).toBe(true);
+    expect(isChannelAllowedByWhitelist('channel', 'C999', [])).toBe(true);
   });
 });

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -522,6 +522,24 @@ function extractSlackErrorCode(resultOrError: unknown): string | undefined {
   return candidate.data?.error ?? candidate.error;
 }
 
+/**
+ * Decide whether the `allowed_channel_ids` whitelist permits an inbound event.
+ *
+ * DMs (`im`) always pass: a DM conversation id is never present in a
+ * channel-id whitelist, so applying the filter there would silently disable
+ * direct messages the moment any whitelist is configured. The whitelist only
+ * governs channel-like surfaces (`channel`/`group`/`mpim`).
+ */
+export function isChannelAllowedByWhitelist(
+  channelType: string,
+  channelId: string | undefined,
+  allowedChannelIds: string[] | undefined
+): boolean {
+  if (channelType === 'im') return true;
+  if (!allowedChannelIds || allowedChannelIds.length === 0) return true;
+  return !!channelId && allowedChannelIds.includes(channelId);
+}
+
 export class SlackConnector implements GatewayConnector {
   readonly channelType: ChannelType = 'slack';
 
@@ -1495,11 +1513,9 @@ export class SlackConnector implements GatewayConnector {
         return;
       }
 
-      // Channel whitelist check (applies to all channel types)
-      if (allowedChannelIds && allowedChannelIds.length > 0) {
-        if (!allowedChannelIds.includes(event.channel)) {
-          return; // Not in whitelist
-        }
+      // Channel whitelist governs channel-like surfaces only; DMs always pass.
+      if (!isChannelAllowedByWhitelist(channelType, event.channel, allowedChannelIds)) {
+        return;
       }
 
       // Mention requirement handling

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -14,7 +14,21 @@ export type {
   SlackThreadHistoryRequest,
   SlackThreadHistoryResult,
 } from './connectors/slack';
-export { markdownToMrkdwn, SlackConnector } from './connectors/slack';
+export {
+  isChannelAllowedByWhitelist,
+  markdownToMrkdwn,
+  SlackConnector,
+} from './connectors/slack';
+export type {
+  SlackAppManifest,
+  SlackBotEventSubscriptions,
+  SlackWizardOptions,
+} from './connectors/slack-manifest';
+export {
+  buildSlackManifest,
+  requiredBotEvents,
+  requiredBotScopes,
+} from './connectors/slack-manifest';
 export {
   extractQuotedReplyText,
   parseThreadId as parseTeamsThreadId,


### PR DESCRIPTION
**PR 1 of a multi-PR feature** improving Slack gateway UX (preset-io/agor-cloud#94). This is the foundation — UI wizard, a test-connection service, and docs follow in later PRs. No React/UI, no service wiring here.

## What's in this PR

### Phase 0 + 1 — Slack app manifest generator (`slack-manifest.ts`)
A pure, dependency-free module that derives Slack OAuth bot scopes, event subscriptions, and a complete app manifest from a small set of capability toggles. The output is the full manifest JSON a user can paste into Slack's "Create app from manifest" flow — nothing needs to be toggled by hand except generating the app-level token.

`SlackWizardOptions`: `appName`, `botDisplayName?`, `publicChannels`, `privateChannels`, `groupDms`, `alignUsers`, `outbound`.

Notable scope decisions (verified against `slack.ts`):
- **DMs are always-on** (no flag): baseline scopes `chat:write`, `im:history`, `im:read`, `users:read` + event `message.im`.
- **`app_mention` is implied** by any channel-like surface (public OR private OR groupDms) → adds scope `app_mentions:read` + event `app_mention`. We deliberately do **not** request `message.channels/groups/mpim` — the connector triggers on `app_mention` only for channel-like surfaces (slack.ts ~1443).
- **outbound** pulls in `chat:write.public`, `channels:read`, `groups:read`, `im:write`, `users:read.email` independent of inbound listening, because name resolution lists public+private channels (`conversations.list`) and DM-by-email opens DMs (`users.lookupByEmail` + `conversations.open`).
- **`allowed_channel_ids` (restrict-to-channels) is runtime config and does NOT change scopes** — there's no manifest flag for it.
- No `assistant_view`, no request URLs / signing secret (Socket Mode), and `connections:write` is **not** a bot scope (user generates that app-level token manually).

`requiredBotScopes` / `requiredBotEvents` return de-duplicated, stable-sorted sets.

#### Scope/event sets per combo
- **DM-only:** scopes `chat:write, im:history, im:read, users:read`; events `message.im`
- **+public:** scopes `app_mentions:read, channels:history, channels:read, chat:write, im:history, im:read, users:read`; events `app_mention, message.im`
- **+private:** scopes `app_mentions:read, chat:write, groups:history, groups:read, im:history, im:read, users:read`; events `app_mention, message.im`
- **+groupDms:** scopes `app_mentions:read, chat:write, im:history, im:read, mpim:history, mpim:read, users:read`; events `app_mention, message.im`
- **+alignUsers:** scopes `chat:write, im:history, im:read, users:read, users:read.email`; events `message.im`
- **+outbound:** scopes `channels:read, chat:write, chat:write.public, groups:read, im:history, im:read, im:write, users:read, users:read.email`; events `message.im`
- **all-on:** scopes `app_mentions:read, channels:history, channels:read, chat:write, chat:write.public, groups:history, groups:read, im:history, im:read, im:write, mpim:history, mpim:read, users:read, users:read.email`; events `app_mention, message.im`

### Phase 0b — DM whitelist fix (`slack.ts`)
The inbound `allowed_channel_ids` filter ran for **every** channel type. Because a DM conversation id (`D…`) is never present in a channel-id whitelist, configuring any whitelist silently disabled all DMs. Extracted the decision into a pure `isChannelAllowedByWhitelist(channelType, channelId, allowedChannelIds)` helper: DMs (`im`) always pass; the whitelist governs `channel`/`group`/`mpim` only. Behavior for channel-like surfaces is unchanged.

## Tests
- `slack-manifest.test.ts`: matrix assertions for representative combos (DM-only, +public, +outbound, +alignUsers, +private, +groupDms, all-on) + inline snapshots of `buildSlackManifest` for DM-only / all-channels / restricted+outbound.
- `slack.test.ts`: added `isChannelAllowedByWhitelist` cases proving a DM passes while a non-listed channel is rejected with `allowed_channel_ids=['C123']`.

> Note: the manifest tests pin the matrix to itself — they guard against accidental edits to the generator, **not** drift between the generator and the live connector. Keeping the two aligned is a manual review step.

## Checks
- `pnpm typecheck` (repo-wide, 9 tasks) ✅
- `biome ci` on changed files ✅
- `@agor/core` unit suite: 97 files, 2652 passed / 2 skipped ✅