### PR TITLE
Harden tenant scope inheritance

### DIFF
--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -7,7 +7,6 @@ import {
   TenantResolutionError,
 } from '@agor/core/config';
 import {
-  type Database,
   eq,
   generateId,
   hash,
@@ -15,6 +14,7 @@ import {
   reattributeLegacyAnonymousRows,
   runWithTenantDatabaseScope,
   select,
+  type TenantScopeAwareDatabase,
   update,
   users,
 } from '@agor/core/db';
@@ -101,7 +101,7 @@ export interface LaunchAuthResult {
 }
 
 export interface LaunchAuthServiceOptions {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   config: AgorConfig;
   jwtSecret: string;
   accessTokenTtl: SignOptions['expiresIn'];
@@ -194,7 +194,7 @@ function derivedEmail(provider: string, issuer: string, subject: string): string
 }
 
 async function chooseLocalEmail(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   requestedEmail: string | undefined,
   key: string,
   provider: string,
@@ -254,7 +254,7 @@ function mapRole(
 }
 
 async function findUserByExternalIdentity(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   key: string
 ): Promise<typeof users.$inferSelect | null> {
   const rows = await select(db).from(users).all();
@@ -266,7 +266,7 @@ async function findUserByExternalIdentity(
 }
 
 async function findUserByTrustedEmail(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   email: string | undefined,
   key: string,
   settings: ResolvedLaunchSettings,

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -624,6 +624,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
 
   const { db } = await initializeDatabase(DB_PATH, {
     tenantId: multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined,
+    requireTenantScope: multiTenancy.mode === 'required_from_auth',
     skipFirstRunAdminBootstrap: config.external_launch?.enabled === true,
   });
 

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -814,7 +814,8 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
             return null;
           }
         }),
-      cliSessions
+      cliSessions,
+      { tenantId: multiTenancy.static_tenant_id }
     );
   });
 }

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -41,7 +41,7 @@ import {
   saveConfig,
   TenantResolutionError,
 } from '@agor/core/config';
-import { getDatabaseUrl } from '@agor/core/db';
+import { getDatabaseUrl, runWithTenantDatabaseScope } from '@agor/core/db';
 import {
   authenticate,
   Forbidden,
@@ -686,7 +686,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
         },
       });
     }
-    startOpenSourceTelemetryUsageSummaryInterval(db);
+    startOpenSourceTelemetryUsageSummaryInterval(db, { tenantId: multiTenancy.static_tenant_id });
     config.telemetry = {
       ...config.telemetry,
       last_reported_version: TELEMETRY_AGOR_VERSION,
@@ -798,13 +798,15 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // --------------------------------------------------------------------------
   runPostStartJob('cli-watcher-rehydrate', async () => {
     const { rehydrateCliWatchers } = await import('./services/claude-cli-integration.js');
-    await rehydrateCliWatchers(app, async (branchId) => {
-      try {
-        const branch = (await app.service('branches').get(branchId)) as { path?: string };
-        return branch?.path ?? null;
-      } catch {
-        return null;
-      }
-    });
+    await runWithTenantDatabaseScope(db, multiTenancy.static_tenant_id, () =>
+      rehydrateCliWatchers(app, async (branchId) => {
+        try {
+          const branch = (await app.service('branches').get(branchId)) as { path?: string };
+          return branch?.path ?? null;
+        } catch {
+          return null;
+        }
+      })
+    );
   });
 }

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -797,16 +797,24 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // the restart is detected and the task is closed.
   // --------------------------------------------------------------------------
   runPostStartJob('cli-watcher-rehydrate', async () => {
-    const { rehydrateCliWatchers } = await import('./services/claude-cli-integration.js');
-    await runWithTenantDatabaseScope(db, multiTenancy.static_tenant_id, () =>
-      rehydrateCliWatchers(app, async (branchId) => {
-        try {
-          const branch = (await app.service('branches').get(branchId)) as { path?: string };
-          return branch?.path ?? null;
-        } catch {
-          return null;
-        }
-      })
+    const { rehydrateCliWatchers, scanCliWatcherRehydrateSessions } = await import(
+      './services/claude-cli-integration.js'
+    );
+    const cliSessions = await runWithTenantDatabaseScope(db, multiTenancy.static_tenant_id, () =>
+      scanCliWatcherRehydrateSessions(app)
+    );
+    await rehydrateCliWatchers(
+      app,
+      (branchId) =>
+        runWithTenantDatabaseScope(db, multiTenancy.static_tenant_id, async () => {
+          try {
+            const branch = (await app.service('branches').get(branchId)) as { path?: string };
+            return branch?.path ?? null;
+          } catch {
+            return null;
+          }
+        }),
+      cliSessions
     );
   });
 }

