### PR TITLE
chore: bump agor-live packages to 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ The reader's first pass is the headline only; sub-bullets are for the curious. K
 
 _No user-visible changes yet._
 
+## 0.23.0 (TBD)
+
+### Chores
+
+- **Prepare the next agor-live minor release** — bumps `agor-live` and `@agor-live/client` to 0.23.0 and keeps the standalone agor-live package lock in sync. ([#1670](https://github.com/preset-io/agor/pull/1670))
+
 ## 0.22.0 (TBD)
 
 ### Chores

--- a/packages/agor-live/package-lock.json
+++ b/packages/agor-live/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agor-live",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agor-live",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bumps `agor-live` and `@agor-live/client` from `0.22.0` to `0.23.0`.
- Keeps the standalone `packages/agor-live/package-lock.json` version metadata in sync.
- Adds the `0.23.0` release entry to `CHANGELOG.md` with this PR link.

## Files changed

- `packages/agor-live/package.json`
- `packages/client/package.json`
- `packages/agor-live/package-lock.json`
- `CHANGELOG.md`

## Checks

- `pnpm check:agor-live-deps`
- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @agor-live/client typecheck`
- `pnpm exec prettier --check CHANGELOG.md packages/agor-live/package.json packages/client/package.json packages/agor-live/package-lock.json`
- `pnpm exec biome check --diagnostic-level=warn CHANGELOG.md packages/agor-live/package.json packages/client/package.json packages/agor-live/package-lock.json`
