### PR TITLE
perf(agor-ui): outer App reads entity maps via store selectors (collapse PR4.5)

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -49,6 +49,17 @@ import {
   useSessionActions,
 } from './hooks';
 import { useSurfaceBranding } from './hooks/useSurfaceBranding';
+import { useAgorStore } from './store/agorStore';
+import {
+  selectBoardById,
+  selectBranchById,
+  selectCommentById,
+  selectRepoById,
+  selectSessionById,
+  selectSessionMcpServerIds,
+  selectSessionsByBranch,
+  selectUserById,
+} from './store/selectors';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
 import type { RouteSurfaceId } from './surfaces/surfaceRegistry';
 import {
@@ -324,14 +335,6 @@ function AppContent() {
   // failure chain we're avoiding.
   // Skip data fetch if user needs to change password — the ForcePasswordChangeModal handles that.
   const {
-    sessionById,
-    sessionsByBranch,
-    boardById,
-    commentById,
-    repoById,
-    branchById,
-    userById,
-    sessionMcpServerIds,
     initialLoadItems,
     initialLoadComplete,
     loadingStage,
@@ -341,6 +344,18 @@ function AppContent() {
     enabled: workspaceSurfaceShouldRun && !user?.must_change_password,
     directSessionId: directSessionIdFromPath,
   });
+
+  // Entity maps are read directly from the store rather than the useAgorData
+  // return so each map is its own narrow subscription — the surface only
+  // re-renders for the slices it actually consumes, not on every entity write.
+  const sessionById = useAgorStore(selectSessionById);
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+  const boardById = useAgorStore(selectBoardById);
+  const commentById = useAgorStore(selectCommentById);
+  const repoById = useAgorStore(selectRepoById);
+  const branchById = useAgorStore(selectBranchById);
+  const userById = useAgorStore(selectUserById);
+  const sessionMcpServerIds = useAgorStore(selectSessionMcpServerIds);
 
   // Session actions
   const { createSession, forkSession, btwForkSession, spawnSession, updateSession, deleteSession } =


### PR DESCRIPTION
## What

Outer `src/App.tsx` (`AppContent`, which mounts `useAgorData`) no longer reads any entity maps from the `useAgorData(...)` destructure. Each of the 8 maps it consumed — `sessionById`, `sessionsByBranch`, `boardById`, `commentById`, `repoById`, `branchById`, `userById`, `sessionMcpServerIds` — now comes from its own narrow `useAgorStore(select*)` subscription. The `useAgorData` destructure keeps only the meta fields (`initialLoadItems`, `initialLoadComplete`, `loadingStage`, `loading`, `error`).

## Why

This is the precondition for the final flip where `useAgorData` stops returning maps entirely. Reading each map as its own store subscription also means the surface only re-renders for the slices it actually consumes rather than on every entity write. Each selector returns the same slice `useAgorData` wrote, so values are identical — only the read path changes.

## Approach

All maps are read via outer-App-local `useAgorStore(select*)` subscriptions, reusing the exact variable names. This keeps every downstream consumer (inline handlers: crash-context `currentUser`, completion-nav, comment-resolve, session-MCP handler, repo-reference options; and child props: `KnowledgePage`, `OnboardingWizard`, `MobileApp`) byte-for-byte unchanged. `useAgorData.ts` itself is untouched — it still returns the maps; the unused returns are harmless.

## Behavior preservation

`OnboardingWizard`, `MobileApp`, `KnowledgePage`, and the home/board surfaces still receive the same map values (same store slices the loader populated), so user-facing behavior is identical. Mirrors the existing pattern already used by the inner `components/App/App.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)