### PR TITLE
perf(agor-ui): inner App reads entity maps via store selectors (collapse PR4)

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -327,19 +327,11 @@ function AppContent() {
     sessionById,
     sessionsByBranch,
     boardById,
-    boardObjectById,
-    boardObjectsByBoardId,
     commentById,
-    cardById,
-    cardTypeById,
     repoById,
     branchById,
     userById,
-    mcpServerById,
-    gatewayChannelById,
-    artifactById,
     sessionMcpServerIds,
-    userAuthenticatedMcpServerIds,
     initialLoadItems,
     initialLoadComplete,
     loadingStage,
@@ -1548,21 +1540,7 @@ function AppContent() {
       user={currentUser}
       connected={connected}
       connecting={connecting}
-      sessionById={sessionById}
-      sessionsByBranch={sessionsByBranch}
       availableAgents={AVAILABLE_AGENTS}
-      boardById={boardById}
-      boardObjectById={boardObjectById}
-      boardObjectsByBoardId={boardObjectsByBoardId}
-      commentById={commentById}
-      cardById={cardById}
-      cardTypeById={cardTypeById}
-      repoById={repoById}
-      branchById={branchById}
-      userById={userById}
-      mcpServerById={mcpServerById}
-      sessionMcpServerIds={sessionMcpServerIds}
-      userAuthenticatedMcpServerIds={userAuthenticatedMcpServerIds}
       openSettingsTab={settingsTabToOpen}
       onSettingsClose={handleSettingsClose}
       openUserSettings={openUserSettings}
@@ -1599,11 +1577,9 @@ function AppContent() {
       onDeleteUser={handleDeleteUser}
       onCreateMCPServer={handleCreateMCPServer}
       onDeleteMCPServer={handleDeleteMCPServer}
-      gatewayChannelById={gatewayChannelById}
       onCreateGatewayChannel={handleCreateGatewayChannel}
       onUpdateGatewayChannel={handleUpdateGatewayChannel}
       onDeleteGatewayChannel={handleDeleteGatewayChannel}
-      artifactById={artifactById}
       onUpdateArtifact={handleUpdateArtifact}
       onDeleteArtifact={handleDeleteArtifact}
       onUpdateSessionMcpServers={handleUpdateSessionMcpServers}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -6,14 +6,11 @@ import type {
   BoardEntityObject,
   BoardID,
   Branch,
-  CardType,
-  CardWithType,
   CreateLocalRepoRequest,
   CreateMCPServerInput,
   CreateRepoRequest,
   CreateUserInput,
   GatewayChannel,
-  MCPServer,
   PermissionMode,
   Repo,
   Session,
@@ -46,6 +43,24 @@ import { useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { useTaskCompletionChime } from '../../hooks/useTaskCompletionChime';
 import { type ActiveUrlTarget, useUrlState } from '../../hooks/useUrlState';
 import { useUserLocalStorage } from '../../hooks/useUserLocalStorage';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectArtifactById,
+  selectBoardById,
+  selectBoardObjectById,
+  selectBoardObjectsByBoardId,
+  selectBranchById,
+  selectCardById,
+  selectCardTypeById,
+  selectCommentById,
+  selectGatewayChannelById,
+  selectMcpServerById,
+  selectRepoById,
+  selectSessionById,
+  selectSessionMcpServerIds,
+  selectSessionsByBranch,
+  selectUserById,
+} from '../../store/selectors';
 import type { AgenticToolOption } from '../../types';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { createAssistantBranch } from '../../utils/assistantCreation';
@@ -90,21 +105,7 @@ export interface AppProps {
   user?: User | null;
   connected?: boolean;
   connecting?: boolean;
-  sessionById: Map<string, Session>; // O(1) lookups by session_id - efficient, stable references
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch-scoped filtering
   availableAgents: AgenticToolOption[];
-  boardById: Map<string, Board>; // Map-based board storage
-  boardObjectById: Map<string, BoardEntityObject>; // Map-based board object storage
-  boardObjectsByBoardId: Map<string, BoardEntityObject[]>;
-  commentById: Map<string, BoardComment>; // Map-based comment storage
-  cardById: Map<string, CardWithType>; // Map-based card storage
-  cardTypeById: Map<string, CardType>; // Map-based card type storage
-  repoById: Map<string, Repo>; // Map-based repo storage
-  branchById: Map<string, Branch>; // Efficient branch lookups
-  userById: Map<string, User>; // Map-based user storage
-  mcpServerById: Map<string, MCPServer>; // Map-based MCP server storage
-  sessionMcpServerIds: Map<string, string[]>; // Map-based session-MCP relationships
-  userAuthenticatedMcpServerIds: Set<string>; // Per-user OAuth auth status
   initialBoardId?: string;
   openSettingsTab?: string | null; // Open settings modal to a specific tab
   onSettingsClose?: () => void; // Called when settings modal closes
@@ -167,11 +168,9 @@ export interface AppProps {
   onDeleteUser?: (userId: string) => void;
   onCreateMCPServer?: (data: CreateMCPServerInput) => void;
   onDeleteMCPServer?: (mcpServerId: string) => void;
-  gatewayChannelById: Map<string, GatewayChannel>;
   onCreateGatewayChannel?: (data: Partial<GatewayChannel>) => void;
   onUpdateGatewayChannel?: (channelId: string, updates: Partial<GatewayChannel>) => void;
   onDeleteGatewayChannel?: (channelId: string) => void;
-  artifactById: Map<string, Artifact>;
   onUpdateArtifact?: (artifactId: string, updates: Partial<Artifact>) => void;
   onDeleteArtifact?: (artifactId: string) => void;
   onUpdateSessionMcpServers?: (sessionId: string, mcpServerIds: string[]) => void;
@@ -237,21 +236,7 @@ export const App: React.FC<AppProps> = ({
   user,
   connected = false,
   connecting = false,
-  sessionById,
-  sessionsByBranch,
   availableAgents,
-  boardById,
-  boardObjectById,
-  boardObjectsByBoardId,
-  commentById,
-  cardById,
-  cardTypeById,
-  repoById,
-  branchById,
-  userById,
-  mcpServerById,
-  sessionMcpServerIds,
-  userAuthenticatedMcpServerIds,
   initialBoardId,
   openSettingsTab,
   onSettingsClose,
@@ -289,11 +274,9 @@ export const App: React.FC<AppProps> = ({
   onDeleteUser,
   onCreateMCPServer,
   onDeleteMCPServer,
-  gatewayChannelById,
   onCreateGatewayChannel,
   onUpdateGatewayChannel,
   onDeleteGatewayChannel,
-  artifactById,
   onUpdateArtifact,
   onDeleteArtifact,
   onUpdateSessionMcpServers,
@@ -311,6 +294,27 @@ export const App: React.FC<AppProps> = ({
   webTerminalEnabled = false,
   branchStorageConfig,
 }) => {
+  // Entity maps are read straight from the store via narrow slice selectors
+  // (rather than received as props). Each selector subscribes to a single
+  // slice, so App only re-renders when that specific slice's reference changes
+  // — and the derivations below keep their exact prior logic and memoization,
+  // only their data SOURCE moves from props to the store.
+  const sessionById = useAgorStore(selectSessionById);
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+  const boardById = useAgorStore(selectBoardById);
+  const boardObjectById = useAgorStore(selectBoardObjectById);
+  const boardObjectsByBoardId = useAgorStore(selectBoardObjectsByBoardId);
+  const commentById = useAgorStore(selectCommentById);
+  const cardById = useAgorStore(selectCardById);
+  const cardTypeById = useAgorStore(selectCardTypeById);
+  const repoById = useAgorStore(selectRepoById);
+  const branchById = useAgorStore(selectBranchById);
+  const userById = useAgorStore(selectUserById);
+  const mcpServerById = useAgorStore(selectMcpServerById);
+  const sessionMcpServerIds = useAgorStore(selectSessionMcpServerIds);
+  const gatewayChannelById = useAgorStore(selectGatewayChannelById);
+  const artifactById = useAgorStore(selectArtifactById);
+
   const { showWarning } = useThemedMessage();
   const location = useLocation();
   const routeParams = useParams<{

--- a/apps/agor-ui/src/store/selectors.ts
+++ b/apps/agor-ui/src/store/selectors.ts
@@ -19,10 +19,14 @@ export const selectSessionsByBranch = (s: AgorState) => s.sessionsByBranch;
 export const selectRepoById = (s: AgorState) => s.repoById;
 export const selectBranchById = (s: AgorState) => s.branchById;
 export const selectBoardById = (s: AgorState) => s.boardById;
+export const selectBoardObjectById = (s: AgorState) => s.boardObjectById;
+export const selectBoardObjectsByBoardId = (s: AgorState) => s.boardObjectsByBoardId;
 export const selectCommentById = (s: AgorState) => s.commentById;
 export const selectCardById = (s: AgorState) => s.cardById;
+export const selectCardTypeById = (s: AgorState) => s.cardTypeById;
 export const selectUserById = (s: AgorState) => s.userById;
 export const selectMcpServerById = (s: AgorState) => s.mcpServerById;
+export const selectGatewayChannelById = (s: AgorState) => s.gatewayChannelById;
 export const selectUserAuthenticatedMcpServerIds = (s: AgorState) =>
   s.userAuthenticatedMcpServerIds;
 export const selectArtifactById = (s: AgorState) => s.artifactById;


### PR DESCRIPTION
## What

Collapse PR4 — inner `components/App/App.tsx` stops consuming entity-map **props** and reads each slice directly from the zustand store via `useAgorStore(select*)`. Every derivation keeps its exact prior logic + memoization; only the data **source** changes. This removes the map props from inner App so the eventual flip (PR5) can drop them from `useAgorData`.

## Changes
- **Inner App** reads all entity maps via selectors (no map props). Added 4 selectors: `selectBoardObjectById`, `selectBoardObjectsByBoardId`, `selectCardTypeById`, `selectGatewayChannelById`.
- **Derived props** still passed to SessionCanvas (`currentBoard`/`boardBranches`/…) and SessionPanel (`selectedSession`/`selectedSessionBranch`/`sessionMcpServerIds`) — now computed from store-sourced slices. Those components are **untouched**.
- **Removed** 16 entity-map props from inner App's `AppProps` + the render site; removed the 8 now-dead maps from outer App's `useAgorData` destructure (`boardObjectById`/`boardObjectsByBoardId`/`cardById`/`cardTypeById`/`mcpServerById`/`userAuthenticatedMcpServerIds`/`gatewayChannelById`/`artifactById`).
- **Kept** in outer App's destructure the maps its own code still uses (MobileApp / onboarding / crash-context / completion-nav / comment-resolve / SharedUserSettingsModal) — those are a later PR's scope. `noUnusedVars` confirms exactly the dead ones were dropped.

## Out of scope
BoardAssistantPanel memo deferred — it receives ~11 raw passthrough handlers that arrive with fresh identities each render, so `React.memo` is ineffective until those are stabilized (own follow-up).

## Behavior
Home / board canvas / session panel behave identically — store slices are the same objects `useAgorData` already wrote, so values are byte-identical to the old props; selectors only make App re-render *less* (per-slice), never differently. `useAgorData` internals + loader gate untouched.

## Gate
typecheck ✓ · biome ✓ · tests (App/store/HomePage) ✓ · build ✓