### PR TITLE
feat(gateway): guided Slack setup wizard (manifest + test connection)

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -2,7 +2,7 @@ import type { AgorClient, Branch, GatewayChannel, MCPServer, User } from '@agor-
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GatewayChannelsTable } from './GatewayChannelsTable';
 
 // The real branch/user pickers are antd v6 `Select`s; opening their dropdowns in
@@ -331,5 +331,114 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     // No unified step indicator and no wizard footer in edit mode.
     expect(screen.queryByText('Tokens & test')).not.toBeInTheDocument();
     expect(queryButton(/^Continue$/)).toBeUndefined();
+  });
+});
+
+/** Render the table at a specific route so the GitHub deep-link effect fires. */
+function renderTableAt(path: string, client: AgorClient | null) {
+  const branch = makeBranch();
+  const user = makeUser();
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AntdApp>
+        <GatewayChannelsTable
+          client={client}
+          gatewayChannelById={new Map<string, GatewayChannel>()}
+          branchById={new Map([[branch.branch_id, branch]])}
+          userById={new Map([[user.user_id, user]])}
+          mcpServerById={new Map<string, MCPServer>()}
+        />
+      </AntdApp>
+    </MemoryRouter>
+  );
+}
+
+describe('GatewayChannelsTable GitHub install deep-link return', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('restores the step-0 draft, syncs channel_type=github, and builds a github payload', async () => {
+    // Simulate the step-0 essentials stashed right before the install redirect.
+    sessionStorage.setItem(
+      'agor.gateway.githubSetupDraft',
+      JSON.stringify({ name: 'My GH', target_branch_id: 'branch-1' })
+    );
+
+    const { client, channelCreate } = makeClient();
+    renderTableAt('/?installation_id=987654', client);
+
+    // Lands on the Credentials step with the GitHub flow active (channelType synced).
+    expect(await screen.findByText('Enter your GitHub App credentials')).toBeInTheDocument();
+    // Restored draft is in the (hidden, mounted) step-0 fields.
+    expect((screen.getByLabelText('branch-select') as HTMLInputElement).value).toBe('branch-1');
+
+    // Credentials → Configure.
+    fireEvent.change(screen.getByPlaceholderText('123456'), { target: { value: '111' } });
+    fireEvent.change(screen.getByPlaceholderText(/BEGIN RSA PRIVATE KEY/), {
+      target: { value: 'pem-body' },
+    });
+    clickButton(/^Continue$/);
+    await flush();
+
+    // Configure: watch repos (tags Select, tokenized via comma) + identity.
+    const watchRepos = document.querySelector('#github_watch_repos') as HTMLInputElement;
+    fireEvent.change(watchRepos, { target: { value: 'preset-io/agor,' } });
+    fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
+
+    clickButton(/Create channel/);
+    await flush();
+
+    await waitFor(() => expect(channelCreate).toHaveBeenCalledTimes(1));
+    expect(channelCreate.mock.calls[0][0]).toMatchObject({
+      channel_type: 'github',
+      name: 'My GH',
+      target_branch_id: 'branch-1',
+      config: { installation_id: 987654, app_id: 111 },
+    });
+  });
+});
+
+describe('GatewayChannelsTable Teams create wizard', () => {
+  it('walks Channel → Setup and builds a teams payload', async () => {
+    const { client, channelCreate } = makeClient();
+    renderTable(client);
+    clickButton(/Add Channel/);
+
+    // Switch the channel type to Microsoft Teams via the (real) antd Select.
+    fireEvent.mouseDown(document.querySelector('.ant-select-selector') as HTMLElement);
+    fireEvent.click(screen.getByText('Microsoft Teams'));
+
+    // Step 0 for Teams includes the generic "Post messages as" identity.
+    fireEvent.change(screen.getByPlaceholderText('e.g., Team Slack, Personal Discord'), {
+      target: { value: 'My Teams' },
+    });
+    fireEvent.change(screen.getByLabelText('branch-select'), { target: { value: 'branch-1' } });
+    fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
+    clickButton(/^Continue$/);
+    await flush();
+
+    // Setup step (final): Azure Bot credentials.
+    fireEvent.change(document.querySelector('#teams_app_id') as HTMLInputElement, {
+      target: { value: 'app-123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Client secret value'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.change(document.querySelector('#teams_tenant_id') as HTMLInputElement, {
+      target: { value: 'tenant-123' },
+    });
+
+    clickButton(/Create channel/);
+    await flush();
+
+    await waitFor(() => expect(channelCreate).toHaveBeenCalledTimes(1));
+    expect(channelCreate.mock.calls[0][0]).toMatchObject({
+      channel_type: 'teams',
+      name: 'My Teams',
+      target_branch_id: 'branch-1',
+      agor_user_id: 'user-1',
+      config: { app_id: 'app-123', tenant_id: 'tenant-123' },
+    });
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -129,38 +129,90 @@ function clickButton(text: RegExp) {
 /** Drain microtasks so a Form.validateFields()-gated step transition settles. */
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-/** Fill the wizard's Options step and advance to the "Create App" step. */
-async function advanceToCreateAppStep() {
+/** Fill the universal "Channel" step (step 0) and advance to "Options" (step 1). */
+async function advanceToOptions() {
   fireEvent.change(screen.getByPlaceholderText('e.g., Team Slack, Personal Discord'), {
     target: { value: 'My Slack' },
   });
   fireEvent.change(screen.getByLabelText('branch-select'), { target: { value: 'branch-1' } });
+  clickButton(/^Continue$/);
+  await flush();
+}
+
+/** Advance from "Options" (fills identity) to the "Create app" step (step 2). */
+async function advanceToCreateAppStep() {
+  await advanceToOptions();
   fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
-  clickButton(/Next: Create App/);
+  clickButton(/^Continue$/);
+  await flush();
+}
+
+/** Advance all the way to the final "Tokens & test" step (step 3). */
+async function advanceToTokensStep() {
+  await advanceToCreateAppStep();
+  clickButton(/^Continue$/);
   await flush();
 }
 
 describe('GatewayChannelsTable Slack create wizard', () => {
-  it('renders the guided Steps wizard (not the Collapse) on create', () => {
+  it('opens on the universal "Channel" step with the unified step indicator', () => {
     renderTable(null);
     clickButton(/Add Channel/);
 
-    // Wizard step titles + first-step controls.
+    // Step indicator titles for the Slack flow sit under the modal title.
+    expect(screen.getByText('Channel')).toBeInTheDocument();
     expect(screen.getByText('Options')).toBeInTheDocument();
-    expect(screen.getByText('Tokens & Test')).toBeInTheDocument();
-    expect(screen.getByText('App Name')).toBeInTheDocument();
-    expect(screen.getByText('Surfaces')).toBeInTheDocument();
-    // DMs are informational (always on), not a toggle.
-    expect(screen.getByText('Direct messages')).toBeInTheDocument();
-    expect(screen.getByText('always on')).toBeInTheDocument();
-    // Slack still owns identity (no generic "Post messages as").
-    expect(screen.getByText('Align Slack users')).toBeInTheDocument();
+    expect(screen.getByText('Create app')).toBeInTheDocument();
+    expect(screen.getByText('Tokens & test')).toBeInTheDocument();
+
+    // Step 0 owns the universal basics; platform options live on later steps.
+    expect(screen.getByText('Channel Type')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Target Branch')).toBeInTheDocument();
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+    // Slack-specific options (App Name / Surfaces) are not shown yet.
+    expect(screen.queryByText('Surfaces')).not.toBeInTheDocument();
+    // Slack owns identity later — no generic "Post messages as".
     expect(screen.queryByText('Post messages as')).not.toBeInTheDocument();
+  });
+
+  it('keeps one footer on every step: Back disabled on step 0, primary verb on the last step', async () => {
+    renderTable(makeClient().client);
+    clickButton(/Add Channel/);
+
+    // Step 0: Back present-but-disabled; primary is "Continue"; no submit verb yet.
+    expect(getButton(/^Back$/).disabled).toBe(true);
+    expect(getButton(/^Cancel$/)).toBeInTheDocument();
+    expect(getButton(/^Continue$/)).toBeInTheDocument();
+    expect(queryButton(/Create channel/)).toBeUndefined();
+
+    // Mid-flow: Back enabled, still on "Continue".
+    await advanceToOptions();
+    expect(getButton(/^Back$/).disabled).toBe(false);
+    expect(getButton(/^Continue$/)).toBeInTheDocument();
+
+    // Surfaces appear on the Options step.
+    expect(screen.getByText('Surfaces')).toBeInTheDocument();
+    expect(screen.getByText('Align Slack users')).toBeInTheDocument();
+
+    // Final step: primary becomes the submit verb, "Continue" is gone.
+    fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
+    clickButton(/^Continue$/);
+    await flush();
+    expect(getButton(/Copy manifest/)).toBeInTheDocument();
+    clickButton(/^Continue$/);
+    await flush();
+    expect(getButton(/Create channel/)).toBeInTheDocument();
+    expect(queryButton(/^Continue$/)).toBeUndefined();
+    expect(screen.getByPlaceholderText('xoxb-...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('xapp-...')).toBeInTheDocument();
   });
 
   it('updates the manifest preview and scope list as surfaces change', async () => {
     renderTable(null);
     clickButton(/Add Channel/);
+    // Surfaces live on the Options step (step 1).
+    await advanceToOptions();
 
     // Public-channel scopes/events are absent until the surface is enabled.
     expect(screen.queryByText('channels:history')).not.toBeInTheDocument();
@@ -176,25 +228,6 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(screen.queryAllByText('app_mention').length).toBeGreaterThan(0);
   });
 
-  it('navigates Options → Create App → Tokens & Test, gating the OK button', async () => {
-    renderTable(makeClient().client);
-    clickButton(/Add Channel/);
-
-    // OK/Create stays hidden until the wizard reaches its final step.
-    expect(getButton(/^Create$/).style.display).toBe('none');
-
-    await advanceToCreateAppStep();
-    expect(getButton(/Copy manifest/)).toBeInTheDocument();
-    expect(getButton(/^Create$/).style.display).toBe('none');
-
-    clickButton(/Next: Tokens & Test/);
-    await flush();
-
-    expect(getButton(/^Create$/).style.display).toBe('');
-    expect(screen.getByPlaceholderText('xoxb-...')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('xapp-...')).toBeInTheDocument();
-  });
-
   it('runs the connection probe and renders team/bot/notVerifiable honestly', async () => {
     const result = {
       ok: true,
@@ -208,9 +241,7 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     renderTable(client);
     clickButton(/Add Channel/);
 
-    await advanceToCreateAppStep();
-    clickButton(/Next: Tokens & Test/);
-    await flush();
+    await advanceToTokensStep();
 
     fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
     fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
@@ -234,14 +265,12 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     renderTable(client);
     clickButton(/Add Channel/);
 
-    await advanceToCreateAppStep();
-    clickButton(/Next: Tokens & Test/);
-    await flush();
+    await advanceToTokensStep();
     fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
     fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
 
-    // OK/Create is only shown once the wizard reaches the final step.
-    clickButton(/^Create$/);
+    // The submit verb appears only on the final step; it drives the create call.
+    clickButton(/Create channel/);
 
     await waitFor(() => expect(channelCreate).toHaveBeenCalledTimes(1));
     expect(channelCreate.mock.calls[0][0]).toMatchObject({
@@ -255,11 +284,15 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     renderTable(client);
     clickButton(/Add Channel/);
 
-    // Enable a public-channel surface so the scope option is in play.
+    // Enable a public-channel surface (Options step) so the scope option is in play.
+    await advanceToOptions();
     fireEvent.click(screen.getByText('Public channels'));
 
-    await advanceToCreateAppStep();
-    clickButton(/Next: Tokens & Test/);
+    // Finish identity + walk to the final Tokens step.
+    fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
+    clickButton(/^Continue$/);
+    await flush();
+    clickButton(/^Continue$/);
     await flush();
     fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
     fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
@@ -295,6 +328,8 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     // Edit keeps the collapsible sections; the create-only wizard is absent.
     expect(screen.getByText('Credentials')).toBeInTheDocument();
     expect(screen.getByText('Message Sources')).toBeInTheDocument();
-    expect(queryButton(/Next: Create App/)).toBeUndefined();
+    // No unified step indicator and no wizard footer in edit mode.
+    expect(screen.queryByText('Tokens & test')).not.toBeInTheDocument();
+    expect(queryButton(/^Continue$/)).toBeUndefined();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -202,6 +202,29 @@ describe('GatewayChannelsTable Slack create wizard', () => {
       config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
     });
   }, 30000);
+
+  it('invalidates a passing test result when a channel-scope option changes', async () => {
+    const { client } = makeClient({ ok: true, failures: [], notVerifiable: [] });
+    renderTable(client);
+    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+    // Enable a public-channel surface so the scope option is in play.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Public channels' }));
+
+    await advanceToCreateAppStep();
+    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+    fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
+    fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
+    fireEvent.click(screen.getByRole('button', { name: /Test connection/i }));
+
+    expect(await screen.findByText('Connection succeeded')).toBeInTheDocument();
+
+    // Narrowing public channels to a specific set changes the probe config and
+    // must clear the now-stale green result.
+    fireEvent.click(screen.getByText('Specific channels only'));
+
+    await waitFor(() => expect(screen.queryByText('Connection succeeded')).toBeNull());
+  }, 30000);
 });
 
 describe('GatewayChannelsTable Slack edit mode', () => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -341,7 +341,7 @@ describe('GatewayChannelsTable GitHub create wizard', () => {
     clickButton(/Add Channel/);
 
     // Switch the channel type to GitHub via the (real) antd Select.
-    fireEvent.mouseDown(document.querySelector('.ant-select-selector') as HTMLElement);
+    fireEvent.mouseDown(screen.getByRole('combobox'));
     fireEvent.click(screen.getByText('GitHub'));
 
     // Step 0 (Channel): GitHub picks identity later, so only name + branch here.
@@ -390,7 +390,7 @@ describe('GatewayChannelsTable Teams create wizard', () => {
     clickButton(/Add Channel/);
 
     // Switch the channel type to Microsoft Teams via the (real) antd Select.
-    fireEvent.mouseDown(document.querySelector('.ant-select-selector') as HTMLElement);
+    fireEvent.mouseDown(screen.getByRole('combobox'));
     fireEvent.click(screen.getByText('Microsoft Teams'));
 
     // Step 0 for Teams includes the generic "Post messages as" identity.

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -77,11 +77,18 @@ function renderTable(client: AgorClient | null) {
   );
 }
 
-/** Open an antd Select by its placeholder, then click the named option. */
-async function selectByPlaceholder(placeholder: string, optionName: string | RegExp) {
+/**
+ * Open an antd Select by its placeholder, then click the option whose label
+ * matches `optionTitle`. The `role="option"` node is an aria helper; the
+ * clickable element is `.ant-select-item-option[title=…]`.
+ */
+async function selectByPlaceholder(placeholder: string, optionTitle: string) {
   fireEvent.mouseDown(screen.getByText(placeholder));
-  const option = await screen.findByRole('option', { name: optionName });
-  fireEvent.click(option);
+  await screen.findByRole('option', { name: optionTitle });
+  const item = document.querySelector(
+    `.ant-select-item-option[title="${optionTitle}"]`
+  ) as HTMLElement;
+  fireEvent.click(item);
 }
 
 /** Fill the wizard's Options step and advance to the "Create App" step. */
@@ -113,7 +120,7 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(screen.queryByText('Post messages as')).not.toBeInTheDocument();
   });
 
-  it('updates the manifest preview and scope list as surfaces change', () => {
+  it('updates the manifest preview and scope list as surfaces change', async () => {
     renderTable(null);
     fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
 
@@ -121,10 +128,12 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(screen.queryByText('channels:history')).not.toBeInTheDocument();
     expect(screen.queryByText('app_mention')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('Public channels'));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Public channels' }));
 
-    // Now they appear in both the manifest JSON and the derived scope/event list.
-    expect(screen.queryAllByText('channels:history').length).toBeGreaterThan(0);
+    // Now they appear in the derived scope/event list (Form.useWatch flush).
+    await waitFor(() =>
+      expect(screen.queryAllByText('channels:history').length).toBeGreaterThan(0)
+    );
     expect(screen.queryAllByText('app_mentions:read').length).toBeGreaterThan(0);
     expect(screen.queryAllByText('app_mention').length).toBeGreaterThan(0);
   });
@@ -139,7 +148,7 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
     expect(screen.getByPlaceholderText('xoxb-...')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('xapp-...')).toBeInTheDocument();
-  });
+  }, 30000);
 
   it('runs the connection probe and renders team/bot/notVerifiable honestly', async () => {
     const result = {
@@ -172,7 +181,7 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(
       screen.getByText('Bot must be invited to each channel before it can post')
     ).toBeInTheDocument();
-  });
+  }, 30000);
 
   it('creates the channel from the final step', async () => {
     const { client, channelCreate } = makeClient();
@@ -192,7 +201,7 @@ describe('GatewayChannelsTable Slack create wizard', () => {
       channel_type: 'slack',
       config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
     });
-  });
+  }, 30000);
 });
 
 describe('GatewayChannelsTable Slack edit mode', () => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -2,7 +2,7 @@ import type { AgorClient, Branch, GatewayChannel, MCPServer, User } from '@agor-
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { GatewayChannelsTable } from './GatewayChannelsTable';
 
 // The real branch/user pickers are antd v6 `Select`s; opening their dropdowns in
@@ -334,46 +334,30 @@ describe('GatewayChannelsTable Slack edit mode', () => {
   });
 });
 
-/** Render the table at a specific route so the GitHub deep-link effect fires. */
-function renderTableAt(path: string, client: AgorClient | null) {
-  const branch = makeBranch();
-  const user = makeUser();
-  return render(
-    <MemoryRouter initialEntries={[path]}>
-      <AntdApp>
-        <GatewayChannelsTable
-          client={client}
-          gatewayChannelById={new Map<string, GatewayChannel>()}
-          branchById={new Map([[branch.branch_id, branch]])}
-          userById={new Map([[user.user_id, user]])}
-          mcpServerById={new Map<string, MCPServer>()}
-        />
-      </AntdApp>
-    </MemoryRouter>
-  );
-}
-
-describe('GatewayChannelsTable GitHub install deep-link return', () => {
-  afterEach(() => {
-    sessionStorage.clear();
-  });
-
-  it('restores the step-0 draft, syncs channel_type=github, and builds a github payload', async () => {
-    // Simulate the step-0 essentials stashed right before the install redirect.
-    sessionStorage.setItem(
-      'agor.gateway.githubSetupDraft',
-      JSON.stringify({ name: 'My GH', target_branch_id: 'branch-1' })
-    );
-
+describe('GatewayChannelsTable GitHub create wizard', () => {
+  it('walks Channel → Create app → Credentials → Configure and builds a github payload', async () => {
     const { client, channelCreate } = makeClient();
-    renderTableAt('/?installation_id=987654', client);
+    renderTable(client);
+    clickButton(/Add Channel/);
 
-    // Lands on the Credentials step with the GitHub flow active (channelType synced).
-    expect(await screen.findByText('Enter your GitHub App credentials')).toBeInTheDocument();
-    // Restored draft is in the (hidden, mounted) step-0 fields.
-    expect((screen.getByLabelText('branch-select') as HTMLInputElement).value).toBe('branch-1');
+    // Switch the channel type to GitHub via the (real) antd Select.
+    fireEvent.mouseDown(document.querySelector('.ant-select-selector') as HTMLElement);
+    fireEvent.click(screen.getByText('GitHub'));
 
-    // Credentials → Configure.
+    // Step 0 (Channel): GitHub picks identity later, so only name + branch here.
+    fireEvent.change(screen.getByPlaceholderText('e.g., Team Slack, Personal Discord'), {
+      target: { value: 'My GH' },
+    });
+    fireEvent.change(screen.getByLabelText('branch-select'), { target: { value: 'branch-1' } });
+    clickButton(/^Continue$/);
+    await flush();
+
+    // Step 1 (Create app): no required fields — Continue straight through.
+    expect(screen.getByText(/Create GitHub App on GitHub/)).toBeInTheDocument();
+    clickButton(/^Continue$/);
+    await flush();
+
+    // Step 2 (Credentials): App ID + private key, then Continue.
     fireEvent.change(screen.getByPlaceholderText('123456'), { target: { value: '111' } });
     fireEvent.change(screen.getByPlaceholderText(/BEGIN RSA PRIVATE KEY/), {
       target: { value: 'pem-body' },
@@ -381,7 +365,7 @@ describe('GatewayChannelsTable GitHub install deep-link return', () => {
     clickButton(/^Continue$/);
     await flush();
 
-    // Configure: watch repos (tags Select, tokenized via comma) + identity.
+    // Step 3 (Configure): watch repos (tags Select, tokenized via comma) + identity.
     const watchRepos = document.querySelector('#github_watch_repos') as HTMLInputElement;
     fireEvent.change(watchRepos, { target: { value: 'preset-io/agor,' } });
     fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
@@ -394,7 +378,7 @@ describe('GatewayChannelsTable GitHub install deep-link return', () => {
       channel_type: 'github',
       name: 'My GH',
       target_branch_id: 'branch-1',
-      config: { installation_id: 987654, app_id: 111 },
+      config: { app_id: 111, watch_repos: ['preset-io/agor'] },
     });
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -1,8 +1,8 @@
-import type { Branch, GatewayChannel, MCPServer, User } from '@agor-live/client';
-import { fireEvent, render, screen } from '@testing-library/react';
+import type { AgorClient, Branch, GatewayChannel, MCPServer, User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { GatewayChannelsTable } from './GatewayChannelsTable';
 
 function renderWithProviders(ui: React.ReactElement) {
@@ -29,26 +29,192 @@ function makeUser(): User {
   } as unknown as User;
 }
 
-describe('GatewayChannelsTable identity settings', () => {
-  it('collapses Slack post-as and alignment controls into one Identity section', () => {
+function makeSlackChannel(): GatewayChannel {
+  return {
+    id: 'channel-1',
+    name: 'Team Slack',
+    channel_type: 'slack',
+    channel_key: 'slack:team',
+    target_branch_id: 'branch-1',
+    agor_user_id: 'user-1',
+    enabled: true,
+    config: { bot_token: '••••••••', enable_channels: true },
+    agentic_config: { agent: 'claude-code' },
+    last_message_at: null,
+  } as unknown as GatewayChannel;
+}
+
+/**
+ * Minimal AgorClient stub exposing only the services the table calls. Records
+ * the `gateway-channels` create payload and the `gateway-channels/test` probe.
+ */
+function makeClient(testResult?: unknown) {
+  const channelCreate = vi.fn().mockResolvedValue({});
+  const testCreate = vi
+    .fn()
+    .mockResolvedValue(testResult ?? { ok: true, failures: [], notVerifiable: [] });
+  const client = {
+    service: (name: string) => {
+      if (name === 'gateway-channels') return { create: channelCreate };
+      if (name === 'gateway-channels/test') return { create: testCreate };
+      return { create: vi.fn(), get: vi.fn() };
+    },
+  } as unknown as AgorClient;
+  return { client, channelCreate, testCreate };
+}
+
+function renderTable(client: AgorClient | null) {
+  const branch = makeBranch();
+  const user = makeUser();
+  return renderWithProviders(
+    <GatewayChannelsTable
+      client={client}
+      gatewayChannelById={new Map<string, GatewayChannel>()}
+      branchById={new Map([[branch.branch_id, branch]])}
+      userById={new Map([[user.user_id, user]])}
+      mcpServerById={new Map<string, MCPServer>()}
+    />
+  );
+}
+
+/** Open an antd Select by its placeholder, then click the named option. */
+async function selectByPlaceholder(placeholder: string, optionName: string | RegExp) {
+  fireEvent.mouseDown(screen.getByText(placeholder));
+  const option = await screen.findByRole('option', { name: optionName });
+  fireEvent.click(option);
+}
+
+/** Fill the wizard's Options step and advance to the "Create App" step. */
+async function advanceToCreateAppStep() {
+  fireEvent.change(screen.getByPlaceholderText('e.g., Team Slack, Personal Discord'), {
+    target: { value: 'My Slack' },
+  });
+  await selectByPlaceholder('Select a branch', 'main');
+  await selectByPlaceholder('Select a user', 'Ada Lovelace');
+  fireEvent.click(screen.getByRole('button', { name: /Next: Create App/i }));
+  await screen.findByRole('button', { name: /Next: Tokens & Test/i });
+}
+
+describe('GatewayChannelsTable Slack create wizard', () => {
+  it('renders the guided Steps wizard (not the Collapse) on create', () => {
+    renderTable(null);
+    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+    // Wizard step titles + first-step controls.
+    expect(screen.getByText('Options')).toBeInTheDocument();
+    expect(screen.getByText('Tokens & Test')).toBeInTheDocument();
+    expect(screen.getByText('App Name')).toBeInTheDocument();
+    expect(screen.getByText('Surfaces')).toBeInTheDocument();
+    // DMs are informational (always on), not a toggle.
+    expect(screen.getByText('Direct messages')).toBeInTheDocument();
+    expect(screen.getByText('always on')).toBeInTheDocument();
+    // Slack still owns identity (no generic "Post messages as").
+    expect(screen.getByText('Align Slack users')).toBeInTheDocument();
+    expect(screen.queryByText('Post messages as')).not.toBeInTheDocument();
+  });
+
+  it('updates the manifest preview and scope list as surfaces change', () => {
+    renderTable(null);
+    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+    // Public-channel scopes/events are absent until the surface is enabled.
+    expect(screen.queryByText('channels:history')).not.toBeInTheDocument();
+    expect(screen.queryByText('app_mention')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Public channels'));
+
+    // Now they appear in both the manifest JSON and the derived scope/event list.
+    expect(screen.queryAllByText('channels:history').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('app_mentions:read').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('app_mention').length).toBeGreaterThan(0);
+  });
+
+  it('navigates Options → Create App → Tokens & Test', async () => {
+    renderTable(makeClient().client);
+    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+    await advanceToCreateAppStep();
+    expect(screen.getByRole('button', { name: /Copy manifest/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+    expect(screen.getByPlaceholderText('xoxb-...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('xapp-...')).toBeInTheDocument();
+  });
+
+  it('runs the connection probe and renders team/bot/notVerifiable honestly', async () => {
+    const result = {
+      ok: true,
+      team: { id: 'T123', name: 'Acme' },
+      bot: { userId: 'U999', name: 'agorbot' },
+      appTokenValid: true,
+      failures: [],
+      notVerifiable: ['Bot must be invited to each channel before it can post'],
+    };
+    const { client, testCreate } = makeClient(result);
+    renderTable(client);
+    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+    await advanceToCreateAppStep();
+    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+
+    fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
+    fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
+    fireEvent.click(screen.getByRole('button', { name: /Test connection/i }));
+
+    await waitFor(() => expect(testCreate).toHaveBeenCalledTimes(1));
+    expect(testCreate.mock.calls[0][0]).toMatchObject({
+      config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+    });
+
+    expect(await screen.findByText('Connection succeeded')).toBeInTheDocument();
+    expect(screen.getByText('Acme')).toBeInTheDocument();
+    expect(screen.getByText('Not verifiable from here')).toBeInTheDocument();
+    expect(
+      screen.getByText('Bot must be invited to each channel before it can post')
+    ).toBeInTheDocument();
+  });
+
+  it('creates the channel from the final step', async () => {
+    const { client, channelCreate } = makeClient();
+    renderTable(client);
+    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+
+    await advanceToCreateAppStep();
+    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+    fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
+    fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
+
+    // OK/Create is only present once the wizard reaches the final step.
+    fireEvent.click(screen.getByRole('button', { name: /^Create$/ }));
+
+    await waitFor(() => expect(channelCreate).toHaveBeenCalledTimes(1));
+    expect(channelCreate.mock.calls[0][0]).toMatchObject({
+      channel_type: 'slack',
+      config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+    });
+  });
+});
+
+describe('GatewayChannelsTable Slack edit mode', () => {
+  it('still renders the Collapse form (not the wizard) when editing', () => {
     const branch = makeBranch();
     const user = makeUser();
-
+    const channel = makeSlackChannel();
     renderWithProviders(
       <GatewayChannelsTable
         client={null}
-        gatewayChannelById={new Map<string, GatewayChannel>()}
+        gatewayChannelById={new Map([[channel.id, channel]])}
         branchById={new Map([[branch.branch_id, branch]])}
         userById={new Map([[user.user_id, user]])}
         mcpServerById={new Map<string, MCPServer>()}
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+    fireEvent.click(screen.getByTitle('Edit'));
 
-    expect(screen.getByText('Identity')).toBeInTheDocument();
-    expect(screen.getByText('Align Slack users')).toBeInTheDocument();
-    expect(screen.getByText('Run as selected user')).toBeInTheDocument();
-    expect(screen.queryByText('Post messages as')).not.toBeInTheDocument();
+    // Edit keeps the collapsible sections; the create-only wizard is absent.
+    expect(screen.getByText('Credentials')).toBeInTheDocument();
+    expect(screen.getByText('Message Sources')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Next: Create App/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -5,6 +5,38 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { GatewayChannelsTable } from './GatewayChannelsTable';
 
+// The real branch/user pickers are antd v6 `Select`s; opening their dropdowns in
+// jsdom is pathologically slow. Replace them with trivial native inputs so the
+// wizard's required identity fields can be filled instantly and deterministically.
+vi.mock('./BranchSelect', () => ({
+  BranchSelect: ({ value, onChange }: { value?: string; onChange?: (value: string) => void }) => (
+    <input
+      aria-label="branch-select"
+      value={value ?? ''}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+vi.mock('./UserSelect', () => ({
+  UserSelect: ({ value, onChange }: { value?: string; onChange?: (value: string) => void }) => (
+    <input
+      aria-label="user-select"
+      value={value ?? ''}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+// The agent-configuration widgets mount inside the wizard's final step and the
+// edit collapse; they're heavy (agent cards + model/MCP selects) and irrelevant
+// to the gateway-wizard assertions. Stub them so step transitions stay fast.
+vi.mock('../AgentSelectionGrid', () => ({
+  AgentSelectionGrid: () => <div data-testid="agent-grid" />,
+}));
+vi.mock('../AgenticToolConfigForm', () => ({
+  AgenticToolConfigForm: () => <div data-testid="agent-config" />,
+}));
+
 function renderWithProviders(ui: React.ReactElement) {
   return render(
     <MemoryRouter>
@@ -77,35 +109,41 @@ function renderTable(client: AgorClient | null) {
   );
 }
 
-/**
- * Open an antd Select by its placeholder, then click the option whose label
- * matches `optionTitle`. The `role="option"` node is an aria helper; the
- * clickable element is `.ant-select-item-option[title=…]`.
- */
-async function selectByPlaceholder(placeholder: string, optionTitle: string) {
-  fireEvent.mouseDown(screen.getByText(placeholder));
-  await screen.findByRole('option', { name: optionTitle });
-  const item = document.querySelector(
-    `.ant-select-item-option[title="${optionTitle}"]`
-  ) as HTMLElement;
-  fireEvent.click(item);
+// `getByRole('button', { name })` computes accessible names across the whole
+// (large) antd modal DOM and costs seconds per call in jsdom — enough to time
+// out the wizard tests in CI. Match buttons by trimmed text via querySelector
+// instead, which is effectively instant.
+function queryButton(text: RegExp): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll('button')).find((b) =>
+    text.test((b.textContent || '').trim())
+  ) as HTMLButtonElement | undefined;
 }
+function getButton(text: RegExp): HTMLButtonElement {
+  const button = queryButton(text);
+  if (!button) throw new Error(`No button matching ${text}`);
+  return button;
+}
+function clickButton(text: RegExp) {
+  fireEvent.click(getButton(text));
+}
+/** Drain microtasks so a Form.validateFields()-gated step transition settles. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 /** Fill the wizard's Options step and advance to the "Create App" step. */
 async function advanceToCreateAppStep() {
   fireEvent.change(screen.getByPlaceholderText('e.g., Team Slack, Personal Discord'), {
     target: { value: 'My Slack' },
   });
-  await selectByPlaceholder('Select a branch', 'main');
-  await selectByPlaceholder('Select a user', 'Ada Lovelace');
-  fireEvent.click(screen.getByRole('button', { name: /Next: Create App/i }));
-  await screen.findByRole('button', { name: /Next: Tokens & Test/i });
+  fireEvent.change(screen.getByLabelText('branch-select'), { target: { value: 'branch-1' } });
+  fireEvent.change(screen.getByLabelText('user-select'), { target: { value: 'user-1' } });
+  clickButton(/Next: Create App/);
+  await flush();
 }
 
 describe('GatewayChannelsTable Slack create wizard', () => {
   it('renders the guided Steps wizard (not the Collapse) on create', () => {
     renderTable(null);
-    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+    clickButton(/Add Channel/);
 
     // Wizard step titles + first-step controls.
     expect(screen.getByText('Options')).toBeInTheDocument();
@@ -122,13 +160,13 @@ describe('GatewayChannelsTable Slack create wizard', () => {
 
   it('updates the manifest preview and scope list as surfaces change', async () => {
     renderTable(null);
-    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+    clickButton(/Add Channel/);
 
     // Public-channel scopes/events are absent until the surface is enabled.
     expect(screen.queryByText('channels:history')).not.toBeInTheDocument();
     expect(screen.queryByText('app_mention')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Public channels' }));
+    fireEvent.click(screen.getByText('Public channels'));
 
     // Now they appear in the derived scope/event list (Form.useWatch flush).
     await waitFor(() =>
@@ -138,17 +176,24 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(screen.queryAllByText('app_mention').length).toBeGreaterThan(0);
   });
 
-  it('navigates Options → Create App → Tokens & Test', async () => {
+  it('navigates Options → Create App → Tokens & Test, gating the OK button', async () => {
     renderTable(makeClient().client);
-    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+    clickButton(/Add Channel/);
+
+    // OK/Create stays hidden until the wizard reaches its final step.
+    expect(getButton(/^Create$/).style.display).toBe('none');
 
     await advanceToCreateAppStep();
-    expect(screen.getByRole('button', { name: /Copy manifest/i })).toBeInTheDocument();
+    expect(getButton(/Copy manifest/)).toBeInTheDocument();
+    expect(getButton(/^Create$/).style.display).toBe('none');
 
-    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+    clickButton(/Next: Tokens & Test/);
+    await flush();
+
+    expect(getButton(/^Create$/).style.display).toBe('');
     expect(screen.getByPlaceholderText('xoxb-...')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('xapp-...')).toBeInTheDocument();
-  }, 30000);
+  });
 
   it('runs the connection probe and renders team/bot/notVerifiable honestly', async () => {
     const result = {
@@ -161,14 +206,15 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     };
     const { client, testCreate } = makeClient(result);
     renderTable(client);
-    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+    clickButton(/Add Channel/);
 
     await advanceToCreateAppStep();
-    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+    clickButton(/Next: Tokens & Test/);
+    await flush();
 
     fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
     fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
-    fireEvent.click(screen.getByRole('button', { name: /Test connection/i }));
+    clickButton(/Test connection/);
 
     await waitFor(() => expect(testCreate).toHaveBeenCalledTimes(1));
     expect(testCreate.mock.calls[0][0]).toMatchObject({
@@ -181,41 +227,43 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     expect(
       screen.getByText('Bot must be invited to each channel before it can post')
     ).toBeInTheDocument();
-  }, 30000);
+  });
 
   it('creates the channel from the final step', async () => {
     const { client, channelCreate } = makeClient();
     renderTable(client);
-    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+    clickButton(/Add Channel/);
 
     await advanceToCreateAppStep();
-    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+    clickButton(/Next: Tokens & Test/);
+    await flush();
     fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
     fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
 
-    // OK/Create is only present once the wizard reaches the final step.
-    fireEvent.click(screen.getByRole('button', { name: /^Create$/ }));
+    // OK/Create is only shown once the wizard reaches the final step.
+    clickButton(/^Create$/);
 
     await waitFor(() => expect(channelCreate).toHaveBeenCalledTimes(1));
     expect(channelCreate.mock.calls[0][0]).toMatchObject({
       channel_type: 'slack',
       config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
     });
-  }, 30000);
+  });
 
   it('invalidates a passing test result when a channel-scope option changes', async () => {
     const { client } = makeClient({ ok: true, failures: [], notVerifiable: [] });
     renderTable(client);
-    fireEvent.click(screen.getByRole('button', { name: /Add Channel/i }));
+    clickButton(/Add Channel/);
 
     // Enable a public-channel surface so the scope option is in play.
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Public channels' }));
+    fireEvent.click(screen.getByText('Public channels'));
 
     await advanceToCreateAppStep();
-    fireEvent.click(screen.getByRole('button', { name: /Next: Tokens & Test/i }));
+    clickButton(/Next: Tokens & Test/);
+    await flush();
     fireEvent.change(screen.getByPlaceholderText('xoxb-...'), { target: { value: 'xoxb-test' } });
     fireEvent.change(screen.getByPlaceholderText('xapp-...'), { target: { value: 'xapp-test' } });
-    fireEvent.click(screen.getByRole('button', { name: /Test connection/i }));
+    clickButton(/Test connection/);
 
     expect(await screen.findByText('Connection succeeded')).toBeInTheDocument();
 
@@ -224,7 +272,7 @@ describe('GatewayChannelsTable Slack create wizard', () => {
     fireEvent.click(screen.getByText('Specific channels only'));
 
     await waitFor(() => expect(screen.queryByText('Connection succeeded')).toBeNull());
-  }, 30000);
+  });
 });
 
 describe('GatewayChannelsTable Slack edit mode', () => {
@@ -247,6 +295,6 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     // Edit keeps the collapsible sections; the create-only wizard is absent.
     expect(screen.getByText('Credentials')).toBeInTheDocument();
     expect(screen.getByText('Message Sources')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Next: Create App/i })).not.toBeInTheDocument();
+    expect(queryButton(/Next: Create App/)).toBeUndefined();
   });
 });

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -330,23 +330,65 @@ interface GitHubSetupParams {
   installation_id?: string;
 }
 
-/** GitHub setup wizard steps */
-const GITHUB_SETUP_STEPS = [
-  { title: 'Create App' },
-  { title: 'Credentials' },
-  { title: 'Configure' },
-];
+// ============================================================================
+// Unified create-wizard step model
+// ============================================================================
+
+/**
+ * Step-indicator items for the create wizard, keyed by channel type. Every flow
+ * shares a universal step 0 ("Channel": type, name, target branch, enabled);
+ * platform-specific steps follow. A single modal footer drives navigation, so
+ * the indicator is the only place step structure differs between platforms.
+ */
+function createStepsForType(type: ChannelType): { title: string }[] {
+  switch (type) {
+    case 'slack':
+      return [
+        { title: 'Channel' },
+        { title: 'Options' },
+        { title: 'Create app' },
+        { title: 'Tokens & test' },
+      ];
+    case 'github':
+      return [
+        { title: 'Channel' },
+        { title: 'Create app' },
+        { title: 'Credentials' },
+        { title: 'Configure' },
+      ];
+    case 'teams':
+      return [{ title: 'Channel' }, { title: 'Setup' }];
+    default:
+      return [{ title: 'Channel' }];
+  }
+}
+
+/**
+ * Form fields the create footer validates before leaving a given step. The final
+ * step returns `[]` — submission runs a full `validateFields()` instead.
+ */
+function createStepFields(type: ChannelType, step: number, alignSlackUsers: boolean): string[] {
+  if (step === 0) {
+    const fields = ['name', 'target_branch_id', 'channel_type'];
+    // Slack and GitHub pick identity inside their platform steps; everyone else
+    // chooses it on the universal Channel step.
+    if (type !== 'slack' && type !== 'github') fields.push('agor_user_id');
+    return fields;
+  }
+  if (type === 'slack' && step === 1) {
+    const fields = ['slack_app_name'];
+    if (!alignSlackUsers) fields.push('agor_user_id');
+    return fields;
+  }
+  if (type === 'github' && step === 2) {
+    return ['github_app_id', 'github_private_key'];
+  }
+  return [];
+}
 
 // ============================================================================
 // Slack Setup Wizard (create mode)
 // ============================================================================
-
-/** Slack guided-setup wizard steps. */
-const SLACK_SETUP_STEPS = [
-  { title: 'Options' },
-  { title: 'Create App' },
-  { title: 'Tokens & Test' },
-];
 
 /**
  * Form fields whose values feed the `gateway-channels/test` probe. Editing any
@@ -498,8 +540,8 @@ const SlackSetupWizard: React.FC<{
   mcpServerById: Map<string, MCPServer>;
   selectedAgent: string;
   onAgentChange: (agent: string) => void;
+  /** Slack sub-step within the unified create wizard (0=Options, 1=Create app, 2=Tokens). */
   step: number;
-  onStepChange: (step: number) => void;
   testResult: SlackTestResult | null;
   testLoading: boolean;
   onTest: () => void;
@@ -510,7 +552,6 @@ const SlackSetupWizard: React.FC<{
   selectedAgent,
   onAgentChange,
   step,
-  onStepChange,
   testResult,
   testLoading,
   onTest,
@@ -602,17 +643,6 @@ const SlackSetupWizard: React.FC<{
     </div>
   );
 
-  const goToCreateApp = async () => {
-    const fields: string[] = ['name', 'target_branch_id', 'slack_app_name'];
-    if (!alignUsers) fields.push('agor_user_id');
-    try {
-      await form.validateFields(fields);
-    } catch {
-      return;
-    }
-    onStepChange(1);
-  };
-
   const handleCopy = async () => {
     const ok = await copyTextToClipboard(manifestJson);
     if (ok) {
@@ -633,8 +663,6 @@ const SlackSetupWizard: React.FC<{
 
   return (
     <>
-      <Steps current={step} size="small" items={SLACK_SETUP_STEPS} style={{ marginBottom: 24 }} />
-
       {/* Step 0: Options (kept mounted so Form.Items stay registered for validation) */}
       <div style={{ display: step === 0 ? undefined : 'none' }}>
         <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
@@ -765,10 +793,6 @@ const SlackSetupWizard: React.FC<{
         </Typography.Text>
         {manifestPreview}
         {scopeList}
-
-        <Button type="primary" block onClick={goToCreateApp}>
-          Next: Create App
-        </Button>
       </div>
 
       {/* Step 1: Create app from manifest */}
@@ -812,13 +836,6 @@ const SlackSetupWizard: React.FC<{
             the <code>connections:write</code> scope — this is your <code>xapp-</code> token.
           </li>
         </ol>
-
-        <Space>
-          <Button onClick={() => onStepChange(0)}>Back</Button>
-          <Button type="primary" onClick={() => onStepChange(2)}>
-            Next: Tokens &amp; Test
-          </Button>
-        </Space>
       </div>
 
       {/* Step 2: Tokens + test */}
@@ -938,10 +955,6 @@ const SlackSetupWizard: React.FC<{
             },
           ]}
         />
-
-        <Button onClick={() => onStepChange(1)} style={{ marginTop: 8 }}>
-          Back
-        </Button>
       </div>
     </>
   );
@@ -959,15 +972,12 @@ const ChannelFormFields: React.FC<{
   selectedAgent: string;
   onAgentChange: (agent: string) => void;
   editingChannel?: GatewayChannel | null;
-  /** GitHub setup wizard state (managed by parent) */
-  githubStep: number;
-  onGithubStepChange: (step: number) => void;
-  githubSetupParams: GitHubSetupParams | null;
+  /** Current step in the unified create wizard (0 = universal "Channel" step). */
+  createStep: number;
+  /** GitHub setup status (create mode only). */
   githubLoading: boolean;
   githubError: string | null;
-  /** Slack setup wizard state (managed by parent, create mode only) */
-  slackStep: number;
-  onSlackStepChange: (step: number) => void;
+  /** Slack guided-setup state (create mode only). */
   slackTestResult: SlackTestResult | null;
   slackTestLoading: boolean;
   onSlackTest: () => void;
@@ -982,13 +992,9 @@ const ChannelFormFields: React.FC<{
   selectedAgent,
   onAgentChange,
   editingChannel,
-  githubStep,
-  onGithubStepChange,
-  githubSetupParams,
+  createStep,
   githubLoading,
   githubError,
-  slackStep,
-  onSlackStepChange,
   slackTestResult,
   slackTestLoading,
   onSlackTest,
@@ -1006,87 +1012,93 @@ const ChannelFormFields: React.FC<{
 
   return (
     <>
-      {/* ── Basic Settings (always visible) ── */}
-      <Form.Item
-        label="Channel Type"
-        name="channel_type"
-        initialValue={mode === 'create' ? 'slack' : undefined}
-        rules={[{ required: true }]}
-      >
-        <Select onChange={(value: ChannelType) => onChannelTypeChange(value)}>
-          {CHANNEL_TYPE_OPTIONS.map((opt) => (
-            <Select.Option key={opt.value} value={opt.value}>
-              <Space>
-                {opt.icon}
-                {opt.label}
-              </Space>
-            </Select.Option>
-          ))}
-        </Select>
-      </Form.Item>
-
-      <Form.Item
-        label="Name"
-        name="name"
-        rules={[{ required: true, message: 'Please enter a channel name' }]}
-      >
-        <Input placeholder="e.g., Team Slack, Personal Discord" />
-      </Form.Item>
-
-      <Form.Item
-        label="Target Branch"
-        name="target_branch_id"
-        rules={[{ required: true, message: 'Please select a target branch' }]}
-        tooltip={
-          mode === 'create'
-            ? 'New sessions from this channel will be created in this branch'
-            : undefined
-        }
-      >
-        <BranchSelect branchById={branchById} />
-      </Form.Item>
-
-      {/* Slack and GitHub choose identity in their platform-specific Identity sections. */}
-      {channelType !== 'slack' && channelType !== 'github' && (
-        <Form.Item
-          label="Post messages as"
-          name="agor_user_id"
-          rules={[{ required: true, message: 'Please select a user' }]}
-          tooltip="Sessions from this channel will run as this Agor user"
-        >
-          <UserSelect userById={userById} />
-        </Form.Item>
-      )}
-
-      <Form.Item
-        label="Enabled"
-        name="enabled"
-        valuePropName="checked"
-        initialValue={mode === 'create' ? true : undefined}
-      >
-        <Switch />
-      </Form.Item>
-
-      {channelType !== 'slack' && channelType !== 'github' && channelType !== 'teams' && (
-        <Alert
-          title={`${channelType.charAt(0).toUpperCase() + channelType.slice(1)} support coming soon`}
-          description="This platform integration is not yet available. Slack, GitHub, and Microsoft Teams are currently supported."
-          type="info"
-          showIcon
-          style={{ marginBottom: 16 }}
+      {/* Unified step indicator — sits directly under the modal title on create. */}
+      {mode === 'create' && (
+        <Steps
+          current={createStep}
+          size="small"
+          items={createStepsForType(channelType)}
+          style={{ marginBottom: 24 }}
         />
       )}
 
-      {/* ── GitHub App Setup Wizard ── */}
+      {/* ── Step 0 "Channel": universal basics. Kept mounted on create so its
+          required fields stay registered for the final validateFields(). ── */}
+      <div style={{ display: mode === 'create' && createStep !== 0 ? 'none' : undefined }}>
+        <Form.Item
+          label="Channel Type"
+          name="channel_type"
+          initialValue={mode === 'create' ? 'slack' : undefined}
+          rules={[{ required: true }]}
+        >
+          <Select onChange={(value: ChannelType) => onChannelTypeChange(value)}>
+            {CHANNEL_TYPE_OPTIONS.map((opt) => (
+              <Select.Option key={opt.value} value={opt.value}>
+                <Space>
+                  {opt.icon}
+                  {opt.label}
+                </Space>
+              </Select.Option>
+            ))}
+          </Select>
+        </Form.Item>
+
+        <Form.Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Please enter a channel name' }]}
+        >
+          <Input placeholder="e.g., Team Slack, Personal Discord" />
+        </Form.Item>
+
+        <Form.Item
+          label="Target Branch"
+          name="target_branch_id"
+          rules={[{ required: true, message: 'Please select a target branch' }]}
+          tooltip={
+            mode === 'create'
+              ? 'New sessions from this channel will be created in this branch'
+              : undefined
+          }
+        >
+          <BranchSelect branchById={branchById} />
+        </Form.Item>
+
+        {/* Slack and GitHub choose identity in their platform-specific Identity sections. */}
+        {channelType !== 'slack' && channelType !== 'github' && (
+          <Form.Item
+            label="Post messages as"
+            name="agor_user_id"
+            rules={[{ required: true, message: 'Please select a user' }]}
+            tooltip="Sessions from this channel will run as this Agor user"
+          >
+            <UserSelect userById={userById} />
+          </Form.Item>
+        )}
+
+        <Form.Item
+          label="Enabled"
+          name="enabled"
+          valuePropName="checked"
+          initialValue={mode === 'create' ? true : undefined}
+        >
+          <Switch />
+        </Form.Item>
+
+        {channelType !== 'slack' && channelType !== 'github' && channelType !== 'teams' && (
+          <Alert
+            title={`${channelType.charAt(0).toUpperCase() + channelType.slice(1)} support coming soon`}
+            description="This platform integration is not yet available. Slack, GitHub, and Microsoft Teams are currently supported."
+            type="info"
+            showIcon
+            style={{ marginBottom: 16 }}
+          />
+        )}
+      </div>
+
+      {/* ── GitHub App Setup (create steps + shared config collapse) ── */}
       {channelType === 'github' && (
         <>
-          <Steps
-            current={githubStep}
-            size="small"
-            items={GITHUB_SETUP_STEPS}
-            style={{ marginBottom: 24 }}
-          />
-
           {githubLoading && (
             <div style={{ textAlign: 'center', padding: '24px 0' }}>
               <Spin indicator={<LoadingOutlined spin />} />
@@ -1106,8 +1118,8 @@ const ChannelFormFields: React.FC<{
             />
           )}
 
-          {/* Step 0: Create GitHub App */}
-          {githubStep === 0 && !githubLoading && mode === 'create' && (
+          {/* Step 1 (Create app): register the GitHub App. */}
+          {mode === 'create' && createStep === 1 && !githubLoading && (
             <div style={{ marginBottom: 16 }}>
               <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
                 Create a GitHub App to connect Agor to your repositories. This uses GitHub&apos;s
@@ -1183,20 +1195,16 @@ const ChannelFormFields: React.FC<{
                 Create GitHub App on GitHub
               </Button>
 
-              <Button
-                type="default"
-                block
-                onClick={() => onGithubStepChange(1)}
-                style={{ marginTop: 12 }}
-              >
-                I&apos;ve created the app — enter credentials
-              </Button>
+              <Typography.Paragraph type="secondary" style={{ fontSize: 12, margin: '12px 0 0' }}>
+                Already created the app? Click <strong>Continue</strong> below to enter its
+                credentials.
+              </Typography.Paragraph>
             </div>
           )}
 
-          {/* Step 1: Installation Picker */}
-          {githubStep >= 1 && !githubLoading && (
-            <div style={{ marginBottom: 16, display: githubStep === 1 ? undefined : 'none' }}>
+          {/* Step 2 (Credentials): App ID + private key. */}
+          {mode === 'create' && createStep === 2 && !githubLoading && (
+            <div style={{ marginBottom: 16 }}>
               <Alert
                 type="info"
                 showIcon
@@ -1219,6 +1227,7 @@ const ChannelFormFields: React.FC<{
               <Form.Item
                 label="App ID"
                 name="github_app_id"
+                rules={[{ required: true, message: 'Enter your GitHub App ID' }]}
                 tooltip="Found on your GitHub App's settings page (General → About)"
               >
                 <Input placeholder="123456" />
@@ -1227,6 +1236,7 @@ const ChannelFormFields: React.FC<{
               <Form.Item
                 label="Private Key (PEM)"
                 name="github_private_key"
+                rules={[{ required: true, message: 'Paste your GitHub App private key' }]}
                 tooltip="Generate a private key on your GitHub App's settings page, then paste the .pem file contents"
               >
                 <Input.TextArea
@@ -1247,35 +1257,11 @@ const ChannelFormFields: React.FC<{
               {githubError && (
                 <Alert type="error" showIcon title={githubError} style={{ marginBottom: 12 }} />
               )}
-
-              <Button
-                type="primary"
-                onClick={() => {
-                  const appId = form.getFieldValue('github_app_id');
-                  const pem = form.getFieldValue('github_private_key');
-                  if (!appId || !pem) {
-                    const errors: { name: string; errors: string[] }[] = [];
-                    if (!appId)
-                      errors.push({ name: 'github_app_id', errors: ['Enter your GitHub App ID'] });
-                    if (!pem)
-                      errors.push({
-                        name: 'github_private_key',
-                        errors: ['Paste your GitHub App private key'],
-                      });
-                    form.setFields(errors);
-                    return;
-                  }
-                  onGithubStepChange(2);
-                }}
-                style={{ marginTop: 8 }}
-              >
-                Next: Configure Channel
-              </Button>
             </div>
           )}
 
-          {/* Step 2: Configuration */}
-          {githubStep === 2 && !githubLoading && (
+          {/* Step 3 (Configure): shared settings collapse — also the edit-mode body. */}
+          {((mode === 'create' && createStep === 3) || mode === 'edit') && !githubLoading && (
             <Collapse
               ghost
               destroyOnHidden={false}
@@ -1486,8 +1472,8 @@ const ChannelFormFields: React.FC<{
         </>
       )}
 
-      {/* ── Collapsible sections (Teams) ── */}
-      {channelType === 'teams' && (
+      {/* ── Teams setup (create step 1, or the whole edit body) ── */}
+      {channelType === 'teams' && (mode === 'edit' || createStep === 1) && (
         <Collapse
           ghost
           destroyOnHidden={false}
@@ -1710,16 +1696,15 @@ const ChannelFormFields: React.FC<{
         />
       )}
 
-      {/* ── Slack guided setup wizard (create) ── */}
-      {channelType === 'slack' && mode === 'create' && (
+      {/* ── Slack guided setup wizard (create steps 1–3) ── */}
+      {channelType === 'slack' && mode === 'create' && createStep >= 1 && (
         <SlackSetupWizard
           form={form}
           userById={userById}
           mcpServerById={mcpServerById}
           selectedAgent={selectedAgent}
           onAgentChange={onAgentChange}
-          step={slackStep}
-          onStepChange={onSlackStepChange}
+          step={createStep - 1}
           testResult={slackTestResult}
           testLoading={slackTestLoading}
           onTest={onSlackTest}
@@ -2086,14 +2071,16 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const loadingReferencedBranchIds = useRef<Set<string>>(new Set());
   const referencedBranchesByIdRef = useRef<Map<string, Branch>>(new Map());
 
-  // ── GitHub App Setup State (lifted from ChannelFormFields) ──
-  const [githubStep, setGithubStep] = useState(0);
+  // ── Unified create-wizard step (0 = universal "Channel" step) ──
+  const [createStep, setCreateStep] = useState(0);
+  const [creating, setCreating] = useState(false);
+
+  // ── GitHub App Setup State (create mode) ──
   const [githubLoading, setGithubLoading] = useState(false);
   const [githubError, setGithubError] = useState<string | null>(null);
   const [githubSetupParams, setGithubSetupParams] = useState<GitHubSetupParams | null>(null);
 
-  // ── Slack Setup Wizard State (lifted from ChannelFormFields) ──
-  const [slackStep, setSlackStep] = useState(0);
+  // ── Slack guided-setup state (create mode) ──
   const [slackTestLoading, setSlackTestLoading] = useState(false);
   const [slackTestResult, setSlackTestResult] = useState<SlackTestResult | null>(null);
 
@@ -2108,12 +2095,21 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     if (installationId) {
       setGithubSetupParams({ installation_id: installationId });
       setChannelType('github');
-      setGithubStep(1); // Skip to credentials step since app is already created
+      // App is already created on GitHub — jump straight to the Credentials step
+      // (Channel=0, Create app=1, Credentials=2 in the unified GitHub flow).
+      setCreateStep(2);
       setCreateModalOpen(true);
       // Clean up URL params
       navigate('/', { replace: true });
     }
   }, [location.search, navigate]);
+
+  // Prefill the installation ID once the create form is mounted (deep-link return).
+  useEffect(() => {
+    if (createModalOpen && githubSetupParams?.installation_id) {
+      createForm.setFieldValue('github_installation_id', githubSetupParams.installation_id);
+    }
+  }, [createModalOpen, githubSetupParams, createForm]);
 
   // Keep referenced target branches resolvable in CRUD even when archived branches
   // are excluded from the core store.
@@ -2185,17 +2181,22 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   // No automatic credential fetch — user provides App ID and PEM manually
 
   const resetGithubState = useCallback(() => {
-    setGithubStep(0);
     setGithubLoading(false);
     setGithubError(null);
     setGithubSetupParams(null);
   }, []);
 
   const resetSlackState = useCallback(() => {
-    setSlackStep(0);
     setSlackTestLoading(false);
     setSlackTestResult(null);
   }, []);
+
+  // Reset the whole create flow back to its universal first step.
+  const resetCreateFlow = useCallback(() => {
+    setCreateStep(0);
+    resetGithubState();
+    resetSlackState();
+  }, [resetGithubState, resetSlackState]);
 
   const invalidateSlackTest = useCallback(() => {
     setSlackTestResult(null);
@@ -2213,15 +2214,14 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     [invalidateSlackTest]
   );
 
-  // Switching channel type abandons any in-progress platform setup, so clear the
-  // wizard state for both platforms.
+  // Switching channel type changes the step structure, so snap back to the
+  // universal first step and clear any in-progress platform setup.
   const handleChannelTypeChange = useCallback(
     (type: ChannelType) => {
       setChannelType(type);
-      resetGithubState();
-      resetSlackState();
+      resetCreateFlow();
     },
-    [resetGithubState, resetSlackState]
+    [resetCreateFlow]
   );
 
   // Probe the entered Slack tokens against the live workspace via the
@@ -2395,6 +2395,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   };
 
   const handleCreate = async () => {
+    setCreating(true);
     try {
       await createForm.validateFields();
       // Use getFieldsValue(true) to include values from collapsed (unmounted)
@@ -2420,8 +2421,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       createForm.resetFields();
       setCreateModalOpen(false);
       setChannelType('slack');
-      resetGithubState();
-      resetSlackState();
+      resetCreateFlow();
     } catch (error: unknown) {
       const err = error as { errorFields?: { errors: string[] }[]; message?: string };
       if (err.errorFields?.length) {
@@ -2429,7 +2429,42 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       } else {
         showError(`Failed to create channel: ${err.message || String(error)}`);
       }
+    } finally {
+      setCreating(false);
     }
+  };
+
+  // Single create-footer primary action: validate the current step, then either
+  // advance or (on the final step) submit. Navigation lives only in the footer.
+  const createSteps = createStepsForType(channelType);
+  const isFinalCreateStep = createStep >= createSteps.length - 1;
+
+  const handleCreatePrimary = async () => {
+    if (isFinalCreateStep) {
+      await handleCreate();
+      return;
+    }
+    const fields = createStepFields(
+      channelType,
+      createStep,
+      createForm.getFieldValue('align_slack_users') ?? false
+    );
+    if (fields.length > 0) {
+      try {
+        await createForm.validateFields(fields);
+      } catch {
+        return;
+      }
+    }
+    setCreateStep((step) => step + 1);
+  };
+
+  const closeCreateModal = () => {
+    createForm.resetFields();
+    setCreateModalOpen(false);
+    setChannelType('slack');
+    setSelectedAgent('claude-code');
+    resetCreateFlow();
   };
 
   const handleEdit = (channel: GatewayChannel) => {
@@ -2726,26 +2761,28 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       <Modal
         title="Add Gateway Channel"
         open={createModalOpen}
-        onOk={handleCreate}
-        onCancel={() => {
-          createForm.resetFields();
-          setCreateModalOpen(false);
-          setChannelType('slack');
-          setSelectedAgent('claude-code');
-          resetGithubState();
-          resetSlackState();
-        }}
-        okText="Create"
-        okButtonProps={{
-          // Hide the Create button until each platform's guided setup reaches its
-          // final step (GitHub config / Slack tokens & test).
-          style:
-            (channelType === 'github' && githubStep < 2) ||
-            (channelType === 'slack' && slackStep < 2)
-              ? { display: 'none' }
-              : undefined,
-        }}
+        onCancel={closeCreateModal}
         width={600}
+        footer={
+          // One structurally-identical footer on every step: Back (left),
+          // Cancel + primary (right). Buttons never move between steps.
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <Button
+              type="link"
+              disabled={createStep === 0}
+              onClick={() => setCreateStep((step) => Math.max(0, step - 1))}
+              style={{ paddingLeft: 0 }}
+            >
+              Back
+            </Button>
+            <Space style={{ marginLeft: 'auto' }}>
+              <Button onClick={closeCreateModal}>Cancel</Button>
+              <Button type="primary" loading={creating} onClick={handleCreatePrimary}>
+                {isFinalCreateStep ? 'Create channel' : 'Continue'}
+              </Button>
+            </Space>
+          </div>
+        }
       >
         <Form
           form={createForm}
@@ -2764,13 +2801,9 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             mcpServerById={mcpServerById}
             selectedAgent={selectedAgent}
             onAgentChange={setSelectedAgent}
-            githubStep={githubStep}
-            onGithubStepChange={setGithubStep}
-            githubSetupParams={githubSetupParams}
+            createStep={createStep}
             githubLoading={githubLoading}
             githubError={githubError}
-            slackStep={slackStep}
-            onSlackStepChange={setSlackStep}
             slackTestResult={slackTestResult}
             slackTestLoading={slackTestLoading}
             onSlackTest={handleSlackTest}
@@ -2805,13 +2838,9 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             selectedAgent={selectedAgent}
             onAgentChange={setSelectedAgent}
             editingChannel={editingChannel}
-            githubStep={2}
-            onGithubStepChange={() => {}}
-            githubSetupParams={null}
+            createStep={0}
             githubLoading={false}
             githubError={null}
-            slackStep={2}
-            onSlackStepChange={() => {}}
             slackTestResult={null}
             slackTestLoading={false}
             onSlackTest={() => {}}

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -367,6 +367,24 @@ const SLACK_SETUP_STEPS = [
 ];
 
 /**
+ * Form fields whose values feed the `gateway-channels/test` probe. Editing any
+ * of them makes a previously-passing test result stale, so the green result is
+ * cleared when one changes.
+ */
+const SLACK_PROBE_FIELDS = new Set<string>([
+  'bot_token',
+  'app_token',
+  'slack_app_name',
+  'enable_channels',
+  'enable_groups',
+  'enable_mpim',
+  'align_slack_users',
+  'outbound_enabled',
+  'slack_public_scope',
+  'allowed_channel_ids',
+]);
+
+/**
  * Copy text to the clipboard, falling back to a transient textarea +
  * `execCommand('copy')` for browsers/contexts where the async Clipboard API is
  * unavailable (e.g. non-secure origins).
@@ -503,7 +521,6 @@ const SlackSetupWizard: React.FC<{
   testResult: SlackTestResult | null;
   testLoading: boolean;
   onTest: () => void;
-  onInvalidateTest: () => void;
 }> = ({
   form,
   userById,
@@ -515,7 +532,6 @@ const SlackSetupWizard: React.FC<{
   testResult,
   testLoading,
   onTest,
-  onInvalidateTest,
 }) => {
   const { token } = theme.useToken();
   const { showError } = useThemedMessage();
@@ -528,9 +544,6 @@ const SlackSetupWizard: React.FC<{
   const alignUsers = Form.useWatch('align_slack_users', form) ?? false;
   const outbound = Form.useWatch('outbound_enabled', form) ?? false;
   const publicScope = (Form.useWatch('slack_public_scope', form) as string) ?? 'all';
-  const allowedChannelIds = (Form.useWatch('allowed_channel_ids', form) as string[]) ?? [];
-  const botToken = (Form.useWatch('bot_token', form) as string) ?? '';
-  const appToken = (Form.useWatch('app_token', form) as string) ?? '';
 
   const wizardOptions: SlackWizardOptions = useMemo(
     () => ({
@@ -551,15 +564,13 @@ const SlackSetupWizard: React.FC<{
   const scopes = useMemo(() => requiredBotScopes(wizardOptions), [wizardOptions]);
   const events = useMemo(() => requiredBotEvents(wizardOptions), [wizardOptions]);
 
-  // Any change that alters the probe config (manifest inputs, tokens, or the
-  // channel-scope options sent to gateway-channels/test) invalidates a prior
-  // test result. A green check against stale config would be misleading.
-  const invalidationKey = `${manifestJson}|${botToken}|${appToken}|${publicScope}|${allowedChannelIds.join(',')}`;
-  // biome-ignore lint/correctness/useExhaustiveDependencies: invalidationKey is the change trigger, not a value read in the body.
+  // Reset the "Copied" affordance whenever the manifest content changes.
+  // (Stale test-result invalidation is owned by the parent's Form onValuesChange,
+  // which fires on real edits without racing useWatch against the async probe.)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: manifestJson is the change trigger, not a value read in the body.
   useEffect(() => {
-    onInvalidateTest();
     setCopied(false);
-  }, [invalidationKey, onInvalidateTest]);
+  }, [manifestJson]);
 
   const manifestPreview = (
     <pre
@@ -978,7 +989,6 @@ const ChannelFormFields: React.FC<{
   slackTestResult: SlackTestResult | null;
   slackTestLoading: boolean;
   onSlackTest: () => void;
-  onInvalidateSlackTest: () => void;
 }> = ({
   form,
   mode,
@@ -1000,7 +1010,6 @@ const ChannelFormFields: React.FC<{
   slackTestResult,
   slackTestLoading,
   onSlackTest,
-  onInvalidateSlackTest,
 }) => {
   const { showError } = useThemedMessage();
 
@@ -1732,7 +1741,6 @@ const ChannelFormFields: React.FC<{
           testResult={slackTestResult}
           testLoading={slackTestLoading}
           onTest={onSlackTest}
-          onInvalidateTest={onInvalidateSlackTest}
         />
       )}
 
@@ -2210,6 +2218,18 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const invalidateSlackTest = useCallback(() => {
     setSlackTestResult(null);
   }, []);
+
+  // Clear a passing Slack test result the moment any probe-affecting field is
+  // edited. Driven by the Form's onValuesChange (real edits only) rather than a
+  // useWatch effect, so it never races the async probe that sets the result.
+  const handleCreateValuesChange = useCallback(
+    (changed: Record<string, unknown>) => {
+      if (Object.keys(changed).some((field) => SLACK_PROBE_FIELDS.has(field))) {
+        invalidateSlackTest();
+      }
+    },
+    [invalidateSlackTest]
+  );
 
   // Switching channel type abandons any in-progress platform setup, so clear the
   // wizard state for both platforms.
@@ -2745,7 +2765,13 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         }}
         width={600}
       >
-        <Form form={createForm} layout="vertical" preserve style={{ marginTop: 16 }}>
+        <Form
+          form={createForm}
+          layout="vertical"
+          preserve
+          onValuesChange={handleCreateValuesChange}
+          style={{ marginTop: 16 }}
+        >
           <ChannelFormFields
             form={createForm}
             mode="create"
@@ -2766,7 +2792,6 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             slackTestResult={slackTestResult}
             slackTestLoading={slackTestLoading}
             onSlackTest={handleSlackTest}
-            onInvalidateSlackTest={invalidateSlackTest}
           />
         </Form>
       </Modal>
@@ -2808,7 +2833,6 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             slackTestResult={null}
             slackTestLoading={false}
             onSlackTest={() => {}}
-            onInvalidateSlackTest={() => {}}
           />
         </Form>
       </Modal>

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -65,7 +65,6 @@ import {
   theme,
 } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { getDaemonUrl } from '@/config/daemon';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
@@ -319,31 +318,6 @@ const GatewayEnvVarsEditor: React.FC<{
     </div>
   );
 };
-
-// ============================================================================
-// GitHub App Setup Types & Helpers
-// ============================================================================
-
-/**
- * State carried across the GitHub App install round-trip. `installation_id`
- * arrives via the deep-link URL; the rest is restored from the sessionStorage
- * draft persisted before the redirect (the install opens a fresh page, so the
- * in-memory form is gone on return).
- */
-interface GitHubSetupParams {
-  installation_id?: string;
-  name?: string;
-  target_branch_id?: string;
-  github_app_name?: string;
-  github_org?: string;
-}
-
-/**
- * sessionStorage key for the step-0 essentials stashed right before the GitHub
- * App install redirect. A new tab opened via `window.open` inherits a copy of
- * the opener's sessionStorage, so the install-callback page can restore them.
- */
-const GITHUB_SETUP_DRAFT_KEY = 'agor.gateway.githubSetupDraft';
 
 // ============================================================================
 // Unified create-wizard step model
@@ -1021,9 +995,6 @@ const ChannelFormFields: React.FC<{
   const enableMpim = Form.useWatch('enable_mpim', form) ?? false;
   const alignSlackUsers = Form.useWatch('align_slack_users', form) ?? false;
   const alignGithubUsers = Form.useWatch('github_align_users', form) ?? false;
-  // Set after an install round-trip; lets the Create-app step recognize the
-  // already-installed case instead of prompting to create the app again.
-  const githubInstallationId = Form.useWatch('github_installation_id', form);
 
   const sourcesEnabled = enableChannels || enableGroups || enableMpim;
 
@@ -1156,21 +1127,6 @@ const ChannelFormFields: React.FC<{
             {/* Step 1 (Create app): register the GitHub App. */}
             {mode === 'create' && createStep === 1 && !githubLoading && (
               <div style={{ marginBottom: 16 }}>
-                {githubInstallationId ? (
-                  <Alert
-                    type="success"
-                    showIcon
-                    title="GitHub App already installed"
-                    description={
-                      <span>
-                        Installation <code>{String(githubInstallationId)}</code> was captured from
-                        the install callback. Click <strong>Continue</strong> to enter its
-                        credentials.
-                      </span>
-                    }
-                    style={{ marginBottom: 16 }}
-                  />
-                ) : null}
                 <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
                   Create a GitHub App to connect Agor to your repositories. This uses GitHub&apos;s
                   URL-parameters registration flow — you&apos;ll be redirected to GitHub with the
@@ -1234,21 +1190,6 @@ const ChannelFormFields: React.FC<{
                         return;
                       }
                       params.set('state', state);
-                      // Stash step-0 essentials so the install-callback page (a
-                      // fresh load) can restore name/branch and land on Credentials.
-                      try {
-                        sessionStorage.setItem(
-                          GITHUB_SETUP_DRAFT_KEY,
-                          JSON.stringify({
-                            name: form.getFieldValue('name') ?? '',
-                            target_branch_id: form.getFieldValue('target_branch_id') ?? '',
-                            github_app_name: appName ?? '',
-                            github_org: org ?? '',
-                          })
-                        );
-                      } catch {
-                        // Non-fatal: the deep-link return falls back to step 0.
-                      }
                       window.open(
                         `${daemonUrl}/api/github/setup/new?${params.toString()}`,
                         '_blank'
@@ -2147,64 +2088,10 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   // ── GitHub App Setup State (create mode) ──
   const [githubLoading, setGithubLoading] = useState(false);
   const [githubError, setGithubError] = useState<string | null>(null);
-  const [githubSetupParams, setGithubSetupParams] = useState<GitHubSetupParams | null>(null);
 
   // ── Slack guided-setup state (create mode) ──
   const [slackTestLoading, setSlackTestLoading] = useState(false);
   const [slackTestResult, setSlackTestResult] = useState<SlackTestResult | null>(null);
-
-  // Detect GitHub setup callback params from URL
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const installationId = params.get('installation_id');
-
-    if (installationId) {
-      // Restore the step-0 essentials stashed before the install redirect.
-      let draft: Partial<GitHubSetupParams> = {};
-      try {
-        const raw = sessionStorage.getItem(GITHUB_SETUP_DRAFT_KEY);
-        if (raw) draft = JSON.parse(raw) as Partial<GitHubSetupParams>;
-      } catch {
-        // Ignore malformed drafts — fall back to step 0 below.
-      }
-
-      setGithubSetupParams({ installation_id: installationId, ...draft });
-      setChannelType('github');
-      // With a restored draft (name + branch), jump straight to Credentials
-      // (Channel=0, Create app=1, Credentials=2). Without it, land on step 0 so
-      // the user can supply the required name/branch first.
-      const hasDraft = Boolean(draft.name && draft.target_branch_id);
-      setCreateStep(hasDraft ? 2 : 0);
-      setCreateModalOpen(true);
-      // Clean up URL params
-      navigate('/', { replace: true });
-    }
-  }, [location.search, navigate]);
-
-  // Once the create form is mounted on a deep-link return, sync the channel type
-  // and restore the captured draft/installation into the form, then drop the
-  // sessionStorage draft so a later manual create can't inherit it.
-  useEffect(() => {
-    if (!createModalOpen || !githubSetupParams) return;
-    const { installation_id, name, target_branch_id, github_app_name, github_org } =
-      githubSetupParams;
-    createForm.setFieldsValue({
-      channel_type: 'github',
-      ...(installation_id ? { github_installation_id: installation_id } : {}),
-      ...(name ? { name } : {}),
-      ...(target_branch_id ? { target_branch_id } : {}),
-      ...(github_app_name ? { github_app_name } : {}),
-      ...(github_org ? { github_org } : {}),
-    });
-    try {
-      sessionStorage.removeItem(GITHUB_SETUP_DRAFT_KEY);
-    } catch {
-      // Best-effort cleanup.
-    }
-  }, [createModalOpen, githubSetupParams, createForm]);
 
   // Keep referenced target branches resolvable in CRUD even when archived branches
   // are excluded from the core store.
@@ -2278,7 +2165,6 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const resetGithubState = useCallback(() => {
     setGithubLoading(false);
     setGithubError(null);
-    setGithubSetupParams(null);
   }, []);
 
   const resetSlackState = useCallback(() => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -1012,1034 +1012,1056 @@ const ChannelFormFields: React.FC<{
 
   return (
     <>
-      {/* Unified step indicator — sits directly under the modal title on create. */}
+      {/* Unified step indicator — sits directly under the modal title on create,
+          fixed above the scrollable content so it never scrolls away. */}
       {mode === 'create' && (
         <Steps
           current={createStep}
           size="small"
           items={createStepsForType(channelType)}
-          style={{ marginBottom: 24 }}
+          style={{ marginBottom: 16, flexShrink: 0 }}
         />
       )}
 
-      {/* ── Step 0 "Channel": universal basics. Kept mounted on create so its
-          required fields stay registered for the final validateFields(). ── */}
-      <div style={{ display: mode === 'create' && createStep !== 0 ? 'none' : undefined }}>
-        <Form.Item
-          label="Channel Type"
-          name="channel_type"
-          initialValue={mode === 'create' ? 'slack' : undefined}
-          rules={[{ required: true }]}
-        >
-          <Select onChange={(value: ChannelType) => onChannelTypeChange(value)}>
-            {CHANNEL_TYPE_OPTIONS.map((opt) => (
-              <Select.Option key={opt.value} value={opt.value}>
-                <Space>
-                  {opt.icon}
-                  {opt.label}
-                </Space>
-              </Select.Option>
-            ))}
-          </Select>
-        </Form.Item>
-
-        <Form.Item
-          label="Name"
-          name="name"
-          rules={[{ required: true, message: 'Please enter a channel name' }]}
-        >
-          <Input placeholder="e.g., Team Slack, Personal Discord" />
-        </Form.Item>
-
-        <Form.Item
-          label="Target Branch"
-          name="target_branch_id"
-          rules={[{ required: true, message: 'Please select a target branch' }]}
-          tooltip={
-            mode === 'create'
-              ? 'New sessions from this channel will be created in this branch'
-              : undefined
-          }
-        >
-          <BranchSelect branchById={branchById} />
-        </Form.Item>
-
-        {/* Slack and GitHub choose identity in their platform-specific Identity sections. */}
-        {channelType !== 'slack' && channelType !== 'github' && (
+      {/* On create the step content scrolls inside a viewport-capped region while
+          the title (antd), step indicator (above) and footer (antd) stay fixed.
+          The paddingInline/marginInline pair lets edge-bleeding Collapses align to
+          the body edge without producing a horizontal scrollbar. */}
+      <div
+        style={
+          mode === 'create'
+            ? {
+                maxHeight: '56vh',
+                overflowY: 'auto',
+                overflowX: 'hidden',
+                paddingInline: 16,
+                marginInline: -16,
+              }
+            : undefined
+        }
+      >
+        {/* ── Step 0 "Channel": universal basics. Kept mounted on create so its
+            required fields stay registered for the final validateFields(). ── */}
+        <div style={{ display: mode === 'create' && createStep !== 0 ? 'none' : undefined }}>
           <Form.Item
-            label="Post messages as"
-            name="agor_user_id"
-            rules={[{ required: true, message: 'Please select a user' }]}
-            tooltip="Sessions from this channel will run as this Agor user"
+            label="Channel Type"
+            name="channel_type"
+            initialValue={mode === 'create' ? 'slack' : undefined}
+            rules={[{ required: true }]}
           >
-            <UserSelect userById={userById} />
+            <Select onChange={(value: ChannelType) => onChannelTypeChange(value)}>
+              {CHANNEL_TYPE_OPTIONS.map((opt) => (
+                <Select.Option key={opt.value} value={opt.value}>
+                  <Space>
+                    {opt.icon}
+                    {opt.label}
+                  </Space>
+                </Select.Option>
+              ))}
+            </Select>
           </Form.Item>
-        )}
 
-        <Form.Item
-          label="Enabled"
-          name="enabled"
-          valuePropName="checked"
-          initialValue={mode === 'create' ? true : undefined}
-        >
-          <Switch />
-        </Form.Item>
+          <Form.Item
+            label="Name"
+            name="name"
+            rules={[{ required: true, message: 'Please enter a channel name' }]}
+          >
+            <Input placeholder="e.g., Team Slack, Personal Discord" />
+          </Form.Item>
 
-        {channelType !== 'slack' && channelType !== 'github' && channelType !== 'teams' && (
-          <Alert
-            title={`${channelType.charAt(0).toUpperCase() + channelType.slice(1)} support coming soon`}
-            description="This platform integration is not yet available. Slack, GitHub, and Microsoft Teams are currently supported."
-            type="info"
-            showIcon
-            style={{ marginBottom: 16 }}
-          />
-        )}
-      </div>
+          <Form.Item
+            label="Target Branch"
+            name="target_branch_id"
+            rules={[{ required: true, message: 'Please select a target branch' }]}
+            tooltip={
+              mode === 'create'
+                ? 'New sessions from this channel will be created in this branch'
+                : undefined
+            }
+          >
+            <BranchSelect branchById={branchById} />
+          </Form.Item>
 
-      {/* ── GitHub App Setup (create steps + shared config collapse) ── */}
-      {channelType === 'github' && (
-        <>
-          {githubLoading && (
-            <div style={{ textAlign: 'center', padding: '24px 0' }}>
-              <Spin indicator={<LoadingOutlined spin />} />
-              <Typography.Text type="secondary" style={{ display: 'block', marginTop: 8 }}>
-                Loading GitHub App data...
-              </Typography.Text>
-            </div>
+          {/* Slack and GitHub choose identity in their platform-specific Identity sections. */}
+          {channelType !== 'slack' && channelType !== 'github' && (
+            <Form.Item
+              label="Post messages as"
+              name="agor_user_id"
+              rules={[{ required: true, message: 'Please select a user' }]}
+              tooltip="Sessions from this channel will run as this Agor user"
+            >
+              <UserSelect userById={userById} />
+            </Form.Item>
           )}
 
-          {githubError && (
+          <Form.Item
+            label="Enabled"
+            name="enabled"
+            valuePropName="checked"
+            initialValue={mode === 'create' ? true : undefined}
+          >
+            <Switch />
+          </Form.Item>
+
+          {channelType !== 'slack' && channelType !== 'github' && channelType !== 'teams' && (
             <Alert
-              type="error"
+              title={`${channelType.charAt(0).toUpperCase() + channelType.slice(1)} support coming soon`}
+              description="This platform integration is not yet available. Slack, GitHub, and Microsoft Teams are currently supported."
+              type="info"
               showIcon
-              title="GitHub Setup Error"
-              description={githubError}
               style={{ marginBottom: 16 }}
             />
           )}
+        </div>
 
-          {/* Step 1 (Create app): register the GitHub App. */}
-          {mode === 'create' && createStep === 1 && !githubLoading && (
-            <div style={{ marginBottom: 16 }}>
-              <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
-                Create a GitHub App to connect Agor to your repositories. This uses GitHub&apos;s
-                URL-parameters registration flow — you&apos;ll be redirected to GitHub with the form
-                pre-filled, then brought back here to complete setup.
-              </Typography.Paragraph>
+        {/* ── GitHub App Setup (create steps + shared config collapse) ── */}
+        {channelType === 'github' && (
+          <>
+            {githubLoading && (
+              <div style={{ textAlign: 'center', padding: '24px 0' }}>
+                <Spin indicator={<LoadingOutlined spin />} />
+                <Typography.Text type="secondary" style={{ display: 'block', marginTop: 8 }}>
+                  Loading GitHub App data...
+                </Typography.Text>
+              </div>
+            )}
 
-              <Form.Item label="App Name" name="github_app_name">
-                <Input placeholder="Agor (optional — defaults to 'Agor')" />
-              </Form.Item>
-
-              <Form.Item
-                label="Target Organization"
-                name="github_org"
-                tooltip="Leave empty to create the app under your personal GitHub account"
-              >
-                <Input placeholder="my-org (optional)" />
-              </Form.Item>
-
-              <Button
-                type="primary"
-                icon={<GithubOutlined />}
-                block
-                onClick={async () => {
-                  const daemonUrl = getDaemonUrl();
-                  const params = new URLSearchParams();
-                  const appName = form.getFieldValue('github_app_name');
-                  const org = form.getFieldValue('github_org');
-                  if (appName) params.set('name', appName);
-                  if (org) params.set('org', org);
-
-                  // Fetch a one-time CSRF state token bound to the current admin.
-                  // This authenticates the install-initiation step and binds the
-                  // post-install callback to this user_id.
-                  try {
-                    const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-                    if (!accessToken) {
-                      showError('You must be logged in as an admin to install the GitHub App.');
-                      return;
-                    }
-                    const stateRes = await fetch(`${daemonUrl}/api/github/setup/state`, {
-                      method: 'POST',
-                      headers: {
-                        Authorization: `Bearer ${accessToken}`,
-                        'Content-Type': 'application/json',
-                      },
-                    });
-                    if (!stateRes.ok) {
-                      const body = await stateRes
-                        .json()
-                        .catch(() => ({}) as Record<string, unknown>);
-                      const err =
-                        typeof body?.error === 'string'
-                          ? body.error
-                          : `Failed to start GitHub App install (HTTP ${stateRes.status})`;
-                      showError(err);
-                      return;
-                    }
-                    const { state } = (await stateRes.json()) as { state?: string };
-                    if (!state) {
-                      showError('Daemon did not return an install state token.');
-                      return;
-                    }
-                    params.set('state', state);
-                    window.open(`${daemonUrl}/api/github/setup/new?${params.toString()}`, '_blank');
-                  } catch (err) {
-                    showError(
-                      err instanceof Error ? err.message : 'Failed to initiate GitHub App install'
-                    );
-                  }
-                }}
-              >
-                Create GitHub App on GitHub
-              </Button>
-
-              <Typography.Paragraph type="secondary" style={{ fontSize: 12, margin: '12px 0 0' }}>
-                Already created the app? Click <strong>Continue</strong> below to enter its
-                credentials.
-              </Typography.Paragraph>
-            </div>
-          )}
-
-          {/* Step 2 (Credentials): App ID + private key. */}
-          {mode === 'create' && createStep === 2 && !githubLoading && (
-            <div style={{ marginBottom: 16 }}>
+            {githubError && (
               <Alert
-                type="info"
+                type="error"
                 showIcon
-                title="Enter your GitHub App credentials"
-                description={
-                  <span>
-                    On your GitHub App&apos;s settings page:
-                    <br />
-                    1. Copy the <strong>App ID</strong> (shown at the top under &quot;About&quot;)
-                    <br />
-                    2. Scroll to &quot;Private keys&quot; and click{' '}
-                    <strong>&quot;Generate a private key&quot;</strong>
-                    <br />
-                    3. Paste the downloaded .pem file contents below
-                  </span>
-                }
+                title="GitHub Setup Error"
+                description={githubError}
                 style={{ marginBottom: 16 }}
               />
+            )}
 
-              <Form.Item
-                label="App ID"
-                name="github_app_id"
-                rules={[{ required: true, message: 'Enter your GitHub App ID' }]}
-                tooltip="Found on your GitHub App's settings page (General → About)"
-              >
-                <Input placeholder="123456" />
-              </Form.Item>
+            {/* Step 1 (Create app): register the GitHub App. */}
+            {mode === 'create' && createStep === 1 && !githubLoading && (
+              <div style={{ marginBottom: 16 }}>
+                <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
+                  Create a GitHub App to connect Agor to your repositories. This uses GitHub&apos;s
+                  URL-parameters registration flow — you&apos;ll be redirected to GitHub with the
+                  form pre-filled, then brought back here to complete setup.
+                </Typography.Paragraph>
 
-              <Form.Item
-                label="Private Key (PEM)"
-                name="github_private_key"
-                rules={[{ required: true, message: 'Paste your GitHub App private key' }]}
-                tooltip="Generate a private key on your GitHub App's settings page, then paste the .pem file contents"
-              >
-                <Input.TextArea
-                  rows={4}
-                  placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..."
-                  style={{ fontFamily: 'monospace', fontSize: 11 }}
+                <Form.Item label="App Name" name="github_app_name">
+                  <Input placeholder="Agor (optional — defaults to 'Agor')" />
+                </Form.Item>
+
+                <Form.Item
+                  label="Target Organization"
+                  name="github_org"
+                  tooltip="Leave empty to create the app under your personal GitHub account"
+                >
+                  <Input placeholder="my-org (optional)" />
+                </Form.Item>
+
+                <Button
+                  type="primary"
+                  icon={<GithubOutlined />}
+                  block
+                  onClick={async () => {
+                    const daemonUrl = getDaemonUrl();
+                    const params = new URLSearchParams();
+                    const appName = form.getFieldValue('github_app_name');
+                    const org = form.getFieldValue('github_org');
+                    if (appName) params.set('name', appName);
+                    if (org) params.set('org', org);
+
+                    // Fetch a one-time CSRF state token bound to the current admin.
+                    // This authenticates the install-initiation step and binds the
+                    // post-install callback to this user_id.
+                    try {
+                      const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+                      if (!accessToken) {
+                        showError('You must be logged in as an admin to install the GitHub App.');
+                        return;
+                      }
+                      const stateRes = await fetch(`${daemonUrl}/api/github/setup/state`, {
+                        method: 'POST',
+                        headers: {
+                          Authorization: `Bearer ${accessToken}`,
+                          'Content-Type': 'application/json',
+                        },
+                      });
+                      if (!stateRes.ok) {
+                        const body = await stateRes
+                          .json()
+                          .catch(() => ({}) as Record<string, unknown>);
+                        const err =
+                          typeof body?.error === 'string'
+                            ? body.error
+                            : `Failed to start GitHub App install (HTTP ${stateRes.status})`;
+                        showError(err);
+                        return;
+                      }
+                      const { state } = (await stateRes.json()) as { state?: string };
+                      if (!state) {
+                        showError('Daemon did not return an install state token.');
+                        return;
+                      }
+                      params.set('state', state);
+                      window.open(
+                        `${daemonUrl}/api/github/setup/new?${params.toString()}`,
+                        '_blank'
+                      );
+                    } catch (err) {
+                      showError(
+                        err instanceof Error ? err.message : 'Failed to initiate GitHub App install'
+                      );
+                    }
+                  }}
+                >
+                  Create GitHub App on GitHub
+                </Button>
+
+                <Typography.Paragraph type="secondary" style={{ fontSize: 12, margin: '12px 0 0' }}>
+                  Already created the app? Click <strong>Continue</strong> below to enter its
+                  credentials.
+                </Typography.Paragraph>
+              </div>
+            )}
+
+            {/* Step 2 (Credentials): App ID + private key. */}
+            {mode === 'create' && createStep === 2 && !githubLoading && (
+              <div style={{ marginBottom: 16 }}>
+                <Alert
+                  type="info"
+                  showIcon
+                  title="Enter your GitHub App credentials"
+                  description={
+                    <span>
+                      On your GitHub App&apos;s settings page:
+                      <br />
+                      1. Copy the <strong>App ID</strong> (shown at the top under &quot;About&quot;)
+                      <br />
+                      2. Scroll to &quot;Private keys&quot; and click{' '}
+                      <strong>&quot;Generate a private key&quot;</strong>
+                      <br />
+                      3. Paste the downloaded .pem file contents below
+                    </span>
+                  }
+                  style={{ marginBottom: 16 }}
                 />
-              </Form.Item>
 
-              <Form.Item
-                label="Installation ID"
-                name="github_installation_id"
-                tooltip="Set automatically via the setup callback, or paste from your GitHub App's installation URL"
-              >
-                <Input placeholder="123456789" />
-              </Form.Item>
+                <Form.Item
+                  label="App ID"
+                  name="github_app_id"
+                  rules={[{ required: true, message: 'Enter your GitHub App ID' }]}
+                  tooltip="Found on your GitHub App's settings page (General → About)"
+                >
+                  <Input placeholder="123456" />
+                </Form.Item>
 
-              {githubError && (
-                <Alert type="error" showIcon title={githubError} style={{ marginBottom: 12 }} />
-              )}
-            </div>
-          )}
+                <Form.Item
+                  label="Private Key (PEM)"
+                  name="github_private_key"
+                  rules={[{ required: true, message: 'Paste your GitHub App private key' }]}
+                  tooltip="Generate a private key on your GitHub App's settings page, then paste the .pem file contents"
+                >
+                  <Input.TextArea
+                    rows={4}
+                    placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..."
+                    style={{ fontFamily: 'monospace', fontSize: 11 }}
+                  />
+                </Form.Item>
 
-          {/* Step 3 (Configure): shared settings collapse — also the edit-mode body. */}
-          {((mode === 'create' && createStep === 3) || mode === 'edit') && !githubLoading && (
-            <Collapse
-              ghost
-              destroyOnHidden={false}
-              defaultActiveKey={mode === 'create' ? ['identity', 'github-config'] : []}
-              style={{ marginLeft: -16, marginRight: -16 }}
-              items={[
-                // ── Credentials (edit mode) ──
-                ...(mode === 'edit'
-                  ? [
-                      {
-                        key: 'github-credentials',
-                        label: (
-                          <SectionLabel
-                            icon={<GithubOutlined />}
-                            title="App Credentials"
-                            subtitle={
-                              editingChannel?.config &&
-                              (editingChannel.config as Record<string, unknown>).private_key
-                                ? 'configured'
-                                : 'not set'
-                            }
-                          />
-                        ),
-                        children: (
-                          <>
-                            <Form.Item
-                              label="App ID"
-                              name="github_app_id"
-                              tooltip="Found on your GitHub App's settings page (General → About)"
-                            >
-                              <Input placeholder="123456" />
-                            </Form.Item>
-                            <Form.Item
-                              label="Private Key (PEM)"
-                              name="github_private_key"
-                              tooltip="Leave empty to keep the existing key. Paste a new .pem to replace it."
-                            >
-                              <Input.TextArea
-                                rows={3}
-                                placeholder={
-                                  editingChannel?.config &&
-                                  (editingChannel.config as Record<string, unknown>).private_key
-                                    ? '(private key is set — paste new key to replace)'
-                                    : '-----BEGIN RSA PRIVATE KEY-----\n...'
-                                }
-                                style={{ fontFamily: 'monospace', fontSize: 11 }}
-                              />
-                            </Form.Item>
-                            <Form.Item
-                              label="Installation ID"
-                              name="github_installation_id"
-                              tooltip="Set automatically via the setup callback, or paste from your GitHub App's installation URL"
-                            >
-                              <Input placeholder="123456789" />
-                            </Form.Item>
-                          </>
-                        ),
-                      },
-                    ]
-                  : []),
-                {
-                  key: 'github-config',
-                  label: (
-                    <SectionLabel
-                      icon={<GithubOutlined />}
-                      title="GitHub Settings"
-                      subtitle="polling & mentions"
-                    />
-                  ),
-                  children: (
-                    <>
-                      <Form.Item
-                        label="Watch Repos"
-                        name="github_watch_repos"
-                        rules={[{ required: true, message: 'At least one repo is required' }]}
-                        tooltip="Repos to watch for @mentions, in owner/repo format"
-                      >
-                        <Select
-                          mode="tags"
-                          placeholder="preset-io/agor"
-                          tokenSeparators={[',', ' ']}
-                        />
-                      </Form.Item>
+                <Form.Item
+                  label="Installation ID"
+                  name="github_installation_id"
+                  tooltip="Set automatically via the setup callback, or paste from your GitHub App's installation URL"
+                >
+                  <Input placeholder="123456789" />
+                </Form.Item>
 
-                      <Form.Item
-                        label="Require @mention"
-                        name="github_require_mention"
-                        valuePropName="checked"
-                        initialValue={true}
-                        tooltip="Only respond to PR/issue comments that @mention the bot"
-                      >
-                        <Switch />
-                      </Form.Item>
+                {githubError && (
+                  <Alert type="error" showIcon title={githubError} style={{ marginBottom: 12 }} />
+                )}
+              </div>
+            )}
 
-                      <Form.Item
-                        label="Mention Name"
-                        name="github_mention_name"
-                        tooltip="The name users type to trigger the bot (e.g., 'agor' for @agor)"
-                        initialValue="agor"
-                      >
-                        <Input prefix="@" placeholder="agor" />
-                      </Form.Item>
-
-                      <Form.Item
-                        label="Poll Interval (seconds)"
-                        name="github_poll_interval_s"
-                        initialValue={30}
-                        tooltip="How frequently to poll the GitHub API for new mentions"
-                      >
-                        <InputNumber min={10} max={300} style={{ width: '100%' }} />
-                      </Form.Item>
-                    </>
-                  ),
-                },
-                // ── Identity ──
-                {
-                  key: 'identity',
-                  label: (
-                    <SectionLabel
-                      icon={<UserOutlined />}
-                      title="Identity"
-                      subtitle={getIdentitySubtitle(alignGithubUsers)}
-                    />
-                  ),
-                  children: (
-                    <PlatformIdentityFields
-                      alignFieldName="github_align_users"
-                      alignLabel="Align GitHub users"
-                      alignDescription="Map GitHub logins to Agor users. Unmapped users are rejected."
-                      alignUsers={alignGithubUsers}
-                      userById={userById}
-                      alignedContent={
+            {/* Step 3 (Configure): shared settings collapse — also the edit-mode body. */}
+            {((mode === 'create' && createStep === 3) || mode === 'edit') && !githubLoading && (
+              <Collapse
+                ghost
+                destroyOnHidden={false}
+                defaultActiveKey={mode === 'create' ? ['identity', 'github-config'] : []}
+                style={{ marginLeft: -16, marginRight: -16 }}
+                items={[
+                  // ── Credentials (edit mode) ──
+                  ...(mode === 'edit'
+                    ? [
+                        {
+                          key: 'github-credentials',
+                          label: (
+                            <SectionLabel
+                              icon={<GithubOutlined />}
+                              title="App Credentials"
+                              subtitle={
+                                editingChannel?.config &&
+                                (editingChannel.config as Record<string, unknown>).private_key
+                                  ? 'configured'
+                                  : 'not set'
+                              }
+                            />
+                          ),
+                          children: (
+                            <>
+                              <Form.Item
+                                label="App ID"
+                                name="github_app_id"
+                                tooltip="Found on your GitHub App's settings page (General → About)"
+                              >
+                                <Input placeholder="123456" />
+                              </Form.Item>
+                              <Form.Item
+                                label="Private Key (PEM)"
+                                name="github_private_key"
+                                tooltip="Leave empty to keep the existing key. Paste a new .pem to replace it."
+                              >
+                                <Input.TextArea
+                                  rows={3}
+                                  placeholder={
+                                    editingChannel?.config &&
+                                    (editingChannel.config as Record<string, unknown>).private_key
+                                      ? '(private key is set — paste new key to replace)'
+                                      : '-----BEGIN RSA PRIVATE KEY-----\n...'
+                                  }
+                                  style={{ fontFamily: 'monospace', fontSize: 11 }}
+                                />
+                              </Form.Item>
+                              <Form.Item
+                                label="Installation ID"
+                                name="github_installation_id"
+                                tooltip="Set automatically via the setup callback, or paste from your GitHub App's installation URL"
+                              >
+                                <Input placeholder="123456789" />
+                              </Form.Item>
+                            </>
+                          ),
+                        },
+                      ]
+                    : []),
+                  {
+                    key: 'github-config',
+                    label: (
+                      <SectionLabel
+                        icon={<GithubOutlined />}
+                        title="GitHub Settings"
+                        subtitle="polling & mentions"
+                      />
+                    ),
+                    children: (
+                      <>
                         <Form.Item
-                          label="User Map"
-                          name="github_user_map"
-                          tooltip="JSON object mapping GitHub logins to Agor email addresses"
-                          rules={[{ validator: validateJSON }]}
+                          label="Watch Repos"
+                          name="github_watch_repos"
+                          rules={[{ required: true, message: 'At least one repo is required' }]}
+                          tooltip="Repos to watch for @mentions, in owner/repo format"
                         >
-                          <JSONEditor
-                            rows={4}
-                            placeholder={'{\n  "octocat": "user@example.com"\n}'}
+                          <Select
+                            mode="tags"
+                            placeholder="preset-io/agor"
+                            tokenSeparators={[',', ' ']}
                           />
                         </Form.Item>
-                      }
-                    />
-                  ),
-                },
-                // ── Agentic Tool Configuration ──
-                {
-                  key: 'agentic-tool-config',
-                  label: (
-                    <SectionLabel
-                      icon={<ThunderboltOutlined />}
-                      title="Agent Configuration"
-                      subtitle={selectedAgent}
-                    />
-                  ),
-                  children: (
-                    <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
-                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                        Configure which agent and settings to use for sessions created from this
-                        channel.
-                      </Typography.Text>
-                      <AgentSelectionGrid
-                        agents={AVAILABLE_AGENTS}
-                        selectedAgentId={selectedAgent}
-                        onSelect={onAgentChange}
-                        columns={2}
-                        showHelperText={false}
-                        showComparisonLink={false}
-                      />
-                      <AgenticToolConfigForm
-                        agenticTool={selectedAgent as AgenticToolName}
-                        mcpServerById={mcpServerById}
-                        showHelpText={false}
-                      />
-                    </Space>
-                  ),
-                },
-                // ── Environment Variables ──
-                {
-                  key: 'env-vars',
-                  label: (
-                    <SectionLabel
-                      icon={<LockOutlined />}
-                      title="Environment Variables"
-                      subtitle="channel-level secrets"
-                    />
-                  ),
-                  children: (
-                    <>
-                      <Typography.Text
-                        type="secondary"
-                        style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                      >
-                        Define environment variables for sessions created from this channel. Useful
-                        for service account tokens or API keys for MCP servers.
-                      </Typography.Text>
-                      <Form.Item name="envVars" noStyle>
-                        <GatewayEnvVarsEditor />
-                      </Form.Item>
-                    </>
-                  ),
-                },
-              ]}
-            />
-          )}
-        </>
-      )}
 
-      {/* ── Teams setup (create step 1, or the whole edit body) ── */}
-      {channelType === 'teams' && (mode === 'edit' || createStep === 1) && (
-        <Collapse
-          ghost
-          destroyOnHidden={false}
-          defaultActiveKey={mode === 'create' ? ['teams-credentials'] : []}
-          style={{ marginLeft: -16, marginRight: -16 }}
-          items={[
-            // ── Credentials ──
-            {
-              key: 'teams-credentials',
-              label: (
-                <SectionLabel
-                  icon={<KeyOutlined />}
-                  title="Azure Bot Credentials"
-                  subtitle={mode === 'edit' ? 'leave blank to keep current' : undefined}
-                />
-              ),
-              children: (
-                <>
-                  <Form.Item
-                    label="App ID"
-                    name="teams_app_id"
-                    rules={
-                      mode === 'create'
-                        ? [{ required: true, message: 'Azure Bot App ID is required' }]
-                        : []
-                    }
-                    tooltip="Azure Bot Registration Application (client) ID"
-                  >
-                    <Input placeholder="00000000-0000-0000-0000-000000000000" />
-                  </Form.Item>
-
-                  <Form.Item
-                    label="App Password"
-                    name="teams_app_password"
-                    rules={
-                      mode === 'create'
-                        ? [{ required: true, message: 'Azure Bot App Password is required' }]
-                        : []
-                    }
-                    tooltip="Azure Bot Registration client secret (value, not the secret ID)"
-                  >
-                    <Input.Password
-                      placeholder={mode === 'edit' ? '••••••••' : 'Client secret value'}
-                    />
-                  </Form.Item>
-
-                  <Form.Item
-                    label="Tenant ID"
-                    name="teams_tenant_id"
-                    rules={[
-                      {
-                        required: true,
-                        message: 'Tenant ID is required for Teams bots',
-                      },
-                    ]}
-                    tooltip="Azure AD Tenant ID. Required so the bot can acquire tokens to send replies."
-                  >
-                    <Input placeholder="00000000-0000-0000-0000-000000000000" />
-                  </Form.Item>
-
-                  <Alert
-                    type="info"
-                    showIcon
-                    message="Azure Bot Setup"
-                    description={
-                      <span>
-                        Create an Azure Bot resource in the{' '}
-                        <Typography.Link
-                          href="https://portal.azure.com/#create/Microsoft.AzureBotService"
-                          target="_blank"
-                          rel="noopener noreferrer"
+                        <Form.Item
+                          label="Require @mention"
+                          name="github_require_mention"
+                          valuePropName="checked"
+                          initialValue={true}
+                          tooltip="Only respond to PR/issue comments that @mention the bot"
                         >
-                          Azure Portal
-                        </Typography.Link>
-                        . Both single-tenant and multi-tenant bots are supported. The{' '}
-                        <strong>Tenant ID</strong> is required so the bot can send replies. Then
-                        sideload the bot as a Teams app via a custom manifest.
-                      </span>
-                    }
-                    style={{ fontSize: 12 }}
+                          <Switch />
+                        </Form.Item>
+
+                        <Form.Item
+                          label="Mention Name"
+                          name="github_mention_name"
+                          tooltip="The name users type to trigger the bot (e.g., 'agor' for @agor)"
+                          initialValue="agor"
+                        >
+                          <Input prefix="@" placeholder="agor" />
+                        </Form.Item>
+
+                        <Form.Item
+                          label="Poll Interval (seconds)"
+                          name="github_poll_interval_s"
+                          initialValue={30}
+                          tooltip="How frequently to poll the GitHub API for new mentions"
+                        >
+                          <InputNumber min={10} max={300} style={{ width: '100%' }} />
+                        </Form.Item>
+                      </>
+                    ),
+                  },
+                  // ── Identity ──
+                  {
+                    key: 'identity',
+                    label: (
+                      <SectionLabel
+                        icon={<UserOutlined />}
+                        title="Identity"
+                        subtitle={getIdentitySubtitle(alignGithubUsers)}
+                      />
+                    ),
+                    children: (
+                      <PlatformIdentityFields
+                        alignFieldName="github_align_users"
+                        alignLabel="Align GitHub users"
+                        alignDescription="Map GitHub logins to Agor users. Unmapped users are rejected."
+                        alignUsers={alignGithubUsers}
+                        userById={userById}
+                        alignedContent={
+                          <Form.Item
+                            label="User Map"
+                            name="github_user_map"
+                            tooltip="JSON object mapping GitHub logins to Agor email addresses"
+                            rules={[{ validator: validateJSON }]}
+                          >
+                            <JSONEditor
+                              rows={4}
+                              placeholder={'{\n  "octocat": "user@example.com"\n}'}
+                            />
+                          </Form.Item>
+                        }
+                      />
+                    ),
+                  },
+                  // ── Agentic Tool Configuration ──
+                  {
+                    key: 'agentic-tool-config',
+                    label: (
+                      <SectionLabel
+                        icon={<ThunderboltOutlined />}
+                        title="Agent Configuration"
+                        subtitle={selectedAgent}
+                      />
+                    ),
+                    children: (
+                      <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
+                        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                          Configure which agent and settings to use for sessions created from this
+                          channel.
+                        </Typography.Text>
+                        <AgentSelectionGrid
+                          agents={AVAILABLE_AGENTS}
+                          selectedAgentId={selectedAgent}
+                          onSelect={onAgentChange}
+                          columns={2}
+                          showHelperText={false}
+                          showComparisonLink={false}
+                        />
+                        <AgenticToolConfigForm
+                          agenticTool={selectedAgent as AgenticToolName}
+                          mcpServerById={mcpServerById}
+                          showHelpText={false}
+                        />
+                      </Space>
+                    ),
+                  },
+                  // ── Environment Variables ──
+                  {
+                    key: 'env-vars',
+                    label: (
+                      <SectionLabel
+                        icon={<LockOutlined />}
+                        title="Environment Variables"
+                        subtitle="channel-level secrets"
+                      />
+                    ),
+                    children: (
+                      <>
+                        <Typography.Text
+                          type="secondary"
+                          style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                        >
+                          Define environment variables for sessions created from this channel.
+                          Useful for service account tokens or API keys for MCP servers.
+                        </Typography.Text>
+                        <Form.Item name="envVars" noStyle>
+                          <GatewayEnvVarsEditor />
+                        </Form.Item>
+                      </>
+                    ),
+                  },
+                ]}
+              />
+            )}
+          </>
+        )}
+
+        {/* ── Teams setup (create step 1, or the whole edit body) ── */}
+        {channelType === 'teams' && (mode === 'edit' || createStep === 1) && (
+          <Collapse
+            ghost
+            destroyOnHidden={false}
+            defaultActiveKey={mode === 'create' ? ['teams-credentials'] : []}
+            style={{ marginLeft: -16, marginRight: -16 }}
+            items={[
+              // ── Credentials ──
+              {
+                key: 'teams-credentials',
+                label: (
+                  <SectionLabel
+                    icon={<KeyOutlined />}
+                    title="Azure Bot Credentials"
+                    subtitle={mode === 'edit' ? 'leave blank to keep current' : undefined}
                   />
-                </>
-              ),
-            },
+                ),
+                children: (
+                  <>
+                    <Form.Item
+                      label="App ID"
+                      name="teams_app_id"
+                      rules={
+                        mode === 'create'
+                          ? [{ required: true, message: 'Azure Bot App ID is required' }]
+                          : []
+                      }
+                      tooltip="Azure Bot Registration Application (client) ID"
+                    >
+                      <Input placeholder="00000000-0000-0000-0000-000000000000" />
+                    </Form.Item>
 
-            // ── Message Sources ──
-            {
-              key: 'teams-message-sources',
-              label: (
-                <SectionLabel
-                  icon={<MessageOutlined />}
-                  title="Message Sources"
-                  subtitle="DMs & channels"
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 16 }}
-                  >
-                    Configure how the bot responds in Teams channels vs 1:1 chats. Direct messages
-                    are always enabled.
-                  </Typography.Text>
+                    <Form.Item
+                      label="App Password"
+                      name="teams_app_password"
+                      rules={
+                        mode === 'create'
+                          ? [{ required: true, message: 'Azure Bot App Password is required' }]
+                          : []
+                      }
+                      tooltip="Azure Bot Registration client secret (value, not the secret ID)"
+                    >
+                      <Input.Password
+                        placeholder={mode === 'edit' ? '••••••••' : 'Client secret value'}
+                      />
+                    </Form.Item>
 
-                  <Form.Item
-                    label="Require @mention in channels"
-                    name="teams_require_mention"
-                    valuePropName="checked"
-                    initialValue={true}
-                    tooltip="When enabled, bot only responds when @mentioned in Teams channels (recommended)"
-                  >
-                    <Switch />
-                  </Form.Item>
-                </>
-              ),
-            },
+                    <Form.Item
+                      label="Tenant ID"
+                      name="teams_tenant_id"
+                      rules={[
+                        {
+                          required: true,
+                          message: 'Tenant ID is required for Teams bots',
+                        },
+                      ]}
+                      tooltip="Azure AD Tenant ID. Required so the bot can acquire tokens to send replies."
+                    >
+                      <Input placeholder="00000000-0000-0000-0000-000000000000" />
+                    </Form.Item>
 
-            // ── Webhook Configuration ──
-            {
-              key: 'teams-webhook',
-              label: (
-                <SectionLabel
-                  icon={<ToolOutlined />}
-                  title="Webhook Configuration"
-                  subtitle="port & path"
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                  >
-                    The Teams connector runs an HTTP server for the Bot Framework messaging
-                    endpoint. Configure the port and path to match your Azure Bot&apos;s messaging
-                    endpoint URL.
-                  </Typography.Text>
-
-                  <Form.Item
-                    label="Webhook Port"
-                    name="teams_webhook_port"
-                    initialValue={3978}
-                    tooltip="Port for the Bot Framework HTTP endpoint"
-                  >
-                    <InputNumber min={1024} max={65535} style={{ width: '100%' }} />
-                  </Form.Item>
-
-                  <Form.Item
-                    label="Webhook Path"
-                    name="teams_webhook_path"
-                    initialValue="/api/messages"
-                    tooltip="URL path for the Bot Framework messaging endpoint"
-                  >
-                    <Input placeholder="/api/messages" />
-                  </Form.Item>
-                </>
-              ),
-            },
-
-            // ── Agentic Tool Configuration ──
-            {
-              key: 'agentic-tool-config',
-              label: (
-                <SectionLabel
-                  icon={<ThunderboltOutlined />}
-                  title="Agent Configuration"
-                  subtitle={selectedAgent}
-                />
-              ),
-              children: (
-                <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
-                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                    Configure which agent and settings to use for sessions created from this
-                    channel.
-                  </Typography.Text>
-                  <AgentSelectionGrid
-                    agents={AVAILABLE_AGENTS}
-                    selectedAgentId={selectedAgent}
-                    onSelect={onAgentChange}
-                    columns={2}
-                    showHelperText={false}
-                    showComparisonLink={false}
-                  />
-                  <AgenticToolConfigForm
-                    agenticTool={selectedAgent as AgenticToolName}
-                    mcpServerById={mcpServerById}
-                    showHelpText={false}
-                  />
-                </Space>
-              ),
-            },
-
-            // ── Environment Variables ──
-            {
-              key: 'env-vars',
-              label: (
-                <SectionLabel
-                  icon={<LockOutlined />}
-                  title="Environment Variables"
-                  subtitle="channel-level secrets"
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                  >
-                    Define environment variables for sessions created from this channel. Useful for
-                    service account tokens or API keys for MCP servers.
-                  </Typography.Text>
-                  <Form.Item name="envVars" noStyle>
-                    <GatewayEnvVarsEditor />
-                  </Form.Item>
-                </>
-              ),
-            },
-          ]}
-        />
-      )}
-
-      {/* ── Slack guided setup wizard (create steps 1–3) ── */}
-      {channelType === 'slack' && mode === 'create' && createStep >= 1 && (
-        <SlackSetupWizard
-          form={form}
-          userById={userById}
-          mcpServerById={mcpServerById}
-          selectedAgent={selectedAgent}
-          onAgentChange={onAgentChange}
-          step={createStep - 1}
-          testResult={slackTestResult}
-          testLoading={slackTestLoading}
-          onTest={onSlackTest}
-        />
-      )}
-
-      {/* ── Collapsible sections (Slack edit) ── */}
-      {channelType === 'slack' && mode === 'edit' && (
-        <Collapse
-          ghost
-          destroyOnHidden={false}
-          defaultActiveKey={[]}
-          style={{ marginLeft: -16, marginRight: -16 }}
-          items={[
-            // ── Identity ──
-            {
-              key: 'identity',
-              label: (
-                <SectionLabel
-                  icon={<TeamOutlined />}
-                  title="Identity"
-                  subtitle={getIdentitySubtitle(alignSlackUsers)}
-                />
-              ),
-              children: (
-                <PlatformIdentityFields
-                  alignFieldName="align_slack_users"
-                  alignLabel="Align Slack users"
-                  alignDescription="Match Slack profile email to an Agor user. Unmatched users are rejected."
-                  alignUsers={alignSlackUsers}
-                  userById={userById}
-                  alignedContent={
                     <Alert
                       type="info"
                       showIcon
-                      title="Requires users:read.email scope"
+                      message="Azure Bot Setup"
                       description={
                         <span>
-                          Add <code>users:read.email</code> to your Slack app so Agor can match
-                          Slack profiles by email.
+                          Create an Azure Bot resource in the{' '}
+                          <Typography.Link
+                            href="https://portal.azure.com/#create/Microsoft.AzureBotService"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Azure Portal
+                          </Typography.Link>
+                          . Both single-tenant and multi-tenant bots are supported. The{' '}
+                          <strong>Tenant ID</strong> is required so the bot can send replies. Then
+                          sideload the bot as a Teams app via a custom manifest.
                         </span>
                       }
                       style={{ fontSize: 12 }}
                     />
-                  }
-                />
-              ),
-            },
-            // ── Credentials ──
-            {
-              key: 'credentials',
-              label: (
-                <SectionLabel
-                  icon={<KeyOutlined />}
-                  title="Credentials"
-                  subtitle={mode === 'edit' ? 'leave blank to keep current' : undefined}
-                />
-              ),
-              children: (
-                <>
-                  <Form.Item
-                    label="Bot Token"
-                    name="bot_token"
-                    tooltip="Slack Bot User OAuth Token (xoxb-...)"
-                  >
-                    <Input.Password placeholder="••••••••" />
-                  </Form.Item>
+                  </>
+                ),
+              },
 
-                  <Form.Item
-                    label="App Token"
-                    name="app_token"
-                    tooltip="Slack App-Level Token for Socket Mode (xapp-...)"
-                  >
-                    <Input.Password placeholder="••••••••" />
-                  </Form.Item>
-
-                  <Alert
-                    type="info"
-                    showIcon
-                    title="Socket Mode Required"
-                    description="Enable Socket Mode in your Slack app settings and generate an app-level token with connections:write scope."
-                    style={{ fontSize: 12 }}
+              // ── Message Sources ──
+              {
+                key: 'teams-message-sources',
+                label: (
+                  <SectionLabel
+                    icon={<MessageOutlined />}
+                    title="Message Sources"
+                    subtitle="DMs & channels"
                   />
-                </>
-              ),
-            },
+                ),
+                children: (
+                  <>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, display: 'block', marginBottom: 16 }}
+                    >
+                      Configure how the bot responds in Teams channels vs 1:1 chats. Direct messages
+                      are always enabled.
+                    </Typography.Text>
 
-            // ── Message Sources ──
-            {
-              key: 'message-sources',
-              label: (
-                <SectionLabel
-                  icon={<MessageOutlined />}
-                  title="Message Sources"
-                  subtitle="DMs always enabled"
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 16 }}
-                  >
-                    Choose where the bot listens for messages. Direct messages are always enabled.
-                  </Typography.Text>
+                    <Form.Item
+                      label="Require @mention in channels"
+                      name="teams_require_mention"
+                      valuePropName="checked"
+                      initialValue={true}
+                      tooltip="When enabled, bot only responds when @mentioned in Teams channels (recommended)"
+                    >
+                      <Switch />
+                    </Form.Item>
+                  </>
+                ),
+              },
 
-                  <Form.Item
-                    label="Public Channels"
-                    name="enable_channels"
-                    valuePropName="checked"
-                    initialValue={false}
-                    tooltip="Bot will respond to messages in public channels it's added to"
-                  >
-                    <Switch />
-                  </Form.Item>
+              // ── Webhook Configuration ──
+              {
+                key: 'teams-webhook',
+                label: (
+                  <SectionLabel
+                    icon={<ToolOutlined />}
+                    title="Webhook Configuration"
+                    subtitle="port & path"
+                  />
+                ),
+                children: (
+                  <>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                    >
+                      The Teams connector runs an HTTP server for the Bot Framework messaging
+                      endpoint. Configure the port and path to match your Azure Bot&apos;s messaging
+                      endpoint URL.
+                    </Typography.Text>
 
-                  <Form.Item
-                    label="Private Channels"
-                    name="enable_groups"
-                    valuePropName="checked"
-                    initialValue={false}
-                    tooltip="Bot will respond to messages in private channels it's added to"
-                  >
-                    <Switch />
-                  </Form.Item>
+                    <Form.Item
+                      label="Webhook Port"
+                      name="teams_webhook_port"
+                      initialValue={3978}
+                      tooltip="Port for the Bot Framework HTTP endpoint"
+                    >
+                      <InputNumber min={1024} max={65535} style={{ width: '100%' }} />
+                    </Form.Item>
 
-                  <Form.Item
-                    label="Group DMs"
-                    name="enable_mpim"
-                    valuePropName="checked"
-                    initialValue={false}
-                    tooltip="Bot will respond to messages in multi-person direct messages"
-                  >
-                    <Switch />
-                  </Form.Item>
+                    <Form.Item
+                      label="Webhook Path"
+                      name="teams_webhook_path"
+                      initialValue="/api/messages"
+                      tooltip="URL path for the Bot Framework messaging endpoint"
+                    >
+                      <Input placeholder="/api/messages" />
+                    </Form.Item>
+                  </>
+                ),
+              },
 
-                  {sourcesEnabled && (
-                    <Alert
-                      type="info"
-                      showIcon
-                      title="Slack mentions are always required"
-                      description="Agor only starts or continues Slack channel threads when this bot is explicitly @mentioned. Missed thread replies are included as catch-up context on the next mention."
-                      style={{ marginBottom: 12 }}
+              // ── Agentic Tool Configuration ──
+              {
+                key: 'agentic-tool-config',
+                label: (
+                  <SectionLabel
+                    icon={<ThunderboltOutlined />}
+                    title="Agent Configuration"
+                    subtitle={selectedAgent}
+                  />
+                ),
+                children: (
+                  <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      Configure which agent and settings to use for sessions created from this
+                      channel.
+                    </Typography.Text>
+                    <AgentSelectionGrid
+                      agents={AVAILABLE_AGENTS}
+                      selectedAgentId={selectedAgent}
+                      onSelect={onAgentChange}
+                      columns={2}
+                      showHelperText={false}
+                      showComparisonLink={false}
                     />
-                  )}
+                    <AgenticToolConfigForm
+                      agenticTool={selectedAgent as AgenticToolName}
+                      mcpServerById={mcpServerById}
+                      showHelpText={false}
+                    />
+                  </Space>
+                ),
+              },
 
-                  {sourcesEnabled && (
+              // ── Environment Variables ──
+              {
+                key: 'env-vars',
+                label: (
+                  <SectionLabel
+                    icon={<LockOutlined />}
+                    title="Environment Variables"
+                    subtitle="channel-level secrets"
+                  />
+                ),
+                children: (
+                  <>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                    >
+                      Define environment variables for sessions created from this channel. Useful
+                      for service account tokens or API keys for MCP servers.
+                    </Typography.Text>
+                    <Form.Item name="envVars" noStyle>
+                      <GatewayEnvVarsEditor />
+                    </Form.Item>
+                  </>
+                ),
+              },
+            ]}
+          />
+        )}
+
+        {/* ── Slack guided setup wizard (create steps 1–3) ── */}
+        {channelType === 'slack' && mode === 'create' && createStep >= 1 && (
+          <SlackSetupWizard
+            form={form}
+            userById={userById}
+            mcpServerById={mcpServerById}
+            selectedAgent={selectedAgent}
+            onAgentChange={onAgentChange}
+            step={createStep - 1}
+            testResult={slackTestResult}
+            testLoading={slackTestLoading}
+            onTest={onSlackTest}
+          />
+        )}
+
+        {/* ── Collapsible sections (Slack edit) ── */}
+        {channelType === 'slack' && mode === 'edit' && (
+          <Collapse
+            ghost
+            destroyOnHidden={false}
+            defaultActiveKey={[]}
+            style={{ marginLeft: -16, marginRight: -16 }}
+            items={[
+              // ── Identity ──
+              {
+                key: 'identity',
+                label: (
+                  <SectionLabel
+                    icon={<TeamOutlined />}
+                    title="Identity"
+                    subtitle={getIdentitySubtitle(alignSlackUsers)}
+                  />
+                ),
+                children: (
+                  <PlatformIdentityFields
+                    alignFieldName="align_slack_users"
+                    alignLabel="Align Slack users"
+                    alignDescription="Match Slack profile email to an Agor user. Unmatched users are rejected."
+                    alignUsers={alignSlackUsers}
+                    userById={userById}
+                    alignedContent={
+                      <Alert
+                        type="info"
+                        showIcon
+                        title="Requires users:read.email scope"
+                        description={
+                          <span>
+                            Add <code>users:read.email</code> to your Slack app so Agor can match
+                            Slack profiles by email.
+                          </span>
+                        }
+                        style={{ fontSize: 12 }}
+                      />
+                    }
+                  />
+                ),
+              },
+              // ── Credentials ──
+              {
+                key: 'credentials',
+                label: (
+                  <SectionLabel
+                    icon={<KeyOutlined />}
+                    title="Credentials"
+                    subtitle={mode === 'edit' ? 'leave blank to keep current' : undefined}
+                  />
+                ),
+                children: (
+                  <>
+                    <Form.Item
+                      label="Bot Token"
+                      name="bot_token"
+                      tooltip="Slack Bot User OAuth Token (xoxb-...)"
+                    >
+                      <Input.Password placeholder="••••••••" />
+                    </Form.Item>
+
+                    <Form.Item
+                      label="App Token"
+                      name="app_token"
+                      tooltip="Slack App-Level Token for Socket Mode (xapp-...)"
+                    >
+                      <Input.Password placeholder="••••••••" />
+                    </Form.Item>
+
                     <Alert
                       type="info"
                       showIcon
-                      title="Required Slack Scopes & Events"
+                      title="Socket Mode Required"
+                      description="Enable Socket Mode in your Slack app settings and generate an app-level token with connections:write scope."
+                      style={{ fontSize: 12 }}
+                    />
+                  </>
+                ),
+              },
+
+              // ── Message Sources ──
+              {
+                key: 'message-sources',
+                label: (
+                  <SectionLabel
+                    icon={<MessageOutlined />}
+                    title="Message Sources"
+                    subtitle="DMs always enabled"
+                  />
+                ),
+                children: (
+                  <>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, display: 'block', marginBottom: 16 }}
+                    >
+                      Choose where the bot listens for messages. Direct messages are always enabled.
+                    </Typography.Text>
+
+                    <Form.Item
+                      label="Public Channels"
+                      name="enable_channels"
+                      valuePropName="checked"
+                      initialValue={false}
+                      tooltip="Bot will respond to messages in public channels it's added to"
+                    >
+                      <Switch />
+                    </Form.Item>
+
+                    <Form.Item
+                      label="Private Channels"
+                      name="enable_groups"
+                      valuePropName="checked"
+                      initialValue={false}
+                      tooltip="Bot will respond to messages in private channels it's added to"
+                    >
+                      <Switch />
+                    </Form.Item>
+
+                    <Form.Item
+                      label="Group DMs"
+                      name="enable_mpim"
+                      valuePropName="checked"
+                      initialValue={false}
+                      tooltip="Bot will respond to messages in multi-person direct messages"
+                    >
+                      <Switch />
+                    </Form.Item>
+
+                    {sourcesEnabled && (
+                      <Alert
+                        type="info"
+                        showIcon
+                        title="Slack mentions are always required"
+                        description="Agor only starts or continues Slack channel threads when this bot is explicitly @mentioned. Missed thread replies are included as catch-up context on the next mention."
+                        style={{ marginBottom: 12 }}
+                      />
+                    )}
+
+                    {sourcesEnabled && (
+                      <Alert
+                        type="info"
+                        showIcon
+                        title="Required Slack Scopes & Events"
+                        description={
+                          <ul style={{ margin: '8px 0 0 0', paddingLeft: 20, fontSize: 12 }}>
+                            <li>
+                              <code>chat:write</code> (always required)
+                            </li>
+                            {enableChannels && (
+                              <>
+                                <li>
+                                  <code>channels:history</code> + <code>app_mentions:read</code>
+                                </li>
+                                <li>
+                                  Events: <code>message.channels</code>, <code>app_mention</code>
+                                </li>
+                              </>
+                            )}
+                            {enableGroups && (
+                              <li>
+                                <code>groups:history</code> + event: <code>message.groups</code>
+                              </li>
+                            )}
+                            {enableMpim && (
+                              <li>
+                                <code>mpim:history</code> + event: <code>message.mpim</code>
+                              </li>
+                            )}
+                          </ul>
+                        }
+                        style={{ fontSize: 12 }}
+                      />
+                    )}
+                  </>
+                ),
+              },
+
+              // ── Outbound ──
+              {
+                key: 'outbound',
+                label: (
+                  <SectionLabel
+                    icon={<MessageOutlined />}
+                    title="Outbound"
+                    subtitle="proactive sends"
+                  />
+                ),
+                children: (
+                  <>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                    >
+                      Allow authorized agents to send proactive Slack messages through this gateway.
+                      Targets can be Slack channel IDs, channel names, or Slack user emails.
+                    </Typography.Text>
+
+                    <Form.Item
+                      label="Enable outbound sends"
+                      name="outbound_enabled"
+                      valuePropName="checked"
+                      initialValue={false}
+                      tooltip="When enabled, branch admins/owners with full branch access can send proactive Slack messages through this gateway."
+                    >
+                      <Switch />
+                    </Form.Item>
+
+                    <Form.Item
+                      label="Default outbound target"
+                      name="default_outbound_target"
+                      tooltip="Optional. Used when the agent omits a target. Examples: #project-updates, channel:C01ABC123, user@example.com."
+                    >
+                      <Input placeholder="#project-updates, channel:C01ABC123, or user@example.com" />
+                    </Form.Item>
+
+                    <Alert
+                      type="info"
+                      showIcon
+                      title="Slack scopes"
                       description={
-                        <ul style={{ margin: '8px 0 0 0', paddingLeft: 20, fontSize: 12 }}>
-                          <li>
-                            <code>chat:write</code> (always required)
-                          </li>
-                          {enableChannels && (
-                            <>
-                              <li>
-                                <code>channels:history</code> + <code>app_mentions:read</code>
-                              </li>
-                              <li>
-                                Events: <code>message.channels</code>, <code>app_mention</code>
-                              </li>
-                            </>
-                          )}
-                          {enableGroups && (
-                            <li>
-                              <code>groups:history</code> + event: <code>message.groups</code>
-                            </li>
-                          )}
-                          {enableMpim && (
-                            <li>
-                              <code>mpim:history</code> + event: <code>message.mpim</code>
-                            </li>
-                          )}
-                        </ul>
+                        <span>
+                          Channel-name targets require <code>channels:read</code> and, for private
+                          channels, <code>groups:read</code>. Email targets require{' '}
+                          <code>users:read.email</code> and open a DM with that Slack user.
+                        </span>
                       }
                       style={{ fontSize: 12 }}
                     />
-                  )}
-                </>
-              ),
-            },
+                  </>
+                ),
+              },
 
-            // ── Outbound ──
-            {
-              key: 'outbound',
-              label: (
-                <SectionLabel
-                  icon={<MessageOutlined />}
-                  title="Outbound"
-                  subtitle="proactive sends"
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                  >
-                    Allow authorized agents to send proactive Slack messages through this gateway.
-                    Targets can be Slack channel IDs, channel names, or Slack user emails.
-                  </Typography.Text>
-
-                  <Form.Item
-                    label="Enable outbound sends"
-                    name="outbound_enabled"
-                    valuePropName="checked"
-                    initialValue={false}
-                    tooltip="When enabled, branch admins/owners with full branch access can send proactive Slack messages through this gateway."
-                  >
-                    <Switch />
-                  </Form.Item>
-
-                  <Form.Item
-                    label="Default outbound target"
-                    name="default_outbound_target"
-                    tooltip="Optional. Used when the agent omits a target. Examples: #project-updates, channel:C01ABC123, user@example.com."
-                  >
-                    <Input placeholder="#project-updates, channel:C01ABC123, or user@example.com" />
-                  </Form.Item>
-
-                  <Alert
-                    type="info"
-                    showIcon
-                    title="Slack scopes"
-                    description={
-                      <span>
-                        Channel-name targets require <code>channels:read</code> and, for private
-                        channels, <code>groups:read</code>. Email targets require{' '}
-                        <code>users:read.email</code> and open a DM with that Slack user.
-                      </span>
-                    }
-                    style={{ fontSize: 12 }}
+              // ── Advanced ──
+              {
+                key: 'advanced',
+                label: (
+                  <SectionLabel
+                    icon={<ToolOutlined />}
+                    title="Advanced"
+                    subtitle="channel whitelist"
                   />
-                </>
-              ),
-            },
+                ),
+                children: (
+                  <>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                    >
+                      Restrict the bot to specific Slack channels by ID. Leave empty to allow all
+                      channels. Find channel IDs: right-click channel &rarr; View channel details
+                      &rarr; scroll to bottom.
+                    </Typography.Text>
+                    <Form.Item
+                      name="allowed_channel_ids"
+                      tooltip="Slack channel IDs (e.g., C01ABC123XY). Press Enter to add each ID."
+                    >
+                      <Select
+                        mode="tags"
+                        placeholder="Add channel IDs... (e.g., C01ABC123XY)"
+                        style={{ width: '100%' }}
+                        tokenSeparators={[',', ' ']}
+                      />
+                    </Form.Item>
+                  </>
+                ),
+              },
 
-            // ── Advanced ──
-            {
-              key: 'advanced',
-              label: (
-                <SectionLabel
-                  icon={<ToolOutlined />}
-                  title="Advanced"
-                  subtitle="channel whitelist"
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                  >
-                    Restrict the bot to specific Slack channels by ID. Leave empty to allow all
-                    channels. Find channel IDs: right-click channel &rarr; View channel details
-                    &rarr; scroll to bottom.
-                  </Typography.Text>
-                  <Form.Item
-                    name="allowed_channel_ids"
-                    tooltip="Slack channel IDs (e.g., C01ABC123XY). Press Enter to add each ID."
-                  >
-                    <Select
-                      mode="tags"
-                      placeholder="Add channel IDs... (e.g., C01ABC123XY)"
-                      style={{ width: '100%' }}
-                      tokenSeparators={[',', ' ']}
+              // ── Agentic Tool Configuration ──
+              {
+                key: 'agentic-tool-config',
+                label: (
+                  <SectionLabel
+                    icon={<ThunderboltOutlined />}
+                    title="Agent Configuration"
+                    subtitle={selectedAgent}
+                  />
+                ),
+                children: (
+                  <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
+                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                      Configure which agent and settings to use for sessions created from this
+                      channel.
+                    </Typography.Text>
+                    <AgentSelectionGrid
+                      agents={AVAILABLE_AGENTS}
+                      selectedAgentId={selectedAgent}
+                      onSelect={onAgentChange}
+                      columns={2}
+                      showHelperText={false}
+                      showComparisonLink={false}
                     />
-                  </Form.Item>
-                </>
-              ),
-            },
-
-            // ── Agentic Tool Configuration ──
-            {
-              key: 'agentic-tool-config',
-              label: (
-                <SectionLabel
-                  icon={<ThunderboltOutlined />}
-                  title="Agent Configuration"
-                  subtitle={selectedAgent}
-                />
-              ),
-              children: (
-                <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
-                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                    Configure which agent and settings to use for sessions created from this
-                    channel.
-                  </Typography.Text>
-                  <AgentSelectionGrid
-                    agents={AVAILABLE_AGENTS}
-                    selectedAgentId={selectedAgent}
-                    onSelect={onAgentChange}
-                    columns={2}
-                    showHelperText={false}
-                    showComparisonLink={false}
+                    <AgenticToolConfigForm
+                      agenticTool={selectedAgent as AgenticToolName}
+                      mcpServerById={mcpServerById}
+                      showHelpText={false}
+                    />
+                  </Space>
+                ),
+              },
+              // ── Environment Variables ──
+              {
+                key: 'env-vars',
+                label: (
+                  <SectionLabel
+                    icon={<LockOutlined />}
+                    title="Environment Variables"
+                    subtitle="channel-level secrets"
                   />
-                  <AgenticToolConfigForm
-                    agenticTool={selectedAgent as AgenticToolName}
-                    mcpServerById={mcpServerById}
-                    showHelpText={false}
-                  />
-                </Space>
-              ),
-            },
-            // ── Environment Variables ──
-            {
-              key: 'env-vars',
-              label: (
-                <SectionLabel
-                  icon={<LockOutlined />}
-                  title="Environment Variables"
-                  subtitle="channel-level secrets"
-                />
-              ),
-              children: (
-                <>
-                  <Typography.Text
-                    type="secondary"
-                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
-                  >
-                    Define environment variables for sessions created from this channel. Useful for
-                    service account tokens or API keys for MCP servers.
-                  </Typography.Text>
-                  <Form.Item name="envVars" noStyle>
-                    <GatewayEnvVarsEditor />
-                  </Form.Item>
-                </>
-              ),
-            },
-          ]}
-        />
-      )}
+                ),
+                children: (
+                  <>
+                    <Typography.Text
+                      type="secondary"
+                      style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                    >
+                      Define environment variables for sessions created from this channel. Useful
+                      for service account tokens or API keys for MCP servers.
+                    </Typography.Text>
+                    <Form.Item name="envVars" noStyle>
+                      <GatewayEnvVarsEditor />
+                    </Form.Item>
+                  </>
+                ),
+              },
+            ]}
+          />
+        )}
+      </div>
     </>
   );
 };

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -54,7 +54,6 @@ import {
   Popconfirm,
   Radio,
   Select,
-  type SelectProps,
   Space,
   Spin,
   Steps,
@@ -79,6 +78,7 @@ import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 import { BranchSelect } from './BranchSelect';
 import { SettingsActionGroup } from './SettingsActionGroup';
+import { UserSelect } from './UserSelect';
 
 interface GatewayChannelsTableProps {
   client: AgorClient | null;
@@ -150,24 +150,6 @@ const SectionLabel: React.FC<{ icon: React.ReactNode; title: string; subtitle?: 
       )}
     </span>
   </Space>
-);
-
-const UserSelect: React.FC<SelectProps<string> & { userById: Map<string, User> }> = ({
-  userById,
-  placeholder = 'Select a user',
-  ...selectProps
-}) => (
-  <Select {...selectProps} placeholder={placeholder} showSearch optionFilterProp="children">
-    {Array.from(userById.values())
-      .sort((a, b) =>
-        (a.name || a.email || a.user_id).localeCompare(b.name || b.email || b.user_id)
-      )
-      .map((u) => (
-        <Select.Option key={u.user_id} value={u.user_id}>
-          {u.name || u.email || u.user_id}
-        </Select.Option>
-      ))}
-  </Select>
 );
 
 const getIdentitySubtitle = (alignUsers: boolean): string =>

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -1,3 +1,12 @@
+// Import the manifest helpers from the connector-free subpath so the browser
+// bundle never pulls in @slack/web-api / @slack/socket-mode (node-only) via the
+// gateway barrel.
+import {
+  buildSlackManifest,
+  requiredBotEvents,
+  requiredBotScopes,
+  type SlackWizardOptions,
+} from '@agor/core/gateway/slack-manifest';
 import type {
   AgenticToolName,
   AgorClient,
@@ -8,12 +17,17 @@ import type {
   GatewayEnvVar,
   MCPServer,
   PermissionMode,
+  SlackTestResult,
   User,
   UUID,
 } from '@agor-live/client';
 import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  CopyOutlined,
   DeleteOutlined,
   EditOutlined,
+  ExclamationCircleOutlined,
   GithubOutlined,
   KeyOutlined,
   LoadingOutlined,
@@ -341,6 +355,603 @@ const GITHUB_SETUP_STEPS = [
   { title: 'Configure' },
 ];
 
+// ============================================================================
+// Slack Setup Wizard (create mode)
+// ============================================================================
+
+/** Slack guided-setup wizard steps. */
+const SLACK_SETUP_STEPS = [
+  { title: 'Options' },
+  { title: 'Create App' },
+  { title: 'Tokens & Test' },
+];
+
+/**
+ * Copy text to the clipboard, falling back to a transient textarea +
+ * `execCommand('copy')` for browsers/contexts where the async Clipboard API is
+ * unavailable (e.g. non-secure origins).
+ */
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the legacy path below.
+  }
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Honest rendering of a Slack connection probe. A green result is advisory:
+ * `notVerifiable` is surfaced as a warning so success is never read as "fully
+ * verified".
+ */
+const SlackTestResultView: React.FC<{ result: SlackTestResult }> = ({ result }) => {
+  const hasFollowups = result.failures.length > 0 || result.notVerifiable.length > 0;
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <Alert
+        type={result.ok ? 'success' : 'error'}
+        showIcon
+        icon={result.ok ? <CheckCircleOutlined /> : <CloseCircleOutlined />}
+        title={result.ok ? 'Connection succeeded' : 'Connection failed'}
+        description={
+          <div style={{ fontSize: 12 }}>
+            {result.team && (
+              <div>
+                Team: <strong>{result.team.name}</strong> ({result.team.id})
+              </div>
+            )}
+            {result.bot && (
+              <div>
+                Bot: <strong>{result.bot.name}</strong> ({result.bot.userId})
+              </div>
+            )}
+            <div>
+              App token (Socket Mode):{' '}
+              <strong>{result.appTokenValid ? 'valid' : 'not verified'}</strong>
+            </div>
+            {result.channelAccess && result.channelAccess.length > 0 && (
+              <div style={{ marginTop: 4 }}>
+                Sampled channel access:
+                <ul style={{ margin: '4px 0 0', paddingLeft: 18 }}>
+                  {result.channelAccess.map((c) => (
+                    <li key={c.channelId}>
+                      <code>{c.channelId}</code>: {c.ok ? 'ok' : 'no access'}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        }
+        style={{ marginBottom: hasFollowups ? 12 : 0 }}
+      />
+      {result.failures.length > 0 && (
+        <Alert
+          type="error"
+          showIcon
+          title="Failures"
+          description={
+            <ul style={{ margin: '4px 0 0', paddingLeft: 18, fontSize: 12 }}>
+              {result.failures.map((f) => (
+                <li key={`${f.capability}:${f.reason}`}>
+                  <strong>{f.capability}</strong>: {f.reason}
+                  {f.needed ? ` (needs ${f.needed})` : ''}
+                </li>
+              ))}
+            </ul>
+          }
+          style={{ marginBottom: result.notVerifiable.length > 0 ? 12 : 0 }}
+        />
+      )}
+      {result.notVerifiable.length > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          icon={<ExclamationCircleOutlined />}
+          title="Not verifiable from here"
+          description={
+            <div style={{ fontSize: 12 }}>
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                A green result does not guarantee these — confirm them in Slack:
+              </Typography.Text>
+              <ul style={{ margin: '4px 0 0', paddingLeft: 18 }}>
+                {result.notVerifiable.map((n) => (
+                  <li key={n}>{n}</li>
+                ))}
+              </ul>
+            </div>
+          }
+          style={{ fontSize: 12 }}
+        />
+      )}
+    </div>
+  );
+};
+
+/**
+ * Guided Slack setup wizard shown on create. Mirrors the GitHub `Steps` flow:
+ * step state is lifted to the parent, the modal's OK button stays hidden until
+ * the final step. Selections drive a live manifest preview + derived scope/event
+ * list via {@link buildSlackManifest} / {@link requiredBotScopes}, so the user
+ * never adds a scope by hand.
+ */
+const SlackSetupWizard: React.FC<{
+  form: FormInstance;
+  userById: Map<string, User>;
+  mcpServerById: Map<string, MCPServer>;
+  selectedAgent: string;
+  onAgentChange: (agent: string) => void;
+  step: number;
+  onStepChange: (step: number) => void;
+  testResult: SlackTestResult | null;
+  testLoading: boolean;
+  onTest: () => void;
+  onInvalidateTest: () => void;
+}> = ({
+  form,
+  userById,
+  mcpServerById,
+  selectedAgent,
+  onAgentChange,
+  step,
+  onStepChange,
+  testResult,
+  testLoading,
+  onTest,
+  onInvalidateTest,
+}) => {
+  const { token } = theme.useToken();
+  const { showError } = useThemedMessage();
+  const [copied, setCopied] = useState(false);
+
+  const appName = (Form.useWatch('slack_app_name', form) as string) ?? '';
+  const enableChannels = Form.useWatch('enable_channels', form) ?? false;
+  const enableGroups = Form.useWatch('enable_groups', form) ?? false;
+  const enableMpim = Form.useWatch('enable_mpim', form) ?? false;
+  const alignUsers = Form.useWatch('align_slack_users', form) ?? false;
+  const outbound = Form.useWatch('outbound_enabled', form) ?? false;
+  const publicScope = (Form.useWatch('slack_public_scope', form) as string) ?? 'all';
+  const botToken = (Form.useWatch('bot_token', form) as string) ?? '';
+  const appToken = (Form.useWatch('app_token', form) as string) ?? '';
+
+  const wizardOptions: SlackWizardOptions = useMemo(
+    () => ({
+      appName: appName || 'Agor',
+      publicChannels: enableChannels,
+      privateChannels: enableGroups,
+      groupDms: enableMpim,
+      alignUsers,
+      outbound,
+    }),
+    [appName, enableChannels, enableGroups, enableMpim, alignUsers, outbound]
+  );
+
+  const manifestJson = useMemo(
+    () => JSON.stringify(buildSlackManifest(wizardOptions), null, 2),
+    [wizardOptions]
+  );
+  const scopes = useMemo(() => requiredBotScopes(wizardOptions), [wizardOptions]);
+  const events = useMemo(() => requiredBotEvents(wizardOptions), [wizardOptions]);
+
+  // Any change to the manifest inputs or tokens invalidates a prior test result.
+  // A green check against stale credentials/options would be misleading.
+  const invalidationKey = `${manifestJson}|${botToken}|${appToken}`;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: invalidationKey is the change trigger, not a value read in the body.
+  useEffect(() => {
+    onInvalidateTest();
+    setCopied(false);
+  }, [invalidationKey, onInvalidateTest]);
+
+  const manifestPreview = (
+    <pre
+      style={{
+        background: token.colorBgContainer,
+        border: `1px solid ${token.colorBorder}`,
+        borderRadius: token.borderRadius,
+        padding: 12,
+        margin: '0 0 16px',
+        maxHeight: 280,
+        overflow: 'auto',
+        fontSize: 11,
+        lineHeight: 1.5,
+        fontFamily: 'monospace',
+      }}
+    >
+      {manifestJson}
+    </pre>
+  );
+
+  const scopeList = (
+    <div style={{ marginBottom: 16 }}>
+      <Typography.Text strong style={{ fontSize: 12 }}>
+        Bot scopes ({scopes.length})
+      </Typography.Text>
+      <div style={{ marginTop: 6 }}>
+        {scopes.map((s) => (
+          <Tag key={s} style={{ marginBottom: 4, fontFamily: 'monospace', fontSize: 11 }}>
+            {s}
+          </Tag>
+        ))}
+      </div>
+      <Typography.Text strong style={{ fontSize: 12, display: 'block', marginTop: 8 }}>
+        Event subscriptions ({events.length})
+      </Typography.Text>
+      <div style={{ marginTop: 6 }}>
+        {events.map((e) => (
+          <Tag
+            key={e}
+            color="blue"
+            style={{ marginBottom: 4, fontFamily: 'monospace', fontSize: 11 }}
+          >
+            {e}
+          </Tag>
+        ))}
+      </div>
+    </div>
+  );
+
+  const goToCreateApp = async () => {
+    const fields: string[] = ['name', 'target_branch_id', 'slack_app_name'];
+    if (!alignUsers) fields.push('agor_user_id');
+    try {
+      await form.validateFields(fields);
+    } catch {
+      return;
+    }
+    onStepChange(1);
+  };
+
+  const handleCopy = async () => {
+    const ok = await copyTextToClipboard(manifestJson);
+    if (ok) {
+      setCopied(true);
+    } else {
+      showError('Copy failed — select the manifest text and copy it manually.');
+    }
+  };
+
+  const handleTestClick = async () => {
+    try {
+      await form.validateFields(['bot_token', 'app_token']);
+    } catch {
+      return;
+    }
+    onTest();
+  };
+
+  return (
+    <>
+      <Steps current={step} size="small" items={SLACK_SETUP_STEPS} style={{ marginBottom: 24 }} />
+
+      {/* Step 0: Options (kept mounted so Form.Items stay registered for validation) */}
+      <div style={{ display: step === 0 ? undefined : 'none' }}>
+        <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
+          Choose what the bot can do. Your selections build a Slack app manifest below — paste it
+          into Slack in the next step so every scope and event is preconfigured for you.
+        </Typography.Paragraph>
+
+        <Form.Item
+          label="App Name"
+          name="slack_app_name"
+          initialValue="Agor"
+          rules={[{ required: true, message: 'Enter a name for the Slack app' }]}
+          tooltip="Display name for the Slack app created from the manifest"
+        >
+          <Input placeholder="Agor" />
+        </Form.Item>
+
+        <div style={{ marginBottom: 16 }}>
+          <Typography.Text strong style={{ fontSize: 13 }}>
+            Surfaces
+          </Typography.Text>
+          <Typography.Paragraph type="secondary" style={{ fontSize: 12, margin: '4px 0 12px' }}>
+            Where the bot listens for messages.
+          </Typography.Paragraph>
+
+          <div style={{ marginBottom: 8 }}>
+            <Checkbox checked disabled>
+              Direct messages
+            </Checkbox>
+            <Typography.Text type="secondary" style={{ fontSize: 12, marginLeft: 8 }}>
+              always on
+            </Typography.Text>
+          </div>
+
+          <div style={{ marginBottom: 8 }}>
+            <Form.Item name="enable_channels" valuePropName="checked" initialValue={false} noStyle>
+              <Checkbox>Public channels</Checkbox>
+            </Form.Item>
+          </div>
+          {enableChannels && (
+            <div style={{ margin: '0 0 8px 24px' }}>
+              <Form.Item name="slack_public_scope" initialValue="all" noStyle>
+                <Radio.Group>
+                  <Space orientation="vertical" size={4}>
+                    <Radio value="all">All public channels the bot is added to</Radio>
+                    <Radio value="specific">Specific channels only</Radio>
+                  </Space>
+                </Radio.Group>
+              </Form.Item>
+              {publicScope === 'specific' && (
+                <Form.Item
+                  name="allowed_channel_ids"
+                  style={{ marginTop: 8, marginBottom: 0 }}
+                  tooltip="Slack channel IDs (e.g., C01ABC123XY). Press Enter to add each ID."
+                >
+                  <Select
+                    mode="tags"
+                    placeholder="C01ABC123XY"
+                    style={{ width: '100%' }}
+                    tokenSeparators={[',', ' ']}
+                  />
+                </Form.Item>
+              )}
+            </div>
+          )}
+
+          <div style={{ marginBottom: 8 }}>
+            <Form.Item name="enable_groups" valuePropName="checked" initialValue={false} noStyle>
+              <Checkbox>Private channels</Checkbox>
+            </Form.Item>
+          </div>
+          <div>
+            <Form.Item name="enable_mpim" valuePropName="checked" initialValue={false} noStyle>
+              <Checkbox>Group DMs</Checkbox>
+            </Form.Item>
+          </div>
+        </div>
+
+        <Form.Item
+          label="Align Slack users"
+          name="align_slack_users"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Match each Slack profile email to an Agor user. Unmatched users are rejected."
+        >
+          <Switch />
+        </Form.Item>
+        {alignUsers ? (
+          <Alert
+            type="info"
+            showIcon
+            title="Requires users:read.email scope"
+            description="Added to the manifest automatically so Agor can match Slack profiles by email."
+            style={{ fontSize: 12, marginBottom: 16 }}
+          />
+        ) : (
+          <Form.Item
+            label="Run as"
+            name="agor_user_id"
+            rules={[{ required: true, message: 'Please select a user' }]}
+            tooltip="All sessions from this channel run as this Agor user"
+          >
+            <UserSelect userById={userById} />
+          </Form.Item>
+        )}
+
+        <Form.Item
+          label="Enable outbound sends"
+          name="outbound_enabled"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Allow authorized agents to send proactive Slack messages through this gateway."
+        >
+          <Switch />
+        </Form.Item>
+        {outbound && (
+          <Form.Item
+            label="Default outbound target"
+            name="default_outbound_target"
+            tooltip="Optional. Used when the agent omits a target. Examples: #project-updates, channel:C01ABC123, user@example.com."
+          >
+            <Input placeholder="#project-updates, channel:C01ABC123, or user@example.com" />
+          </Form.Item>
+        )}
+
+        <Typography.Text strong style={{ fontSize: 13, display: 'block', marginBottom: 8 }}>
+          Manifest preview
+        </Typography.Text>
+        {manifestPreview}
+        {scopeList}
+
+        <Button type="primary" block onClick={goToCreateApp}>
+          Next: Create App
+        </Button>
+      </div>
+
+      {/* Step 1: Create app from manifest */}
+      <div style={{ display: step === 1 ? undefined : 'none' }}>
+        <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
+          Create the Slack app from this manifest. Slack preconfigures every scope and event for you
+          — no manual scope entry needed.
+        </Typography.Paragraph>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+          <Button
+            size="small"
+            icon={copied ? <CheckCircleOutlined /> : <CopyOutlined />}
+            onClick={handleCopy}
+          >
+            {copied ? 'Copied' : 'Copy manifest'}
+          </Button>
+        </div>
+        {manifestPreview}
+
+        <ol style={{ paddingLeft: 20, margin: '0 0 16px', fontSize: 13 }}>
+          <li>
+            Open{' '}
+            <Typography.Link
+              href="https://api.slack.com/apps?new_app=1"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              api.slack.com/apps
+            </Typography.Link>{' '}
+            → <strong>Create New App</strong> → <strong>From a manifest</strong>.
+          </li>
+          <li>
+            Pick your workspace, paste the manifest above, and click <strong>Create</strong>.
+          </li>
+          <li>
+            <strong>Install</strong> the app to your workspace when prompted.
+          </li>
+          <li>
+            Go to <strong>Basic Information → App-Level Tokens</strong> and generate a token with
+            the <code>connections:write</code> scope — this is your <code>xapp-</code> token.
+          </li>
+        </ol>
+
+        <Space>
+          <Button onClick={() => onStepChange(0)}>Back</Button>
+          <Button type="primary" onClick={() => onStepChange(2)}>
+            Next: Tokens &amp; Test
+          </Button>
+        </Space>
+      </div>
+
+      {/* Step 2: Tokens + test */}
+      <div style={{ display: step === 2 ? undefined : 'none' }}>
+        <Alert
+          type="info"
+          showIcon
+          title="Where to find these tokens"
+          description={
+            <span>
+              <strong>Bot token (xoxb-)</strong>: OAuth &amp; Permissions → Bot User OAuth Token.
+              <br />
+              <strong>App token (xapp-)</strong>: Basic Information → App-Level Tokens.
+            </span>
+          }
+          style={{ marginBottom: 16, fontSize: 12 }}
+        />
+
+        <Form.Item
+          label="Bot Token"
+          name="bot_token"
+          rules={[{ required: true, message: 'Bot token is required' }]}
+          tooltip="OAuth & Permissions → Bot User OAuth Token (xoxb-...)"
+        >
+          <Input.Password placeholder="xoxb-..." />
+        </Form.Item>
+
+        <Form.Item
+          label="App Token"
+          name="app_token"
+          rules={[{ required: true, message: 'App token is required' }]}
+          tooltip="Basic Information → App-Level Tokens (xapp-...)"
+        >
+          <Input.Password placeholder="xapp-..." />
+        </Form.Item>
+
+        <Button
+          icon={<ThunderboltOutlined />}
+          loading={testLoading}
+          onClick={handleTestClick}
+          style={{ marginBottom: 12 }}
+        >
+          Test connection
+        </Button>
+
+        {testResult && <SlackTestResultView result={testResult} />}
+
+        {!testResult?.ok && (
+          <Alert
+            type="warning"
+            showIcon
+            title="Testing is optional"
+            description="Slack can't be fully verified up front. You can save now and confirm by sending the bot a message — but an untested channel may not work."
+            style={{ marginBottom: 16, fontSize: 12 }}
+          />
+        )}
+
+        <Collapse
+          ghost
+          destroyOnHidden={false}
+          style={{ marginLeft: -16, marginRight: -16 }}
+          items={[
+            {
+              key: 'agentic-tool-config',
+              label: (
+                <SectionLabel
+                  icon={<ThunderboltOutlined />}
+                  title="Agent Configuration"
+                  subtitle={selectedAgent}
+                />
+              ),
+              children: (
+                <Space orientation="vertical" size="middle" style={{ width: '100%' }}>
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                    Configure which agent and settings to use for sessions created from this
+                    channel.
+                  </Typography.Text>
+                  <AgentSelectionGrid
+                    agents={AVAILABLE_AGENTS}
+                    selectedAgentId={selectedAgent}
+                    onSelect={onAgentChange}
+                    columns={2}
+                    showHelperText={false}
+                    showComparisonLink={false}
+                  />
+                  <AgenticToolConfigForm
+                    agenticTool={selectedAgent as AgenticToolName}
+                    mcpServerById={mcpServerById}
+                    showHelpText={false}
+                  />
+                </Space>
+              ),
+            },
+            {
+              key: 'env-vars',
+              label: (
+                <SectionLabel
+                  icon={<LockOutlined />}
+                  title="Environment Variables"
+                  subtitle="channel-level secrets"
+                />
+              ),
+              children: (
+                <>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+                  >
+                    Define environment variables for sessions created from this channel. Useful for
+                    service account tokens or API keys for MCP servers.
+                  </Typography.Text>
+                  <Form.Item name="envVars" noStyle>
+                    <GatewayEnvVarsEditor />
+                  </Form.Item>
+                </>
+              ),
+            },
+          ]}
+        />
+
+        <Button onClick={() => onStepChange(1)} style={{ marginTop: 8 }}>
+          Back
+        </Button>
+      </div>
+    </>
+  );
+};
+
 /** Shared form fields for create and edit modals */
 const ChannelFormFields: React.FC<{
   form: FormInstance;
@@ -359,6 +970,13 @@ const ChannelFormFields: React.FC<{
   githubSetupParams: GitHubSetupParams | null;
   githubLoading: boolean;
   githubError: string | null;
+  /** Slack setup wizard state (managed by parent, create mode only) */
+  slackStep: number;
+  onSlackStepChange: (step: number) => void;
+  slackTestResult: SlackTestResult | null;
+  slackTestLoading: boolean;
+  onSlackTest: () => void;
+  onInvalidateSlackTest: () => void;
 }> = ({
   form,
   mode,
@@ -375,6 +993,12 @@ const ChannelFormFields: React.FC<{
   githubSetupParams,
   githubLoading,
   githubError,
+  slackStep,
+  onSlackStepChange,
+  slackTestResult,
+  slackTestLoading,
+  onSlackTest,
+  onInvalidateSlackTest,
 }) => {
   const { showError } = useThemedMessage();
 
@@ -1093,12 +1717,29 @@ const ChannelFormFields: React.FC<{
         />
       )}
 
-      {/* ── Collapsible sections (Slack only) ── */}
-      {channelType === 'slack' && (
+      {/* ── Slack guided setup wizard (create) ── */}
+      {channelType === 'slack' && mode === 'create' && (
+        <SlackSetupWizard
+          form={form}
+          userById={userById}
+          mcpServerById={mcpServerById}
+          selectedAgent={selectedAgent}
+          onAgentChange={onAgentChange}
+          step={slackStep}
+          onStepChange={onSlackStepChange}
+          testResult={slackTestResult}
+          testLoading={slackTestLoading}
+          onTest={onSlackTest}
+          onInvalidateTest={onInvalidateSlackTest}
+        />
+      )}
+
+      {/* ── Collapsible sections (Slack edit) ── */}
+      {channelType === 'slack' && mode === 'edit' && (
         <Collapse
           ghost
           destroyOnHidden={false}
-          defaultActiveKey={mode === 'create' ? ['identity', 'credentials'] : []}
+          defaultActiveKey={[]}
           style={{ marginLeft: -16, marginRight: -16 }}
           items={[
             // ── Identity ──
@@ -1150,27 +1791,17 @@ const ChannelFormFields: React.FC<{
                   <Form.Item
                     label="Bot Token"
                     name="bot_token"
-                    rules={
-                      mode === 'create'
-                        ? [{ required: true, message: 'Bot token is required' }]
-                        : []
-                    }
                     tooltip="Slack Bot User OAuth Token (xoxb-...)"
                   >
-                    <Input.Password placeholder={mode === 'edit' ? '••••••••' : 'xoxb-...'} />
+                    <Input.Password placeholder="••••••••" />
                   </Form.Item>
 
                   <Form.Item
                     label="App Token"
                     name="app_token"
-                    rules={
-                      mode === 'create'
-                        ? [{ required: true, message: 'App token is required' }]
-                        : []
-                    }
                     tooltip="Slack App-Level Token for Socket Mode (xapp-...)"
                   >
-                    <Input.Password placeholder={mode === 'edit' ? '••••••••' : 'xapp-...'} />
+                    <Input.Password placeholder="••••••••" />
                   </Form.Item>
 
                   <Alert
@@ -1469,6 +2100,11 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const [githubError, setGithubError] = useState<string | null>(null);
   const [githubSetupParams, setGithubSetupParams] = useState<GitHubSetupParams | null>(null);
 
+  // ── Slack Setup Wizard State (lifted from ChannelFormFields) ──
+  const [slackStep, setSlackStep] = useState(0);
+  const [slackTestLoading, setSlackTestLoading] = useState(false);
+  const [slackTestResult, setSlackTestResult] = useState<SlackTestResult | null>(null);
+
   // Detect GitHub setup callback params from URL
   const location = useLocation();
   const navigate = useNavigate();
@@ -1562,6 +2198,69 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     setGithubError(null);
     setGithubSetupParams(null);
   }, []);
+
+  const resetSlackState = useCallback(() => {
+    setSlackStep(0);
+    setSlackTestLoading(false);
+    setSlackTestResult(null);
+  }, []);
+
+  const invalidateSlackTest = useCallback(() => {
+    setSlackTestResult(null);
+  }, []);
+
+  // Switching channel type abandons any in-progress platform setup, so clear the
+  // wizard state for both platforms.
+  const handleChannelTypeChange = useCallback(
+    (type: ChannelType) => {
+      setChannelType(type);
+      resetGithubState();
+      resetSlackState();
+    },
+    [resetGithubState, resetSlackState]
+  );
+
+  // Probe the entered Slack tokens against the live workspace via the
+  // `gateway-channels/test` service. No gatewayChannelId — the channel doesn't
+  // exist yet, so the probe runs purely against the supplied config.
+  const handleSlackTest = useCallback(async () => {
+    if (!client) {
+      showError('Not connected to server');
+      return;
+    }
+    const values = createForm.getFieldsValue(true);
+    const config: Record<string, unknown> = {
+      bot_token: values.bot_token,
+      app_token: values.app_token,
+      enable_channels: values.enable_channels ?? false,
+      enable_groups: values.enable_groups ?? false,
+      enable_mpim: values.enable_mpim ?? false,
+      align_slack_users: values.align_slack_users ?? false,
+      allowed_channel_ids: values.allowed_channel_ids ?? [],
+      outbound_enabled: values.outbound_enabled ?? false,
+    };
+    setSlackTestLoading(true);
+    setSlackTestResult(null);
+    try {
+      const result = (await client
+        .service('gateway-channels/test')
+        .create({ config })) as SlackTestResult;
+      setSlackTestResult(result);
+    } catch (error) {
+      setSlackTestResult({
+        ok: false,
+        failures: [
+          {
+            capability: 'connection',
+            reason: error instanceof Error ? error.message : String(error),
+          },
+        ],
+        notVerifiable: [],
+      });
+    } finally {
+      setSlackTestLoading(false);
+    }
+  }, [client, createForm, showError]);
 
   // Pre-populate agentic config form with user defaults when agent changes
   useEffect(() => {
@@ -1697,6 +2396,14 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       // Use getFieldsValue(true) to include values from collapsed (unmounted)
       // panels that validateFields() may omit.
       const values = createForm.getFieldsValue(true);
+      // The whitelist only applies when the wizard limits public channels to a
+      // specific set; "all public channels" (or no public channels) must clear it.
+      if (
+        values.channel_type === 'slack' &&
+        (values.slack_public_scope !== 'specific' || !values.enable_channels)
+      ) {
+        values.allowed_channel_ids = [];
+      }
       const data = extractFormData(values, undefined, selectedAgent);
 
       if (!client) {
@@ -1710,6 +2417,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       setCreateModalOpen(false);
       setChannelType('slack');
       resetGithubState();
+      resetSlackState();
     } catch (error: unknown) {
       const err = error as { errorFields?: { errors: string[] }[]; message?: string };
       if (err.errorFields?.length) {
@@ -2021,11 +2729,17 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
           setChannelType('slack');
           setSelectedAgent('claude-code');
           resetGithubState();
+          resetSlackState();
         }}
         okText="Create"
         okButtonProps={{
-          // Hide the Create button when GitHub setup hasn't reached the config step
-          style: channelType === 'github' && githubStep < 2 ? { display: 'none' } : undefined,
+          // Hide the Create button until each platform's guided setup reaches its
+          // final step (GitHub config / Slack tokens & test).
+          style:
+            (channelType === 'github' && githubStep < 2) ||
+            (channelType === 'slack' && slackStep < 2)
+              ? { display: 'none' }
+              : undefined,
         }}
         width={600}
       >
@@ -2034,7 +2748,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             form={createForm}
             mode="create"
             channelType={channelType}
-            onChannelTypeChange={setChannelType}
+            onChannelTypeChange={handleChannelTypeChange}
             branchById={branchOptionsById}
             userById={userById}
             mcpServerById={mcpServerById}
@@ -2045,6 +2759,12 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             githubSetupParams={githubSetupParams}
             githubLoading={githubLoading}
             githubError={githubError}
+            slackStep={slackStep}
+            onSlackStepChange={setSlackStep}
+            slackTestResult={slackTestResult}
+            slackTestLoading={slackTestLoading}
+            onSlackTest={handleSlackTest}
+            onInvalidateSlackTest={invalidateSlackTest}
           />
         </Form>
       </Modal>
@@ -2081,6 +2801,12 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             githubSetupParams={null}
             githubLoading={false}
             githubError={null}
+            slackStep={2}
+            onSlackStepChange={() => {}}
+            slackTestResult={null}
+            slackTestLoading={false}
+            onSlackTest={() => {}}
+            onInvalidateSlackTest={() => {}}
           />
         </Form>
       </Modal>

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -528,6 +528,7 @@ const SlackSetupWizard: React.FC<{
   const alignUsers = Form.useWatch('align_slack_users', form) ?? false;
   const outbound = Form.useWatch('outbound_enabled', form) ?? false;
   const publicScope = (Form.useWatch('slack_public_scope', form) as string) ?? 'all';
+  const allowedChannelIds = (Form.useWatch('allowed_channel_ids', form) as string[]) ?? [];
   const botToken = (Form.useWatch('bot_token', form) as string) ?? '';
   const appToken = (Form.useWatch('app_token', form) as string) ?? '';
 
@@ -550,9 +551,10 @@ const SlackSetupWizard: React.FC<{
   const scopes = useMemo(() => requiredBotScopes(wizardOptions), [wizardOptions]);
   const events = useMemo(() => requiredBotEvents(wizardOptions), [wizardOptions]);
 
-  // Any change to the manifest inputs or tokens invalidates a prior test result.
-  // A green check against stale credentials/options would be misleading.
-  const invalidationKey = `${manifestJson}|${botToken}|${appToken}`;
+  // Any change that alters the probe config (manifest inputs, tokens, or the
+  // channel-scope options sent to gateway-channels/test) invalidates a prior
+  // test result. A green check against stale config would be misleading.
+  const invalidationKey = `${manifestJson}|${botToken}|${appToken}|${publicScope}|${allowedChannelIds.join(',')}`;
   // biome-ignore lint/correctness/useExhaustiveDependencies: invalidationKey is the change trigger, not a value read in the body.
   useEffect(() => {
     onInvalidateTest();

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -324,11 +324,26 @@ const GatewayEnvVarsEditor: React.FC<{
 // GitHub App Setup Types & Helpers
 // ============================================================================
 
-/** Credentials fetched from the daemon after GitHub App manifest creation */
-/** Parameters passed via URL from the GitHub App setup callback */
+/**
+ * State carried across the GitHub App install round-trip. `installation_id`
+ * arrives via the deep-link URL; the rest is restored from the sessionStorage
+ * draft persisted before the redirect (the install opens a fresh page, so the
+ * in-memory form is gone on return).
+ */
 interface GitHubSetupParams {
   installation_id?: string;
+  name?: string;
+  target_branch_id?: string;
+  github_app_name?: string;
+  github_org?: string;
 }
+
+/**
+ * sessionStorage key for the step-0 essentials stashed right before the GitHub
+ * App install redirect. A new tab opened via `window.open` inherits a copy of
+ * the opener's sessionStorage, so the install-callback page can restore them.
+ */
+const GITHUB_SETUP_DRAFT_KEY = 'agor.gateway.githubSetupDraft';
 
 // ============================================================================
 // Unified create-wizard step model
@@ -528,11 +543,10 @@ const SlackTestResultView: React.FC<{ result: SlackTestResult }> = ({ result }) 
 };
 
 /**
- * Guided Slack setup wizard shown on create. Mirrors the GitHub `Steps` flow:
- * step state is lifted to the parent, the modal's OK button stays hidden until
- * the final step. Selections drive a live manifest preview + derived scope/event
- * list via {@link buildSlackManifest} / {@link requiredBotScopes}, so the user
- * never adds a scope by hand.
+ * Guided Slack setup wizard shown on create. Step state is lifted to the parent
+ * and navigation lives in the unified modal footer. Selections drive a live
+ * manifest preview + derived scope/event list via {@link buildSlackManifest} /
+ * {@link requiredBotScopes}, so the user never adds a scope by hand.
  */
 const SlackSetupWizard: React.FC<{
   form: FormInstance;
@@ -1007,6 +1021,9 @@ const ChannelFormFields: React.FC<{
   const enableMpim = Form.useWatch('enable_mpim', form) ?? false;
   const alignSlackUsers = Form.useWatch('align_slack_users', form) ?? false;
   const alignGithubUsers = Form.useWatch('github_align_users', form) ?? false;
+  // Set after an install round-trip; lets the Create-app step recognize the
+  // already-installed case instead of prompting to create the app again.
+  const githubInstallationId = Form.useWatch('github_installation_id', form);
 
   const sourcesEnabled = enableChannels || enableGroups || enableMpim;
 
@@ -1139,6 +1156,21 @@ const ChannelFormFields: React.FC<{
             {/* Step 1 (Create app): register the GitHub App. */}
             {mode === 'create' && createStep === 1 && !githubLoading && (
               <div style={{ marginBottom: 16 }}>
+                {githubInstallationId ? (
+                  <Alert
+                    type="success"
+                    showIcon
+                    title="GitHub App already installed"
+                    description={
+                      <span>
+                        Installation <code>{String(githubInstallationId)}</code> was captured from
+                        the install callback. Click <strong>Continue</strong> to enter its
+                        credentials.
+                      </span>
+                    }
+                    style={{ marginBottom: 16 }}
+                  />
+                ) : null}
                 <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
                   Create a GitHub App to connect Agor to your repositories. This uses GitHub&apos;s
                   URL-parameters registration flow — you&apos;ll be redirected to GitHub with the
@@ -1202,6 +1234,21 @@ const ChannelFormFields: React.FC<{
                         return;
                       }
                       params.set('state', state);
+                      // Stash step-0 essentials so the install-callback page (a
+                      // fresh load) can restore name/branch and land on Credentials.
+                      try {
+                        sessionStorage.setItem(
+                          GITHUB_SETUP_DRAFT_KEY,
+                          JSON.stringify({
+                            name: form.getFieldValue('name') ?? '',
+                            target_branch_id: form.getFieldValue('target_branch_id') ?? '',
+                            github_app_name: appName ?? '',
+                            github_org: org ?? '',
+                          })
+                        );
+                      } catch {
+                        // Non-fatal: the deep-link return falls back to step 0.
+                      }
                       window.open(
                         `${daemonUrl}/api/github/setup/new?${params.toString()}`,
                         '_blank'
@@ -2115,21 +2162,47 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     const installationId = params.get('installation_id');
 
     if (installationId) {
-      setGithubSetupParams({ installation_id: installationId });
+      // Restore the step-0 essentials stashed before the install redirect.
+      let draft: Partial<GitHubSetupParams> = {};
+      try {
+        const raw = sessionStorage.getItem(GITHUB_SETUP_DRAFT_KEY);
+        if (raw) draft = JSON.parse(raw) as Partial<GitHubSetupParams>;
+      } catch {
+        // Ignore malformed drafts — fall back to step 0 below.
+      }
+
+      setGithubSetupParams({ installation_id: installationId, ...draft });
       setChannelType('github');
-      // App is already created on GitHub — jump straight to the Credentials step
-      // (Channel=0, Create app=1, Credentials=2 in the unified GitHub flow).
-      setCreateStep(2);
+      // With a restored draft (name + branch), jump straight to Credentials
+      // (Channel=0, Create app=1, Credentials=2). Without it, land on step 0 so
+      // the user can supply the required name/branch first.
+      const hasDraft = Boolean(draft.name && draft.target_branch_id);
+      setCreateStep(hasDraft ? 2 : 0);
       setCreateModalOpen(true);
       // Clean up URL params
       navigate('/', { replace: true });
     }
   }, [location.search, navigate]);
 
-  // Prefill the installation ID once the create form is mounted (deep-link return).
+  // Once the create form is mounted on a deep-link return, sync the channel type
+  // and restore the captured draft/installation into the form, then drop the
+  // sessionStorage draft so a later manual create can't inherit it.
   useEffect(() => {
-    if (createModalOpen && githubSetupParams?.installation_id) {
-      createForm.setFieldValue('github_installation_id', githubSetupParams.installation_id);
+    if (!createModalOpen || !githubSetupParams) return;
+    const { installation_id, name, target_branch_id, github_app_name, github_org } =
+      githubSetupParams;
+    createForm.setFieldsValue({
+      channel_type: 'github',
+      ...(installation_id ? { github_installation_id: installation_id } : {}),
+      ...(name ? { name } : {}),
+      ...(target_branch_id ? { target_branch_id } : {}),
+      ...(github_app_name ? { github_app_name } : {}),
+      ...(github_org ? { github_org } : {}),
+    });
+    try {
+      sessionStorage.removeItem(GITHUB_SETUP_DRAFT_KEY);
+    } catch {
+      // Best-effort cleanup.
     }
   }, [createModalOpen, githubSetupParams, createForm]);
 

--- a/apps/agor-ui/src/components/SettingsModal/UserSelect.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSelect.tsx
@@ -1,0 +1,21 @@
+import type { User } from '@agor-live/client';
+import { Select, type SelectProps } from 'antd';
+
+/** Searchable Agor-user picker used by the gateway channel forms. */
+export const UserSelect: React.FC<SelectProps<string> & { userById: Map<string, User> }> = ({
+  userById,
+  placeholder = 'Select a user',
+  ...selectProps
+}) => (
+  <Select {...selectProps} placeholder={placeholder} showSearch optionFilterProp="children">
+    {Array.from(userById.values())
+      .sort((a, b) =>
+        (a.name || a.email || a.user_id).localeCompare(b.name || b.email || b.user_id)
+      )
+      .map((u) => (
+        <Select.Option key={u.user_id} value={u.user_id}>
+          {u.name || u.email || u.user_id}
+        </Select.Option>
+      ))}
+  </Select>
+);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -334,6 +334,12 @@
       "import": "./dist/gateway/index.js",
       "require": "./dist/gateway/index.cjs"
     },
+    "./gateway/slack-manifest": {
+      "source": "./src/gateway/connectors/slack-manifest.ts",
+      "types": "./dist/gateway/connectors/slack-manifest.d.ts",
+      "import": "./dist/gateway/connectors/slack-manifest.js",
+      "require": "./dist/gateway/connectors/slack-manifest.cjs"
+    },
     "./git/pure": {
       "source": "./src/git/pure.ts",
       "types": "./dist/git/pure.d.ts",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
     'unix/index': 'src/unix/index.ts', // Unix group management utilities for branch isolation
     'mcp/index': 'src/mcp/index.ts', // MCP template resolution utilities
     'gateway/index': 'src/gateway/index.ts', // Gateway platform connectors (Slack, etc.)
+    'gateway/connectors/slack-manifest': 'src/gateway/connectors/slack-manifest.ts', // Browser-safe Slack manifest/scope derivation (no connector deps)
     'yaml/index': 'src/yaml/index.ts', // Browser-safe js-yaml re-export
     'knowledge/index': 'src/knowledge/index.ts', // Knowledge editing helpers
   },


### PR DESCRIPTION
## Summary

Adds a guided **create** wizard for Slack gateway channels, mirroring the existing GitHub `Steps` wizard in the same component. Wizard is **create-only**; edit mode keeps the existing `Collapse` form (no Form/Wizard toggle).

### Three-step flow
1. **Options** — `appName`, surfaces (DMs shown as always-on/informational; checkboxes for Public/Private channels + Group DMs, with all-vs-specific channel scoping), and toggles for user alignment + outbound. Selections drive a **live read-only manifest preview + derived scope/event list** via `buildSlackManifest` / `requiredBotScopes` / `requiredBotEvents`.
2. **Create app from manifest** — read-only manifest JSON with a **Copy** button (clipboard + `execCommand` fallback), a link to `api.slack.com/apps?new_app=1`, and step-by-step instructions through install + generating the `xapp-` app-level token (`connections:write`).
3. **Tokens & Test** — `xoxb-` (OAuth & Permissions) + `xapp-` (Basic Information) inputs with exact pointers, a **Test connection** button calling `gateway-channels/test`, and an honest result render (team/bot/appTokenValid/failures + the `notVerifiable` list — green ≠ fully verified). Save creates the channel.

### Behavior
- Step + test state lifted to the parent (mirrors GitHub). The modal's OK/Save button stays hidden until the final step.
- Step + test state reset on cancel, successful create, and channel-type change.
- A passing test is **invalidated** when tokens or options change.
- A passing test is **advisory, not required** — a warning shows if untested/failed, but Save is always allowed (Slack can't be fully verified up front).

### Browser-safe manifest import
`buildSlackManifest` lives in `packages/core`, whose `gateway` barrel also re-exports the Slack **connector** (node-only `@slack/web-api` / `@slack/socket-mode`). Importing the manifest fn through the barrel would drag node-only code into the browser bundle. Solved by adding a dedicated **`@agor/core/gateway/slack-manifest`** subpath export pointing straight at the dependency-free `slack-manifest` module, and importing the manifest helpers from that subpath in the UI — the connectors are never pulled in.

### Tests
Extended `GatewayChannelsTable.test.tsx`: wizard renders (not Collapse) on create; manifest preview + scope/event list update as surfaces change; step navigation Options → Create App → Tokens & Test; Test button calls `gateway-channels/test` and renders the result incl. `notVerifiable`; Save creates the channel; edit mode still renders the `Collapse`.

---

Part of preset-io/agor-cloud#94. PR 3 of a multi-PR feature; builds on merged #1635 + #1645.