### PR TITLE
Fix executor realtime tenant scope fallback

### DIFF
--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1798,7 +1798,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     // this.patch() calls the raw implementation and bypasses Feathers event
     // dispatch, so the patched event is not automatically emitted. Emit it
     // manually so WebSocket clients receive the environment status update.
-    this.app.service('branches').emit('patched', branch);
+    this.app.service('branches').emit?.('patched', branch);
 
     return branch;
   }

--- a/apps/agor-daemon/src/services/session-token-service.test.ts
+++ b/apps/agor-daemon/src/services/session-token-service.test.ts
@@ -1,6 +1,9 @@
+import { runWithTenantDatabaseScope, type TenantScopeAwareDatabase } from '@agor/core/db';
 import jwt from 'jsonwebtoken';
 import { describe, expect, it } from 'vitest';
 import { SessionTokenService } from './session-token-service';
+
+const scopeOnlyDb = { run: () => undefined } as unknown as TenantScopeAwareDatabase;
 
 describe('SessionTokenService runtime scoping', () => {
   it('issues executor-purpose tokens with task/session/branch scope and enforces max uses', async () => {
@@ -57,5 +60,23 @@ describe('SessionTokenService runtime scoping', () => {
         branchId: 'branch-1',
       })
     ).resolves.toMatchObject({ session_id: 'session-1', task_id: 'task-1' });
+  });
+
+  it('copies the ambient tenant scope into executor-session token claims', async () => {
+    const service = new SessionTokenService({ expiration_ms: 60_000, max_uses: 1 });
+    service.setJwtSecret('session-token-test-secret');
+
+    const token = await runWithTenantDatabaseScope(scopeOnlyDb, 'tenant-a', () =>
+      service.generateToken('session-1', 'user-1', {
+        taskId: 'task-1',
+        branchId: 'branch-1',
+      })
+    );
+    const decoded = jwt.verify(token, 'session-token-test-secret', {
+      issuer: 'agor',
+      audience: 'https://agor.dev',
+    }) as jwt.JwtPayload;
+
+    expect(decoded.tenant_id).toBe('tenant-a');
   });
 });

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -11,6 +11,7 @@
  * built-in JWT authentication infrastructure, avoiding the complexity of custom strategies.
  */
 
+import { getCurrentTenantId } from '@agor/core/db';
 import jwt from 'jsonwebtoken';
 
 const DEBUG_SESSION_TOKENS =
