### PR TITLE
feat(gateway): Slack edit-form polish (copy manifest, test connection, scope clarity, secret status)

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -308,22 +308,34 @@ describe('GatewayChannelsTable Slack create wizard', () => {
   });
 });
 
+/**
+ * Render the table with a single Slack channel and open its edit modal. The
+ * edit Collapse keeps inactive panels mounted (`destroyOnHidden={false}`), but
+ * children render lazily — call {@link expandPanel} to reveal a section's body.
+ */
+function renderEditTable(client: AgorClient | null, channel: GatewayChannel) {
+  const branch = makeBranch();
+  const user = makeUser();
+  renderWithProviders(
+    <GatewayChannelsTable
+      client={client}
+      gatewayChannelById={new Map([[channel.id, channel]])}
+      branchById={new Map([[branch.branch_id, branch]])}
+      userById={new Map([[user.user_id, user]])}
+      mcpServerById={new Map<string, MCPServer>()}
+    />
+  );
+  fireEvent.click(screen.getByTitle('Edit'));
+}
+
+/** Expand a Collapse section by clicking its header label. */
+function expandPanel(title: string) {
+  fireEvent.click(screen.getByText(title));
+}
+
 describe('GatewayChannelsTable Slack edit mode', () => {
   it('still renders the Collapse form (not the wizard) when editing', () => {
-    const branch = makeBranch();
-    const user = makeUser();
-    const channel = makeSlackChannel();
-    renderWithProviders(
-      <GatewayChannelsTable
-        client={null}
-        gatewayChannelById={new Map([[channel.id, channel]])}
-        branchById={new Map([[branch.branch_id, branch]])}
-        userById={new Map([[user.user_id, user]])}
-        mcpServerById={new Map<string, MCPServer>()}
-      />
-    );
-
-    fireEvent.click(screen.getByTitle('Edit'));
+    renderEditTable(null, makeSlackChannel());
 
     // Edit keeps the collapsible sections; the create-only wizard is absent.
     expect(screen.getByText('Credentials')).toBeInTheDocument();
@@ -331,6 +343,82 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     // No unified step indicator and no wizard footer in edit mode.
     expect(screen.queryByText('Tokens & test')).not.toBeInTheDocument();
     expect(queryButton(/^Continue$/)).toBeUndefined();
+  });
+
+  it('copies the recommended manifest derived from the channel options', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    // enable_channels: true ⇒ public-channel scopes + the app_mention event.
+    renderEditTable(null, makeSlackChannel());
+    expandPanel('App Manifest');
+
+    // The manifest derives from Form.useWatch, which propagates the edited
+    // values on the next tick — wait for the public-channel scope to appear.
+    await waitFor(() =>
+      expect(document.querySelector('pre')?.textContent ?? '').toContain('"channels:history"')
+    );
+    const manifest = document.querySelector('pre')?.textContent ?? '';
+    expect(manifest).toContain('"app_mention"');
+    // Channel surfaces trigger on app_mention, never message.* channel events.
+    expect(manifest).not.toContain('message.channels');
+
+    clickButton(/Copy app manifest/);
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).toContain('"channels:history"');
+  });
+
+  it('tests an existing channel via gatewayChannelId (never form tokens)', async () => {
+    const result = {
+      ok: true,
+      team: { id: 'T123', name: 'Acme' },
+      appTokenValid: true,
+      failures: [],
+      notVerifiable: [],
+    };
+    const { client, testCreate } = makeClient(result);
+    renderEditTable(client, makeSlackChannel());
+    expandPanel('Credentials');
+
+    clickButton(/Test connection/);
+
+    await waitFor(() => expect(testCreate).toHaveBeenCalledTimes(1));
+    expect(testCreate.mock.calls[0][0]).toEqual({ gatewayChannelId: 'channel-1' });
+    expect(await screen.findByText('Connection succeeded')).toBeInTheDocument();
+    expect(screen.getByText('Acme')).toBeInTheDocument();
+  });
+
+  it('derives the Message Sources scope/event list (no stale message.* events)', async () => {
+    renderEditTable(null, makeSlackChannel());
+    expandPanel('Message Sources');
+
+    // Derived from requiredBotScopes/requiredBotEvents for public channels; the
+    // watched enable_channels value propagates on the next tick.
+    await waitFor(() =>
+      expect(screen.queryAllByText('channels:history').length).toBeGreaterThan(0)
+    );
+    expect(screen.queryAllByText('app_mentions:read').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('app_mention').length).toBeGreaterThan(0);
+    // Channel surfaces subscribe to app_mention, never message.* channel events.
+    expect(screen.queryByText('message.channels')).toBeNull();
+  });
+
+  it('shows stored vs not-set status for the token fields', () => {
+    // bot_token is stored (non-empty fixture value); app_token is absent.
+    renderEditTable(null, makeSlackChannel());
+    expandPanel('Credentials');
+
+    expect(screen.getByText('Stored')).toBeInTheDocument();
+    expect(screen.getByText('Not set')).toBeInTheDocument();
+    expect(
+      screen.getByText('A token is stored. Leave blank to keep it; enter a value to overwrite it.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('No token stored yet. Enter the app token (xapp-...).')
+    ).toBeInTheDocument();
   });
 });
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -346,11 +346,20 @@ describe('GatewayChannelsTable Slack edit mode', () => {
   });
 
   it('copies the recommended manifest derived from the channel options', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText },
