### PR TITLE
fix(env): scope background health monitor DB work

### DIFF
--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { ENVIRONMENT } from '@agor/core/config';
+import { getCurrentTenantId } from '@agor/core/db';
 import type { Branch } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HealthMonitor } from './health-monitor';
@@ -57,6 +58,37 @@ describe('HealthMonitor tenant context', () => {
       query: { $limit: 1000 },
       paginate: false,
     });
+    monitor.cleanup();
+  });
+
+  it('enters a tenant database scope for timer-driven health checks', async () => {
+    const observedTenantIds: Array<string | undefined> = [];
+    const branches = new BranchServiceMock();
+    branches.get.mockImplementation(async (branchId: string) => {
+      observedTenantIds.push(getCurrentTenantId());
+      return makeBranch({ branch_id: branchId, environment_instance: { status: 'running' } });
+    });
+    branches.checkHealth.mockImplementation(async () => {
+      observedTenantIds.push(getCurrentTenantId());
+    });
+
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      db: { run: vi.fn() } as never,
+      defaultParams: { tenant: { tenant_id: 'default', source: 'static' } },
+    });
+
+    branches.emit(
+      'patched',
+      makeBranch({
+        branch_id: 'branch-default',
+        environment_instance: { status: 'running' },
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalled());
+    expect(observedTenantIds).toEqual(['default', 'default']);
     monitor.cleanup();
   });
 

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -12,7 +12,7 @@
  */
 
 import { ENVIRONMENT } from '@agor/core/config';
-import { shortId } from '@agor/core/db';
+import { runWithTenantDatabaseScope, shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Branch, BranchID, TenantContext, TenantID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
@@ -37,6 +37,8 @@ export interface HealthMonitorParams {
 export interface HealthMonitorOptions {
   /** Internal params used for startup/background scans when no request context exists. */
   defaultParams?: HealthMonitorParams;
+  /** Tenant-aware database used to open fresh background DB scopes. */
+  db?: TenantScopeAwareDatabase;
 }
 
 function tenantParamsFromBranch(branch: Branch): HealthMonitorParams | undefined {
@@ -51,11 +53,27 @@ export class HealthMonitor {
   private branchParams = new Map<BranchID, HealthMonitorParams>();
   private isShuttingDown = false;
   private defaultParams?: HealthMonitorParams;
+  private db?: TenantScopeAwareDatabase;
 
   constructor(app: Application, options: HealthMonitorOptions = {}) {
     this.app = app;
     this.defaultParams = options.defaultParams;
+    this.db = options.db;
     this.setupBranchListeners();
+  }
+
+  private async runWithHealthTenantScope<T>(
+    params: HealthMonitorParams | undefined,
+    work: () => Promise<T>
+  ): Promise<T> {
+    if (!this.db) return work();
+
+    const tenantId = params?.tenant?.tenant_id;
+    if (!tenantId) {
+      throw new Error('Missing tenant context for background health check');
+    }
+
+    return runWithTenantDatabaseScope(this.db, tenantId, work);
   }
 
   /**
@@ -153,22 +171,24 @@ export class HealthMonitor {
 
       const params = this.branchParams.get(branchId) ?? this.defaultParams;
 
-      // Get current branch state
-      const branch = await branchesService.get(branchId, params as never);
+      await this.runWithHealthTenantScope(params, async () => {
+        // Get current branch state
+        const branch = await branchesService.get(branchId, params as never);
 
-      // Only check if still running or starting
-      const status = branch.environment_instance?.status;
-      if (status !== 'running' && status !== 'starting') {
-        // Silently stop monitoring (not an error - expected when env stops)
-        // Start/stop logs are already handled in handleBranchUpdate()
-        this.stopMonitoring(branchId);
-        return;
-      }
+        // Only check if still running or starting
+        const status = branch.environment_instance?.status;
+        if (status !== 'running' && status !== 'starting') {
+          // Silently stop monitoring (not an error - expected when env stops)
+          // Start/stop logs are already handled in handleBranchUpdate()
+          this.stopMonitoring(branchId);
+          return;
+        }
 
-      // Perform health check via the service method
-      // This will update environment_instance and broadcast via WebSocket
-      // Logging is handled in checkHealth() method - only logs on state changes
-      await branchesService.checkHealth(branchId, params as never);
+        // Perform health check via the service method
+        // This will update environment_instance and broadcast via WebSocket
+        // Logging is handled in checkHealth() method - only logs on state changes
+        await branchesService.checkHealth(branchId, params as never);
+      });
     } catch (error) {
       // If branch was deleted or not found, stop monitoring silently
       // This is expected when branches are deleted while health checks are in progress
@@ -199,13 +219,15 @@ export class HealthMonitor {
       const branchesService = this.app.service('branches');
 
       // Find all branches with running status
-      const result = await branchesService.find({
-        ...this.defaultParams,
-        query: {
-          $limit: 1000,
-        },
-        paginate: false,
-      } as never);
+      const result = await this.runWithHealthTenantScope(this.defaultParams, () =>
+        branchesService.find({
+          ...this.defaultParams,
+          query: {
+            $limit: 1000,
+          },
+          paginate: false,
+        } as never)
+      );
 
       // Handle both paginated and non-paginated responses
       const branches = (Array.isArray(result) ? result : result.data) as Branch[];

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -515,7 +515,10 @@ export async function startup(ctx: StartupContext): Promise<void> {
 
   // 2. Register Health Monitor listeners before serving requests. The initial
   // full scan of already-running environments is deferred until after listen.
-  const healthMonitor = new HealthMonitor(app, { defaultParams: startupTenantParams(config) });
+  const healthMonitor = new HealthMonitor(app, {
+    db,
+    defaultParams: startupTenantParams(config),
+  });
 
   // 3. Validate/generate master secret for API key encryption
   await ensureMasterSecret(config);


### PR DESCRIPTION
## Root cause

The health monitor is a daemon-owned background service, not a request/auth path. It passed tenant params into `branches.get/checkHealth`, but it did not itself enter a tenant database scope before calling those service methods. That matters because `BranchesService.checkHealth()` performs internal `this.get()` / `updateEnvironment()` work that can bypass the normal Feathers route around hook and therefore needs an ambient DB scope for the tenant-aware DB proxy.

This can leave background health checks unable to see/update branches in scoped deployments, while manual health checks through authenticated routes still work.

## Behavior change

- `HealthMonitor` now accepts the tenant-aware DB from startup.
- Startup/background scans and timer-driven health checks run inside `runWithTenantDatabaseScope(...)` for the captured/default tenant.
- Event-driven checks still prefer the hidden tenant id from the branch event when present, falling back to the startup/default static tenant params for single-tenant deployments.
- Missing tenant context for background health checks now fails closed with a clear diagnostic instead of silently running unscoped.

## Tests/checks

- `pnpm --filter @agor/daemon test -- src/services/health-monitor.test.ts src/services/branches.test.ts src/utils/tenant-db-scope.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `pnpm exec biome check --write apps/agor-daemon/src/services/health-monitor.ts apps/agor-daemon/src/services/health-monitor.test.ts apps/agor-daemon/src/startup.ts`

## Multi-tenant caveats / follow-ups

This restores the default/static tenant path and scopes event-driven health checks per branch tenant when that tenant metadata is present. Like the scheduler, a fully multi-tenant startup sweep still needs a future control-plane tenant enumeration pass; this PR does not introduce cross-tenant global reads.
