### PR TITLE
feat(env): add demo-fixtures variants (sqlite-demo, postgres-demo)

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -61,3 +61,29 @@ environment:
       nuke: >-
         docker compose -f docker-compose.yml -f docker-compose.override.postgres.yml -p
         agor-{{branch.name}} --profile postgres down -v
+    sqlite-demo:
+      start: >-
+        UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true LOAD_FIXTURES=true docker compose -p agor-{{branch.name}} up -d --build
+      description: >-
+        SQLite dev + demo fixtures (SEED + LOAD_FIXTURES): boots a populated demo board with 4
+        loginable demo users (demo.alice@agor.live / demo-password-alice, …) for instant E2E
+        testing. Dev-only.
+      extends: sqlite
+    postgres-demo:
+      start: >-
+        UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
+        branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true LOAD_FIXTURES=true docker compose -f docker-compose.yml -f
+        docker-compose.override.postgres.yml -p agor-{{branch.name}} --profile postgres up -d
+        --build
+      stop: >-
+        docker compose -f docker-compose.yml -f docker-compose.override.postgres.yml -p
+        agor-{{branch.name}} --profile postgres down
+      description: >-
+        PostgreSQL dev + demo fixtures (SEED + LOAD_FIXTURES): boots a populated demo board with 4
+        loginable demo users (demo.alice@agor.live / demo-password-alice, …) on a Postgres backend
+        for instant E2E testing. Dev-only.
+      extends: sqlite
+      nuke: >-
+        docker compose -f docker-compose.yml -f docker-compose.override.postgres.yml -p
+        agor-{{branch.name}} --profile postgres down -v

--- a/apps/agor-docs/pages/guide/development.mdx
+++ b/apps/agor-docs/pages/guide/development.mdx
@@ -34,6 +34,15 @@ SEED=true LOAD_FIXTURES=true docker compose up
   live Sandpack artifact. Idempotent and **dev-only**. You can also run it manually
   with `pnpm load:fixtures`.
 
+The `SEED=true LOAD_FIXTURES=true docker compose up` form is for running compose
+directly on a host. **In an Agor-managed env** the start command comes pre-rendered
+from a `.agor.yml` variant, so pick a demo variant instead of injecting env vars:
+the `sqlite-demo` and `postgres-demo` variants below are the `sqlite` / `postgres`
+variants with `LOAD_FIXTURES=true` added next to `SEED=true`. Select one via the
+**Branch → Environment** tab variant picker, the MCP call
+`agor_environment_set({ branchId, variant: "sqlite-demo", andStart: true })`, or at
+branch creation with `variant: "sqlite-demo"`.
+
 Both are off by default and can be enabled independently. With `LOAD_FIXTURES`,
 extra demo logins are available (passwords printed in the seed log):
 
@@ -56,6 +65,8 @@ Agor's repo ships [`.agor.yml`](https://github.com/preset-io/agor/blob/main/.ago
 | **`postgres`**           | Postgres backend (closer to multi-user prod). RBAC off. **Requires Postgres 13+** (migrations use `gen_random_uuid()` from pg_catalog).       | same as `sqlite`                                  |
 | **`full`**               | Postgres + branch RBAC + strict Unix-user impersonation. Requires the sudoers config under `docker/sudoers/`. Same PG13+ floor as `postgres`. | same as `sqlite`                                  |
 | **`docs`**               | The Nextra docs site (`apps/agor-docs`) in its own self-contained container. Standalone — no daemon, no DB.                                   | `7000 + branch.unique_id`                         |
+| **`sqlite-demo`**        | `sqlite` plus `LOAD_FIXTURES=true` — boots a populated demo board with 4 loginable demo users for instant E2E testing. Dev-only.              | same as `sqlite`                                  |
+| **`postgres-demo`**      | `postgres` plus `LOAD_FIXTURES=true` — same demo fixtures on a Postgres backend. Dev-only.                                                    | same as `sqlite`                                  |
 
 Ports derive from `branch.unique_id` so multiple branches run side-by-side without colliding. The `docs` variant uses `{{host.ip_address}}` in its app URL so the dev server is reachable from your laptop, not just localhost on the daemon host.
 

--- a/packages/core/src/config/agor-yml.test.ts
+++ b/packages/core/src/config/agor-yml.test.ts
@@ -5,9 +5,15 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import type { RepoEnvironment, RepoEnvironmentConfigV1 } from '../types/branch';
 import { parseAgorYml, resolveVariant, writeAgorYml } from './agor-yml';
