### PR TITLE
feat(agor-ui): zero-click inline image paste in session composer

### DIFF
--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
@@ -111,6 +111,44 @@ const renderMentionAutocomplete = (
 const waitForDebounce = () => new Promise((resolve) => setTimeout(resolve, 350));
 const waitForStateUpdate = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+const renderPasteHarness = (handlers: {
+  onImagePaste?: (files: File[]) => void;
+  onFilesDrop?: (files: File[]) => void;
+}) => {
+  const Harness = () => {
+    const [value, setValue] = useState('');
+    return (
+      <AutocompleteTextarea
+        value={value}
+        onChange={setValue}
+        placeholder="Prompt"
+        client={null}
+        sessionId={null}
+        userById={new Map()}
+        onImagePaste={handlers.onImagePaste}
+        onFilesDrop={handlers.onFilesDrop}
+      />
+    );
+  };
+  render(<Harness />);
+  return screen.getByPlaceholderText('Prompt') as HTMLTextAreaElement;
+};
+
+// Build a ClipboardEvent-ish init whose items mimic a pasted image (or plain text).
+const clipboardWith = (kind: 'image' | 'text') => {
+  const items =
+    kind === 'image'
+      ? [
+          {
+            kind: 'file' as const,
+            type: 'image/png',
+            getAsFile: () => new File(['fake'], 'screenshot.png', { type: 'image/png' }),
+          },
+        ]
+      : [{ kind: 'string' as const, type: 'text/plain', getAsFile: () => null }];
+  return { items };
+};
+
 describe('AutocompleteTextarea', () => {
   it('selects the default highlighted autocomplete item with Enter', async () => {
     const textarea = renderSlashAutocomplete();
@@ -242,5 +280,43 @@ describe('AutocompleteTextarea', () => {
     });
     expect(kbSearchFind).not.toHaveBeenCalled();
     expect(kbDocumentsFind).not.toHaveBeenCalled();
+  });
+
+  it('routes a pasted image to onImagePaste (inline) and not onFilesDrop', () => {
+    const onImagePaste = vi.fn();
+    const onFilesDrop = vi.fn();
+    const textarea = renderPasteHarness({ onImagePaste, onFilesDrop });
+
+    fireEvent.paste(textarea, { clipboardData: clipboardWith('image') });
+
+    expect(onImagePaste).toHaveBeenCalledTimes(1);
+    expect(onFilesDrop).not.toHaveBeenCalled();
+    const files = onImagePaste.mock.calls[0][0] as File[];
+    expect(files).toHaveLength(1);
+    // The handler renames pasted images to a friendly screenshot name.
+    expect(files[0].name).toMatch(/^pasted-screenshot-.*\.png$/);
+    expect(files[0].type).toBe('image/png');
+  });
+
+  it('falls back to onFilesDrop (modal) for a pasted image when onImagePaste is absent', () => {
+    const onFilesDrop = vi.fn();
+    const textarea = renderPasteHarness({ onFilesDrop });
+
+    fireEvent.paste(textarea, { clipboardData: clipboardWith('image') });
+
+    expect(onFilesDrop).toHaveBeenCalledTimes(1);
+    const files = onFilesDrop.mock.calls[0][0] as File[];
+    expect(files).toHaveLength(1);
+  });
+
+  it('ignores plain-text paste (no handler fired, default paste preserved)', () => {
+    const onImagePaste = vi.fn();
+    const onFilesDrop = vi.fn();
+    const textarea = renderPasteHarness({ onImagePaste, onFilesDrop });
+
+    fireEvent.paste(textarea, { clipboardData: clipboardWith('text') });
+
+    expect(onImagePaste).not.toHaveBeenCalled();
+    expect(onFilesDrop).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -96,6 +96,13 @@ interface AutocompleteTextareaProps {
     maxRows?: number;
   };
   onFilesDrop?: (files: File[]) => void;
+  /**
+   * Handle image files pasted from the clipboard. When provided, pasted images
+   * are routed here instead of `onFilesDrop`, letting the composer attach them
+   * inline (no upload modal). Falls back to `onFilesDrop` when omitted so other
+   * consumers keep their existing paste-into-modal behavior.
+   */
+  onImagePaste?: (files: File[]) => void;
   /** Available slash commands from the SDK (stored on session.custom_context) */
   slashCommands?: string[];
   /** Available skills from the SDK (stored on session.custom_context) */
@@ -365,6 +372,7 @@ export const AutocompleteTextarea = React.forwardRef<
       userById,
       autoSize,
       onFilesDrop,
+      onImagePaste,
       slashCommands = EMPTY_SLASH_COMMANDS,
       skills = EMPTY_SKILLS,
       enableKnowledgeMentions = false,
@@ -1110,7 +1118,10 @@ export const AutocompleteTextarea = React.forwardRef<
 
     const handlePaste = useCallback(
       (e: React.ClipboardEvent) => {
-        if (!onFilesDrop) return;
+        // Prefer the inline-paste handler; fall back to the drop handler (modal)
+        // for consumers that do not opt into inline attachments.
+        const pasteHandler = onImagePaste ?? onFilesDrop;
+        if (!pasteHandler) return;
 
         const imageFiles: File[] = [];
         for (const item of Array.from(e.clipboardData.items)) {
@@ -1129,9 +1140,9 @@ export const AutocompleteTextarea = React.forwardRef<
         if (imageFiles.length === 0) return;
 
         e.preventDefault();
-        onFilesDrop(imageFiles);
+        pasteHandler(imageFiles);
       },
-      [onFilesDrop]
+      [onImagePaste, onFilesDrop]
     );
 
     /**

--- a/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
+++ b/apps/agor-ui/src/components/FileUpload/FileUpload.tsx
@@ -4,7 +4,7 @@ import type { RcFile, UploadFile } from 'antd/es/upload/interface';
 import type React from 'react';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { useThemedMessage } from '../../utils/message';
-import { ACCESS_TOKEN_KEY } from '../../utils/tokenRefresh';
+import { type UploadedFile, uploadSessionFiles } from './uploadSessionFiles';
 
 const { TextArea } = Input;
 const { Text } = Typography;
@@ -12,12 +12,7 @@ const { Text } = Typography;
 const DEFAULT_AGENT_UPLOAD_MESSAGE =
   'Note: the user uploaded file(s): {filepath}\n\nPlease review and use them as context for this task.';
 
-export interface UploadedFile {
-  filename: string;
-  path: string;
-  size: number;
-  mimeType: string;
-}
+export type { UploadedFile } from './uploadSessionFiles';
 
 export interface FileUploadProps {
   sessionId: string;
@@ -94,69 +89,39 @@ export const FileUpload: React.FC<FileUploadProps> = ({
     setUploading(true);
 
     try {
-      const formData = new FormData();
-
+      const files: File[] = [];
       fileList.forEach((file) => {
         if (file.originFileObj) {
-          formData.append('files', file.originFileObj);
+          files.push(file.originFileObj);
         } else {
           console.warn('[FileUpload] File missing originFileObj:', file.name);
         }
       });
-      formData.append('notifyAgent', String(notifyAgent));
-      formData.append('message', agentMessage);
 
-      const uploadUrl = `${daemonUrl}/sessions/${sessionId}/upload`;
-
-      // Get JWT token from localStorage (same as Feathers client)
-      const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-      const headers: HeadersInit = {};
-
-      if (accessToken) {
-        headers.Authorization = `Bearer ${accessToken}`;
-      } else {
-        console.warn('[FileUpload] No access token found in localStorage');
-      }
-
-      const response = await fetch(uploadUrl, {
-        method: 'POST',
-        headers,
-        body: formData,
-        // No `credentials: 'include'` — the upload endpoint is Bearer-only
-        // (cookie auth was removed to avoid CSRF). Sending credentials would
-        // also force a non-wildcard Access-Control-Allow-Origin, which the
-        // daemon's CORS layer answers with '*', breaking the preflight.
+      const uploaded = await uploadSessionFiles({
+        sessionId,
+        daemonUrl,
+        files,
+        notifyAgent,
+        message: agentMessage,
       });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        let error: { error?: string } = {};
-        try {
-          error = JSON.parse(errorText);
-        } catch {
-          error = { error: errorText || 'Upload failed' };
-        }
-        throw new Error(error.error || 'Upload failed');
-      }
-
-      const result = await response.json();
-
       // Show success message with final filename(s) so user knows what to reference
-      if (result.files.length === 1) {
-        showSuccess(`Uploaded as: ${result.files[0].filename}`);
+      if (uploaded.length === 1) {
+        showSuccess(`Uploaded as: ${uploaded[0].filename}`);
       } else {
-        showSuccess(`Uploaded ${result.files.length} files successfully`);
+        showSuccess(`Uploaded ${uploaded.length} files successfully`);
       }
 
       // Call completion callback
       if (onUploadComplete) {
-        onUploadComplete(result.files);
+        onUploadComplete(uploaded);
       }
 
       // If not notifying agent, optionally insert @filepath mention
-      if (!notifyAgent && onInsertMention && result.files.length > 0) {
+      if (!notifyAgent && onInsertMention && uploaded.length > 0) {
         // Insert first file path as mention
-        const firstFile = result.files[0];
+        const firstFile = uploaded[0];
         // Quote paths with spaces to prevent breaking mention parser
         const mentionPath = firstFile.path.includes(' ') ? `"${firstFile.path}"` : firstFile.path;
         onInsertMention(mentionPath);

--- a/apps/agor-ui/src/components/FileUpload/index.ts
+++ b/apps/agor-ui/src/components/FileUpload/index.ts
@@ -4,3 +4,4 @@ export type {
   UploadedFile,
 } from './FileUpload';
 export { FileUpload, FileUploadButton } from './FileUpload';
+export { uploadSessionFiles } from './uploadSessionFiles';

--- a/apps/agor-ui/src/components/FileUpload/uploadSessionFiles.ts
+++ b/apps/agor-ui/src/components/FileUpload/uploadSessionFiles.ts
@@ -1,0 +1,76 @@
+import { ACCESS_TOKEN_KEY } from '../../utils/tokenRefresh';
+
+export interface UploadedFile {
+  filename: string;
+  path: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface UploadSessionFilesParams {
+  sessionId: string;
+  daemonUrl: string;
+  files: File[];
+  /** When true, the daemon posts an agent notification referencing the file(s). */
+  notifyAgent: boolean;
+  /** Notification body; `{filepath}` is substituted server-side. Only used when notifyAgent. */
+  message?: string;
+}
+
+/**
+ * Upload one or more files to a session via `POST /sessions/:id/upload`.
+ *
+ * Shared by the FileUpload modal and the inline image-paste flow so both speak
+ * to the exact same endpoint, auth scheme, and response shape. Returns the
+ * stored files (path + final filename) on success and throws a clean Error on
+ * failure for the caller to surface.
+ */
+export async function uploadSessionFiles({
+  sessionId,
+  daemonUrl,
+  files,
+  notifyAgent,
+  message,
+}: UploadSessionFilesParams): Promise<UploadedFile[]> {
+  const formData = new FormData();
+  for (const file of files) {
+    formData.append('files', file);
+  }
+  formData.append('notifyAgent', String(notifyAgent));
+  if (message !== undefined) {
+    formData.append('message', message);
+  }
+
+  // Get JWT token from localStorage (same as Feathers client)
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  const headers: HeadersInit = {};
+  if (accessToken) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  } else {
+    console.warn('[uploadSessionFiles] No access token found in localStorage');
+  }
+
+  const response = await fetch(`${daemonUrl}/sessions/${sessionId}/upload`, {
+    method: 'POST',
+    headers,
+    body: formData,
+    // No `credentials: 'include'` — the upload endpoint is Bearer-only
+    // (cookie auth was removed to avoid CSRF). Sending credentials would
+    // also force a non-wildcard Access-Control-Allow-Origin, which the
+    // daemon's CORS layer answers with '*', breaking the preflight.
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let error: { error?: string } = {};
+    try {
+      error = JSON.parse(errorText);
+    } catch {
+      error = { error: errorText || 'Upload failed' };
+    }
+    throw new Error(error.error || 'Upload failed');
+  }
+
+  const result = await response.json();
+  return result.files as UploadedFile[];
+}

--- a/apps/agor-ui/src/components/SessionPanel/PendingAttachments.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/PendingAttachments.tsx
@@ -1,0 +1,130 @@
+import { CloseOutlined, LoadingOutlined } from '@ant-design/icons';
+import { Tooltip, Typography, theme } from 'antd';
+import type React from 'react';
+
+const { Text } = Typography;
+
+/**
+ * An image pasted into the composer and attached inline (no upload modal).
+ * Uploaded to the session immediately on paste; `path` is filled in once the
+ * upload resolves and is what gets appended to the outgoing prompt as a mention.
+ */
+export interface PendingImageAttachment {
+  /** Stable client-side id (also used to revoke the preview URL). */
+  id: string;
+  /** Display name (the generated `pasted-screenshot-*.png`). */
+  name: string;
+  /** Local object URL for the thumbnail preview. */
+  previewUrl: string;
+  /** Server upload path; present once `status === 'done'`. */
+  path?: string;
+  status: 'uploading' | 'done';
+}
+
+interface PendingAttachmentsProps {
+  attachments: PendingImageAttachment[];
+  onRemove: (id: string) => void;
+}
+
+/**
+ * Compact inline thumbnail chips for images pasted into the prompt composer.
+ * Renders nothing when there are no attachments.
+ */
+export const PendingAttachments: React.FC<PendingAttachmentsProps> = ({
+  attachments,
+  onRemove,
+}) => {
+  const { token } = theme.useToken();
+
+  if (attachments.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: token.sizeUnit * 2,
+        marginBottom: token.sizeUnit * 2,
+      }}
+      data-testid="pending-attachments"
+    >
+      {attachments.map((att) => (
+        <div
+          key={att.id}
+          style={{
+            position: 'relative',
+            width: 56,
+            height: 56,
+            borderRadius: token.borderRadius,
+            border: `1px solid ${token.colorBorder}`,
+            overflow: 'hidden',
+            background: token.colorFillQuaternary,
+            flexShrink: 0,
+          }}
+          title={att.name}
+        >
+          <img
+            src={att.previewUrl}
+            alt={att.name}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              display: 'block',
+              opacity: att.status === 'uploading' ? 0.5 : 1,
+            }}
+          />
+
+          {att.status === 'uploading' && (
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <LoadingOutlined style={{ color: token.colorPrimary, fontSize: 18 }} />
+            </div>
+          )}
+
+          <Tooltip title="Remove">
+            <button
+              type="button"
+              aria-label={`Remove ${att.name}`}
+              onClick={() => onRemove(att.id)}
+              style={{
+                position: 'absolute',
+                top: 2,
+                right: 2,
+                width: 18,
+                height: 18,
+                padding: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                border: 'none',
+                borderRadius: '50%',
+                cursor: 'pointer',
+                color: token.colorWhite,
+                background: 'rgba(0, 0, 0, 0.55)',
+                lineHeight: 1,
+              }}
+            >
+              <CloseOutlined style={{ fontSize: 10 }} />
+            </button>
+          </Tooltip>
+        </div>
+      ))}
+
+      <Text
+        type="secondary"
+        style={{ fontSize: token.fontSizeSM, alignSelf: 'center' }}
+        aria-hidden="true"
+      >
+        {attachments.some((a) => a.status === 'uploading') ? 'Uploading…' : ''}
+      </Text>
+    </div>
+  );
+};

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -46,12 +46,13 @@ import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
-import { FileUpload } from '../FileUpload';
+import { FileUpload, uploadSessionFiles } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
 import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
 import { getUrlDisplayLabel } from '../Pill/url-helpers';
 import { ToolIcon } from '../ToolIcon';
+import { PendingAttachments, type PendingImageAttachment } from './PendingAttachments';
 import type { SessionAttachmentItem } from './SessionAttachmentsDropdown';
 import { SessionAttachmentsDropdown } from './SessionAttachmentsDropdown';
 import { SessionFooter } from './SessionFooter';
@@ -89,6 +90,8 @@ interface PromptInputProps {
   client: AgorClient | null;
   userById: Map<string, User>;
   onFilesDrop?: (files: File[]) => void;
+  /** Inline image paste (skips the upload modal) */
+  onImagePaste?: (files: File[]) => void;
   slashCommands?: string[];
   skills?: string[];
 }
@@ -108,6 +111,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
       client,
       userById,
       onFilesDrop,
+      onImagePaste,
       slashCommands,
       skills,
     },
