### PR TITLE
fix(env): handle stop during startup

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -252,7 +252,7 @@ function createFindHarness(opts: {
 }
 
 describe('BranchesService environment start async behavior', () => {
-  function createStartHarness() {
+  function createStartHarness(status: 'stopped' | 'starting' | 'stopping' | 'running' = 'stopped') {
     const { service } = createServiceHarness();
     const branch = {
       branch_id: 'wt-start' as BranchID,
@@ -263,7 +263,7 @@ describe('BranchesService environment start async behavior', () => {
       branch_unique_id: 1,
       start_command: 'docker compose up -d --build',
       app_url: 'http://localhost:3000',
-      environment_instance: { status: 'stopped' },
+      environment_instance: { status },
     };
 
     let currentEnvironment: Record<string, unknown> = { ...branch.environment_instance };
@@ -337,6 +337,19 @@ describe('BranchesService environment start async behavior', () => {
         }),
       ])
     );
+  });
+
+  it('rejects starting while a lifecycle transition is already in progress', async () => {
+    for (const status of ['starting', 'stopping'] as const) {
+      const { service, branch, environmentUpdates } = createStartHarness(status);
+
+      await expect(service.startEnvironment(branch.branch_id)).rejects.toThrow(
+        status === 'starting' ? 'already starting' : 'is stopping'
+      );
+
+      expect(environmentUpdates).toEqual([]);
+      expect(mockedSpawnExecutor).not.toHaveBeenCalled();
+    }
   });
 
   it('preserves daemon stop fallback when restarting a running shell env without stop command', async () => {
@@ -449,9 +462,15 @@ describe('BranchesService environment start async behavior', () => {
       };
       return { ...branch, environment_instance: currentEnvironment } as never;
     });
-    mockedRunExecutorCommand.mockResolvedValue({
-      success: true,
-      data: { branchId: branch.branch_id, action: 'stop' },
+    mockedRunExecutorCommand.mockImplementation(async () => {
+      currentEnvironment = {
+        ...currentEnvironment,
+        status: 'stopped',
+      };
+      return {
+        success: true,
+        data: { branchId: branch.branch_id, action: 'stop' },
+      };
     });
 
     await service.restartEnvironment(branch.branch_id);

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1841,8 +1841,15 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       throw new Error('No start command configured for this branch');
     }
 
-    if (branch.environment_instance?.status === 'running') {
+    const currentStatus = branch.environment_instance?.status;
+    if (currentStatus === 'running') {
       throw new Error('Environment is already running');
+    }
+    if (currentStatus === 'starting') {
+      throw new Error('Environment is already starting');
+    }
+    if (currentStatus === 'stopping') {
+      throw new Error('Environment is stopping; wait for it to stop before starting again');
     }
 
     const command = branch.start_command;

--- a/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx
@@ -636,6 +636,7 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                   !canTriggerEnv ||
                   envStatus === 'running' ||
                   envStatus === 'starting' ||
+                  envStatus === 'stopping' ||
                   isStarting ||
                   isStopping ||
                   isRestarting
@@ -649,7 +650,12 @@ export const EnvironmentTab: React.FC<EnvironmentTabProps> = ({
                 icon={isStopping ? <LoadingOutlined /> : <PoweroffOutlined />}
                 onClick={handleStop}
                 loading={isStopping}
-                disabled={!canTriggerEnv}
+                disabled={
+                  !canTriggerEnv ||
+                  envStatus === 'stopped' ||
+                  envStatus === 'stopping' ||
+                  isStopping
+                }
                 title={triggerDisabledTooltip}
                 danger
               >

--- a/packages/executor/src/commands/environment.test.ts
+++ b/packages/executor/src/commands/environment.test.ts
@@ -1,0 +1,92 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EnvironmentLifecyclePayload } from '../payload-types.js';
+import { createExecutorClient } from '../services/feathers-client.js';
+import { handleEnvironmentLifecycle } from './environment.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough;
+        stderr: PassThrough;
+        pid: number;
+      };
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      child.pid = 1234;
+      setImmediate(() => child.emit('exit', 0));
+      return child;
+    }),
+  };
+});
+
+vi.mock('../services/feathers-client.js', () => ({
+  createExecutorClient: vi.fn(),
+}));
+
+const mockedCreateExecutorClient = vi.mocked(createExecutorClient);
+
+describe('handleEnvironmentLifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('honors stop requests that arrive while a start command is still running', async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    const branchesService = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({
+          branch_id: '550e8400-e29b-41d4-a716-446655440000',
+          path: '/tmp/agor-env-test',
+          environment_instance: { status: 'starting' },
+        })
+        .mockResolvedValueOnce({
+          branch_id: '550e8400-e29b-41d4-a716-446655440000',
+          path: '/tmp/agor-env-test',
+          environment_instance: { status: 'stopping' },
+        }),
+      updateEnvironment: vi.fn(
+        async (envelope: { environment_update: Record<string, unknown> }) => {
+          updates.push(envelope.environment_update);
+        }
+      ),
+    };
+    mockedCreateExecutorClient.mockResolvedValue({
+      service: vi.fn((name: string) => {
+        if (name !== 'branches') throw new Error(`Unexpected service ${name}`);
+        return branchesService;
+      }),
+    } as never);
+
+    const payload: EnvironmentLifecyclePayload = {
+      command: 'environment.lifecycle',
+      sessionToken: 'token',
+      daemonUrl: 'http://daemon.test',
+      params: {
+        branchId: '550e8400-e29b-41d4-a716-446655440000',
+        branchPath: '/tmp/agor-env-test',
+        action: 'start',
+        startCommand: 'echo start',
+        stopCommand: 'echo stop',
+      },
+    };
+
+    const result = await handleEnvironmentLifecycle(payload, {});
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ cancelled: true });
+    expect(updates.at(-1)).toMatchObject({
+      status: 'stopped',
+      process: null,
+      last_command: expect.objectContaining({
+        action: 'stop',
+        status: 'succeeded',
+      }),
+    });
+  });
+});

