### PR TITLE
fix(gateway): preserve tenant scope for inbound routing

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -26,6 +26,7 @@ import {
   shouldDrainQueueAfterSessionPostTurnPatch,
   shouldRunSessionPostTurnHooks,
   shouldValidateRepoEnvironmentPayload,
+  TENANT_OWNED_SERVICE_PATHS,
 } from './register-hooks';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization';
 
@@ -45,6 +46,12 @@ const makeSession = (sessionId: string): import('@agor/core/types').Session =>
     ready_for_prompt: false,
     archived: false,
   }) as import('@agor/core/types').Session;
+
+describe('tenant-owned service registration', () => {
+  it('wraps gateway inbound routing in tenant database scope', () => {
+    expect(TENANT_OWNED_SERVICE_PATHS).toContain('gateway');
+  });
+});
 
 describe('shouldValidateRepoEnvironmentPayload', () => {
   it('skips absent repo environment payloads', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -383,6 +383,48 @@ export interface RegisterHooksContext {
 /**
  * Register all FeathersJS service hooks.
  */
+export const TENANT_OWNED_SERVICE_PATHS = [
+  'sessions',
+  'session-relationships',
+  'tasks',
+  'messages',
+  'boards',
+  'repos',
+  'branches',
+  'branches/:id/owners',
+  'boards/:id/owners',
+  'schedules',
+  'users',
+  'groups',
+  'group-memberships',
+  'branches/:id/group-grants',
+  'boards/:id/group-grants',
+  'app-variables',
+  'mcp-servers',
+  'card-types',
+  'cards',
+  'artifacts',
+  'artifact-trust-grants',
+  'board-objects',
+  'session-mcp-servers',
+  'user-mcp-oauth-tokens',
+  'board-comments',
+  'gateway-channels',
+  'gateway',
+  'thread-session-map',
+  'gateway-outbound-messages',
+  'session-env-selections',
+  'kb/namespaces',
+  'kb/documents',
+  'kb/document-edits',
+  'kb/versions',
+  'kb/search',
+  'kb/settings',
+  'kb/indexing/status',
+  'kb/indexing/reindex',
+  'leaderboard',
+];
+
 export function registerHooks(ctx: RegisterHooksContext): void {
   const {
     db,
@@ -413,46 +455,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   const tenantColumnsEnabled = resolveMultiTenancyDatabaseDialect(config) === 'postgresql';
   const executionMode = resolveExecutionSecurityMode(config);
 
-  const tenantOwnedServicePaths = [
-    'sessions',
-    'session-relationships',
-    'tasks',
-    'messages',
-    'boards',
-    'repos',
-    'branches',
-    'branches/:id/owners',
-    'boards/:id/owners',
-    'schedules',
-    'users',
-    'groups',
-    'group-memberships',
-    'branches/:id/group-grants',
-    'boards/:id/group-grants',
-    'app-variables',
-    'mcp-servers',
-    'card-types',
-    'cards',
-    'artifacts',
-    'artifact-trust-grants',
-    'board-objects',
-    'session-mcp-servers',
-    'user-mcp-oauth-tokens',
-    'board-comments',
-    'gateway-channels',
-    'thread-session-map',
-    'gateway-outbound-messages',
-    'session-env-selections',
-    'kb/namespaces',
-    'kb/documents',
-    'kb/document-edits',
-    'kb/versions',
-    'kb/search',
-    'kb/settings',
-    'kb/indexing/status',
-    'kb/indexing/reindex',
-    'leaderboard',
-  ];
+  const tenantOwnedServicePaths = TENANT_OWNED_SERVICE_PATHS;
 
   const stampTenantData = (data: unknown, tenantId: string): unknown => {
     if (Array.isArray(data)) return data.map((item) => stampTenantData(item, tenantId));

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1,8 +1,8 @@
-import { getCurrentTenantId } from '@agor/core/db';
+import { attachHiddenTenant, getCurrentTenantId } from '@agor/core/db';
 import type { GatewayChannel, ThreadSessionMap, User } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
-import { GatewayService } from './gateway.js';
+import { GatewayService, tenantIdFromGatewayChannel } from './gateway.js';
 
 const user: User = {
   user_id: 'user-1',
@@ -119,6 +119,15 @@ function makeGatewayHarness(args: {
 
   return { service, promptCreate, sessionsCreate, channelRepo, threadMapRepo };
 }
+
+describe('gateway tenant metadata helpers', () => {
+  it('extracts non-enumerable tenant metadata from gateway channel DTOs', () => {
+    const channel = attachHiddenTenant({ ...slackChannel }, { tenant_id: 'tenant-channel' });
+
+    expect(tenantIdFromGatewayChannel(channel)).toBe('tenant-channel');
+    expect(Object.keys(channel)).not.toContain('tenant_id');
+  });
+});
 
 describe('GatewayService Slack thread catch-up', () => {
   it('runs listener inbound callbacks inside a fresh channel tenant DB scope', async () => {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -12,6 +12,7 @@ import {
   GatewayChannelRepository,
   GatewayOutboundMessageRepository,
   getCurrentTenantId,
+  getHiddenTenantId,
   MCPServerRepository,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
@@ -193,9 +194,8 @@ function hasListeningConfig(channel: GatewayChannel): boolean {
   }
 }
 
-function tenantIdFromGatewayChannel(channel: GatewayChannel): TenantID | string | undefined {
-  const tenantId = (channel as GatewayChannel & { tenant_id?: unknown }).tenant_id;
-  return typeof tenantId === 'string' && tenantId.length > 0 ? tenantId : undefined;
+export function tenantIdFromGatewayChannel(channel: GatewayChannel): TenantID | string | undefined {
+  return getHiddenTenantId(channel);
 }
 
 function isSlackThinkingPlaceholder(text: string): boolean {

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -26,6 +26,7 @@ import { decryptApiKey, encryptApiKey } from '../encryption';
 import { type GatewayChannelInsert, type GatewayChannelRow, gatewayChannels } from '../schema';
 import {
   AmbiguousIdError,
+  attachHiddenTenant,
   type BaseRepository,
   EntityNotFoundError,
   RepositoryError,
@@ -147,21 +148,24 @@ export class GatewayChannelRepository
       (row.agentic_config as Record<string, unknown> | null) ?? null
     );
 
-    return {
-      id: row.id as GatewayChannelID,
-      created_by: row.created_by,
-      name: row.name,
-      channel_type: row.channel_type as ChannelType,
-      target_branch_id: row.target_branch_id as UUID,
-      agor_user_id: row.agor_user_id as UUID,
-      channel_key: row.channel_key,
-      config: decryptConfig(config),
-      agentic_config: (agenticConfig as unknown as GatewayAgenticConfig) ?? null,
-      enabled: Boolean(row.enabled),
-      created_at: new Date(row.created_at).toISOString(),
-      updated_at: new Date(row.updated_at).toISOString(),
-      last_message_at: row.last_message_at ? new Date(row.last_message_at).toISOString() : null,
-    };
+    return attachHiddenTenant(
+      {
+        id: row.id as GatewayChannelID,
+        created_by: row.created_by,
+        name: row.name,
+        channel_type: row.channel_type as ChannelType,
+        target_branch_id: row.target_branch_id as UUID,
+        agor_user_id: row.agor_user_id as UUID,
+        channel_key: row.channel_key,
+        config: decryptConfig(config),
+        agentic_config: (agenticConfig as unknown as GatewayAgenticConfig) ?? null,
+        enabled: Boolean(row.enabled),
+        created_at: new Date(row.created_at).toISOString(),
+        updated_at: new Date(row.updated_at).toISOString(),
+        last_message_at: row.last_message_at ? new Date(row.last_message_at).toISOString() : null,
+      },
+      row
+    );
   }
 
   /**


### PR DESCRIPTION
## Root cause

The gateway orchestration service runs inbound platform messages through repository lookups and internal service calls, but `/gateway` itself was not registered with the generic tenant DB around-hook. Tenant-owned supporting services (`gateway-channels`, `thread-session-map`, `gateway-outbound-messages`) were scoped, but webhook-style gateway entrypoints could run before tenant scope was established.

Gateway Socket Mode / listener startup also attempted to capture tenant context from the channel object, but `GatewayChannelRepository` did not preserve hidden `tenant_id` metadata on channel DTOs. That made listener tenant capture depend on ambient scope fallback rather than the channel row itself.

## Behavior change

- Adds `gateway` to the tenant-owned service hook list so inbound gateway create/route methods run through `tenantDatabaseScopeAround`.
- Exports the tenant-owned service path list so this regression is unit-tested.
- Preserves hidden tenant metadata on `GatewayChannelRepository` DTOs using the centralized `attachHiddenTenant` helper.
- Reuses centralized `getHiddenTenantId` for gateway channel tenant extraction.

## Scope / caveats

This improves static/custom-static deployments and listener flows that already have tenant context. It does not introduce a new cross-tenant channel-key discovery mechanism for `multi_tenancy.mode=required_from_auth` webhook deployments. Under Postgres `FORCE ROW LEVEL SECURITY`, a normal DB user still cannot globally resolve `channel_key -> tenant_id` without a deliberate routing primitive such as a trusted tenant header, tenant-specific webhook URL, privileged lookup function, or non-RLS routing table.

## Tests / checks

- `pnpm --filter @agor/daemon test -- src/services/gateway.test.ts src/register-hooks.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm --filter @agor/core test -- src/db/repositories/gateway-channels.test.ts src/db/repositories/gateway-outbound-messages.test.ts`
- `pnpm exec biome check apps/agor-daemon/src/services/gateway.ts apps/agor-daemon/src/services/gateway.test.ts apps/agor-daemon/src/register-hooks.ts apps/agor-daemon/src/register-hooks.test.ts packages/core/src/db/repositories/gateway-channels.ts`
