### PR TITLE
fix: start integration executors after tenant commit

### DIFF
--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1,4 +1,4 @@
-import { attachHiddenTenant, getCurrentTenantId } from '@agor/core/db';
+import { attachHiddenTenant, getCurrentTenantId, runWithTenantDatabaseScope } from '@agor/core/db';
 import type { GatewayChannel, ThreadSessionMap, User } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -166,6 +166,33 @@ describe('GatewayService Slack thread catch-up', () => {
     });
 
     expect(seenTenants).toEqual(['tenant-channel']);
+  });
+
+  it('passes ambient tenant context into the internal prompt call', async () => {
+    const mapping = makeMapping();
+    const { service, promptCreate } = makeGatewayHarness({
+      existingMapping: mapping,
+      connector: {},
+    });
+
+    await runWithTenantDatabaseScope({ run: vi.fn() } as never, 'tenant-channel', () =>
+      service.create({
+        channel_key: 'slack-key',
+        thread_id: 'C123-100.000000',
+        text: 'please answer',
+        metadata: {
+          channel: 'C123',
+          channel_type: 'channel',
+          slack_has_mention: true,
+          slack_message_ts: '103.000000',
+        },
+      })
+    );
+
+    expect(promptCreate.mock.calls[0][1]).toMatchObject({
+      route: { id: 'sess-1' },
+      tenant: { tenant_id: 'tenant-channel', source: 'explicit' },
+    });
   });
 
   it('fetches missed Slack messages after the last delivered cursor and advances the cursor', async () => {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -2148,9 +2148,14 @@ export class GatewayService {
 
       // Internal call: pass user, omit provider to bypass auth hooks
       // Mark message source as 'gateway' so it won't be echoed back to the platform
+      const tenantId = getCurrentTenantId();
       const task = await promptService.create(
         { prompt: promptText, permissionMode, messageSource: 'gateway' },
-        { route: { id: sessionId }, user }
+        {
+          route: { id: sessionId },
+          user,
+          ...(tenantId ? { tenant: { tenant_id: tenantId, source: 'explicit' as const } } : {}),
+        }
       );
 
       if (channel.channel_type === 'slack' && slackCursorTsToWrite && mappingForCursor) {

--- a/apps/agor-daemon/src/services/scheduler.ts
+++ b/apps/agor-daemon/src/services/scheduler.ts
@@ -50,6 +50,7 @@ import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import {
   advisoryLockKeyForUuid,
   BranchRepository,
+  getCurrentTenantId,
   isPostgresDatabase,
   runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
@@ -775,6 +776,7 @@ export class SchedulerService {
 
       // 8. Trigger prompt execution (creates task and starts agent).
       const promptService = this.app.service('/sessions/:id/prompt');
+      const tenantId = getCurrentTenantId();
       await promptService.create(
         {
           prompt: renderedPrompt,
@@ -785,6 +787,7 @@ export class SchedulerService {
           route: { id: createdSession.session_id },
           provider: undefined, // Bypass auth for internal scheduler call
           user: creator, // Pass creator user for session token generation
+          ...(tenantId ? { tenant: { tenant_id: tenantId, source: 'explicit' as const } } : {}),
         } as import('@agor/core/types').AuthenticatedParams & { route: { id: string } }
       );
 

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -273,6 +273,48 @@ describe('createTenantDatabaseScopeAroundHook', () => {
     });
   });
 
+  it('waits until the active tenant transaction commits before running deferred work', async () => {
+    const events: string[] = [];
+    const tx = { execute: vi.fn(async () => []) };
+    const db = {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+        events.push('tx:start');
+        const result = await callback(tx);
+        events.push('tx:committed');
+        return result;
+      }),
+    };
+
+    const done = new Promise<void>((resolve, reject) => {
+      runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {
+        deferWithTenantDatabaseScope(
+          db as never,
+          {},
+          async () => {
+            events.push(`work:${getCurrentTenantId()}`);
+            resolve();
+          },
+          reject
+        );
+        events.push('scheduled');
+      }).catch(reject);
+    });
+
+    await done;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(events).toEqual([
+      'tx:start',
+      'scheduled',
+      'tx:committed',
+      'tx:start',
+      'tx:committed',
+      'tx:start',
+      'work:tenant-a',
+      'tx:committed',
+    ]);
+  });
+
   it('fails deferred tenant-scoped work loudly when no tenant can be resolved', async () => {
     const { db } = makePgDb();
     const onError = vi.fn();

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -5,6 +5,7 @@ import {
   TenantResolutionError,
 } from '@agor/core/config';
 import {
+  enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantId,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
@@ -66,17 +67,29 @@ export function deferWithTenantDatabaseScope(
     return;
   }
 
-  runWithoutTenantDatabaseScope(() => {
-    setImmediate(() => {
-      void runWithTenantDatabaseScope(db, tenantId, work).catch((error) => {
-        if (onError) {
-          onError(error);
-          return;
-        }
-        console.error('[tenant-db-scope] Deferred tenant-scoped work failed:', error);
+  const schedule = () => {
+    runWithoutTenantDatabaseScope(() => {
+      setImmediate(() => {
+        void runWithTenantDatabaseScope(db, tenantId, work).catch((error) => {
+          if (onError) {
+            onError(error);
+            return;
+          }
+          console.error('[tenant-db-scope] Deferred tenant-scoped work failed:', error);
+        });
       });
     });
-  });
+  };
+
+  // If the caller is inside a tenant DB transaction, wait until the
+  // transaction commits before opening the fresh scope. Otherwise executor
+  // startup can race ahead and read rows (sessions/tasks/messages) that are
+  // still invisible on its new connection.
+  if (enqueueTenantDatabasePostCommitCallback(async () => schedule())) {
+    return;
+  }
+
+  schedule();
 }
 
 export function createTenantDatabaseScopeAroundHook(options: TenantDatabaseScopeOptions) {


### PR DESCRIPTION
## Root cause

Scheduler- and gateway-triggered prompts can create the session/task inside an active tenant-scoped Postgres transaction, then schedule executor startup through `deferWithTenantDatabaseScope`.

That deferred executor work intentionally opens a fresh tenant DB scope/connection. When it runs before the outer transaction commits, the executor cannot see the just-created session and fails during SDK setup with:

`Session not found: <session_id>`

Gateway also needs to carry explicit tenant params into its internal `/sessions/:id/prompt` handoff because the inbound channel listener/webhook is a background integration path, not a normal user request where tenant is ambient from auth headers.

## Behavior change

- `deferWithTenantDatabaseScope` now registers deferred work as a tenant DB post-commit callback when an active tenant transaction exists.
- After commit, it still exits the stale ALS transaction context and re-enters a fresh tenant DB scope before running the work.
- Scheduler internal prompt dispatch passes the current tenant context explicitly to the prompt route params when available.
- Gateway internal prompt dispatch also passes the current tenant context explicitly to the prompt route params when available.
- Single-tenant/default behavior is preserved; multi-tenant scheduler/gateway executor handoff no longer races uncommitted tenant rows or drops tenant params between integration routing and prompt execution.

## Tests / checks

- `pnpm --filter @agor/daemon test -- src/services/scheduler.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm --filter @agor/daemon test -- src/services/gateway.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm exec biome check apps/agor-daemon/src/utils/tenant-db-scope.ts apps/agor-daemon/src/utils/tenant-db-scope.test.ts apps/agor-daemon/src/services/scheduler.ts`
- `pnpm exec biome check apps/agor-daemon/src/services/gateway.ts apps/agor-daemon/src/services/gateway.test.ts`
- Attempted `pnpm --filter @agor/daemon typecheck`; it failed because this worktree cannot resolve `@agor/core/*` package declarations in daemon-only typecheck, producing broad pre-existing module-resolution errors unrelated to this change.

## Multi-tenant caveats / follow-ups

- This fix keeps executor startup outside long-running scheduler/gateway transactions while preserving tenant scope.
- The scheduler still depends on per-schedule tenant routing from the schedule row/static tenant config; required-from-auth deployments without safe system schedule discovery remain fail-closed as before.