-      configurable: true,
-    });
+    // Intercept the clipboard write robustly. Some jsdom builds ship a real
+    // `navigator.clipboard` whose method a `defineProperty({ value })` swap does
+    // not replace — the component then calls the real `writeText` and a fresh
+    // mock records 0 calls. Spy on whatever clipboard object exists (creating a
+    // minimal one only when the environment provides none) so OUR spy is always
+    // the function invoked. A secure context keeps the modern Clipboard path on.
+    Object.defineProperty(globalThis, 'isSecureContext', { value: true, configurable: true });
+    if (!navigator.clipboard?.writeText) {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: () => Promise.resolve() },
+        configurable: true,
+      });
+    }
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
 
     // enable_channels: true ⇒ public-channel scopes + the app_mention event.
     renderEditTable(null, makeSlackChannel());

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -21,6 +21,7 @@ import type {
   User,
   UUID,
 } from '@agor-live/client';
+import { GATEWAY_REDACTED_SENTINEL } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -517,6 +518,91 @@ const SlackTestResultView: React.FC<{ result: SlackTestResult }> = ({ result }) 
 };
 
 /**
+ * Recommended Slack app manifest for an existing channel. Derived from the
+ * channel's current capability toggles via {@link buildSlackManifest}, so it
+ * always shows the manifest the app *should* have — not a readout of the app's
+ * live Slack configuration. Paste it back into Slack to align scopes/events.
+ */
+const SlackManifestPanel: React.FC<{ options: SlackWizardOptions }> = ({ options }) => {
+  const { token } = theme.useToken();
+  const { showError } = useThemedMessage();
+  const [copied, setCopied] = useState(false);
+
+  const manifestJson = useMemo(
+    () => JSON.stringify(buildSlackManifest(options), null, 2),
+    [options]
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: manifestJson is the change trigger, not a value read in the body.
+  useEffect(() => {
+    setCopied(false);
+  }, [manifestJson]);
+
+  const handleCopy = async () => {
+    const ok = await copyTextToClipboard(manifestJson);
+    if (ok) {
+      setCopied(true);
+    } else {
+      showError('Copy failed — select the manifest text and copy it manually.');
+    }
+  };
+
+  return (
+    <>
+      <Typography.Text
+        type="secondary"
+        style={{ fontSize: 12, display: 'block', marginBottom: 12 }}
+      >
+        The recommended manifest for this channel&apos;s current options — the desired Slack app
+        configuration, not a readout of your app&apos;s live settings. Paste it into{' '}
+        <strong>App Manifest</strong> in your Slack app to align its scopes and events.
+      </Typography.Text>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+        <Button
+          size="small"
+          icon={copied ? <CheckCircleOutlined /> : <CopyOutlined />}
+          onClick={handleCopy}
+        >
+          {copied ? 'Copied' : 'Copy app manifest'}
+        </Button>
+      </div>
+      <pre
+        style={{
+          background: token.colorBgContainer,
+          border: `1px solid ${token.colorBorder}`,
+          borderRadius: token.borderRadius,
+          padding: 12,
+          margin: 0,
+          maxHeight: 280,
+          overflow: 'auto',
+          fontSize: 11,
+          lineHeight: 1.5,
+          fontFamily: 'monospace',
+        }}
+      >
+        {manifestJson}
+      </pre>
+    </>
+  );
+};
+
+/** Whether a sensitive config field is already stored (API redacts it to the sentinel). */
+function isSecretStored(config: Record<string, unknown> | undefined, field: string): boolean {
+  const value = config?.[field];
+  return value === GATEWAY_REDACTED_SENTINEL || (typeof value === 'string' && value.length > 0);
+}
+
+/** Inline "Stored" / "Not set" badge for an edit-form secret field. */
+const SecretStatusTag: React.FC<{ stored: boolean }> = ({ stored }) =>
+  stored ? (
+    <Tag color="green" icon={<CheckCircleOutlined />} style={{ marginInlineStart: 8 }}>
+      Stored
+    </Tag>
+  ) : (
+    <Tag style={{ marginInlineStart: 8 }}>Not set</Tag>
+  );
+
+/**
  * Guided Slack setup wizard shown on create. Step state is lifted to the parent
  * and navigation lives in the unified modal footer. Selections drive a live
  * manifest preview + derived scope/event list via {@link buildSlackManifest} /
@@ -989,14 +1075,49 @@ const ChannelFormFields: React.FC<{
 }) => {
   const { showError } = useThemedMessage();
 
-  // Watch message source settings for showing warnings/scope requirements
-  const enableChannels = Form.useWatch('enable_channels', form) ?? false;
-  const enableGroups = Form.useWatch('enable_groups', form) ?? false;
-  const enableMpim = Form.useWatch('enable_mpim', form) ?? false;
-  const alignSlackUsers = Form.useWatch('align_slack_users', form) ?? false;
+  // Watch message source settings for showing warnings/scope requirements. A
+  // watched value is `undefined` while its (lazily-rendered) Collapse panel is
+  // still collapsed, so on edit fall back to the channel's stored config —
+  // otherwise the manifest/scope sections would render as if every surface were
+  // off until the user first expands Message Sources.
+  const slackConfig = editingChannel?.config as Record<string, unknown> | undefined;
+  const enableChannels = Boolean(
+    Form.useWatch('enable_channels', form) ?? slackConfig?.enable_channels
+  );
+  const enableGroups = Boolean(Form.useWatch('enable_groups', form) ?? slackConfig?.enable_groups);
+  const enableMpim = Boolean(Form.useWatch('enable_mpim', form) ?? slackConfig?.enable_mpim);
+  const alignSlackUsers = Boolean(
+    Form.useWatch('align_slack_users', form) ?? slackConfig?.align_slack_users
+  );
+  const outboundEnabled = Boolean(
+    Form.useWatch('outbound_enabled', form) ?? slackConfig?.outbound_enabled
+  );
   const alignGithubUsers = Form.useWatch('github_align_users', form) ?? false;
+  // Track the live Name field so the manifest preview reflects in-progress edits,
+  // falling back to the stored channel name.
+  const channelName = (Form.useWatch('name', form) as string | undefined) ?? editingChannel?.name;
 
   const sourcesEnabled = enableChannels || enableGroups || enableMpim;
+
+  // Derive the recommended manifest + required scopes/events from the channel's
+  // live toggles so the edit form is a single source of truth that can never
+  // drift from the core generator.
+  const slackOptions: SlackWizardOptions = useMemo(
+    () => ({
+      appName: channelName || 'Agor',
+      publicChannels: enableChannels,
+      privateChannels: enableGroups,
+      groupDms: enableMpim,
+      alignUsers: alignSlackUsers,
+      outbound: outboundEnabled,
+    }),
+    [channelName, enableChannels, enableGroups, enableMpim, alignSlackUsers, outboundEnabled]
+  );
+  const slackScopes = useMemo(() => requiredBotScopes(slackOptions), [slackOptions]);
+  const slackEvents = useMemo(() => requiredBotEvents(slackOptions), [slackOptions]);
+
+  const botTokenStored = isSecretStored(slackConfig, 'bot_token');
+  const appTokenStored = isSecretStored(slackConfig, 'app_token');
 
   return (
     <>
@@ -1769,25 +1890,43 @@ const ChannelFormFields: React.FC<{
                   <SectionLabel
                     icon={<KeyOutlined />}
                     title="Credentials"
-                    subtitle={mode === 'edit' ? 'leave blank to keep current' : undefined}
+                    subtitle="blank keeps stored values"
                   />
                 ),
                 children: (
                   <>
                     <Form.Item
-                      label="Bot Token"
+                      label={
+                        <span>
+                          Bot Token <SecretStatusTag stored={botTokenStored} />
+                        </span>
+                      }
                       name="bot_token"
                       tooltip="Slack Bot User OAuth Token (xoxb-...)"
+                      extra={
+                        botTokenStored
+                          ? 'A token is stored. Leave blank to keep it; enter a value to overwrite it.'
+                          : 'No token stored yet. Enter the bot token (xoxb-...).'
+                      }
                     >
-                      <Input.Password placeholder="••••••••" />
+                      <Input.Password placeholder={botTokenStored ? '••••••••' : 'xoxb-...'} />
                     </Form.Item>
 
                     <Form.Item
-                      label="App Token"
+                      label={
+                        <span>
+                          App Token <SecretStatusTag stored={appTokenStored} />
+                        </span>
+                      }
                       name="app_token"
                       tooltip="Slack App-Level Token for Socket Mode (xapp-...)"
+                      extra={
+                        appTokenStored
+                          ? 'A token is stored. Leave blank to keep it; enter a value to overwrite it.'
+                          : 'No token stored yet. Enter the app token (xapp-...).'
+                      }
                     >
-                      <Input.Password placeholder="••••••••" />
+                      <Input.Password placeholder={appTokenStored ? '••••••••' : 'xapp-...'} />
                     </Form.Item>
 
                     <Alert
@@ -1795,10 +1934,37 @@ const ChannelFormFields: React.FC<{
                       showIcon
                       title="Socket Mode Required"
                       description="Enable Socket Mode in your Slack app settings and generate an app-level token with connections:write scope."
-                      style={{ fontSize: 12 }}
+                      style={{ fontSize: 12, marginBottom: 12 }}
                     />
+
+                    <Button
+                      icon={<ThunderboltOutlined />}
+                      loading={slackTestLoading}
+                      onClick={onSlackTest}
+                      style={{ marginBottom: 12 }}
+                    >
+                      Test connection
+                    </Button>
+                    <Typography.Text type="secondary" style={{ fontSize: 12, marginLeft: 8 }}>
+                      Tests the stored credentials against your Slack workspace.
+                    </Typography.Text>
+
+                    {slackTestResult && <SlackTestResultView result={slackTestResult} />}
                   </>
                 ),
+              },
+
+              // ── App Manifest ──
+              {
+                key: 'manifest',
+                label: (
+                  <SectionLabel
+                    icon={<SlackOutlined />}
+                    title="App Manifest"
+                    subtitle="recommended scopes & events"
+                  />
+                ),
+                children: <SlackManifestPanel options={slackOptions} />,
               },
 
               // ── Message Sources ──
@@ -1860,41 +2026,52 @@ const ChannelFormFields: React.FC<{
                       />
                     )}
 
-                    {sourcesEnabled && (
-                      <Alert
-                        type="info"
-                        showIcon
-                        title="Required Slack Scopes & Events"
-                        description={
-                          <ul style={{ margin: '8px 0 0 0', paddingLeft: 20, fontSize: 12 }}>
-                            <li>
-                              <code>chat:write</code> (always required)
-                            </li>
-                            {enableChannels && (
-                              <>
-                                <li>
-                                  <code>channels:history</code> + <code>app_mentions:read</code>
-                                </li>
-                                <li>
-                                  Events: <code>message.channels</code>, <code>app_mention</code>
-                                </li>
-                              </>
-                            )}
-                            {enableGroups && (
-                              <li>
-                                <code>groups:history</code> + event: <code>message.groups</code>
-                              </li>
-                            )}
-                            {enableMpim && (
-                              <li>
-                                <code>mpim:history</code> + event: <code>message.mpim</code>
-                              </li>
-                            )}
-                          </ul>
-                        }
-                        style={{ fontSize: 12 }}
-                      />
-                    )}
+                    <Alert
+                      type="info"
+                      showIcon
+                      title="Required Slack Scopes & Events"
+                      description={
+                        <div style={{ fontSize: 12 }}>
+                          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                            Derived from the selected surfaces — channel-like surfaces trigger on{' '}
+                            <code>app_mention</code>, not <code>message.*</code> channel events.
+                            Copy the full manifest from the App Manifest section.
+                          </Typography.Text>
+                          <div style={{ marginTop: 8 }}>
+                            <Typography.Text strong style={{ fontSize: 12 }}>
+                              Bot scopes ({slackScopes.length})
+                            </Typography.Text>
+                            <div style={{ marginTop: 6 }}>
+                              {slackScopes.map((s) => (
+                                <Tag
+                                  key={s}
+                                  style={{ marginBottom: 4, fontFamily: 'monospace', fontSize: 11 }}
+                                >
+                                  {s}
+                                </Tag>
+                              ))}
+                            </div>
+                          </div>
+                          <div style={{ marginTop: 8 }}>
+                            <Typography.Text strong style={{ fontSize: 12 }}>
+                              Event subscriptions ({slackEvents.length})
+                            </Typography.Text>
+                            <div style={{ marginTop: 6 }}>
+                              {slackEvents.map((e) => (
+                                <Tag
+                                  key={e}
+                                  color="blue"
+                                  style={{ marginBottom: 4, fontFamily: 'monospace', fontSize: 11 }}
+                                >
+                                  {e}
+                                </Tag>
+                              ))}
+                            </div>
+                          </div>
+                        </div>
+                      }
+                      style={{ fontSize: 12 }}
+                    />
                   </>
                 ),
               },
@@ -2247,6 +2424,38 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     }
   }, [client, createForm, showError]);
 
+  // Probe an existing Slack channel via the `gateway-channels/test` service. The
+  // backend resolves the stored decrypted tokens from `gatewayChannelId`, so the
+  // edit form never sends credentials.
+  const handleSlackEditTest = useCallback(async () => {
+    if (!client) {
+      showError('Not connected to server');
+      return;
+    }
+    if (!editingChannel) return;
+    setSlackTestLoading(true);
+    setSlackTestResult(null);
+    try {
+      const result = (await client
+        .service('gateway-channels/test')
+        .create({ gatewayChannelId: editingChannel.id })) as SlackTestResult;
+      setSlackTestResult(result);
+    } catch (error) {
+      setSlackTestResult({
+        ok: false,
+        failures: [
+          {
+            capability: 'connection',
+            reason: error instanceof Error ? error.message : String(error),
+          },
+        ],
+        notVerifiable: [],
+      });
+    } finally {
+      setSlackTestLoading(false);
+    }
+  }, [client, editingChannel, showError]);
+
   // Pre-populate agentic config form with user defaults when agent changes
   useEffect(() => {
     const agentDefaults = currentUser?.default_agentic_config?.[selectedAgent as AgenticToolName];
@@ -2453,6 +2662,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     setChannelType(channel.channel_type);
     const agent = channel.agentic_config?.agent || 'claude-code';
     setSelectedAgent(agent);
+    resetSlackState();
     editForm.resetFields();
 
     const config = channel.config as Record<string, unknown>;
@@ -2803,6 +3013,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
           setEditingChannel(null);
           setChannelType('slack');
           setSelectedAgent('claude-code');
+          resetSlackState();
         }}
         okText="Save"
         width={600}
@@ -2822,9 +3033,9 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             createStep={0}
             githubLoading={false}
             githubError={null}
-            slackTestResult={null}
-            slackTestLoading={false}
-            onSlackTest={() => {}}
+            slackTestResult={slackTestResult}
+            slackTestLoading={slackTestLoading}
+            onSlackTest={handleSlackEditTest}
           />
         </Form>
       </Modal>


### PR DESCRIPTION
Polishes the existing Slack **edit** `Collapse` form in `GatewayChannelsTable`. CREATE is handled by the wizard (#1650); this PR only touches the edit path (no GitHub/Teams/create-wizard changes).

## What's in here (4 items)
1. **Copy app manifest** — derives `SlackWizardOptions` from the channel's current config (`enable_channels`→publicChannels, `enable_groups`→privateChannels, `enable_mpim`→groupDms, `align_slack_users`→alignUsers, `outbound_enabled`→outbound) and renders `buildSlackManifest` from `@agor/core/gateway/slack-manifest`. New **App Manifest** section shows + copies the JSON, labeled the recommended/desired manifest (not a readout of the app's live Slack settings).
2. **Test connection** — calls `client.service('gateway-channels/test').create({ gatewayChannelId })` for the existing channel; the backend resolves the stored decrypted tokens (no tokens are sent from the edit form). Renders the `SlackTestResult` honestly (team/bot/appTokenValid/failures/notVerifiable) via the shared `SlackTestResultView`.
3. **Scope/event clarity** — the stale inline Alert that hardcoded `message.channels`/`message.groups`/`message.mpim` now derives its scopes/events from `requiredBotScopes(options)` / `requiredBotEvents(options)`, so the displayed list can't drift from the core generator. Channel surfaces trigger on `app_mention`, not `message.*` channel events.
4. **Secret set/not-set clarity** (Max's #1639 ask) — `bot_token`/`app_token` fields show a **Stored**/**Not set** badge (the API returns the `••••••••` sentinel when set) and state that leaving the field blank KEEPS the stored value while entering a value OVERWRITES it. Existing `extractFormData` redaction handling is untouched.

## Reuse
`buildSlackManifest`/`requiredBotScopes`/`requiredBotEvents` from `@agor/core/gateway/slack-manifest`, the `gateway-channels/test` service, `SlackTestResultView`, and `GATEWAY_REDACTED_SENTINEL`.

## Tests
Extends `GatewayChannelsTable.test.tsx` with edit-mode coverage: copy-manifest derives the right manifest; test-connection calls the service with `{ gatewayChannelId }`; the scope list is derived (no stale `message.*`); token fields show stored vs not-set. Uses the established fast patterns (mocked heavy pickers, `queryButton`/`clickButton` helpers).

PR 4, stacked on #1650. Refs preset-io/agor-cloud#94.