+
+const REPO_ROOT_AGOR_YML = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../.agor.yml'
+);
 
 function withTmpFile<T>(fn: (filePath: string) => T): T {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agor-yml-test-'));
@@ -258,6 +264,36 @@ describe('parseAgorYml — misc', () => {
       fs.writeFileSync(file, `invalid: yaml: syntax:`);
       expect(() => parseAgorYml(file)).toThrow(/Invalid YAML/);
     });
+  });
+});
+
+describe('parseAgorYml — repo .agor.yml demo variants', () => {
+  it('resolves sqlite-demo / postgres-demo with LOAD_FIXTURES and required start/stop', () => {
+    const env = parseAgorYml(REPO_ROOT_AGOR_YML);
+    expect(env).not.toBeNull();
+    // Additive only — the default stays sqlite.
+    expect(env?.default).toBe('sqlite');
+
+    for (const name of ['sqlite-demo', 'postgres-demo']) {
+      const resolved = resolveVariant(env!, name);
+      expect(resolved, `${name} resolves`).not.toBeNull();
+      expect(resolved!.start, `${name}.start`).toMatch(/SEED=true LOAD_FIXTURES=true/);
+      expect(resolved!.stop, `${name}.stop`).toBeTruthy();
+      // extends: sqlite is resolved away.
+      expect(
+        (resolved as RepoEnvironment['variants'][string] & { extends?: string }).extends
+      ).toBeUndefined();
+    }
+
+    // The demo variants differ from their siblings by exactly LOAD_FIXTURES=true.
+    const withFixtures = (start: string | undefined) =>
+      start?.replace('SEED=true', 'SEED=true LOAD_FIXTURES=true');
+    expect(resolveVariant(env!, 'sqlite-demo')!.start).toBe(
+      withFixtures(resolveVariant(env!, 'sqlite')!.start)
+    );
+    expect(resolveVariant(env!, 'postgres-demo')!.start).toBe(
+      withFixtures(resolveVariant(env!, 'postgres')!.start)
+    );
   });
 });
 

--- a/packages/core/src/seed/README.md
+++ b/packages/core/src/seed/README.md
@@ -97,7 +97,7 @@ the real `agor` repo (or its `test-branch`) created by `SEED`.
 ### Usage
 
 ```bash
-# Docker — recommended combo (real branch + rich fakes)
+# Docker — recommended combo (real branch + rich fakes), run directly on a host
 SEED=true LOAD_FIXTURES=true docker compose up
 
 # Just the demo data
@@ -108,6 +108,20 @@ pnpm load:fixtures
 pnpm load:fixtures --skip-if-exists
 pnpm tsx scripts/load-fixtures.ts --skip-if-exists --user-id <admin-uuid>
 ```
+
+#### In an Agor-managed env
+
+Agor-managed environments start from a pre-rendered command in [`.agor.yml`](../../../../.agor.yml),
+so you can't inject `LOAD_FIXTURES` by hand. Instead, pick a demo variant — these
+are the `sqlite` / `postgres` variants with `LOAD_FIXTURES=true` added alongside
+`SEED=true`:
+
+- **`sqlite-demo`** — SQLite + demo fixtures.
+- **`postgres-demo`** — Postgres + demo fixtures.
+
+Select one via the **Branch → Environment** tab variant picker, the MCP call
+`agor_environment_set({ branchId, variant: "sqlite-demo", andStart: true })`, or at
+branch creation with `variant: "sqlite-demo"`.
 
 The docker entrypoint runs `LOAD_FIXTURES` **after** `SEED`. Passing
 `--user-id <admin-uuid>` (the entrypoint passes the bootstrapped admin) also adds


### PR DESCRIPTION
## Why

`LOAD_FIXTURES=true` (the demo-data seeder) was only documented as a `docker compose` env var. But Agor-managed environments start via a **pre-rendered command from `.agor.yml` variants**, and `agor_environment_start` takes no env vars — the variant is the only lever. None of the existing variants (`sqlite`, `postgres`, `full`, `docs`) set `LOAD_FIXTURES`, so there was no way for an agent (or the Environment tab) to spin up an env with demo fixtures already loaded. This exposes it as first-class variants.

## What

- **`.agor.yml`** — two additive variants:
  - `sqlite-demo` (`extends: sqlite`) — `start` identical to `sqlite` plus `LOAD_FIXTURES=true`.
  - `postgres-demo` (`extends: sqlite`) — postgres `start`/`stop`/`nuke` plus `LOAD_FIXTURES=true`.
  - `default` stays `sqlite`; no existing variant changed. Each demo variant differs from its non-demo sibling by exactly the added `LOAD_FIXTURES=true`.
- **Docs** (`packages/core/src/seed/README.md`, `apps/agor-docs/pages/guide/development.mdx`) — add an "In an Agor-managed env" path next to the existing host `docker compose` instructions.
- **Test** (`packages/core/src/config/agor-yml.test.ts`) — parses the real `.agor.yml`, asserts both demo variants resolve (extends collapsed, `start`/`stop` present, carry `SEED=true LOAD_FIXTURES=true`), `default` unchanged, and each demo `start` equals its sibling with `LOAD_FIXTURES=true` spliced in.

## Usage

In a managed env: `agor_environment_set({ branchId, variant: "sqlite-demo", andStart: true })`, pick the variant in the Branch → Environment tab, or set it at branch creation via `variant: "sqlite-demo"`. Demo logins: `demo.alice@agor.live` / `demo-password-alice` (+ bob/carol/dave).

## Gate

`pnpm typecheck` (9/9), `pnpm build` (7/7), and `pnpm --filter @agor/core test` (2683 passed, incl. the new test) are green. Diff is the 4 files above (+88/−1).

> Heads-up: `pnpm check` also surfaces one **pre-existing** `check:shortid` failure at `apps/agor-daemon/src/services/terminals.test.ts:53` (`id.slice(0, 8)`, landed in #1617). It's untouched by this PR and not run in CI — flagging only so it isn't read as a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
