### PR TITLE
fix(env): defer lifecycle executor dispatch until tenant commit

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -5,6 +5,7 @@ import {
   GroupRepository,
   KnowledgeNamespaceRepository,
   RepoRepository,
+  runWithTenantDatabaseScope,
   UsersRepository,
 } from '@agor/core/db';
 import type { Application, BoardID, BranchID, UUID } from '@agor/core/types';
@@ -22,6 +23,10 @@ vi.mock('../utils/spawn-executor.js', async (importOriginal) => {
     getDaemonUrl: vi.fn(() => 'http://daemon.test'),
   };
 });
+
+function createTenantScopeTestDb() {
+  return { run: vi.fn() };
+}
 
 function createRenderEnvHarness(opts: {
   current: string | null;
@@ -48,7 +53,7 @@ function createRenderEnvHarness(opts: {
       throw new Error(`Unknown service: ${path}`);
     },
   } as unknown as Application;
-  const service = new BranchesService({} as never, app);
+  const service = new BranchesService(createTenantScopeTestDb() as never, app);
   // Bypass the auth gate (it would otherwise call loadConfig); the running
   // guard fires after auth and is what we're testing here.
   vi.spyOn(service as never, 'ensureCanTriggerEnv').mockResolvedValue(undefined as never);
@@ -115,7 +120,7 @@ function createPatchHarness(opts: {
       primary_assistant_id: branchId,
     })),
   };
-  const service = new BranchesService({} as never, app);
+  const service = new BranchesService(createTenantScopeTestDb() as never, app);
   (service as unknown as { repository: typeof repository }).repository = repository;
   (service as unknown as { boardRepo: typeof boardRepo }).boardRepo = boardRepo;
   (service as unknown as { branchRepo: { enrichWithZoneInfo: typeof vi.fn } }).branchRepo = {
@@ -168,8 +173,16 @@ function createServiceHarness() {
     },
   } as unknown as Application;
 
-  const service = new BranchesService({} as never, app);
+  const service = new BranchesService(createTenantScopeTestDb() as never, app);
   return { service, boardObjectsService, sessionsService };
+}
+
+async function runInTestTenantScope<T>(work: () => Promise<T>): Promise<T> {
+  return runWithTenantDatabaseScope(createTenantScopeTestDb() as never, 'tenant-test', work);
+}
+
+function waitForDeferredWork(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 const mockedSpawnExecutor = vi.mocked(spawnExecutor);
@@ -231,7 +244,7 @@ function createFindHarness(opts: {
       }))
     ),
   };
-  const service = new BranchesService({} as never, app);
+  const service = new BranchesService(createTenantScopeTestDb() as never, app);
   (service as unknown as { repository: typeof repository }).repository = repository;
   (service as unknown as { branchRepo: typeof branchRepo }).branchRepo = branchRepo;
 
