### PR TITLE
fix(client): hydrate latest task messages at bootstrap in lazy mode

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,6 +39,8 @@
     "check:pack": "node scripts/validate-pack-artifact.mjs",
     "dev": "tsup --watch",
     "prepublishOnly": "pnpm build && pnpm check:pack",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -54,7 +56,8 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.6.0",
     "tsup": "^8.5.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
   },
   "keywords": [
     "agor",

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -123,4 +123,68 @@ describe('ReactiveSessionHandle bootstrap hydration', () => {
     // The latest task is left unhydrated for TaskBlock to lazy-load later.
     expect(handle.isTaskLoaded('task-2')).toBe(false);
   });
+
+  it('lazy: hydrates nothing when every task is queued', async () => {
+    const allQueued = [
+      makeTask('task-1', TaskStatus.QUEUED),
+      makeTask('task-2', TaskStatus.QUEUED),
+    ];
+    const { handle, messageFindAll } = await bootstrapHandle(
+      { tasks: allQueued, messagesByTask: {} },
+      'lazy'
+    );
+
+    expect(handle.state.loading).toBe(false);
+    expect(handle.isTaskLoaded('task-1')).toBe(false);
+    expect(handle.isTaskLoaded('task-2')).toBe(false);
+    expect(messageFindAll).not.toHaveBeenCalled();
+  });
+
+  it('lazy: hydrates nothing when there are no tasks', async () => {
+    const { handle, messageFindAll } = await bootstrapHandle(
+      { tasks: [], messagesByTask: {} },
+      'lazy'
+    );
+
+    expect(handle.state.loading).toBe(false);
+    expect(messageFindAll).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReactiveSessionHandle resync hydration parity', () => {
+  it('lazy: keeps the latest task hydrated and adopts a new latest task on resync', async () => {
+    const opts: MockClientOptions = {
+      tasks: [
+        makeTask('task-1', TaskStatus.COMPLETED),
+        makeTask('task-2', TaskStatus.COMPLETED),
+        makeTask('task-3', TaskStatus.QUEUED),
+      ],
+      messagesByTask: {
+        'task-1': [makeMessage('task-1', 0)],
+        'task-2': [makeMessage('task-2', 0)],
+      },
+    };
+    const { client, messageFindAll } = createMockClient(opts);
+    const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration: 'lazy' });
+    await handle.ready();
+
+    expect(handle.isTaskLoaded('task-2')).toBe(true);
+
+    // Reconnect with no change: the latest (scroll-target) task stays hydrated.
+    await handle.resync();
+    expect(handle.isTaskLoaded('task-2')).toBe(true);
+    expect(handle.getTaskMessages('task-2')).toHaveLength(1);
+
+    // A new non-queued task became the latest while disconnected.
+    opts.tasks = [...opts.tasks, makeTask('task-4', TaskStatus.COMPLETED)];
+    opts.messagesByTask['task-4'] = [makeMessage('task-4', 0)];
+
+    await handle.resync();
+
+    expect(handle.isTaskLoaded('task-4')).toBe(true);
+    expect(handle.getTaskMessages('task-4')).toHaveLength(1);
+    expect(messageFindAll).toHaveBeenCalledWith({
+      query: { task_id: 'task-4', $sort: { index: 1 } },
+    });
+  });
 });

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -1,0 +1,126 @@
+import type { AgorClient, Message, Session, Task } from '@agor/core/client';
+import { TaskStatus } from '@agor/core/client';
+import { describe, expect, it, vi } from 'vitest';
+import { ReactiveSessionHandle, type TaskHydrationMode } from './reactive-session';
+
+const SESSION_ID = 'session-1';
+
+function makeTask(taskId: string, status: TaskStatus): Task {
+  return {
+    task_id: taskId,
+    session_id: SESSION_ID,
+    status,
+  } as unknown as Task;
+}
+
+function makeMessage(taskId: string, index: number): Message {
+  return {
+    message_id: `${taskId}-msg-${index}`,
+    session_id: SESSION_ID,
+    task_id: taskId,
+    index,
+  } as unknown as Message;
+}
+
+interface MockClientOptions {
+  tasks: Task[];
+  messagesByTask: Record<string, Message[]>;
+  failTaskMessageFetch?: boolean;
+}
+
+function createMockClient(opts: MockClientOptions) {
+  const messageFindAll = vi.fn(async ({ query }: { query: Record<string, unknown> }) => {
+    if (typeof query.task_id === 'string') {
+      if (opts.failTaskMessageFetch) {
+        throw new Error('latest-task message fetch failed');
+      }
+      return opts.messagesByTask[query.task_id] ?? [];
+    }
+    // Eager path: every message for the session.
+    return Object.values(opts.messagesByTask).flat();
+  });
+
+  const listener = () => ({ on: vi.fn(), removeListener: vi.fn() });
+
+  const services: Record<string, unknown> = {
+    sessions: { get: vi.fn(async () => ({ session_id: SESSION_ID }) as Session), ...listener() },
+    tasks: { findAll: vi.fn(async () => opts.tasks), ...listener() },
+    messages: { findAll: messageFindAll, ...listener() },
+  };
+  const queueService = { find: vi.fn(async () => ({ data: [] })) };
+
+  const client = {
+    io: { connected: true, on: vi.fn(), off: vi.fn() },
+    service: vi.fn((name: string) =>
+      name.includes('/tasks/queue') ? queueService : services[name]
+    ),
+  } as unknown as AgorClient;
+
+  return { client, messageFindAll };
+}
+
+async function bootstrapHandle(opts: MockClientOptions, taskHydration: TaskHydrationMode) {
+  const { client, messageFindAll } = createMockClient(opts);
+  const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration });
+  await handle.ready();
+  return { handle, messageFindAll };
+}
+
+describe('ReactiveSessionHandle bootstrap hydration', () => {
+  const tasks = [
+    makeTask('task-1', TaskStatus.COMPLETED),
+    makeTask('task-2', TaskStatus.COMPLETED),
+    makeTask('task-3', TaskStatus.QUEUED),
+  ];
+  const messagesByTask = {
+    'task-1': [makeMessage('task-1', 0)],
+    'task-2': [makeMessage('task-2', 1), makeMessage('task-2', 0)],
+  };
+
+  it('lazy: hydrates the latest non-queued task only', async () => {
+    const { handle, messageFindAll } = await bootstrapHandle({ tasks, messagesByTask }, 'lazy');
+
+    // task-3 is queued, so the latest hydratable task is task-2.
+    expect(handle.isTaskLoaded('task-2')).toBe(true);
+    expect(handle.isTaskLoaded('task-1')).toBe(false);
+    expect(handle.isTaskLoaded('task-3')).toBe(false);
+
+    // Messages are seeded and index-sorted.
+    expect(handle.getTaskMessages('task-2').map((m) => m.index)).toEqual([0, 1]);
+    expect(handle.getTaskMessages('task-1')).toEqual([]);
+
+    // Only the latest task's messages were fetched at bootstrap.
+    expect(messageFindAll).toHaveBeenCalledTimes(1);
+    expect(messageFindAll).toHaveBeenCalledWith({
+      query: { task_id: 'task-2', $sort: { index: 1 } },
+    });
+  });
+
+  it('eager: hydrates every task', async () => {
+    const { handle } = await bootstrapHandle({ tasks, messagesByTask }, 'eager');
+
+    expect(handle.isTaskLoaded('task-1')).toBe(true);
+    expect(handle.isTaskLoaded('task-2')).toBe(true);
+  });
+
+  it('none: hydrates no task', async () => {
+    const { handle, messageFindAll } = await bootstrapHandle({ tasks, messagesByTask }, 'none');
+
+    expect(handle.isTaskLoaded('task-1')).toBe(false);
+    expect(handle.isTaskLoaded('task-2')).toBe(false);
+    expect(messageFindAll).not.toHaveBeenCalled();
+  });
+
+  it('lazy: a failing latest-task fetch still resolves bootstrap (graceful degradation)', async () => {
+    const { handle } = await bootstrapHandle(
+      { tasks, messagesByTask, failTaskMessageFetch: true },
+      'lazy'
+    );
+
+    // Bootstrap completed despite the fetch throwing.
+    expect(handle.state.loading).toBe(false);
+    expect(handle.state.error).toBeNull();
+    // The latest task is left unhydrated for TaskBlock to lazy-load later.
+    expect(handle.isTaskLoaded('task-2')).toBe(false);
+  });
+});

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -926,19 +926,28 @@ export class ReactiveSessionHandle {
         });
         messagesByTask = groupMessagesByTask(allMessages);
         loadedTaskIds = new Set(messagesByTask.keys());
