### PR TITLE
fix(env): scope health monitor startup by tenant

### DIFF
--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -60,6 +60,81 @@ describe('HealthMonitor tenant context', () => {
     monitor.cleanup();
   });
 
+  it('discovers active environments by tenant metadata on startup', async () => {
+    const branches = new BranchServiceMock();
+    branches.get.mockImplementation(async (branchId: string) =>
+      makeBranch({
+        branch_id: branchId,
+        tenant_id: branchId === 'branch-tenant-a' ? 'tenant-a' : 'tenant-b',
+        environment_instance: { status: 'running' },
+      })
+    );
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      requireTenantParams: true,
+      discoverActiveEnvironmentRefs: async () => [
+        { branchId: 'branch-tenant-a' as never, tenantId: 'tenant-a' },
+        { branchId: 'branch-tenant-b' as never, tenantId: 'tenant-b' },
+      ],
+    });
+
+    await monitor.initialize();
+
+    expect(branches.find).not.toHaveBeenCalled();
+    expect(branches.get).toHaveBeenCalledWith('branch-tenant-a', {
+      tenant: { tenant_id: 'tenant-a', source: 'explicit' },
+    });
+    expect(branches.get).toHaveBeenCalledWith('branch-tenant-b', {
+      tenant: { tenant_id: 'tenant-b', source: 'explicit' },
+    });
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(2));
+    expect(branches.checkHealth).toHaveBeenCalledWith('branch-tenant-a', {
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+    });
+    expect(branches.checkHealth).toHaveBeenCalledWith('branch-tenant-b', {
+      tenant: { tenant_id: 'tenant-b', source: 'auth_claim' },
+    });
+    monitor.cleanup();
+  });
+
+  it('uses the configured static tenant for startup discovery refs without tenant metadata', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      tenantId: 'default',
+      discoverActiveEnvironmentRefs: async () => [{ branchId: 'branch-static' as never }],
+    });
+
+    await monitor.initialize();
+
+    expect(branches.get).toHaveBeenCalledWith('branch-static', {
+      tenant: { tenant_id: 'default', source: 'static' },
+    });
+    monitor.cleanup();
+  });
+
+  it('fails closed when required tenant metadata is missing for event-driven monitoring', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      requireTenantParams: true,
+    });
+
+    branches.emit(
+      'patched',
+      makeBranch({
+        branch_id: 'branch-without-tenant',
+        environment_instance: { status: 'running' },
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+
+    expect(branches.get).not.toHaveBeenCalled();
+    expect(branches.checkHealth).not.toHaveBeenCalled();
+    monitor.cleanup();
+  });
+
   it('uses branch tenant_id for event-driven background health checks', async () => {
     const branches = new BranchServiceMock();
     const monitor = new HealthMonitor(makeApp(branches) as never, {

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -344,11 +344,27 @@ export class HealthMonitor {
   }
 
   private async findActiveEnvironmentRefs(): Promise<ActiveEnvironmentBranchRef[]> {
+    type RepositoryActiveEnvironmentBranchRef = {
+      branch_id: BranchID;
+      tenant_id?: TenantID | string;
+    };
+
+    const normalizeRef = (
+      ref: ActiveEnvironmentBranchRef | RepositoryActiveEnvironmentBranchRef,
+      tenantId?: TenantID | string
+    ): ActiveEnvironmentBranchRef => {
+      if ('branchId' in ref) {
+        return { branchId: ref.branchId, tenantId: tenantId ?? ref.tenantId };
+      }
+      return { branchId: ref.branch_id, tenantId: tenantId ?? ref.tenant_id };
+    };
+
     const findRefs = async (tenantId?: TenantID | string) => {
-      const refs = this.discoverActiveEnvironmentRefs
+      const refs: Array<ActiveEnvironmentBranchRef | RepositoryActiveEnvironmentBranchRef> = this
+        .discoverActiveEnvironmentRefs
         ? await this.discoverActiveEnvironmentRefs()
         : await this.branchRepo!.findActiveEnvironmentRefs();
-      return refs.map((ref) => ({ ...ref, tenantId: tenantId ?? ref.tenantId }));
+      return refs.map((ref) => normalizeRef(ref, tenantId));
     };
 
     if (this.tenantId) {

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -12,7 +12,13 @@
  */
 
 import { ENVIRONMENT } from '@agor/core/config';
-import { shortId } from '@agor/core/db';
+import {
+  BranchRepository,
+  runWithSystemDatabaseScope,
+  runWithTenantDatabaseScope,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Branch, BranchID, TenantContext, TenantID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
@@ -34,9 +40,22 @@ export interface HealthMonitorParams {
   tenant?: TenantContext;
 }
 
+export interface ActiveEnvironmentBranchRef {
+  branchId: BranchID;
+  tenantId?: TenantID | string;
+}
+
 export interface HealthMonitorOptions {
   /** Internal params used for startup/background scans when no request context exists. */
   defaultParams?: HealthMonitorParams;
+  /** Database used for tenant-aware startup discovery. */
+  db?: TenantScopeAwareDatabase;
+  /** Static/single-tenant id used for request-less startup scans. Undefined means discover tenant metadata from branch rows. */
+  tenantId?: TenantID | string;
+  /** Fail closed for event-driven monitoring when branch events do not carry tenant metadata. */
+  requireTenantParams?: boolean;
+  /** Test seam for startup discovery. Production uses BranchRepository when db is provided. */
+  discoverActiveEnvironmentRefs?: () => Promise<ActiveEnvironmentBranchRef[]>;
 }
 
 function tenantParamsFromBranch(branch: Branch): HealthMonitorParams | undefined {
@@ -51,11 +70,30 @@ export class HealthMonitor {
   private branchParams = new Map<BranchID, HealthMonitorParams>();
   private isShuttingDown = false;
   private defaultParams?: HealthMonitorParams;
+  private db?: TenantScopeAwareDatabase;
+  private branchRepo?: BranchRepository;
+  private tenantId?: TenantID | string;
+  private requireTenantParams: boolean;
+  private discoverActiveEnvironmentRefs?: () => Promise<ActiveEnvironmentBranchRef[]>;
 
   constructor(app: Application, options: HealthMonitorOptions = {}) {
     this.app = app;
     this.defaultParams = options.defaultParams;
+    this.db = options.db;
+    this.branchRepo = options.db ? new BranchRepository(options.db) : undefined;
+    this.tenantId =
+      typeof options.tenantId === 'string' && options.tenantId.trim()
+        ? options.tenantId.trim()
+        : undefined;
+    this.requireTenantParams = options.requireTenantParams ?? false;
+    this.discoverActiveEnvironmentRefs = options.discoverActiveEnvironmentRefs;
     this.setupBranchListeners();
+  }
+
+  private paramsForBranch(branch: Branch): HealthMonitorParams | undefined {
+    return (
+      tenantParamsFromBranch(branch) ?? (this.requireTenantParams ? undefined : this.defaultParams)
+    );
   }
 
   /**
@@ -92,7 +130,13 @@ export class HealthMonitor {
     if (status === 'running' || status === 'starting') {
       // Start monitoring if not already monitored.
       // Monitor both 'running' and 'starting' - health checks will transition 'starting' → 'running'.
-      const params = tenantParamsFromBranch(branch) ?? this.defaultParams;
+      const params = this.paramsForBranch(branch);
+      if (!params && this.requireTenantParams) {
+        console.error(
+          `❌ Health monitoring skipped for branch ${shortId(branch.branch_id)}: missing tenant metadata`
+        );
+        return;
+      }
       if (params) this.branchParams.set(branch.branch_id, params);
       if (!this.intervals.has(branch.branch_id)) {
         healthMonitorDebug(`🏥 Starting health monitoring for branch: ${branch.name}`);
@@ -151,7 +195,16 @@ export class HealthMonitor {
     try {
       const branchesService = this.app.service('branches') as unknown as BranchesServiceImpl;
 
-      const params = this.branchParams.get(branchId) ?? this.defaultParams;
+      const params =
+        this.branchParams.get(branchId) ??
+        (this.requireTenantParams ? undefined : this.defaultParams);
+      if (!params && this.requireTenantParams) {
+        console.error(
+          `❌ Health check skipped for branch ${shortId(branchId)}: missing tenant metadata`
+        );
+        this.stopMonitoring(branchId);
+        return;
+      }
 
       // Get current branch state
       const branch = await branchesService.get(branchId, params as never);
@@ -196,36 +249,117 @@ export class HealthMonitor {
    */
   async initialize() {
     try {
-      const branchesService = this.app.service('branches');
+      const activeBranches =
+        this.branchRepo || this.discoverActiveEnvironmentRefs
+          ? await this.initializeFromTenantAwareDiscovery()
+          : await this.initializeFromDefaultParamsScan();
 
-      // Find all branches with running status
-      const result = await branchesService.find({
-        ...this.defaultParams,
-        query: {
-          $limit: 1000,
-        },
-        paginate: false,
-      } as never);
-
-      // Handle both paginated and non-paginated responses
-      const branches = (Array.isArray(result) ? result : result.data) as Branch[];
-
-      // Start monitoring running or starting branches
-      const activeBranches = branches.filter(
-        (w) =>
-          w.environment_instance?.status === 'running' ||
-          w.environment_instance?.status === 'starting'
-      );
-
-      for (const branch of activeBranches) {
-        const params = tenantParamsFromBranch(branch) ?? this.defaultParams;
-        if (params) this.branchParams.set(branch.branch_id, params);
-        this.startMonitoring(branch.branch_id, params);
-      }
-      console.log(`🏥 Health Monitor initialized (${activeBranches.length} active environment(s))`);
+      console.log(`🏥 Health Monitor initialized (${activeBranches} active environment(s))`);
     } catch (error) {
       console.error('❌ Failed to initialize Health Monitor:', error);
     }
+  }
+
+  private async initializeFromDefaultParamsScan(): Promise<number> {
+    const branchesService = this.app.service('branches');
+
+    // Find all branches with running status in the configured static/startup tenant.
+    const result = await branchesService.find({
+      ...this.defaultParams,
+      query: {
+        $limit: 1000,
+      },
+      paginate: false,
+    } as never);
+
+    // Handle both paginated and non-paginated responses
+    const branches = (Array.isArray(result) ? result : result.data) as Branch[];
+
+    // Start monitoring running or starting branches
+    const activeBranches = branches.filter(
+      (w) =>
+        w.environment_instance?.status === 'running' ||
+        w.environment_instance?.status === 'starting'
+    );
+
+    for (const branch of activeBranches) {
+      const params = this.paramsForBranch(branch);
+      if (!params && this.requireTenantParams) {
+        console.error(
+          `❌ Health monitoring skipped for branch ${shortId(branch.branch_id)}: missing tenant metadata`
+        );
+        continue;
+      }
+      if (params) this.branchParams.set(branch.branch_id, params);
+      this.startMonitoring(branch.branch_id, params);
+    }
+
+    return activeBranches.length;
+  }
+
+  private async initializeFromTenantAwareDiscovery(): Promise<number> {
+    const refs = await this.findActiveEnvironmentRefs();
+    const branchesService = this.app.service('branches') as unknown as BranchesServiceImpl;
+    let activeCount = 0;
+
+    for (const ref of refs) {
+      if (!ref.tenantId) {
+        console.error(
+          `❌ Health monitoring skipped for branch ${shortId(ref.branchId)}: missing tenant metadata`
+        );
+        continue;
+      }
+
+      const params: HealthMonitorParams = {
+        tenant: {
+          tenant_id: ref.tenantId as TenantID,
+          source: this.tenantId ? 'static' : 'explicit',
+        },
+      };
+
+      try {
+        const loadAndStart = async () => {
+          const branch = await branchesService.get(ref.branchId, params as never);
+          const status = branch.environment_instance?.status;
+          if (status !== 'running' && status !== 'starting') return;
+          this.branchParams.set(branch.branch_id, tenantParamsFromBranch(branch) ?? params);
+          this.startMonitoring(branch.branch_id, this.branchParams.get(branch.branch_id));
+          activeCount += 1;
+        };
+
+        if (this.db) {
+          await runWithTenantDatabaseScope(this.db, ref.tenantId, loadAndStart);
+        } else {
+          await loadAndStart();
+        }
+      } catch (error) {
+        console.error(
+          `❌ Failed to initialize health monitoring for branch ${shortId(ref.branchId)}:`,
+          error
+        );
+      }
+    }
+
+    return activeCount;
+  }
+
+  private async findActiveEnvironmentRefs(): Promise<ActiveEnvironmentBranchRef[]> {
+    const findRefs = async (tenantId?: TenantID | string) => {
+      const refs = this.discoverActiveEnvironmentRefs
+        ? await this.discoverActiveEnvironmentRefs()
+        : await this.branchRepo!.findActiveEnvironmentRefs();
+      return refs.map((ref) => ({ ...ref, tenantId: tenantId ?? ref.tenantId }));
+    };
+
+    if (this.tenantId) {
+      if (!this.db) return findRefs(this.tenantId);
+      return runWithTenantDatabaseScope(this.db, this.tenantId, () => findRefs(this.tenantId));
+    }
+
+    if (!this.db) return findRefs();
+    return runWithSystemDatabaseScope(this.db, 'health monitor active environment discovery', () =>
+      findRefs()
+    );
   }
 
   /**

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -14,6 +14,7 @@
 import { ENVIRONMENT } from '@agor/core/config';
 import {
   BranchRepository,
+  getHiddenTenantId,
   runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
   shortId,
@@ -40,7 +41,7 @@ export interface HealthMonitorParams {
   tenant?: TenantContext;
 }
 
-export interface ActiveEnvironmentBranchRef {
+export interface HealthMonitorActiveEnvironmentRef {
   branchId: BranchID;
   tenantId?: TenantID | string;
 }
@@ -55,12 +56,12 @@ export interface HealthMonitorOptions {
   /** Fail closed for event-driven monitoring when branch events do not carry tenant metadata. */
   requireTenantParams?: boolean;
   /** Test seam for startup discovery. Production uses BranchRepository when db is provided. */
-  discoverActiveEnvironmentRefs?: () => Promise<ActiveEnvironmentBranchRef[]>;
+  discoverActiveEnvironmentRefs?: () => Promise<HealthMonitorActiveEnvironmentRef[]>;
 }
 
 function tenantParamsFromBranch(branch: Branch): HealthMonitorParams | undefined {
-  const tenantId = (branch as Branch & { tenant_id?: unknown }).tenant_id;
-  if (typeof tenantId !== 'string' || tenantId.length === 0) return undefined;
+  const tenantId = getHiddenTenantId(branch);
+  if (!tenantId) return undefined;
   return { tenant: { tenant_id: tenantId as TenantID, source: 'auth_claim' } };
 }
 
@@ -74,7 +75,7 @@ export class HealthMonitor {
   private branchRepo?: BranchRepository;
   private tenantId?: TenantID | string;
   private requireTenantParams: boolean;
-  private discoverActiveEnvironmentRefs?: () => Promise<ActiveEnvironmentBranchRef[]>;
+  private discoverActiveEnvironmentRefs?: () => Promise<HealthMonitorActiveEnvironmentRef[]>;
 
   constructor(app: Application, options: HealthMonitorOptions = {}) {
     this.app = app;
@@ -343,16 +344,15 @@ export class HealthMonitor {
     return activeCount;
   }
 
-  private async findActiveEnvironmentRefs(): Promise<ActiveEnvironmentBranchRef[]> {
-    type RepositoryActiveEnvironmentBranchRef = {
-      branch_id: BranchID;
-      tenant_id?: TenantID | string;
-    };
+  private async findActiveEnvironmentRefs(): Promise<HealthMonitorActiveEnvironmentRef[]> {
+    type BranchRepositoryActiveEnvironmentRef = Awaited<
+      ReturnType<BranchRepository['findActiveEnvironmentRefs']>
+    >[number];
 
     const normalizeRef = (
-      ref: ActiveEnvironmentBranchRef | RepositoryActiveEnvironmentBranchRef,
+      ref: HealthMonitorActiveEnvironmentRef | BranchRepositoryActiveEnvironmentRef,
       tenantId?: TenantID | string
-    ): ActiveEnvironmentBranchRef => {
+    ): HealthMonitorActiveEnvironmentRef => {
       if ('branchId' in ref) {
         return { branchId: ref.branchId, tenantId: tenantId ?? ref.tenantId };
       }
@@ -360,10 +360,10 @@ export class HealthMonitor {
     };
 
     const findRefs = async (tenantId?: TenantID | string) => {
-      const refs: Array<ActiveEnvironmentBranchRef | RepositoryActiveEnvironmentBranchRef> = this
-        .discoverActiveEnvironmentRefs
-        ? await this.discoverActiveEnvironmentRefs()
-        : await this.branchRepo!.findActiveEnvironmentRefs();
+      const refs: Array<HealthMonitorActiveEnvironmentRef | BranchRepositoryActiveEnvironmentRef> =
+        this.discoverActiveEnvironmentRefs
+          ? await this.discoverActiveEnvironmentRefs()
+          : await this.branchRepo!.findActiveEnvironmentRefs();
       return refs.map((ref) => normalizeRef(ref, tenantId));
     };
 

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -515,7 +515,14 @@ export async function startup(ctx: StartupContext): Promise<void> {
 
   // 2. Register Health Monitor listeners before serving requests. The initial
   // full scan of already-running environments is deferred until after listen.
-  const healthMonitor = new HealthMonitor(app, { defaultParams: startupTenantParams(config) });
+  const startupMultiTenancy = resolveMultiTenancyConfig(config);
+  const healthMonitor = new HealthMonitor(app, {
+    defaultParams: startupTenantParams(config),
+    db,
+    tenantId:
+      startupMultiTenancy.mode === 'static' ? startupMultiTenancy.static_tenant_id : undefined,
+    requireTenantParams: startupMultiTenancy.mode !== 'static',
+  });
 
   // 3. Validate/generate master secret for API key encryption
   await ensureMasterSecret(config);

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -628,6 +628,63 @@ describe('BranchRepository.findAll', () => {
 // FindByRepoAndName
 // ============================================================================
 
+describe('BranchRepository.findActiveEnvironmentRefs', () => {
+  dbTest(
+    'returns routing refs for running and starting branch environments only',
+    async ({ db }) => {
+      const repoRepo = new RepoRepository(db);
+      const branchRepo = new BranchRepository(db);
+
+      const repo = await repoRepo.create(createRepoData({ slug: 'active-env-refs' }));
+
+      const running = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          name: 'env-running',
+          branch_unique_id: 1,
+          environment_instance: { status: 'running' },
+        })
+      );
+      const starting = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          name: 'env-starting',
+          branch_unique_id: 2,
+          environment_instance: { status: 'starting' },
+        })
+      );
+      await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          name: 'env-stopped',
+          branch_unique_id: 3,
+          environment_instance: { status: 'stopped' },
+        })
+      );
+      await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          name: 'env-error',
+          branch_unique_id: 4,
+          environment_instance: { status: 'error' },
+        })
+      );
+      await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          name: 'env-missing',
+          branch_unique_id: 5,
+        })
+      );
+
+      const refs = await branchRepo.findActiveEnvironmentRefs();
+      const branchIds = refs.map((ref) => ref.branch_id).sort();
+
+      expect(branchIds).toEqual([running.branch_id, starting.branch_id].sort());
+    }
+  );
+});
+
 describe('BranchRepository.findByRepoAndName', () => {
   dbTest('should find by repo_id and name with case sensitivity', async ({ db }) => {
     const repoRepo = new RepoRepository(db);

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -23,6 +23,7 @@ import type { Database } from '../client';
 import {
   deleteFrom,
   insert,
+  isPostgresDatabase,
   jsonExtract,
   lockRowForUpdate,
   select,
@@ -95,6 +96,11 @@ export interface BranchWithZone extends Branch {
  */
 export interface BranchWithZoneAndSessions extends BranchWithZone {
   sessions?: BranchSessionActivity[];
+}
+
+export interface ActiveEnvironmentBranchRef {
+  branch_id: BranchID;
+  tenant_id?: string;
 }
 
 /**
@@ -415,6 +421,32 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
 
     const baseUrl = await getBaseUrl();
     return rows.map((row: BranchRow) => this.rowToBranch(row, baseUrl));
+  }
+
+  /**
+   * Health-monitor discovery query. Returns only routing metadata so the
+   * background monitor can enter the correct tenant DB scope before loading
+   * branch contents or patching health state.
+   */
+  async findActiveEnvironmentRefs(): Promise<ActiveEnvironmentBranchRef[]> {
+    const tenantColumn = (branches as unknown as { tenant_id?: unknown }).tenant_id;
+    const columns =
+      isPostgresDatabase(this.db) && tenantColumn
+        ? { branch_id: branches.branch_id, tenant_id: tenantColumn }
+        : { branch_id: branches.branch_id };
+
+    const statusExpr = sql`${jsonExtract(this.db, branches.data, 'environment_instance.status')}`;
+    const rows = await select(this.db, columns)
+      .from(branches)
+      .where(or(eq(statusExpr, 'running'), eq(statusExpr, 'starting')))
+      .all();
+
+    return (rows as Array<{ branch_id: string; tenant_id?: unknown }>).map((row) => ({
+      branch_id: row.branch_id as BranchID,
+      ...(typeof row.tenant_id === 'string' && row.tenant_id.length > 0
+        ? { tenant_id: row.tenant_id }
+        : {}),
+    }));
   }
 
   /**


### PR DESCRIPTION
## Summary

- Audit the managed environment health monitor against the recent tenant-scope/post-commit fixes.
- Keep event-driven health checks tenant-scoped, but make startup rehydration discover active environment refs with tenant metadata instead of scanning only the static startup tenant.
- In `required_from_auth` mode, fail closed when branch events/discovery rows do not carry tenant metadata.
- Address AI review follow-ups: repository coverage for active environment refs, clearer daemon-local ref naming, and reuse of the shared hidden-tenant helper.

## Analysis

Recent fixes established this pattern for daemon background work:

- Background loops should not perform tenant-owned DB reads/writes without an explicit tenant DB scope.
- Static/single-tenant mode can keep using `multi_tenancy.static_tenant_id`.
- `required_from_auth` multi-tenant mode should either discover tenant routing metadata in an explicit system scope and then re-enter per-tenant scopes, or skip/fail closed when tenant metadata is unavailable.
- Delayed side effects that need newly-committed rows should be dispatched after tenant commit.

The health monitor already did the right thing for branch events that include hidden `tenant_id`: it stores tenant params and passes them into `branches.get()` / `branches.checkHealth()`. Its startup `initialize()` path was weaker: it used only `startupTenantParams(config)`, so in auth-resolved multi-tenant mode it could miss already-running environments outside the static/bootstrap tenant after daemon restart.

This PR adds tenant-aware active environment discovery for startup rehydration and keeps static mode behavior explicit.

## Tests

- ✅ `pnpm i`
- ⚠️ `pnpm check`
  - typecheck passed
  - lint passed with existing warnings
  - shortid check passed
  - failed at `check:multitenancy-boundaries` due existing unrelated baseline entries:
    - `apps/agor-daemon/src/services/branches.test.ts` bare `setImmediate`
    - `apps/agor-daemon/src/utils/tenant-db-scope.test.ts` bare `setImmediate`
- ✅ `pnpm --filter @agor/daemon test -- src/services/health-monitor.test.ts`
- ✅ `pnpm --filter @agor/core test -- src/db/repositories/branches.test.ts`
- ✅ `pnpm exec biome check apps/agor-daemon/src/services/health-monitor.ts apps/agor-daemon/src/services/health-monitor.test.ts apps/agor-daemon/src/startup.ts packages/core/src/db/repositories/branches.ts packages/core/src/db/repositories/branches.test.ts`
- ✅ `git diff --check`

## AI review

- Initial Codex review: approve with nits, no blockers.
- Follow-up changes addressed all nits.
- Follow-up Codex review: approve, no remaining substantive issues.
- PR labeled `ai-reviewed-gpt-5-5`.
