### PR TITLE
perf(agor-ui): HomePage + BoardAssistantPanel read entity maps via store selectors (collapse PR3)

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1124,10 +1124,6 @@ export const App: React.FC<AppProps> = ({
                   primaryAssistantBranch={primaryAssistantBranch}
                   primaryAssistantRepo={primaryAssistantRepo}
                   primaryAssistantInaccessible={primaryAssistantInaccessible}
-                  sessionsByBranch={sessionsByBranch}
-                  branchById={branchById}
-                  repoById={repoById}
-                  userById={userById}
                   currentUserId={user?.user_id}
                   selectedSessionId={effectiveSelectedSessionId}
                   onSessionClick={handleSessionClick}
@@ -1146,10 +1142,6 @@ export const App: React.FC<AppProps> = ({
                   onViewLogs={setLogsModalBranchId}
                   onNukeEnvironment={onNukeEnvironment}
                   onExecuteScheduleNow={onExecuteScheduleNow}
-                  comments={mapToArray(commentById).filter(
-                    (c: BoardComment) => c.board_id === currentBoardId
-                  )}
-                  boardObjects={currentBoard?.objects}
                   onSendComment={(content) => onSendComment?.(currentBoardId || '', content)}
                   onReplyComment={onReplyComment}
                   onResolveComment={onResolveComment}
@@ -1221,13 +1213,7 @@ export const App: React.FC<AppProps> = ({
                       <HomePage
                         client={client}
                         connected={connected}
-                        boardById={boardById}
                         recentBoardIds={recentBoardIds}
-                        branchById={branchById}
-                        repoById={repoById}
-                        sessionById={sessionById}
-                        sessionsByBranch={sessionsByBranch}
-                        userById={userById}
                         currentUserId={user?.user_id}
                         onBoardClick={navigation.goToBoard}
                         onBranchClick={navigation.goToBranch}

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.test.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.test.tsx
@@ -15,10 +15,6 @@ const renderPanel = (props: Partial<ComponentProps<typeof BoardAssistantPanel>> 
         activeTab="comments"
         onTabChange={vi.fn()}
         primaryAssistantInaccessible={false}
-        sessionsByBranch={new Map()}
-        branchById={new Map()}
-        repoById={new Map()}
-        userById={new Map()}
         onSessionClick={vi.fn()}
         client={null}
         {...props}

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -102,16 +102,16 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
 }) => {
   const { token } = theme.useToken();
   const { message } = AntApp.useApp();
-  // Entity maps read straight from the store so this panel no longer re-renders
-  // on every App store-tick that re-derives the prop maps.
+  // Subscribe to entity maps by slice from the store: each selector only wakes
+  // this panel when its own slice changes.
   const sessionsByBranch = useAgorStore(selectSessionsByBranch);
   const branchById = useAgorStore(selectBranchById);
   const repoById = useAgorStore(selectRepoById);
   const userById = useAgorStore(selectUserById);
   const commentById = useAgorStore(selectCommentById);
-  // Derive the board-scoped comment list and board objects here rather than
-  // re-drilling them: comments only render when a board is selected, where
-  // `board.board_id` is the same id App filtered on.
+  // Derive the board-scoped comment list and board objects locally: comments
+  // only render when a board is selected, so filtering by `board.board_id`
+  // scopes them to that board.
   const comments = useMemo(
     () => mapToArray(commentById).filter((c) => c.board_id === board?.board_id),
     [commentById, board?.board_id]

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -1,14 +1,4 @@
-import type {
-  AgorClient,
-  Board,
-  BoardComment,
-  BoardObject,
-  Branch,
-  Repo,
-  Session,
-  SpawnConfig,
-  User,
-} from '@agor-live/client';
+import type { AgorClient, Board, Branch, Repo, SpawnConfig } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import { LeftOutlined, RobotOutlined } from '@ant-design/icons';
 import {
@@ -26,6 +16,15 @@ import {
 } from 'antd';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectBranchById,
+  selectCommentById,
+  selectRepoById,
+  selectSessionsByBranch,
+  selectUserById,
+} from '../../store/selectors';
+import { mapToArray } from '../../utils/mapHelpers';
 import { BranchSessionSections } from '../BranchCard';
 import { BranchHeaderPill } from '../BranchHeaderPill';
 import { BoardSessionList } from '../BranchListDrawer';
@@ -44,10 +43,6 @@ interface BoardAssistantPanelProps {
   primaryAssistantBranch?: Branch;
   primaryAssistantRepo?: Repo;
   primaryAssistantInaccessible: boolean;
-  sessionsByBranch: Map<string, Session[]>;
-  branchById: Map<string, Branch>;
-  repoById: Map<string, Repo>;
-  userById: Map<string, User>;
   currentUserId?: string;
   selectedSessionId?: string | null;
   onSessionClick: (sessionId: string) => void;
@@ -69,8 +64,6 @@ interface BoardAssistantPanelProps {
   onViewLogs?: (branchId: string) => void;
   onNukeEnvironment?: (branchId: string) => void;
   onExecuteScheduleNow?: (branchId: string) => Promise<void>;
-  comments?: BoardComment[];
-  boardObjects?: Record<string, BoardObject>;
   onSendComment?: (content: string) => void;
   onReplyComment?: (parentId: string, content: string) => void;
   onResolveComment?: (commentId: string) => void;
@@ -89,10 +82,6 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
   primaryAssistantBranch,
   primaryAssistantRepo,
   primaryAssistantInaccessible,
-  sessionsByBranch,
-  branchById,
-  repoById,
-  userById,
   currentUserId,
   selectedSessionId,
   onSessionClick,
@@ -101,8 +90,6 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
   onSpawnSession,
   onOpenSettings,
   onOpenSessionSettings,
-  comments = [],
-  boardObjects,
   onSendComment,
   onReplyComment,
   onResolveComment,
@@ -115,6 +102,21 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
 }) => {
   const { token } = theme.useToken();
   const { message } = AntApp.useApp();
+  // Entity maps read straight from the store so this panel no longer re-renders
+  // on every App store-tick that re-derives the prop maps.
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+  const branchById = useAgorStore(selectBranchById);
+  const repoById = useAgorStore(selectRepoById);
+  const userById = useAgorStore(selectUserById);
+  const commentById = useAgorStore(selectCommentById);
+  // Derive the board-scoped comment list and board objects here rather than
+  // re-drilling them: comments only render when a board is selected, where
+  // `board.board_id` is the same id App filtered on.
+  const comments = useMemo(
+    () => mapToArray(commentById).filter((c) => c.board_id === board?.board_id),
+    [commentById, board?.board_id]
+  );
+  const boardObjects = board?.objects;
   const defaultTab: BoardAssistantPanelTab = primaryAssistantInaccessible
     ? 'all-sessions'
     : 'assistant';

--- a/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
@@ -25,7 +25,7 @@ import { formatRelativeTime } from '../../utils/time';
 import { AssistantPill, BoardPill, BranchPill, SessionPill, UserPill } from '../Pill';
 import { HomeSectionHeader } from './HomeSectionHeader';
 import { glassCardStyle } from './homeStyles';
-import type { HomePageProps } from './types';
+import type { HomeSectionProps } from './types';
 
 const { Text } = Typography;
 
@@ -71,7 +71,7 @@ const ActivityFeedItem: React.FC<{
 
 export const HomeActivitySection: React.FC<
   Pick<
-    HomePageProps,
+    HomeSectionProps,
     | 'branchById'
     | 'boardById'
     | 'sessionById'

--- a/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
@@ -13,7 +13,7 @@ import { formatRelativeTime } from '../../utils/time';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { HomeSectionHeader } from './HomeSectionHeader';
 import { glassCardStyle, withAlpha } from './homeStyles';
-import type { HomePageProps } from './types';
+import type { HomeSectionProps } from './types';
 
 const { Text } = Typography;
 
@@ -62,7 +62,7 @@ const deriveBoardRows = ({
   recentBoardIds,
   branchById,
   sessionsByBranch,
-}: Pick<HomePageProps, 'boardById' | 'recentBoardIds' | 'branchById' | 'sessionsByBranch'>) => {
+}: Pick<HomeSectionProps, 'boardById' | 'recentBoardIds' | 'branchById' | 'sessionsByBranch'>) => {
   const visitRank = new Map((recentBoardIds ?? []).map((boardId, index) => [boardId, index]));
   const branchesByBoard = groupBranchesByBoard(branchById);
   const visibleSessionsByBranch = groupVisibleSessionsByBranch(sessionsByBranch);
@@ -238,7 +238,7 @@ const BoardHomeCard: React.FC<{
 
 export const HomeBoardsSection: React.FC<
   Pick<
-    HomePageProps,
+    HomeSectionProps,
     'boardById' | 'recentBoardIds' | 'branchById' | 'sessionsByBranch' | 'onBoardClick'
   >
 > = ({ boardById, recentBoardIds = [], branchById, sessionsByBranch, onBoardClick }) => {

--- a/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
@@ -1,0 +1,88 @@
+import type { Board } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { HomePage } from './HomePage';
+
+// HomePage renders its sections unconditionally. HomeBoardsSection is mocked to a
+// bare render counter so its invocation count is a faithful proxy for how many
+// times HomePage itself rendered.
+let homeRenders = 0;
+
+vi.mock('./HomeBoardsSection', () => ({
+  HomeBoardsSection: () => {
+    homeRenders += 1;
+    return null;
+  },
+}));
+vi.mock('./HomeSessionsSection', () => ({
+  HomeSessionsSection: () => null,
+}));
+vi.mock('./HomeActivitySection', () => ({
+  HomeActivitySection: () => null,
+}));
+vi.mock('./HomeKnowledgeSection', () => ({
+  HomeKnowledgeSection: () => null,
+}));
+
+const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as unknown as Board;
+
+function renderHome() {
+  return render(
+    <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
+      <HomePage
+        client={null}
+        onBoardClick={() => {}}
+        onBranchClick={() => {}}
+        onSessionClick={() => {}}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('HomePage store-selector re-render isolation', () => {
+  beforeEach(() => {
+    homeRenders = 0;
+    agorStore.setState({ ...EMPTY_MAPS });
+  });
+
+  it('a patch to a slice HomePage does not select leaves it un-rendered', async () => {
+    renderHome();
+
+    await waitFor(() => {
+      expect(homeRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = homeRenders;
+
+    // Patch a slice HomePage never selects (comments). zustand notifies every
+    // subscriber, but each of HomePage's selected slices keeps its reference, so
+    // its subscriptions stay quiet and it does not re-render.
+    act(() => {
+      agorStore.setState({ commentById: new Map([['c-1', { board_id: 'board-1' } as never]]) });
+    });
+
+    expect(homeRenders).toBe(baseline);
+  });
+
+  it('a patch to a selected slice (boards) re-renders HomePage', async () => {
+    renderHome();
+
+    await waitFor(() => {
+      expect(homeRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = homeRenders;
+
+    // Contrast: HomePage subscribes to boardById (it derives the boards section
+    // from it), so a boards patch MUST wake it — proving the subscription is
+    // live and the isolation above is meaningful.
+    act(() => {
+      agorStore.setState({ boardById: new Map([[board.board_id, board]]) });
+    });
+
+    await waitFor(() => {
+      expect(homeRenders).toBeGreaterThan(baseline);
+    });
+  });
+});

--- a/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
@@ -1,5 +1,6 @@
 import type { Board } from '@agor-live/client';
 import { act, render, waitFor } from '@testing-library/react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EMPTY_MAPS } from '../../store/agorMaps';
@@ -79,6 +80,105 @@ describe('HomePage store-selector re-render isolation', () => {
     // live and the isolation above is meaningful.
     act(() => {
       agorStore.setState({ boardById: new Map([[board.board_id, board]]) });
+    });
+
+    await waitFor(() => {
+      expect(homeRenders).toBeGreaterThan(baseline);
+    });
+  });
+});
+
+// Mirror of App's `useStableCallback`: freeze a handler's identity across renders
+// while delegating to the latest impl via a ref. App stabilizes HomePage's
+// callbacks the same way, so reproducing it exercises the real contract.
+function useStableCallback<TFn extends (...args: never[]) => unknown>(
+  callback: TFn | undefined
+): TFn | undefined {
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+  const stable = useCallback(((...args: never[]) => callbackRef.current?.(...args)) as TFn, []);
+  return callback ? stable : undefined;
+}
+
+// Lets a test trigger a parent re-render without touching HomePage's props.
+let triggerParentRerender: () => void = () => {};
+
+// The complete prop set App passes, minus the one callback the harness flips.
+// Module-level so the identities stay stable across parent re-renders — the
+// whole point of the guard is that NOTHING HomePage receives churns, so
+// React.memo can bail out. A reintroduced unstable prop here (e.g. a fresh
+// array) would start failing the stable-props bailout below.
+const noop = () => {};
+const EMPTY_RECENT: string[] = [];
+const STABLE_HOME_PROPS = {
+  client: null,
+  connected: true,
+  recentBoardIds: EMPTY_RECENT,
+  currentUserId: 'u1',
+  onBoardClick: noop,
+  onBranchClick: noop,
+} as const;
+
+// Parent harness rendering the REAL memo'd HomePage the way App does. The
+// flipped `onSessionClick` flows through `useStableCallback` when `stabilize` is
+// true and is a fresh arrow otherwise, so the same harness proves both halves of
+// the guard while every other prop stays referentially stable. A `useState` bump
+// re-renders THIS parent without touching any prop value.
+function ParentHarness({ stabilize }: { stabilize: boolean }) {
+  const [, setTick] = useState(0);
+  triggerParentRerender = () => setTick((tick) => tick + 1);
+
+  const sessionImpl = () => {};
+  const stableSession = useStableCallback(sessionImpl);
+  const onSessionClick = stabilize ? stableSession : sessionImpl;
+
+  return (
+    <MemoryRouter basename="/ui" initialEntries={['/ui/']}>
+      <HomePage {...STABLE_HOME_PROPS} onSessionClick={onSessionClick} />
+    </MemoryRouter>
+  );
+}
+
+describe('HomePage memo + prop-stabilization re-render bailout', () => {
+  beforeEach(() => {
+    homeRenders = 0;
+    triggerParentRerender = () => {};
+    agorStore.setState({ ...EMPTY_MAPS });
+  });
+
+  it('a parent re-render does not re-render the memo’d HomePage when props are stable', async () => {
+    render(<ParentHarness stabilize={true} />);
+
+    await waitFor(() => {
+      expect(homeRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = homeRenders;
+
+    // Parent re-renders without changing any prop value or touching the store.
+    // The memo bailout must keep HomePage at its baseline render count; if
+    // `React.memo` were removed this assertion would fail (count would climb).
+    act(() => {
+      triggerParentRerender();
+    });
+
+    expect(homeRenders).toBe(baseline);
+  });
+
+  it('a parent re-render DOES re-render HomePage when a prop identity churns', async () => {
+    render(<ParentHarness stabilize={false} />);
+
+    await waitFor(() => {
+      expect(homeRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = homeRenders;
+
+    // Contrast: a fresh `onSessionClick` each parent render defeats the memo, so
+    // HomePage must re-render — proving the bailout above is meaningful and not
+    // just an artifact of the parent never re-rendering.
+    act(() => {
+      triggerParentRerender();
     });
 
     await waitFor(() => {

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -1,6 +1,15 @@
 import { Space, Typography, theme } from 'antd';
 import type React from 'react';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectBoardById,
+  selectBranchById,
+  selectRepoById,
+  selectSessionById,
+  selectSessionsByBranch,
+  selectUserById,
+} from '../../store/selectors';
 import { isDarkTheme } from '../../utils/theme';
 import { HomeActivitySection } from './HomeActivitySection';
 import { HomeBoardsSection } from './HomeBoardsSection';
@@ -13,6 +22,14 @@ const { Text, Title } = Typography;
 export const HomePage: React.FC<HomePageProps> = (props) => {
   const { token } = theme.useToken();
   const homeBackground = DEFAULT_BACKGROUNDS[isDarkTheme(token) ? 'dark' : 'light'];
+  // Entity maps come straight from the store so this large home surface no
+  // longer re-renders on every App store-tick that re-derives prop maps.
+  const boardById = useAgorStore(selectBoardById);
+  const branchById = useAgorStore(selectBranchById);
+  const repoById = useAgorStore(selectRepoById);
+  const sessionById = useAgorStore(selectSessionById);
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+  const userById = useAgorStore(selectUserById);
   return (
     <div style={{ height: '100%', width: '100%', overflow: 'hidden', background: homeBackground }}>
       <div
@@ -39,27 +56,27 @@ export const HomePage: React.FC<HomePageProps> = (props) => {
             </Space>
           </div>
           <HomeBoardsSection
-            boardById={props.boardById}
+            boardById={boardById}
             recentBoardIds={props.recentBoardIds}
-            branchById={props.branchById}
-            sessionsByBranch={props.sessionsByBranch}
+            branchById={branchById}
+            sessionsByBranch={sessionsByBranch}
             onBoardClick={props.onBoardClick}
           />
           <HomeSessionsSection
-            sessionById={props.sessionById}
-            branchById={props.branchById}
-            boardById={props.boardById}
-            repoById={props.repoById}
+            sessionById={sessionById}
+            branchById={branchById}
+            boardById={boardById}
+            repoById={repoById}
             currentUserId={props.currentUserId}
             onSessionClick={props.onSessionClick}
           />
         </main>
         <aside style={{ minHeight: 0, display: 'flex', flexDirection: 'column', gap: 16 }}>
           <HomeActivitySection
-            branchById={props.branchById}
-            boardById={props.boardById}
-            sessionById={props.sessionById}
-            userById={props.userById}
+            branchById={branchById}
+            boardById={boardById}
+            sessionById={sessionById}
+            userById={userById}
             onBoardClick={props.onBoardClick}
             onBranchClick={props.onBranchClick}
             onSessionClick={props.onSessionClick}

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Space, Typography, theme } from 'antd';
-import type React from 'react';
+import { memo } from 'react';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
 import { useAgorStore } from '../../store/agorStore';
 import {
@@ -19,7 +19,7 @@ import type { HomePageProps } from './types';
 
 const { Text, Title } = Typography;
 
-export const HomePage: React.FC<HomePageProps> = (props) => {
+export const HomePage = memo(function HomePage(props: HomePageProps) {
   const { token } = theme.useToken();
   const homeBackground = DEFAULT_BACKGROUNDS[isDarkTheme(token) ? 'dark' : 'light'];
   // Entity maps come straight from the store so this large home surface no
@@ -86,6 +86,6 @@ export const HomePage: React.FC<HomePageProps> = (props) => {
       </div>
     </div>
   );
-};
+});
 
 export default HomePage;

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -22,8 +22,8 @@ const { Text, Title } = Typography;
 export const HomePage = memo(function HomePage(props: HomePageProps) {
   const { token } = theme.useToken();
   const homeBackground = DEFAULT_BACKGROUNDS[isDarkTheme(token) ? 'dark' : 'light'];
-  // Entity maps come straight from the store so this large home surface no
-  // longer re-renders on every App store-tick that re-derives prop maps.
+  // Subscribe to entity maps by slice from the store: each selector only wakes
+  // this large home surface when its own slice changes.
   const boardById = useAgorStore(selectBoardById);
   const branchById = useAgorStore(selectBranchById);
   const repoById = useAgorStore(selectRepoById);

--- a/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
@@ -21,7 +21,7 @@ import { BoardPill, BranchPill } from '../Pill';
 import { SessionSearchToolbar } from '../SessionSearchControls';
 import { HomeSectionHeader } from './HomeSectionHeader';
 import { glassCardStyle } from './homeStyles';
-import type { HomePageProps } from './types';
+import type { HomeSectionProps } from './types';
 
 const { Text } = Typography;
 
@@ -116,7 +116,7 @@ const HomeSessionRow: React.FC<{
 
 export const HomeSessionsSection: React.FC<
   Pick<
-    HomePageProps,
+    HomeSectionProps,
     'sessionById' | 'branchById' | 'boardById' | 'repoById' | 'currentUserId' | 'onSessionClick'
   >
 > = ({ sessionById, branchById, boardById, repoById, currentUserId, onSessionClick }) => {

--- a/apps/agor-ui/src/components/HomePage/types.ts
+++ b/apps/agor-ui/src/components/HomePage/types.ts
@@ -4,18 +4,29 @@ import type { AgorClient, Board, Branch, Repo, Session, User } from '@agor-live/
 export interface HomePageProps {
   client: AgorClient | null;
   connected?: boolean;
-  boardById: Map<string, Board>;
   recentBoardIds?: string[];
-  branchById: Map<string, Branch>;
-  repoById: Map<string, Repo>;
-  sessionById: Map<string, Session>;
-  sessionsByBranch: Map<string, Session[]>;
-  userById: Map<string, User>;
   currentUserId?: string;
   onBoardClick: (boardId: string) => void;
   onBranchClick: (branchId: string) => void;
   onSessionClick: (sessionId: string) => void;
 }
+
+/**
+ * Entity maps the home sub-sections consume. HomePage reads these from the
+ * store and drills them into its sections, so they live separately from
+ * HomePageProps (HomePage itself no longer receives them as props).
+ */
+export interface HomeEntityMaps {
+  boardById: Map<string, Board>;
+  branchById: Map<string, Branch>;
+  repoById: Map<string, Repo>;
+  sessionById: Map<string, Session>;
+  sessionsByBranch: Map<string, Session[]>;
+  userById: Map<string, User>;
+}
+
+/** Props available to home sub-sections: HomePage's own props plus entity maps. */
+export type HomeSectionProps = HomePageProps & HomeEntityMaps;
 
 export interface KnowledgeDocument
   extends Omit<CoreKnowledgeDocument, 'created_at' | 'updated_at' | 'archived_at'> {

--- a/apps/agor-ui/src/components/HomePage/types.ts
+++ b/apps/agor-ui/src/components/HomePage/types.ts
@@ -13,8 +13,8 @@ export interface HomePageProps {
 
 /**
  * Entity maps the home sub-sections consume. HomePage reads these from the
- * store and drills them into its sections, so they live separately from
- * HomePageProps (HomePage itself no longer receives them as props).
+ * store and drills them into its sections, so they're typed separately from
+ * HomePageProps (which carries only HomePage's own props).
  */
 export interface HomeEntityMaps {
   boardById: Map<string, Board>;


### PR DESCRIPTION
## What

PR3 of collapsing the `useAgorData` shim. Peels `HomePage` and `BoardAssistantPanel` off the entity-`Map` props drilled from inner `components/App/App.tsx` — each now reads the slices it needs directly from the zustand store via `useAgorStore(selectX)` — and removes those map props from the App render sites + component interfaces.

## HomePage

- Reads `boardById` / `branchById` / `repoById` / `sessionById` / `sessionsByBranch` / `userById` from the store via the existing narrow selectors, and drills them into its sub-sections exactly as before.
- Sub-section prop contracts move from `Pick<HomePageProps, …>` to a dedicated `HomeEntityMaps` (combined as `HomeSectionProps`), since `HomePage` itself no longer receives those maps as props.
- Wrapped in `React.memo` — its remaining props (navigation handlers, `recentBoardIds`, scalars) are referentially stable, so it bails out of App's store-tick re-renders. Guarded by a render-count test mirroring `AppHeader.rerender.test.tsx`.

## BoardAssistantPanel

- Reads `sessionsByBranch` / `branchById` / `repoById` / `userById` / `commentById` from the store.
- Derives its board-scoped `comments` list (`useMemo` over `commentById` filtered by `board?.board_id`) and `boardObjects` (`board?.objects`) locally instead of re-drilling pre-computed values from App. The comment list only renders inside the `board ?` branch, where `board.board_id === currentBoardId`, so the derivation is behavior-identical.

## Behavior preservation

The home page is a protected surface — only the **source** of the data changes (store selector vs prop), never **what** data or **how** it renders. Every map `HomePage` consumed via props resolves to the identical store slice the props were derived from.

## Deferred

`BoardAssistantPanel`'s App render site passes inline-arrow props (`onOpenSettings`, `onSendComment`, `onCollapse`), so `React.memo` there is ineffective until those are stabilized App-side — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)