### PR TITLE
feat(gateway): MCP tool to generate Slack app manifest

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -3,7 +3,12 @@ import {
   GatewayChannelRepository,
   ThreadSessionMapRepository,
 } from '@agor/core/db';
-import { getConnector } from '@agor/core/gateway';
+import {
+  buildSlackManifest,
+  getConnector,
+  requiredBotEvents,
+  requiredBotScopes,
+} from '@agor/core/gateway';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -679,5 +684,112 @@ describe('agor_gateway_channels MCP tools', () => {
       target: 'thread:C123:171234.000100',
     });
     expect(existingThread.success).toBe(false);
+  });
+});
+
+describe('agor_gateway_slack_manifest_generate MCP tool', () => {
+  const dmOnly = {
+    appName: 'Agor',
+    publicChannels: false,
+    privateChannels: false,
+    groupDms: false,
+    alignUsers: false,
+    outbound: false,
+  };
+
+  it('marks the manifest generator read-only', async () => {
+    const tools = await captureTools('admin');
+    expect(tools.agor_gateway_slack_manifest_generate.cfg.annotations).toMatchObject({
+      readOnlyHint: true,
+    });
+  });
+
+  it('generates a DM-only manifest matching the core generator', async () => {
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_slack_manifest_generate.handler(dmOnly);
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.manifest).toEqual(buildSlackManifest(dmOnly));
+    expect(payload.bot_scopes).toEqual(requiredBotScopes(dmOnly));
+    expect(payload.bot_events).toEqual(requiredBotEvents(dmOnly));
+    expect(payload.bot_scopes).not.toContain('app_mentions:read');
+    expect(payload.bot_events).toEqual(['message.im']);
+    expect(payload.create_channel_config_hint).toEqual({
+      channel_type: 'slack',
+      config: {
+        enable_channels: false,
+        enable_groups: false,
+        enable_mpim: false,
+        align_slack_users: false,
+        outbound_enabled: false,
+      },
+    });
+    expect(Array.isArray(payload.setup_steps)).toBe(true);
+    expect(payload.caveats).toEqual(
+      expect.arrayContaining([expect.stringContaining('GENERATED ONLY')])
+    );
+  });
+
+  it('adds outbound scopes and config when outbound is enabled', async () => {
+    const opts = { ...dmOnly, outbound: true };
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_slack_manifest_generate.handler(opts);
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.manifest).toEqual(buildSlackManifest(opts));
+    expect(payload.bot_scopes).toEqual(requiredBotScopes(opts));
+    expect(payload.bot_scopes).toEqual(expect.arrayContaining(['chat:write.public', 'im:write']));
+    expect(payload.create_channel_config_hint.config.outbound_enabled).toBe(true);
+  });
+
+  it('generates an all-on manifest and maps restrictToChannelIds to allowed_channel_ids', async () => {
+    const opts = {
+      appName: 'Agor',
+      botDisplayName: 'Agor Bot',
+      publicChannels: true,
+      privateChannels: true,
+      groupDms: true,
+      alignUsers: true,
+      outbound: true,
+    };
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_slack_manifest_generate.handler({
+      ...opts,
+      restrictToChannelIds: ['C123', 'C456'],
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.manifest).toEqual(buildSlackManifest(opts));
+    expect(payload.manifest.features.bot_user.display_name).toBe('Agor Bot');
+    expect(payload.bot_scopes).toEqual(requiredBotScopes(opts));
+    expect(payload.bot_events).toEqual(requiredBotEvents(opts));
+    expect(payload.bot_events).toEqual(expect.arrayContaining(['app_mention', 'message.im']));
+    expect(payload.create_channel_config_hint.config).toMatchObject({
+      enable_channels: true,
+      enable_groups: true,
+      enable_mpim: true,
+      align_slack_users: true,
+      outbound_enabled: true,
+      allowed_channel_ids: ['C123', 'C456'],
+    });
+  });
+
+  it('applies schema defaults so omitted toggles yield a DM-only manifest', async () => {
+    const tools = await captureTools('admin');
+    const parsed = tools.agor_gateway_slack_manifest_generate.cfg.inputSchema.parse({
+      appName: 'Agor',
+    });
+    const result = await tools.agor_gateway_slack_manifest_generate.handler(parsed);
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.manifest).toEqual(buildSlackManifest(dmOnly));
+    expect(payload.create_channel_config_hint.config).not.toHaveProperty('allowed_channel_ids');
+  });
+
+  it('denies the manifest generator for non-admin users', async () => {
+    const tools = await captureTools('member');
+    await expect(tools.agor_gateway_slack_manifest_generate.handler(dmOnly)).rejects.toThrow(
+      'admin role required'
+    );
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -728,6 +728,18 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
     expect(payload.caveats).toEqual(
       expect.arrayContaining([expect.stringContaining('GENERATED ONLY')])
     );
+
+    // Secrets must never flow into the create payload the agent would paste —
+    // setup_steps reference the xoxb-/xapp- token names as instructions, so the
+    // no-token invariant is scoped to create_channel_config_hint.
+    const hintConfig = payload.create_channel_config_hint.config;
+    expect(hintConfig).not.toHaveProperty('bot_token');
+    expect(hintConfig).not.toHaveProperty('app_token');
+    const serializedHint = JSON.stringify(payload.create_channel_config_hint);
+    expect(serializedHint).not.toContain('bot_token');
+    expect(serializedHint).not.toContain('app_token');
+    expect(serializedHint).not.toContain('xoxb');
+    expect(serializedHint).not.toContain('xapp');
   });
 
   it('adds outbound scopes and config when outbound is enabled', async () => {
@@ -772,6 +784,16 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
       outbound_enabled: true,
       allowed_channel_ids: ['C123', 'C456'],
     });
