### PR TITLE
fix(gateway): defer Slack presence updates

### DIFF
--- a/apps/agor-daemon/src/hooks/gateway-route.ts
+++ b/apps/agor-daemon/src/hooks/gateway-route.ts
@@ -94,13 +94,16 @@ export const gatewayRouteHook = async (context: HookContext) => {
   // not only for tool-only rows.
   if (latestToolUse) {
     try {
-      void gatewayService.updateProgress({
-        session_id: message.session_id,
-        state: 'working',
-        task_id: message.task_id,
-        tool_name: latestToolUse.name,
-        tool_input: latestToolUse.input,
-      });
+      gatewayService.updateProgressAfterCommit(
+        {
+          session_id: message.session_id,
+          state: 'working',
+          task_id: message.task_id,
+          tool_name: latestToolUse.name,
+          tool_input: latestToolUse.input,
+        },
+        context.params
+      );
     } catch (error) {
       console.warn('[gateway-route] Failed to route tool progress:', error);
     }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -724,11 +724,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           const toolName =
             typeof data.data.tool_name === 'string' ? data.data.tool_name : undefined;
           if (sessionId) {
-            void (app.service('gateway') as unknown as GatewayService).updateProgress({
-              session_id: sessionId,
-              state: 'working',
-              task_id: typeof data.data.task_id === 'string' ? data.data.task_id : undefined,
-              tool_name: toolName,
+            deferInFreshTenantScope(params, async () => {
+              await (app.service('gateway') as unknown as GatewayService).updateProgress({
+                session_id: sessionId,
+                state: 'working',
+                task_id: typeof data.data.task_id === 'string' ? data.data.task_id : undefined,
+                tool_name: toolName,
+              });
             });
           }
         }

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -501,6 +501,76 @@ describe('GatewayService outbound routing tenant scope', () => {
   });
 });
 
+describe('GatewayService Slack progress tenant scope', () => {
+  it('defers Slack assistant status updates until the current tenant transaction commits', async () => {
+    const events: string[] = [];
+    const tx = {
+      execute: vi.fn(async () => []),
+    };
+    let transactionCount = 0;
+    let resolveUpdated!: () => void;
+    const updated = new Promise<void>((resolve) => {
+      resolveUpdated = resolve;
+    });
+    const db = {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+        transactionCount += 1;
+        events.push('tx:start');
+        const result = await callback(tx);
+        events.push('tx:commit');
+        if (transactionCount === 3) resolveUpdated();
+        return result;
+      }),
+    } as TenantScopeAwareDatabase;
+
+    const seenTenants: Array<string | undefined> = [];
+    const setThreadStatus = vi.fn(async () => {
+      events.push('status');
+      seenTenants.push(getCurrentTenantId() as string | undefined);
+    });
+
+    const { service } = makeGatewayHarness({
+      db,
+      existingMapping: makeMapping(),
+      connector: { setThreadStatus },
+    });
+
+    await runWithTenantDatabaseScope(db, 'tenant-channel', async () => {
+      service.updateProgressAfterCommit(
+        {
+          session_id: 'sess-1',
+          state: 'working',
+          task_id: 'task-1',
+          tool_name: 'Read',
+        },
+        { tenant: { tenant_id: 'tenant-channel' } }
+      );
+      events.push('scheduled');
+      expect(setThreadStatus).not.toHaveBeenCalled();
+    });
+
+    await updated;
+
+    expect(setThreadStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 'C123-100.000000',
+        status: 'is using Read.',
+      })
+    );
+    expect(seenTenants).toEqual(['tenant-channel']);
+    expect(events).toEqual([
+      'tx:start',
+      'scheduled',
+      'tx:commit',
+      'tx:start',
+      'tx:commit',
+      'tx:start',
+      'status',
+      'tx:commit',
+    ]);
+  });
+});
+
 describe('GatewayService Slack streaming', () => {
   it('does not stream assistant chunks into channel-like Slack threads', async () => {
     const startStream = vi.fn(async () => '104.000000');

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -993,6 +993,25 @@ export class GatewayService {
     }
   }
 
+  /**
+   * Schedule Slack assistant progress/status updates after the current
+   * tenant-scoped database work commits, then update inside a fresh tenant
+   * scope. Presence/status updates are often emitted from hooks and streaming
+   * routes whose enclosing transaction is about to close.
+   */
+  updateProgressAfterCommit(data: GatewayProgressData, params?: unknown): void {
+    deferWithTenantDatabaseScope(
+      this.db,
+      params,
+      async () => {
+        await this.updateProgress(data);
+      },
+      (error) => {
+        console.warn('[gateway] Failed to update Slack progress after commit:', error);
+      }
+    );
+  }
+
   wasMessageStreamedToSlack(messageId: string): boolean {
     return this.slackStreamedMessageIds.has(messageId);
   }
@@ -2186,7 +2205,7 @@ export class GatewayService {
           `Session is busy, message queued at position ${task.queue_position}`,
           { suppressSlack: true }
         );
-        void this.updateProgress({
+        this.updateProgressAfterCommit({
           session_id: sessionId,
           state: 'queued',
           task_id: task.task_id,
@@ -2196,7 +2215,7 @@ export class GatewayService {
         console.log(
           `[gateway] Prompt sent to session ${shortId(sessionId)} via /sessions/:id/prompt`
         );
-        void this.updateProgress({
+        this.updateProgressAfterCommit({
           session_id: sessionId,
           state: 'working',
           task_id: task.task_id,
@@ -2205,7 +2224,7 @@ export class GatewayService {
     } catch (error) {
       console.error('[gateway] Failed to send prompt to session:', error);
       this.sendSystemMessage(channel, data.thread_id, `Error sending prompt: ${error}`);
-      void this.updateProgress({
+      this.updateProgressAfterCommit({
         session_id: sessionId,
         state: 'failed',
         error_message: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Root cause

Slack assistant presence/status is managed by `GatewayService.updateProgress()` and ultimately calls Slack `assistant.threads.setStatus` through the Slack connector.

After fixing Slack reply delivery, the message/status paths that drive Slack presence were still doing fire-and-forget async work from hooks and streaming routes. Those callbacks can inherit a tenant transaction that is about to commit, or run before session/thread mapping rows are visible from a fresh tenant-scoped connection. In that case replies can arrive, but Slack assistant presence/status updates are skipped or fail to find the mapping.

## Behavior change

- Adds `GatewayService.updateProgressAfterCommit()` using the existing `deferWithTenantDatabaseScope()` utility.
- Uses it for tool-use progress from the message route hook.
- Defers `/tasks/streaming` `tool:start` status updates into a fresh tenant scope.
- Uses it for initial gateway prompt states (`working`, `queued`, `failed`).
- Keeps direct `updateProgress()` unchanged for already-awaited/fresh-scope callers like session post-turn finalization.

## Tests/checks

- `pnpm --filter @agor/daemon test -- src/services/gateway.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm turbo run build typecheck --filter='!@agor/docs'`

## Caveats/follow-ups

If Slack presence is still absent after this, the next likely place to inspect is connector-level Slack API failures/scopes for `assistant.threads.setStatus`.
