### PR TITLE
fix(env): clear stale process on stopped callbacks

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -606,6 +606,39 @@ describe('BranchesService environment start async behavior', () => {
     expect(patchedEnvironment).not.toHaveProperty('last_error');
     expect(patchedEnvironment).not.toHaveProperty('last_command');
   });
+
+  it('clears stale process metadata when old executor callbacks report stopped', async () => {
+    const { service } = createServiceHarness();
+    const branch = {
+      branch_id: 'wt-env-old-executor' as BranchID,
+      repo_id: 'repo-1',
+      name: 'wt-env-old-executor',
+      path: '/tmp/wt-env-old-executor',
+      created_by: 'user-1' as UUID,
+      branch_unique_id: 1,
+      environment_instance: {
+        status: 'stopping',
+        process: { pid: 789, started_at: '2026-01-01T00:00:00.000Z' },
+      },
+    };
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    const patchSpy = vi.spyOn(service, 'patch').mockImplementation(async (_id, data) => {
+      return { ...branch, ...(data as object) } as never;
+    });
+
+    await service.updateEnvironment({
+      branch_id: branch.branch_id,
+      // Simulates an old executor callback where `process: undefined` was
+      // dropped by JSON before the daemon received the update.
+      environment_update: { status: 'stopped' },
+    });
+
+    const patchedEnvironment = patchSpy.mock.calls[0]?.[1]?.environment_instance as
+      | Record<string, unknown>
+      | undefined;
+    expect(patchedEnvironment).toMatchObject({ status: 'stopped' });
+    expect(patchedEnvironment).not.toHaveProperty('process');
+  });
 });
 
 describe('BranchesService.patch primary assistant invariants', () => {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1759,6 +1759,13 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         delete updatedEnvironment[key];
       }
     }
+    // Backward compatibility for already-deployed executors that reported
+    // successful stop/nuke as `{ status: 'stopped', process: undefined }`
+    // across JSON. The undefined key is dropped before it reaches this merge,
+    // but a stopped environment must not keep stale process metadata.
+    if (environmentUpdate.status === 'stopped' && !Object.hasOwn(environmentUpdate, 'process')) {
+      delete updatedEnvironment.process;
+    }
 
     // Check if environment state actually changed (ignoring timestamp-only updates)
     // For health checks, we only care about status and message changes, not timestamp


### PR DESCRIPTION
## Root cause

After deploying the previous queue/env callback fixes, prod still showed stale environment runtime state after stop callbacks in at least one path. The deployed state confirmed `status: "stopped"` and a successful stop `last_command`, but still retained old `environment_instance.process` metadata.

That points at mixed-version/backward-compatible executor callbacks: older executors reported successful stop as `process: undefined`, which is dropped across the JSON/Feathers boundary before the daemon sees it.

## Fix

Make `BranchesService.updateEnvironment` defensively clear stale `process` metadata whenever an incoming environment update sets `status: "stopped"` and does not explicitly include `process`.

This complements the newer `null` sentinel contract while remaining compatible with already-deployed/older executor callback payloads.

## Tests

- Added regression coverage for an old-executor-style callback: `{ status: "stopped" }` with existing process metadata must persist as stopped without `process`.

## Checks

- `pnpm exec biome format --write apps/agor-daemon/src/services/branches.ts apps/agor-daemon/src/services/branches.test.ts`
- `pnpm --filter @agor/daemon test -- src/services/branches.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- pre-commit Biome

## Caveats

If a branch remains stuck in `stopping` with no stop `last_command`, that is a different failure mode: the executor callback is not reaching the daemon at all. This PR fixes the stale-process/status-display compatibility case where the stop callback does arrive but old JSON-dropping semantics leave stale runtime metadata behind.
