### PR TITLE
perf(agor-ui): modals read entity maps via store selectors (collapse PR1)

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1644,7 +1644,6 @@ function AppContent() {
             onClose={() => setOpenUserSettings(false)}
             user={currentUser}
             client={client}
-            mcpServerById={mcpServerById}
             onUpdateUser={handleUpdateUser}
             onRefreshCurrentUser={reAuthenticate}
             onRestartOnboarding={handleRestartOnboarding}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1445,10 +1445,8 @@ export const App: React.FC<AppProps> = ({
                 availableAgents={availableAgents}
                 branchId={newSessionBranchId}
                 branch={newSessionBranch || undefined}
-                mcpServerById={mcpServerById}
                 currentUser={user}
                 client={client}
-                userById={userById}
               />
             )}
             <SettingsModal
@@ -1519,10 +1517,6 @@ export const App: React.FC<AppProps> = ({
                 open={!!sessionSettingsId}
                 onClose={() => setSessionSettingsId(null)}
                 session={sessionSettingsSession}
-                mcpServerById={mcpServerById}
-                sessionMcpServerIds={
-                  sessionSettingsId ? sessionMcpServerIds.get(sessionSettingsId) || [] : []
-                }
                 onUpdate={onUpdateSession}
                 onUpdateSessionMcpServers={onUpdateSessionMcpServers}
                 onUpdateSessionEnvSelections={onUpdateSessionEnvSelections}
@@ -1540,8 +1534,6 @@ export const App: React.FC<AppProps> = ({
               branch={selectedBranch || null}
               repo={selectedBranchRepo || null}
               sessions={branchSessions}
-              boardById={boardById}
-              mcpServerById={mcpServerById}
               client={client}
               currentUser={user}
               onUpdateBranch={onUpdateBranch}
@@ -1570,8 +1562,6 @@ export const App: React.FC<AppProps> = ({
                 setNewBranchDefaultPosition(null);
               }}
               defaultTab={createDialogDefaultTab}
-              repoById={repoById}
-              boardById={boardById}
               currentBoardId={currentBoardId}
               defaultPosition={newBranchDefaultPosition || undefined}
               onCreateBranch={handleCreateBranch}
@@ -1580,7 +1570,6 @@ export const App: React.FC<AppProps> = ({
               onCreateLocalRepo={(data) => onCreateLocalRepo?.(data)}
               onCreateAssistant={handleCreateAssistant}
               availableAgents={availableAgents}
-              mcpServerById={mcpServerById}
               currentUser={user}
               client={client}
               branchStorageConfig={branchStorageConfig}
@@ -1602,7 +1591,6 @@ export const App: React.FC<AppProps> = ({
               }}
               user={user || null}
               currentUser={user || null}
-              mcpServerById={mcpServerById}
               client={client}
               onUpdate={onUpdateUser}
               onRestartOnboarding={async () => {

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1461,7 +1461,6 @@ export const App: React.FC<AppProps> = ({
               boardObjects={mapToArray(boardObjectById)}
               repoById={repoById}
               branchById={branchById}
-              sessionById={sessionById}
               sessionsByBranch={sessionsByBranch}
               userById={userById}
               mcpServerById={mcpServerById}

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -1,17 +1,10 @@
-import type {
-  AgorClient,
-  Board,
-  BoardEntityObject,
-  Branch,
-  MCPServer,
-  Repo,
-  Session,
-  User,
-} from '@agor-live/client';
+import type { AgorClient, BoardEntityObject, Branch, Repo, Session, User } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import { Badge, Button, Modal, Space, Tabs, theme } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectMcpServerById } from '../../store/selectors';
 import { useThemedMessage } from '../../utils/message';
 import { AssistantTab } from './tabs/AssistantTab';
 import { EnvironmentTab } from './tabs/EnvironmentTab';
@@ -39,9 +32,7 @@ export interface BranchModalProps {
   branch: Branch | null;
   repo: Repo | null;
   sessions: Session[]; // Used for GeneralTab session count
-  boardById?: Map<string, Board>;
   boardObjects?: BoardEntityObject[];
-  mcpServerById?: Map<string, MCPServer>;
   client: AgorClient | null;
   currentUser?: User | null; // Current user for RBAC
   // Used by EnvironmentTab for its independent start/stop/snapshot actions.
@@ -68,9 +59,7 @@ export const BranchModal: React.FC<BranchModalProps> = ({
   branch,
   repo,
   sessions,
-  boardById = new Map(),
   boardObjects = [],
-  mcpServerById = new Map(),
   client,
   currentUser,
   onUpdateBranch,
@@ -81,6 +70,10 @@ export const BranchModal: React.FC<BranchModalProps> = ({
   onExecuteScheduleNow,
   defaultTab,
 }) => {
+  // Entity maps are read from the store rather than drilled through props so
+  // the App shell doesn't have to forward them into every modal.
+  const boardById = useAgorStore(selectBoardById);
+  const mcpServerById = useAgorStore(selectMcpServerById);
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
   const [activeTab, setActiveTab] = useState<BranchModalTab>('general');

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
@@ -21,6 +21,8 @@
 import type { Repo } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
 import { CreateDialog } from './CreateDialog';
 
 function makeRepo(overrides: Partial<Repo> = {}): Repo {
@@ -50,16 +52,18 @@ const userRepo = makeRepo({
 });
 
 function renderDialog(props: Partial<React.ComponentProps<typeof CreateDialog>> = {}) {
+  // CreateDialog reads entity maps from the store, so seed the repos there
+  // rather than passing them as props.
   const repoById = new Map<string, Repo>([
     [frameworkRepo.repo_id, frameworkRepo],
     [userRepo.repo_id, userRepo],
   ]);
+  agorStore.setState({ ...EMPTY_MAPS, repoById });
 
   return render(
     <CreateDialog
       open
       onClose={vi.fn()}
-      repoById={repoById}
       availableAgents={[
         { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: 'Claude' },
       ]}

--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.tsx
@@ -3,8 +3,6 @@ import type {
   Board,
   CreateLocalRepoRequest,
   CreateRepoRequest,
-  MCPServer,
-  Repo,
   User,
 } from '@agor-live/client';
 import {
@@ -16,6 +14,8 @@ import {
 import { Alert, Button, Modal, Tabs } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectMcpServerById, selectRepoById } from '../../store/selectors';
 import type { AgenticToolOption } from '../../types';
 import type { AssistantTabResult } from './tabs/AssistantTab';
 import { AssistantTab } from './tabs/AssistantTab';
@@ -68,12 +68,9 @@ const ACTION_LABELS: Record<ActiveTab, string> = {
 export interface CreateDialogProps {
   open: boolean;
   onClose: () => void;
-  repoById: Map<string, Repo>;
-  boardById: Map<string, Board>;
   currentBoardId?: string;
   defaultPosition?: { x: number; y: number };
   availableAgents: AgenticToolOption[];
-  mcpServerById?: Map<string, MCPServer>;
   currentUser?: User | null;
   client?: AgorClient | null;
   defaultTab?: ActiveTab;
@@ -100,12 +97,9 @@ function fireAndForget(result: void | Promise<void>) {
 export const CreateDialog: React.FC<CreateDialogProps> = ({
   open,
   onClose,
-  repoById,
-  boardById,
   currentBoardId,
   defaultPosition,
   availableAgents,
-  mcpServerById,
   currentUser,
   client,
   defaultTab = 'assistant',
@@ -116,6 +110,11 @@ export const CreateDialog: React.FC<CreateDialogProps> = ({
   onCreateAssistant,
   branchStorageConfig,
 }) => {
+  // Entity maps are read from the store rather than drilled through props so
+  // the App shell doesn't have to forward them into every modal.
+  const repoById = useAgorStore(selectRepoById);
+  const boardById = useAgorStore(selectBoardById);
+  const mcpServerById = useAgorStore(selectMcpServerById);
   const [activeTab, setActiveTab] = useState<ActiveTab>(defaultTab);
   // Validity is tracked per tab so a sibling tab's empty-form state (or a
   // deferred validity push from its init effect) can't clobber the active

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -5,7 +5,6 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
-  MCPServer,
   PermissionMode,
   User,
 } from '@agor-live/client';
@@ -13,6 +12,8 @@ import { getDefaultPermissionMode, mapToCodexPermissionConfig } from '@agor-live
 import { DownOutlined } from '@ant-design/icons';
 import { Alert, Collapse, Form, Input, Modal, Typography } from 'antd';
 import { useEffect, useState } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import { selectMcpServerById, selectUserById } from '../../store/selectors';
 import { AgenticToolConfigForm, getFormValuesFromConfig } from '../AgenticToolConfigForm';
 import {
   type AgenticToolOption,
@@ -51,10 +52,8 @@ export interface NewSessionModalProps {
   availableAgents: AgenticToolOption[];
   branchId: string; // Required - the branch to create the session in
   branch?: Branch; // Optional - branch details for display
-  mcpServerById?: Map<string, MCPServer>;
   currentUser?: User | null; // Optional - current user for default settings
   client: AgorClient | null;
-  userById: Map<string, User>;
 }
 
 export const NewSessionModal: React.FC<NewSessionModalProps> = ({
@@ -64,11 +63,13 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
   availableAgents,
   branchId,
   branch,
-  mcpServerById = new Map(),
   currentUser,
   client,
-  userById,
 }) => {
+  // Entity maps are read from the store rather than drilled through props so
+  // the App shell doesn't have to forward them into every modal.
+  const mcpServerById = useAgorStore(selectMcpServerById);
+  const userById = useAgorStore(selectUserById);
   const [form] = Form.useForm();
   const [selectedAgent, setSelectedAgent] = useState<string>('claude-code');
   const [isCreating, setIsCreating] = useState(false);

--- a/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SessionSettingsModal/SessionSettingsModal.tsx
@@ -19,7 +19,6 @@ import type {
   AgorClient,
   CodexApprovalPolicy,
   CodexSandboxMode,
-  MCPServer,
   PermissionMode,
   Session,
   User,
@@ -29,6 +28,8 @@ import { DownOutlined, KeyOutlined, SettingOutlined, ThunderboltOutlined } from 
 import type { CollapseProps } from 'antd';
 import { Collapse, Divider, Form, Modal, Typography } from 'antd';
 import React from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import { selectMcpServerById, selectSessionMcpServerIds } from '../../store/selectors';
 import { AdvancedSettingsForm } from '../AdvancedSettingsForm';
 import { AgenticToolConfigForm } from '../AgenticToolConfigForm';
 import { CallbackConfigForm } from '../CallbackConfigForm';
@@ -43,8 +44,6 @@ export interface SessionSettingsModalProps {
   open: boolean;
   onClose: () => void;
   session: Session;
-  mcpServerById: Map<string, MCPServer>;
-  sessionMcpServerIds: string[];
   onUpdate?: (sessionId: string, updates: Partial<Session>) => void;
   onUpdateSessionMcpServers?: (sessionId: string, mcpServerIds: string[]) => void;
   /**
@@ -74,6 +73,11 @@ interface FormValues {
     template?: string;
   };
 }
+
+// Stable empty array for sessions with no attached MCP servers — keeps the
+// derived per-session slice reference-stable so the form-reset effect (which
+// depends on it) doesn't re-fire on unrelated store patches.
+const EMPTY_MCP_SERVER_IDS: string[] = [];
 
 function buildInitialValues(session: Session, sessionMcpServerIds: string[]): FormValues {
   const permissionMode: PermissionMode =
@@ -164,14 +168,18 @@ export const SessionSettingsModal: React.FC<SessionSettingsModalProps> = ({
   open,
   onClose,
   session,
-  mcpServerById,
-  sessionMcpServerIds,
   onUpdate,
   onUpdateSessionMcpServers,
   onUpdateSessionEnvSelections,
   client,
   currentUser,
 }) => {
+  // Entity maps come from the store rather than being drilled through the App
+  // shell. The whole session→MCP map is sliced to this session's ids here so
+  // the rest of the component keeps working with a plain `string[]`.
+  const mcpServerById = useAgorStore(selectMcpServerById);
+  const sessionMcpServerIds =
+    useAgorStore(selectSessionMcpServerIds).get(session.session_id) ?? EMPTY_MCP_SERVER_IDS;
   const [form] = Form.useForm();
   const [initialValues, setInitialValues] = React.useState<FormValues>(() =>
     buildInitialValues(session, sessionMcpServerIds)

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -64,7 +64,6 @@ export interface SettingsModalProps {
   boardObjects: BoardEntityObject[];
   repoById: Map<string, Repo>;
   branchById: Map<string, Branch>;
-  sessionById: Map<string, Session>; // O(1) ID lookups - efficient, stable references
   sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
   userById: Map<string, User>;
   mcpServerById: Map<string, MCPServer>;

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -461,7 +461,6 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         return (
           <UsersTable
             userById={userById}
-            mcpServerById={mcpServerById}
             gatewayChannelById={gatewayChannelById}
             client={client}
             currentUser={currentUser}
@@ -558,9 +557,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         branch={selectedBranch}
         repo={selectedRepo}
         sessions={branchSessions}
-        boardById={boardById}
         boardObjects={boardObjects}
-        mcpServerById={mcpServerById}
         client={client}
         currentUser={currentUser}
         onUpdateBranch={onUpdateBranch}

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -85,7 +85,6 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
         user={user}
         currentUser={user}
         client={null as AgorClient | null}
-        mcpServerById={new Map()}
         onUpdate={onUpdate}
       />
     );
@@ -126,7 +125,6 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
         user={user}
         currentUser={user}
         client={null as AgorClient | null}
-        mcpServerById={new Map()}
         onUpdate={onUpdate}
       />
     );
@@ -171,7 +169,6 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
           user={user}
           currentUser={user}
           client={null as AgorClient | null}
-          mcpServerById={new Map()}
           onUpdate={async (userId, updates) => {
             updateSpy(userId, updates);
             if (updates.env_vars) {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -5,7 +5,6 @@ import type {
   EnvVarScope,
   Group,
   GroupMembership,
-  MCPServer,
   UpdateUserInput,
   User,
 } from '@agor-live/client';
@@ -40,6 +39,8 @@ import {
   theme,
 } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import { selectMcpServerById } from '../../store/selectors';
 import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
 import { searchableSelectProps, toGroupSelectOption } from '../../utils/selectSearch';
 import {
@@ -76,7 +77,6 @@ export interface UserSettingsModalProps {
   open: boolean;
   onClose: () => void;
   user: User | null;
-  mcpServerById: Map<string, MCPServer>;
   client: AgorClient | null;
   currentUser?: User | null;
   onUpdate?: (userId: string, updates: UpdateUserInput) => void;
@@ -87,12 +87,14 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   open,
   onClose,
   user,
-  mcpServerById,
   client,
   currentUser,
   onUpdate,
   onRestartOnboarding,
 }) => {
+  // Entity maps are read from the store rather than drilled through props so
+  // the App shell doesn't have to forward them into every modal.
+  const mcpServerById = useAgorStore(selectMcpServerById);
   const [form] = Form.useForm();
   const [activeTab, setActiveTab] = useState<string>('general');
   const initializedUserIdRef = useRef<string | null>(null);

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -4,7 +4,6 @@ import type {
   GatewayChannel,
   Group,
   GroupMembership,
-  MCPServer,
   UpdateUserInput,
   User,
 } from '@agor-live/client';
@@ -38,7 +37,6 @@ import { UserSettingsModal } from './UserSettingsModal';
 
 interface UsersTableProps {
   userById: Map<string, User>;
-  mcpServerById: Map<string, MCPServer>;
   gatewayChannelById?: Map<string, GatewayChannel>;
   client: AgorClient | null;
   currentUser?: User | null;
@@ -49,7 +47,6 @@ interface UsersTableProps {
 
 export const UsersTable: React.FC<UsersTableProps> = ({
   userById,
-  mcpServerById,
   gatewayChannelById = new Map(),
   client,
   currentUser,
@@ -366,7 +363,6 @@ export const UsersTable: React.FC<UsersTableProps> = ({
           void loadGroups();
         }}
         user={editingUser}
-        mcpServerById={mcpServerById}
         client={client}
         currentUser={currentUser}
         onUpdate={onUpdate}

--- a/apps/agor-ui/src/store/selectors.ts
+++ b/apps/agor-ui/src/store/selectors.ts
@@ -26,6 +26,7 @@ export const selectMcpServerById = (s: AgorState) => s.mcpServerById;
 export const selectUserAuthenticatedMcpServerIds = (s: AgorState) =>
   s.userAuthenticatedMcpServerIds;
 export const selectArtifactById = (s: AgorState) => s.artifactById;
+export const selectSessionMcpServerIds = (s: AgorState) => s.sessionMcpServerIds;
 
 /**
  * Select a single board's board-object array. Curried so callers can memoize

--- a/apps/agor-ui/src/surfaces/SharedUserSettingsModal.tsx
+++ b/apps/agor-ui/src/surfaces/SharedUserSettingsModal.tsx
@@ -1,13 +1,10 @@
-import type { AgorClient, MCPServer, UpdateUserInput, User } from '@agor-live/client';
+import type { AgorClient, UpdateUserInput, User } from '@agor-live/client';
 import { UserSettingsModal } from '../components/SettingsModal';
-
-const EMPTY_MCP_SERVER_MAP: Map<string, MCPServer> = new Map();
 
 export interface SharedUserSettingsModalProps {
   open: boolean;
   user: User | null;
   client: AgorClient | null;
-  mcpServerById?: Map<string, MCPServer>;
   onClose: () => void;
   onUpdateUser: (userId: string, updates: UpdateUserInput) => Promise<void>;
   onRefreshCurrentUser: () => Promise<unknown>;
@@ -19,14 +16,14 @@ export interface SharedUserSettingsModalProps {
  *
  * Workspace still renders its full settings stack inside `AgorApp`; lightweight
  * surfaces use this wrapper so a user menu/settings flow does not require the
- * Workspace route tree to mount first. The MCP server map is optional because
- * a fresh Knowledge deep link intentionally has not loaded Workspace data yet.
+ * Workspace route tree to mount first. The MCP server map is read by
+ * `UserSettingsModal` straight from the store, so a fresh Knowledge deep link
+ * that has not loaded Workspace data yet simply sees an empty map.
  */
 export const SharedUserSettingsModal: React.FC<SharedUserSettingsModalProps> = ({
   open,
   user,
   client,
-  mcpServerById = EMPTY_MCP_SERVER_MAP,
   onClose,
   onUpdateUser,
   onRefreshCurrentUser,
@@ -37,7 +34,6 @@ export const SharedUserSettingsModal: React.FC<SharedUserSettingsModalProps> = (
     onClose={onClose}
     user={user}
     currentUser={user}
-    mcpServerById={mcpServerById}
     client={client}
     onUpdate={async (userId, updates) => {
       await onUpdateUser(userId, updates);


### PR DESCRIPTION
## What

First PR in the **collapse-the-useAgorData-shim** sequence. Stops drilling entity `Map`s through the App shell into the session/branch/create/user-settings modals — each subscribes to the slices it needs directly from the zustand store, and the corresponding map props are dropped from the App render sites + modal interfaces.

## Peeled
- **NewSessionModal** (mcpServerById, userById)
- **SessionSettingsModal** (mcpServerById, sessionMcpServerIds — sliced per-session internally with a reference-stable empty array so the form-reset effect doesn't re-fire)
- **BranchModal** (boardById, mcpServerById)
- **CreateDialog** (repoById, boardById, mcpServerById)
- **UserSettingsModal** + **SharedUserSettingsModal** (mcpServerById)
- **UsersTable** leaf (mcpServerById → UserSettingsModal chain)

Added `selectSessionMcpServerIds`. Tests seed the store instead of passing map props.

## Out of scope
SettingsModal still consumes several maps across its tabs, so its own peel is left for a focused follow-up; only its `UsersTable` leaf moves here.

## Why
These maps don't change per-render but the props were fresh each App render; reading from the store removes them from App's prop surface (a prerequisite for the eventual `useAgorData` → `useAgorBootstrap` flip). No behavior change.

## Gate
typecheck ✓ · biome ✓ · test 553/553 ✓ · build ✓