### PR TITLE
perf(agor-ui): outer App re-renders only on load-state + memoize BoardAssistantPanel (collapse finish)

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -18,12 +18,7 @@ import type {
   User,
   UUID,
 } from '@agor-live/client';
-import {
-  boardPath,
-  ENTITY_PATH_SEGMENTS,
-  getRepoReferenceOptions,
-  sessionPath,
-} from '@agor-live/client';
+import { boardPath, ENTITY_PATH_SEGMENTS, sessionPath } from '@agor-live/client';
 import { Alert, App as AntApp, ConfigProvider } from 'antd';
 import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
@@ -49,17 +44,7 @@ import {
   useSessionActions,
 } from './hooks';
 import { useSurfaceBranding } from './hooks/useSurfaceBranding';
-import { useAgorStore } from './store/agorStore';
-import {
-  selectBoardById,
-  selectBranchById,
-  selectCommentById,
-  selectRepoById,
-  selectSessionById,
-  selectSessionMcpServerIds,
-  selectSessionsByBranch,
-  selectUserById,
-} from './store/selectors';
+import { agorStore, useAgorStore } from './store/agorStore';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
 import type { RouteSurfaceId } from './surfaces/surfaceRegistry';
 import {
@@ -346,17 +331,12 @@ function AppContent() {
     directSessionId: directSessionIdFromPath,
   });
 
-  // Entity maps are read directly from the store rather than the useAgorData
-  // return so each map is its own narrow subscription — the surface only
-  // re-renders for the slices it actually consumes, not on every entity write.
-  const sessionById = useAgorStore(selectSessionById);
-  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
-  const boardById = useAgorStore(selectBoardById);
-  const commentById = useAgorStore(selectCommentById);
-  const repoById = useAgorStore(selectRepoById);
-  const branchById = useAgorStore(selectBranchById);
-  const userById = useAgorStore(selectUserById);
-  const sessionMcpServerIds = useAgorStore(selectSessionMcpServerIds);
+  // Entity maps are NOT subscribed here. Each surface that needs a whole map
+  // (MobileApp, OnboardingWizard, KnowledgePage) self-subscribes via
+  // `useAgorStore(selectX)` at its own top, so the outer shell re-renders only
+  // on load-state — not on every entity write. Outer App's own handler-time
+  // lookups read imperatively through `agorStore.getState()`, and the single
+  // render-time entity read (currentUser) uses a narrow by-id selector below.
 
   // Session actions
   const { createSession, forkSession, btwForkSession, spawnSession, updateSession, deleteSession } =
@@ -424,10 +404,14 @@ function AppContent() {
     <InitialLoadingScreen message="Loading surface…" />
   );
 
-  // Get current user from users Map (real-time updates via WebSocket)
-  // This ensures we get the latest onboarding_completed status
-  // Fall back to user from auth if users Map hasn't loaded yet
-  const currentUser = user ? userById.get(user.user_id) || user : null;
+  // Get current user from users Map (real-time updates via WebSocket).
+  // Narrow by-id selector: subscribes to this ONE user entity, not the whole
+  // userById map, so unrelated user writes don't re-render the shell. Falls
+  // back to the auth user until the map has loaded that row.
+  const storedCurrentUser = useAgorStore((s) =>
+    user ? (s.userById.get(user.user_id) ?? null) : null
+  );
+  const currentUser = user ? storedCurrentUser || user : null;
 
   // Keep the global ErrorBoundary's crash context populated so a render
   // crash anywhere below us can produce a useful report (build SHA + signed-in
