### PR TITLE
Simplify upload storage

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1774,49 +1774,21 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // File upload endpoint
   // ============================================================================
 
-  const sessionRepo = new SessionRepository(db);
   const branchRepo = new BranchRepository(db);
-  const uploadMiddleware = createUploadMiddleware(sessionRepo);
+  const uploadMiddleware = createUploadMiddleware();
   const DEBUG_UPLOAD = process.env.NODE_ENV !== 'production';
 
-  // biome-ignore lint/suspicious/noExplicitAny: Express 5 + multer type compatibility
-  const uploadHandler: any = async (req: any, res: any, next: any) => {
+  // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
+  const authorizeUpload: any = async (req: any, res: any, next: any) => {
     try {
-      if (DEBUG_UPLOAD) {
-        console.log('🚀 [Upload Handler] Request received');
-        console.log('   Headers:', {
-          contentType: req.headers['content-type'],
-          authorization: req.headers.authorization ? 'present' : 'missing',
-          cookie: req.headers.cookie ? 'present' : 'missing',
-        });
-      }
-
       const { sessionId } = req.params;
-      const { notifyAgent, message } = req.body;
-      const files = req.files as Express.Multer.File[];
-
-      if (DEBUG_UPLOAD) {
-        console.log(
-          `📎 [Upload Handler] Processing for session ${sessionId ? shortId(sessionId) : 'unknown'}`
-        );
-        console.log(`   Notify agent: ${notifyAgent === 'true' || notifyAgent === true}`);
-        console.log(`   Files received: ${files?.length || 0}`);
-      }
-
       const params = req.feathers as AuthenticatedParams;
-      if (DEBUG_UPLOAD) {
-        console.log(`   Auth params:`, {
-          hasUser: !!params?.user,
-          userId: params?.user?.user_id ? shortId(params.user.user_id) : undefined,
-          provider: params?.provider,
-        });
-      }
 
       ensureMinimumRole(params, ROLES.MEMBER, 'upload files');
 
       const session = await sessionsService.get(sessionId, params);
       if (!session) {
-        console.error(`❌ [Upload Handler] Session not found: ${shortId(sessionId)}`);
+        console.error(`❌ [Upload Authz] Session not found: ${shortId(sessionId)}`);
         return res.status(404).json({ error: 'Session not found' });
       }
 
@@ -1852,10 +1824,49 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
         if (!canUpload) {
           console.error(
-            `❌ [Upload Handler] User ${shortId(userId)} has '${effectiveLevel}' permission, cannot upload to branch ${shortId(wt.branch_id)}`
+            `❌ [Upload Authz] User ${shortId(userId)} has '${effectiveLevel}' permission, cannot upload to branch ${shortId(wt.branch_id)}`
           );
           return res.status(403).json({ error: 'Not authorized to upload to this session' });
         }
+      }
+
+      next();
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: Express 5 + multer type compatibility
+  const uploadHandler: any = async (req: any, res: any, next: any) => {
+    try {
+      if (DEBUG_UPLOAD) {
+        console.log('🚀 [Upload Handler] Request received');
+        console.log('   Headers:', {
+          contentType: req.headers['content-type'],
+          authorization: req.headers.authorization ? 'present' : 'missing',
+          cookie: req.headers.cookie ? 'present' : 'missing',
+        });
+      }
+
+      const { sessionId } = req.params;
+      const { notifyAgent, message } = req.body;
+      const files = req.files as Express.Multer.File[];
+
+      if (DEBUG_UPLOAD) {
+        console.log(
+          `📎 [Upload Handler] Processing for session ${sessionId ? shortId(sessionId) : 'unknown'}`
+        );
+        console.log(`   Notify agent: ${notifyAgent === 'true' || notifyAgent === true}`);
+        console.log(`   Files received: ${files?.length || 0}`);
+      }
+
+      const params = req.feathers as AuthenticatedParams;
+      if (DEBUG_UPLOAD) {
+        console.log(`   Auth params:`, {
+          hasUser: !!params?.user,
+          userId: params?.user?.user_id ? shortId(params.user.user_id) : undefined,
+          provider: params?.provider,
+        });
       }
 
       if (!files || files.length === 0) {
@@ -1996,6 +2007,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // time writing oversize uploads to disk.
     // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
     enforceTotalUploadSize() as any,
+    authorizeUpload,
     // biome-ignore lint/suspicious/noExplicitAny: Express 5 + multer type compatibility
     uploadMiddleware.array('files', 10) as any,
     // Defence-in-depth aggregate-size check using the actual file sizes that

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1776,7 +1776,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   const sessionRepo = new SessionRepository(db);
   const branchRepo = new BranchRepository(db);
-  const uploadMiddleware = createUploadMiddleware(sessionRepo, branchRepo);
+  const uploadMiddleware = createUploadMiddleware(sessionRepo);
   const DEBUG_UPLOAD = process.env.NODE_ENV !== 'production';
 
   // biome-ignore lint/suspicious/noExplicitAny: Express 5 + multer type compatibility
@@ -1792,14 +1792,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       }
 
       const { sessionId } = req.params;
-      const { destination, notifyAgent, message } = req.body;
+      const { notifyAgent, message } = req.body;
       const files = req.files as Express.Multer.File[];
 
       if (DEBUG_UPLOAD) {
         console.log(
           `📎 [Upload Handler] Processing for session ${sessionId ? shortId(sessionId) : 'unknown'}`
         );
-        console.log(`   Destination: ${destination || 'branch'}`);
         console.log(`   Notify agent: ${notifyAgent === 'true' || notifyAgent === true}`);
         console.log(`   Files received: ${files?.length || 0}`);
       }
@@ -1864,23 +1863,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         return res.status(400).json({ error: 'No files uploaded' });
       }
 
-      let branch: Awaited<ReturnType<typeof branchRepo.findById>> | undefined;
-      if (session.branch_id) {
-        branch = await branchRepo.findById(session.branch_id);
-      }
-
-      const uploadedFiles = files.map((f) => {
-        let relativePath = f.path;
-        if (branch && f.path.startsWith(branch.path)) {
-          relativePath = f.path.substring(branch.path.length + 1);
-        }
-        return {
-          filename: f.filename,
-          path: relativePath,
-          size: f.size,
-          mimeType: f.mimetype,
-        };
-      });
+      const uploadedFiles = files.map((f) => ({
+        filename: f.filename,
+        path: f.path,
+        size: f.size,
+        mimeType: f.mimetype,
+      }));
 
       if (DEBUG_UPLOAD) {
         console.log(`   Uploaded ${uploadedFiles.length} file(s):`);

--- a/apps/agor-daemon/src/utils/upload.test.ts
+++ b/apps/agor-daemon/src/utils/upload.test.ts
@@ -8,6 +8,8 @@
  *   - aggregate-size middlewares reject oversize requests (pre + post multer)
  */
 
+import os from 'node:os';
+import path from 'node:path';
 import type { NextFunction, Request, Response } from 'express';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -15,9 +17,11 @@ import {
   createUploadMiddleware,
   enforceParsedTotalUploadSize,
   enforceTotalUploadSize,
+  getUploadDirectory,
   MAX_UPLOAD_FILE_SIZE,
   MAX_UPLOAD_FILES_PER_REQUEST,
   MAX_UPLOAD_TOTAL_SIZE,
+  validateUploadDestinationQuery,
 } from './upload';
 
 function mockRes() {
@@ -54,10 +58,7 @@ describe('upload allowlist', () => {
   it('multer instance carries the configured limits', () => {
     // Tiny stand-ins for the repos — the limit fields are read off the multer
     // instance directly, so the storage callbacks never run.
-    const mw = createUploadMiddleware(
-      {} as Parameters<typeof createUploadMiddleware>[0],
-      {} as Parameters<typeof createUploadMiddleware>[1]
-    );
+    const mw = createUploadMiddleware({} as Parameters<typeof createUploadMiddleware>[0]);
     // multer attaches the original options under `.limits`
     const limits = (mw as unknown as { limits?: Record<string, number> }).limits;
     expect(limits?.fileSize).toBe(MAX_UPLOAD_FILE_SIZE);
@@ -68,6 +69,24 @@ describe('upload allowlist', () => {
     // VALUES (a single text input), not combined file payload. If it ever
     // reappears here it likely means someone re-introduced the bad ceiling.
     expect(limits?.fieldSize).toBeUndefined();
+  });
+});
+
+describe('upload destination handling', () => {
+  it('stores daemon-side uploads under ~/.agor/uploads', () => {
+    expect(getUploadDirectory()).toBe(path.join(os.homedir(), '.agor', 'uploads'));
+  });
+
+  it('ignores only legacy no-op destination values', () => {
+    expect(() => validateUploadDestinationQuery(undefined)).not.toThrow();
+    expect(() => validateUploadDestinationQuery('')).not.toThrow();
+    expect(() => validateUploadDestinationQuery('branch')).not.toThrow();
+    expect(() => validateUploadDestinationQuery('global')).not.toThrow();
+  });
+
+  it('rejects unsupported upload destinations', () => {
+    expect(() => validateUploadDestinationQuery('temp')).toThrow(/no longer supported/i);
+    expect(() => validateUploadDestinationQuery('workspace')).toThrow(/no longer supported/i);
   });
 });
 

--- a/apps/agor-daemon/src/utils/upload.test.ts
+++ b/apps/agor-daemon/src/utils/upload.test.ts
@@ -58,7 +58,7 @@ describe('upload allowlist', () => {
   it('multer instance carries the configured limits', () => {
     // Tiny stand-ins for the repos — the limit fields are read off the multer
     // instance directly, so the storage callbacks never run.
-    const mw = createUploadMiddleware({} as Parameters<typeof createUploadMiddleware>[0]);
+    const mw = createUploadMiddleware();
     // multer attaches the original options under `.limits`
     const limits = (mw as unknown as { limits?: Record<string, number> }).limits;
     expect(limits?.fileSize).toBe(MAX_UPLOAD_FILE_SIZE);

--- a/apps/agor-daemon/src/utils/upload.ts
+++ b/apps/agor-daemon/src/utils/upload.ts
@@ -7,8 +7,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { getAgorHome } from '@agor/core/config';
-import type { SessionRepository } from '@agor/core/db';
-import { shortId } from '@agor/core/db';
 import type { NextFunction, Request, Response } from 'express';
 import multer from 'multer';
 
@@ -84,7 +82,7 @@ export function validateUploadDestinationQuery(destination: unknown): void {
 /**
  * Create multer storage configuration
  */
-export function createUploadStorage(sessionRepo: SessionRepository) {
+export function createUploadStorage() {
   const storage = multer.diskStorage({
     destination: async (req: Request, _file, cb) => {
       try {
@@ -97,20 +95,8 @@ export function createUploadStorage(sessionRepo: SessionRepository) {
 
         if (DEBUG_UPLOAD) {
           console.log(
-            `📂 [Upload Storage] Processing upload for session ${sessionId ? shortId(sessionId) : 'unknown'}`
+            `📂 [Upload Storage] Processing upload for session ${sessionId || 'unknown'}`
           );
-        }
-
-        if (!sessionId) {
-          console.error('❌ [Upload Storage] No session ID provided');
-          return cb(new Error('Session ID required'), '');
-        }
-
-        // Verify the target session before writing bytes to daemon-owned storage.
-        const session = await sessionRepo.findById(sessionId);
-        if (!session) {
-          console.error(`❌ [Upload Storage] Session not found: ${shortId(sessionId)}`);
-          return cb(new Error(`Session not found: ${sessionId}`), '');
         }
 
         const dest = getUploadDirectory();
@@ -162,8 +148,8 @@ export function createUploadStorage(sessionRepo: SessionRepository) {
 /**
  * Create configured multer instance
  */
-export function createUploadMiddleware(sessionRepo: SessionRepository) {
-  const storage = createUploadStorage(sessionRepo);
+export function createUploadMiddleware() {
+  const storage = createUploadStorage();
 
   return multer({
     storage,

--- a/apps/agor-daemon/src/utils/upload.ts
+++ b/apps/agor-daemon/src/utils/upload.ts
@@ -1,16 +1,13 @@
 /**
  * Upload middleware using multer for file upload handling
  *
- * Supports uploading files to:
- * - Branch (.agor/uploads/) - Default, agent-accessible
- * - Temp folder - Ephemeral uploads
- * - Global (~/.agor/uploads/) - Shared across sessions
+ * Stores daemon-side uploads under ~/.agor/uploads/.
  */
 
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
-import type { BranchRepository, SessionRepository } from '@agor/core/db';
+import { getAgorHome } from '@agor/core/config';
+import type { SessionRepository } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
 import type { NextFunction, Request, Response } from 'express';
 import multer from 'multer';
@@ -56,34 +53,52 @@ export const MAX_UPLOAD_TOTAL_SIZE = 100 * 1024 * 1024; // 100 MB
 // Debug logging only in development
 const DEBUG_UPLOAD = process.env.NODE_ENV !== 'production';
 
+const LEGACY_IGNORED_UPLOAD_DESTINATIONS = new Set(['branch', 'global']);
+
 /**
- * Destination types for file uploads
+ * Resolve the only supported daemon-side upload directory.
  */
-export type UploadDestination = 'branch' | 'temp' | 'global';
+export function getUploadDirectory(): string {
+  return path.join(getAgorHome(), 'uploads');
+}
+
+export function validateUploadDestinationQuery(destination: unknown): void {
+  if (destination == null || destination === '') return;
+  if (Array.isArray(destination)) {
+    throw Object.assign(new Error('Upload destination options are no longer supported'), {
+      status: 400,
+    });
+  }
+  const value = String(destination);
+  // Old clients sent the previous default (`branch`) or explicit `global`.
+  // Treat those as no-ops so they write to the single supported location.
+  if (LEGACY_IGNORED_UPLOAD_DESTINATIONS.has(value)) return;
+  throw Object.assign(
+    new Error(
+      `Upload destination '${value}' is no longer supported; uploads are stored in ~/.agor/uploads/`
+    ),
+    { status: 400 }
+  );
+}
 
 /**
  * Create multer storage configuration
  */
-export function createUploadStorage(sessionRepo: SessionRepository, branchRepo: BranchRepository) {
+export function createUploadStorage(sessionRepo: SessionRepository) {
   const storage = multer.diskStorage({
     destination: async (req: Request, _file, cb) => {
       try {
         const { sessionId } = req.params;
         // NOTE: req.body is NOT available yet during multer's destination callback
-        // because multer hasn't parsed the body fields yet. We read from query params instead.
-        const destination = (req.query.destination as UploadDestination) || 'branch';
-
-        // Validate destination
-        if (!['branch', 'temp', 'global'].includes(destination)) {
-          console.error(`❌ [Upload Storage] Invalid destination: ${destination}`);
-          return cb(new Error(`Invalid destination: ${destination}`), '');
-        }
+        // because multer hasn't parsed the body fields yet. Legacy clients may
+        // still send destination as a query param; only the old no-op values are
+        // tolerated, and all uploads are written to ~/.agor/uploads/.
+        validateUploadDestinationQuery(req.query.destination);
 
         if (DEBUG_UPLOAD) {
           console.log(
             `📂 [Upload Storage] Processing upload for session ${sessionId ? shortId(sessionId) : 'unknown'}`
           );
-          console.log(`   Destination type: ${destination}`);
         }
 
         if (!sessionId) {
@@ -91,32 +106,14 @@ export function createUploadStorage(sessionRepo: SessionRepository, branchRepo: 
           return cb(new Error('Session ID required'), '');
         }
 
-        // Get session to find associated branch
+        // Verify the target session before writing bytes to daemon-owned storage.
         const session = await sessionRepo.findById(sessionId);
         if (!session) {
           console.error(`❌ [Upload Storage] Session not found: ${shortId(sessionId)}`);
           return cb(new Error(`Session not found: ${sessionId}`), '');
         }
 
-        if (!session.branch_id) {
-          console.error(`❌ [Upload Storage] Session ${shortId(sessionId)} has no branch`);
-          return cb(new Error(`Session ${sessionId} has no associated branch`), '');
-        }
-
-        const branch = await branchRepo.findById(session.branch_id);
-        if (!branch) {
-          console.error(`❌ [Upload Storage] Branch not found: ${shortId(session.branch_id)}`);
-          return cb(new Error(`Branch not found: ${session.branch_id}`), '');
-        }
-
-        // Map destination to actual path
-        const paths: Record<UploadDestination, string> = {
-          branch: path.join(branch.path, '.agor', 'uploads'),
-          temp: path.join(os.tmpdir(), 'agor-uploads'),
-          global: path.join(os.homedir(), '.agor', 'uploads'),
-        };
-
-        const dest = paths[destination] || paths.branch;
+        const dest = getUploadDirectory();
 
         if (DEBUG_UPLOAD) console.log(`📁 [Upload Storage] Target directory: ${dest}`);
 
@@ -165,11 +162,8 @@ export function createUploadStorage(sessionRepo: SessionRepository, branchRepo: 
 /**
  * Create configured multer instance
  */
-export function createUploadMiddleware(
-  sessionRepo: SessionRepository,
-  branchRepo: BranchRepository
-) {
-  const storage = createUploadStorage(sessionRepo, branchRepo);
+export function createUploadMiddleware(sessionRepo: SessionRepository) {
+  const storage = createUploadStorage(sessionRepo);
 
   return multer({
     storage,

--- a/apps/agor-docs/pages/guide/rich-chat-ux.mdx
+++ b/apps/agor-docs/pages/guide/rich-chat-ux.mdx
@@ -256,12 +256,6 @@ See **[Security](/security)** for the trust boundary on per-user secrets.
 
 **Drop files into the agent's context with one click.** Uploads are stored under `~/.agor/uploads/`, and the agent receives that file path. A checked-by-default toggle auto-prompts the agent with a templated message referencing the path; the agent can copy or move the file into a branch if needed.
 
-<img
-  src="/screenshots/upload-modal.png"
-  alt="Upload modal with a checked 'Notify the agent about this file' toggle and a templated message using {filepath}"
-  style={{ maxWidth: '500px' }}
-/>
-
 Useful for handing screenshots, designs, error logs, or test fixtures to the agent without leaving the chat.
 
 ---

--- a/apps/agor-docs/pages/guide/rich-chat-ux.mdx
+++ b/apps/agor-docs/pages/guide/rich-chat-ux.mdx
@@ -254,11 +254,11 @@ See **[Security](/security)** for the trust boundary on per-user secrets.
 
 ## 📎 File Uploads
 
-**Drop files into the agent's context with one click.** The upload modal lets you choose where the file lands — committable inside the branch, ephemeral in a temp folder, or shared across sessions in `~/.agor/uploads/`. A toggle auto-prompts the agent with a templated message referencing the file path.
+**Drop files into the agent's context with one click.** Uploads are stored under `~/.agor/uploads/`, and the agent receives that file path. A checked-by-default toggle auto-prompts the agent with a templated message referencing the path; the agent can copy or move the file into a branch if needed.
 
 <img
   src="/screenshots/upload-modal.png"
-  alt="Upload modal with three destination options (branch, temp folder, global) and a 'Notify the agent about this file' toggle with a templated message using {filepath}"
+  alt="Upload modal with a checked 'Notify the agent about this file' toggle and a templated message using {filepath}"
   style={{ maxWidth: '500px' }}
 />
 

--- a/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
+++ b/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
@@ -212,8 +212,8 @@ export const FileUpload: React.FC<FileUploadProps> = ({
         </Upload>
 
         <Text type="secondary" style={{ fontSize: '12px' }}>
-          Files are uploaded to <Text code>~/.agor/uploads/</Text>. The agent receives the full file
-          path and can copy or move it into the branch if needed.
+          Files are uploaded to <Text code>~/.agor/uploads/</Text>. When notified, the agent
+          receives the full file path and can copy or move it into the branch if needed.
         </Text>
 
         {/* Notify agent option */}

--- a/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
+++ b/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
@@ -9,6 +9,9 @@ import { ACCESS_TOKEN_KEY } from '../../utils/tokenRefresh';
 const { TextArea } = Input;
 const { Text } = Typography;
 
+const DEFAULT_AGENT_UPLOAD_MESSAGE =
+  'Note: the user uploaded file(s): {filepath}\n\nPlease review and use them as context for this task.';
+
 export interface UploadedFile {
   filename: string;
   path: string;
@@ -38,7 +41,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   const { showSuccess, showWarning, showError } = useThemedMessage();
   const [fileList, setFileList] = useState<UploadFile[]>([]);
   const [notifyAgent, setNotifyAgent] = useState(true);
-  const [agentMessage, setAgentMessage] = useState('Please review this file: {filepath}');
+  const [agentMessage, setAgentMessage] = useState(DEFAULT_AGENT_UPLOAD_MESSAGE);
   const [uploading, setUploading] = useState(false);
 
   // Mirror fileList in a ref so cleanup (unmount/reset) can revoke object URLs
@@ -162,7 +165,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
       // Reset and close
       resetFileList();
       setNotifyAgent(true);
-      setAgentMessage('Please review this file: {filepath}');
+      setAgentMessage(DEFAULT_AGENT_UPLOAD_MESSAGE);
       onClose();
     } catch (error) {
       console.error('Upload error:', error);
@@ -175,7 +178,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
   const handleCancel = () => {
     resetFileList();
     setNotifyAgent(true);
-    setAgentMessage('Please review this file: {filepath}');
+    setAgentMessage(DEFAULT_AGENT_UPLOAD_MESSAGE);
     onClose();
   };
 
@@ -207,6 +210,11 @@ export const FileUpload: React.FC<FileUploadProps> = ({
         >
           <Button icon={<UploadOutlined />}>Select Files</Button>
         </Upload>
+
+        <Text type="secondary" style={{ fontSize: '12px' }}>
+          Files are uploaded to <Text code>~/.agor/uploads/</Text>. The agent receives the full file
+          path and can copy or move it into the branch if needed.
+        </Text>
 
         {/* Notify agent option */}
         <div>

--- a/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
+++ b/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
@@ -1,5 +1,5 @@
 import { PaperClipOutlined, UploadOutlined } from '@ant-design/icons';
-import { Button, Checkbox, Input, Modal, Radio, Space, Typography, Upload } from 'antd';
+import { Button, Checkbox, Input, Modal, Space, Typography, Upload } from 'antd';
 import type { RcFile, UploadFile } from 'antd/es/upload/interface';
 import type React from 'react';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
@@ -8,8 +8,6 @@ import { ACCESS_TOKEN_KEY } from '../../utils/tokenRefresh';
 
 const { TextArea } = Input;
 const { Text } = Typography;
-
-export type UploadDestination = 'branch' | 'temp' | 'global';
 
 export interface UploadedFile {
   filename: string;
@@ -39,7 +37,6 @@ export const FileUpload: React.FC<FileUploadProps> = ({
 }) => {
   const { showSuccess, showWarning, showError } = useThemedMessage();
   const [fileList, setFileList] = useState<UploadFile[]>([]);
-  const [destination, setDestination] = useState<UploadDestination>('branch');
   const [notifyAgent, setNotifyAgent] = useState(true);
   const [agentMessage, setAgentMessage] = useState('Please review this file: {filepath}');
   const [uploading, setUploading] = useState(false);
@@ -103,12 +100,10 @@ export const FileUpload: React.FC<FileUploadProps> = ({
           console.warn('[FileUpload] File missing originFileObj:', file.name);
         }
       });
-      // Note: destination is sent as query param because multer can't access req.body
-      // during the destination callback
       formData.append('notifyAgent', String(notifyAgent));
       formData.append('message', agentMessage);
 
-      const uploadUrl = `${daemonUrl}/sessions/${sessionId}/upload?destination=${encodeURIComponent(destination)}`;
+      const uploadUrl = `${daemonUrl}/sessions/${sessionId}/upload`;
 
       // Get JWT token from localStorage (same as Feathers client)
       const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
@@ -166,7 +161,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
 
       // Reset and close
       resetFileList();
-      setNotifyAgent(false);
+      setNotifyAgent(true);
       setAgentMessage('Please review this file: {filepath}');
       onClose();
     } catch (error) {
@@ -179,7 +174,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({
 
   const handleCancel = () => {
     resetFileList();
-    setNotifyAgent(false);
+    setNotifyAgent(true);
     setAgentMessage('Please review this file: {filepath}');
     onClose();
   };
@@ -212,43 +207,6 @@ export const FileUpload: React.FC<FileUploadProps> = ({
         >
           <Button icon={<UploadOutlined />}>Select Files</Button>
         </Upload>
-
-        {/* Destination selector */}
-        <div>
-          <Text strong>Destination:</Text>
-          <Radio.Group
-            value={destination}
-            onChange={(e) => setDestination(e.target.value)}
-            style={{ marginTop: 8, display: 'block' }}
-          >
-            <Space orientation="vertical">
-              <Radio value="branch">
-                <Space orientation="vertical" size={0}>
-                  <Text>Branch (.agor/uploads/)</Text>
-                  <Text type="secondary" style={{ fontSize: '12px' }}>
-                    Default - Agent-accessible, can be committed
-                  </Text>
-                </Space>
-              </Radio>
-              <Radio value="temp">
-                <Space orientation="vertical" size={0}>
-                  <Text>Temp folder</Text>
-                  <Text type="secondary" style={{ fontSize: '12px' }}>
-                    Ephemeral, auto-cleanup
-                  </Text>
-                </Space>
-              </Radio>
-              <Radio value="global">
-                <Space orientation="vertical" size={0}>
-                  <Text>Global (~/.agor/uploads/)</Text>
-                  <Text type="secondary" style={{ fontSize: '12px' }}>
-                    Shared across sessions
-                  </Text>
-                </Space>
-              </Radio>
-            </Space>
-          </Radio.Group>
-        </div>
 
         {/* Notify agent option */}
         <div>

--- a/apps/agor-ui/src/components/FileUpload/index.ts
+++ b/apps/agor-ui/src/components/FileUpload/index.ts
@@ -1,7 +1,6 @@
 export type {
   FileUploadButtonProps,
   FileUploadProps,
-  UploadDestination,
   UploadedFile,
 } from './FileUpload';
 export { FileUpload, FileUploadButton } from './FileUpload';


### PR DESCRIPTION
## Summary
- store daemon-side uploads only in `~/.agor/uploads/` and return absolute uploaded paths to agents
- remove upload destination selection from the UI and keep notify-agent checked by default
- reject unsupported legacy destination values while ignoring old no-op `branch`/`global` query values
- update upload tests and docs for the single storage location

## Tests
- `pnpm --filter @agor/daemon test -- src/utils/upload.test.ts`
- `biome check apps/agor-daemon/src/utils/upload.ts apps/agor-daemon/src/utils/upload.test.ts apps/agor-daemon/src/register-routes.ts apps/agor-ui/src/components/FileUpload/FileUpload.tsx apps/agor-ui/src/components/FileUpload/index.ts apps/agor-docs/pages/guide/rich-chat-ux.mdx`

Note: full daemon/UI typecheck was attempted in this dependency-less worktree using borrowed node_modules and failed on broad pre-existing dependency/type mismatches unrelated to these upload changes.