### PR TITLE
fix(agor-ui): copy frozen store array before sorting in ZoneTriggerModal

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx
@@ -1,0 +1,63 @@
+import type { BranchID, Session } from '@agor-live/client';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ZoneTriggerModal } from './ZoneTriggerModal';
+
+// Isolate the modal's own smart-default selection logic from its heavy config
+// children — the regression lives entirely in ZoneTriggerModal's render-time
+// useMemo, which runs regardless of what these children render.
+vi.mock('../../AgentSelectionGrid', () => ({
+  AgentSelectionGrid: () => null,
+}));
+vi.mock('../../AgenticToolConfigForm', () => ({
+  AgenticToolConfigForm: () => null,
+}));
+
+const BRANCH_ID = 'branch-1' as BranchID;
+
+const makeSession = (id: string, status: string, lastUpdated: string, title: string): Session =>
+  ({
+    session_id: id,
+    branch_id: BRANCH_ID,
+    status,
+    title,
+    archived: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_updated: lastUpdated,
+  }) as unknown as Session;
+
+describe('ZoneTriggerModal smart-default session selection', () => {
+  it('resolves the most-recent session without mutating the frozen store bucket', () => {
+    const older = makeSession('s-old', 'completed', '2026-06-01T00:00:00.000Z', 'Older session');
+    const newer = makeSession('s-new', 'completed', '2026-06-20T00:00:00.000Z', 'Newer session');
+
+    // The store uses Immer, which deeply freezes every `sessionsByBranch`
+    // bucket. Sorting such an array in place throws, so the modal must sort a
+    // copy. Freeze here to reproduce the store's contract.
+    const frozenBucket = Object.freeze([older, newer]);
+    const sessionsByBranch = new Map<string, Session[]>([[BRANCH_ID, frozenBucket]]);
+
+    expect(() =>
+      render(
+        <ZoneTriggerModal
+          open
+          onCancel={() => {}}
+          client={null}
+          branchId={BRANCH_ID}
+          branch={undefined}
+          sessionsByBranch={sessionsByBranch}
+          zoneName="Zone"
+          trigger={{ template: 'do {{thing}}' } as never}
+          availableAgents={[]}
+          mcpServerById={new Map()}
+          onExecute={async () => {}}
+        />
+      )
+    ).not.toThrow();
+
+    // With no running sessions, the smart default is the most-recently-updated
+    // session — surfaced as the closed Select's selected value.
+    expect(document.body.textContent).toContain('Newer session');
+    expect(document.body.textContent).not.toContain('Older session');
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.tsx
@@ -126,7 +126,7 @@ export const ZoneTriggerModal = ({
     }
 
     // Otherwise most recent session
-    return branchSessions.sort(
+    return [...branchSessions].sort(
       (a, b) =>
         new Date(b.last_updated || b.created_at).getTime() -
         new Date(a.last_updated || a.created_at).getTime()


### PR DESCRIPTION
## The bug

Dragging a session/branch card into a **triggered** zone mounts `ZoneTriggerModal`, whose `smartDefaultSession` `useMemo` crashed the page with:

```
TypeError: Cannot assign to read only property '0' of object '[object Array]'
    at Array.sort
```

## Root cause

The store (`apps/agor-ui/src/store/agorStore.ts`) uses the zustand `immer` middleware with no `setAutoFreeze(false)`, so Immer **deeply freezes** all store state — including every `sessionsByBranch` bucket array. This regressed when the entity maps moved into the Immer store.

In `ZoneTriggerModal.tsx`, `branchSessions` is the frozen store array (no copy). The `// Otherwise most recent session` branch then did `branchSessions.sort(...)[0]` — an **in-place** sort that mutates the frozen array and throws.

**Trigger:** drag a card into a triggered zone for a branch that has sessions but **none** with `status === 'running'` (the common case).

The two nearby sorts were already safe: line ~121 sorts the result of `.filter()` (a fresh array), and the create-new effect at line ~160 already does `[...branchSessions].sort(...)` with an explicit "avoid mutating the array" comment. Only the smart-default branch was wrong.

## The fix

One line — sort a copy, matching the existing safe pattern:

```diff
-    return branchSessions.sort(
+    return [...branchSessions].sort(
```

## Regression test

`apps/agor-ui/src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx` renders the open modal via RTL with a `sessionsByBranch` bucket that is `Object.freeze([...])` (mirroring Immer's deep freeze) containing sessions with none running, and asserts the render does not throw and resolves the most-recently-updated session as the smart default. It **fails** before the fix (`TypeError: Cannot assign to read only property '0'`) and **passes** after.

## Verification

- `turbo run typecheck --filter=agor-ui` ✅
- `biome check` on changed files ✅
- `vitest run src/components/SessionCanvas` → 17 passed ✅

Reproduced on sandbox build `6fa1d93b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)