### PR TITLE
Polish running BranchCard background

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -95,7 +95,7 @@ describe('BranchCard drag handle', () => {
     );
 
     expect(container.querySelector('.ant-card')?.getAttribute('style')).toContain(
-      'background-color: color-mix(in srgb, rgb(1, 2, 3), rgb(10, 11, 12));'
+      'background-color: color-mix(in srgb, rgb(1, 2, 3) 67%, rgb(10, 11, 12));'
     );
     expect(container.querySelector('.agor-branch-session-tree .ant-tree-title > div')).toHaveStyle({
       width: '100%',

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -84,7 +84,6 @@ describe('BranchCard drag handle', () => {
             sessions={[runningSession]}
             userById={new Map()}
             client={null}
-            defaultExpanded={false}
           />
         </ConnectionProvider>
       </ConfigProvider>
@@ -92,6 +91,9 @@ describe('BranchCard drag handle', () => {
 
     expect(container.querySelector('.ant-card')).toHaveStyle({
       backgroundColor: 'rgb(1, 2, 3)',
+    });
+    expect(container.querySelector('.agor-branch-session-tree .ant-tree-title > div')).toHaveStyle({
+      width: '100%',
     });
   });
 });

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -79,7 +79,7 @@ describe('BranchCard drag handle', () => {
       <ConfigProvider
         theme={{
           algorithm: antdTheme.darkAlgorithm,
-          token: { colorBgContainer: 'rgb(10, 11, 12)', colorPrimaryBg: 'rgb(1, 2, 3)' },
+          token: { colorBgBase: 'rgb(10, 11, 12)', colorPrimaryBg: 'rgb(1, 2, 3)' },
         }}
       >
         <ConnectionProvider value={connected}>
@@ -95,7 +95,7 @@ describe('BranchCard drag handle', () => {
     );
 
     expect(container.querySelector('.ant-card')?.getAttribute('style')).toContain(
-      'background-color: color-mix(in srgb, rgb(1, 2, 3) 70%, rgb(10, 11, 12));'
+      'background-color: color-mix(in srgb, rgb(1, 2, 3), rgb(10, 11, 12));'
     );
     expect(container.querySelector('.agor-branch-session-tree .ant-tree-title > div')).toHaveStyle({
       width: '100%',

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -1,6 +1,6 @@
 import type { Branch, Repo, Session } from '@agor-live/client';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { ConfigProvider } from 'antd';
+import { theme as antdTheme, ConfigProvider } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import {
@@ -62,7 +62,7 @@ describe('BranchCard drag handle', () => {
     expect(onOpenTerminal).toHaveBeenCalledWith([], 'branch-1');
   });
 
-  it('uses the primary background token while a branch session is executing', () => {
+  it('uses a darker primary background surface while a branch session is executing', () => {
     const runningSession = {
       session_id: 'session-running',
       branch_id: 'branch-1',
@@ -76,7 +76,12 @@ describe('BranchCard drag handle', () => {
     } as unknown as Session;
 
     const { container } = render(
-      <ConfigProvider theme={{ token: { colorPrimaryBg: 'rgb(1, 2, 3)' } }}>
+      <ConfigProvider
+        theme={{
+          algorithm: antdTheme.darkAlgorithm,
+          token: { colorBgContainer: 'rgb(10, 11, 12)', colorPrimaryBg: 'rgb(1, 2, 3)' },
+        }}
+      >
         <ConnectionProvider value={connected}>
           <BranchCard
             branch={branch}
@@ -89,9 +94,9 @@ describe('BranchCard drag handle', () => {
       </ConfigProvider>
     );
 
-    expect(container.querySelector('.ant-card')).toHaveStyle({
-      backgroundColor: 'rgb(1, 2, 3)',
-    });
+    expect(container.querySelector('.ant-card')?.getAttribute('style')).toContain(
+      'background-color: color-mix(in srgb, rgb(1, 2, 3) 70%, rgb(10, 11, 12));'
+    );
     expect(container.querySelector('.agor-branch-session-tree .ant-tree-title > div')).toHaveStyle({
       width: '100%',
     });

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -97,7 +97,7 @@ describe('BranchCard drag handle', () => {
     expect(container.querySelector('.ant-card')?.getAttribute('style')).toContain(
       'background-color: color-mix(in srgb, rgb(1, 2, 3) 67%, rgb(10, 11, 12));'
     );
-    expect(container.querySelector('.agor-branch-session-tree .ant-tree-title > div')).toHaveStyle({
+    expect(container.querySelector('.ant-tree-title > div')).toHaveStyle({
       width: '100%',
     });
   });

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -1,5 +1,6 @@
-import type { Branch, Repo } from '@agor-live/client';
+import type { Branch, Repo, Session } from '@agor-live/client';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import {
@@ -16,26 +17,22 @@ const connected = {
   currentSha: null,
 };
 
+const branch = {
+  branch_id: 'branch-1',
+  name: 'feature/canvas-drag',
+  repo_id: 'repo-1',
+  path: '/tmp/feature-canvas-drag',
+  filesystem_status: 'ready',
+  archived: false,
+} as unknown as Branch;
+
+const repo = { repo_id: 'repo-1', slug: 'preset-io/agor' } as unknown as Repo;
+
 describe('BranchCard drag handle', () => {
   it('lets the branch title participate in the header drag handle', () => {
     render(
       <ConnectionProvider value={connected}>
-        <BranchCard
-          branch={
-            {
-              branch_id: 'branch-1',
-              name: 'feature/canvas-drag',
-              repo_id: 'repo-1',
-              path: '/tmp/feature-canvas-drag',
-              filesystem_status: 'ready',
-              archived: false,
-            } as unknown as Branch
-          }
-          repo={{ repo_id: 'repo-1', slug: 'preset-io/agor' } as unknown as Repo}
-          sessions={[]}
-          userById={new Map()}
-          client={null}
-        />
+        <BranchCard branch={branch} repo={repo} sessions={[]} userById={new Map()} client={null} />
       </ConnectionProvider>
     );
 
@@ -50,17 +47,8 @@ describe('BranchCard drag handle', () => {
     render(
       <ConnectionProvider value={connected}>
         <BranchCard
-          branch={
-            {
-              branch_id: 'branch-1',
-              name: 'feature/canvas-drag',
-              repo_id: 'repo-1',
-              path: '/tmp/feature-canvas-drag',
-              filesystem_status: 'ready',
-              archived: false,
-            } as unknown as Branch
-          }
-          repo={{ repo_id: 'repo-1', slug: 'preset-io/agor' } as unknown as Repo}
+          branch={branch}
+          repo={repo}
           sessions={[]}
           userById={new Map()}
           client={null}
@@ -72,5 +60,38 @@ describe('BranchCard drag handle', () => {
     fireEvent.click(screen.getByTitle('Open terminal in branch directory'));
 
     expect(onOpenTerminal).toHaveBeenCalledWith([], 'branch-1');
+  });
+
+  it('uses the primary background token while a branch session is executing', () => {
+    const runningSession = {
+      session_id: 'session-running',
+      branch_id: 'branch-1',
+      title: 'Running task',
+      status: 'running',
+      archived: false,
+      agentic_tool: 'codex',
+      ready_for_prompt: false,
+      created_at: '2026-06-30T00:00:00.000Z',
+      updated_at: '2026-06-30T00:00:00.000Z',
+    } as unknown as Session;
+
+    const { container } = render(
+      <ConfigProvider theme={{ token: { colorPrimaryBg: 'rgb(1, 2, 3)' } }}>
+        <ConnectionProvider value={connected}>
+          <BranchCard
+            branch={branch}
+            repo={repo}
+            sessions={[runningSession]}
+            userById={new Map()}
+            client={null}
+            defaultExpanded={false}
+          />
+        </ConnectionProvider>
+      </ConfigProvider>
+    );
+
+    expect(container.querySelector('.ant-card')).toHaveStyle({
+      backgroundColor: 'rgb(1, 2, 3)',
+    });
   });
 });

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -215,9 +215,9 @@ const BranchCardComponent = ({
   const isDarkMode = isDarkTheme(token);
   // AntD exposes `colorPrimaryBg` as the subtle primary surface token.
   // In dark mode it can still read a bit bright on a large card, so mix it
-  // back toward the container surface while staying in the primary token family.
+  // with the base background while staying in the primary token family.
   const runningCardBackgroundColor = isDarkMode
-    ? `color-mix(in srgb, ${token.colorPrimaryBg} 70%, ${token.colorBgContainer})`
+    ? `color-mix(in srgb, ${token.colorPrimaryBg} 50%, ${token.colorBgBase})`
     : token.colorPrimaryBg;
   const cardBackgroundColor = hasRunningSession
     ? runningCardBackgroundColor

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -192,6 +192,11 @@ const BranchCardComponent = ({
   // Check if this branch is a persisted agent
   const assistantConfig = useMemo(() => getAssistantConfig(branch), [branch]);
   const isAgent = isAssistant(branch);
+  const cardBackgroundColor = hasRunningSession
+    ? token.colorPrimaryBg
+    : isAgent
+      ? token.colorInfoBg
+      : undefined;
 
   // True when one of this branch's sessions is the currently opened
   // conversation. Drives the "focused" highlight on the canvas card and
@@ -306,10 +311,10 @@ const BranchCardComponent = ({
         width: panelMode ? '100%' : peekedSessions.length > 0 ? 880 : 500,
         cursor: 'default', // Override React Flow's drag cursor - only drag handles should show grab cursor
         transition:
-          'box-shadow 0.6s ease-in-out, outline 0.2s ease-in-out, border 0.6s ease-in-out, opacity 0.2s ease-in-out',
+          'background-color 0.2s ease-in-out, box-shadow 0.6s ease-in-out, outline 0.2s ease-in-out, border 0.6s ease-in-out, opacity 0.2s ease-in-out',
         willChange: needsAttention && !inPopover ? 'box-shadow' : 'auto',
         ...highlightStyle,
-        ...(isAgent ? { backgroundColor: token.colorInfoBg } : {}),
+        ...(cardBackgroundColor ? { backgroundColor: cardBackgroundColor } : {}),
         // Disconnected chokepoint: block all in-card interactions (clicking
         // into a session, env pill actions, modals) and dim to communicate
         // the state. Canvas pan/zoom and the slim app-shell banner remain

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -217,7 +217,7 @@ const BranchCardComponent = ({
   // In dark mode it can still read a bit bright on a large card, so mix it
   // with the base background while staying in the primary token family.
   const runningCardBackgroundColor = isDarkMode
-    ? `color-mix(in srgb, ${token.colorPrimaryBg} 50%, ${token.colorBgBase})`
+    ? `color-mix(in srgb, ${token.colorPrimaryBg} 67%, ${token.colorBgBase})`
     : token.colorPrimaryBg;
   const cardBackgroundColor = hasRunningSession
     ? runningCardBackgroundColor

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -192,11 +192,6 @@ const BranchCardComponent = ({
   // Check if this branch is a persisted agent
   const assistantConfig = useMemo(() => getAssistantConfig(branch), [branch]);
   const isAgent = isAssistant(branch);
-  const cardBackgroundColor = hasRunningSession
-    ? token.colorPrimaryBg
-    : isAgent
-      ? token.colorInfoBg
-      : undefined;
 
   // True when one of this branch's sessions is the currently opened
   // conversation. Drives the "focused" highlight on the canvas card and
@@ -218,6 +213,17 @@ const BranchCardComponent = ({
   }, [activeSessions, branch.needs_attention, isFocused]);
 
   const isDarkMode = isDarkTheme(token);
+  // AntD exposes `colorPrimaryBg` as the subtle primary surface token.
+  // In dark mode it can still read a bit bright on a large card, so mix it
+  // back toward the container surface while staying in the primary token family.
+  const runningCardBackgroundColor = isDarkMode
+    ? `color-mix(in srgb, ${token.colorPrimaryBg} 70%, ${token.colorBgContainer})`
+    : token.colorPrimaryBg;
+  const cardBackgroundColor = hasRunningSession
+    ? runningCardBackgroundColor
+    : isAgent
+      ? token.colorInfoBg
+      : undefined;
 
   // Memoize glow shadow string to avoid recomputing color normalization on every render
   const attentionGlowShadow = useMemo(() => {

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -136,7 +136,7 @@ const SessionItemWithActions: React.FC<{
 
   return (
     <div
-      style={{ position: 'relative', minWidth: 120 }}
+      style={{ position: 'relative', minWidth: 0, width: '100%' }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
@@ -519,6 +519,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           : 'transparent',
       display: 'flex',
       alignItems: 'center',
+      width: '100%',
+      boxSizing: 'border-box',
       cursor: 'pointer',
       marginBottom: 4,
       opacity: isRemoteSurrogate ? 0.78 : undefined,
@@ -716,7 +718,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const sessionListContent = (
     <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
       <Tree
-        className="agor-flat-tree"
+        className="agor-flat-tree agor-branch-session-tree"
         treeData={sessionTreeData}
         expandedKeys={expandedKeys}
         onExpand={(keys) => setExpandedKeys(keys as React.Key[])}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -718,12 +718,13 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const sessionListContent = (
     <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
       <Tree
-        className="agor-flat-tree agor-branch-session-tree"
+        className="agor-flat-tree"
         treeData={sessionTreeData}
         expandedKeys={expandedKeys}
         onExpand={(keys) => setExpandedKeys(keys as React.Key[])}
         showLine
         showIcon={false}
+        blockNode
         selectable={false}
         style={{ background: 'transparent', borderRadius: 0, padding: 0 }}
         titleRender={renderSessionNode}

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -393,20 +393,3 @@ html.dark .dark\:hidden {
   border-radius: 0;
   padding: 0;
 }
-
-/* Branch-card session rows should read as cards inside the tree: keep the
-   indentation/guides, but let the row surface stretch to the card's right edge. */
-.agor-branch-session-tree.ant-tree .ant-tree-treenode {
-  align-items: stretch;
-  width: 100%;
-}
-
-.agor-branch-session-tree.ant-tree .ant-tree-node-content-wrapper {
-  flex: 1;
-  min-width: 0;
-}
-
-.agor-branch-session-tree.ant-tree .ant-tree-title {
-  display: block;
-  width: 100%;
-}

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -393,3 +393,20 @@ html.dark .dark\:hidden {
   border-radius: 0;
   padding: 0;
 }
+
+/* Branch-card session rows should read as cards inside the tree: keep the
+   indentation/guides, but let the row surface stretch to the card's right edge. */
+.agor-branch-session-tree.ant-tree .ant-tree-treenode {
+  align-items: stretch;
+  width: 100%;
+}
+
+.agor-branch-session-tree.ant-tree .ant-tree-node-content-wrapper {
+  flex: 1;
+  min-width: 0;
+}
+
+.agor-branch-session-tree.ant-tree .ant-tree-title {
+  display: block;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary

- Highlight BranchCards with executing sessions using a primary-tinted background.
- In dark mode, tune the running-card surface to `color-mix(in srgb, colorPrimaryBg 67%, colorBgBase)` so it pops without being too bright.
- Keep assistant `colorInfoBg` behavior for non-running assistant cards.
- Let session rows inside the BranchCard tree stretch to the right edge via AntD Tree `blockNode` and inline row sizing.
- Add/update focused BranchCard regression coverage.

## Checks

- ✅ `pnpm i`
- ⚠️ `pnpm check`
  - Typecheck/build/lint portions ran.
  - Failed at existing `check:multitenancy-boundaries` baseline entries unrelated to this BranchCard change:
    - `apps/agor-daemon/src/services/branches.test.ts`
    - `apps/agor-daemon/src/utils/tenant-db-scope.test.ts`
- ✅ `pnpm -C apps/agor-ui exec vitest run src/components/BranchCard/BranchCard.drag.test.tsx src/components/BranchCard/latestSessionTask.test.ts`

## Notes

No additional changes were produced by `pnpm i` or the final checks.