### PR TITLE
fix(agor-ui): move useLocalStorage side effects out of the state updater

### DIFF
--- a/apps/agor-ui/src/hooks/useLocalStorage.test.tsx
+++ b/apps/agor-ui/src/hooks/useLocalStorage.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, render, renderHook } from '@testing-library/react';
+import { useEffect, useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLocalStorage } from './useLocalStorage';
 
@@ -29,5 +30,45 @@ describe('useLocalStorage', () => {
 
     expect(result.current[0]).toBe('recent');
     expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('does not trigger a setState-in-render warning when a sibling hook shares the key', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    function Writer() {
+      const [, setValue] = useLocalStorage<string>(KEY, 'recent');
+      const [, setTick] = useState(0);
+      useEffect(() => {
+        // Queue an unrelated update first so the writer's fiber already has
+        // pending work when setValue runs. That defeats React's eager-state
+        // bailout, forcing the state updater to execute during the render
+        // phase — the same condition under which a side effect dispatched
+        // from inside the updater would call a sibling's setState mid-render.
+        setTick((tick) => tick + 1);
+        setValue('written');
+      }, [setValue]);
+      return null;
+    }
+
+    function Reader() {
+      const [value] = useLocalStorage<string>(KEY, 'recent');
+      return <span>{value}</span>;
+    }
+
+    act(() => {
+      render(
+        <>
+          <Writer />
+          <Reader />
+        </>
+      );
+    });
+
+    const offendingCalls = consoleError.mock.calls.filter((callArgs) =>
+      callArgs.some(
+        (arg) => typeof arg === 'string' && arg.includes('while rendering a different component')
+      )
+    );
+    expect(offendingCalls).toEqual([]);
   });
 });

--- a/apps/agor-ui/src/hooks/useLocalStorage.ts
+++ b/apps/agor-ui/src/hooks/useLocalStorage.ts
@@ -26,21 +26,29 @@ export function useLocalStorage<T>(
   const keyRef = useRef(key);
   keyRef.current = key;
 
+  // Mirror the latest value into a ref so the functional form of `setValue` can
+  // resolve against it WITHOUT persisting + dispatching from inside the
+  // `setStoredValue` updater. React runs updaters during the render phase, so a
+  // change event dispatched there would make a sibling hook's listener call
+  // setState mid-render; keeping the side effects in the setter body (an
+  // event/effect context) keeps them out of render.
+  const storedValueRef = useRef(storedValue);
+  storedValueRef.current = storedValue;
+
   // Stable setter that persists to localStorage
   const setValue = useCallback((value: T | ((val: T) => T)) => {
     try {
-      setStoredValue((prev) => {
-        const valueToStore = value instanceof Function ? value(prev) : value;
-        writeLocalStorageJson(keyRef.current, valueToStore);
-        if (typeof window !== 'undefined') {
-          window.dispatchEvent(
-            new CustomEvent<LocalStorageChangeDetail>(LOCAL_STORAGE_CHANGE_EVENT, {
-              detail: { key: keyRef.current, value: valueToStore },
-            })
-          );
-        }
-        return valueToStore;
-      });
+      const valueToStore =
+        value instanceof Function ? (value as (val: T) => T)(storedValueRef.current) : value;
+      writeLocalStorageJson(keyRef.current, valueToStore);
+      setStoredValue(valueToStore);
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(
+          new CustomEvent<LocalStorageChangeDetail>(LOCAL_STORAGE_CHANGE_EVENT, {
+            detail: { key: keyRef.current, value: valueToStore },
+          })
+        );
+      }
     } catch (error) {
       console.error(`Error setting localStorage key "${keyRef.current}":`, error);
     }


### PR DESCRIPTION
## Problem

`useLocalStorage` performed its `localStorage` write **and** its `agor-local-storage-change` `CustomEvent` dispatch *inside* the `setStoredValue((prev) => {...})` updater. React runs state updaters during the **render phase**, so when one component updated the value (e.g. App's `trackBoardVisit`), the dispatch synchronously fired a **sibling** hook instance's `storage-change` listener → that listener called `setState` mid-render → React warned:

```
Cannot update a component (`AppHeaderInner`) while rendering a different component (`App`).
```

This surfaced once two instances of `useLocalStorage('agor:recentBoardIds')` began coexisting (App + AppHeader): the writer's render-phase dispatch reached into the reader's listener and updated it during render.

## Fix

Resolve the functional form of `setValue` against a `storedValueRef`, then perform the write + `setStoredValue` + dispatch in the **setter body** instead of inside the updater. The setter runs in an event/effect context, so the side effects no longer execute during render and the cross-instance dispatch can't trigger a sibling `setState` mid-render. The storage-listener `useEffect` and the hook's return value are unchanged.

## Test

Adds a regression case to `useLocalStorage.test.tsx`: a `Writer` calls its setter inside a `useEffect` while a sibling `Reader` reads the same key; the test asserts React logged no `while rendering a different component` warning. An unrelated state update is queued before the setter so the writer's fiber has pending work — this defeats React's eager-state bailout and forces the updater to run in the render phase, reproducing the real-app condition.

Verified non-vacuous: with the side effects moved back inside the `setStoredValue` updater, the new test fails (React logs the warning, attributed to `Reader` updating during `Writer`'s render); with the fix in place it passes.

## Gate

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm exec vitest run src/hooks/useLocalStorage.test.tsx src/hooks/useUserLocalStorage.test.tsx` ✅ (6 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)