### PR TITLE
feat: add xhigh reasoning effort level

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Terms you'll see across the codebase, UI, and docs:
 | **Unix user mode** | `simple` / `insulated` / `strict` — progressive OS-level isolation tiers. See "Feature Flags" below.                                                                                            |
 | **Genealogy**      | Parent/child + fork ancestry of a session. Surfaced as a tree inside a branch card.                                                                                                             |
 | **Short ID**       | First 8 chars of a UUIDv7, used in UI and CLI. Resolved at API boundary via a `resolveShortId` hook. See [`context/concepts/id-management.md`](context/concepts/id-management.md).              |
-| **Effort**         | Reasoning depth knob (`low`/`medium`/`high`/`max`) on `model_config`. Maps to Claude API `output_config.effort`.                                                                                |
+| **Effort**         | Reasoning depth knob (`low`/`medium`/`high`/`xhigh`/`max`) on `model_config`. Maps to Claude API `output_config.effort`.                                                                       |
 
 ## Where to look first
 
@@ -412,16 +412,19 @@ security toggles stored alongside permissions:
 
 ## Effort Level (Reasoning Depth)
 
-Agor exposes Claude's `effort` parameter to control how much reasoning Claude applies to responses. This maps directly to the Claude API's `output_config.effort` and the Claude Code CLI's `--effort` flag.
+Agor exposes the `effort` parameter to control how much reasoning the agent applies to responses. This maps directly to the Claude API's `output_config.effort` and the Claude Code CLI's `--effort` flag.
 
 ### Levels
 
-| Level    | Description                    | Use case                         |
-| -------- | ------------------------------ | -------------------------------- |
-| `low`    | Minimal thinking, fastest      | Simple tasks, quick lookups      |
-| `medium` | Moderate thinking              | Balanced speed/quality           |
-| `high`   | Deep reasoning (default)       | Complex coding, reviews          |
-| `max`    | Maximum effort (Opus 4.6 only) | Critical decisions, architecture |
+| Level    | Description                      | Use case                         |
+| -------- | -------------------------------- | -------------------------------- |
+| `low`    | Minimal thinking, fastest        | Simple tasks, quick lookups      |
+| `medium` | Moderate thinking                | Balanced speed/quality           |
+| `high`   | Deep reasoning (default)         | Complex coding, reviews          |
+| `xhigh`  | Extra reasoning depth            | Demanding tasks before max       |
+| `max`    | Highest effort (model-dependent) | Critical decisions, architecture |
+
+On Codex, both `xhigh` and `max` map to Codex's `xhigh` (its ceiling). Codex `minimal` is not exposed by Agor.
 
 ### Extended Context (1M tokens)
 

