### PR TITLE
Guard broad MCP message searches

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/messages.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.test.ts
@@ -3,9 +3,8 @@
  *
  * Focus: the tool bypasses the Feathers hook pipeline by running a raw Drizzle
  * query against the messages table. These tests verify that when
- * `branch_rbac` is enabled, the raw query is restricted to sessions the
- * caller can access (preventing cross-branch leakage via the `search`
- * parameter).
+ * `branch_rbac` is enabled, the raw query uses the shared visible-session SQL
+ * predicate (preventing cross-branch leakage via the `search` parameter).
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -13,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoist-safe mocks must be declared before the module under test is imported.
 const mockIsBranchRbacEnabled = vi.fn(() => false);
-const mockFindAccessibleSessions = vi.fn(async () => [] as Array<{ session_id: string }>);
+const mockVisibleSessionReferenceAccessExists = vi.fn();
 
 vi.mock('@agor/core/config', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@agor/core/config');
@@ -23,14 +22,6 @@ vi.mock('@agor/core/config', async () => {
   };
 });
 
-// Bind the static SessionRepository constructor to a class whose instances
-// delegate findAccessibleSessions to our spy.
-class FakeSessionRepository {
-  async findAccessibleSessions(userId: string) {
-    return mockFindAccessibleSessions(userId);
-  }
-}
-
 // Capture the raw query the tool builds so we can assert on its shape.
 const mockWhereSpy = vi.fn();
 const mockAllSpy = vi.fn(async () => [] as unknown[]);