@@ -200,6 +204,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
         sessionId={sessionId}
         userById={userById}
         onFilesDrop={onFilesDrop}
+        onImagePaste={onImagePaste}
         slashCommands={slashCommands}
         skills={skills}
         enableKnowledgeMentions
@@ -344,6 +349,14 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [spawnModalOpen, setSpawnModalOpen] = React.useState(false);
   const [uploadModalOpen, setUploadModalOpen] = React.useState(false);
   const [droppedFiles, setDroppedFiles] = React.useState<File[]>([]);
+  // Images pasted inline into the composer (no upload modal). Uploaded on paste;
+  // their server paths are appended to the prompt as @mentions on submit.
+  const [pendingAttachments, setPendingAttachments] = React.useState<PendingImageAttachment[]>([]);
+  // Mirror in a ref so the (async) send handler reads the latest list/paths
+  // without re-creating itself, and track in-flight uploads so a fast send waits.
+  const pendingAttachmentsRef = React.useRef<PendingImageAttachment[]>([]);
+  pendingAttachmentsRef.current = pendingAttachments;
+  const uploadPromisesRef = React.useRef<Map<string, Promise<void>>>(new Map());
   const [stopRequestInFlight, setStopRequestInFlight] = React.useState(false);
   const reactiveSessionId = session?.session_id ?? null;
   const { state: reactiveSessionState } = useSharedReactiveSession(client, reactiveSessionId, {
@@ -530,6 +543,86 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     setEffortLevel(session?.model_config?.effort || 'high');
   }, [session?.model_config?.effort]);
 
