### PR TITLE
fix(tasks): defer completion callbacks until post-commit

### DIFF
--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -1,3 +1,4 @@
+import { runWithTenantDatabaseScope } from '@agor/core/db';
 import { type Session, type Task, TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { TasksService } from './tasks';
@@ -157,6 +158,46 @@ function makeService(
 }
 
 describe('TasksService completion callbacks', () => {
+  it('defers callback dispatch until after the tenant transaction commits', async () => {
+    const events: string[] = [];
+    const { service, createPending } = makeService();
+    const tx = {
+      execute: vi.fn(async () => []),
+    };
+    const db = {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+        events.push('tx:start');
+        const result = await callback(tx);
+        events.push('tx:committed');
+        return result;
+      }),
+    };
+    createPending.mockImplementationOnce(async (data: Partial<Task>) => {
+      events.push('callback:queued');
+      return {
+        ...makeTask({
+          task_id: callbackTaskId,
+          session_id: parentSessionId,
+          status: TaskStatus.QUEUED,
+        }),
+        ...data,
+      };
+    });
+
+    await runWithTenantDatabaseScope(db as never, 'tenant-1', async () => {
+      await service.patch(taskId, {
+        status: TaskStatus.COMPLETED,
+        completed_at: '2026-01-01T00:00:05.000Z',
+      });
+
+      events.push('patch:returned');
+      expect(createPending).not.toHaveBeenCalled();
+    });
+
+    expect(events).toEqual(['tx:start', 'patch:returned', 'tx:committed', 'callback:queued']);
+    expect(createPending).toHaveBeenCalledTimes(1);
+  });
+
   it('queues exactly one templated callback with last-message metadata for a completed subsession task', async () => {
     const {
       service,

--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -194,7 +194,16 @@ describe('TasksService completion callbacks', () => {
       expect(createPending).not.toHaveBeenCalled();
     });
 
-    expect(events).toEqual(['tx:start', 'patch:returned', 'tx:committed', 'callback:queued']);
+    expect(events).toEqual([
+      'tx:start',
+      'patch:returned',
+      'tx:committed',
+      'tx:start',
+      'callback:queued',
+      'tx:committed',
+      'tx:start',
+      'tx:committed',
+    ]);
     expect(createPending).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -12,8 +12,8 @@ import {
 } from '@agor/core/callbacks/child-completion-template';
 import { PAGINATION, resolveExecutorHeartbeatConfig } from '@agor/core/config';
 import {
-  addTenantDatabasePostCommitCallback,
   type Database,
+  enqueueTenantDatabasePostCommitCallback,
   shortId,
   TaskRepository,
 } from '@agor/core/db';
@@ -400,27 +400,36 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     this.heartbeatCallbackRunner.run(payload);
   }
 
-  private async dispatchCompletionCallbacksAfterCommit(
-    task: Task,
-    session: Session,
-    params?: TaskParams
+  private async runAfterTenantDatabaseCommit(
+    label: string,
+    work: () => Promise<void>
   ): Promise<void> {
-    const dispatch = async () => {
+    const run = async () => {
       try {
-        await this.dispatchCompletionCallbacks(task, session, params);
+        await work();
       } catch (error) {
         console.warn(
-          `⚠️  [TasksService] Failed to dispatch completion callbacks for task ${shortId(task.task_id)}:`,
+          `⚠️  [TasksService] ${label} failed:`,
           error instanceof Error ? error.message : String(error)
         );
       }
     };
 
-    if (addTenantDatabasePostCommitCallback(dispatch)) {
+    if (enqueueTenantDatabasePostCommitCallback(run)) {
       return;
     }
 
-    await dispatch();
+    await run();
+  }
+
+  private async dispatchCompletionCallbacksAfterCommit(
+    task: Task,
+    session: Session,
+    params?: TaskParams
+  ): Promise<void> {
+    await this.runAfterTenantDatabaseCommit('dispatchCompletionCallbacks', () =>
+      this.dispatchCompletionCallbacks(task, session, params)
+    );
   }
 
   /**
@@ -642,7 +651,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           // extend this transaction and cause proxy CONNECTION_CLOSED kills.
           const sessionsService = this.app.service('sessions') as unknown as SessionsService;
           if (!params?.suppressTerminalQueueProcessing && sessionsService.triggerQueueProcessing) {
-            this.firePostCommit('triggerQueueProcessing', () =>
+            await this.runAfterTenantDatabaseCommit('triggerQueueProcessing', () =>
               sessionsService.triggerQueueProcessing!(task.session_id)
             );
           } else if (params?.suppressTerminalQueueProcessing) {
@@ -797,38 +806,6 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
    * from notifying its parent once via the rich/template path and again via a
    * second generic/raw path.
    */
-  <<<<<<<
-  HEAD;
-  /**
-   * Fire an async callback after the current transaction commits.
-   *
-   * Breaks out of the AsyncLocalStorage transaction scope via exit() so the
-   * callback opens its own fresh connection rather than reusing the caller's
-   * transaction. The outer transaction therefore commits immediately — eliminating
-   * idle-in-transaction time and the resulting "write CONNECTION_CLOSED" proxy kills.
-   */
-  private firePostCommit(label: string, fn: () => Promise<void>): void {
-    void tenantDatabaseScope.exit(() =>
-      fn().catch((err) => console.error(`[TasksService] ${label}:`, err))
-    );
-  }
-
-  private fireCallbacksPostCommit(task: Task, session: Session, params?: TaskParams): void {
-    this.firePostCommit('dispatchCompletionCallbacks', () =>
-      this.dispatchCompletionCallbacks(task, session, params)
-    );
-  }
-
-  =======
->>>>>>> 6506fb83 (
-  fix(tasks): defer
-  completion;
-  callbacks;
-  until;
-  post;
-  -
-  commit;
-  )
   private async dispatchCompletionCallbacks(
     task: Task,
     childSession: Session,

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -11,7 +11,12 @@ import {
   renderChildCompletionCallback,
 } from '@agor/core/callbacks/child-completion-template';
 import { PAGINATION, resolveExecutorHeartbeatConfig } from '@agor/core/config';
-import { type Database, shortId, TaskRepository, tenantDatabaseScope } from '@agor/core/db';
+import {
+  addTenantDatabasePostCommitCallback,
+  type Database,
+  shortId,
+  TaskRepository,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
   ContentBlock,
@@ -360,7 +365,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     // Dispatch completion callbacks outside the task-patch transaction.
     // Both patches have committed at this point, so callbacks run in fresh transactions.
     if (updatedSession) {
-      void this.dispatchCompletionCallbacks(failedTask, updatedSession, params).catch(
+      void this.dispatchCompletionCallbacksAfterCommit(failedTask, updatedSession, params).catch(
         (error: unknown) => {
           console.warn(
             `[executor-heartbeat] Failed to dispatch completion callbacks for task ${shortId(failedTask.task_id)}:`,
@@ -393,6 +398,29 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     }
 
     this.heartbeatCallbackRunner.run(payload);
+  }
+
+  private async dispatchCompletionCallbacksAfterCommit(
+    task: Task,
+    session: Session,
+    params?: TaskParams
+  ): Promise<void> {
+    const dispatch = async () => {
+      try {
+        await this.dispatchCompletionCallbacks(task, session, params);
+      } catch (error) {
+        console.warn(
+          `⚠️  [TasksService] Failed to dispatch completion callbacks for task ${shortId(task.task_id)}:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    };
+
+    if (addTenantDatabasePostCommitCallback(dispatch)) {
+      return;
+    }
+
+    await dispatch();
   }
 
   /**
@@ -543,7 +571,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             // Process completion callbacks only for naturally-terminal tasks (COMPLETED/FAILED).
             // STOPPED means the work was abandoned — don't notify the parent.
             if (!suppressCompletionCallbacks && !isStop) {
-              this.fireCallbacksPostCommit(task, session, params);
+              await this.dispatchCompletionCallbacksAfterCommit(task, session, params);
             }
             return result;
           }
@@ -579,7 +607,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
           }
 
           if (!suppressCompletionCallbacks && !isStop) {
-            this.fireCallbacksPostCommit(task, session, params);
+            await this.dispatchCompletionCallbacksAfterCommit(task, session, params);
           }
 
           // "btw" fork origin: auto-archive the ephemeral fork after task completion.
@@ -769,6 +797,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
    * from notifying its parent once via the rich/template path and again via a
    * second generic/raw path.
    */
+  <<<<<<<
+  HEAD;
   /**
    * Fire an async callback after the current transaction commits.
    *
@@ -789,6 +819,16 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     );
   }
 
+  =======
+>>>>>>> 6506fb83 (
+  fix(tasks): defer
+  completion;
+  callbacks;
+  until;
+  post;
+  -
+  commit;
+  )
   private async dispatchCompletionCallbacks(
     task: Task,
     childSession: Session,

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -1,4 +1,8 @@
-import { getCurrentTenantId } from '@agor/core/db';
+import {
+  addTenantDatabasePostCommitCallback,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+} from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
 import jwt from 'jsonwebtoken';
 import { describe, expect, it, vi } from 'vitest';
@@ -47,6 +51,53 @@ describe('createTenantDatabaseScopeAroundHook', () => {
     });
     expect(db.transaction).toHaveBeenCalledTimes(1);
     expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs registered post-commit callbacks after the scoped transaction resolves', async () => {
+    const events: string[] = [];
+    const tx = {
+      execute: vi.fn(async () => []),
+    };
+    const db = {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+        events.push('tx:start');
+        const result = await callback(tx);
+        events.push('tx:committed');
+        return result;
+      }),
+    };
+
+    await runWithTenantDatabaseScope(db as never, 'tenant-static', async () => {
+      expect(
+        addTenantDatabasePostCommitCallback(async () => {
+          events.push('post-commit');
+        })
+      ).toBe(true);
+      events.push('work:done');
+    });
+
+    expect(events).toEqual(['tx:start', 'work:done', 'tx:committed', 'post-commit']);
+  });
+
+  it('does not run post-commit callbacks when the scoped transaction rolls back', async () => {
+    const callback = vi.fn(async () => undefined);
+    const tx = {
+      execute: vi.fn(async () => []),
+    };
+    const db = {
+      transaction: vi.fn(async (transactionCallback: (tx: unknown) => Promise<unknown>) => {
+        await transactionCallback(tx);
+        throw new Error('rollback');
+      }),
+    };
+
+    await expect(
+      runWithTenantDatabaseScope(db as never, 'tenant-static', async () => {
+        expect(addTenantDatabasePostCommitCallback(callback)).toBe(true);
+      })
+    ).rejects.toThrow('rollback');
+
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it('resolves required tenant context from a signed bearer JWT', async () => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -1,5 +1,5 @@
 import {
-  addTenantDatabasePostCommitCallback,
+  enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantId,
   runWithTenantDatabaseScope,
 } from '@agor/core/db';
@@ -69,14 +69,24 @@ describe('createTenantDatabaseScopeAroundHook', () => {
 
     await runWithTenantDatabaseScope(db as never, 'tenant-static', async () => {
       expect(
-        addTenantDatabasePostCommitCallback(async () => {
+        enqueueTenantDatabasePostCommitCallback(async () => {
+          expect(getCurrentTenantId()).toBe('tenant-static');
           events.push('post-commit');
         })
       ).toBe(true);
       events.push('work:done');
     });
 
-    expect(events).toEqual(['tx:start', 'work:done', 'tx:committed', 'post-commit']);
+    expect(events).toEqual([
+      'tx:start',
+      'work:done',
+      'tx:committed',
+      'tx:start',
+      'post-commit',
+      'tx:committed',
+    ]);
+    expect(db.transaction).toHaveBeenCalledTimes(2);
+    expect(tx.execute).toHaveBeenCalledTimes(2);
   });
 
   it('does not run post-commit callbacks when the scoped transaction rolls back', async () => {
@@ -93,7 +103,7 @@ describe('createTenantDatabaseScopeAroundHook', () => {
 
     await expect(
       runWithTenantDatabaseScope(db as never, 'tenant-static', async () => {
-        expect(addTenantDatabasePostCommitCallback(callback)).toBe(true);
+        expect(enqueueTenantDatabasePostCommitCallback(callback)).toBe(true);
       })
     ).rejects.toThrow('rollback');
 

--- a/packages/core/src/db/tenant-context.ts
+++ b/packages/core/src/db/tenant-context.ts
@@ -18,7 +18,7 @@ export function getCurrentTenantId(): TenantID | string | undefined {
   return tenantDatabaseScope.getStore()?.tenantId;
 }
 
-export function addTenantDatabasePostCommitCallback(callback: () => Promise<void>): boolean {
+export function enqueueTenantDatabasePostCommitCallback(callback: () => Promise<void>): boolean {
   const store = tenantDatabaseScope.getStore();
   if (!store?.postCommitCallbacks) return false;
   store.postCommitCallbacks.push(callback);

--- a/packages/core/src/db/tenant-context.ts
+++ b/packages/core/src/db/tenant-context.ts
@@ -5,6 +5,7 @@ import type { Database } from './client';
 export interface TenantDatabaseScope {
   db: Database;
   tenantId?: TenantID | string;
+  postCommitCallbacks?: Array<() => Promise<void>>;
 }
 
 export const tenantDatabaseScope = new AsyncLocalStorage<TenantDatabaseScope>();
@@ -15,4 +16,11 @@ export function getCurrentTenantDatabase(): Database | undefined {
 
 export function getCurrentTenantId(): TenantID | string | undefined {
   return tenantDatabaseScope.getStore()?.tenantId;
+}
+
+export function addTenantDatabasePostCommitCallback(callback: () => Promise<void>): boolean {
+  const store = tenantDatabaseScope.getStore();
+  if (!store?.postCommitCallbacks) return false;
+  store.postCommitCallbacks.push(callback);
+  return true;
 }

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -3,7 +3,7 @@ import type { TenantID } from '../types/tenant';
 import { tenantDatabaseScope } from './tenant-context';
 
 export {
-  addTenantDatabasePostCommitCallback,
+  enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantDatabase,
   getCurrentTenantId,
   tenantDatabaseScope,
@@ -76,9 +76,7 @@ export async function runWithTenantDatabaseScope<T>(
       { db: baseDb, tenantId, postCommitCallbacks },
       work
     );
-    for (const callback of postCommitCallbacks) {
-      await callback();
-    }
+    await drainTenantDatabasePostCommitCallbacks(baseDb, tenantId, postCommitCallbacks);
     return result;
   }
 
@@ -89,8 +87,16 @@ export async function runWithTenantDatabaseScope<T>(
     );
     return tenantDatabaseScope.run({ db: scopedDb, tenantId, postCommitCallbacks }, work);
   });
-  for (const callback of postCommitCallbacks) {
-    await callback();
-  }
+  await drainTenantDatabasePostCommitCallbacks(baseDb, tenantId, postCommitCallbacks);
   return result;
+}
+
+async function drainTenantDatabasePostCommitCallbacks(
+  baseDb: Database,
+  tenantId: TenantID | string | undefined,
+  callbacks: Array<() => Promise<void>>
+): Promise<void> {
+  for (const callback of callbacks) {
+    await runWithTenantDatabaseScope(baseDb, tenantId, callback);
+  }
 }

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -3,6 +3,7 @@ import type { TenantID } from '../types/tenant';
 import { tenantDatabaseScope } from './tenant-context';
 
 export {
+  addTenantDatabasePostCommitCallback,
   getCurrentTenantDatabase,
   getCurrentTenantId,
   tenantDatabaseScope,
@@ -68,16 +69,28 @@ export async function runWithTenantDatabaseScope<T>(
   }
 
   const baseDb = unwrapTenantScopedDatabaseProxy(db);
+  const postCommitCallbacks: Array<() => Promise<void>> = [];
 
   if (!isPostgresDatabase(baseDb) || !tenantId) {
-    return tenantDatabaseScope.run({ db: baseDb, tenantId }, work);
+    const result = await tenantDatabaseScope.run(
+      { db: baseDb, tenantId, postCommitCallbacks },
+      work
+    );
+    for (const callback of postCommitCallbacks) {
+      await callback();
+    }
+    return result;
   }
 
-  return baseDb.transaction(async (tx) => {
+  const result = await baseDb.transaction(async (tx) => {
     const scopedDb = tx as unknown as Database;
     await (scopedDb as unknown as { execute(query: unknown): Promise<unknown> }).execute(
       sql`SELECT set_config('agor.tenant_id', ${tenantId}, true)`
     );
-    return tenantDatabaseScope.run({ db: scopedDb, tenantId }, work);
+    return tenantDatabaseScope.run({ db: scopedDb, tenantId, postCommitCallbacks }, work);
   });
+  for (const callback of postCommitCallbacks) {
+    await callback();
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

- Add a tenant-scope post-commit callback queue.
- Defer task completion callback dispatch until after the outer tenant transaction commits.
- Drain queued post-commit callbacks in a fresh tenant-scoped transaction so Postgres RLS / `agor.tenant_id` is preserved without reusing the completed transaction.
- Add regression coverage for post-commit ordering, rollback behavior, and tenant context preservation during callback drain.

## Root cause

`dispatchCompletionCallbacks` was invoked from `TasksService.patch` completion side effects while Feathers service/route handling was still wrapped by `tenantDatabaseScopeAround`. On Postgres, that meant callback lookup/queueing work could run inside the same tenant-scoped transaction that completed the task, extending the transaction window and contributing to idle-in-transaction zombies.

## Implementation details

- Extended `runWithTenantDatabaseScope` with a per-outer-scope post-commit callback queue.
- The queue drains only after the outer transaction resolves successfully; it is skipped if the transaction rolls back.
- Each drained callback now runs in a fresh tenant database scope/transaction for the original tenant.
- Added `enqueueTenantDatabasePostCommitCallback` so services can register work without depending on hook internals.
- Updated task completion callback dispatch to enqueue with the post-commit queue when a tenant scope is active, falling back to immediate dispatch outside tenant scopes.
- Preserved the existing `suppressCompletionCallbacks` / STOPPED-task behavior for administrative or abandoned-work paths.
- Left the `idle_in_transaction_session_timeout = 45s` backstop unchanged.

## Tests / checks

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/tasks.callbacks.test.ts src/utils/tenant-db-scope.test.ts src/services/tasks.executor-heartbeat.test.ts src/utils/session-stop.test.ts`
- Pre-commit lint-staged hook passed.

## Caveats

- `pnpm check` passes with existing Biome warnings in unrelated docs/core test files.
