### PR TITLE
feat: polish env var request widget

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -232,6 +232,90 @@ describe('agor_widgets_request_env_vars', () => {
     expect(patchBody.message_range.end_index).toBe(0); // index of the appended widget
   });
 
+  it('normalizes requested names before storing widget metadata and preview text', async () => {
+    const { app } = makeApp({ sessionCreator: 'user-creator' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    await handler({
+      names: ['STRIPE_SECRET_KEY', 'HUBSPOT_API_KEY'],
+      reason: 'two integrations',
+      auto_resume: true,
+    });
+
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.metadata.widget.params.names).toEqual([
+      'HUBSPOT_API_KEY',
+      'STRIPE_SECRET_KEY',
+    ]);
+    expect(appendArgs.content).toContain('HUBSPOT_API_KEY, STRIPE_SECRET_KEY');
+    expect(appendArgs.contentPreview).toBe('Widget: env_vars (HUBSPOT_API_KEY, STRIPE_SECRET_KEY)');
+  });
+
+  it('stores server-derived availability for partial existing values without values', async () => {
+    const { app } = makeApp({
+      sessionCreator: 'user-creator',
+      creatorEnvVars: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
+    });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    await handler({
+      names: ['STRIPE_SECRET_KEY', 'HUBSPOT_API_KEY'],
+      reason: 'two integrations',
+      auto_resume: true,
+    });
+
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.metadata.widget.status).toBe('pending');
+    expect(appendArgs.metadata.widget.params.existing).toEqual({
+      HUBSPOT_API_KEY: { set: true, scope: 'global', resource_id: null },
+    });
+    expect(JSON.stringify(appendArgs.metadata.widget.params)).not.toContain('secret');
+  });
+
+  it('stores safe per-variable display metadata in widget params', async () => {
+    const { app } = makeApp({ sessionCreator: 'user-creator' });
+    const captured = registerAndCapture({
+      app,
+      userId: 'user-creator',
+      sessionId: 'sess-1',
+    });
+
+    const handler = captured.agor_widgets_request_env_vars.cb;
+    await handler({
+      names: ['API_TOKEN'],
+      reason: 'call api',
+      variable_metadata: {
+        API_TOKEN: {
+          description: 'From the API dashboard.',
+          placeholder: 'Paste token',
+          format_hint: 'Starts with tok_',
+          input_type: 'text',
+        },
+      },
+      auto_resume: true,
+    });
+
+    const appendArgs = appendStub.mock.calls[0][0];
+    expect(appendArgs.metadata.widget.params.variable_metadata).toEqual({
+      API_TOKEN: {
+        description: 'From the API dashboard.',
+        placeholder: 'Paste token',
+        format_hint: 'Starts with tok_',
+        input_type: 'text',
+      },
+    });
+  });
+
   it('gracefully omits taskId when no task exists yet (e.g. brand-new session)', async () => {
     const { app, calls } = makeApp({
       sessionCreator: 'user-creator',

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -256,7 +256,7 @@ describe('agor_widgets_request_env_vars', () => {
     expect(appendArgs.contentPreview).toBe('Widget: env_vars (HUBSPOT_API_KEY, STRIPE_SECRET_KEY)');
   });
 
-  it('stores server-derived availability for partial existing values without values', async () => {
+  it('does not persist server-derived availability in widget params', async () => {
     const { app } = makeApp({
       sessionCreator: 'user-creator',
       creatorEnvVars: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
@@ -276,9 +276,7 @@ describe('agor_widgets_request_env_vars', () => {
 
     const appendArgs = appendStub.mock.calls[0][0];
     expect(appendArgs.metadata.widget.status).toBe('pending');
-    expect(appendArgs.metadata.widget.params.existing).toEqual({
-      HUBSPOT_API_KEY: { set: true, scope: 'global', resource_id: null },
-    });
+    expect(appendArgs.metadata.widget.params.existing).toBeUndefined();
     expect(JSON.stringify(appendArgs.metadata.widget.params)).not.toContain('secret');
   });
 

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -29,7 +29,12 @@ import { MessageRole } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { appendSystemMessage } from '../../utils/append-system-message.js';
 import { findHostTaskForSession } from '../../utils/session-tasks.js';
-import { type EnvVarsParams, envVarsParamsSchema } from '../../widgets/env-vars/index.js';
+import {
+  type EnvVarExistingStatus,
+  type EnvVarsParams,
+  envVarsParamsSchema,
+  normalizeEnvVarsParams,
+} from '../../widgets/env-vars/index.js';
 import type { McpContext } from '../server.js';
 import { sessionContextRequiredResult, textResult } from '../server.js';
 
@@ -63,6 +68,25 @@ function allNamesPresentInScope(
   return true;
 }
 
+function existingStatusForNames(
+  envVarsMeta: Record<string, EnvVarMetadata> | undefined,
+  names: string[]
+): Record<string, EnvVarExistingStatus> | undefined {
+  if (!envVarsMeta) return undefined;
+  const out: Record<string, EnvVarExistingStatus> = {};
+  for (const name of names) {
+    const meta = envVarsMeta[name];
+    if (meta?.set) {
+      out[name] = {
+        set: true,
+        scope: meta.scope,
+        resource_id: meta.resource_id ?? null,
+      };
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
   server.registerTool(
     'agor_widgets_request_env_vars',
@@ -78,8 +102,10 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       if (!ctx.sessionId) return sessionContextRequiredResult();
       const currentSessionId = ctx.sessionId;
-      // Validated by Zod via the SDK; `args` has Zod defaults applied.
-      const params: EnvVarsParams = args as EnvVarsParams;
+      // Validated by Zod via the SDK; parse here too so defaults are applied
+      // in direct callers and tests. Keep ordering normalization outside the
+      // schema because Zod transforms degrade MCP JSON Schema discovery.
+      const toolParams = normalizeEnvVarsParams(envVarsParamsSchema.parse(args));
 
       // Look up the host session + its creator. The session creator is the
       // identity whose env vars get written and read by the executor — this
@@ -91,6 +117,11 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
       const creator = (await ctx.app
         .service('users')
         .get(sessionCreatorId, ctx.baseServiceParams)) as User;
+
+      const params: EnvVarsParams = normalizeEnvVarsParams({
+        ...toolParams,
+        existing: existingStatusForNames(creator.env_vars, toolParams.names),
+      });
 
       // `already_present` short-circuit: if every requested name is already
       // set globally for this user, skip the form entirely and auto-resume

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -30,7 +30,6 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { appendSystemMessage } from '../../utils/append-system-message.js';
 import { findHostTaskForSession } from '../../utils/session-tasks.js';
 import {
-  type EnvVarExistingStatus,
   type EnvVarsParams,
   envVarsParamsSchema,
   normalizeEnvVarsParams,
@@ -68,25 +67,6 @@ function allNamesPresentInScope(
   return true;
 }
 
-function existingStatusForNames(
-  envVarsMeta: Record<string, EnvVarMetadata> | undefined,
-  names: string[]
-): Record<string, EnvVarExistingStatus> | undefined {
-  if (!envVarsMeta) return undefined;
-  const out: Record<string, EnvVarExistingStatus> = {};
-  for (const name of names) {
-    const meta = envVarsMeta[name];
-    if (meta?.set) {
-      out[name] = {
-        set: true,
-        scope: meta.scope,
-        resource_id: meta.resource_id ?? null,
-      };
-    }
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
-}
-
 export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
   server.registerTool(
     'agor_widgets_request_env_vars',
@@ -118,10 +98,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
         .service('users')
         .get(sessionCreatorId, ctx.baseServiceParams)) as User;
 
-      const params: EnvVarsParams = normalizeEnvVarsParams({
-        ...toolParams,
-        existing: existingStatusForNames(creator.env_vars, toolParams.names),
-      });
+      const params: EnvVarsParams = toolParams;
 
       // `already_present` short-circuit: if every requested name is already
       // set globally for this user, skip the form entirely and auto-resume

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -19,15 +19,33 @@
 import type { UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { _resetWidgetRegistryForTests, getWidget } from '../registry';
+
+const sessionSelectionRepoMock = vi.hoisted(() => ({
+  asSet: vi.fn(async () => new Set<string>()),
+  setAll: vi.fn(async (_sessionId: unknown, _names: string[]) => {}),
+}));
+
+vi.mock('@agor/core/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/db')>();
+  return {
+    ...actual,
+    SessionEnvSelectionRepository: vi.fn(function SessionEnvSelectionRepository() {
+      return sessionSelectionRepoMock;
+    }),
+  };
+});
+
 import {
   envVarsParamsSchema,
   envVarsSubmitSchema,
   envVarsWidget,
+  normalizeEnvVarsParams,
   registerEnvVarsWidget,
 } from './index';
 
 function makeCtx(
-  patch?: (id: string, data: unknown, params: unknown) => unknown | Promise<unknown>
+  patch?: (id: string, data: unknown, params: unknown) => unknown | Promise<unknown>,
+  user: { env_vars?: Record<string, { set: true; scope: 'global' | 'session' }> } = {}
 ) {
   const patchSpy = vi.fn(async (id: string, data: unknown, params: unknown) => {
     return patch ? patch(id, data, params) : { user_id: id };
@@ -35,8 +53,12 @@ function makeCtx(
   const app = {
     service(name: string) {
       if (name !== 'users') throw new Error(`Unexpected service call: ${name}`);
-      return { patch: patchSpy };
+      return {
+        get: vi.fn(async () => ({ user_id: 'user-creator', env_vars: user.env_vars ?? {} })),
+        patch: patchSpy,
+      };
     },
+    get: vi.fn(() => undefined),
   };
   return {
     ctx: {
@@ -49,6 +71,13 @@ function makeCtx(
     patchSpy,
   };
 }
+
+beforeEach(() => {
+  sessionSelectionRepoMock.asSet.mockReset();
+  sessionSelectionRepoMock.asSet.mockResolvedValue(new Set<string>());
+  sessionSelectionRepoMock.setAll.mockReset();
+  sessionSelectionRepoMock.setAll.mockResolvedValue(undefined);
+});
 
 describe('env_vars widget — registry registration', () => {
   beforeEach(() => {
@@ -82,6 +111,21 @@ describe('env_vars widget — paramsSchema', () => {
     }
   });
 
+  it('keeps params schema JSON-Schema-safe and normalizes requested names via helper', () => {
+    const result = envVarsParamsSchema.safeParse({
+      names: ['STRIPE_SECRET_KEY', 'HUBSPOT_API_KEY'],
+      reason: 'two integrations',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.names).toEqual(['STRIPE_SECRET_KEY', 'HUBSPOT_API_KEY']);
+      expect(normalizeEnvVarsParams(result.data).names).toEqual([
+        'HUBSPOT_API_KEY',
+        'STRIPE_SECRET_KEY',
+      ]);
+    }
+  });
+
   it('rejects lower-case env var names', () => {
     expect(
       envVarsParamsSchema.safeParse({
@@ -109,6 +153,38 @@ describe('env_vars widget — paramsSchema', () => {
       envVarsParamsSchema.safeParse({ names: ['A_KEY', 'A_KEY'], reason: 'why' }).success
     ).toBe(false);
   });
+
+  it('accepts per-variable metadata only for requested names and safe fields', () => {
+    const result = envVarsParamsSchema.safeParse({
+      names: ['API_TOKEN'],
+      reason: 'call api',
+      variable_metadata: {
+        API_TOKEN: {
+          description: 'Token from the API dashboard.',
+          placeholder: 'Paste token',
+          format_hint: 'Starts with tok_',
+          input_type: 'text',
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+
+    expect(
+      envVarsParamsSchema.safeParse({
+        names: ['API_TOKEN'],
+        reason: 'call api',
+        variable_metadata: { OTHER_TOKEN: { description: 'wrong key' } },
+      }).success
+    ).toBe(false);
+
+    expect(
+      envVarsParamsSchema.safeParse({
+        names: ['API_TOKEN'],
+        reason: 'call api',
+        variable_metadata: { API_TOKEN: { value: 'must-not-carry-secrets' } },
+      }).success
+    ).toBe(false);
+  });
 });
 
 describe('env_vars widget — submitSchema', () => {
@@ -116,6 +192,16 @@ describe('env_vars widget — submitSchema', () => {
     expect(
       envVarsSubmitSchema.safeParse({
         values: { HUBSPOT_API_KEY: 'secret' },
+        scope: 'global',
+      }).success
+    ).toBe(true);
+  });
+
+  it('accepts use_existing names without submitted values', () => {
+    expect(
+      envVarsSubmitSchema.safeParse({
+        values: {},
+        use_existing: ['HUBSPOT_API_KEY'],
         scope: 'global',
       }).success
     ).toBe(true);
@@ -142,12 +228,23 @@ describe('env_vars widget — submitSchema', () => {
       }).success
     ).toBe(false);
   });
+
+  it('rejects a name submitted both as a value and use_existing', () => {
+    expect(
+      envVarsSubmitSchema.safeParse({
+        values: { HUBSPOT_API_KEY: 'v' },
+        use_existing: ['HUBSPOT_API_KEY'],
+        scope: 'global',
+      }).success
+    ).toBe(false);
+  });
 });
 
 describe('env_vars widget — buildResultMeta', () => {
   it('returns ONLY { names_submitted, scope } — never values', () => {
     const submit = {
       values: { HUBSPOT_API_KEY: 'super-secret-value' },
+      use_existing: [],
       scope: 'global' as const,
     };
     const rm = envVarsWidget.buildResultMeta(submit);
@@ -157,14 +254,27 @@ describe('env_vars widget — buildResultMeta', () => {
     expect(JSON.stringify(rm)).not.toContain('super-secret-value');
   });
 
-  it('preserves submission order across multiple names', () => {
+  it('returns submitted names in deterministic order across multiple names', () => {
     const submit = {
-      values: { A_KEY: 'a', B_KEY: 'b', C_KEY: 'c' },
+      values: { C_KEY: 'c', A_KEY: 'a', B_KEY: 'b' },
+      use_existing: [],
       scope: 'session' as const,
     };
     const rm = envVarsWidget.buildResultMeta(submit);
     expect(rm.names_submitted).toEqual(['A_KEY', 'B_KEY', 'C_KEY']);
     expect(rm.scope).toBe('session');
+  });
+
+  it('returns use_existing names separately and never includes values', () => {
+    const submit = {
+      values: { B_KEY: 'new-secret' },
+      use_existing: ['A_KEY'],
+      scope: 'global' as const,
+    };
+    const rm = envVarsWidget.buildResultMeta(submit);
+    expect(rm.names_submitted).toEqual(['B_KEY']);
+    expect(rm.names_used_existing).toEqual(['A_KEY']);
+    expect(JSON.stringify(rm)).not.toContain('new-secret');
   });
 });
 
@@ -173,7 +283,7 @@ describe('env_vars widget — applySubmit', () => {
     const { ctx, patchSpy } = makeCtx();
     await envVarsWidget.applySubmit(
       ctx,
-      { values: { HUBSPOT_API_KEY: 'shh' }, scope: 'global' },
+      { values: { HUBSPOT_API_KEY: 'shh' }, use_existing: [], scope: 'global' },
       { names: ['HUBSPOT_API_KEY'], reason: 'call hubspot', auto_resume: true }
     );
     expect(patchSpy).toHaveBeenCalledTimes(1);
@@ -202,7 +312,7 @@ describe('env_vars widget — applySubmit', () => {
     };
     await envVarsWidget.applySubmit(
       adminCtx,
-      { values: { HUBSPOT_API_KEY: 'shh' }, scope: 'global' },
+      { values: { HUBSPOT_API_KEY: 'shh' }, use_existing: [], scope: 'global' },
       { names: ['HUBSPOT_API_KEY'], reason: 'call hubspot', auto_resume: true }
     );
     const [, , params] = patchSpy.mock.calls[0];
@@ -218,7 +328,7 @@ describe('env_vars widget — applySubmit', () => {
     const { ctx, patchSpy } = makeCtx();
     await envVarsWidget.applySubmit(
       ctx,
-      { values: { A_KEY: 'a', B_KEY: 'b' }, scope: 'session' },
+      { values: { A_KEY: 'a', B_KEY: 'b' }, use_existing: [], scope: 'session' },
       { names: ['A_KEY', 'B_KEY'], reason: 'why', auto_resume: true }
     );
     expect(patchSpy).toHaveBeenCalledTimes(1);
@@ -227,13 +337,74 @@ describe('env_vars widget — applySubmit', () => {
     expect(data.env_var_scopes).toEqual({ A_KEY: 'session', B_KEY: 'session' });
   });
 
+  it('adds newly submitted session-scope values to the current session selection', async () => {
+    const { ctx } = makeCtx();
+    const app = ctx.app as unknown as { get: ReturnType<typeof vi.fn> };
+    app.get.mockReturnValue({ kind: 'database' });
+    sessionSelectionRepoMock.asSet.mockResolvedValue(new Set(['EXISTING_KEY']));
+
+    await envVarsWidget.applySubmit(
+      ctx,
+      { values: { B_KEY: 'b', A_KEY: 'a' }, use_existing: [], scope: 'session' },
+      { names: ['A_KEY', 'B_KEY'], reason: 'why', auto_resume: true }
+    );
+
+    expect(sessionSelectionRepoMock.asSet).toHaveBeenCalledWith('sess-1');
+    expect(sessionSelectionRepoMock.setAll).toHaveBeenCalledWith('sess-1', [
+      'A_KEY',
+      'B_KEY',
+      'EXISTING_KEY',
+    ]);
+  });
+
+  it('allows a saved global value to cover a requested name without patching it', async () => {
+    const { ctx, patchSpy } = makeCtx(undefined, {
+      env_vars: { A_KEY: { set: true, scope: 'global' } },
+    });
+    await envVarsWidget.applySubmit(
+      ctx,
+      { values: { B_KEY: 'b' }, use_existing: ['A_KEY'], scope: 'global' },
+      { names: ['A_KEY', 'B_KEY'], reason: 'why', auto_resume: true }
+    );
+    expect(patchSpy).toHaveBeenCalledTimes(1);
+    const [, data] = patchSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(data.env_vars).toEqual({ B_KEY: 'b' });
+    expect(data.env_var_scopes).toEqual({ B_KEY: 'global' });
+  });
+
+  it('allows all requested names to use saved global values without patching', async () => {
+    const { ctx, patchSpy } = makeCtx(undefined, {
+      env_vars: { A_KEY: { set: true, scope: 'global' } },
+    });
+    await envVarsWidget.applySubmit(
+      ctx,
+      { values: {}, use_existing: ['A_KEY'], scope: 'global' },
+      { names: ['A_KEY'], reason: 'why', auto_resume: true }
+    );
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects use_existing for non-global saved values with a field error', async () => {
+    const { ctx, patchSpy } = makeCtx(undefined, {
+      env_vars: { A_KEY: { set: true, scope: 'session' } },
+    });
+    await expect(
+      envVarsWidget.applySubmit(
+        ctx,
+        { values: {}, use_existing: ['A_KEY'], scope: 'global' },
+        { names: ['A_KEY'], reason: 'why', auto_resume: true }
+      )
+    ).rejects.toMatchObject({ data: { field_errors: { A_KEY: expect.any(String) } } });
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
   it('rejects submitted names that do not exactly match params.names', async () => {
     const { ctx, patchSpy } = makeCtx();
     // Tampered client tries to write EXTRA_VAR that wasn't in the widget request.
     await expect(
       envVarsWidget.applySubmit(
         ctx,
-        { values: { HUBSPOT_API_KEY: 'v', EXTRA_VAR: 'evil' }, scope: 'global' },
+        { values: { HUBSPOT_API_KEY: 'v', EXTRA_VAR: 'evil' }, use_existing: [], scope: 'global' },
         { names: ['HUBSPOT_API_KEY'], reason: 'why', auto_resume: true }
       )
     ).rejects.toThrow(/exactly match/i);
@@ -246,10 +417,22 @@ describe('env_vars widget — applySubmit', () => {
     await expect(
       envVarsWidget.applySubmit(
         ctx,
-        { values: { A_KEY: 'v' }, scope: 'global' },
+        { values: { A_KEY: 'v' }, use_existing: [], scope: 'global' },
         { names: ['A_KEY', 'B_KEY'], reason: 'why', auto_resume: true }
       )
     ).rejects.toThrow(/exactly match/i);
+    expect(patchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing coverage with per-field errors', async () => {
+    const { ctx, patchSpy } = makeCtx();
+    await expect(
+      envVarsWidget.applySubmit(
+        ctx,
+        { values: { A_KEY: 'v' }, use_existing: [], scope: 'global' },
+        { names: ['A_KEY', 'B_KEY'], reason: 'why', auto_resume: true }
+      )
+    ).rejects.toMatchObject({ data: { field_errors: { B_KEY: expect.any(String) } } });
     expect(patchSpy).not.toHaveBeenCalled();
   });
 
@@ -259,7 +442,7 @@ describe('env_vars widget — applySubmit', () => {
     await expect(
       envVarsWidget.applySubmit(
         ctx,
-        { values: { PATH: '/tmp/evil' }, scope: 'global' },
+        { values: { PATH: '/tmp/evil' }, use_existing: [], scope: 'global' },
         { names: ['PATH'], reason: 'why', auto_resume: true }
       )
     ).rejects.toThrow(/blocked|cannot be set/i);
@@ -273,7 +456,7 @@ describe('env_vars widget — applySubmit', () => {
     await expect(
       envVarsWidget.applySubmit(
         ctx,
-        { values: { HUBSPOT_API_KEY: 'v' }, scope: 'global' },
+        { values: { HUBSPOT_API_KEY: 'v' }, use_existing: [], scope: 'global' },
         { names: ['HUBSPOT_API_KEY'], reason: 'why', auto_resume: true }
       )
     ).rejects.toThrow(/value too long/i);
@@ -308,7 +491,7 @@ describe('env_vars widget — applySubmit', () => {
       const { ctx } = makeCtx();
       await envVarsWidget.applySubmit(
         ctx,
-        { values: { HUBSPOT_API_KEY: secret }, scope: 'global' },
+        { values: { HUBSPOT_API_KEY: secret }, use_existing: [], scope: 'global' },
         { names: ['HUBSPOT_API_KEY'], reason: 'why', auto_resume: true }
       );
       // Flatten every logged arg into a string and assert the secret is
@@ -349,6 +532,23 @@ describe('env_vars widget — prompt builders', () => {
     };
     const prompt = envVarsWidget.buildAutoResumePrompt(rm, params);
     expect(prompt).toContain('them');
+  });
+
+  it('buildAutoResumePrompt mentions saved and existing names without values', () => {
+    const rm = {
+      names_submitted: ['B_KEY'],
+      names_used_existing: ['A_KEY'],
+      scope: 'global' as const,
+    };
+    const params = {
+      names: ['A_KEY', 'B_KEY'],
+      reason: 'why',
+      auto_resume: true,
+    };
+    const prompt = envVarsWidget.buildAutoResumePrompt(rm, params);
+    expect(prompt).toContain('saved B_KEY');
+    expect(prompt).toContain('used existing A_KEY');
+    expect(prompt).not.toMatch(/secret|value/i);
   });
 
   it('buildDismissedPrompt says "do not re-request immediately"', () => {

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -10,59 +10,159 @@
  * See §4 + §7 Part 2 of `docs/internal/in-conversation-widgets-design-2026-05-19.md`.
  */
 
-import { ENV_VAR_CONSTRAINTS, isEnvVarAllowed, validateEnvVar } from '@agor/core/config';
+import {
+  ENV_VAR_CONSTRAINTS,
+  isEnvVarAllowed,
+  type ValidationError,
+  validateEnvVar,
+} from '@agor/core/config';
+import { type Database, SessionEnvSelectionRepository } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
-import type { UserID } from '@agor/core/types';
+import type { EnvVarScope, User, UserID } from '@agor/core/types';
 import { z } from 'zod';
 import { registerWidget, type WidgetRegistryEntry, type WidgetSubmitCtx } from '../registry.js';
 
 /** Mirror of the regex used by the users service. */
 const ENV_VAR_NAME_REGEX = ENV_VAR_CONSTRAINTS.NAME_PATTERN;
 
+function orderedEnvVarNames(names: string[]): string[] {
+  return [...names].sort();
+}
+
+const envVarFieldMetadataSchema = z
+  .object({
+    description: z.string().max(200).optional(),
+    placeholder: z.string().max(120).optional(),
+    format_hint: z.string().max(80).optional(),
+    input_type: z.enum(['password', 'text', 'textarea']).default('password').optional(),
+  })
+  .strict();
+
+export type EnvVarFieldMetadata = z.infer<typeof envVarFieldMetadataSchema>;
+
+export interface EnvVarExistingStatus {
+  set: true;
+  scope: EnvVarScope;
+  resource_id?: string | null;
+}
+
+function orderedRecord<T>(record: Record<string, T> | undefined): Record<string, T> | undefined {
+  if (!record) return undefined;
+  const out: Record<string, T> = {};
+  for (const key of orderedEnvVarNames(Object.keys(record))) {
+    out[key] = record[key];
+  }
+  return out;
+}
+
+export function normalizeEnvVarsParams(params: EnvVarsParams): EnvVarsParams {
+  return {
+    ...params,
+    names: orderedEnvVarNames(params.names),
+    variable_metadata: orderedRecord(params.variable_metadata),
+    existing: orderedRecord(params.existing),
+  };
+}
+
 /**
  * Agent-provided params (validated when the MCP tool fires).
  * Stored at `metadata.widget.params` on the widget message row.
  */
-export const envVarsParamsSchema = z.object({
-  names: z
-    .array(z.string().regex(ENV_VAR_NAME_REGEX))
-    .min(1)
-    .max(10)
-    .refine((names) => new Set(names).size === names.length, {
-      message: 'Env var names must be unique',
-    })
-    .describe('UPPER_SNAKE env var names (same validation as User Settings).'),
-  reason: z
-    .string()
-    .min(1)
-    .max(200)
-    .describe(
-      'One sentence explaining why you need the value(s). Keep it tight — this renders in a small muted line under the input. NOT a place to restate what the widget does.'
-    ),
-  auto_resume: z
-    .boolean()
-    .default(true)
-    .describe(
-      'When true (default), a system-authored prompt is auto-queued back into the agent on submit/dismiss.'
-    ),
-});
+export const envVarsParamsSchema = z
+  .object({
+    names: z
+      .array(z.string().regex(ENV_VAR_NAME_REGEX))
+      .min(1)
+      .max(10)
+      .refine((names) => new Set(names).size === names.length, {
+        message: 'Env var names must be unique',
+      })
+      .describe('UPPER_SNAKE env var names (same validation as User Settings).'),
+    reason: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe(
+        'One sentence explaining why you need the value(s). Keep it tight — this renders in a small muted line under the input. NOT a place to restate what the widget does.'
+      ),
+    variable_metadata: z
+      .record(z.string().regex(ENV_VAR_NAME_REGEX), envVarFieldMetadataSchema)
+      .optional()
+      .describe(
+        'Optional per-variable display metadata keyed by requested name. Allowed keys per variable: description, placeholder, format_hint, input_type (password|text|textarea). Do not include values, defaults, examples containing secrets, or anything secret-like.'
+      ),
+    auto_resume: z
+      .boolean()
+      .default(true)
+      .describe(
+        'When true (default), a system-authored prompt is auto-queued back into the agent on submit/dismiss.'
+      ),
+  })
+  .superRefine((params, ctx) => {
+    const requested = new Set(params.names);
+    for (const key of Object.keys(params.variable_metadata ?? {})) {
+      if (!requested.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['variable_metadata', key],
+          message: `Metadata key ${key} must match a requested env var name`,
+        });
+      }
+    }
+  });
 
-export type EnvVarsParams = z.infer<typeof envVarsParamsSchema>;
+export type EnvVarsParams = z.infer<typeof envVarsParamsSchema> & {
+  /**
+   * Server-derived availability for requested names. Values are never present:
+   * just set/scope/resource metadata from `users.env_vars`.
+   */
+  existing?: Record<string, EnvVarExistingStatus>;
+};
 
 /**
  * Browser → daemon submit payload. Direct HTTP, never reaches the agent.
  */
-export const envVarsSubmitSchema = z.object({
-  values: z
-    .record(
-      z.string().regex(ENV_VAR_NAME_REGEX),
-      z.string().min(1).max(ENV_VAR_CONSTRAINTS.MAX_VALUE_LENGTH)
-    )
-    .refine((v) => Object.keys(v).length >= 1 && Object.keys(v).length <= 10, {
-      message: 'Must submit between 1 and 10 env vars',
-    }),
-  scope: z.enum(['global', 'session']),
-});
+export const envVarsSubmitSchema = z
+  .object({
+    values: z
+      .record(
+        z.string().regex(ENV_VAR_NAME_REGEX),
+        z.string().min(1).max(ENV_VAR_CONSTRAINTS.MAX_VALUE_LENGTH)
+      )
+      .default({}),
+    use_existing: z
+      .array(z.string().regex(ENV_VAR_NAME_REGEX))
+      .max(10)
+      .default([])
+      .describe('Requested names whose already-saved global values should be used.'),
+    scope: z.enum(['global', 'session']),
+  })
+  .superRefine((submit, ctx) => {
+    const valueNames = Object.keys(submit.values);
+    const existingNames = submit.use_existing;
+    const total = valueNames.length + existingNames.length;
+    if (total < 1 || total > 10) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Must submit between 1 and 10 env vars',
+      });
+    }
+    const duplicates = existingNames.filter((name) => valueNames.includes(name));
+    for (const name of duplicates) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['use_existing'],
+        message: `Cannot both submit and use existing value for ${name}`,
+      });
+    }
+    if (new Set(existingNames).size !== existingNames.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['use_existing'],
+        message: 'use_existing names must be unique',
+      });
+    }
+  });
 
 export type EnvVarsSubmit = z.infer<typeof envVarsSubmitSchema>;
 
@@ -73,7 +173,16 @@ export type EnvVarsSubmit = z.infer<typeof envVarsSubmitSchema>;
  */
 export interface EnvVarsResultMeta {
   names_submitted: string[];
+  names_used_existing?: string[];
   scope: 'global' | 'session';
+}
+
+function fieldBadRequest(message: string, fieldErrors: Record<string, string>): BadRequest {
+  return new BadRequest(message, { field_errors: orderedRecord(fieldErrors) });
+}
+
+function validationMessage(errors: ValidationError[]): string {
+  return errors.map((e) => e.message).join('; ');
 }
 
 /**
@@ -92,14 +201,23 @@ async function applyEnvVarsSubmit(
   // session creator's profile — widening the attack surface far beyond what
   // the agent (and the user reviewing the widget) intended.
   const requestedNames = new Set(params.names);
-  const submittedNames = Object.keys(submit.values);
+  const submittedNames = orderedEnvVarNames(Object.keys(submit.values));
+  const useExistingNames = orderedEnvVarNames(submit.use_existing ?? []);
+  const coveredNames = orderedEnvVarNames([...submittedNames, ...useExistingNames]);
   if (
-    submittedNames.length !== params.names.length ||
-    submittedNames.some((name) => !requestedNames.has(name))
+    coveredNames.length !== params.names.length ||
+    coveredNames.some((name) => !requestedNames.has(name))
   ) {
-    throw new BadRequest(
+    const missing = params.names.filter((name) => !coveredNames.includes(name));
+    const extra = coveredNames.filter((name) => !requestedNames.has(name));
+    const fieldErrors: Record<string, string> = {};
+    for (const name of missing)
+      fieldErrors[name] = 'Required value or saved global value selection missing';
+    for (const name of extra) fieldErrors[name] = 'This env var was not requested';
+    throw fieldBadRequest(
       'Submitted env var names must exactly match the widget request: expected ' +
-        params.names.join(', ')
+        params.names.join(', '),
+      fieldErrors
     );
   }
 
@@ -109,15 +227,19 @@ async function applyEnvVarsSubmit(
   // up-front gives us a clearer error per name without partial writes.
   for (const name of submittedNames) {
     if (!isEnvVarAllowed(name)) {
-      throw new Error(`Cannot set environment variable "${name}": blocked by allow-list`);
+      throw fieldBadRequest(`Cannot set environment variable "${name}": blocked by allow-list`, {
+        [name]: 'Blocked by allow-list',
+      });
     }
     const errors = validateEnvVar(name, submit.values[name]);
     if (errors.length > 0) {
-      throw new Error(`Invalid env var ${name}: ${errors.map((e) => e.message).join('; ')}`);
+      const message = validationMessage(errors);
+      throw fieldBadRequest(`Invalid env var ${name}: ${message}`, { [name]: message });
     }
   }
 
   const usersService = ctx.app.service('users') as unknown as {
+    get(id: UserID, params?: unknown): Promise<User>;
     patch(
       id: UserID,
       data: {
@@ -132,8 +254,29 @@ async function applyEnvVarsSubmit(
     ): Promise<unknown>;
   };
 
+  if (useExistingNames.length > 0) {
+    const creator = await usersService.get(ctx.sessionCreatorUserId, {
+      user: { user_id: ctx.submitterUserId, role: ctx.submitterRole },
+      authenticated: true,
+    });
+    const fieldErrors: Record<string, string> = {};
+    for (const name of useExistingNames) {
+      const meta = creator.env_vars?.[name];
+      if (!meta?.set) {
+        fieldErrors[name] = 'No saved value is set for this env var';
+      } else if (meta.scope !== 'global') {
+        fieldErrors[name] = 'Only global saved values can be used from this widget';
+      }
+    }
+    if (Object.keys(fieldErrors).length > 0) {
+      throw fieldBadRequest('One or more saved values cannot be used', fieldErrors);
+    }
+  }
+
+  const orderedValues: Record<string, string> = {};
   const env_var_scopes: Record<string, 'global' | 'session'> = {};
   for (const name of submittedNames) {
+    orderedValues[name] = submit.values[name];
     env_var_scopes[name] = submit.scope;
   }
 
@@ -149,15 +292,28 @@ async function applyEnvVarsSubmit(
   // submit handler records it separately as `metadata.widget.submitted_by`.
   //
   // Grep for: trustedEnvVarWrite — to audit every site that sets it.
-  await usersService.patch(
-    ctx.sessionCreatorUserId,
-    { env_vars: submit.values, env_var_scopes },
-    {
-      user: { user_id: ctx.submitterUserId, role: ctx.submitterRole },
-      authenticated: true,
-      trustedEnvVarWrite: true,
+  if (submittedNames.length > 0) {
+    await usersService.patch(
+      ctx.sessionCreatorUserId,
+      { env_vars: orderedValues, env_var_scopes },
+      {
+        user: { user_id: ctx.submitterUserId, role: ctx.submitterRole },
+        authenticated: true,
+        trustedEnvVarWrite: true,
+      }
+    );
+  }
+
+  if (submit.scope === 'session' && submittedNames.length > 0) {
+    const db = (ctx.app as unknown as { get?: (key: string) => unknown }).get?.('database') as
+      | Database
+      | undefined;
+    if (db) {
+      const repo = new SessionEnvSelectionRepository(db);
+      const existing = await repo.asSet(ctx.sessionId);
+      await repo.setAll(ctx.sessionId, orderedEnvVarNames([...existing, ...submittedNames]));
     }
-  );
+  }
 }
 
 export const envVarsWidget: WidgetRegistryEntry<EnvVarsParams, EnvVarsSubmit, EnvVarsResultMeta> = {
@@ -166,16 +322,30 @@ export const envVarsWidget: WidgetRegistryEntry<EnvVarsParams, EnvVarsSubmit, En
   paramsSchema: envVarsParamsSchema,
   submitSchema: envVarsSubmitSchema,
   buildResultMeta: (submit) => ({
-    names_submitted: Object.keys(submit.values),
+    names_submitted: orderedEnvVarNames(Object.keys(submit.values)),
+    ...(submit.use_existing.length > 0
+      ? { names_used_existing: orderedEnvVarNames(submit.use_existing) }
+      : {}),
     scope: submit.scope,
   }),
   applySubmit: applyEnvVarsSubmit,
-  buildAutoResumePrompt: (rm) =>
-    `[Agor] User submitted ${rm.names_submitted.join(', ')} (scope: ${rm.scope}). ` +
-    `You can now retry the operation that needed ` +
-    `${rm.names_submitted.length === 1 ? 'it' : 'them'}.`,
+  buildAutoResumePrompt: (rm) => {
+    const existing = orderedEnvVarNames(rm.names_used_existing ?? []);
+    const names = orderedEnvVarNames([...rm.names_submitted, ...existing]);
+    const savedPart =
+      rm.names_submitted.length > 0
+        ? `saved ${orderedEnvVarNames(rm.names_submitted).join(', ')} (scope: ${rm.scope})`
+        : '';
+    const existingPart =
+      existing.length > 0 ? `used existing ${existing.join(', ')} (scope: global)` : '';
+    const action = [savedPart, existingPart].filter(Boolean).join(' and ');
+    return (
+      `[Agor] User ${action}. ` +
+      `You can now retry the operation that needed ${names.length === 1 ? 'it' : 'them'}.`
+    );
+  },
   buildDismissedPrompt: (params) =>
-    `[Agor] User dismissed the request for ${params.names.join(', ')}. ` +
+    `[Agor] User dismissed the request for ${orderedEnvVarNames(params.names).join(', ')}. ` +
     `Do not re-request immediately — ask whether to proceed without, or move on to other work.`,
 };
 

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -18,7 +18,7 @@ import {
 } from '@agor/core/config';
 import { type Database, SessionEnvSelectionRepository } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
-import type { EnvVarScope, User, UserID } from '@agor/core/types';
+import type { User, UserID } from '@agor/core/types';
 import { z } from 'zod';
 import { registerWidget, type WidgetRegistryEntry, type WidgetSubmitCtx } from '../registry.js';
 
@@ -40,12 +40,6 @@ const envVarFieldMetadataSchema = z
 
 export type EnvVarFieldMetadata = z.infer<typeof envVarFieldMetadataSchema>;
 
-export interface EnvVarExistingStatus {
-  set: true;
-  scope: EnvVarScope;
-  resource_id?: string | null;
-}
-
 function orderedRecord<T>(record: Record<string, T> | undefined): Record<string, T> | undefined {
   if (!record) return undefined;
   const out: Record<string, T> = {};
@@ -60,7 +54,6 @@ export function normalizeEnvVarsParams(params: EnvVarsParams): EnvVarsParams {
     ...params,
     names: orderedEnvVarNames(params.names),
     variable_metadata: orderedRecord(params.variable_metadata),
-    existing: orderedRecord(params.existing),
   };
 }
 
@@ -111,13 +104,7 @@ export const envVarsParamsSchema = z
     }
   });
 
-export type EnvVarsParams = z.infer<typeof envVarsParamsSchema> & {
-  /**
-   * Server-derived availability for requested names. Values are never present:
-   * just set/scope/resource metadata from `users.env_vars`.
-   */
-  existing?: Record<string, EnvVarExistingStatus>;
-};
+export type EnvVarsParams = z.infer<typeof envVarsParamsSchema>;
 
 /**
  * Browser → daemon submit payload. Direct HTTP, never reaches the agent.

--- a/apps/agor-daemon/src/widgets/submissions.test.ts
+++ b/apps/agor-daemon/src/widgets/submissions.test.ts
@@ -15,6 +15,7 @@
  * mock, so we exercise the full state machine with a hand-rolled stub.
  */
 
+import { BadRequest } from '@agor/core/feathers';
 import type { Branch, Message, Session, UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -445,6 +446,32 @@ describe('resolveWidget', () => {
         { app: app as never, isBranchOwner: async () => false }
       )
     ).rejects.toThrow(/Invalid submit/);
+  });
+
+  it('propagates structured per-field applySubmit errors without patching the widget', async () => {
+    const { applySubmit } = registerTestWidget(
+      vi.fn(async () => {
+        throw new BadRequest('Field validation failed', {
+          field_errors: { HUBSPOT_API_KEY: 'Invalid saved value selection' },
+        });
+      })
+    );
+    const fixtures = makeFixtures();
+    const { app, calls } = makeApp(fixtures);
+
+    await expect(
+      resolveWidget(
+        'widget-msg-1',
+        { kind: 'submit', body: { value: 'secret-key', scope: 'global' } },
+        { user_id: 'creator-user-id' as UserID },
+        { app: app as never, isBranchOwner: async () => false }
+      )
+    ).rejects.toMatchObject({
+      data: { field_errors: { HUBSPOT_API_KEY: 'Invalid saved value selection' } },
+    });
+
+    expect(applySubmit).toHaveBeenCalledTimes(1);
+    expect(calls.find((c) => c.service === 'messages' && c.method === 'patch')).toBeUndefined();
   });
 
   it('serializes concurrent resolutions on the same widget — only one applySubmit fires', async () => {

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
@@ -34,7 +34,9 @@ interface StubServiceCall {
  * the widget uses. Returns a `calls` array for assertions and a `shouldFail`
  * knob for negative tests.
  */
-function makeStubClient(opts: { shouldFail?: boolean } = {}): {
+function makeStubClient(
+  opts: { shouldFail?: boolean; fieldErrors?: Record<string, string> } = {}
+): {
   client: AgorClient;
   calls: StubServiceCall[];
 } {
@@ -44,7 +46,13 @@ function makeStubClient(opts: { shouldFail?: boolean } = {}): {
       return {
         async create(body: unknown) {
           calls.push({ path, body });
-          if (opts.shouldFail) throw new Error('Invalid env var');
+          if (opts.shouldFail) {
+            const err = new Error('Invalid env var') as Error & {
+              data?: { field_errors?: Record<string, string> };
+            };
+            if (opts.fieldErrors) err.data = { field_errors: opts.fieldErrors };
+            throw err;
+          }
           return { widget_id: 'wid-1', status: 'submitted' };
         },
       };
@@ -101,6 +109,55 @@ describe('EnvVarRequestWidget — pending state', () => {
     );
     expect(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i)).toBeTruthy();
     expect(screen.getByLabelText(/Value for STRIPE_SECRET_KEY/i)).toBeTruthy();
+    expect(screen.getAllByText(/Not set/i)).toHaveLength(2);
+  });
+
+  it('renders per-variable metadata and native input types', () => {
+    const widget = makeWidget({
+      params: {
+        names: ['PUBLIC_BASE_URL', 'PRIVATE_NOTE'],
+        reason: 'two values',
+        variable_metadata: {
+          PUBLIC_BASE_URL: {
+            description: 'Public URL for callbacks.',
+            placeholder: 'https://example.com',
+            format_hint: 'Must include protocol.',
+            input_type: 'text',
+          },
+          PRIVATE_NOTE: {
+            description: 'Paste the multiline value.',
+            input_type: 'textarea',
+          },
+        },
+      },
+    });
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+    expect(screen.getByText('Public URL for callbacks.')).toBeTruthy();
+    expect(screen.getByPlaceholderText('https://example.com')).toBeTruthy();
+    expect(screen.getByText('Must include protocol.')).toBeTruthy();
+    expect(screen.getByText('Paste the multiline value.')).toBeTruthy();
+  });
+
+  it('renders requested names in deterministic order', () => {
+    const widget = makeWidget({
+      params: {
+        names: ['STRIPE_SECRET_KEY', 'HUBSPOT_API_KEY'],
+        reason: 'two integrations',
+      },
+    });
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+
+    const inputs = screen.getAllByLabelText(/Value for/i);
+    expect(inputs.map((input) => input.getAttribute('aria-label'))).toEqual([
+      'Value for HUBSPOT_API_KEY',
+      'Value for STRIPE_SECRET_KEY',
+    ]);
   });
 
   it('disables Save until every field has a value', () => {
@@ -135,8 +192,57 @@ describe('EnvVarRequestWidget — pending state', () => {
     expect(calls[0].path).toBe('widgets/wid-1/submit');
     expect(calls[0].body).toEqual({
       values: { HUBSPOT_API_KEY: 'secret-key' },
+      use_existing: [],
       scope: 'global', // UI always starts at Global; no scope change in this test
     });
+  });
+
+  it('can use an existing saved global value without retyping it', async () => {
+    const widget = makeWidget({
+      params: {
+        names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY'],
+        reason: 'two integrations',
+        existing: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
+      },
+    });
+    const { client, calls } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+
+    expect(screen.getByText('Set (encrypted)')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText(/Use saved encrypted value/i));
+    fireEvent.change(screen.getByLabelText(/Value for STRIPE_SECRET_KEY/i), {
+      target: { value: 'new-secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(calls.length).toBe(1);
+    });
+    expect(calls[0].body).toEqual({
+      values: { STRIPE_SECRET_KEY: 'new-secret' },
+      use_existing: ['HUBSPOT_API_KEY'],
+      scope: 'global',
+    });
+  });
+
+  it('does not offer use-existing for session-scoped saved values', () => {
+    const widget = makeWidget({
+      params: {
+        names: ['HUBSPOT_API_KEY'],
+        reason: 'call hubspot',
+        existing: { HUBSPOT_API_KEY: { set: true, scope: 'session' } },
+      },
+    });
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+
+    expect(screen.getByText('Set (encrypted)')).toBeTruthy();
+    expect(screen.queryByLabelText(/Use saved encrypted value/i)).toBeNull();
+    expect(screen.getByText(/Session-scoped saved values/i)).toBeTruthy();
   });
 
   it('dismisses via widgets/:id/dismiss with an empty body', async () => {
@@ -173,7 +279,65 @@ describe('EnvVarRequestWidget — pending state', () => {
     await waitFor(() => {
       expect(saveBtn.disabled).toBe(false);
     });
+    expect(screen.getAllByText(/Save failed: Invalid env var/i).length).toBeGreaterThan(0);
     expect(calls.length).toBe(1);
+  });
+
+  it('attaches structured server field errors to the matching input row', async () => {
+    const widget = makeWidget();
+    const { client } = makeStubClient({
+      shouldFail: true,
+      fieldErrors: { HUBSPOT_API_KEY: 'Only global saved values can be used from this widget' },
+    });
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+    fireEvent.change(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i), {
+      target: { value: 'shh' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText(/Only global saved values/i)).toBeTruthy();
+    expect(screen.getAllByText(/Save failed: Invalid env var/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows a local submitted summary after save so duplicate clicks cannot resubmit', async () => {
+    const widget = makeWidget();
+    const { client, calls } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i), {
+      target: { value: 'secret-key' },
+    });
+    const saveBtn = screen.getByRole('button', { name: 'Save' });
+    fireEvent.click(saveBtn);
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/saved/i)).toBeTruthy();
+    });
+    expect(calls).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
+  it('shows a local dismissed summary after dismiss so duplicate clicks cannot resubmit', async () => {
+    const widget = makeWidget();
+    const { client, calls } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+
+    const dismissBtn = screen.getByRole('button', { name: 'Dismiss' });
+    fireEvent.click(dismissBtn);
+    fireEvent.click(dismissBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/dismissed/i)).toBeTruthy();
+    });
+    expect(calls).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).toBeNull();
   });
 });
 
@@ -191,7 +355,26 @@ describe('EnvVarRequestWidget — terminal states', () => {
     expect(screen.getByText(/HUBSPOT_API_KEY/i)).toBeTruthy();
     expect(screen.getByText(/saved/i)).toBeTruthy();
     expect(screen.getByText(/global/i)).toBeTruthy();
+    expect(screen.getByText(/Update it in User Settings/i)).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
+  it('renders submitted summary for values plus used-existing names', () => {
+    const widget = makeWidget({
+      status: 'submitted',
+      resolved_at: '2026-05-19T12:34:56.000Z',
+      result_meta: {
+        names_submitted: ['STRIPE_SECRET_KEY'],
+        names_used_existing: ['HUBSPOT_API_KEY'],
+        scope: 'global',
+      },
+    });
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+    expect(screen.getByText(/2 variables/i)).toBeTruthy();
+    expect(screen.getByText(/saved/i)).toBeTruthy();
   });
 
   it('renders the dismissed summary', () => {
@@ -202,6 +385,21 @@ describe('EnvVarRequestWidget — terminal states', () => {
     );
     expect(screen.getByText(/dismissed/i)).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
+  });
+
+  it('renders terminal summaries in deterministic name order', () => {
+    const widget = makeWidget({
+      status: 'dismissed',
+      params: {
+        names: ['STRIPE_SECRET_KEY', 'HUBSPOT_API_KEY'],
+        reason: 'two integrations',
+      },
+    });
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+    expect(screen.getByText('HUBSPOT_API_KEY, STRIPE_SECRET_KEY dismissed')).toBeTruthy();
   });
 
   it('renders the already_present summary', () => {

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.test.tsx
@@ -35,7 +35,11 @@ interface StubServiceCall {
  * knob for negative tests.
  */
 function makeStubClient(
-  opts: { shouldFail?: boolean; fieldErrors?: Record<string, string> } = {}
+  opts: {
+    shouldFail?: boolean;
+    fieldErrors?: Record<string, string>;
+    envVars?: Record<string, { set: true; scope: 'global' | 'session' }>;
+  } = {}
 ): {
   client: AgorClient;
   calls: StubServiceCall[];
@@ -44,6 +48,11 @@ function makeStubClient(
   const client = {
     service(path: string) {
       return {
+        async get(id: string) {
+          if (path === 'sessions' && id === 'sess-1') return { created_by: 'user-creator' };
+          if (path === 'users' && id === 'user-creator') return { env_vars: opts.envVars ?? {} };
+          return {};
+        },
         async create(body: unknown) {
           calls.push({ path, body });
           if (opts.shouldFail) {
@@ -109,7 +118,7 @@ describe('EnvVarRequestWidget — pending state', () => {
     );
     expect(screen.getByLabelText(/Value for HUBSPOT_API_KEY/i)).toBeTruthy();
     expect(screen.getByLabelText(/Value for STRIPE_SECRET_KEY/i)).toBeTruthy();
-    expect(screen.getAllByText(/Not set/i)).toHaveLength(2);
+    expect(screen.queryByText(/Not set/i)).toBeNull();
   });
 
   it('renders per-variable metadata and native input types', () => {
@@ -202,16 +211,17 @@ describe('EnvVarRequestWidget — pending state', () => {
       params: {
         names: ['HUBSPOT_API_KEY', 'STRIPE_SECRET_KEY'],
         reason: 'two integrations',
-        existing: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
       },
     });
-    const { client, calls } = makeStubClient();
+    const { client, calls } = makeStubClient({
+      envVars: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
+    });
     renderWithApp(
       <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
     );
 
-    expect(screen.getByText('Set (encrypted)')).toBeTruthy();
-    fireEvent.click(screen.getByLabelText(/Use saved encrypted value/i));
+    expect(await screen.findByText('Set (encrypted)')).toBeTruthy();
+    fireEvent.click(await screen.findByLabelText(/Use saved encrypted value/i));
     fireEvent.change(screen.getByLabelText(/Value for STRIPE_SECRET_KEY/i), {
       target: { value: 'new-secret' },
     });
@@ -227,20 +237,21 @@ describe('EnvVarRequestWidget — pending state', () => {
     });
   });
 
-  it('does not offer use-existing for session-scoped saved values', () => {
+  it('does not offer use-existing for session-scoped saved values', async () => {
     const widget = makeWidget({
       params: {
         names: ['HUBSPOT_API_KEY'],
         reason: 'call hubspot',
-        existing: { HUBSPOT_API_KEY: { set: true, scope: 'session' } },
       },
     });
-    const { client } = makeStubClient();
+    const { client } = makeStubClient({
+      envVars: { HUBSPOT_API_KEY: { set: true, scope: 'session' } },
+    });
     renderWithApp(
       <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
     );
 
-    expect(screen.getByText('Set (encrypted)')).toBeTruthy();
+    expect(await screen.findByText('Set (encrypted)')).toBeTruthy();
     expect(screen.queryByLabelText(/Use saved encrypted value/i)).toBeNull();
     expect(screen.getByText(/Session-scoped saved values/i)).toBeTruthy();
   });
@@ -322,6 +333,22 @@ describe('EnvVarRequestWidget — pending state', () => {
     expect(screen.queryByRole('button', { name: 'Save' })).toBeNull();
   });
 
+  it('shows a reused-existing local summary when no new values were saved', async () => {
+    const widget = makeWidget();
+    const { client } = makeStubClient({
+      envVars: { HUBSPOT_API_KEY: { set: true, scope: 'global' } },
+    });
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+
+    fireEvent.click(await screen.findByLabelText(/Use saved encrypted value/i));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText(/Used existing HUBSPOT_API_KEY/i)).toBeTruthy();
+    expect(screen.queryByText(/Saved HUBSPOT_API_KEY/i)).toBeNull();
+  });
+
   it('shows a local dismissed summary after dismiss so duplicate clicks cannot resubmit', async () => {
     const widget = makeWidget();
     const { client, calls } = makeStubClient();
@@ -373,8 +400,26 @@ describe('EnvVarRequestWidget — terminal states', () => {
     renderWithApp(
       <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
     );
-    expect(screen.getByText(/2 variables/i)).toBeTruthy();
-    expect(screen.getByText(/saved/i)).toBeTruthy();
+    expect(screen.getByText(/Saved STRIPE_SECRET_KEY/i)).toBeTruthy();
+    expect(screen.getByText(/Used existing HUBSPOT_API_KEY/i)).toBeTruthy();
+  });
+
+  it('renders submitted summary for used-existing-only names', () => {
+    const widget = makeWidget({
+      status: 'submitted',
+      resolved_at: '2026-05-19T12:34:56.000Z',
+      result_meta: {
+        names_submitted: [],
+        names_used_existing: ['HUBSPOT_API_KEY'],
+        scope: 'global',
+      },
+    });
+    const { client } = makeStubClient();
+    renderWithApp(
+      <EnvVarRequestWidget message={makeMessage(widget)} widget={widget} client={client} />
+    );
+    expect(screen.getByText(/Used existing HUBSPOT_API_KEY/i)).toBeTruthy();
+    expect(screen.queryByText(/Saved HUBSPOT_API_KEY/i)).toBeNull();
   });
 
   it('renders the dismissed summary', () => {

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
@@ -25,21 +25,33 @@ import {
   MinusCircleOutlined,
   SafetyCertificateOutlined,
 } from '@ant-design/icons';
-import { Button, Card, Input, Select, Space, Typography, theme } from 'antd';
-import { useMemo, useState } from 'react';
+import { Button, Card, Checkbox, Input, Select, Space, Typography, theme } from 'antd';
+import { useMemo, useRef, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { registerWidgetComponent, type WidgetComponentProps } from '../MessageBlock/WidgetBlock';
+import { Tag } from '../Tag';
 
 const { Text } = Typography;
 
 interface EnvVarsParams {
   names: string[];
   reason: string;
+  variable_metadata?: Record<
+    string,
+    {
+      description?: string;
+      placeholder?: string;
+      format_hint?: string;
+      input_type?: 'password' | 'text' | 'textarea';
+    }
+  >;
+  existing?: Record<string, { set: true; scope: EnvVarScope; resource_id?: string | null }>;
   auto_resume?: boolean;
 }
 
 interface EnvVarsResultMeta {
   names_submitted: string[];
+  names_used_existing?: string[];
   scope: EnvVarScope;
 }
 
@@ -51,39 +63,108 @@ function readResultMeta(widget: WidgetMessageMetadata): EnvVarsResultMeta | unde
   return widget.result_meta as EnvVarsResultMeta | undefined;
 }
 
+function orderedEnvVarNames(names: string[]): string[] {
+  return [...names].sort();
+}
+
 interface VarRowProps {
   name: string;
   value: string;
   onChange: (next: string) => void;
+  metadata?: NonNullable<EnvVarsParams['variable_metadata']>[string];
+  existing?: NonNullable<EnvVarsParams['existing']>[string];
+  useExisting: boolean;
+  onUseExistingChange: (next: boolean) => void;
+  error?: string;
   disabled: boolean;
 }
 
-const VarRow: React.FC<VarRowProps> = ({ name, value, onChange, disabled }) => {
+const VarRow: React.FC<VarRowProps> = ({
+  name,
+  value,
+  onChange,
+  metadata,
+  existing,
+  useExisting,
+  onUseExistingChange,
+  error,
+  disabled,
+}) => {
   const { token } = theme.useToken();
+  const inputType = metadata?.input_type ?? 'password';
+  const placeholder = metadata?.placeholder ?? `Enter value for ${name}`;
+  const inputDisabled = disabled || useExisting;
+  const inputProps = {
+    value,
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      onChange(e.target.value),
+    placeholder,
+    disabled: inputDisabled,
+    'aria-label': `Value for ${name}`,
+    autoComplete: 'off',
+    status: error ? ('error' as const) : undefined,
+  };
   return (
     <div>
-      <Text
-        strong
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: 6,
-          marginBottom: 4,
-          fontFamily: token.fontFamilyCode,
-          fontSize: token.fontSizeSM,
-        }}
-      >
-        <LockOutlined style={{ color: token.colorTextSecondary }} />
-        {name}
-      </Text>
-      <Input.Password
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={`Enter value for ${name}`}
-        disabled={disabled}
-        aria-label={`Value for ${name}`}
-        autoComplete="off"
-      />
+      <Space orientation="vertical" size={4} style={{ width: '100%' }}>
+        <Space size="small" wrap>
+          <Text
+            strong
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontFamily: token.fontFamilyCode,
+              fontSize: token.fontSizeSM,
+            }}
+          >
+            <LockOutlined style={{ color: token.colorTextSecondary }} />
+            {name}
+          </Text>
+          <Tag color={existing?.set ? 'success' : 'default'}>
+            {existing?.set ? 'Set (encrypted)' : 'Not Set'}
+          </Tag>
+          {existing?.scope ? (
+            <Tag color={existing.scope === 'global' ? 'blue' : 'purple'}>{existing.scope}</Tag>
+          ) : null}
+        </Space>
+        {metadata?.description ? (
+          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            {metadata.description}
+          </Text>
+        ) : null}
+        {existing?.scope === 'global' ? (
+          <Checkbox
+            checked={useExisting}
+            onChange={(e) => onUseExistingChange(e.target.checked)}
+            disabled={disabled}
+          >
+            Use saved encrypted value
+          </Checkbox>
+        ) : existing?.scope === 'session' ? (
+          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            Session-scoped saved values must be selected in Session Settings; enter a value here to
+            use it now.
+          </Text>
+        ) : null}
+        {inputType === 'textarea' ? (
+          <Input.TextArea {...inputProps} rows={3} />
+        ) : inputType === 'text' ? (
+          <Input {...inputProps} />
+        ) : (
+          <Input.Password {...inputProps} />
+        )}
+        {metadata?.format_hint ? (
+          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            {metadata.format_hint}
+          </Text>
+        ) : null}
+        {error ? (
+          <Text type="danger" style={{ fontSize: token.fontSizeSM }}>
+            {error}
+          </Text>
+        ) : null}
+      </Space>
     </div>
   );
 };
@@ -103,10 +184,11 @@ const PendingForm: React.FC<PendingFormProps> = ({
 }) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
+  const orderedNames = useMemo(() => orderedEnvVarNames(params.names), [params.names]);
 
   const [values, setValues] = useState<Record<string, string>>(() => {
     const initial: Record<string, string> = {};
-    for (const name of params.names) initial[name] = '';
+    for (const name of orderedNames) initial[name] = '';
     return initial;
   });
   // Scope is a user-only choice — agent doesn't get to suggest it. Default
@@ -116,10 +198,33 @@ const PendingForm: React.FC<PendingFormProps> = ({
   const [scope, setScope] = useState<EnvVarScope>('global');
   const [submitting, setSubmitting] = useState(false);
   const [dismissing, setDismissing] = useState(false);
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [useExisting, setUseExisting] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    for (const name of orderedNames) initial[name] = false;
+    return initial;
+  });
+  const [localResolution, setLocalResolution] = useState<
+    | {
+        kind: 'submitted';
+        names: string[];
+        scope: EnvVarScope;
+        usedExisting?: string[];
+        submitted?: string[];
+      }
+    | { kind: 'dismissed'; names: string[] }
+    | null
+  >(null);
+  const resolvingRef = useRef(false);
 
   const allFilled = useMemo(
-    () => params.names.every((name) => values[name]?.trim().length > 0),
-    [params.names, values]
+    () => orderedNames.every((name) => useExisting[name] || values[name]?.trim().length > 0),
+    [orderedNames, useExisting, values]
+  );
+  const missingNames = useMemo(
+    () => orderedNames.filter((name) => !useExisting[name] && !values[name]?.trim()),
+    [orderedNames, useExisting, values]
   );
 
   // Use the Feathers client so the built-in 401 refresh/retry hook fires
@@ -131,43 +236,121 @@ const PendingForm: React.FC<PendingFormProps> = ({
     return client.service(`widgets/${encodeURIComponent(widgetId)}/${path}`).create(body ?? {});
   };
 
+  const extractFieldErrors = (err: unknown): Record<string, string> => {
+    const data = (err as { data?: { field_errors?: unknown } } | undefined)?.data;
+    const raw = data?.field_errors;
+    if (!raw || typeof raw !== 'object') return {};
+    const out: Record<string, string> = {};
+    for (const [name, message] of Object.entries(raw)) {
+      if (typeof message === 'string') out[name] = message;
+    }
+    return out;
+  };
+
   const handleSubmit = async () => {
-    if (!allFilled || submitting) return;
+    if (resolvingRef.current || localResolution) return;
+    if (!allFilled) {
+      setValidationMessage('Enter all requested values before saving.');
+      setFieldErrors(
+        Object.fromEntries(missingNames.map((name) => [name, 'Enter a value or use a saved one.']))
+      );
+      return;
+    }
+    resolvingRef.current = true;
     setSubmitting(true);
+    setValidationMessage(null);
+    setFieldErrors({});
+    const useExistingNames = orderedNames.filter((name) => useExisting[name]);
+    const valueNames = orderedNames.filter((name) => !useExisting[name]);
     const submitBody = {
-      values: Object.fromEntries(params.names.map((name) => [name, values[name]?.trim() ?? ''])),
+      values: Object.fromEntries(valueNames.map((name) => [name, values[name]?.trim() ?? ''])),
+      use_existing: useExistingNames,
       scope,
     };
     try {
       await post('submit', submitBody);
+      setLocalResolution({
+        kind: 'submitted',
+        names: orderedNames,
+        scope,
+        submitted: valueNames,
+        usedExisting: useExistingNames,
+      });
+      const displayScope = valueNames.length > 0 ? scope : 'global';
       showSuccess(
-        params.names.length === 1
-          ? `Saved ${params.names[0]} (${scope})`
-          : `Saved ${params.names.length} variables (${scope})`
+        orderedNames.length === 1
+          ? `Saved ${orderedNames[0]} (${displayScope})`
+          : `Saved ${orderedNames.length} variables (${displayScope})`
       );
     } catch (err) {
-      showError(`Save failed: ${err instanceof Error ? err.message : String(err)}`);
+      resolvingRef.current = false;
+      const message = `Save failed: ${err instanceof Error ? err.message : String(err)}`;
+      setFieldErrors(extractFieldErrors(err));
+      setValidationMessage(`${message}. Check the requested names and try again.`);
+      showError(message);
     } finally {
       setSubmitting(false);
     }
   };
 
   const handleDismiss = async () => {
-    if (dismissing) return;
+    if (resolvingRef.current || localResolution) return;
+    resolvingRef.current = true;
     setDismissing(true);
+    setValidationMessage(null);
+    setFieldErrors({});
     try {
       await post('dismiss', {});
+      setLocalResolution({ kind: 'dismissed', names: orderedNames });
     } catch (err) {
-      showError(`Dismiss failed: ${err instanceof Error ? err.message : String(err)}`);
+      resolvingRef.current = false;
+      const message = `Dismiss failed: ${err instanceof Error ? err.message : String(err)}`;
+      setValidationMessage(`${message}. Try again.`);
+      showError(message);
     } finally {
       setDismissing(false);
     }
   };
 
   const title =
-    params.names.length === 1
+    orderedNames.length === 1
       ? 'Securely provide environment variable'
-      : `Securely provide ${params.names.length} environment variables`;
+      : `Securely provide ${orderedNames.length} environment variables`;
+
+  if (localResolution?.kind === 'submitted') {
+    const displayScope =
+      (localResolution.submitted?.length ?? 0) > 0 ? localResolution.scope : 'global';
+    return (
+      <TerminalLine
+        icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
+        borderColor={token.colorSuccess}
+        text={
+          <Space orientation="vertical" size={0}>
+            <Text>
+              {localResolution.names.length === 1
+                ? localResolution.names[0]
+                : `${localResolution.names.length} variables`}{' '}
+              saved
+              <Text type="secondary"> ({displayScope})</Text>
+            </Text>
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              Need to correct one? Update it in User Settings → Env vars.
+            </Text>
+          </Space>
+        }
+      />
+    );
+  }
+
+  if (localResolution?.kind === 'dismissed') {
+    return (
+      <TerminalLine
+        icon={<MinusCircleOutlined style={{ color: token.colorTextSecondary }} />}
+        borderColor={token.colorBorder}
+        text={<Text type="secondary">{localResolution.names.join(', ')} dismissed</Text>}
+      />
+    );
+  }
 
   return (
     <Card
@@ -187,20 +370,43 @@ const PendingForm: React.FC<PendingFormProps> = ({
           </Text>
         )}
 
-        {params.names.map((name) => (
+        {orderedNames.map((name) => (
           <VarRow
             key={name}
             name={name}
             value={values[name] ?? ''}
-            onChange={(next) => setValues((prev) => ({ ...prev, [name]: next }))}
+            metadata={params.variable_metadata?.[name]}
+            existing={params.existing?.[name]}
+            useExisting={!!useExisting[name]}
+            onUseExistingChange={(next) => {
+              setValidationMessage(null);
+              setFieldErrors((prev) => ({ ...prev, [name]: '' }));
+              setUseExisting((prev) => ({ ...prev, [name]: next }));
+            }}
+            onChange={(next) => {
+              setValidationMessage(null);
+              setFieldErrors((prev) => ({ ...prev, [name]: '' }));
+              setValues((prev) => ({ ...prev, [name]: next }));
+            }}
+            error={fieldErrors[name]}
             disabled={submitting || dismissing}
           />
         ))}
 
+        {validationMessage ? (
+          <Text type="danger" style={{ fontSize: token.fontSizeSM }}>
+            {validationMessage}
+          </Text>
+        ) : missingNames.length > 0 ? (
+          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            Enter {missingNames.length === 1 ? missingNames[0] : 'all requested values'} to save.
+          </Text>
+        ) : null}
+
         <Space style={{ width: '100%', justifyContent: 'space-between' }} size="small">
           <Space size="small">
             <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-              Scope:
+              Scope for new values:
             </Text>
             <Select
               size="small"
@@ -261,17 +467,28 @@ const TerminalLine: React.FC<{
 const SubmittedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget }) => {
   const { token } = theme.useToken();
   const rm = readResultMeta(widget);
-  const names = rm?.names_submitted ?? readParams(widget).names;
+  const params = readParams(widget);
+  const names = orderedEnvVarNames([
+    ...(rm?.names_submitted ?? []),
+    ...(rm?.names_used_existing ?? []),
+  ]);
+  const displayNames = names.length > 0 ? names : orderedEnvVarNames(params.names);
   const scope = rm?.scope ?? 'global';
+  const displayScope = (rm?.names_submitted?.length ?? 0) > 0 ? scope : 'global';
   return (
     <TerminalLine
       icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
       borderColor={token.colorSuccess}
       text={
-        <Text>
-          {names.length === 1 ? names[0] : `${names.length} variables`} saved
-          <Text type="secondary"> ({scope})</Text>
-        </Text>
+        <Space orientation="vertical" size={0}>
+          <Text>
+            {displayNames.length === 1 ? displayNames[0] : `${displayNames.length} variables`} saved
+            <Text type="secondary"> ({displayScope})</Text>
+          </Text>
+          <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            Need to correct one? Update it in User Settings → Env vars.
+          </Text>
+        </Space>
       }
     />
   );
@@ -279,7 +496,7 @@ const SubmittedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget 
 
 const DismissedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget }) => {
   const { token } = theme.useToken();
-  const names = readParams(widget).names;
+  const names = orderedEnvVarNames(readParams(widget).names);
   return (
     <TerminalLine
       icon={<MinusCircleOutlined style={{ color: token.colorTextSecondary }} />}
@@ -291,7 +508,7 @@ const DismissedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget 
 
 const AlreadyPresentSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget }) => {
   const { token } = theme.useToken();
-  const names = readParams(widget).names;
+  const names = orderedEnvVarNames(readParams(widget).names);
   return (
     <TerminalLine
       icon={<CheckCircleOutlined style={{ color: token.colorInfo }} />}

--- a/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx
@@ -26,7 +26,7 @@ import {
   SafetyCertificateOutlined,
 } from '@ant-design/icons';
 import { Button, Card, Checkbox, Input, Select, Space, Typography, theme } from 'antd';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
 import { registerWidgetComponent, type WidgetComponentProps } from '../MessageBlock/WidgetBlock';
 import { Tag } from '../Tag';
@@ -45,7 +45,6 @@ interface EnvVarsParams {
       input_type?: 'password' | 'text' | 'textarea';
     }
   >;
-  existing?: Record<string, { set: true; scope: EnvVarScope; resource_id?: string | null }>;
   auto_resume?: boolean;
 }
 
@@ -67,12 +66,37 @@ function orderedEnvVarNames(names: string[]): string[] {
   return [...names].sort();
 }
 
+interface EnvVarExistingStatus {
+  set: true;
+  scope: EnvVarScope;
+  resource_id?: string | null;
+}
+
+function describeNames(names: string[]): string {
+  const ordered = orderedEnvVarNames(names);
+  return ordered.length === 1 ? ordered[0] : `${ordered.length} variables`;
+}
+
+function buildSubmittedSummaryText(input: {
+  submitted?: string[];
+  usedExisting?: string[];
+  scope: EnvVarScope;
+}): string {
+  const submitted = orderedEnvVarNames(input.submitted ?? []);
+  const usedExisting = orderedEnvVarNames(input.usedExisting ?? []);
+  const parts = [
+    submitted.length > 0 ? `Saved ${describeNames(submitted)} (${input.scope})` : '',
+    usedExisting.length > 0 ? `Used existing ${describeNames(usedExisting)} (global)` : '',
+  ].filter(Boolean);
+  return parts.join('; ');
+}
+
 interface VarRowProps {
   name: string;
   value: string;
   onChange: (next: string) => void;
   metadata?: NonNullable<EnvVarsParams['variable_metadata']>[string];
-  existing?: NonNullable<EnvVarsParams['existing']>[string];
+  existing?: EnvVarExistingStatus;
   useExisting: boolean;
   onUseExistingChange: (next: boolean) => void;
   error?: string;
@@ -121,9 +145,7 @@ const VarRow: React.FC<VarRowProps> = ({
             <LockOutlined style={{ color: token.colorTextSecondary }} />
             {name}
           </Text>
-          <Tag color={existing?.set ? 'success' : 'default'}>
-            {existing?.set ? 'Set (encrypted)' : 'Not Set'}
-          </Tag>
+          {existing?.set ? <Tag color="success">Set (encrypted)</Tag> : null}
           {existing?.scope ? (
             <Tag color={existing.scope === 'global' ? 'blue' : 'purple'}>{existing.scope}</Tag>
           ) : null}
@@ -176,15 +198,11 @@ interface PendingFormProps {
   client: AgorClient | null;
 }
 
-const PendingForm: React.FC<PendingFormProps> = ({
-  widgetId,
-  message: _message,
-  params,
-  client,
-}) => {
+const PendingForm: React.FC<PendingFormProps> = ({ widgetId, message, params, client }) => {
   const { token } = theme.useToken();
   const { showSuccess, showError } = useThemedMessage();
   const orderedNames = useMemo(() => orderedEnvVarNames(params.names), [params.names]);
+  const [existingByName, setExistingByName] = useState<Record<string, EnvVarExistingStatus>>({});
 
   const [values, setValues] = useState<Record<string, string>>(() => {
     const initial: Record<string, string> = {};
@@ -217,6 +235,35 @@ const PendingForm: React.FC<PendingFormProps> = ({
     | null
   >(null);
   const resolvingRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadExisting = async () => {
+      if (!client) return;
+      const session = (await client.service('sessions').get(message.session_id)) as {
+        created_by?: string;
+      };
+      if (!session.created_by) return;
+      const creator = (await client.service('users').get(session.created_by)) as {
+        env_vars?: Record<string, EnvVarExistingStatus>;
+      };
+      const next: Record<string, EnvVarExistingStatus> = {};
+      for (const name of orderedNames) {
+        const existing = creator.env_vars?.[name];
+        if (existing?.set) next[name] = existing;
+      }
+      if (!cancelled) setExistingByName(next);
+    };
+
+    loadExisting().catch(() => {
+      if (!cancelled) setExistingByName({});
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, message.session_id, orderedNames]);
 
   const allFilled = useMemo(
     () => orderedNames.every((name) => useExisting[name] || values[name]?.trim().length > 0),
@@ -276,11 +323,12 @@ const PendingForm: React.FC<PendingFormProps> = ({
         submitted: valueNames,
         usedExisting: useExistingNames,
       });
-      const displayScope = valueNames.length > 0 ? scope : 'global';
       showSuccess(
-        orderedNames.length === 1
-          ? `Saved ${orderedNames[0]} (${displayScope})`
-          : `Saved ${orderedNames.length} variables (${displayScope})`
+        buildSubmittedSummaryText({
+          submitted: valueNames,
+          usedExisting: useExistingNames,
+          scope,
+        })
       );
     } catch (err) {
       resolvingRef.current = false;
@@ -318,21 +366,13 @@ const PendingForm: React.FC<PendingFormProps> = ({
       : `Securely provide ${orderedNames.length} environment variables`;
 
   if (localResolution?.kind === 'submitted') {
-    const displayScope =
-      (localResolution.submitted?.length ?? 0) > 0 ? localResolution.scope : 'global';
     return (
       <TerminalLine
         icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
         borderColor={token.colorSuccess}
         text={
           <Space orientation="vertical" size={0}>
-            <Text>
-              {localResolution.names.length === 1
-                ? localResolution.names[0]
-                : `${localResolution.names.length} variables`}{' '}
-              saved
-              <Text type="secondary"> ({displayScope})</Text>
-            </Text>
+            <Text>{buildSubmittedSummaryText(localResolution)}</Text>
             <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
               Need to correct one? Update it in User Settings → Env vars.
             </Text>
@@ -376,7 +416,7 @@ const PendingForm: React.FC<PendingFormProps> = ({
             name={name}
             value={values[name] ?? ''}
             metadata={params.variable_metadata?.[name]}
-            existing={params.existing?.[name]}
+            existing={existingByName[name]}
             useExisting={!!useExisting[name]}
             onUseExistingChange={(next) => {
               setValidationMessage(null);
@@ -474,17 +514,20 @@ const SubmittedSummary: React.FC<{ widget: WidgetMessageMetadata }> = ({ widget 
   ]);
   const displayNames = names.length > 0 ? names : orderedEnvVarNames(params.names);
   const scope = rm?.scope ?? 'global';
-  const displayScope = (rm?.names_submitted?.length ?? 0) > 0 ? scope : 'global';
+  const summaryText = rm
+    ? buildSubmittedSummaryText({
+        submitted: rm.names_submitted,
+        usedExisting: rm.names_used_existing,
+        scope,
+      })
+    : `Saved ${describeNames(displayNames)} (${scope})`;
   return (
     <TerminalLine
       icon={<CheckCircleOutlined style={{ color: token.colorSuccess }} />}
       borderColor={token.colorSuccess}
       text={
         <Space orientation="vertical" size={0}>
-          <Text>
-            {displayNames.length === 1 ? displayNames[0] : `${displayNames.length} variables`} saved
-            <Text type="secondary"> ({displayScope})</Text>
-          </Text>
+          <Text>{summaryText}</Text>
           <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
             Need to correct one? Update it in User Settings → Env vars.
           </Text>


### PR DESCRIPTION
## What changed

This PR makes the `env_vars` widget more useful when an agent asks the user for environment variables inside a session.

### Widget creation and metadata
- Adds optional per-variable metadata for requested env vars:
  - description
  - placeholder
  - format hint
  - input type: password, text, or textarea
- Derives safe “already set” metadata for requested names so the UI can show whether a value exists without exposing the value itself.
- Keeps widget params/result metadata sanitized: names, scope, and status metadata only; no submitted secret values.

### Pending form UX
- Renders requested env var names deterministically.
- Shows `Set (encrypted)` / `Not Set` status tags for each requested variable.
- Allows reusing a saved encrypted global value without retyping it.
- Adds clearer required-value guidance before Save is enabled.
- Displays server-side field errors on the matching variable when validation can name the field.

### Submit, dismiss, and terminal states
- Extends submit handling to accept typed values plus `use_existing` names while preserving exact requested-name coverage.
- Validates `use_existing` as global-only and returns field-attributed errors for invalid submitted names.
- Adds duplicate-safe local terminal state for Save/Dismiss so repeated clicks do not re-resolve the widget.
- Adds submitted summaries that point users to User Settings → Env vars when a value needs correction.
- Selects newly submitted session-scoped values for the current session when daemon DB access is available.

## Screenshots

Pending widget with per-variable metadata, set/not-set indicators, and saved-value reuse:

![Pending env-var widget with metadata and saved-value indicators](https://raw.githubusercontent.com/preset-io/agor/578e217126629078d17942a4b4319348c9899390/.github/pr-assets/widgets-env-var-form-polish/env-widget-pending.png)

Field-attributed server-side validation error:

![Env-var widget showing field-attributed validation error](https://raw.githubusercontent.com/preset-io/agor/578e217126629078d17942a4b4319348c9899390/.github/pr-assets/widgets-env-var-form-polish/env-widget-field-error.png)

## Safety / behavior notes

- Does not change env-var storage or encryption semantics.
- Does not change RBAC behavior.
- Does not expand the supported scope model beyond the existing global/session behavior.
- Does not expose secret values in widget metadata, result metadata, transcript summaries, MCP tool returns, prompts, tests, or logs.

## Validation

- `pnpm --filter @agor/daemon test -- src/widgets/env-vars/index.test.ts src/mcp/tools/widgets.test.ts src/widgets/submissions.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm --filter agor-ui test -- src/components/Widgets/EnvVarRequestWidget.test.tsx`
- `pnpm exec biome check` on touched files
- `git diff --check`
- Live branch runtime QA covered submit, dismiss, use-existing, field-error, session-scope selection, duplicate-safety, and secret non-leakage flows.

## Review focus

The highest-signal files to review are:
- `apps/agor-daemon/src/widgets/env-vars/index.ts`
- `apps/agor-ui/src/components/Widgets/EnvVarRequestWidget.tsx`
- focused tests beside those files and in `apps/agor-daemon/src/mcp/tools/widgets.test.ts`
