### PR TITLE
Inherit tenant scope for nested service calls

### DIFF
--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -153,6 +153,30 @@ describe('createTenantDatabaseScopeAroundHook', () => {
     expect(db.transaction).not.toHaveBeenCalled();
   });
 
+  it('inherits an active tenant database scope for nested internal service calls', async () => {
+    const { db } = makePgDb();
+    const hook = createTenantDatabaseScopeAroundHook({
+      db: db as never,
+      jwtSecret: 'secret',
+      config: {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      },
+    });
+    const context = { params: {} } as never;
+
+    await runWithTenantDatabaseScope(db as never, 'tenant-inherited', async () => {
+      await hook(context, async () => {
+        expect(getCurrentTenantId()).toBe('tenant-inherited');
+      });
+    });
+
+    expect((context as { params: { tenant?: unknown } }).params.tenant).toEqual({
+      tenant_id: 'tenant-inherited',
+      source: 'explicit',
+    });
+  });
+
   it('reuses tenant context already attached to a socket connection', async () => {
     const { db } = makePgDb();
     const hook = createTenantDatabaseScopeAroundHook({

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -4,9 +4,9 @@ import {
   resolveTenantContext,
   TenantResolutionError,
 } from '@agor/core/config';
-import { type Database, runWithTenantDatabaseScope } from '@agor/core/db';
+import { type Database, getCurrentTenantId, runWithTenantDatabaseScope } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
-import type { HookContext } from '@agor/core/types';
+import type { HookContext, TenantID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 
@@ -60,6 +60,11 @@ export function createTenantDatabaseScopeAroundHook(options: TenantDatabaseScope
       'tenant_id' in connectionTenant
     ) {
       return connectionTenant as ReturnType<typeof resolveTenantContext>;
+    }
+
+    const inheritedTenantId = getCurrentTenantId();
+    if (inheritedTenantId) {
+      return { tenant_id: inheritedTenantId as TenantID, source: 'explicit' as const };
     }
 
     return resolveTenantContext(multiTenancy, {


### PR DESCRIPTION
## Summary
- let the tenant DB scope hook reuse an already-active tenant scope for nested internal service calls
- covers nested calls made while handling authenticated Cloud runtime requests, e.g. tasks.patch/session lookup and board permission updates
- adds regression coverage for required_from_auth internal nesting

## Tests
- pnpm --filter @agor/daemon test -- tenant-db-scope
- pnpm --filter @agor/core build
- pnpm --filter @agor/daemon typecheck

## Dev deploy
- rebuilt agor-daemon:dev from e23ebf7 + this patch
- loaded into kind cluster agor-cloud-workspace-cell-data-plane-erd
- upgraded Helm release agor-runtime-dev-main
- /health reports 0.23.0, buildSha e23ebf7d56cf, builtAt 2026-06-29T04:43:50Z