### PR TITLE
Fix executor tenant token propagation

### DIFF
--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -20,6 +20,8 @@ import { assertUserTokenNotInvalidated, type UserAuthTokenPayload } from './toke
 
 type JwtConnectionState = {
   authentication?: { strategy?: string; accessToken?: string; payload?: unknown };
+  tenant?: { tenant_id: string; source: 'auth_claim' };
+  data?: { tenant?: { tenant_id: string; source: 'auth_claim' } };
   feathers?: { authentication?: { strategy?: string; accessToken?: string; payload?: unknown } };
 };
 
@@ -59,10 +61,14 @@ function propagateTenantFromJwtPayload(
 ): void {
   const tenantId = readRuntimeTenantClaim(payload ?? undefined, tenantClaim);
   if (!tenantId) return;
-  const tenantParams = params as Params & {
-    tenant?: { tenant_id: string; source: 'auth_claim' };
-  };
-  tenantParams.tenant ??= { tenant_id: tenantId, source: 'auth_claim' };
+  const tenant = { tenant_id: tenantId, source: 'auth_claim' as const };
+  const tenantParams = params as Params & { tenant?: typeof tenant };
+  tenantParams.tenant ??= tenant;
+
+  const connection = (params as { connection?: JwtConnectionState } | undefined)?.connection;
+  if (!connection) return;
+  connection.tenant ??= tenant;
+  if (connection.data) connection.data.tenant ??= tenant;
 }
 
 /**

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -82,7 +82,11 @@ import { runPostStartJob, startup } from './startup.js';
 import { ensureOpenSourceTelemetryEnvEnabledConfig } from './utils/open-source-telemetry-config.js';
 import { shouldEmitOpenSourceTelemetryDaemonActive } from './utils/open-source-telemetry-heartbeat.js';
 import { startOpenSourceTelemetryUsageSummaryInterval } from './utils/open-source-telemetry-usage.js';
-import { configureDaemonUrl, configureExecutor } from './utils/spawn-executor.js';
+import {
+  configureDaemonUrl,
+  configureExecutor,
+  configureExecutorTokenTenantScoping,
+} from './utils/spawn-executor.js';
 import { registerAllWidgets } from './widgets/index.js';
 
 // Load daemon version at startup
@@ -300,6 +304,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   // when execution.executor_command_template is unset (no behavior change
   // for existing deployments).
   configureExecutor(config.execution);
+  configureExecutorTokenTenantScoping(config);
 
   initializeAnthropicApiKey(config, process.env.ANTHROPIC_API_KEY);
   initializeAnthropicAuthToken(config, process.env.ANTHROPIC_AUTH_TOKEN);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -10,6 +10,7 @@ import {
   PublicBaseUrlNotConfiguredError,
   requirePublicBaseUrl,
   resolveExecutionSecurityMode,
+  resolveMultiTenancyConfig,
 } from '@agor/core/config';
 import {
   and,
@@ -190,9 +191,12 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
 
   // Initialize session token service
   const { SessionTokenService } = await import('./services/session-token-service.js');
+  const multiTenancy = resolveMultiTenancyConfig(config);
   const sessionTokenService = new SessionTokenService({
     expiration_ms: config.execution?.session_token_expiration_ms || 24 * 60 * 60 * 1000,
     max_uses: config.execution?.session_token_max_uses || -1,
+    require_tenant_scope: multiTenancy.mode === 'required_from_auth',
+    tenant_claim: multiTenancy.auth_claim ?? 'tenant_id',
   });
 
   const appRecord = app as unknown as Record<string, unknown>;

--- a/apps/agor-daemon/src/services/session-token-service.test.ts
+++ b/apps/agor-daemon/src/services/session-token-service.test.ts
@@ -79,4 +79,21 @@ describe('SessionTokenService runtime scoping', () => {
 
     expect(decoded.tenant_id).toBe('tenant-a');
   });
+
+  it('fails closed when required_from_auth executor-session token issuance lacks tenant scope', async () => {
+    const service = new SessionTokenService({
+      expiration_ms: 60_000,
+      max_uses: 1,
+      require_tenant_scope: true,
+      tenant_claim: 'tenant_id',
+    });
+    service.setJwtSecret('session-token-test-secret');
+
+    await expect(
+      service.generateToken('session-1', 'user-1', {
+        taskId: 'task-1',
+        branchId: 'branch-1',
+      })
+    ).rejects.toThrow(/Missing tenant context/);
+  });
 });

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -13,6 +13,7 @@
 
 import { getCurrentTenantId } from '@agor/core/db';
 import jwt from 'jsonwebtoken';
+import { runtimeTenantClaims } from '../auth/runtime-tokens.js';
 
 const DEBUG_SESSION_TOKENS =
   process.env.AGOR_DEBUG_SESSION_TOKENS === '1' || process.env.DEBUG?.includes('session-token');
@@ -49,6 +50,8 @@ export class SessionTokenService {
     private config: {
       expiration_ms: number; // Default: 86400000 (24 hours)
       max_uses: number; // Default: -1 (unlimited)
+      require_tenant_scope?: boolean;
+      tenant_claim?: string;
     }
   ) {
     // Start cleanup timer (run every hour)
@@ -79,6 +82,11 @@ export class SessionTokenService {
     const now = new Date();
     const expiresAt = new Date(now.getTime() + this.config.expiration_ms);
     const tenantId = getCurrentTenantId();
+    if (this.config.require_tenant_scope && !tenantId) {
+      throw new Error(
+        'Missing tenant context for executor session token in multi_tenancy.required_from_auth'
+      );
+    }
 
     // Create a JWT payload matching Feathers authentication format
     // This JWT will work seamlessly with the standard JWT strategy
@@ -90,7 +98,7 @@ export class SessionTokenService {
       session_id: sessionId,
       task_id: scope.taskId,
       branch_id: scope.branchId,
-      ...(tenantId ? { tenant_id: tenantId } : {}),
+      ...runtimeTenantClaims(tenantId, this.config.tenant_claim ?? 'tenant_id'),
       iat: Math.floor(now.getTime() / 1000), // Issued at
       exp: Math.floor(expiresAt.getTime() / 1000), // Expiration
       aud: 'https://agor.dev', // Must match Feathers jwtOptions.audience

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -322,6 +322,128 @@ describe('socket handshake tenant propagation', () => {
       })
     );
     expect(socket.feathers?.user).toMatchObject({ user_id: ALICE, tenant_id: 'tenant-a' });
+    expect(socket.feathers?.authentication?.payload).toMatchObject({ tenant_id: 'tenant-a' });
+    expect(socket.data.tenant).toEqual({ tenant_id: 'tenant-a', source: 'auth_claim' });
+  });
+
+  it('attaches tenant and auth payload for service-token sockets', async () => {
+    const app = {
+      service: () => ({ get: vi.fn() }),
+      on: () => {},
+    } as unknown as Application;
+    const io = makeIO();
+    const config = createSocketIOConfig(app, {
+      corsOrigin: '*',
+      jwtSecret: 'test-secret',
+      credentialsAllowed: false,
+      webTerminalEnabled: true,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as never,
+        auth_claim: 'tenant_id',
+      },
+    } as SocketIOOptions);
+    config.callback(io as any);
+    const socket = makeSocket('tenant-service-socket', io);
+    socket.handshake.auth = {
+      token: issueRuntimeToken(
+        {
+          sub: 'executor-service',
+          type: 'service',
+          purpose: 'executor-service',
+          role: 'service',
+          tenant_id: 'tenant-a',
+        },
+        'test-secret',
+        '5m'
+      ),
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      io.middlewares[0]?.(socket, (error?: Error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+    expect(socket.feathers?.user).toMatchObject({
+      user_id: 'executor-service',
+      _isServiceAccount: true,
+    });
+    expect(socket.feathers?.authentication?.payload).toMatchObject({ tenant_id: 'tenant-a' });
+    expect(socket.tenant).toEqual({ tenant_id: 'tenant-a', source: 'auth_claim' });
+    expect(socket.data.tenant).toEqual({ tenant_id: 'tenant-a', source: 'auth_claim' });
+  });
+
+  it('validates executor-session socket tokens and attaches tenant service params', async () => {
+    const usersGet = vi.fn(async () => ({ user_id: ALICE, email: 'alice@example.test' }));
+    const validateToken = vi.fn(async () => ({
+      session_id: 'session-1',
+      task_id: 'task-1',
+      branch_id: 'branch-1',
+      user_id: ALICE,
+    }));
+    const app = {
+      service: () => ({ get: usersGet }),
+      on: () => {},
+      sessionTokenService: { validateToken },
+    } as unknown as Application;
+    const io = makeIO();
+    const config = createSocketIOConfig(app, {
+      corsOrigin: '*',
+      jwtSecret: 'test-secret',
+      credentialsAllowed: false,
+      webTerminalEnabled: true,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as never,
+        auth_claim: 'tenant_id',
+      },
+    } as SocketIOOptions);
+    config.callback(io as any);
+    const socket = makeSocket('tenant-executor-socket', io);
+    const token = issueRuntimeToken(
+      {
+        sub: ALICE,
+        type: 'executor-session',
+        purpose: 'executor-task',
+        session_id: 'session-1',
+        task_id: 'task-1',
+        branch_id: 'branch-1',
+        tenant_id: 'tenant-a',
+      },
+      'test-secret',
+      '5m'
+    );
+    socket.handshake.auth = { token };
+
+    await new Promise<void>((resolve, reject) => {
+      io.middlewares[0]?.(socket, (error?: Error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+
+    expect(validateToken).toHaveBeenCalledWith(token, {
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      branchId: 'branch-1',
+    });
+    expect(usersGet).toHaveBeenCalledWith(
+      ALICE,
+      expect.objectContaining({
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        authentication: { payload: expect.objectContaining({ tenant_id: 'tenant-a' }) },
+      })
+    );
+    expect(socket.feathers).toMatchObject({
+      user: { user_id: ALICE, tenant_id: 'tenant-a' },
+      session_id: 'session-1',
+      task_id: 'task-1',
+      branch_id: 'branch-1',
+      authentication: { payload: { tenant_id: 'tenant-a' } },
+    });
+    expect(socket.tenant).toEqual({ tenant_id: 'tenant-a', source: 'auth_claim' });
     expect(socket.data.tenant).toEqual({ tenant_id: 'tenant-a', source: 'auth_claim' });
   });
 });

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -57,6 +57,10 @@ interface FeathersSocket extends Socket {
     // `AuthenticatedUser` is the shape Feathers JWT strategies attach to
     // params/connections — it already carries `_isServiceAccount?: boolean`.
     user?: AuthenticatedUser;
+    authentication?: { strategy?: string; accessToken?: string; payload?: unknown };
+    session_id?: string;
+    task_id?: string;
+    branch_id?: string;
   };
   data: {
     isService?: boolean;
@@ -338,13 +342,28 @@ export function createSocketIOConfig(
         const decoded = jwt.verify(token, jwtSecret, {
           issuer: RUNTIME_JWT_ISSUER,
           audience: RUNTIME_JWT_AUDIENCE,
-        }) as { sub: string; type?: string; role?: string };
+        }) as {
+          sub: string;
+          type?: string;
+          role?: string;
+          purpose?: string;
+          session_id?: string;
+          sessionId?: string;
+          task_id?: string;
+          branch_id?: string;
+        };
 
         // Allow user tokens and service tokens (used by executor)
-        // - undefined/access: User tokens (SessionTokenService doesn't set type claim)
+        // - undefined/access: User tokens
         // - service: Executor service tokens (for terminal streaming, git ops, etc.)
+        // - executor-session: Prompt executor runtime tokens scoped to one turn
         const tokenType = decoded.type;
-        if (tokenType !== undefined && tokenType !== 'access' && tokenType !== 'service') {
+        if (
+          tokenType !== undefined &&
+          tokenType !== 'access' &&
+          tokenType !== 'service' &&
+          tokenType !== 'executor-session'
+        ) {
           return next(new Error('Invalid token type'));
         }
 
@@ -374,6 +393,7 @@ export function createSocketIOConfig(
               role: 'service',
               _isServiceAccount: true,
             },
+            authentication: { strategy: 'jwt', accessToken: token, payload: decoded },
           };
           // Keep the handshake fast-path marker too — older code and any
           // future callers that only look at socket.data still see it.
@@ -388,6 +408,45 @@ export function createSocketIOConfig(
           return next();
         }
 
+        if (tokenType === 'executor-session') {
+          if (decoded.purpose !== 'executor-task') {
+            return next(new Error('Invalid executor token purpose'));
+          }
+          const appRecord = app as unknown as {
+            sessionTokenService?: import('../services/session-token-service.js').SessionTokenService;
+          };
+          const sessionInfo = await appRecord.sessionTokenService?.validateToken(token, {
+            sessionId: decoded.session_id ?? decoded.sessionId,
+            taskId: decoded.task_id,
+            branchId: decoded.branch_id,
+          });
+          if (!sessionInfo) {
+            return next(new Error('Invalid or expired executor token'));
+          }
+
+          const user = await app.service('users').get(
+            decoded.sub as import('@agor/core/types').UUID,
+            {
+              ...(tenant ? { tenant } : {}),
+              authentication: { payload: decoded },
+            } as never
+          );
+          const fs = socket as FeathersSocket;
+          fs.feathers = {
+            user: tenant ? { ...user, tenant_id: tenant.tenant_id } : user,
+            authentication: { strategy: 'jwt', accessToken: token, payload: decoded },
+            session_id: sessionInfo.session_id,
+            task_id: sessionInfo.task_id,
+            branch_id: sessionInfo.branch_id,
+          };
+          if (tenant) {
+            (fs as FeathersSocket & { tenant?: TenantContext }).tenant = tenant;
+            if (fs.data) fs.data.tenant = tenant;
+          }
+          console.log(`🔐 WebSocket authenticated (executor): ${socket.id}`);
+          return next();
+        }
+
         // Handle user access tokens - fetch user from database
         const user = await app.service('users').get(
           decoded.sub as import('@agor/core/types').UUID,
@@ -399,7 +458,10 @@ export function createSocketIOConfig(
 
         // Attach user to socket (FeathersJS convention)
         const fs = socket as FeathersSocket;
-        fs.feathers = { user: tenant ? { ...user, tenant_id: tenant.tenant_id } : user };
+        fs.feathers = {
+          user: tenant ? { ...user, tenant_id: tenant.tenant_id } : user,
+          authentication: { strategy: 'jwt', accessToken: token, payload: decoded },
+        };
         if (tenant) {
           (fs as FeathersSocket & { tenant?: TenantContext }).tenant = tenant;
           if (fs.data) fs.data.tenant = tenant;

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -293,6 +293,44 @@ describe('configureRealtimePublish', () => {
     expect(app.channel).not.toHaveBeenCalledWith('tenant:tenant-a');
   });
 
+  it('routes branch patch publishes from auth-derived tenant instead of payload tenant_id', async () => {
+    const tenantUser = user('tenant-user');
+    const otherTenantUser = user('other-tenant-user');
+    const app = makeApp(
+      [{ user: tenantUser }, { user: otherTenantUser }],
+      {},
+      {
+        authenticated: [{ user: tenantUser }, { user: otherTenantUser }],
+        'tenant:tenant-a': [{ user: tenantUser }],
+        'tenant:tenant-b': [{ user: otherTenantUser }],
+      }
+    );
+    const r = repos({ branch: branch('b1'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as any,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    const channel = await app.runPublish(
+      { branch_id: 'b1', tenant_id: 'tenant-b' },
+      {
+        path: 'branches',
+        method: 'patch',
+        event: 'patched',
+        params: { authentication: { payload: { tenant_id: 'tenant-a' } } },
+      }
+    );
+
+    expect(channel.connections).toEqual([{ user: tenantUser }]);
+    expect(app.channel).toHaveBeenCalledWith('tenant:tenant-a');
+  });
+
   it('filters branch events to users with view access when RBAC is enabled', async () => {
     const allowed = user('allowed');
     const denied = user('denied');

--- a/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
@@ -1,13 +1,23 @@
+import { runWithTenantDatabaseScope, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { AuthenticatedParams } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
+  configureExecutorTokenTenantScoping,
   createServiceToken,
+  EXECUTOR_TOKEN_GLOBAL_SCOPE_CLAIM,
   generateScopedServiceToken,
+  globalExecutorTokenScope,
   serviceTokenScopeForParams,
 } from './spawn-executor';
 
+const scopeOnlyDb = { run: () => undefined } as unknown as TenantScopeAwareDatabase;
+
 describe('executor service token scoping', () => {
+  afterEach(() => {
+    configureExecutorTokenTenantScoping(null);
+  });
+
   it('copies tenant context into service token claims', () => {
     const scope = serviceTokenScopeForParams({
       tenant: { tenant_id: 'tenant-a' as never, source: 'auth_claim' },
@@ -35,6 +45,53 @@ describe('executor service token scoping', () => {
 
   it('omits tenant claim for single-tenant/internal calls without tenant context', () => {
     expect(serviceTokenScopeForParams({})).toEqual({});
+  });
+
+  it('copies ambient tenant database scope into service token claims', async () => {
+    configureExecutorTokenTenantScoping({
+      mode: 'required_from_auth',
+      static_tenant_id: 'default' as never,
+      auth_claim: 'tenant_id',
+    });
+
+    const scope = await runWithTenantDatabaseScope(scopeOnlyDb, 'tenant-ambient', () =>
+      Promise.resolve(serviceTokenScopeForParams({}))
+    );
+    const token = createServiceToken('test-secret', '5m', scope);
+    const decoded = jwt.decode(token) as { tenant_id?: string; type?: string };
+
+    expect(decoded.type).toBe('service');
+    expect(decoded.tenant_id).toBe('tenant-ambient');
+  });
+
+  it('fails closed for required_from_auth service token issuance without tenant context', () => {
+    configureExecutorTokenTenantScoping({
+      mode: 'required_from_auth',
+      static_tenant_id: 'default' as never,
+      auth_claim: 'tenant_id',
+    });
+
+    expect(() => serviceTokenScopeForParams({})).toThrow(/Missing tenant context/);
+    expect(() => createServiceToken('test-secret', '5m')).toThrow(/Missing tenant context/);
+  });
+
+  it('keeps explicit global executor token escape searchable', () => {
+    configureExecutorTokenTenantScoping({
+      mode: 'required_from_auth',
+      static_tenant_id: 'default' as never,
+      auth_claim: 'tenant_id',
+    });
+
+    const token = createServiceToken('test-secret', '5m', {
+      ...globalExecutorTokenScope('test-only non-tenant-owned executor check'),
+    });
+    const decoded = jwt.decode(token) as Record<string, unknown>;
+
+    expect(decoded.type).toBe('service');
+    expect(decoded.tenant_id).toBeUndefined();
+    expect(decoded[EXECUTOR_TOKEN_GLOBAL_SCOPE_CLAIM]).toBe(
+      'test-only non-tenant-owned executor check'
+    );
   });
 
   it('generates tenant-scoped service tokens directly from params', () => {

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -25,7 +25,15 @@ import { type ChildProcess, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { AgorExecutionSettings } from '@agor/core/config';
+import {
+  type AgorConfig,
+  type AgorExecutionSettings,
+  type ResolvedMultiTenancyConfig,
+  resolveMultiTenancyConfig,
+  resolveTenantContext,
+  TenantResolutionError,
+} from '@agor/core/config';
+import { getCurrentTenantId } from '@agor/core/db';
 import type { AuthenticatedParams } from '@agor/core/types';
 import {
   attachEnvFileCleanup,
@@ -35,7 +43,11 @@ import {
 } from '@agor/core/unix';
 import { getCurrentLogLevel } from '@agor/core/utils/logger';
 import type { SignOptions } from 'jsonwebtoken';
-import { issueRuntimeToken } from '../auth/runtime-tokens.js';
+import {
+  issueRuntimeToken,
+  readRuntimeTenantClaim,
+  runtimeTenantClaims,
+} from '../auth/runtime-tokens.js';
 import { withResolvedConfig } from './build-resolved-config-slice.js';
 
 let configuredDaemonUrl: string | null = null;
@@ -62,6 +74,28 @@ export function configureDaemonUrl(url: string): void {
 }
 
 let configuredExecutorDefaults: ExecutorSpawnDefaults = {};
+let configuredExecutorMultiTenancy: ResolvedMultiTenancyConfig = resolveMultiTenancyConfig({});
+
+export const EXECUTOR_TOKEN_GLOBAL_SCOPE_CLAIM = 'agor_global_scope';
+
+export function globalExecutorTokenScope(reason: string): Record<string, string> {
+  const trimmed = reason.trim();
+  if (!trimmed) {
+    throw new Error('Global executor token scope requires a reason');
+  }
+  return { [EXECUTOR_TOKEN_GLOBAL_SCOPE_CLAIM]: trimmed };
+}
+
+/** Configure tenant enforcement for executor/service tokens. Call once at daemon startup. */
+export function configureExecutorTokenTenantScoping(
+  config?: Pick<AgorConfig, 'multi_tenancy'> | ResolvedMultiTenancyConfig | null
+): void {
+  configuredExecutorMultiTenancy = config
+    ? 'static_tenant_id' in config
+      ? config
+      : resolveMultiTenancyConfig(config)
+    : resolveMultiTenancyConfig({});
+}
 
 /** Set default executor template + impersonation user from config. Call once at daemon startup. */
 export function configureExecutor(config?: ExecutorConfig | null): void {
@@ -821,6 +855,7 @@ export function createServiceToken(
   expiresIn?: SignOptions['expiresIn'],
   scope: Record<string, unknown> = {}
 ): string {
+  const resolvedScope = completeExecutorTokenTenantScope(scope);
   return issueRuntimeToken(
     {
       sub: 'executor-service',
@@ -828,10 +863,75 @@ export function createServiceToken(
       purpose: 'executor-service',
       // Service tokens can perform privileged operations
       role: 'service',
-      ...scope,
+      ...resolvedScope,
     },
     jwtSecret,
     expiresIn || '5m'
+  );
+}
+
+type ExecutorTokenTenantScopeOptions = {
+  multiTenancy?: ResolvedMultiTenancyConfig;
+  allowGlobalTenantScopeReason?: string;
+};
+
+function hasGlobalExecutorScope(scope: Record<string, unknown>): boolean {
+  return typeof scope[EXECUTOR_TOKEN_GLOBAL_SCOPE_CLAIM] === 'string';
+}
+
+function tokenScopeHasTenantClaim(
+  scope: Record<string, unknown>,
+  multiTenancy: ResolvedMultiTenancyConfig
+): boolean {
+  return readRuntimeTenantClaim(scope, multiTenancy.auth_claim ?? 'tenant_id') !== undefined;
+}
+
+function tenantClaimsForToken(
+  tenantId: string,
+  multiTenancy: ResolvedMultiTenancyConfig
+): Record<string, string> {
+  return runtimeTenantClaims(tenantId, multiTenancy.auth_claim ?? 'tenant_id');
+}
+
+function tenantIdFromParams(
+  params: Partial<AuthenticatedParams> | undefined,
+  multiTenancy: ResolvedMultiTenancyConfig
+): string | undefined {
+  if (!params) return undefined;
+
+  if (multiTenancy.mode === 'required_from_auth') {
+    try {
+      return resolveTenantContext(multiTenancy, { params }).tenant_id;
+    } catch (error) {
+      if (!(error instanceof TenantResolutionError)) throw error;
+    }
+  }
+
+  return params.tenant?.tenant_id ?? params.tenant_id ?? params.user?.tenant_id;
+}
+
+function completeExecutorTokenTenantScope(
+  scope: Record<string, unknown>,
+  options: ExecutorTokenTenantScopeOptions = {}
+): Record<string, unknown> {
+  const multiTenancy = options.multiTenancy ?? configuredExecutorMultiTenancy;
+  if (tokenScopeHasTenantClaim(scope, multiTenancy) || hasGlobalExecutorScope(scope)) {
+    return scope;
+  }
+
+  if (multiTenancy.mode !== 'required_from_auth') return scope;
+
+  const ambientTenantId = getCurrentTenantId();
+  if (ambientTenantId) {
+    return { ...scope, ...tenantClaimsForToken(ambientTenantId, multiTenancy) };
+  }
+
+  if (options.allowGlobalTenantScopeReason) {
+    return { ...scope, ...globalExecutorTokenScope(options.allowGlobalTenantScopeReason) };
+  }
+
+  throw new Error(
+    'Missing tenant context for executor service token in multi_tenancy.required_from_auth'
   );
 }
 
@@ -842,10 +942,25 @@ export function createServiceToken(
  * them as the static/default tenant.
  */
 export function serviceTokenScopeForParams(
-  params?: Partial<AuthenticatedParams>
+  params?: Partial<AuthenticatedParams>,
+  options: ExecutorTokenTenantScopeOptions = {}
 ): Record<string, unknown> {
-  const tenantId = params?.tenant?.tenant_id ?? params?.tenant_id ?? params?.user?.tenant_id;
-  return tenantId ? { tenant_id: tenantId } : {};
+  const multiTenancy = options.multiTenancy ?? configuredExecutorMultiTenancy;
+  const paramsTenantId = tenantIdFromParams(params, multiTenancy);
+  if (paramsTenantId) return tenantClaimsForToken(paramsTenantId, multiTenancy);
+
+  if (multiTenancy.mode !== 'required_from_auth') return {};
+
+  const tenantId = getCurrentTenantId();
+  if (tenantId) return tenantClaimsForToken(tenantId, multiTenancy);
+
+  if (options.allowGlobalTenantScopeReason) {
+    return globalExecutorTokenScope(options.allowGlobalTenantScopeReason);
+  }
+
+  throw new Error(
+    'Missing tenant context for executor service token in multi_tenancy.required_from_auth'
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- centralize executor/service-token tenant derivation in `spawn-executor` and enforce tenant-bearing tokens in `multi_tenancy.required_from_auth`
- make executor-session token issuance fail closed without ambient tenant scope in required-from-auth deployments
- persist token-derived tenant context onto Feathers params/socket connection state for service and executor-session auth
- add regression coverage for service-token claims, ambient DB scope, explicit global escape, socket auth, and auth-derived realtime tenant routing

## Validation

- `pnpm --filter @agor/daemon test`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm check:shortid`
- `pnpm check:multitenancy-boundaries`
