### PR TITLE
Propagate tenant context through auth paths

### DIFF
--- a/apps/agor-daemon/src/auth/api-key-strategy.test.ts
+++ b/apps/agor-daemon/src/auth/api-key-strategy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApiKeyStrategy } from './api-key-strategy.js';
+
+describe('ApiKeyStrategy tenant propagation', () => {
+  it('passes the resolved tenant params into the user lookup', async () => {
+    const strategy = new ApiKeyStrategy();
+    const apiKeysRepo = {
+      verifyKey: vi.fn(async () => ({ id: 'key-1', user_id: 'user-1' })),
+      updateLastUsed: vi.fn(async () => undefined),
+    };
+    const usersService = {
+      get: vi.fn(async () => ({ user_id: 'user-1', email: 'user@example.test' })),
+    };
+    const params = { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } };
+    strategy.setDependencies(apiKeysRepo as never, usersService as never);
+
+    await strategy.authenticate({ apiKey: 'agor_sk_test' }, params);
+
+    expect(apiKeysRepo.verifyKey).toHaveBeenCalledWith('agor_sk_test');
+    expect(usersService.get).toHaveBeenCalledWith('user-1', params);
+  });
+});

--- a/apps/agor-daemon/src/auth/api-key-strategy.ts
+++ b/apps/agor-daemon/src/auth/api-key-strategy.ts
@@ -42,7 +42,7 @@ export class ApiKeyStrategy extends AuthenticationBaseStrategy {
     });
 
     // Load the user
-    const user = await this.usersService.get(keyRow.user_id);
+    const user = await this.usersService.get(keyRow.user_id, params);
     if (!user) {
       throw new NotAuthenticated('User not found for API key');
     }

