### PR TITLE
fix(scheduler): restore static tenant cron scope

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3050,6 +3050,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   });
 
   app.service('/schedules/:id/run-now').hooks({
+    around: { all: [tenantDatabaseScopeAround] },
     before: {
       create: [
         requireAuth,
@@ -3141,6 +3142,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   });
 
   app.service('/branches/:id/execute-schedule-now').hooks({
+    around: { all: [tenantDatabaseScopeAround] },
     before: {
       create: [
         requireAuth,

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -51,6 +51,7 @@ import {
   advisoryLockKeyForUuid,
   BranchRepository,
   isPostgresDatabase,
+  runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
   ScheduleRepository,
   SessionMCPServerRepository,
@@ -202,7 +203,7 @@ export interface SchedulerConfig {
   debug?: boolean;
   /** Unix user mode for validation (default: 'simple') */
   unixUserMode?: UnixUserMode;
-  /** Tenant used for cron/background ticks when no request auth scope exists. */
+  /** Static/single-tenant id used for request-less cron ticks. Undefined means discover due schedule tenants from schedule rows. */
   tenantId?: TenantID | string;
 }
 
@@ -226,7 +227,10 @@ export class SchedulerService {
       gracePeriod: config.gracePeriod ?? 120000, // 2 minutes
       debug: config.debug ?? false,
       unixUserMode: config.unixUserMode ?? 'simple',
-      tenantId: config.tenantId,
+      tenantId:
+        typeof config.tenantId === 'string' && config.tenantId.trim()
+          ? config.tenantId.trim()
+          : undefined,
     };
     this.branchRepo = new BranchRepository(db);
     this.scheduleRepo = new ScheduleRepository(db);
@@ -291,30 +295,34 @@ export class SchedulerService {
    * 3. Process the schedule (dedup, concurrency check, spawn).
    */
   private async tick(): Promise<void> {
-    if (this.config.tenantId) {
-      return runWithTenantDatabaseScope(this.db, this.config.tenantId, () => this.tickInScope());
-    }
-    return this.tickInScope();
-  }
-
-  private async tickInScope(): Promise<void> {
     const now = Date.now();
 
     try {
-      const dueSchedules = await this.scheduleRepo.findDue(now + this.config.gracePeriod);
+      const dueScheduleRefs = await this.findDueScheduleRefs(now);
 
       if (this.config.debug) {
-        console.log(`🔄 Scheduler tick: Found ${dueSchedules.length} due schedules`);
+        console.log(`🔄 Scheduler tick: Found ${dueScheduleRefs.length} due schedules`);
       }
 
-      for (const schedule of dueSchedules) {
-        try {
-          await this.processSchedule(schedule, now);
-        } catch (error) {
+      for (const ref of dueScheduleRefs) {
+        if (!ref.tenantId) {
           console.error(
-            `❌ Failed to process schedule ${schedule.schedule_id} (${schedule.name}):`,
-            error
+            `❌ Skipping due schedule ${shortId(ref.scheduleId)}: missing tenant metadata`
           );
+          continue;
+        }
+
+        try {
+          await runWithTenantDatabaseScope(this.db, ref.tenantId, async () => {
+            // Re-load inside the tenant scope before reading schedule content or
+            // spawning work. The system discovery phase only supplies routing
+            // metadata.
+            const schedule = await this.scheduleRepo.findById(ref.scheduleId);
+            if (!schedule) return;
+            await this.processSchedule(schedule, now);
+          });
+        } catch (error) {
+          console.error(`❌ Failed to process schedule ${shortId(ref.scheduleId)}:`, error);
           // Continue processing other schedules
         }
       }
@@ -322,6 +330,26 @@ export class SchedulerService {
       console.error('❌ Scheduler tick failed:', error);
       throw error;
     }
+  }
+
+  private async findDueScheduleRefs(
+    now: number
+  ): Promise<Array<{ scheduleId: ScheduleID; tenantId?: TenantID | string }>> {
+    const findDue = async (tenantId?: TenantID | string) => {
+      const dueSchedules = await this.scheduleRepo.findDueRefs(now + this.config.gracePeriod);
+      return dueSchedules.map((schedule) => ({
+        scheduleId: schedule.schedule_id,
+        tenantId: tenantId ?? schedule.tenant_id,
+      }));
+    };
+
+    if (this.config.tenantId) {
+      return runWithTenantDatabaseScope(this.db, this.config.tenantId, () =>
+        findDue(this.config.tenantId)
+      );
+    }
+
+    return runWithSystemDatabaseScope(this.db, 'scheduler due schedule discovery', () => findDue());
   }
 
   /**

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -586,18 +586,20 @@ export async function startup(ctx: StartupContext): Promise<void> {
   // 6. Start scheduler service (background worker)
   let schedulerService: SchedulerService | null = null;
   if (svcEnabled('scheduler')) {
+    const multiTenancy = resolveMultiTenancyConfig(config);
     schedulerService = new SchedulerService(db, app, {
       tickInterval: 30000, // 30 seconds
       gracePeriod: 120000, // 2 minutes
       debug: process.env.NODE_ENV !== 'production',
       unixUserMode: config.execution?.unix_user_mode ?? 'simple',
-      tenantId: startupTenantParams(config).tenant.tenant_id,
+      // Static mode keeps the historical single-tenant scope. Auth-resolved
+      // multi-tenant mode leaves this undefined so the scheduler discovers due
+      // schedule tenant metadata at the DB boundary on each tick.
+      tenantId: multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined,
     });
-    schedulerService.start();
-    // Expose on app so route handlers (e.g. /branches/:id/execute-schedule-now)
-    // can reuse the scheduler's spawn code path.
     app.set('scheduler', schedulerService);
-    console.log(`🔄 Scheduler started (tick interval: 30s)`);
+    schedulerService.start();
+    console.log('🔄 Scheduler started (tick interval: 30s)');
   }
 
   // 7. Start Knowledge embedding indexer (no-op unless semantic search is configured)

--- a/packages/core/src/db/repositories/base.test.ts
+++ b/packages/core/src/db/repositories/base.test.ts
@@ -8,7 +8,13 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { AmbiguousIdError, EntityNotFoundError, RepositoryError } from './base';
+import {
+  AmbiguousIdError,
+  attachHiddenTenant,
+  EntityNotFoundError,
+  getHiddenTenantId,
+  RepositoryError,
+} from './base';
 
 // ============================================================================
 // RepositoryError
@@ -131,5 +137,26 @@ describe('AmbiguousIdError', () => {
 
     expect(error.message).toContain("Ambiguous ID prefix '' for Task");
     expect(error.prefix).toBe('');
+  });
+});
+
+// ============================================================================
+// Hidden tenant metadata
+// ============================================================================
+
+describe('hidden tenant metadata helpers', () => {
+  it('attaches tenant_id as non-enumerable metadata and reads it back', () => {
+    const dto = attachHiddenTenant({ id: 'schedule-1' }, { tenant_id: 'tenant-a' });
+
+    expect(getHiddenTenantId(dto)).toBe('tenant-a');
+    expect(Object.keys(dto)).toEqual(['id']);
+    expect(JSON.stringify(dto)).toBe('{"id":"schedule-1"}');
+  });
+
+  it('ignores missing or empty tenant ids', () => {
+    const dto = attachHiddenTenant({ id: 'schedule-1' }, { tenant_id: '' });
+
+    expect(getHiddenTenantId(dto)).toBeUndefined();
+    expect(Object.keys(dto)).toEqual(['id']);
   });
 });

--- a/packages/core/src/db/repositories/base.ts
+++ b/packages/core/src/db/repositories/base.ts
@@ -146,9 +146,14 @@ export function currentTenantInsert(): { tenant_id?: string } {
  * to see it before serialization, especially in dev databases whose owner role
  * can bypass RLS.
  */
-export function attachHiddenTenant<T extends object>(dto: T, row: unknown): T {
+export function getHiddenTenantId(row: unknown): string | undefined {
   const tenantId = (row as { tenant_id?: unknown } | undefined)?.tenant_id;
-  if (typeof tenantId === 'string') {
+  return typeof tenantId === 'string' && tenantId.length > 0 ? tenantId : undefined;
+}
+
+export function attachHiddenTenant<T extends object>(dto: T, row: unknown): T {
+  const tenantId = getHiddenTenantId(row);
+  if (tenantId) {
     Object.defineProperty(dto, 'tenant_id', {
       value: tenantId,
       enumerable: false,

--- a/packages/core/src/db/repositories/schedules.test.ts
+++ b/packages/core/src/db/repositories/schedules.test.ts
@@ -179,6 +179,26 @@ describe('ScheduleRepository.findDue', () => {
     expect(dueIds.has(never.schedule_id)).toBe(true);
     expect(dueList.length).toBe(2);
   });
+
+  dbTest('findDueRefs returns only due schedule routing refs', async ({ db }) => {
+    const ctx = await setupContext(db);
+    const now = Date.now();
+
+    const due = await ctx.scheduleRepo.create({
+      ...scheduleData({ name: 'due-ref', next_run_at: now - 1000 }),
+      branch_id: ctx.branchId,
+      created_by: ctx.userId,
+    });
+    await ctx.scheduleRepo.create({
+      ...scheduleData({ name: 'future-ref', next_run_at: now + 60 * 60 * 1000 }),
+      branch_id: ctx.branchId,
+      created_by: ctx.userId,
+    });
+
+    const refs = await ctx.scheduleRepo.findDueRefs(now);
+
+    expect(refs).toEqual([{ schedule_id: due.schedule_id }]);
+  });
 });
 
 describe('ScheduleRepository.findAccessibleSchedules', () => {

--- a/packages/core/src/db/repositories/schedules.ts
+++ b/packages/core/src/db/repositories/schedules.ts
@@ -17,7 +17,15 @@ import type {
 import { and, asc, desc, eq, isNull, like, lte, or, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
+import {
+  deleteFrom,
+  insert,
+  isPostgresDatabase,
+  lockRowForUpdate,
+  select,
+  txAsDb,
+  update,
+} from '../database-wrapper';
 import {
   branches,
   branchOwners,
@@ -26,6 +34,7 @@ import {
   schedules,
 } from '../schema';
 import {
+  attachHiddenTenant,
   type BaseRepository,
   EntityNotFoundError,
   RESOLVE_SHORT_ID_FETCH_LIMIT,
@@ -34,6 +43,11 @@ import {
 } from './base';
 import { visibleBranchAccessCondition } from './branch-access';
 import { deepMerge } from './merge-utils';
+
+export interface DueScheduleRef {
+  schedule_id: ScheduleID;
+  tenant_id?: string;
+}
 
 export class ScheduleRepository implements BaseRepository<Schedule, Partial<Schedule>> {
   constructor(private db: Database) {}
@@ -50,26 +64,29 @@ export class ScheduleRepository implements BaseRepository<Schedule, Partial<Sche
         ? (JSON.parse(row.agentic_tool_config) as ScheduleAgenticToolConfig)
         : (row.agentic_tool_config as ScheduleAgenticToolConfig);
 
-    return {
-      schedule_id: row.schedule_id as ScheduleID,
-      branch_id: row.branch_id as BranchID,
-      name: row.name,
-      description: row.description ?? undefined,
-      cron_expression: row.cron_expression,
-      timezone_mode: row.timezone_mode as TimezoneMode,
-      timezone: row.timezone ?? undefined,
-      prompt: row.prompt,
-      agentic_tool_config: config,
-      enabled: Boolean(row.enabled),
-      allow_concurrent_runs: Boolean(row.allow_concurrent_runs),
-      retention: row.retention,
-      last_run_at: row.last_run_at ?? undefined,
-      last_run_session_id: (row.last_run_session_id as SessionID | null) ?? undefined,
-      next_run_at: row.next_run_at ?? undefined,
-      created_at: new Date(row.created_at).toISOString(),
-      updated_at: new Date(row.updated_at).toISOString(),
-      created_by: row.created_by as UUID,
-    };
+    return attachHiddenTenant(
+      {
+        schedule_id: row.schedule_id as ScheduleID,
+        branch_id: row.branch_id as BranchID,
+        name: row.name,
+        description: row.description ?? undefined,
+        cron_expression: row.cron_expression,
+        timezone_mode: row.timezone_mode as TimezoneMode,
+        timezone: row.timezone ?? undefined,
+        prompt: row.prompt,
+        agentic_tool_config: config,
+        enabled: Boolean(row.enabled),
+        allow_concurrent_runs: Boolean(row.allow_concurrent_runs),
+        retention: row.retention,
+        last_run_at: row.last_run_at ?? undefined,
+        last_run_session_id: (row.last_run_session_id as SessionID | null) ?? undefined,
+        next_run_at: row.next_run_at ?? undefined,
+        created_at: new Date(row.created_at).toISOString(),
+        updated_at: new Date(row.updated_at).toISOString(),
+        created_by: row.created_by as UUID,
+      },
+      row
+    );
   }
 
   private scheduleToInsert(s: Partial<Schedule>): ScheduleInsert {
@@ -204,18 +221,46 @@ export class ScheduleRepository implements BaseRepository<Schedule, Partial<Sche
    *
    * Uses the `schedules_enabled_next_run_idx` covering index.
    */
+  private dueCondition(now: number) {
+    return and(
+      eq(schedules.enabled, true),
+      or(isNull(schedules.next_run_at), lte(schedules.next_run_at, now))
+    );
+  }
+
   async findDue(now: number = Date.now()): Promise<Schedule[]> {
     const rows = await select(this.db)
       .from(schedules)
-      .where(
-        and(
-          eq(schedules.enabled, true),
-          or(isNull(schedules.next_run_at), lte(schedules.next_run_at, now))
-        )
-      )
+      .where(this.dueCondition(now))
       .orderBy(asc(schedules.next_run_at))
       .all();
     return rows.map((row: ScheduleRow) => this.rowToSchedule(row));
+  }
+
+  /**
+   * Scheduler discovery query. Returns only routing metadata so background
+   * workers can enter the correct tenant DB scope before loading schedule
+   * contents or spawning sessions.
+   */
+  async findDueRefs(now: number = Date.now()): Promise<DueScheduleRef[]> {
+    const tenantColumn = (schedules as unknown as { tenant_id?: unknown }).tenant_id;
+    const columns =
+      isPostgresDatabase(this.db) && tenantColumn
+        ? { schedule_id: schedules.schedule_id, tenant_id: tenantColumn }
+        : { schedule_id: schedules.schedule_id };
+
+    const rows = await select(this.db, columns)
+      .from(schedules)
+      .where(this.dueCondition(now))
+      .orderBy(asc(schedules.next_run_at))
+      .all();
+
+    return (rows as Array<{ schedule_id: string; tenant_id?: unknown }>).map((row) => ({
+      schedule_id: row.schedule_id as ScheduleID,
+      ...(typeof row.tenant_id === 'string' && row.tenant_id.length > 0
+        ? { tenant_id: row.tenant_id }
+        : {}),
+    }));
   }
 
   /**


### PR DESCRIPTION
## Root cause

Recent app-level multi-tenancy changes made request-less scheduler work ambiguous. The scheduler runs outside a request/auth context, but tenant-owned DB access now needs an explicit tenant database scope.

For static/default deployments, scheduler ticks need to run under the configured `multi_tenancy.static_tenant_id` (default: `default`). Without that scope, guarded tenant DB access can fail or only partially work.

Manual run-now routes also did not have their own tenant DB around-hook, so schedule/branch lookups could run outside the tenant scope expected by the guarded DB proxy.

## Behavior change

- Restores static/default scheduler behavior by running background ticks under `multi_tenancy.static_tenant_id` when `multi_tenancy.mode` is `static` or omitted.
- Keeps SQLite/default installs working; tenant scope is effectively a no-op there.
- Keeps static Postgres installs working by setting `agor.tenant_id` through `runWithTenantDatabaseScope` before schedule queries and schedule execution.
- Adds a schedule discovery helper that returns due schedule refs, then re-loads the schedule inside the active tenant scope before reading schedule content or spawning work.
- Adds centralized hidden tenant metadata extraction next to `attachHiddenTenant`, and preserves hidden tenant metadata on schedule DTOs.
- Adds `tenantDatabaseScopeAround` to canonical and legacy manual run-now routes.
- Avoids logging tenant IDs from scheduler messages.

## Multi-tenant caveat

This PR does **not** claim to fully solve background cron for `multi_tenancy.mode=required_from_auth` deployments.

In required-auth multi-tenant mode, an all-tenant due-schedule scan is only possible if the deployment has a deliberate cross-tenant discovery mechanism, such as:

- a tightly scoped privileged DB function / role that can return only due schedule routing refs, or
- a tenant/control-plane registry that lets the scheduler iterate tenants explicitly, or
- a non-RLS scheduler queue table maintained from tenant-scoped schedule writes.

The current code has a system-scope discovery path for deployments that can support it, but ordinary Postgres roles under `FORCE ROW LEVEL SECURITY` will not bypass RLS simply by using `runWithSystemDatabaseScope`.

## Tests / checks

- `pnpm --filter @agor/core test -- src/config/multitenancy.test.ts src/db/repositories/base.test.ts src/db/repositories/schedules.test.ts`
- `pnpm --filter @agor/daemon test -- src/services/scheduler.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm exec biome check apps/agor-daemon/src/register-routes.ts apps/agor-daemon/src/services/scheduler.ts apps/agor-daemon/src/services/scheduler.test.ts apps/agor-daemon/src/startup.ts packages/core/src/config/multitenancy.ts packages/core/src/config/multitenancy.test.ts packages/core/src/config/types.ts packages/core/src/db/repositories/base.ts packages/core/src/db/repositories/base.test.ts packages/core/src/db/repositories/schedules.ts packages/core/src/db/repositories/schedules.test.ts`
- `pnpm check:multitenancy-boundaries`

Attempted package typechecks earlier, but this clean worktree does not have built workspace package declaration outputs, so `@agor/core`/`@agor/git` imports fail to resolve during `tsc --noEmit` without building dependent packages.
