### PR TITLE
fix: rename session attachment label to links

### DIFF
--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -51,7 +51,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
 
   return (
     <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
-      <Tooltip title="Attachments">
+      <Tooltip title="Links">
         <Badge count={items.length} color={token.colorPrimary} size="small" offset={[-4, 4]}>
           <Button type="text" icon={<LinkOutlined style={{ color: token.colorPrimary }} />} />
         </Badge>


### PR DESCRIPTION
## Linked issue

N/A — no public issue link.

## Summary

- Rename the session widget tooltip from “Attachments” to “Links”.

## Why / context

The widget currently surfaces branch links such as issues and pull requests, so “Links” is a clearer label than “Attachments”.

## Implementation notes

- Updates only the user-facing tooltip copy in `SessionAttachmentsDropdown`.
- Leaves the broader links/attachments data model, collection, previews, and upload behavior out of scope.

## Validation / test plan

- [x] `pnpm exec biome check apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx`

## Screenshots / demos

Not captured; this is a one-word tooltip copy change.

## Risks / rollout / rollback

Low-risk UI copy change. Rollback is reverting the string change.

## Out of scope / follow-ups

- Links/attachments foundation and parse-on-ingest pipeline.
- Type-aware link/image/document previews.
- Auto-collection of conversation KB/agor references.
- New-session upload parity.
