### PR TITLE
perf(agor-daemon): push find filters into SQL for branches/boards/cards/artifacts

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -223,7 +223,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
    * `filterData`, an override only needs to return a superset of the matching
    * rows for the result to stay identical.
    */
-  protected async fetchData(_query: Query): Promise<T[]> {
+  protected async fetchData(_query: Query, _params?: P): Promise<T[]> {
     return this.repository.findAll();
   }
 
@@ -235,7 +235,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
 
     // Get the candidate row set (whole table by default; subclasses may push
     // predicates into SQL — filterData below still applies every query filter)
-    let data = await this.fetchData(query);
+    let data = await this.fetchData(query, params);
 
     // Apply filters
     data = this.filterData(data, query);

--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -215,13 +215,27 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   }
 
   /**
+   * Resolve the candidate row set that `find` filters, sorts, and paginates.
+   *
+   * The base implementation reads the whole table and relies on `filterData` to
+   * narrow it in memory. Subclasses may override this to push high-selectivity
+   * predicates into SQL; because `find` always re-applies every query filter via
+   * `filterData`, an override only needs to return a superset of the matching
+   * rows for the result to stay identical.
+   */
+  protected async fetchData(_query: Query): Promise<T[]> {
+    return this.repository.findAll();
+  }
+
+  /**
    * Find records
    */
   async find(params?: P): Promise<Paginated<T> | T[]> {
     const query = this.getQuery(params);
 
-    // Get all data from repository
-    let data = await this.repository.findAll();
+    // Get the candidate row set (whole table by default; subclasses may push
+    // predicates into SQL — filterData below still applies every query filter)
+    let data = await this.fetchData(query);
 
     // Apply filters
     data = this.filterData(data, query);

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -17,7 +17,6 @@ import {
 } from '@agor/core/config';
 import {
   ArtifactRepository,
-  BoardObjectRepository,
   BoardRepository,
   type BranchRepository,
   type Database,
@@ -75,7 +74,6 @@ import type {
 } from './declarations.js';
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
-import { normalizeBoardObjectFindQuery } from './services/board-objects.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
 import {
@@ -105,7 +103,6 @@ import {
   loadScheduleAndBranch,
   loadSession,
   loadSessionBranch,
-  PERMISSION_RANK,
   resolveSessionContext,
   scopeFindToAccessibleBoardsSql,
   scopeFindToAccessibleBranchesSql,
@@ -609,8 +606,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // ============================================================================
   // Board objects hooks
   // ============================================================================
-  const boardObjectRepository = new BoardObjectRepository(db);
-
   safeService('board-objects')?.hooks({
     before: {
       all: [
@@ -618,133 +613,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireAuth,
         requireMinimumRole(ROLES.MEMBER, 'manage board objects'),
       ],
-      // NOTE: We deliberately do NOT add the generic scopeFindToAccessibleBranches here.
-      // Board-objects may reference `branch_id` (branch cards) OR `card_id`
-      // (kanban cards with no branch) OR neither (zones, layout objects).
-      // That generic hook would filter out rows with null branch_id, breaking
-      // card-only boards. The RBAC find hook below uses a board-object-specific
-      // SQL query that preserves card/zone rows while scoping branch-bound ones.
-      find: [
-        ...(branchRbacEnabled
-          ? [
-              async (context: HookContext) => {
-                if (!context.params.provider) return context;
-
-                const userId = context.params.user?.user_id as
-                  | import('@agor/core/types').UUID
-                  | undefined;
-                const normalized = normalizeBoardObjectFindQuery(context.params.query);
-
-                if (!userId) {
-                  context.result = {
-                    total: 0,
-                    limit: normalized.limit,
-                    skip: normalized.skip,
-                    data: [],
-                  };
-                  return context;
-                }
-
-                const [total, data] = await Promise.all([
-                  boardObjectRepository.countVisibleToUser(userId, normalized.filters),
-                  boardObjectRepository.findVisibleToUser(
-                    userId,
-                    normalized.filters,
-                    normalized.pagination
-                  ),
-                ]);
-
-                context.result = {
-                  total,
-                  limit: normalized.limit,
-                  skip: normalized.skip,
-                  data,
-                };
-                (context.params as { _boardObjectsRbacScoped?: boolean })._boardObjectsRbacScoped =
-                  true;
-                return context;
-              },
-            ]
-          : []),
-      ],
-    },
-    after: {
-      find: [
-        ...(branchRbacEnabled
-          ? [
-              // Filter board-objects based on branch access permissions
-              async (context: HookContext) => {
-                if (
-                  (context.params as { _boardObjectsRbacScoped?: boolean })._boardObjectsRbacScoped
-                ) {
-                  return context;
-                }
-
-                // Skip for internal calls
-                if (!context.params.provider) {
-                  return context;
-                }
-
-                const userId = context.params.user?.user_id as
-                  | import('@agor/core/types').UUID
-                  | undefined;
-                if (!userId) {
-                  // Not authenticated - return empty results
-                  context.result = {
-                    total: 0,
-                    limit: context.result?.limit ?? 0,
-                    skip: context.result?.skip ?? 0,
-                    data: [],
-                  };
-                  return context;
-                }
-
-                // Get all board objects from result
-                // biome-ignore lint/suspicious/noExplicitAny: BoardObject type not fully available in hook context
-                const boardObjects: any[] = context.result?.data ?? context.result ?? [];
-
-                // Filter based on branch access
-                const authorizedBoardObjects = [];
-                for (const boardObject of boardObjects) {
-                  // Board objects may reference branches or sessions
-                  if (boardObject.branch_id) {
-                    // Check branch access
-                    const branch = await branchRepository.findById(boardObject.branch_id);
-                    if (!branch) {
-                      continue; // Skip if branch doesn't exist
-                    }
-
-                    const effectivePermission = await branchRepository.resolveUserPermission(
-                      branch,
-                      userId
-                    );
-                    const hasAccess = PERMISSION_RANK[effectivePermission] >= PERMISSION_RANK.view;
-
-                    if (hasAccess) {
-                      authorizedBoardObjects.push(boardObject);
-                    }
-                  } else if (boardObject.card_id) {
-                    // Card board objects: cards inherit board-level access (no per-card RBAC)
-                    authorizedBoardObjects.push(boardObject);
-                  } else {
-                    // No branch or card reference - allow access (e.g., zones, other board objects)
-                    authorizedBoardObjects.push(boardObject);
-                  }
-                }
-
-                // Update result
-                if (context.result?.data) {
-                  context.result.data = authorizedBoardObjects;
-                  context.result.total = authorizedBoardObjects.length;
-                } else {
-                  context.result = authorizedBoardObjects;
-                }
-
-                return context;
-              },
-            ]
-          : []),
-      ],
+      // Board-objects may reference a branch or may be loose board/card/layout
+      // rows. The service composes this marker into an object-specific SQL
+      // predicate: branch-bound rows require branch access; loose rows require
+      // board visibility.
+      find: [...(branchRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : [])],
     },
   });
 
@@ -1039,6 +912,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   safeService('board-comments')?.hooks({
     before: {
       all: [typedValidateQuery(boardCommentQueryValidator), requireAuth],
+      find: [
+        // Board comments inherit board visibility for pure board/spatial
+        // comments and branch/session/task/message visibility for attached
+        // comments. The service pushes the marker into SQL.
+        ...(branchRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
+      ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create board comments'), injectCreatedBy()],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update board comments')],
       remove: [requireMinimumRole(ROLES.MEMBER, 'delete board comments')],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -107,8 +107,8 @@ import {
   loadSessionBranch,
   PERMISSION_RANK,
   resolveSessionContext,
-  scopeFindToAccessibleBoards,
-  scopeFindToAccessibleBranches,
+  scopeFindToAccessibleBoardsSql,
+  scopeFindToAccessibleBranchesSql,
   scopeFindToAccessibleSessions,
   scopeScheduleQuery,
   scopeSessionQuery,
@@ -807,13 +807,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [requireAuth],
       find: [
         // RBAC: Artifacts carry a `branch_id` (nullable — survives branch deletion).
-        // Scope find() to the branches the caller can access. Rows with null
-        // branch_id (orphaned artifacts) will be excluded by the $in filter,
-        // which is the safe default — orphans can only be surfaced via explicit
-        // board-scoped queries.
-        ...(branchRbacEnabled
-          ? [scopeFindToAccessibleBranches(branchRepository, superadminOpts)]
-          : []),
+        // Scope find() to the branches the caller can access. The service pushes
+        // this into SQL as a correlated visibility predicate rather than
+        // preloading ids and injecting `branch_id IN (...)`.
+        ...(branchRbacEnabled ? [scopeFindToAccessibleBranchesSql(superadminOpts)] : []),
       ],
       create: [requireMinimumRole(ROLES.MEMBER, 'create artifacts'), injectCreatedBy()],
       patch: [requireMinimumRole(ROLES.MEMBER, 'update artifacts'), ensureArtifactOwnerOrAdmin()],
@@ -1089,11 +1086,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         requireMinimumRole(ROLES.MEMBER, 'access branches'),
       ],
       find: [
-        // RBAC: compose an accessible branch_id filter and let BranchesService.find()
-        // handle service-level filters/enrichment (including virtual zone_id).
-        ...(branchRbacEnabled
-          ? [scopeFindToAccessibleBranches(branchRepository, superadminOpts)]
-          : []),
+        // RBAC: mark external regular-user finds for BranchesService to compose
+        // the shared branch visibility predicate directly into its SQL read.
+        ...(branchRbacEnabled ? [scopeFindToAccessibleBranchesSql(superadminOpts)] : []),
       ],
       get: [
         ...(branchRbacEnabled
@@ -2870,11 +2865,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [typedValidateQuery(boardQueryValidator), requireAuth],
       find: [
         // RBAC: restrict boards.find to boards the caller created or has a
-        // branch on. Runs at the SQL layer via BoardRepository.findVisibleBoardIds
-        // to avoid hydrating every accessible branch in-memory.
-        ...(branchRbacEnabled
-          ? [scopeFindToAccessibleBoards(boardRepository, superadminOpts)]
-          : []),
+        // branch on. The service pushes this into the repository query as one
+        // SQL predicate, avoiding a preloaded `board_id IN (...)` list.
+        ...(branchRbacEnabled ? [scopeFindToAccessibleBoardsSql(superadminOpts)] : []),
       ],
       get: [ensureCanViewBoard('view this board')],
       findBySlug: [ensureCanViewBoard('view this board')],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -109,9 +109,8 @@ import {
   resolveSessionContext,
   scopeFindToAccessibleBoardsSql,
   scopeFindToAccessibleBranchesSql,
-  scopeFindToAccessibleSessions,
+  scopeFindToAccessibleSessionsSql,
   scopeScheduleQuery,
-  scopeSessionQuery,
   setSessionUnixUsername,
   validateSessionUnixUsername,
 } from './utils/branch-authorization.js';
@@ -523,9 +522,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // RBAC: Scope messages.find() to sessions the caller can access.
         // Without this backstop, any authenticated member could list messages
         // across every session/branch by omitting the session_id filter.
-        ...(branchRbacEnabled
-          ? [scopeFindToAccessibleSessions(sessionsRepository, superadminOpts)]
-          : []),
+        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
       get: [
         ...(branchRbacEnabled
@@ -1495,9 +1492,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       find: [
         requireMinimumRole(ROLES.MEMBER, 'list session MCP servers'),
         // RBAC: Scope to sessions the caller can access.
-        ...(branchRbacEnabled
-          ? [scopeFindToAccessibleSessions(sessionsRepository, superadminOpts)]
-          : []),
+        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
     },
     after: {
@@ -1516,10 +1511,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [requireAuth],
       find: [
         requireMinimumRole(ROLES.MEMBER, 'list session env selections'),
-        // RBAC: Scope to sessions the caller can access.
-        ...(branchRbacEnabled
-          ? [scopeFindToAccessibleSessions(sessionsRepository, superadminOpts)]
-          : []),
+        // This top-level service is event-only and always returns []; do not
+        // run RBAC preloads for an intentionally empty result set.
       ],
     },
   });
@@ -2224,8 +2217,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     before: {
       all: [typedValidateQuery(sessionQueryValidator), requireAuth, executorRuntimeScopeGuard()],
       find: [
-        // RBAC: Optimized SQL-based filtering (single query with JOIN on branches, no N+1)
-        ...(branchRbacEnabled ? [scopeSessionQuery(sessionsRepository, superadminOpts)] : []),
+        // RBAC: mark external regular-user finds for SessionsService to compose
+        // the shared branch visibility predicate directly into its SQL read.
+        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
       get: [
         ...(branchRbacEnabled
@@ -2405,10 +2399,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     after: {
       find: [
         async (context) => {
-          // In RBAC mode, scopeSessionQuery() resolves the paginated result in
-          // before.find for SQL-efficient access control. That intentionally
-          // short-circuits SessionsService.find(), so enrich list payloads here
-          // as a single batched query over the final page.
+          // Session find results may be produced by custom hooks or service
+          // methods. Enrich once, as a single batched query over the final page.
           context.result = await enrichSessionFindResultWithRemoteRelationships(
             context.result as Paginated<Session> | Session[],
             sessionsService
@@ -2752,9 +2744,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [typedValidateQuery(taskQueryValidator), requireAuth, executorRuntimeScopeGuard()],
       find: [
         // RBAC: Scope tasks.find() to sessions the caller can access.
-        ...(branchRbacEnabled
-          ? [scopeFindToAccessibleSessions(sessionsRepository, superadminOpts)]
-          : []),
+        ...(branchRbacEnabled ? [scopeFindToAccessibleSessionsSql(superadminOpts)] : []),
       ],
       get: [
         ...(branchRbacEnabled

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -24,6 +24,7 @@ import {
   sessionMcpServers,
   shortId,
   UserMCPOAuthTokenRepository,
+  visibleSessionReferenceAccessExists,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
@@ -36,6 +37,7 @@ import type {
   Params,
   SessionID,
   UserID,
+  UUID,
 } from '@agor/core/types';
 import {
   AGENTIC_TOOL_CAPABILITIES,
@@ -571,10 +573,11 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
           mcp_server_id?: string;
           enabled?: boolean;
         };
+        _agorSqlSessionAccessUserId?: UUID;
       }) {
         const conditions: ReturnType<typeof eq>[] = [];
-        // session_id may be a scalar string or `{ $in: [...] }` — the latter is
-        // injected by the RBAC scoping hook to restrict rows to accessible sessions.
+        // session_id may be a scalar string or `{ $in: [...] }` from callers.
+        // RBAC scoping is composed below via `_agorSqlSessionAccessUserId`.
         const sessionIdFilter = params?.query?.session_id;
         if (typeof sessionIdFilter === 'string') {
           conditions.push(eq(sessionMcpServers.session_id, sessionIdFilter));
@@ -593,6 +596,15 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
         }
         if (params?.query?.enabled !== undefined) {
           conditions.push(eq(sessionMcpServers.enabled, params.query.enabled));
+        }
+        if (params?._agorSqlSessionAccessUserId) {
+          conditions.push(
+            visibleSessionReferenceAccessExists(
+              db,
+              params._agorSqlSessionAccessUserId,
+              sessionMcpServers.session_id
+            )
+          );
         }
         let query = select(db).from(sessionMcpServers);
         if (conditions.length > 0) {

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1857,6 +1857,24 @@ describe('ArtifactsService.find SQL pushdown', () => {
     }
   );
 
+  dbTest('pushes the RBAC SQL visibility marker into the repository read', async ({ db }) => {
+    const { service, boardA } = await seedPushdownFixture(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { artifactRepo: ArtifactRepository }).artifactRepo,
+      'findAll'
+    );
+
+    await service.find({
+      _agorSqlBranchAccessUserId: 'viewer-1' as UUID,
+      query: { board_id: boardA },
+    });
+
+    expect(repoFindAll).toHaveBeenCalledWith({
+      board_id: boardA,
+      visibleToUserId: 'viewer-1',
+    });
+  });
+
   // branch_id is nullable: a `{ $in }` containing a non-string element must NOT
   // be pushed, because SQL `IN (NULL)` never matches an orphan's null branch_id
   // while the JS `includes` path does. Pushing it would return a SUBSET.

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1856,4 +1856,41 @@ describe('ArtifactsService.find SQL pushdown', () => {
       expect(result.data).toHaveLength(0);
     }
   );
+
+  // branch_id is nullable: a `{ $in }` containing a non-string element must NOT
+  // be pushed, because SQL `IN (NULL)` never matches an orphan's null branch_id
+  // while the JS `includes` path does. Pushing it would return a SUBSET.
+  dbTest('does NOT push a $in containing null — orphans stay visible', async ({ db }) => {
+    const { service } = await seedPushdownFixture(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { artifactRepo: ArtifactRepository }).artifactRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({
+      query: { branch_id: { $in: [null as unknown as BranchID] } },
+    })) as { data: Artifact[]; total: number };
+
+    // Fell through to the whole-table read (no branchIds pushed); filterData
+    // applied the $in in JS, which matches the orphan's null branch_id.
+    expect(repoFindAll).toHaveBeenCalledWith({});
+    expect(result.data.map((a) => a.name)).toEqual(['a-orphan']);
+    expect(result.data.every((a) => a.branch_id === null)).toBe(true);
+  });
+
+  dbTest('does NOT push a mixed null + string $in — orphans stay visible', async ({ db }) => {
+    const { service, branch1 } = await seedPushdownFixture(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { artifactRepo: ArtifactRepository }).artifactRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({
+      query: { branch_id: { $in: [null as unknown as BranchID, branch1] } },
+    })) as { data: Artifact[]; total: number };
+
+    // Whole-table fall-through; JS $in matches the orphan AND both branch1 rows.
+    expect(repoFindAll).toHaveBeenCalledWith({});
+    expect(result.data.map((a) => a.name).sort()).toEqual(['a-branch1', 'a-orphan', 'b-branch1']);
+  });
 });

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -1734,3 +1734,126 @@ describe('ArtifactsService.queryArtifactRuntime', () => {
     realApp.app = originalApp;
   });
 });
+
+describe('ArtifactsService.find SQL pushdown', () => {
+  async function seedPushdownFixture(db: Database) {
+    const boardA = (await seedBoard(db)).board_id as BoardID;
+    const boardB = (await seedBoard(db)).board_id as BoardID;
+    const branch1 = (await seedRepoAndBranch(db, '/tmp/artifact-branch-1')).branch_id as BranchID;
+    const branch2 = (await seedRepoAndBranch(db, '/tmp/artifact-branch-2')).branch_id as BranchID;
+    const artifactRepo = new ArtifactRepository(db);
+    const files = { '/index.js': 'console.log("hi")' };
+
+    // boardA: branch1, branch2, and an orphan (null branch_id).
+    const onBranch1 = await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: boardA,
+      branch_id: branch1,
+      name: 'a-branch1',
+      files,
+    });
+    await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: boardA,
+      branch_id: branch2,
+      name: 'a-branch2',
+      files,
+    });
+    await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: boardA,
+      branch_id: null,
+      name: 'a-orphan',
+      files,
+    });
+    // boardB: branch1 — must be excluded by a boardA-scoped query.
+    await artifactRepo.create({
+      artifact_id: generateId(),
+      board_id: boardB,
+      branch_id: branch1,
+      name: 'b-branch1',
+      files,
+    });
+
+    const service = new ArtifactsService(db, makeFakeApp());
+    return { service, boardA, boardB, branch1, branch2, onBranch1 };
+  }
+
+  dbTest('pushes board_id into the repository read (rbac off)', async ({ db }) => {
+    const { service, boardA } = await seedPushdownFixture(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { artifactRepo: ArtifactRepository }).artifactRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({ query: { board_id: boardA } })) as {
+      data: Artifact[];
+      total: number;
+    };
+
+    // SQL-bounded: the board predicate reaches the repository, not a whole-table read.
+    expect(repoFindAll).toHaveBeenCalledWith({ board_id: boardA });
+    // boardA has 3 artifacts (branch1, branch2, orphan).
+    expect(result.total).toBe(3);
+    expect(result.data.every((a) => a.board_id === boardA)).toBe(true);
+    // Per-row enrichment ran on the reduced set (rowToArtifact populates files).
+    expect(result.data.every((a) => a.files !== undefined)).toBe(true);
+  });
+
+  dbTest(
+    'pushes board_id + accessible branch_id $in and excludes orphans (rbac on)',
+    async ({ db }) => {
+      const { service, boardA, branch1, onBranch1 } = await seedPushdownFixture(db);
+      const repoFindAll = vi.spyOn(
+        (service as unknown as { artifactRepo: ArtifactRepository }).artifactRepo,
+        'findAll'
+      );
+
+      const result = (await service.find({
+        query: { board_id: boardA, branch_id: { $in: [branch1] } },
+      })) as { data: Artifact[]; total: number };
+
+      expect(repoFindAll).toHaveBeenCalledWith({ board_id: boardA, branchIds: [branch1] });
+      // Only the boardA + branch1 artifact survives; branch2 and the orphan are excluded.
+      expect(result.total).toBe(1);
+      expect(result.data.map((a) => a.artifact_id)).toEqual([onBranch1.artifact_id]);
+    }
+  );
+
+  dbTest('pushes a scalar branch_id as a single-id set', async ({ db }) => {
+    const { service, branch1 } = await seedPushdownFixture(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { artifactRepo: ArtifactRepository }).artifactRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({ query: { branch_id: branch1 } })) as {
+      data: Artifact[];
+      total: number;
+    };
+
+    expect(repoFindAll).toHaveBeenCalledWith({ branchIds: [branch1] });
+    // branch1 has artifacts on both boardA and boardB.
+    expect(result.total).toBe(2);
+  });
+
+  dbTest(
+    'returns no rows for an empty accessible set without reading the table',
+    async ({ db }) => {
+      const { service } = await seedPushdownFixture(db);
+      const repoFindAll = vi.spyOn(
+        (service as unknown as { artifactRepo: ArtifactRepository }).artifactRepo,
+        'findAll'
+      );
+
+      const result = (await service.find({ query: { branch_id: { $in: [] } } })) as {
+        data: Artifact[];
+        total: number;
+      };
+
+      expect(repoFindAll).toHaveBeenCalledWith({ branchIds: [] });
+      expect(result.total).toBe(0);
+      expect(result.data).toHaveLength(0);
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -61,7 +61,7 @@ import {
   proxyGrantEnvName,
   ROLES,
 } from '@agor/core/types';
-import { DrizzleService } from '../adapters/drizzle.js';
+import { DrizzleService, type Query } from '../adapters/drizzle.js';
 import { ARTIFACT_RUNTIME_JWT_AUDIENCE, issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { AGOR_RUNTIME_SOURCE } from '../utils/agor-runtime-source.js';
 import {
@@ -348,6 +348,39 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     this.boardRepo = new BoardRepository(db);
     this.app = app;
     this.dbRef = db;
+  }
+
+  /**
+   * Push the list read's high-selectivity predicates into SQL.
+   *
+   * The generic adapter would read the entire artifacts table and filter in
+   * memory. Artifacts are fetched on initial app load, so we narrow the read to
+   * the board, archived state, and the accessible-branch set (injected by RBAC
+   * scoping via `scopeFindToAccessibleBranches`) before rows leave the database.
+   * The per-row `rowToArtifact` / `getBaseUrl` enrichment runs inside
+   * `artifactRepo.findAll` on the reduced set, and `find` still re-applies every
+   * query filter in memory, so this only ever returns a superset of the matching
+   * rows.
+   *
+   * Artifacts are not query-validated, so values arrive uncoerced: only push
+   * when the value already has the column's type (string `board_id`, boolean
+   * `archived`, string / `{ $in }` `branch_id`). Anything else falls through to
+   * the unchanged in-memory filter, preserving current behavior exactly.
+   */
+  protected async fetchData(query: Query): Promise<Artifact[]> {
+    const filter: { board_id?: BoardID; archived?: boolean; branchIds?: BranchID[] } = {};
+
+    if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;
+    if (typeof query.archived === 'boolean') filter.archived = query.archived;
+
+    const branchId = query.branch_id;
+    if (typeof branchId === 'string') {
+      filter.branchIds = [branchId as BranchID];
+    } else if (branchId && typeof branchId === 'object' && Array.isArray(branchId.$in)) {
+      filter.branchIds = branchId.$in as BranchID[];
+    }
+
+    return this.artifactRepo.findAll(filter);
   }
 
   // Direct Feathers create is intentionally rejected — artifacts require

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -52,6 +52,7 @@ import type {
   SessionID,
   UserID,
   UserRole,
+  UUID,
 } from '@agor/core/types';
 import {
   ARTIFACT_SCOPED_ONLY_GRANT_KEYS,
@@ -207,7 +208,10 @@ export type ArtifactParams = QueryParams<{
   board_id?: BoardID;
   branch_id?: BranchID;
   archived?: boolean;
-}>;
+}> & {
+  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+  _agorSqlBranchAccessUserId?: UUID;
+};
 
 const MAX_CONSOLE_ENTRIES = 100;
 
@@ -355,8 +359,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    *
    * The generic adapter would read the entire artifacts table and filter in
    * memory. Artifacts are fetched on initial app load, so we narrow the read to
-   * the board, archived state, and the accessible-branch set (injected by RBAC
-   * scoping via `scopeFindToAccessibleBranches`) before rows leave the database.
+   * the board, archived state, explicit branch ids, and any RBAC SQL branch
+   * visibility marker before rows leave the database.
    * The per-row `rowToArtifact` / `getBaseUrl` enrichment runs inside
    * `artifactRepo.findAll` on the reduced set, and `find` still re-applies every
    * query filter in memory, so this only ever returns a superset of the matching
@@ -374,11 +378,19 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * does — pushing it would return a SUBSET and break the superset contract.
    * board_id / archived may still be pushed in that case.
    */
-  protected async fetchData(query: Query): Promise<Artifact[]> {
-    const filter: { board_id?: BoardID; archived?: boolean; branchIds?: BranchID[] } = {};
+  protected async fetchData(query: Query, params?: ArtifactParams): Promise<Artifact[]> {
+    const filter: {
+      board_id?: BoardID;
+      archived?: boolean;
+      branchIds?: BranchID[];
+      visibleToUserId?: UUID;
+    } = {};
 
     if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;
     if (typeof query.archived === 'boolean') filter.archived = query.archived;
+    if (params?._agorSqlBranchAccessUserId) {
+      filter.visibleToUserId = params._agorSqlBranchAccessUserId;
+    }
 
     const branchId = query.branch_id;
     if (typeof branchId === 'string') {

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -364,8 +364,15 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    *
    * Artifacts are not query-validated, so values arrive uncoerced: only push
    * when the value already has the column's type (string `board_id`, boolean
-   * `archived`, string / `{ $in }` `branch_id`). Anything else falls through to
-   * the unchanged in-memory filter, preserving current behavior exactly.
+   * `archived`, string / all-string `{ $in }` `branch_id`). Anything else falls
+   * through to the unchanged in-memory filter, preserving current behavior
+   * exactly.
+   *
+   * `artifacts.branch_id` is nullable, so a `{ $in }` that contains a non-string
+   * element (e.g. `null`) is deliberately NOT pushed: `filterData` matches null
+   * branch_ids against such a set via JS `includes`, but SQL `IN (NULL)` never
+   * does — pushing it would return a SUBSET and break the superset contract.
+   * board_id / archived may still be pushed in that case.
    */
   protected async fetchData(query: Query): Promise<Artifact[]> {
     const filter: { board_id?: BoardID; archived?: boolean; branchIds?: BranchID[] } = {};
@@ -376,7 +383,12 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const branchId = query.branch_id;
     if (typeof branchId === 'string') {
       filter.branchIds = [branchId as BranchID];
-    } else if (branchId && typeof branchId === 'object' && Array.isArray(branchId.$in)) {
+    } else if (
+      branchId &&
+      typeof branchId === 'object' &&
+      Array.isArray(branchId.$in) &&
+      branchId.$in.every((el: unknown) => typeof el === 'string')
+    ) {
       filter.branchIds = branchId.$in as BranchID[];
     }
 

--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -13,7 +13,7 @@
 
 import { PAGINATION } from '@agor/core/config';
 import { BoardCommentsRepository, type Database } from '@agor/core/db';
-import type { BoardComment, QueryParams } from '@agor/core/types';
+import type { BoardComment, QueryParams, UUID } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 
 /**
@@ -27,7 +27,10 @@ export type BoardCommentsParams = QueryParams<{
   branch_id?: string;
   resolved?: boolean;
   created_by?: string;
-}>;
+}> & {
+  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+  _agorSqlBoardAccessUserId?: UUID;
+};
 
 /**
  * Extended board comments service with custom methods
@@ -60,8 +63,7 @@ export class BoardCommentsService extends DrizzleService<
   async find(params?: BoardCommentsParams) {
     const filters = params?.query || {};
 
-    // Get all matching comments
-    const allComments = await this.commentsRepo.findAll({
+    const queryFilters = {
       board_id: filters.board_id,
       session_id: filters.session_id,
       task_id: filters.task_id,
@@ -69,19 +71,21 @@ export class BoardCommentsService extends DrizzleService<
       branch_id: filters.branch_id,
       resolved: filters.resolved,
       created_by: filters.created_by,
-    });
+      visibleToUserId: params?._agorSqlBoardAccessUserId,
+    };
 
-    // Apply pagination if requested
     const $limit = filters.$limit ?? PAGINATION.DEFAULT_LIMIT;
     const $skip = filters.$skip ?? 0;
-    const paginated = allComments.slice($skip, $skip + $limit);
+    const [total, data] = await Promise.all([
+      this.commentsRepo.count(queryFilters),
+      this.commentsRepo.findAll(queryFilters, { limit: $limit, offset: $skip }),
+    ]);
 
-    // Return paginated result format expected by FeathersJS
     return {
-      total: allComments.length,
+      total,
       limit: $limit,
       skip: $skip,
-      data: paginated,
+      data,
     };
   }
 

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -18,6 +18,7 @@ import type {
   BranchID,
   CardID,
   QueryParams,
+  UUID,
 } from '@agor/core/types';
 
 export type BoardObjectPatchedEventPayload = Omit<BoardEntityObject, 'zone_id'> & {
@@ -42,7 +43,10 @@ export type BoardObjectParams = QueryParams<{
   card_id?: CardID;
   zone_id?: string;
   entity_type?: BoardEntityType;
-}>;
+}> & {
+  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+  _agorSqlBoardAccessUserId?: UUID;
+};
 
 export interface NormalizedBoardObjectFindQuery {
   filters: BoardObjectFindFilters;
@@ -126,10 +130,22 @@ export class BoardObjectsService {
    */
   async find(params?: BoardObjectParams) {
     const normalized = normalizeBoardObjectFindQuery(params?.query);
-    const [total, data] = await Promise.all([
-      this.boardObjectRepo.count(normalized.filters),
-      this.boardObjectRepo.findAll(normalized.filters, normalized.pagination),
-    ]);
+    const visibleToUserId = params?._agorSqlBoardAccessUserId;
+    const [total, data] = await Promise.all(
+      visibleToUserId
+        ? [
+            this.boardObjectRepo.countVisibleToUser(visibleToUserId, normalized.filters),
+            this.boardObjectRepo.findVisibleToUser(
+              visibleToUserId,
+              normalized.filters,
+              normalized.pagination
+            ),
+          ]
+        : [
+            this.boardObjectRepo.count(normalized.filters),
+            this.boardObjectRepo.findAll(normalized.filters, normalized.pagination),
+          ]
+    );
 
     return {
       total,

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -383,23 +383,25 @@ describe('BoardsService.find SQL pushdown', () => {
     return { service, b1, b2, archived };
   }
 
-  dbTest('pushes archived into the repository read (rbac off)', async ({ db }) => {
+  dbTest('reads the whole table when no scope is present (rbac off)', async ({ db }) => {
     const { service } = await seed(db);
     const repoFindAll = vi.spyOn(
       (service as unknown as { boardRepo: BoardRepository }).boardRepo,
       'findAll'
     );
 
-    const result = (await service.find({ query: { archived: false, $sort: { name: 1 } } })) as {
+    // The boards validator strips `archived`, so with no board_id scope there is
+    // nothing high-selectivity to push: the read falls through to the whole
+    // table and `find` returns every board (including archived) — the real win
+    // is the RBAC board_id $in scope covered below.
+    const result = (await service.find({ query: { $sort: { name: 1 } } })) as {
       data: Board[];
       total: number;
     };
 
-    // SQL-bounded: the scoped predicate reaches the repository, not a whole-table read.
-    expect(repoFindAll).toHaveBeenCalledWith({ archived: false });
-    // Parity: archived board excluded, sorted by name.
-    expect(result.total).toBe(2);
-    expect(result.data.map((b) => b.name)).toEqual(['Alpha', 'Beta']);
+    expect(repoFindAll).toHaveBeenCalledWith({});
+    expect(result.total).toBe(3);
+    expect(result.data.map((b) => b.name)).toEqual(['Alpha', 'Beta', 'Gamma']);
   });
 
   dbTest('pushes an accessible board_id $in set into SQL (rbac on)', async ({ db }) => {

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -6,13 +6,14 @@
 
 import {
   BoardObjectRepository,
+  BoardRepository,
   BranchRepository,
   type Database,
   generateId,
   RepoRepository,
   UsersRepository,
 } from '@agor/core/db';
-import type { Board, BranchID, UUID } from '@agor/core/types';
+import type { Board, BoardID, BranchID, UUID } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { BoardsService } from './boards';
@@ -357,4 +358,102 @@ describe('BoardsService - Custom Methods', () => {
     expect(typeof service.clone).toBe('function');
     expect(typeof service.ensureAssistantWelcomeNote).toBe('function');
   });
+});
+
+describe('BoardsService.find SQL pushdown', () => {
+  async function seed(db: Database) {
+    const service = new BoardsService(db);
+    const repo = new BoardRepository(db);
+    const b1 = (await service.create({
+      name: 'Beta',
+      slug: 'beta',
+      created_by: TEST_USER,
+    })) as Board;
+    const b2 = (await service.create({
+      name: 'Alpha',
+      slug: 'alpha',
+      created_by: TEST_USER,
+    })) as Board;
+    const archived = (await service.create({
+      name: 'Gamma',
+      slug: 'gamma',
+      created_by: TEST_USER,
+    })) as Board;
+    await repo.update(archived.board_id, { archived: true });
+    return { service, b1, b2, archived };
+  }
+
+  dbTest('pushes archived into the repository read (rbac off)', async ({ db }) => {
+    const { service } = await seed(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { boardRepo: BoardRepository }).boardRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({ query: { archived: false, $sort: { name: 1 } } })) as {
+      data: Board[];
+      total: number;
+    };
+
+    // SQL-bounded: the scoped predicate reaches the repository, not a whole-table read.
+    expect(repoFindAll).toHaveBeenCalledWith({ archived: false });
+    // Parity: archived board excluded, sorted by name.
+    expect(result.total).toBe(2);
+    expect(result.data.map((b) => b.name)).toEqual(['Alpha', 'Beta']);
+  });
+
+  dbTest('pushes an accessible board_id $in set into SQL (rbac on)', async ({ db }) => {
+    const { service, b1, b2 } = await seed(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { boardRepo: BoardRepository }).boardRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({
+      query: { board_id: { $in: [b1.board_id as BoardID, b2.board_id as BoardID] } },
+    })) as { data: Board[]; total: number };
+
+    expect(repoFindAll).toHaveBeenCalledWith({
+      boardIds: [b1.board_id, b2.board_id],
+    });
+    expect(result.total).toBe(2);
+    expect(result.data.map((b) => b.board_id).sort()).toEqual([b1.board_id, b2.board_id].sort());
+  });
+
+  dbTest('pushes a scalar board_id as a single-id set', async ({ db }) => {
+    const { service, b1 } = await seed(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { boardRepo: BoardRepository }).boardRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({ query: { board_id: b1.board_id } })) as {
+      data: Board[];
+      total: number;
+    };
+
+    expect(repoFindAll).toHaveBeenCalledWith({ boardIds: [b1.board_id] });
+    expect(result.total).toBe(1);
+    expect(result.data[0].board_id).toBe(b1.board_id);
+  });
+
+  dbTest(
+    'returns no rows for an empty accessible set without reading the table',
+    async ({ db }) => {
+      const { service } = await seed(db);
+      const repoFindAll = vi.spyOn(
+        (service as unknown as { boardRepo: BoardRepository }).boardRepo,
+        'findAll'
+      );
+
+      const result = (await service.find({ query: { board_id: { $in: [] } } })) as {
+        data: Board[];
+        total: number;
+      };
+
+      expect(repoFindAll).toHaveBeenCalledWith({ boardIds: [] });
+      expect(result.total).toBe(0);
+      expect(result.data).toHaveLength(0);
+    }
+  );
 });

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -16,7 +16,7 @@ import {
 import type { Board, BoardID, BranchID, UUID } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
-import { BoardsService } from './boards';
+import { type BoardParams, BoardsService } from './boards';
 
 const TEST_USER = 'test-user' as UUID;
 const TEST_PARAMS = { user: { user_id: TEST_USER } } as never;
@@ -458,4 +458,19 @@ describe('BoardsService.find SQL pushdown', () => {
       expect(result.data).toHaveLength(0);
     }
   );
+
+  dbTest('pushes the RBAC SQL visibility marker into the repository read', async ({ db }) => {
+    const { service } = await seed(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { boardRepo: BoardRepository }).boardRepo,
+      'findAll'
+    );
+
+    await service.find({
+      _agorSqlBoardAccessUserId: TEST_USER as UUID,
+      query: {},
+    } as BoardParams);
+
+    expect(repoFindAll).toHaveBeenCalledWith({ visibleToUserId: TEST_USER });
+  });
 });

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -16,12 +16,13 @@ import type {
   AuthenticatedParams,
   Board,
   BoardExportBlob,
+  BoardID,
   BoardObject,
   QueryParams,
   UUID,
 } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
-import { DrizzleService } from '../adapters/drizzle';
+import { DrizzleService, type Query } from '../adapters/drizzle';
 import {
   type BoardObjectPatchedEventPayload,
   toBoardObjectPatchedEventPayload,
@@ -65,6 +66,32 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     this.boardRepo = boardRepo;
     this.boardObjectRepo = new BoardObjectRepository(db);
     this.emitBoardObjectPatched = emitBoardObjectPatched;
+  }
+
+  /**
+   * Push the list read's high-selectivity predicates into SQL.
+   *
+   * The generic adapter would read the entire boards table and filter in
+   * memory. `boards` is fetched on initial app load, so we narrow the read to
+   * the archived state and any accessible-id set (injected by RBAC scoping via
+   * `findVisibleBoardIds`) before rows leave the database. `find` still
+   * re-applies every query filter in memory, so this only ever returns a
+   * superset of the matching rows and the downstream sort/pagination is
+   * unaffected.
+   */
+  protected async fetchData(query: Query): Promise<Board[]> {
+    const filter: { archived?: boolean; boardIds?: BoardID[] } = {};
+
+    if (typeof query.archived === 'boolean') filter.archived = query.archived;
+
+    const boardId = query.board_id;
+    if (typeof boardId === 'string') {
+      filter.boardIds = [boardId as BoardID];
+    } else if (boardId && typeof boardId === 'object' && Array.isArray(boardId.$in)) {
+      filter.boardIds = boardId.$in as BoardID[];
+    }
+
+    return this.boardRepo.findAll(filter);
   }
 
   /**

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -73,21 +73,28 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
    *
    * The generic adapter would read the entire boards table and filter in
    * memory. `boards` is fetched on initial app load, so we narrow the read to
-   * the archived state and any accessible-id set (injected by RBAC scoping via
-   * `findVisibleBoardIds`) before rows leave the database. `find` still
-   * re-applies every query filter in memory, so this only ever returns a
-   * superset of the matching rows and the downstream sort/pagination is
-   * unaffected.
+   * the accessible-id set (injected by RBAC scoping via `findVisibleBoardIds`)
+   * before rows leave the database. `find` still re-applies every query filter
+   * in memory, so this only ever returns a superset of the matching rows and the
+   * downstream sort/pagination is unaffected.
+   *
+   * The boards query validator (`boardQuerySchema`) does not accept `archived`
+   * and strips it before the service runs, so there is nothing to push beyond
+   * the board-id scope. A `{ $in }` is only pushed when every element is a
+   * string, keeping the superset invariant unconditional.
    */
   protected async fetchData(query: Query): Promise<Board[]> {
-    const filter: { archived?: boolean; boardIds?: BoardID[] } = {};
-
-    if (typeof query.archived === 'boolean') filter.archived = query.archived;
+    const filter: { boardIds?: BoardID[] } = {};
 
     const boardId = query.board_id;
     if (typeof boardId === 'string') {
       filter.boardIds = [boardId as BoardID];
-    } else if (boardId && typeof boardId === 'object' && Array.isArray(boardId.$in)) {
+    } else if (
+      boardId &&
+      typeof boardId === 'object' &&
+      Array.isArray(boardId.$in) &&
+      boardId.$in.every((el: unknown) => typeof el === 'string')
+    ) {
       filter.boardIds = boardId.$in as BoardID[];
     }
 

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -39,6 +39,8 @@ export interface BoardParams
   user?: AuthenticatedParams['user'];
   /** Internal hook signal; set only when ensureAssistantWelcomeNote writes. */
   assistantWelcomeNoteMutated?: boolean;
+  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+  _agorSqlBoardAccessUserId?: UUID;
 }
 
 /**
@@ -73,18 +75,22 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
    *
    * The generic adapter would read the entire boards table and filter in
    * memory. `boards` is fetched on initial app load, so we narrow the read to
-   * the accessible-id set (injected by RBAC scoping via `findVisibleBoardIds`)
-   * before rows leave the database. `find` still re-applies every query filter
+   * explicit board ids and any RBAC SQL visibility marker before rows leave the
+   * database. `find` still re-applies every query filter
    * in memory, so this only ever returns a superset of the matching rows and the
    * downstream sort/pagination is unaffected.
    *
    * The boards query validator (`boardQuerySchema`) does not accept `archived`
-   * and strips it before the service runs, so there is nothing to push beyond
-   * the board-id scope. A `{ $in }` is only pushed when every element is a
+   * and strips it before the service runs, so there is no archived predicate to
+   * push. A `{ $in }` is only pushed when every element is a
    * string, keeping the superset invariant unconditional.
    */
-  protected async fetchData(query: Query): Promise<Board[]> {
-    const filter: { boardIds?: BoardID[] } = {};
+  protected async fetchData(query: Query, params?: BoardParams): Promise<Board[]> {
+    const filter: { boardIds?: BoardID[]; visibleToUserId?: UUID } = {};
+
+    if (params?._agorSqlBoardAccessUserId) {
+      filter.visibleToUserId = params._agorSqlBoardAccessUserId;
+    }
 
     const boardId = query.board_id;
     if (typeof boardId === 'string') {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -189,6 +189,28 @@ function createFindHarness(opts: {
       throw new Error(`Unknown service: ${path}`);
     },
   } as unknown as Application;
+  // Faithfully simulate the SQL pushdown performed by BranchRepository.findAll:
+  // narrow the candidate rows by the predicates fetchData hands the repository.
+  // DrizzleService.find still re-applies every query filter in memory, so the
+  // returned set only needs to match what the real WHERE clause would select.
+  const applyFilter = (filter?: {
+    repo_id?: string;
+    board_id?: string;
+    archived?: boolean;
+    branchIds?: BranchID[];
+  }) =>
+    opts.branches.filter((branch) => {
+      if (filter?.repo_id !== undefined && branch.repo_id !== filter.repo_id) return false;
+      if (filter?.board_id !== undefined && branch.board_id !== filter.board_id) return false;
+      if (filter?.archived !== undefined && Boolean(branch.archived) !== filter.archived)
+        return false;
+      if (
+        filter?.branchIds !== undefined &&
+        !filter.branchIds.includes(branch.branch_id as BranchID)
+      )
+        return false;
+      return true;
+    });
   const repository = {
     findAll: vi.fn(async () => opts.branches),
     findById: vi.fn(),
@@ -197,6 +219,7 @@ function createFindHarness(opts: {
     delete: vi.fn(),
   };
   const branchRepo = {
+    findAll: vi.fn(async (filter?: Parameters<typeof applyFilter>[0]) => applyFilter(filter)),
     findBranchIdsByZone: vi.fn(async () => opts.branchIdsInZone),
     enrichManyWithZoneInfo: vi.fn(async (branches: Array<Record<string, unknown>>) =>
       branches.map((branch: Record<string, unknown>) => ({
@@ -863,6 +886,93 @@ describe('BranchesService.find zone filtering', () => {
     expect(result.total).toBe(1);
     expect(result.data).toHaveLength(1);
     expect(result.data[0].branch_id).toBe('branch-3');
+  });
+});
+
+describe('BranchesService.find SQL pushdown', () => {
+  // Mixed fixture: two boards, archived + active rows, so a whole-table read
+  // would over-fetch relative to a board+archived scoped query.
+  const fixture = () => [
+    { branch_id: 'b1', name: 'beta', board_id: 'board-1', archived: false },
+    { branch_id: 'b2', name: 'alpha', board_id: 'board-1', archived: false },
+    { branch_id: 'b3', name: 'gamma', board_id: 'board-1', archived: true },
+    { branch_id: 'b4', name: 'delta', board_id: 'board-2', archived: false },
+  ];
+
+  it('pushes board_id + archived into the repository read and never reads the whole table (rbac off)', async () => {
+    const { service, repository, branchRepo } = createFindHarness({
+      branches: fixture(),
+      branchIdsInZone: [],
+    });
+
+    const result = (await service.find({
+      query: { board_id: 'board-1', archived: false, $sort: { name: 1 } },
+    })) as { data: Array<Record<string, unknown>>; total: number };
+
+    // Read is SQL-bounded: the scoped repo read runs, the whole-table read does not.
+    expect(branchRepo.findAll).toHaveBeenCalledWith({ board_id: 'board-1', archived: false });
+    expect(repository.findAll).not.toHaveBeenCalled();
+
+    // Parity: same rows the JS filter would keep, same order, same total + zone enrichment.
+    expect(result.total).toBe(2);
+    expect(result.data.map((b) => b.branch_id)).toEqual(['b2', 'b1']);
+    expect(result.data.every((b) => 'zone_id' in b)).toBe(true);
+  });
+
+  it('pushes an accessible branch_id $in set alongside board_id + archived (rbac on)', async () => {
+    const { service, repository, branchRepo } = createFindHarness({
+      branches: fixture(),
+      branchIdsInZone: [],
+    });
+
+    const result = (await service.find({
+      query: {
+        board_id: 'board-1',
+        archived: false,
+        branch_id: { $in: ['b1' as BranchID, 'b3' as BranchID, 'b4' as BranchID] },
+      },
+    })) as { data: Array<Record<string, unknown>>; total: number };
+
+    expect(branchRepo.findAll).toHaveBeenCalledWith({
+      board_id: 'board-1',
+      archived: false,
+      branchIds: ['b1', 'b3', 'b4'],
+    });
+    expect(repository.findAll).not.toHaveBeenCalled();
+
+    // b3 is archived, b4 is on board-2 → only b1 survives the intersection.
+    expect(result.total).toBe(1);
+    expect(result.data.map((b) => b.branch_id)).toEqual(['b1']);
+  });
+
+  it('pushes a scalar branch_id as a single-id set', async () => {
+    const { service, branchRepo } = createFindHarness({
+      branches: fixture(),
+      branchIdsInZone: [],
+    });
+
+    const result = (await service.find({
+      query: { branch_id: 'b2' as BranchID },
+    })) as { data: Array<Record<string, unknown>>; total: number };
+
+    expect(branchRepo.findAll).toHaveBeenCalledWith({ branchIds: ['b2'] });
+    expect(result.total).toBe(1);
+    expect(result.data[0].branch_id).toBe('b2');
+  });
+
+  it('returns no rows for an empty accessible set without reading the table', async () => {
+    const { service, branchRepo } = createFindHarness({
+      branches: fixture(),
+      branchIdsInZone: [],
+    });
+
+    const result = (await service.find({
+      query: { branch_id: { $in: [] } },
+    })) as { data: Array<Record<string, unknown>>; total: number };
+
+    expect(branchRepo.findAll).toHaveBeenCalledWith({ branchIds: [] });
+    expect(result.total).toBe(0);
+    expect(result.data).toHaveLength(0);
   });
 });
 

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -198,6 +198,7 @@ function createFindHarness(opts: {
     board_id?: string;
     archived?: boolean;
     branchIds?: BranchID[];
+    visibleToUserId?: string;
   }) =>
     opts.branches.filter((branch) => {
       if (filter?.repo_id !== undefined && branch.repo_id !== filter.repo_id) return false;
@@ -973,6 +974,23 @@ describe('BranchesService.find SQL pushdown', () => {
     expect(branchRepo.findAll).toHaveBeenCalledWith({ branchIds: [] });
     expect(result.total).toBe(0);
     expect(result.data).toHaveLength(0);
+  });
+
+  it('pushes the RBAC SQL visibility marker into the repository read', async () => {
+    const { service, branchRepo } = createFindHarness({
+      branches: fixture(),
+      branchIdsInZone: [],
+    });
+
+    await service.find({
+      _agorSqlBranchAccessUserId: 'viewer-1' as UUID,
+      query: { board_id: 'board-1' },
+    } as BranchParams);
+
+    expect(branchRepo.findAll).toHaveBeenCalledWith({
+      board_id: 'board-1',
+      visibleToUserId: 'viewer-1',
+    });
   });
 });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -55,7 +55,7 @@ import {
 } from '@agor/core/unix';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
-import { DrizzleService } from '../adapters/drizzle';
+import { DrizzleService, type Query } from '../adapters/drizzle';
 import { buildBranchCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { ensureCanControlBranchEnvironment } from '../utils/branch-authorization.js';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
@@ -1085,6 +1085,44 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
 
     return withZone as BranchWithZoneAndSessions;
+  }
+
+  /**
+   * Push the list read's high-selectivity predicates into SQL.
+   *
+   * The generic adapter would read the entire branches table and filter in
+   * memory, so the cost scaled with total branch count rather than the scoped
+   * result. `branches` is the highest-cardinality entity fetched during initial
+   * app load, so we narrow the read to the board scope, archived state, and any
+   * accessible-id set (injected by RBAC scoping or resolved from `zone_id`)
+   * before rows leave the database. `find` still re-applies every query filter
+   * in memory, so this only ever returns a superset of the matching rows and the
+   * downstream sort/pagination/enrichment is unaffected.
+   *
+   * `zone_id` is deliberately not pushed here — it is virtual (backed by
+   * board_objects, not a branches column) and is already resolved to a
+   * `branch_id` filter in `find` before this runs.
+   */
+  protected async fetchData(query: Query): Promise<Branch[]> {
+    const filter: {
+      repo_id?: UUID;
+      board_id?: BoardID;
+      archived?: boolean;
+      branchIds?: BranchID[];
+    } = {};
+
+    if (typeof query.repo_id === 'string') filter.repo_id = query.repo_id as UUID;
+    if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;
+    if (typeof query.archived === 'boolean') filter.archived = query.archived;
+
+    const branchId = query.branch_id;
+    if (typeof branchId === 'string') {
+      filter.branchIds = [branchId as BranchID];
+    } else if (branchId && typeof branchId === 'object' && Array.isArray(branchId.$in)) {
+      filter.branchIds = branchId.$in as BranchID[];
+    }
+
+    return this.branchRepo.findAll(filter);
   }
 
   /**

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -88,6 +88,8 @@ export type BranchParams = QueryParams<{
   InternalEnrichmentParams & {
     /** Root-level include_sessions flag (bypasses Feathers query filtering, used by internal service calls) */
     _include_sessions?: boolean | 'true' | 'false';
+    /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+    _agorSqlBranchAccessUserId?: UUID;
   };
 
 type EnvironmentLifecycleAction = 'start' | 'stop' | 'restart' | 'nuke';
@@ -1093,9 +1095,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * The generic adapter would read the entire branches table and filter in
    * memory, so the cost scaled with total branch count rather than the scoped
    * result. `branches` is the highest-cardinality entity fetched during initial
-   * app load, so we narrow the read to the board scope, archived state, and any
-   * accessible-id set (injected by RBAC scoping or resolved from `zone_id`)
-   * before rows leave the database. `find` still re-applies every query filter
+   * app load, so we narrow the read to the board scope, archived state,
+   * explicit/zone-derived branch ids, and any RBAC SQL visibility marker before
+   * rows leave the database. `find` still re-applies every query filter
    * in memory, so this only ever returns a superset of the matching rows and the
    * downstream sort/pagination/enrichment is unaffected.
    *
@@ -1107,17 +1109,21 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * is non-null so it can't diverge today, but the guard keeps the superset
    * invariant unconditional and avoids handing a malformed element to SQL.
    */
-  protected async fetchData(query: Query): Promise<Branch[]> {
+  protected async fetchData(query: Query, params?: BranchParams): Promise<Branch[]> {
     const filter: {
       repo_id?: UUID;
       board_id?: BoardID;
       archived?: boolean;
       branchIds?: BranchID[];
+      visibleToUserId?: UUID;
     } = {};
 
     if (typeof query.repo_id === 'string') filter.repo_id = query.repo_id as UUID;
     if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;
     if (typeof query.archived === 'boolean') filter.archived = query.archived;
+    if (params?._agorSqlBranchAccessUserId) {
+      filter.visibleToUserId = params._agorSqlBranchAccessUserId;
+    }
 
     const branchId = query.branch_id;
     if (typeof branchId === 'string') {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1102,6 +1102,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    * `zone_id` is deliberately not pushed here — it is virtual (backed by
    * board_objects, not a branches column) and is already resolved to a
    * `branch_id` filter in `find` before this runs.
+   *
+   * A `{ $in }` is only pushed when every element is a string. `branches.branch_id`
+   * is non-null so it can't diverge today, but the guard keeps the superset
+   * invariant unconditional and avoids handing a malformed element to SQL.
    */
   protected async fetchData(query: Query): Promise<Branch[]> {
     const filter: {
@@ -1118,7 +1122,12 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const branchId = query.branch_id;
     if (typeof branchId === 'string') {
       filter.branchIds = [branchId as BranchID];
-    } else if (branchId && typeof branchId === 'object' && Array.isArray(branchId.$in)) {
+    } else if (
+      branchId &&
+      typeof branchId === 'object' &&
+      Array.isArray(branchId.$in) &&
+      branchId.$in.every((el: unknown) => typeof el === 'string')
+    ) {
       filter.branchIds = branchId.$in as BranchID[];
     }
 

--- a/apps/agor-daemon/src/services/cards.test.ts
+++ b/apps/agor-daemon/src/services/cards.test.ts
@@ -1,0 +1,88 @@
+/**
+ * CardsService Tests
+ *
+ * Verifies the SQL pushdown on CardsService.find: board_id + archived predicates
+ * reach the repository read while results stay identical to the in-memory path.
+ */
+
+import { BoardRepository, CardRepository, type Database, generateId } from '@agor/core/db';
+import type { BoardID, Card } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { CardsService } from './cards';
+
+async function seed(db: Database) {
+  const boardRepo = new BoardRepository(db);
+  const cardRepo = new CardRepository(db);
+  const boardA = (
+    await boardRepo.create({ board_id: generateId(), name: 'A', created_by: 'test-user' })
+  ).board_id as BoardID;
+  const boardB = (
+    await boardRepo.create({ board_id: generateId(), name: 'B', created_by: 'test-user' })
+  ).board_id as BoardID;
+
+  const a1 = await cardRepo.create({ board_id: boardA, title: 'beta' });
+  const a2 = await cardRepo.create({ board_id: boardA, title: 'alpha' });
+  const aArchived = await cardRepo.create({ board_id: boardA, title: 'gamma' });
+  await cardRepo.archive(aArchived.card_id);
+  await cardRepo.create({ board_id: boardB, title: 'other' });
+
+  const service = new CardsService(db);
+  return { service, boardA, boardB, a1, a2, aArchived };
+}
+
+describe('CardsService.find SQL pushdown', () => {
+  dbTest('pushes board_id into the repository read', async ({ db }) => {
+    const { service, boardA } = await seed(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { cardRepo: CardRepository }).cardRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({ query: { board_id: boardA } })) as {
+      data: Card[];
+      total: number;
+    };
+
+    // SQL-bounded: the board predicate reaches the repository, not a whole-table read.
+    expect(repoFindAll).toHaveBeenCalledWith({ board_id: boardA });
+    // boardA has 3 cards (2 active + 1 archived).
+    expect(result.total).toBe(3);
+    expect(result.data.every((c) => c.board_id === boardA)).toBe(true);
+  });
+
+  dbTest('pushes board_id + archived and preserves sort/total parity', async ({ db }) => {
+    const { service, boardA } = await seed(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { cardRepo: CardRepository }).cardRepo,
+      'findAll'
+    );
+
+    const result = (await service.find({
+      query: { board_id: boardA, archived: false, $sort: { title: 1 } },
+    })) as { data: Card[]; total: number };
+
+    expect(repoFindAll).toHaveBeenCalledWith({ board_id: boardA, archived: false });
+    expect(result.total).toBe(2);
+    expect(result.data.map((c) => c.title)).toEqual(['alpha', 'beta']);
+  });
+
+  dbTest('leaves an uncoerced string archived to the in-memory filter', async ({ db }) => {
+    const { service, boardA } = await seed(db);
+    const repoFindAll = vi.spyOn(
+      (service as unknown as { cardRepo: CardRepository }).cardRepo,
+      'findAll'
+    );
+
+    // Cards are not query-validated; a raw string 'false' must NOT be pushed as a
+    // boolean. The repository read carries only board_id; the string predicate
+    // falls through to the in-memory equality filter exactly as before (no card
+    // row has archived === 'false', so the result is empty).
+    const result = (await service.find({
+      query: { board_id: boardA, archived: 'false' as unknown as boolean },
+    })) as { data: Card[]; total: number };
+
+    expect(repoFindAll).toHaveBeenCalledWith({ board_id: boardA });
+    expect(result.total).toBe(0);
+  });
+});

--- a/apps/agor-daemon/src/services/cards.ts
+++ b/apps/agor-daemon/src/services/cards.ts
@@ -19,7 +19,7 @@ import type {
   QueryParams,
   ZoneBoardObject,
 } from '@agor/core/types';
-import { DrizzleService } from '../adapters/drizzle';
+import { DrizzleService, type Query } from '../adapters/drizzle';
 
 export type CardParams = QueryParams<{
   board_id?: BoardID;
@@ -44,6 +44,29 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
     });
     this.cardRepo = cardRepo;
     this.boardObjectRepo = new BoardObjectRepository(db);
+  }
+
+  /**
+   * Push the list read's high-selectivity predicates into SQL.
+   *
+   * The generic adapter would read the entire cards table and filter in memory.
+   * The board bootstrap fetches cards both board-scoped and as a global
+   * fallback, so narrowing the read to a board (and archived state) before rows
+   * leave the database is the win. `find` still re-applies every query filter in
+   * memory, so this only ever returns a superset of the matching rows.
+   *
+   * Cards are not query-validated, so values arrive uncoerced: only push when
+   * the value already has the column's type (string `board_id`, boolean
+   * `archived`). Anything else falls through to the unchanged in-memory filter,
+   * preserving current behavior exactly.
+   */
+  protected async fetchData(query: Query): Promise<Card[]> {
+    const filter: { board_id?: BoardID; archived?: boolean } = {};
+
+    if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;
+    if (typeof query.archived === 'boolean') filter.archived = query.archived;
+
+    return this.cardRepo.findAll(filter);
   }
 
   /**

--- a/apps/agor-daemon/src/services/cards.ts
+++ b/apps/agor-daemon/src/services/cards.ts
@@ -60,7 +60,7 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
    * `archived`). Anything else falls through to the unchanged in-memory filter,
    * preserving current behavior exactly.
    */
-  protected async fetchData(query: Query): Promise<Card[]> {
+  protected async fetchData(query: Query, _params?: CardParams): Promise<Card[]> {
     const filter: { board_id?: BoardID; archived?: boolean } = {};
 
     if (typeof query.board_id === 'string') filter.board_id = query.board_id as BoardID;

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -14,8 +14,9 @@ import type {
   QueryParams,
   SessionID,
   TaskID,
+  UUID,
 } from '@agor/core/types';
-import { DrizzleService } from '../adapters/drizzle';
+import { DrizzleService, type Query } from '../adapters/drizzle';
 
 /**
  * Message service params
@@ -25,7 +26,10 @@ export type MessageParams = QueryParams<{
   task_id?: TaskID;
   type?: Message['type'];
   role?: Message['role'];
-}>;
+}> & {
+  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+  _agorSqlSessionAccessUserId?: UUID;
+};
 
 /**
  * Extended messages service with custom methods
@@ -48,10 +52,38 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
     this.messagesRepo = messagesRepo;
   }
 
+  protected async fetchData(query: Query, params?: MessageParams): Promise<Message[]> {
+    const sessionId = query.session_id;
+    const filter: Parameters<MessagesRepository['findAll']>[0] = {};
+
+    if (typeof sessionId === 'string') {
+      filter.sessionId = sessionId as SessionID;
+    } else if (
+      sessionId &&
+      typeof sessionId === 'object' &&
+      Array.isArray(sessionId.$in) &&
+      sessionId.$in.every((el: unknown) => typeof el === 'string')
+    ) {
+      filter.sessionIds = sessionId.$in as SessionID[];
+    }
+    if (typeof query.task_id === 'string') filter.taskId = query.task_id as TaskID;
+    if (typeof query.type === 'string') filter.type = query.type as Message['type'];
+    if (typeof query.role === 'string') filter.role = query.role as Message['role'];
+    if (params?._agorSqlSessionAccessUserId) {
+      filter.visibleToUserId = params._agorSqlSessionAccessUserId;
+    }
+
+    return this.messagesRepo.findAll(filter);
+  }
+
   /**
    * Override find to support task-based and session-based filtering
    */
   async find(params?: MessageParams): Promise<Message[] | Paginated<Message>> {
+    if (params?._agorSqlSessionAccessUserId) {
+      return super.find(params);
+    }
+
     // If filtering by task_id (scalar string), use repository method.
     // The RBAC scoping hook may also inject `session_id` (scalar or `$in`)
     // alongside a user-supplied `task_id`; without intersecting here, callers

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -91,6 +91,8 @@ export type SessionParams = QueryParams<{
   InternalEnrichmentParams & {
     /** Root-level include_last_message flag (bypasses Feathers query filtering, used by internal service calls) */
     _include_last_message?: boolean | 'true' | 'false';
+    /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+    _agorSqlSessionAccessUserId?: UUID;
   };
 
 /**
@@ -102,13 +104,13 @@ export type SessionParams = QueryParams<{
  * with extra filters, operators, or `$select` falls through to the existing path
  * so we never silently drop semantics findPage doesn't implement.
  */
-function shouldSqlPageSessionQuery(query?: Record<string, unknown>): boolean {
-  if (!query) return false;
+function shouldSqlPageSessionQuery(query?: Record<string, unknown>, forcePage = false): boolean {
+  if (!query) return forcePage;
 
   const sort = query.$sort as Record<string, unknown> | undefined;
   const wantsRecency = !!sort && sort.updated_at !== undefined;
   const wantsBoard = query.board_id !== undefined;
-  if (!wantsRecency && !wantsBoard) return false;
+  if (!wantsRecency && !wantsBoard && !forcePage) return false;
 
   const allowedKeys = new Set(['archived', 'board_id', '$sort', '$limit', '$skip']);
   for (const key of Object.keys(query)) {
@@ -196,6 +198,12 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     // without going through app.service('users') — matches the convention used
     // by scheduler.ts / gateway.ts / terminals.ts.
     this.usersRepo = new UsersRepository(db);
+  }
+
+  protected async fetchData(_query: Query, params?: SessionParams): Promise<Session[]> {
+    return this.sessionRepo.findAll({
+      visibleToUserId: params?._agorSqlSessionAccessUserId,
+    });
   }
 
   async enrichRemoteRelationships(sessionList: Session[]): Promise<Session[]> {
@@ -863,9 +871,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
    */
   async find(params?: SessionParams): Promise<Paginated<Session> | Session[]> {
     // SQL-pushdown path for the recency-sorted / board-scoped list queries the
-    // first-paint loader issues. When RBAC is enabled, scopeSessionQuery resolves
-    // the result in a before-hook and this method never runs; when it's disabled,
-    // this is where board_id + `$sort:{updated_at}` are honored.
+    // first-paint loader issues. In RBAC mode the before-hook stamps a marker
+    // here so the same SQL path can compose branch visibility into the query;
+    // in open-access mode this path still handles board_id + `$sort:{updated_at}`.
     //
     // We can't lean on DrizzleService's generic path: (1) its filter matches
     // `item.board_id`, but sessions expose the board as `branch_board_id`, so a
@@ -874,7 +882,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     // and the bounded slice wouldn't be ordered by recency. findPage does the
     // filter + recency sort + limit/offset in SQL instead.
     const query = params?.query as Record<string, unknown> | undefined;
-    if (shouldSqlPageSessionQuery(query)) {
+    if (shouldSqlPageSessionQuery(query, !!params?._agorSqlSessionAccessUserId)) {
       const sortSpec = query?.$sort as { updated_at?: 1 | -1 } | undefined;
       const limit = (query?.$limit as number | undefined) ?? PAGINATION.DEFAULT_LIMIT;
       const skip = (query?.$skip as number | undefined) ?? 0;
@@ -884,6 +892,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         sortUpdatedAt: sortSpec?.updated_at,
         limit,
         skip,
+        visibleToUserId: params?._agorSqlSessionAccessUserId,
       });
       const enriched = await this.enrichRemoteRelationships(data);
       return markRemoteRelationshipsEnrichedResult({ total, limit, skip, data: enriched });
@@ -902,7 +911,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
         unknown
       >;
       const residual = residualQuery as Query;
-      const rows = await this.sessionRepo.findByBoard(boardId);
+      const rows = await this.sessionRepo.findByBoard(boardId as string, {
+        visibleToUserId: params?._agorSqlSessionAccessUserId,
+      });
       const filtered = this.filterData(rows, residual);
       const total = filtered.length;
       const sorted = this.sortData(filtered, residual.$sort);

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -21,6 +21,7 @@ import type {
   SessionID,
   Task,
   TaskID,
+  UUID,
 } from '@agor/core/types';
 import {
   isTerminalTaskStatus,
@@ -28,7 +29,7 @@ import {
   type TaskMetadata,
   TaskStatus,
 } from '@agor/core/types';
-import { DrizzleService } from '../adapters/drizzle';
+import { DrizzleService, type Query } from '../adapters/drizzle';
 import { appendSystemMessage } from '../utils/append-system-message.js';
 import {
   type ExecutorHeartbeatCallbackPayload,
@@ -80,6 +81,8 @@ export type TaskParams = QueryParams<{
    * terminal transition. Most callers should leave this unset.
    */
   suppressBtwCleanup?: boolean;
+  /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
+  _agorSqlSessionAccessUserId?: UUID;
 };
 
 interface CompletionCallbackDispatchResult {
@@ -122,6 +125,10 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
    * Override find to support session-based filtering
    */
   async find(params?: TaskParams): Promise<Task[] | Paginated<Task>> {
+    if (params?._agorSqlSessionAccessUserId) {
+      return super.find(params);
+    }
+
     // If filtering by session_id as a scalar string, use repository shortcut.
     // Note: `session_id` may be injected as `{ $in: [...] }` by the RBAC scoping
     // hook — in that case we fall through to `super.find`, whose adapter's
@@ -166,6 +173,28 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 
     // Otherwise use default find
     return super.find(params);
+  }
+
+  protected async fetchData(query: Query, params?: TaskParams): Promise<Task[]> {
+    const sessionId = query.session_id;
+    const filter: Parameters<TaskRepository['findAll']>[0] = {};
+
+    if (typeof sessionId === 'string') {
+      filter.sessionId = sessionId as SessionID;
+    } else if (
+      sessionId &&
+      typeof sessionId === 'object' &&
+      Array.isArray(sessionId.$in) &&
+      sessionId.$in.every((el: unknown) => typeof el === 'string')
+    ) {
+      filter.sessionIds = sessionId.$in as SessionID[];
+    }
+    if (typeof query.status === 'string') filter.status = query.status as Task['status'];
+    if (params?._agorSqlSessionAccessUserId) {
+      filter.visibleToUserId = params._agorSqlSessionAccessUserId;
+    }
+
+    return this.taskRepo.findAll(filter);
   }
 
   /**

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -1628,6 +1628,25 @@ export function scopeFindToAccessibleSessions(
 }
 
 /**
+ * Mark a session-scoped find() request for repository-level SQL RBAC pushdown.
+ *
+ * This is the single-query alternative to {@link scopeFindToAccessibleSessions}:
+ * instead of preloading every accessible session id and injecting a large
+ * `session_id IN (...)` filter, services that understand this marker compose
+ * the shared branch visibility predicate through the session's branch.
+ */
+export function scopeFindToAccessibleSessionsSql(options?: { allowSuperadmin?: boolean }) {
+  return async (context: HookContext) => {
+    const decision = await resolveFindSqlScopeAccess(context, options);
+    if (decision.kind !== 'filter') return context;
+
+    (context.params as { _agorSqlSessionAccessUserId?: UUID })._agorSqlSessionAccessUserId =
+      decision.userId;
+    return context;
+  };
+}
+
+/**
  * Scope find() queries on the boards service to the set of boards the caller
  * can see.
  *

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -1467,6 +1467,32 @@ async function resolveFindScopeAccess(
   return { kind: 'filter', accessibleIds: new Set<string>(ids) };
 }
 
+type FindSqlScopeDecision =
+  | { kind: 'passThrough' }
+  | { kind: 'handled' }
+  | { kind: 'filter'; userId: UUID };
+
+async function resolveFindSqlScopeAccess(
+  context: HookContext,
+  options: { allowSuperadmin?: boolean } | undefined
+): Promise<FindSqlScopeDecision> {
+  if (context.method !== 'find') return { kind: 'passThrough' };
+  if (!context.params.provider) return { kind: 'passThrough' };
+  if (context.params.user?._isServiceAccount) return { kind: 'passThrough' };
+
+  const userId = context.params.user?.user_id as UUID | undefined;
+  if (!userId) {
+    emptyFindResult(context);
+    return { kind: 'handled' };
+  }
+
+  const userRole = context.params.user?.role as string | undefined;
+  const allowSuperadmin = options?.allowSuperadmin ?? true;
+  if (isSuperAdmin(userRole, allowSuperadmin)) return { kind: 'passThrough' };
+
+  return { kind: 'filter', userId };
+}
+
 /**
  * Intersect the existing `query[field]` filter with the caller's accessible
  * id set. Handles scalar string, `{ $in: [...] }`, and unset cases.
@@ -1547,6 +1573,25 @@ export function scopeFindToAccessibleBranches(
 }
 
 /**
+ * Mark a branch-scoped find() request for repository-level SQL RBAC pushdown.
+ *
+ * This is the single-query alternative to {@link scopeFindToAccessibleBranches}:
+ * instead of preloading every accessible branch id and injecting a large
+ * `branch_id IN (...)` filter, services that understand this marker compose the
+ * shared branch visibility predicate directly into their repository query.
+ */
+export function scopeFindToAccessibleBranchesSql(options?: { allowSuperadmin?: boolean }) {
+  return async (context: HookContext) => {
+    const decision = await resolveFindSqlScopeAccess(context, options);
+    if (decision.kind !== 'filter') return context;
+
+    (context.params as { _agorSqlBranchAccessUserId?: UUID })._agorSqlBranchAccessUserId =
+      decision.userId;
+    return context;
+  };
+}
+
+/**
  * Scope find() queries on session-scoped resources to the set of sessions
  * the caller can access (via their accessible branches).
  *
@@ -1611,6 +1656,22 @@ export function scopeFindToAccessibleBoards(
 
     if (decision.kind !== 'filter') return context;
     return intersectFindQuery(context, 'board_id', decision.accessibleIds);
+  };
+}
+
+/**
+ * Mark a boards.find() request for repository-level SQL board-visibility
+ * pushdown. Avoids resolving visible board ids into a large `board_id IN (...)`
+ * list before the service query runs.
+ */
+export function scopeFindToAccessibleBoardsSql(options?: { allowSuperadmin?: boolean }) {
+  return async (context: HookContext) => {
+    const decision = await resolveFindSqlScopeAccess(context, options);
+    if (decision.kind !== 'filter') return context;
+
+    (context.params as { _agorSqlBoardAccessUserId?: UUID })._agorSqlBoardAccessUserId =
+      decision.userId;
+    return context;
   };
 }
 

--- a/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
+++ b/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
@@ -18,6 +18,7 @@ import {
   scopeFindToAccessibleBranches,
   scopeFindToAccessibleBranchesSql,
   scopeFindToAccessibleSessions,
+  scopeFindToAccessibleSessionsSql,
 } from './branch-authorization';
 
 const USER_ID = 'user-aaaa-0001' as import('@agor/core/types').UUID;
@@ -260,6 +261,22 @@ describe('scopeFindToAccessibleBoardsSql', () => {
 
     expect((ctx.params as any)._agorSqlBoardAccessUserId).toBe(USER_ID);
     expect((ctx.params.query as any).board_id).toBe('board1');
+  });
+});
+
+describe('scopeFindToAccessibleSessionsSql', () => {
+  it('marks regular external callers for repository SQL session visibility pushdown', async () => {
+    const hook = scopeFindToAccessibleSessionsSql();
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { session_id: 's1' },
+    });
+
+    await hook(ctx);
+
+    expect((ctx.params as any)._agorSqlSessionAccessUserId).toBe(USER_ID);
+    expect((ctx.params.query as any).session_id).toBe('s1');
   });
 });
 

--- a/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
+++ b/apps/agor-daemon/src/utils/rbac-find-scoping.test.ts
@@ -14,7 +14,9 @@ import type { Branch, HookContext, Session } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  scopeFindToAccessibleBoardsSql,
   scopeFindToAccessibleBranches,
+  scopeFindToAccessibleBranchesSql,
   scopeFindToAccessibleSessions,
 } from './branch-authorization';
 
@@ -198,6 +200,66 @@ describe('scopeFindToAccessibleBranches', () => {
     expect(out.result).toBeUndefined();
     expect((ctx.params.query as any).branch_id).toBeUndefined();
     expect(repo.findAccessibleBranches).not.toHaveBeenCalled();
+  });
+});
+
+describe('scopeFindToAccessibleBranchesSql', () => {
+  it('marks regular external callers for repository SQL visibility pushdown', async () => {
+    const hook = scopeFindToAccessibleBranchesSql();
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { branch_id: 'wt1' },
+    });
+
+    await hook(ctx);
+
+    expect((ctx.params as any)._agorSqlBranchAccessUserId).toBe(USER_ID);
+    // The SQL path deliberately does not materialize/intersect ids in the hook;
+    // explicit filters are composed with visibility in the repository query.
+    expect((ctx.params.query as any).branch_id).toBe('wt1');
+  });
+
+  it('preserves superadmin and internal pass-through semantics', async () => {
+    const hook = scopeFindToAccessibleBranchesSql();
+    const superCtx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.SUPERADMIN },
+    });
+    const internalCtx = makeContext({ provider: undefined, user: undefined });
+
+    await hook(superCtx);
+    await hook(internalCtx);
+
+    expect((superCtx.params as any)._agorSqlBranchAccessUserId).toBeUndefined();
+    expect((internalCtx.params as any)._agorSqlBranchAccessUserId).toBeUndefined();
+  });
+
+  it('returns an empty find result for unauthenticated external callers', async () => {
+    const hook = scopeFindToAccessibleBranchesSql();
+    const ctx = makeContext({ provider: 'rest', user: undefined, query: { $limit: 25 } });
+
+    const out = await hook(ctx);
+
+    expect((out.result as any).data).toEqual([]);
+    expect((out.result as any).total).toBe(0);
+    expect((out.result as any).limit).toBe(25);
+  });
+});
+
+describe('scopeFindToAccessibleBoardsSql', () => {
+  it('marks regular external callers for repository SQL board visibility pushdown', async () => {
+    const hook = scopeFindToAccessibleBoardsSql();
+    const ctx = makeContext({
+      provider: 'rest',
+      user: { user_id: USER_ID, role: ROLES.MEMBER },
+      query: { board_id: 'board1' },
+    });
+
+    await hook(ctx);
+
+    expect((ctx.params as any)._agorSqlBoardAccessUserId).toBe(USER_ID);
+    expect((ctx.params.query as any).board_id).toBe('board1');
   });
 });
 

--- a/packages/core/src/db/repositories/artifacts.test.ts
+++ b/packages/core/src/db/repositories/artifacts.test.ts
@@ -13,6 +13,7 @@ import { ArtifactRepository } from './artifacts';
 import { BoardRepository } from './boards';
 import { BranchRepository } from './branches';
 import { RepoRepository } from './repos';
+import { UsersRepository } from './users';
 
 async function createBoard(db: Database): Promise<BoardID> {
   const board = await new BoardRepository(db).create({
@@ -23,7 +24,10 @@ async function createBoard(db: Database): Promise<BoardID> {
   return board.board_id as BoardID;
 }
 
-async function createBranch(db: Database): Promise<BranchID> {
+async function createBranch(
+  db: Database,
+  overrides?: { created_by?: UUID; others_can?: 'none' | 'view' | 'session' | 'prompt' | 'all' }
+): Promise<BranchID> {
   const repo = await new RepoRepository(db).create({
     repo_id: generateId() as UUID,
     slug: `repo-${generateId()}`,
@@ -40,7 +44,9 @@ async function createBranch(db: Database): Promise<BranchID> {
     ref: 'refs/heads/feature',
     branch_unique_id: 1,
     path: `/tmp/${generateId()}`,
-    created_by: 'test-user' as UUID,
+    created_by: overrides?.created_by ?? ('test-user' as UUID),
+    permission_source: 'override',
+    others_can: overrides?.others_can,
   });
   return branch.branch_id as BranchID;
 }
@@ -114,5 +120,43 @@ describe('ArtifactRepository.findAll', () => {
     await repo.create({ artifact_id: generateId(), board_id: board, name: 'a1' });
 
     expect(await repo.findAll({ branchIds: [] })).toEqual([]);
+  });
+
+  dbTest('pushes branch visibility directly into findAll SQL', async ({ db }) => {
+    const repo = new ArtifactRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const usersRepo = new UsersRepository(db);
+    const board = await createBoard(db);
+    const viewerId = generateId() as UUID;
+    await usersRepo.create({
+      user_id: viewerId,
+      email: 'artifact-visible-branch@example.com',
+      name: 'Artifact Viewer',
+    });
+    const visibleBranch = await createBranch(db, { others_can: 'none' });
+    const hiddenBranch = await createBranch(db, { others_can: 'none' });
+    await branchRepo.addOwner(visibleBranch, viewerId);
+
+    const visibleArtifact = await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      branch_id: visibleBranch,
+      name: 'visible',
+    });
+    await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      branch_id: hiddenBranch,
+      name: 'hidden',
+    });
+    await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      branch_id: null,
+      name: 'orphan',
+    });
+
+    const visible = await repo.findAll({ visibleToUserId: viewerId });
+    expect(visible.map((a) => a.artifact_id)).toEqual([visibleArtifact.artifact_id]);
   });
 });

--- a/packages/core/src/db/repositories/artifacts.test.ts
+++ b/packages/core/src/db/repositories/artifacts.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ArtifactRepository Tests
+ *
+ * Focused on the find filters that back the SQL pushdown on ArtifactsService.find.
+ */
+
+import type { BoardID, BranchID, UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { ArtifactRepository } from './artifacts';
+import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+
+async function createBoard(db: Database): Promise<BoardID> {
+  const board = await new BoardRepository(db).create({
+    board_id: generateId(),
+    name: `Board ${generateId()}`,
+    created_by: 'test-user',
+  });
+  return board.board_id as BoardID;
+}
+
+async function createBranch(db: Database): Promise<BranchID> {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId() as UUID,
+    slug: `repo-${generateId()}`,
+    name: 'Repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/tmp/${generateId()}`,
+    default_branch: 'main',
+  });
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId() as BranchID,
+    repo_id: repo.repo_id,
+    name: `branch-${generateId()}`,
+    ref: 'refs/heads/feature',
+    branch_unique_id: 1,
+    path: `/tmp/${generateId()}`,
+    created_by: 'test-user' as UUID,
+  });
+  return branch.branch_id as BranchID;
+}
+
+describe('ArtifactRepository.findAll', () => {
+  dbTest('filters by board_id', async ({ db }) => {
+    const repo = new ArtifactRepository(db);
+    const boardA = await createBoard(db);
+    const boardB = await createBoard(db);
+
+    await repo.create({ artifact_id: generateId(), board_id: boardA, name: 'a1' });
+    await repo.create({ artifact_id: generateId(), board_id: boardA, name: 'a2' });
+    await repo.create({ artifact_id: generateId(), board_id: boardB, name: 'b1' });
+
+    const onBoardA = await repo.findAll({ board_id: boardA });
+    expect(onBoardA.map((a) => a.name).sort()).toEqual(['a1', 'a2']);
+  });
+
+  dbTest('filters by exact archived state', async ({ db }) => {
+    const repo = new ArtifactRepository(db);
+    const board = await createBoard(db);
+
+    const active = await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      name: 'active',
+    });
+    const archived = await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      name: 'archived',
+    });
+    await repo.update(archived.artifact_id, { archived: true });
+
+    const activeOnly = await repo.findAll({ archived: false });
+    expect(activeOnly.map((a) => a.artifact_id)).toEqual([active.artifact_id]);
+  });
+
+  dbTest('restricts to a branchIds set and excludes null-branch orphans', async ({ db }) => {
+    const repo = new ArtifactRepository(db);
+    const board = await createBoard(db);
+    const branch1 = await createBranch(db);
+    const branch2 = await createBranch(db);
+
+    const onBranch1 = await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      branch_id: branch1,
+      name: 'on-branch1',
+    });
+    await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      branch_id: branch2,
+      name: 'on-branch2',
+    });
+    await repo.create({
+      artifact_id: generateId(),
+      board_id: board,
+      branch_id: null,
+      name: 'orphan',
+    });
+
+    const scoped = await repo.findAll({ branchIds: [branch1] });
+    expect(scoped.map((a) => a.artifact_id)).toEqual([onBranch1.artifact_id]);
+  });
+
+  dbTest('returns no rows for an empty branchIds set', async ({ db }) => {
+    const repo = new ArtifactRepository(db);
+    const board = await createBoard(db);
+    await repo.create({ artifact_id: generateId(), board_id: board, name: 'a1' });
+
+    expect(await repo.findAll({ branchIds: [] })).toEqual([]);
+  });
+});

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -32,6 +32,7 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
+import { visibleBranchReferenceAccessExists } from './branch-access';
 
 export class ArtifactRepository implements BaseRepository<Artifact, Partial<Artifact>> {
   constructor(private db: Database) {}
@@ -175,11 +176,16 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
    * @param filter.archived - Filter to an exact archived state
    * @param filter.branchIds - Restrict to a set of branch IDs (empty set yields
    *   no rows, matching an `{ $in: [] }` filter)
+   * @param filter.visibleToUserId - Restrict to artifacts whose branch is
+   *   visible to this user under branch RBAC, pushed down as a correlated SQL
+   *   EXISTS instead of a preloaded `branch_id IN (...)` list. Null-branch
+   *   artifacts are excluded, matching the existing RBAC find-hook behavior.
    */
   async findAll(filter?: {
     board_id?: BoardID;
     archived?: boolean;
     branchIds?: BranchID[];
+    visibleToUserId?: UUID;
   }): Promise<Artifact[]> {
     try {
       // An explicit empty id set can never match a row; short-circuit so we skip
@@ -197,6 +203,11 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
       }
       if (filter?.branchIds !== undefined) {
         conditions.push(inArray(artifacts.branch_id, filter.branchIds));
+      }
+      if (filter?.visibleToUserId) {
+        conditions.push(
+          visibleBranchReferenceAccessExists(this.db, filter.visibleToUserId, artifacts.branch_id)
+        );
       }
 
       const query = select(this.db).from(artifacts);

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -17,7 +17,7 @@ import type {
   SessionID,
   UUID,
 } from '@agor/core/types';
-import { and, eq, like, or } from 'drizzle-orm';
+import { and, eq, inArray, like, or } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
 import { getArtifactFullscreenUrl, getArtifactUrl } from '../../utils/url';
@@ -160,9 +160,48 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
     }
   }
 
-  async findAll(): Promise<Artifact[]> {
+  /**
+   * Find all artifacts (with optional filters).
+   *
+   * The `board_id`, `archived`, and `branchIds` filters let the list read path
+   * (`ArtifactsService.find`) push its high-selectivity predicates — including
+   * the accessible-branch set injected by RBAC scoping — into SQL so it no
+   * longer materializes the whole table before filtering in memory. Rows with a
+   * null `branch_id` (orphaned artifacts) are excluded by a `branchIds` filter,
+   * matching the in-memory `{ $in }` semantics.
+   *
+   * @param filter - Optional filters
+   * @param filter.board_id - Filter to a single board
+   * @param filter.archived - Filter to an exact archived state
+   * @param filter.branchIds - Restrict to a set of branch IDs (empty set yields
+   *   no rows, matching an `{ $in: [] }` filter)
+   */
+  async findAll(filter?: {
+    board_id?: BoardID;
+    archived?: boolean;
+    branchIds?: BranchID[];
+  }): Promise<Artifact[]> {
     try {
-      const rows = await select(this.db).from(artifacts).all();
+      // An explicit empty id set can never match a row; short-circuit so we skip
+      // the read entirely and avoid emitting an empty `IN ()` predicate.
+      if (filter?.branchIds !== undefined && filter.branchIds.length === 0) {
+        return [];
+      }
+
+      const conditions = [];
+      if (filter?.board_id) {
+        conditions.push(eq(artifacts.board_id, filter.board_id));
+      }
+      if (filter?.archived !== undefined) {
+        conditions.push(eq(artifacts.archived, filter.archived));
+      }
+      if (filter?.branchIds !== undefined) {
+        conditions.push(inArray(artifacts.branch_id, filter.branchIds));
+      }
+
+      const query = select(this.db).from(artifacts);
+      const rows =
+        conditions.length > 0 ? await query.where(and(...conditions)).all() : await query.all();
       const baseUrl = await getBaseUrl();
       return rows.map((row: ArtifactRow) => this.rowToArtifact(row, baseUrl));
     } catch (error) {

--- a/packages/core/src/db/repositories/board-comments.test.ts
+++ b/packages/core/src/db/repositories/board-comments.test.ts
@@ -6,12 +6,18 @@
  */
 
 import type { BoardComment, CommentID, UUID } from '@agor/core/types';
+import { MessageRole, SessionStatus, TaskStatus } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, shortId, toShortId } from '../../lib/ids';
 import { dbTest } from '../test-helpers';
 import { AmbiguousIdError, EntityNotFoundError, RepositoryError } from './base';
 import { BoardCommentsRepository } from './board-comments';
 import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { MessagesRepository } from './messages';
+import { RepoRepository } from './repos';
+import { SessionRepository } from './sessions';
+import { TaskRepository } from './tasks';
 
 /**
  * Create test comment data with required fields
@@ -32,6 +38,76 @@ function createCommentData(overrides?: Partial<BoardComment>): Partial<BoardComm
 /**
  * Create a test board (comments require a board FK)
  */
+
+async function createAttachedCommentTarget(
+  db: any,
+  boardId: UUID,
+  othersCan: 'view' | 'none',
+  suffix: string
+) {
+  const repoRepo = new RepoRepository(db);
+  const branchRepo = new BranchRepository(db);
+  const sessionRepo = new SessionRepository(db);
+  const taskRepo = new TaskRepository(db);
+  const messagesRepo = new MessagesRepository(db);
+
+  const gitRepo = await repoRepo.create({
+    repo_id: generateId(),
+    slug: `comment-rbac-repo-${suffix}-${Date.now()}`,
+    name: `Comment RBAC Repo ${suffix}`,
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/comment-rbac.git',
+    local_path: `/tmp/comment-rbac-${suffix}`,
+    default_branch: 'main',
+  });
+  const branch = await branchRepo.create({
+    branch_id: generateId(),
+    repo_id: gitRepo.repo_id,
+    name: `branch-${suffix}`,
+    ref: `branch-${suffix}`,
+    branch_unique_id: Math.floor(Math.random() * 1000000),
+    path: `/tmp/comment-rbac-${suffix}/branch`,
+    base_ref: 'main',
+    new_branch: false,
+    board_id: boardId,
+    created_by: generateId() as UUID,
+    permission_source: 'override',
+    others_can: othersCan,
+  });
+  const session = await sessionRepo.create({
+    session_id: generateId(),
+    branch_id: branch.branch_id,
+    agentic_tool: 'claude-code',
+    status: SessionStatus.IDLE,
+    created_by: generateId() as UUID,
+    git_state: { ref: 'main', base_sha: 'abc123', current_sha: 'def456' },
+  });
+  const task = await taskRepo.create({
+    task_id: generateId(),
+    session_id: session.session_id,
+    created_by: generateId() as UUID,
+    full_prompt: 'Test prompt',
+    status: TaskStatus.CREATED,
+    message_range: { start_index: 0, end_index: 0, start_timestamp: new Date().toISOString() },
+    tool_use_count: 0,
+    git_state: { ref_at_start: 'main', sha_at_start: 'abc123' },
+    model: 'claude-sonnet-4-6',
+  });
+  const message = await messagesRepo.create({
+    message_id: generateId(),
+    session_id: session.session_id,
+    task_id: task.task_id,
+    type: 'user',
+    role: MessageRole.USER,
+    index: 0,
+    timestamp: new Date().toISOString(),
+    content_preview: 'Test message',
+    content: 'Test message content',
+  });
+
+  return { branch, session, task, message };
+}
+
 async function createTestBoard(db: any, overrides?: { board_id?: UUID }) {
   const boardRepo = new BoardRepository(db);
   return boardRepo.create({
@@ -330,6 +406,94 @@ describe('BoardCommentsRepository.findAll', () => {
       expect(c.board_id).toBe(board1.board_id);
     }
   });
+
+  dbTest(
+    'should scope board and attached task/message comments with visibleToUserId',
+    async ({ db }) => {
+      const repo = new BoardCommentsRepository(db);
+      const userId = generateId() as UUID;
+      const privateBoard = await createTestBoard(db, { board_id: generateId() as UUID });
+      await new BoardRepository(db).update(privateBoard.board_id, { access_mode: 'private' });
+
+      const visibleTarget = await createAttachedCommentTarget(
+        db,
+        privateBoard.board_id,
+        'view',
+        'visible'
+      );
+      const hiddenTarget = await createAttachedCommentTarget(
+        db,
+        privateBoard.board_id,
+        'none',
+        'hidden'
+      );
+
+      const boardOnlyComment = await repo.create(
+        createCommentData({
+          board_id: privateBoard.board_id,
+          content: 'board-only visible via board',
+        })
+      );
+      const visibleTaskComment = await repo.create(
+        createCommentData({
+          board_id: privateBoard.board_id,
+          task_id: visibleTarget.task.task_id,
+          content: 'visible task comment',
+        })
+      );
+      const visibleMessageComment = await repo.create(
+        createCommentData({
+          board_id: privateBoard.board_id,
+          message_id: visibleTarget.message.message_id,
+          content: 'visible message comment',
+        })
+      );
+      await repo.create(
+        createCommentData({
+          board_id: privateBoard.board_id,
+          task_id: hiddenTarget.task.task_id,
+          content: 'hidden task comment',
+        })
+      );
+      await repo.create(
+        createCommentData({
+          board_id: privateBoard.board_id,
+          message_id: hiddenTarget.message.message_id,
+          content: 'hidden message comment',
+        })
+      );
+
+      const comments = await repo.findAll({
+        board_id: privateBoard.board_id,
+        visibleToUserId: userId,
+      });
+
+      expect(comments.map((comment) => comment.comment_id).sort()).toEqual(
+        [
+          boardOnlyComment.comment_id,
+          visibleTaskComment.comment_id,
+          visibleMessageComment.comment_id,
+        ].sort()
+      );
+      await expect(
+        repo.count({ board_id: privateBoard.board_id, visibleToUserId: userId })
+      ).resolves.toBe(3);
+
+      const isolatedPrivateBoard = await createTestBoard(db, { board_id: generateId() as UUID });
+      await new BoardRepository(db).update(isolatedPrivateBoard.board_id, {
+        access_mode: 'private',
+      });
+      await repo.create(
+        createCommentData({
+          board_id: isolatedPrivateBoard.board_id,
+          content: 'isolated board-only hidden',
+        })
+      );
+      await expect(
+        repo.count({ board_id: isolatedPrivateBoard.board_id, visibleToUserId: userId })
+      ).resolves.toBe(0);
+    }
+  );
 
   dbTest('should filter by null session_id', async ({ db }) => {
     const repo = new BoardCommentsRepository(db);

--- a/packages/core/src/db/repositories/board-comments.test.ts
+++ b/packages/core/src/db/repositories/board-comments.test.ts
@@ -492,6 +492,26 @@ describe('BoardCommentsRepository.findAll', () => {
       await expect(
         repo.count({ board_id: isolatedPrivateBoard.board_id, visibleToUserId: userId })
       ).resolves.toBe(0);
+
+      const reply = await repo.createReply(
+        visibleTaskComment.comment_id,
+        createCommentData({ content: 'visible reply inherits task attachment' })
+      );
+      const withReply = await repo.findAll({
+        board_id: privateBoard.board_id,
+        visibleToUserId: userId,
+      });
+      expect(withReply.map((comment) => comment.comment_id).sort()).toEqual(
+        [
+          boardOnlyComment.comment_id,
+          visibleTaskComment.comment_id,
+          visibleMessageComment.comment_id,
+          reply.comment_id,
+        ].sort()
+      );
+      await expect(
+        repo.count({ board_id: privateBoard.board_id, visibleToUserId: userId })
+      ).resolves.toBe(4);
     }
   );
 
@@ -1047,6 +1067,24 @@ describe('BoardCommentsRepository.createReply', () => {
     );
 
     expect(reply.board_id).toBe(board.board_id);
+  });
+
+  dbTest('should persist inherited attachments on replies', async ({ db }) => {
+    const repo = new BoardCommentsRepository(db);
+    const board = await createTestBoard(db);
+    const target = await createAttachedCommentTarget(db, board.board_id, 'view', 'reply-inherit');
+    const root = await repo.create(
+      createCommentData({
+        board_id: board.board_id,
+        task_id: target.task.task_id,
+        message_id: target.message.message_id,
+      })
+    );
+
+    const reply = await repo.createReply(root.comment_id, createCommentData({ content: 'Reply' }));
+
+    expect(reply.task_id).toBe(target.task.task_id);
+    expect(reply.message_id).toBe(target.message.message_id);
   });
 
   dbTest('should strip position from replies', async ({ db }) => {

--- a/packages/core/src/db/repositories/board-comments.ts
+++ b/packages/core/src/db/repositories/board-comments.ts
@@ -6,7 +6,7 @@
  */
 
 import type { BoardComment, CommentID, UUID } from '@agor/core/types';
-import { and, eq, isNull, like } from 'drizzle-orm';
+import { and, eq, isNotNull, isNull, like, or, type SQL, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
@@ -19,6 +19,13 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
+import {
+  visibleBoardReferenceAccessExists,
+  visibleBranchReferenceAccessExists,
+  visibleMessageReferenceAccessExists,
+  visibleSessionReferenceAccessExists,
+  visibleTaskReferenceAccessExists,
+} from './branch-access';
 
 /**
  * Generate content preview (first 200 chars)
@@ -172,63 +179,129 @@ export class BoardCommentsRepository
     }
   }
 
+  private buildFindConditions(filters?: {
+    board_id?: string;
+    session_id?: string | null;
+    task_id?: string | null;
+    message_id?: string | null;
+    branch_id?: string | null;
+    resolved?: boolean;
+    created_by?: string;
+    visibleToUserId?: UUID;
+  }): SQL[] {
+    const conditions: SQL[] = [];
+    if (filters?.board_id) {
+      conditions.push(eq(boardComments.board_id, filters.board_id));
+    }
+    if (filters?.session_id !== undefined) {
+      conditions.push(
+        filters.session_id === null
+          ? isNull(boardComments.session_id)
+          : eq(boardComments.session_id, filters.session_id)
+      );
+    }
+    if (filters?.task_id !== undefined) {
+      conditions.push(
+        filters.task_id === null
+          ? isNull(boardComments.task_id)
+          : eq(boardComments.task_id, filters.task_id)
+      );
+    }
+    if (filters?.message_id !== undefined) {
+      conditions.push(
+        filters.message_id === null
+          ? isNull(boardComments.message_id)
+          : eq(boardComments.message_id, filters.message_id)
+      );
+    }
+    if (filters?.branch_id !== undefined) {
+      conditions.push(
+        filters.branch_id === null
+          ? isNull(boardComments.branch_id)
+          : eq(boardComments.branch_id, filters.branch_id)
+      );
+    }
+    if (filters?.resolved !== undefined) {
+      conditions.push(eq(boardComments.resolved, filters.resolved));
+    }
+    if (filters?.created_by) {
+      conditions.push(eq(boardComments.created_by, filters.created_by));
+    }
+    if (filters?.visibleToUserId) {
+      conditions.push(this.buildVisibleToUserCondition(filters.visibleToUserId));
+    }
+    return conditions;
+  }
+
+  private buildVisibleToUserCondition(userId: UUID): SQL {
+    const hasAttachedResource = or(
+      isNotNull(boardComments.branch_id),
+      isNotNull(boardComments.session_id),
+      isNotNull(boardComments.task_id),
+      isNotNull(boardComments.message_id)
+    );
+
+    return (
+      and(
+        // If a specific resource is attached, every non-null attachment must be
+        // visible through its branch/session chain. We intentionally do not also
+        // require board visibility in that case: the attachment is the stronger,
+        // more specific access path.
+        or(
+          isNull(boardComments.branch_id),
+          visibleBranchReferenceAccessExists(this.db, userId, boardComments.branch_id)
+        ),
+        or(
+          isNull(boardComments.session_id),
+          visibleSessionReferenceAccessExists(this.db, userId, boardComments.session_id)
+        ),
+        or(
+          isNull(boardComments.task_id),
+          visibleTaskReferenceAccessExists(this.db, userId, boardComments.task_id)
+        ),
+        or(
+          isNull(boardComments.message_id),
+          visibleMessageReferenceAccessExists(this.db, userId, boardComments.message_id)
+        ),
+        // Pure board/spatial comments have no stronger attachment, so they
+        // inherit board visibility.
+        or(
+          hasAttachedResource,
+          visibleBoardReferenceAccessExists(this.db, userId, boardComments.board_id)
+        )
+      ) ?? sql`false`
+    );
+  }
+
   /**
    * Find all comments (optionally filtered by board, session, task, etc.)
    */
-  async findAll(filters?: {
-    board_id?: string;
-    session_id?: string;
-    task_id?: string;
-    message_id?: string;
-    branch_id?: string;
-    resolved?: boolean;
-    created_by?: string;
-  }): Promise<BoardComment[]> {
+  async findAll(
+    filters?: {
+      board_id?: string;
+      session_id?: string;
+      task_id?: string;
+      message_id?: string;
+      branch_id?: string;
+      resolved?: boolean;
+      created_by?: string;
+      visibleToUserId?: UUID;
+    },
+    options?: { limit?: number; offset?: number }
+  ): Promise<BoardComment[]> {
     try {
       let query = select(this.db).from(boardComments);
-
-      // Apply filters
-      const conditions = [];
-      if (filters?.board_id) {
-        conditions.push(eq(boardComments.board_id, filters.board_id));
-      }
-      if (filters?.session_id !== undefined) {
-        if (filters.session_id === null) {
-          conditions.push(isNull(boardComments.session_id));
-        } else {
-          conditions.push(eq(boardComments.session_id, filters.session_id));
-        }
-      }
-      if (filters?.task_id !== undefined) {
-        if (filters.task_id === null) {
-          conditions.push(isNull(boardComments.task_id));
-        } else {
-          conditions.push(eq(boardComments.task_id, filters.task_id));
-        }
-      }
-      if (filters?.message_id !== undefined) {
-        if (filters.message_id === null) {
-          conditions.push(isNull(boardComments.message_id));
-        } else {
-          conditions.push(eq(boardComments.message_id, filters.message_id));
-        }
-      }
-      if (filters?.branch_id !== undefined) {
-        if (filters.branch_id === null) {
-          conditions.push(isNull(boardComments.branch_id));
-        } else {
-          conditions.push(eq(boardComments.branch_id, filters.branch_id));
-        }
-      }
-      if (filters?.resolved !== undefined) {
-        conditions.push(eq(boardComments.resolved, filters.resolved));
-      }
-      if (filters?.created_by) {
-        conditions.push(eq(boardComments.created_by, filters.created_by));
-      }
+      const conditions = this.buildFindConditions(filters);
 
       if (conditions.length > 0) {
         query = query.where(and(...conditions)) as typeof query;
+      }
+
+      if (options?.limit !== undefined) {
+        query = query.limit(options.limit) as typeof query;
+      }
+      if (options?.offset !== undefined) {
+        query = query.offset(options.offset) as typeof query;
       }
 
       const rows = await query.all();
@@ -236,6 +309,30 @@ export class BoardCommentsRepository
     } catch (error) {
       throw new RepositoryError(
         `Failed to find comments: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  async count(filters?: {
+    board_id?: string;
+    session_id?: string | null;
+    task_id?: string | null;
+    message_id?: string | null;
+    branch_id?: string | null;
+    resolved?: boolean;
+    created_by?: string;
+    visibleToUserId?: UUID;
+  }): Promise<number> {
+    try {
+      const conditions = this.buildFindConditions(filters);
+      const query = select(this.db, { count: sql<number>`count(*)` }).from(boardComments);
+      const row =
+        conditions.length > 0 ? await query.where(and(...conditions)).one() : await query.one();
+      return Number(row?.count ?? 0);
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to count comments: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }

--- a/packages/core/src/db/repositories/board-comments.ts
+++ b/packages/core/src/db/repositories/board-comments.ts
@@ -571,11 +571,12 @@ export class BoardCommentsRepository
         ...data,
         parent_comment_id: parent.comment_id,
         board_id: parent.board_id, // Inherit board_id from parent
-        // Replies don't have attachments - they inherit context from parent
-        session_id: undefined,
-        task_id: undefined,
-        message_id: undefined,
-        branch_id: undefined,
+        // Persist inherited attachments so replies remain visible through the
+        // same branch/session/task/message access path as the thread root.
+        session_id: parent.session_id,
+        task_id: parent.task_id,
+        message_id: parent.message_id,
+        branch_id: parent.branch_id,
         position: undefined,
       };
 

--- a/packages/core/src/db/repositories/board-objects.test.ts
+++ b/packages/core/src/db/repositories/board-objects.test.ts
@@ -54,17 +54,101 @@ function createBranchData(overrides?: { branch_id?: BranchID; repo_id?: UUID; na
 /**
  * Create test board
  */
-async function createBoard(db: Database, overrides?: { board_id?: BoardID; name?: string }) {
+async function createBoard(
+  db: Database,
+  overrides?: { board_id?: BoardID; name?: string; access_mode?: 'private' | 'shared' }
+) {
   const boardId = (overrides?.board_id ?? generateId()) as BoardID;
   await (db as any).insert(boards).values({
     board_id: boardId,
     created_at: new Date(),
     created_by: 'test-user',
     name: overrides?.name ?? 'Test Board',
-    data: {},
+    data: { access_mode: overrides?.access_mode ?? 'shared' },
   });
   return boardId;
 }
+
+// ============================================================================
+// RBAC visibility
+// ============================================================================
+
+describe('BoardObjectRepository.findVisibleToUser', () => {
+  dbTest(
+    'should require board visibility for loose objects but branch visibility for branch objects',
+    async ({ db }) => {
+      const repoRepo = new RepoRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const boRepo = new BoardObjectRepository(db);
+      const userId = generateId() as UUID;
+      const privateBoardId = await createBoard(db, {
+        name: 'Private Board',
+        access_mode: 'private',
+      });
+
+      const gitRepo = await repoRepo.create(
+        createRepoData({ slug: `board-object-rbac-${Date.now()}` })
+      );
+      const visibleBranch = await branchRepo.create({
+        ...createBranchData({ repo_id: gitRepo.repo_id, name: 'visible-branch' }),
+        board_id: privateBoardId,
+        permission_source: 'override',
+        others_can: 'view',
+      });
+      const hiddenBranch = await branchRepo.create({
+        ...createBranchData({ repo_id: gitRepo.repo_id, name: 'hidden-branch' }),
+        branch_unique_id: 2,
+        board_id: privateBoardId,
+        permission_source: 'override',
+        others_can: 'none',
+      });
+
+      const looseObjectId = generateId();
+      await (db as any).insert(boardObjects).values({
+        object_id: looseObjectId,
+        board_id: privateBoardId,
+        branch_id: null,
+        card_id: null,
+        created_at: new Date(),
+        data: { position: { x: 0, y: 0 } },
+      });
+      const visibleBranchObject = await boRepo.create({
+        board_id: privateBoardId,
+        branch_id: visibleBranch.branch_id,
+        position: { x: 100, y: 100 },
+      });
+      await boRepo.create({
+        board_id: privateBoardId,
+        branch_id: hiddenBranch.branch_id,
+        position: { x: 200, y: 200 },
+      });
+
+      const visible = await boRepo.findVisibleToUser(userId, { board_id: privateBoardId });
+      expect(visible.map((object) => object.object_id).sort()).toEqual(
+        [looseObjectId, visibleBranchObject.object_id].sort()
+      );
+      await expect(boRepo.countVisibleToUser(userId, { board_id: privateBoardId })).resolves.toBe(
+        2
+      );
+
+      const isolatedPrivateBoardId = await createBoard(db, {
+        name: 'Isolated Private Board',
+        access_mode: 'private',
+      });
+      await (db as any).insert(boardObjects).values({
+        object_id: generateId(),
+        board_id: isolatedPrivateBoardId,
+        branch_id: null,
+        card_id: null,
+        created_at: new Date(),
+        data: { position: { x: 0, y: 0 } },
+      });
+      await expect(
+        boRepo.countVisibleToUser(userId, { board_id: isolatedPrivateBoardId })
+      ).resolves.toBe(0);
+    }
+  );
+});
 
 // ============================================================================
 // Create

--- a/packages/core/src/db/repositories/board-objects.ts
+++ b/packages/core/src/db/repositories/board-objects.ts
@@ -26,7 +26,7 @@ import {
   branchOwners,
 } from '../schema';
 import { EntityNotFoundError, RepositoryError } from './base';
-import { visibleBranchAccessCondition } from './branch-access';
+import { visibleBoardReferenceAccessExists, visibleBranchAccessCondition } from './branch-access';
 
 export interface BoardObjectFindFilters {
   board_id?: BoardID;
@@ -75,8 +75,13 @@ export class BoardObjectRepository {
 
   private buildVisibleToUserCondition(userId: UUID): SQL {
     return (
-      or(isNull(boardObjects.branch_id), visibleBranchAccessCondition(this.db, userId)) ??
-      sql`false`
+      or(
+        and(isNotNull(boardObjects.branch_id), visibleBranchAccessCondition(this.db, userId)),
+        and(
+          isNull(boardObjects.branch_id),
+          visibleBoardReferenceAccessExists(this.db, userId, boardObjects.board_id)
+        )
+      ) ?? sql`false`
     );
   }
 

--- a/packages/core/src/db/repositories/boards.test.ts
+++ b/packages/core/src/db/repositories/boards.test.ts
@@ -5,7 +5,7 @@
  * board object management (zones/text), and JSON field handling.
  */
 
-import type { Board, BoardObject, UUID } from '@agor/core/types';
+import type { Board, BoardID, BoardObject, UUID } from '@agor/core/types';
 import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
 import { generateId, shortId, toShortId } from '../../lib/ids';
@@ -540,6 +540,40 @@ describe('BoardRepository.findAll', () => {
     expect(found.color).toBe('#1677ff');
     expect(found.created_at).toBeDefined();
     expect(found.last_updated).toBeDefined();
+  });
+
+  dbTest('should filter by exact archived state', async ({ db }) => {
+    const repo = new BoardRepository(db);
+
+    const active = await repo.create(createBoardData({ name: 'Active', slug: 'active' }));
+    const archived = await repo.create(createBoardData({ name: 'Archived', slug: 'archived' }));
+    await repo.update(archived.board_id, { archived: true });
+
+    const activeOnly = await repo.findAll({ archived: false });
+    expect(activeOnly.map((b) => b.board_id)).toEqual([active.board_id]);
+
+    const archivedOnly = await repo.findAll({ archived: true });
+    expect(archivedOnly.map((b) => b.board_id)).toEqual([archived.board_id]);
+  });
+
+  dbTest('should restrict to an explicit boardIds set', async ({ db }) => {
+    const repo = new BoardRepository(db);
+
+    const b1 = await repo.create(createBoardData({ name: 'B1', slug: 'b1' }));
+    const b2 = await repo.create(createBoardData({ name: 'B2', slug: 'b2' }));
+    await repo.create(createBoardData({ name: 'B3', slug: 'b3' }));
+
+    const scoped = await repo.findAll({
+      boardIds: [b1.board_id as BoardID, b2.board_id as BoardID],
+    });
+    expect(scoped.map((b) => b.name).sort()).toEqual(['B1', 'B2']);
+  });
+
+  dbTest('should return no rows for an empty boardIds set', async ({ db }) => {
+    const repo = new BoardRepository(db);
+    await repo.create(createBoardData({ name: 'B1', slug: 'b1' }));
+
+    expect(await repo.findAll({ boardIds: [] })).toEqual([]);
   });
 });
 

--- a/packages/core/src/db/repositories/boards.test.ts
+++ b/packages/core/src/db/repositories/boards.test.ts
@@ -575,6 +575,31 @@ describe('BoardRepository.findAll', () => {
 
     expect(await repo.findAll({ boardIds: [] })).toEqual([]);
   });
+
+  dbTest('should push board visibility directly into findAll SQL', async ({ db }) => {
+    const repo = new BoardRepository(db);
+    const viewerId = generateId() as UUID;
+
+    const ownedPrivate = await repo.create(
+      createBoardData({
+        name: 'Owned private',
+        slug: 'owned-private',
+        access_mode: 'private',
+        created_by: viewerId,
+      })
+    );
+    await repo.create(
+      createBoardData({
+        name: 'Other private',
+        slug: 'other-private',
+        access_mode: 'private',
+        created_by: generateId() as UUID,
+      })
+    );
+
+    const visible = await repo.findAll({ visibleToUserId: viewerId });
+    expect(visible.map((b) => b.board_id)).toEqual([ownedPrivate.board_id]);
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -15,7 +15,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { isAssistant } from '@agor/core/types';
-import { and, eq, exists, inArray, isNull, like, ne, or, sql } from 'drizzle-orm';
+import { and, eq, exists, inArray, isNull, like, ne, or, type SQL, sql } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
@@ -332,17 +332,74 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   /**
    * Find all boards (with optional filters).
    *
-   * The `board_id` and `archived` filters let the list read path
-   * (`BoardsService.find`) push its high-selectivity predicates — including the
-   * accessible-id set injected by RBAC scoping — into SQL so it no longer
-   * materializes the whole table before filtering in memory.
+   * The `board_id`, `archived`, and `visibleToUserId` filters let the list read
+   * path (`BoardsService.find`) push high-selectivity predicates — including
+   * board RBAC visibility — into SQL so it no longer materializes the whole
+   * table before filtering in memory.
    *
    * @param filter - Optional filters
    * @param filter.archived - Filter to an exact archived state
    * @param filter.boardIds - Restrict to a set of board IDs (empty set yields no
    *   rows, matching an `{ $in: [] }` filter)
+   * @param filter.visibleToUserId - Restrict to boards visible to this user
+   *   under branch RBAC.
    */
-  async findAll(filter?: { archived?: boolean; boardIds?: BoardID[] }): Promise<Board[]> {
+  private visibleBoardCondition(userId: UUID): SQL {
+    // Raw drizzle builder for the EXISTS subqueries — `exists()` expects a
+    // drizzle SelectQueryBuilder, not the cross-dialect wrapper shape, and
+    // the subqueries don't need `.all()` / `.one()` execution methods.
+    const accessibleBranchExists = exists(
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+      (this.db as any)
+        .select({ _: sql`1` })
+        .from(branches)
+        .leftJoin(
+          branchOwners,
+          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+        )
+        .where(
+          and(eq(branches.board_id, boards.board_id), visibleBranchAccessCondition(this.db, userId))
+        )
+    );
+    const accessiblePrimaryAssistantExists = exists(
+      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+      (this.db as any)
+        .select({ _: sql`1` })
+        .from(branches)
+        .leftJoin(
+          branchOwners,
+          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+        )
+        .where(
+          and(
+            eq(branches.branch_id, boards.primary_assistant_id),
+            visibleBranchAccessCondition(this.db, userId)
+          )
+        )
+    );
+
+    return (
+      or(
+        eq(boards.created_by, userId),
+        exists(
+          // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+          (this.db as any)
+            .select({ _: sql`1` })
+            .from(boardOwners)
+            .where(and(eq(boardOwners.board_id, boards.board_id), eq(boardOwners.user_id, userId)))
+        ),
+        sql`coalesce(${jsonExtract(this.db, boards.data, 'access_mode')}, 'shared') = 'shared'`,
+        accessibleBranchExists,
+        accessiblePrimaryAssistantExists
+      ) ?? sql`false`
+    );
+  }
+
+  async findAll(filter?: {
+    archived?: boolean;
+    boardIds?: BoardID[];
+    visibleToUserId?: UUID;
+  }): Promise<Board[]> {
     try {
       // An explicit empty id set can never match a row; short-circuit so we skip
       // the read entirely and avoid emitting an empty `IN ()` predicate.
@@ -356,6 +413,9 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       }
       if (filter?.boardIds !== undefined) {
         conditions.push(inArray(boards.board_id, filter.boardIds));
+      }
+      if (filter?.visibleToUserId) {
+        conditions.push(this.visibleBoardCondition(filter.visibleToUserId));
       }
 
       const baseUrl = await getBaseUrl();
@@ -393,57 +453,9 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
    * @returns Array of board ids the user can see
    */
   async findVisibleBoardIds(userId: UUID): Promise<string[]> {
-    // Raw drizzle builder for the EXISTS subquery — `exists()` expects a
-    // drizzle SelectQueryBuilder, not the cross-dialect wrapper shape, and
-    // the subquery doesn't need `.all()` / `.one()` execution methods.
-    const accessibleBranchExists = exists(
-      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
-      (this.db as any)
-        .select({ _: sql`1` })
-        .from(branches)
-        .leftJoin(
-          branchOwners,
-          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
-        )
-        .where(
-          and(eq(branches.board_id, boards.board_id), visibleBranchAccessCondition(this.db, userId))
-        )
-    );
-    const accessiblePrimaryAssistantExists = exists(
-      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
-      (this.db as any)
-        .select({ _: sql`1` })
-        .from(branches)
-        .leftJoin(
-          branchOwners,
-          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
-        )
-        .where(
-          and(
-            eq(branches.branch_id, boards.primary_assistant_id),
-            visibleBranchAccessCondition(this.db, userId)
-          )
-        )
-    );
     const rows = await select(this.db, { board_id: boards.board_id })
       .from(boards)
-      .where(
-        or(
-          eq(boards.created_by, userId),
-          exists(
-            // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
-            (this.db as any)
-              .select({ _: sql`1` })
-              .from(boardOwners)
-              .where(
-                and(eq(boardOwners.board_id, boards.board_id), eq(boardOwners.user_id, userId))
-              )
-          ),
-          sql`coalesce(${jsonExtract(this.db, boards.data, 'access_mode')}, 'shared') = 'shared'`,
-          accessibleBranchExists,
-          accessiblePrimaryAssistantExists
-        )
-      )
+      .where(this.visibleBoardCondition(userId))
       .all();
     return rows.map((r: { board_id: string }) => r.board_id);
   }

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -15,7 +15,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { isAssistant } from '@agor/core/types';
-import { and, eq, exists, inArray, isNull, like, ne, or, type SQL, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNull, like, ne, type SQL } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
@@ -23,15 +23,13 @@ import { generateSlug } from '../../lib/slugs';
 import { normalizeExactEmojiShortcode } from '../../utils/emoji-shortcodes';
 import { getBoardUrl } from '../../utils/url';
 import type { Database } from '../client';
-import { deleteFrom, insert, jsonExtract, select, update } from '../database-wrapper';
+import { deleteFrom, insert, select, update } from '../database-wrapper';
 import {
   type BoardInsert,
   type BoardRow,
   boardGroupGrants,
   boardOwners,
   boards,
-  branches,
-  branchOwners,
   groupMemberships,
   groups,
 } from '../schema';
@@ -43,7 +41,7 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
-import { visibleBranchAccessCondition } from './branch-access';
+import { visibleBoardAccessCondition } from './branch-access';
 import { BranchRepository } from './branches';
 
 const BOARD_ACCESS_MODES = ['private', 'shared'] as const;
@@ -345,54 +343,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
    *   under branch RBAC.
    */
   private visibleBoardCondition(userId: UUID): SQL {
-    // Raw drizzle builder for the EXISTS subqueries — `exists()` expects a
-    // drizzle SelectQueryBuilder, not the cross-dialect wrapper shape, and
-    // the subqueries don't need `.all()` / `.one()` execution methods.
-    const accessibleBranchExists = exists(
-      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
-      (this.db as any)
-        .select({ _: sql`1` })
-        .from(branches)
-        .leftJoin(
-          branchOwners,
-          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
-        )
-        .where(
-          and(eq(branches.board_id, boards.board_id), visibleBranchAccessCondition(this.db, userId))
-        )
-    );
-    const accessiblePrimaryAssistantExists = exists(
-      // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
-      (this.db as any)
-        .select({ _: sql`1` })
-        .from(branches)
-        .leftJoin(
-          branchOwners,
-          and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
-        )
-        .where(
-          and(
-            eq(branches.branch_id, boards.primary_assistant_id),
-            visibleBranchAccessCondition(this.db, userId)
-          )
-        )
-    );
-
-    return (
-      or(
-        eq(boards.created_by, userId),
-        exists(
-          // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
-          (this.db as any)
-            .select({ _: sql`1` })
-            .from(boardOwners)
-            .where(and(eq(boardOwners.board_id, boards.board_id), eq(boardOwners.user_id, userId)))
-        ),
-        sql`coalesce(${jsonExtract(this.db, boards.data, 'access_mode')}, 'shared') = 'shared'`,
-        accessibleBranchExists,
-        accessiblePrimaryAssistantExists
-      ) ?? sql`false`
-    );
+    return visibleBoardAccessCondition(this.db, userId);
   }
 
   async findAll(filter?: {

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -8,13 +8,14 @@ import type {
   Board,
   BoardAccessMode,
   BoardExportBlob,
+  BoardID,
   BoardObject,
   Branch,
   BranchPermissionLevel,
   UUID,
 } from '@agor/core/types';
 import { isAssistant } from '@agor/core/types';
-import { and, eq, exists, isNull, like, ne, or, sql } from 'drizzle-orm';
+import { and, eq, exists, inArray, isNull, like, ne, or, sql } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
@@ -329,12 +330,38 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   }
 
   /**
-   * Find all boards
+   * Find all boards (with optional filters).
+   *
+   * The `board_id` and `archived` filters let the list read path
+   * (`BoardsService.find`) push its high-selectivity predicates — including the
+   * accessible-id set injected by RBAC scoping — into SQL so it no longer
+   * materializes the whole table before filtering in memory.
+   *
+   * @param filter - Optional filters
+   * @param filter.archived - Filter to an exact archived state
+   * @param filter.boardIds - Restrict to a set of board IDs (empty set yields no
+   *   rows, matching an `{ $in: [] }` filter)
    */
-  async findAll(): Promise<Board[]> {
+  async findAll(filter?: { archived?: boolean; boardIds?: BoardID[] }): Promise<Board[]> {
     try {
+      // An explicit empty id set can never match a row; short-circuit so we skip
+      // the read entirely and avoid emitting an empty `IN ()` predicate.
+      if (filter?.boardIds !== undefined && filter.boardIds.length === 0) {
+        return [];
+      }
+
+      const conditions = [];
+      if (filter?.archived !== undefined) {
+        conditions.push(eq(boards.archived, filter.archived));
+      }
+      if (filter?.boardIds !== undefined) {
+        conditions.push(inArray(boards.board_id, filter.boardIds));
+      }
+
       const baseUrl = await getBaseUrl();
-      const rows = await select(this.db).from(boards).all();
+      const query = select(this.db).from(boards);
+      const rows =
+        conditions.length > 0 ? await query.where(and(...conditions)).all() : await query.all();
       return rows.map((row: BoardRow) => this.rowToBoard(row, baseUrl));
     } catch (error) {
       throw new RepositoryError(

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -25,6 +25,7 @@ import {
   branchOwners,
   groupMemberships,
   groups,
+  sessions,
 } from '../schema';
 
 export const VISIBLE_BRANCH_PERMISSION_LEVELS = BRANCH_PERMISSION_LEVELS.filter(
@@ -169,5 +170,32 @@ export function visibleBranchReferenceAccessExists(
         and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
       )
       .where(and(eq(branches.branch_id, branchId), visibleBranchAccessCondition(db, userId)))
+  );
+}
+
+/**
+ * Correlated visibility predicate for tables that carry a session_id.
+ *
+ * The referenced session is visible when its branch is visible to the user.
+ * This avoids resolving all accessible sessions into `session_id IN (...)` and
+ * works for high-cardinality child tables such as messages and tasks.
+ */
+export function visibleSessionReferenceAccessExists(
+  db: Database,
+  userId: UUID,
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle's eq accepts columns/SQL wrappers across dialects
+  sessionId: any
+): SQL {
+  return exists(
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+    (db as any)
+      .select({ _: sql`1` })
+      .from(sessions)
+      .innerJoin(branches, eq(sessions.branch_id, branches.branch_id))
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(and(eq(sessions.session_id, sessionId), visibleBranchAccessCondition(db, userId)))
   );
 }

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -144,3 +144,30 @@ export function visibleBranchAccessCondition(db: Database, userId: UUID): SQL {
     ) ?? sql`false`
   );
 }
+
+/**
+ * Correlated branch-visibility predicate for tables that carry a branch_id.
+ *
+ * This is the SQL-pushdown equivalent of resolving all accessible branch ids
+ * first and applying `branch_id IN (...)`, but it avoids hydrating branch rows
+ * and avoids very large parameter lists. The `branchId` expression is normally
+ * a column from the outer query (for example `artifacts.branch_id`).
+ */
+export function visibleBranchReferenceAccessExists(
+  db: Database,
+  userId: UUID,
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle's eq accepts columns/SQL wrappers across dialects
+  branchId: any
+): SQL {
+  return exists(
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+    (db as any)
+      .select({ _: sql`1` })
+      .from(branches)
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(and(eq(branches.branch_id, branchId), visibleBranchAccessCondition(db, userId)))
+  );
+}

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -25,7 +25,9 @@ import {
   branchOwners,
   groupMemberships,
   groups,
+  messages,
   sessions,
+  tasks,
 } from '../schema';
 
 export const VISIBLE_BRANCH_PERMISSION_LEVELS = BRANCH_PERMISSION_LEVELS.filter(
@@ -147,6 +149,76 @@ export function visibleBranchAccessCondition(db: Database, userId: UUID): SQL {
 }
 
 /**
+ * Board visibility predicate correlated against the `boards` table in scope.
+ *
+ * A board is visible if the user owns it, is an explicit board owner, the board
+ * is shared, or at least one of its branches / primary assistant branch is
+ * visible through the branch RBAC predicate. All branch-derived checks are
+ * EXISTS-based so the outer row is never multiplied and no DISTINCT is needed.
+ */
+export function visibleBoardAccessCondition(db: Database, userId: UUID): SQL {
+  const accessibleBranchExists = exists(
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+    (db as any)
+      .select({ _: sql`1` })
+      .from(branches)
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(and(eq(branches.board_id, boards.board_id), visibleBranchAccessCondition(db, userId)))
+  );
+  const accessiblePrimaryAssistantExists = exists(
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+    (db as any)
+      .select({ _: sql`1` })
+      .from(branches)
+      .leftJoin(
+        branchOwners,
+        and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
+      )
+      .where(
+        and(
+          eq(branches.branch_id, boards.primary_assistant_id),
+          visibleBranchAccessCondition(db, userId)
+        )
+      )
+  );
+
+  return (
+    or(
+      eq(boards.created_by, userId),
+      exists(
+        // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+        (db as any)
+          .select({ _: sql`1` })
+          .from(boardOwners)
+          .where(and(eq(boardOwners.board_id, boards.board_id), eq(boardOwners.user_id, userId)))
+      ),
+      eq(sql`coalesce(${jsonExtract(db, boards.data, 'access_mode')}, 'shared')`, 'shared'),
+      accessibleBranchExists,
+      accessiblePrimaryAssistantExists
+    ) ?? sql`false`
+  );
+}
+
+/** Correlated board-visibility predicate for tables that carry a board_id. */
+export function visibleBoardReferenceAccessExists(
+  db: Database,
+  userId: UUID,
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle's eq accepts columns/SQL wrappers across dialects
+  boardId: any
+): SQL {
+  return exists(
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+    (db as any)
+      .select({ _: sql`1` })
+      .from(boards)
+      .where(and(eq(boards.board_id, boardId), visibleBoardAccessCondition(db, userId)))
+  );
+}
+
+/**
  * Correlated branch-visibility predicate for tables that carry a branch_id.
  *
  * This is the SQL-pushdown equivalent of resolving all accessible branch ids
@@ -197,5 +269,47 @@ export function visibleSessionReferenceAccessExists(
         and(eq(branchOwners.branch_id, branches.branch_id), eq(branchOwners.user_id, userId))
       )
       .where(and(eq(sessions.session_id, sessionId), visibleBranchAccessCondition(db, userId)))
+  );
+}
+
+/** Correlated visibility predicate for tables that carry a task_id. */
+export function visibleTaskReferenceAccessExists(
+  db: Database,
+  userId: UUID,
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle's eq accepts columns/SQL wrappers across dialects
+  taskId: any
+): SQL {
+  return exists(
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+    (db as any)
+      .select({ _: sql`1` })
+      .from(tasks)
+      .where(
+        and(
+          eq(tasks.task_id, taskId),
+          visibleSessionReferenceAccessExists(db, userId, tasks.session_id)
+        )
+      )
+  );
+}
+
+/** Correlated visibility predicate for tables that carry a message_id. */
+export function visibleMessageReferenceAccessExists(
+  db: Database,
+  userId: UUID,
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle's eq accepts columns/SQL wrappers across dialects
+  messageId: any
+): SQL {
+  return exists(
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle select has complex cross-dialect overloads
+    (db as any)
+      .select({ _: sql`1` })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.message_id, messageId),
+          visibleSessionReferenceAccessExists(db, userId, messages.session_id)
+        )
+      )
   );
 }

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -4,7 +4,7 @@
  * Tests for type-safe CRUD operations on branches with short ID support.
  */
 
-import type { BranchID, UUID } from '@agor/core/types';
+import type { BoardID, BranchID, UUID } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, shortId } from '../../lib/ids';
 import { boards } from '../schema';
@@ -502,6 +502,89 @@ describe('BranchRepository.findAll', () => {
 
     const filtered = await wtRepo.findAll({ repo_id: generateId() });
     expect(filtered).toEqual([]);
+  });
+
+  dbTest('should filter by board_id', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const wtRepo = new BranchRepository(db);
+
+    const repo = await repoRepo.create(createRepoData());
+    const boardA = generateId() as UUID;
+    const boardB = generateId() as UUID;
+    for (const boardId of [boardA, boardB]) {
+      await (db as any).insert(boards).values({
+        board_id: boardId,
+        created_at: new Date(),
+        created_by: 'test-user' as UUID,
+        name: 'Board',
+        data: {},
+      });
+    }
+
+    await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'a1', branch_unique_id: 1, board_id: boardA })
+    );
+    await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'a2', branch_unique_id: 2, board_id: boardA })
+    );
+    await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'b1', branch_unique_id: 3, board_id: boardB })
+    );
+
+    const boardABranches = await wtRepo.findAll({ board_id: boardA as BoardID });
+    expect(boardABranches.map((w) => w.name).sort()).toEqual(['a1', 'a2']);
+    expect(boardABranches.every((w) => w.board_id === boardA)).toBe(true);
+  });
+
+  dbTest('should filter by exact archived state', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const wtRepo = new BranchRepository(db);
+
+    const repo = await repoRepo.create(createRepoData());
+    const active = await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'active', branch_unique_id: 1 })
+    );
+    const archived = await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'archived', branch_unique_id: 2 })
+    );
+    await wtRepo.update(archived.branch_id, { archived: true });
+
+    const activeOnly = await wtRepo.findAll({ archived: false });
+    expect(activeOnly.map((w) => w.branch_id)).toEqual([active.branch_id]);
+
+    const archivedOnly = await wtRepo.findAll({ archived: true });
+    expect(archivedOnly.map((w) => w.branch_id)).toEqual([archived.branch_id]);
+  });
+
+  dbTest('should restrict to an explicit branchIds set', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const wtRepo = new BranchRepository(db);
+
+    const repo = await repoRepo.create(createRepoData());
+    const b1 = await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'b1', branch_unique_id: 1 })
+    );
+    const b2 = await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'b2', branch_unique_id: 2 })
+    );
+    await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'b3', branch_unique_id: 3 })
+    );
+
+    const scoped = await wtRepo.findAll({ branchIds: [b1.branch_id, b2.branch_id] });
+    expect(scoped.map((w) => w.name).sort()).toEqual(['b1', 'b2']);
+  });
+
+  dbTest('should return no rows for an empty branchIds set', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const wtRepo = new BranchRepository(db);
+
+    const repo = await repoRepo.create(createRepoData());
+    await wtRepo.create(
+      createBranchData({ repo_id: repo.repo_id, name: 'b1', branch_unique_id: 1 })
+    );
+
+    expect(await wtRepo.findAll({ branchIds: [] })).toEqual([]);
   });
 });
 

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -586,6 +586,42 @@ describe('BranchRepository.findAll', () => {
 
     expect(await wtRepo.findAll({ branchIds: [] })).toEqual([]);
   });
+
+  dbTest('should push branch visibility directly into findAll SQL', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const wtRepo = new BranchRepository(db);
+    const usersRepo = new UsersRepository(db);
+    const viewerId = generateId() as UUID;
+    await usersRepo.create({
+      user_id: viewerId,
+      email: 'findall-visible-branch@example.com',
+      name: 'Visible Branch Viewer',
+    });
+
+    const repo = await repoRepo.create(createRepoData());
+    const ownedPrivate = await wtRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        name: 'owned-private',
+        branch_unique_id: 1,
+        permission_source: 'override',
+        others_can: 'none',
+      })
+    );
+    await wtRepo.addOwner(ownedPrivate.branch_id, viewerId);
+    await wtRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        name: 'other-private',
+        branch_unique_id: 2,
+        permission_source: 'override',
+        others_can: 'none',
+      })
+    );
+
+    const visible = await wtRepo.findAll({ visibleToUserId: viewerId });
+    expect(visible.map((w) => w.name)).toEqual(['owned-private']);
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -337,11 +337,32 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
    * Callers that explicitly want to exclude archived branches should pass
    * `{ includeArchived: false }`.
    *
-   * @param filter - Optional filters (repo_id, includeArchived)
+   * The `board_id`, `archived`, and `branchIds` filters let the list read path
+   * (`BranchesService.find`) push its high-selectivity predicates into SQL so it
+   * no longer materializes the whole table before filtering in memory.
+   *
+   * @param filter - Optional filters
    * @param filter.repo_id - Filter by repository ID
    * @param filter.includeArchived - Include archived branches (default: true)
+   * @param filter.board_id - Filter to a single board
+   * @param filter.archived - Filter to an exact archived state (takes precedence
+   *   over `includeArchived`)
+   * @param filter.branchIds - Restrict to a set of branch IDs (empty set yields
+   *   no rows, matching an `{ $in: [] }` filter)
    */
-  async findAll(filter?: { repo_id?: UUID; includeArchived?: boolean }): Promise<Branch[]> {
+  async findAll(filter?: {
+    repo_id?: UUID;
+    includeArchived?: boolean;
+    board_id?: BoardID;
+    archived?: boolean;
+    branchIds?: BranchID[];
+  }): Promise<Branch[]> {
+    // An explicit empty id set can never match a row; short-circuit so we skip
+    // the read entirely and avoid emitting an empty `IN ()` predicate.
+    if (filter?.branchIds !== undefined && filter.branchIds.length === 0) {
+      return [];
+    }
+
     const includeArchived = filter?.includeArchived ?? true;
 
     // Build where conditions
@@ -349,8 +370,16 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     if (filter?.repo_id) {
       conditions.push(eq(branches.repo_id, filter.repo_id));
     }
-    if (!includeArchived) {
+    if (filter?.board_id) {
+      conditions.push(eq(branches.board_id, filter.board_id));
+    }
+    if (filter?.archived !== undefined) {
+      conditions.push(eq(branches.archived, filter.archived));
+    } else if (!includeArchived) {
       conditions.push(eq(branches.archived, false));
+    }
+    if (filter?.branchIds !== undefined) {
+      conditions.push(inArray(branches.branch_id, filter.branchIds));
     }
 
     const query = select(this.db).from(branches);

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -349,6 +349,9 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
    *   over `includeArchived`)
    * @param filter.branchIds - Restrict to a set of branch IDs (empty set yields
    *   no rows, matching an `{ $in: [] }` filter)
+   * @param filter.visibleToUserId - Restrict to branches visible to this user
+   *   under branch RBAC, pushed down as a SQL predicate instead of a preloaded
+   *   `branch_id IN (...)` list.
    */
   async findAll(filter?: {
     repo_id?: UUID;
@@ -356,6 +359,7 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     board_id?: BoardID;
     archived?: boolean;
     branchIds?: BranchID[];
+    visibleToUserId?: UUID;
   }): Promise<Branch[]> {
     // An explicit empty id set can never match a row; short-circuit so we skip
     // the read entirely and avoid emitting an empty `IN ()` predicate.
@@ -381,10 +385,29 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     if (filter?.branchIds !== undefined) {
       conditions.push(inArray(branches.branch_id, filter.branchIds));
     }
+    if (filter?.visibleToUserId) {
+      conditions.push(visibleBranchAccessCondition(this.db, filter.visibleToUserId));
+    }
 
-    const query = select(this.db).from(branches);
+    // The join shape differs only when RBAC SQL scoping is active. Keep the
+    // execution below uniform; Drizzle's cross-dialect builder types are more
+    // precise than this conditional can express.
+    // biome-ignore lint/suspicious/noExplicitAny: Conditional query builder shape differs with the RBAC join
+    const baseQuery: any = filter?.visibleToUserId
+      ? select(this.db, getTableColumns(branches))
+          .from(branches)
+          .leftJoin(
+            branchOwners,
+            and(
+              eq(branchOwners.branch_id, branches.branch_id),
+              eq(branchOwners.user_id, filter.visibleToUserId)
+            )
+          )
+      : select(this.db).from(branches);
     const rows =
-      conditions.length > 0 ? await query.where(and(...conditions)).all() : await query.all();
+      conditions.length > 0
+        ? await baseQuery.where(and(...conditions)).all()
+        : await baseQuery.all();
 
     const baseUrl = await getBaseUrl();
     return rows.map((row: BranchRow) => this.rowToBranch(row, baseUrl));

--- a/packages/core/src/db/repositories/cards.test.ts
+++ b/packages/core/src/db/repositories/cards.test.ts
@@ -1,0 +1,78 @@
+/**
+ * CardRepository Tests
+ *
+ * Focused on the find filters that back the SQL pushdown on CardsService.find.
+ */
+
+import type { BoardID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { BoardRepository } from './boards';
+import { CardRepository } from './cards';
+
+async function createBoard(db: Database): Promise<BoardID> {
+  const board = await new BoardRepository(db).create({
+    board_id: generateId(),
+    name: `Board ${generateId()}`,
+    created_by: 'test-user',
+  });
+  return board.board_id as BoardID;
+}
+
+describe('CardRepository.findAll', () => {
+  dbTest('returns all cards unfiltered', async ({ db }) => {
+    const repo = new CardRepository(db);
+    const board = await createBoard(db);
+
+    await repo.create({ board_id: board, title: 'a' });
+    await repo.create({ board_id: board, title: 'b' });
+
+    const cards = await repo.findAll();
+    expect(cards.map((c) => c.title).sort()).toEqual(['a', 'b']);
+  });
+
+  dbTest('filters by board_id', async ({ db }) => {
+    const repo = new CardRepository(db);
+    const boardA = await createBoard(db);
+    const boardB = await createBoard(db);
+
+    await repo.create({ board_id: boardA, title: 'a1' });
+    await repo.create({ board_id: boardA, title: 'a2' });
+    await repo.create({ board_id: boardB, title: 'b1' });
+
+    const onBoardA = await repo.findAll({ board_id: boardA });
+    expect(onBoardA.map((c) => c.title).sort()).toEqual(['a1', 'a2']);
+    expect(onBoardA.every((c) => c.board_id === boardA)).toBe(true);
+  });
+
+  dbTest('filters by exact archived state', async ({ db }) => {
+    const repo = new CardRepository(db);
+    const board = await createBoard(db);
+
+    const active = await repo.create({ board_id: board, title: 'active' });
+    const archived = await repo.create({ board_id: board, title: 'archived' });
+    await repo.archive(archived.card_id);
+
+    const activeOnly = await repo.findAll({ archived: false });
+    expect(activeOnly.map((c) => c.card_id)).toEqual([active.card_id]);
+
+    const archivedOnly = await repo.findAll({ archived: true });
+    expect(archivedOnly.map((c) => c.card_id)).toEqual([archived.card_id]);
+  });
+
+  dbTest('combines board_id and archived', async ({ db }) => {
+    const repo = new CardRepository(db);
+    const boardA = await createBoard(db);
+    const boardB = await createBoard(db);
+
+    await repo.create({ board_id: boardA, title: 'a-active' });
+    const aArchived = await repo.create({ board_id: boardA, title: 'a-archived' });
+    await repo.archive(aArchived.card_id);
+    await repo.create({ board_id: boardB, title: 'b-active' });
+
+    const result = await repo.findAll({ board_id: boardA, archived: false });
+    expect(result.map((c) => c.title)).toEqual(['a-active']);
+  });
+});

--- a/packages/core/src/db/repositories/cards.ts
+++ b/packages/core/src/db/repositories/cards.ts
@@ -161,9 +161,30 @@ export class CardRepository implements BaseRepository<Card, Partial<Card>> {
     };
   }
 
-  async findAll(): Promise<Card[]> {
+  /**
+   * Find all cards (with optional filters).
+   *
+   * The `board_id` and `archived` filters let the list read path
+   * (`CardsService.find`) push its high-selectivity predicates into SQL so it no
+   * longer materializes the whole table before filtering in memory.
+   *
+   * @param filter - Optional filters
+   * @param filter.board_id - Filter to a single board
+   * @param filter.archived - Filter to an exact archived state
+   */
+  async findAll(filter?: { board_id?: BoardID; archived?: boolean }): Promise<Card[]> {
     try {
-      const rows = await select(this.db).from(cards).all();
+      const conditions = [];
+      if (filter?.board_id) {
+        conditions.push(eq(cards.board_id, filter.board_id));
+      }
+      if (filter?.archived !== undefined) {
+        conditions.push(eq(cards.archived, filter.archived));
+      }
+
+      const query = select(this.db).from(cards);
+      const rows =
+        conditions.length > 0 ? await query.where(and(...conditions)).all() : await query.all();
       return rows.map((row: CardRow) => this.rowToCard(row));
     } catch (error) {
       throw new RepositoryError(

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -9,6 +9,7 @@ export * from './base';
 export * from './board-comments';
 export * from './board-objects';
 export * from './boards';
+export * from './branch-access';
 export * from './branches';
 export * from './card-types';
 export * from './cards';

--- a/packages/core/src/db/repositories/messages.test.ts
+++ b/packages/core/src/db/repositories/messages.test.ts
@@ -15,6 +15,7 @@ import { MessagesRepository } from './messages';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
 import { TaskRepository } from './tasks';
+import { UsersRepository } from './users';
 
 // Counter to ensure unique repo/branch names across tests
 let testCounter = 0;
@@ -286,6 +287,68 @@ describe('MessagesRepository.findAll', () => {
     expect(all[0].index).toBe(0);
     expect(all[1].index).toBe(1);
     expect(all[2].index).toBe(2);
+  });
+
+  dbTest('should restrict by visibleToUserId through session branch access', async ({ db }) => {
+    const messages = new MessagesRepository(db);
+    const users = new UsersRepository(db);
+    const repos = new RepoRepository(db);
+    const branches = new BranchRepository(db);
+    const sessions = new SessionRepository(db);
+    const viewerId = generateId() as UUID;
+    await users.create({
+      user_id: viewerId,
+      email: 'messages-visible@example.com',
+      name: 'Messages Viewer',
+    });
+    const repo = await repos.create({
+      slug: `messages-visible-${testCounter++}`,
+      name: 'Messages Visible',
+      repo_type: 'remote',
+      remote_url: 'https://github.com/test/repo.git',
+      local_path: `/tmp/messages-visible-${testCounter}`,
+      default_branch: 'main',
+    });
+    const visibleBranch = await branches.create({
+      repo_id: repo.repo_id,
+      name: `visible-${testCounter}`,
+      path: `/tmp/visible-${testCounter}`,
+      ref: 'main',
+      branch_unique_id: testCounter++,
+      created_by: 'test-user' as UUID,
+      permission_source: 'override',
+      others_can: 'none',
+    });
+    const hiddenBranch = await branches.create({
+      repo_id: repo.repo_id,
+      name: `hidden-${testCounter}`,
+      path: `/tmp/hidden-${testCounter}`,
+      ref: 'main',
+      branch_unique_id: testCounter++,
+      created_by: 'test-user' as UUID,
+      permission_source: 'override',
+      others_can: 'none',
+    });
+    await branches.addOwner(visibleBranch.branch_id, viewerId);
+    const visibleSession = await sessions.create({
+      branch_id: visibleBranch.branch_id,
+      title: 'visible',
+      created_by: 'test-user' as UUID,
+    });
+    const hiddenSession = await sessions.create({
+      branch_id: hiddenBranch.branch_id,
+      title: 'hidden',
+      created_by: 'test-user' as UUID,
+    });
+    const visibleMessage = await messages.create(
+      createMessageData({ session_id: visibleSession.session_id as SessionID, index: 0 })
+    );
+    await messages.create(
+      createMessageData({ session_id: hiddenSession.session_id as SessionID, index: 1 })
+    );
+
+    const visible = await messages.findAll({ visibleToUserId: viewerId });
+    expect(visible.map((m) => m.message_id)).toEqual([visibleMessage.message_id]);
   });
 });
 

--- a/packages/core/src/db/repositories/messages.ts
+++ b/packages/core/src/db/repositories/messages.ts
@@ -6,10 +6,11 @@
  */
 
 import type { Message, MessageID, SessionID, TaskID, UUID } from '@agor/core/types';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { type MessageInsert, type MessageRow, messages } from '../schema';
+import { visibleSessionReferenceAccessExists } from './branch-access';
 
 export class MessagesRepository {
   constructor(private db: Database) {}
@@ -90,8 +91,32 @@ export class MessagesRepository {
   /**
    * Get all messages (used by FeathersJS service adapter)
    */
-  async findAll(): Promise<Message[]> {
-    const rows = await select(this.db).from(messages).orderBy(messages.index).all();
+  async findAll(filter?: {
+    sessionId?: SessionID;
+    sessionIds?: SessionID[];
+    taskId?: TaskID;
+    type?: Message['type'];
+    role?: Message['role'];
+    visibleToUserId?: UUID;
+  }): Promise<Message[]> {
+    if (filter?.sessionIds !== undefined && filter.sessionIds.length === 0) return [];
+
+    const conditions = [];
+    if (filter?.sessionId) conditions.push(eq(messages.session_id, filter.sessionId));
+    if (filter?.sessionIds !== undefined)
+      conditions.push(inArray(messages.session_id, filter.sessionIds));
+    if (filter?.taskId) conditions.push(eq(messages.task_id, filter.taskId));
+    if (filter?.type) conditions.push(eq(messages.type, filter.type));
+    if (filter?.role) conditions.push(eq(messages.role, filter.role));
+    if (filter?.visibleToUserId) {
+      conditions.push(
+        visibleSessionReferenceAccessExists(this.db, filter.visibleToUserId, messages.session_id)
+      );
+    }
+
+    let query = select(this.db).from(messages);
+    if (conditions.length > 0) query = query.where(and(...conditions));
+    const rows = await query.orderBy(messages.index).all();
     return rows.map((r: MessageRow) => this.rowToMessage(r));
   }
 

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -449,6 +449,66 @@ describe('SessionRepository.findAll', () => {
     expect(found.status).toBe(SessionStatus.RUNNING);
     expect(found.branch_id).toBe(branch.branch_id);
   });
+
+  dbTest(
+    'should push visibleToUserId branch access filtering into findAll/findPage',
+    async ({ db }) => {
+      const repo = new SessionRepository(db);
+      const repoRepo = new RepoRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const userId = generateId() as UUID;
+
+      const gitRepo = await repoRepo.create({
+        repo_id: generateId(),
+        slug: `session-rbac-repo-${Date.now()}`,
+        name: 'Session RBAC Repo',
+        repo_type: 'remote' as const,
+        remote_url: 'https://github.com/test/session-rbac.git',
+        local_path: '/tmp/session-rbac-repo',
+        default_branch: 'main',
+      });
+      const visibleBranch = await branchRepo.create({
+        branch_id: generateId(),
+        repo_id: gitRepo.repo_id,
+        name: 'visible',
+        ref: 'visible',
+        branch_unique_id: Math.floor(Math.random() * 1000000),
+        path: '/tmp/session-rbac-visible',
+        base_ref: 'main',
+        new_branch: false,
+        created_by: generateId() as UUID,
+        permission_source: 'override',
+        others_can: 'view',
+      });
+      const hiddenBranch = await branchRepo.create({
+        branch_id: generateId(),
+        repo_id: gitRepo.repo_id,
+        name: 'hidden',
+        ref: 'hidden',
+        branch_unique_id: Math.floor(Math.random() * 1000000),
+        path: '/tmp/session-rbac-hidden',
+        base_ref: 'main',
+        new_branch: false,
+        created_by: generateId() as UUID,
+        permission_source: 'override',
+        others_can: 'none',
+      });
+
+      const visibleSession = await repo.create(
+        createSessionData({ branch_id: visibleBranch.branch_id, title: 'Visible Session' })
+      );
+      await repo.create(
+        createSessionData({ branch_id: hiddenBranch.branch_id, title: 'Hidden Session' })
+      );
+
+      const visible = await repo.findAll({ visibleToUserId: userId });
+      expect(visible.map((session) => session.session_id)).toEqual([visibleSession.session_id]);
+
+      const page = await repo.findPage({ visibleToUserId: userId, limit: 10, skip: 0 });
+      expect(page.total).toBe(1);
+      expect(page.data.map((session) => session.session_id)).toEqual([visibleSession.session_id]);
+    }
+  );
 });
 
 // ============================================================================

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -293,14 +293,33 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
    *
    * LEFT JOINs with branches to populate board_id and url in a single query.
    */
-  async findAll(): Promise<Session[]> {
+  async findAll(filter?: { visibleToUserId?: UUID }): Promise<Session[]> {
     try {
       const baseUrl = await getBaseUrl();
 
-      const results = await select(this.db)
-        .from(sessions)
-        .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
-        .all();
+      const conditions = [];
+      if (filter?.visibleToUserId) {
+        conditions.push(visibleBranchAccessCondition(this.db, filter.visibleToUserId));
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: Conditional query builder shape differs with the RBAC join
+      const query: any = filter?.visibleToUserId
+        ? select(this.db)
+            .from(sessions)
+            .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
+            .leftJoin(
+              branchOwners,
+              and(
+                eq(branchOwners.branch_id, branches.branch_id),
+                eq(branchOwners.user_id, filter.visibleToUserId)
+              )
+            )
+        : select(this.db)
+            .from(sessions)
+            .leftJoin(branches, eq(sessions.branch_id, branches.branch_id));
+
+      const results =
+        conditions.length > 0 ? await query.where(and(...conditions)).all() : await query.all();
 
       return results.map(
         (result: {
@@ -365,16 +384,32 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
    * the branch join is the authoritative source. This still pushes the
    * filter down to SQL (one indexed JOIN), not an in-memory scan.
    */
-  async findByBoard(boardId: string): Promise<Session[]> {
+  async findByBoard(boardId: string, filter?: { visibleToUserId?: UUID }): Promise<Session[]> {
     try {
       const baseUrl = await getBaseUrl();
 
+      const conditions = [eq(branches.board_id, boardId)];
+      if (filter?.visibleToUserId) {
+        conditions.push(visibleBranchAccessCondition(this.db, filter.visibleToUserId));
+      }
+
       // Filter on the branch's board_id via the JOIN (sessions.board_id is dead).
-      const results = await select(this.db)
-        .from(sessions)
-        .innerJoin(branches, eq(sessions.branch_id, branches.branch_id))
-        .where(eq(branches.board_id, boardId))
-        .all();
+      // biome-ignore lint/suspicious/noExplicitAny: Conditional query builder shape differs with the RBAC join
+      const query: any = filter?.visibleToUserId
+        ? select(this.db)
+            .from(sessions)
+            .innerJoin(branches, eq(sessions.branch_id, branches.branch_id))
+            .leftJoin(
+              branchOwners,
+              and(
+                eq(branchOwners.branch_id, branches.branch_id),
+                eq(branchOwners.user_id, filter.visibleToUserId)
+              )
+            )
+        : select(this.db)
+            .from(sessions)
+            .innerJoin(branches, eq(sessions.branch_id, branches.branch_id));
+      const results = await query.where(and(...conditions)).all();
 
       return results.map(
         (result: {
@@ -419,6 +454,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
     sortUpdatedAt?: 1 | -1;
     limit?: number;
     skip?: number;
+    visibleToUserId?: UUID;
   }): Promise<{ data: Session[]; total: number }> {
     try {
       const baseUrl = await getBaseUrl();
@@ -426,19 +462,42 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       const conditions = [];
       if (opts.boardId !== undefined) conditions.push(eq(branches.board_id, opts.boardId));
       if (opts.archived !== undefined) conditions.push(eq(sessions.archived, opts.archived));
+      if (opts.visibleToUserId) {
+        conditions.push(visibleBranchAccessCondition(this.db, opts.visibleToUserId));
+      }
       const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
       // Total matching rows — drives Feathers pagination + the findAll loop.
-      const countQuery = select(this.db, { count: sql<number>`count(*)` })
+      // biome-ignore lint/suspicious/noExplicitAny: Conditional query builder shape differs with the RBAC join
+      let countQuery: any = select(this.db, { count: sql<number>`count(*)` })
         .from(sessions)
         .leftJoin(branches, eq(sessions.branch_id, branches.branch_id));
+      if (opts.visibleToUserId) {
+        countQuery = countQuery.leftJoin(
+          branchOwners,
+          and(
+            eq(branchOwners.branch_id, branches.branch_id),
+            eq(branchOwners.user_id, opts.visibleToUserId)
+          )
+        );
+      }
       const countRow = await (whereClause ? countQuery.where(whereClause) : countQuery).one();
       const total = Number(countRow?.count ?? 0);
 
       // Page of rows, recency-sorted in SQL on the real `updated_at` column.
-      let dataQuery = select(this.db)
+      // biome-ignore lint/suspicious/noExplicitAny: Conditional query builder shape differs with the RBAC join
+      let dataQuery: any = select(this.db)
         .from(sessions)
         .leftJoin(branches, eq(sessions.branch_id, branches.branch_id));
+      if (opts.visibleToUserId) {
+        dataQuery = dataQuery.leftJoin(
+          branchOwners,
+          and(
+            eq(branchOwners.branch_id, branches.branch_id),
+            eq(branchOwners.user_id, opts.visibleToUserId)
+          )
+        );
+      }
       if (whereClause) dataQuery = dataQuery.where(whereClause);
       if (opts.sortUpdatedAt !== undefined) {
         dataQuery = dataQuery.orderBy(

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -15,6 +15,7 @@ import { BranchRepository } from './branches';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
 import { TaskRepository } from './tasks';
+import { UsersRepository } from './users';
 
 /**
  * Create test task data
@@ -433,6 +434,73 @@ describe('TaskRepository.findAll', () => {
     expect(found.full_prompt).toBe(data.full_prompt);
     expect(found.status).toBe(data.status);
     expect(found.tool_use_count).toBe(data.tool_use_count);
+  });
+
+  dbTest('should restrict by visibleToUserId through session branch access', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const users = new UsersRepository(db);
+    const repos = new RepoRepository(db);
+    const branches = new BranchRepository(db);
+    const sessions = new SessionRepository(db);
+    const viewerId = generateId() as UUID;
+    await users.create({
+      user_id: viewerId,
+      email: 'tasks-visible@example.com',
+      name: 'Tasks Viewer',
+    });
+    const repo = await repos.create({
+      repo_id: generateId(),
+      slug: `tasks-visible-${branchCounter++}`,
+      name: 'Tasks Visible',
+      repo_type: 'remote' as const,
+      remote_url: 'https://github.com/test/repo.git',
+      local_path: '/tmp/tasks-visible',
+      default_branch: 'main',
+    });
+    const visibleBranch = await branches.create({
+      branch_id: generateId(),
+      repo_id: repo.repo_id,
+      name: `visible-${branchCounter}`,
+      ref: 'main',
+      branch_unique_id: branchCounter++,
+      path: '/tmp/tasks-visible/visible',
+      created_by: 'test-user' as UUID,
+      permission_source: 'override',
+      others_can: 'none',
+    });
+    const hiddenBranch = await branches.create({
+      branch_id: generateId(),
+      repo_id: repo.repo_id,
+      name: `hidden-${branchCounter}`,
+      ref: 'main',
+      branch_unique_id: branchCounter++,
+      path: '/tmp/tasks-visible/hidden',
+      created_by: 'test-user' as UUID,
+      permission_source: 'override',
+      others_can: 'none',
+    });
+    await branches.addOwner(visibleBranch.branch_id, viewerId);
+    const visibleSession = await sessions.create({
+      session_id: generateId(),
+      branch_id: visibleBranch.branch_id,
+      agentic_tool: 'claude-code',
+      created_by: 'test-user' as UUID,
+    });
+    const hiddenSession = await sessions.create({
+      session_id: generateId(),
+      branch_id: hiddenBranch.branch_id,
+      agentic_tool: 'claude-code',
+      created_by: 'test-user' as UUID,
+    });
+    const visibleTask = await taskRepo.create(
+      createTaskData({ session_id: visibleSession.session_id, full_prompt: 'visible' })
+    );
+    await taskRepo.create(
+      createTaskData({ session_id: hiddenSession.session_id, full_prompt: 'hidden' })
+    );
+
+    const visible = await taskRepo.findAll({ visibleToUserId: viewerId });
+    expect(visible.map((task) => task.task_id)).toEqual([visibleTask.task_id]);
   });
 });
 

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -6,7 +6,7 @@
 
 import type { SessionID, Task, TaskMetadata, UUID } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
-import { eq, inArray, like, sql } from 'drizzle-orm';
+import { and, eq, inArray, like, sql } from 'drizzle-orm';
 import { generateId, shortId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
@@ -19,6 +19,7 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
+import { visibleSessionReferenceAccessExists } from './branch-access';
 import { deepMerge } from './merge-utils';
 
 /**
@@ -201,9 +202,29 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
   /**
    * Find all tasks
    */
-  async findAll(): Promise<Task[]> {
+  async findAll(filter?: {
+    sessionId?: SessionID;
+    sessionIds?: SessionID[];
+    status?: Task['status'];
+    visibleToUserId?: UUID;
+  }): Promise<Task[]> {
     try {
-      const rows = await select(this.db).from(tasks).all();
+      if (filter?.sessionIds !== undefined && filter.sessionIds.length === 0) return [];
+
+      const conditions = [];
+      if (filter?.sessionId) conditions.push(eq(tasks.session_id, filter.sessionId));
+      if (filter?.sessionIds !== undefined)
+        conditions.push(inArray(tasks.session_id, filter.sessionIds));
+      if (filter?.status) conditions.push(eq(tasks.status, filter.status));
+      if (filter?.visibleToUserId) {
+        conditions.push(
+          visibleSessionReferenceAccessExists(this.db, filter.visibleToUserId, tasks.session_id)
+        );
+      }
+
+      const query = select(this.db).from(tasks);
+      const rows =
+        conditions.length > 0 ? await query.where(and(...conditions)).all() : await query.all();
       return rows.map((row: TaskRow) => this.rowToTask(row));
     } catch (error) {
       throw new RepositoryError(


### PR DESCRIPTION
## Summary

Four highest-cardinality entities fetched on initial app load — **branches**, **boards**, **cards**, **artifacts** — each rode the generic `DrizzleService.find`, which read the **entire table** via `repository.findAll()` and then applied filters, sort, and pagination in JavaScript. Cost scaled with *total* row count rather than the scoped/accessible/board subset, making these the clearest initial-load query bottlenecks.

This PR pushes the high-selectivity predicates into SQL via a single, backward-compatible seam.

## Approach

Add a protected `fetchData(query)` hook to `DrizzleService.find`:

- **Default** implementation stays `this.repository.findAll()` → **every other service is byte-for-byte unchanged**.
- `find()` still re-applies **every** query filter (`filterData`), then sorts, selects, and paginates exactly as before. An override therefore only needs to return a **superset** of the matching rows for results to stay identical.

Each of the four services overrides `fetchData` to push its real-column predicates into an extended `findAll` on its repository:

| Service | Pushed into SQL | RBAC-injected filter | Notes |
|---|---|---|---|
| branches | `repo_id`, `board_id`, `archived`, `branch_id` (scalar/`$in`) | `branch_id {$in}` (accessible set) | virtual `zone_id` stays resolved to a `branch_id` filter *before* the read — never pushed to the table |
| boards | `board_id` (scalar/`$in`), `archived` | `board_id {$in}` (`findVisibleBoardIds`) | — |
| cards | `board_id`, `archived` | none (cards aren't RBAC-scoped) | board bootstrap fetches board-scoped + global fallback |
| artifacts | `board_id`, `archived`, `branch_id` (scalar/`$in`) | `branch_id {$in}` (accessible branches) | `branchIds` filter excludes null-branch orphans, matching in-memory `{$in}`; per-row enrichment runs on the reduced set |

## Parity guarantees

- **Identical** rows / order / pagination `total` / virtual fields / enrichment in **both `branch_rbac` OFF and ON** modes — verified by tests.
- Filter shapes honored exactly: absent | scalar | `{$in:[]}`. An empty `$in` short-circuits to `[]` without emitting an `IN ()` predicate.
- **cards & artifacts have no query validator** (uncoerced values): `fetchData` only pushes a value that already matches the column type (`typeof` guards); anything else (e.g. a raw string `archived='false'`) falls through to the unchanged in-memory filter — current behavior preserved exactly, including its quirks.
- The shared adapter change is strictly additive; no other service's behavior changes.

## Tests

Per service: repository-level tests proving the SQL `WHERE` (board scope, exact archived, id-set, empty-set, orphan exclusion) **and** service-level parity + SQL-bounded tests (asserting the repo read is called with the scoped filter, in both RBAC modes, with sort/pagination/enrichment parity).

## Gate

`pnpm i` → `pnpm check` (typecheck + biome + check:shortid + build): **GREEN**. Full suite: `@agor/core` 2648 passed, `@agor/daemon` 1263 passed, `@agor/cli`/`@agor/ui` green. Pre-existing `@agor/executor` sandbox/OTel test failures are unrelated (reproduce identically on `main`; no executor files touched).

## Follow-ups

Other services on the same generic-adapter path can adopt the same `fetchData` seam if they become load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)