--- a/packages/executor/src/commands/environment.ts
+++ b/packages/executor/src/commands/environment.ts
@@ -239,6 +239,47 @@ export async function handleEnvironmentLifecycle(
         commandType: 'start',
       });
 
+      const latest = await client.service('branches').get(branchId);
+      const latestStatus = latest.environment_instance?.status;
+      const startupWasCancelled = latestStatus === 'stopping' || latestStatus === 'stopped';
+      if (startupWasCancelled) {
+        let cancellationOutput: string | undefined;
+        if (payload.params.stopCommand) {
+          const stopResult = await runShellCommand({
+            command: payload.params.stopCommand,
+            cwd,
+            env: payload.env,
+            commandType: 'stop',
+          });
+          cancellationOutput = stopResult.output;
+        }
+
+        await updateBranchEnvironment(client, branchId, {
+          status: 'stopped',
+          process: null,
+          last_health_check: {
+            timestamp: new Date().toISOString(),
+            status: 'unknown',
+            message: 'Environment startup cancelled',
+          },
+          last_error: null,
+          last_command: {
+            action: 'stop',
+            status: 'succeeded',
+            timestamp: new Date().toISOString(),
+            message: payload.params.stopCommand
+              ? 'Startup cancelled; stop command completed'
+              : 'Startup cancelled after start command completed',
+            ...(cancellationOutput ? { output: cancellationOutput } : {}),
+          },
+        });
+
+        return {
+          success: true,
+          data: { branchId, action: payload.params.action, cancelled: true },
+        };
+      }
+
       await updateBranchEnvironment(client, branchId, {
         process: {
           ...(branch.environment_instance?.process ?? {}),


### PR DESCRIPTION
## Root cause

The deferred executor dispatch fix made lifecycle executors reliably start, but the environment lifecycle still allowed overlapping transitions:

- `startEnvironment` only rejected `running`, so a new start could be requested while the branch was still `stopping`.
- The Environment tab disabled start for `running`/`starting`, but not for `stopping`, and allowed stop even when already stopped/stopping.
- If a user hit Stop while a Start executor was still running, the stop command could complete first and mark the env stopped, then the original start command could still finish and leave real containers running or stale process/command metadata behind.

## Behavior change

- Backend rejects Start while the env is already `starting` or `stopping`.
- Environment tab now mirrors the other env controls by disabling Start during `stopping`, and disabling Stop while already `stopped`/`stopping`.
- Executor start completion now re-checks branch environment state before writing success metadata. If a stop request arrived while start was still running, it treats the start as cancelled, runs the stop command once more when available, and leaves the environment `stopped` with cleared process state.

This keeps Stop fire-and-forget from the request/transaction perspective, but makes stop-during-start converge to stopped instead of allowing stale start completion to win.

## Tests/checks

- `pnpm --filter @agor/daemon test -- src/services/branches.test.ts`
- `pnpm --filter @agor/executor test -- src/commands/environment.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm --filter @agor/executor typecheck`
- `pnpm exec biome check --write apps/agor-daemon/src/services/branches.ts apps/agor-daemon/src/services/branches.test.ts apps/agor-ui/src/components/BranchModal/tabs/EnvironmentTab.tsx packages/executor/src/commands/environment.ts packages/executor/src/commands/environment.test.ts`

Note: `pnpm --filter agor-ui typecheck` currently fails before reaching this change because `@agor-live/client` declarations are missing from the local checkout/dist state.