--- a/apps/agor-daemon/src/knowledge/pgvector.ts
+++ b/apps/agor-daemon/src/knowledge/pgvector.ts
@@ -1,4 +1,4 @@
-import { type Database, executeRaw, isPostgresDatabase, sql } from '@agor/core/db';
+import { executeRaw, isPostgresDatabase, sql, type TenantScopeAwareDatabase } from '@agor/core/db';
 
 export interface KnowledgePgvectorCapability {
   available: boolean;
@@ -32,7 +32,7 @@ export function semanticUnavailableMessage(reason?: string | null): string {
   return `Semantic Knowledge search is unavailable${reason ? `: ${reason}` : ''}. ${SETUP_HINT}`;
 }
 
-async function ensureEmbeddingTenantIsolation(db: Database): Promise<void> {
+async function ensureEmbeddingTenantIsolation(db: TenantScopeAwareDatabase): Promise<void> {
   await executeRaw(
     db,
     sql`ALTER TABLE kb_unit_embeddings ADD COLUMN IF NOT EXISTS tenant_id text DEFAULT 'default' NOT NULL`
@@ -55,7 +55,9 @@ async function ensureEmbeddingTenantIsolation(db: Database): Promise<void> {
   );
 }
 
-async function readCapability(db: Database): Promise<KnowledgePgvectorStorageState> {
+async function readCapability(
+  db: TenantScopeAwareDatabase
+): Promise<KnowledgePgvectorStorageState> {
   if (!isPostgresDatabase(db)) {
     return {
       available: false,
@@ -121,13 +123,13 @@ async function readCapability(db: Database): Promise<KnowledgePgvectorStorageSta
 }
 
 export async function getKnowledgePgvectorCapability(
-  db: Database
+  db: TenantScopeAwareDatabase
 ): Promise<KnowledgePgvectorCapability> {
   return readCapability(db);
 }
 
 export async function ensureKnowledgePgvectorStorage(
-  db: Database
+  db: TenantScopeAwareDatabase
 ): Promise<KnowledgePgvectorCapability> {
   if (!isPostgresDatabase(db)) return readCapability(db);
 

--- a/apps/agor-daemon/src/knowledge/units.ts
+++ b/apps/agor-daemon/src/knowledge/units.ts
@@ -1,7 +1,6 @@
 import type { AgorConfig } from '@agor/core/config';
 import {
   and,
-  type Database,
   eq,
   KnowledgeDocumentRepository,
   kbDocuments,
@@ -9,6 +8,7 @@ import {
   kbNamespaces,
   type ReplaceKnowledgeUnitInput,
   select,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { KnowledgeDocumentVersionID } from '@agor/core/types';
 import { DEFAULT_KNOWLEDGE_CHUNKING } from './embeddings.js';
@@ -47,7 +47,7 @@ export function knowledgeUnitsForMarkdown(
 }
 
 export async function rebuildCurrentKnowledgeUnits(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   config: AgorConfig,
   options: { embeddingConfigured: boolean }
 ): Promise<number> {

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -14,7 +14,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { shortId, UserApiKeysRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { DaemonServicesConfig, ServiceGroupName, SessionID, UserID } from '@agor/core/types';
@@ -63,7 +63,7 @@ function mcpRequestDebug(...args: unknown[]): void {
  */
 export interface McpContext {
   app: Application;
-  db: Database;
+  db: TenantScopeAwareDatabase;
   userId: UserID;
   /** Current Agor session context, when the caller supplied or authenticated with one. */
   sessionId?: SessionID;
@@ -405,7 +405,7 @@ function createMcpServer(
  */
 export function setupMCPRoutes(
   app: Application,
-  db: Database,
+  db: TenantScopeAwareDatabase,
   toolSearchEnabled = true,
   servicesConfig?: DaemonServicesConfig
 ): void {

--- a/apps/agor-daemon/src/mcp/tokens.ts
+++ b/apps/agor-daemon/src/mcp/tokens.ts
@@ -25,7 +25,12 @@
  */
 
 import { MCP_TOKEN } from '@agor/core/config';
-import { type Database, generateId, SessionRepository, shortId } from '@agor/core/db';
+import {
+  generateId,
+  SessionRepository,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import {
   MCP_TOKEN_AUDIENCE,
@@ -68,7 +73,7 @@ export interface McpTokenContext {
 }
 
 export interface McpTokenInitOptions {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   /** Token lifetime in ms. Falls back to `MCP_TOKEN.DEFAULT_EXPIRATION_MS` (24h). */
   expirationMs?: number;
   /** Override `Date.now()` for tests. */

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -24,10 +24,10 @@ import {
   ArtifactRepository,
   BoardRepository,
   type BranchRepository,
-  type Database,
   ScheduleRepository,
   type SessionRepository,
   shortId,
+  type TenantScopeAwareDatabase,
   UserMCPOAuthTokenRepository,
   type UsersRepository,
 } from '@agor/core/db';
@@ -362,7 +362,7 @@ interface RouteParams extends Params {
  * Interface for dependencies needed by hook registration.
  */
 export interface RegisterHooksContext {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   app: Application & { io?: import('socket.io').Server };
   config: AgorConfig;
   svcEnabled: (group: string) => boolean;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -25,10 +25,10 @@ import {
   BoardRepository,
   type BranchRepository,
   type Database,
+  runWithoutTenantDatabaseScope,
   ScheduleRepository,
   type SessionRepository,
   shortId,
-  tenantDatabaseScope,
   UserMCPOAuthTokenRepository,
   type UsersRepository,
 } from '@agor/core/db';
@@ -2660,11 +2660,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             // buffered message as a PR/issue comment. Must happen before queue
             // processing so the response is posted before the next prompt starts.
             //
-            // tenantDatabaseScope.exit() breaks ALS inheritance so this
+            // runWithoutTenantDatabaseScope() breaks ALS inheritance so this
             // setImmediate fires outside the outer tenantDatabaseScopeAround
             // transaction — otherwise the gateway I/O runs inside that
             // transaction and can leave a zombie idle-in-transaction backend.
-            tenantDatabaseScope.exit(() =>
+            runWithoutTenantDatabaseScope(() =>
               setImmediate(async () => {
                 try {
                   const gatewayService = context.app.service(
@@ -2688,7 +2688,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               // Same ALS-escape pattern: queue processing must run outside the
               // outer transaction so it uses a fresh connection and doesn't
               // block behind the in-flight turn lock from within that transaction.
-              tenantDatabaseScope.exit(() =>
+              runWithoutTenantDatabaseScope(() =>
                 setImmediate(async () => {
                   try {
                     console.log(

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -25,7 +25,6 @@ import {
   BoardRepository,
   type BranchRepository,
   type Database,
-  runWithoutTenantDatabaseScope,
   ScheduleRepository,
   type SessionRepository,
   shortId,
@@ -148,7 +147,10 @@ import {
   serviceTokenScopeForParams,
   spawnExecutorFireAndForget,
 } from './utils/spawn-executor.js';
-import { createTenantDatabaseScopeAroundHook } from './utils/tenant-db-scope.js';
+import {
+  createTenantDatabaseScopeAroundHook,
+  deferWithTenantDatabaseScope,
+} from './utils/tenant-db-scope.js';
 
 const DEBUG_MCP_TOKENS =
   process.env.AGOR_DEBUG_MCP_TOKENS === '1' || process.env.DEBUG?.includes('mcp-tokens');
@@ -2660,54 +2662,43 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             // buffered message as a PR/issue comment. Must happen before queue
             // processing so the response is posted before the next prompt starts.
             //
-            // runWithoutTenantDatabaseScope() breaks ALS inheritance so this
-            // setImmediate fires outside the outer tenantDatabaseScopeAround
-            // transaction — otherwise the gateway I/O runs inside that
-            // transaction and can leave a zombie idle-in-transaction backend.
-            runWithoutTenantDatabaseScope(() =>
-              setImmediate(async () => {
-                try {
-                  const gatewayService = context.app.service(
-                    'gateway'
-                  ) as unknown as GatewayService;
-                  await gatewayService.flushGitHubBuffer(session.session_id);
-                  await gatewayService.updateProgress({
-                    session_id: session.session_id,
-                    state: 'done',
-                  });
-                } catch (error) {
-                  console.warn(
-                    `[gateway] Failed to flush gateway buffers/status for session ${shortId(session.session_id)}:`,
-                    error
-                  );
-                }
-              })
-            );
+            // Defer outside the just-finished transaction, then re-enter a fresh
+            // tenant scope so gateway DB work keeps Cloud RLS context without
+            // inheriting a committed transaction object.
+            deferWithTenantDatabaseScope(db, context.params, async () => {
+              try {
+                const gatewayService = context.app.service('gateway') as unknown as GatewayService;
+                await gatewayService.flushGitHubBuffer(session.session_id);
+                await gatewayService.updateProgress({
+                  session_id: session.session_id,
+                  state: 'done',
+                });
+              } catch (error) {
+                console.warn(
+                  `[gateway] Failed to flush gateway buffers/status for session ${shortId(session.session_id)}:`,
+                  error
+                );
+              }
+            });
 
             if (shouldDrainQueueAfterSessionPostTurnPatch(session, context.params)) {
-              // Same ALS-escape pattern: queue processing must run outside the
-              // outer transaction so it uses a fresh connection and doesn't
-              // block behind the in-flight turn lock from within that transaction.
-              runWithoutTenantDatabaseScope(() =>
-                setImmediate(async () => {
-                  try {
-                    console.log(
-                      `🔄 [SessionsService.after.patch] Session ${shortId(session.session_id)} became promptable (${session.status}), checking for queued tasks...`
-                    );
+              // Same fresh-scope pattern: queue processing must run outside the
+              // outer transaction but still inside the session tenant for RLS.
+              deferWithTenantDatabaseScope(db, context.params, async () => {
+                try {
+                  console.log(
+                    `🔄 [SessionsService.after.patch] Session ${shortId(session.session_id)} became promptable (${session.status}), checking for queued tasks...`
+                  );
 
-                    await sessionsService.triggerQueueProcessing(
-                      session.session_id,
-                      context.params
-                    );
-                  } catch (error) {
-                    console.error(
-                      `❌ [SessionsService.after.patch] Failed to process queue for session ${shortId(session.session_id)}:`,
-                      error
-                    );
-                    // Don't throw - queue processing failure shouldn't break session patches
-                  }
-                })
-              );
+                  await sessionsService.triggerQueueProcessing(session.session_id, context.params);
+                } catch (error) {
+                  console.error(
+                    `❌ [SessionsService.after.patch] Failed to process queue for session ${shortId(session.session_id)}:`,
+                    error
+                  );
+                  // Don't throw - queue processing failure shouldn't break session patches
+                }
+              });
             } else {
               console.log(
                 `⏭️  [SessionsService.after.patch] Queue drain suppressed for session ${shortId(session.session_id)} (suppressTerminalQueueProcessing or not ready)`

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -19,7 +19,6 @@ import {
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
-  runWithoutTenantDatabaseScope,
   ScheduleRepository,
   SessionMCPServerRepository,
   SessionRepository,
@@ -134,7 +133,10 @@ import {
 } from './utils/session-task-state.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
-import { createTenantDatabaseScopeAroundHook } from './utils/tenant-db-scope.js';
+import {
+  createTenantDatabaseScopeAroundHook,
+  deferWithTenantDatabaseScope,
+} from './utils/tenant-db-scope.js';
 import {
   createUploadMiddleware,
   enforceParsedTotalUploadSize,
@@ -283,14 +285,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const tenantDatabaseScopeAround = createTenantDatabaseScopeAroundHook({ db, config, jwtSecret });
 
   /**
-   * Schedule fn in a new event-loop tick, outside any ALS tenant scope.
+   * Schedule fn in a new event-loop tick with a fresh tenant DB scope.
    * Always use this instead of bare setImmediate inside route/service code —
-   * a bare setImmediate inherits the active tenant DB scope (which may
-   * hold a committed Postgres transaction) and causes silent DB hangs when
-   * that stale connection is reused.
+   * bare setImmediate inherits the active transaction ALS store, while a plain
+   * ALS exit loses Postgres RLS tenant context for session/task lookups.
    */
-  function deferOutsideScope(fn: () => Promise<void>): void {
-    runWithoutTenantDatabaseScope(() => setImmediate(fn));
+  function deferInFreshTenantScope(params: RouteParams, fn: () => Promise<void>): void {
+    deferWithTenantDatabaseScope(db, params, fn);
   }
 
   const registerAuthenticatedRoute: typeof registerAuthenticatedRouteBase = (
@@ -1173,7 +1174,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       const { setPendingCliTask } = await import('./services/claude-cli-integration.js');
       setPendingCliTask(sessionId as SessionID, taskId as TaskID, messageStartIndex);
 
-      deferOutsideScope(async () => {
+      deferInFreshTenantScope(params, async () => {
         try {
           const targetUserId = session.created_by;
           if (!targetUserId) {
@@ -1245,9 +1246,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // Background spawn + failure handling. Returning the patched Task to the
     // caller before this resolves matches the previous behavior — the HTTP
     // response should not block on the executor process being live.
-    // deferOutsideScope escapes any inherited ALS tenant scope so the executor
-    // spawn uses a fresh DB connection and not a stale committed transaction.
-    deferOutsideScope(async () => {
+    // deferInFreshTenantScope uses a fresh DB connection and tenant RLS scope
+    // instead of inheriting a stale committed transaction.
+    deferInFreshTenantScope(params, async () => {
       try {
         console.log(
           `🚀 [Daemon] Routing ${session.agentic_tool} to Feathers/WebSocket executor (task ${shortId(taskId)})`
@@ -1466,7 +1467,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               app.service('tasks').emit('queued', queuedTask);
 
               if (sessionCanStartTask(lockedSession.status, lockedSession.ready_for_prompt)) {
-                deferOutsideScope(async () => {
+                deferInFreshTenantScope(params, async () => {
                   try {
                     await sessionsService.triggerQueueProcessing(id as SessionID, params);
                   } catch (error) {
@@ -2128,7 +2129,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         );
 
         if (result.success) {
-          deferOutsideScope(async () => {
+          deferInFreshTenantScope(params, async () => {
             try {
               await sessionsServiceWithHooks.triggerQueueProcessing(id as SessionID, params);
             } catch (error) {
@@ -2221,7 +2222,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
       if (!queueRetryScheduled.has(sessionId)) {
         queueRetryScheduled.add(sessionId);
-        deferOutsideScope(async () => {
+        deferInFreshTenantScope(params, async () => {
           queueRetryScheduled.delete(sessionId);
           try {
             await processNextQueuedTask(sessionId, params);

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -14,7 +14,6 @@ import {
 } from '@agor/core/config';
 import {
   BranchRepository,
-  type Database,
   generateId,
   MCPServerRepository,
   MessagesRepository,
@@ -24,6 +23,7 @@ import {
   SessionRepository,
   shortId,
   TaskRepository,
+  type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import { MANAGED_ENV_EXECUTION_MODE_DEFAULT } from '@agor/core/environment/webhook';
@@ -205,7 +205,7 @@ function isPaginated<T>(result: T[] | Paginated<T>): result is Paginated<T> {
  * Interface for dependencies needed by route registration.
  */
 export interface RegisterRoutesContext {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   app: Application & { io?: import('socket.io').Server };
   config: AgorConfig;
   svcEnabled: (group: string) => boolean;

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -19,12 +19,12 @@ import {
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
+  runWithoutTenantDatabaseScope,
   ScheduleRepository,
   SessionMCPServerRepository,
   SessionRepository,
   shortId,
   TaskRepository,
-  tenantDatabaseScope,
   UsersRepository,
 } from '@agor/core/db';
 import { MANAGED_ENV_EXECUTION_MODE_DEFAULT } from '@agor/core/environment/webhook';
@@ -285,12 +285,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   /**
    * Schedule fn in a new event-loop tick, outside any ALS tenant scope.
    * Always use this instead of bare setImmediate inside route/service code —
-   * a bare setImmediate inherits the active tenantDatabaseScope (which may
+   * a bare setImmediate inherits the active tenant DB scope (which may
    * hold a committed Postgres transaction) and causes silent DB hangs when
    * that stale connection is reused.
    */
   function deferOutsideScope(fn: () => Promise<void>): void {
-    tenantDatabaseScope.exit(() => setImmediate(fn));
+    runWithoutTenantDatabaseScope(() => setImmediate(fn));
   }
 
   const registerAuthenticatedRoute: typeof registerAuthenticatedRouteBase = (

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -15,7 +15,6 @@ import {
   and,
   BoardRepository,
   BranchRepository,
-  type Database,
   eq,
   inArray,
   MCPServerRepository,
@@ -24,6 +23,7 @@ import {
   select,
   sessionMcpServers,
   shortId,
+  type TenantScopeAwareDatabase,
   UserMCPOAuthTokenRepository,
   visibleSessionReferenceAccessExists,
 } from '@agor/core/db';
@@ -138,7 +138,7 @@ import { spawnExecutor } from './utils/spawn-executor.js';
  * Interface for dependencies needed by service registration.
  */
 export interface RegisterServicesContext {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   app: Application & { io?: import('socket.io').Server };
   config: AgorConfig;
   svcEnabled: (group: string) => boolean;

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -30,8 +30,8 @@ import {
   ArtifactTrustGrantRepository,
   BoardRepository,
   BranchRepository,
-  type Database,
   shortId,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
@@ -225,7 +225,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
   private boardRepo: BoardRepository;
   private app: Application;
   /** Held for `resolveUserEnvironment` (scope-aware env-var resolution). */
-  private dbRef: Database;
+  private dbRef: TenantScopeAwareDatabase;
 
   /**
    * In-memory ring buffer for console logs.
@@ -336,7 +336,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     return { folderPath: validated.folderPath, matchedBranchId: branchId };
   }
 
-  constructor(db: Database, app: Application) {
+  constructor(db: TenantScopeAwareDatabase, app: Application) {
     const artifactRepo = new ArtifactRepository(db);
     super(artifactRepo, {
       id: 'artifact_id',
@@ -2558,6 +2558,9 @@ function escapeEnvValue(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
 }
 
-export function createArtifactsService(db: Database, app: Application): ArtifactsService {
+export function createArtifactsService(
+  db: TenantScopeAwareDatabase,
+  app: Application
+): ArtifactsService {
   return new ArtifactsService(db, app);
 }

--- a/apps/agor-daemon/src/services/assistant-knowledge.ts
+++ b/apps/agor-daemon/src/services/assistant-knowledge.ts
@@ -1,8 +1,8 @@
 import {
   BranchRepository,
-  type Database,
   KnowledgeNamespaceRepository,
   shortId,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type {
   AssistantKnowledgeConfig,
@@ -62,7 +62,7 @@ async function uniqueAssistantNamespaceSlug(
 }
 
 export async function ensureAssistantKnowledgeNamespace(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   branchId: BranchID,
   userId?: UserID | null
 ): Promise<{ namespace: KnowledgeNamespace; branch: Branch }> {

--- a/apps/agor-daemon/src/services/board-comments.ts
+++ b/apps/agor-daemon/src/services/board-comments.ts
@@ -12,7 +12,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { BoardCommentsRepository, type Database } from '@agor/core/db';
+import { BoardCommentsRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { BoardComment, QueryParams, UUID } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 
@@ -42,7 +42,7 @@ export class BoardCommentsService extends DrizzleService<
 > {
   private commentsRepo: BoardCommentsRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const commentsRepo = new BoardCommentsRepository(db);
     super(commentsRepo, {
       id: 'comment_id',
@@ -185,6 +185,6 @@ export class BoardCommentsService extends DrizzleService<
 /**
  * Service factory function
  */
-export function createBoardCommentsService(db: Database): BoardCommentsService {
+export function createBoardCommentsService(db: TenantScopeAwareDatabase): BoardCommentsService {
   return new BoardCommentsService(db);
 }

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -9,7 +9,7 @@ import {
   type BoardObjectFindFilters,
   type BoardObjectFindOptions,
   BoardObjectRepository,
-  type Database,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type {
   BoardEntityObject,
@@ -85,7 +85,7 @@ export class BoardObjectsService {
   private boardObjectRepo: BoardObjectRepository;
   public emit?: (event: string, data: BoardEntityObject, params?: BoardObjectParams) => void;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     this.boardObjectRepo = new BoardObjectRepository(db);
   }
 
@@ -287,6 +287,6 @@ export class BoardObjectsService {
 /**
  * Service factory function
  */
-export function createBoardObjectsService(db: Database): BoardObjectsService {
+export function createBoardObjectsService(db: TenantScopeAwareDatabase): BoardObjectsService {
   return new BoardObjectsService(db);
 }

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -6,7 +6,11 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { BoardObjectRepository, BoardRepository, type Database } from '@agor/core/db';
+import {
+  BoardObjectRepository,
+  BoardRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import {
   ASSISTANT_WELCOME_NOTE_OBJECT_ID,
   buildAssistantWelcomeNoteObject,
@@ -52,7 +56,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
   private emitBoardObjectPatched?: (boardObject: BoardObjectPatchedEventPayload) => void;
 
   constructor(
-    db: Database,
+    db: TenantScopeAwareDatabase,
     emitBoardObjectPatched?: (boardObject: BoardObjectPatchedEventPayload) => void
   ) {
     const boardRepo = new BoardRepository(db);
@@ -491,7 +495,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
  * Service factory function
  */
 export function createBoardsService(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   emitBoardObjectPatched?: (boardObject: BoardObjectPatchedEventPayload) => void
 ): BoardsService {
   return new BoardsService(db, emitBoardObjectPatched);

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -19,8 +19,8 @@ import {
   BoardRepository,
   BranchRepository,
   type BranchWithZoneAndSessions,
-  type Database,
   KnowledgeNamespaceRepository,
+  type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
@@ -134,7 +134,7 @@ interface ManagedProcess {
 export class BranchesService extends DrizzleService<Branch, Partial<Branch>, BranchParams> {
   private branchRepo: BranchRepository;
   private boardRepo: BoardRepository;
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
   private app: Application;
   private processes = new Map<BranchID, ManagedProcess>();
   // Cache board-objects service reference (lazy-loaded to avoid circular deps)
@@ -146,7 +146,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     patch: (id: string, data: { zone_id?: string | null }) => Promise<unknown>;
   };
 
-  constructor(db: Database, app: Application) {
+  constructor(db: TenantScopeAwareDatabase, app: Application) {
     const branchRepo = new BranchRepository(db);
     super(branchRepo, {
       id: 'branch_id',
@@ -2417,6 +2417,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 /**
  * Service factory function
  */
-export function createBranchesService(db: Database, app: Application): BranchesService {
+export function createBranchesService(
+  db: TenantScopeAwareDatabase,
+  app: Application
+): BranchesService {
   return new BranchesService(db, app);
 }

--- a/apps/agor-daemon/src/services/card-types.ts
+++ b/apps/agor-daemon/src/services/card-types.ts
@@ -6,7 +6,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { CardTypeRepository, type Database } from '@agor/core/db';
+import { CardTypeRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { CardType, QueryParams } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 
@@ -15,7 +15,7 @@ export type CardTypeParams = QueryParams<{
 }>;
 
 export class CardTypesService extends DrizzleService<CardType, Partial<CardType>, CardTypeParams> {
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     super(new CardTypeRepository(db), {
       id: 'card_type_id',
       resourceType: 'CardType',
@@ -27,6 +27,6 @@ export class CardTypesService extends DrizzleService<CardType, Partial<CardType>
   }
 }
 
-export function createCardTypesService(db: Database): CardTypesService {
+export function createCardTypesService(db: TenantScopeAwareDatabase): CardTypesService {
   return new CardTypesService(db);
 }

--- a/apps/agor-daemon/src/services/cards.ts
+++ b/apps/agor-daemon/src/services/cards.ts
@@ -8,7 +8,11 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { BoardObjectRepository, CardRepository, type Database } from '@agor/core/db';
+import {
+  BoardObjectRepository,
+  CardRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type {
   BoardEntityObject,
   BoardID,
@@ -32,7 +36,7 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   private cardRepo: CardRepository;
   private boardObjectRepo: BoardObjectRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const cardRepo = new CardRepository(db);
     super(cardRepo, {
       id: 'card_id',
@@ -223,6 +227,6 @@ export class CardsService extends DrizzleService<Card, Partial<Card>, CardParams
   }
 }
 
-export function createCardsService(db: Database): CardsService {
+export function createCardsService(db: TenantScopeAwareDatabase): CardsService {
   return new CardsService(db);
 }

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -23,7 +23,7 @@ import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { resolveApiKey } from '@agor/core/config';
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import type { SDKUserMessage } from '@agor/core/sdk';
 import { Claude } from '@agor/core/sdk';
 import type {
@@ -233,7 +233,7 @@ async function validateApiKey(tool: string, key: string): Promise<boolean> {
   }
 }
 
-export function createCheckAuthService(db: Database) {
+export function createCheckAuthService(db: TenantScopeAwareDatabase) {
   return {
     async create(
       data: { tool: string; apiKey?: string },

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -54,6 +54,7 @@ import {
 import { type AgorConfig, resolveMultiTenancyConfig } from '@agor/core/config';
 import {
   generateId,
+  getCurrentTenantId,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
   SessionRepository,
@@ -98,18 +99,30 @@ function getDb(app: Application): TenantScopeAwareDatabase | null {
   return db ?? null;
 }
 
-function getCliCallbackTenantId(app: Application): string {
+const cliWatcherTenantBySession = new Map<string, string>();
+
+function getCliFallbackTenantId(app: Application): string {
   const config = app.get('config') as AgorConfig | undefined;
   return resolveMultiTenancyConfig(config ?? {}).static_tenant_id;
 }
 
+function captureCliWatcherTenantId(app: Application): string {
+  return getCurrentTenantId() ?? getCliFallbackTenantId(app);
+}
+
+function rememberCliWatcherTenant(sessionId: string, tenantId: string): void {
+  cliWatcherTenantBySession.set(sessionId, tenantId);
+}
+
 async function runCliCallbackDatabaseScope<T>(
   app: Application,
+  sessionId: string,
   work: () => Promise<T>
 ): Promise<T> {
   const db = getDb(app);
   if (!db) return work();
-  return runWithTenantDatabaseScope(db, getCliCallbackTenantId(app), work);
+  const tenantId = cliWatcherTenantBySession.get(sessionId) ?? captureCliWatcherTenantId(app);
+  return runWithTenantDatabaseScope(db, tenantId, work);
 }
 
 /** Per-turn accumulator used by the sink between `user_message` and `turn_end`. */
@@ -339,7 +352,7 @@ function startTaskWatchdog(app: Application, sessionId: SessionID): void {
   stopTaskWatchdog(sessionId);
   runWithoutTenantDatabaseScope(() => {
     const timer = setInterval(() => {
-      void runCliCallbackDatabaseScope(app, async () => {
+      void runCliCallbackDatabaseScope(app, sessionId, async () => {
         const active = activeCliTurn.get(sessionId);
         if (!active) {
           // Turn already closed by some other path — stop watching.
@@ -377,7 +390,7 @@ function startTaskWatchdog(app: Application, sessionId: SessionID): void {
 export function buildCliPersister(app: Application): CliWatcherStatePersister {
   return {
     async saveOffset(sessionId, update) {
-      await runCliCallbackDatabaseScope(app, async () => {
+      await runCliCallbackDatabaseScope(app, sessionId, async () => {
         const db = getDb(app);
         if (!db) return;
         const repo = new SessionRepository(db);
@@ -969,7 +982,7 @@ export function buildCliEventSink(app: Application): CliWatcherEventSink {
   // Same code path = same analytics + DB writes whether the close was
   // triggered by claude itself or by the watchdog noticing claude died.
   const scopedSink: CliWatcherEventSink = (sessionId, event) =>
-    runCliCallbackDatabaseScope(app, async () => {
+    runCliCallbackDatabaseScope(app, sessionId, async () => {
       await sink(sessionId, event);
     });
 
@@ -1416,13 +1429,18 @@ export async function onCliSessionCreated(
   // 2) Register the JSONL watcher (sits idle until `claude` writes its first line).
   try {
     const reg = getCliWatcherRegistry(app);
-    await reg.register({
-      sessionId: session.session_id,
-      cwd: branchCwd,
-      homeDir,
-      startOffset: session.cli_state?.watcher_offset ?? 0,
+    const watcherTenantId = captureCliWatcherTenantId(app);
+    await runWithoutTenantDatabaseScope(async () => {
+      rememberCliWatcherTenant(session.session_id, watcherTenantId);
+      await reg.register({
+        sessionId: session.session_id,
+        cwd: branchCwd,
+        homeDir,
+        startOffset: session.cli_state?.watcher_offset ?? 0,
+      });
     });
   } catch (err) {
+    cliWatcherTenantBySession.delete(session.session_id);
     console.warn(
       `[claude-cli-integration] watcher register failed for session ${session.session_id}:`,
       err
@@ -1465,6 +1483,7 @@ export async function onCliSessionEnded(app: Application, sessionId: SessionID):
   // mid-turn" path.
   stopTaskWatchdog(sessionId);
   activeCliTurn.delete(sessionId);
+  cliWatcherTenantBySession.delete(sessionId);
 }
 
 /**
@@ -1486,7 +1505,8 @@ export async function scanCliWatcherRehydrateSessions(app: Application): Promise
 export async function rehydrateCliWatchers(
   app: Application,
   branchCwdLookup: (branchId: string) => Promise<string | null>,
-  sessions: Session[]
+  sessions: Session[],
+  options: { tenantId: string }
 ): Promise<void> {
   const reg = getCliWatcherRegistry(app);
   let rehydrated = 0;
@@ -1502,6 +1522,7 @@ export async function rehydrateCliWatchers(
         // the very first post-restart event sees the right task linkage.
         // This also starts watchdog timers, so keep it outside any tenant DB
         // transaction ALS; watcher and watchdog callbacks enter fresh DB scope.
+        rememberCliWatcherTenant(session.session_id, options.tenantId);
         primeActiveCliTurnFromSession(app, session);
         await reg.register({
           sessionId: session.session_id,
@@ -1512,6 +1533,7 @@ export async function rehydrateCliWatchers(
       });
       rehydrated++;
     } catch (err) {
+      cliWatcherTenantBySession.delete(session.session_id);
       console.warn(
         `[claude-cli-integration] failed to rehydrate watcher for ${session.session_id}:`,
         err

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -51,8 +51,11 @@ import {
   permissionModeForCli,
   slugForCwd,
 } from '@agor/core/claude-cli';
+import { type AgorConfig, resolveMultiTenancyConfig } from '@agor/core/config';
 import {
   generateId,
+  runWithoutTenantDatabaseScope,
+  runWithTenantDatabaseScope,
   SessionRepository,
   shortId,
   TaskRepository,
@@ -93,6 +96,20 @@ import {
 function getDb(app: Application): TenantScopeAwareDatabase | null {
   const db = (app.get('database') ?? app.get('db')) as TenantScopeAwareDatabase | undefined;
   return db ?? null;
+}
+
+function getCliCallbackTenantId(app: Application): string {
+  const config = app.get('config') as AgorConfig | undefined;
+  return resolveMultiTenancyConfig(config ?? {}).static_tenant_id;
+}
+
+async function runCliCallbackDatabaseScope<T>(
+  app: Application,
+  work: () => Promise<T>
+): Promise<T> {
+  const db = getDb(app);
+  if (!db) return work();
+  return runWithTenantDatabaseScope(db, getCliCallbackTenantId(app), work);
 }
 
 /** Per-turn accumulator used by the sink between `user_message` and `turn_end`. */
@@ -320,55 +337,63 @@ let closeActiveTurnDispatch:
 
 function startTaskWatchdog(app: Application, sessionId: SessionID): void {
   stopTaskWatchdog(sessionId);
-  const timer = setInterval(async () => {
-    const active = activeCliTurn.get(sessionId);
-    if (!active) {
-      // Turn already closed by some other path — stop watching.
-      stopTaskWatchdog(sessionId);
-      return;
-    }
-    const idleMs = Date.now() - (Date.parse(active.lastTimestamp) || active.startedAtMs);
-    if (idleMs < WATCHDOG_IDLE_THRESHOLD_MS) return;
-    const alive = await isClaudeRunningFor(sessionId);
-    if (alive) return;
-    console.log(
-      JSON.stringify({
-        layer: 'claude-cli-watcher.watchdog',
-        sessionId,
-        idleMs,
-        note: 'claude process not running — closing stale turn',
-      })
-    );
-    try {
-      await closeActiveTurnDispatch?.(sessionId, 'claude_exited', new Date().toISOString());
-    } catch (err) {
-      console.warn('[claude-cli-watcher.watchdog] close dispatch failed', err);
-    }
-    stopTaskWatchdog(sessionId);
-  }, WATCHDOG_TICK_MS);
-  // Don't keep the event loop alive just for the watchdog.
-  timer.unref?.();
-  watchdogTimers.set(sessionId, timer);
+  runWithoutTenantDatabaseScope(() => {
+    const timer = setInterval(() => {
+      void runCliCallbackDatabaseScope(app, async () => {
+        const active = activeCliTurn.get(sessionId);
+        if (!active) {
+          // Turn already closed by some other path — stop watching.
+          stopTaskWatchdog(sessionId);
+          return;
+        }
+        const idleMs = Date.now() - (Date.parse(active.lastTimestamp) || active.startedAtMs);
+        if (idleMs < WATCHDOG_IDLE_THRESHOLD_MS) return;
+        const alive = await isClaudeRunningFor(sessionId);
+        if (alive) return;
+        console.log(
+          JSON.stringify({
+            layer: 'claude-cli-watcher.watchdog',
+            sessionId,
+            idleMs,
+            note: 'claude process not running — closing stale turn',
+          })
+        );
+        try {
+          await closeActiveTurnDispatch?.(sessionId, 'claude_exited', new Date().toISOString());
+        } catch (err) {
+          console.warn('[claude-cli-watcher.watchdog] close dispatch failed', err);
+        }
+        stopTaskWatchdog(sessionId);
+      }).catch((err: unknown) => {
+        console.warn('[claude-cli-watcher.watchdog] scoped tick failed', err);
+      });
+    }, WATCHDOG_TICK_MS);
+    // Don't keep the event loop alive just for the watchdog.
+    timer.unref?.();
+    watchdogTimers.set(sessionId, timer);
+  });
 }
 
 export function buildCliPersister(app: Application): CliWatcherStatePersister {
   return {
     async saveOffset(sessionId, update) {
-      const db = getDb(app);
-      if (!db) return;
-      const repo = new SessionRepository(db);
-      const row = await repo.findById(sessionId).catch(() => null);
-      if (!row) return;
-      const existing = row.cli_state ?? {};
-      const patch = {
-        cli_state: {
-          ...existing,
-          watcher_offset: update.watcher_offset,
-          last_event_ts: update.last_event_ts ?? existing.last_event_ts,
-          last_event_uuid: update.last_event_uuid ?? existing.last_event_uuid,
-        },
-      } satisfies Partial<Session>;
-      await repo.update(sessionId, patch);
+      await runCliCallbackDatabaseScope(app, async () => {
+        const db = getDb(app);
+        if (!db) return;
+        const repo = new SessionRepository(db);
+        const row = await repo.findById(sessionId).catch(() => null);
+        if (!row) return;
+        const existing = row.cli_state ?? {};
+        const patch = {
+          cli_state: {
+            ...existing,
+            watcher_offset: update.watcher_offset,
+            last_event_ts: update.last_event_ts ?? existing.last_event_ts,
+            last_event_uuid: update.last_event_uuid ?? existing.last_event_uuid,
+          },
+        } satisfies Partial<Session>;
+        await repo.update(sessionId, patch);
+      });
     },
   };
 }
@@ -943,19 +968,24 @@ export function buildCliEventSink(app: Application): CliWatcherEventSink {
   // a `turn_end` event and lets the sink's existing branch handle it.
   // Same code path = same analytics + DB writes whether the close was
   // triggered by claude itself or by the watchdog noticing claude died.
+  const scopedSink: CliWatcherEventSink = (sessionId, event) =>
+    runCliCallbackDatabaseScope(app, async () => {
+      await sink(sessionId, event);
+    });
+
   closeActiveTurnDispatch = async (
     sessionId: SessionID,
     _reason: 'turn_end' | 'claude_exited',
     ts: string
   ) => {
-    await sink(sessionId, {
+    await scopedSink(sessionId, {
       type: 'turn_end',
       messageId: 'watchdog-synthetic',
       timestamp: ts,
     });
   };
 
-  return sink;
+  return scopedSink;
 }
 
 /**
@@ -1442,35 +1472,43 @@ export async function onCliSessionEnded(app: Application, sessionId: SessionID):
  * daemon startup. Picks up wherever the previous daemon process left off
  * via the persisted `watcher_offset` byte counter.
  */
-export async function rehydrateCliWatchers(
-  app: Application,
-  branchCwdLookup: (branchId: string) => Promise<string | null>
-): Promise<void> {
+export async function scanCliWatcherRehydrateSessions(app: Application): Promise<Session[]> {
   const db = getDb(app);
-  if (!db) return;
+  if (!db) return [];
   const repo = new SessionRepository(db);
 
   // Scan for active CLI sessions. We don't have a direct "give me active
   // claude-code-cli sessions" query, so do the simple thing: list all
   // sessions, filter in memory. Numbers are small (hundreds at most).
-  const all = await repo.findAll();
+  return repo.findAll();
+}
+
+export async function rehydrateCliWatchers(
+  app: Application,
+  branchCwdLookup: (branchId: string) => Promise<string | null>,
+  sessions: Session[]
+): Promise<void> {
   const reg = getCliWatcherRegistry(app);
   let rehydrated = 0;
-  for (const session of all) {
+  for (const session of sessions) {
     if (session.agentic_tool !== 'claude-code-cli') continue;
     if (session.status === 'completed' || session.status === 'failed') continue;
     if (session.archived) continue;
     const cwd = await branchCwdLookup(session.branch_id);
     if (!cwd) continue;
-    // Prime the in-memory active turn BEFORE registering the watcher so
-    // the very first post-restart event sees the right task linkage.
-    primeActiveCliTurnFromSession(app, session);
     try {
-      await reg.register({
-        sessionId: session.session_id,
-        cwd,
-        homeDir: resolveHomeDirForCliSession(session),
-        startOffset: session.cli_state?.watcher_offset ?? 0,
+      await runWithoutTenantDatabaseScope(async () => {
+        // Prime the in-memory active turn BEFORE registering the watcher so
+        // the very first post-restart event sees the right task linkage.
+        // This also starts watchdog timers, so keep it outside any tenant DB
+        // transaction ALS; watcher and watchdog callbacks enter fresh DB scope.
+        primeActiveCliTurnFromSession(app, session);
+        await reg.register({
+          sessionId: session.session_id,
+          cwd,
+          homeDir: resolveHomeDirForCliSession(session),
+          startOffset: session.cli_state?.watcher_offset ?? 0,
+        });
       });
       rehydrated++;
     } catch (err) {

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -1453,7 +1453,7 @@ export async function rehydrateCliWatchers(
   // Scan for active CLI sessions. We don't have a direct "give me active
   // claude-code-cli sessions" query, so do the simple thing: list all
   // sessions, filter in memory. Numbers are small (hundreds at most).
-  const all = await repo.findAll().catch(() => [] as Session[]);
+  const all = await repo.findAll();
   const reg = getCliWatcherRegistry(app);
   let rehydrated = 0;
   for (const session of all) {

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -52,11 +52,11 @@ import {
   slugForCwd,
 } from '@agor/core/claude-cli';
 import {
-  type Database,
   generateId,
   SessionRepository,
   shortId,
   TaskRepository,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import {
@@ -90,8 +90,8 @@ import {
  * and the cast lives in exactly one place. Returns `null` rather than
  * throwing because the test harness wires apps without a DB.
  */
-function getDb(app: Application): Database | null {
-  const db = (app.get('database') ?? app.get('db')) as Database | undefined;
+function getDb(app: Application): TenantScopeAwareDatabase | null {
+  const db = (app.get('database') ?? app.get('db')) as TenantScopeAwareDatabase | undefined;
   return db ?? null;
 }
 

--- a/apps/agor-daemon/src/services/claude-models.ts
+++ b/apps/agor-daemon/src/services/claude-models.ts
@@ -7,7 +7,7 @@
  */
 
 import { resolveApiKey } from '@agor/core/config';
-import { type Database, shortId } from '@agor/core/db';
+import { shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { AVAILABLE_CLAUDE_MODEL_ALIASES, DEFAULT_CLAUDE_MODEL } from '@agor/core/models';
 import type { Params, UserID } from '@agor/core/types';
 import Anthropic from '@anthropic-ai/sdk';
@@ -96,7 +96,7 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, message: string):
 }
 
 export class ClaudeModelsService {
-  constructor(private db: Database) {}
+  constructor(private db: TenantScopeAwareDatabase) {}
 
   async find(params?: AuthenticatedParams): Promise<ClaudeModelsResult> {
     const userId = params?.user?.user_id;
@@ -152,6 +152,6 @@ export class ClaudeModelsService {
   }
 }
 
-export function createClaudeModelsService(db: Database): ClaudeModelsService {
+export function createClaudeModelsService(db: TenantScopeAwareDatabase): ClaudeModelsService {
   return new ClaudeModelsService(db);
 }

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -12,7 +12,7 @@ import {
   resolveApiKey,
   saveConfig,
 } from '@agor/core/config';
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
   type AgenticToolName,
@@ -122,11 +122,11 @@ function maskCredentials(config: AgorConfig): AgorConfig {
  * Config service class
  */
 export class ConfigService {
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
   /** App reference injected after registration for cross-service calls */
   app?: Application;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     this.db = db;
   }
 
@@ -390,6 +390,6 @@ export class ConfigService {
 /**
  * Service factory function
  */
-export function createConfigService(db: Database): ConfigService {
+export function createConfigService(db: TenantScopeAwareDatabase): ConfigService {
   return new ConfigService(db);
 }

--- a/apps/agor-daemon/src/services/copilot-models.ts
+++ b/apps/agor-daemon/src/services/copilot-models.ts
@@ -25,7 +25,7 @@
  */
 
 import { resolveApiKey } from '@agor/core/config';
-import { type Database, shortId } from '@agor/core/db';
+import { shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { COPILOT_MODEL_METADATA, DEFAULT_COPILOT_MODEL } from '@agor/core/models';
 import type { Params, UserID } from '@agor/core/types';
 import { CopilotClient, type ModelInfo } from '@github/copilot-sdk';
@@ -70,7 +70,7 @@ interface AuthenticatedParams extends Params {
 }
 
 export class CopilotModelsService {
-  constructor(private db: Database) {}
+  constructor(private db: TenantScopeAwareDatabase) {}
 
   async find(params?: AuthenticatedParams): Promise<CopilotModelsResult> {
     const userId = params?.user?.user_id;
@@ -134,6 +134,6 @@ export class CopilotModelsService {
   }
 }
 
-export function createCopilotModelsService(db: Database): CopilotModelsService {
+export function createCopilotModelsService(db: TenantScopeAwareDatabase): CopilotModelsService {
   return new CopilotModelsService(db);
 }

--- a/apps/agor-daemon/src/services/cursor-models.ts
+++ b/apps/agor-daemon/src/services/cursor-models.ts
@@ -8,7 +8,7 @@
  */
 
 import { resolveApiKey } from '@agor/core/config';
-import { type Database, shortId } from '@agor/core/db';
+import { shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { CURSOR_MODEL_METADATA, DEFAULT_CURSOR_MODEL } from '@agor/core/models';
 import type { Params, UserID } from '@agor/core/types';
 import { Cursor, type SDKModel } from '@cursor/sdk';
@@ -69,7 +69,7 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, message: string):
 }
 
 export class CursorModelsService {
-  constructor(private db: Database) {}
+  constructor(private db: TenantScopeAwareDatabase) {}
 
   async find(params?: AuthenticatedParams): Promise<CursorModelsResult> {
     const userId = params?.user?.user_id;
@@ -110,6 +110,6 @@ export class CursorModelsService {
   }
 }
 
-export function createCursorModelsService(db: Database): CursorModelsService {
+export function createCursorModelsService(db: TenantScopeAwareDatabase): CursorModelsService {
   return new CursorModelsService(db);
 }

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -6,7 +6,12 @@
  * managed branch checkout.
  */
 
-import { BranchRepository, type Database, SessionRepository, UsersRepository } from '@agor/core/db';
+import {
+  BranchRepository,
+  SessionRepository,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, SessionID, UserID } from '@agor/core/types';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
@@ -58,7 +63,7 @@ export class FilesService {
   private usersRepo: UsersRepository;
 
   constructor(
-    private db: Database,
+    private db: TenantScopeAwareDatabase,
     private app: Application
   ) {
     this.sessionRepo = new SessionRepository(db);
@@ -145,6 +150,6 @@ export class FilesService {
 /**
  * Service factory function
  */
-export function createFilesService(db: Database, app: Application): FilesService {
+export function createFilesService(db: TenantScopeAwareDatabase, app: Application): FilesService {
   return new FilesService(db, app);
 }

--- a/apps/agor-daemon/src/services/gateway-channels-test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-test.ts
@@ -10,7 +10,7 @@
  * values.
  */
 
-import { type Database, GatewayChannelRepository } from '@agor/core/db';
+import { GatewayChannelRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { NotFound } from '@agor/core/feathers';
 import { getConnector } from '@agor/core/gateway';
 import type { AuthenticatedParams, ChannelType, SlackTestResult } from '@agor/core/types';
@@ -48,7 +48,7 @@ function resolveEffectiveConfig(
 /**
  * Factory for the `gateway-channels/test` service.
  */
-export function createGatewayChannelsTestService(db: Database) {
+export function createGatewayChannelsTestService(db: TenantScopeAwareDatabase) {
   const channelRepo = new GatewayChannelRepository(db);
 
   return {

--- a/apps/agor-daemon/src/services/gateway-channels.ts
+++ b/apps/agor-daemon/src/services/gateway-channels.ts
@@ -6,7 +6,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, GatewayChannelRepository } from '@agor/core/db';
+import { GatewayChannelRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { GatewayChannel } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 
@@ -14,7 +14,7 @@ export class GatewayChannelsService extends DrizzleService<
   GatewayChannel,
   Partial<GatewayChannel>
 > {
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const repo = new GatewayChannelRepository(db);
     super(repo, {
       id: 'id',
@@ -30,6 +30,6 @@ export class GatewayChannelsService extends DrizzleService<
 /**
  * Service factory function
  */
-export function createGatewayChannelsService(db: Database): GatewayChannelsService {
+export function createGatewayChannelsService(db: TenantScopeAwareDatabase): GatewayChannelsService {
   return new GatewayChannelsService(db);
 }

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1,3 +1,4 @@
+import { getCurrentTenantId } from '@agor/core/db';
 import type { GatewayChannel, ThreadSessionMap, User } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -120,6 +121,44 @@ function makeGatewayHarness(args: {
 }
 
 describe('GatewayService Slack thread catch-up', () => {
+  it('runs listener inbound callbacks inside a fresh channel tenant DB scope', async () => {
+    const seenTenants: Array<string | undefined> = [];
+    const app = {
+      service: vi.fn(),
+    };
+    const service = new GatewayService({ run: vi.fn() } as never, app as never);
+    vi.spyOn(service, 'create').mockImplementation(async () => {
+      seenTenants.push(getCurrentTenantId() as string | undefined);
+      return { success: true, sessionId: 'sess-1', created: false };
+    });
+
+    const channel = {
+      ...slackChannel,
+      tenant_id: 'tenant-channel',
+    } as GatewayChannel & { tenant_id: string };
+
+    await (
+      service as unknown as {
+        handleListenerInboundMessage(
+          channel: GatewayChannel,
+          tenantId: string | undefined,
+          msg: {
+            threadId: string;
+            text: string;
+            userId: string;
+            metadata?: Record<string, unknown>;
+          }
+        ): Promise<void>;
+      }
+    ).handleListenerInboundMessage(channel, channel.tenant_id, {
+      threadId: 'C123-100.000000',
+      text: 'hello',
+      userId: 'U123',
+    });
+
+    expect(seenTenants).toEqual(['tenant-channel']);
+  });
+
   it('fetches missed Slack messages after the last delivered cursor and advances the cursor', async () => {
     const sendMessage = vi.fn(async () => '104.000000');
     const fetchThreadHistory = vi.fn(async () => ({

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -12,7 +12,10 @@ import {
   type Database,
   GatewayChannelRepository,
   GatewayOutboundMessageRepository,
+  getCurrentTenantId,
   MCPServerRepository,
+  runWithoutTenantDatabaseScope,
+  runWithTenantDatabaseScope,
   shortId,
   ThreadSessionMapRepository,
   UserMCPOAuthTokenRepository,
@@ -49,6 +52,7 @@ import type {
   Session,
   SessionID,
   Task,
+  TenantID,
   ThreadSessionMap,
   User,
   UserID,
@@ -187,6 +191,11 @@ function hasListeningConfig(channel: GatewayChannel): boolean {
     default:
       return false;
   }
+}
+
+function tenantIdFromGatewayChannel(channel: GatewayChannel): TenantID | string | undefined {
+  const tenantId = (channel as GatewayChannel & { tenant_id?: unknown }).tenant_id;
+  return typeof tenantId === 'string' && tenantId.length > 0 ? tenantId : undefined;
 }
 
 function isSlackThinkingPlaceholder(text: string): boolean {
@@ -523,6 +532,7 @@ function buildGatewayContext(channel: GatewayChannel, data: PostMessageData): Ga
  * Gateway routing service
  */
 export class GatewayService {
+  private db: Database;
   private channelRepo: GatewayChannelRepository;
   private threadMapRepo: ThreadSessionMapRepository;
   private outboundRepo: GatewayOutboundMessageRepository;
@@ -570,6 +580,7 @@ export class GatewayService {
   private static SLACK_STREAMED_MESSAGE_CACHE_MAX = 500;
 
   constructor(db: Database, app: Application) {
+    this.db = db;
     this.channelRepo = new GatewayChannelRepository(db);
     this.threadMapRepo = new ThreadSessionMapRepository(db);
     this.outboundRepo = new GatewayOutboundMessageRepository(db);
@@ -2471,34 +2482,52 @@ export class GatewayService {
       return; // Already listening
     }
 
-    try {
-      const connector = getConnector(channel.channel_type as ChannelType, channel.config);
+    const listenerTenantId = tenantIdFromGatewayChannel(channel) ?? getCurrentTenantId();
 
-      if (!connector.startListening) {
-        return; // Connector doesn't support listening
+    return runWithoutTenantDatabaseScope(async () => {
+      try {
+        const connector = getConnector(channel.channel_type as ChannelType, channel.config);
+
+        if (!connector.startListening) {
+          return; // Connector doesn't support listening
+        }
+
+        const callback = (msg: InboundMessage) => {
+          this.handleListenerInboundMessage(channel, listenerTenantId, msg).catch((error) => {
+            console.error(
+              `[gateway] Failed to process inbound message for channel ${channel.name}:`,
+              error
+            );
+          });
+        };
+
+        await connector.startListening(callback);
+        this.activeListeners.set(channel.id, connector);
+        console.log(`[gateway] Socket Mode listener started for channel "${channel.name}"`);
+      } catch (error) {
+        console.error(`[gateway] Failed to start listener for channel "${channel.name}":`, error);
       }
+    });
+  }
 
-      const callback = (msg: InboundMessage) => {
-        this.create({
-          channel_key: channel.channel_key,
-          thread_id: msg.threadId,
-          text: msg.text,
-          user_name: msg.userId,
-          metadata: msg.metadata,
-        }).catch((error) => {
-          console.error(
-            `[gateway] Failed to process inbound message for channel ${channel.name}:`,
-            error
-          );
-        });
-      };
-
-      await connector.startListening(callback);
-      this.activeListeners.set(channel.id, connector);
-      console.log(`[gateway] Socket Mode listener started for channel "${channel.name}"`);
-    } catch (error) {
-      console.error(`[gateway] Failed to start listener for channel "${channel.name}":`, error);
+  private async handleListenerInboundMessage(
+    channel: GatewayChannel,
+    tenantId: TenantID | string | undefined,
+    msg: InboundMessage
+  ): Promise<void> {
+    if (!tenantId) {
+      throw new Error(`Missing tenant context for gateway listener channel ${channel.id}`);
     }
+
+    await runWithTenantDatabaseScope(this.db, tenantId, async () => {
+      await this.create({
+        channel_key: channel.channel_key,
+        thread_id: msg.threadId,
+        text: msg.text,
+        user_name: msg.userId,
+        metadata: msg.metadata,
+      });
+    });
   }
 
   /**

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -9,7 +9,6 @@
 import { PublicBaseUrlNotConfiguredError, requirePublicBaseUrl } from '@agor/core/config';
 import {
   BranchRepository,
-  type Database,
   GatewayChannelRepository,
   GatewayOutboundMessageRepository,
   getCurrentTenantId,
@@ -17,6 +16,7 @@ import {
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
   shortId,
+  type TenantScopeAwareDatabase,
   ThreadSessionMapRepository,
   UserMCPOAuthTokenRepository,
   UsersRepository,
@@ -532,7 +532,7 @@ function buildGatewayContext(channel: GatewayChannel, data: PostMessageData): Ga
  * Gateway routing service
  */
 export class GatewayService {
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
   private channelRepo: GatewayChannelRepository;
   private threadMapRepo: ThreadSessionMapRepository;
   private outboundRepo: GatewayOutboundMessageRepository;
@@ -579,7 +579,7 @@ export class GatewayService {
   private static SLACK_STREAM_STATUS_REFRESH_MS = 300;
   private static SLACK_STREAMED_MESSAGE_CACHE_MAX = 500;
 
-  constructor(db: Database, app: Application) {
+  constructor(db: TenantScopeAwareDatabase, app: Application) {
     this.db = db;
     this.channelRepo = new GatewayChannelRepository(db);
     this.threadMapRepo = new ThreadSessionMapRepository(db);
@@ -2551,6 +2551,9 @@ export class GatewayService {
 /**
  * Service factory function
  */
-export function createGatewayService(db: Database, app: Application): GatewayService {
+export function createGatewayService(
+  db: TenantScopeAwareDatabase,
+  app: Application
+): GatewayService {
   return new GatewayService(db, app);
 }

--- a/apps/agor-daemon/src/services/github-app-setup.ts
+++ b/apps/agor-daemon/src/services/github-app-setup.ts
@@ -32,7 +32,7 @@
  * browser redirects and HTML responses, which don't fit the Feathers service model.
  */
 
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
 import type express from 'express';
@@ -254,7 +254,7 @@ function handleNewApp(uiUrl: string, daemonUrl: string) {
  * proven by the state token — it is only issued from an authenticated
  * admin session (POST /api/github/setup/state) and is validated here.
  */
-function handleSetupCallback(db: Database, uiUrl: string) {
+function handleSetupCallback(db: TenantScopeAwareDatabase, uiUrl: string) {
   return async (req: express.Request, res: express.Response) => {
     const state = typeof req.query.state === 'string' ? req.query.state : undefined;
     const installationIdRaw =
@@ -349,7 +349,7 @@ function handleSetupCallback(db: Database, uiUrl: string) {
  *   1. A query param (during setup flow, from the UI)
  *   2. An existing gateway channel (query param: channel_id)
  */
-function handleListInstallations(_db: Database) {
+function handleListInstallations(_db: TenantScopeAwareDatabase) {
   return async (req: express.Request, res: express.Response) => {
     const appIdStr = req.query.app_id as string | undefined;
     const channelId = req.query.channel_id as string | undefined;
@@ -444,7 +444,7 @@ export function registerGitHubAppSetupRoutes(
   opts: {
     uiUrl: string;
     daemonUrl: string;
-    db: Database;
+    db: TenantScopeAwareDatabase;
   }
 ): void {
   app.post('/api/github/setup/state', handleIssueState(app));

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -5,7 +5,7 @@
  */
 
 import type { BranchRepository } from '@agor/core/db';
-import { BoardRepository, type Database, GroupRepository } from '@agor/core/db';
+import { BoardRepository, GroupRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
   BoardGroupGrantWithGroup,
@@ -77,7 +77,7 @@ export function branchGroupGrantPermissionLevelOrDefault(value: unknown): Branch
   return nextCan;
 }
 
-export function createGroupsService(db: Database) {
+export function createGroupsService(db: TenantScopeAwareDatabase) {
   const repo = new GroupRepository(db);
   return {
     async find(params?: Params): Promise<Group[]> {
@@ -111,7 +111,7 @@ export function createGroupsService(db: Database) {
   };
 }
 
-export function createGroupMembershipsService(db: Database) {
+export function createGroupMembershipsService(db: TenantScopeAwareDatabase) {
   const repo = new GroupRepository(db);
   return {
     async find(params?: Params): Promise<GroupMembership[]> {
@@ -189,7 +189,7 @@ export async function requireBranchGrantManager(
 
 export function setupBranchGroupGrantsService(
   app: import('@agor/core/feathers').Application,
-  db: Database,
+  db: TenantScopeAwareDatabase,
   branchRepo: BranchRepository
 ) {
   const repo = new GroupRepository(db);
@@ -261,7 +261,10 @@ export function setupBranchGroupGrantsService(
   });
 }
 
-async function requireBoardGrantViewer(db: Database, context: HookContext): Promise<HookContext> {
+async function requireBoardGrantViewer(
+  db: TenantScopeAwareDatabase,
+  context: HookContext
+): Promise<HookContext> {
   if (!context.params.provider) return context;
   if (context.params.user?._isServiceAccount) return context;
   const user = context.params.user;
@@ -276,7 +279,10 @@ async function requireBoardGrantViewer(db: Database, context: HookContext): Prom
   return context;
 }
 
-async function requireBoardGrantManager(db: Database, context: HookContext): Promise<HookContext> {
+async function requireBoardGrantManager(
+  db: TenantScopeAwareDatabase,
+  context: HookContext
+): Promise<HookContext> {
   if (!context.params.provider) return context;
   if (context.params.user?._isServiceAccount) return context;
   const user = context.params.user;
@@ -293,7 +299,7 @@ async function requireBoardGrantManager(db: Database, context: HookContext): Pro
 
 export function setupBoardGroupGrantsService(
   app: import('@agor/core/feathers').Application,
-  db: Database
+  db: TenantScopeAwareDatabase
 ) {
   const repo = new GroupRepository(db);
   app.use(

--- a/apps/agor-daemon/src/services/knowledge-document-edits.ts
+++ b/apps/agor-daemon/src/services/knowledge-document-edits.ts
@@ -1,4 +1,4 @@
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { KnowledgeDocumentVersionRepository, KnowledgeNamespaceRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
@@ -70,7 +70,7 @@ function extractChangedRanges(
 
 export class KnowledgeDocumentEditsService {
   constructor(
-    db: Database,
+    db: TenantScopeAwareDatabase,
     private readonly documentsService: KnowledgeDocumentsService,
     private readonly versionRepo = new KnowledgeDocumentVersionRepository(db),
     private readonly namespaceRepo = new KnowledgeNamespaceRepository(db)
@@ -217,7 +217,7 @@ export class KnowledgeDocumentEditsService {
 }
 
 export function createKnowledgeDocumentEditsService(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   _app: Application,
   documentsService: KnowledgeDocumentsService
 ) {

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -9,13 +9,13 @@ import { loadConfig, PAGINATION } from '@agor/core/config';
 import {
   AppVariableRepository,
   type CreateKnowledgeDocumentInput,
-  type Database,
   isPostgresDatabase,
   type KnowledgeDocumentFilters,
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
   KnowledgeGraphRepository,
   KnowledgeNamespaceRepository,
+  type TenantScopeAwareDatabase,
   type UpdateKnowledgeDocumentInput,
 } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
@@ -130,7 +130,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
   private graph: KnowledgeGraphRepository;
 
   constructor(
-    private db: Database,
+    private db: TenantScopeAwareDatabase,
     private app?: Application
   ) {
     const repo = new KnowledgeDocumentRepository(db);
@@ -681,7 +681,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
 }
 
 export function createKnowledgeDocumentsService(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   app?: Application
 ): KnowledgeDocumentsService {
   return new KnowledgeDocumentsService(db, app);

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -10,12 +10,13 @@ import {
   kbDocumentUnits,
   kbDocumentVersions,
   kbEmbeddingSpaces,
+  runWithTenantDatabaseScope,
   select,
   shortId,
   sql,
   update,
 } from '@agor/core/db';
-import type { KnowledgeDocumentUnitID } from '@agor/core/types';
+import type { KnowledgeDocumentUnitID, TenantID } from '@agor/core/types';
 import {
   DEFAULT_OPENAI_EMBEDDING_DIMENSIONS,
   DEFAULT_OPENAI_EMBEDDING_MODEL,
@@ -195,7 +196,10 @@ export class KnowledgeEmbeddingIndexer {
   private lastIndexedAt: Date | null = null;
   private pgvectorStorageReady = false;
 
-  constructor(private db: Database) {
+  constructor(
+    private db: Database,
+    private options: { tenantId?: TenantID | string } = {}
+  ) {
     this.variables = new AppVariableRepository(db);
   }
 
@@ -375,6 +379,13 @@ export class KnowledgeEmbeddingIndexer {
   }
 
   async tick(): Promise<void> {
+    if (this.options.tenantId) {
+      return runWithTenantDatabaseScope(this.db, this.options.tenantId, () => this.tickInScope());
+    }
+    return this.tickInScope();
+  }
+
+  private async tickInScope(): Promise<void> {
     if (this.running) return;
     this.running = true;
     try {

--- a/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
+++ b/apps/agor-daemon/src/services/knowledge-embedding-indexer.ts
@@ -1,7 +1,6 @@
 import { loadConfig } from '@agor/core/config';
 import {
   AppVariableRepository,
-  type Database,
   executeRaw,
   generateId,
   inArray,
@@ -14,6 +13,7 @@ import {
   select,
   shortId,
   sql,
+  type TenantScopeAwareDatabase,
   update,
 } from '@agor/core/db';
 import type { KnowledgeDocumentUnitID, TenantID } from '@agor/core/types';
@@ -197,7 +197,7 @@ export class KnowledgeEmbeddingIndexer {
   private pgvectorStorageReady = false;
 
   constructor(
-    private db: Database,
+    private db: TenantScopeAwareDatabase,
     private options: { tenantId?: TenantID | string } = {}
   ) {
     this.variables = new AppVariableRepository(db);

--- a/apps/agor-daemon/src/services/knowledge-graph.ts
+++ b/apps/agor-daemon/src/services/knowledge-graph.ts
@@ -3,13 +3,13 @@
  */
 
 import {
-  type Database,
   KnowledgeDocumentRepository,
   type KnowledgeGraphLinkInput,
   type KnowledgeGraphNeighborsQuery,
   KnowledgeGraphRepository,
   KnowledgeNamespaceRepository,
   type KnowledgeNodeRef,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import { Forbidden, NotFound } from '@agor/core/feathers';
 import type {
@@ -57,7 +57,7 @@ export class KnowledgeGraphService {
   private documents: KnowledgeDocumentRepository;
   private namespaces: KnowledgeNamespaceRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     this.graph = new KnowledgeGraphRepository(db);
     this.documents = new KnowledgeDocumentRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
@@ -307,6 +307,6 @@ export class KnowledgeGraphService {
   }
 }
 
-export function createKnowledgeGraphService(db: Database): KnowledgeGraphService {
+export function createKnowledgeGraphService(db: TenantScopeAwareDatabase): KnowledgeGraphService {
   return new KnowledgeGraphService(db);
 }

--- a/apps/agor-daemon/src/services/knowledge-indexing.ts
+++ b/apps/agor-daemon/src/services/knowledge-indexing.ts
@@ -1,11 +1,11 @@
 import { loadConfig } from '@agor/core/config';
 import {
   AppVariableRepository,
-  type Database,
   isPostgresDatabase,
   kbDocumentUnits,
   select,
   sql,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
@@ -37,7 +37,7 @@ export class KnowledgeIndexingStatusService {
   private variables: AppVariableRepository;
 
   constructor(
-    private db: Database,
+    private db: TenantScopeAwareDatabase,
     private app?: Application
   ) {
     this.variables = new AppVariableRepository(db);
@@ -103,7 +103,7 @@ export class KnowledgeIndexingStatusService {
 }
 
 export function createKnowledgeIndexingStatusService(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   app?: Application
 ): KnowledgeIndexingStatusService {
   return new KnowledgeIndexingStatusService(db, app);

--- a/apps/agor-daemon/src/services/knowledge-namespaces.ts
+++ b/apps/agor-daemon/src/services/knowledge-namespaces.ts
@@ -3,7 +3,11 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, GroupRepository, KnowledgeNamespaceRepository } from '@agor/core/db';
+import {
+  GroupRepository,
+  KnowledgeNamespaceRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
@@ -53,7 +57,7 @@ export class KnowledgeNamespacesService extends DrizzleService<
   private repo: KnowledgeNamespaceRepository;
   private groups: GroupRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const repo = new KnowledgeNamespaceRepository(db);
     super(repo, {
       id: 'namespace_id',
@@ -509,6 +513,8 @@ export class KnowledgeNamespacesService extends DrizzleService<
   }
 }
 
-export function createKnowledgeNamespacesService(db: Database): KnowledgeNamespacesService {
+export function createKnowledgeNamespacesService(
+  db: TenantScopeAwareDatabase
+): KnowledgeNamespacesService {
   return new KnowledgeNamespacesService(db);
 }

--- a/apps/agor-daemon/src/services/knowledge-reindex.ts
+++ b/apps/agor-daemon/src/services/knowledge-reindex.ts
@@ -1,5 +1,9 @@
 import { loadConfig } from '@agor/core/config';
-import { AppVariableRepository, type Database, isPostgresDatabase } from '@agor/core/db';
+import {
+  AppVariableRepository,
+  isPostgresDatabase,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { AuthenticatedParams, KnowledgeEmbeddingStatus, Params } from '@agor/core/types';
 import {
@@ -21,7 +25,7 @@ export class KnowledgeReindexService {
   private variables: AppVariableRepository;
 
   constructor(
-    private db: Database,
+    private db: TenantScopeAwareDatabase,
     private app?: Application
   ) {
     this.variables = new AppVariableRepository(db);
@@ -52,7 +56,7 @@ export class KnowledgeReindexService {
 }
 
 export function createKnowledgeReindexService(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   app?: Application
 ): KnowledgeReindexService {
   return new KnowledgeReindexService(db, app);

--- a/apps/agor-daemon/src/services/knowledge-search.ts
+++ b/apps/agor-daemon/src/services/knowledge-search.ts
@@ -5,7 +5,6 @@
 import { getBaseUrl, loadConfig } from '@agor/core/config';
 import {
   AppVariableRepository,
-  type Database,
   executeRaw,
   isPostgresDatabase,
   KnowledgeDocumentRepository,
@@ -13,6 +12,7 @@ import {
   type KnowledgeSearchQuery,
   KnowledgeSearchRepository,
   sql,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
 import {
@@ -48,7 +48,7 @@ export class KnowledgeSearchService {
   private variables: AppVariableRepository;
   private embeddingProvider = new OpenAIEmbeddingProvider();
 
-  constructor(private db: Database) {
+  constructor(private db: TenantScopeAwareDatabase) {
     this.repo = new KnowledgeSearchRepository(db);
     this.documents = new KnowledgeDocumentRepository(db);
     this.namespaces = new KnowledgeNamespaceRepository(db);
@@ -411,6 +411,6 @@ export class KnowledgeSearchService {
   }
 }
 
-export function createKnowledgeSearchService(db: Database): KnowledgeSearchService {
+export function createKnowledgeSearchService(db: TenantScopeAwareDatabase): KnowledgeSearchService {
   return new KnowledgeSearchService(db);
 }

--- a/apps/agor-daemon/src/services/knowledge-settings.ts
+++ b/apps/agor-daemon/src/services/knowledge-settings.ts
@@ -1,11 +1,11 @@
 import { type AgorKnowledgeSettings, loadConfig, saveConfig } from '@agor/core/config';
 import {
   AppVariableRepository,
-  type Database,
   executeRaw,
   isPostgresDatabase,
   kbDocumentUnits,
   sql,
+  type TenantScopeAwareDatabase,
   update,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
@@ -57,7 +57,7 @@ export class KnowledgeSettingsService {
   private variables: AppVariableRepository;
 
   constructor(
-    private db: Database,
+    private db: TenantScopeAwareDatabase,
     private app?: Application
   ) {
     this.variables = new AppVariableRepository(db);
@@ -258,7 +258,7 @@ export class KnowledgeSettingsService {
 }
 
 export function createKnowledgeSettingsService(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   app?: Application
 ): KnowledgeSettingsService {
   return new KnowledgeSettingsService(db, app);

--- a/apps/agor-daemon/src/services/knowledge-versions.ts
+++ b/apps/agor-daemon/src/services/knowledge-versions.ts
@@ -4,10 +4,10 @@
 
 import { PAGINATION } from '@agor/core/config';
 import {
-  type Database,
   KnowledgeDocumentRepository,
   KnowledgeDocumentVersionRepository,
   KnowledgeNamespaceRepository,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import { BadRequest, Forbidden } from '@agor/core/feathers';
 import {
@@ -42,7 +42,7 @@ export class KnowledgeVersionsService extends DrizzleService<
   private documents: KnowledgeDocumentRepository;
   private namespaces: KnowledgeNamespaceRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const versions = new KnowledgeDocumentVersionRepository(db);
     super(versions, {
       id: 'version_id',
@@ -115,6 +115,8 @@ export class KnowledgeVersionsService extends DrizzleService<
   }
 }
 
-export function createKnowledgeVersionsService(db: Database): KnowledgeVersionsService {
+export function createKnowledgeVersionsService(
+  db: TenantScopeAwareDatabase
+): KnowledgeVersionsService {
   return new KnowledgeVersionsService(db);
 }

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -10,7 +10,6 @@ import {
   and,
   asc,
   branches,
-  type Database,
   type DateBucket,
   dateTruncUtc,
   desc,
@@ -21,6 +20,7 @@ import {
   type SQL,
   sessions,
   sql,
+  type TenantScopeAwareDatabase,
   tasks,
   users,
 } from '@agor/core/db';
@@ -128,9 +128,9 @@ function parseGroupBy(groupBy: string): Set<LeaderboardDimension> {
  * custom aggregation queries.
  */
 export class LeaderboardService {
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     this.db = db;
   }
 
@@ -429,6 +429,6 @@ export class LeaderboardService {
 /**
  * Service factory function
  */
-export function createLeaderboardService(db: Database): LeaderboardService {
+export function createLeaderboardService(db: TenantScopeAwareDatabase): LeaderboardService {
   return new LeaderboardService(db);
 }

--- a/apps/agor-daemon/src/services/mcp-servers.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.ts
@@ -6,7 +6,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, MCPServerRepository } from '@agor/core/db';
+import { MCPServerRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type {
   CreateMCPServerInput,
   MCPScope,
@@ -41,7 +41,7 @@ export class MCPServersService extends DrizzleService<
 > {
   private mcpServerRepo: MCPServerRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const mcpServerRepo = new MCPServerRepository(db);
     super(mcpServerRepo, {
       id: 'mcp_server_id',
@@ -105,6 +105,6 @@ export class MCPServersService extends DrizzleService<
 /**
  * Service factory function
  */
-export function createMCPServersService(db: Database): MCPServersService {
+export function createMCPServersService(db: TenantScopeAwareDatabase): MCPServersService {
   return new MCPServersService(db);
 }

--- a/apps/agor-daemon/src/services/messages.ts
+++ b/apps/agor-daemon/src/services/messages.ts
@@ -6,7 +6,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, MessagesRepository } from '@agor/core/db';
+import { MessagesRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type {
   Message,
   MessageID,
@@ -37,7 +37,7 @@ export type MessageParams = QueryParams<{
 export class MessagesService extends DrizzleService<Message, Partial<Message>, MessageParams> {
   private messagesRepo: MessagesRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const messagesRepo = new MessagesRepository(db);
     super(messagesRepo, {
       id: 'message_id',
@@ -189,6 +189,6 @@ export class MessagesService extends DrizzleService<Message, Partial<Message>, M
 /**
  * Service factory function
  */
-export function createMessagesService(db: Database): MessagesService {
+export function createMessagesService(db: TenantScopeAwareDatabase): MessagesService {
   return new MessagesService(db);
 }

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -22,7 +22,12 @@ import {
   resolveBranchStorageConfig,
   resolveExecutionSecurityMode,
 } from '@agor/core/config';
-import { BranchRepository, type Database, RepoRepository, shortId } from '@agor/core/db';
+import {
+  BranchRepository,
+  RepoRepository,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { autoAssignBranchUniqueId } from '@agor/core/environment/variable-resolver';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
@@ -115,9 +120,9 @@ async function deriveLocalRepoSlug(path: string, explicitSlug?: string): Promise
 export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams> {
   private repoRepo: RepoRepository;
   private app: Application;
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
 
-  constructor(db: Database, app: Application) {
+  constructor(db: TenantScopeAwareDatabase, app: Application) {
     const repoRepo = new RepoRepository(db);
     super(repoRepo, {
       id: 'repo_id',
@@ -1267,6 +1272,6 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
 /**
  * Service factory function
  */
-export function createReposService(db: Database, app: Application): ReposService {
+export function createReposService(db: TenantScopeAwareDatabase, app: Application): ReposService {
   return new ReposService(db, app);
 }

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -46,7 +46,7 @@
  *   as a v0.19 backwards-compat alias.
  */
 
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import {
   advisoryLockKeyForUuid,
   BranchRepository,
@@ -208,7 +208,7 @@ export interface SchedulerConfig {
 
 export class SchedulerService {
   private app: Application;
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
   private config: Required<Omit<SchedulerConfig, 'tenantId'>> & Pick<SchedulerConfig, 'tenantId'>;
   private intervalHandle?: NodeJS.Timeout;
   private isRunning = false;
@@ -218,7 +218,7 @@ export class SchedulerService {
   private userRepo: UsersRepository;
   private sessionMCPRepo: SessionMCPServerRepository;
 
-  constructor(db: Database, app: Application, config: SchedulerConfig = {}) {
+  constructor(db: TenantScopeAwareDatabase, app: Application, config: SchedulerConfig = {}) {
     this.app = app;
     this.db = db;
     this.config = {

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -51,6 +51,7 @@ import {
   advisoryLockKeyForUuid,
   BranchRepository,
   isPostgresDatabase,
+  runWithTenantDatabaseScope,
   ScheduleRepository,
   SessionMCPServerRepository,
   SessionRepository,
@@ -69,6 +70,7 @@ import type {
   ScheduleID,
   Session,
   SessionID,
+  TenantID,
   User,
   UUID,
 } from '@agor/core/types';
@@ -200,12 +202,14 @@ export interface SchedulerConfig {
   debug?: boolean;
   /** Unix user mode for validation (default: 'simple') */
   unixUserMode?: UnixUserMode;
+  /** Tenant used for cron/background ticks when no request auth scope exists. */
+  tenantId?: TenantID | string;
 }
 
 export class SchedulerService {
   private app: Application;
   private db: Database;
-  private config: Required<SchedulerConfig>;
+  private config: Required<Omit<SchedulerConfig, 'tenantId'>> & Pick<SchedulerConfig, 'tenantId'>;
   private intervalHandle?: NodeJS.Timeout;
   private isRunning = false;
   private branchRepo: BranchRepository;
@@ -222,6 +226,7 @@ export class SchedulerService {
       gracePeriod: config.gracePeriod ?? 120000, // 2 minutes
       debug: config.debug ?? false,
       unixUserMode: config.unixUserMode ?? 'simple',
+      tenantId: config.tenantId,
     };
     this.branchRepo = new BranchRepository(db);
     this.scheduleRepo = new ScheduleRepository(db);
@@ -286,6 +291,13 @@ export class SchedulerService {
    * 3. Process the schedule (dedup, concurrency check, spawn).
    */
   private async tick(): Promise<void> {
+    if (this.config.tenantId) {
+      return runWithTenantDatabaseScope(this.db, this.config.tenantId, () => this.tickInScope());
+    }
+    return this.tickInScope();
+  }
+
+  private async tickInScope(): Promise<void> {
     const now = Date.now();
 
     try {

--- a/apps/agor-daemon/src/services/schedules.ts
+++ b/apps/agor-daemon/src/services/schedules.ts
@@ -15,7 +15,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, ScheduleRepository } from '@agor/core/db';
+import { ScheduleRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { AuthenticatedParams, BranchID, QueryParams, Schedule, UUID } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 
@@ -27,7 +27,7 @@ export type ScheduleParams = QueryParams<{
   AuthenticatedParams;
 
 export class SchedulesService extends DrizzleService<Schedule, Partial<Schedule>, ScheduleParams> {
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const repo = new ScheduleRepository(db);
     super(repo, {
       id: 'schedule_id',
@@ -40,6 +40,6 @@ export class SchedulesService extends DrizzleService<Schedule, Partial<Schedule>
   }
 }
 
-export function createSchedulesService(db: Database): SchedulesService {
+export function createSchedulesService(db: TenantScopeAwareDatabase): SchedulesService {
   return new SchedulesService(db);
 }

--- a/apps/agor-daemon/src/services/session-env-selections.ts
+++ b/apps/agor-daemon/src/services/session-env-selections.ts
@@ -15,7 +15,7 @@
  * credentials.
  */
 
-import { type Database, SessionEnvSelectionRepository } from '@agor/core/db';
+import { SessionEnvSelectionRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { QueryParams, SessionEnvSelection, SessionID } from '@agor/core/types';
 
 /**
@@ -32,7 +32,7 @@ export type SessionEnvSelectionParams = QueryParams<{
 export class SessionEnvSelectionsService {
   private repo: SessionEnvSelectionRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     this.repo = new SessionEnvSelectionRepository(db);
   }
 
@@ -83,6 +83,8 @@ export class SessionEnvSelectionsService {
 /**
  * Service factory
  */
-export function createSessionEnvSelectionsService(db: Database): SessionEnvSelectionsService {
+export function createSessionEnvSelectionsService(
+  db: TenantScopeAwareDatabase
+): SessionEnvSelectionsService {
   return new SessionEnvSelectionsService(db);
 }

--- a/apps/agor-daemon/src/services/session-mcp-servers.ts
+++ b/apps/agor-daemon/src/services/session-mcp-servers.ts
@@ -5,7 +5,7 @@
  * Provides API for adding/removing/toggling MCP servers for sessions.
  */
 
-import { type Database, SessionMCPServerRepository } from '@agor/core/db';
+import { SessionMCPServerRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { MCPServer, MCPServerID, QueryParams, SessionID } from '@agor/core/types';
 
 /**
@@ -24,7 +24,7 @@ export type SessionMCPParams = QueryParams<{
 export class SessionMCPServersService {
   private sessionMCPRepo: SessionMCPServerRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     this.sessionMCPRepo = new SessionMCPServerRepository(db);
   }
 
@@ -99,6 +99,8 @@ export class SessionMCPServersService {
 /**
  * Service factory function
  */
-export function createSessionMCPServersService(db: Database): SessionMCPServersService {
+export function createSessionMCPServersService(
+  db: TenantScopeAwareDatabase
+): SessionMCPServersService {
   return new SessionMCPServersService(db);
 }

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -8,12 +8,12 @@
 import { PAGINATION } from '@agor/core/config';
 import {
   BranchRepository,
-  type Database,
   SessionEnvSelectionRepository,
   SessionMCPServerRepository,
   SessionRelationshipRepository,
   SessionRepository,
   type SessionWithLastMessage,
+  type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden } from '@agor/core/feathers';
@@ -176,7 +176,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     }
   }
 
-  constructor(db: Database, app: Application) {
+  constructor(db: TenantScopeAwareDatabase, app: Application) {
     const sessionRepo = new SessionRepository(db);
     super(sessionRepo, {
       id: 'session_id',
@@ -946,6 +946,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
 /**
  * Service factory function
  */
-export function createSessionsService(db: Database, app: Application): SessionsService {
+export function createSessionsService(
+  db: TenantScopeAwareDatabase,
+  app: Application
+): SessionsService {
   return new SessionsService(db, app);
 }

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -12,10 +12,10 @@ import {
 } from '@agor/core/callbacks/child-completion-template';
 import { PAGINATION, resolveExecutorHeartbeatConfig } from '@agor/core/config';
 import {
-  type Database,
   enqueueTenantDatabasePostCommitCallback,
   shortId,
   TaskRepository,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
@@ -100,14 +100,14 @@ interface CompletionCallbackDispatchResult {
 export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams> {
   private taskRepo: TaskRepository;
   private app: Application;
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
   private heartbeatCallbackRunner: ExecutorHeartbeatCallbackRunner;
   private completionCallbackDispatches = new Map<
     string,
     Promise<CompletionCallbackDispatchResult>
   >();
 
-  constructor(db: Database, app: Application) {
+  constructor(db: TenantScopeAwareDatabase, app: Application) {
     const taskRepo = new TaskRepository(db);
     super(taskRepo, {
       id: 'task_id',
@@ -1237,6 +1237,6 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 /**
  * Service factory function
  */
-export function createTasksService(db: Database, app: Application): TasksService {
+export function createTasksService(db: TenantScopeAwareDatabase, app: Application): TasksService {
   return new TasksService(db, app);
 }

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -30,9 +30,9 @@ import {
 } from '@agor/core/config';
 import {
   BranchRepository,
-  type Database,
   SessionRepository,
   shortId,
+  type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
@@ -220,12 +220,12 @@ ${exportLines.join('\n')}
  */
 export class TerminalsService {
   private app: Application;
-  private db: Database;
+  private db: TenantScopeAwareDatabase;
 
   /** Whether Zellij is available on this system */
   private zellijAvailable: boolean;
 
-  constructor(app: Application, db: Database) {
+  constructor(app: Application, db: TenantScopeAwareDatabase) {
     this.app = app;
     this.db = db;
 

--- a/apps/agor-daemon/src/services/thread-session-map.ts
+++ b/apps/agor-daemon/src/services/thread-session-map.ts
@@ -6,7 +6,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, ThreadSessionMapRepository } from '@agor/core/db';
+import { type TenantScopeAwareDatabase, ThreadSessionMapRepository } from '@agor/core/db';
 import type { ThreadSessionMap } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 
@@ -16,7 +16,7 @@ export class ThreadSessionMapService extends DrizzleService<
 > {
   private threadMapRepo: ThreadSessionMapRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const repo = new ThreadSessionMapRepository(db);
     super(repo, {
       id: 'id',
@@ -41,6 +41,8 @@ export class ThreadSessionMapService extends DrizzleService<
 /**
  * Service factory function
  */
-export function createThreadSessionMapService(db: Database): ThreadSessionMapService {
+export function createThreadSessionMapService(
+  db: TenantScopeAwareDatabase
+): ThreadSessionMapService {
   return new ThreadSessionMapService(db);
 }

--- a/apps/agor-daemon/src/services/user-avatar-sync.ts
+++ b/apps/agor-daemon/src/services/user-avatar-sync.ts
@@ -1,7 +1,7 @@
 import {
   AppVariableRepository,
-  type Database,
   GatewayChannelRepository,
+  type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import { type Application, Forbidden } from '@agor/core/feathers';
@@ -62,7 +62,7 @@ export class UserAvatarSyncManager {
   private users: UsersRepository;
 
   constructor(
-    db: Database,
+    db: TenantScopeAwareDatabase,
     private app: Application
   ) {
     this.variables = new AppVariableRepository(db);

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -18,7 +18,6 @@ import {
 import {
   and,
   compare,
-  type Database,
   decryptApiKey,
   deleteFrom,
   encryptApiKey,
@@ -26,6 +25,7 @@ import {
   hash,
   insert,
   select,
+  type TenantScopeAwareDatabase,
   update,
   users,
 } from '@agor/core/db';
@@ -257,7 +257,7 @@ export class UsersService {
   private avatarSync?: UserAvatarSyncManager;
 
   constructor(
-    protected db: Database,
+    protected db: TenantScopeAwareDatabase,
     app?: Application
   ) {
     if (app) {
@@ -956,6 +956,9 @@ class UsersServiceWithAuth extends UsersService {
 /**
  * Create users service
  */
-export function createUsersService(db: Database, app?: Application): UsersServiceWithAuth {
+export function createUsersService(
+  db: TenantScopeAwareDatabase,
+  app?: Application
+): UsersServiceWithAuth {
   return new UsersServiceWithAuth(db, app);
 }

--- a/apps/agor-daemon/src/services/zone-trigger.ts
+++ b/apps/agor-daemon/src/services/zone-trigger.ts
@@ -11,7 +11,7 @@
  * same session-defaults resolution, same MCP-attach behaviour.
  */
 
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { resolveSessionDefaults } from '@agor/core/sessions';
 import { renderTemplate } from '@agor/core/templates/handlebars-helpers';
 import { buildZoneTriggerContext } from '@agor/core/templates/zone-trigger-context';
@@ -88,7 +88,7 @@ export async function fireAlwaysNewZoneTrigger(
     mcp_server_ids: inheritedMcpIds,
   } = resolveSessionDefaults({ agenticTool, user, branch });
 
-  const db = (app.get('database') ?? app.get('db')) as Database | undefined;
+  const db = (app.get('database') ?? app.get('db')) as TenantScopeAwareDatabase | undefined;
   const asUser = db ? await resolveExecutorReadAsUser(db, user) : undefined;
 
   const { currentSha, currentRef } = await inspectBranchViaExecutor(app, branch.branch_id, {

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -12,6 +12,7 @@ import {
   createDatabaseAsync,
   createTenantScopedDatabaseProxy,
   formatPendingMigrationsMessage,
+  runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
   seedInitialData,
 } from '@agor/core/db';
@@ -102,7 +103,11 @@ async function checkAndReportMigrations(
  */
 export async function initializeDatabase(
   dbPath: string,
-  options: { tenantId?: TenantID | string; skipFirstRunAdminBootstrap?: boolean } = {}
+  options: {
+    tenantId?: TenantID | string;
+    requireTenantScope?: boolean;
+    skipFirstRunAdminBootstrap?: boolean;
+  } = {}
 ): Promise<DatabaseInitResult> {
   console.log(`📦 Connecting to database: ${dbPath}`);
 
@@ -111,12 +116,15 @@ export async function initializeDatabase(
 
   // Create database with foreign keys enabled
   const db = await createDatabaseAsync({ url: dbPath });
-  const scopedDb = createTenantScopedDatabaseProxy(db);
+  const scopedDb = createTenantScopedDatabaseProxy(db, {
+    requireScope: options.requireTenantScope === true,
+    label: 'daemon database',
+  });
 
   // Check migrations (exits if pending)
   await checkAndReportMigrations(db, dbPath);
 
-  await runWithTenantDatabaseScope(scopedDb, options.tenantId, async () => {
+  const runInitialDataSetup = async () => {
     // Seed initial data (idempotent - only creates if missing). In static
     // Postgres deployments, scope this to the configured tenant so changing
     // multi_tenancy.static_tenant_id starts from a clean tenant-local slate.
@@ -136,7 +144,13 @@ export async function initializeDatabase(
       const bootstrapResult = await runFirstRunAdminBootstrap(scopedDb);
       logFirstRunAdminBootstrap(bootstrapResult);
     }
-  });
+  };
+
+  if (options.tenantId) {
+    await runWithTenantDatabaseScope(scopedDb, options.tenantId, runInitialDataSetup);
+  } else {
+    await runWithSystemDatabaseScope(scopedDb, 'database initialization', runInitialDataSetup);
+  }
 
   console.log('✅ Database ready');
 

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -15,6 +15,7 @@ import {
   runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
   seedInitialData,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { TenantID } from '@agor/core/types';
 import { extractDbFilePath } from '@agor/core/utils/path';
@@ -22,7 +23,7 @@ import { logFirstRunAdminBootstrap, runFirstRunAdminBootstrap } from './first-ru
 
 export interface DatabaseInitResult {
   /** Initialized database instance */
-  db: Awaited<ReturnType<typeof createDatabaseAsync>>;
+  db: TenantScopeAwareDatabase;
 }
 
 /**

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -25,8 +25,8 @@ import {
   BOOTSTRAP_ADMIN_EMAIL,
   bootstrapFirstRunAdmin,
   createUser,
-  type Database,
   generateAdminPassword,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 
 const openP = promisify(open);
@@ -145,7 +145,7 @@ export interface DaemonBootstrapResult extends AdminBootstrapResult {
  * accept the `~/.agor` default.
  */
 export async function runFirstRunAdminBootstrap(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   options: { credentialsBaseDir?: string } = {}
 ): Promise<DaemonBootstrapResult> {
   const credentialsPath = getAdminCredentialsPath(options.credentialsBaseDir);

--- a/apps/agor-daemon/src/startup.test.ts
+++ b/apps/agor-daemon/src/startup.test.ts
@@ -1,0 +1,86 @@
+import { createTenantScopedDatabaseProxy, MissingTenantDatabaseScopeError } from '@agor/core/db';
+import { describe, expect, it, vi } from 'vitest';
+import { cleanupOrphanStatuses, type StartupContext } from './startup.js';
+
+function makeStartupContextWithGuardedDb() {
+  const baseDb = {
+    run: vi.fn(),
+    marker: vi.fn(() => 'scoped'),
+  };
+  const db = createTenantScopedDatabaseProxy(baseDb as never, {
+    requireScope: true,
+    label: 'startup test db',
+  });
+  const touchDb = () => (db as unknown as { marker(): string }).marker();
+
+  const tasksService = {
+    getOrphaned: vi.fn(async () => {
+      touchDb();
+      return [];
+    }),
+    find: vi.fn(async () => {
+      touchDb();
+      return { data: [] };
+    }),
+    patch: vi.fn(),
+  };
+  const sessionsService = {
+    find: vi.fn(async () => {
+      touchDb();
+      return { data: [] };
+    }),
+    get: vi.fn(),
+    patch: vi.fn(),
+  };
+  const services = new Map<string, unknown>([
+    ['tasks', tasksService],
+    ['sessions', sessionsService],
+  ]);
+  const app = {
+    service: vi.fn((name: string) => services.get(name)),
+  };
+
+  const ctx = {
+    app,
+    db,
+    config: {
+      multi_tenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'startup-tenant',
+        auth_claim: 'tenant_id',
+      },
+    },
+    DAEMON_PORT: 3030,
+    DAEMON_HOST: 'localhost',
+    svcEnabled: vi.fn(() => false),
+    safeService: vi.fn(),
+    getSocketServer: vi.fn(() => null),
+    sessionsService,
+    terminalsService: null,
+  } as unknown as StartupContext;
+
+  return { ctx, baseDb };
+}
+
+describe('startup tenant database scope', () => {
+  it('runs orphan cleanup inside an explicit startup tenant DB scope', async () => {
+    const { ctx, baseDb } = makeStartupContextWithGuardedDb();
+
+    await expect(cleanupOrphanStatuses(ctx)).resolves.toMatchObject({
+      orphanedTasks: [],
+      orphanedSessions: [],
+      queuedTasks: [],
+      sessionsResetFromOrphanedTasks: 0,
+    });
+    expect(baseDb.marker).toHaveBeenCalled();
+  });
+
+  it('demonstrates guarded startup DB access fails without scope', () => {
+    const { baseDb, ctx } = makeStartupContextWithGuardedDb();
+
+    expect(() => (ctx.db as unknown as { marker(): string }).marker()).toThrow(
+      MissingTenantDatabaseScopeError
+    );
+    expect(baseDb.marker).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -13,12 +13,12 @@ import {
   resolveExecutorHeartbeatConfig,
   resolveMultiTenancyConfig,
 } from '@agor/core/config';
-import type { Database } from '@agor/core/db';
 import {
   MessagesRepository,
   runWithTenantDatabaseScope,
   SessionRepository,
   shortId,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Id, Paginated, Session, SessionID, Task, TenantContext } from '@agor/core/types';
 import { SessionStatus, TaskStatus } from '@agor/core/types';
@@ -47,7 +47,7 @@ function startupDebug(...args: unknown[]): void {
 
 export interface StartupContext {
   app: Application;
-  db: Database;
+  db: TenantScopeAwareDatabase;
   config: AgorConfig;
   DAEMON_PORT: number;
   /** Bind address (default: 'localhost', use '0.0.0.0' for containers) */

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -14,7 +14,12 @@ import {
   resolveMultiTenancyConfig,
 } from '@agor/core/config';
 import type { Database } from '@agor/core/db';
-import { MessagesRepository, SessionRepository, shortId } from '@agor/core/db';
+import {
+  MessagesRepository,
+  runWithTenantDatabaseScope,
+  SessionRepository,
+  shortId,
+} from '@agor/core/db';
 import type { Id, Paginated, Session, SessionID, Task, TenantContext } from '@agor/core/types';
 import { SessionStatus, TaskStatus } from '@agor/core/types';
 import type { Application, SessionsServiceImpl, TasksServiceImpl } from './declarations.js';
@@ -120,6 +125,16 @@ function startupTenantParams(config: AgorConfig): { tenant: TenantContext } {
   };
 }
 
+async function runStartupTenantDatabaseScope<T>(
+  ctx: Pick<StartupContext, 'config' | 'db'>,
+  work: () => Promise<T>
+): Promise<T> {
+  // Startup/background daemon jobs have no request auth context. Keep the
+  // historical bootstrap/static tenant behavior explicit at the DB boundary so
+  // guarded required_from_auth databases fail closed everywhere else.
+  return runWithTenantDatabaseScope(ctx.db, startupTenantParams(ctx.config).tenant.tenant_id, work);
+}
+
 interface OrphanCleanupResult {
   wasGraceful: boolean;
   orphanedTasks: Task[];
@@ -129,7 +144,13 @@ interface OrphanCleanupResult {
   sessionsResetFromOrphanedTasks: number;
 }
 
-async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanupResult> {
+export async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanupResult> {
+  return runStartupTenantDatabaseScope(ctx, () => cleanupOrphanStatusesInTenantScope(ctx));
+}
+
+async function cleanupOrphanStatusesInTenantScope(
+  ctx: StartupContext
+): Promise<OrphanCleanupResult> {
   const { app, sessionsService } = ctx;
 
   // Get tasks service from the app (registered during services phase)
@@ -295,6 +316,15 @@ async function cleanupOrphanStatuses(ctx: StartupContext): Promise<OrphanCleanup
 }
 
 async function injectRestartNotices(
+  ctx: StartupContext,
+  cleanupResult: OrphanCleanupResult
+): Promise<void> {
+  return runStartupTenantDatabaseScope(ctx, () =>
+    injectRestartNoticesInTenantScope(ctx, cleanupResult)
+  );
+}
+
+async function injectRestartNoticesInTenantScope(
   ctx: StartupContext,
   cleanupResult: OrphanCleanupResult
 ): Promise<void> {
@@ -510,7 +540,9 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // accepting requests. This is best-effort; filesystem config scrubbing
   // deliberately skips registered local repos to avoid surprising writes
   // outside Agor-managed storage.
-  runPostStartJob('git-remote-credential-scrub', () => scrubManagedGitRemoteCredentials(db));
+  runPostStartJob('git-remote-credential-scrub', () =>
+    runStartupTenantDatabaseScope(ctx, () => scrubManagedGitRemoteCredentials(db))
+  );
 
   // Log the host IP that will be frozen into env command templates as
   // {{host.ip_address}}. Explicit config overrides autodetection.
@@ -559,6 +591,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
       gracePeriod: 120000, // 2 minutes
       debug: process.env.NODE_ENV !== 'production',
       unixUserMode: config.execution?.unix_user_mode ?? 'simple',
+      tenantId: startupTenantParams(config).tenant.tenant_id,
     });
     schedulerService.start();
     // Expose on app so route handlers (e.g. /branches/:id/execute-schedule-now)
@@ -570,7 +603,9 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // 7. Start Knowledge embedding indexer (no-op unless semantic search is configured)
   let knowledgeEmbeddingIndexer: KnowledgeEmbeddingIndexer | null = null;
   if (svcEnabled('knowledge')) {
-    knowledgeEmbeddingIndexer = new KnowledgeEmbeddingIndexer(db);
+    knowledgeEmbeddingIndexer = new KnowledgeEmbeddingIndexer(db, {
+      tenantId: startupTenantParams(config).tenant.tenant_id,
+    });
     knowledgeEmbeddingIndexer.start();
     app.set('knowledgeEmbeddingIndexer', knowledgeEmbeddingIndexer);
     console.log('🧠 Knowledge embedding indexer started');
@@ -579,10 +614,9 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // 8. Initialize gateway: refresh channel state cache, then start Socket Mode listeners
   const gatewayService = safeService('gateway') as unknown as GatewayService | undefined;
   if (gatewayService) {
-    gatewayService
-      .refreshChannelState()
+    runStartupTenantDatabaseScope(ctx, () => gatewayService.refreshChannelState())
       .then(() => {
-        return gatewayService.startListeners();
+        return runStartupTenantDatabaseScope(ctx, () => gatewayService.startListeners());
       })
       .catch((error: unknown) => {
         console.error('[gateway] Failed to start listeners:', error);

--- a/apps/agor-daemon/src/utils/append-system-message.ts
+++ b/apps/agor-daemon/src/utils/append-system-message.ts
@@ -10,7 +10,7 @@
  * message_range.end_index (e.g. startup.ts) can read it from message.index.
  */
 
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { generateId, SessionRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type {
@@ -26,7 +26,7 @@ import { MessageRole } from '@agor/core/types';
 
 export interface AppendSystemMessageOptions {
   app: Application;
-  db: Database;
+  db: TenantScopeAwareDatabase;
   sessionId: string;
   taskId?: string;
   content: string | ContentBlock[];

--- a/apps/agor-daemon/src/utils/executor-read-impersonation.ts
+++ b/apps/agor-daemon/src/utils/executor-read-impersonation.ts
@@ -1,5 +1,5 @@
 import { loadConfigSync } from '@agor/core/config';
-import { type Database, UsersRepository } from '@agor/core/db';
+import { type TenantScopeAwareDatabase, UsersRepository } from '@agor/core/db';
 import type { User, UserID } from '@agor/core/types';
 
 /**
@@ -12,7 +12,7 @@ import type { User, UserID } from '@agor/core/types';
  * requesting user.
  */
 export async function resolveExecutorReadAsUser(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   userOrId: User | UserID | undefined | null
 ): Promise<string | undefined> {
   const config = loadConfigSync();

--- a/apps/agor-daemon/src/utils/git-impersonation.ts
+++ b/apps/agor-daemon/src/utils/git-impersonation.ts
@@ -19,7 +19,7 @@
  * required.
  */
 
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import type { Branch, UserID } from '@agor/core/types';
 
 /**
@@ -71,7 +71,7 @@ export async function resolveDaemonUserForGroupRefresh(): Promise<string | undef
  * @returns Daemon username when sudo wrap is needed, otherwise undefined
  */
 export async function resolveGitImpersonationForUser(
-  _db: Database,
+  _db: TenantScopeAwareDatabase,
   _userId: UserID | undefined
 ): Promise<string | undefined> {
   return resolveDaemonUserForGroupRefresh();
@@ -83,7 +83,7 @@ export async function resolveGitImpersonationForUser(
  * @see resolveGitImpersonationForUser
  */
 export async function resolveGitImpersonationForBranch(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   branch: Branch
 ): Promise<string | undefined> {
   return resolveGitImpersonationForUser(db, branch.created_by);

--- a/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
+++ b/apps/agor-daemon/src/utils/git-remote-credential-scan.ts
@@ -1,4 +1,9 @@
-import { BranchRepository, type Database, RepoRepository, shortId } from '@agor/core/db';
+import {
+  BranchRepository,
+  RepoRepository,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { scrubGitConfigRemoteCredentials } from '@agor/core/git/exec';
 
 /**
@@ -13,7 +18,9 @@ import { scrubGitConfigRemoteCredentials } from '@agor/core/git/exec';
  * scrubbed at Agor git-operation boundaries and can be repaired explicitly via
  * `agor local scrub-git-remotes --write`.
  */
-export async function scrubManagedGitRemoteCredentials(db: Database): Promise<void> {
+export async function scrubManagedGitRemoteCredentials(
+  db: TenantScopeAwareDatabase
+): Promise<void> {
   const repoRepo = new RepoRepository(db);
   const branchRepo = new BranchRepository(db);
 

--- a/apps/agor-daemon/src/utils/open-source-telemetry-usage.ts
+++ b/apps/agor-daemon/src/utils/open-source-telemetry-usage.ts
@@ -3,12 +3,12 @@ import {
   and,
   branches,
   count,
-  type Database,
   eq,
   gte,
   lt,
   select,
   sessions,
+  type TenantScopeAwareDatabase,
   tasks,
 } from '@agor/core/db';
 import {
@@ -43,7 +43,7 @@ function previousUtcDayRange(now = new Date()): { day: string; start: Date; end:
 }
 
 async function countCreatedRows(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   table: typeof tasks | typeof sessions | typeof branches,
   start: Date,
   end: Date
@@ -56,7 +56,7 @@ async function countCreatedRows(
 }
 
 async function addDistinctCreatedBy(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   table: typeof tasks | typeof sessions | typeof branches,
   start: Date,
   end: Date,
@@ -73,7 +73,11 @@ async function addDistinctCreatedBy(
   }
 }
 
-async function getTaskUsageRows(db: Database, start: Date, end: Date): Promise<TaskUsageRow[]> {
+async function getTaskUsageRows(
+  db: TenantScopeAwareDatabase,
+  start: Date,
+  end: Date
+): Promise<TaskUsageRow[]> {
   return (await select(db, {
     taskData: tasks.data,
     agenticTool: sessions.agentic_tool,
@@ -85,7 +89,9 @@ async function getTaskUsageRows(db: Database, start: Date, end: Date): Promise<T
     .all()) as TaskUsageRow[];
 }
 
-export async function flushOpenSourceTelemetryUsageSummary(db: Database): Promise<void> {
+export async function flushOpenSourceTelemetryUsageSummary(
+  db: TenantScopeAwareDatabase
+): Promise<void> {
   if (!openSourceTelemetryLogger.isEnabled()) return;
 
   const { day, start, end } = previousUtcDayRange();
@@ -144,7 +150,9 @@ export async function flushOpenSourceTelemetryUsageSummary(db: Database): Promis
   await saveConfig(pruneDefaultOpenSourceTelemetryDestination(config));
 }
 
-export function startOpenSourceTelemetryUsageSummaryInterval(db: Database): NodeJS.Timeout {
+export function startOpenSourceTelemetryUsageSummaryInterval(
+  db: TenantScopeAwareDatabase
+): NodeJS.Timeout {
   // Check hourly, but emit at most once per UTC day. The DB query only runs
   // when the previous day has not yet been reported, keeping steady-state
   // overhead to one config read per hour.

--- a/apps/agor-daemon/src/utils/open-source-telemetry-usage.ts
+++ b/apps/agor-daemon/src/utils/open-source-telemetry-usage.ts
@@ -6,6 +6,7 @@ import {
   eq,
   gte,
   lt,
+  runWithTenantDatabaseScope,
   select,
   sessions,
   type TenantScopeAwareDatabase,
@@ -17,7 +18,7 @@ import {
   openSourceTelemetryLogger,
   pruneDefaultOpenSourceTelemetryDestination,
 } from '@agor/core/telemetry';
-import type { Session } from '@agor/core/types';
+import type { Session, TenantID } from '@agor/core/types';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
@@ -150,14 +151,22 @@ export async function flushOpenSourceTelemetryUsageSummary(
   await saveConfig(pruneDefaultOpenSourceTelemetryDestination(config));
 }
 
+export interface OpenSourceTelemetryUsageSummaryIntervalOptions {
+  /** Tenant used for daemon-global telemetry scans that have no request auth context. */
+  tenantId: TenantID | string;
+}
+
 export function startOpenSourceTelemetryUsageSummaryInterval(
-  db: TenantScopeAwareDatabase
+  db: TenantScopeAwareDatabase,
+  options: OpenSourceTelemetryUsageSummaryIntervalOptions
 ): NodeJS.Timeout {
   // Check hourly, but emit at most once per UTC day. The DB query only runs
   // when the previous day has not yet been reported, keeping steady-state
   // overhead to one config read per hour.
   const run = (): void => {
-    flushOpenSourceTelemetryUsageSummary(db).catch((error) => {
+    runWithTenantDatabaseScope(db, options.tenantId, () =>
+      flushOpenSourceTelemetryUsageSummary(db)
+    ).catch((error) => {
       console.warn(
         '[telemetry] failed to emit usage summary:',
         error instanceof Error ? error.message : String(error)

--- a/apps/agor-daemon/src/utils/session-state-hooks.ts
+++ b/apps/agor-daemon/src/utils/session-state-hooks.ts
@@ -9,7 +9,7 @@
  * register-services.ts and operate on the daemon's DB + filesystem directly.
  */
 
-import { type Database, SerializedSessionRepository, shortId } from '@agor/core/db';
+import { SerializedSessionRepository, shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { AgenticToolName } from '@agor/core/types';
 import {
   computeFileHash,
@@ -23,7 +23,7 @@ import {
 const STALE_PROCESSING_THRESHOLD_MS = 30_000; // 30 seconds
 
 interface PullContext {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   sessionId: string;
   sdkSessionId: string;
   branchPath: string;
@@ -33,7 +33,7 @@ interface PullContext {
 }
 
 interface PushContext {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   sessionId: string;
   branchId: string;
   taskId: string;

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -8,7 +8,10 @@ import { NotAuthenticated } from '@agor/core/feathers';
 import jwt from 'jsonwebtoken';
 import { describe, expect, it, vi } from 'vitest';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
-import { createTenantDatabaseScopeAroundHook } from './tenant-db-scope.js';
+import {
+  createTenantDatabaseScopeAroundHook,
+  deferWithTenantDatabaseScope,
+} from './tenant-db-scope.js';
 
 function makePgDb() {
   const tx = {
@@ -231,6 +234,52 @@ describe('createTenantDatabaseScopeAroundHook', () => {
       tenant_id: 'tenant-a',
       source: 'explicit',
     });
+  });
+
+  it('re-enters a fresh tenant scope for deferred executor session startup', async () => {
+    const { db } = makePgDb();
+    const hook = createTenantDatabaseScopeAroundHook({
+      db: db as never,
+      jwtSecret: 'secret',
+      config: {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      },
+    });
+    const context = {
+      params: { provider: 'rest', authentication: { payload: { tenant_id: 'tenant-a' } } },
+    } as never;
+    const sessionRepo = {
+      async findById(sessionId: string) {
+        return getCurrentTenantId() === 'tenant-a'
+          ? { session_id: sessionId, tenant_id: 'tenant-a' }
+          : null;
+      },
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      hook(context, async () => {
+        deferWithTenantDatabaseScope(
+          db as never,
+          (context as { params: { tenant?: { tenant_id?: string } } }).params,
+          async () => {
+            const session = await sessionRepo.findById('session-1');
+            expect(session).toEqual({ session_id: 'session-1', tenant_id: 'tenant-a' });
+            resolve();
+          },
+          reject
+        );
+      }).catch(reject);
+    });
+  });
+
+  it('documents the failed startup mode when deferred work only exits ALS', async () => {
+    const { db } = makePgDb();
+    const missing = await runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {
+      return runWithoutTenantDatabaseScope(() => getCurrentTenantId());
+    });
+
+    expect(missing).toBeUndefined();
   });
 
   it('keeps board owner lookups tenant-scoped under required_from_auth', async () => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -1,6 +1,7 @@
 import {
   enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantId,
+  runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
 } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
@@ -175,6 +176,102 @@ describe('createTenantDatabaseScopeAroundHook', () => {
       tenant_id: 'tenant-inherited',
       source: 'explicit',
     });
+  });
+
+  it('does not let a nested explicit tenant switch silently', async () => {
+    const { db } = makePgDb();
+    const hook = createTenantDatabaseScopeAroundHook({
+      db: db as never,
+      jwtSecret: 'secret',
+      config: {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      },
+    });
+    const context = {
+      params: { tenant: { tenant_id: 'tenant-b', source: 'auth_claim' } },
+    } as never;
+
+    await expect(
+      runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {
+        await hook(context, async () => undefined);
+      })
+    ).rejects.toThrow(/Cannot enter tenant scope tenant-b from active tenant scope tenant-a/);
+  });
+
+  it('treats provider-less nested calls as tenant-scoped rather than global', async () => {
+    const { db } = makePgDb();
+    const hook = createTenantDatabaseScopeAroundHook({
+      db: db as never,
+      jwtSecret: 'secret',
+      config: {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      },
+    });
+    const outer = {
+      params: { provider: 'rest', authentication: { payload: { tenant_id: 'tenant-a' } } },
+    } as never;
+    const innerTasksPatch = { params: {} } as never;
+    const innerSessionLookup = { params: { provider: undefined } } as never;
+    const events: string[] = [];
+
+    await hook(outer, async () => {
+      events.push(`outer:${getCurrentTenantId()}`);
+      await hook(innerTasksPatch, async () => {
+        events.push(`tasks.patch:${getCurrentTenantId()}`);
+      });
+      await hook(innerSessionLookup, async () => {
+        events.push(`sessions.get:${getCurrentTenantId()}`);
+      });
+    });
+
+    expect(events).toEqual(['outer:tenant-a', 'tasks.patch:tenant-a', 'sessions.get:tenant-a']);
+    expect((innerTasksPatch as { params: { tenant?: unknown } }).params.tenant).toEqual({
+      tenant_id: 'tenant-a',
+      source: 'explicit',
+    });
+  });
+
+  it('keeps board owner lookups tenant-scoped under required_from_auth', async () => {
+    const { db } = makePgDb();
+    const hook = createTenantDatabaseScopeAroundHook({
+      db: db as never,
+      jwtSecret: 'secret',
+      config: {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      },
+    });
+    const boardOwnersFind = {
+      params: { provider: 'rest', authentication: { payload: { tenant_id: 'tenant-board' } } },
+    } as never;
+    const nestedUsersGet = { params: {} } as never;
+    const events: string[] = [];
+
+    await hook(boardOwnersFind, async () => {
+      events.push(`boards/:id/owners.find:${getCurrentTenantId()}`);
+      await hook(nestedUsersGet, async () => {
+        events.push(`users.get:${getCurrentTenantId()}`);
+      });
+    });
+
+    expect(events).toEqual(['boards/:id/owners.find:tenant-board', 'users.get:tenant-board']);
+  });
+
+  it('allows an explicit global/system escape hatch outside the active scope', async () => {
+    const { db } = makePgDb();
+    const seen: Array<string | undefined> = [];
+
+    await runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {
+      seen.push(getCurrentTenantId());
+      runWithoutTenantDatabaseScope(() => {
+        seen.push(getCurrentTenantId());
+      });
+      seen.push(getCurrentTenantId());
+    });
+
+    expect(seen).toEqual(['tenant-a', undefined, 'tenant-a']);
   });
 
   it('reuses tenant context already attached to a socket connection', async () => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -273,6 +273,21 @@ describe('createTenantDatabaseScopeAroundHook', () => {
     });
   });
 
+  it('fails deferred tenant-scoped work loudly when no tenant can be resolved', async () => {
+    const { db } = makePgDb();
+    const onError = vi.fn();
+    const work = vi.fn(async () => undefined);
+
+    deferWithTenantDatabaseScope(db as never, {}, work, onError);
+
+    expect(work).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Missing tenant context for deferred tenant-scoped work',
+      })
+    );
+  });
+
   it('documents the failed startup mode when deferred work only exits ALS', async () => {
     const { db } = makePgDb();
     const missing = await runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -5,10 +5,10 @@ import {
   TenantResolutionError,
 } from '@agor/core/config';
 import {
-  type Database,
   getCurrentTenantId,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
 import type { HookContext, TenantContext, TenantID } from '@agor/core/types';
@@ -16,7 +16,7 @@ import jwt from 'jsonwebtoken';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 
 interface TenantDatabaseScopeOptions {
-  db: Database;
+  db: TenantScopeAwareDatabase;
   config: AgorConfig;
   jwtSecret: string;
 }
@@ -50,7 +50,7 @@ export function resolveTenantIdForDeferredScope(params?: unknown): string | unde
  * RLS context entirely.
  */
 export function deferWithTenantDatabaseScope(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   params: unknown,
   work: () => Promise<void>,
   onError?: (error: unknown) => void

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -11,7 +11,7 @@ import {
   runWithTenantDatabaseScope,
 } from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
-import type { HookContext, TenantID } from '@agor/core/types';
+import type { HookContext, TenantContext, TenantID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 
@@ -35,7 +35,7 @@ function readHeaderValue(
   return null;
 }
 
-type TenantScopedParams = { tenant?: { tenant_id?: string } } | undefined;
+type TenantScopedParams = { tenant?: Pick<TenantContext, 'tenant_id'> } | undefined;
 
 export function resolveTenantIdForDeferredScope(params?: unknown): string | undefined {
   const scopedParams = params as TenantScopedParams;
@@ -56,6 +56,16 @@ export function deferWithTenantDatabaseScope(
   onError?: (error: unknown) => void
 ): void {
   const tenantId = resolveTenantIdForDeferredScope(params);
+  if (!tenantId) {
+    const error = new Error('Missing tenant context for deferred tenant-scoped work');
+    if (onError) {
+      onError(error);
+    } else {
+      console.error('[tenant-db-scope] Deferred tenant-scoped work skipped:', error);
+    }
+    return;
+  }
+
   runWithoutTenantDatabaseScope(() => {
     setImmediate(() => {
       void runWithTenantDatabaseScope(db, tenantId, work).catch((error) => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -54,24 +54,30 @@ export function createTenantDatabaseScopeAroundHook(options: TenantDatabaseScope
       connection?: { tenant?: unknown; data?: { tenant?: unknown } };
     };
     const connectionTenant = params.connection?.tenant ?? params.connection?.data?.tenant;
-    if (
-      connectionTenant &&
-      typeof connectionTenant === 'object' &&
-      'tenant_id' in connectionTenant
-    ) {
-      return connectionTenant as ReturnType<typeof resolveTenantContext>;
-    }
+    const paramsWithConnectionTenant =
+      connectionTenant && typeof connectionTenant === 'object' && 'tenant_id' in connectionTenant
+        ? ({ ...params, tenant: params.tenant ?? connectionTenant } as typeof params)
+        : params;
 
-    const inheritedTenantId = getCurrentTenantId();
-    if (inheritedTenantId) {
-      return { tenant_id: inheritedTenantId as TenantID, source: 'explicit' as const };
+    try {
+      // Resolve explicit/auth/socket tenant context first, even for internal
+      // calls. If this is nested inside a different active tenant scope,
+      // runWithTenantDatabaseScope below will reject the cross-tenant switch
+      // instead of silently inheriting or switching.
+      return resolveTenantContext(multiTenancy, {
+        params: paramsWithConnectionTenant,
+        authPayload:
+          paramsWithConnectionTenant.authentication?.payload ??
+          bearerPayloadFromHeaders(paramsWithConnectionTenant.headers),
+        headers: paramsWithConnectionTenant.headers,
+      });
+    } catch (error) {
+      const inheritedTenantId = getCurrentTenantId();
+      if (error instanceof TenantResolutionError && inheritedTenantId) {
+        return { tenant_id: inheritedTenantId as TenantID, source: 'explicit' as const };
+      }
+      throw error;
     }
-
-    return resolveTenantContext(multiTenancy, {
-      params,
-      authPayload: params.authentication?.payload ?? bearerPayloadFromHeaders(params.headers),
-      headers: params.headers,
-    });
   };
 
   return async (context: HookContext, next: () => Promise<void>): Promise<void> => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -37,8 +37,9 @@ function readHeaderValue(
 
 type TenantScopedParams = { tenant?: { tenant_id?: string } } | undefined;
 
-export function resolveTenantIdForDeferredScope(params?: TenantScopedParams): string | undefined {
-  return params?.tenant?.tenant_id ?? getCurrentTenantId();
+export function resolveTenantIdForDeferredScope(params?: unknown): string | undefined {
+  const scopedParams = params as TenantScopedParams;
+  return scopedParams?.tenant?.tenant_id ?? getCurrentTenantId();
 }
 
 /**
@@ -50,7 +51,7 @@ export function resolveTenantIdForDeferredScope(params?: TenantScopedParams): st
  */
 export function deferWithTenantDatabaseScope(
   db: Database,
-  params: TenantScopedParams,
+  params: unknown,
   work: () => Promise<void>,
   onError?: (error: unknown) => void
 ): void {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -4,7 +4,12 @@ import {
   resolveTenantContext,
   TenantResolutionError,
 } from '@agor/core/config';
-import { type Database, getCurrentTenantId, runWithTenantDatabaseScope } from '@agor/core/db';
+import {
+  type Database,
+  getCurrentTenantId,
+  runWithoutTenantDatabaseScope,
+  runWithTenantDatabaseScope,
+} from '@agor/core/db';
 import { NotAuthenticated } from '@agor/core/feathers';
 import type { HookContext, TenantID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
@@ -28,6 +33,39 @@ function readHeaderValue(
     return typeof raw === 'string' && raw.trim() ? raw.trim() : null;
   }
   return null;
+}
+
+type TenantScopedParams = { tenant?: { tenant_id?: string } } | undefined;
+
+export function resolveTenantIdForDeferredScope(params?: TenantScopedParams): string | undefined {
+  return params?.tenant?.tenant_id ?? getCurrentTenantId();
+}
+
+/**
+ * Schedule asynchronous work outside the current ALS store, then re-enter a
+ * fresh tenant database scope for the captured tenant. Use this for delayed
+ * executor/queue/gateway work: bare setImmediate inherits possibly-committed
+ * transaction objects, but a bare runWithoutTenantDatabaseScope loses Postgres
+ * RLS context entirely.
+ */
+export function deferWithTenantDatabaseScope(
+  db: Database,
+  params: TenantScopedParams,
+  work: () => Promise<void>,
+  onError?: (error: unknown) => void
+): void {
+  const tenantId = resolveTenantIdForDeferredScope(params);
+  runWithoutTenantDatabaseScope(() => {
+    setImmediate(() => {
+      void runWithTenantDatabaseScope(db, tenantId, work).catch((error) => {
+        if (onError) {
+          onError(error);
+          return;
+        }
+        console.error('[tenant-db-scope] Deferred tenant-scoped work failed:', error);
+      });
+    });
+  });
 }
 
 export function createTenantDatabaseScopeAroundHook(options: TenantDatabaseScopeOptions) {

--- a/apps/agor-daemon/src/utils/unix-group-init.ts
+++ b/apps/agor-daemon/src/utils/unix-group-init.ts
@@ -14,7 +14,7 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { getDaemonUser } from '@agor/core/config';
-import type { Database } from '@agor/core/db';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { shortId, UsersRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { BranchID, RepoID } from '@agor/core/types';
@@ -53,7 +53,7 @@ async function runCommands(commands: string[]): Promise<void> {
 // ── Repo group init ──────────────────────────────────────────────────────
 
 export async function initializeRepoUnixGroup(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   app: Application,
   repoId: string,
   userId?: string
@@ -132,7 +132,7 @@ export async function initializeRepoUnixGroup(
 // ── Branch group init ──────────────────────────────────────────────────
 
 export async function initializeBranchUnixGroup(
-  db: Database,
+  db: TenantScopeAwareDatabase,
   app: Application,
   branchId: string,
   othersAccess: 'none' | 'read' | 'write'

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -173,7 +173,7 @@ async function configureSQLitePragmas(client: Client): Promise<void> {
  * });
  * ```
  */
-export function createDatabase(config: DbConfig): Database {
+export function createDatabase(config: DbConfig): RawDatabase {
   // Auto-detect dialect from URL if not explicitly set
   let dialect = config.dialect;
 
@@ -192,10 +192,10 @@ export function createDatabase(config: DbConfig): Database {
   }
 
   if (dialect === 'postgresql') {
-    return createPostgresDatabase(config);
+    return createPostgresDatabase(config) as unknown as RawDatabase;
   }
 
-  return createSQLiteDatabase(config);
+  return createSQLiteDatabase(config) as unknown as RawDatabase;
 }
 
 /**
@@ -275,7 +275,7 @@ function createSQLiteDatabase(config: DbConfig): LibSQLDatabase<typeof sqliteSch
  * @param config Database configuration
  * @returns Promise resolving to Drizzle database instance
  */
-export async function createDatabaseAsync(config: DbConfig): Promise<Database> {
+export async function createDatabaseAsync(config: DbConfig): Promise<RawDatabase> {
   // Determine dialect: use config.dialect, then auto-detect from URL, then fallback to env/default
   let dialect = config.dialect;
   if (!dialect && config.url) {
@@ -287,14 +287,14 @@ export async function createDatabaseAsync(config: DbConfig): Promise<Database> {
 
   if (dialect === 'postgresql') {
     // PostgreSQL doesn't need pragma configuration
-    return createPostgresDatabase(config);
+    return createPostgresDatabase(config) as unknown as RawDatabase;
   }
 
   // SQLite: Wait for pragmas to be configured
   const client = createLibSQLClient(config);
   const db = drizzleSQLite(client, { schema: sqliteSchema });
   await configureSQLitePragmas(client);
-  return db;
+  return db as unknown as RawDatabase;
 }
 
 /**
@@ -303,6 +303,38 @@ export async function createDatabaseAsync(config: DbConfig): Promise<Database> {
 export type Database =
   | LibSQLDatabase<typeof sqliteSchema>
   | PostgresJsDatabase<typeof postgresSchema>;
+
+declare const rawDatabaseBrand: unique symbol;
+declare const tenantScopeAwareDatabaseBrand: unique symbol;
+declare const tenantScopedDatabaseBrand: unique symbol;
+declare const systemDatabaseBrand: unique symbol;
+
+/**
+ * Raw Drizzle database handle. This should be limited to setup, migrations,
+ * and low-level scope plumbing. Application services should generally receive
+ * a TenantScopeAwareDatabase instead.
+ */
+export type RawDatabase = Database & { readonly [rawDatabaseBrand]: 'raw-database' };
+
+/**
+ * Long-lived daemon/repository database handle. It is not itself tenant-scoped;
+ * it is a proxy that resolves to the active tenant/system scope at call time.
+ */
+export type TenantScopeAwareDatabase = Database & {
+  readonly [tenantScopeAwareDatabaseBrand]: 'tenant-scope-aware-database';
+};
+
+/**
+ * Database handle available only while an active tenant DB scope is running.
+ */
+export type TenantScopedDatabase = Database & {
+  readonly [tenantScopedDatabaseBrand]: 'tenant-scoped-database';
+};
+
+/**
+ * Database handle available only while explicit global/system DB work is running.
+ */
+export type SystemDatabase = Database & { readonly [systemDatabaseBrand]: 'system-database' };
 
 /**
  * Default database path for local development

--- a/packages/core/src/db/tenant-context.ts
+++ b/packages/core/src/db/tenant-context.ts
@@ -18,6 +18,26 @@ export function getCurrentTenantId(): TenantID | string | undefined {
   return tenantDatabaseScope.getStore()?.tenantId;
 }
 
+export function requireCurrentTenantId(
+  message = 'Missing active tenant context'
+): TenantID | string {
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) throw new Error(message);
+  return tenantId;
+}
+
+/**
+ * Explicitly leave the ambient tenant DB scope for global/system work.
+ *
+ * Use this for deferred work that must open its own transaction/scope (for
+ * example post-response executor/queue fanout). A bare setImmediate/setTimeout
+ * inherits AsyncLocalStorage, including transaction objects that may have
+ * already committed.
+ */
+export function runWithoutTenantDatabaseScope<T>(work: () => T): T {
+  return tenantDatabaseScope.exit(work);
+}
+
 export function enqueueTenantDatabasePostCommitCallback(callback: () => Promise<void>): boolean {
   const store = tenantDatabaseScope.getStore();
   if (!store?.postCommitCallbacks) return false;

--- a/packages/core/src/db/tenant-context.ts
+++ b/packages/core/src/db/tenant-context.ts
@@ -4,7 +4,9 @@ import type { Database } from './client';
 
 export interface TenantDatabaseScope {
   db: Database;
+  kind: 'tenant' | 'system';
   tenantId?: TenantID | string;
+  systemReason?: string;
   postCommitCallbacks?: Array<() => Promise<void>>;
 }
 
@@ -15,7 +17,12 @@ export function getCurrentTenantDatabase(): Database | undefined {
 }
 
 export function getCurrentTenantId(): TenantID | string | undefined {
-  return tenantDatabaseScope.getStore()?.tenantId;
+  const store = tenantDatabaseScope.getStore();
+  return store?.kind === 'tenant' ? store.tenantId : undefined;
+}
+
+export function getCurrentTenantDatabaseScope(): TenantDatabaseScope | undefined {
+  return tenantDatabaseScope.getStore();
 }
 
 export function requireCurrentTenantId(

--- a/packages/core/src/db/tenant-scope.test.ts
+++ b/packages/core/src/db/tenant-scope.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Database } from './client';
 import { insert } from './database-wrapper';
-import { createTenantScopedDatabaseProxy, runWithTenantDatabaseScope } from './tenant-scope';
+import {
+  createTenantScopedDatabaseProxy,
+  getCurrentTenantId,
+  requireCurrentTenantId,
+  runWithoutTenantDatabaseScope,
+  runWithTenantDatabaseScope,
+} from './tenant-scope';
 
 describe('tenant-scoped database proxy', () => {
   it('routes repository-style calls to the active tenant transaction', async () => {
@@ -123,5 +129,25 @@ describe('tenant-scoped database proxy', () => {
         { id: 'row-3', tenant_id: 'explicit' },
       ],
     ]);
+  });
+
+  it('supports requiring and explicitly escaping the ambient tenant scope', async () => {
+    const base = {
+      run: vi.fn(),
+    };
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database);
+    const seen: Array<string | undefined> = [];
+
+    await runWithTenantDatabaseScope(db, 'tenant-a', async () => {
+      expect(requireCurrentTenantId()).toBe('tenant-a');
+      seen.push(getCurrentTenantId());
+      runWithoutTenantDatabaseScope(() => {
+        seen.push(getCurrentTenantId());
+        expect(() => requireCurrentTenantId()).toThrow('Missing active tenant context');
+      });
+      seen.push(getCurrentTenantId());
+    });
+
+    expect(seen).toEqual(['tenant-a', undefined, 'tenant-a']);
   });
 });

--- a/packages/core/src/db/tenant-scope.test.ts
+++ b/packages/core/src/db/tenant-scope.test.ts
@@ -4,8 +4,10 @@ import { insert } from './database-wrapper';
 import {
   createTenantScopedDatabaseProxy,
   getCurrentTenantId,
+  MissingTenantDatabaseScopeError,
   requireCurrentTenantId,
   runWithoutTenantDatabaseScope,
+  runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
 } from './tenant-scope';
 
@@ -149,5 +151,54 @@ describe('tenant-scoped database proxy', () => {
     });
 
     expect(seen).toEqual(['tenant-a', undefined, 'tenant-a']);
+  });
+
+  it('guarded proxies reject DB access without tenant or system scope', async () => {
+    const base = {
+      marker: vi.fn(() => 'base'),
+    };
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: true,
+      label: 'test db',
+    });
+
+    expect(() => (db as unknown as { marker(): string }).marker()).toThrow(
+      MissingTenantDatabaseScopeError
+    );
+    expect(() => (db as unknown as { marker(): string }).marker()).toThrow(
+      'Missing tenant database scope for test db access'
+    );
+  });
+  it('guarded proxies allow tenant-scoped and explicit system-scoped DB access', async () => {
+    const base = {
+      run: vi.fn(),
+      marker: vi.fn(() => 'base'),
+    };
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: true,
+    });
+
+    await runWithTenantDatabaseScope(db, 'tenant-a', async () => {
+      expect((db as unknown as { marker(): string }).marker()).toBe('base');
+    });
+
+    await runWithSystemDatabaseScope(db, 'test global setup', async () => {
+      expect((db as unknown as { marker(): string }).marker()).toBe('base');
+    });
+  });
+
+  it('does not allow switching from explicit system scope into tenant scope', async () => {
+    const base = {
+      marker: vi.fn(() => 'base'),
+    };
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: true,
+    });
+
+    await expect(
+      runWithSystemDatabaseScope(db, 'test global setup', async () =>
+        runWithTenantDatabaseScope(db, 'tenant-a', async () => undefined)
+      )
+    ).rejects.toThrow(/Cannot enter tenant scope tenant-a from active system database scope/);
   });
 });

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -12,10 +12,16 @@ export {
   tenantDatabaseScope,
 } from './tenant-context';
 
-import type { Database } from './client';
+import type {
+  Database,
+  RawDatabase,
+  SystemDatabase,
+  TenantScopeAwareDatabase,
+  TenantScopedDatabase,
+} from './client';
 import { isPostgresDatabase } from './database-wrapper';
 
-const tenantScopedProxyTargets = new WeakMap<object, Database>();
+const tenantScopedProxyTargets = new WeakMap<object, RawDatabase | Database>();
 const tenantScopedProxyOptions = new WeakMap<object, TenantScopedDatabaseProxyOptions>();
 
 export interface TenantScopedDatabaseProxyOptions {
@@ -51,7 +57,7 @@ function scopedTarget(base: Database): Database {
   return base;
 }
 
-function unwrapTenantScopedDatabaseProxy(db: Database): Database {
+function unwrapTenantScopedDatabaseProxy(db: Database): RawDatabase | Database {
   return tenantScopedProxyTargets.get(db as unknown as object) ?? db;
 }
 
@@ -61,9 +67,9 @@ function unwrapTenantScopedDatabaseProxy(db: Database): Database {
  * accepting `Database` without knowing whether they are inside a tenant scope.
  */
 export function createTenantScopedDatabaseProxy(
-  base: Database,
+  base: RawDatabase | Database,
   options: TenantScopedDatabaseProxyOptions = {}
-): Database {
+): TenantScopeAwareDatabase {
   const proxy = new Proxy(base as object, {
     get(_target, property, receiver) {
       const target = scopedTarget(base) as unknown as Record<PropertyKey, unknown>;
@@ -79,7 +85,7 @@ export function createTenantScopedDatabaseProxy(
     getOwnPropertyDescriptor(_target, property) {
       return Reflect.getOwnPropertyDescriptor(scopedTarget(base) as unknown as object, property);
     },
-  }) as Database;
+  }) as TenantScopeAwareDatabase;
   tenantScopedProxyTargets.set(proxy as unknown as object, base);
   tenantScopedProxyOptions.set(base as unknown as object, options);
   return proxy;
@@ -91,9 +97,9 @@ export function createTenantScopedDatabaseProxy(
  * On SQLite this is a no-op scope because SQLite is static-only.
  */
 export async function runWithTenantDatabaseScope<T>(
-  db: Database,
+  db: TenantScopeAwareDatabase | RawDatabase | Database,
   tenantId: TenantID | string | undefined,
-  work: () => Promise<T>
+  work: (db: TenantScopedDatabase) => Promise<T>
 ): Promise<T> {
   const existingScope = tenantDatabaseScope.getStore();
   if (existingScope) {
@@ -103,14 +109,14 @@ export async function runWithTenantDatabaseScope<T>(
           `Cannot enter tenant scope ${tenantId} from active system database scope (${existingScope.systemReason})`
         );
       }
-      return work();
+      return work(existingScope.db as TenantScopedDatabase);
     }
     if (tenantId && existingScope.tenantId && tenantId !== existingScope.tenantId) {
       throw new Error(
         `Cannot enter tenant scope ${tenantId} from active tenant scope ${existingScope.tenantId}`
       );
     }
-    return work();
+    return work(existingScope.db as TenantScopedDatabase);
   }
 
   const baseDb = unwrapTenantScopedDatabaseProxy(db);
@@ -119,7 +125,7 @@ export async function runWithTenantDatabaseScope<T>(
   if (!isPostgresDatabase(baseDb) || !tenantId) {
     const result = await tenantDatabaseScope.run(
       { db: baseDb, kind: 'tenant', tenantId, postCommitCallbacks },
-      work
+      () => work(baseDb as TenantScopedDatabase)
     );
     await drainTenantDatabasePostCommitCallbacks(baseDb, tenantId, postCommitCallbacks);
     return result;
@@ -132,7 +138,7 @@ export async function runWithTenantDatabaseScope<T>(
     );
     return tenantDatabaseScope.run(
       { db: scopedDb, kind: 'tenant', tenantId, postCommitCallbacks },
-      work
+      () => work(scopedDb as TenantScopedDatabase)
     );
   });
   await drainTenantDatabasePostCommitCallbacks(baseDb, tenantId, postCommitCallbacks);
@@ -145,9 +151,9 @@ export async function runWithTenantDatabaseScope<T>(
  * bug in required multi-tenant deployments.
  */
 export async function runWithSystemDatabaseScope<T>(
-  db: Database,
+  db: TenantScopeAwareDatabase | RawDatabase | Database,
   reason: string,
-  work: () => Promise<T>
+  work: (db: SystemDatabase) => Promise<T>
 ): Promise<T> {
   const existingScope = tenantDatabaseScope.getStore();
   if (existingScope) {
@@ -156,11 +162,13 @@ export async function runWithSystemDatabaseScope<T>(
         `Cannot enter system database scope (${reason}) from active tenant scope ${existingScope.tenantId}`
       );
     }
-    return work();
+    return work(existingScope.db as SystemDatabase);
   }
 
   const baseDb = unwrapTenantScopedDatabaseProxy(db);
-  return tenantDatabaseScope.run({ db: baseDb, kind: 'system', systemReason: reason }, work);
+  return tenantDatabaseScope.run({ db: baseDb, kind: 'system', systemReason: reason }, () =>
+    work(baseDb as SystemDatabase)
+  );
 }
 
 async function drainTenantDatabasePostCommitCallbacks(

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -6,6 +6,8 @@ export {
   enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantDatabase,
   getCurrentTenantId,
+  requireCurrentTenantId,
+  runWithoutTenantDatabaseScope,
   tenantDatabaseScope,
 } from './tenant-context';
 

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -5,6 +5,7 @@ import { tenantDatabaseScope } from './tenant-context';
 export {
   enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantDatabase,
+  getCurrentTenantDatabaseScope,
   getCurrentTenantId,
   requireCurrentTenantId,
   runWithoutTenantDatabaseScope,
@@ -15,9 +16,39 @@ import type { Database } from './client';
 import { isPostgresDatabase } from './database-wrapper';
 
 const tenantScopedProxyTargets = new WeakMap<object, Database>();
+const tenantScopedProxyOptions = new WeakMap<object, TenantScopedDatabaseProxyOptions>();
+
+export interface TenantScopedDatabaseProxyOptions {
+  /** Throw on DB access unless a tenant or explicit system DB scope is active. */
+  requireScope?: boolean;
+  /** Human-readable label included in guard errors. */
+  label?: string;
+}
+
+export class MissingTenantDatabaseScopeError extends Error {
+  constructor(label = 'database') {
+    super(`Missing tenant database scope for ${label} access`);
+    this.name = 'MissingTenantDatabaseScopeError';
+  }
+}
+
+function assertDatabaseScopeAllowed(base: Database): void {
+  const options = tenantScopedProxyOptions.get(base as unknown as object);
+  if (!options?.requireScope) return;
+  const store = tenantDatabaseScope.getStore();
+  if (store?.kind === 'system') return;
+  if (store?.kind === 'tenant' && store.tenantId) return;
+  throw new MissingTenantDatabaseScopeError(options.label);
+}
 
 function scopedTarget(base: Database): Database {
-  return tenantDatabaseScope.getStore()?.db ?? base;
+  const scoped = tenantDatabaseScope.getStore()?.db;
+  if (scoped) {
+    assertDatabaseScopeAllowed(base);
+    return scoped;
+  }
+  assertDatabaseScopeAllowed(base);
+  return base;
 }
 
 function unwrapTenantScopedDatabaseProxy(db: Database): Database {
@@ -29,7 +60,10 @@ function unwrapTenantScopedDatabaseProxy(db: Database): Database {
  * current tenant-scoped transaction when one is active. Repositories can keep
  * accepting `Database` without knowing whether they are inside a tenant scope.
  */
-export function createTenantScopedDatabaseProxy(base: Database): Database {
+export function createTenantScopedDatabaseProxy(
+  base: Database,
+  options: TenantScopedDatabaseProxyOptions = {}
+): Database {
   const proxy = new Proxy(base as object, {
     get(_target, property, receiver) {
       const target = scopedTarget(base) as unknown as Record<PropertyKey, unknown>;
@@ -47,6 +81,7 @@ export function createTenantScopedDatabaseProxy(base: Database): Database {
     },
   }) as Database;
   tenantScopedProxyTargets.set(proxy as unknown as object, base);
+  tenantScopedProxyOptions.set(base as unknown as object, options);
   return proxy;
 }
 
@@ -62,6 +97,14 @@ export async function runWithTenantDatabaseScope<T>(
 ): Promise<T> {
   const existingScope = tenantDatabaseScope.getStore();
   if (existingScope) {
+    if (existingScope.kind === 'system') {
+      if (tenantId) {
+        throw new Error(
+          `Cannot enter tenant scope ${tenantId} from active system database scope (${existingScope.systemReason})`
+        );
+      }
+      return work();
+    }
     if (tenantId && existingScope.tenantId && tenantId !== existingScope.tenantId) {
       throw new Error(
         `Cannot enter tenant scope ${tenantId} from active tenant scope ${existingScope.tenantId}`
@@ -75,7 +118,7 @@ export async function runWithTenantDatabaseScope<T>(
 
   if (!isPostgresDatabase(baseDb) || !tenantId) {
     const result = await tenantDatabaseScope.run(
-      { db: baseDb, tenantId, postCommitCallbacks },
+      { db: baseDb, kind: 'tenant', tenantId, postCommitCallbacks },
       work
     );
     await drainTenantDatabasePostCommitCallbacks(baseDb, tenantId, postCommitCallbacks);
@@ -87,10 +130,37 @@ export async function runWithTenantDatabaseScope<T>(
     await (scopedDb as unknown as { execute(query: unknown): Promise<unknown> }).execute(
       sql`SELECT set_config('agor.tenant_id', ${tenantId}, true)`
     );
-    return tenantDatabaseScope.run({ db: scopedDb, tenantId, postCommitCallbacks }, work);
+    return tenantDatabaseScope.run(
+      { db: scopedDb, kind: 'tenant', tenantId, postCommitCallbacks },
+      work
+    );
   });
   await drainTenantDatabasePostCommitCallbacks(baseDb, tenantId, postCommitCallbacks);
   return result;
+}
+
+/**
+ * Run explicit global/system database work. This is the only supported no-tenant
+ * scope for guarded database proxies; absence of tenant scope is treated as a
+ * bug in required multi-tenant deployments.
+ */
+export async function runWithSystemDatabaseScope<T>(
+  db: Database,
+  reason: string,
+  work: () => Promise<T>
+): Promise<T> {
+  const existingScope = tenantDatabaseScope.getStore();
+  if (existingScope) {
+    if (existingScope.kind === 'tenant') {
+      throw new Error(
+        `Cannot enter system database scope (${reason}) from active tenant scope ${existingScope.tenantId}`
+      );
+    }
+    return work();
+  }
+
+  const baseDb = unwrapTenantScopedDatabaseProxy(db);
+  return tenantDatabaseScope.run({ db: baseDb, kind: 'system', systemReason: reason }, work);
 }
 
 async function drainTenantDatabasePostCommitCallbacks(

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -78,12 +78,12 @@ const checks = [
     },
   },
   {
-    name: 'raw daemon Database type imports',
+    name: 'raw daemon Database/RawDatabase imports',
     roots: ['apps/agor-daemon/src'],
     excludeTests: true,
     patterns: [
-      /import\s+type\s*{[^}]*\bDatabase\b[^}]*}\s*from\s*['"]@agor\/core\/db['"]/gs,
-      /import\s*{[^}]*\btype\s+Database\b[^}]*}\s*from\s*['"]@agor\/core\/db['"]/gs,
+      /import\s+(?:type\s+)?{[^}]*(?:\bDatabase\b|\bRawDatabase\b)[^}]*}\s*from\s*['"]@agor\/core\/db(?:\/client)?['"]/gs,
+      /import\s+\*\s+as\s+\w+\s+from\s*['"]@agor\/core\/db(?:\/client)?['"]/gs,
     ],
     baseline: {},
   },

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -54,6 +54,29 @@ const checks = [
       'apps/agor-daemon/src/setup/socketio.ts': 18,
     },
   },
+
+  {
+    name: 'raw tenant database scope imports',
+    roots: ['apps/agor-daemon/src'],
+    patterns: [/import\s*{[^}]*\btenantDatabaseScope\b[^}]*}\s*from\s*['"]@agor\/core\/db['"]/gs],
+    baseline: {},
+  },
+  {
+    name: 'raw tenant database scope exits',
+    roots: ['packages/core/src', 'apps/agor-daemon/src'],
+    patterns: [/\btenantDatabaseScope\.exit\s*\(/g],
+    baseline: {
+      'packages/core/src/db/tenant-context.ts': 1,
+    },
+  },
+  {
+    name: 'bare daemon setImmediate scheduling',
+    roots: ['apps/agor-daemon/src'],
+    patterns: [/\bsetImmediate\s*\(/g],
+    baseline: {
+      'apps/agor-daemon/src/utils/tenant-db-scope.ts': 1,
+    },
+  },
   {
     name: 'raw Drizzle transactions',
     roots: ['packages/core/src', 'apps/agor-daemon/src'],

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -78,6 +78,16 @@ const checks = [
     },
   },
   {
+    name: 'raw daemon Database type imports',
+    roots: ['apps/agor-daemon/src'],
+    excludeTests: true,
+    patterns: [
+      /import\s+type\s*{[^}]*\bDatabase\b[^}]*}\s*from\s*['"]@agor\/core\/db['"]/gs,
+      /import\s*{[^}]*\btype\s+Database\b[^}]*}\s*from\s*['"]@agor\/core\/db['"]/gs,
+    ],
+    baseline: {},
+  },
+  {
     name: 'raw Drizzle transactions',
     roots: ['packages/core/src', 'apps/agor-daemon/src'],
     patterns: [/\.transaction\s*\(/g],
@@ -109,6 +119,7 @@ for (const check of checks) {
   const observed = new Map();
   for (const root of check.roots) {
     for (const file of filesUnder(root)) {
+      if (check.excludeTests && file.endsWith('.test.ts')) continue;
       const count = countMatches(readFileSync(file, 'utf8'), check.patterns);
       if (count > 0) observed.set(file, count);
     }

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -83,7 +83,7 @@ const checks = [
     excludeTests: true,
     patterns: [
       /import\s+(?:type\s+)?{[^}]*(?:\bDatabase\b|\bRawDatabase\b)[^}]*}\s*from\s*['"]@agor\/core\/db(?:\/client)?['"]/gs,
-      /import\s+\*\s+as\s+\w+\s+from\s*['"]@agor\/core\/db(?:\/client)?['"]/gs,
+      /import\s+(?:type\s+)?\*\s+as\s+\w+\s+from\s*['"]@agor\/core\/db(?:\/client)?['"]/gs,
     ],
     baseline: {},
   },


### PR DESCRIPTION
## Summary
- centralize ambient tenant-scope helpers (`requireCurrentTenantId`, `runWithoutTenantDatabaseScope`)
- harden tenant DB around-hook inheritance for nested/internal Feathers service calls under `required_from_auth`
- add `deferWithTenantDatabaseScope(...)` so deferred executor/queue/gateway work exits stale transaction ALS but re-enters a fresh tenant DB/RLS scope
- replace route/hook deferred startup/queue callsites with the fresh-scope helper
- add a guarded tenant-scoped DB proxy mode for Cloud `required_from_auth`, so missing tenant/system scope fails before SQLite/local patterns can drift into Postgres/RLS-only bugs
- make no-tenant database work explicit with `runWithSystemDatabaseScope(...)` and forbid silent tenant↔system scope switches
- add branded database capability types (`RawDatabase`, `TenantScopeAwareDatabase`, `TenantScopedDatabase`, `SystemDatabase`) so daemon services receive the long-lived tenant-aware proxy type instead of an unqualified raw `Database`
- extend multitenancy boundary checks to ban raw `Database`/`RawDatabase` imports in daemon production code, keeping raw handles limited to setup/tests/low-level scope plumbing
- scope daemon startup/background DB entrypoints explicitly: orphan cleanup, restart notices, credential scrub, scheduler ticks, knowledge indexer ticks, telemetry usage summaries, CLI watcher rehydrate, and gateway startup refresh/listeners
- make gateway Socket Mode listener registration leave startup/request ALS, then re-enter a fresh channel tenant DB scope for each inbound callback
- extend multitenancy boundary checks to ban raw daemon ALS exits/imports and bare daemon `setImmediate(...)` scheduling outside the tenant-scope utility
- add regression coverage for nested tasks/session lookup, board owner/user lookup, missing-tenant fail-closed, cross-tenant nesting, explicit global escape, deferred executor session startup, guarded DB access invariants, guarded startup orphan cleanup, and gateway listener callback tenant scope

## Context
This follows PR #1682 and keeps Cloud multi-tenancy centralized at JWT/auth + Feathers/DB scope + executor/deferred-work boundaries, without passing `tenant_id` through feature code.

The later Cloud/kind failure:

> The agent failed to start. Session not found: `<session_id>`

was caused by deferred assistant startup escaping ALS to avoid stale committed transactions, but not re-entering a fresh tenant DB scope. On Postgres/RLS, the session lookup then ran without `agor.tenant_id` and looked like a missing session.

Follow-up hardening adds a lower-level guard for `required_from_auth`: daemon database access must happen inside either a tenant scope or an explicit system scope. That gives local/SQLite-style code paths a fail-closed mechanism instead of letting missing scope become a Cloud-only RLS miss. Startup/background daemon work has no request auth context, so those entrypoints now enter the historical bootstrap/static tenant scope explicitly instead of relying on params-only context or ambient absence. Long-lived gateway listener callbacks explicitly avoid inheriting the startup transaction and open a fresh channel tenant scope per inbound message. Remaining daemon post-start timers/jobs that query DB directly (telemetry usage summaries and CLI watcher rehydrate) now also enter the startup tenant scope and no longer silently treat scope failures as empty scans. CLI watcher setup now captures the active/session tenant before registering watcher resources, exits tenant DB ALS before long-lived filesystem watcher/watchdog registration on both normal create and rehydrate paths, and wraps watcher persister/event-sink/watchdog callbacks in fresh DB scope for that captured tenant.

The latest refactor makes that boundary more visible at the type level: raw Drizzle handles remain available for setup, tests, and low-level scope machinery, while daemon production services now accept `TenantScopeAwareDatabase`. Active tenant/system scopes produce branded scoped handles, and the boundary script prevents production daemon code from drifting back to raw `Database` imports.

## Tests
- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon exec vitest run src/services/gateway.test.ts src/startup.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm --filter @agor/core exec vitest run src/db/tenant-scope.test.ts`
- `pnpm check:multitenancy-boundaries`



