### PR TITLE
Decouple branch RBAC from Unix isolation for trusted launch

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -3,7 +3,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgorConfig } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
-import { createDatabase, eq, hash, initializeDatabase, insert, select, update, users } from '@agor/core/db';
+import {
+  createDatabase,
+  eq,
+  hash,
+  initializeDatabase,
+  insert,
+  select,
+  update,
+  users,
+} from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
 import type { InternalUser, User, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';

--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgorConfig } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
-import { createDatabase, eq, initializeDatabase, select, update, users } from '@agor/core/db';
+import { createDatabase, eq, hash, initializeDatabase, insert, select, update, users } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
 import type { InternalUser, User, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
@@ -289,6 +289,39 @@ describe('one-time launch auth service', () => {
       audience: 'https://agor.dev',
     }) as jwt.JwtPayload;
     expect(decoded.auth_time_ms).toBe(marker.getTime() + 1);
+  });
+
+  it('links to an existing local user by verified email when explicitly trusted', async () => {
+    const now = new Date();
+    await insert(db, users)
+      .values({
+        user_id: 'local-user-1',
+        created_at: now,
+        updated_at: now,
+        email: 'person@example.test',
+        password: await hash('local-password', 10),
+        name: 'Existing Local User',
+        emoji: '👤',
+        role: 'member',
+        onboarding_completed: false,
+        must_change_password: false,
+        data: { preferences: {} },
+      })
+      .run();
+
+    mockExchange(signClaims({ email_verified: true }));
+    const result = await service({
+      external_launch: {
+        ...baseConfig().external_launch,
+        trust_verified_email_for_linking: true,
+      },
+    }).create({ launchCode: 'trusted-email' });
+
+    expect(result.user.user_id).toBe('local-user-1');
+    expect(result.user.email).toBe('person@example.test');
+
+    const row = await select(db).from(users).where(eq(users.user_id, 'local-user-1')).one();
+    expect((row?.data as { external_identities?: unknown[] }).external_identities).toHaveLength(1);
   });
 
   it('does not merge a new external identity by email alone', async () => {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -12,6 +12,7 @@ import {
   generateId,
   hash,
   insert,
+  reattributeLegacyAnonymousRows,
   runWithTenantDatabaseScope,
   select,
   update,
@@ -352,6 +353,7 @@ async function upsertLaunchUser(
       })
       .where(eq(users.user_id, existing.user_id))
       .run();
+    await reattributeLegacyAnonymousRows(db, existing.user_id);
 
     return usersService.get(existing.user_id as UserID, userLookupParams);
   }
@@ -382,6 +384,7 @@ async function upsertLaunchUser(
       } as UserDataWithExternalIdentities,
     })
     .run();
+  await reattributeLegacyAnonymousRows(db, userId);
 
   return usersService.get(userId, userLookupParams);
 }

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -52,6 +52,7 @@ interface ResolvedLaunchSettings {
   devSharedSecret?: string;
   serviceCredential?: string;
   allowAdminRoles: boolean;
+  trustVerifiedEmailForLinking: boolean;
   requestTimeoutMs: number;
   algorithms?: string[];
 }
@@ -71,6 +72,7 @@ interface LaunchClaims extends JwtPayload {
   sub: string;
   aud?: string | string[];
   email?: string;
+  email_verified?: boolean;
   name?: string;
   picture?: string;
   avatar?: string;
@@ -128,6 +130,7 @@ export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSetting
     devSharedSecret: process.env[sharedSecretEnv] || raw?.dev_shared_secret,
     serviceCredential: process.env[serviceTokenEnv] || raw?.service_credential,
     allowAdminRoles: raw?.allow_admin_roles === true,
+    trustVerifiedEmailForLinking: raw?.trust_verified_email_for_linking === true,
     requestTimeoutMs: raw?.request_timeout_ms ?? DEFAULT_TIMEOUT_MS,
     algorithms: raw?.algorithms,
   };
@@ -261,6 +264,31 @@ async function findUserByExternalIdentity(
   return null;
 }
 
