### PR TITLE
fix(scheduler): scope schedule concurrency per schedule

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -149,7 +149,9 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
         allow_concurrent_runs: z
           .boolean()
           .optional()
-          .describe('Allow runs to overlap (default: false)'),
+          .describe(
+            'Allow overlapping runs from this schedule (default: false). Sibling schedules on the same branch are independent.'
+          ),
         retention: mcpOptionalNonNegativeInt(
           'retention',
           'Number of sessions to keep; 0 = keep all (default: 5)'

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -18,16 +18,12 @@
  * **Per-schedule advisory lock (Postgres only):** each due schedule's
  * spawn runs inside its own transaction with
  * `pg_try_advisory_xact_lock(hash(schedule_id))`. This serves
- * same-schedule dedup if multi-daemon is ever wired up — but Agor
- * **is single-daemon only today**, and the per-schedule lock does NOT
- * by itself preserve the branch-wide `allow_concurrent_runs=false`
- * invariant across daemons (two daemons could lock two different
- * schedules on the same branch and both pass the branch concurrency
- * check). Branch-scoped advisory locking is deferred until multi-
- * daemon is actually supported; the partial unique index
- * `sessions_schedule_run_unique` provides DB-level dedup either way.
- * SQLite is single-node by definition; the lock helper is a no-op
- * there.
+ * same-schedule dedup if multi-daemon is ever wired up. Because the
+ * concurrency guard is intentionally per-schedule, different schedules
+ * on the same branch may run at the same time; the partial unique index
+ * `sessions_schedule_run_unique` provides DB-level dedup for a single
+ * schedule fire either way. SQLite is single-node by definition; the
+ * lock helper is a no-op there.
  *
  * **Smart Recovery:**
  * - If scheduler is down for an extended period, only schedules LATEST
@@ -164,15 +160,15 @@ export function renderSchedulePrompt(
 }
 
 /**
- * Error thrown when execute-now is blocked because a session is already running
- * in the branch and allow_concurrent_runs is not enabled. Routes can catch
+ * Error thrown when execute-now is blocked because an active run from the same
+ * schedule exists and allow_concurrent_runs is not enabled. Routes can catch
  * this and surface it as a 409 Conflict.
  */
 export class ScheduleBusyError extends Error {
   public readonly code = 'schedule_busy';
-  constructor(branchName: string) {
+  constructor(scheduleName: string) {
     super(
-      `A session is already running in branch "${branchName}" and allow_concurrent_runs is disabled.`
+      `An active run from schedule "${scheduleName}" is already in progress and allow_concurrent_runs is disabled.`
     );
     this.name = 'ScheduleBusyError';
   }
@@ -416,7 +412,7 @@ export class SchedulerService {
    * @throws ScheduleNotReadyError when the schedule is disabled or its
    *   branch can't be loaded.
    * @throws ScheduleBusyError when allow_concurrent_runs is false and
-   *   the branch already has an active session.
+   *   this schedule already has an active run.
    */
   async executeScheduleNow(opts: { scheduleId: ScheduleID; triggeredBy: UUID }): Promise<Session> {
     const { scheduleId, triggeredBy } = opts;
@@ -539,13 +535,10 @@ export class SchedulerService {
    * 9. Enforce retention policy (oldest sessions on this schedule_id
    *    are deleted).
    *
-   * NOTE (multi-daemon, deferred): with the current per-schedule
-   * advisory lock, two daemons can each lock different schedules on
-   * the same branch and both pass the branch-wide concurrency guard
-   * before either creates a session, then both spawn. Branch-scoped
-   * coordination (lock on branch when allow_concurrent_runs=false)
-   * will be needed once we support multi-daemon. Out of scope for V1
-   * since multi-daemon isn't supported yet.
+   * NOTE (multi-daemon, deferred): the per-schedule advisory lock and
+   * partial unique index guard same-schedule races. They deliberately do
+   * not serialize sibling schedules on the same branch, matching the
+   * schedule-scoped meaning of `allow_concurrent_runs=false`.
    */
   private async spawnScheduledSession(
     schedule: Schedule,
@@ -594,7 +587,7 @@ export class SchedulerService {
           console.log(
             `   ⛔ ${schedule.name}: manual run blocked — active run from this schedule present (allow_concurrent_runs=false)`
           );
-          throw new ScheduleBusyError(branch.name);
+          throw new ScheduleBusyError(schedule.name);
         }
         console.log(
           `   ⏭️  ${schedule.name}: scheduled run skipped — active run from this schedule present (allow_concurrent_runs=false)`

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -524,9 +524,9 @@ export class SchedulerService {
    * 1. Look up the schedule's branch (cascaded delete means it should
    *    always exist; we still handle null defensively).
    * 2. Dedup against `sessions(schedule_id, scheduled_run_at)`.
-   * 3. Enforce `allow_concurrent_runs` against any active session in the
-   *    SAME BRANCH (sibling schedules on the same branch are sequential
-   *    by default; opt out per-schedule via allow_concurrent_runs).
+   * 3. Enforce `allow_concurrent_runs` against any active session spawned
+   *    by the SAME SCHEDULE. Different schedules on the same branch do not
+   *    block one another.
    * 4. Render prompt template (Handlebars).
    * 5. Look up creator's unix_username for execution context.
    * 6. Create session with schedule metadata + `schedule_id` FK.
@@ -580,25 +580,24 @@ export class SchedulerService {
       return existingSession;
     }
 
-    // 2. Concurrency guard — branch-wide. Any active session in the
-    //    branch blocks scheduled runs, regardless of which schedule it
-    //    came from. Sibling schedules on the same branch are sequential
-    //    by default; opt out per-schedule via allow_concurrent_runs.
-    //    Existence probe (LIMIT 1) — no need to count.
+    // 2. Concurrency guard — per-schedule. An active run from this same
+    //    schedule blocks its next fire by default, but sibling schedules
+    //    on the same branch are independent and should not suppress one
+    //    another. Existence probe (LIMIT 1) — no need to count.
     if (!schedule.allow_concurrent_runs) {
-      const active = await this.sessionRepo.existsInBranchWithStatuses(
-        branch.branch_id,
+      const active = await this.sessionRepo.existsInScheduleWithStatuses(
+        schedule.schedule_id,
         ACTIVE_SESSION_STATUSES
       );
       if (active) {
         if (manual) {
           console.log(
-            `   ⛔ ${schedule.name}: manual run blocked — active session present (allow_concurrent_runs=false)`
+            `   ⛔ ${schedule.name}: manual run blocked — active run from this schedule present (allow_concurrent_runs=false)`
           );
           throw new ScheduleBusyError(branch.name);
         }
         console.log(
-          `   ⏭️  ${schedule.name}: scheduled run skipped — active session present (allow_concurrent_runs=false)`
+          `   ⏭️  ${schedule.name}: scheduled run skipped — active run from this schedule present (allow_concurrent_runs=false)`
         );
         await this.updateScheduleMetadata(schedule, scheduledRunAt, null, now);
         return null;

--- a/apps/agor-ui/src/components/ScheduleModal/ScheduleModal.tsx
+++ b/apps/agor-ui/src/components/ScheduleModal/ScheduleModal.tsx
@@ -413,10 +413,16 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
                   <Form.Item name="retention" label="Retention (sessions to keep; 0 = keep all)">
                     <InputNumber min={0} />
                   </Form.Item>
-                  <Form.Item name="allow_concurrent_runs" label="Concurrency">
+                  <Form.Item
+                    name="allow_concurrent_runs"
+                    label="Concurrency"
+                    extra="Controls overlap for this schedule only; sibling schedules on the same branch are independent."
+                  >
                     <Radio.Group>
-                      <Radio value={false}>Block (default)</Radio>
-                      <Radio value={true}>Allow concurrent runs</Radio>
+                      <Radio value={false}>
+                        Block overlapping runs from this schedule (default)
+                      </Radio>
+                      <Radio value={true}>Allow overlapping runs from this schedule</Radio>
                     </Radio.Group>
                   </Form.Item>
                 </>

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -1442,25 +1442,28 @@ describe('SessionRepository schedule-link queries', () => {
     expect(await repo.existsInScheduleWithStatuses(scheduleB, ACTIVE)).toBe(false);
   });
 
-  dbTest('existsInScheduleWithStatuses ignores inactive runs and empty status lists', async ({ db }) => {
-    const repo = new SessionRepository(db);
-    const branch = await createTestBranch(db);
-    const scheduleId = await createTestSchedule(db, branch.branch_id);
-    const ACTIVE = [SessionStatus.RUNNING] as const;
+  dbTest(
+    'existsInScheduleWithStatuses ignores inactive runs and empty status lists',
+    async ({ db }) => {
+      const repo = new SessionRepository(db);
+      const branch = await createTestBranch(db);
+      const scheduleId = await createTestSchedule(db, branch.branch_id);
+      const ACTIVE = [SessionStatus.RUNNING] as const;
 
-    await repo.create(
-      createSessionData({
-        branch_id: branch.branch_id,
-        schedule_id: scheduleId,
-        scheduled_run_at: 1_700_000_000_000,
-        scheduled_from_branch: true,
-        status: SessionStatus.IDLE,
-      })
-    );
+      await repo.create(
+        createSessionData({
+          branch_id: branch.branch_id,
+          schedule_id: scheduleId,
+          scheduled_run_at: 1_700_000_000_000,
+          scheduled_from_branch: true,
+          status: SessionStatus.IDLE,
+        })
+      );
 
-    expect(await repo.existsInScheduleWithStatuses(scheduleId, ACTIVE)).toBe(false);
-    expect(await repo.existsInScheduleWithStatuses(scheduleId, [])).toBe(false);
-  });
+      expect(await repo.existsInScheduleWithStatuses(scheduleId, ACTIVE)).toBe(false);
+      expect(await repo.existsInScheduleWithStatuses(scheduleId, [])).toBe(false);
+    }
+  );
 
   // The DB-level race guard. Two inserts with the same
   // (schedule_id, scheduled_run_at) must conflict; the second one

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -1421,6 +1421,47 @@ describe('SessionRepository schedule-link queries', () => {
     expect(await repo.existsInBranchWithStatuses(branch.branch_id, [])).toBe(false);
   });
 
+  dbTest('existsInScheduleWithStatuses is scoped per schedule', async ({ db }) => {
+    const repo = new SessionRepository(db);
+    const branch = await createTestBranch(db);
+    const scheduleA = await createTestSchedule(db, branch.branch_id);
+    const scheduleB = await createTestSchedule(db, branch.branch_id);
+    const ACTIVE = [SessionStatus.RUNNING] as const;
+
+    await repo.create(
+      createSessionData({
+        branch_id: branch.branch_id,
+        schedule_id: scheduleA,
+        scheduled_run_at: 1_700_000_000_000,
+        scheduled_from_branch: true,
+        status: SessionStatus.RUNNING,
+      })
+    );
+
+    expect(await repo.existsInScheduleWithStatuses(scheduleA, ACTIVE)).toBe(true);
+    expect(await repo.existsInScheduleWithStatuses(scheduleB, ACTIVE)).toBe(false);
+  });
+
+  dbTest('existsInScheduleWithStatuses ignores inactive runs and empty status lists', async ({ db }) => {
+    const repo = new SessionRepository(db);
+    const branch = await createTestBranch(db);
+    const scheduleId = await createTestSchedule(db, branch.branch_id);
+    const ACTIVE = [SessionStatus.RUNNING] as const;
+
+    await repo.create(
+      createSessionData({
+        branch_id: branch.branch_id,
+        schedule_id: scheduleId,
+        scheduled_run_at: 1_700_000_000_000,
+        scheduled_from_branch: true,
+        status: SessionStatus.IDLE,
+      })
+    );
+
+    expect(await repo.existsInScheduleWithStatuses(scheduleId, ACTIVE)).toBe(false);
+    expect(await repo.existsInScheduleWithStatuses(scheduleId, [])).toBe(false);
+  });
+
   // The DB-level race guard. Two inserts with the same
   // (schedule_id, scheduled_run_at) must conflict; the second one
   // raises, and the scheduler's spawn path catches it as a dedup hit.

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -892,6 +892,30 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   }
 
   /**
+   * True iff at least one session for this schedule has a status in the
+   * given set. Used by the scheduler's per-schedule concurrency guard.
+   */
+  async existsInScheduleWithStatuses(
+    scheduleId: import('@agor/core/types').ScheduleID,
+    statuses: ReadonlyArray<Session['status']>
+  ): Promise<boolean> {
+    if (statuses.length === 0) return false;
+    try {
+      const row = await select(this.db, { one: sql<number>`1` })
+        .from(sessions)
+        .where(and(eq(sessions.schedule_id, scheduleId), inArray(sessions.status, [...statuses])))
+        .limit(1)
+        .one();
+      return row != null;
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to probe sessions in schedule: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Find all sessions in branches accessible to a user (optimized RBAC query)
    *
    * Uses INNER JOIN + LEFT JOIN to filter sessions by branch access in one query

--- a/packages/core/src/types/schedule.ts
+++ b/packages/core/src/types/schedule.ts
@@ -159,9 +159,10 @@ export interface Schedule {
   enabled: boolean;
 
   /**
-   * When `false` (default), the scheduler skips a fire if a session is
-   * already actively running in the same branch (cron = silent skip;
-   * manual `run_now` = 409 ScheduleBusyError).
+   * When `false` (default), the scheduler skips a fire if this schedule
+   * already has an active run (cron = silent skip; manual `run_now` =
+   * 409 ScheduleBusyError). Sibling schedules on the same branch are
+   * independent and do not block each other.
    *
    * Active = status in RUNNING / STOPPING / AWAITING_PERMISSION /
    * AWAITING_INPUT. IDLE / COMPLETED / FAILED / TIMED_OUT don't count.


### PR DESCRIPTION
## Summary
Fixes #1637

- change the scheduler concurrency guard from branch-wide to per-schedule
- add a schedule-scoped active-session repository probe
- cover the schedule-scoped behavior with repository tests

## Test Plan
- `corepack pnpm --filter @agor/core test -- src/db/repositories/sessions.test.ts`
- `corepack pnpm --filter @agor/core typecheck` *(fails in this checkout due pre-existing @agor/git export/module resolution errors)*

Co-Authored-By: Claude <noreply@anthropic.com>