### PR TITLE
Draft: sketch multi-tenant DB routing and websocket isolation

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -66,6 +66,18 @@ export interface Repository<T> {
 }
 
 /**
+ * Optional low-level seam for multi-tenant deployments. Existing services pass a
+ * concrete repository. A future tenant-aware service can pass a resolver that
+ * chooses the repository/database from Feathers `params` for this method call.
+ *
+ * This mirrors Feathers' documented per-request adapter customization pattern
+ * (`params.adapter`) without mutating any global app/service database handle.
+ */
+export type RepositoryResolver<T, P extends Params = Params> =
+  | Repository<T>
+  | ((params?: P) => Repository<T> | Promise<Repository<T>>);
+
+/**
  * Drizzle Service Adapter
  *
  * Implements FeathersJS service methods using a Drizzle repository.
@@ -83,13 +95,26 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   emit?: (event: string, ...args: any[]) => boolean;
 
   constructor(
-    private repository: Repository<T>,
+    private readonly repositoryOrResolver: RepositoryResolver<T, P>,
     options: DrizzleAdapterOptions = {}
   ) {
     this.id = options.id ?? 'id';
     this.paginate = options.paginate;
     this.multi = options.multi ?? false;
     this.resourceType = options.resourceType ?? 'Record';
+  }
+
+  /**
+   * Resolve the repository for a method call. In normal single-tenant mode this
+   * returns the repository that was injected at service construction. In a
+   * multi-tenant service, callers can inject a resolver that reads `params.tenant`
+   * / `params.adapter.tenantId` and returns the tenant-specific repository.
+   */
+  protected async getRepository(params?: P): Promise<Repository<T>> {
+    if (typeof this.repositoryOrResolver === 'function') {
+      return await this.repositoryOrResolver(params);
+    }
+    return this.repositoryOrResolver;
   }
 
   /**
@@ -224,7 +249,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
    * rows for the result to stay identical.
    */
   protected async fetchData(_query: Query, _params?: P): Promise<T[]> {
-    return this.repository.findAll();
+    return (await this.getRepository(_params)).findAll();
   }
 
   /**
@@ -282,7 +307,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
       return prefetched.record;
     }
 
-    const result = await this.repository.findById(String(id));
+    const result = await (await this.getRepository(_params)).findById(String(id));
 
     if (!result) {
       throw new NotFoundError(this.resourceType, String(id));
@@ -298,7 +323,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
     if (Array.isArray(data)) {
       // Bulk create
       const results = await Promise.all(
-        data.map((item) => this.repository.create(item as Partial<T>))
+        data.map(async (item) => (await this.getRepository(params)).create(item as Partial<T>))
       );
       // Emit created event for each item
       for (const result of results) {
@@ -307,7 +332,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
       return results;
     }
 
-    const result = await this.repository.create(data as Partial<T>);
+    const result = await (await this.getRepository(params)).create(data as Partial<T>);
     this.emit?.('created', result, params);
     return result;
   }
@@ -326,7 +351,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
     // Verify record exists (throws NotFoundError if not found)
     await this.get(id, params);
 
-    const result = await this.repository.update(String(id), data as Partial<T>);
+    const result = await (await this.getRepository(params)).update(String(id), data as Partial<T>);
     this.emit?.('updated', result, params);
     return result;
   }
@@ -343,12 +368,13 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
 
       // Find all matching records and patch them
       const query = this.getQuery(params);
-      let records = await this.repository.findAll();
+      let records = await (await this.getRepository(params)).findAll();
       records = this.filterData(records, query);
 
+      const repository = await this.getRepository(params);
       const results = await Promise.all(
         records.map((record) =>
-          this.repository.update(
+          repository.update(
             (record as Record<string, unknown>)[this.id] as string,
             data as Partial<T>
           )
@@ -367,7 +393,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
     // Verify record exists (throws NotFoundError if not found)
     await this.get(id, params);
 
-    const result = await this.repository.update(String(id), data as Partial<T>);
+    const result = await (await this.getRepository(params)).update(String(id), data as Partial<T>);
     this.emit?.('patched', result, params);
     return result;
   }
@@ -384,11 +410,14 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
 
       // Find all matching records and remove them
       const query = this.getQuery(params);
-      let records = await this.repository.findAll();
+      let records = await (await this.getRepository(params)).findAll();
       records = this.filterData(records, query);
 
       // biome-ignore lint/suspicious/noExplicitAny: Need to access ID field dynamically
-      await Promise.all(records.map((record) => this.repository.delete((record as any)[this.id])));
+      const repository = await this.getRepository(params);
+      await Promise.all(
+        records.map(async (record) => repository.delete((record as any)[this.id]))
+      );
 
       // Emit removed event for each record
       for (const record of records) {
@@ -402,7 +431,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
     // Get record before deletion (throws NotFoundError if not found)
     const existing = await this.get(id, params);
 
-    await this.repository.delete(String(id));
+    await (await this.getRepository(params)).delete(String(id));
     this.emit?.('removed', existing, params);
     return existing;
   }

--- a/apps/agor-daemon/src/tenancy/README.md
+++ b/apps/agor-daemon/src/tenancy/README.md
@@ -1,0 +1,73 @@
+# Multi-tenant daemon POC (exploratory)
+
+This folder is intentionally a **presentation/PR scaffold**, not a production
+feature flag. It shows where the tenant boundary should live if one daemon serves
+multiple Agor tenants backed by separate Postgres databases.
+
+## Request path
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Feathers as Feathers REST/Socket method
+  participant Auth as Auth hook/strategy
+  participant TenantHook as resolveTenantContext hook
+  participant Service as Agor service
+  participant Provider as TenantRepositoryProvider
+  participant Registry as TenantDatabaseRegistry
+  participant PG as Tenant Postgres DB
+
+  Client->>Feathers: service.method(data, params/auth)
+  Feathers->>Auth: authenticate JWT/API key
+  Auth-->>Feathers: params.user + params.authentication.payload
+  Feathers->>TenantHook: before/around all tenant-scoped services
+  TenantHook-->>Feathers: params.tenant + params.adapter.tenantId
+  Feathers->>Service: method(data, params)
+  Service->>Provider: repositoryFor(params.tenant)
+  Provider->>Registry: dbFor(tenantId)
+  Registry-->>Provider: tenant-specific Drizzle client/pool
+  Provider-->>Service: tenant-specific repository
+  Service->>PG: query/update tenant-local rows
+```
+
+## Realtime path
+
+```mermaid
+flowchart TD
+  A[Socket login / JWT handshake] --> B[Resolve trusted tenantId]
+  B --> C[Stamp socket.feathers.tenant]
+  C --> D[Join tenant/<tenantId>/authenticated]
+  E[Service event] --> F[Resolve event tenant from context.params.tenant or data]
+  F --> G{Tenant known?}
+  G -- no --> H[Fail closed: service-only or null]
+  G -- yes --> I[Filter channel to same tenant]
+  I --> J[Apply existing branch/RBAC filtering]
+  J --> K[Deliver event]
+```
+
+## Files
+
+- `tenant-context.ts`: hook-level mechanics for trusted tenant resolution.
+- `tenant-db-registry.ts`: lazy DB/pool registry and repository provider.
+- `tenant-channel-scope.ts`: fail-closed websocket tenant filter.
+- `tenant-routed-adapter-poc.ts`: small standalone adapter sketch.
+- `tenant-routing-poc.test.ts`: tests demonstrating same IDs in two tenants do
+  not cross and missing tenant events fail closed.
+
+## Production integration points
+
+1. **Auth/JWT resolution**: `apps/agor-daemon/src/auth/service-jwt-strategy.ts`
+   should validate or surface a trusted tenant claim. Socket handshake logic in
+   `apps/agor-daemon/src/setup/socketio.ts` needs the same tenant resolution.
+2. **App/service hook**: register `resolveTenantContext()` after auth and before
+   tenant-scoped service hooks.
+3. **Database seam**: `apps/agor-daemon/src/adapters/drizzle.ts` now accepts a
+   `RepositoryResolver`, so a service can resolve repositories from `params`
+   without mutating a global DB.
+4. **Direct DB users**: services/hooks/routes that keep `this.db`, `branchRepo`,
+   or `app.get('database')` need to move to providers or be explicitly marked as
+   landlord/global-only.
+5. **Realtime**: tenant filtering must be unconditional and happen before the
+   current branch/RBAC filtering in `utils/realtime-publish.ts`.
+6. **Background jobs/executors/MCP**: every non-HTTP path must carry tenant id;
+   otherwise tenant-scoped DB access should throw.

--- a/apps/agor-daemon/src/tenancy/README.md
+++ b/apps/agor-daemon/src/tenancy/README.md
@@ -71,3 +71,64 @@ flowchart TD
    current branch/RBAC filtering in `utils/realtime-publish.ts`.
 6. **Background jobs/executors/MCP**: every non-HTTP path must carry tenant id;
    otherwise tenant-scoped DB access should throw.
+
+## HA / autoscaled sockets mental model
+
+Rooms are not assigned to daemon pods. A room is a logical label that exists on
+whatever pods currently have local sockets joined to that room. The load
+balancer does not need a room map, and we should not shard tenants/sessions to
+specific daemons for the initial architecture.
+
+```mermaid
+flowchart LR
+  U1[User 1] --> LB[ELB / ingress]
+  U2[User 2] --> LB
+
+  LB --> D1[Daemon A]
+  LB --> D2[Daemon B]
+  LB --> D3[Daemon C]
+
+  D1 <--> R[(Redis / Socket.IO adapter)]
+  D2 <--> R
+  D3 <--> R
+
+  D1 --> TDB[(Tenant Postgres)]
+  D2 --> TDB
+  D3 --> TDB
+```
+
+If User 1 and User 2 both view `tenant:t1:session:s1` but connect to different
+pods, both sockets join the same deterministic room name on their respective
+pods. An emit to that room from any pod is fanned out through the Socket.IO
+adapter; each receiving pod delivers only to its local sockets in that room.
+
+```mermaid
+sequenceDiagram
+  participant U1 as User 1
+  participant D1 as Daemon A
+  participant R as Redis adapter
+  participant D3 as Daemon C
+  participant U2 as User 2
+
+  U1->>D1: prompt session s1
+  D1->>D1: patch task/session/message
+  D1->>D1: emit to tenant:t1:session:s1
+  D1->>U1: local delivery
+  D1->>R: publish room packet
+  R->>D3: room packet
+  D3->>U2: local delivery
+```
+
+### Scaling notes
+
+- Redis here is pub/sub fanout, not the durable message queue/source of truth.
+- Socket events are live hints; tenant Postgres remains durable truth.
+- On disconnect/reconnect, clients should resubscribe rooms and refetch current
+  page/session state over REST to recover missed events.
+- Room-targeted emits avoid scanning every connected socket. Cost is closer to
+  `O(pods) + O(room recipients)`, not `O(total users)` per event.
+- A broad `authenticated` channel scan is the path to avoid at GA scale.
+- For thousands of tenants, DB pool lifecycle is a separate bottleneck: lazy
+  pools, small max size, idle eviction, and likely PgBouncer/managed pooling.
+- Background jobs still need distributed locks/queues; Socket.IO Redis adapter
+  only solves realtime fanout.

--- a/apps/agor-daemon/src/tenancy/README.md
+++ b/apps/agor-daemon/src/tenancy/README.md
@@ -132,3 +132,35 @@ sequenceDiagram
   pools, small max size, idle eviction, and likely PgBouncer/managed pooling.
 - Background jobs still need distributed locks/queues; Socket.IO Redis adapter
   only solves realtime fanout.
+
+## Tenant placement / pooling note
+
+For thousands of GA/self-serve tenants, schema-per-tenant inside a shared/cell
+Postgres database may be a better default than database-per-tenant. It preserves
+normal app pool behavior:
+
+```text
+10 pods × small number of cell DB pools × pool max N
+```
+
+instead of:
+
+```text
+10 pods × active tenants × pool max N
+```
+
+The likely placement model is hybrid:
+
+```ts
+type TenantPlacement =
+  | { kind: 'cell-schema'; cellId: string; schema: string; role: string }
+  | { kind: 'dedicated-database'; databaseUrl: string; databaseUser: string };
+```
+
+Caveat for review: shared-login `SET LOCAL ROLE` is not automatically a full
+SQL-injection containment boundary. If the shared app pool user can assume every
+tenant role, arbitrary injected SQL might be able to `RESET ROLE` / `SET ROLE`
+unless permissions are designed and tested carefully. The app pool user should
+not have direct cross-tenant table access; tenant roles should be `NOLOGIN`,
+minimal, and preferably non-inherited. Dedicated tenant DB users remain the
+stronger isolation tier.

--- a/apps/agor-daemon/src/tenancy/tenant-channel-scope.ts
+++ b/apps/agor-daemon/src/tenancy/tenant-channel-scope.ts
@@ -1,0 +1,45 @@
+/** EXPLORATORY POC: tenant-scoped channel filtering helpers. Not production-wired. */
+
+import type { Application } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { tenantFromParams, type TenantID } from './tenant-context.js';
+
+type ConnectionWithTenant = {
+  tenant?: { tenantId?: TenantID };
+  user?: { _isServiceAccount?: boolean; role?: string };
+  authentication?: { user?: { _isServiceAccount?: boolean; role?: string } };
+};
+
+type Channel = ReturnType<Application['channel']>;
+
+function connectionTenantId(connection: unknown): TenantID | undefined {
+  return (connection as ConnectionWithTenant | undefined)?.tenant?.tenantId;
+}
+
+function isServiceConnection(connection: unknown): boolean {
+  const c = connection as ConnectionWithTenant | undefined;
+  const user = c?.user ?? c?.authentication?.user;
+  return user?._isServiceAccount === true || user?.role === 'service';
+}
+
+/**
+ * Fail-closed tenant filter. If the event lacks tenant context, only service
+ * connections receive it so bugs do not broadcast across tenants by default.
+ */
+export function filterChannelToTenant(channel: Channel, tenantId: TenantID | undefined): Channel {
+  return channel.filter((connection: unknown) => {
+    if (isServiceConnection(connection)) return true;
+    return !!tenantId && connectionTenantId(connection) === tenantId;
+  });
+}
+
+export function configureTenantPublishPoc(app: Application): void {
+  app.publish((data: unknown, context: HookContext) => {
+    const tenantId =
+      tenantFromParams(context.params)?.tenantId ??
+      ((data && typeof data === 'object' && 'tenant_id' in data
+        ? (data as { tenant_id?: TenantID }).tenant_id
+        : undefined) as TenantID | undefined);
+    return filterChannelToTenant(app.channel('authenticated'), tenantId);
+  });
+}