@@ -39,7 +30,10 @@ vi.mock('@agor/core/db', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('@agor/core/db');
   return {
     ...actual,
-    SessionRepository: FakeSessionRepository,
+    visibleSessionReferenceAccessExists: (...args: unknown[]) => {
+      mockVisibleSessionReferenceAccessExists(...args);
+      return actual.sql`visible-session-access`;
+    },
     select: () => ({
       from: () => ({
         where: (cond: unknown) => {
@@ -100,12 +94,11 @@ async function registerAndGetHandler(ctx: { userId: string; role?: string }): Pr
 describe('agor_messages_list MCP tool', () => {
   beforeEach(() => {
     mockIsBranchRbacEnabled.mockReset();
-    mockFindAccessibleSessions.mockReset();
+    mockVisibleSessionReferenceAccessExists.mockReset();
     mockWhereSpy.mockReset();
     mockAllSpy.mockReset();
     mockAllSpy.mockResolvedValue([]);
     mockIsBranchRbacEnabled.mockReturnValue(false);
-    mockFindAccessibleSessions.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -179,62 +172,26 @@ describe('agor_messages_list MCP tool', () => {
     mockIsBranchRbacEnabled.mockReturnValue(false);
     const handler = await registerAndGetHandler({ userId: 'user-1' });
     await handler({ search: 'secret', createdAfter: recentIso() });
-    expect(mockFindAccessibleSessions).not.toHaveBeenCalled();
+    expect(mockVisibleSessionReferenceAccessExists).not.toHaveBeenCalled();
     expect(mockAllSpy).toHaveBeenCalled();
   });
 
-  it('short-circuits to empty when user has no accessible sessions', async () => {
+  it('restricts raw query through the shared visible-session EXISTS predicate', async () => {
     mockIsBranchRbacEnabled.mockReturnValue(true);
-    mockFindAccessibleSessions.mockResolvedValue([]);
-
-    const handler = await registerAndGetHandler({ userId: 'user-1' });
-    const result = await handler({ search: 'secret', createdAfter: recentIso() });
-
-    expect(mockFindAccessibleSessions).toHaveBeenCalledWith('user-1');
-    // Query must NOT be executed when there are no accessible sessions.
-    expect(mockAllSpy).not.toHaveBeenCalled();
-
-    const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.messages).toEqual([]);
-    expect(parsed.total).toBe(0);
-  });
-
-  it('restricts raw query to accessible session ids for regular users', async () => {
-    mockIsBranchRbacEnabled.mockReturnValue(true);
-    mockFindAccessibleSessions.mockResolvedValue([
-      { session_id: 'sess-allowed-1' },
-      { session_id: 'sess-allowed-2' },
-    ]);
 
     const handler = await registerAndGetHandler({ userId: 'user-1', role: 'member' });
     await handler({ search: 'secret', createdAfter: recentIso() });
 
-    expect(mockFindAccessibleSessions).toHaveBeenCalledWith('user-1');
+    expect(mockVisibleSessionReferenceAccessExists).toHaveBeenCalledTimes(1);
+    expect(mockVisibleSessionReferenceAccessExists.mock.calls[0]?.[1]).toBe('user-1');
     expect(mockAllSpy).toHaveBeenCalled();
-    // Drizzle builds a SQL AST; walk it with a seen-set to avoid circular
-    // refs and collect every string leaf so we can assert both ids appear.
-    const seen = new WeakSet<object>();
-    const strings: string[] = [];
-    const walk = (v: unknown) => {
-      if (typeof v === 'string') {
-        strings.push(v);
-        return;
-      }
-      if (!v || typeof v !== 'object') return;
-      if (seen.has(v as object)) return;
-      seen.add(v as object);
-      for (const val of Object.values(v as Record<string, unknown>)) walk(val);
-    };
-    walk(mockWhereSpy.mock.calls[0]?.[0]);
-    expect(strings).toContain('sess-allowed-1');
-    expect(strings).toContain('sess-allowed-2');
   });
 
   it('bypasses RBAC filter for superadmin role', async () => {
     mockIsBranchRbacEnabled.mockReturnValue(true);
     const handler = await registerAndGetHandler({ userId: 'user-1', role: 'superadmin' });
     await handler({ search: 'secret', createdAfter: recentIso() });
-    expect(mockFindAccessibleSessions).not.toHaveBeenCalled();
+    expect(mockVisibleSessionReferenceAccessExists).not.toHaveBeenCalled();
     expect(mockAllSpy).toHaveBeenCalled();
   });
 

--- a/apps/agor-daemon/src/mcp/tools/messages.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.test.ts
@@ -65,6 +65,20 @@ type CapturedTool = {
 
 const recentIso = () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
+function row(index: number, text = `message ${index}`) {
+  return {
+    message_id: `message-${index}`,
+    session_id: 'sess-0001',
+    task_id: null,
+    type: 'user',
+    role: 'user',
+    index,
+    timestamp: new Date('2026-06-01T00:00:00Z'),
+    content_preview: text,
+    data: { content: text },
+  };
+}
+
 async function registerAndGetTool(ctx: { userId: string; role?: string }): Promise<CapturedTool> {
   const { registerMessageTools } = await import('./messages.js');
   let captured: CapturedTool | undefined;
@@ -201,5 +215,18 @@ describe('agor_messages_list MCP tool', () => {
     await handler({ sessionId: 'sess-0001' });
 
     expect(mockAllSpy).toHaveBeenCalled();
+  });
+
+  it('sets next_offset to the raw rows consumed for the returned page', async () => {
+    mockAllSpy.mockResolvedValue([row(0), row(1), row(2)]);
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+
+    const result = await handler({ sessionId: 'sess-0001', limit: 2 });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.messages.map((m: { index: number }) => m.index)).toEqual([0, 1]);
+    expect(parsed.returned).toBe(2);
+    expect(parsed.has_more).toBe(true);
+    expect(parsed.next_offset).toBe(2);
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/messages.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.test.ts
@@ -45,7 +45,9 @@ vi.mock('@agor/core/db', async () => {
         where: (cond: unknown) => {
           mockWhereSpy(cond);
           return {
-            orderBy: () => ({ all: () => mockAllSpy() }),
+            orderBy: () => ({
+              limit: () => ({ offset: () => ({ all: () => mockAllSpy() }) }),
+            }),
           };
         },
       }),
@@ -66,6 +68,8 @@ type CapturedTool = {
   cfg: { inputSchema?: { parse: (v: unknown) => unknown; safeParse: (v: unknown) => any } };
   cb: ToolHandler;
 };
+
+const recentIso = () => new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
 async function registerAndGetTool(ctx: { userId: string; role?: string }): Promise<CapturedTool> {
   const { registerMessageTools } = await import('./messages.js');
@@ -133,10 +137,48 @@ describe('agor_messages_list MCP tool', () => {
     );
   });
 
+  it('validates createdAfter and createdBefore dates', async () => {
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+
+    await expect(handler({ search: 'secret', createdAfter: 'not-a-date' })).rejects.toThrow(
+      /createdAfter must be a valid ISO-8601 date string/
+    );
+
+    await expect(
+      handler({
+        search: 'secret',
+        createdAfter: '2026-06-02T00:00:00Z',
+        createdBefore: '2026-06-01T00:00:00Z',
+      })
+    ).rejects.toThrow(/createdAfter must be earlier than or equal to createdBefore/);
+  });
+
+  it('fails fast for broad cross-session keyword search without time bounds', async () => {
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+
+    await expect(handler({ search: 'secret' })).rejects.toThrow(
+      /Broad cross-session message search must be scoped/
+    );
+    expect(mockAllSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails fast for broad cross-session keyword search with an over-wide window', async () => {
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+
+    await expect(
+      handler({
+        search: 'secret',
+        createdAfter: '2026-01-01T00:00:00Z',
+        createdBefore: '2026-03-15T00:00:00Z',
+      })
+    ).rejects.toThrow(/window of 31 days or less/);
+    expect(mockAllSpy).not.toHaveBeenCalled();
+  });
+
   it('does not enforce RBAC when branch_rbac is disabled', async () => {
     mockIsBranchRbacEnabled.mockReturnValue(false);
     const handler = await registerAndGetHandler({ userId: 'user-1' });
-    await handler({ search: 'secret' });
+    await handler({ search: 'secret', createdAfter: recentIso() });
     expect(mockFindAccessibleSessions).not.toHaveBeenCalled();
     expect(mockAllSpy).toHaveBeenCalled();
   });
@@ -146,7 +188,7 @@ describe('agor_messages_list MCP tool', () => {
     mockFindAccessibleSessions.mockResolvedValue([]);
 
     const handler = await registerAndGetHandler({ userId: 'user-1' });
-    const result = await handler({ search: 'secret' });
+    const result = await handler({ search: 'secret', createdAfter: recentIso() });
 
     expect(mockFindAccessibleSessions).toHaveBeenCalledWith('user-1');
     // Query must NOT be executed when there are no accessible sessions.
@@ -165,7 +207,7 @@ describe('agor_messages_list MCP tool', () => {
     ]);
 
     const handler = await registerAndGetHandler({ userId: 'user-1', role: 'member' });
-    await handler({ search: 'secret' });
+    await handler({ search: 'secret', createdAfter: recentIso() });
 
     expect(mockFindAccessibleSessions).toHaveBeenCalledWith('user-1');
     expect(mockAllSpy).toHaveBeenCalled();
@@ -191,8 +233,16 @@ describe('agor_messages_list MCP tool', () => {
   it('bypasses RBAC filter for superadmin role', async () => {
     mockIsBranchRbacEnabled.mockReturnValue(true);
     const handler = await registerAndGetHandler({ userId: 'user-1', role: 'superadmin' });
-    await handler({ search: 'secret' });
+    await handler({ search: 'secret', createdAfter: recentIso() });
     expect(mockFindAccessibleSessions).not.toHaveBeenCalled();
+    expect(mockAllSpy).toHaveBeenCalled();
+  });
+
+  it('allows browsing a specific session transcript without a time bound', async () => {
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+
+    await handler({ sessionId: 'sess-0001' });
+
     expect(mockAllSpy).toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -4,7 +4,9 @@ import {
   asc,
   desc,
   eq,
+  gte,
   inArray,
+  lte,
   messages as messagesTable,
   or,
   SessionRepository,
@@ -19,6 +21,25 @@ import { resolveSessionId, resolveTaskId } from '../resolve-ids.js';
 import { mcpLimit, mcpOffset, mcpOptionalId, mcpOptionalString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
+
+const BROAD_SEARCH_GUIDANCE =
+  'Broad cross-session message search must be scoped to sessionId/taskId or bounded with createdAfter. Use a window of 31 days or less; add createdBefore for historical searches. Example: { "search": "SEO", "createdAfter": "2026-06-01T00:00:00Z", "createdBefore": "2026-06-15T00:00:00Z" }. This prevents full-table scans on large message databases.';
+
+const MAX_CROSS_SESSION_SEARCH_WINDOW_MS = 31 * 24 * 60 * 60 * 1000;
+
+function parseDateArg(name: string, value: unknown): Date | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`${name} must be an ISO-8601 date string, for example "2026-06-01T00:00:00Z".`);
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `${name} must be a valid ISO-8601 date string, for example "2026-06-01" or "2026-06-01T00:00:00Z".`
+    );
+  }
+  return date;
+}
 
 export function registerMessageTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_messages_list
@@ -37,7 +58,15 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
         taskId: mcpOptionalId('taskId', 'Task', 'Task ID to scope messages to (optional)'),
         search: mcpOptionalString(
           'search',
-          'Keyword search across message content. Space-separated terms are AND\'d, pipe (|) for OR. Example: "OAuth middleware" requires both; "OAuth | JWT" matches either.'
+          'Keyword search across message content. Space-separated terms are AND\'d, pipe (|) for OR. Example: "OAuth middleware" requires both; "OAuth | JWT" matches either. Cross-session search must include sessionId/taskId or a createdAfter-bounded window of 31 days or less.'
+        ),
+        createdAfter: mcpOptionalString(
+          'createdAfter',
+          'Only include messages at or after this message timestamp. ISO-8601 date/time, e.g. "2026-06-01" or "2026-06-01T00:00:00Z". Recommended for broad searches.'
+        ),
+        createdBefore: mcpOptionalString(
+          'createdBefore',
+          'Only include messages before or at this message timestamp. ISO-8601 date/time, e.g. "2026-06-28T23:59:59Z". Use with createdAfter for historical cross-session searches.'
         ),
         includeToolCalls: z
           .boolean()
@@ -66,11 +95,30 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
       const sessionIdRaw = coerceString(args.sessionId);
       const taskIdRaw = coerceString(args.taskId);
       const search = coerceString(args.search);
+      const createdAfter = parseDateArg('createdAfter', args.createdAfter);
+      const createdBefore = parseDateArg('createdBefore', args.createdBefore);
+
+      if (createdAfter && createdBefore && createdAfter.getTime() > createdBefore.getTime()) {
+        throw new Error('createdAfter must be earlier than or equal to createdBefore.');
+      }
 
       if (!sessionIdRaw && !taskIdRaw && !search) {
         throw new Error(
-          'At least one of sessionId, taskId, or search must be provided as a non-empty string. Example: { "sessionId": "01abcdef" } or { "search": "OAuth middleware" }.'
+          'At least one of sessionId, taskId, or search must be provided as a non-empty string. Example: { "sessionId": "01abcdef" } or { "search": "OAuth middleware", "createdAfter": "2026-06-01T00:00:00Z" }.'
         );
+      }
+
+      if (search && !sessionIdRaw && !taskIdRaw) {
+        if (!createdAfter) {
+          throw new Error(BROAD_SEARCH_GUIDANCE);
+        }
+        const effectiveCreatedBefore = createdBefore ?? new Date();
+        if (
+          effectiveCreatedBefore.getTime() - createdAfter.getTime() >
+          MAX_CROSS_SESSION_SEARCH_WINDOW_MS
+        ) {
+          throw new Error(BROAD_SEARCH_GUIDANCE);
+        }
       }
 
       const sessionId = sessionIdRaw ? await resolveSessionId(ctx, sessionIdRaw) : undefined;
@@ -95,6 +143,8 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
       if (sessionId) conditions.push(eq(messagesTable.session_id, sessionId));
       if (taskId) conditions.push(eq(messagesTable.task_id, taskId));
       if (role) conditions.push(eq(messagesTable.role, role));
+      if (createdAfter) conditions.push(gte(messagesTable.timestamp, createdAfter));
+      if (createdBefore) conditions.push(lte(messagesTable.timestamp, createdBefore));
 
       if (!includeToolCalls) {
         conditions.push(
@@ -137,10 +187,16 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
 
       const orderCol = sessionId ? messagesTable.index : messagesTable.timestamp;
       const orderBy = order === 'desc' ? desc(orderCol) : asc(orderCol);
+      // Keep every invocation bounded. The small over-fetch preserves the
+      // existing "hide tool-only noise by default" behavior without loading
+      // every matching row into daemon memory.
+      const fetchLimit = Math.min(limit + 100, 200);
       const allRows = await select(ctx.db)
         .from(messagesTable)
         .where(conditions.length > 0 ? and(...conditions) : undefined)
         .orderBy(orderBy)
+        .limit(fetchLimit)
+        .offset(offset)
         .all();
 
       // Post-process
@@ -220,8 +276,8 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
         processed.push(msg);
       }
 
-      const total = processed.length;
-      const paged = processed.slice(offset, offset + limit);
+      const total = offset + processed.length;
+      const paged = processed.slice(0, limit);
       return textResult({ messages: paged, total, offset, limit });
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -207,8 +207,11 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
       };
 
       const processed: ProcessedMessage[] = [];
+      let consumedRows = 0;
 
       for (const row of allRows) {
+        if (processed.length >= limit) break;
+        consumedRows++;
         const data = row.data as {
           content?: unknown;
           tool_uses?: unknown[];
@@ -271,17 +274,16 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
         processed.push(msg);
       }
 
-      const paged = processed.slice(0, limit);
-      const hasMore = allRows.length === fetchLimit;
+      const hasMore = allRows.length > consumedRows || allRows.length === fetchLimit;
       return textResult({
-        messages: paged,
-        returned: paged.length,
+        messages: processed,
+        returned: processed.length,
         offset,
         limit,
         scanned: allRows.length,
         scan_limit: fetchLimit,
         has_more: hasMore,
-        next_offset: hasMore ? offset + fetchLimit : undefined,
+        next_offset: hasMore ? offset + consumedRows : undefined,
       });
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -5,13 +5,12 @@ import {
   desc,
   eq,
   gte,
-  inArray,
   lte,
   messages as messagesTable,
   or,
-  SessionRepository,
   select,
   sql,
+  visibleSessionReferenceAccessExists,
 } from '@agor/core/db';
 import type { ContentBlock } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -169,19 +168,15 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
       }
 
       // RBAC enforcement: when branch_rbac is enabled, restrict this search
-      // to sessions the caller can access. Superadmins bypass. When RBAC is
-      // disabled (default / open-access mode), skip this filter entirely to
-      // preserve backward-compatible behavior.
+      // to sessions the caller can access. Use the same SQL EXISTS predicate
+      // as high-cardinality repository paths instead of materializing every
+      // accessible session id into an IN (...) list.
       if (isBranchRbacEnabled()) {
         const userRole = ctx.authenticatedUser?.role as string | undefined;
         if (!isSuperAdmin(userRole)) {
-          const sessionRepo = new SessionRepository(ctx.db);
-          const accessibleSessions = await sessionRepo.findAccessibleSessions(ctx.userId);
-          const accessibleIds = accessibleSessions.map((s) => s.session_id);
-          if (accessibleIds.length === 0) {
-            return textResult({ messages: [], total: 0, offset, limit });
-          }
-          conditions.push(inArray(messagesTable.session_id, accessibleIds));
+          conditions.push(
+            visibleSessionReferenceAccessExists(ctx.db, ctx.userId, messagesTable.session_id)
+          );
         }
       }
 
@@ -276,9 +271,18 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
         processed.push(msg);
       }
 
-      const total = offset + processed.length;
       const paged = processed.slice(0, limit);
-      return textResult({ messages: paged, total, offset, limit });
+      const hasMore = allRows.length === fetchLimit;
+      return textResult({
+        messages: paged,
+        returned: paged.length,
+        offset,
+        limit,
+        scanned: allRows.length,
+        scan_limit: fetchLimit,
+        has_more: hasMore,
+        next_offset: hasMore ? offset + fetchLimit : undefined,
+      });
     }
   );
 }

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -172,7 +172,7 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     expect(createPending).toHaveBeenCalledWith(
       expect.objectContaining({
         session_id: parentSessionId,
@@ -230,7 +230,7 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
     expect(callbackPrompt).toContain('[Agor] Child session');
     expect(callbackPrompt).toContain('**Result:**');
@@ -263,7 +263,7 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
     expect(callbackPrompt).toContain('[Agor] Child session');
     expect(callbackPrompt).toContain('## Original Prompt');
@@ -293,7 +293,7 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
     expect(callbackPrompt).toContain('[Agor] Child session');
     expect(callbackPrompt).toContain('## Original Prompt');

--- a/packages/core/drizzle/postgres/0057_message_timestamp_indexes.sql
+++ b/packages/core/drizzle/postgres/0057_message_timestamp_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS "messages_tenant_timestamp_idx" ON "messages" ("tenant_id","timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "messages_timestamp_idx" ON "messages" ("timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "messages_session_timestamp_idx" ON "messages" ("session_id","timestamp");

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1782200000000,
       "tag": "0056_composite_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1782300000000,
+      "tag": "0057_message_timestamp_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0064_message_timestamp_indexes.sql
+++ b/packages/core/drizzle/sqlite/0064_message_timestamp_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS `messages_timestamp_idx` ON `messages` (`timestamp`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `messages_session_timestamp_idx` ON `messages` (`session_id`,`timestamp`);

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1782000000000,
       "tag": "0063_composite_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "6",
+      "when": 1782100000000,
+      "tag": "0064_message_timestamp_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -484,10 +484,16 @@ export const messages = pgTable(
   },
   (table) => ({
     tenantIdx: index('messages_tenant_id_idx').on(table.tenant_id),
+    tenantTimestampIdx: index('messages_tenant_timestamp_idx').on(table.tenant_id, table.timestamp),
     // Indexes for efficient lookups
     sessionIdx: index('messages_session_id_idx').on(table.session_id),
     taskIdx: index('messages_task_id_idx').on(table.task_id),
     sessionIndexIdx: index('messages_session_index_idx').on(table.session_id, table.index),
+    timestampIdx: index('messages_timestamp_idx').on(table.timestamp),
+    sessionTimestampIdx: index('messages_session_timestamp_idx').on(
+      table.session_id,
+      table.timestamp
+    ),
   })
 );
 

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -280,7 +280,7 @@ export const sessionRelationships = sqliteTable(
     targetIdx: index('session_relationships_target_idx').on(table.target_session_id),
     callbackIdx: index('session_relationships_callback_idx').on(table.callback_session_id),
     // Note: no tenant_source/tenant_target composite indexes here — SQLite schema
-    // has no tenant_id column on this table (RLS is Postgres-only). The standalone
+    // has no tenant column on this table (RLS is Postgres-only). The standalone
     // source/target indexes above are sufficient for SQLite.
     sourceTargetTypeUnique: uniqueIndex('session_relationships_source_target_type_unique').on(
       table.source_session_id,

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -478,6 +478,11 @@ export const messages = sqliteTable(
     sessionIdx: index('messages_session_id_idx').on(table.session_id),
     taskIdx: index('messages_task_id_idx').on(table.task_id),
     sessionIndexIdx: index('messages_session_index_idx').on(table.session_id, table.index),
+    timestampIdx: index('messages_timestamp_idx').on(table.timestamp),
+    sessionTimestampIdx: index('messages_session_timestamp_idx').on(
+      table.session_id,
+      table.timestamp
+    ),
   })
 );
 


### PR DESCRIPTION
## Summary

- Add `createdAfter` / `createdBefore` filters to `agor_messages_list` and push those bounds into the SQL `WHERE` clause.
- Fail fast for broad cross-session keyword searches unless they are scoped to `sessionId` / `taskId` or use a `createdAfter`-bounded window of 31 days or less.
- Bound per-call row retrieval with SQL `LIMIT` / `OFFSET` plus small over-fetch for tool-noise filtering.
- Add SQLite/Postgres message timestamp indexes to support bounded searches and timestamp ordering.
- Rebase on the recent composite-index / idle-transaction changes and renumber message migrations after them (`postgres/0057`, `sqlite/0064`).
- Align RBAC with existing high-cardinality table patterns by using the shared SQL `visibleSessionReferenceAccessExists` predicate instead of materializing accessible session IDs.
- Return bounded pagination metadata (`returned`, `scanned`, `scan_limit`, `has_more`, `next_offset`) instead of a misleading full-result `total`. `next_offset` advances by raw rows actually consumed to produce the returned page, avoiding skipped messages.

## Root cause

`agor_messages_list` allowed keyword searches across all messages with no time bound. The query applied `LOWER(CAST(data AS TEXT)) LIKE ...` across a very large table, then loaded all matching rows before pagination/post-processing. Broad terms like `SEO` could therefore full-scan for minutes and keep the daemon tied up even after the tool call was stopped.

## Behavior changes

- `createdAfter` and `createdBefore` accept ISO-8601 date strings, for example `2026-06-01` or `2026-06-01T00:00:00Z`.
- Cross-session keyword searches now require either:
  - `sessionId` or `taskId`, or
  - `createdAfter` with an effective window of at most 31 days (`createdBefore` defaults to now for validation when omitted).
- Specific session transcript browsing still works without a time bound.
- Results are fetched in bounded pages instead of materializing all matching rows.
- `next_offset` is based on consumed raw rows, so over-fetching for tool-noise filtering does not skip valid messages.
- RBAC filtering stays in SQL via the same visible-session EXISTS helper used by repository paths.

## Indexes / migrations

- SQLite migration: `0064_message_timestamp_indexes.sql`
  - `messages_timestamp_idx`
  - `messages_session_timestamp_idx`
- Postgres migration: `0057_message_timestamp_indexes.sql`
  - `messages_tenant_timestamp_idx`
  - `messages_timestamp_idx`
  - `messages_session_timestamp_idx`

These now follow the recent composite-index migrations (`sqlite/0063`, `postgres/0056`).

## Timeout/default-window choice

I chose fail-fast guidance over silently applying a default recent window. Silent defaults can make agents miss older messages and misinterpret partial results as exhaustive. A 31-day explicit window is small enough to keep broad searches practical on large tables while still allowing historical searches by chunking date ranges.

This PR uses a max-scan/row cap (`limit + 100`, capped at 200 rows fetched) rather than a database-driver timeout, because a JS `Promise.race` timeout would not reliably cancel an already-running SQLite/Postgres query and could leave work continuing in the daemon. The main protection is preventing unbounded SQL scans up front.

## Checks

- `pnpm i`
- `pnpm check`
- `pnpm exec biome check apps/agor-daemon/src/mcp/tools/messages.ts apps/agor-daemon/src/mcp/tools/messages.test.ts packages/core/src/db/schema.sqlite.ts packages/core/src/db/schema.postgres.ts`
- `pnpm --filter @agor/daemon test -- src/mcp/tools/messages.test.ts`