@@ -510,7 +494,12 @@ function AppContent() {
     if (result.sessionId) {
       navigate(sessionPath(result.sessionId as SessionID));
     } else if (result.boardId) {
-      navigate(boardPath(result.boardId as BoardID, boardById.get(result.boardId)?.slug));
+      navigate(
+        boardPath(
+          result.boardId as BoardID,
+          agorStore.getState().boardById.get(result.boardId)?.slug
+        )
+      );
     } else {
       navigate('/');
     }
@@ -1435,7 +1424,7 @@ function AppContent() {
 
     try {
       // Get current session-MCP relationships for this session
-      const currentIds = sessionMcpServerIds.get(sessionId) || [];
+      const currentIds = agorStore.getState().sessionMcpServerIds.get(sessionId) || [];
       await updateSessionMcpServers(client, sessionId, currentIds, mcpServerIds);
 
       // Note: Don't show success message here - it's part of the session settings save
@@ -1467,7 +1456,7 @@ function AppContent() {
   const handleResolveComment = async (commentId: string) => {
     if (!client) return;
     try {
-      const comment = commentById.get(commentId);
+      const comment = agorStore.getState().commentById.get(commentId);
       await client.service('board-comments').patch(commentId, {
         resolved: !comment?.resolved,
       });
@@ -1518,14 +1507,6 @@ function AppContent() {
     }
   };
 
-  // Generate repo reference options for dropdowns
-  const allOptions = getRepoReferenceOptions(
-    Array.from(repoById.values()),
-    Array.from(branchById.values())
-  );
-  const _branchOptions = allOptions.filter((opt) => opt.type === 'managed-branch');
-  const _repoOptions = allOptions.filter((opt) => opt.type === 'managed');
-
   // Modal close handlers
   const handleSettingsClose = () => {
     setSettingsTabToOpen(null);
@@ -1543,7 +1524,6 @@ function AppContent() {
     <KnowledgePage
       client={client}
       currentUser={currentUser}
-      userById={userById}
       onUserSettingsClick={() => setOpenUserSettings(true)}
       onLogout={logout}
     />
@@ -1666,9 +1646,6 @@ function AppContent() {
           key={`${currentUser?.user_id ?? '__anon__'}:${onboardingWizardInstance}`}
           open={onboardingWizardOpen}
           onComplete={handleOnboardingComplete}
-          repoById={repoById}
-          branchById={branchById}
-          boardById={boardById}
           user={currentUser}
           client={client}
           onCreateRepo={handleCreateRepo}
@@ -1724,13 +1701,6 @@ function AppContent() {
                 <MobileApp
                   client={client}
                   user={user}
-                  sessionById={sessionById}
-                  sessionsByBranch={sessionsByBranch}
-                  boardById={boardById}
-                  commentById={commentById}
-                  repoById={repoById}
-                  branchById={branchById}
-                  userById={userById}
                   onSendPrompt={handleSendPrompt}
                   onSendComment={handleSendComment}
                   onReplyComment={handleReplyComment}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1031,6 +1031,26 @@ export const App: React.FC<AppProps> = ({
   const stableOnStopEnvironment = useStableCallback(onStopEnvironment);
   const stableOnNukeEnvironment = useStableCallback(onNukeEnvironment);
 
+  // Stabilize the remaining passthrough props (schedule + comment actions) and
+  // the panel's inline-arrow handlers so the memoized BoardAssistantPanel's
+  // React.memo bailout holds — every prop it receives stays referentially stable
+  // across store-driven re-renders that don't change what it draws.
+  const stableOnExecuteScheduleNow = useStableCallback(onExecuteScheduleNow);
+  const stableOnReplyComment = useStableCallback(onReplyComment);
+  const stableOnResolveComment = useStableCallback(onResolveComment);
+  const stableOnToggleReaction = useStableCallback(onToggleReaction);
+  const stableOnDeleteComment = useStableCallback(onDeleteComment);
+  const handleAssistantOpenSettings = useStableCallback(
+    (branchId: string, tab?: BranchModalTab) => {
+      setBranchModalBranchId(branchId);
+      setBranchModalTab(tab);
+    }
+  );
+  const handleAssistantSendComment = useStableCallback((content: string) =>
+    onSendComment?.(currentBoardId || '', content)
+  );
+  const handleAssistantCollapse = useStableCallback(() => setCommentsPanelCollapsed(true));
+
   // Header action handlers, frozen so the memoized AppHeader's React.memo bailout
   // isn't defeated by a fresh inline-arrow identity on every App re-render. Each
   // delegates to the latest impl via useStableCallback, so they read current
@@ -1136,28 +1156,25 @@ export const App: React.FC<AppProps> = ({
                   selectedSessionId={effectiveSelectedSessionId}
                   onSessionClick={handleSessionClick}
                   onCreateSession={setNewSessionBranchId}
-                  onForkSession={onForkSession}
-                  onSpawnSession={onSpawnSession}
-                  onArchiveOrDelete={onArchiveOrDeleteBranch}
-                  onOpenSettings={(branchId, tab) => {
-                    setBranchModalBranchId(branchId);
-                    setBranchModalTab(tab);
-                  }}
+                  onForkSession={stableOnForkSession}
+                  onSpawnSession={stableOnSpawnSession}
+                  onArchiveOrDelete={stableOnArchiveOrDeleteBranch}
+                  onOpenSettings={handleAssistantOpenSettings}
                   onOpenSessionSettings={setSessionSettingsId}
                   onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
-                  onStartEnvironment={onStartEnvironment}
-                  onStopEnvironment={onStopEnvironment}
+                  onStartEnvironment={stableOnStartEnvironment}
+                  onStopEnvironment={stableOnStopEnvironment}
                   onViewLogs={setLogsModalBranchId}
-                  onNukeEnvironment={onNukeEnvironment}
-                  onExecuteScheduleNow={onExecuteScheduleNow}
-                  onSendComment={(content) => onSendComment?.(currentBoardId || '', content)}
-                  onReplyComment={onReplyComment}
-                  onResolveComment={onResolveComment}
-                  onToggleReaction={onToggleReaction}
-                  onDeleteComment={onDeleteComment}
+                  onNukeEnvironment={stableOnNukeEnvironment}
+                  onExecuteScheduleNow={stableOnExecuteScheduleNow}
+                  onSendComment={handleAssistantSendComment}
+                  onReplyComment={stableOnReplyComment}
+                  onResolveComment={stableOnResolveComment}
+                  onToggleReaction={stableOnToggleReaction}
+                  onDeleteComment={stableOnDeleteComment}
                   hoveredCommentId={hoveredCommentId}
                   selectedCommentId={selectedCommentId}
-                  onCollapse={() => setCommentsPanelCollapsed(true)}
+                  onCollapse={handleAssistantCollapse}
                 />
               )}
             </Panel>

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.rerender.test.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.rerender.test.tsx
@@ -1,0 +1,142 @@
+import type { Board } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { BoardAssistantPanel } from './BoardAssistantPanel';
+
+// BoardAssistantPanel renders the active tab's content. With activeTab="comments"
+// the comments pane mounts CommentsPanel, mocked here to a bare render counter so
+// its invocation count is a faithful proxy for how many times the (memoized)
+// BoardAssistantPanel itself rendered.
+let panelRenders = 0;
+
+vi.mock('../CommentsPanel', () => ({
+  CommentsPanel: () => {
+    panelRenders += 1;
+    return null;
+  },
+}));
+
+const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as unknown as Board;
+
+// Mirror of App's `useStableCallback`: freeze a handler's identity across renders
+// while delegating to the latest impl via a ref. The inner App stabilizes the
+// panel's callbacks the same way, so reproducing it exercises the real contract.
+function useStableCallback<TFn extends (...args: never[]) => unknown>(
+  callback: TFn | undefined
+): TFn | undefined {
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+  const stable = useCallback(((...args: never[]) => callbackRef.current?.(...args)) as TFn, []);
+  return callback ? stable : undefined;
+}
+
+// Lets a test trigger a parent re-render without touching the panel's props.
+let triggerParentRerender: () => void = () => {};
+
+// The complete prop set App passes, minus the one callback the harness flips.
+// Module-level so the identities stay stable across parent re-renders — the whole
+// point of the guard is that NOTHING the panel receives churns, so React.memo can
+// bail out. A reintroduced unstable prop here would start failing the bailout.
+const noop = () => {};
+const asyncNoop = async () => {};
+const STABLE_PANEL_PROPS = {
+  client: null,
+  board,
+  activeTab: 'comments' as const,
+  onTabChange: noop,
+  primaryAssistantInaccessible: false,
+  currentUserId: 'u1',
+  selectedSessionId: null,
+  onCreateSession: noop,
+  onForkSession: asyncNoop,
+  onSpawnSession: asyncNoop,
+  onArchiveOrDelete: noop,
+  onOpenSettings: noop,
+  onOpenSessionSettings: noop,
+  onOpenTerminal: noop,
+  onStartEnvironment: noop,
+  onStopEnvironment: noop,
+  onViewLogs: noop,
+  onNukeEnvironment: noop,
+  onExecuteScheduleNow: asyncNoop,
+  onSendComment: noop,
+  onReplyComment: noop,
+  onResolveComment: noop,
+  onToggleReaction: noop,
+  onDeleteComment: noop,
+  hoveredCommentId: null,
+  selectedCommentId: null,
+  onCollapse: noop,
+} as const;
+
+// Parent harness rendering the REAL memo'd BoardAssistantPanel the way App does.
+// The flipped `onSessionClick` flows through `useStableCallback` when `stabilize`
+// is true and is a fresh arrow otherwise, so the same harness proves both halves
+// of the guard while every other prop stays referentially stable. A `useState`
+// bump re-renders THIS parent without touching any prop value.
+function ParentHarness({ stabilize }: { stabilize: boolean }) {
+  const [, setTick] = useState(0);
+  triggerParentRerender = () => setTick((tick) => tick + 1);
+
+  const sessionImpl = (_sessionId: string) => {};
+  const stableSession = useStableCallback(sessionImpl);
+  const onSessionClick = stabilize ? stableSession : sessionImpl;
+
+  return (
+    <AntApp>
+      <BoardAssistantPanel {...STABLE_PANEL_PROPS} onSessionClick={onSessionClick} />
+    </AntApp>
+  );
+}
+
+describe('BoardAssistantPanel memo + prop-stabilization re-render bailout', () => {
+  beforeEach(() => {
+    panelRenders = 0;
+    triggerParentRerender = () => {};
+    agorStore.setState({ ...EMPTY_MAPS });
+  });
+
+  it('a parent re-render does not re-render the memo’d BoardAssistantPanel when props are stable', async () => {
+    render(<ParentHarness stabilize={true} />);
+
+    await waitFor(() => {
+      expect(panelRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = panelRenders;
+
+    // Parent re-renders without changing any prop value or touching the store.
+    // The memo bailout must keep the panel at its baseline render count; if
+    // `React.memo` were removed this assertion would fail (count would climb).
+    act(() => {
+      triggerParentRerender();
+    });
+
+    expect(panelRenders).toBe(baseline);
+  });
+
+  it('a parent re-render DOES re-render BoardAssistantPanel when a prop identity churns', async () => {
+    render(<ParentHarness stabilize={false} />);
+
+    await waitFor(() => {
+      expect(panelRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = panelRenders;
+
+    // Contrast: a fresh `onSessionClick` each parent render defeats the memo, so
+    // the panel must re-render — proving the bailout above is meaningful and not
+    // just an artifact of the parent never re-rendering.
+    act(() => {
+      triggerParentRerender();
+    });
+
+    await waitFor(() => {
+      expect(panelRenders).toBeGreaterThan(baseline);
+    });
+  });
+});

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -15,7 +15,7 @@ import {
   theme,
 } from 'antd';
 import type React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import {
   selectBranchById,
@@ -75,7 +75,7 @@ interface BoardAssistantPanelProps {
   client: AgorClient | null;
 }
 
-export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
+const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
   board,
   activeTab: controlledActiveTab,
   onTabChange,
@@ -454,5 +454,10 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
     </div>
   );
 };
+
+// Memoized: the inner App stabilizes every handler prop it passes (via
+// useStableCallback), so React.memo bails out of re-renders driven by unrelated
+// store patches and only re-renders when a value prop it draws actually changes.
+export const BoardAssistantPanel = memo(BoardAssistantPanelComponent);
 
 export default BoardAssistantPanel;

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -1,7 +1,9 @@
 import type { Board, Branch, Repo, User } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { FRAMEWORK_REPO_SLUG } from '../../hooks/useFrameworkRepo';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
 import { OnboardingWizard } from './OnboardingWizard';
 
 vi.mock('../EmojiPickerInput/EmojiPickerInput', () => ({
@@ -58,7 +60,25 @@ function makeBranch(overrides: Partial<Branch> = {}): Branch {
   } as Branch;
 }
 
-function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>> = {}) {
+// The wizard now self-subscribes to repoById / branchById / boardById from the
+// store instead of receiving them as props, so the harness seeds those slices
+// into the store rather than passing them through. Map seeds may be supplied
+// alongside the component-prop overrides; they're split out here.
+function renderWizard(
+  overrides: Partial<ComponentProps<typeof OnboardingWizard>> & {
+    repoById?: Map<string, Repo>;
+    branchById?: Map<string, Branch>;
+    boardById?: Map<string, Board>;
+  } = {}
+) {
+  const { repoById, branchById, boardById, ...componentOverrides } = overrides;
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    ...(repoById ? { repoById } : {}),
+    ...(branchById ? { branchById } : {}),
+    ...(boardById ? { boardById } : {}),
+  });
+
   const boardsService = {
     create: vi.fn(async () => ({ board_id: 'board-1', created_by: 'user-1' })),
     setPrimaryAssistant: vi.fn(async () => undefined),
@@ -77,9 +97,6 @@ function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>
   const props = {
     open: true,
     onComplete: vi.fn(),
-    repoById: new Map<string, Repo>(),
-    branchById: new Map<string, Branch>(),
-    boardById: new Map<string, Board>(),
     user: makeUser(),
     client,
     onCreateRepo: vi.fn(async () => undefined),
@@ -87,7 +104,7 @@ function renderWizard(overrides: Partial<ComponentProps<typeof OnboardingWizard>
     onCreateBranch: vi.fn(async () => makeBranch()),
     onCreateSession: vi.fn(async () => 'session-1'),
     onUpdateUser: vi.fn(async () => undefined),
-    ...overrides,
+    ...componentOverrides,
   } satisfies ComponentProps<typeof OnboardingWizard>;
 
   return { ...render(<OnboardingWizard {...props} />), props, client, boardsService };
@@ -238,7 +255,7 @@ describe('OnboardingWizard', () => {
       ],
     ]);
     const onCreateRepo = vi.fn(async () => undefined);
-    const view = renderWizard({ repoById, onCreateRepo });
+    renderWizard({ repoById, onCreateRepo });
 
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }));
     fireEvent.click(await screen.findByRole('button', { name: /continue without key/i }));
@@ -257,7 +274,9 @@ describe('OnboardingWizard', () => {
         clone_error: { message: 'new failure', exit_code: 1 },
       })
     );
-    view.rerender(<OnboardingWizard {...view.props} repoById={nextRepoById} />);
+    act(() => {
+      agorStore.setState({ repoById: nextRepoById });
+    });
 
     expect(await screen.findByText(/Setup failed/i)).toBeInTheDocument();
     expect(screen.getByText(/new failure/i)).toBeInTheDocument();
@@ -442,9 +461,10 @@ describe('OnboardingWizard', () => {
     fireEvent.click(await screen.findByRole('button', { name: /continue with codex cli auth/i }));
 
     expect(await screen.findByText(/Cloning assistant framework/i)).toBeInTheDocument();
-    repoById.set('repo-1', makeRepo());
-    const readyRepoById = new Map(repoById);
-    view.rerender(<OnboardingWizard {...view.props} repoById={readyRepoById} />);
+    const readyRepoById = new Map(repoById).set('repo-1', makeRepo());
+    act(() => {
+      agorStore.setState({ repoById: readyRepoById });
+    });
 
     await waitFor(() => {
       expect(onCreateBranch).toHaveBeenCalledWith(

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -55,9 +55,9 @@ import {
   FRAMEWORK_REPO_URL,
   findFrameworkRepo,
 } from '../../hooks/useFrameworkRepo';
-import type { CreateRepoOptions } from '../../types';
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById, selectBranchById, selectRepoById } from '../../store/selectors';
+import type { CreateRepoOptions } from '../../types';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { ensureAssistantWelcomeNote } from '../../utils/assistantWelcomeNote';
 import { slugify } from '../../utils/repoSlug';

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -11,7 +11,6 @@ import type {
   AgenticToolName,
   AssistantConfig,
   AuthCheckResult,
-  Board,
   Branch,
   CloneRepositoryResult,
   CodexApprovalPolicy,
@@ -57,6 +56,8 @@ import {
   findFrameworkRepo,
 } from '../../hooks/useFrameworkRepo';
 import type { CreateRepoOptions } from '../../types';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectBranchById, selectRepoById } from '../../store/selectors';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { ensureAssistantWelcomeNote } from '../../utils/assistantWelcomeNote';
 import { slugify } from '../../utils/repoSlug';
@@ -84,9 +85,6 @@ export interface OnboardingWizardProps {
     path: WizardPath;
   }) => void;
 
-  repoById: Map<string, Repo>;
-  branchById: Map<string, Branch>;
-  boardById: Map<string, Board>;
   user?: User | null;
   // biome-ignore lint/suspicious/noExplicitAny: AgorClient type varies across package boundaries in tests/apps.
   client: any;
@@ -235,9 +233,6 @@ function authMethodOptionsForAgent(agent: AgenticToolName) {
 export function OnboardingWizard({
   open,
   onComplete,
-  repoById,
-  branchById,
-  boardById,
   user,
   client,
   onCreateRepo,
@@ -247,6 +242,12 @@ export function OnboardingWizard({
   onCheckAuth,
   frameworkRepoUrl,
 }: OnboardingWizardProps) {
+  // Self-subscribe to the entity maps this wizard reads. The subscription used
+  // to live in the outer App shell; relocating it here keeps the shell from
+  // re-rendering on every repo/branch/board write.
+  const repoById = useAgorStore(selectRepoById);
+  const branchById = useAgorStore(selectBranchById);
+  const boardById = useAgorStore(selectBoardById);
   const { token } = useToken();
   const [currentStep, setCurrentStep] = useState<WizardStep>('identity');
   const [assistantDisplayName, setAssistantDisplayName] = useState('My Assistant');

--- a/apps/agor-ui/src/components/mobile/MobileApp.tsx
+++ b/apps/agor-ui/src/components/mobile/MobileApp.tsx
@@ -1,16 +1,18 @@
-import type {
-  AgorClient,
-  Board,
-  BoardComment,
-  Branch,
-  Repo,
-  Session,
-  User,
-} from '@agor-live/client';
+import type { AgorClient, User } from '@agor-live/client';
 import { Drawer, Layout, Typography } from 'antd';
 import { useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { BRAND, brandMarkHref } from '../../branding/brand';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectBoardById,
+  selectBranchById,
+  selectCommentById,
+  selectRepoById,
+  selectSessionById,
+  selectSessionsByBranch,
+  selectUserById,
+} from '../../store/selectors';
 import { MobileCommentsPage } from './MobileCommentsPage';
 import { MobileHeader } from './MobileHeader';
 import { MobileNavTree } from './MobileNavTree';
@@ -22,13 +24,6 @@ const { Text } = Typography;
 interface MobileAppProps {
   client: AgorClient | null;
   user?: User | null;
-  sessionById: Map<string, Session>; // O(1) ID lookups
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
-  boardById: Map<string, Board>;
-  commentById: Map<string, BoardComment>;
-  repoById: Map<string, Repo>;
-  branchById: Map<string, Branch>;
-  userById: Map<string, User>;
   onSendPrompt?: (
     sessionId: string,
     prompt: string
@@ -46,13 +41,6 @@ interface MobileAppProps {
 export const MobileApp: React.FC<MobileAppProps> = ({
   client,
   user,
-  sessionById,
-  sessionsByBranch,
-  boardById,
-  commentById,
-  repoById,
-  branchById,
-  userById,
   onSendPrompt,
   onSendComment,
   onReplyComment,
@@ -63,6 +51,16 @@ export const MobileApp: React.FC<MobileAppProps> = ({
   promptDrafts,
   onUpdateDraft,
 }) => {
+  // Self-subscribe to the entity maps this surface drills into. The subscription
+  // used to live in the outer App shell; relocating it here makes MobileApp the
+  // subscription boundary so the shell re-renders only on load-state.
+  const sessionById = useAgorStore(selectSessionById);
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+  const boardById = useAgorStore(selectBoardById);
+  const commentById = useAgorStore(selectCommentById);
+  const repoById = useAgorStore(selectRepoById);
+  const branchById = useAgorStore(selectBranchById);
+  const userById = useAgorStore(selectUserById);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   return (

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -101,6 +101,8 @@ import { MarkdownRenderer } from '../components/MarkdownRenderer';
 import { ThemeSwitcher } from '../components/ThemeSwitcher';
 import { DiffBlock } from '../components/ToolUseRenderer/renderers/DiffBlock';
 import { useUserLocalStorage } from '../hooks/useUserLocalStorage';
+import { useAgorStore } from '../store/agorStore';
+import { selectUserById } from '../store/selectors';
 import {
   buildKnowledgeRoutePath,
   decodeKnowledgeRoutePath,
@@ -195,13 +197,9 @@ type KnowledgeNamespacesClientServiceWithMethods = KnowledgeNamespacesClientServ
 interface KnowledgePageProps {
   client: AgorClient | null;
   currentUser?: User | null;
-  /** All known users, keyed by id — powers `@` user mentions in the editor. */
-  userById?: Map<string, User>;
   onUserSettingsClick?: () => void;
   onLogout?: () => void;
 }
-
-const EMPTY_USER_MAP: Map<string, User> = new Map();
 
 const DEFAULT_MARKDOWN = `# New Knowledge Page\n\nWrite markdown here.\n`;
 const DRAFT_DOCUMENT_ID = '__knowledge_draft__' as CoreKnowledgeDocument['document_id'];
@@ -714,10 +712,13 @@ interface FolderSection {
 export function KnowledgePage({
   client,
   currentUser = null,
-  userById = EMPTY_USER_MAP,
   onUserSettingsClick,
   onLogout,
 }: KnowledgePageProps) {
+  // Self-subscribe to the user map (powers `@` user mentions). The subscription
+  // used to live in the outer App shell; relocating it here keeps the shell from
+  // re-rendering on every user write.
+  const userById = useAgorStore(selectUserById);
   const { token } = theme.useToken();
   const { confirm } = useThemedModal();
   const navigate = useNavigate();


### PR DESCRIPTION
## What

The follow-up that finishes the collapse (an architecture audit confirmed the core is complete + sound; these are the remaining items it flagged). Stacked on the flip.

### 1. Outer `src/App.tsx` re-renders only on load-state
Dropped all ~8 whole-map `useAgorStore` subscriptions:
- **Pass-through maps** relocated *into* the consumers — `MobileApp`, `OnboardingWizard`, `KnowledgePage` now self-subscribe at their own top (they become the subscription boundary; their internal drilling is unchanged).
- **Outer App's own handler reads** (comment-resolve, session-MCP update) → imperative `agorStore.getState()` at call time.
- **Render-time single-entity reads** (currentUser) → a narrow by-id selector.

Result: `src/App.tsx` has **zero whole-map subscriptions** (only one by-id `storedCurrentUser`), so the app shell re-renders only when load-state changes — *completing the flip's stated goal*.

### 2. Memoize `BoardAssistantPanel`
Stabilized its ~13 passthrough/inline handler props via `useStableCallback` so `React.memo` actually bails, wrapped it in `memo`, and added `BoardAssistantPanel.rerender.test.tsx` (parent re-render with stable props → no re-render; verified it fails if `memo` is reverted).

## Behavior
Mobile / onboarding / knowledge / home / board behave identically — the selectors return the same data, only the read *location* moved. No `useAgorData` / loader-gate changes.

## Deferred
An outer-App rerender guard test (asserting App doesn't re-render on an unrelated entity patch) — reliable mounting of the App shell in jsdom is finicky; tracked as a follow-up.

## Gate
deps built · typecheck ✓ · biome ✓ · test **566/566** ✓ (incl. new BoardAssistantPanel guard) · vite build via CI