--- a/apps/agor-daemon/src/tenancy/tenant-context.ts
+++ b/apps/agor-daemon/src/tenancy/tenant-context.ts
@@ -1,0 +1,96 @@
+/**
+ * EXPLORATORY POC: multi-tenant request context plumbing.
+ *
+ * This file is intentionally not wired into daemon startup. It demonstrates the
+ * low-level mechanics recommended in the KB research doc: resolve a trusted
+ * tenant before service code runs, attach it to Feathers params/connection, and
+ * make downstream database/channel code consume that explicit params value.
+ */
+
+import type { HookContext, Params } from '@agor/core/types';
+
+export type TenantID = string & { readonly __brand: 'TenantID' };
+
+export interface TenantContext {
+  tenantId: TenantID;
+}
+
+export type TenantParams<P extends Params = Params> = P & {
+  tenant?: TenantContext;
+  adapter?: P extends { adapter?: infer A } ? A & { tenantId?: TenantID } : { tenantId?: TenantID };
+};
+
+type TenantConnection = {
+  tenant?: TenantContext;
+  authentication?: { payload?: Record<string, unknown> };
+  user?: Record<string, unknown>;
+};
+
+type TenantResolverOptions = {
+  /** JWT/session payload claim to trust after authentication, e.g. `tenant_id`. */
+  claim?: string;
+  /** Optional allowlist/normalizer. Throw to reject unknown tenants. */
+  normalize?: (tenantId: string) => TenantID | null | undefined;
+};
+
+const DEFAULT_TENANT_CLAIM = 'tenant_id';
+
+export function asTenantId(value: string): TenantID {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error('Tenant id is required');
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$/.test(trimmed)) {
+    throw new Error('Tenant id contains unsupported characters');
+  }
+  return trimmed as TenantID;
+}
+
+function readString(obj: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = obj?.[key];
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+export function tenantFromParams(params: Params | undefined): TenantContext | undefined {
+  return (params as TenantParams | undefined)?.tenant;
+}
+
+export function requireTenant(params: Params | undefined): TenantContext {
+  const tenant = tenantFromParams(params);
+  if (!tenant?.tenantId) throw new Error('Tenant context is required');
+  return tenant;
+}
+
+/**
+ * Feathers before/around hook that stamps `params.tenant` from authenticated
+ * server-side data. Do not read a tenant id directly from client query/body here.
+ */
+export function resolveTenantContext(options: TenantResolverOptions = {}) {
+  const claim = options.claim ?? DEFAULT_TENANT_CLAIM;
+  return async (context: HookContext): Promise<HookContext> => {
+    const params = context.params as TenantParams | undefined;
+    const connection = params?.connection as TenantConnection | undefined;
+    const payload = params?.authentication?.payload as Record<string, unknown> | undefined;
+    const user = params?.user as Record<string, unknown> | undefined;
+
+    const rawTenantId =
+      readString(payload, claim) ??
+      readString(user, claim) ??
+      readString(connection?.authentication?.payload, claim) ??
+      readString(connection?.user, claim) ??
+      connection?.tenant?.tenantId;
+
+    if (!rawTenantId) throw new Error(`Authenticated request is missing ${claim}`);
+
+    const tenantId = options.normalize ? options.normalize(rawTenantId) : asTenantId(rawTenantId);
+    if (!tenantId) throw new Error(`Unknown tenant: ${rawTenantId}`);
+
+    context.params = {
+      ...(params ?? {}),
+      tenant: { tenantId },
+      // Mirrors the Feathers documented per-request adapter override pattern.
+      adapter: { ...(params?.adapter ?? {}), tenantId },
+    } as typeof context.params;
+
+    if (connection) connection.tenant = { tenantId };
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/tenancy/tenant-db-registry.ts
+++ b/apps/agor-daemon/src/tenancy/tenant-db-registry.ts
@@ -1,0 +1,62 @@
+/** EXPLORATORY POC: tenant database registry/provider. Not production-wired. */
+
+import type { Database } from '@agor/core/db';
+import type { Params } from '@agor/core/types';
+import { requireTenant, type TenantID } from './tenant-context.js';
+
+export type TenantDatabaseFactory = (tenantId: TenantID) => Promise<Database> | Database;
+
+export interface TenantDatabaseRegistryOptions {
+  createDatabase: TenantDatabaseFactory;
+  closeDatabase?: (db: Database, tenantId: TenantID) => Promise<void> | void;
+}
+
+export class TenantDatabaseRegistry {
+  private readonly databases = new Map<TenantID, Promise<Database>>();
+
+  constructor(private readonly options: TenantDatabaseRegistryOptions) {}
+
+  get(tenantId: TenantID): Promise<Database> {
+    let existing = this.databases.get(tenantId);
+    if (!existing) {
+      existing = Promise.resolve(this.options.createDatabase(tenantId));
+      this.databases.set(tenantId, existing);
+    }
+    return existing;
+  }
+
+  async getForParams(params: Params | undefined): Promise<Database> {
+    return this.get(requireTenant(params).tenantId);
+  }
+
+  async closeAll(): Promise<void> {
+    if (!this.options.closeDatabase) {
+      this.databases.clear();
+      return;
+    }
+    const entries = [...this.databases.entries()];
+    this.databases.clear();
+    await Promise.all(entries.map(async ([tenantId, db]) => this.options.closeDatabase!(await db, tenantId)));
+  }
+}
+
+export type RepositoryFactory<R> = (db: Database) => R;
+
+export class TenantRepositoryProvider<R> {
+  private readonly repositories = new Map<TenantID, Promise<R>>();
+
+  constructor(
+    private readonly registry: TenantDatabaseRegistry,
+    private readonly factory: RepositoryFactory<R>
+  ) {}
+
+  forParams(params: Params | undefined): Promise<R> {
+    const { tenantId } = requireTenant(params);
+    let existing = this.repositories.get(tenantId);
+    if (!existing) {
+      existing = this.registry.get(tenantId).then((db) => this.factory(db));
+      this.repositories.set(tenantId, existing);
+    }
+    return existing;
+  }
+}

--- a/apps/agor-daemon/src/tenancy/tenant-routed-adapter-poc.ts
+++ b/apps/agor-daemon/src/tenancy/tenant-routed-adapter-poc.ts
@@ -1,0 +1,50 @@
+/**
+ * EXPLORATORY POC: params-aware repository seam for DrizzleService.
+ *
+ * Agor's current DrizzleService stores one repository created with one db. This
+ * sketch shows the preferred mechanical change: services resolve a repository
+ * from `params.tenant` per method call instead of mutating any global db handle.
+ */
+
+import type { Id, NullableId, Params } from '@agor/core/types';
+import type { Repository } from '../adapters/drizzle.js';
+import type { TenantRepositoryProvider } from './tenant-db-registry.js';
+
+export class TenantRoutedRepositoryAdapter<T, D = Partial<T>, P extends Params = Params> {
+  constructor(
+    private readonly repositories: TenantRepositoryProvider<Repository<T>>,
+    private readonly idField: keyof T & string
+  ) {}
+
+  private repo(params?: P): Promise<Repository<T>> {
+    return this.repositories.forParams(params);
+  }
+
+  async find(params?: P): Promise<T[]> {
+    return (await this.repo(params)).findAll();
+  }
+
+  async get(id: Id, params?: P): Promise<T> {
+    const result = await (await this.repo(params)).findById(String(id));
+    if (!result) throw new Error(`Record not found: ${String(id)}`);
+    return result;
+  }
+
+  async create(data: D, params?: P): Promise<T> {
+    return (await this.repo(params)).create(data as Partial<T>);
+  }
+
+  async patch(id: NullableId, data: D, params?: P): Promise<T> {
+    if (id === null) throw new Error('Multi-patch omitted from tenant routing POC');
+    return (await this.repo(params)).update(String(id), data as Partial<T>);
+  }
+
+  async remove(id: NullableId, params?: P): Promise<T> {
+    if (id === null) throw new Error('Multi-remove omitted from tenant routing POC');
+    const repo = await this.repo(params);
+    const existing = await repo.findById(String(id));
+    if (!existing) throw new Error(`Record not found: ${String(id)}`);
+    await repo.delete(String((existing as Record<string, unknown>)[this.idField]));
+    return existing;
+  }
+}

--- a/apps/agor-daemon/src/tenancy/tenant-routing-poc.test.ts
+++ b/apps/agor-daemon/src/tenancy/tenant-routing-poc.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Repository } from '../adapters/drizzle';
+import { filterChannelToTenant } from './tenant-channel-scope';
+import { asTenantId, resolveTenantContext, type TenantParams } from './tenant-context';
+import { TenantDatabaseRegistry, TenantRepositoryProvider } from './tenant-db-registry';
+import { TenantRoutedRepositoryAdapter } from './tenant-routed-adapter-poc';
+
+class FakeChannel {
+  constructor(public connections: unknown[]) {}
+  filter(fn: (connection: unknown) => boolean) {
+    return new FakeChannel(this.connections.filter(fn));
+  }
+}
+
+type Row = { id: string; value: string };
+
+function repo(label: string): Repository<Row> {
+  const rows = new Map<string, Row>();
+  return {
+    async create(data) {
+      const row = { id: data.id ?? `${label}-id`, value: data.value ?? label };
+      rows.set(row.id, row);
+      return row;
+    },
+    async findById(id) {
+      return rows.get(id) ?? null;
+    },
+    async findAll() {
+      return [...rows.values()];
+    },
+    async update(id, updates) {
+      const next = { ...(rows.get(id) ?? { id, value: label }), ...updates };
+      rows.set(id, next);
+      return next;
+    },
+    async delete(id) {
+      rows.delete(id);
+    },
+  };
+}
+
+describe('tenant routing POC', () => {
+  it('stamps tenant context from trusted auth payload and socket connection', async () => {
+    const hook = resolveTenantContext({ claim: 'tenant_id' });
+    const connection = {};
+    const context = await hook({
+      params: { authentication: { payload: { tenant_id: 'tenant-a' } }, connection },
+    } as any);
+
+    expect((context.params as TenantParams).tenant?.tenantId).toBe('tenant-a');
+    expect((context.params as TenantParams).adapter?.tenantId).toBe('tenant-a');
+    expect((connection as any).tenant.tenantId).toBe('tenant-a');
+  });
+
+  it('routes repository operations to the database selected by params.tenant', async () => {
+    const dbs = new Map<string, unknown>();
+    const registry = new TenantDatabaseRegistry({
+      createDatabase: vi.fn(async (tenantId) => {
+        const db = { tenantId } as any;
+        dbs.set(tenantId, db);
+        return db;
+      }),
+    });
+    const provider = new TenantRepositoryProvider(registry, (db: any) => repo(db.tenantId));
+    const service = new TenantRoutedRepositoryAdapter<Row>(provider, 'id');
+
+    const tenantA = { tenant: { tenantId: asTenantId('tenant-a') } } as TenantParams;
+    const tenantB = { tenant: { tenantId: asTenantId('tenant-b') } } as TenantParams;
+
+    await service.create({ id: 'same-id', value: 'A' }, tenantA);
+    await service.create({ id: 'same-id', value: 'B' }, tenantB);
+
+    await expect(service.get('same-id', tenantA)).resolves.toMatchObject({ value: 'A' });
+    await expect(service.get('same-id', tenantB)).resolves.toMatchObject({ value: 'B' });
+    expect(dbs.size).toBe(2);
+  });
+
+  it('filters websocket event channels by tenant and fails closed without tenant context', () => {
+    const tenantA = asTenantId('tenant-a');
+    const tenantB = asTenantId('tenant-b');
+    const service = { user: { role: 'service', _isServiceAccount: true } };
+    const channel = new FakeChannel([
+      { tenant: { tenantId: tenantA }, user: { user_id: 'a' } },
+      { tenant: { tenantId: tenantB }, user: { user_id: 'b' } },
+      service,
+      { user: { user_id: 'missing-tenant' } },
+    ]) as any;
+
+    expect(filterChannelToTenant(channel, tenantA).connections).toEqual([
+      { tenant: { tenantId: tenantA }, user: { user_id: 'a' } },
+      service,
+    ]);
+    expect(filterChannelToTenant(channel, undefined).connections).toEqual([service]);
+  });
+});


### PR DESCRIPTION
## Summary

Exploratory PR scaffold for the architect review of a multi-tenant Agor daemon:

- Adds a low-level `DrizzleService` repository resolver seam so future services can resolve repositories from Feathers `params` per method call instead of capturing one global DB forever. Existing services that pass concrete repositories continue to work.
- Adds `apps/agor-daemon/src/tenancy/` with commented mechanics for:
  - resolving trusted tenant context from auth payload/connection,
  - tenant DB/pool registry and repository provider,
  - tenant-first websocket channel filtering,
  - same-ID-cross-tenant POC tests,
  - a README with Mermaid diagrams for the Zoom review.

## What this is

This is deliberately a **draft architecture/mechanics PR**, not a production feature flag. The goal is to make the proposal reviewable in code and point at the exact seams we would harden next.

## What is intentionally not wired yet

- JWT/host tenant resolution in `service-jwt-strategy.ts` and `setup/socketio.ts`
- App-wide registration of the tenant hook after auth
- Full service migration away from captured `db` / `this.db` / `app.get('database')`
- Tenant-first integration into `utils/realtime-publish.ts`
- Scheduler/executor/MCP tenant propagation
- Real tenant registry config/migrations/pool lifecycle

## Review docs

KB: https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/research/plans/feathers-multi-tenant-db-routing.md

## Validation

Not run locally: this worktree does not have `node_modules`, so `vitest` is unavailable. No hooks were bypassed.