@@ -77,6 +78,7 @@ export class SessionTokenService {
 
     const now = new Date();
     const expiresAt = new Date(now.getTime() + this.config.expiration_ms);
+    const tenantId = getCurrentTenantId();
 
     // Create a JWT payload matching Feathers authentication format
     // This JWT will work seamlessly with the standard JWT strategy
@@ -88,6 +90,7 @@ export class SessionTokenService {
       session_id: sessionId,
       task_id: scope.taskId,
       branch_id: scope.branchId,
+      ...(tenantId ? { tenant_id: tenantId } : {}),
       iat: Math.floor(now.getTime() / 1000), // Issued at
       exp: Math.floor(expiresAt.getTime() / 1000), // Expiration
       aud: 'https://agor.dev', // Must match Feathers jwtOptions.audience

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -1,3 +1,4 @@
+import { runWithTenantDatabaseScope, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { Branch, BranchPermissionLevel, Session, User } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -52,6 +53,8 @@ function branch(id: string, others_can: Branch['others_can'] = 'none'): Branch {
 function session(id: string, branchId: string): Session {
   return { session_id: id, branch_id: branchId } as Session;
 }
+
+const scopeOnlyDb = { run: vi.fn() } as unknown as TenantScopeAwareDatabase;
 
 function repos(options: {
   branch: Branch;
@@ -140,6 +143,154 @@ describe('configureRealtimePublish', () => {
     );
 
     expect(channel.connections).toEqual([service]);
+  });
+
+  it('uses ambient tenant database scope for internal/manual emits without params tenant', async () => {
+    const tenantUser = user('tenant-user');
+    const otherTenantUser = user('other-tenant-user');
+    const app = makeApp(
+      [{ user: tenantUser }, { user: otherTenantUser }],
+      {},
+      {
+        authenticated: [{ user: tenantUser }, { user: otherTenantUser }],
+        'tenant:tenant-a': [{ user: tenantUser }],
+        'tenant:tenant-b': [{ user: otherTenantUser }],
+      }
+    );
+    const r = repos({ branch: branch('b1'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as any,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    const channel = await runWithTenantDatabaseScope(scopeOnlyDb, 'tenant-a', async () =>
+      app.runPublish(
+        { branch_id: 'b1' },
+        { path: 'branches', method: 'patch', event: 'patched', params: {} }
+      )
+    );
+
+    expect(channel.connections).toEqual([{ user: tenantUser }]);
+  });
+
+  it('uses authenticated socket connection tenant for executor/service emits without params tenant', async () => {
+    const tenantUser = user('tenant-user');
+    const otherTenantUser = user('other-tenant-user');
+    const app = makeApp(
+      [{ user: tenantUser }, { user: otherTenantUser }],
+      {},
+      {
+        authenticated: [{ user: tenantUser }, { user: otherTenantUser }],
+        'tenant:tenant-a': [{ user: tenantUser }],
+        'tenant:tenant-b': [{ user: otherTenantUser }],
+      }
+    );
+    const r = repos({ branch: branch('b1'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as any,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1' },
+      {
+        path: 'branches',
+        method: 'patch',
+        event: 'patched',
+        params: {
+          connection: {
+            tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+          },
+        },
+      }
+    );
+
+    expect(channel.connections).toEqual([{ user: tenantUser }]);
+  });
+
+  it('uses authenticated socket data tenant for executor/service emits without params tenant', async () => {
+    const tenantUser = user('tenant-user');
+    const otherTenantUser = user('other-tenant-user');
+    const app = makeApp(
+      [{ user: tenantUser }, { user: otherTenantUser }],
+      {},
+      {
+        authenticated: [{ user: tenantUser }, { user: otherTenantUser }],
+        'tenant:tenant-a': [{ user: tenantUser }],
+        'tenant:tenant-b': [{ user: otherTenantUser }],
+      }
+    );
+    const r = repos({ branch: branch('b1'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as any,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1' },
+      {
+        path: 'branches',
+        method: 'patch',
+        event: 'patched',
+        params: {
+          connection: {
+            data: { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
+          },
+        },
+      }
+    );
+
+    expect(channel.connections).toEqual([{ user: tenantUser }]);
+  });
+
+  it('does not trust event payload tenant_id without auth or ambient tenant scope', async () => {
+    const member = user('member');
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp(
+      [{ user: member }, service],
+      {},
+      {
+        authenticated: [{ user: member }, service],
+        'tenant:tenant-a': [{ user: member }],
+      }
+    );
+    const r = repos({ branch: branch('b1'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as any,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1', tenant_id: 'tenant-a' },
+      { path: 'branches', method: 'patch', event: 'patched', params: {} }
+    );
+
+    expect(channel.connections).toEqual([service]);
+    expect(app.channel).not.toHaveBeenCalledWith('tenant:tenant-a');
   });
 
   it('filters branch events to users with view access when RBAC is enabled', async () => {

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -4,7 +4,7 @@ import {
   TenantResolutionError,
 } from '@agor/core/config';
 import type { BranchRepository, SessionRepository } from '@agor/core/db';
-import { shortId } from '@agor/core/db';
+import { getCurrentTenantId, shortId } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { BranchID, HookContext, User, UserID } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
@@ -304,6 +304,36 @@ function filterToUserIdsOrSuperadmins(
   });
 }
 
+function extractConnectionTenantId(context: HookContext): string | undefined {
+  const params = context.params as
+    | {
+        connection?: {
+          tenant?: unknown;
+          data?: { tenant?: unknown };
+        };
+      }
+    | undefined;
+  const tenant = params?.connection?.tenant ?? params?.connection?.data?.tenant;
+  return tenant && typeof tenant === 'object' && 'tenant_id' in tenant
+    ? typeof tenant.tenant_id === 'string'
+      ? tenant.tenant_id
+      : undefined
+    : undefined;
+}
+
+function resolveRealtimeTenantId(multiTenancy: ResolvedMultiTenancyConfig, context: HookContext) {
+  try {
+    return resolveTenantContext(multiTenancy, { params: context.params }).tenant_id;
+  } catch (error) {
+    const connectionTenantId = extractConnectionTenantId(context);
+    if (error instanceof TenantResolutionError && connectionTenantId) return connectionTenantId;
+
+    const ambientTenantId = getCurrentTenantId();
+    if (error instanceof TenantResolutionError && ambientTenantId) return ambientTenantId;
+    throw error;
+  }
+}
+
 /**
  * Register the single global Feathers publish handler.
  *
@@ -342,8 +372,8 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     let tenantScoped = authenticated;
     if (multiTenancy) {
       try {
-        const tenant = resolveTenantContext(multiTenancy, { params: context.params });
-        tenantScoped = app.channel(tenantChannelName(tenant.tenant_id));
+        const tenantId = resolveRealtimeTenantId(multiTenancy, context);
+        tenantScoped = app.channel(tenantChannelName(tenantId));
       } catch (error) {
         if (error instanceof TenantResolutionError) {
           console.warn('[realtime] Suppressing event without tenant context', {


### PR DESCRIPTION
## Summary

Fix executor/manual realtime tenant routing in `multi_tenancy.required_from_auth` without trusting tenant IDs from event payloads.

Changes:
- Realtime publish now resolves tenant from centralized context:
  1. `context.params.tenant`
  2. authenticated Socket.io connection tenant (`params.connection.tenant` / `params.connection.data.tenant`)
  3. active ambient tenant DB scope (`getCurrentTenantId()`)
  4. otherwise fail closed/service-only
- Event payload `tenant_id` / `tenantId` is intentionally **not** used as authority for realtime tenant routing.
- `SessionTokenService.generateToken()` now copies the ambient tenant DB scope into executor-session JWT claims, so executor session tokens generated from tenant-scoped daemon work preserve tenant context on subsequent executor Feathers calls.
- Rebases on latest `main` and makes the manual `branches.patched` emit in `updateEnvironment()` safe for minimal service test doubles while keeping the production emit.

## Why

After #1683, Cloud/kind showed branch patch realtime symptoms where the DB row persisted but the board updated only after refresh. The suspected path is executor/service-originated `branches.patch`: the executor authenticates over Socket.io and patches the branch, but the realtime publish callback may not always receive `context.params.tenant` directly.

The safe fix is to recover tenant from authenticated runtime boundaries (socket auth / ambient DB scope / executor JWT), not from arbitrary event data.

## Tests / validation

- `pnpm exec biome check --write apps/agor-daemon/src/services/branches.ts apps/agor-daemon/src/utils/realtime-publish.ts apps/agor-daemon/src/utils/realtime-publish.test.ts apps/agor-daemon/src/services/session-token-service.ts apps/agor-daemon/src/services/session-token-service.test.ts`
- `pnpm --filter @agor/daemon exec vitest run src/services/branches.test.ts src/utils/realtime-publish.test.ts src/services/session-token-service.test.ts`
- `pnpm --filter @agor/git build && pnpm --filter @agor/core build && pnpm --filter @agor/daemon exec tsc --noEmit --pretty false`
- `pnpm check:multitenancy-boundaries`
- Earlier: `pnpm check`

Note: `pnpm i` completed, but the environment lacks `make`, so `node-pty`'s native install script logged a node-gyp failure. pnpm still completed successfully and the checks above passed.
