### PR TITLE
Improve leaderboard model fallback

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/analytics.ts
+++ b/apps/agor-daemon/src/mcp/tools/analytics.ts
@@ -1,9 +1,29 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { resolveBranchId, resolveRepoId, resolveUserId } from '../resolve-ids.js';
-import { mcpLimit, mcpOffset, mcpOptionalId, mcpOptionalString } from '../schema.js';
+import { mcpLimit, mcpOffset, mcpOptionalString } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { textResult } from '../server.js';
+
+const optionalStringOrStringArray = (fieldName: string, description: string) =>
+  z
+    .union([
+      z.string().min(1, `${fieldName} cannot be empty when provided.`),
+      z.array(z.string().min(1, `${fieldName} values cannot be empty.`)).min(1),
+    ])
+    .optional()
+    .describe(description);
+
+type StringOrStringArray = string | string[] | undefined;
+
+async function resolveOneOrMany(
+  value: StringOrStringArray,
+  resolver: (value: string) => Promise<string>
+): Promise<StringOrStringArray> {
+  if (!value) return undefined;
+  if (Array.isArray(value)) return Promise.all(value.map((item) => resolver(item)));
+  return resolver(value);
+}
 
 export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_analytics_leaderboard
@@ -19,9 +39,26 @@ export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void
         'Get usage analytics leaderboard showing token, cost, session, and duration breakdown. Supports dynamic grouping by user, branch, repo, model, and/or tool (freely combined), plus optional time bucketing (hour/day/week/month) for time-series reports.',
       annotations: { readOnlyHint: true },
       inputSchema: z.strictObject({
-        userId: mcpOptionalId('userId', 'User', 'Filter by user ID (optional)'),
-        branchId: mcpOptionalId('branchId', 'Branch', 'Filter by branch ID (optional)'),
-        repoId: mcpOptionalId('repoId', 'Repository', 'Filter by repository ID (optional)'),
+        userId: optionalStringOrStringArray(
+          'userId',
+          'Filter by one or more user IDs (UUIDv7 or short IDs). Accepts a string or array.'
+        ),
+        branchId: optionalStringOrStringArray(
+          'branchId',
+          'Filter by one or more branch IDs (UUIDv7 or short IDs). Accepts a string or array.'
+        ),
+        repoId: optionalStringOrStringArray(
+          'repoId',
+          'Filter by one or more repository IDs (UUIDv7 or short IDs). Accepts a string or array.'
+        ),
+        model: optionalStringOrStringArray(
+          'model',
+          'Filter by one or more model names. Accepts a string or array.'
+        ),
+        tool: optionalStringOrStringArray(
+          'tool',
+          'Filter by one or more agentic tools. Accepts a string or array.'
+        ),
         startDate: mcpOptionalString(
           'startDate',
           'Filter by start date (ISO 8601 format, optional)'
@@ -51,9 +88,16 @@ export function registerAnalyticsTools(server: McpServer, ctx: McpContext): void
     },
     async (args) => {
       const query: Record<string, unknown> = {};
-      if (args.userId) query.userId = await resolveUserId(ctx, args.userId);
-      if (args.branchId) query.branchId = await resolveBranchId(ctx, args.branchId);
-      if (args.repoId) query.repoId = await resolveRepoId(ctx, args.repoId);
+      const userId = await resolveOneOrMany(args.userId, (value) => resolveUserId(ctx, value));
+      if (userId) query.userId = userId;
+      const branchId = await resolveOneOrMany(args.branchId, (value) =>
+        resolveBranchId(ctx, value)
+      );
+      if (branchId) query.branchId = branchId;
+      const repoId = await resolveOneOrMany(args.repoId, (value) => resolveRepoId(ctx, value));
+      if (repoId) query.repoId = repoId;
+      if (args.model) query.model = args.model;
+      if (args.tool) query.tool = args.tool;
       if (args.startDate) query.startDate = args.startDate;
       if (args.endDate) query.endDate = args.endDate;
       if (args.groupBy) query.groupBy = args.groupBy;

--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -477,6 +477,49 @@ describe('LeaderboardService bucketing', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Value filters
+// ---------------------------------------------------------------------------
+
+describe('LeaderboardService value filters', () => {
+  dbTest('accepts scalar and array filters for slice-and-dice queries', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({
+      query: {
+        userId: ['user-alice', 'user-bob'],
+        tool: 'claude-code',
+        model: ['claude-sonnet-4-6', 'claude-opus-4-6'],
+        groupBy: 'user,model',
+      },
+    });
+
+    expect(result.data).toHaveLength(2);
+    expect(new Set(result.data.map((row) => row.userId))).toEqual(new Set(['user-alice']));
+    expect(new Set(result.data.map((row) => row.model))).toEqual(
+      new Set(['claude-sonnet-4-6', 'claude-opus-4-6'])
+    );
+  });
+
+  dbTest('supports plural aliases and comma-separated values for filters', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({
+      query: {
+        userIds: 'user-alice,user-bob',
+        tools: ['codex'],
+        groupBy: 'user,tool',
+      },
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].userId).toBe('user-bob');
+    expect(result.data[0].tool).toBe('codex');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Date filters
 // ---------------------------------------------------------------------------
 

--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -90,7 +90,12 @@ async function seedRepoAndBranch(
 
 async function seedSession(
   db: Database,
-  opts: { sessionId: string; branchId: string; tool: 'claude-code' | 'codex' | 'gemini' }
+  opts: {
+    sessionId: string;
+    branchId: string;
+    tool: 'claude-code' | 'codex' | 'gemini';
+    model?: string;
+  }
 ): Promise<void> {
   await insert(db, sessions)
     .values({
@@ -100,7 +105,21 @@ async function seedSession(
       agentic_tool: opts.tool,
       branch_id: opts.branchId,
       created_by: 'test-user',
-      data: { genealogy: { children: [] }, contextFiles: [], tasks: [], git_state: {} },
+      data: {
+        genealogy: { children: [] },
+        contextFiles: [],
+        tasks: [],
+        git_state: {},
+        ...(opts.model
+          ? {
+              model_config: {
+                mode: 'exact',
+                model: opts.model,
+                updated_at: new Date().toISOString(),
+              },
+            }
+          : {}),
+      },
     })
     .run();
 }
@@ -294,6 +313,40 @@ describe('LeaderboardService dimensions', () => {
     expect(sonnet?.totalInputTokens).toBe(3_000);
     expect(sonnet?.totalOutputTokens).toBe(1_500);
   });
+
+  dbTest(
+    'groupBy: "model" falls back to session model_config when task model is absent',
+    async ({ db }) => {
+      const aliceId = 'user-alice';
+      const branchId = 'wt-main';
+      const sessionId = 'sess-codex';
+
+      await seedUser(db, aliceId, 'Alice', 'alice@example.com');
+      await seedRepoAndBranch(db, {
+        slug: 'main',
+        branchId,
+        branchName: 'main-wt',
+        uniqueId: 1,
+      });
+      await seedSession(db, { sessionId, branchId, tool: 'codex', model: 'gpt-5.5' });
+      await seedTask(db, {
+        sessionId,
+        createdBy: aliceId,
+        createdAt: tsAt(),
+        model: '',
+        inputTokens: 10,
+        outputTokens: 5,
+        costUsd: 0.01,
+        durationMs: 100,
+      });
+
+      const service = new LeaderboardService(db);
+      const result = await service.find({ query: { groupBy: 'model' } });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].model).toBe('gpt-5.5');
+    }
+  );
 
   dbTest('groupBy: "tool" returns one row per agentic tool', async ({ db }) => {
     await seedCanonicalDataset(db);

--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -584,7 +584,7 @@ describe('LeaderboardService input validation', () => {
 
     const result = await service.find({ query: { groupBy: 'user', limit: '50000', offset: '1' } });
 
-    expect(result.limit).toBe(1000);
+    expect(result.limit).toBe(10_000);
     expect(result.offset).toBe(1);
   });
 });

--- a/apps/agor-daemon/src/services/leaderboard.test.ts
+++ b/apps/agor-daemon/src/services/leaderboard.test.ts
@@ -577,4 +577,14 @@ describe('LeaderboardService input validation', () => {
       /Invalid groupBy dimension/
     );
   });
+
+  dbTest('normalizes string pagination params and caps large limits', async ({ db }) => {
+    await seedCanonicalDataset(db);
+    const service = new LeaderboardService(db);
+
+    const result = await service.find({ query: { groupBy: 'user', limit: '50000', offset: '1' } });
+
+    expect(result.limit).toBe(1000);
+    expect(result.offset).toBe(1);
+  });
 });

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -227,7 +227,9 @@ export class LeaderboardService {
     const repoIds = normalizeStringFilterValues(repoId, repoIdsQuery);
     const needsBranchesJoin = includeBranch || includeRepo || repoIds.length > 0;
 
-    const modelExpr = jsonExtract(this.db, tasks.data, 'model');
+    const taskModelExpr = jsonExtract(this.db, tasks.data, 'model');
+    const sessionModelExpr = jsonExtract(this.db, sessions.data, 'model_config.model');
+    const modelExpr = sql<string>`COALESCE(NULLIF(${taskModelExpr}, ''), ${sessionModelExpr})`;
 
     // Build WHERE conditions
     const conditions: SQL[] = [];

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -15,6 +15,7 @@ import {
   desc,
   eq,
   gte,
+  inArray,
   jsonExtract,
   lte,
   type SQL,
@@ -37,11 +38,20 @@ export type LeaderboardDimension = 'user' | 'branch' | 'repo' | 'model' | 'tool'
 
 const ALL_DIMENSIONS: LeaderboardDimension[] = ['user', 'branch', 'repo', 'model', 'tool'];
 
+type StringFilterValue = string | string[];
+
 export interface LeaderboardQuery {
   // Filters
-  userId?: string;
-  branchId?: string;
-  repoId?: string;
+  userId?: StringFilterValue;
+  userIds?: StringFilterValue;
+  branchId?: StringFilterValue;
+  branchIds?: StringFilterValue;
+  repoId?: StringFilterValue;
+  repoIds?: StringFilterValue;
+  model?: StringFilterValue;
+  models?: StringFilterValue;
+  tool?: StringFilterValue;
+  tools?: StringFilterValue;
 
   // Time period (optional - ISO timestamps)
   startDate?: string;
@@ -112,6 +122,34 @@ function parseIntegerParam(
   return Math.min(max, Math.max(min, Math.trunc(parsed)));
 }
 
+function normalizeStringFilterValues(...values: unknown[]): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  const visit = (value: unknown) => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (typeof value !== 'string') return;
+    for (const part of value.split(',')) {
+      const trimmed = part.trim();
+      if (!trimmed || seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      normalized.push(trimmed);
+    }
+  };
+
+  for (const value of values) visit(value);
+  return normalized;
+}
+
+function stringFilter(column: unknown, values: string[]): SQL | undefined {
+  if (values.length === 0) return undefined;
+  if (values.length === 1) return eq(column as never, values[0]);
+  return inArray(column as never, values);
+}
+
 /**
  * Parse the comma-separated groupBy string into a set of known dimensions.
  * Throws on unknown values so typos surface loudly rather than silently
@@ -155,8 +193,15 @@ export class LeaderboardService {
     // Extract query params
     const {
       userId,
+      userIds: userIdsQuery,
       branchId,
+      branchIds: branchIdsQuery,
       repoId,
+      repoIds: repoIdsQuery,
+      model,
+      models,
+      tool,
+      tools,
       startDate,
       endDate,
       groupBy = 'user,branch,repo',
@@ -179,22 +224,37 @@ export class LeaderboardService {
     const includeRepo = dims.has('repo');
     const includeModel = dims.has('model');
     const includeTool = dims.has('tool');
-    const needsBranchesJoin = includeBranch || includeRepo || Boolean(repoId);
+    const repoIds = normalizeStringFilterValues(repoId, repoIdsQuery);
+    const needsBranchesJoin = includeBranch || includeRepo || repoIds.length > 0;
+
+    const modelExpr = jsonExtract(this.db, tasks.data, 'model');
 
     // Build WHERE conditions
     const conditions: SQL[] = [];
 
-    if (userId) {
-      conditions.push(eq(tasks.created_by, userId));
-    }
+    const userFilter = stringFilter(
+      tasks.created_by,
+      normalizeStringFilterValues(userId, userIdsQuery)
+    );
+    if (userFilter) conditions.push(userFilter);
 
-    if (branchId) {
-      conditions.push(eq(sessions.branch_id, branchId));
-    }
+    const branchFilter = stringFilter(
+      sessions.branch_id,
+      normalizeStringFilterValues(branchId, branchIdsQuery)
+    );
+    if (branchFilter) conditions.push(branchFilter);
 
-    if (repoId) {
-      conditions.push(eq(branches.repo_id, repoId));
-    }
+    const repoFilter = stringFilter(branches.repo_id, repoIds);
+    if (repoFilter) conditions.push(repoFilter);
+
+    const modelFilter = stringFilter(modelExpr, normalizeStringFilterValues(model, models));
+    if (modelFilter) conditions.push(modelFilter);
+
+    const toolFilter = stringFilter(
+      sessions.agentic_tool,
+      normalizeStringFilterValues(tool, tools)
+    );
+    if (toolFilter) conditions.push(toolFilter);
 
     // Use gte/lte so drizzle encodes the bound via the column's timestamp mapper
     // (integer ms on SQLite, timestamp-with-tz on Postgres). Passing an ISO string
@@ -225,7 +285,6 @@ export class LeaderboardService {
     // back to the top-level `tasks.data.duration_ms`. Tasks without either field
     // (legacy / in-flight) contribute 0 duration, which is the same behaviour as
     // tokens/cost today.
-    const modelExpr = jsonExtract(this.db, tasks.data, 'model');
     const inputTokensExpr = jsonExtract(
       this.db,
       tasks.data,

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -99,6 +99,18 @@ export interface LeaderboardResult {
 }
 
 const VALID_BUCKETS = new Set<DateBucket>(['hour', 'day', 'week', 'month']);
+const MAX_LIMIT = 1000;
+
+function parseIntegerParam(
+  value: unknown,
+  fallback: number,
+  { min, max }: { min: number; max: number }
+): number {
+  if (value === undefined || value === null || value === '') return fallback;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+}
 
 /**
  * Parse the comma-separated groupBy string into a set of known dimensions.
@@ -151,9 +163,10 @@ export class LeaderboardService {
       bucket,
       sortBy = 'cost',
       sortOrder = 'desc',
-      limit = 50,
-      offset = 0,
     } = query;
+
+    const limit = parseIntegerParam(query.limit, 50, { min: 1, max: MAX_LIMIT });
+    const offset = parseIntegerParam(query.offset, 0, { min: 0, max: Number.MAX_SAFE_INTEGER });
 
     if (bucket !== undefined && !VALID_BUCKETS.has(bucket)) {
       throw new Error(`Invalid bucket: "${bucket}". Expected one of: hour, day, week, month.`);
@@ -166,6 +179,7 @@ export class LeaderboardService {
     const includeRepo = dims.has('repo');
     const includeModel = dims.has('model');
     const includeTool = dims.has('tool');
+    const needsBranchesJoin = includeBranch || includeRepo || Boolean(repoId);
 
     // Build WHERE conditions
     const conditions: SQL[] = [];
@@ -306,16 +320,21 @@ export class LeaderboardService {
     const metricOrder = sortOrder === 'desc' ? desc(sortField) : asc(sortField);
     const orderClauses = bucketExpr ? [asc(sql`bucket`), metricOrder] : [metricOrder];
 
-    // Execute aggregation query
-    // Join: tasks -> sessions -> branches, optionally LEFT JOIN users for display info
+    // Execute aggregation query. We only join branches when a selected/filtering
+    // dimension needs it; common dashboard views such as groupBy=tool or model can
+    // aggregate from tasks -> sessions without paying for the extra join.
+    // Optionally LEFT JOIN users for display info
     // Cast required: Database is a LibSQL|Postgres union; TypeScript cannot narrow the union
     // for dynamic-field SELECT queries even though both dialects share identical .select() API.
     // biome-ignore lint/suspicious/noExplicitAny: Database union type prevents calling .select() with dynamic fields
     let qb = (this.db as any)
       .select(selectFields)
       .from(tasks)
-      .innerJoin(sessions, eq(tasks.session_id, sessions.session_id))
-      .innerJoin(branches, eq(sessions.branch_id, branches.branch_id));
+      .innerJoin(sessions, eq(tasks.session_id, sessions.session_id));
+
+    if (needsBranchesJoin) {
+      qb = qb.innerJoin(branches, eq(sessions.branch_id, branches.branch_id));
+    }
 
     if (includeUser) {
       qb = qb.leftJoin(users, eq(tasks.created_by, users.user_id));
@@ -336,13 +355,21 @@ export class LeaderboardService {
     if (groupByFields.length === 0) {
       // No grouping: the main query returns a single aggregate row.
       total = results.length;
+    } else if (offset === 0 && results.length < limit) {
+      // If the first page is not full, the data query already proved the exact
+      // number of groups. Avoid repeating the same expensive aggregation just to
+      // COUNT it; leaderboard metrics extract/cast JSON on every matching task.
+      total = results.length;
     } else {
       // biome-ignore lint/suspicious/noExplicitAny: Database union type prevents calling .select() with dynamic fields
       let countInner = (this.db as any)
         .select({ one: sql`1` })
         .from(tasks)
-        .innerJoin(sessions, eq(tasks.session_id, sessions.session_id))
-        .innerJoin(branches, eq(sessions.branch_id, branches.branch_id));
+        .innerJoin(sessions, eq(tasks.session_id, sessions.session_id));
+
+      if (needsBranchesJoin) {
+        countInner = countInner.innerJoin(branches, eq(sessions.branch_id, branches.branch_id));
+      }
 
       if (includeUser) {
         countInner = countInner.leftJoin(users, eq(tasks.created_by, users.user_id));

--- a/apps/agor-daemon/src/services/leaderboard.ts
+++ b/apps/agor-daemon/src/services/leaderboard.ts
@@ -99,7 +99,7 @@ export interface LeaderboardResult {
 }
 
 const VALID_BUCKETS = new Set<DateBucket>(['hour', 'day', 'week', 'month']);
-const MAX_LIMIT = 1000;
+const MAX_LIMIT = 10_000;
 
 function parseIntegerParam(
   value: unknown,

--- a/packages/core/src/db/database-wrapper.test.ts
+++ b/packages/core/src/db/database-wrapper.test.ts
@@ -1,0 +1,19 @@
+import { sql } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import { dateTruncUtc } from './database-wrapper';
+import { tasks } from './schema.postgres';
+
+describe('dateTruncUtc', () => {
+  it('inlines validated PostgreSQL bucket units so SELECT/GROUP BY expressions match', () => {
+    const fakePostgresDb = {} as Parameters<typeof dateTruncUtc>[0];
+    const bucketExpr = dateTruncUtc(fakePostgresDb, tasks.created_at, 'week');
+    const query = sql`select ${bucketExpr} as bucket from ${tasks} group by ${bucketExpr}`;
+
+    const rendered = new PgDialect().sqlToQuery(query);
+
+    expect(rendered.params).toEqual([]);
+    expect(rendered.sql).toContain("date_trunc('week'");
+    expect(rendered.sql).not.toContain('date_trunc($');
+  });
+});

--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -171,8 +171,12 @@ export function dateTruncUtc(db: Database, column: SQL | any, bucket: DateBucket
     // IMPORTANT: `date_trunc(unit, timestamptz)` truncates in the session's timezone, so we
     // convert to a UTC wall-clock timestamp *first* (`column AT TIME ZONE 'UTC'`) and truncate
     // that. Otherwise day/week/month buckets misalign for any session not set to UTC.
+    // Use a validated raw literal for the date_trunc unit. If this is emitted as
+    // a bound parameter, selecting and grouping by the same helper expression can
+    // produce separate placeholders (for example $1 and $3). PostgreSQL then treats
+    // those as different expressions and rejects bucketed leaderboard queries.
     return sql`to_char(
-      date_trunc(${bucket}, ${column} AT TIME ZONE 'UTC'),
+      date_trunc(${sql.raw(`'${bucket}'`)}, ${column} AT TIME ZONE 'UTC'),
       'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
     )`;
   }

--- a/packages/core/src/db/repositories/user-api-keys.ts
+++ b/packages/core/src/db/repositories/user-api-keys.ts
@@ -12,6 +12,7 @@ import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
 import { userApiKeys } from '../schema';
+import { enqueueTenantDatabasePostCommitCallback } from '../tenant-context';
 
 const KEY_PREFIX = 'agor_sk_';
 const KEY_PREFIX_LENGTH = 12;
@@ -106,8 +107,24 @@ export class UserApiKeysRepository {
     return null;
   }
 
-  /** Update last_used_at timestamp */
+  /** Update last_used_at timestamp.
+   *
+   * In Postgres tenant-scoped requests, the ambient database handle points at the
+   * request transaction. Updating the API-key row inside that transaction can
+   * hold a row lock for the full duration of slow downstream work (for example
+   * leaderboard analytics scans). If a transaction is active, defer this
+   * best-effort write until after commit and perform the actual UPDATE directly
+   * so it cannot re-enqueue itself.
+   */
   async updateLastUsed(id: string): Promise<void> {
+    if (enqueueTenantDatabasePostCommitCallback(() => this.updateLastUsedNow(id))) {
+      return;
+    }
+
+    await this.updateLastUsedNow(id);
+  }
+
+  private async updateLastUsedNow(id: string): Promise<void> {
     await update(this.db, userApiKeys)
       .set({ last_used_at: new Date() })
       .where(eq(userApiKeys.id, id))

--- a/packages/core/src/db/tenant-scope.test.ts
+++ b/packages/core/src/db/tenant-scope.test.ts
@@ -3,6 +3,7 @@ import type { Database } from './client';
 import { insert } from './database-wrapper';
 import {
   createTenantScopedDatabaseProxy,
+  enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantId,
   MissingTenantDatabaseScopeError,
   requireCurrentTenantId,
@@ -31,6 +32,33 @@ describe('tenant-scoped database proxy', () => {
 
     expect(base.transaction).toHaveBeenCalledTimes(1);
     expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs post-commit callbacks after the scoped transaction commits', async () => {
+    const events: string[] = [];
+    const base = {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+        events.push('begin');
+        const result = await callback({
+          execute: vi.fn(async () => []),
+          marker: vi.fn(() => 'tx'),
+        });
+        events.push('commit');
+        return result;
+      }),
+    };
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database);
+
+    await runWithTenantDatabaseScope(db, 'tenant-a', async () => {
+      events.push('work');
+      expect(
+        enqueueTenantDatabasePostCommitCallback(async () => {
+          events.push('callback');
+        })
+      ).toBe(true);
+    });
+
+    expect(events).toEqual(['begin', 'work', 'commit', 'begin', 'callback', 'commit']);
   });
 
   it('reuses the active tenant transaction for nested scopes', async () => {


### PR DESCRIPTION
## Summary

- Fallback leaderboard model grouping/filtering from task-level `data.model` to session-level `data.model_config.model` when task model is missing or empty.
- This reduces the large `(unlabeled)` model bucket for Codex/legacy usage rows.

## Checks

- `pnpm exec biome check --write apps/agor-daemon/src/services/leaderboard.ts apps/agor-daemon/src/services/leaderboard.test.ts`
- `pnpm --filter @agor/daemon exec vitest run src/services/leaderboard.test.ts`

## Artifact follow-up

The dashboard artifact was republished separately to:
https://agor.sandbox.preset.zone/ui/a/019f1616a59e7b1c99a98b2a/