--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -64,7 +64,7 @@ async function makeDb(): Promise<{ db: Database; cleanup: () => void }> {
 
 function makeUsersService(db: Database) {
   return {
-    async get(id: UserID): Promise<InternalUser> {
+    async get(id: UserID, _params?: unknown): Promise<InternalUser> {
       const row = await select(db).from(users).where(eq(users.user_id, id)).one();
       if (!row) throw new Error('missing user');
       return {
@@ -100,14 +100,14 @@ describe('one-time launch auth service', () => {
     cleanup?.();
   });
 
-  function service(config = baseConfig()) {
+  function service(config = baseConfig(), usersService = makeUsersService(db)) {
     return createLaunchAuthService({
       db,
       config,
       jwtSecret: RUNTIME_JWT_SECRET,
       accessTokenTtl: '15m',
       refreshTokenTtl: '30d',
-      usersService: makeUsersService(db),
+      usersService,
     });
   }
 
@@ -210,6 +210,38 @@ describe('one-time launch auth service', () => {
     }) as { sub: string; type: string };
     expect(decoded.sub).toBe(result.user.user_id);
     expect(decoded.type).toBe('access');
+  });
+
+  it('scopes launch auth with the configured tenant claim', async () => {
+    const usersService = makeUsersService(db);
+    const getSpy = vi.spyOn(usersService, 'get');
+    mockExchange(
+      signClaims({
+        sub: 'tenant-launch-user',
+        email: 'tenant-launch@example.test',
+        tenant_id: 'tenant-a',
+      })
+    );
+    const result = await service(
+      {
+        ...baseConfig(),
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      },
+      usersService
+    ).create({ launchCode: 'tenant-code' });
+
+    expect(getSpy).toHaveBeenCalledWith(
+      result.user.user_id,
+      expect.objectContaining({
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+      })
+    );
+    const decoded = jwt.verify(result.accessToken, RUNTIME_JWT_SECRET, {
+      issuer: 'agor',
+      audience: 'https://agor.dev',
+    }) as { tenant_id?: string };
+    expect(decoded.tenant_id).toBe('tenant-a');
   });
 
   it('maps admin roles only when explicitly allowed', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -1,12 +1,12 @@
 import type { JsonWebKey, KeyObject } from 'node:crypto';
 import { createHash, createPublicKey, randomBytes } from 'node:crypto';
-import type { AgorConfig } from '@agor/core/config';
+import { type AgorConfig, resolveMultiTenancyConfig } from '@agor/core/config';
 import { type Database, eq, generateId, hash, insert, select, update, users } from '@agor/core/db';
 import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
 import type { Params, User, UserExternalIdentity, UserID, UserRole } from '@agor/core/types';
 import { normalizeRole, ROLES } from '@agor/core/types';
 import jwt, { type JwtHeader, type JwtPayload, type SignOptions } from 'jsonwebtoken';
-import { issueRuntimeTokenPair } from './runtime-tokens.js';
+import { issueRuntimeTokenPair, runtimeTenantClaims } from './runtime-tokens.js';
 import { authTokenIssuedAtClaim } from './token-invalidation.js';
 import { redactUserAuthMetadata } from './user-redaction.js';
 
@@ -444,15 +444,13 @@ function issueRuntimeTokens(
   user: User,
   jwtSecret: string,
   accessTokenTtl: SignOptions['expiresIn'],
-  refreshTokenTtl: SignOptions['expiresIn']
+  refreshTokenTtl: SignOptions['expiresIn'],
+  tenantClaim = 'tenant_id'
 ): LaunchAuthResult {
-  const tokens = issueRuntimeTokenPair(
-    user,
-    jwtSecret,
-    accessTokenTtl,
-    refreshTokenTtl,
-    authTokenIssuedAtClaim(Date.now(), user)
-  );
+  const tokens = issueRuntimeTokenPair(user, jwtSecret, accessTokenTtl, refreshTokenTtl, {
+    ...authTokenIssuedAtClaim(Date.now(), user),
+    ...runtimeTenantClaims((user as { tenant_id?: string }).tenant_id, tenantClaim),
+  });
 
   return {
     ...tokens,
@@ -462,6 +460,7 @@ function issueRuntimeTokens(
 }
 
 export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
+  const tenantClaim = resolveMultiTenancyConfig(options.config).auth_claim ?? 'tenant_id';
   return {
     async create(data: { launchCode?: string; launch_code?: string }, _params?: Params) {
       const launchCode =
@@ -491,7 +490,8 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
           user,
           options.jwtSecret,
           options.accessTokenTtl,
-          options.refreshTokenTtl
+          options.refreshTokenTtl,
+          tenantClaim
         );
       } catch (error) {
         if (error instanceof BadRequest || error instanceof NotAuthenticated) {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -1,9 +1,31 @@
 import type { JsonWebKey, KeyObject } from 'node:crypto';
 import { createHash, createPublicKey, randomBytes } from 'node:crypto';
-import { type AgorConfig, resolveMultiTenancyConfig } from '@agor/core/config';
-import { type Database, eq, generateId, hash, insert, select, update, users } from '@agor/core/db';
+import {
+  type AgorConfig,
+  resolveMultiTenancyConfig,
+  resolveTenantContext,
+  TenantResolutionError,
+} from '@agor/core/config';
+import {
+  type Database,
+  eq,
+  generateId,
+  hash,
+  insert,
+  runWithTenantDatabaseScope,
+  select,
+  update,
+  users,
+} from '@agor/core/db';
 import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
-import type { Params, User, UserExternalIdentity, UserID, UserRole } from '@agor/core/types';
+import type {
+  Params,
+  TenantContext,
+  User,
+  UserExternalIdentity,
+  UserID,
+  UserRole,
+} from '@agor/core/types';
 import { normalizeRole, ROLES } from '@agor/core/types';
 import jwt, { type JwtHeader, type JwtPayload, type SignOptions } from 'jsonwebtoken';
 import { issueRuntimeTokenPair, runtimeTenantClaims } from './runtime-tokens.js';
@@ -241,12 +263,17 @@ async function findUserByExternalIdentity(
 
 async function upsertLaunchUser(
   options: LaunchAuthServiceOptions,
-  claims: LaunchClaims
+  claims: LaunchClaims,
+  tenant?: TenantContext
 ): Promise<User> {
   const { db, config, usersService } = options;
   const issuer = claims.iss;
   const subject = claims.sub;
   const settings = resolveLaunchSettings(config);
+  const userLookupParams = {
+    provider: undefined,
+    ...(tenant ? { tenant } : {}),
+  };
   const provider = claims.provider || settings.providerId || issuer;
   const key = identityKey(provider, issuer, subject);
   const now = new Date();
@@ -296,7 +323,7 @@ async function upsertLaunchUser(
       .where(eq(users.user_id, existing.user_id))
       .run();
 
-    return usersService.get(existing.user_id as UserID, { provider: undefined });
+    return usersService.get(existing.user_id as UserID, userLookupParams);
   }
 
   const role = mapRole(claims.role, settings, config.execution?.allow_superadmin);
@@ -326,7 +353,7 @@ async function upsertLaunchUser(
     })
     .run();
 
-  return usersService.get(userId, { provider: undefined });
+  return usersService.get(userId, userLookupParams);
 }
 
 async function fetchJson(url: string, init: RequestInit, timeoutMs: number): Promise<unknown> {
@@ -445,11 +472,12 @@ function issueRuntimeTokens(
   jwtSecret: string,
   accessTokenTtl: SignOptions['expiresIn'],
   refreshTokenTtl: SignOptions['expiresIn'],
-  tenantClaim = 'tenant_id'
+  tenantClaim = 'tenant_id',
+  tenantId?: string
 ): LaunchAuthResult {
   const tokens = issueRuntimeTokenPair(user, jwtSecret, accessTokenTtl, refreshTokenTtl, {
     ...authTokenIssuedAtClaim(Date.now(), user),
-    ...runtimeTenantClaims((user as { tenant_id?: string }).tenant_id, tenantClaim),
+    ...runtimeTenantClaims(tenantId ?? (user as { tenant_id?: string }).tenant_id, tenantClaim),
   });
 
   return {
@@ -460,9 +488,10 @@ function issueRuntimeTokens(
 }
 
 export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
-  const tenantClaim = resolveMultiTenancyConfig(options.config).auth_claim ?? 'tenant_id';
+  const multiTenancy = resolveMultiTenancyConfig(options.config);
+  const tenantClaim = multiTenancy.auth_claim ?? 'tenant_id';
   return {
-    async create(data: { launchCode?: string; launch_code?: string }, _params?: Params) {
+    async create(data: { launchCode?: string; launch_code?: string }, params?: Params) {
       const launchCode =
         typeof data?.launchCode === 'string'
           ? data.launchCode.trim()
@@ -485,17 +514,28 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
           throw new NotAuthenticated('Invalid one-time launch exchange response');
         }
         const claims = await verifyLaunchAssertion(exchange.assertion, settings);
-        const user = await upsertLaunchUser(options, claims);
-        return issueRuntimeTokens(
-          user,
-          options.jwtSecret,
-          options.accessTokenTtl,
-          options.refreshTokenTtl,
-          tenantClaim
-        );
+        const tenant = resolveTenantContext(multiTenancy, {
+          params,
+          authPayload: claims,
+          headers: params?.headers as Record<string, unknown> | undefined,
+        });
+        return await runWithTenantDatabaseScope(options.db, tenant.tenant_id, async () => {
+          const user = await upsertLaunchUser(options, claims, tenant);
+          return issueRuntimeTokens(
+            user,
+            options.jwtSecret,
+            options.accessTokenTtl,
+            options.refreshTokenTtl,
+            tenantClaim,
+            tenant.tenant_id
+          );
+        });
       } catch (error) {
         if (error instanceof BadRequest || error instanceof NotAuthenticated) {
           throw error;
+        }
+        if (error instanceof TenantResolutionError) {
+          throw new NotAuthenticated(error.message);
         }
         throw new NotAuthenticated('Invalid or expired one-time launch code');
       }

--- a/apps/agor-daemon/src/auth/refresh-token-service.ts
+++ b/apps/agor-daemon/src/auth/refresh-token-service.ts
@@ -5,6 +5,8 @@ import {
   issueRuntimeTokenPair,
   RUNTIME_JWT_AUDIENCE,
   RUNTIME_JWT_ISSUER,
+  readRuntimeTenantClaim,
+  runtimeTenantClaims,
 } from './runtime-tokens.js';
 import {
   assertUserTokenNotInvalidated,
@@ -17,6 +19,7 @@ interface RefreshTokenServiceOptions {
   jwtSecret: string;
   accessTokenTtl: SignOptions['expiresIn'];
   refreshTokenTtl: SignOptions['expiresIn'];
+  tenantClaim?: string;
   usersService: {
     get(id: UserID, params?: Params): Promise<User>;
   };
@@ -35,7 +38,16 @@ export function createRefreshTokenService(options: RefreshTokenServiceOptions) {
           throw new Error('Invalid token type');
         }
 
-        const user = await options.usersService.get(decoded.sub as UserID);
+        const tenantId = readRuntimeTenantClaim(decoded, options.tenantClaim);
+        const user = await options.usersService.get(
+          decoded.sub as UserID,
+          tenantId
+            ? ({
+                tenant: { tenant_id: tenantId, source: 'auth_claim' },
+                authentication: { payload: decoded },
+              } as Params)
+            : ({ authentication: { payload: decoded } } as Params)
+        );
         assertUserTokenNotInvalidated(user, decoded);
 
         // Use the same access-token TTL as the auth-service config. Refresh tokens
@@ -48,9 +60,10 @@ export function createRefreshTokenService(options: RefreshTokenServiceOptions) {
           options.refreshTokenTtl,
           {
             ...authTokenIssuedAtClaim(Date.now(), user),
-            ...((user as { tenant_id?: string }).tenant_id
-              ? { tenant_id: (user as { tenant_id?: string }).tenant_id }
-              : {}),
+            ...runtimeTenantClaims(
+              tenantId ?? (user as { tenant_id?: string }).tenant_id,
+              options.tenantClaim
+            ),
           }
         );
 

--- a/apps/agor-daemon/src/auth/runtime-tokens.ts
+++ b/apps/agor-daemon/src/auth/runtime-tokens.ts
@@ -18,6 +18,25 @@ export interface RuntimeTokenPair {
   refreshToken: string;
 }
 
+export function runtimeTenantClaims(
+  tenantId: string | undefined,
+  claimName = 'tenant_id'
+): Record<string, string> {
+  if (!tenantId) return {};
+  if (claimName === 'tenant_id') return { tenant_id: tenantId };
+  return { tenant_id: tenantId, [claimName]: tenantId };
+}
+
+export function readRuntimeTenantClaim(
+  payload: unknown,
+  claimName = 'tenant_id'
+): string | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const record = payload as Record<string, unknown>;
+  const value = record[claimName] ?? record.tenant_id;
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
 export function issueRuntimeToken(
   payload: RuntimeTokenPayload,
   jwtSecret: string,

--- a/apps/agor-daemon/src/auth/token-invalidation.test.ts
+++ b/apps/agor-daemon/src/auth/token-invalidation.test.ts
@@ -2,7 +2,7 @@ import { AuthenticationService, feathers } from '@agor/core/feathers';
 import type { User, UserID } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { eq, update, users } from '../../../../packages/core/src/db';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { AgorLocalStrategy } from '../register-routes';
@@ -13,6 +13,8 @@ import {
   issueRuntimeTokenPair,
   RUNTIME_JWT_AUDIENCE,
   RUNTIME_JWT_ISSUER,
+  readRuntimeTenantClaim,
+  runtimeTenantClaims,
 } from './runtime-tokens';
 import { ServiceJWTStrategy } from './service-jwt-strategy';
 import {
@@ -45,6 +47,16 @@ test('treats tokens issued at the invalidation boundary as stale', () => {
     assertUserTokenNotInvalidated(user, { sub: 'user-1', type: 'access', ...authTime(1_000) })
   ).toThrow(/Session expired/);
   expect(authTokenIssuedAtClaim(1_000, user)[AUTH_TOKEN_ISSUED_AT_MS_CLAIM]).toBe(1_001);
+});
+
+test('runtime tenant helpers preserve standard and custom tenant claims', () => {
+  expect(runtimeTenantClaims('tenant-a')).toEqual({ tenant_id: 'tenant-a' });
+  expect(runtimeTenantClaims('tenant-a', 'org_id')).toEqual({
+    tenant_id: 'tenant-a',
+    org_id: 'tenant-a',
+  });
+  expect(readRuntimeTenantClaim({ org_id: 'tenant-b' }, 'org_id')).toBe('tenant-b');
+  expect(readRuntimeTenantClaim({ tenant_id: 'tenant-c' }, 'org_id')).toBe('tenant-c');
 });
 
 function createAuthApp(db: Parameters<typeof createUsersService>[0]) {
@@ -189,6 +201,49 @@ dbTest('rejects a refresh token issued before the password change marker', async
   await expect(refreshService.create({ refreshToken: oldRefreshToken })).rejects.toThrow(
     /Invalid or expired refresh token/
   );
+});
+
+test('refresh token lookup is scoped to the tenant claim and reissues tenant-bearing tokens', async () => {
+  const user = {
+    user_id: 'tenant-user' as UserID,
+    email: 'tenant-user@example.test',
+    name: 'Tenant User',
+    role: ROLES.MEMBER,
+    onboarding_completed: true,
+    must_change_password: false,
+    created_at: new Date(),
+    tenant_id: 'tenant-a',
+  } as User & { tenant_id: string };
+  const usersService = {
+    get: async (_id: UserID, _params?: unknown) => user,
+  };
+  const getSpy = vi.spyOn(usersService, 'get');
+  const refreshService = createRefreshTokenService({
+    jwtSecret: JWT_SECRET,
+    accessTokenTtl: ACCESS_TOKEN_TTL,
+    refreshTokenTtl: REFRESH_TOKEN_TTL,
+    tenantClaim: 'tenant_id',
+    usersService,
+  });
+  const refreshToken = issueRuntimeToken(
+    { sub: user.user_id, type: 'refresh', tenant_id: 'tenant-a' },
+    JWT_SECRET,
+    REFRESH_TOKEN_TTL
+  );
+
+  const result = await refreshService.create({ refreshToken });
+
+  expect(getSpy).toHaveBeenCalledWith(
+    user.user_id,
+    expect.objectContaining({
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+      authentication: { payload: expect.objectContaining({ tenant_id: 'tenant-a' }) },
+    })
+  );
+  expectNoTokenMarker(result.user);
+  expect(result.user).not.toHaveProperty('tenant_id');
+  const decoded = jwt.verify(result.accessToken, JWT_SECRET) as jwt.JwtPayload;
+  expect(decoded.tenant_id).toBe('tenant-a');
 });
 
 dbTest(

--- a/apps/agor-daemon/src/auth/user-redaction.ts
+++ b/apps/agor-daemon/src/auth/user-redaction.ts
@@ -3,12 +3,18 @@ import type { User } from '@agor/core/types';
 type UserWithBackendFields = User & {
   tokens_valid_after?: unknown;
   password?: unknown;
+  tenant_id?: unknown;
 };
 
 /**
  * Remove backend-only auth metadata before returning a user object to browser clients.
  */
 export function redactUserAuthMetadata(user: UserWithBackendFields): User {
-  const { tokens_valid_after: _tokensValidAfter, password: _password, ...publicUser } = user;
+  const {
+    tokens_valid_after: _tokensValidAfter,
+    password: _password,
+    tenant_id: _tenantId,
+    ...publicUser
+  } = user;
   return publicUser;
 }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -6,7 +6,12 @@
  * Extracted from index.ts for maintainability.
  */
 
-import { type AgorConfig, loadConfig, resolveBranchStorageConfig } from '@agor/core/config';
+import {
+  type AgorConfig,
+  loadConfig,
+  resolveBranchStorageConfig,
+  resolveMultiTenancyConfig,
+} from '@agor/core/config';
 import {
   BranchRepository,
   type Database,
@@ -74,6 +79,7 @@ import {
   issueRuntimeTokenPair,
   RUNTIME_JWT_AUDIENCE,
   RUNTIME_JWT_ISSUER,
+  runtimeTenantClaims,
 } from './auth/runtime-tokens.js';
 import { authTokenIssuedAtClaim } from './auth/token-invalidation.js';
 import { redactUserAuthMetadata } from './auth/user-redaction.js';
@@ -307,6 +313,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // ============================================================================
 
   const authStrategiesArray = ['api-key', 'jwt', 'local'];
+  const multiTenancy = resolveMultiTenancyConfig(config);
+  const tenantTokenClaim = multiTenancy.auth_claim ?? 'tenant_id';
   if (sessionTokenService) {
     authStrategiesArray.push('session-token');
   }
@@ -430,6 +438,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           });
 
           if (context.result?.user) {
+            const tenantId =
+              context.params?.tenant?.tenant_id ??
+              (context.result.user as { tenant_id?: string }).tenant_id;
             const tokens = issueRuntimeTokenPair(
               context.result.user,
               jwtSecret,
@@ -437,9 +448,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               REFRESH_TOKEN_TTL,
               {
                 ...authTokenIssuedAtClaim(Date.now(), context.result.user),
-                ...(context.result.user.tenant_id
-                  ? { tenant_id: context.result.user.tenant_id }
-                  : {}),
+                ...runtimeTenantClaims(tenantId, tenantTokenClaim),
               }
             );
             context.result.accessToken = tokens.accessToken;
@@ -487,6 +496,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       jwtSecret,
       accessTokenTtl: ACCESS_TOKEN_TTL,
       refreshTokenTtl: REFRESH_TOKEN_TTL,
+      tenantClaim: tenantTokenClaim,
       usersService,
     })
   );

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -866,6 +866,9 @@ export class UsersService {
     if (includeAuthMetadata && row.tokens_valid_after) {
       (user as InternalUser).tokens_valid_after = new Date(row.tokens_valid_after);
     }
+    if (includeAuthMetadata && 'tenant_id' in row) {
+      (user as InternalUser).tenant_id = row.tenant_id;
+    }
 
     // Include password for authentication (FeathersJS LocalStrategy needs this)
     if (includePassword) {

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -23,6 +23,7 @@
 
 import type { Application } from '@agor/core/feathers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { issueRuntimeToken } from '../auth/runtime-tokens.js';
 import {
   boardPresenceRoomName,
   configureChannels,
@@ -270,6 +271,58 @@ describe('createTokenBucket', () => {
     expect(limit()).toBe(true);
     expect(limit()).toBe(true);
     expect(limit()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handshake authentication
+// ---------------------------------------------------------------------------
+
+describe('socket handshake tenant propagation', () => {
+  it('passes resolved JWT tenant context into the user lookup', async () => {
+    const usersGet = vi.fn(async () => ({ user_id: ALICE, email: 'alice@example.test' }));
+    const app = {
+      service: () => ({ get: usersGet }),
+      on: () => {},
+    } as unknown as Application;
+    const io = makeIO();
+    const config = createSocketIOConfig(app, {
+      corsOrigin: '*',
+      jwtSecret: 'test-secret',
+      credentialsAllowed: false,
+      webTerminalEnabled: true,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as never,
+        auth_claim: 'tenant_id',
+      },
+    } as SocketIOOptions);
+    config.callback(io as any);
+    const socket = makeSocket('tenant-user-socket', io);
+    socket.handshake.auth = {
+      token: issueRuntimeToken(
+        { sub: ALICE, type: 'access', tenant_id: 'tenant-a' },
+        'test-secret',
+        '5m'
+      ),
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      io.middlewares[0]?.(socket, (error?: Error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+    expect(usersGet).toHaveBeenCalledWith(
+      ALICE,
+      expect.objectContaining({
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        authentication: { payload: expect.objectContaining({ tenant_id: 'tenant-a' }) },
+      })
+    );
+    expect(socket.feathers?.user).toMatchObject({ user_id: ALICE, tenant_id: 'tenant-a' });
+    expect(socket.data.tenant).toEqual({ tenant_id: 'tenant-a', source: 'auth_claim' });
   });
 });
 

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -389,7 +389,13 @@ export function createSocketIOConfig(
         }
 
         // Handle user access tokens - fetch user from database
-        const user = await app.service('users').get(decoded.sub as import('@agor/core/types').UUID);
+        const user = await app.service('users').get(
+          decoded.sub as import('@agor/core/types').UUID,
+          {
+            ...(tenant ? { tenant } : {}),
+            authentication: { payload: decoded },
+          } as never
+        );
 
         // Attach user to socket (FeathersJS convention)
         const fs = socket as FeathersSocket;

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -47,6 +47,18 @@ describe('multi-tenancy config and tenant resolution', () => {
     ).toThrow(/auth_claim or multi_tenancy\.trusted_header/);
   });
 
+  it('rejects reserved JWT claims as the tenant auth claim', () => {
+    vi.stubEnv('AGOR_DB_DIALECT', '');
+    vi.stubEnv('DATABASE_URL', '');
+
+    expect(() =>
+      assertValidMultiTenancyConfig({
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'sub' },
+      })
+    ).toThrow(/auth_claim cannot be reserved JWT claim 'sub'/);
+  });
+
   it('resolves required tenant from configured JWT/auth claim', () => {
     const ctx = resolveTenantContext(
       { multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' } },

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -54,6 +54,13 @@ describe('multi-tenancy config and tenant resolution', () => {
     expect(() =>
       assertValidMultiTenancyConfig({
         database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'static', auth_claim: 'sub' },
+      })
+    ).toThrow(/auth_claim cannot be reserved JWT claim 'sub'/);
+
+    expect(() =>
+      assertValidMultiTenancyConfig({
+        database: { dialect: 'postgresql' },
         multi_tenancy: { mode: 'required_from_auth', auth_claim: 'sub' },
       })
     ).toThrow(/auth_claim cannot be reserved JWT claim 'sub'/);

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -113,6 +113,11 @@ export function assertValidMultiTenancyConfig(
   if (!resolved.static_tenant_id) {
     throw new Error('Config error: multi_tenancy.static_tenant_id must not be empty');
   }
+  if (resolved.auth_claim && RESERVED_AUTH_CLAIMS.has(resolved.auth_claim)) {
+    throw new Error(
+      `Config error: multi_tenancy.auth_claim cannot be reserved JWT claim '${resolved.auth_claim}'`
+    );
+  }
   if (resolved.mode === 'required_from_auth') {
     if (resolveMultiTenancyDatabaseDialect(config) !== 'postgresql') {
       throw new Error(
@@ -122,11 +127,6 @@ export function assertValidMultiTenancyConfig(
     if (!resolved.auth_claim && !resolved.trusted_header) {
       throw new Error(
         'Config error: multi_tenancy.required_from_auth requires multi_tenancy.auth_claim or multi_tenancy.trusted_header'
-      );
-    }
-    if (resolved.auth_claim && RESERVED_AUTH_CLAIMS.has(resolved.auth_claim)) {
-      throw new Error(
-        `Config error: multi_tenancy.auth_claim cannot be reserved JWT claim '${resolved.auth_claim}'`
       );
     }
   }

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -2,6 +2,7 @@ import type { TenantContext, TenantID } from '../types/tenant';
 import type { AgorConfig, AgorMultiTenancySettings } from './types';
 
 export const DEFAULT_STATIC_TENANT_ID = 'default' as TenantID;
+const RESERVED_AUTH_CLAIMS = new Set(['aud', 'exp', 'iat', 'iss', 'jti', 'nbf', 'sub', 'type']);
 
 export interface ResolvedMultiTenancyConfig {
   mode: 'static' | 'required_from_auth';
@@ -121,6 +122,11 @@ export function assertValidMultiTenancyConfig(
     if (!resolved.auth_claim && !resolved.trusted_header) {
       throw new Error(
         'Config error: multi_tenancy.required_from_auth requires multi_tenancy.auth_claim or multi_tenancy.trusted_header'
+      );
+    }
+    if (resolved.auth_claim && RESERVED_AUTH_CLAIMS.has(resolved.auth_claim)) {
+      throw new Error(
+        `Config error: multi_tenancy.auth_claim cannot be reserved JWT claim '${resolved.auth_claim}'`
       );
     }
   }

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -470,6 +470,8 @@ export interface User extends BaseUserFields {
 export type UserAuthMetadata = object & {
   /** Tokens issued at or before this timestamp are no longer valid. */
   tokens_valid_after?: Date;
+  /** Backend-only tenant id used while issuing/validating runtime tokens. */
+  tenant_id?: string;
 };
 
 export type InternalUser = User & UserAuthMetadata;


### PR DESCRIPTION
## Summary

Follow-up to the post-merge Codex review of #1665. Fixes tenant propagation gaps in auth entry points used by `multi_tenancy.mode: required_from_auth`.

## Changes

- Include backend-only `tenant_id` on internal user objects and redact it from public user DTOs.
- Issue access/refresh tokens with the resolved tenant claim during local auth and launch auth.
- Scope refresh-token user lookup to the tenant claim carried by the refresh token.
- Pass resolved tenant params through socket handshake user lookup.
- Pass existing params through API-key user lookup.
- Add tests for refresh tenant claims, socket handshake tenant propagation, and API-key tenant propagation.

## Review context

Addresses blocking review feedback from the Codex subsession reviewing #1665:

- Browser tokens omitted tenant claims.
- Refresh token path did not scope user lookup to the token tenant.
- Socket/API-key auth paths dropped tenant context during user lookup.

## Checks

- `pnpm --filter @agor/daemon test -- src/auth/token-invalidation.test.ts src/auth/api-key-strategy.test.ts src/setup/socketio.test.ts src/utils/tenant-db-scope.test.ts src/adapters/drizzle.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm --filter @agor/core typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm check:multitenancy-boundaries`

## Known limitations

- This does not add live Postgres RLS integration tests; current coverage is targeted unit/regression coverage around the reviewed auth gaps.