+  // Remove a pending inline attachment and release its preview URL.
+  const handleRemoveAttachment = React.useCallback((id: string) => {
+    setPendingAttachments((prev) => {
+      const target = prev.find((a) => a.id === id);
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((a) => a.id !== id);
+    });
+  }, []);
+
+  // Drop all pending attachments and release their preview URLs (after send or
+  // when leaving the composer).
+  const clearPendingAttachments = React.useCallback(() => {
+    for (const att of pendingAttachmentsRef.current) {
+      URL.revokeObjectURL(att.previewUrl);
+    }
+    setPendingAttachments([]);
+  }, []);
+
+  // Release preview URLs on unmount so pasted thumbnails don't leak memory.
+  React.useEffect(() => {
+    return () => {
+      for (const att of pendingAttachmentsRef.current) {
+        URL.revokeObjectURL(att.previewUrl);
+      }
+    };
+  }, []);
+
+  // Pasted attachments belong to a single session — drop them when switching to
+  // a different session so they don't bleed into the next conversation.
+  const attachmentsSessionId = session?.session_id ?? null;
+  const prevAttachmentsSessionIdRef = React.useRef(attachmentsSessionId);
+  React.useEffect(() => {
+    if (prevAttachmentsSessionIdRef.current !== attachmentsSessionId) {
+      prevAttachmentsSessionIdRef.current = attachmentsSessionId;
+      clearPendingAttachments();
+    }
+  }, [attachmentsSessionId, clearPendingAttachments]);
+
+  // Inline image paste: skip the upload modal, show a thumbnail chip, and upload
+  // immediately to the same endpoint the modal uses (notifyAgent: false). The
+  // returned path is appended to the prompt as an @mention on submit.
+  const handleImagePaste = React.useCallback(
+    (files: File[]) => {
+      const activeSession = session;
+      if (!activeSession) return;
+      for (const file of files) {
+        const id = crypto.randomUUID();
+        const previewUrl = URL.createObjectURL(file);
+        setPendingAttachments((prev) => [
+          ...prev,
+          { id, name: file.name, previewUrl, status: 'uploading' },
+        ]);
+
+        const uploadPromise = uploadSessionFiles({
+          sessionId: activeSession.session_id,
+          daemonUrl: getDaemonUrl(),
+          files: [file],
+          notifyAgent: false,
+        })
+          .then((uploaded) => {
+            const path = uploaded[0]?.path;
+            if (!path) throw new Error('Upload returned no file path');
+            setPendingAttachments((prev) =>
+              prev.map((a) => (a.id === id ? { ...a, status: 'done', path } : a))
+            );
+          })
+          .catch((error) => {
+            showError(error instanceof Error ? error.message : 'Failed to upload pasted image');
+            handleRemoveAttachment(id);
+          })
+          .finally(() => {
+            uploadPromisesRef.current.delete(id);
+          });
+
+        uploadPromisesRef.current.set(id, uploadPromise);
+      }
+    },
+    [session, showError, handleRemoveAttachment]
+  );
+
   // When there's no session, render nothing (panel is collapsed to zero).
   // When open=false, we still render the component tree (hidden) so that
   // antd's CSS-in-JS doesn't garbage-collect component styles.