+async function findUserByTrustedEmail(
+  db: Database,
+  email: string | undefined,
+  key: string,
+  settings: ResolvedLaunchSettings,
+  claims: LaunchClaims
+): Promise<typeof users.$inferSelect | null> {
+  if (!settings.trustVerifiedEmailForLinking || claims.email_verified !== true || !email) {
+    return null;
+  }
+
+  const existing = await select(db).from(users).where(eq(users.email, email)).one();
+  if (!existing) return null;
+
+  const identities = getExternalIdentities(existing.data as UserDataWithExternalIdentities);
+  // Preserve explicit mappings to other external identities. The trusted-email
+  // path is primarily for first Agor Cloud joins where a local seeded/manual
+  // account already exists with the verified registration email.
+  if (identities.length > 0 && !identities.some((identity) => identity.key === key)) {
+    return null;
+  }
+
+  return existing;
+}
+
 async function upsertLaunchUser(
   options: LaunchAuthServiceOptions,
   claims: LaunchClaims,
@@ -291,7 +319,9 @@ async function upsertLaunchUser(
     last_login_at: nowIso,
   };
 
-  const existing = await findUserByExternalIdentity(db, key);
+  const existing =
+    (await findUserByExternalIdentity(db, key)) ??
+    (await findUserByTrustedEmail(db, email, key, settings, claims));
   if (existing) {
     const role = mapRole(
       claims.role,

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -12,8 +12,10 @@
 
 import { JWTStrategy } from '@agor/core/feathers';
 import type { Params, UserAuthMetadata } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
 import type { SessionTokenService } from '../services/session-token-service.js';
 import { markAuthenticationUserLookup } from '../services/users.js';
+import { readRuntimeTenantClaim } from './runtime-tokens.js';
 import { assertUserTokenNotInvalidated, type UserAuthTokenPayload } from './token-invalidation.js';
 
 type JwtConnectionState = {
@@ -50,6 +52,19 @@ function persistExecutorJwtPayloadOnConnection(
   };
 }
 
+function propagateTenantFromJwtPayload(
+  params: Params,
+  payload: UserAuthTokenPayload | null | undefined,
+  tenantClaim?: string
+): void {
+  const tenantId = readRuntimeTenantClaim(payload ?? undefined, tenantClaim);
+  if (!tenantId) return;
+  const tenantParams = params as Params & {
+    tenant?: { tenant_id: string; source: 'auth_claim' };
+  };
+  tenantParams.tenant ??= { tenant_id: tenantId, source: 'auth_claim' };
+}
+
 /**
  * Extended JWT Strategy that handles service tokens
  *
@@ -57,7 +72,10 @@ function persistExecutorJwtPayloadOnConnection(
  * for privileged operations (unix.sync-*, git.*, etc.)
  */
 export class ServiceJWTStrategy extends JWTStrategy {
-  constructor(private sessionTokenService?: SessionTokenService) {
+  constructor(
+    private sessionTokenService?: SessionTokenService,
+    private tenantClaim?: string
+  ) {
     super();
   }
   /**
@@ -79,7 +97,16 @@ export class ServiceJWTStrategy extends JWTStrategy {
       };
     }
 
-    // Regular user token validation needs backend-only auth metadata.
+    // Regular user token validation needs backend-only auth metadata. In
+    // required_from_auth mode the Users service is tenant-scoped, so propagate
+    // the tenant claim from the already-verified JWT payload before the
+    // strategy asks the service to load the user entity.
+    propagateTenantFromJwtPayload(
+      params,
+      (params.authentication as { payload?: UserAuthTokenPayload } | undefined)?.payload,
+      this.tenantClaim
+    );
+
     markAuthenticationUserLookup(params);
     return super.getEntity(id, params);
   }
@@ -92,6 +119,9 @@ export class ServiceJWTStrategy extends JWTStrategy {
    */
   // biome-ignore lint/suspicious/noExplicitAny: Feathers type compatibility
   async authenticate(authentication: any, params: any): Promise<any> {
+    const decoded = jwt.decode(authentication?.accessToken) as UserAuthTokenPayload | null;
+    propagateTenantFromJwtPayload(params, decoded, this.tenantClaim);
+
     // Call parent to verify JWT signature and get payload
     const result = (await super.authenticate(authentication, params)) as {
       accessToken?: string;

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -624,6 +624,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
 
   const { db } = await initializeDatabase(DB_PATH, {
     tenantId: multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined,
+    skipFirstRunAdminBootstrap: config.external_launch?.enabled === true,
   });
 
   // --------------------------------------------------------------------------

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -33,6 +33,7 @@ import type { SessionParams } from '../../services/sessions.js';
 import { ensureCanPromptTargetSession } from '../../utils/branch-authorization.js';
 import { inspectBranchViaExecutor } from '../../utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from '../../utils/executor-read-impersonation.js';
+import { serviceTokenScopeForParams } from '../../utils/spawn-executor.js';
 import {
   resolveBoardId,
   resolveBranchId,
@@ -977,6 +978,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       const { currentSha, currentRef } = await inspectBranchViaExecutor(ctx.app, branch.branch_id, {
         asUser: await resolveExecutorReadAsUser(ctx.db, user),
         logPrefix: `[mcp.sessions.create ${branch.name}]`,
+        serviceTokenScope: serviceTokenScopeForParams(ctx.baseServiceParams),
       });
 
       // Resolve permission_config / model_config / inherited mcp_server_ids

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -144,6 +144,7 @@ import {
 import {
   createServiceToken,
   getDaemonUrl,
+  serviceTokenScopeForParams,
   spawnExecutorFireAndForget,
 } from './utils/spawn-executor.js';
 import { createTenantDatabaseScopeAroundHook } from './utils/tenant-db-scope.js';
@@ -2317,6 +2318,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                             | undefined
                         ),
                         logPrefix: `[sessions.create ${branch.name}]`,
+                        serviceTokenScope: serviceTokenScopeForParams(
+                          context.params as AuthenticatedParams
+                        ),
                       }
                     );
                     (context.data as Record<string, unknown>).git_state = {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -11,6 +11,7 @@ import {
   type AgorConfig,
   isUnixImpersonationEnabled,
   loadConfig,
+  resolveExecutionSecurityMode,
   resolveMultiTenancyConfig,
   resolveMultiTenancyDatabaseDialect,
   resolveTenantContext,
@@ -408,6 +409,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   const multiTenancy = resolveMultiTenancyConfig(config);
   const tenantColumnsEnabled = resolveMultiTenancyDatabaseDialect(config) === 'postgresql';
+  const executionMode = resolveExecutionSecurityMode(config);
 
   const tenantOwnedServicePaths = [
     'sessions',
@@ -559,12 +561,30 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
-  const syncBranchUnixAccess = (branchId: BranchID, logPrefix: string): void => {
-    if (!jwtSecret) return;
-    const serviceToken = createServiceToken(jwtSecret, undefined, {
+  const createExecutorServiceToken = (
+    params: Partial<AuthenticatedParams> | undefined,
+    scope: Record<string, unknown>
+  ): string | undefined => {
+    if (!jwtSecret) return undefined;
+    return createServiceToken(jwtSecret, undefined, {
+      ...serviceTokenScopeForParams(params),
+      ...scope,
+    });
+  };
+
+  const syncBranchUnixAccess = (
+    branchId: BranchID,
+    logPrefix: string,
+    params?: Partial<AuthenticatedParams>,
+    options?: { delete?: boolean; scope?: Record<string, unknown> }
+  ): void => {
+    if (!executionMode.unixFsIsolationEnabled) return;
+    const serviceToken = createExecutorServiceToken(params, {
+      ...options?.scope,
       branch_id: branchId,
       command: 'unix.sync-branch',
     });
+    if (!serviceToken) return;
     spawnExecutorFireAndForget(
       {
         command: 'unix.sync-branch',
@@ -573,6 +593,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         params: {
           branchId,
           daemonUser: config.daemon?.unix_user,
+          ...(options?.delete ? { delete: true } : {}),
         },
       },
       { logPrefix }
@@ -581,9 +602,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   const syncUnixAccessForBoardAlignedBranches = async (
     boardId: unknown,
-    logPrefix: string
+    logPrefix: string,
+    params?: Partial<AuthenticatedParams>
   ): Promise<void> => {
-    if (!jwtSecret || typeof boardId !== 'string' || boardId.length === 0) return;
+    if (!executionMode.unixFsIsolationEnabled) return;
+    if (typeof boardId !== 'string' || boardId.length === 0) return;
     const alignedBranches = await branchRepository.findBoardAlignedBranches(boardId as BoardID);
     if (alignedBranches.length === 0) return;
     console.log(
@@ -593,10 +616,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       await invalidateRealtimeBranchAccess(branch.branch_id);
     }
 
-    const serviceToken = createServiceToken(jwtSecret, undefined, {
+    const serviceToken = createExecutorServiceToken(params, {
       board_id: boardId,
       command: 'unix.sync-board',
     });
+    if (!serviceToken) return;
     spawnExecutorFireAndForget(
       {
         command: 'unix.sync-board',
@@ -615,7 +639,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     context: HookContext,
     logPrefix: string
   ): Promise<HookContext> => {
-    await syncUnixAccessForBoardAlignedBranches(context.params.route?.id, logPrefix);
+    await syncUnixAccessForBoardAlignedBranches(
+      context.params.route?.id,
+      logPrefix,
+      context.params as Partial<AuthenticatedParams>
+    );
     return context;
   };
 
@@ -623,10 +651,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     context: HookContext,
     logPrefix: string
   ): Promise<HookContext> => {
-    if (!jwtSecret) return context;
+    if (!executionMode.unixFsIsolationEnabled) return context;
     const branches = await branchRepository.findAll({ includeArchived: false });
     for (const branch of branches) {
-      syncBranchUnixAccess(branch.branch_id as BranchID, logPrefix);
+      syncBranchUnixAccess(
+        branch.branch_id as BranchID,
+        logPrefix,
+        context.params as Partial<AuthenticatedParams>
+      );
       await invalidateRealtimeBranchAccess(branch.branch_id);
     }
     return context;
@@ -1159,7 +1191,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(branchRbacEnabled
           ? [
               async (context: HookContext) => {
-                // RBAC + Unix Integration: Create Unix group and add initial owner
+                // RBAC: Add the creator as the initial branch owner
                 const branch = context.result as import('@agor/core/types').Branch;
                 const creatorId = branch.created_by;
 
@@ -1184,7 +1216,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       patch: [
         invalidateRealtimeBranchFromResult,
-        ...(branchRbacEnabled
+        ...(executionMode.unixFsIsolationEnabled
           ? [
               async (context: HookContext) => {
                 // Unix Integration: Sync branch permissions when others_fs_access changes
@@ -1223,29 +1255,16 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                   return context;
                 }
 
-                // Fire-and-forget sync to executor
-                // The executor will handle permission changes idempotently
-                if (jwtSecret) {
-                  console.log(
-                    `[Unix Integration] Syncing permissions for branch ${shortId(branch.branch_id)} (others_fs_access: ${previousValue} -> ${branch.others_fs_access})`
-                  );
-                  const serviceToken = createServiceToken(jwtSecret, undefined, {
-                    branch_id: branch.branch_id,
-                    command: 'unix.sync-branch',
-                  });
-                  spawnExecutorFireAndForget(
-                    {
-                      command: 'unix.sync-branch',
-                      sessionToken: serviceToken,
-                      daemonUrl: getDaemonUrl(),
-                      params: {
-                        branchId: branch.branch_id,
-                        daemonUser: config.daemon?.unix_user,
-                      },
-                    },
-                    { logPrefix: '[Executor/branch.patch]' }
-                  );
-                }
+                // Fire-and-forget sync to executor.
+                // The executor will handle permission changes idempotently.
+                console.log(
+                  `[Unix Integration] Syncing permissions for branch ${shortId(branch.branch_id)} (others_fs_access: ${previousValue} -> ${branch.others_fs_access})`
+                );
+                syncBranchUnixAccess(
+                  branch.branch_id,
+                  '[Executor/branch.patch]',
+                  context.params as Partial<AuthenticatedParams>
+                );
 
                 return context;
               },
@@ -1254,32 +1273,19 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       remove: [
         invalidateRealtimeBranchFromResult,
-        ...(branchRbacEnabled
+        ...(executionMode.unixFsIsolationEnabled
           ? [
               async (context: HookContext) => {
                 // Unix Integration: Delete Unix group when branch is deleted
                 const branchId = context.id as import('@agor/core/types').BranchID;
 
-                // Fire-and-forget sync with delete flag to executor
-                if (jwtSecret) {
-                  const serviceToken = createServiceToken(jwtSecret, undefined, {
-                    branch_id: branchId,
-                    command: 'unix.sync-branch',
-                  });
-                  spawnExecutorFireAndForget(
-                    {
-                      command: 'unix.sync-branch',
-                      sessionToken: serviceToken,
-                      daemonUrl: getDaemonUrl(),
-                      params: {
-                        branchId,
-                        daemonUser: config.daemon?.unix_user,
-                        delete: true, // Signal to delete the group instead of syncing
-                      },
-                    },
-                    { logPrefix: '[Executor/branch.remove]' }
-                  );
-                }
+                // Fire-and-forget sync with delete flag to executor.
+                syncBranchUnixAccess(
+                  branchId,
+                  '[Executor/branch.remove]',
+                  context.params as Partial<AuthenticatedParams>,
+                  { delete: true }
+                );
 
                 return context;
               },
@@ -1864,7 +1870,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         (context: HookContext) => {
           const branchId = context.params.route?.id;
           if (typeof branchId === 'string') {
-            syncBranchUnixAccess(branchId as BranchID, '[Executor/branch-group-grants.create]');
+            syncBranchUnixAccess(
+              branchId as BranchID,
+              '[Executor/branch-group-grants.create]',
+              context.params as Partial<AuthenticatedParams>
+            );
           }
           return context;
         },
@@ -1874,7 +1884,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         (context: HookContext) => {
           const branchId = context.params.route?.id;
           if (typeof branchId === 'string') {
-            syncBranchUnixAccess(branchId as BranchID, '[Executor/branch-group-grants.patch]');
+            syncBranchUnixAccess(
+              branchId as BranchID,
+              '[Executor/branch-group-grants.patch]',
+              context.params as Partial<AuthenticatedParams>
+            );
           }
           return context;
         },
@@ -1884,7 +1898,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         (context: HookContext) => {
           const branchId = context.params.route?.id;
           if (typeof branchId === 'string') {
-            syncBranchUnixAccess(branchId as BranchID, '[Executor/branch-group-grants.remove]');
+            syncBranchUnixAccess(
+              branchId as BranchID,
+              '[Executor/branch-group-grants.remove]',
+              context.params as Partial<AuthenticatedParams>
+            );
           }
           return context;
         },
@@ -2075,8 +2093,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       // After user create/patch: optionally ensure Unix user exists and sync password
       create: [
         async (context: HookContext) => {
-          // Need JWT secret for service tokens (required by executor)
-          if (!jwtSecret) {
+          // Need Unix integration and JWT secret for executor service tokens.
+          if (!executionMode.unixImpersonationEnabled || !jwtSecret) {
             return context;
           }
 
@@ -2098,10 +2116,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
           // Fire-and-forget sync to executor
           console.log(`[Unix Integration] Syncing Unix user for: ${user.unix_username}`);
-          const serviceToken = createServiceToken(jwtSecret, undefined, {
-            user_id: user.user_id,
-            command: 'unix.sync-user',
-          });
+          const serviceToken = createExecutorServiceToken(
+            context.params as Partial<AuthenticatedParams>,
+            {
+              user_id: user.user_id,
+              command: 'unix.sync-user',
+            }
+          );
+          if (!serviceToken) return context;
           spawnExecutorFireAndForget(
             {
               command: 'unix.sync-user',
@@ -2139,8 +2161,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       patch: [
         async (context: HookContext) => {
-          // Need JWT secret for service tokens (required by executor)
-          if (!jwtSecret) {
+          // Need Unix integration and JWT secret for executor service tokens.
+          if (!executionMode.unixImpersonationEnabled || !jwtSecret) {
             return context;
           }
 
@@ -2167,10 +2189,14 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
           // Fire-and-forget sync to executor
           console.log(`[Unix Integration] Syncing Unix user for: ${user.unix_username}`);
-          const serviceToken = createServiceToken(jwtSecret, undefined, {
-            user_id: user.user_id,
-            command: 'unix.sync-user',
-          });
+          const serviceToken = createExecutorServiceToken(
+            context.params as Partial<AuthenticatedParams>,
+            {
+              user_id: user.user_id,
+              command: 'unix.sync-user',
+            }
+          );
+          if (!serviceToken) return context;
           spawnExecutorFireAndForget(
             {
               command: 'unix.sync-user',
@@ -2573,7 +2599,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // unix groups. Without this, non-owners can't access the .git/ directory
         // (which uses 2770 = no others access) even if the branch directory itself
         // allows "others" access via ACLs.
-        ...(branchRbacEnabled
+        ...(executionMode.unixFsIsolationEnabled
           ? [
               async (context: HookContext) => {
                 const session = context.result as Session;
@@ -2597,29 +2623,16 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                   }
 
                   // Fire-and-forget: trigger unix.sync-branch to add session user to groups
-                  if (jwtSecret) {
-                    console.log(
-                      `[Unix Integration] Non-owner session created in branch ${shortId(session.branch_id)} ` +
-                        `by ${session.unix_username} (others_fs_access: ${branch.others_fs_access}), syncing group membership`
-                    );
-                    const serviceToken = createServiceToken(jwtSecret, undefined, {
-                      branch_id: branch.branch_id,
-                      session_id: session.session_id,
-                      command: 'unix.sync-branch',
-                    });
-                    spawnExecutorFireAndForget(
-                      {
-                        command: 'unix.sync-branch',
-                        sessionToken: serviceToken,
-                        daemonUrl: getDaemonUrl(),
-                        params: {
-                          branchId: session.branch_id,
-                          daemonUser: config.daemon?.unix_user,
-                        },
-                      },
-                      { logPrefix: '[Executor/session.create.unix-group]' }
-                    );
-                  }
+                  console.log(
+                    `[Unix Integration] Non-owner session created in branch ${shortId(session.branch_id)} ` +
+                      `by ${session.unix_username} (others_fs_access: ${branch.others_fs_access}), syncing group membership`
+                  );
+                  syncBranchUnixAccess(
+                    branch.branch_id,
+                    '[Executor/session.create.unix-group]',
+                    context.params as Partial<AuthenticatedParams>,
+                    { scope: { session_id: session.session_id } }
+                  );
                 } catch (error) {
                   // Don't fail session creation if unix sync fails
                   console.error(

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1158,8 +1158,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               ensureBranchPermission('all', 'update branches', superadminOpts), // Require 'all' permission to update
             ]
           : []),
-        // Capture previous others_fs_access for comparison in after hook
-        ...(branchRbacEnabled
+        // Capture previous others_fs_access for comparison in after Unix sync hook.
+        ...(executionMode.unixFsIsolationEnabled
           ? [
               async (context: HookContext) => {
                 const patchData = context.data as Partial<import('@agor/core/types').Branch>;
@@ -1169,7 +1169,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 };
                 if (Object.hasOwn(patchData, 'others_fs_access') && !params._skipUnixSync) {
                   // Fetch current value to compare in after hook
-                  const branch = await context.service.get(context.id);
+                  const branch = await context.service.get(context.id, context.params);
                   params._previousOthersFsAccess = branch.others_fs_access;
                 }
                 return context;

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -367,7 +367,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const { ServiceJWTStrategy } = await import('./auth/service-jwt-strategy.js');
 
   // Register authentication strategies
-  authentication.register('jwt', new ServiceJWTStrategy(sessionTokenService));
+  authentication.register('jwt', new ServiceJWTStrategy(sessionTokenService, tenantTokenClaim));
   authentication.register('local', new AgorLocalStrategy());
 
   // Register API key authentication strategy

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -370,7 +370,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     });
   }
 
-  if (branchRbacEnabled) {
+  if ((config.execution?.unix_user_mode ?? 'simple') !== 'simple') {
     const daemonUser = config.daemon?.unix_user || 'agor';
     console.log(`[Unix Integration] Executor-based sync enabled (daemon user: ${daemonUser})`);
   }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -364,9 +364,11 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     !app.services['branches/:id/owners/:userId']
   ) {
     const branchRepo = new BranchRepository(db);
+    const executionMode = resolveExecutionSecurityMode(config);
     setupBranchOwnersService(app, branchRepo, {
       jwtSecret,
       daemonUser: config.daemon?.unix_user,
+      unixFsIsolationEnabled: executionMode.unixFsIsolationEnabled,
       allowSuperadmin,
     });
   }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -9,6 +9,7 @@ import {
   type AgorConfig,
   PublicBaseUrlNotConfiguredError,
   requirePublicBaseUrl,
+  resolveExecutionSecurityMode,
 } from '@agor/core/config';
 import {
   and,
@@ -370,7 +371,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     });
   }
 
-  if ((config.execution?.unix_user_mode ?? 'simple') !== 'simple') {
+  if (resolveExecutionSecurityMode(config).unixFsIsolationEnabled) {
     const daemonUser = config.daemon?.unix_user || 'agor';
     console.log(`[Unix Integration] Executor-based sync enabled (daemon user: ${daemonUser})`);
   }

--- a/apps/agor-daemon/src/services/branch-owners.test.ts
+++ b/apps/agor-daemon/src/services/branch-owners.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { setupBranchOwnersService } from './branch-owners';
+
+const mocks = vi.hoisted(() => ({
+  createServiceToken: vi.fn(() => 'service-token'),
+  spawnExecutorFireAndForget: vi.fn(),
+}));
+
+vi.mock('../utils/spawn-executor.js', () => ({
+  createServiceToken: mocks.createServiceToken,
+  getDaemonUrl: () => 'http://localhost:3030',
+  serviceTokenScopeForParams: (params?: { tenant?: { tenant_id?: string } }) =>
+    params?.tenant?.tenant_id ? { tenant_id: params.tenant.tenant_id } : {},
+  spawnExecutorFireAndForget: mocks.spawnExecutorFireAndForget,
+}));
+
+function makeApp() {
+  const services = new Map<string, any>();
+  services.set('users', {
+    get: vi.fn(async (userId: string) => ({ user_id: userId, email: `${userId}@example.com` })),
+  });
+
+  return {
+    use: vi.fn((path: string, service: any) => {
+      service.hooks = vi.fn((hooks: unknown) => {
+        service.registeredHooks = hooks;
+      });
+      services.set(path, service);
+    }),
+    service: vi.fn((path: string) => services.get(path)),
+  };
+}
+
+const branchRepo = {
+  getOwners: vi.fn(async () => []),
+  addOwner: vi.fn(async () => undefined),
+  removeOwner: vi.fn(async () => undefined),
+  isOwner: vi.fn(async () => true),
+  findById: vi.fn(async () => ({ branch_id: 'branch-1', others_can: 'all' })),
+  resolveUserPermission: vi.fn(async () => 'all'),
+};
+
+describe('setupBranchOwnersService Unix sync hooks', () => {
+  it('does not spawn Unix sync in RBAC-only simple mode', async () => {
+    vi.clearAllMocks();
+    const app = makeApp();
+    setupBranchOwnersService(app as never, branchRepo as never, {
+      jwtSecret: 'secret',
+      unixFsIsolationEnabled: false,
+    });
+
+    const service = app.service('branches/:id/owners');
+    await service.registeredHooks.after.create[0]({
+      params: { route: { id: 'branch-1' } },
+    });
+
+    expect(mocks.spawnExecutorFireAndForget).not.toHaveBeenCalled();
+    expect(mocks.createServiceToken).not.toHaveBeenCalled();
+  });
+
+  it('spawns tenant-scoped Unix sync when filesystem isolation is enabled', async () => {
+    vi.clearAllMocks();
+    const app = makeApp();
+    setupBranchOwnersService(app as never, branchRepo as never, {
+      jwtSecret: 'secret',
+      unixFsIsolationEnabled: true,
+      daemonUser: 'agor',
+    });
+
+    const service = app.service('branches/:id/owners');
+    await service.registeredHooks.after.create[0]({
+      params: {
+        route: { id: 'branch-1' },
+        tenant: { tenant_id: 'tenant-a' },
+      },
+    });
+
+    expect(mocks.createServiceToken).toHaveBeenCalledWith('secret', undefined, {
+      tenant_id: 'tenant-a',
+      branch_id: 'branch-1',
+      command: 'unix.sync-branch',
+    });
+    expect(mocks.spawnExecutorFireAndForget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'unix.sync-branch',
+        sessionToken: 'service-token',
+        params: expect.objectContaining({ branchId: 'branch-1', daemonUser: 'agor' }),
+      }),
+      { logPrefix: '[Executor/branch-owners.create]' }
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/branch-owners.ts
+++ b/apps/agor-daemon/src/services/branch-owners.ts
@@ -13,7 +13,7 @@
  * - Only branch owners can manage other owners (requires 'all' permission)
  *
  * Unix Integration:
- * - When owners are added/removed, fire-and-forget sync to executor
+ * - When Unix filesystem isolation is enabled, owner changes fire-and-forget sync to executor
  *
  * @see context/guides/rbac-and-unix-isolation.md
  */
@@ -21,11 +21,12 @@
 import type { BranchRepository } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
 import { type Application, Forbidden, NotAuthenticated } from '@agor/core/feathers';
-import type { BranchID, HookContext, User, UUID } from '@agor/core/types';
+import type { AuthenticatedParams, BranchID, HookContext, User, UUID } from '@agor/core/types';
 import { isSuperAdmin, PERMISSION_RANK } from '../utils/branch-authorization.js';
 import {
   createServiceToken,
   getDaemonUrl,
+  serviceTokenScopeForParams,
   spawnExecutorFireAndForget,
 } from '../utils/spawn-executor.js';
 
@@ -143,6 +144,8 @@ export interface BranchOwnersServiceConfig {
   jwtSecret?: string;
   /** Daemon Unix user (for group membership) */
   daemonUser?: string;
+  /** Whether Unix filesystem isolation is enabled */
+  unixFsIsolationEnabled?: boolean;
   /** Whether superadmin bypass is enabled (default: true) */
   allowSuperadmin?: boolean;
 }
@@ -246,8 +249,8 @@ export function setupBranchOwnersService(
       // The executor will handle adding user to branch group, repo group, and creating symlinks
       create: [
         async (context: HookContext) => {
-          // Skip if no jwtSecret (Unix integration not configured)
-          if (!config.jwtSecret) {
+          // Skip unless Unix filesystem isolation is enabled/configured.
+          if (!config.unixFsIsolationEnabled || !config.jwtSecret) {
             return context;
           }
 
@@ -257,6 +260,7 @@ export function setupBranchOwnersService(
           // Syncing the branch will pick up the new owner from the DB
           console.log(`[Unix Integration] Syncing branch ${shortId(branchId)} after owner added`);
           const serviceToken = createServiceToken(config.jwtSecret, undefined, {
+            ...serviceTokenScopeForParams(context.params as Partial<AuthenticatedParams>),
             branch_id: branchId,
             command: 'unix.sync-branch',
           });
@@ -280,8 +284,8 @@ export function setupBranchOwnersService(
       // The executor will handle removing user from groups and updating permissions
       remove: [
         async (context: HookContext) => {
-          // Skip if no jwtSecret (Unix integration not configured)
-          if (!config.jwtSecret) {
+          // Skip unless Unix filesystem isolation is enabled/configured.
+          if (!config.unixFsIsolationEnabled || !config.jwtSecret) {
             return context;
           }
 
@@ -291,6 +295,7 @@ export function setupBranchOwnersService(
           // Syncing the branch will handle the removed owner
           console.log(`[Unix Integration] Syncing branch ${shortId(branchId)} after owner removed`);
           const serviceToken = createServiceToken(config.jwtSecret, undefined, {
+            ...serviceTokenScopeForParams(context.params as Partial<AuthenticatedParams>),
             branch_id: branchId,
             command: 'unix.sync-branch',
           });

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -11,9 +11,9 @@ import { analyticsLogger } from '@agor/core/analytics';
 import {
   createUserProcessEnvironment,
   ENVIRONMENT,
-  isUnixGroupRefreshNeeded,
   loadConfig,
   PAGINATION,
+  resolveExecutionSecurityMode,
 } from '@agor/core/config';
 import {
   BoardRepository,
@@ -1490,7 +1490,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       // Unix group initialization is a filesystem concern controlled by
       // unix_user_mode. Logical branch RBAC may be enabled in simple/Cloud mode
       // without creating OS groups.
-      const initUnixGroup = isUnixGroupRefreshNeeded();
+      const initUnixGroup = resolveExecutionSecurityMode().shouldInitUnixGroups;
       const { getDaemonUser } = await import('@agor/core/config');
       const daemonUser = getDaemonUser();
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -62,7 +62,7 @@ import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { resolveGitImpersonationForBranch } from '../utils/git-impersonation.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
 import {
-  generateSessionToken,
+  generateScopedServiceToken,
   getDaemonUrl,
   runExecutorCommand,
   spawnExecutor,
@@ -1521,8 +1521,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         // Use a service JWT so the executor can patch rendered env command
         // templates without tripping requireAdminForEnvConfig when unarchive
         // is performed by a non-admin user.
-        const sessionToken = generateSessionToken(
-          this.app as unknown as { settings: { authentication?: { secret?: string } } }
+        const sessionToken = generateScopedServiceToken(
+          this.app as unknown as { settings: { authentication?: { secret?: string } } },
+          params
         );
         spawnExecutor(
           {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -11,7 +11,6 @@ import { analyticsLogger } from '@agor/core/analytics';
 import {
   createUserProcessEnvironment,
   ENVIRONMENT,
-  isBranchRbacEnabled,
   isUnixGroupRefreshNeeded,
   loadConfig,
   PAGINATION,
@@ -1488,8 +1487,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       const reposService = this.app.service('repos');
       const repo = (await reposService.get(branch.repo_id)) as Repo;
 
-      const rbacEnabled = isBranchRbacEnabled();
-      const initUnixGroup = rbacEnabled && isUnixGroupRefreshNeeded();
+      // Unix group initialization is a filesystem concern controlled by
+      // unix_user_mode. Logical branch RBAC may be enabled in simple/Cloud mode
+      // without creating OS groups.
+      const initUnixGroup = isUnixGroupRefreshNeeded();
       const { getDaemonUser } = await import('@agor/core/config');
       const daemonUser = getDaemonUser();
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -12,6 +12,7 @@ import {
   createUserProcessEnvironment,
   ENVIRONMENT,
   isBranchRbacEnabled,
+  isUnixGroupRefreshNeeded,
   loadConfig,
   PAGINATION,
 } from '@agor/core/config';
@@ -1488,6 +1489,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       const repo = (await reposService.get(branch.repo_id)) as Repo;
 
       const rbacEnabled = isBranchRbacEnabled();
+      const initUnixGroup = rbacEnabled && isUnixGroupRefreshNeeded();
       const { getDaemonUser } = await import('@agor/core/config');
       const daemonUser = getDaemonUser();
 
@@ -1542,7 +1544,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
               restoreMode: true,
               sourceBranch: branch.base_ref || repo.default_branch || 'main',
               // Unix group isolation
-              initUnixGroup: rbacEnabled,
+              initUnixGroup,
               othersAccess: branch.others_fs_access || 'read',
               daemonUser,
               repoUnixGroup: repo.unix_group,

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -10,7 +10,12 @@ import { BranchRepository, type Database, SessionRepository, UsersRepository } f
 import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, SessionID, UserID } from '@agor/core/types';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
-import { generateSessionToken, getDaemonUrl, runExecutorCommand } from '../utils/spawn-executor.js';
+import {
+  generateSessionToken,
+  getDaemonUrl,
+  runExecutorCommand,
+  serviceTokenScopeForParams,
+} from '../utils/spawn-executor.js';
 
 // Constants for file search
 const MAX_FILE_RESULTS = 10;
@@ -95,7 +100,8 @@ export class FilesService {
       }
 
       const sessionToken = generateSessionToken(
-        this.app as unknown as { settings: { authentication?: { secret?: string } } }
+        this.app as unknown as { settings: { authentication?: { secret?: string } } },
+        serviceTokenScopeForParams(params)
       );
 
       const currentUserId = params.user?.user_id as UserID | undefined;

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -11,10 +11,9 @@ import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, SessionID, UserID } from '@agor/core/types';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
 import {
-  generateSessionToken,
+  generateScopedServiceToken,
   getDaemonUrl,
   runExecutorCommand,
-  serviceTokenScopeForParams,
 } from '../utils/spawn-executor.js';
 
 // Constants for file search
@@ -99,9 +98,9 @@ export class FilesService {
         return [];
       }
 
-      const sessionToken = generateSessionToken(
+      const sessionToken = generateScopedServiceToken(
         this.app as unknown as { settings: { authentication?: { secret?: string } } },
-        serviceTokenScopeForParams(params)
+        params
       );
 
       const currentUserId = params.user?.user_id as UserID | undefined;

--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -1,0 +1,89 @@
+import { EventEmitter } from 'node:events';
+import { ENVIRONMENT } from '@agor/core/config';
+import type { Branch } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HealthMonitor } from './health-monitor';
+
+class BranchServiceMock extends EventEmitter {
+  find = vi.fn(async () => []);
+  get = vi.fn(async (branchId: string) =>
+    makeBranch({ branch_id: branchId, environment_instance: { status: 'running' } })
+  );
+  checkHealth = vi.fn(async () => undefined);
+}
+
+function makeBranch(overrides: Partial<Branch> & { tenant_id?: string } = {}): Branch {
+  return {
+    branch_id: 'branch-1',
+    repo_id: 'repo-1',
+    name: 'branch-1',
+    path: '/tmp/branch-1',
+    ref: 'branch-1',
+    ref_type: 'branch',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    created_by: 'user-1',
+    ...overrides,
+  } as Branch;
+}
+
+function makeApp(branches: BranchServiceMock) {
+  return {
+    service: vi.fn((path: string) => {
+      if (path === 'branches') return branches;
+      throw new Error(`Unexpected service: ${path}`);
+    }),
+  };
+}
+
+describe('HealthMonitor tenant context', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses startup tenant params for the initial background scan', async () => {
+    const branches = new BranchServiceMock();
+    const defaultParams = { tenant: { tenant_id: 'default', source: 'static' as const } };
+    const monitor = new HealthMonitor(makeApp(branches) as never, { defaultParams });
+
+    await monitor.initialize();
+
+    expect(branches.find).toHaveBeenCalledWith({
+      ...defaultParams,
+      query: { $limit: 1000 },
+      paginate: false,
+    });
+    monitor.cleanup();
+  });
+
+  it('uses branch tenant_id for event-driven background health checks', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      defaultParams: { tenant: { tenant_id: 'default', source: 'static' } },
+    });
+
+    branches.emit(
+      'patched',
+      makeBranch({
+        branch_id: 'branch-tenant-a',
+        tenant_id: 'tenant-a',
+        environment_instance: { status: 'running' },
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+
+    await vi.waitFor(() => expect(branches.get).toHaveBeenCalled());
+    expect(branches.get).toHaveBeenCalledWith('branch-tenant-a', {
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+    });
+    expect(branches.checkHealth).toHaveBeenCalledWith('branch-tenant-a', {
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+    });
+    monitor.cleanup();
+  });
+});

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -14,7 +14,7 @@
 import { ENVIRONMENT } from '@agor/core/config';
 import { shortId } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Branch, BranchID } from '@agor/core/types';
+import type { Branch, BranchID, TenantContext, TenantID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { BranchesServiceImpl } from '../declarations';
 
@@ -30,13 +30,31 @@ function healthMonitorDebug(...args: unknown[]): void {
 /**
  * Health Monitor - Singleton service for periodic health checks
  */
+export interface HealthMonitorParams {
+  tenant?: TenantContext;
+}
+
+export interface HealthMonitorOptions {
+  /** Internal params used for startup/background scans when no request context exists. */
+  defaultParams?: HealthMonitorParams;
+}
+
+function tenantParamsFromBranch(branch: Branch): HealthMonitorParams | undefined {
+  const tenantId = (branch as Branch & { tenant_id?: unknown }).tenant_id;
+  if (typeof tenantId !== 'string' || tenantId.length === 0) return undefined;
+  return { tenant: { tenant_id: tenantId as TenantID, source: 'auth_claim' } };
+}
+
 export class HealthMonitor {
   private app: Application;
   private intervals = new Map<BranchID, NodeJS.Timeout>();
+  private branchParams = new Map<BranchID, HealthMonitorParams>();
   private isShuttingDown = false;
+  private defaultParams?: HealthMonitorParams;
 
-  constructor(app: Application) {
+  constructor(app: Application, options: HealthMonitorOptions = {}) {
     this.app = app;
+    this.defaultParams = options.defaultParams;
     this.setupBranchListeners();
   }
 
@@ -59,6 +77,7 @@ export class HealthMonitor {
     // Listen for branch removal (cleanup monitoring)
     branchesService.on('removed', (branch: Branch) => {
       this.stopMonitoring(branch.branch_id);
+      this.branchParams.delete(branch.branch_id);
     });
   }
 
@@ -71,27 +90,31 @@ export class HealthMonitor {
     const status = branch.environment_instance?.status;
 
     if (status === 'running' || status === 'starting') {
-      // Start monitoring if not already monitored
-      // Monitor both 'running' and 'starting' - health checks will transition 'starting' → 'running'
+      // Start monitoring if not already monitored.
+      // Monitor both 'running' and 'starting' - health checks will transition 'starting' → 'running'.
+      const params = tenantParamsFromBranch(branch) ?? this.defaultParams;
+      if (params) this.branchParams.set(branch.branch_id, params);
       if (!this.intervals.has(branch.branch_id)) {
         healthMonitorDebug(`🏥 Starting health monitoring for branch: ${branch.name}`);
-        this.startMonitoring(branch.branch_id);
+        this.startMonitoring(branch.branch_id, params);
       }
     } else {
-      // Stop monitoring if status is not running or starting
+      // Stop monitoring if status is not running or starting.
       if (this.intervals.has(branch.branch_id)) {
         healthMonitorDebug(`🏥 Stopping health monitoring for branch: ${branch.name}`);
         this.stopMonitoring(branch.branch_id);
       }
+      this.branchParams.delete(branch.branch_id);
     }
   }
 
   /**
    * Start monitoring a branch's health
    */
-  private startMonitoring(branchId: BranchID) {
+  private startMonitoring(branchId: BranchID, params = this.branchParams.get(branchId)) {
     // Clear existing interval if any
     this.stopMonitoring(branchId);
+    if (params) this.branchParams.set(branchId, params);
 
     // Wait grace period before first check
     setTimeout(() => {
@@ -128,8 +151,10 @@ export class HealthMonitor {
     try {
       const branchesService = this.app.service('branches') as unknown as BranchesServiceImpl;
 
+      const params = this.branchParams.get(branchId) ?? this.defaultParams;
+
       // Get current branch state
-      const branch = await branchesService.get(branchId);
+      const branch = await branchesService.get(branchId, params as never);
 
       // Only check if still running or starting
       const status = branch.environment_instance?.status;
@@ -143,7 +168,7 @@ export class HealthMonitor {
       // Perform health check via the service method
       // This will update environment_instance and broadcast via WebSocket
       // Logging is handled in checkHealth() method - only logs on state changes
-      await branchesService.checkHealth(branchId);
+      await branchesService.checkHealth(branchId, params as never);
     } catch (error) {
       // If branch was deleted or not found, stop monitoring silently
       // This is expected when branches are deleted while health checks are in progress
@@ -175,11 +200,12 @@ export class HealthMonitor {
 
       // Find all branches with running status
       const result = await branchesService.find({
+        ...this.defaultParams,
         query: {
           $limit: 1000,
         },
         paginate: false,
-      });
+      } as never);
 
       // Handle both paginated and non-paginated responses
       const branches = (Array.isArray(result) ? result : result.data) as Branch[];
@@ -192,7 +218,9 @@ export class HealthMonitor {
       );
 
       for (const branch of activeBranches) {
-        this.startMonitoring(branch.branch_id);
+        const params = tenantParamsFromBranch(branch) ?? this.defaultParams;
+        if (params) this.branchParams.set(branch.branch_id, params);
+        this.startMonitoring(branch.branch_id, params);
       }
       console.log(`🏥 Health Monitor initialized (${activeBranches.length} active environment(s))`);
     } catch (error) {
@@ -215,6 +243,7 @@ export class HealthMonitor {
     }
 
     this.intervals.clear();
+    this.branchParams.clear();
     console.log(`🏥 Health Monitor cleaned up (${stoppedCount} monitor(s) stopped)`);
   }
 
@@ -233,8 +262,11 @@ export class HealthMonitor {
 /**
  * Create and initialize Health Monitor service
  */
-export async function createHealthMonitor(app: Application): Promise<HealthMonitor> {
-  const monitor = new HealthMonitor(app);
+export async function createHealthMonitor(
+  app: Application,
+  options: HealthMonitorOptions = {}
+): Promise<HealthMonitor> {
+  const monitor = new HealthMonitor(app, options);
   await monitor.initialize();
   return monitor;
 }

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -14,7 +14,6 @@ import path from 'node:path';
 import {
   ensureBranchStorageModeAllowed,
   extractSlugFromUrl,
-  isBranchRbacEnabled,
   isUnixGroupRefreshNeeded,
   isValidGitUrl,
   isValidSlug,
@@ -59,18 +58,13 @@ import {
   generateSessionToken,
   getDaemonUrl,
   runExecutorCommand,
+  serviceTokenScopeForParams,
   spawnExecutorFireAndForget,
 } from '../utils/spawn-executor.js';
 
 /**
  * Repo service params
  */
-
-function serviceTokenScopeForParams(params?: RepoParams): Record<string, unknown> {
-  const tenantId = (params as Partial<AuthenticatedParams> | undefined)?.tenant?.tenant_id;
-  return tenantId ? { tenant_id: tenantId } : {};
-}
-
 export type RepoParams = QueryParams<{
   slug?: string;
   managed_by_agor?: boolean;
@@ -234,9 +228,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       serviceTokenScopeForParams(params)
     );
 
-    // Unix group initialization gates on RBAC explicitly.
-    const rbacEnabled = isBranchRbacEnabled();
-    const initUnixGroup = rbacEnabled && isUnixGroupRefreshNeeded();
+    // Unix group initialization is a filesystem concern controlled by
+    // unix_user_mode, not by app-level branch RBAC.
+    const initUnixGroup = isUnixGroupRefreshNeeded();
 
     // Sudo wrap (asUser) is gated inside the resolver — returns undefined
     // in simple/no-RBAC mode so hosts without passwordless sudoers work
@@ -770,7 +764,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Create DB record EARLY with 'creating' status
     // Executor will:
     // 1. Create git branch on filesystem
-    // 2. Initialize Unix groups (if RBAC enabled)
+    // 2. Initialize Unix groups (if unix_user_mode needs filesystem isolation)
     // 3. Render environment templates with full context including GID
     // 4. Patch branch to 'ready' with rendered templates
     const branch = (await branchesService.create(
@@ -923,9 +917,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         serviceTokenScopeForParams(params)
       );
 
-      // Unix group initialization gates on RBAC explicitly.
-      const rbacEnabled = isBranchRbacEnabled();
-    const initUnixGroup = rbacEnabled && isUnixGroupRefreshNeeded();
+      // Unix group initialization is a filesystem concern controlled by
+      // unix_user_mode, not by app-level branch RBAC.
+      const initUnixGroup = isUnixGroupRefreshNeeded();
 
       // Sudo wrap (asUser) is gated inside the resolver — returns undefined
       // in simple/no-RBAC mode so hosts without passwordless sudoers work
@@ -949,7 +943,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             createBranch: data.createBranch,
             refType: data.refType,
             userId: userId as string | undefined,
-            // Unix group isolation (only when RBAC is enabled)
+            // Unix group isolation (only when unix_user_mode is non-simple)
             initUnixGroup,
             othersAccess: branch.others_fs_access || 'read',
             // Branch storage mode (forwarded for the clone-mode code path)

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -14,13 +14,13 @@ import path from 'node:path';
 import {
   ensureBranchStorageModeAllowed,
   extractSlugFromUrl,
-  isUnixGroupRefreshNeeded,
   isValidGitUrl,
   isValidSlug,
   normalizeRepoUrl,
   PAGINATION,
   parseAgorYml,
   resolveBranchStorageConfig,
+  resolveExecutionSecurityMode,
 } from '@agor/core/config';
 import { BranchRepository, type Database, RepoRepository, shortId } from '@agor/core/db';
 import { autoAssignBranchUniqueId } from '@agor/core/environment/variable-resolver';
@@ -55,10 +55,9 @@ import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
 import { resolveGitImpersonationForUser } from '../utils/git-impersonation.js';
 import {
-  generateSessionToken,
+  generateScopedServiceToken,
   getDaemonUrl,
   runExecutorCommand,
-  serviceTokenScopeForParams,
   spawnExecutorFireAndForget,
 } from '../utils/spawn-executor.js';
 
@@ -223,14 +222,14 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // token ensures hooks like requireAdminForEnvConfig bypass via
     // _isServiceAccount. Executor fetches per-user credentials via Feathers
     // RPC (users.getGitEnvironment) using the same service JWT.
-    const sessionToken = generateSessionToken(
+    const sessionToken = generateScopedServiceToken(
       this.app as unknown as { settings: { authentication?: { secret?: string } } },
-      serviceTokenScopeForParams(params)
+      params
     );
 
     // Unix group initialization is a filesystem concern controlled by
     // unix_user_mode, not by app-level branch RBAC.
-    const initUnixGroup = isUnixGroupRefreshNeeded();
+    const initUnixGroup = resolveExecutionSecurityMode().shouldInitUnixGroups;
 
     // Sudo wrap (asUser) is gated inside the resolver — returns undefined
     // in simple/no-RBAC mode so hosts without passwordless sudoers work
@@ -912,14 +911,14 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Per-user credentials: Feathers RPC (users.getGitEnvironment)
     // Unix group init: Feathers RPC (branches.initializeUnixGroup) — runs daemon-side
     try {
-      const sessionToken = generateSessionToken(
+      const sessionToken = generateScopedServiceToken(
         this.app as unknown as { settings: { authentication?: { secret?: string } } },
-        serviceTokenScopeForParams(params)
+        params
       );
 
       // Unix group initialization is a filesystem concern controlled by
       // unix_user_mode, not by app-level branch RBAC.
-      const initUnixGroup = isUnixGroupRefreshNeeded();
+      const initUnixGroup = resolveExecutionSecurityMode().shouldInitUnixGroups;
 
       // Sudo wrap (asUser) is gated inside the resolver — returns undefined
       // in simple/no-RBAC mode so hosts without passwordless sudoers work
@@ -1003,9 +1002,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     params: Record<string, unknown>,
     serviceParams?: RepoParams
   ) {
-    const sessionToken = generateSessionToken(
+    const sessionToken = generateScopedServiceToken(
       this.app as unknown as { settings: { authentication?: { secret?: string } } },
-      serviceTokenScopeForParams(serviceParams)
+      serviceParams
     );
     const asUser = await resolveExecutorReadAsUser(
       this.db,
@@ -1188,9 +1187,9 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // If cleanup is requested and this is a remote repo, delete filesystem directories FIRST.
     // Delegate to the executor so the daemon never rm -rfs managed repo/branch dirs itself.
     if (cleanup && repo.repo_type === 'remote') {
-      const sessionToken = generateSessionToken(
+      const sessionToken = generateScopedServiceToken(
         this.app as unknown as { settings: { authentication?: { secret?: string } } },
-        serviceTokenScopeForParams(params)
+        params
       );
 
       const cleanupResult = await runExecutorCommand(

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -64,6 +64,12 @@ import {
 /**
  * Repo service params
  */
+
+function serviceTokenScopeForParams(params?: RepoParams): Record<string, unknown> {
+  const tenantId = (params as Partial<AuthenticatedParams> | undefined)?.tenant?.tenant_id;
+  return tenantId ? { tenant_id: tenantId } : {};
+}
+
 export type RepoParams = QueryParams<{
   slug?: string;
   managed_by_agor?: boolean;
@@ -223,7 +229,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // _isServiceAccount. Executor fetches per-user credentials via Feathers
     // RPC (users.getGitEnvironment) using the same service JWT.
     const sessionToken = generateSessionToken(
-      this.app as unknown as { settings: { authentication?: { secret?: string } } }
+      this.app as unknown as { settings: { authentication?: { secret?: string } } },
+      serviceTokenScopeForParams(params)
     );
 
     // Unix group initialization gates on RBAC explicitly.
@@ -910,7 +917,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Unix group init: Feathers RPC (branches.initializeUnixGroup) — runs daemon-side
     try {
       const sessionToken = generateSessionToken(
-        this.app as unknown as { settings: { authentication?: { secret?: string } } }
+        this.app as unknown as { settings: { authentication?: { secret?: string } } },
+        serviceTokenScopeForParams(params)
       );
 
       // Unix group initialization gates on RBAC explicitly.
@@ -999,7 +1007,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     serviceParams?: RepoParams
   ) {
     const sessionToken = generateSessionToken(
-      this.app as unknown as { settings: { authentication?: { secret?: string } } }
+      this.app as unknown as { settings: { authentication?: { secret?: string } } },
+      serviceTokenScopeForParams(serviceParams)
     );
     const asUser = await resolveExecutorReadAsUser(
       this.db,
@@ -1183,7 +1192,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // Delegate to the executor so the daemon never rm -rfs managed repo/branch dirs itself.
     if (cleanup && repo.repo_type === 'remote') {
       const sessionToken = generateSessionToken(
-        this.app as unknown as { settings: { authentication?: { secret?: string } } }
+        this.app as unknown as { settings: { authentication?: { secret?: string } } },
+        serviceTokenScopeForParams(params)
       );
 
       const cleanupResult = await runExecutorCommand(

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -15,6 +15,7 @@ import {
   ensureBranchStorageModeAllowed,
   extractSlugFromUrl,
   isBranchRbacEnabled,
+  isUnixGroupRefreshNeeded,
   isValidGitUrl,
   isValidSlug,
   normalizeRepoUrl,
@@ -235,6 +236,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
 
     // Unix group initialization gates on RBAC explicitly.
     const rbacEnabled = isBranchRbacEnabled();
+    const initUnixGroup = rbacEnabled && isUnixGroupRefreshNeeded();
 
     // Sudo wrap (asUser) is gated inside the resolver — returns undefined
     // in simple/no-RBAC mode so hosts without passwordless sudoers work
@@ -294,7 +296,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
           ...(data.default_branch ? { default_branch: data.default_branch } : {}),
           createDbRecord: true,
           userId: userId as string | undefined,
-          initUnixGroup: rbacEnabled,
+          initUnixGroup,
         },
       },
       {
@@ -923,6 +925,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
 
       // Unix group initialization gates on RBAC explicitly.
       const rbacEnabled = isBranchRbacEnabled();
+    const initUnixGroup = rbacEnabled && isUnixGroupRefreshNeeded();
 
       // Sudo wrap (asUser) is gated inside the resolver — returns undefined
       // in simple/no-RBAC mode so hosts without passwordless sudoers work
@@ -947,7 +950,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             refType: data.refType,
             userId: userId as string | undefined,
             // Unix group isolation (only when RBAC is enabled)
-            initUnixGroup: rbacEnabled,
+            initUnixGroup,
             othersAccess: branch.others_fs_access || 'read',
             // Branch storage mode (forwarded for the clone-mode code path)
             storageMode,

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -553,7 +553,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
               .then((branch) => {
                 const repoId = branch?.repo_id;
                 if (!repoId) return;
-                return ensureRepoOriginAlignedById(this.app, repoId);
+                return ensureRepoOriginAlignedById(this.app, repoId, params);
               })
               .catch((err: unknown) => {
                 const message = err instanceof Error ? err.message : String(err);

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -74,6 +74,7 @@ vi.mock('../utils/mcp-token-authorization.js', () => ({
 
 vi.mock('../utils/spawn-executor.js', () => ({
   generateSessionToken: () => 'session-token',
+  generateScopedServiceToken: () => 'session-token',
   serviceTokenScopeForParams: () => ({}),
   spawnExecutorFireAndForget: mocks.spawnExecutorFireAndForget,
 }));

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -74,6 +74,7 @@ vi.mock('../utils/mcp-token-authorization.js', () => ({
 
 vi.mock('../utils/spawn-executor.js', () => ({
   generateSessionToken: () => 'session-token',
+  serviceTokenScopeForParams: () => ({}),
   spawnExecutorFireAndForget: mocks.spawnExecutorFireAndForget,
 }));
 

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -47,11 +47,7 @@ import {
 } from '@agor/core/unix';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
 import { canControlCliSession } from '../utils/mcp-token-authorization.js';
-import {
-  generateSessionToken,
-  serviceTokenScopeForParams,
-  spawnExecutorFireAndForget,
-} from '../utils/spawn-executor.js';
+import { generateScopedServiceToken, spawnExecutorFireAndForget } from '../utils/spawn-executor.js';
 import {
   buildSpawnConfigForSession,
   isClaudeRunningFor,
@@ -799,7 +795,7 @@ export class TerminalsService {
 
       // Generate session token for executor
       const daemonUrl = `http://localhost:${config.daemon?.port || 3030}`;
-      const sessionToken = generateSessionToken(this.app, serviceTokenScopeForParams(params));
+      const sessionToken = generateScopedServiceToken(this.app, params);
 
       // Get user environment and write env file for shell sourcing
       const userEnv = await resolveUserEnvironment(userId, this.db);

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -47,7 +47,11 @@ import {
 } from '@agor/core/unix';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
 import { canControlCliSession } from '../utils/mcp-token-authorization.js';
-import { generateSessionToken, spawnExecutorFireAndForget } from '../utils/spawn-executor.js';
+import {
+  generateSessionToken,
+  serviceTokenScopeForParams,
+  spawnExecutorFireAndForget,
+} from '../utils/spawn-executor.js';
 import {
   buildSpawnConfigForSession,
   isClaudeRunningFor,
@@ -795,7 +799,7 @@ export class TerminalsService {
 
       // Generate session token for executor
       const daemonUrl = `http://localhost:${config.daemon?.port || 3030}`;
-      const sessionToken = generateSessionToken(this.app);
+      const sessionToken = generateSessionToken(this.app, serviceTokenScopeForParams(params));
 
       // Get user environment and write env file for shell sourcing
       const userEnv = await resolveUserEnvironment(userId, this.db);

--- a/apps/agor-daemon/src/services/zone-trigger.ts
+++ b/apps/agor-daemon/src/services/zone-trigger.ts
@@ -18,6 +18,7 @@ import { buildZoneTriggerContext } from '@agor/core/templates/zone-trigger-conte
 import type { AgenticToolName, Branch, Session, Task, User } from '@agor/core/types';
 import { inspectBranchViaExecutor } from '../utils/branch-inspect.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
+import { serviceTokenScopeForParams } from '../utils/spawn-executor.js';
 
 export interface FireAlwaysNewZoneTriggerInput {
   // biome-ignore lint/suspicious/noExplicitAny: Feathers app type varies across callers
@@ -93,6 +94,7 @@ export async function fireAlwaysNewZoneTrigger(
   const { currentSha, currentRef } = await inspectBranchViaExecutor(app, branch.branch_id, {
     asUser,
     logPrefix: `[zone-trigger ${branch.name}]`,
+    serviceTokenScope: serviceTokenScopeForParams(params),
   });
 
   const newSession: Session = await app.service('sessions').create(

--- a/apps/agor-daemon/src/setup/build-info.test.ts
+++ b/apps/agor-daemon/src/setup/build-info.test.ts
@@ -37,15 +37,23 @@ afterEach(() => {
 });
 
 /**
- * loadBuildInfo() takes an `import.meta.url`-style file URL and walks up two
- * candidate paths looking for `.build-info`. Build a fake module URL inside
- * tmpRoot so each test controls its own filesystem.
+ * loadBuildInfo() takes an `import.meta.url`-style file URL and checks the
+ * daemon dist layout plus parent fallbacks for `.build-info`. Build fake module
+ * URLs inside tmpRoot so each test controls its own filesystem.
  */
 function fakeModuleUrl(): string {
-  // Mirror the dist layout: <tmp>/setup/build-info.js
+  // Mirror an imported helper layout: <tmp>/setup/build-info.js
   const setupDir = join(tmpRoot, 'setup');
   mkdirSync(setupDir, { recursive: true });
   return pathToFileURL(join(setupDir, 'build-info.js')).toString();
+}
+
+function fakeDistEntryUrl(): string {
+  // Mirror the production entry layout: <tmp>/dist/index.js with
+  // <tmp>/dist/.build-info next to it.
+  const distDir = join(tmpRoot, 'dist');
+  mkdirSync(distDir, { recursive: true });
+  return pathToFileURL(join(distDir, 'index.js')).toString();
 }
 
 describe('loadBuildInfo', () => {
@@ -71,6 +79,20 @@ describe('loadBuildInfo', () => {
     const info = loadBuildInfo(fakeModuleUrl());
     expect(info.sha).toBe('abc1234');
     expect(info.builtAt).toBe('2026-04-23T10:00:00Z');
+    expect(info.source).toBe('file');
+  });
+
+  it('reads .build-info next to a dist-root entrypoint', () => {
+    const distDir = join(tmpRoot, 'dist');
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(
+      join(distDir, '.build-info'),
+      JSON.stringify({ sha: 'dist1234', builtAt: '2026-04-23T11:00:00Z' })
+    );
+
+    const info = loadBuildInfo(fakeDistEntryUrl());
+    expect(info.sha).toBe('dist1234');
+    expect(info.builtAt).toBe('2026-04-23T11:00:00Z');
     expect(info.source).toBe('file');
   });
 

--- a/apps/agor-daemon/src/setup/build-info.ts
+++ b/apps/agor-daemon/src/setup/build-info.ts
@@ -8,7 +8,7 @@
  *
  * Precedence (first match wins):
  *   1. process.env.AGOR_BUILD_SHA           — Docker --build-arg, CI
- *   2. <daemon-dist>/.build-info            — written by packages/agor-live/build.sh
+ *   2. <daemon-dist>/.build-info            — written by daemon build script
  *   3. git rev-parse --short HEAD           — local source installs
  *   4. 'dev'                                — disables the version check entirely
  */
@@ -46,11 +46,17 @@ export function loadBuildInfo(importMetaUrl: string): BuildInfo {
     };
   }
 
-  // 2. .build-info file written by packages/agor-live/build.sh into the
-  //    daemon dist. The file sits next to the entry point; try both common
-  //    layouts (src/setup/ in dev, dist/ root in agor-live).
+  // 2. .build-info file written by the daemon build script into daemon dist.
+  //    Try the common runtime layouts:
+  //    - dist/index.js        → dist/.build-info
+  //    - dist/setup/*.js     → dist/.build-info
+  //    - source/test layouts → parent fallbacks
   const currentDir = dirname(fileURLToPath(importMetaUrl));
-  const candidates = [join(currentDir, '../.build-info'), join(currentDir, '../../.build-info')];
+  const candidates = [
+    join(currentDir, '.build-info'),
+    join(currentDir, '../.build-info'),
+    join(currentDir, '../../.build-info'),
+  ];
   for (const path of candidates) {
     try {
       const raw = readFileSync(path, 'utf-8');

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -129,7 +129,9 @@ export async function initializeDatabase(
     // bootstrap account; the first trusted launch user becomes the attribution
     // target instead.
     if (options.skipFirstRunAdminBootstrap) {
-      console.log('🔐 Skipping local first-run admin bootstrap; external launch owns user identity.');
+      console.log(
+        '🔐 Skipping local first-run admin bootstrap; external launch owns user identity.'
+      );
     } else {
       const bootstrapResult = await runFirstRunAdminBootstrap(scopedDb);
       logFirstRunAdminBootstrap(bootstrapResult);

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -102,7 +102,7 @@ async function checkAndReportMigrations(
  */
 export async function initializeDatabase(
   dbPath: string,
-  options: { tenantId?: TenantID | string } = {}
+  options: { tenantId?: TenantID | string; skipFirstRunAdminBootstrap?: boolean } = {}
 ): Promise<DatabaseInitResult> {
   console.log(`📦 Connecting to database: ${dbPath}`);
 
@@ -125,9 +125,15 @@ export async function initializeDatabase(
 
     // First-run admin bootstrap: create a default admin if no users exist in
     // the current tenant, and re-attribute any legacy `created_by='anonymous'`
-    // rows to a real user.
-    const bootstrapResult = await runFirstRunAdminBootstrap(scopedDb);
-    logFirstRunAdminBootstrap(bootstrapResult);
+    // rows to a real user. External-launch managed deployments skip the local
+    // bootstrap account; the first trusted launch user becomes the attribution
+    // target instead.
+    if (options.skipFirstRunAdminBootstrap) {
+      console.log('🔐 Skipping local first-run admin bootstrap; external launch owns user identity.');
+    } else {
+      const bootstrapResult = await runFirstRunAdminBootstrap(scopedDb);
+      logFirstRunAdminBootstrap(bootstrapResult);
+    }
   });
 
   console.log('✅ Database ready');

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -485,7 +485,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
 
   // 2. Register Health Monitor listeners before serving requests. The initial
   // full scan of already-running environments is deferred until after listen.
-  const healthMonitor = new HealthMonitor(app);
+  const healthMonitor = new HealthMonitor(app, { defaultParams: startupTenantParams(config) });
 
   // 3. Validate/generate master secret for API key encryption
   await ensureMasterSecret(config);

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -8,10 +8,14 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { AgorConfig } from '@agor/core/config';
-import { getAgorHome, resolveExecutorHeartbeatConfig } from '@agor/core/config';
+import {
+  getAgorHome,
+  resolveExecutorHeartbeatConfig,
+  resolveMultiTenancyConfig,
+} from '@agor/core/config';
 import type { Database } from '@agor/core/db';
 import { MessagesRepository, SessionRepository, shortId } from '@agor/core/db';
-import type { Id, Paginated, Session, SessionID, Task } from '@agor/core/types';
+import type { Id, Paginated, Session, SessionID, Task, TenantContext } from '@agor/core/types';
 import { SessionStatus, TaskStatus } from '@agor/core/types';
 import type { Application, SessionsServiceImpl, TasksServiceImpl } from './declarations.js';
 import { ExecutorHeartbeatSupervisor } from './services/executor-heartbeat-supervisor.js';
@@ -106,6 +110,16 @@ async function readAndClearSentinel(): Promise<boolean> {
 // Orphan cleanup
 // ---------------------------------------------------------------------------
 
+function startupTenantParams(config: AgorConfig): { tenant: TenantContext } {
+  const multiTenancy = resolveMultiTenancyConfig(config);
+  return {
+    tenant: {
+      tenant_id: multiTenancy.static_tenant_id,
+      source: 'static',
+    },
+  };
+}
+
 interface OrphanCleanupResult {
   wasGraceful: boolean;
   orphanedTasks: Task[];
@@ -120,18 +134,28 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
 
   // Get tasks service from the app (registered during services phase)
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
+  // Startup cleanup runs before any user request/auth context exists. In
+  // auth-resolved multi-tenant deployments, scope cleanup to the configured
+  // bootstrap/static tenant instead of failing daemon boot. Tenant-specific
+  // crash cleanup for every active tenant belongs in a later control-plane/DataPlane
+  // reconciler pass; startup must stay non-blocking for launch-auth tenants.
+  const startupParams = startupTenantParams(ctx.config);
 
   // Determine restart type before touching anything — sentinel is consumed here
   const wasGraceful = await readAndClearSentinel();
 
   // Find all orphaned executor-owned tasks (running, stopping, awaiting_permission, awaiting_input)
-  const orphanedTasks = await tasksService.getOrphaned();
+  const orphanedTasks = await tasksService.getOrphaned(startupParams as never);
 
   if (orphanedTasks.length > 0) {
     for (const task of orphanedTasks) {
-      await tasksService.patch(task.task_id, {
-        status: TaskStatus.STOPPED,
-      });
+      await tasksService.patch(
+        task.task_id,
+        {
+          status: TaskStatus.STOPPED,
+        },
+        startupParams as never
+      );
       startupDebug(
         `[startup] stopped orphaned task ${shortId(task.task_id)} (was: ${task.status})`
       );
@@ -144,14 +168,19 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   // hook (triggered below) from draining queued tasks that should be discarded.
   const queuedResult = (await tasksService.find({
     query: { status: TaskStatus.QUEUED, $limit: 1000 },
+    ...startupParams,
   })) as unknown as Paginated<Task>;
   const queuedTasks = queuedResult.data;
 
   if (queuedTasks.length > 0) {
     for (const task of queuedTasks) {
-      await tasksService.patch(task.task_id, {
-        status: TaskStatus.STOPPED,
-      });
+      await tasksService.patch(
+        task.task_id,
+        {
+          status: TaskStatus.STOPPED,
+        },
+        startupParams as never
+      );
     }
   }
 
@@ -166,6 +195,7 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   ]) {
     const result = (await sessionsService.find({
       query: { status, $limit: 1000 },
+      ...startupParams,
     })) as unknown as Paginated<Session>;
     orphanedSessions.push(...result.data);
   }
@@ -180,7 +210,7 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
           status: SessionStatus.IDLE,
           ready_for_prompt: true,
         },
-        {}
+        startupParams as never
       );
       startupDebug(
         `   ✓ Marked session ${shortId(session.session_id)} as idle (was: ${session.status})`
@@ -195,7 +225,7 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   let sessionsResetFromOrphanedTasks = 0;
   if (sessionIdsWithOrphanedTasks.size > 0) {
     for (const sessionId of sessionIdsWithOrphanedTasks) {
-      const session = await sessionsService.get(sessionId as Id);
+      const session = await sessionsService.get(sessionId as Id, startupParams as never);
       // If session is still in an active state after orphaned task cleanup, set to IDLE
       if (
         session.status === SessionStatus.RUNNING ||
@@ -209,7 +239,7 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
             status: SessionStatus.IDLE,
             ready_for_prompt: true,
           },
-          {}
+          startupParams as never
         );
         sessionsResetFromOrphanedTasks++;
         startupDebug(
@@ -226,12 +256,15 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
   // ready_for_prompt=false is never a legitimate persistent state.
   const stuckIdleResult = (await sessionsService.find({
     query: { status: SessionStatus.IDLE, ready_for_prompt: false, $limit: 1000 },
+    ...startupParams,
   })) as unknown as Paginated<Session>;
   const stuckIdleSessions = stuckIdleResult.data;
 
   if (stuckIdleSessions.length > 0) {
     for (const session of stuckIdleSessions) {
-      await app.service('sessions').patch(session.session_id, { ready_for_prompt: true }, {});
+      await app
+        .service('sessions')
+        .patch(session.session_id, { ready_for_prompt: true }, startupParams as never);
       startupDebug(
         `   ✓ Unblocked stuck-idle session ${shortId(session.session_id)} (ready_for_prompt was false)`
       );
@@ -271,6 +304,7 @@ async function injectRestartNotices(
 
   // Get tasks service from the app (registered during services phase)
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
+  const startupParams = startupTenantParams(ctx.config);
 
   // Inject a system message into every affected session so the user (and the
   // agent on resume) see an in-transcript explanation — not a toast, a
@@ -319,10 +353,10 @@ async function injectRestartNotices(
       if (!attachTask) {
         // Sessions maintain an ordered task-ID list; the last entry is the most
         // recent task without relying on TasksService.find() sort behavior.
-        const session = await sessionsService.get(sessionId as Id);
+        const session = await sessionsService.get(sessionId as Id, startupParams as never);
         const latestTaskId = session.tasks?.at(-1);
         if (latestTaskId) {
-          attachTask = await tasksService.get(latestTaskId);
+          attachTask = await tasksService.get(latestTaskId, startupParams as never);
         }
       }
       if (!attachTask) {

--- a/apps/agor-daemon/src/utils/branch-inspect.ts
+++ b/apps/agor-daemon/src/utils/branch-inspect.ts
@@ -19,10 +19,15 @@ function isBranchInspectResult(value: unknown): value is BranchInspectResult {
 export async function inspectBranchViaExecutor(
   app: Application,
   branchId: BranchID,
-  options: { asUser?: string | null; logPrefix?: string } = {}
+  options: {
+    asUser?: string | null;
+    logPrefix?: string;
+    serviceTokenScope?: Record<string, unknown>;
+  } = {}
 ): Promise<BranchInspectResult> {
   const sessionToken = generateSessionToken(
-    app as unknown as { settings: { authentication?: { secret?: string } } }
+    app as unknown as { settings: { authentication?: { secret?: string } } },
+    options.serviceTokenScope
   );
 
   const result = await runExecutorCommand(

--- a/apps/agor-daemon/src/utils/git-impersonation.test.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.test.ts
@@ -2,11 +2,11 @@
  * Regression test for #1140 — `repo clone fails when user is not sudoer` —
  * and its sister bug #1143 — same failure mode in `git.branch.remove`.
  *
- * In the open-access default (`branch_rbac: false`, `unix_user_mode:
- * simple`) no supplemental Unix groups are ever created, so wrapping git
- * operations in `sudo -u` is pure overhead. Worse: it breaks for users
- * who never configured passwordless sudoers, with the daemon failing to
- * clone repos (or remove branches) against `user not in sudoers`.
+ * In simple Unix mode no supplemental Unix groups are created, even when
+ * app-level `branch_rbac` is enabled, so wrapping git operations in
+ * `sudo -u` is pure overhead. Worse: it breaks for users who never configured
+ * passwordless sudoers, with the daemon failing to clone repos (or remove
+ * branches) against `user not in sudoers`.
  *
  * The gate must live INSIDE the resolver — not at the call site — so every
  * caller is covered uniformly. #1141 fixed clone + branch.add + (later)
@@ -60,7 +60,7 @@ describe('resolveGitImpersonationForUser', () => {
     expect(result).toBeUndefined();
   });
 
-  it('returns daemon user when group refresh is needed (RBAC or insulated/strict)', async () => {
+  it('returns daemon user when group refresh is needed (insulated/strict)', async () => {
     mockIsUnixGroupRefreshNeeded.mockReturnValue(true);
     const result = await resolveGitImpersonationForUser(fakeDb, fakeUserId);
     expect(result).toBe('agorpg');

--- a/apps/agor-daemon/src/utils/git-impersonation.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.ts
@@ -6,10 +6,10 @@
  * via `initgroups()` so the daemon can see `agor_wt_*` groups added at
  * runtime — but only when supplemental groups actually exist.
  *
- * In the open-access default (`branch_rbac: false`, `unix_user_mode:
- * simple`) no supplemental groups are ever created, so wrapping in sudo is
- * pure overhead AND breaks for users who never configured passwordless
- * sudoers (#1140). Return undefined in that case so callers spawn directly.
+ * In simple Unix mode no supplemental branch groups are created, even when
+ * app-level `branch_rbac` is enabled, so wrapping in sudo is pure overhead
+ * AND breaks for users who never configured passwordless sudoers (#1140).
+ * Return undefined in that case so callers spawn directly.
  *
  * The gate lives HERE on purpose: every caller that resolves impersonation
  * needs the same check, and dropping it at a call site is exactly how the
@@ -57,9 +57,9 @@ export async function resolveDaemonUserForGroupRefresh(): Promise<string | undef
  * Resolve Unix user for git operations.
  *
  * Returns the daemon user when group refresh via `sudo -u` is needed
- * (RBAC enabled or non-simple unix_user_mode — see
- * `isUnixGroupRefreshNeeded`). Returns `undefined` in the open-access
- * default so callers spawn directly without sudo wrap (#1140).
+ * (non-simple unix_user_mode — see `isUnixGroupRefreshNeeded`). Returns
+ * `undefined` in simple mode so callers spawn directly without sudo wrap
+ * (#1140), regardless of app-level branch RBAC.
  *
  * @param db - Database instance (unused today, kept on the signature for
  *             the planned per-user resolution refactor)

--- a/apps/agor-daemon/src/utils/realign-repo-origin.test.ts
+++ b/apps/agor-daemon/src/utils/realign-repo-origin.test.ts
@@ -10,6 +10,7 @@ import { spawnExecutorFireAndForget } from './spawn-executor.js';
 vi.mock('./spawn-executor.js', () => ({
   generateSessionToken: vi.fn(() => 'service-token'),
   getDaemonUrl: vi.fn(() => 'http://localhost:3030'),
+  serviceTokenScopeForParams: vi.fn(() => ({})),
   spawnExecutorFireAndForget: vi.fn(),
 }));
 

--- a/apps/agor-daemon/src/utils/realign-repo-origin.test.ts
+++ b/apps/agor-daemon/src/utils/realign-repo-origin.test.ts
@@ -9,6 +9,7 @@ import { spawnExecutorFireAndForget } from './spawn-executor.js';
 
 vi.mock('./spawn-executor.js', () => ({
   generateSessionToken: vi.fn(() => 'service-token'),
+  generateScopedServiceToken: vi.fn(() => 'service-token'),
   getDaemonUrl: vi.fn(() => 'http://localhost:3030'),
   serviceTokenScopeForParams: vi.fn(() => ({})),
   spawnExecutorFireAndForget: vi.fn(),

--- a/apps/agor-daemon/src/utils/realign-repo-origin.ts
+++ b/apps/agor-daemon/src/utils/realign-repo-origin.ts
@@ -1,9 +1,8 @@
 import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, HookContext, Repo, RepoID } from '@agor/core/types';
 import {
-  generateSessionToken,
+  generateScopedServiceToken,
   getDaemonUrl,
-  serviceTokenScopeForParams,
   spawnExecutorFireAndForget,
 } from './spawn-executor.js';
 
@@ -40,9 +39,9 @@ export async function ensureRepoOriginAlignedForRepo(
   if (!repo.remote_url) return;
   if (!repo.local_path) return;
 
-  const sessionToken = generateSessionToken(
+  const sessionToken = generateScopedServiceToken(
     app as unknown as { settings: { authentication?: { secret?: string } } },
-    serviceTokenScopeForParams(params)
+    params
   );
 
   spawnExecutorFireAndForget(

--- a/apps/agor-daemon/src/utils/realign-repo-origin.ts
+++ b/apps/agor-daemon/src/utils/realign-repo-origin.ts
@@ -1,8 +1,9 @@
 import type { Application } from '@agor/core/feathers';
-import type { HookContext, Repo, RepoID } from '@agor/core/types';
+import type { AuthenticatedParams, HookContext, Repo, RepoID } from '@agor/core/types';
 import {
   generateSessionToken,
   getDaemonUrl,
+  serviceTokenScopeForParams,
   spawnExecutorFireAndForget,
 } from './spawn-executor.js';
 
@@ -15,24 +16,33 @@ import {
  */
 
 /** Look up the repo row, then realign. Use when caller only has a repoId. */
-export async function ensureRepoOriginAlignedById(app: Application, repoId: RepoID): Promise<void> {
+export async function ensureRepoOriginAlignedById(
+  app: Application,
+  repoId: RepoID,
+  params?: Partial<AuthenticatedParams>
+): Promise<void> {
   let repo: Repo;
   try {
-    repo = (await app.service('repos').get(repoId)) as Repo;
+    repo = (await app.service('repos').get(repoId, params as never)) as Repo;
   } catch {
     return;
   }
-  return ensureRepoOriginAlignedForRepo(app, repo);
+  return ensureRepoOriginAlignedForRepo(app, repo, params);
 }
 
 /** Realign using a Repo row the caller already has (no extra DB fetch before spawning). */
-export async function ensureRepoOriginAlignedForRepo(app: Application, repo: Repo): Promise<void> {
+export async function ensureRepoOriginAlignedForRepo(
+  app: Application,
+  repo: Repo,
+  params?: Partial<AuthenticatedParams>
+): Promise<void> {
   if (repo.repo_type !== 'remote') return;
   if (!repo.remote_url) return;
   if (!repo.local_path) return;
 
   const sessionToken = generateSessionToken(
-    app as unknown as { settings: { authentication?: { secret?: string } } }
+    app as unknown as { settings: { authentication?: { secret?: string } } },
+    serviceTokenScopeForParams(params)
   );
 
   spawnExecutorFireAndForget(
@@ -72,12 +82,14 @@ export function realignRepoOriginAfterPatchHook() {
     const repos = Array.isArray(result) ? result : [result];
     for (const repo of repos) {
       if (!repo?.repo_id) continue;
-      ensureRepoOriginAlignedForRepo(context.app as Application, repo).catch((err: unknown) => {
-        const message = err instanceof Error ? err.message : String(err);
-        console.warn(
-          `⚠️  [repos.after.patch] ensureRepoOriginAlignedForRepo failed for repo ${repo.repo_id}: ${message}`
-        );
-      });
+      ensureRepoOriginAlignedForRepo(context.app as Application, repo, context.params).catch(
+        (err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(
+            `⚠️  [repos.after.patch] ensureRepoOriginAlignedForRepo failed for repo ${repo.repo_id}: ${message}`
+          );
+        }
+      );
     }
     return context;
   };

--- a/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
@@ -1,0 +1,35 @@
+import type { AuthenticatedParams } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
+import { describe, expect, it } from 'vitest';
+import { createServiceToken, serviceTokenScopeForParams } from './spawn-executor';
+
+describe('executor service token scoping', () => {
+  it('copies tenant context into service token claims', () => {
+    const scope = serviceTokenScopeForParams({
+      tenant: { tenant_id: 'tenant-a' as never, source: 'auth_claim' },
+    } satisfies Partial<AuthenticatedParams>);
+
+    const token = createServiceToken('test-secret', '5m', scope);
+    const decoded = jwt.decode(token) as { tenant_id?: string; type?: string };
+
+    expect(decoded.type).toBe('service');
+    expect(decoded.tenant_id).toBe('tenant-a');
+  });
+
+  it('falls back to user tenant metadata when explicit params are absent', () => {
+    expect(
+      serviceTokenScopeForParams({
+        user: {
+          user_id: 'u1',
+          email: 'u1@example.test',
+          role: 'member',
+          tenant_id: 'tenant-from-user' as never,
+        },
+      })
+    ).toEqual({ tenant_id: 'tenant-from-user' });
+  });
+
+  it('omits tenant claim for single-tenant/internal calls without tenant context', () => {
+    expect(serviceTokenScopeForParams({})).toEqual({});
+  });
+});

--- a/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
@@ -1,7 +1,11 @@
 import type { AuthenticatedParams } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { describe, expect, it } from 'vitest';
-import { createServiceToken, serviceTokenScopeForParams } from './spawn-executor';
+import {
+  createServiceToken,
+  generateScopedServiceToken,
+  serviceTokenScopeForParams,
+} from './spawn-executor';
 
 describe('executor service token scoping', () => {
   it('copies tenant context into service token claims', () => {
@@ -31,5 +35,16 @@ describe('executor service token scoping', () => {
 
   it('omits tenant claim for single-tenant/internal calls without tenant context', () => {
     expect(serviceTokenScopeForParams({})).toEqual({});
+  });
+
+  it('generates tenant-scoped service tokens directly from params', () => {
+    const token = generateScopedServiceToken(
+      { settings: { authentication: { secret: 'test-secret' } } },
+      { tenant: { tenant_id: 'tenant-b' as never, source: 'auth_claim' } }
+    );
+    const decoded = jwt.decode(token) as { tenant_id?: string; type?: string };
+
+    expect(decoded.type).toBe('service');
+    expect(decoded.tenant_id).toBe('tenant-b');
   });
 });

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -870,6 +870,22 @@ export function generateSessionToken(
   return createServiceToken(jwtSecret, undefined, scope);
 }
 
+/**
+ * Generate a tenant-scoped executor service token from Feathers params.
+ *
+ * Prefer this over manually composing `generateSessionToken(app,
+ * serviceTokenScopeForParams(params))` so required-from-auth deployments do not
+ * accidentally drop tenant context on new executor call paths.
+ */
+export function generateScopedServiceToken(
+  app: {
+    settings: { authentication?: { secret?: string } };
+  },
+  params?: Partial<AuthenticatedParams>
+): string {
+  return generateSessionToken(app, serviceTokenScopeForParams(params));
+}
+
 // ============================================================================
 // Config-aware executor spawning
 // ============================================================================

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -843,14 +843,17 @@ export function createServiceToken(
  * @param app - FeathersJS application with sessionTokenService
  * @returns JWT access token
  */
-export function generateSessionToken(app: {
-  settings: { authentication?: { secret?: string } };
-}): string {
+export function generateSessionToken(
+  app: {
+    settings: { authentication?: { secret?: string } };
+  },
+  scope: Record<string, unknown> = {}
+): string {
   const jwtSecret = app.settings.authentication?.secret;
   if (!jwtSecret) {
     throw new Error('JWT secret not configured in app settings');
   }
-  return createServiceToken(jwtSecret);
+  return createServiceToken(jwtSecret, undefined, scope);
 }
 
 // ============================================================================

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -358,6 +358,13 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     return;
   }
 
+  let reportedExit = false;
+  const reportExit = (code: number | null): void => {
+    if (reportedExit) return;
+    reportedExit = true;
+    options.onExit?.(code);
+  };
+
   const executorProcess = spawn(cmd, args, {
     cwd,
     env: asUser ? undefined : { ...envWithDaemonUrl }, // When impersonating, env is in the command; otherwise pass to spawn
@@ -375,6 +382,11 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
 
   executorProcess.on('error', (error) => {
     console.error(`${logPrefix} Spawn error:`, error.message);
+    // child_process may emit `error` without a following `exit` when the
+    // executable itself cannot be spawned (for example, missing sudo in a dev
+    // image). Surface that through the normal onExit safety net so callers do
+    // not leave persistent rows stuck in in-progress states.
+    reportExit(127);
   });
 
   executorProcess.on('exit', (code) => {
@@ -383,7 +395,7 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     } else {
       console.error(`${logPrefix} Executor exited with code ${code}`);
     }
-    options.onExit?.(code);
+    reportExit(code);
   });
 
   executorProcess.stdin?.write(JSON.stringify(payload));
@@ -407,6 +419,13 @@ function spawnExecutorWithTemplate(
   console.log(`${logPrefix} Command: ${payload.command}`);
   console.log(`${logPrefix} Template command (first 200 chars): ${command.slice(0, 200)}...`);
 
+  let reportedExit = false;
+  const reportExit = (code: number | null): void => {
+    if (reportedExit) return;
+    reportedExit = true;
+    options.onExit?.(code);
+  };
+
   const executorProcess = spawn('sh', ['-c', command], {
     env: { ...process.env, LOG_LEVEL: logLevel },
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -424,6 +443,7 @@ function spawnExecutorWithTemplate(
 
   executorProcess.on('error', (error) => {
     console.error(`${logPrefix} Spawn error:`, error.message);
+    reportExit(127);
   });
 
   executorProcess.on('exit', (code) => {
@@ -436,7 +456,7 @@ function spawnExecutorWithTemplate(
         `${logPrefix} Executor exited with code ${code} (task: ${templateVariables.task_id})`
       );
     }
-    options.onExit?.(code);
+    reportExit(code);
   });
 
   executorProcess.stdin?.write(JSON.stringify(payload));

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -26,6 +26,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AgorExecutionSettings } from '@agor/core/config';
+import type { AuthenticatedParams } from '@agor/core/types';
 import {
   attachEnvFileCleanup,
   buildSpawnArgs,
@@ -832,6 +833,19 @@ export function createServiceToken(
     jwtSecret,
     expiresIn || '5m'
   );
+}
+
+/**
+ * Build extra JWT claims for executor/service tokens from authenticated service
+ * params. In Cloud required-from-auth mode, executor RPCs must carry the same
+ * tenant claim as the request that spawned them; otherwise the daemon handles
+ * them as the static/default tenant.
+ */
+export function serviceTokenScopeForParams(
+  params?: Partial<AuthenticatedParams>
+): Record<string, unknown> {
+  const tenantId = params?.tenant?.tenant_id ?? params?.tenant_id ?? params?.user?.tenant_id;
+  return tenantId ? { tenant_id: tenantId } : {};
 }
 
 /**

--- a/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/pages/guide/multiplayer-unix-isolation.mdx
@@ -214,14 +214,15 @@ agor ALL=(ALL) NOPASSWD: /usr/bin/readlink *
 - The file includes extensive comments and troubleshooting tips
 - Read the full file before deploying to production
 
-### 4. Enable RBAC and Unix Isolation
+### 4. Enable app RBAC and/or Unix Isolation
 
 Configure Agor's execution mode via config:
 
 ```yaml
 # ~/.agor/config.yaml
 execution:
-  # Enable RBAC system (default: false)
+  # Enable app-level branch ownership/visibility (default: false).
+  # This does not create Unix groups or require sudoers by itself.
   branch_rbac: true
 
   # Unix user mode (default: simple)
@@ -248,6 +249,10 @@ execution:
 - **`simple`** - Default, single user or fully trusted team, no setup required
 - **`insulated`** - Recommended for shared development, isolates daemon from executors
 - **`strict`** - Production environments, compliance requirements, full audit trail
+
+`branch_rbac` and `unix_user_mode` are intentionally independent: RBAC controls
+Agor app permissions; non-`simple` Unix modes control OS identities, Unix groups,
+and filesystem permissions.
 
 ### 4b. (Optional) Disable the Web Terminal
 

--- a/context/guides/rbac-and-unix-isolation.md
+++ b/context/guides/rbac-and-unix-isolation.md
@@ -263,7 +263,8 @@ Before enabling RBAC + Unix integration, ensure:
 ```yaml
 # ~/.agor/config.yaml
 execution:
-  # Enable RBAC + Unix integration
+  # Enable app-level RBAC. This does not create Unix groups or require sudoers
+  # unless paired with a non-simple unix_user_mode.
   branch_rbac: true
 
   # Unix user mode (choose one):
@@ -894,7 +895,7 @@ GET    /messages/:id                            # 403 if no view permission on s
 
 ## Conclusion
 
-Agor's RBAC + Unix integration brings back the benefits of shared development environments while adding modern multi-tenant security. By coupling app-layer permission checks with OS-layer enforcement, teams can collaborate closely while maintaining proper isolation and audit trails.
+Agor's RBAC and Unix integration bring back the benefits of shared development environments while adding modern multi-tenant security. App-layer permissions and OS-layer enforcement are configured independently: teams can enable RBAC for organization, then add Unix isolation when they need filesystem/process enforcement.
 
 **Start simple** (Mode 1: Open Access), **add RBAC when you need organization** (Mode 2: Soft Privacy), and **enable Unix integration when you need true security** (Mode 3: Hard Security).
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -30,6 +30,7 @@ import {
   requireDaemonUser,
   requirePublicBaseUrl,
   resolveBranchStorageConfig,
+  resolveExecutionSecurityMode,
   saveConfig,
   setConfigValue,
   unsetConfigValue,
@@ -426,6 +427,63 @@ describe('loadConfig cache', () => {
     expect(() => requireDaemonUser(loadConfigSync())).toThrow(
       /execution\.unix_user_mode is insulated or strict/
     );
+  });
+
+  it.each([
+    {
+      name: 'open access simple',
+      config: { execution: { branch_rbac: false, unix_user_mode: 'simple' } } as AgorConfig,
+      expected: {
+        appRbacEnabled: false,
+        unixUserMode: 'simple',
+        unixImpersonationEnabled: false,
+        unixFsIsolationEnabled: false,
+        unixGroupRefreshNeeded: false,
+        requiresDaemonUnixUser: false,
+        shouldInitUnixGroups: false,
+      },
+    },
+    {
+      name: 'app RBAC simple',
+      config: { execution: { branch_rbac: true, unix_user_mode: 'simple' } } as AgorConfig,
+      expected: {
+        appRbacEnabled: true,
+        unixUserMode: 'simple',
+        unixImpersonationEnabled: false,
+        unixFsIsolationEnabled: false,
+        unixGroupRefreshNeeded: false,
+        requiresDaemonUnixUser: false,
+        shouldInitUnixGroups: false,
+      },
+    },
+    {
+      name: 'Unix insulated without app RBAC',
+      config: { execution: { branch_rbac: false, unix_user_mode: 'insulated' } } as AgorConfig,
+      expected: {
+        appRbacEnabled: false,
+        unixUserMode: 'insulated',
+        unixImpersonationEnabled: true,
+        unixFsIsolationEnabled: true,
+        unixGroupRefreshNeeded: true,
+        requiresDaemonUnixUser: true,
+        shouldInitUnixGroups: true,
+      },
+    },
+    {
+      name: 'Unix strict with app RBAC',
+      config: { execution: { branch_rbac: true, unix_user_mode: 'strict' } } as AgorConfig,
+      expected: {
+        appRbacEnabled: true,
+        unixUserMode: 'strict',
+        unixImpersonationEnabled: true,
+        unixFsIsolationEnabled: true,
+        unixGroupRefreshNeeded: true,
+        requiresDaemonUnixUser: true,
+        shouldInitUnixGroups: true,
+      },
+    },
+  ])('resolves execution security mode: $name', ({ config, expected }) => {
+    expect(resolveExecutionSecurityMode(config)).toEqual(expected);
   });
 });
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -21,9 +21,13 @@ import {
   getDefaultConfig,
   getReposDir,
   initConfig,
+  isBranchRbacEnabled,
+  isUnixGroupRefreshNeeded,
+  isUnixImpersonationEnabled,
   loadConfig,
   loadConfigSync,
   PublicBaseUrlNotConfiguredError,
+  requireDaemonUser,
   requirePublicBaseUrl,
   resolveBranchStorageConfig,
   saveConfig,
@@ -398,6 +402,30 @@ describe('loadConfig cache', () => {
     expect(() => loadConfigSync()).toThrow(/opportunistic.*deprecated/s);
     // And async path stays consistent.
     await expect(loadConfig()).rejects.toThrow(/opportunistic.*deprecated/s);
+  });
+
+  it('treats branch_rbac as app-level only in simple Unix mode', async () => {
+    await writeConfigFile({
+      execution: { branch_rbac: true, unix_user_mode: 'simple' },
+    });
+
+    expect(isBranchRbacEnabled()).toBe(true);
+    expect(isUnixImpersonationEnabled()).toBe(false);
+    expect(isUnixGroupRefreshNeeded()).toBe(false);
+    expect(() => requireDaemonUser(loadConfigSync())).not.toThrow();
+  });
+
+  it('requires daemon.unix_user only for non-simple Unix modes', async () => {
+    await writeConfigFile({
+      execution: { branch_rbac: false, unix_user_mode: 'insulated' },
+    });
+
+    expect(isBranchRbacEnabled()).toBe(false);
+    expect(isUnixImpersonationEnabled()).toBe(true);
+    expect(isUnixGroupRefreshNeeded()).toBe(true);
+    expect(() => requireDaemonUser(loadConfigSync())).toThrow(
+      /execution\.unix_user_mode is insulated or strict/
+    );
   });
 });
 

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -765,7 +765,7 @@ export function getCredential(key: ConfigCredentialKey): string | undefined {
  * @example
  * ```ts
  * const daemonUser = getDaemonUser();
- * if (daemonUser && isBranchRbacEnabled()) {
+ * if (daemonUser && isUnixGroupRefreshNeeded()) {
  *   runAsUser('git status', { asUser: daemonUser });
  * }
  * ```
@@ -808,7 +808,7 @@ export function requireDaemonUser(config: AgorConfig): string {
 
   if (unixIsolationEnabled) {
     throw new Error(
-      'Unix isolation is enabled (branch_rbac or unix_user_mode) but daemon.unix_user is not configured.\n' +
+      'Unix isolation is enabled (execution.unix_user_mode is insulated or strict) but daemon.unix_user is not configured.\n' +
         'Please set daemon.unix_user in ~/.agor/config.yaml to the user running the daemon.\n' +
         'Example:\n' +
         '  daemon:\n' +

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -800,10 +800,11 @@ export function requireDaemonUser(config: AgorConfig): string {
     return config.daemon.unix_user;
   }
 
-  // 2. Check if Unix isolation is enabled - if so, require explicit config
+  // 2. Check if Unix impersonation/isolation is enabled - if so, require explicit config.
+  // Branch RBAC alone is logical app-level authorization and does not require
+  // Unix users/groups in Cloud simple mode.
   const unixIsolationEnabled =
-    config.execution?.branch_rbac === true ||
-    (config.execution?.unix_user_mode && config.execution.unix_user_mode !== 'simple');
+    config.execution?.unix_user_mode && config.execution.unix_user_mode !== 'simple';
 
   if (unixIsolationEnabled) {
     throw new Error(
@@ -827,9 +828,11 @@ export function requireDaemonUser(config: AgorConfig): string {
 }
 
 /**
- * Check if branch RBAC is enabled
+ * Check if logical branch RBAC is enabled.
  *
- * When RBAC is enabled, git operations need to run via sudo to get fresh group memberships.
+ * This controls app-level branch ownership/visibility. It does not necessarily
+ * imply Unix group/ACL setup; Cloud simple mode may enable branch RBAC while
+ * running all filesystem work as the daemon user.
  *
  * @returns true if branch_rbac is enabled in config
  */
@@ -915,20 +918,13 @@ export function ensureBranchStorageModeAllowed(mode: import('./types').BranchSto
  * Whether the daemon needs to wrap git operations in `sudo -u` to pick up
  * supplemental Unix groups created after daemon startup.
  *
- * `sudo -u` is the only way to force a fresh `initgroups()` on a long-running
- * daemon process — without it, `agor_wt_*` groups added at runtime are
- * invisible and ACL-gated git operations fail with permission errors.
+ * Cloud simple mode can enable logical `branch_rbac` without Unix groups. Only
+ * non-simple Unix modes require group refresh / sudo wrapping.
  *
- * Why: Issue #1140 — in the open-access default (no RBAC, simple unix mode)
- * no supplemental groups are ever created, so wrapping in sudo is pure
- * overhead AND breaks for users who never configured passwordless sudoers.
- *
- * Returns true when:
- * - `branch_rbac` is enabled (RBAC creates `agor_wt_*` groups), OR
- * - `unix_user_mode` is `insulated` or `strict` (per-user impersonation)
+ * Returns true when `unix_user_mode` is `insulated` or `strict`.
  */
 export function isUnixGroupRefreshNeeded(): boolean {
-  return isBranchRbacEnabled() || isUnixImpersonationEnabled();
+  return isUnixImpersonationEnabled();
 }
 
 // =============================================================================

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -803,8 +803,7 @@ export function requireDaemonUser(config: AgorConfig): string {
   // 2. Check if Unix impersonation/isolation is enabled - if so, require explicit config.
   // Branch RBAC alone is logical app-level authorization and does not require
   // Unix users/groups in Cloud simple mode.
-  const unixIsolationEnabled =
-    config.execution?.unix_user_mode && config.execution.unix_user_mode !== 'simple';
+  const unixIsolationEnabled = resolveExecutionSecurityMode(config).requiresDaemonUnixUser;
 
   if (unixIsolationEnabled) {
     throw new Error(
@@ -827,6 +826,48 @@ export function requireDaemonUser(config: AgorConfig): string {
   return user;
 }
 
+export interface ResolvedExecutionSecurityMode {
+  /** App-layer branch ownership/visibility/action enforcement. */
+  appRbacEnabled: boolean;
+  /** Configured Unix execution mode with default applied. */
+  unixUserMode: import('./types').UnixUserMode;
+  /** Whether executors/terminals may run as non-daemon OS users. */
+  unixImpersonationEnabled: boolean;
+  /** Whether branch filesystem permissions/groups should be materialized. */
+  unixFsIsolationEnabled: boolean;
+  /** Whether git/executor spawns need fresh supplemental Unix groups. */
+  unixGroupRefreshNeeded: boolean;
+  /** Whether daemon.unix_user must be explicitly configured. */
+  requiresDaemonUnixUser: boolean;
+  /** Whether new repos/branches should initialize Unix groups. */
+  shouldInitUnixGroups: boolean;
+}
+
+/**
+ * Resolve the execution security posture from config.
+ *
+ * Keep this as the single semantic boundary between app-layer RBAC and
+ * OS/filesystem isolation:
+ * - `branch_rbac` controls Agor app permissions only.
+ * - non-`simple` `unix_user_mode` controls Unix impersonation/groups/FS ACLs.
+ */
+export function resolveExecutionSecurityMode(
+  config: AgorConfig = loadConfigSync()
+): ResolvedExecutionSecurityMode {
+  const unixUserMode = config.execution?.unix_user_mode ?? 'simple';
+  const unixIsolationEnabled = unixUserMode !== 'simple';
+
+  return {
+    appRbacEnabled: config.execution?.branch_rbac === true,
+    unixUserMode,
+    unixImpersonationEnabled: unixIsolationEnabled,
+    unixFsIsolationEnabled: unixIsolationEnabled,
+    unixGroupRefreshNeeded: unixIsolationEnabled,
+    requiresDaemonUnixUser: unixIsolationEnabled,
+    shouldInitUnixGroups: unixIsolationEnabled,
+  };
+}
+
 /**
  * Check if logical branch RBAC is enabled.
  *
@@ -838,8 +879,7 @@ export function requireDaemonUser(config: AgorConfig): string {
  */
 export function isBranchRbacEnabled(): boolean {
   try {
-    const config = loadConfigSync();
-    return config.execution?.branch_rbac === true;
+    return resolveExecutionSecurityMode().appRbacEnabled;
   } catch {
     return false;
   }
@@ -853,9 +893,7 @@ export function isBranchRbacEnabled(): boolean {
  */
 export function isUnixImpersonationEnabled(): boolean {
   try {
-    const config = loadConfigSync();
-    const mode = config.execution?.unix_user_mode;
-    return mode !== undefined && mode !== 'simple';
+    return resolveExecutionSecurityMode().unixImpersonationEnabled;
   } catch {
     return false;
   }
@@ -924,7 +962,7 @@ export function ensureBranchStorageModeAllowed(mode: import('./types').BranchSto
  * Returns true when `unix_user_mode` is `insulated` or `strict`.
  */
 export function isUnixGroupRefreshNeeded(): boolean {
-  return isUnixImpersonationEnabled();
+  return resolveExecutionSecurityMode().unixGroupRefreshNeeded;
 }
 
 // =============================================================================

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -237,6 +237,12 @@ export interface AgorExternalLaunchSettings {
   allow_admin_roles?: boolean;
 
   /**
+   * Trust a verified assertion email when linking launch auth to an existing
+   * local user that does not yet have this provider identity recorded.
+   */
+  trust_verified_email_for_linking?: boolean;
+
+  /**
    * Optional HTTP(S) URL shown in the unauthenticated UI when external launch
    * sign-in is unavailable, missing, expired, or invalid.
    */

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -115,9 +115,11 @@ export interface AgorDaemonSettings {
    *  agents discover others via agor_search_tools (default: true) */
   mcpToolSearch?: boolean;
 
-  /** Unix user the daemon runs as. Used to ensure daemon has access to all Unix groups.
-   * Required when Unix isolation is enabled (branch_rbac or unix_user_mode).
-   * In dev mode without isolation, falls back to current process user. */
+  /** Unix user the daemon runs as. Used to refresh supplemental Unix groups.
+   * Required when Unix impersonation/isolation is enabled (`unix_user_mode`
+   * is `insulated` or `strict`). App-level `branch_rbac` alone does not
+   * require Unix impersonation. In dev mode without isolation, falls back to
+   * current process user. */
   unix_user?: string;
 
   /** Instance label for deployment identification (e.g., "staging", "prod-us-east").

--- a/packages/core/src/seed/dev-fixtures.ts
+++ b/packages/core/src/seed/dev-fixtures.ts
@@ -12,7 +12,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import type { BranchID, RepoID, UUID } from '@agor/core/types';
-import { isUnixGroupRefreshNeeded, loadConfigSync } from '../config/config-manager';
+import { loadConfigSync, resolveExecutionSecurityMode } from '../config/config-manager';
 import { resolveMultiTenancyConfig } from '../config/multitenancy';
 import {
   BoardObjectRepository,
@@ -90,8 +90,8 @@ export async function seedDevFixtures(options: SeedOptions): Promise<SeedResult>
 
     // Setup Unix integration only when filesystem isolation is enabled.
     let unixIntegrationService: UnixIntegrationService | null = null;
-    const unixGroupRefreshNeeded = isUnixGroupRefreshNeeded();
-    if (unixGroupRefreshNeeded) {
+    const unixSecurityMode = resolveExecutionSecurityMode();
+    if (unixSecurityMode.unixFsIsolationEnabled) {
       const config = loadConfigSync();
       const daemonUser = config.daemon?.unix_user || os.userInfo().username;
       console.log(`🔐 Unix integration active (daemon user: ${daemonUser})`);

--- a/packages/core/src/seed/dev-fixtures.ts
+++ b/packages/core/src/seed/dev-fixtures.ts
@@ -12,7 +12,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import type { BranchID, RepoID, UUID } from '@agor/core/types';
-import { isBranchRbacEnabled, loadConfigSync } from '../config/config-manager';
+import { isUnixGroupRefreshNeeded, loadConfigSync } from '../config/config-manager';
 import { resolveMultiTenancyConfig } from '../config/multitenancy';
 import {
   BoardObjectRepository,
@@ -88,13 +88,13 @@ export async function seedDevFixtures(options: SeedOptions): Promise<SeedResult>
     const boardRepo = new BoardRepository(db);
     const boardObjectRepo = new BoardObjectRepository(db);
 
-    // Setup Unix integration if RBAC is enabled
+    // Setup Unix integration only when filesystem isolation is enabled.
     let unixIntegrationService: UnixIntegrationService | null = null;
-    const rbacEnabled = isBranchRbacEnabled();
-    if (rbacEnabled) {
+    const unixGroupRefreshNeeded = isUnixGroupRefreshNeeded();
+    if (unixGroupRefreshNeeded) {
       const config = loadConfigSync();
       const daemonUser = config.daemon?.unix_user || os.userInfo().username;
-      console.log(`🔐 RBAC enabled - Unix integration active (daemon user: ${daemonUser})`);
+      console.log(`🔐 Unix integration active (daemon user: ${daemonUser})`);
       unixIntegrationService = new UnixIntegrationService(db, new DirectExecutor(), {
         enabled: true,
         daemonUser,


### PR DESCRIPTION
## Summary

- Decouples app-level branch RBAC from Unix impersonation / filesystem group setup.
- Keeps trusted launch / one-time launch email auth compatible with Agor Cloud-style `branch_rbac: true` + `unix_user_mode: simple` deployments.
- Adds tenant-aware auth/service-token plumbing for trusted launch and executor calls.
- Centralizes runtime security mode semantics so new code paths can ask one resolver whether they need app RBAC, Unix impersonation, or filesystem isolation.

## Root cause / context

`execution.branch_rbac` is an Agor app authorization switch, but several paths treated it like a signal that Unix groups, daemon Unix users, or executor filesystem permissions should exist. That made Cloud/simple-mode setups brittle: enabling RBAC for app visibility/actions could accidentally require OS-level impersonation or filesystem preparation.

Trusted launch also needs auth-scoped startup and tenant-aware lookup behavior without inheriting branch filesystem assumptions from RBAC.

## Implementation details

- Unix group creation and filesystem permission refreshes are now controlled by non-`simple` `execution.unix_user_mode`, not by `execution.branch_rbac`.
- Added `resolveExecutionSecurityMode()` in core config as the central semantic boundary:
  - app RBAC (`branch_rbac`) controls app permissions/visibility/actions;
  - Unix impersonation / filesystem isolation are derived from `unix_user_mode`.
- Updated branch/repo/service registration/dev fixture paths to use the resolved mode instead of ad-hoc flag checks.
- Gated Unix sync hooks (`unix.sync-*`, owner/group/board grant sync, non-owner session group sync, and user Unix sync) on Unix filesystem/impersonation mode instead of app RBAC.
- Added `generateScopedServiceToken()` and scoped register-hook/branch-owner service-token creation so executor/service call paths preserve tenant context consistently.
- Scoped trusted launch/auth user lookups by tenant claim where applicable, and kept auth-scoped runtime startup cleanup separate from normal permission checks.
- Made the health monitor tenant-aware for startup/background checks so required-from-auth Cloud deployments do not run branch service calls without tenant context.
- Fixed build-info lookup to read `.build-info` from the daemon dist entrypoint directory, matching where the build script writes it.
- Preserved simple-mode behavior: RBAC-only Cloud setups do not require Unix group setup, daemon Unix user config, or branch filesystem impersonation.

## Tests / checks

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/core test -- src/config/config-manager.test.ts`
- `pnpm --filter @agor/daemon test -- src/services/health-monitor.test.ts src/setup/build-info.test.ts src/services/branch-owners.test.ts src/auth/launch-auth.test.ts src/utils/spawn-executor.service-token.test.ts src/utils/git-impersonation.test.ts src/utils/realign-repo-origin.test.ts src/services/terminals.test.ts`

## Caveats

- Trusted launch remains explicitly gated by config/env and verified email semantics; this PR does not broaden who can launch.
- Existing Unix filesystem permissions/groups are not cleaned up when switching back to simple mode; this matches current config semantics.