### PR TITLE
Fix assistant onboarding repo reuse

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -57,6 +57,7 @@ import {
   routeUsesDeviceRouter,
 } from './surfaces/surfaceRegistry';
 import { useWorkspaceSurfaceLifecycle } from './surfaces/useWorkspaceSurfaceLifecycle';
+import type { CreateRepoOptions } from './types';
 import { isMobileDevice } from './utils/deviceDetection';
 import { completeForcedPasswordChange } from './utils/forcePasswordChange';
 import { useThemedMessage } from './utils/message';
@@ -928,7 +929,7 @@ function AppContent() {
   };
 
   // Handle repo CRUD
-  const handleCreateRepo = async (data: CreateRepoRequest, options: { silent?: boolean } = {}) => {
+  const handleCreateRepo = async (data: CreateRepoRequest, options: CreateRepoOptions = {}) => {
     if (!client) {
       showError('Not connected to daemon — cannot clone repository');
       return;

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -928,7 +928,7 @@ function AppContent() {
   };
 
   // Handle repo CRUD
-  const handleCreateRepo = async (data: CreateRepoRequest) => {
+  const handleCreateRepo = async (data: CreateRepoRequest, options: { silent?: boolean } = {}) => {
     if (!client) {
       showError('Not connected to daemon — cannot clone repository');
       return;
@@ -943,7 +943,7 @@ function AppContent() {
     // executors that don't patch still surface failures.
     const toastKey = `clone-repo-${data.slug}`;
     const CLONE_TIMEOUT_MS = 120_000;
-    showLoading(`Cloning ${data.slug}...`, { key: toastKey });
+    if (!options.silent) showLoading(`Cloning ${data.slug}...`, { key: toastKey });
 
     const reposService = client.service('repos');
     let settled = false;
@@ -961,14 +961,14 @@ function AppContent() {
       // and any direct executor-path that bypasses the placeholder.
       if (repo.clone_status === 'cloning') return;
       settled = true;
-      showSuccess(`Cloned ${data.slug}`, { key: toastKey });
+      if (!options.silent) showSuccess(`Cloned ${data.slug}`, { key: toastKey });
       cleanup();
     };
     const handlePatched = (repo: Repo) => {
       if (settled || repo.slug !== data.slug) return;
       if (repo.clone_status === 'ready') {
         settled = true;
-        showSuccess(`Cloned ${data.slug}`, { key: toastKey });
+        if (!options.silent) showSuccess(`Cloned ${data.slug}`, { key: toastKey });
         cleanup();
       } else if (repo.clone_status === 'failed') {
         settled = true;
@@ -980,9 +980,11 @@ function AppContent() {
           err?.category === 'auth_failed'
             ? ' — configure GITHUB_TOKEN in Settings → API Keys for private repos'
             : '';
-        showError(`Failed to clone ${data.slug}: ${err?.message ?? 'unknown error'}${hint}`, {
-          key: toastKey,
-        });
+        if (!options.silent) {
+          showError(`Failed to clone ${data.slug}: ${err?.message ?? 'unknown error'}${hint}`, {
+            key: toastKey,
+          });
+        }
         cleanup();
       }
     };
@@ -990,17 +992,21 @@ function AppContent() {
       if (settled) return;
       if (payload.slug !== data.slug && payload.url !== data.url) return;
       settled = true;
-      showError(`Failed to clone ${data.slug}: ${payload.error ?? 'unknown error'}`, {
-        key: toastKey,
-      });
+      if (!options.silent) {
+        showError(`Failed to clone ${data.slug}: ${payload.error ?? 'unknown error'}`, {
+          key: toastKey,
+        });
+      }
       cleanup();
     };
     const timeoutHandle = setTimeout(() => {
       if (settled) return;
       settled = true;
-      showError(`Clone of ${data.slug} timed out after 2 minutes. Check daemon logs.`, {
-        key: toastKey,
-      });
+      if (!options.silent) {
+        showError(`Clone of ${data.slug} timed out after 2 minutes. Check daemon logs.`, {
+          key: toastKey,
+        });
+      }
       cleanup();
     }, CLONE_TIMEOUT_MS);
 
@@ -1020,17 +1026,21 @@ function AppContent() {
       // resolve the loading toast here instead of waiting for the timeout.
       if (result?.status === 'exists' && !settled) {
         settled = true;
-        showWarning(`Repository "${data.slug}" is already added`, { key: toastKey });
+        if (!options.silent) {
+          showWarning(`Repository "${data.slug}" is already added`, { key: toastKey });
+        }
         cleanup();
       }
       return result;
     } catch (error) {
       if (!settled) {
         settled = true;
-        showError(
-          `Failed to clone repository: ${error instanceof Error ? error.message : String(error)}`,
-          { key: toastKey }
-        );
+        if (!options.silent) {
+          showError(
+            `Failed to clone repository: ${error instanceof Error ? error.message : String(error)}`,
+            { key: toastKey }
+          );
+        }
         cleanup();
       }
       throw error;

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -64,7 +64,12 @@ function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>
     setPrimaryAssistant: vi.fn(async () => undefined),
     ensureAssistantWelcomeNote: vi.fn(async () => undefined),
   };
-  const reposService = { on: vi.fn(), removeListener: vi.fn() };
+  const reposService = {
+    find: vi.fn(async () => ({ data: [] })),
+    get: vi.fn(async () => undefined),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  };
   const client = {
     io: { on: vi.fn(), off: vi.fn() },
     service: vi.fn((name: string) => (name === 'boards' ? boardsService : reposService)),
@@ -262,6 +267,7 @@ describe('OnboardingWizard', () => {
     const readyRepo = makeRepo({ repo_id: 'repo-existing' });
     const reposService = {
       get: vi.fn(async () => readyRepo),
+      find: vi.fn(async () => ({ data: [readyRepo] })),
       on: vi.fn(),
       removeListener: vi.fn(),
     };
@@ -271,7 +277,11 @@ describe('OnboardingWizard', () => {
     };
     const client = {
       io: { on: vi.fn(), off: vi.fn() },
-      service: vi.fn((name: string) => (name === 'boards' ? boardsService : reposService)),
+      service: vi.fn((name: string) => {
+        if (name === 'boards') return boardsService;
+        if (name === 'repos') return reposService;
+        return { find: vi.fn(async () => ({ data: [] })) };
+      }),
     };
     const onCreateRepo = vi.fn(async () => ({
       status: 'exists' as const,
@@ -285,9 +295,60 @@ describe('OnboardingWizard', () => {
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
 
+    await waitFor(() =>
+      expect(onCreateRepo).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: FRAMEWORK_REPO_SLUG }),
+        { silent: true }
+      )
+    );
     await waitFor(() => expect(reposService.get).toHaveBeenCalledWith('repo-existing'));
     await waitFor(() => expect(onCreateBranch).toHaveBeenCalled());
     expect(onCreateBranch.mock.calls[0]?.[0]).toBe('repo-existing');
+  });
+
+  it('reuses an existing framework repo when duplicate clone returns no repo id', async () => {
+    const readyRepo = makeRepo({ repo_id: 'repo-existing' });
+    const reposService = {
+      find: vi.fn(async () => ({ data: [readyRepo] })),
+      get: vi.fn(async () => undefined),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    const boardsService = {
+      create: vi.fn(async () => ({ board_id: 'board-1', created_by: 'user-1' })),
+      setPrimaryAssistant: vi.fn(async () => undefined),
+    };
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) => {
+        if (name === 'boards') return boardsService;
+        if (name === 'repos') return reposService;
+        return { find: vi.fn(async () => ({ data: [] })) };
+      }),
+    };
+    const onCreateRepo = vi.fn(async () => ({
+      status: 'exists' as const,
+      slug: FRAMEWORK_REPO_SLUG,
+    }));
+    const onCreateBranch = vi.fn(async () => makeBranch({ repo_id: 'repo-existing' }));
+    const onComplete = vi.fn();
+
+    renderWizard({ client, onCreateRepo, onCreateBranch, onComplete });
+
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
+
+    await waitFor(() => expect(reposService.find).toHaveBeenCalled());
+    await waitFor(() => expect(onCreateBranch).toHaveBeenCalled());
+    expect(screen.queryByText(/Cloning assistant framework/i)).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith({
+        branchId: 'branch-1',
+        sessionId: 'session-1',
+        boardId: 'board-1',
+        path: 'assistant',
+      })
+    );
   });
 
   it('reuses an existing assistant branch and session when retrying setup', async () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -307,7 +307,7 @@ describe('OnboardingWizard', () => {
   });
 
   it('reuses an existing framework repo when duplicate clone returns no repo id', async () => {
-    const readyRepo = makeRepo({ repo_id: 'repo-existing' });
+    const readyRepo = makeRepo({ repo_id: 'repo-existing', default_branch: 'develop' });
     const reposService = {
       find: vi.fn(async () => ({ data: [readyRepo] })),
       get: vi.fn(async () => undefined),
@@ -339,7 +339,12 @@ describe('OnboardingWizard', () => {
     fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
 
     await waitFor(() => expect(reposService.find).toHaveBeenCalled());
-    await waitFor(() => expect(onCreateBranch).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(onCreateBranch).toHaveBeenCalledWith(
+        'repo-existing',
+        expect.objectContaining({ sourceBranch: 'develop' })
+      )
+    );
     expect(screen.queryByText(/Cloning assistant framework/i)).not.toBeInTheDocument();
     await waitFor(() =>
       expect(onComplete).toHaveBeenCalledWith({

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -56,6 +56,7 @@ import {
   FRAMEWORK_REPO_URL,
   findFrameworkRepo,
 } from '../../hooks/useFrameworkRepo';
+import type { CreateRepoOptions } from '../../types';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { ensureAssistantWelcomeNote } from '../../utils/assistantWelcomeNote';
 import { slugify } from '../../utils/repoSlug';
@@ -92,7 +93,7 @@ export interface OnboardingWizardProps {
 
   onCreateRepo: (
     data: CreateRepoRequest,
-    options?: { silent?: boolean }
+    options?: CreateRepoOptions
   ) => Promise<CloneRepositoryResult | undefined>;
   onCreateLocalRepo: (data: CreateLocalRepoRequest) => void | Promise<void>;
   onCreateBranch: (
@@ -136,8 +137,8 @@ function findReadyFrameworkRepo(repoById: Map<string, Repo>): [string, Repo] | u
   return findFrameworkRepo(repoById, { readyOnly: true });
 }
 
-function isUsableFrameworkRepo(repo: Repo | undefined): repo is Repo {
-  return !!repo && repo.clone_status !== 'failed';
+function entriesByRepoId(repos: Repo[]): Map<string, Repo> {
+  return new Map(repos.map((repo) => [repo.repo_id, repo]));
 }
 
 function apiKeyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-key'): string {
@@ -453,21 +454,15 @@ export function OnboardingWizard({
         query: { slug: FRAMEWORK_REPO_SLUG, $limit: 1 },
       });
       const exactRepos = Array.isArray(exactResult) ? exactResult : (exactResult?.data ?? []);
-      const exactRepo = exactRepos.find(isUsableFrameworkRepo) as Repo | undefined;
-      if (exactRepo) return exactRepo;
+      const exactMatch = findFrameworkRepo(entriesByRepoId(exactRepos), { excludeFailed: true });
+      if (exactMatch) return exactMatch[1];
 
       const fallbackResult = await client?.service('repos').find({ query: { $limit: 50 } });
       const fallbackRepos = Array.isArray(fallbackResult)
         ? fallbackResult
         : (fallbackResult?.data ?? []);
       return (
-        (fallbackRepos.find(
-          (repo: Repo) =>
-            isUsableFrameworkRepo(repo) &&
-            (repo.remote_url?.includes('agor-assistant') ||
-              repo.remote_url?.includes('agor-openclaw') ||
-              repo.slug?.includes('agor-assistant-private'))
-        ) as Repo | undefined) ?? null
+        findFrameworkRepo(entriesByRepoId(fallbackRepos), { excludeFailed: true })?.[1] ?? null
       );
     } catch {
       return null;
@@ -475,7 +470,7 @@ export function OnboardingWizard({
   }, [client]);
 
   const finishSetupFromRepo = useCallback(
-    async (repoId: string) => {
+    async (repoId: string, repoOverride?: Repo) => {
       if (completingRepoRef.current === repoId) return;
       completingRepoRef.current = repoId;
       if (cloneTimeoutRef.current) {
@@ -517,7 +512,8 @@ export function OnboardingWizard({
 
         setSetupStage('branch');
         setOperationText('Creating the default assistant branch…');
-        const sourceBranch = repoById.get(repoId)?.default_branch || 'main';
+        const sourceBranch =
+          repoOverride?.default_branch || repoById.get(repoId)?.default_branch || 'main';
         const assistantConfig: AssistantConfig = {
           kind: 'assistant',
           displayName: assistantDisplayName.trim() || 'My Assistant',
@@ -640,7 +636,7 @@ export function OnboardingWizard({
             return;
           }
           if (repo.clone_status === 'ready' || repo.clone_status === undefined) {
-            await finishSetupFromRepo(repo.repo_id);
+            await finishSetupFromRepo(repo.repo_id, repo);
             return;
           }
         } catch {
@@ -666,7 +662,7 @@ export function OnboardingWizard({
     const readyRepo = findReadyFrameworkRepo(repoById);
     if (readyRepo) {
       setOperationText('Preparing assistant workspace…');
-      void finishSetupFromRepo(readyRepo[0]);
+      void finishSetupFromRepo(readyRepo[0], readyRepo[1]);
       return;
     }
 
@@ -713,7 +709,7 @@ export function OnboardingWizard({
           startCloneTimeout();
         } else {
           setOperationText('Preparing assistant workspace…');
-          void finishSetupFromRepo(existingRepo.repo_id);
+          void finishSetupFromRepo(existingRepo.repo_id, existingRepo);
         }
         return;
       }
@@ -727,7 +723,7 @@ export function OnboardingWizard({
           pollRepoUntilReady(existingRepo.repo_id);
           startCloneTimeout();
         } else {
-          void finishSetupFromRepo(existingRepo.repo_id);
+          void finishSetupFromRepo(existingRepo.repo_id, existingRepo);
         }
         return;
       }
@@ -746,7 +742,7 @@ export function OnboardingWizard({
   useEffect(() => {
     if (currentStep !== 'loading' || setupStage !== 'cloning') return;
     const readyRepo = findReadyFrameworkRepo(repoById);
-    if (readyRepo) void finishSetupFromRepo(readyRepo[0]);
+    if (readyRepo) void finishSetupFromRepo(readyRepo[0], readyRepo[1]);
   }, [currentStep, finishSetupFromRepo, repoById, setupStage]);
 
   useEffect(() => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -90,7 +90,10 @@ export interface OnboardingWizardProps {
   // biome-ignore lint/suspicious/noExplicitAny: AgorClient type varies across package boundaries in tests/apps.
   client: any;
 
-  onCreateRepo: (data: CreateRepoRequest) => Promise<CloneRepositoryResult | undefined>;
+  onCreateRepo: (
+    data: CreateRepoRequest,
+    options?: { silent?: boolean }
+  ) => Promise<CloneRepositoryResult | undefined>;
   onCreateLocalRepo: (data: CreateLocalRepoRequest) => void | Promise<void>;
   onCreateBranch: (
     repoId: string,
@@ -131,6 +134,10 @@ function defaultAssistantBranchName(displayName: string): string {
 
 function findReadyFrameworkRepo(repoById: Map<string, Repo>): [string, Repo] | undefined {
   return findFrameworkRepo(repoById, { readyOnly: true });
+}
+
+function isUsableFrameworkRepo(repo: Repo | undefined): repo is Repo {
+  return !!repo && repo.clone_status !== 'failed';
 }
 
 function apiKeyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-key'): string {
@@ -440,6 +447,33 @@ export function OnboardingWizard({
     [client]
   );
 
+  const fetchExistingFrameworkRepo = useCallback(async (): Promise<Repo | null> => {
+    try {
+      const exactResult = await client?.service('repos').find({
+        query: { slug: FRAMEWORK_REPO_SLUG, $limit: 1 },
+      });
+      const exactRepos = Array.isArray(exactResult) ? exactResult : (exactResult?.data ?? []);
+      const exactRepo = exactRepos.find(isUsableFrameworkRepo) as Repo | undefined;
+      if (exactRepo) return exactRepo;
+
+      const fallbackResult = await client?.service('repos').find({ query: { $limit: 50 } });
+      const fallbackRepos = Array.isArray(fallbackResult)
+        ? fallbackResult
+        : (fallbackResult?.data ?? []);
+      return (
+        (fallbackRepos.find(
+          (repo: Repo) =>
+            isUsableFrameworkRepo(repo) &&
+            (repo.remote_url?.includes('agor-assistant') ||
+              repo.remote_url?.includes('agor-openclaw') ||
+              repo.slug?.includes('agor-assistant-private'))
+        ) as Repo | undefined) ?? null
+      );
+    } catch {
+      return null;
+    }
+  }, [client]);
+
   const finishSetupFromRepo = useCallback(
     async (repoId: string) => {
       if (completingRepoRef.current === repoId) return;
@@ -642,26 +676,72 @@ export function OnboardingWizard({
         .map((repo) => repo.repo_id)
     );
 
-    try {
-      const cloneResult = await onCreateRepo({
-        url: effectiveFrameworkUrl,
-        slug: FRAMEWORK_REPO_SLUG,
-        default_branch: 'main',
-      });
-      if (cloneResult?.repo_id) {
-        pollRepoUntilReady(cloneResult.repo_id);
-      }
+    const startCloneTimeout = () => {
+      if (cloneTimeoutRef.current) clearTimeout(cloneTimeoutRef.current);
       cloneTimeoutRef.current = setTimeout(() => {
         setSetupStage('error');
         setError(
           'Clone is taking longer than expected. Please check the repository connection and try again.'
         );
       }, CLONE_TIMEOUT_MS);
+    };
+
+    try {
+      const cloneResult = await onCreateRepo(
+        {
+          url: effectiveFrameworkUrl,
+          slug: FRAMEWORK_REPO_SLUG,
+          default_branch: 'main',
+        },
+        { silent: true }
+      );
+
+      if (cloneResult?.status === 'exists') {
+        setOperationText('Preparing assistant workspace…');
+      }
+
+      if (cloneResult?.repo_id) {
+        pollRepoUntilReady(cloneResult.repo_id);
+        startCloneTimeout();
+        return;
+      }
+
+      const existingRepo = await fetchExistingFrameworkRepo();
+      if (existingRepo?.repo_id) {
+        if (existingRepo.clone_status === 'cloning') {
+          pollRepoUntilReady(existingRepo.repo_id);
+          startCloneTimeout();
+        } else {
+          setOperationText('Preparing assistant workspace…');
+          void finishSetupFromRepo(existingRepo.repo_id);
+        }
+        return;
+      }
+
+      startCloneTimeout();
     } catch (err) {
+      const existingRepo = await fetchExistingFrameworkRepo();
+      if (existingRepo?.repo_id) {
+        setOperationText('Preparing assistant workspace…');
+        if (existingRepo.clone_status === 'cloning') {
+          pollRepoUntilReady(existingRepo.repo_id);
+          startCloneTimeout();
+        } else {
+          void finishSetupFromRepo(existingRepo.repo_id);
+        }
+        return;
+      }
       setSetupStage('error');
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, [effectiveFrameworkUrl, finishSetupFromRepo, onCreateRepo, pollRepoUntilReady, repoById]);
+  }, [
+    effectiveFrameworkUrl,
+    fetchExistingFrameworkRepo,
+    finishSetupFromRepo,
+    onCreateRepo,
+    pollRepoUntilReady,
+    repoById,
+  ]);
 
   useEffect(() => {
     if (currentStep !== 'loading' || setupStage !== 'cloning') return;

--- a/apps/agor-ui/src/hooks/useFrameworkRepo.ts
+++ b/apps/agor-ui/src/hooks/useFrameworkRepo.ts
@@ -57,7 +57,7 @@ export function useFrameworkRepo(repos: Repo[]): Repo | undefined {
  */
 export function findFrameworkRepo(
   repos: Iterable<[string, Repo]>,
-  options?: { readyOnly?: boolean }
+  options?: { readyOnly?: boolean; excludeFailed?: boolean }
 ): [string, Repo] | undefined {
   const repoArray: Repo[] = [];
   const entryMap = new Map<string, [string, Repo]>();
@@ -65,6 +65,9 @@ export function findFrameworkRepo(
   for (const entry of repos) {
     const repo = entry[1];
     if (options?.readyOnly && repo.clone_status !== 'ready' && repo.clone_status !== undefined) {
+      continue;
+    }
+    if (options?.excludeFailed && repo.clone_status === 'failed') {
       continue;
     }
     repoArray.push(repo);

--- a/apps/agor-ui/src/types/ui.ts
+++ b/apps/agor-ui/src/types/ui.ts
@@ -13,3 +13,11 @@ export interface AgenticToolOption {
   description?: string;
   beta?: boolean; // Show beta badge for experimental features
 }
+
+/**
+ * UI-level clone behavior options for shared repository creation handlers.
+ */
+export interface CreateRepoOptions {
+  /** Suppress shared toast side effects when the caller owns progress/error UI. */
+  silent?: boolean;
+}


### PR DESCRIPTION
## Summary

- Make assistant onboarding treat an already-registered `preset-io/agor-assistant` framework repo as a silent, successful idempotent path.
- Continue setup by resolving/reusing the existing repo, then creating/reusing the assistant board, branch, and bootstrap session.
- Keep clone/repo toasts quiet during onboarding so the wizard progress UI owns the user feedback.
- Add regression coverage for duplicate-framework-repo onboarding reuse and the silent clone option.

## Root cause

The shared repo clone handler showed a warning toast when `/repos/clone` returned `status: "exists"`. In onboarding, that is expected for a second user on an instance. The wizard also only advanced reliably when the clone result included a repo id or the local repo map had already hydrated; if the duplicate response lacked enough local state, the UI could sit on the clone step until timeout instead of resolving the existing framework repo and continuing.

## Behavior changes

- Onboarding calls repo clone with a silent option, suppressing duplicate-repo/loading/success/error toasts from the shared clone handler.
- `status: "exists"` updates wizard copy to “Preparing assistant workspace…” and continues via the returned repo id when available.
- If a duplicate/failed clone call does not provide a usable repo id, onboarding queries registered repos for the framework slug/fallback framework repo and proceeds when it finds a non-failed repo.
- Existing framework repo reuse now flows through branch/session creation instead of blocking at “Cloning assistant framework…”.

## Tests/checks

- `pnpm i` ✅
- `pnpm check` ✅
- `pnpm --filter agor-ui test -- OnboardingWizard.test.tsx` ✅

## Notes on skip setup behavior

Current `main` includes the skip setup action. The streamlined wizard removed it in #1558, and #1602 restored it. This branch leaves the current restored skip behavior intact; Max’s “no skip” observation is likely from an older deployed UI rather than current intended behavior.