### PR TITLE
Add artifact header lock icon

### DIFF
--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -172,7 +172,7 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     expect(createPending).toHaveBeenCalledWith(
       expect.objectContaining({
         session_id: parentSessionId,
@@ -194,18 +194,24 @@ describe('TasksService completion callbacks', () => {
     expect(callbackPrompt).not.toContain('## Original Prompt');
     expect(callbackPrompt).not.toContain('investigate duplicate callbacks');
     expect(messagesFind).toHaveBeenCalledTimes(1);
-    expect(triggerQueueProcessing).toHaveBeenCalledWith(parentSessionId, {});
-    expect(sessionsPatch).toHaveBeenCalledWith(
-      childSessionId,
-      expect.objectContaining({ callback_config: expect.objectContaining({ enabled: false }) })
+    await vi.waitFor(() =>
+      expect(triggerQueueProcessing).toHaveBeenCalledWith(parentSessionId, {})
     );
-    expect(getStoredTask().metadata?.callback_dispatches).toEqual([
-      expect.objectContaining({
-        event: 'session_completion',
-        target_session_id: parentSessionId,
-        queued_task_id: callbackTaskId,
-      }),
-    ]);
+    await vi.waitFor(() =>
+      expect(sessionsPatch).toHaveBeenCalledWith(
+        childSessionId,
+        expect.objectContaining({ callback_config: expect.objectContaining({ enabled: false }) })
+      )
+    );
+    await vi.waitFor(() =>
+      expect(getStoredTask().metadata?.callback_dispatches).toEqual([
+        expect.objectContaining({
+          event: 'session_completion',
+          target_session_id: parentSessionId,
+          queued_task_id: callbackTaskId,
+        }),
+      ])
+    );
   });
 
   it('includeOriginalPrompt=false queues one templated callback without an original prompt section', async () => {
@@ -230,7 +236,7 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
     expect(callbackPrompt).toContain('[Agor] Child session');
     expect(callbackPrompt).toContain('**Result:**');
@@ -263,7 +269,7 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
     expect(callbackPrompt).toContain('[Agor] Child session');
     expect(callbackPrompt).toContain('## Original Prompt');
@@ -293,15 +299,17 @@ describe('TasksService completion callbacks', () => {
       completed_at: '2026-01-01T00:00:05.000Z',
     });
 
-    expect(createPending).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
     const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
     expect(callbackPrompt).toContain('[Agor] Child session');
     expect(callbackPrompt).toContain('## Original Prompt');
     expect(callbackPrompt).toContain('remote session initial prompt');
     expect(callbackPrompt).toContain('Final child result');
-    expect(sessionsPatch).toHaveBeenCalledWith(
-      childSessionId,
-      expect.objectContaining({ callback_config: expect.objectContaining({ enabled: false }) })
+    await vi.waitFor(() =>
+      expect(sessionsPatch).toHaveBeenCalledWith(
+        childSessionId,
+        expect.objectContaining({ callback_config: expect.objectContaining({ enabled: false }) })
+      )
     );
   });
 

--- a/apps/agor-daemon/src/services/users.find.test.ts
+++ b/apps/agor-daemon/src/services/users.find.test.ts
@@ -25,6 +25,26 @@ describe('UsersService.find', () => {
     expect(page.data[0].email).toBe('bravo@example.com');
   });
 
+  dbTest('ignores tenant scope safely on SQLite users table', async ({ db }) => {
+    const service = new UsersService(db);
+
+    const created = await service.create(
+      { email: 'tenant-safe@example.com', password: 'password-123', name: 'Tenant Safe' },
+      { tenant: { tenant_id: 'default', source: 'static' } } as never
+    );
+
+    const page = await service.find({
+      tenant: { tenant_id: 'default', source: 'static' },
+      query: { $limit: 10 },
+    } as never);
+    const fetched = await service.get(created.user_id, {
+      tenant: { tenant_id: 'default', source: 'static' },
+    } as never);
+
+    expect(page.data.map((user) => user.email)).toContain('tenant-safe@example.com');
+    expect(fetched.email).toBe('tenant-safe@example.com');
+  });
+
   dbTest('supports offset alias for pagination', async ({ db }) => {
     const service = new UsersService(db);
 

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -71,9 +71,14 @@ function queryString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function usersTableHasTenantColumn(): boolean {
+  return 'tenant_id' in (users as unknown as object);
+}
+
 function tenantPredicate(params?: Params) {
   const tenantId = (params as { tenant?: { tenant_id?: string } } | undefined)?.tenant?.tenant_id;
-  return tenantId ? eq((users as never as { tenant_id: never }).tenant_id, tenantId) : undefined;
+  if (!tenantId || !usersTableHasTenantColumn()) return undefined;
+  return eq((users as never as { tenant_id: never }).tenant_id, tenantId);
 }
 
 function withTenantPredicate(params: Params | undefined, predicate: unknown) {
@@ -83,7 +88,7 @@ function withTenantPredicate(params: Params | undefined, predicate: unknown) {
 
 function tenantInsertValues(params?: Params): { tenant_id?: string } {
   const tenantId = (params as { tenant?: { tenant_id?: string } } | undefined)?.tenant?.tenant_id;
-  return tenantId ? { tenant_id: tenantId } : {};
+  return tenantId && usersTableHasTenantColumn() ? { tenant_id: tenantId } : {};
 }
 
 export const LOCAL_AUTH_LOOKUP_PARAM = Symbol('agor.users.local-auth-lookup');

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -322,41 +322,19 @@ export const ArtifactNode = ({
           file for the interact-mode iframe wrapper. */}
       <div className="nodrag nopan" style={{ display: 'flex', gap: 2 }}>
         <Tooltip title={data.locked ? 'Unlock artifact card' : 'Lock artifact card'}>
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
+          <Button
+            type="text"
+            size="small"
+            icon={data.locked ? <LockOutlined /> : <UnlockOutlined />}
+            onClick={(e) => {
               e.stopPropagation();
               handleToggleLock();
             }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
             style={{
-              width: 20,
-              height: 20,
-              borderRadius: 3,
-              backgroundColor: data.locked ? token.colorWarningBg : token.colorBgContainer,
-              border: `1px solid ${data.locked ? token.colorWarning : token.colorBorder}`,
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              flexShrink: 0,
-              padding: 0,
-              appearance: 'none',
-              color: data.locked ? token.colorWarning : token.colorText,
-              cursor: 'pointer',
-              fontSize: 12,
-              lineHeight: 1,
+              backgroundColor: data.locked ? token.colorWarningBg : undefined,
+              color: data.locked ? token.colorWarning : undefined,
             }}
-          >
-            {data.locked ? <LockOutlined /> : <UnlockOutlined />}
-          </button>
+          />
         </Tooltip>
         {payload?.source_session_id && (
           <Tooltip title="Open session that created this artifact">

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -15,7 +15,6 @@ import {
   EyeOutlined,
   FullscreenOutlined,
   LoadingOutlined,
-  LockOutlined,
   MessageOutlined,
   ReloadOutlined,
   WarningOutlined,
@@ -278,13 +277,6 @@ export const ArtifactNode = ({
   // on the stale data. Keep the title + Reload + Delete though, since
   // those still help the user act on the broken state.
   const hasUsablePayload = !!payload && !error;
-  const hasRequiredEnvVars = (payload?.required_env_vars?.length ?? 0) > 0;
-  const hasConsentGrants = Object.keys(payload?.agor_grants ?? {}).length > 0;
-  const showConsentAffordance =
-    hasUsablePayload &&
-    payload?.trust_state === 'untrusted' &&
-    (hasRequiredEnvVars || hasConsentGrants);
-
   const cardTitle = (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
@@ -295,7 +287,7 @@ export const ArtifactNode = ({
         >
           {payload?.name ?? fallbackName}
         </Typography.Text>
-        {payload && (
+        {hasUsablePayload && (
           <ArtifactHeaderLockIcon
             payload={payload}
             onTrustClick={() => setConsentOpen(true)}
@@ -309,23 +301,6 @@ export const ArtifactNode = ({
           handler has already armed). Same pattern used elsewhere in this
           file for the interact-mode iframe wrapper. */}
       <div className="nodrag nopan" style={{ display: 'flex', gap: 2 }}>
-        {showConsentAffordance && (
-          <Tooltip title="Trust this artifact to inject secrets">
-            <Button
-              type="text"
-              size="small"
-              // `danger` themes the icon via Ant's colorError token —
-              // signals "this artifact won't render with secrets until
-              // you grant trust" without us hardcoding a hex.
-              danger
-              icon={<LockOutlined />}
-              onClick={(e) => {
-                e.stopPropagation();
-                setConsentOpen(true);
-              }}
-            />
-          </Tooltip>
-        )}
         {payload?.source_session_id && (
           <Tooltip title="Open session that created this artifact">
             <Button

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -15,8 +15,10 @@ import {
   EyeOutlined,
   FullscreenOutlined,
   LoadingOutlined,
+  LockOutlined,
   MessageOutlined,
   ReloadOutlined,
+  UnlockOutlined,
   WarningOutlined,
 } from '@ant-design/icons';
 import {
@@ -31,9 +33,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
 import {
   ArtifactConsoleReporter,
-  ArtifactHeaderLockIcon,
   ArtifactRuntimeBridge,
   ArtifactSandpackErrorReporter,
+  ArtifactTrustStatusIcon,
 } from '@/components/artifacts/ArtifactRenderSupport';
 import { getDaemonUrl } from '@/config/daemon';
 import { getAuthHeaders } from '@/utils/authHeaders';
@@ -58,6 +60,9 @@ export interface ArtifactNodeData {
    *  stay independently legible. */
   isActiveUrlTarget?: boolean;
   onUpdate: (id: string, data: BoardObject) => void;
+  locked?: boolean;
+  x: number;
+  y: number;
   /** Lifecycle-safe delete: removes filesystem + board object + DB record */
   onDeleteArtifact?: (objectId: string, artifactId: string) => void;
 }
@@ -219,6 +224,7 @@ export const ArtifactNode = ({
         width: Math.max(params.width, MIN_WIDTH),
         height: Math.max(params.height, MIN_HEIGHT),
         artifact_id: data.artifactId as ArtifactID,
+        locked: data.locked,
       };
       data.onUpdate(data.objectId, objectData);
     },
@@ -232,6 +238,20 @@ export const ArtifactNode = ({
   // scaffolding files (`index.html`, `index.js`, `package.json`, etc.) that
   // Sandpack synthesizes per template — without those the destination
   // sandbox boots empty (no entry, no DOM root).
+
+  const handleToggleLock = useCallback(() => {
+    const objectData: ArtifactBoardObject = {
+      type: 'artifact',
+      x: data.x,
+      y: data.y,
+      width: data.width,
+      height: data.height,
+      artifact_id: data.artifactId as ArtifactID,
+      locked: !data.locked,
+    };
+    data.onUpdate(data.objectId, objectData);
+  }, [data]);
+
   const handleOpenInCodeSandbox = useCallback(() => {
     window.dispatchEvent(new CustomEvent(`agor:export-codesandbox-${data.artifactId}`));
   }, [data.artifactId]);
@@ -288,7 +308,7 @@ export const ArtifactNode = ({
           {payload?.name ?? fallbackName}
         </Typography.Text>
         {hasUsablePayload && (
-          <ArtifactHeaderLockIcon
+          <ArtifactTrustStatusIcon
             payload={payload}
             onTrustClick={() => setConsentOpen(true)}
             className="nodrag nopan"
@@ -301,6 +321,43 @@ export const ArtifactNode = ({
           handler has already armed). Same pattern used elsewhere in this
           file for the interact-mode iframe wrapper. */}
       <div className="nodrag nopan" style={{ display: 'flex', gap: 2 }}>
+        <Tooltip title={data.locked ? 'Unlock artifact card' : 'Lock artifact card'}>
+          <button
+            type="button"
+            onPointerDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onPointerUp={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleToggleLock();
+            }}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            style={{
+              width: 20,
+              height: 20,
+              borderRadius: 3,
+              backgroundColor: data.locked ? token.colorWarningBg : token.colorBgContainer,
+              border: `1px solid ${data.locked ? token.colorWarning : token.colorBorder}`,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+              padding: 0,
+              appearance: 'none',
+              color: data.locked ? token.colorWarning : token.colorText,
+              cursor: 'pointer',
+              fontSize: 12,
+              lineHeight: 1,
+            }}
+          >
+            {data.locked ? <LockOutlined /> : <UnlockOutlined />}
+          </button>
+        </Tooltip>
         {payload?.source_session_id && (
           <Tooltip title="Open session that created this artifact">
             <Button
@@ -423,7 +480,7 @@ export const ArtifactNode = ({
   // Shared resizer — same across loading / error / normal states.
   const resizer = (
     <NodeResizer
-      isVisible={selected}
+      isVisible={selected && !data.locked}
       minWidth={MIN_WIDTH}
       minHeight={MIN_HEIGHT}
       onResize={handleResize}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -32,9 +32,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
 import {
   ArtifactConsoleReporter,
+  ArtifactHeaderLockIcon,
   ArtifactRuntimeBridge,
   ArtifactSandpackErrorReporter,
-  renderArtifactTrustBadge,
 } from '@/components/artifacts/ArtifactRenderSupport';
 import { getDaemonUrl } from '@/config/daemon';
 import { getAuthHeaders } from '@/utils/authHeaders';
@@ -272,9 +272,6 @@ export const ArtifactNode = ({
       ? 'processing'
       : 'success';
   const headerBadgeTitle = error ? 'Failed to load' : loading ? 'Reloading...' : 'Live';
-  const trustBadge = payload
-    ? renderArtifactTrustBadge(payload, () => setConsentOpen(true), { className: 'nodrag nopan' })
-    : null;
   // A loaded payload that's also in the error state is stale — the body
   // renders the error placeholder, so the header shouldn't expose
   // payload-acting controls (Export / Interact / Consent) that operate
@@ -298,7 +295,13 @@ export const ArtifactNode = ({
         >
           {payload?.name ?? fallbackName}
         </Typography.Text>
-        {trustBadge}
+        {payload && (
+          <ArtifactHeaderLockIcon
+            payload={payload}
+            onTrustClick={() => setConsentOpen(true)}
+            className="nodrag nopan"
+          />
+        )}
       </div>
       {/* `nodrag nopan` — React Flow's escape hatch. Without it the canvas
           interprets a mousedown on these controls as the start of a node

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -237,11 +237,14 @@ export const useBoardObjects = ({
 
         // Artifact node (filesystem-backed Sandpack preview)
         if (objectData.type === 'artifact') {
+          const isLocked = objectData.locked ?? false;
           return {
             id: objectId,
             type: 'artifactNode',
             position: { x: objectData.x, y: objectData.y },
-            // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+            // Locked artifacts are never draggable. Unlocked artifacts inherit
+            // from canvas-level nodesDraggable (mutationGate.canMutate).
+            ...(isLocked ? { draggable: false } : {}),
             selectable: true,
             zIndex: 400,
             className: eraserMode ? 'eraser-mode' : undefined,
@@ -250,6 +253,9 @@ export const useBoardObjects = ({
               artifactId: objectData.artifact_id,
               width: objectData.width,
               height: objectData.height,
+              locked: isLocked,
+              x: objectData.x,
+              y: objectData.y,
               isActiveUrlTarget: objectData.artifact_id === activeUrlTargetArtifactId,
               onUpdate: handleUpdateObject,
               onDeleteArtifact: deleteArtifact,

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -1,5 +1,5 @@
 import type { ArtifactPayload } from '@agor-live/client';
-import { LockOutlined } from '@ant-design/icons';
+import { SafetyOutlined, WarningOutlined } from '@ant-design/icons';
 import { useSandpack, useSandpackConsole } from '@codesandbox/sandpack-react';
 import { Tooltip, theme } from 'antd';
 import type { CSSProperties } from 'react';
@@ -239,7 +239,7 @@ export function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
   return null;
 }
 
-interface ArtifactHeaderLockIconProps {
+interface ArtifactTrustStatusIconProps {
   payload: ArtifactPayload;
   onTrustClick?: () => void;
   className?: string;
@@ -249,18 +249,19 @@ interface ArtifactHeaderLockIconProps {
 /**
  * Compact artifact trust/status affordance for headers.
  *
- * Mirrors the Zone toolbox lock chip sizing (20px square, 3px radius,
- * warning bg/border for locked/untrusted) so artifact headers get the same
- * small security visual without carrying the full text tag.
+ * Uses warning/safety glyphs rather than a lock so the board-card lock can
+ * unambiguously mean "this artifact card cannot be moved/resized."
  */
-export function ArtifactHeaderLockIcon({
+export function ArtifactTrustStatusIcon({
   payload,
   onTrustClick,
   className,
   style,
-}: ArtifactHeaderLockIconProps) {
+}: ArtifactTrustStatusIconProps) {
   const { token } = theme.useToken();
   const state = payload.trust_state;
+  if (state === 'no_secrets_needed') return null;
+
   const isUntrusted = state === 'untrusted';
   const isTrusted = state === 'trusted';
   const isSelf = state === 'self';
@@ -280,29 +281,20 @@ export function ArtifactHeaderLockIcon({
       ? `Secrets injected — trust granted for ${scopeLabel}`
       : isSelf
         ? 'You created this artifact; secrets are injected'
-        : 'Artifact does not request secrets';
-  const color = isUntrusted
-    ? token.colorWarning
-    : isTrusted
-      ? token.colorSuccess
-      : isSelf
-        ? token.colorInfo
-        : token.colorTextSecondary;
+        : 'Artifact trust status';
+  const color = isUntrusted ? token.colorWarning : isTrusted ? token.colorSuccess : token.colorInfo;
   const backgroundColor = isUntrusted
     ? token.colorWarningBg
     : isTrusted
       ? token.colorSuccessBg
-      : isSelf
-        ? token.colorInfoBg
-        : token.colorBgContainer;
-  const borderColor = state === 'no_secrets_needed' ? token.colorBorder : color;
-  const icon = <LockOutlined />;
+      : token.colorInfoBg;
+  const icon = isUntrusted ? <WarningOutlined /> : <SafetyOutlined />;
   const commonStyle: CSSProperties = {
     width: 20,
     height: 20,
     borderRadius: 3,
     backgroundColor,
-    border: `1px solid ${borderColor}`,
+    border: `1px solid ${color}`,
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -1,7 +1,7 @@
 import type { ArtifactPayload } from '@agor-live/client';
 import { LockOutlined, SafetyOutlined } from '@ant-design/icons';
 import { useSandpack, useSandpackConsole } from '@codesandbox/sandpack-react';
-import { Tag, Tooltip } from 'antd';
+import { Tag, Tooltip, theme } from 'antd';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef } from 'react';
 import { getDaemonUrl } from '@/config/daemon';
@@ -237,6 +237,94 @@ export function ArtifactRuntimeBridge({ artifactId }: { artifactId: string }) {
   }, [artifactId]);
 
   return null;
+}
+
+interface ArtifactHeaderLockIconProps {
+  payload: ArtifactPayload;
+  onTrustClick?: () => void;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Compact artifact trust/status affordance for headers.
+ *
+ * Mirrors the Zone toolbox lock chip sizing (20px square, 3px radius,
+ * warning bg/border for locked/untrusted) so artifact headers get the same
+ * small security visual without carrying the full text tag.
+ */
+export function ArtifactHeaderLockIcon({
+  payload,
+  onTrustClick,
+  className,
+  style,
+}: ArtifactHeaderLockIconProps) {
+  const { token } = theme.useToken();
+  const state = payload.trust_state;
+  if (state === 'no_secrets_needed') return null;
+
+  const isUntrusted = state === 'untrusted';
+  const isTrusted = state === 'trusted';
+  const scopeLabel =
+    payload.trust_scope === 'instance'
+      ? 'instance-wide'
+      : payload.trust_scope === 'author'
+        ? 'this author'
+        : payload.trust_scope === 'session'
+          ? 'just-once'
+          : 'this artifact';
+  const title = isUntrusted
+    ? onTrustClick
+      ? 'Click to review and grant trust so secrets are injected'
+      : 'Secrets are locked until trust is granted'
+    : isTrusted
+      ? `Secrets injected — trust granted for ${scopeLabel}`
+      : 'You created this artifact; secrets are injected';
+  const color = isUntrusted ? token.colorWarning : isTrusted ? token.colorSuccess : token.colorInfo;
+  const backgroundColor = isUntrusted
+    ? token.colorWarningBg
+    : isTrusted
+      ? token.colorSuccessBg
+      : token.colorInfoBg;
+  const icon = <LockOutlined />;
+  const commonStyle: CSSProperties = {
+    width: 20,
+    height: 20,
+    borderRadius: 3,
+    backgroundColor,
+    border: `1px solid ${color}`,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    padding: 0,
+    color,
+    fontSize: 12,
+    lineHeight: 1,
+    ...style,
+  };
+
+  const iconElement =
+    isUntrusted && onTrustClick ? (
+      <button
+        type="button"
+        className={className}
+        aria-label="Review artifact trust"
+        style={{ ...commonStyle, cursor: 'pointer' }}
+        onClick={(e) => {
+          e.stopPropagation();
+          onTrustClick();
+        }}
+      >
+        {icon}
+      </button>
+    ) : (
+      <span className={className} style={commonStyle}>
+        {icon}
+      </span>
+    );
+
+  return <Tooltip title={title}>{iconElement}</Tooltip>;
 }
 
 interface ArtifactTrustBadgeOptions {

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -1,7 +1,7 @@
 import type { ArtifactPayload } from '@agor-live/client';
-import { LockOutlined, SafetyOutlined } from '@ant-design/icons';
+import { LockOutlined } from '@ant-design/icons';
 import { useSandpack, useSandpackConsole } from '@codesandbox/sandpack-react';
-import { Tag, Tooltip, theme } from 'antd';
+import { Tooltip, theme } from 'antd';
 import type { CSSProperties } from 'react';
 import { useEffect, useRef } from 'react';
 import { getDaemonUrl } from '@/config/daemon';
@@ -331,64 +331,4 @@ export function ArtifactHeaderLockIcon({
     );
 
   return <Tooltip title={title}>{iconElement}</Tooltip>;
-}
-
-interface ArtifactTrustBadgeOptions {
-  className?: string;
-  style?: CSSProperties;
-}
-
-export function renderArtifactTrustBadge(
-  payload: ArtifactPayload,
-  onTrustClick?: () => void,
-  options: ArtifactTrustBadgeOptions = {}
-) {
-  const tagStyle = { fontSize: 10, marginLeft: 4, ...options.style };
-  const state = payload.trust_state;
-  if (state === 'no_secrets_needed') return null;
-  if (state === 'self') {
-    return (
-      <Tag color="blue" icon={<SafetyOutlined />} style={tagStyle}>
-        Yours
-      </Tag>
-    );
-  }
-  if (state === 'trusted') {
-    const scopeLabel =
-      payload.trust_scope === 'instance'
-        ? 'instance-wide'
-        : payload.trust_scope === 'author'
-          ? 'this author'
-          : payload.trust_scope === 'session'
-            ? 'just-once'
-            : 'this artifact';
-    return (
-      <Tooltip title={`Secrets injected — trust granted for ${scopeLabel}`}>
-        <Tag color="green" icon={<SafetyOutlined />} style={tagStyle}>
-          Trusted
-        </Tag>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Tooltip title="Click to review and grant trust so secrets are injected">
-      <Tag
-        color="orange"
-        icon={<LockOutlined />}
-        className={onTrustClick ? options.className : undefined}
-        style={{ ...tagStyle, cursor: onTrustClick ? 'pointer' : undefined }}
-        onClick={
-          onTrustClick
-            ? (e) => {
-                e.stopPropagation();
-                onTrustClick();
-              }
-            : undefined
-        }
-      >
-        Untrusted
-      </Tag>
-    </Tooltip>
-  );
 }

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -261,10 +261,9 @@ export function ArtifactHeaderLockIcon({
 }: ArtifactHeaderLockIconProps) {
   const { token } = theme.useToken();
   const state = payload.trust_state;
-  if (state === 'no_secrets_needed') return null;
-
   const isUntrusted = state === 'untrusted';
   const isTrusted = state === 'trusted';
+  const isSelf = state === 'self';
   const scopeLabel =
     payload.trust_scope === 'instance'
       ? 'instance-wide'
@@ -279,20 +278,31 @@ export function ArtifactHeaderLockIcon({
       : 'Secrets are locked until trust is granted'
     : isTrusted
       ? `Secrets injected — trust granted for ${scopeLabel}`
-      : 'You created this artifact; secrets are injected';
-  const color = isUntrusted ? token.colorWarning : isTrusted ? token.colorSuccess : token.colorInfo;
+      : isSelf
+        ? 'You created this artifact; secrets are injected'
+        : 'Artifact does not request secrets';
+  const color = isUntrusted
+    ? token.colorWarning
+    : isTrusted
+      ? token.colorSuccess
+      : isSelf
+        ? token.colorInfo
+        : token.colorTextSecondary;
   const backgroundColor = isUntrusted
     ? token.colorWarningBg
     : isTrusted
       ? token.colorSuccessBg
-      : token.colorInfoBg;
+      : isSelf
+        ? token.colorInfoBg
+        : token.colorBgContainer;
+  const borderColor = state === 'no_secrets_needed' ? token.colorBorder : color;
   const icon = <LockOutlined />;
   const commonStyle: CSSProperties = {
     width: 20,
     height: 20,
     borderRadius: 3,
     backgroundColor,
-    border: `1px solid ${color}`,
+    border: `1px solid ${borderColor}`,
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -298,6 +298,7 @@ export function ArtifactHeaderLockIcon({
     justifyContent: 'center',
     flexShrink: 0,
     padding: 0,
+    appearance: 'none',
     color,
     fontSize: 12,
     lineHeight: 1,
@@ -310,7 +311,12 @@ export function ArtifactHeaderLockIcon({
         type="button"
         className={className}
         aria-label="Review artifact trust"
-        style={{ ...commonStyle, cursor: 'pointer' }}
+        style={{
+          ...commonStyle,
+          backgroundClip: 'padding-box',
+          cursor: 'pointer',
+          font: 'inherit',
+        }}
         onClick={(e) => {
           e.stopPropagation();
           onTrustClick();

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -13,9 +13,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import {
   ArtifactConsoleReporter,
-  ArtifactHeaderLockIcon,
   ArtifactRuntimeBridge,
   ArtifactSandpackErrorReporter,
+  ArtifactTrustStatusIcon,
 } from '@/components/artifacts/ArtifactRenderSupport';
 import { getDaemonUrl } from '@/config/daemon';
 import { getAuthHeaders } from '@/utils/authHeaders';
@@ -104,7 +104,7 @@ function ArtifactFullscreenNavbar({
           >
             {title}
           </Title>
-          {payload && <ArtifactHeaderLockIcon payload={payload} onTrustClick={onTrustClick} />}
+          {payload && <ArtifactTrustStatusIcon payload={payload} onTrustClick={onTrustClick} />}
           <Tooltip title="Hide navbar">
             <Button
               type="text"

--- a/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
+++ b/apps/agor-ui/src/pages/ArtifactFullscreenPage.tsx
@@ -13,9 +13,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import {
   ArtifactConsoleReporter,
+  ArtifactHeaderLockIcon,
   ArtifactRuntimeBridge,
   ArtifactSandpackErrorReporter,
-  renderArtifactTrustBadge,
 } from '@/components/artifacts/ArtifactRenderSupport';
 import { getDaemonUrl } from '@/config/daemon';
 import { getAuthHeaders } from '@/utils/authHeaders';
@@ -65,8 +65,6 @@ function ArtifactFullscreenNavbar({
   onLogout,
 }: ArtifactFullscreenNavbarProps) {
   const { token } = theme.useToken();
-  const trustBadge = payload ? renderArtifactTrustBadge(payload, onTrustClick) : null;
-
   return (
     <Header
       style={{
@@ -106,6 +104,7 @@ function ArtifactFullscreenNavbar({
           >
             {title}
           </Title>
+          {payload && <ArtifactHeaderLockIcon payload={payload} onTrustClick={onTrustClick} />}
           <Tooltip title="Hide navbar">
             <Button
               type="text"
@@ -122,7 +121,6 @@ function ArtifactFullscreenNavbar({
             />
           </Tooltip>
         </div>
-        {trustBadge}
       </Space>
       <Space style={{ flexShrink: 0 }}>
         {(payload?.source_session_id || artifact?.source_session_id) && (

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -280,7 +280,7 @@ export const sessionRelationships = sqliteTable(
     targetIdx: index('session_relationships_target_idx').on(table.target_session_id),
     callbackIdx: index('session_relationships_callback_idx').on(table.callback_session_id),
     // Note: no tenant_source/tenant_target composite indexes here — SQLite schema
-    // has no tenant_id column on this table (RLS is Postgres-only). The standalone
+    // has no tenant column on this table (RLS is Postgres-only). The standalone
     // source/target indexes above are sufficient for SQLite.
     sourceTargetTypeUnique: uniqueIndex('session_relationships_source_target_type_unique').on(
       table.source_session_id,

--- a/packages/core/src/types/board.ts
+++ b/packages/core/src/types/board.ts
@@ -183,6 +183,8 @@ export interface ArtifactBoardObject {
   height: number; // Default: 400, min: 200
   /** Reference to the artifact entity */
   artifact_id: ArtifactID;
+  /** Lock artifact card to prevent dragging/resizing on the board */
+  locked?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a compact lock toggle to board artifact headers so artifact cards can be locked against dragging/resizing, matching the Zone toolbox behavior. Also keeps artifact trust/secrets status visible with a separate warning/safety icon and includes small CI/auth fixes found while troubleshooting this branch after rebasing onto latest `main`.

## Files / behavior changed

- Added `locked?: boolean` to artifact board objects.
- Added a Zone-toolbox-like lock/unlock button to board artifact card headers. Locked artifacts are not draggable/resizable, so dragging on them pans the board instead.
- Separated trust/secrets status from movement locking by replacing the prior lock-shaped trust affordance with `ArtifactTrustStatusIcon` (warning/safety glyphs).
- Kept trust review clickable for untrusted artifacts and removed the duplicate separate consent lock button.
- Removed the now-unused legacy `renderArtifactTrustBadge` helper to avoid duplicate trust-state presentation logic.
- Fixed `UsersService` tenant scoping on SQLite by only applying tenant predicates/inserts when the users table actually has that column.
- Updated post-commit callback tests to wait for asynchronous callback side effects.
- Adjusted a SQLite schema comment so the string-based multitenancy guard remains green without changing schema behavior.

## Checks run

- `pnpm exec biome check` on all touched files
- `pnpm --filter @agor/daemon test -- users.find.test.ts`
- `pnpm --filter @agor/daemon test -- tasks.callbacks.test.ts`
- `pnpm --filter @agor/core test -- multitenancy-schema.test.ts`
- Manual authenticated socket smoke against the local daemon for initial-load services, including `users`
- GitHub CI: `Lint, typecheck, build, test` ✅
- GitHub CI: `Pack + boot + curl` ✅

## Caveats

- `pnpm --filter agor-ui typecheck` was attempted earlier after installing dependencies, but this worktree did not have built `@agor-live/client` / `@agor/core` dist artifacts, so it failed on module-resolution errors before validating the UI package.