@@ -287,11 +300,15 @@ describe('BranchesService environment start async behavior', () => {
     const { service, branch, environmentUpdates } = createStartHarness();
 
     const result = await Promise.race([
-      service.startEnvironment(branch.branch_id),
+      runInTestTenantScope(() => service.startEnvironment(branch.branch_id)),
       new Promise<'timed-out'>((resolve) => setTimeout(() => resolve('timed-out'), 50)),
     ]);
 
     expect(result).not.toBe('timed-out');
+    expect(mockedSpawnExecutor).not.toHaveBeenCalled();
+
+    await waitForDeferredWork();
+
     expect(mockedSpawnExecutor).toHaveBeenCalledWith(
       expect.objectContaining({
         command: 'environment.lifecycle',
@@ -362,9 +379,13 @@ describe('BranchesService environment start async behavior', () => {
       service as unknown as { processes: Map<BranchID, { process: { kill: () => void } }> }
     ).processes.set(branch.branch_id, { process: { kill } });
 
-    await service.restartEnvironment(branch.branch_id);
+    await runInTestTenantScope(() => service.restartEnvironment(branch.branch_id));
 
     expect(kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mockedSpawnExecutor).not.toHaveBeenCalled();
+
+    await waitForDeferredWork();
+
     expect(mockedSpawnExecutor).toHaveBeenCalledWith(
       expect.objectContaining({
         command: 'environment.lifecycle',
@@ -1642,7 +1663,7 @@ describe('BranchesService environment health recovery', () => {
         throw new Error(`Unknown service: ${path}`);
       },
     } as unknown as Application;
-    const service = new BranchesService({} as never, app);
+    const service = new BranchesService(createTenantScopeTestDb() as never, app);
     vi.spyOn(service, 'get').mockResolvedValue(branch as never);
     const updateEnvironment = vi.spyOn(service, 'updateEnvironment').mockImplementation(
       async (_id, update) =>

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -72,6 +72,7 @@ import {
   runExecutorCommand,
   spawnExecutor,
 } from '../utils/spawn-executor.js';
+import { deferWithTenantDatabaseScope } from '../utils/tenant-db-scope.js';
 import { ensureAssistantKnowledgeNamespace as ensureAssistantKnowledgeNamespaceForBranch } from './assistant-knowledge.js';
 import { isKnowledgeAdmin } from './knowledge-access.js';
 import type { InternalEnrichmentParams } from './sessions';
@@ -393,16 +394,42 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     action: EnvironmentLifecycleAction;
     params?: BranchParams;
   }): Promise<void> {
-    const { branch, action } = options;
+    const { branch, action, params } = options;
     const { payload, asUser, env } = await this.createEnvironmentExecutorPayload(options);
+    const logPrefix = `[Environment.${action} ${branch.name}]`;
 
-    spawnExecutor(payload, {
-      logPrefix: `[Environment.${action} ${branch.name}]`,
-      asUser,
-      preparedEnv: env,
-      templateVariables: {
-        branch_id: branch.branch_id,
-      },
+    const spawnLifecycleExecutor = async () => {
+      try {
+        spawnExecutor(payload, {
+          logPrefix,
+          asUser,
+          preparedEnv: env,
+          templateVariables: {
+            branch_id: branch.branch_id,
+          },
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to spawn environment executor';
+        await this.updateEnvironment(
+          branch.branch_id,
+          {
+            status: 'error',
+            last_health_check: {
+              timestamp: new Date().toISOString(),
+              status: 'unhealthy',
+              message,
+            },
+            last_error: message,
+          },
+          params
+        );
+        throw error;
+      }
+    };
+
+    deferWithTenantDatabaseScope(this.db, params, spawnLifecycleExecutor, (error) => {
+      console.error(`${logPrefix} Failed to dispatch executor:`, error);
     });
   }
 


### PR DESCRIPTION
## Root cause

Environment lifecycle commands (`start`/`stop`/`restart`/`nuke`) set branch environment state in the daemon, then immediately spawned a fire-and-forget executor. Under the tenant-scoped request/transaction wrapper, that executor could start before the environment state update transaction committed and while ambient async-local DB context was still tied to the request.

Prompt/session executors already avoid this race by deferring executor startup until after the tenant-scoped transaction commits and then re-entering a fresh tenant DB scope. Environment lifecycle executors were still using the older immediate dispatch path.

## Behavior change

- Environment lifecycle executor payload/token creation still happens synchronously, so request-time setup errors are surfaced to the caller.
- The actual fire-and-forget `spawnExecutor(...)` is now scheduled with `deferWithTenantDatabaseScope(...)`:
  - waits for an active tenant DB transaction to commit;
  - exits stale async-local transaction state;
  - re-enters a fresh tenant DB scope before spawning;
  - works for static/default tenant routes because the existing route/service tenant scope is reused.
- If synchronous executor spawning throws after defer, the branch environment is marked `error` instead of remaining indefinitely in `starting`/`stopping`.

## Tests/checks

- `pnpm --filter @agor/daemon test -- src/services/branches.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm exec biome check --write apps/agor-daemon/src/services/branches.ts apps/agor-daemon/src/services/branches.test.ts`

## Multi-tenant caveats / follow-ups

This keeps the environment executor scoped through the same low-level tenant utility used by prompt/gateway deferred work. It does not add tenant IDs to logs. Direct service calls that bypass authenticated routes/MCP context still need an ambient tenant scope; otherwise `deferWithTenantDatabaseScope` fails closed and skips the spawn.
