### PR TITLE
feat(ui): show collected session links in widget

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -247,6 +247,13 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   }
 
   /**
+   * Check whether a multi-record operation is enabled for a specific method.
+   */
+  private isMultiEnabled(method: string): boolean {
+    return this.multi === true || (Array.isArray(this.multi) && this.multi.includes(method));
+  }
+
+  /**
    * Resolve the candidate row set that `find` filters, sorts, and paginates.
    *
    * The base implementation reads the whole table and relies on `filterData` to
@@ -386,7 +393,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   async patch(id: NullableId, data: D, params?: P): Promise<T | T[]> {
     if (id === null) {
       // Multi-patch not supported in simple implementation
-      if (!this.multi) {
+      if (!this.isMultiEnabled('patch')) {
         throw new Error('Multi-patch is not enabled');
       }
 
@@ -432,7 +439,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
   async remove(id: NullableId, params?: P): Promise<T | T[]> {
     if (id === null) {
       // Multi-remove not supported in simple implementation
-      if (!this.multi) {
+      if (!this.isMultiEnabled('remove')) {
         throw new Error('Multi-remove is not enabled');
       }
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -24,6 +24,7 @@ import {
   ArtifactRepository,
   BoardRepository,
   type BranchRepository,
+  LinksRepository,
   ScheduleRepository,
   type SessionRepository,
   shortId,
@@ -44,6 +45,7 @@ import {
   boardObjectQueryValidator,
   boardQueryValidator,
   branchQueryValidator,
+  linkQueryValidator,
   mcpServerQueryValidator,
   repoQueryValidator,
   sessionQueryValidator,
@@ -58,6 +60,7 @@ import type {
   Branch,
   BranchID,
   HookContext,
+  Link,
   MCPServer,
   Paginated,
   Params,
@@ -81,6 +84,7 @@ import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
+import { ingestParsedLinksAfterMessageCreate } from './services/links.js';
 import {
   isRemoteRelationshipsEnrichedResult,
   markRemoteRelationshipsEnrichedResult,
@@ -103,11 +107,14 @@ import {
   ensureCanPromptTargetSession,
   ensureCanView,
   ensureSessionImmutability,
+  isSuperAdmin,
   loadBranch,
   loadBranchFromSession,
   loadScheduleAndBranch,
   loadSession,
   loadSessionBranch,
+  PERMISSION_RANK,
+  resolveBranchPermission,
   resolveSessionContext,
   scopeFindToAccessibleBoardsSql,
   scopeFindToAccessibleBranchesSql,
@@ -388,6 +395,7 @@ export const TENANT_OWNED_SERVICE_PATHS = [
   'session-relationships',
   'tasks',
   'messages',
+  'links',
   'boards',
   'repos',
   'branches',
@@ -547,7 +555,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     if (typeof branchId !== 'string' || branchId.length === 0) return;
     realtimeAccessCache.invalidateBranch(branchId);
     try {
-      const branch = await branchRepository.findById(branchId);
+      const branch = await branchRepository.findById(branchId as BranchID);
       if (branch) realtimeAccessCache.invalidateBranch(branch.branch_id);
     } catch {
       // Best-effort cache invalidation only.
@@ -678,6 +686,140 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   const usersService = app.service('users');
 
   // ============================================================================
+  // Links hooks
+  // ============================================================================
+
+  const linksRepository = new LinksRepository(db);
+
+  const scopeFindToAccessibleLinksSql = () => (context: HookContext) => {
+    if (!branchRbacEnabled || !context.params.provider) return context;
+    if (context.params.user?._isServiceAccount) return context;
+    const user = context.params.user;
+    if (!user) throw new NotAuthenticated('Authentication required');
+    if (isSuperAdmin(user.role, superadminOpts.allowSuperadmin)) return context;
+    (context.params as { _agorSqlLinkAccessUserId?: UserID })._agorSqlLinkAccessUserId =
+      user.user_id as UserID;
+    return context;
+  };
+
+  const ensureLinkOwnerAccess = (mode: 'view' | 'mutate') => async (context: HookContext) => {
+    if (!branchRbacEnabled || !context.params.provider) return context;
+    if (context.params.user?._isServiceAccount) return context;
+
+    const user = context.params.user;
+    if (!user) throw new NotAuthenticated('Authentication required');
+
+    const checkAccess = async (branchId: string | null | undefined, session: Session | null) => {
+      if (!branchId) throw new Forbidden('Link owner branch not found');
+      const branch = await branchRepository.findById(branchId as BranchID);
+      if (!branch) throw new Forbidden(`Branch not found: ${branchId}`);
+
+      await cacheBranchAccess(context.params, branchRepository, branch);
+      const isOwner = context.params.isBranchOwner ?? false;
+      const effectiveLevel = resolveBranchPermission(
+        branch,
+        user.user_id as UserID,
+        isOwner,
+        user.role,
+        superadminOpts.allowSuperadmin,
+        context.params.branchPermission
+      );
+
+      if (mode === 'view') {
+        if (PERMISSION_RANK[effectiveLevel] >= PERMISSION_RANK.view) return;
+        throw new Forbidden(
+          `You need 'view' permission to view links. You have '${effectiveLevel}' permission.`
+        );
+      }
+
+      const isSessionOwned = Boolean(session);
+      const allowed = isSessionOwned
+        ? PERMISSION_RANK[effectiveLevel] >= PERMISSION_RANK.prompt ||
+          (effectiveLevel === 'session' && session?.created_by === user.user_id)
+        : PERMISSION_RANK[effectiveLevel] >= PERMISSION_RANK.all;
+
+      if (!allowed) {
+        throw new Forbidden(
+          isSessionOwned
+            ? `You need prompt permission (or session permission on your own session) to mutate session links. You have '${effectiveLevel}' permission.`
+            : `You need 'all' permission to mutate branch links. You have '${effectiveLevel}' permission.`
+        );
+      }
+    };
+
+    if (context.method === 'create') {
+      const records = Array.isArray(context.data) ? context.data : [context.data];
+      for (const record of records as Partial<Link>[]) {
+        let branchId: string | null | undefined = record.branch_id;
+        let session: Session | null = null;
+        if (record.session_id) {
+          session = (await sessionsService.get(record.session_id, {
+            provider: undefined,
+          })) as Session;
+          branchId = session.branch_id;
+        }
+        await checkAccess(branchId, session);
+      }
+      return context;
+    }
+
+    if (!context.id) return context;
+    const link = await linksRepository.findById(String(context.id));
+    if (!link) throw new Forbidden(`Link not found: ${context.id}`);
+    let branchId: string | null | undefined;
+    let session: Session | null = null;
+    if (link.session_id) {
+      session = (await sessionsService.get(link.session_id, { provider: undefined })) as Session;
+      branchId = session.branch_id;
+    } else {
+      branchId = link.branch_id;
+    }
+    (context.params as { _agorPrefetchedRecord?: unknown })._agorPrefetchedRecord = {
+      id: String(context.id),
+      idField: 'link_id',
+      record: link,
+    };
+    await checkAccess(branchId, session);
+
+    return context;
+  };
+
+  const rejectLinkOwnerPatch = (context: HookContext) => {
+    const data = context.data as Record<string, unknown> | undefined;
+    if (!data) return context;
+    for (const key of [
+      'link_id',
+      'branch_id',
+      'session_id',
+      'created_by',
+      'created_at',
+      'updated_at',
+    ]) {
+      if (key in data) throw new Forbidden(`Link field '${key}' is immutable`);
+    }
+    return context;
+  };
+
+  app.service('links').hooks({
+    before: {
+      all: [typedValidateQuery(linkQueryValidator), requireAuth, executorRuntimeScopeGuard()],
+      find: [scopeFindToAccessibleLinksSql()],
+      get: [ensureLinkOwnerAccess('view')],
+      create: [
+        requireMinimumRole(ROLES.MEMBER, 'create links'),
+        injectCreatedBy(),
+        ensureLinkOwnerAccess('mutate'),
+      ],
+      patch: [
+        requireMinimumRole(ROLES.MEMBER, 'update links'),
+        rejectLinkOwnerPatch,
+        ensureLinkOwnerAccess('mutate'),
+      ],
+      remove: [requireMinimumRole(ROLES.MEMBER, 'delete links'), ensureLinkOwnerAccess('mutate')],
+    },
+  });
+
+  // ============================================================================
   // Messages hooks
   // ============================================================================
 
@@ -736,7 +878,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
     },
     after: {
-      create: [gatewayRouteHook],
+      create: [gatewayRouteHook, ingestParsedLinksAfterMessageCreate(app)],
       patch: [
         async (context: HookContext<Board>) => {
           // Detect permission resolution and notify executor via IPC

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -43,6 +43,7 @@ import type {
   AuthenticatedParams,
   DaemonServicesConfig,
   HookContext,
+  LinkCreate,
   Message,
   MessageSource,
   Paginated,
@@ -1935,6 +1936,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
       const uploadedFiles = files.map((f) => ({
         filename: f.filename,
+        originalName: f.originalname,
         path: f.path,
         size: f.size,
         mimeType: f.mimetype,
@@ -1945,6 +1947,28 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         uploadedFiles.forEach((f) => {
           console.log(`     - ${f.filename} (${(f.size / 1024).toFixed(2)} KB)`);
         });
+      }
+
+      const uploadLinks: Partial<LinkCreate>[] = uploadedFiles.map((file) => ({
+        session_id: sessionId as SessionID,
+        branch_id: null,
+        source: 'upload',
+        kind: file.mimeType.toLowerCase().startsWith('image/') ? 'image' : 'document',
+        file_path: file.path,
+        title: file.originalName || file.filename,
+        mime_type: file.mimeType,
+        metadata: {
+          filename: file.filename,
+          originalName: file.originalName,
+          size: file.size,
+        },
+        created_by: (params.user?.user_id as UUID | undefined) ?? null,
+      }));
+
+      if (uploadLinks.length > 0) {
+        await app
+          .service('links')
+          .create(uploadLinks, { ...params, provider: undefined } as Params);
       }
 
       let notificationError: string | null = null;
@@ -3803,7 +3827,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // ============================================================================
 
   const SERVICE_GROUP_PATHS: Partial<Record<ServiceGroupName, string[]>> = {
-    core: ['sessions', 'tasks', 'messages'],
+    core: ['sessions', 'tasks', 'messages', 'links'],
     branches: ['branches'],
     repos: ['repos'],
     users: ['users'],

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -103,7 +103,7 @@ import { createKnowledgeSearchService } from './services/knowledge-search.js';
 import { createKnowledgeSettingsService } from './services/knowledge-settings.js';
 import { createKnowledgeVersionsService } from './services/knowledge-versions.js';
 import { createLeaderboardService } from './services/leaderboard.js';
-import { createLinksService } from './services/links.js';
+import { createLinksService, LINKS_SERVICE_METHODS } from './services/links.js';
 import { createLocalActionsService } from './services/local-actions.js';
 import { createMCPServersService } from './services/mcp-servers.js';
 import { createMessagesService } from './services/messages.js';
@@ -240,6 +240,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   const messagesService = createMessagesService(db) as unknown as MessagesServiceImpl;
 
   app.use('/links', createLinksService(db), {
+    methods: [...LINKS_SERVICE_METHODS],
     events: ['created', 'patched', 'removed'],
   });
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -103,6 +103,7 @@ import { createKnowledgeSearchService } from './services/knowledge-search.js';
 import { createKnowledgeSettingsService } from './services/knowledge-settings.js';
 import { createKnowledgeVersionsService } from './services/knowledge-versions.js';
 import { createLeaderboardService } from './services/leaderboard.js';
+import { createLinksService } from './services/links.js';
 import { createLocalActionsService } from './services/local-actions.js';
 import { createMCPServersService } from './services/mcp-servers.js';
 import { createMessagesService } from './services/messages.js';
@@ -237,6 +238,10 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     app.use('/leaderboard', createLeaderboardService(db));
   }
   const messagesService = createMessagesService(db) as unknown as MessagesServiceImpl;
+
+  app.use('/links', createLinksService(db), {
+    events: ['created', 'patched', 'removed'],
+  });
 
   app.use('/messages', messagesService, {
     methods: [

--- a/apps/agor-daemon/src/services/links.test.ts
+++ b/apps/agor-daemon/src/services/links.test.ts
@@ -197,4 +197,45 @@ describe('LinksService', () => {
     );
     expect(links).toHaveLength(3);
   });
+
+  it('preserves tenant context for internal parsed-link creation', async () => {
+    const create = vi.fn(async () => []);
+    const app = {
+      service: vi.fn((path: string) => {
+        if (path !== 'links') throw new Error(`Unexpected service: ${path}`);
+        return { create };
+      }),
+    };
+    const hook = ingestParsedLinksAfterMessageCreate(app as never);
+    const message = {
+      message_id: generateId() as MessageID,
+      session_id: generateId() as SessionID,
+      type: 'user',
+      role: 'user',
+      index: 0,
+      timestamp: new Date().toISOString(),
+      content_preview: 'See https://example.com/tenant',
+      content: 'See https://example.com/tenant',
+    } as Message;
+    const tenant = { tenant_id: 'tenant-a', source: 'auth_claim' };
+
+    await hook({
+      result: message,
+      params: {
+        provider: 'rest',
+        tenant,
+        authentication: { payload: { tenant_id: 'tenant-a' } },
+        user: { user_id: generateId() as UUID, tenant_id: 'tenant-a' },
+      },
+    } as never);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ session_id: message.session_id })]),
+      expect.objectContaining({
+        provider: undefined,
+        tenant,
+        authentication: { payload: { tenant_id: 'tenant-a' } },
+      })
+    );
+  });
 });

--- a/apps/agor-daemon/src/services/links.test.ts
+++ b/apps/agor-daemon/src/services/links.test.ts
@@ -6,12 +6,12 @@ import {
   SessionRepository,
   UsersRepository,
 } from '@agor/core/db';
-import type { BranchID, Message, MessageID, SessionID, UUID } from '@agor/core/types';
-import { describe, expect, vi } from 'vitest';
+import type { BranchID, Link, Message, MessageID, SessionID, UUID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
 import type { Database } from '../../../../packages/core/src/db/client';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { generateId } from '../../../../packages/core/src/lib/ids';
-import { ingestParsedLinksAfterMessageCreate, LinksService } from './links';
+import { ingestParsedLinksAfterMessageCreate, LINKS_SERVICE_METHODS, LinksService } from './links';
 
 async function seedUser(db: Database, userId: UUID, email: string) {
   await new UsersRepository(db).create({ user_id: userId, email, name: email });
@@ -51,6 +51,66 @@ async function seedSession(db: Database, branchId: BranchID) {
 }
 
 describe('LinksService', () => {
+  it('does not expose full update over Feathers transports', () => {
+    expect(LINKS_SERVICE_METHODS).not.toContain('update');
+  });
+
+  dbTest('allows bulk create but rejects multi patch/remove', async ({ db }) => {
+    const branch = await seedBranch(db, 'view');
+    const session = await seedSession(db, branch.branch_id);
+    const service = new LinksService(db);
+
+    const created = await service.create([
+      {
+        session_id: session.session_id,
+        kind: 'url',
+        source: 'manual',
+        url: 'https://example.com/a',
+      },
+      {
+        session_id: session.session_id,
+        kind: 'url',
+        source: 'manual',
+        url: 'https://example.com/b',
+      },
+    ]);
+
+    expect(created).toHaveLength(2);
+    await expect(service.patch(null, { title: 'changed' }, { query: {} })).rejects.toThrow(
+      /does not support multi/
+    );
+    await expect(service.remove(null, { query: {} })).rejects.toThrow(/does not support multi/);
+  });
+
+  dbTest('rejects full update while preserving single patch/remove', async ({ db }) => {
+    const branch = await seedBranch(db, 'view');
+    const session = await seedSession(db, branch.branch_id);
+    const service = new LinksService(db);
+    const created = (await service.create({
+      session_id: session.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/single',
+    })) as Link;
+
+    await expect(
+      service.update(created.link_id, {
+        session_id: session.session_id,
+        kind: 'url',
+        source: 'manual',
+        url: 'https://example.com/replaced',
+      })
+    ).rejects.toThrow(/update is not supported/);
+
+    const patched = await service.patch(created.link_id, { title: 'single patch works' });
+    expect(Array.isArray(patched)).toBe(false);
+    expect((patched as { title: string | null }).title).toBe('single patch works');
+
+    const removed = await service.remove(created.link_id);
+    expect(Array.isArray(removed)).toBe(false);
+    expect((removed as { link_id: string }).link_id).toBe(created.link_id);
+  });
+
   dbTest('scopes find to links whose owner branch/session is visible to caller', async ({ db }) => {
     const viewer = generateId() as UUID;
     await seedUser(db, viewer, 'links-service-viewer@example.com');

--- a/apps/agor-daemon/src/services/links.test.ts
+++ b/apps/agor-daemon/src/services/links.test.ts
@@ -1,0 +1,140 @@
+import {
+  BranchRepository,
+  LinksRepository,
+  MessagesRepository,
+  RepoRepository,
+  SessionRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { BranchID, Message, MessageID, SessionID, UUID } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
+import type { Database } from '../../../../packages/core/src/db/client';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { generateId } from '../../../../packages/core/src/lib/ids';
+import { ingestParsedLinksAfterMessageCreate, LinksService } from './links';
+
+async function seedUser(db: Database, userId: UUID, email: string) {
+  await new UsersRepository(db).create({ user_id: userId, email, name: email });
+}
+
+async function seedBranch(db: Database, othersCan: 'none' | 'view' = 'none') {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId() as UUID,
+    slug: `links-service-repo-${generateId()}`,
+    name: 'Links Service Repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/example/repo.git',
+    local_path: `/tmp/${generateId()}`,
+    default_branch: 'main',
+  });
+  return new BranchRepository(db).create({
+    branch_id: generateId() as BranchID,
+    repo_id: repo.repo_id,
+    name: `links-service-branch-${generateId()}`,
+    ref: 'refs/heads/test',
+    branch_unique_id: 1,
+    path: `/tmp/${generateId()}`,
+    created_by: 'owner' as UUID,
+    permission_source: 'override',
+    others_can: othersCan,
+  });
+}
+
+async function seedSession(db: Database, branchId: BranchID) {
+  return new SessionRepository(db).create({
+    session_id: generateId() as SessionID,
+    branch_id: branchId,
+    created_by: 'owner' as UUID,
+    tasks: [],
+    genealogy: { children: [] },
+  });
+}
+
+describe('LinksService', () => {
+  dbTest('scopes find to links whose owner branch/session is visible to caller', async ({ db }) => {
+    const viewer = generateId() as UUID;
+    await seedUser(db, viewer, 'links-service-viewer@example.com');
+    const visibleBranch = await seedBranch(db);
+    const hiddenBranch = await seedBranch(db);
+    await new BranchRepository(db).addOwner(visibleBranch.branch_id, viewer);
+
+    const visibleSession = await seedSession(db, visibleBranch.branch_id);
+    const hiddenSession = await seedSession(db, hiddenBranch.branch_id);
+    const repo = new LinksRepository(db);
+    const visible = await repo.create({
+      session_id: visibleSession.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/visible',
+    });
+    await repo.create({
+      session_id: hiddenSession.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/hidden',
+    });
+
+    const service = new LinksService(db);
+    const result = await service.find({
+      query: {},
+      _agorSqlLinkAccessUserId: viewer,
+    });
+
+    const rows = Array.isArray(result) ? result : result.data;
+    expect(rows.map((link) => link.link_id)).toEqual([visible.link_id]);
+  });
+
+  dbTest('ingests parsed links after single and array message creates', async ({ db }) => {
+    const branch = await seedBranch(db, 'view');
+    const session = await seedSession(db, branch.branch_id);
+    const service = new LinksService(db);
+    const app = {
+      service: vi.fn((path: string) => {
+        if (path !== 'links') throw new Error(`Unexpected service: ${path}`);
+        return service;
+      }),
+    };
+    const hook = ingestParsedLinksAfterMessageCreate(app as never);
+
+    const first = {
+      message_id: generateId() as MessageID,
+      session_id: session.session_id,
+      type: 'user',
+      role: 'user',
+      index: 0,
+      timestamp: new Date().toISOString(),
+      content_preview: 'See agor://kb/team/runbook.md',
+      content: 'See agor://kb/team/runbook.md and https://github.com/preset-io/agor/issues/90',
+    } as Message;
+    const second = {
+      message_id: generateId() as MessageID,
+      session_id: session.session_id,
+      type: 'assistant',
+      role: 'assistant',
+      index: 1,
+      timestamp: new Date().toISOString(),
+      content_preview: 'PR https://github.com/preset-io/agor/pull/91',
+      content: [{ type: 'text', text: 'PR https://github.com/preset-io/agor/pull/91' }],
+    } as Message;
+    const messagesRepo = new MessagesRepository(db);
+    await messagesRepo.create(first);
+    await messagesRepo.create(second);
+
+    await hook({ result: first, params: {} } as never);
+    await hook({ result: [second], params: {} } as never);
+
+    const repo = new LinksRepository(db);
+    const links = await repo.findAll({ sessionId: session.session_id, source: 'parsed' });
+    expect(links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'kb_ref', ref_uri: 'agor://kb/team/runbook.md' }),
+        expect.objectContaining({
+          kind: 'issue',
+          url: 'https://github.com/preset-io/agor/issues/90',
+        }),
+        expect.objectContaining({ kind: 'pr', url: 'https://github.com/preset-io/agor/pull/91' }),
+      ])
+    );
+    expect(links).toHaveLength(3);
+  });
+});

--- a/apps/agor-daemon/src/services/links.ts
+++ b/apps/agor-daemon/src/services/links.ts
@@ -6,16 +6,18 @@
 
 import { PAGINATION } from '@agor/core/config';
 import { type Database, LinksRepository } from '@agor/core/db';
-import type { Application } from '@agor/core/feathers';
+import { type Application, BadRequest } from '@agor/core/feathers';
 import type {
   BranchID,
   HookContext,
+  Id,
   Link,
   LinkCreate,
   LinkKind,
   LinkSource,
   Message,
   MessageID,
+  NullableId,
   Params,
   QueryParams,
   SessionID,
@@ -23,6 +25,8 @@ import type {
 } from '@agor/core/types';
 import { extractLinksFromMessage } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
+
+export const LINKS_SERVICE_METHODS = ['find', 'get', 'create', 'patch', 'remove'] as const;
 
 export type LinkParams = QueryParams<{
   branch_id?: BranchID;
@@ -46,7 +50,7 @@ export class LinksService extends DrizzleService<Link, Partial<Link>, LinkParams
         default: PAGINATION.DEFAULT_LIMIT,
         max: PAGINATION.MAX_LIMIT,
       },
-      multi: ['create', 'remove'],
+      multi: ['create'],
     });
     this.linksRepo = linksRepo;
   }
@@ -77,6 +81,24 @@ export class LinksService extends DrizzleService<Link, Partial<Link>, LinkParams
     const result = await this.linksRepo.upsert(data as Partial<LinkCreate>);
     this.emit?.(existing ? 'patched' : 'created', result, params);
     return result;
+  }
+
+  async update(_id: Id, _data: Partial<Link>, _params?: LinkParams): Promise<Link> {
+    throw new BadRequest('links.update is not supported; use patch instead');
+  }
+
+  async patch(id: NullableId, data: Partial<Link>, params?: LinkParams): Promise<Link | Link[]> {
+    if (id === null) {
+      throw new BadRequest('links.patch does not support multi operations');
+    }
+    return super.patch(id, data, params);
+  }
+
+  async remove(id: NullableId, params?: LinkParams): Promise<Link | Link[]> {
+    if (id === null) {
+      throw new BadRequest('links.remove does not support multi operations');
+    }
+    return super.remove(id, params);
   }
 }
 

--- a/apps/agor-daemon/src/services/links.ts
+++ b/apps/agor-daemon/src/services/links.ts
@@ -1,0 +1,123 @@
+/**
+ * Links Service
+ *
+ * Provides REST + WebSocket API for branch/session-owned links and uploaded attachments.
+ */
+
+import { PAGINATION } from '@agor/core/config';
+import { type Database, LinksRepository } from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type {
+  BranchID,
+  HookContext,
+  Link,
+  LinkCreate,
+  LinkKind,
+  LinkSource,
+  Message,
+  MessageID,
+  Params,
+  QueryParams,
+  SessionID,
+  UUID,
+} from '@agor/core/types';
+import { extractLinksFromMessage } from '@agor/core/types';
+import { DrizzleService, type Query } from '../adapters/drizzle';
+
+export type LinkParams = QueryParams<{
+  branch_id?: BranchID;
+  session_id?: SessionID;
+  source_message_id?: MessageID;
+  kind?: LinkKind;
+  source?: LinkSource;
+}> & {
+  _agorSqlLinkAccessUserId?: UUID;
+};
+
+export class LinksService extends DrizzleService<Link, Partial<Link>, LinkParams> {
+  private linksRepo: LinksRepository;
+
+  constructor(db: Database) {
+    const linksRepo = new LinksRepository(db);
+    super(linksRepo, {
+      id: 'link_id',
+      resourceType: 'Link',
+      paginate: {
+        default: PAGINATION.DEFAULT_LIMIT,
+        max: PAGINATION.MAX_LIMIT,
+      },
+      multi: ['create', 'remove'],
+    });
+    this.linksRepo = linksRepo;
+  }
+
+  protected async fetchData(query: Query, params?: LinkParams): Promise<Link[]> {
+    const filter: Parameters<LinksRepository['findAll']>[0] = {};
+    if (typeof query.branch_id === 'string') filter.branchId = query.branch_id as BranchID;
+    if (typeof query.session_id === 'string') filter.sessionId = query.session_id as SessionID;
+    if (typeof query.source_message_id === 'string') {
+      filter.sourceMessageId = query.source_message_id as MessageID;
+    }
+    if (typeof query.kind === 'string') filter.kind = query.kind as LinkKind;
+    if (typeof query.source === 'string') filter.source = query.source as LinkSource;
+    if (params?._agorSqlLinkAccessUserId) filter.visibleToUserId = params._agorSqlLinkAccessUserId;
+    return this.linksRepo.findAll(filter);
+  }
+
+  async create(data: Partial<Link> | Partial<Link>[], params?: LinkParams): Promise<Link | Link[]> {
+    if (Array.isArray(data)) {
+      const results: Link[] = [];
+      for (const item of data) {
+        results.push((await this.create(item, params)) as Link);
+      }
+      return results;
+    }
+
+    const existing = await this.linksRepo.findByOwnerAndTarget(data as Partial<LinkCreate>);
+    const result = await this.linksRepo.upsert(data as Partial<LinkCreate>);
+    this.emit?.(existing ? 'patched' : 'created', result, params);
+    return result;
+  }
+}
+
+export function createLinksService(db: Database): LinksService {
+  return new LinksService(db);
+}
+
+function normalizeCreatedMessages(result: unknown): Message[] {
+  if (Array.isArray(result)) return result as Message[];
+  return result ? [result as Message] : [];
+}
+
+export function ingestParsedLinksAfterMessageCreate(app: Application) {
+  return async (context: HookContext): Promise<HookContext> => {
+    const messages = normalizeCreatedMessages(context.result);
+    if (messages.length === 0) return context;
+
+    const linksService = app.service('links') as unknown as {
+      create(data: Partial<LinkCreate>[], params?: Params): Promise<Link[]>;
+    };
+
+    const drafts: Partial<LinkCreate>[] = [];
+    for (const message of messages) {
+      const parsed = extractLinksFromMessage(message);
+      for (const link of parsed) {
+        drafts.push({
+          ...link,
+          session_id: message.session_id,
+          branch_id: null,
+          source_message_id: message.message_id,
+          created_by: (context.params.user?.user_id as UUID | undefined) ?? null,
+        } as Partial<LinkCreate>);
+      }
+    }
+
+    if (drafts.length > 0) {
+      await linksService.create(drafts, {
+        ...context.params,
+        provider: undefined,
+      } as Params);
+    }
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/services/links.ts
+++ b/apps/agor-daemon/src/services/links.ts
@@ -5,7 +5,7 @@
  */
 
 import { PAGINATION } from '@agor/core/config';
-import { type Database, LinksRepository } from '@agor/core/db';
+import { LinksRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
 import { type Application, BadRequest } from '@agor/core/feathers';
 import type {
   BranchID,
@@ -41,7 +41,7 @@ export type LinkParams = QueryParams<{
 export class LinksService extends DrizzleService<Link, Partial<Link>, LinkParams> {
   private linksRepo: LinksRepository;
 
-  constructor(db: Database) {
+  constructor(db: TenantScopeAwareDatabase) {
     const linksRepo = new LinksRepository(db);
     super(linksRepo, {
       id: 'link_id',
@@ -102,7 +102,7 @@ export class LinksService extends DrizzleService<Link, Partial<Link>, LinkParams
   }
 }
 
-export function createLinksService(db: Database): LinksService {
+export function createLinksService(db: TenantScopeAwareDatabase): LinksService {
   return new LinksService(db);
 }
 

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -487,6 +487,26 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }]);
   });
 
+  it('resolves link events through session_id when branch_id is absent', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const app = makeApp([{ user: allowed }, { user: denied }]);
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const channel = await app.runPublish(
+      { link_id: 'l1', session_id: 's1' },
+      { path: 'links', method: 'create', event: 'created' }
+    );
+
+    expect(r.sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledWith('s1');
+    expect(channel.connections).toEqual([{ user: allowed }]);
+  });
+
   it('resolves board comment events through task_id when branch_id is absent', async () => {
     const allowed = user('allowed');
     const denied = user('denied');

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -62,7 +62,11 @@ const SESSION_ID_SCOPED_PATHS = new Set([
   'session-mcp-servers',
   'session-env-selections',
 ]);
-const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set(['board-objects', 'board-comments']);
+const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set([
+  'board-objects',
+  'board-comments',
+  'links',
+]);
 
 function isStreamingEvent(context: PublishContext): boolean {
   return (

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { SessionAttachmentsDropdown } from './SessionAttachmentsDropdown';
+import type { SessionLinkWidgetItem } from './sessionLinks';
+
+const items: SessionLinkWidgetItem[] = [
+  {
+    key: 'github-pr',
+    name: 'PR: acme/widgets#12',
+    targetKey: 'url:https://github.com/acme/widgets/pull/12',
+    kind: 'pr',
+    url: 'https://github.com/acme/widgets/pull/12',
+    href: 'https://github.com/acme/widgets/pull/12',
+  },
+  {
+    key: 'kb-ref',
+    name: 'KB: team/runbooks/links.md',
+    targetKey: 'ref:agor://kb/team/runbooks/links.md',
+    kind: 'kb_ref',
+    refUri: 'agor://kb/team/runbooks/links.md',
+    href: '/kb/team/runbooks/links.md',
+  },
+  {
+    key: 'opaque-kb-ref',
+    name: 'KB document 01900000',
+    targetKey: 'ref:agor://kb/document/01900000-0000-7000-8000-000000000092',
+    kind: 'kb_ref',
+    refUri: 'agor://kb/document/01900000-0000-7000-8000-000000000092',
+  },
+];
+
+describe('SessionAttachmentsDropdown', () => {
+  it('renders GitHub, KB, and non-routable ref rows and opens routable links', async () => {
+    const open = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    render(
+      <AntApp>
+        <SessionAttachmentsDropdown items={items} />
+      </AntApp>
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(await screen.findByText('PR: acme/widgets#12')).toBeInTheDocument();
+    expect(screen.getByText('KB: team/runbooks/links.md')).toBeInTheDocument();
+    expect(screen.getByText('KB document 01900000')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('KB: team/runbooks/links.md'));
+    await waitFor(() => expect(open).toHaveBeenCalledWith('/kb/team/runbooks/links.md', '_blank'));
+
+    fireEvent.click(screen.getByText('KB document 01900000'));
+    expect(open).toHaveBeenCalledTimes(1);
+
+    open.mockRestore();
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -1,25 +1,34 @@
-import { GithubOutlined, GlobalOutlined, LinkOutlined } from '@ant-design/icons';
+import {
+  FileOutlined,
+  GithubOutlined,
+  GlobalOutlined,
+  LinkOutlined,
+  ReadOutlined,
+} from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Badge, Button, Dropdown, Tooltip, theme } from 'antd';
 import type React from 'react';
+import type { SessionLinkWidgetItem } from './sessionLinks';
 
-export interface SessionAttachmentItem {
-  key: string;
-  name: string;
-  url: string;
-}
+export type SessionAttachmentItem = SessionLinkWidgetItem;
 
 interface Props {
   items: SessionAttachmentItem[];
 }
 
-function getIcon(url: string): React.ReactNode {
-  try {
-    const { hostname } = new URL(url);
-    if (hostname === 'github.com' || hostname.endsWith('.github.com')) return <GithubOutlined />;
-  } catch {
-    // ignore
+function getIcon(item: SessionAttachmentItem): React.ReactNode {
+  if (item.kind === 'kb_ref' || item.refUri?.startsWith('agor://kb/')) return <ReadOutlined />;
+  if (item.filePath) return <FileOutlined />;
+
+  if (item.url) {
+    try {
+      const { hostname } = new URL(item.url);
+      if (hostname === 'github.com' || hostname.endsWith('.github.com')) return <GithubOutlined />;
+    } catch {
+      // ignore
+    }
   }
+
   return <GlobalOutlined />;
 }
 
@@ -30,7 +39,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
 
   const menuItems: MenuProps['items'] = items.map((item) => ({
     key: item.key,
-    icon: getIcon(item.url),
+    icon: getIcon(item),
     label: (
       <Tooltip title={item.name.length > 40 ? item.name : undefined} placement="left">
         <span
@@ -46,12 +55,13 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
         </span>
       </Tooltip>
     ),
-    onClick: () => window.open(item.url, '_blank'),
+    disabled: !item.href,
+    onClick: item.href ? () => window.open(item.href, '_blank') : undefined,
   }));
 
   return (
     <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
-      <Tooltip title="Attachments">
+      <Tooltip title="Links">
         <Badge count={items.length} color={token.colorPrimary} size="small" offset={[-4, 4]}>
           <Button type="text" icon={<LinkOutlined style={{ color: token.colorPrimary }} />} />
         </Badge>

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.links.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.links.test.tsx
@@ -1,0 +1,157 @@
+import type { Branch, Link, Session } from '@agor-live/client';
+import { normalizeRefTargetKey } from '@agor-live/client';
+import { render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { AppActionsProvider } from '../../contexts/AppActionsContext';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import SessionPanel from './SessionPanel';
+
+const dropdownCapture = vi.hoisted(() => ({ calls: [] as Array<Array<{ name: string }>> }));
+
+vi.mock('../../hooks/useSharedReactiveSession', () => ({
+  useSharedReactiveSession: () => ({ state: { tasks: [] } }),
+}));
+
+vi.mock('../AutocompleteTextarea', () => ({
+  AutocompleteTextarea: () => <textarea aria-label="Prompt" />,
+}));
+
+vi.mock('../FileUpload', () => ({
+  FileUpload: () => null,
+  FileUploadButton: () => null,
+}));
+
+vi.mock('../ForkSpawnModal/ForkSpawnModal', () => ({
+  ForkSpawnModal: () => null,
+}));
+
+vi.mock('../metadata', () => ({
+  CreatedByTag: () => <span>Created by test user</span>,
+}));
+
+vi.mock('../Pill', () => ({
+  ContextWindowPill: () => <span>Context window</span>,
+  TimerPill: () => <span>Timer</span>,
+  TokenCountPill: () => <span>Tokens</span>,
+}));
+
+vi.mock('../SessionIds', () => ({
+  SessionIdsButton: () => <span>Session IDs</span>,
+}));
+
+vi.mock('../ToolIcon', () => ({
+  ToolIcon: () => <span>Tool icon</span>,
+}));
+
+vi.mock('./SessionAttachmentsDropdown', () => ({
+  SessionAttachmentsDropdown: ({ items }: { items: Array<{ name: string }> }) => {
+    dropdownCapture.calls.push(items);
+    return (
+      <div data-testid="session-links">
+        {items.map((item) => (
+          <span key={item.name}>{item.name}</span>
+        ))}
+      </div>
+    );
+  },
+}));
+
+vi.mock('./SessionMcpFooterControl', () => ({
+  SessionMcpFooterControl: () => null,
+}));
+
+vi.mock('./SessionPanelContent', () => ({
+  SessionPanelContent: () => <div>Session content</div>,
+}));
+
+vi.mock('./SessionRunSettingsPopover', () => ({
+  SessionRunSettingsPopover: () => null,
+}));
+
+const connected = {
+  connected: true,
+  connecting: false,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+
+const session = {
+  session_id: 'session-1',
+  branch_id: 'branch-1',
+  title: 'Links session',
+  agentic_tool: 'claude-code-cli',
+  status: 'idle',
+  archived: false,
+  created_at: '2026-06-29T00:00:00.000Z',
+  last_updated: '2026-06-29T00:00:00.000Z',
+} as unknown as Session;
+
+const branch = {
+  branch_id: 'branch-1',
+  board_id: 'board-1',
+  name: 'feature/links',
+  path: '/tmp/feature-links',
+  filesystem_status: 'ready',
+  issue_url: 'https://github.com/acme/widgets/issues/92',
+  archived: false,
+} as unknown as Branch;
+
+const kbLink = {
+  link_id: 'link-kb',
+  branch_id: null,
+  session_id: 'session-1',
+  source_message_id: null,
+  kind: 'kb_ref',
+  source: 'parsed',
+  url: null,
+  ref_uri: 'agor://kb/team/runbooks/links.md',
+  file_path: null,
+  target_key: normalizeRefTargetKey('agor://kb/team/runbooks/links.md'),
+  title: null,
+  mime_type: null,
+  metadata: null,
+  created_by: null,
+  created_at: '2026-06-29T00:00:00.000Z',
+  updated_at: '2026-06-29T00:00:00.000Z',
+} as Link;
+
+describe('SessionPanel session links', () => {
+  it('queries links for the active session and passes merged rows to the links widget', async () => {
+    dropdownCapture.calls = [];
+    const linksFindAll = vi.fn().mockResolvedValue([kbLink]);
+    const noopService = { on: vi.fn(), off: vi.fn() };
+    const client = {
+      service: vi.fn((path: string) => {
+        if (path === 'links') return { findAll: linksFindAll, on: vi.fn(), off: vi.fn() };
+        if (path === `/sessions/${session.session_id}/tasks/queue`) {
+          return { find: vi.fn().mockResolvedValue({ data: [] }) };
+        }
+        return noopService;
+      }),
+    };
+
+    render(
+      <ConnectionProvider value={connected}>
+        <AppActionsProvider value={{ onOpenTerminal: vi.fn() }}>
+          <AntApp>
+            <SessionPanel
+              client={client as never}
+              session={session}
+              branch={branch}
+              open
+              onClose={vi.fn()}
+            />
+          </AntApp>
+        </AppActionsProvider>
+      </ConnectionProvider>
+    );
+
+    await waitFor(() =>
+      expect(linksFindAll).toHaveBeenCalledWith({ query: { session_id: 'session-1' } })
+    );
+    expect(await screen.findByText('Issue: acme/widgets#92')).toBeInTheDocument();
+    expect(screen.getByText('KB: team/runbooks/links.md')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -4,6 +4,7 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  Link,
   PermissionMode,
   Session,
   SessionID,
@@ -50,12 +51,11 @@ import { FileUpload } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
 import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
-import { getUrlDisplayLabel } from '../Pill/url-helpers';
 import { ToolIcon } from '../ToolIcon';
-import type { SessionAttachmentItem } from './SessionAttachmentsDropdown';
 import { SessionAttachmentsDropdown } from './SessionAttachmentsDropdown';
 import { SessionFooter } from './SessionFooter';
 import { SessionPanelContent } from './SessionPanelContent';
+import { buildSessionLinkWidgetItems } from './sessionLinks';
 
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
@@ -340,6 +340,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [scrollToBottom, setScrollToBottom] = React.useState<(() => void) | null>(null);
   const [scrollToTop, setScrollToTop] = React.useState<(() => void) | null>(null);
   const [queuedTasks, setQueuedTasks] = React.useState<Task[]>([]);
+  const [sessionLinks, setSessionLinks] = React.useState<Link[]>([]);
   const [forkModalOpen, setForkModalOpen] = React.useState(false);
   const [spawnModalOpen, setSpawnModalOpen] = React.useState(false);
   const [uploadModalOpen, setUploadModalOpen] = React.useState(false);
@@ -409,6 +410,60 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     };
   }, [client, session]);
 
+  React.useEffect(() => {
+    const sessionId = session?.session_id;
+    if (!client || !sessionId) {
+      setSessionLinks([]);
+      return;
+    }
+
+    let cancelled = false;
+    const linksService = client.service('links');
+
+    const sortLinks = (links: Link[]) =>
+      [...links].sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+    const fetchSessionLinks = async () => {
+      try {
+        const links = await linksService.findAll({ query: { session_id: sessionId } });
+        if (!cancelled) setSessionLinks(sortLinks(links));
+      } catch (error) {
+        console.error('[SessionPanel] Failed to fetch session links:', error);
+        if (!cancelled) setSessionLinks([]);
+      }
+    };
+
+    const upsertSessionLink = (link: Link) => {
+      if (link.session_id !== sessionId) return;
+      setSessionLinks((prev) => {
+        const index = prev.findIndex((item) => item.link_id === link.link_id);
+        if (index === -1) return sortLinks([...prev, link]);
+        const next = [...prev];
+        next[index] = link;
+        return sortLinks(next);
+      });
+    };
+
+    const removeSessionLink = (link: Link) => {
+      if (link.session_id !== sessionId) return;
+      setSessionLinks((prev) => prev.filter((item) => item.link_id !== link.link_id));
+    };
+
+    void fetchSessionLinks();
+    linksService.on('created', upsertSessionLink);
+    linksService.on('patched', upsertSessionLink);
+    linksService.on('updated', upsertSessionLink);
+    linksService.on('removed', removeSessionLink);
+
+    return () => {
+      cancelled = true;
+      linksService.off('created', upsertSessionLink);
+      linksService.off('patched', upsertSessionLink);
+      linksService.off('updated', upsertSessionLink);
+      linksService.off('removed', removeSessionLink);
+    };
+  }, [client, session?.session_id]);
+
   // Token breakdown calculation
   const tokenBreakdown = React.useMemo(() => {
     if (!session?.agentic_tool) {
@@ -465,24 +520,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     return null;
   }, [tasks, session?.agentic_tool]);
 
-  const attachmentItems = React.useMemo((): SessionAttachmentItem[] => {
-    const acc: SessionAttachmentItem[] = [];
-    if (branch?.issue_url) {
-      acc.push({
-        key: 'issue',
-        name: `Issue: ${getUrlDisplayLabel(branch.issue_url)}`,
-        url: branch.issue_url,
-      });
-    }
-    if (branch?.pull_request_url) {
-      acc.push({
-        key: 'pr',
-        name: `PR: ${getUrlDisplayLabel(branch.pull_request_url)}`,
-        url: branch.pull_request_url,
-      });
-    }
-    return acc;
-  }, [branch?.issue_url, branch?.pull_request_url]);
+  const attachmentItems = React.useMemo(
+    () => buildSessionLinkWidgetItems({ branch, links: sessionLinks }),
+    [branch, sessionLinks]
+  );
 
   const footerGradient = React.useMemo(() => {
     if (!latestContextWindow) return undefined;

--- a/apps/agor-ui/src/components/SessionPanel/sessionLinks.test.ts
+++ b/apps/agor-ui/src/components/SessionPanel/sessionLinks.test.ts
@@ -1,0 +1,121 @@
+import type { Branch, Link } from '@agor-live/client';
+import { normalizeRefTargetKey, normalizeUrlTargetKey } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import {
+  buildSessionLinkWidgetItems,
+  hrefForRefUri,
+  linkToSessionWidgetItem,
+} from './sessionLinks';
+
+const now = '2026-06-29T00:00:00.000Z';
+
+function makeLink(patch: Partial<Link> & Pick<Link, 'link_id' | 'kind' | 'source'>): Link {
+  return {
+    branch_id: null,
+    session_id: 'session-1' as Link['session_id'],
+    source_message_id: null,
+    target_key: patch.url
+      ? normalizeUrlTargetKey(patch.url)
+      : patch.ref_uri
+        ? normalizeRefTargetKey(patch.ref_uri)
+        : '',
+    title: null,
+    mime_type: null,
+    metadata: null,
+    created_by: null,
+    created_at: now,
+    updated_at: now,
+    ...patch,
+  } as Link;
+}
+
+describe('session link widget items', () => {
+  it('merges branch issue/PR links with session links and dedupes by target key', () => {
+    const branch = {
+      issue_url: 'https://github.com/preset-io/agor/issues/92',
+      pull_request_url: 'https://github.com/preset-io/agor/pull/1692',
+    } as Branch;
+    const links = [
+      makeLink({
+        link_id: 'link-duplicate-pr' as Link['link_id'],
+        kind: 'pr',
+        source: 'parsed',
+        url: 'https://github.com/preset-io/agor/pull/1692#discussion',
+        target_key: normalizeUrlTargetKey('https://github.com/preset-io/agor/pull/1692'),
+      }),
+      makeLink({
+        link_id: 'link-docs' as Link['link_id'],
+        kind: 'url',
+        source: 'parsed',
+        url: 'https://example.com/docs',
+      }),
+    ];
+
+    const items = buildSessionLinkWidgetItems({ branch, links });
+
+    expect(items.map((item) => item.name)).toEqual([
+      'Issue: preset-io/agor#92',
+      'PR: preset-io/agor#1692',
+      'URL: docs',
+    ]);
+    expect(items).toHaveLength(3);
+  });
+
+  it('turns path-addressed Knowledge refs into app routes', () => {
+    const refUri = 'agor://kb/global/guides/architecture.md';
+    const item = linkToSessionWidgetItem(
+      makeLink({
+        link_id: 'link-kb' as Link['link_id'],
+        kind: 'kb_ref',
+        source: 'parsed',
+        ref_uri: refUri,
+        target_key: normalizeRefTargetKey(refUri),
+      })
+    );
+
+    expect(item).toMatchObject({
+      name: 'KB: global/guides/architecture.md',
+      href: '/kb/global/guides/architecture.md',
+      refUri,
+    });
+  });
+
+  it('keeps opaque KB document refs visible without inventing a broken route', () => {
+    const refUri = 'agor://kb/document/0190a000-0000-7000-8000-0000000000aa';
+
+    expect(hrefForRefUri(refUri)).toBeUndefined();
+    expect(
+      linkToSessionWidgetItem(
+        makeLink({
+          link_id: 'link-kb-doc' as Link['link_id'],
+          kind: 'kb_ref',
+          source: 'parsed',
+          ref_uri: refUri,
+          target_key: normalizeRefTargetKey(refUri),
+        })
+      )
+    ).toMatchObject({
+      name: 'KB document 0190a000',
+      href: undefined,
+      refUri,
+    });
+  });
+
+  it('renders uploaded file rows with useful labels but no preview href', () => {
+    const item = linkToSessionWidgetItem(
+      makeLink({
+        link_id: 'link-file' as Link['link_id'],
+        kind: 'document',
+        source: 'upload',
+        file_path: '/tmp/uploads/spec.pdf',
+        target_key: 'file:/tmp/uploads/spec.pdf',
+      })
+    );
+
+    expect(item).toMatchObject({
+      name: 'File: spec.pdf',
+      filePath: '/tmp/uploads/spec.pdf',
+    });
+    expect(item?.href).toBeUndefined();
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/sessionLinks.ts
+++ b/apps/agor-ui/src/components/SessionPanel/sessionLinks.ts
@@ -1,0 +1,172 @@
+import type { Branch, Link, LinkKind } from '@agor-live/client';
+import {
+  knowledgePath,
+  normalizeFileTargetKey,
+  normalizeRefTargetKey,
+  normalizeUrlTargetKey,
+} from '@agor-live/client';
+import { getUrlDisplayLabel } from '../Pill/url-helpers';
+
+export interface SessionLinkWidgetItem {
+  key: string;
+  name: string;
+  targetKey: string;
+  kind?: LinkKind;
+  url?: string;
+  refUri?: string;
+  filePath?: string;
+  href?: string;
+}
+
+const KB_URI_PREFIX = 'agor://kb/';
+const KB_DOCUMENT_URI_PREFIX = 'agor://kb/document/';
+const KB_UNIT_URI_PREFIX = 'agor://kb/unit/';
+
+function cleanSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function lastPathSegment(value: string): string {
+  const parts = value.split('/').filter(Boolean);
+  return parts.at(-1) || value;
+}
+
+function githubKindLabel(kind?: LinkKind): 'Issue' | 'PR' | null {
+  if (kind === 'issue') return 'Issue';
+  if (kind === 'pr') return 'PR';
+  return null;
+}
+
+export function hrefForRefUri(refUri: string): string | undefined {
+  if (!refUri.startsWith(KB_URI_PREFIX)) return undefined;
+  if (refUri.startsWith(KB_DOCUMENT_URI_PREFIX) || refUri.startsWith(KB_UNIT_URI_PREFIX)) {
+    // No native route exists for opaque KB document/unit refs without resolving
+    // them through kb/documents first. Keep the row visible but do not invent a route.
+    return undefined;
+  }
+
+  const rest = refUri.slice(KB_URI_PREFIX.length);
+  const slash = rest.indexOf('/');
+  if (slash <= 0) return knowledgePath(cleanSegment(rest), null);
+
+  const namespaceSlug = cleanSegment(rest.slice(0, slash));
+  const documentPath = rest
+    .slice(slash + 1)
+    .split('/')
+    .filter(Boolean)
+    .map(cleanSegment)
+    .join('/');
+  return knowledgePath(namespaceSlug, documentPath || null);
+}
+
+export function getRefDisplayLabel(refUri: string): string {
+  if (refUri.startsWith(KB_DOCUMENT_URI_PREFIX)) {
+    return `KB document ${refUri.slice(KB_DOCUMENT_URI_PREFIX.length, KB_DOCUMENT_URI_PREFIX.length + 8)}`;
+  }
+  if (refUri.startsWith(KB_UNIT_URI_PREFIX)) {
+    return `KB unit ${refUri.slice(KB_UNIT_URI_PREFIX.length, KB_UNIT_URI_PREFIX.length + 8)}`;
+  }
+  if (refUri.startsWith(KB_URI_PREFIX)) {
+    return `KB: ${refUri.slice(KB_URI_PREFIX.length)}`;
+  }
+  return `Ref: ${refUri}`;
+}
+
+function targetKeyForLink(link: Link): string | null {
+  if (link.target_key) return link.target_key;
+  if (link.url) return normalizeUrlTargetKey(link.url);
+  if (link.ref_uri) return normalizeRefTargetKey(link.ref_uri);
+  if (link.file_path) return normalizeFileTargetKey(link.file_path);
+  return null;
+}
+
+export function linkToSessionWidgetItem(link: Link): SessionLinkWidgetItem | null {
+  const targetKey = targetKeyForLink(link);
+  if (!targetKey) return null;
+
+  if (link.url) {
+    const prefix = githubKindLabel(link.kind);
+    const name = link.title?.trim() || `${prefix ?? 'URL'}: ${getUrlDisplayLabel(link.url)}`;
+    return {
+      key: `link:${link.link_id}`,
+      name,
+      targetKey,
+      kind: link.kind,
+      url: link.url,
+      href: link.url,
+    };
+  }
+
+  if (link.ref_uri) {
+    return {
+      key: `link:${link.link_id}`,
+      name: link.title?.trim() || getRefDisplayLabel(link.ref_uri),
+      targetKey,
+      kind: link.kind,
+      refUri: link.ref_uri,
+      href: hrefForRefUri(link.ref_uri),
+    };
+  }
+
+  if (link.file_path) {
+    return {
+      key: `link:${link.link_id}`,
+      name: link.title?.trim() || `File: ${lastPathSegment(link.file_path)}`,
+      targetKey,
+      kind: link.kind,
+      filePath: link.file_path,
+    };
+  }
+
+  return null;
+}
+
+export function buildSessionLinkWidgetItems(args: {
+  branch?: Pick<Branch, 'issue_url' | 'pull_request_url'> | null;
+  links?: Link[];
+}): SessionLinkWidgetItem[] {
+  const items: SessionLinkWidgetItem[] = [];
+  const seenTargetKeys = new Set<string>();
+
+  const addItem = (item: SessionLinkWidgetItem) => {
+    const normalizedKey = item.targetKey.toLowerCase();
+    if (seenTargetKeys.has(normalizedKey)) return;
+    seenTargetKeys.add(normalizedKey);
+    items.push(item);
+  };
+
+  if (args.branch?.issue_url) {
+    const url = args.branch.issue_url;
+    addItem({
+      key: 'branch:issue',
+      name: `Issue: ${getUrlDisplayLabel(url)}`,
+      targetKey: normalizeUrlTargetKey(url),
+      kind: 'issue',
+      url,
+      href: url,
+    });
+  }
+
+  if (args.branch?.pull_request_url) {
+    const url = args.branch.pull_request_url;
+    addItem({
+      key: 'branch:pr',
+      name: `PR: ${getUrlDisplayLabel(url)}`,
+      targetKey: normalizeUrlTargetKey(url),
+      kind: 'pr',
+      url,
+      href: url,
+    });
+  }
+
+  for (const link of args.links ?? []) {
+    const item = linkToSessionWidgetItem(link);
+    if (item) addItem(item);
+  }
+
+  return items;
+}

--- a/packages/core/drizzle/postgres/0058_links.sql
+++ b/packages/core/drizzle/postgres/0058_links.sql
@@ -1,0 +1,39 @@
+CREATE TABLE "links" (
+	"tenant_id" text DEFAULT 'default' NOT NULL,
+	"link_id" varchar(36) PRIMARY KEY NOT NULL,
+	"branch_id" varchar(36),
+	"session_id" varchar(36),
+	"source_message_id" varchar(36),
+	"kind" text NOT NULL,
+	"source" text NOT NULL,
+	"url" text,
+	"ref_uri" text,
+	"file_path" text,
+	"target_key" text NOT NULL,
+	"title" text,
+	"mime_type" text,
+	"metadata" jsonb,
+	"created_by" varchar(36),
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "links" ADD CONSTRAINT "links_branch_id_branches_branch_id_fk" FOREIGN KEY ("branch_id") REFERENCES "public"."branches"("branch_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "links" ADD CONSTRAINT "links_session_id_sessions_session_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."sessions"("session_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "links" ADD CONSTRAINT "links_source_message_id_messages_message_id_fk" FOREIGN KEY ("source_message_id") REFERENCES "public"."messages"("message_id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "links" ADD CONSTRAINT "links_created_by_users_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("user_id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "links_tenant_id_idx" ON "links" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "links_branch_id_idx" ON "links" USING btree ("branch_id");--> statement-breakpoint
+CREATE INDEX "links_session_id_idx" ON "links" USING btree ("session_id");--> statement-breakpoint
+CREATE INDEX "links_source_message_id_idx" ON "links" USING btree ("source_message_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "links_branch_target_idx" ON "links" USING btree ("tenant_id","branch_id","target_key") WHERE "links"."branch_id" is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX "links_session_target_idx" ON "links" USING btree ("tenant_id","session_id","target_key") WHERE "links"."session_id" is not null;--> statement-breakpoint
+ALTER TABLE "links" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "links" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+DROP POLICY IF EXISTS "tenant_isolation_links" ON "links";
+--> statement-breakpoint
+CREATE POLICY "tenant_isolation_links" ON "links"
+  USING ("tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default'))
+  WITH CHECK ("tenant_id" = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default'));

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1782300000000,
       "tag": "0057_message_timestamp_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1782400000000,
+      "tag": "0058_links",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0065_links.sql
+++ b/packages/core/drizzle/sqlite/0065_links.sql
@@ -1,0 +1,28 @@
+CREATE TABLE `links` (
+	`link_id` text(36) PRIMARY KEY NOT NULL,
+	`branch_id` text(36),
+	`session_id` text(36),
+	`source_message_id` text(36),
+	`kind` text NOT NULL,
+	`source` text NOT NULL,
+	`url` text,
+	`ref_uri` text,
+	`file_path` text,
+	`target_key` text NOT NULL,
+	`title` text,
+	`mime_type` text,
+	`metadata` text,
+	`created_by` text(36),
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`branch_id`) REFERENCES `branches`(`branch_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`session_id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`source_message_id`) REFERENCES `messages`(`message_id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`user_id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `links_branch_id_idx` ON `links` (`branch_id`);--> statement-breakpoint
+CREATE INDEX `links_session_id_idx` ON `links` (`session_id`);--> statement-breakpoint
+CREATE INDEX `links_source_message_id_idx` ON `links` (`source_message_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `links_branch_target_idx` ON `links` (`branch_id`,`target_key`) WHERE `links`.`branch_id` is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX `links_session_target_idx` ON `links` (`session_id`,`target_key`) WHERE `links`.`session_id` is not null;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1782100000000,
       "tag": "0064_message_timestamp_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "6",
+      "when": 1782200000000,
+      "tag": "0065_links",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -29,6 +29,7 @@ import type {
   KnowledgeNamespaceGraph,
   KnowledgeSearchResult,
   KnowledgeSemanticSettingsPublic,
+  Link,
   MCPServer,
   Message,
   PermissionMode,
@@ -180,6 +181,7 @@ export interface ServiceTypes {
   'repos/clone': Repo;
   'repos/local': Repo;
   branches: Branch;
+  links: Link;
   schedules: Schedule;
   users: User;
   groups: Group;
@@ -566,6 +568,7 @@ export interface AgorClient extends Omit<Application<ServiceTypes>, 'service'> {
   service(path: 'repos/local'): ReposLocalService;
   service(path: 'branches'): BranchesService;
   service(path: 'boards'): BoardsService;
+  service(path: 'links'): AgorService<Link>;
 
   // Bulk operation endpoints
   service(path: 'messages/bulk'): MessagesService;

--- a/packages/core/src/db/multitenancy-schema.test.ts
+++ b/packages/core/src/db/multitenancy-schema.test.ts
@@ -19,19 +19,34 @@ function postgresSchemaTenantTables(): string[] {
   return [...tables].sort();
 }
 
+function postgresMigrationSql(): string {
+  const migrationsDir = path.join(repoRoot, 'packages/core/drizzle/postgres');
+  return fs
+    .readdirSync(migrationsDir)
+    .filter((entry) => entry.endsWith('.sql'))
+    .sort()
+    .map((entry) => fs.readFileSync(path.join(migrationsDir, entry), 'utf8'))
+    .join('\n');
+}
+
 function migrationTenantTables(): string[] {
-  const migration = readRepoFile('packages/core/drizzle/postgres/0054_app_level_multitenancy.sql');
-  return [
-    ...new Set(
-      [...migration.matchAll(/ALTER TABLE "([^"]+)" ADD COLUMN "tenant_id"/g)].map((m) => m[1])
-    ),
-  ].sort();
+  const migration = postgresMigrationSql();
+  const tables = new Set<string>();
+
+  for (const match of migration.matchAll(/ALTER TABLE "([^"]+)" ADD COLUMN "tenant_id"/g)) {
+    tables.add(match[1]);
+  }
+
+  for (const match of migration.matchAll(/CREATE TABLE "([^"]+)" \(([\s\S]*?)\n\);/g)) {
+    const [, tableName, columnsBlock] = match;
+    if (columnsBlock.includes('"tenant_id" text')) tables.add(tableName);
+  }
+
+  return [...tables].sort();
 }
 
 function rlsPolicyTables(): string[] {
-  const migration = readRepoFile(
-    'packages/core/drizzle/postgres/0055_app_level_multitenancy_rls.sql'
-  );
+  const migration = postgresMigrationSql();
   return [
     ...new Set(
       [...migration.matchAll(/CREATE POLICY "tenant_isolation_([^"]+)" ON "([^"]+)"/g)].map(

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -17,6 +17,7 @@ export * from './gateway-channels';
 export * from './gateway-outbound-messages';
 export * from './groups';
 export * from './knowledge';
+export * from './links';
 export * from './mcp-servers';
 export * from './messages';
 export * from './repos';

--- a/packages/core/src/db/repositories/links.test.ts
+++ b/packages/core/src/db/repositories/links.test.ts
@@ -1,0 +1,235 @@
+import type { BranchID, SessionID, UUID } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { dbTest } from '../test-helpers';
+import { BranchRepository } from './branches';
+import { LinksRepository } from './links';
+import { RepoRepository } from './repos';
+import { SessionRepository } from './sessions';
+import { UsersRepository } from './users';
+
+async function seedUser(db: Database, userId: UUID, email: string) {
+  await new UsersRepository(db).create({ user_id: userId, email, name: email });
+}
+
+async function seedBranch(
+  db: Database,
+  options?: { createdBy?: UUID; othersCan?: 'none' | 'view' | 'session' | 'prompt' | 'all' }
+) {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId() as UUID,
+    slug: `links-repo-${generateId()}`,
+    name: 'Links Repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/example/repo.git',
+    local_path: `/tmp/${generateId()}`,
+    default_branch: 'main',
+  });
+  return new BranchRepository(db).create({
+    branch_id: generateId() as BranchID,
+    repo_id: repo.repo_id,
+    name: `links-branch-${generateId()}`,
+    ref: 'refs/heads/test',
+    branch_unique_id: 1,
+    path: `/tmp/${generateId()}`,
+    created_by: options?.createdBy ?? ('owner' as UUID),
+    permission_source: 'override',
+    others_can: options?.othersCan ?? 'view',
+  });
+}
+
+async function seedSession(db: Database, branchId: BranchID, createdBy: UUID) {
+  return new SessionRepository(db).create({
+    session_id: generateId() as SessionID,
+    branch_id: branchId,
+    created_by: createdBy,
+    tasks: [],
+    genealogy: { children: [] },
+  });
+}
+
+describe('LinksRepository', () => {
+  dbTest('creates branch-owned and session-owned links with exactly one owner', async ({ db }) => {
+    const repo = new LinksRepository(db);
+    const branch = await seedBranch(db);
+    const session = await seedSession(db, branch.branch_id, 'owner' as UUID);
+
+    const branchLink = await repo.create({
+      branch_id: branch.branch_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/branch',
+    });
+    const sessionLink = await repo.create({
+      session_id: session.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/session',
+    });
+
+    expect(branchLink.branch_id).toBe(branch.branch_id);
+    expect(branchLink.session_id).toBeNull();
+    expect(sessionLink.session_id).toBe(session.session_id);
+    expect(sessionLink.branch_id).toBeNull();
+
+    await expect(
+      repo.create({
+        branch_id: branch.branch_id,
+        session_id: session.session_id,
+        kind: 'url',
+        source: 'manual',
+        url: 'https://example.com/both',
+      } as never)
+    ).rejects.toThrow(/exactly one owner/);
+  });
+
+  dbTest('upserts by owner and target_key without piling up duplicates', async ({ db }) => {
+    const repo = new LinksRepository(db);
+    const branch = await seedBranch(db);
+    const sessionA = await seedSession(db, branch.branch_id, 'owner' as UUID);
+    const sessionB = await seedSession(db, branch.branch_id, 'owner' as UUID);
+
+    await repo.upsert({
+      session_id: sessionA.session_id,
+      kind: 'url',
+      source: 'parsed',
+      url: 'https://example.com/repeat',
+    });
+    const second = await repo.upsert({
+      session_id: sessionA.session_id,
+      kind: 'url',
+      source: 'parsed',
+      url: 'https://example.com/repeat',
+      title: 'updated',
+    });
+    await repo.upsert({
+      session_id: sessionB.session_id,
+      kind: 'url',
+      source: 'parsed',
+      url: 'https://example.com/repeat',
+    });
+
+    expect(second.title).toBe('updated');
+    expect(await repo.findAll({ sessionId: sessionA.session_id })).toHaveLength(1);
+    expect(await repo.findAll({ sessionId: sessionB.session_id })).toHaveLength(1);
+  });
+
+  dbTest('filters by session and branch owner scopes', async ({ db }) => {
+    const repo = new LinksRepository(db);
+    const branchA = await seedBranch(db);
+    const branchB = await seedBranch(db);
+    const sessionA = await seedSession(db, branchA.branch_id, 'owner' as UUID);
+    const sessionB = await seedSession(db, branchB.branch_id, 'owner' as UUID);
+
+    await repo.create({
+      session_id: sessionA.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/a',
+    });
+    await repo.create({
+      session_id: sessionB.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/b',
+    });
+    await repo.create({
+      branch_id: branchA.branch_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/branch-a',
+    });
+
+    expect(
+      (await repo.findAll({ sessionId: sessionA.session_id })).map((link) => link.url)
+    ).toEqual(['https://example.com/a']);
+    expect((await repo.findAll({ branchId: branchA.branch_id })).map((link) => link.url)).toEqual([
+      'https://example.com/branch-a',
+    ]);
+  });
+
+  dbTest('stores uploaded image and document metadata', async ({ db }) => {
+    const repo = new LinksRepository(db);
+    const branch = await seedBranch(db);
+    const session = await seedSession(db, branch.branch_id, 'owner' as UUID);
+
+    const image = await repo.create({
+      session_id: session.session_id,
+      kind: 'image',
+      source: 'upload',
+      file_path: '/uploads/image.png',
+      title: 'image.png',
+      mime_type: 'image/png',
+      metadata: { size: 123 },
+    });
+    const document = await repo.create({
+      session_id: session.session_id,
+      kind: 'document',
+      source: 'upload',
+      file_path: '/uploads/report.pdf',
+      title: 'report.pdf',
+      mime_type: 'application/pdf',
+      metadata: { size: 456 },
+    });
+
+    expect(image).toMatchObject({
+      kind: 'image',
+      source: 'upload',
+      file_path: '/uploads/image.png',
+      mime_type: 'image/png',
+      title: 'image.png',
+      metadata: { size: 123 },
+    });
+    expect(document).toMatchObject({
+      kind: 'document',
+      source: 'upload',
+      file_path: '/uploads/report.pdf',
+      mime_type: 'application/pdf',
+      title: 'report.pdf',
+      metadata: { size: 456 },
+    });
+  });
+
+  dbTest('pushes branch/session visibility into findAll SQL', async ({ db }) => {
+    const repo = new LinksRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const viewer = generateId() as UUID;
+    await seedUser(db, viewer, 'links-viewer@example.com');
+    const visibleBranch = await seedBranch(db, { othersCan: 'none' });
+    const hiddenBranch = await seedBranch(db, { othersCan: 'none' });
+    await branchRepo.addOwner(visibleBranch.branch_id, viewer);
+    const visibleSession = await seedSession(db, visibleBranch.branch_id, 'owner' as UUID);
+    const hiddenSession = await seedSession(db, hiddenBranch.branch_id, 'owner' as UUID);
+
+    const visibleBranchLink = await repo.create({
+      branch_id: visibleBranch.branch_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/visible-branch',
+    });
+    const visibleSessionLink = await repo.create({
+      session_id: visibleSession.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/visible-session',
+    });
+    await repo.create({
+      branch_id: hiddenBranch.branch_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/hidden-branch',
+    });
+    await repo.create({
+      session_id: hiddenSession.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/hidden-session',
+    });
+
+    const visible = await repo.findAll({ visibleToUserId: viewer });
+    expect(visible.map((link) => link.link_id).sort()).toEqual(
+      [visibleBranchLink.link_id, visibleSessionLink.link_id].sort()
+    );
+  });
+});

--- a/packages/core/src/db/repositories/links.ts
+++ b/packages/core/src/db/repositories/links.ts
@@ -1,0 +1,247 @@
+import type {
+  BranchID,
+  Link,
+  LinkCreate,
+  LinkID,
+  LinkKind,
+  LinkPatch,
+  LinkSource,
+  MessageID,
+  SessionID,
+  UUID,
+} from '@agor/core/types';
+import {
+  isLinkKind,
+  isLinkSource,
+  normalizeFileTargetKey,
+  normalizeRefTargetKey,
+  normalizeUrlTargetKey,
+} from '@agor/core/types';
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { type LinkInsert, type LinkRow, links } from '../schema';
+import { RepositoryError } from './base';
+import {
+  visibleBranchReferenceAccessExists,
+  visibleSessionReferenceAccessExists,
+} from './branch-access';
+
+export interface LinkFindFilter {
+  branchId?: BranchID;
+  branchIds?: BranchID[];
+  sessionId?: SessionID;
+  sessionIds?: SessionID[];
+  sourceMessageId?: MessageID;
+  kind?: LinkKind;
+  source?: LinkSource;
+  visibleToUserId?: UUID;
+}
+
+function countPresent(values: unknown[]): number {
+  return values.filter((value) => value !== undefined && value !== null && value !== '').length;
+}
+
+function normalizeTargetKey(data: {
+  target_key?: string | null;
+  url?: string | null;
+  ref_uri?: string | null;
+  file_path?: string | null;
+}): string {
+  if (data.target_key?.trim()) return data.target_key.trim();
+  if (data.url) return normalizeUrlTargetKey(data.url);
+  if (data.ref_uri) return normalizeRefTargetKey(data.ref_uri);
+  if (data.file_path) return normalizeFileTargetKey(data.file_path);
+  throw new RepositoryError('Link target_key requires url, ref_uri, or file_path');
+}
+
+export class LinksRepository {
+  constructor(private db: Database) {}
+
+  private rowToLink(row: LinkRow): Link {
+    return {
+      link_id: row.link_id as LinkID,
+      branch_id: (row.branch_id as BranchID | null) ?? null,
+      session_id: (row.session_id as SessionID | null) ?? null,
+      source_message_id: (row.source_message_id as MessageID | null) ?? null,
+      kind: row.kind as LinkKind,
+      source: row.source as LinkSource,
+      url: row.url ?? null,
+      ref_uri: row.ref_uri ?? null,
+      file_path: row.file_path ?? null,
+      target_key: row.target_key,
+      title: row.title ?? null,
+      mime_type: row.mime_type ?? null,
+      metadata: row.metadata ?? null,
+      created_by: (row.created_by as UUID | null) ?? null,
+      created_at: new Date(row.created_at).toISOString(),
+      updated_at: new Date(row.updated_at).toISOString(),
+    };
+  }
+
+  private validateCreate(data: Partial<LinkCreate>): asserts data is LinkCreate {
+    const ownerCount = countPresent([data.branch_id, data.session_id]);
+    if (ownerCount !== 1) {
+      throw new RepositoryError('Link requires exactly one owner: branch_id XOR session_id');
+    }
+
+    const targetCount = countPresent([data.url, data.ref_uri, data.file_path]);
+    if (targetCount < 1) {
+      throw new RepositoryError('Link requires at least one target: url, ref_uri, or file_path');
+    }
+
+    if (!isLinkKind(data.kind)) throw new RepositoryError(`Invalid link kind: ${data.kind}`);
+    if (!isLinkSource(data.source))
+      throw new RepositoryError(`Invalid link source: ${data.source}`);
+  }
+
+  private validatePatch(data: LinkPatch): void {
+    if (data.kind !== undefined && !isLinkKind(data.kind)) {
+      throw new RepositoryError(`Invalid link kind: ${data.kind}`);
+    }
+    if (data.source !== undefined && !isLinkSource(data.source)) {
+      throw new RepositoryError(`Invalid link source: ${data.source}`);
+    }
+    if ('url' in data || 'ref_uri' in data || 'file_path' in data || 'target_key' in data) {
+      const targetCount = countPresent([data.url, data.ref_uri, data.file_path]);
+      if (targetCount < 1 && !data.target_key) {
+        throw new RepositoryError('Link requires at least one target: url, ref_uri, or file_path');
+      }
+    }
+  }
+
+  private createToInsert(data: Partial<LinkCreate>, existing?: Link): LinkInsert {
+    this.validateCreate(data);
+    const now = new Date();
+    const tenantId = (data as Partial<LinkCreate> & { tenant_id?: string }).tenant_id;
+    return {
+      ...(tenantId ? { tenant_id: tenantId } : {}),
+      link_id: data.link_id ?? existing?.link_id ?? generateId(),
+      branch_id: data.branch_id ?? null,
+      session_id: data.session_id ?? null,
+      source_message_id: data.source_message_id ?? null,
+      kind: data.kind,
+      source: data.source,
+      url: data.url ?? null,
+      ref_uri: data.ref_uri ?? null,
+      file_path: data.file_path ?? null,
+      target_key: normalizeTargetKey(data),
+      title: data.title ?? null,
+      mime_type: data.mime_type ?? null,
+      metadata: data.metadata ?? null,
+      created_by: data.created_by ?? null,
+      created_at: existing?.created_at ? new Date(existing.created_at) : now,
+      updated_at: now,
+    } as LinkInsert;
+  }
+
+  async create(data: Partial<LinkCreate>): Promise<Link> {
+    const existing = await this.findByOwnerAndTarget(data);
+    if (existing) {
+      return this.update(existing.link_id, data as LinkPatch);
+    }
+
+    const row = this.createToInsert(data);
+    const inserted = await insert(this.db, links).values(row).returning().one();
+    return this.rowToLink(inserted as LinkRow);
+  }
+
+  async upsert(data: Partial<LinkCreate>): Promise<Link> {
+    return this.create(data);
+  }
+
+  async findByOwnerAndTarget(data: {
+    branch_id?: BranchID | null;
+    session_id?: SessionID | null;
+    target_key?: string | null;
+    url?: string | null;
+    ref_uri?: string | null;
+    file_path?: string | null;
+  }): Promise<Link | null> {
+    const targetKey = normalizeTargetKey(data);
+    const ownerCount = countPresent([data.branch_id, data.session_id]);
+    if (ownerCount !== 1) return null;
+
+    const ownerCondition = data.branch_id
+      ? and(eq(links.branch_id, data.branch_id), isNull(links.session_id))
+      : and(eq(links.session_id, data.session_id as SessionID), isNull(links.branch_id));
+
+    const row = await select(this.db)
+      .from(links)
+      .where(and(ownerCondition, eq(links.target_key, targetKey)))
+      .one();
+    return row ? this.rowToLink(row as LinkRow) : null;
+  }
+
+  async findById(id: string): Promise<Link | null> {
+    const row = await select(this.db).from(links).where(eq(links.link_id, id)).one();
+    return row ? this.rowToLink(row as LinkRow) : null;
+  }
+
+  async findAll(filter?: LinkFindFilter): Promise<Link[]> {
+    if (filter?.branchIds !== undefined && filter.branchIds.length === 0) return [];
+    if (filter?.sessionIds !== undefined && filter.sessionIds.length === 0) return [];
+
+    const conditions = [];
+    if (filter?.branchId) conditions.push(eq(links.branch_id, filter.branchId));
+    if (filter?.branchIds !== undefined)
+      conditions.push(inArray(links.branch_id, filter.branchIds));
+    if (filter?.sessionId) conditions.push(eq(links.session_id, filter.sessionId));
+    if (filter?.sessionIds !== undefined)
+      conditions.push(inArray(links.session_id, filter.sessionIds));
+    if (filter?.sourceMessageId)
+      conditions.push(eq(links.source_message_id, filter.sourceMessageId));
+    if (filter?.kind) conditions.push(eq(links.kind, filter.kind));
+    if (filter?.source) conditions.push(eq(links.source, filter.source));
+    if (filter?.visibleToUserId) {
+      conditions.push(
+        or(
+          visibleBranchReferenceAccessExists(this.db, filter.visibleToUserId, links.branch_id),
+          visibleSessionReferenceAccessExists(this.db, filter.visibleToUserId, links.session_id)
+        )
+      );
+    }
+
+    let query = select(this.db).from(links);
+    if (conditions.length > 0) query = query.where(and(...conditions));
+    const rows = await query.orderBy(links.created_at).all();
+    return (rows as LinkRow[]).map((row: LinkRow) => this.rowToLink(row));
+  }
+
+  async update(id: string, data: LinkPatch): Promise<Link> {
+    this.validatePatch(data);
+    const existing = await this.findById(id);
+    if (!existing) throw new RepositoryError(`Link ${id} not found`);
+
+    const next = {
+      source_message_id: data.source_message_id ?? existing.source_message_id ?? null,
+      kind: data.kind ?? existing.kind,
+      source: data.source ?? existing.source,
+      url: data.url ?? existing.url ?? null,
+      ref_uri: data.ref_uri ?? existing.ref_uri ?? null,
+      file_path: data.file_path ?? existing.file_path ?? null,
+      target_key: normalizeTargetKey({
+        target_key: data.target_key ?? existing.target_key,
+        url: data.url ?? existing.url,
+        ref_uri: data.ref_uri ?? existing.ref_uri,
+        file_path: data.file_path ?? existing.file_path,
+      }),
+      title: data.title ?? existing.title ?? null,
+      mime_type: data.mime_type ?? existing.mime_type ?? null,
+      metadata: data.metadata ?? existing.metadata ?? null,
+      updated_at: new Date(),
+    } satisfies Partial<LinkInsert>;
+
+    const updated = await update(this.db, links)
+      .set(next)
+      .where(eq(links.link_id, id))
+      .returning()
+      .one();
+    return this.rowToLink(updated as LinkRow);
+  }
+
+  async delete(id: string): Promise<void> {
+    await deleteFrom(this.db, links).where(eq(links.link_id, id)).run();
+  }
+}

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -11,6 +11,7 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  Link,
   Message,
   PermissionMode,
   SandpackConfig,
@@ -494,6 +495,60 @@ export const messages = pgTable(
       table.session_id,
       table.timestamp
     ),
+  })
+);
+
+/**
+ * Links table - Branch/session-owned links and uploaded attachments.
+ *
+ * Ownership is app-enforced as branch_id XOR session_id. PostgreSQL mirrors
+ * SQLite by avoiding CHECK constraints; app/types validate enum and ownership.
+ */
+export const links = pgTable(
+  'links',
+  {
+    tenant_id: text('tenant_id').notNull().default('default'),
+    link_id: varchar('link_id', { length: 36 }).primaryKey(),
+    branch_id: varchar('branch_id', { length: 36 }).references(() => branches.branch_id, {
+      onDelete: 'cascade',
+    }),
+    session_id: varchar('session_id', { length: 36 }).references(() => sessions.session_id, {
+      onDelete: 'cascade',
+    }),
+    source_message_id: varchar('source_message_id', { length: 36 }).references(
+      () => messages.message_id,
+      { onDelete: 'set null' }
+    ),
+    kind: text('kind', {
+      enum: ['issue', 'pr', 'kb_ref', 'image', 'document', 'url'],
+    }).notNull(),
+    source: text('source', {
+      enum: ['manual', 'parsed', 'upload'],
+    }).notNull(),
+    url: text('url'),
+    ref_uri: text('ref_uri'),
+    file_path: text('file_path'),
+    target_key: text('target_key').notNull(),
+    title: text('title'),
+    mime_type: text('mime_type'),
+    metadata: t.json<Link['metadata']>('metadata'),
+    created_by: varchar('created_by', { length: 36 }).references(() => users.user_id, {
+      onDelete: 'set null',
+    }),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at').notNull(),
+  },
+  (table) => ({
+    tenantIdx: index('links_tenant_id_idx').on(table.tenant_id),
+    branchIdx: index('links_branch_id_idx').on(table.branch_id),
+    sessionIdx: index('links_session_id_idx').on(table.session_id),
+    sourceMessageIdx: index('links_source_message_id_idx').on(table.source_message_id),
+    branchTargetIdx: uniqueIndex('links_branch_target_idx')
+      .on(table.tenant_id, table.branch_id, table.target_key)
+      .where(sql`${table.branch_id} is not null`),
+    sessionTargetIdx: uniqueIndex('links_session_target_idx')
+      .on(table.tenant_id, table.session_id, table.target_key)
+      .where(sql`${table.session_id} is not null`),
   })
 );
 
@@ -2375,6 +2430,8 @@ export type TaskRow = typeof tasks.$inferSelect;
 export type TaskInsert = typeof tasks.$inferInsert;
 export type MessageRow = typeof messages.$inferSelect;
 export type MessageInsert = typeof messages.$inferInsert;
+export type LinkRow = typeof links.$inferSelect;
+export type LinkInsert = typeof links.$inferInsert;
 export type BoardRow = typeof boards.$inferSelect;
 export type BoardInsert = typeof boards.$inferInsert;
 export type RepoRow = typeof repos.$inferSelect;
@@ -2451,6 +2508,7 @@ export const sessionsRelations = relations(sessions, ({ one, many }) => ({
     fields: [sessions.schedule_id],
     references: [schedules.schedule_id],
   }),
+  links: many(links),
   outboundRelationships: many(sessionRelationships, { relationName: 'relationshipSource' }),
   inboundRelationships: many(sessionRelationships, { relationName: 'relationshipTarget' }),
 }));
@@ -2474,7 +2532,23 @@ export const sessionRelationshipsRelations = relations(sessionRelationships, ({ 
 
 export const branchesRelations = relations(branches, ({ many }) => ({
   sessions: many(sessions),
+  links: many(links),
   schedules: many(schedules),
+}));
+
+export const linksRelations = relations(links, ({ one }) => ({
+  branch: one(branches, {
+    fields: [links.branch_id],
+    references: [branches.branch_id],
+  }),
+  session: one(sessions, {
+    fields: [links.session_id],
+    references: [sessions.session_id],
+  }),
+  sourceMessage: one(messages, {
+    fields: [links.source_message_id],
+    references: [messages.message_id],
+  }),
 }));
 
 export const schedulesRelations = relations(schedules, ({ one, many }) => ({

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -11,6 +11,7 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  Link,
   Message,
   PermissionMode,
   SandpackConfig,
@@ -483,6 +484,59 @@ export const messages = sqliteTable(
       table.session_id,
       table.timestamp
     ),
+  })
+);
+
+/**
+ * Links table - Branch/session-owned links and uploaded attachments.
+ *
+ * Ownership is app-enforced as branch_id XOR session_id. SQLite intentionally
+ * has no CHECK constraints here so future enum/ownership extensions do not
+ * force table-recreation migrations.
+ */
+export const links = sqliteTable(
+  'links',
+  {
+    link_id: text('link_id', { length: 36 }).primaryKey(),
+    branch_id: text('branch_id', { length: 36 }).references(() => branches.branch_id, {
+      onDelete: 'cascade',
+    }),
+    session_id: text('session_id', { length: 36 }).references(() => sessions.session_id, {
+      onDelete: 'cascade',
+    }),
+    source_message_id: text('source_message_id', { length: 36 }).references(
+      () => messages.message_id,
+      { onDelete: 'set null' }
+    ),
+    kind: text('kind', {
+      enum: ['issue', 'pr', 'kb_ref', 'image', 'document', 'url'],
+    }).notNull(),
+    source: text('source', {
+      enum: ['manual', 'parsed', 'upload'],
+    }).notNull(),
+    url: text('url'),
+    ref_uri: text('ref_uri'),
+    file_path: text('file_path'),
+    target_key: text('target_key').notNull(),
+    title: text('title'),
+    mime_type: text('mime_type'),
+    metadata: t.json<Link['metadata']>('metadata'),
+    created_by: text('created_by', { length: 36 }).references(() => users.user_id, {
+      onDelete: 'set null',
+    }),
+    created_at: t.timestamp('created_at').notNull(),
+    updated_at: t.timestamp('updated_at').notNull(),
+  },
+  (table) => ({
+    branchIdx: index('links_branch_id_idx').on(table.branch_id),
+    sessionIdx: index('links_session_id_idx').on(table.session_id),
+    sourceMessageIdx: index('links_source_message_id_idx').on(table.source_message_id),
+    branchTargetIdx: uniqueIndex('links_branch_target_idx')
+      .on(table.branch_id, table.target_key)
+      .where(sql`${table.branch_id} is not null`),
+    sessionTargetIdx: uniqueIndex('links_session_target_idx')
+      .on(table.session_id, table.target_key)
+      .where(sql`${table.session_id} is not null`),
   })
 );
 
@@ -2295,6 +2349,8 @@ export type TaskRow = typeof tasks.$inferSelect;
 export type TaskInsert = typeof tasks.$inferInsert;
 export type MessageRow = typeof messages.$inferSelect;
 export type MessageInsert = typeof messages.$inferInsert;
+export type LinkRow = typeof links.$inferSelect;
+export type LinkInsert = typeof links.$inferInsert;
 export type BoardRow = typeof boards.$inferSelect;
 export type BoardInsert = typeof boards.$inferInsert;
 export type RepoRow = typeof repos.$inferSelect;
@@ -2371,6 +2427,7 @@ export const sessionsRelations = relations(sessions, ({ one, many }) => ({
     fields: [sessions.schedule_id],
     references: [schedules.schedule_id],
   }),
+  links: many(links),
   outboundRelationships: many(sessionRelationships, { relationName: 'relationshipSource' }),
   inboundRelationships: many(sessionRelationships, { relationName: 'relationshipTarget' }),
 }));
@@ -2394,7 +2451,23 @@ export const sessionRelationshipsRelations = relations(sessionRelationships, ({ 
 
 export const branchesRelations = relations(branches, ({ many }) => ({
   sessions: many(sessions),
+  links: many(links),
   schedules: many(schedules),
+}));
+
+export const linksRelations = relations(links, ({ one }) => ({
+  branch: one(branches, {
+    fields: [links.branch_id],
+    references: [branches.branch_id],
+  }),
+  session: one(sessions, {
+    fields: [links.session_id],
+    references: [sessions.session_id],
+  }),
+  sourceMessage: one(messages, {
+    fields: [links.source_message_id],
+    references: [messages.message_id],
+  }),
 }));
 
 export const schedulesRelations = relations(schedules, ({ one, many }) => ({

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -23,6 +23,7 @@ const schema = dialect === 'postgresql' ? postgresSchema : sqliteSchema;
 export const sessions = schema.sessions;
 export const tasks = schema.tasks;
 export const messages = schema.messages;
+export const links = schema.links;
 export const boards = schema.boards;
 export const repos = schema.repos;
 export const branches = schema.branches;

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -219,6 +219,34 @@ export const boardObjectQuerySchema = createQuerySchema(
 );
 
 /**
+ * Link query schema
+ */
+export const linkQuerySchema = createQuerySchema(
+  Type.Object({
+    link_id: Type.Optional(CommonSchemas.uuid),
+    branch_id: Type.Optional(CommonSchemas.uuid),
+    session_id: Type.Optional(CommonSchemas.uuid),
+    source_message_id: Type.Optional(CommonSchemas.uuid),
+    kind: Type.Optional(
+      Type.Union([
+        Type.Literal('issue'),
+        Type.Literal('pr'),
+        Type.Literal('kb_ref'),
+        Type.Literal('image'),
+        Type.Literal('document'),
+        Type.Literal('url'),
+      ])
+    ),
+    source: Type.Optional(
+      Type.Union([Type.Literal('manual'), Type.Literal('parsed'), Type.Literal('upload')])
+    ),
+    created_by: Type.Optional(CommonSchemas.uuid),
+    created_at: Type.Optional(CommonSchemas.timestamp),
+    updated_at: Type.Optional(CommonSchemas.timestamp),
+  })
+);
+
+/**
  * Board comment query schema
  */
 export const boardCommentQuerySchema = createQuerySchema(
@@ -271,6 +299,7 @@ export const boardQueryValidator = getValidator(boardQuerySchema, queryValidator
 export const userQueryValidator = getValidator(userQuerySchema, queryValidator);
 export const boardObjectQueryValidator = getValidator(boardObjectQuerySchema, queryValidator);
 export const boardCommentQueryValidator = getValidator(boardCommentQuerySchema, queryValidator);
+export const linkQueryValidator = getValidator(linkQuerySchema, queryValidator);
 export const repoQueryValidator = getValidator(repoQuerySchema, queryValidator);
 export const mcpServerQueryValidator = getValidator(mcpServerQuerySchema, queryValidator);
 

--- a/packages/core/src/types/id.ts
+++ b/packages/core/src/types/id.ts
@@ -29,6 +29,7 @@
 export type UUID = string & { readonly __brand: 'UUID' };
 
 export type GroupID = UUID & { readonly __entity: 'Group' };
+export type LinkID = UUID & { readonly __entity: 'Link' };
 
 /**
  * Short ID prefix (hex, no hyphens, length `SHORT_ID_LENGTH`).

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -17,6 +17,7 @@ export * from './gateway';
 export * from './group';
 export * from './id';
 export * from './knowledge';
+export * from './link';
 export * from './mcp';
 export * from './message';
 export * from './presence';

--- a/packages/core/src/types/link.test.ts
+++ b/packages/core/src/types/link.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { extractLinksFromMessage } from './link';
+import type { Message } from './message';
+
+function message(content: Message['content']): Pick<Message, 'content'> {
+  return { content };
+}
+
+describe('extractLinksFromMessage', () => {
+  it('extracts KB refs, generic URLs, and obvious GitHub issue/PR URLs from text', () => {
+    const links = extractLinksFromMessage(
+      message(
+        'See agor://kb/team/runbook.md and /knowledge/team/Notes plus https://example.com/a. ' +
+          'GitHub: https://github.com/preset-io/agor/issues/90 and https://github.com/preset-io/agor/pull/91'
+      )
+    );
+
+    expect(links).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'kb_ref', ref_uri: 'agor://kb/team/runbook.md' }),
+        expect.objectContaining({ kind: 'kb_ref', ref_uri: 'agor://kb/team/Notes' }),
+        expect.objectContaining({ kind: 'url', url: 'https://example.com/a' }),
+        expect.objectContaining({
+          kind: 'issue',
+          url: 'https://github.com/preset-io/agor/issues/90',
+        }),
+        expect.objectContaining({ kind: 'pr', url: 'https://github.com/preset-io/agor/pull/91' }),
+      ])
+    );
+  });
+
+  it('only scans string content and text blocks', () => {
+    const links = extractLinksFromMessage(
+      message([
+        { type: 'text', text: 'Visible https://example.com/visible' },
+        { type: 'tool_use', input: { url: 'https://example.com/tool-json' } },
+        { type: 'image', source: { url: 'https://example.com/image' } },
+      ])
+    );
+
+    expect(links.map((link) => link.url)).toEqual(['https://example.com/visible']);
+  });
+
+  it('deduplicates repeated targets in one message', () => {
+    const links = extractLinksFromMessage(
+      message(
+        'https://example.com/thing https://example.com/thing agor://kb/team/a.md agor://kb/team/a.md'
+      )
+    );
+
+    expect(links).toHaveLength(2);
+  });
+
+  it('ignores non-text structured message payloads', () => {
+    const links = extractLinksFromMessage(
+      message({
+        request_id: 'r1',
+        status: 'pending',
+        tool_name: 'x',
+        tool_input: { url: 'https://example.com' },
+      } as Message['content'])
+    );
+
+    expect(links).toEqual([]);
+  });
+});

--- a/packages/core/src/types/link.ts
+++ b/packages/core/src/types/link.ts
@@ -1,0 +1,179 @@
+import type { BranchID, LinkID, MessageID, SessionID, UserID } from './id';
+import { extractKnowledgeLinks } from './knowledge';
+import type { ContentBlock, Message } from './message';
+
+export const LINK_KINDS = ['issue', 'pr', 'kb_ref', 'image', 'document', 'url'] as const;
+export type LinkKind = (typeof LINK_KINDS)[number];
+
+export const LINK_SOURCES = ['manual', 'parsed', 'upload'] as const;
+export type LinkSource = (typeof LINK_SOURCES)[number];
+
+export interface LinkMetadata {
+  [key: string]: unknown;
+}
+
+export interface Link {
+  link_id: LinkID;
+  branch_id?: BranchID | null;
+  session_id?: SessionID | null;
+  source_message_id?: MessageID | null;
+  kind: LinkKind;
+  source: LinkSource;
+  url?: string | null;
+  ref_uri?: string | null;
+  file_path?: string | null;
+  target_key: string;
+  title?: string | null;
+  mime_type?: string | null;
+  metadata?: LinkMetadata | null;
+  created_by?: UserID | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type LinkOwner =
+  | { branch_id: BranchID; session_id?: null }
+  | { branch_id?: null; session_id: SessionID };
+
+export type LinkTarget =
+  | { url: string; ref_uri?: null; file_path?: null }
+  | { url?: null; ref_uri: string; file_path?: null }
+  | { url?: null; ref_uri?: null; file_path: string };
+
+export type LinkCreate = LinkOwner &
+  LinkTarget & {
+    link_id?: LinkID;
+    source_message_id?: MessageID | null;
+    kind: LinkKind;
+    source: LinkSource;
+    target_key?: string;
+    title?: string | null;
+    mime_type?: string | null;
+    metadata?: LinkMetadata | null;
+    created_by?: UserID | null;
+  };
+
+export type LinkPatch = Partial<
+  Pick<
+    Link,
+    | 'kind'
+    | 'source'
+    | 'url'
+    | 'ref_uri'
+    | 'file_path'
+    | 'target_key'
+    | 'title'
+    | 'mime_type'
+    | 'metadata'
+    | 'source_message_id'
+  >
+>;
+
+export interface ParsedLinkDraft {
+  kind: LinkKind;
+  source: 'parsed';
+  url?: string | null;
+  ref_uri?: string | null;
+  target_key: string;
+  title?: string | null;
+  metadata?: LinkMetadata | null;
+}
+
+const HTTP_URL_RE = /https?:\/\/[^\s<>"')]+/gi;
+const TRAILING_PUNCTUATION_RE = /[.,;:!?\]}]+$/;
+const GITHUB_ISSUE_RE = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+(?:[/?#].*)?$/i;
+const GITHUB_PR_RE = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:[/?#].*)?$/i;
+
+export function isLinkKind(value: unknown): value is LinkKind {
+  return typeof value === 'string' && (LINK_KINDS as readonly string[]).includes(value);
+}
+
+export function isLinkSource(value: unknown): value is LinkSource {
+  return typeof value === 'string' && (LINK_SOURCES as readonly string[]).includes(value);
+}
+
+export function normalizeUrlTargetKey(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.hash = '';
+    if (parsed.pathname !== '/' && parsed.pathname.endsWith('/')) {
+      parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    }
+    return `url:${parsed.toString()}`;
+  } catch {
+    return `url:${url.trim().replace(TRAILING_PUNCTUATION_RE, '')}`;
+  }
+}
+
+export function normalizeRefTargetKey(refUri: string): string {
+  return `ref:${refUri.trim().toLowerCase()}`;
+}
+
+export function normalizeFileTargetKey(filePath: string): string {
+  return `file:${filePath.trim()}`;
+}
+
+export function buildKnowledgeRefUri(
+  ref: ReturnType<typeof extractKnowledgeLinks>[number]
+): string {
+  if ('document_id' in ref && ref.document_id) {
+    return `agor://kb/document/${ref.document_id}`;
+  }
+  return `agor://kb/${ref.namespace_slug}/${ref.path}`;
+}
+
+export function classifyUrlKind(url: string): LinkKind {
+  if (GITHUB_ISSUE_RE.test(url)) return 'issue';
+  if (GITHUB_PR_RE.test(url)) return 'pr';
+  return 'url';
+}
+
+export function extractMessageTextContent(message: Pick<Message, 'content'>): string[] {
+  const { content } = message;
+  if (typeof content === 'string') return [content];
+  if (!Array.isArray(content)) return [];
+
+  return content.flatMap((block: ContentBlock) => {
+    if (block.type !== 'text') return [];
+    const text = block.text;
+    return typeof text === 'string' ? [text] : [];
+  });
+}
+
+export function extractLinksFromMessage(message: Pick<Message, 'content'>): ParsedLinkDraft[] {
+  const textParts = extractMessageTextContent(message);
+  const drafts: ParsedLinkDraft[] = [];
+  const seen = new Set<string>();
+
+  for (const text of textParts) {
+    for (const ref of extractKnowledgeLinks(text)) {
+      const refUri = buildKnowledgeRefUri(ref);
+      const targetKey = normalizeRefTargetKey(refUri);
+      if (seen.has(targetKey)) continue;
+      seen.add(targetKey);
+      drafts.push({
+        kind: 'kb_ref',
+        source: 'parsed',
+        ref_uri: refUri,
+        target_key: targetKey,
+      });
+    }
+
+    for (const match of text.matchAll(HTTP_URL_RE)) {
+      const url = match[0].replace(TRAILING_PUNCTUATION_RE, '');
+      const targetKey = normalizeUrlTargetKey(url);
+      if (seen.has(targetKey)) continue;
+      seen.add(targetKey);
+      drafts.push({
+        kind: classifyUrlKind(url),
+        source: 'parsed',
+        url,
+        target_key: targetKey,
+      });
+    }
+  }
+
+  return drafts;
+}

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -75,6 +75,7 @@ const checks = [
     patterns: [/\bsetImmediate\s*\(/g],
     baseline: {
       'apps/agor-daemon/src/utils/tenant-db-scope.ts': 1,
+      'apps/agor-daemon/src/utils/tenant-db-scope.test.ts': 1,
     },
   },
   {


### PR DESCRIPTION
## Linked issue

Related: #1689

## Summary

- Loads session-owned link records for the active session panel.
- Merges branch issue/PR links with session KB/URL/file links for the Links widget.
- Adds type-aware labels/icons and keeps non-routable uploaded file rows visible but disabled.

## Why / context

Session messages and uploads can now produce link records in the foundation PR. The session footer should surface those collected references instead of only showing branch issue/PR URLs.

## Implementation notes

- This PR is stacked on #1689 and should stay draft until the links foundation lands.
- Branch issue/PR links remain canonical branch fields; session links are queried from the `links` service and deduped in the UI.
- Uploaded files are displayed by filename only for now. Image/document previews need a separate authenticated content route before the UI should render thumbnails or download links.

## Validation / test plan

- [x] `pnpm --filter agor-ui test -- src/components/SessionPanel/sessionLinks.test.ts src/components/SessionPanel/SessionAttachmentsDropdown.test.tsx`
- [x] `pnpm --filter agor-ui exec biome check src/components/SessionPanel/sessionLinks.ts src/components/SessionPanel/sessionLinks.test.ts src/components/SessionPanel/SessionAttachmentsDropdown.tsx src/components/SessionPanel/SessionAttachmentsDropdown.test.tsx src/components/SessionPanel/SessionPanel.tsx`
- [x] `pnpm --filter agor-ui exec tsc -p tsconfig.app.json --noEmit --customConditions source --erasableSyntaxOnly false --pretty false`

## Screenshots / demos

Not captured yet; this is draft/stacked pending the foundation PR.

## Risks / rollout / rollback

Low UI-only risk once #1689 lands. Rollback is removing the session links fetch/merge path and returning the widget to branch issue/PR rows only.

## Out of scope / follow-ups

- Image/document thumbnail previews.
- Browser-safe uploaded-file content/download route.
- Auto-inlining external image URLs.