-      } else if (this.stateSnapshot.loadedTaskIds.size > 0) {
-        const refreshedByTask = new Map<string, Message[]>();
-        for (const taskId of this.stateSnapshot.loadedTaskIds) {
-          const taskMessages = await this.client.service('messages').findAll({
-            query: {
-              task_id: taskId,
-              $sort: { index: 1 },
-            },
-          });
-          refreshedByTask.set(taskId, sortMessagesByIndex(taskMessages));
+      } else if (this.options.taskHydration === 'lazy') {
+        // Preserve the bootstrap invariant across reconnect: the latest
+        // (expanded / scroll-target) task must stay hydrated even if a new task
+        // became the latest while disconnected, or bootstrap's hydration failed
+        // and left loadedTaskIds empty.
+        const latestId = findLatestHydratableTask(tasks)?.task_id;
+        const toRefresh = new Set(this.stateSnapshot.loadedTaskIds);
+        if (latestId) toRefresh.add(latestId);
+        if (toRefresh.size > 0) {
+          const refreshedByTask = new Map<string, Message[]>();
+          for (const taskId of toRefresh) {
+            const taskMessages = await this.client.service('messages').findAll({
+              query: {
+                task_id: taskId,
+                $sort: { index: 1 },
+              },
+            });
+            refreshedByTask.set(taskId, sortMessagesByIndex(taskMessages));
+          }
+          messagesByTask = refreshedByTask;
+          loadedTaskIds = new Set(refreshedByTask.keys());
         }
-        messagesByTask = refreshedByTask;
-        loadedTaskIds = new Set(refreshedByTask.keys());
       }
 
       if (this.disposed) return;

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -6,6 +6,7 @@ import type {
   SessionPromptResult,
   Task,
 } from '@agor/core/client';
+import { TaskStatus } from '@agor/core/client';
 
 export type TaskHydrationMode = 'none' | 'lazy' | 'eager';
 
@@ -349,6 +350,29 @@ export class ReactiveSessionHandle {
         });
         messagesByTask = groupMessagesByTask(allMessages);
         loadedTaskIds = new Set(messagesByTask.keys());