@@ -608,14 +701,30 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const handleSendPrompt = async () => {
     const value = promptRef.current?.getValue() ?? '';
-    if (!value.trim() || connectionDisabled) return;
+    const hasAttachments = pendingAttachmentsRef.current.length > 0;
+    if ((!value.trim() && !hasAttachments) || connectionDisabled) return;
 
-    const promptToSend = value.trim();
+    // Wait for any in-flight uploads so their paths are available to mention.
+    if (uploadPromisesRef.current.size > 0) {
+      await Promise.allSettled([...uploadPromisesRef.current.values()]);
+    }
+
+    // Append uploaded image paths as @mentions, mirroring the upload modal's
+    // "insert mention" path. Quote paths with spaces to keep the mention parser
+    // from splitting them.
+    const mentions = pendingAttachmentsRef.current
+      .filter((a) => a.status === 'done' && a.path)
+      .map((a) => `@${(a.path as string).includes(' ') ? `"${a.path}"` : a.path}`)
+      .join(' ');
+    const trimmed = value.trim();
+    const promptToSend = mentions ? `${trimmed} ${mentions}`.trim() : trimmed;
+    if (!promptToSend) return;
 
     // Single entry point: /prompt. The daemon decides run-vs-queue based on
     // session state and reports it back via `task.status`. The 'queued'
     // WebSocket event populates the queue panel for queued prompts.
     promptRef.current?.clear();
+    clearPendingAttachments();
     onSendPrompt?.(session.session_id, promptToSend, permissionMode);
 
     // Re-engage the bottom lock so a scrolled-up user follows their just-sent
@@ -834,7 +943,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       isRunning={isRunning}
       isStopping={isStopping}
       stopRequestInFlight={stopRequestInFlight}
-      hasInput={hasInput}
+      hasInput={hasInput || pendingAttachments.length > 0}
       connectionDisabled={connectionDisabled}
       toolCaps={toolCaps}
       effortLevel={effortLevel}
@@ -857,36 +966,40 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       onPermissionModeChange={handlePermissionModeChange}
       onCodexPermissionChange={handleCodexPermissionChange}
       promptInputSlot={
-        <PromptInput
-          ref={promptRef}
-          sessionId={session.session_id}
-          getDraft={getDraft}
-          saveDraft={saveDraft}
-          deleteDraft={deleteDraft}
-          onHasInputChange={handleHasInputChange}
-          inputValueRef={inputValueRef}
-          onSubmit={handleSendPrompt}
-          placeholder={
-            isRunning
-              ? 'Queue here… @ for mentions, : for emoji'
-              : 'Prompt here… @ for mentions, : for emoji'
-          }
-          autoSize={{ minRows: 1, maxRows: 10 }}
-          client={client}
-          userById={userById}
-          onFilesDrop={(files) => {
-            setDroppedFiles(files);
-            setUploadModalOpen(true);
-          }}
-          slashCommands={(() => {
-            const ctx = session?.custom_context as Record<string, unknown> | undefined;
-            return Array.isArray(ctx?.slash_commands) ? ctx.slash_commands : undefined;
-          })()}
-          skills={(() => {
-            const ctx = session?.custom_context as Record<string, unknown> | undefined;
-            return Array.isArray(ctx?.skills) ? ctx.skills : undefined;
-          })()}
-        />
+        <>
+          <PendingAttachments attachments={pendingAttachments} onRemove={handleRemoveAttachment} />
+          <PromptInput
+            ref={promptRef}
+            sessionId={session.session_id}
+            getDraft={getDraft}
+            saveDraft={saveDraft}
+            deleteDraft={deleteDraft}
+            onHasInputChange={handleHasInputChange}
+            inputValueRef={inputValueRef}
+            onSubmit={handleSendPrompt}
+            placeholder={
+              isRunning
+                ? 'Queue here… @ for mentions, : for emoji'
+                : 'Prompt here… @ for mentions, : for emoji'
+            }
+            autoSize={{ minRows: 1, maxRows: 10 }}
+            client={client}
+            userById={userById}
+            onFilesDrop={(files) => {
+              setDroppedFiles(files);
+              setUploadModalOpen(true);
+            }}
+            onImagePaste={handleImagePaste}
+            slashCommands={(() => {
+              const ctx = session?.custom_context as Record<string, unknown> | undefined;
+              return Array.isArray(ctx?.slash_commands) ? ctx.slash_commands : undefined;
+            })()}
+            skills={(() => {
+              const ctx = session?.custom_context as Record<string, unknown> | undefined;
+              return Array.isArray(ctx?.skills) ? ctx.skills : undefined;
+            })()}
+          />
+        </>
       }
     />
   );


