### PR TITLE
perf(agor-ui): useAgorData returns only load state + subscribes narrowly (collapse flip)

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -49,6 +49,17 @@ import {
   useSessionActions,
 } from './hooks';
 import { useSurfaceBranding } from './hooks/useSurfaceBranding';
+import { useAgorStore } from './store/agorStore';
+import {
+  selectBoardById,
+  selectBranchById,
+  selectCommentById,
+  selectRepoById,
+  selectSessionById,
+  selectSessionMcpServerIds,
+  selectSessionsByBranch,
+  selectUserById,
+} from './store/selectors';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
 import type { RouteSurfaceId } from './surfaces/surfaceRegistry';
 import {
@@ -324,14 +335,6 @@ function AppContent() {
   // failure chain we're avoiding.
   // Skip data fetch if user needs to change password — the ForcePasswordChangeModal handles that.
   const {
-    sessionById,
-    sessionsByBranch,
-    boardById,
-    commentById,
-    repoById,
-    branchById,
-    userById,
-    sessionMcpServerIds,
     initialLoadItems,
     initialLoadComplete,
     loadingStage,
@@ -341,6 +344,18 @@ function AppContent() {
     enabled: workspaceSurfaceShouldRun && !user?.must_change_password,
     directSessionId: directSessionIdFromPath,
   });
+
+  // Entity maps are read directly from the store rather than the useAgorData
+  // return so each map is its own narrow subscription — the surface only
+  // re-renders for the slices it actually consumes, not on every entity write.
+  const sessionById = useAgorStore(selectSessionById);
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+  const boardById = useAgorStore(selectBoardById);
+  const commentById = useAgorStore(selectCommentById);
+  const repoById = useAgorStore(selectRepoById);
+  const branchById = useAgorStore(selectBranchById);
+  const userById = useAgorStore(selectUserById);
+  const sessionMcpServerIds = useAgorStore(selectSessionMcpServerIds);
 
   // Session actions
   const { createSession, forkSession, btwForkSession, spawnSession, updateSession, deleteSession } =

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -9,11 +9,16 @@
  * store (idempotent patch, archive event for an unknown id, etc.), an
  * earlier bug always produced a fresh `maps` reference, cascading
  * re-renders into the board canvas. These tests pin down the bailout
- * contract: if an event doesn't change byId content, the hook return
- * shape is reference-stable.
+ * contract: if an event doesn't change byId content, the entity map
+ * references in the store are stable.
+ *
+ * The hook itself returns only load-state (it no longer surfaces the entity
+ * maps); the maps live in `agorStore`, so map assertions read them via
+ * `agorStore.getState().<map>` while load-state reads stay on `result.current`.
  */
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { agorStore } from '../store/agorStore';
 import { useAgorData } from './useAgorData';
 
 /**
@@ -223,12 +228,12 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client, { directSessionId: 's-archived' }));
     await waitForInitialLoad(result);
 
-    expect(result.current.sessionById.get('s-archived-full')).toMatchObject({
+    expect(agorStore.getState().sessionById.get('s-archived-full')).toMatchObject({
       archived: true,
       branch_id: 'b-archived',
     });
-    expect(result.current.sessionsByBranch.has('b-archived')).toBe(false);
-    expect(result.current.branchById.has('b-archived')).toBe(false);
+    expect(agorStore.getState().sessionsByBranch.has('b-archived')).toBe(false);
+    expect(agorStore.getState().branchById.has('b-archived')).toBe(false);
   });
 
   it('drops a duplicate `sessions.patched` (content-equal) without changing byId references', async () => {
@@ -237,15 +242,15 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const beforeSessions = result.current.sessionById;
-    const beforeByBranch = result.current.sessionsByBranch;
+    const beforeSessions = agorStore.getState().sessionById;
+    const beforeByBranch = agorStore.getState().sessionsByBranch;
 
     // Feathers re-emits a fresh object on every patch — same content,
     // different reference. The hook MUST bail out (no-op patch).
     act(() => emit('sessions', 'patched', { ...session }));
 
-    expect(result.current.sessionById).toBe(beforeSessions);
-    expect(result.current.sessionsByBranch).toBe(beforeByBranch);
+    expect(agorStore.getState().sessionById).toBe(beforeSessions);
+    expect(agorStore.getState().sessionsByBranch).toBe(beforeByBranch);
   });
 
   it('updates byId references when a session field actually changes', async () => {
@@ -254,12 +259,12 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const beforeSessions = result.current.sessionById;
+    const beforeSessions = agorStore.getState().sessionById;
 
     act(() => emit('sessions', 'patched', { ...session, status: 'running' }));
 
-    expect(result.current.sessionById).not.toBe(beforeSessions);
-    expect(result.current.sessionById.get('s-1')).toMatchObject({ status: 'running' });
+    expect(agorStore.getState().sessionById).not.toBe(beforeSessions);
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'running' });
   });
 
   it('updates branch-card session buckets when stop patches a running session idle', async () => {
@@ -276,11 +281,11 @@ describe('useAgorData — socket-event bailouts', () => {
       })
     );
 
-    expect(result.current.sessionById.get('s-1')).toMatchObject({
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({
       status: 'idle',
       ready_for_prompt: true,
     });
-    expect(result.current.sessionsByBranch.get('b-1')?.[0]).toMatchObject({
+    expect(agorStore.getState().sessionsByBranch.get('b-1')?.[0]).toMatchObject({
       status: 'idle',
       ready_for_prompt: true,
     });
@@ -291,13 +296,13 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const beforeSessions = result.current.sessionById;
-    const beforeByBranch = result.current.sessionsByBranch;
+    const beforeSessions = agorStore.getState().sessionById;
+    const beforeByBranch = agorStore.getState().sessionsByBranch;
 
     act(() => emit('sessions', 'removed', makeSession({ session_id: 'unknown' })));
 
-    expect(result.current.sessionById).toBe(beforeSessions);
-    expect(result.current.sessionsByBranch).toBe(beforeByBranch);
+    expect(agorStore.getState().sessionById).toBe(beforeSessions);
+    expect(agorStore.getState().sessionsByBranch).toBe(beforeByBranch);
   });
 
   it('drops a no-op `branches.patched` (idempotent content)', async () => {
@@ -306,9 +311,9 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const before = result.current.branchById;
+    const before = agorStore.getState().branchById;
     act(() => emit('branches', 'patched', { ...branch }));
-    expect(result.current.branchById).toBe(before);
+    expect(agorStore.getState().branchById).toBe(before);
   });
 
   it('updates branchById when a branch field flips', async () => {
@@ -317,11 +322,11 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const before = result.current.branchById;
+    const before = agorStore.getState().branchById;
     act(() => emit('branches', 'patched', { ...branch, name: 'feature/x' }));
 
-    expect(result.current.branchById).not.toBe(before);
-    expect(result.current.branchById.get('b-1')?.name).toBe('feature/x');
+    expect(agorStore.getState().branchById).not.toBe(before);
+    expect(agorStore.getState().branchById.get('b-1')?.name).toBe('feature/x');
   });
 
   it('drops a duplicate `sessions.created` for an existing id', async () => {
@@ -330,13 +335,13 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const beforeSessions = result.current.sessionById;
-    const beforeByBranch = result.current.sessionsByBranch;
+    const beforeSessions = agorStore.getState().sessionById;
+    const beforeByBranch = agorStore.getState().sessionsByBranch;
 
     act(() => emit('sessions', 'created', { ...session }));
 
-    expect(result.current.sessionById).toBe(beforeSessions);
-    expect(result.current.sessionsByBranch).toBe(beforeByBranch);
+    expect(agorStore.getState().sessionById).toBe(beforeSessions);
+    expect(agorStore.getState().sessionsByBranch).toBe(beforeByBranch);
   });
 
   it('keeps unrelated byId maps reference-stable across a session patch', async () => {
@@ -346,18 +351,18 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const beforeBranches = result.current.branchById;
-    const beforeBoards = result.current.boardById;
-    const beforeUsers = result.current.userById;
+    const beforeBranches = agorStore.getState().branchById;
+    const beforeBoards = agorStore.getState().boardById;
+    const beforeUsers = agorStore.getState().userById;
 
     act(() => emit('sessions', 'patched', { ...session, status: 'running' }));
 
     // Only sessionById / sessionsByBranch flip — the rest must stay put so
     // their consumers (SessionCanvas, boards UI, user settings) don't
     // needlessly re-render.
-    expect(result.current.branchById).toBe(beforeBranches);
-    expect(result.current.boardById).toBe(beforeBoards);
-    expect(result.current.userById).toBe(beforeUsers);
+    expect(agorStore.getState().branchById).toBe(beforeBranches);
+    expect(agorStore.getState().boardById).toBe(beforeBoards);
+    expect(agorStore.getState().userById).toBe(beforeUsers);
   });
 
   it('migrates a session between branches when branch_id changes', async () => {
@@ -366,14 +371,24 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    expect(result.current.sessionsByBranch.get('b-1')?.map((s) => s.session_id)).toEqual(['s-1']);
+    expect(
+      agorStore
+        .getState()
+        .sessionsByBranch.get('b-1')
+        ?.map((s) => s.session_id)
+    ).toEqual(['s-1']);
 
     act(() => emit('sessions', 'patched', { ...session, branch_id: 'b-2' }));
 
     // Old branch bucket is cleaned up; new branch bucket holds the session.
-    expect(result.current.sessionsByBranch.has('b-1')).toBe(false);
-    expect(result.current.sessionsByBranch.get('b-2')?.map((s) => s.session_id)).toEqual(['s-1']);
-    expect(result.current.sessionById.get('s-1')?.branch_id).toBe('b-2');
+    expect(agorStore.getState().sessionsByBranch.has('b-1')).toBe(false);
+    expect(
+      agorStore
+        .getState()
+        .sessionsByBranch.get('b-2')
+        ?.map((s) => s.session_id)
+    ).toEqual(['s-1']);
+    expect(agorStore.getState().sessionById.get('s-1')?.branch_id).toBe('b-2');
   });
 
   it('evicts a branch and its sessions on `branches.removed`', async () => {
@@ -383,15 +398,15 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    expect(result.current.branchById.has('b-1')).toBe(true);
-    expect(result.current.sessionById.has('s-1')).toBe(true);
-    expect(result.current.sessionsByBranch.has('b-1')).toBe(true);
+    expect(agorStore.getState().branchById.has('b-1')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(true);
+    expect(agorStore.getState().sessionsByBranch.has('b-1')).toBe(true);
 
     act(() => emit('branches', 'removed', branch));
 
-    expect(result.current.branchById.has('b-1')).toBe(false);
-    expect(result.current.sessionById.has('s-1')).toBe(false);
-    expect(result.current.sessionsByBranch.has('b-1')).toBe(false);
+    expect(agorStore.getState().branchById.has('b-1')).toBe(false);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(false);
+    expect(agorStore.getState().sessionsByBranch.has('b-1')).toBe(false);
   });
 
   it('dispatches `agor:artifact-patched` when the artifact actually changes', async () => {
@@ -414,7 +429,7 @@ describe('useAgorData — socket-event bailouts', () => {
       act(() => emit('artifacts', 'patched', { ...artifact, content_hash: 'h2' }));
 
       expect(events).toEqual([{ artifactId: 'a-1', contentHash: 'h2' }]);
-      expect(result.current.artifactById.get('a-1')?.content_hash).toBe('h2');
+      expect(agorStore.getState().artifactById.get('a-1')?.content_hash).toBe('h2');
     } finally {
       window.removeEventListener('agor:artifact-patched', listener);
     }
@@ -436,11 +451,11 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const before = result.current.artifactById;
+    const before = agorStore.getState().artifactById;
 
     act(() => emit('artifacts', 'patched', { ...artifact }));
 
-    expect(result.current.artifactById).toBe(before);
+    expect(agorStore.getState().artifactById).toBe(before);
   });
 
   it('builds derived board-object indexes during initial load', async () => {
@@ -462,16 +477,23 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    expect(result.current.boardObjectById.get('bo-branch')).toMatchObject({ branch_id: 'b-1' });
-    expect(result.current.boardObjectsByBoardId.get('board-1')?.map((bo) => bo.object_id)).toEqual([
-      'bo-branch',
-      'bo-card',
-    ]);
-    expect(result.current.boardObjectsByBoardId.get('board-2')?.map((bo) => bo.object_id)).toEqual([
-      'bo-other',
-    ]);
-    expect(result.current.boardObjectByBranchId.get('b-1')?.object_id).toBe('bo-branch');
-    expect(result.current.boardObjectByCardId.get('c-1')?.object_id).toBe('bo-card');
+    expect(agorStore.getState().boardObjectById.get('bo-branch')).toMatchObject({
+      branch_id: 'b-1',
+    });
+    expect(
+      agorStore
+        .getState()
+        .boardObjectsByBoardId.get('board-1')
+        ?.map((bo) => bo.object_id)
+    ).toEqual(['bo-branch', 'bo-card']);
+    expect(
+      agorStore
+        .getState()
+        .boardObjectsByBoardId.get('board-2')
+        ?.map((bo) => bo.object_id)
+    ).toEqual(['bo-other']);
+    expect(agorStore.getState().boardObjectByBranchId.get('b-1')?.object_id).toBe('bo-branch');
+    expect(agorStore.getState().boardObjectByCardId.get('c-1')?.object_id).toBe('bo-card');
   });
 
   it('keeps board-object derived indexes in sync across patch and remove events', async () => {
@@ -494,18 +516,21 @@ describe('useAgorData — socket-event bailouts', () => {
       })
     );
 
-    expect(result.current.boardObjectsByBoardId.has('board-1')).toBe(false);
-    expect(result.current.boardObjectsByBoardId.get('board-2')?.map((bo) => bo.object_id)).toEqual([
-      'bo-1',
-    ]);
-    expect(result.current.boardObjectByBranchId.has('b-1')).toBe(false);
-    expect(result.current.boardObjectByBranchId.get('b-2')?.zone_id).toBe('zone-b');
+    expect(agorStore.getState().boardObjectsByBoardId.has('board-1')).toBe(false);
+    expect(
+      agorStore
+        .getState()
+        .boardObjectsByBoardId.get('board-2')
+        ?.map((bo) => bo.object_id)
+    ).toEqual(['bo-1']);
+    expect(agorStore.getState().boardObjectByBranchId.has('b-1')).toBe(false);
+    expect(agorStore.getState().boardObjectByBranchId.get('b-2')?.zone_id).toBe('zone-b');
 
     act(() => emit('board-objects', 'removed', { ...boardObject, board_id: 'board-2' }));
 
-    expect(result.current.boardObjectById.has('bo-1')).toBe(false);
-    expect(result.current.boardObjectsByBoardId.has('board-2')).toBe(false);
-    expect(result.current.boardObjectByBranchId.has('b-2')).toBe(false);
+    expect(agorStore.getState().boardObjectById.has('bo-1')).toBe(false);
+    expect(agorStore.getState().boardObjectsByBoardId.has('board-2')).toBe(false);
+    expect(agorStore.getState().boardObjectByBranchId.has('b-2')).toBe(false);
   });
 
   it('keeps unrelated board-object buckets reference-stable on other-board patches', async () => {
@@ -521,7 +546,7 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    const beforeCurrentBoardBucket = result.current.boardObjectsByBoardId.get('board-1');
+    const beforeCurrentBoardBucket = agorStore.getState().boardObjectsByBoardId.get('board-1');
 
     act(() =>
       emit('board-objects', 'patched', {
@@ -530,8 +555,10 @@ describe('useAgorData — socket-event bailouts', () => {
       })
     );
 
-    expect(result.current.boardObjectsByBoardId.get('board-1')).toBe(beforeCurrentBoardBucket);
-    expect(result.current.boardObjectsByBoardId.get('board-2')?.[0]?.zone_id).toBe(
+    expect(agorStore.getState().boardObjectsByBoardId.get('board-1')).toBe(
+      beforeCurrentBoardBucket
+    );
+    expect(agorStore.getState().boardObjectsByBoardId.get('board-2')?.[0]?.zone_id).toBe(
       'zone-on-other-board'
     );
   });
@@ -567,13 +594,14 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    expect(result.current.sessionById.has('s-1')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(true);
     // s-2 was absent from first paint and only arrives via the hydration.
-    expect(result.current.sessionById.has('s-2')).toBe(true);
-    expect(result.current.branchById.has('b-1')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-2')).toBe(true);
+    expect(agorStore.getState().branchById.has('b-1')).toBe(true);
     expect(
-      result.current.sessionsByBranch
-        .get('b-1')
+      agorStore
+        .getState()
+        .sessionsByBranch.get('b-1')
         ?.map((s) => s.session_id)
         .sort()
     ).toEqual(['s-1', 's-2']);
@@ -600,8 +628,8 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     // The first snapshot was discarded (it raced) and a second fetch applied.
     expect(fetchCount('sessions', 'findAll')).toBe(2);
     // The racing live create survived AND the hydration filled in s-2.
-    expect(result.current.sessionById.has('s-3')).toBe(true);
-    expect(result.current.sessionById.has('s-2')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-3')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-2')).toBe(true);
   });
 
   it('retries after races until a quiet window, then applies the fresh snapshot (never gives up)', async () => {
@@ -621,7 +649,7 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    await waitFor(() => expect(result.current.sessionById.has('s-2')).toBe(true), {
+    await waitFor(() => expect(agorStore.getState().sessionById.has('s-2')).toBe(true), {
       timeout: 4000,
     });
     // Applied on the first quiet window (3rd attempt) — not skipped forever.
@@ -653,10 +681,10 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
       timeout: 5000,
     });
 
-    expect(result.current.sessionById.has('s-1')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(true);
     // The stale snapshot was never applied (it never went quiet), so s-2 stays
     // removed — a racy snapshot is never force-applied.
-    expect(result.current.sessionById.has('s-2')).toBe(false);
+    expect(agorStore.getState().sessionById.has('s-2')).toBe(false);
   });
 
   it('applies an unrelated collection while another keeps racing (per-collection revisions)', async () => {
@@ -678,10 +706,10 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     await waitForInitialLoad(result);
 
     // …the mcp-servers hydration is independent of `sessions`, so it applied.
-    await waitFor(() => expect(result.current.mcpServerById.has('m-1')).toBe(true));
-    expect(result.current.mcpServerById.has('m-2')).toBe(true);
+    await waitFor(() => expect(agorStore.getState().mcpServerById.has('m-1')).toBe(true));
+    expect(agorStore.getState().mcpServerById.has('m-2')).toBe(true);
     // …while the still-racing sessions hydration has not applied (s-2 absent).
-    expect(result.current.sessionById.has('s-2')).toBe(false);
+    expect(agorStore.getState().sessionById.has('s-2')).toBe(false);
   });
 
   it('decouples per-collection hydration: session churn does not block the branch apply', async () => {
@@ -704,9 +732,9 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     await waitForInitialLoad(result);
 
     // Branches hydrated on their own quiet window despite perpetual session churn.
-    await waitFor(() => expect(result.current.branchById.has('b-1')).toBe(true));
+    await waitFor(() => expect(agorStore.getState().branchById.has('b-1')).toBe(true));
     // Sessions still racing → not applied (coupling would have blocked branches).
-    expect(result.current.sessionById.has('s-2')).toBe(false);
+    expect(agorStore.getState().sessionById.has('s-2')).toBe(false);
   });
 
   it('runs backoff retries with delays preceding attempts (off-by-one)', async () => {
@@ -728,7 +756,7 @@ describe('useAgorData — skip-apply-on-race hydration', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    await waitFor(() => expect(result.current.sessionById.has('s-2')).toBe(true), {
+    await waitFor(() => expect(agorStore.getState().sessionById.has('s-2')).toBe(true), {
       timeout: 4000,
     });
     expect(fetchCount('sessions', 'findAll')).toBe(6);
@@ -772,7 +800,7 @@ describe('useAgorData — bulk-write revision bumps', () => {
       await new Promise<void>((r) => setTimeout(r, 0));
     });
     // Reconnect applied the newer snapshot and bumped revisions.
-    expect(result.current.sessionById.has('s-new')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-new')).toBe(true);
 
     // Release the stale in-flight hydration. Its snapshot ([s-1] only) would, if
     // applied, drop s-new — but the reconnect's revision bump fails its quiet
@@ -782,8 +810,8 @@ describe('useAgorData — bulk-write revision bumps', () => {
       await new Promise<void>((r) => setTimeout(r, 0));
     });
     await flush();
-    expect(result.current.sessionById.has('s-new')).toBe(true);
-    expect(result.current.sessionById.has('s-1')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-new')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(true);
   });
 
   it('logout reset bumps generation/revisions so an in-flight hydration cannot repopulate after logout', async () => {
@@ -809,7 +837,7 @@ describe('useAgorData — bulk-write revision bumps', () => {
       rerender({ c: null });
       await new Promise<void>((r) => setTimeout(r, 0));
     });
-    expect(result.current.sessionById.size).toBe(0);
+    expect(agorStore.getState().sessionById.size).toBe(0);
 
     // Release the in-flight hydration. Its snapshot ([s-1]) must NOT repopulate
     // the cleared Maps: the reset bumped the generation (cancels the loop) and
@@ -819,8 +847,8 @@ describe('useAgorData — bulk-write revision bumps', () => {
       await new Promise<void>((r) => setTimeout(r, 0));
     });
     await flush();
-    expect(result.current.sessionById.size).toBe(0);
-    expect(result.current.sessionById.has('s-1')).toBe(false);
+    expect(agorStore.getState().sessionById.size).toBe(0);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(false);
   });
 });
 
@@ -858,7 +886,7 @@ describe('useAgorData — lean boards list + objects hydration', () => {
     const { result } = renderHook(() => useAgorData(client));
     try {
       await waitForInitialLoad(result);
-      const board = result.current.boardById.get('board-D');
+      const board = agorStore.getState().boardById.get('board-D');
       expect(board?.objects).toBeDefined();
       expect(Object.keys(board?.objects ?? {})).toContain('zone-1');
       expect(board?.custom_css).toBe('.x{}');
@@ -898,7 +926,7 @@ describe('useAgorData — lean boards list + objects hydration', () => {
     const { result } = renderHook(() => useAgorData(client));
     try {
       await waitForInitialLoad(result);
-      const board = result.current.boardById.get(boardId);
+      const board = agorStore.getState().boardById.get(boardId);
       expect(board?.objects).toBeDefined();
       expect(Object.keys(board?.objects ?? {})).toContain('zone-1');
       expect(board?.custom_css).toBe('.x{}');
@@ -929,7 +957,7 @@ describe('useAgorData — lean boards list + objects hydration', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
     await flush();
-    expect(result.current.boardById.get('board-A')?.objects).toBeDefined();
-    expect(result.current.boardById.get('board-B')?.objects).toBeDefined();
+    expect(agorStore.getState().boardById.get('board-A')?.objects).toBeDefined();
+    expect(agorStore.getState().boardById.get('board-B')?.objects).toBeDefined();
   });
 });

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -55,12 +55,6 @@ import {
   resolveSessionFromShortIdPure,
 } from '../utils/urlResolution';
 
-export type { DataMaps } from '../store/agorMaps';
-// Re-exported for backward compatibility: the canonical data-map shape +
-// empties now live in `../store/agorMaps`, but existing importers (and tests)
-// reference them via this module.
-export { EMPTY_MAPS } from '../store/agorMaps';
-
 // Canonical list of initial-load items tracked by the loading checklist —
 // the ESSENTIAL set the first-paint gate blocks on. Internal only; consumers
 // receive the derived `initialLoadItems` array (each entry carries

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -233,7 +233,7 @@ export function useAgorData(
   const directSessionId = options?.directSessionId ?? null;
 
   // Reset the shared singleton store once per hook (re)mount, synchronously
-  // BEFORE the first `useStore` read below. This mirrors the old per-mount
+  // BEFORE the first store-subscription read below. This mirrors the old per-mount
   // `useState(EMPTY_MAPS)` / `useState(true)` semantics: the store is a module
   // singleton (so a remount — and each test's `renderHook` — would otherwise
   // inherit stale state), and `useAgorData` is its sole owner (mounted once in

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -6,11 +6,14 @@
  *
  * State ownership lives in the zustand store (`agorStore`); this hook is the
  * single DRIVER of that store — the fetch effect and socket subscriptions
- * dispatch store actions, and the hook reads full state back via `useStore` and
- * returns `UseAgorDataResult`. The realtime entity reducers + index/merge
- * helpers live in `../store/agorRealtimeActions` and `../store/agorMaps`, and
- * the background-hydration bookkeeping (per-collection revision counters,
- * generation tokens, `runHydration`) in `../store/agorHydration`.
+ * dispatch store actions. It returns only load-state (`UseAgorDataResult`) and
+ * subscribes narrowly to the store's load-state fields, so its owner re-renders
+ * on load progress rather than on every entity patch; entity-map consumers
+ * subscribe to the store directly via their own selectors. The realtime entity
+ * reducers + index/merge helpers live in `../store/agorRealtimeActions` and
+ * `../store/agorMaps`, and the background-hydration bookkeeping (per-collection
+ * revision counters, generation tokens, `runHydration`) in
+ * `../store/agorHydration`.
  */
 
 import type {
@@ -27,7 +30,6 @@ import type {
 } from '@agor-live/client';
 import { ENTITY_PATH_SEGMENTS, findByShortIdPrefix, PAGINATION } from '@agor-live/client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useStore } from 'zustand';
 import {
   bumpFirstPaintMergeRevisions,
   bumpRevision,
@@ -41,12 +43,10 @@ import {
   buildById,
   buildSessionMaps,
   buildSessionMcpMap,
-  type DataMaps,
-  pickMaps,
   replaceIfChanged,
 } from '../store/agorMaps';
 import * as realtime from '../store/agorRealtimeActions';
-import { agorStore } from '../store/agorStore';
+import { agorStore, shallow, useStoreWithEqualityFn } from '../store/agorStore';
 import { createInitialLoadDebugTimer, isInitialLoadDebugEnabled } from '../utils/initialLoadDebug';
 import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 import {
@@ -108,7 +108,7 @@ export interface InitialLoadItem {
 
 export type InitialLoadingStage = 'idle' | 'fetching' | 'indexing';
 
-interface UseAgorDataResult extends DataMaps {
+interface UseAgorDataResult {
   initialLoadItems: InitialLoadItem[];
   initialLoadComplete: boolean;
   loadingStage: InitialLoadingStage;
@@ -250,9 +250,21 @@ export function useAgorData(
     return null;
   });
 
-  // Full store state, re-rendering this owner on every committed store change —
-  // exactly as the old single `useState<DataMaps>` + meta `useState`s did.
-  const storeState = useStore(agorStore);
+  // Narrow selective subscription so the bootstrap owner re-renders only on a
+  // load-state change — not on every entity patch. The fetch effect and socket
+  // subscriptions still drive the full store; map consumers subscribe to it via
+  // their own `useAgorStore` selectors, and the few reads in this hook that need
+  // an entity map reach for it imperatively through `agorStore.getState()`.
+  const storeState = useStoreWithEqualityFn(
+    agorStore,
+    (s) => ({
+      loadingStage: s.loadingStage,
+      loading: s.loading,
+      error: s.error,
+      itemCounts: s.itemCounts,
+    }),
+    shallow
+  );
 
   // Track if we've done initial fetch. The initial fetch happens once on mount;
   // socket reconnects after that re-trigger fetchData() to recover any events
@@ -994,10 +1006,9 @@ export function useAgorData(
   // sessions openable without changing the default list query.
   useEffect(() => {
     if (!client || !enabled || !hasInitiallyFetched || !directSessionId) return;
-    if (storeState.sessionById.has(directSessionId)) return;
-    if (
-      hasIdMatchingPrefix(directSessionId, storeState.sessionById.values(), (s) => s.session_id)
-    ) {
+    const { sessionById } = agorStore.getState();
+    if (sessionById.has(directSessionId)) return;
+    if (hasIdMatchingPrefix(directSessionId, sessionById.values(), (s) => s.session_id)) {
       return;
     }
 
@@ -1030,7 +1041,7 @@ export function useAgorData(
         if (
           !directSession.archived &&
           directSession.branch_id &&
-          !storeState.branchById.has(directSession.branch_id)
+          !agorStore.getState().branchById.has(directSession.branch_id)
         ) {
           try {
             const directBranch = (await client
@@ -1058,14 +1069,7 @@ export function useAgorData(
     return () => {
       cancelled = true;
     };
-  }, [
-    client,
-    directSessionId,
-    enabled,
-    hasInitiallyFetched,
-    storeState.branchById,
-    storeState.sessionById,
-  ]);
+  }, [client, directSessionId, enabled, hasInitiallyFetched]);
 
   // Subscribe to real-time updates
   //
@@ -1415,7 +1419,6 @@ export function useAgorData(
   );
 
   return {
-    ...pickMaps(storeState),
     initialLoadItems,
     initialLoadComplete,
     loadingStage: storeState.loadingStage,

--- a/apps/agor-ui/src/store/agorMaps.ts
+++ b/apps/agor-ui/src/store/agorMaps.ts
@@ -27,8 +27,8 @@ import { shallowEqualEntity } from '../utils/shallowEqual';
 /**
  * All server-backed data maps held in a single state object.
  *
- * Adding a new map here + to EMPTY_MAPS is all that's required —
- * `setMaps(EMPTY_MAPS)` in the reset effect covers every field automatically.
+ * Adding a new map here + to `EMPTY_MAPS` is all that's required — resetting
+ * the store covers every field automatically.
  */
 export type DataMaps = {
   sessionById: Map<string, Session>;
@@ -117,7 +117,7 @@ export function replaceIfChanged<T extends object>(
 
 // Build a plain `byId` Map from a fetched list. Used by the background
 // (non-gated) fetches whose results land via their own setter rather than the
-// single atomic setMaps the essential gate performs.
+// single atomic map-apply the essential gate performs.
 export function buildById<T>(list: readonly T[], key: keyof T): Map<string, T> {
   const map = new Map<string, T>();
   for (const item of list) {

--- a/apps/agor-ui/src/store/agorStore.test.ts
+++ b/apps/agor-ui/src/store/agorStore.test.ts
@@ -1,6 +1,6 @@
 import type { Session } from '@agor-live/client';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { EMPTY_MAPS } from '../hooks/useAgorData';
+import { EMPTY_MAPS } from './agorMaps';
 import { agorStore } from './agorStore';
 
 // Reset the singleton before each test so cases don't bleed into each other.

--- a/apps/agor-ui/src/store/agorStore.ts
+++ b/apps/agor-ui/src/store/agorStore.ts
@@ -60,8 +60,8 @@ interface AgorActions {
   /** Accepts a value or a functional updater (mirrors `useState`). */
   setItemCounts: (value: ItemCounts | ((prev: ItemCounts) => ItemCounts)) => void;
   /**
-   * Replace a single data map. Mirrors `useAgorData`'s `setMapSlice`: accepts a
-   * value or a functional updater, and short-circuits on `Object.is` equality so
+   * Replace a single data map: accepts a value or a functional updater, and
+   * short-circuits on `Object.is` equality so
    * a no-op write preserves the outer state reference (no subscriber notify).
    */
   setMap: <K extends keyof DataMaps>(


### PR DESCRIPTION
## The flip

Final step of collapsing the `useAgorData` shim. On the base (`collapse-outer-app-selectors`), nothing reads entity maps from `useAgorData`'s return anymore — every consumer uses `useAgorStore` selectors. This PR makes the hook stop returning the maps **and** stop subscribing to the whole store, so its owner (outer `src/App.tsx`) re-renders only on load-state changes, not on every entity patch. That is the perf payoff.

## Changes (`hooks/useAgorData.ts`)

- **Narrow render subscription.** `useStore(agorStore)` (whole store) → `useStoreWithEqualityFn(agorStore, s => ({ loadingStage, loading, error, itemCounts }), shallow)`. The owner now re-renders only on a load-state change.
- **Return only load-state.** Dropped `...pickMaps(storeState)`; returns `{ initialLoadItems, initialLoadComplete, loadingStage, loading, error, refetch }`.
- **Type.** `UseAgorDataResult` no longer `extends DataMaps` — only the 6 meta fields.
- **Direct-session deep-link heal** reads `sessionById`/`branchById` imperatively via `agorStore.getState()` (the realtime/hydration machinery already reads that way), so it no longer depends on a reactive map subscription. Those two maps dropped from the effect deps.
- Removed now-dead imports (`useStore`, `pickMaps`, `DataMaps` local import). Hook name kept as `useAgorData`.

## What is preserved exactly

Initial fetch, all socket subscriptions, `runHydration` + Phase-1.5 revision/generation machinery, reconnect-refetch, token-refresh retry, direct-session healing, reset-on-mount, logout reset. The flip only changes the render subscription + return shape — no side effect changed. The loader-gate fields (`loading`/`error`/`initialLoadComplete`/`loadingStage`/`initialLoadItems`) are byte-identical.

## Test oracle

`hooks/useAgorData.test.tsx` behavior coverage (idempotent no-ops, skip-apply-on-race, revision bumps, deep-link heal, reconnect/logout) is fully preserved. Only the **read path** of each map assertion changed: `result.current.<map>` → `agorStore.getState().<map>` (84 reads across 11 maps). Load-state assertions (`loading`, `initialLoadComplete`) stay on the hook return. No behavior test was deleted. Map reference-identity assertions still validate the store's `replaceIfChanged` no-op contract — identical references, just read from the store.

Stacked on PR4.5 (#1675).

🤖 Generated with [Claude Code](https://claude.com/claude-code)