+      } else if (this.options.taskHydration === 'lazy') {
+        // The conversation view expands the latest non-queued task by default
+        // and auto-scrolls to it. Hydrating that task's messages here — before
+        // we flip loading:false so ready() resolves with them in place —
+        // guarantees the scroll target exists in the first render, instead of
+        // landing on a header placeholder while TaskBlock lazy-loads the
+        // messages afterward.
+        const latestTask = findLatestHydratableTask(tasks);
+        if (latestTask) {
+          try {
+            const latestMessages = await this.client.service('messages').findAll({
+              query: {
+                task_id: latestTask.task_id,
+                $sort: { index: 1 },
+              },
+            });
+            messagesByTask.set(latestTask.task_id, sortMessagesByIndex(latestMessages));
+            loadedTaskIds.add(latestTask.task_id);
+          } catch {
+            // Non-fatal: leave the latest task unhydrated so the rest of
+            // bootstrap still succeeds; TaskBlock will lazy-load it as before.
+          }
+        }
       }
 
       this.updateState((prev) => ({
@@ -1061,6 +1085,18 @@ export function releaseReactiveSession(
   if (clientSessions.size === 0) {
     SHARED_REACTIVE_SESSIONS.delete(client);
   }
+}
+
+/**
+ * The task the conversation view expands (and scrolls to) by default: the last
+ * task in the created_at-ascending list whose status isn't QUEUED. Queued tasks
+ * have no messages yet, so they are never the hydration / scroll target.
+ */
+function findLatestHydratableTask(tasks: Task[]): Task | undefined {
+  for (let i = tasks.length - 1; i >= 0; i--) {
+    if (tasks[i].status !== TaskStatus.QUEUED) return tasks[i];
+  }
+  return undefined;
 }
 
 function sortMessagesByIndex(messages: Message[]): Message[] {

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const coreSrc = fileURLToPath(new URL('../core/src', import.meta.url));
+
+export default defineConfig({
+  // Resolve @agor/core subpaths to their TypeScript source so tests run
+  // against the live source without first building the package's dist.
+  resolve: {
+    conditions: ['source'],
+    alias: {
+      '@agor/core/client': path.join(coreSrc, 'client/index.ts'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    testTimeout: 10000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,6 +711,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.10.0)(@vitest/coverage-v8@4.1.8)(jsdom@27.1.0)(vite@8.0.16(@types/node@24.10.0)(esbuild@0.25.12)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -6833,7 +6836,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:


### PR DESCRIPTION
## Root cause

The conversation view always renders the **latest non-queued task expanded** and auto-scrolls to it. But the reactive session's `lazy` hydration loads the task **list** with zero messages — each task's messages load on-demand only *after* its `TaskBlock` mounts.

So on open, the expanded latest task is just a header + spinner placeholder when the auto-scroll fires. The scroll lands on the header, and the messages stream in afterward. Under real latency this loses the race and the view stays stuck at the last message's header — looking "collapsed".

## Fix

Make the data layer guarantee the scroll target exists. In `ReactiveSessionHandle.bootstrap()`, the `lazy` branch now:

1. Picks the latest hydratable task — the last task in the `created_at`-ascending list with `status !== QUEUED`, exactly matching ConversationView's expand-by-default selection.
2. Fetches that task's messages (reusing `loadTaskMessages`'s query shape: by `task_id`, `$sort: { index: 1 }`).
3. Seeds `messagesByTask` + `loadedTaskIds` into the **same** `updateState` that flips `loading: false`, so `ready()` resolves with the scroll target already hydrated and the first render is complete — no header-only flash, no two-phase jump.

The latest-task fetch is **non-fatal**: if it throws, bootstrap still succeeds and the task is left for `TaskBlock` to lazy-load as before (graceful degradation). `TaskBlock` already skips its lazy load when `taskMessagesLoaded` is true, so the pre-hydrated task does not double-fetch.

`eager` and `none` modes are unchanged. This is the default behavior for `lazy`, benefiting both `lazy` consumers (`ConversationView` and `BranchCard/SessionLatestTaskPeek`); `SessionPanel` uses `none` and is unaffected.

## Tests

Adds vitest scaffolding to `@agor-live/client` (the package had none) and `reactive-session.test.ts` asserting:
- `lazy` hydrates the latest non-queued task only (not older tasks, not queued tasks)
- `eager` hydrates every task; `none` hydrates none
- a failing latest-task fetch still resolves bootstrap (graceful degradation)

## Stacked

Stacked on #1655 (`conversation-autoscroll-race`) — base is set to that branch so the diff is only this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)