### PR DESCRIPTION
## What

Pasting an image (Cmd/Ctrl+V) into the session prompt composer no longer pops the FileUpload confirmation modal. The image now attaches **inline** as a pending thumbnail chip (with a remove ✕ affordance). You type your question and submit normally; on submit the image is uploaded and referenced **exactly** as a modal-confirmed upload would be. Claude-CLI style.

## Why

Evan's papercut: every screenshot paste interrupted the flow with a modal that had to be confirmed before you could even start typing your question. For the overwhelmingly common "paste a screenshot, ask about it" loop this is one click and one context-switch too many. Zero-click inline paste removes the friction.

## Before / After UX

**Before:** Paste image → modal pops → confirm upload → modal inserts `@path` → now type your question.

**After:** Paste image → thumbnail chip appears inline under the composer (uploads in the background, no modal) → type your question → Send. The uploaded file's `@path` mention is appended to the prompt on submit, just like the modal did.

## Scope (intentionally narrow)

- **Paste flow only.** The 📎 upload button and drag-and-drop keep their existing modal behavior.
- **Plain text paste is untouched** — only `image/*` clipboard items are intercepted.
- **Multiple images** supported (multiple chips).

## How it works

- `AutocompleteTextarea` gains an `onImagePaste` prop, preferred over `onFilesDrop` for pasted images. Consumers that don't opt in keep the old paste-into-modal behavior (clean fallback).
- `FileUpload` is refactored to extract a shared `uploadSessionFiles()` helper so the modal and the inline-paste path hit the **identical** endpoint (`POST /sessions/:id/upload`), auth scheme (Bearer), and response shape — no divergent data model.
- `SessionPanel` renders a `PendingAttachments` thumbnail strip above the composer, uploads each pasted image immediately (`notifyAgent: false`), awaits any in-flight uploads on send so paths are ready, and appends them as `@path` mentions (quoting paths with spaces) — mirroring the modal's "insert mention" path. Preview object URLs are revoked on remove / send / unmount / session-switch to avoid leaks.

## Validation

- `pnpm lint` (biome) ✅
- `pnpm typecheck` (`tsc -b`) ✅
- `pnpm build` ✅
- `pnpm vitest run` for `AutocompleteTextarea` (10 passed, incl. 3 new paste tests: inline routing, modal fallback, text-ignored) and `SessionPanel` suites (23 passed) ✅

## Manual test steps

1. Open a session, take a screenshot to the clipboard.
2. Click into the composer and paste (Cmd/Ctrl+V) → **inline thumbnail chip appears, no modal**.
3. Confirm the ✕ on the chip removes it before sending.
4. Type a question and Send → the prompt is sent with the image's `@path` appended; the agent can read the file.
5. Sanity-check un-regressed paths: 📎 button still opens the modal; drag-and-drop still opens the modal; plain text paste still pastes text.

## Limitations / follow-ups

- Inline chips are image-only; non-image clipboard files still go through the modal.
- Uploads start on paste; if you paste then immediately remove, the file may already be uploaded server-side (orphaned upload). Cleanup of orphaned uploads is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)