--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -34,7 +34,7 @@ const agenticToolConfigSchema = z
       .object({
         mode: z.enum(['alias', 'exact']).optional(),
         model: mcpOptionalString('model_config.model', 'Model name override.'),
-        effort: z.enum(['low', 'medium', 'high', 'max']).optional(),
+        effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
         advisorModel: mcpOptionalString(
           'model_config.advisorModel',
           "Claude Code advisor model override (e.g. 'opus', 'sonnet', 'fable')."

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -399,6 +399,46 @@ describe('agor_sessions_create', () => {
     expect(parsed.session).not.toHaveProperty('mcp_token');
   });
 
+  it('accepts effort: xhigh and threads it through to session.model_config', async () => {
+    const sessionCreates: unknown[] = [];
+    const app = makeFakeApp({
+      users: { get: async () => baseUser },
+      branches: { get: async () => baseBranch },
+      sessions: {
+        create: async (data: unknown) => {
+          sessionCreates.push(data);
+          return {
+            session_id: 'sess-xhigh',
+            mcp_token: 'secret-token',
+            ...(data as Record<string, unknown>),
+          };
+        },
+        get: async (id: string) => ({
+          session_id: id,
+          branch_id: 'wt-1',
+          genealogy: { children: [] },
+        }),
+        patch: async () => ({}),
+      },
+      '/sessions/:id/mcp-servers': { create: async () => ({}) },
+    });
+
+    const { agor_sessions_create } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-caller' },
+      ['agor_sessions_create']
+    );
+
+    await agor_sessions_create({
+      branchId: 'wt-1',
+      agenticTool: 'claude-code',
+      modelConfig: { model: 'claude-sonnet-4-6', mode: 'alias', effort: 'xhigh' },
+    });
+
+    expect(sessionCreates).toHaveLength(1);
+    const created = sessionCreates[0] as Record<string, any>;
+    expect(created.model_config.effort).toBe('xhigh');
+  });
+
   it("attributes sessions created from another user's session context to the acting MCP user and uses their defaults", async () => {
     const sessionCreates: unknown[] = [];
     const baseServiceParams = {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -90,7 +90,7 @@ const modelConfigObjectSchema = z.object({
     "Model identifier (e.g. 'claude-opus-4-6', 'claude-sonnet-4-6')"
   ),
   effort: z
-    .enum(['low', 'medium', 'high', 'max'])
+    .enum(['low', 'medium', 'high', 'xhigh', 'max'])
     .optional()
     .describe('Reasoning effort level (default: high)'),
   advisorModel: mcpOptionalString(

--- a/apps/agor-docs/pages/guide/sessions.mdx
+++ b/apps/agor-docs/pages/guide/sessions.mdx
@@ -203,7 +203,7 @@ Each level delegates to specialized agents. Each session has a focused context w
 A session has more knobs than a CLI invocation:
 
 - **Model** — Switch model mid-session from the panel footer
-- **Effort** (Claude) — `low` / `medium` / `high` / `max` reasoning depth
+- **Effort** — `low` / `medium` / `high` / `xhigh` / `max` reasoning depth
 - **Permissions** — How tool calls are gated (auto-approve, supervised, manual)
 - **MCP servers** — Which tool sets are attached
 - **Effort and 1M context** — Models with `[1m]` enable extended context

--- a/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
+++ b/apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx
@@ -1,14 +1,15 @@
 /**
- * EffortSelector - Compact selector for Claude's effort level
+ * EffortSelector - Compact selector for reasoning effort level
  *
- * Effort controls how much reasoning Claude applies to responses.
+ * Effort controls how much reasoning the agent applies to responses.
  * Maps to the SDK's effort parameter (output_config.effort in the API).
  *
  * Levels:
  * - Low: Minimal thinking, fastest responses
  * - Medium: Moderate thinking
  * - High: Deep reasoning (default)
- * - Max: Maximum effort (Opus only)
+ * - X-High: Extra reasoning depth, below maximum
+ * - Max: Highest effort level (model-dependent)
  */
 
 import type { EffortLevel } from '@agor-live/client';
@@ -39,7 +40,18 @@ const EFFORT_OPTIONS: {
   },
   { value: 'medium', shortLabel: 'Md', label: 'Medium', description: 'Moderate thinking' },
   { value: 'high', shortLabel: 'Hi', label: 'High', description: 'Deep reasoning (default)' },
-  { value: 'max', shortLabel: 'Mx', label: 'Max', description: 'Maximum effort (Opus only)' },
+  {
+    value: 'xhigh',
+    shortLabel: 'Xh',
+    label: 'X-High',
+    description: 'Extra reasoning depth, below maximum',
+  },
+  {
+    value: 'max',
+    shortLabel: 'Mx',
+    label: 'Max',
+    description: 'Highest effort level (model-dependent)',
+  },
 ];
 
 /**

--- a/context/concepts/mcp-session-tools.md
+++ b/context/concepts/mcp-session-tools.md
@@ -17,7 +17,7 @@ All enforce the branch-centric model (every session references a branch). Permis
 
 `agor_sessions_create`, `agor_sessions_spawn`, and `agor_sessions_prompt` with `mode: "subsession"` all accept:
 
-- **`modelConfig`** — `{ model: string, mode?: 'alias' | 'exact', effort?: 'low' | 'medium' | 'high' | 'max', provider?: string }`. `model` is required when the object is provided. Threaded into `session.model_config` and consumed by `packages/executor/src/sdk-handlers/claude/query-builder.ts`.
+- **`modelConfig`** — `{ model: string, mode?: 'alias' | 'exact', effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max', provider?: string }`. `model` is required when the object is provided. Threaded into `session.model_config` and consumed by `packages/executor/src/sdk-handlers/claude/query-builder.ts`.
 - **`mcpServerIds`** — pins which MCP servers attach. `[]` = no MCPs. Omit to inherit (branch → parent → user default). Failed attachments surface as `mcpAttachFailures: [{ mcp_server_id, reason }]` in the response (not silently logged).
 
 ## Security note for spawn/fork

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -40,6 +40,11 @@ describe('resolveModelConfig', () => {
     expect(withoutEffort).not.toHaveProperty('effort');
   });
 
+  it('round-trips xhigh effort through resolveModelConfig', () => {
+    const result = resolveModelConfig({ model: 'x', effort: 'xhigh' }, { now });
+    expect(result).toHaveProperty('effort', 'xhigh');
+  });
+
   it('includes advisorModel only when defined (omits the key otherwise)', () => {
     const withAdvisor = resolveModelConfig({ model: 'x', advisorModel: 'opus' }, { now });
     expect(withAdvisor).toHaveProperty('advisorModel', 'opus');

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -4,7 +4,7 @@
  * Effort level controls how much reasoning Claude applies.
  * Maps to Claude API's output_config.effort and the Claude Code CLI's --effort flag.
  */
-export type EffortLevel = 'low' | 'medium' | 'high' | 'max';
+export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 import type {
   AgenticToolName,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -54,18 +54,17 @@ import { forkCodexThreadViaAppServer } from './app-server-client.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
 
 /**
- * Map Agor's effort level (`low`/`medium`/`high`/`max`) to Codex SDK's
+ * Map Agor's effort level (`low`/`medium`/`high`/`xhigh`/`max`) to Codex SDK's
  * `ModelReasoningEffort` (`minimal`/`low`/`medium`/`high`/`xhigh`).
  *
- * Agor has no equivalent for `minimal`, and Codex has no equivalent for `max`
- * — `max` is the user's "go as deep as possible" intent, which on Codex maps
- * to `xhigh`.
+ * Agor has no equivalent for `minimal`. Codex has no `max` — both Agor `max`
+ * and Agor `xhigh` map to Codex `xhigh` (the Codex ceiling).
  */
 function toCodexReasoningEffort(
   effort: EffortLevel | undefined
 ): 'low' | 'medium' | 'high' | 'xhigh' | undefined {
   if (!effort) return undefined;
-  return effort === 'max' ? 'xhigh' : effort;
+  return effort === 'max' || effort === 'xhigh' ? 'xhigh' : effort;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Widens Agor's `EffortLevel` union to include `'xhigh'` between `'high'` and `'max'`, matching the installed Claude Agent SDK 0.3.154 (`low|medium|high|xhigh|max`) and Codex SDK 0.135.0 (`minimal|low|medium|high|xhigh`)
- No DB migration: `effort` is stored in the `model_config` JSON blob, not a DB enum/CHECK column
- `packages/core/src/claude-cli/spawn-config.ts` and the Claude Agent SDK already accept `xhigh`; only Agor's own canonical union and hand-written Zod enums needed updating

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/types/session.ts` | Widen `EffortLevel` (source of truth) |
| `apps/agor-daemon/src/mcp/tools/sessions.ts` | Add `'xhigh'` to Zod enum |
| `apps/agor-daemon/src/mcp/tools/schedules.ts` | Add `'xhigh'` to Zod enum |
| `apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx` | Add X-High option (shortLabel `Xh`, label `X-High`); fix misleading `max` description from `'Maximum effort (Opus only)'` to `'Highest effort level (model-dependent)'` |
| `packages/executor/src/sdk-handlers/codex/prompt-service.ts` | Explicit `xhigh → xhigh` branch in `toCodexReasoningEffort`; update doc comment: both Agor `max` and `xhigh` map to Codex `xhigh` (its ceiling) |
| `AGENTS.md` | Add `xhigh` to effort table; add Codex mapping note |
| `apps/agor-docs/pages/guide/sessions.mdx` | Add `xhigh` to effort list; drop misleading `(Claude)` qualifier |
| `context/concepts/mcp-session-tools.md` | Update `modelConfig.effort` type signature |
| `packages/core/src/models/resolve-config.test.ts` | `xhigh` round-trips through `resolveModelConfig` |
| `apps/agor-daemon/src/mcp/tools/sessions.test.ts` | `effort: 'xhigh'` threads through to `session.model_config` |

## How Agor effort maps to Codex

| Agor | Codex SDK |
|------|-----------|
| `low` | `low` |
| `medium` | `medium` |
| `high` | `high` |
| `xhigh` | `xhigh` |
| `max` | `xhigh` (Codex ceiling; no native `max`) |

Codex `minimal` is NOT exposed by Agor (would require per-tool clamping to avoid reaching Claude).

## Test plan

- [x] `pnpm --filter @agor/daemon test -- src/mcp/tools/sessions.test.ts` → 34 passed (33 pre-existing + 1 new xhigh test)
- [x] `pnpm --filter @agor/core test -- src/models/resolve-config.test.ts` → 26 passed (25 pre-existing + 1 new xhigh round-trip)
- [x] `biome check` on all 10 changed files → no issues
- [ ] UI: `EffortSelector` dropdown now shows Low / Medium / High / X-High / Max

## Explicit follow-ups (out of scope for this PR)

- `ultracode` (Claude SDK Settings boolean) — different axis, needs separate plumbing
- Codex-only `minimal` — needs per-tool clamping so it never reaches Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)