+    expect(payload.caveats).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('restrictToChannelIds maps to config.allowed_channel_ids'),
+      ])
+    );
+    expect(payload.caveats).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/restrictToChannelIds.*does NOT change the manifest scopes/),
+      ])
+    );
   });
 
   it('applies schema defaults so omitted toggles yield a DM-only manifest', async () => {

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -5,10 +5,14 @@ import {
   ThreadSessionMapRepository,
 } from '@agor/core/db';
 import {
+  buildSlackManifest,
   getConnector,
+  requiredBotEvents,
+  requiredBotScopes,
   type SlackThreadHistoryMessage,
   type SlackThreadHistoryRequest,
   type SlackThreadHistoryResult,
+  type SlackWizardOptions,
 } from '@agor/core/gateway';
 import {
   type Branch,
@@ -535,6 +539,74 @@ function toServiceUpdateData(args: z.infer<typeof gatewayChannelUpdateSchema>) {
   return updates;
 }
 
+const slackManifestGenerateSchema = z.strictObject({
+  appName: mcpRequiredString('appName', 'Slack app display name, e.g. "Agor".'),
+  botDisplayName: mcpOptionalNonEmptyString(
+    'botDisplayName',
+    'Bot user display name. Defaults to appName.'
+  ),
+  publicChannels: z
+    .boolean()
+    .default(false)
+    .describe('Listen in public channels (#channel) via @mention.'),
+  privateChannels: z
+    .boolean()
+    .default(false)
+    .describe('Listen in private channels (groups) via @mention.'),
+  groupDms: z
+    .boolean()
+    .default(false)
+    .describe('Listen in group DMs (multi-person IMs) via @mention.'),
+  alignUsers: z
+    .boolean()
+    .default(false)
+    .describe('Resolve Slack user email → Agor user (adds the users:read.email scope).'),
+  outbound: z
+    .boolean()
+    .default(false)
+    .describe('Proactive outbound: post to channels by name and DM users by email.'),
+  restrictToChannelIds: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      'Slack channel ID whitelist. Maps to config.allowed_channel_ids when you call agor_gateway_channels_create; it does NOT change the manifest scopes or events.'
+    ),
+});
+
+function toSlackWizardOptions(
+  args: z.infer<typeof slackManifestGenerateSchema>
+): SlackWizardOptions {
+  return {
+    appName: args.appName,
+    ...(args.botDisplayName ? { botDisplayName: args.botDisplayName } : {}),
+    publicChannels: args.publicChannels,
+    privateChannels: args.privateChannels,
+    groupDms: args.groupDms,
+    alignUsers: args.alignUsers,
+    outbound: args.outbound,
+  };
+}
+
+/**
+ * Channel config the agent passes to agor_gateway_channels_create, derived from
+ * the same toggles. Secrets (bot_token, app_token) are write-only and obtained
+ * from the manual setup steps, so they are intentionally absent here — the agent
+ * adds them to config when creating the channel.
+ */
+function toCreateChannelConfigHint(args: z.infer<typeof slackManifestGenerateSchema>) {
+  const config: Record<string, unknown> = {
+    enable_channels: args.publicChannels,
+    enable_groups: args.privateChannels,
+    enable_mpim: args.groupDms,
+    align_slack_users: args.alignUsers,
+    outbound_enabled: args.outbound,
+  };
+  if (args.restrictToChannelIds && args.restrictToChannelIds.length > 0) {
+    config.allowed_channel_ids = args.restrictToChannelIds;
+  }
+  return { channel_type: 'slack' as const, config };
+}
+
 export function registerGatewayChannelTools(server: McpServer, ctx: McpContext): void {
   server.registerTool(
     'agor_gateway_channels_list',
@@ -605,6 +677,39 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         next_steps: [
           'Verify the channel in Settings > Gateway Channels or with agor_gateway_channels_list.',
           'Channel credentials, env vars, and inbound channel keys are intentionally redacted from MCP responses.',
+        ],
+      });
+    }
+  );
+
+  server.registerTool(
+    'agor_gateway_slack_manifest_generate',
+    {
+      description:
+        'Generate a ready-to-install Slack app manifest from desired gateway capabilities (admin-only). The agent-driven equivalent of the Slack setup wizard, backed by the same core generator. Returns the manifest JSON, the derived bot scopes/events, ordered setup steps, and the channel config to pass to agor_gateway_channels_create. This is pure: it creates no Slack app, no Agor channel, and validates no tokens.',
+      annotations: { readOnlyHint: true },
+      inputSchema: slackManifestGenerateSchema,
+    },
+    async (args) => {
+      requireAdmin(ctx, 'generate Slack app manifests');
+      const options = toSlackWizardOptions(args);
+
+      return textResult({
+        manifest: buildSlackManifest(options),
+        bot_scopes: requiredBotScopes(options),
+        bot_events: requiredBotEvents(options),
+        setup_steps: [
+          'Open https://api.slack.com/apps?new_app=1 and choose "Create New App".',
+          'Select "From a manifest", pick the target workspace, paste the manifest JSON below, and click "Create".',
+          'Install the app to the workspace, then open OAuth & Permissions and copy the Bot User OAuth Token (starts with "xoxb-").',
+          'Open Basic Information → App-Level Tokens → Generate Token and Scopes, add the connections:write scope, generate it, and copy the App-Level Token (starts with "xapp-").',
+          'Call agor_gateway_channels_create with channel_type "slack", the xoxb- bot_token, the xapp- app_token, and create_channel_config_hint below.',
+        ],
+        create_channel_config_hint: toCreateChannelConfigHint(args),
+        caveats: [
+          'GENERATED ONLY — no Slack app created, no Agor channel created, no tokens validated, no event delivery verified.',
+          'The app-level connections:write token is generated manually and is NOT part of the manifest bot scopes.',
+          'restrictToChannelIds maps to config.allowed_channel_ids when you call create — it does NOT change the manifest scopes or events.',
         ],
       });
     }


### PR DESCRIPTION
## Summary

Adds `agor_gateway_slack_manifest_generate` — an MCP tool that generates a ready-to-install Slack app manifest from desired gateway features. It's the agent-driven equivalent of the UI setup wizard, backed by the **same** core `buildSlackManifest` / `requiredBotScopes` / `requiredBotEvents` (single source of truth).

The tool is **pure, read-only (`readOnlyHint: true`), and admin-gated** (same `requireAdmin` gate as `agor_gateway_channels_create`). It is **generated-only**: it creates no Slack app, no Agor channel, and validates no tokens.

## Input (zod, mirrors `SlackWizardOptions`)

- `appName` (required), `botDisplayName?`
- `publicChannels`, `privateChannels`, `groupDms`, `alignUsers`, `outbound` (booleans, default `false`)
- `restrictToChannelIds?: string[]`

## Structured output (`textResult` JSON)

- `manifest` — the `SlackAppManifest` object
- `bot_scopes`, `bot_events` — derived arrays (transparency)
- `setup_steps` — ordered: create app from manifest → install + copy `xoxb-` bot token → generate app-level token with `connections:write` (`xapp-`) → call `agor_gateway_channels_create`
- `create_channel_config_hint` — `{ channel_type: 'slack', config: { enable_channels, enable_groups, enable_mpim, align_slack_users, outbound_enabled, allowed_channel_ids? } }` derived from the options, using the real connector config keys. Secrets are write-only, so `bot_token`/`app_token` are intentionally absent — the agent fills them from the setup steps.
- `caveats` — explicit notes that it's generated-only, that the app-level `connections:write` token is manual and not a manifest bot scope, and that `restrictToChannelIds` maps to `config.allowed_channel_ids` on create without changing manifest scopes/events.

## Tests

New tests in `gateway-channels.test.ts` parse `result.content[0].text` as JSON and assert `manifest`/`bot_scopes`/`bot_events` match the core generator for DM-only, +outbound, and all-on option sets; that `caveats` are present and `readOnlyHint` is set; that schema defaults yield a DM-only manifest; and that the admin gate rejects non-admins.

Full daemon test suite green (1295 passed), repo typecheck + lint clean.

## Context

Phase 6 of the Slack gateway feature, preset-io/agor-cloud#94. Depends on the merged core manifest module (#1635).

🤖 Generated with [Claude Code](https://claude.com/claude-code)