### PR TITLE
feat(agor-ui): add Resume button to daemon restart/crash notice

### DIFF
--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -358,8 +358,8 @@ async function injectRestartNoticesInTenantScope(
 
   const restartType = wasGraceful ? ('daemon_restart' as const) : ('daemon_crash' as const);
   const messageText = wasGraceful
-    ? 'The Agor daemon was restarted while this session was running. Ask the agent to resume where it left off.'
-    : 'The Agor daemon restarted unexpectedly while this session was running. Ask the agent to resume where it left off.';
+    ? 'The Agor daemon was restarted while this session was running.'
+    : 'The Agor daemon restarted unexpectedly while this session was running.';
 
   // Build session → last orphaned task map so we can attach notices to a task_id.
   // Prefer orphaned tasks (they were the active tasks at shutdown); fall back to

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -22,9 +22,9 @@ import {
 } from '@agor-live/client';
 import { RobotOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons';
 import { Bubble } from '@ant-design/x';
-import { Tooltip, theme } from 'antd';
+import { Button, Tooltip, theme } from 'antd';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { BRAND, brandMarkHref } from '../../branding/brand';
 import { formatTimestampWithRelative } from '../../utils/time';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
@@ -234,6 +234,77 @@ function getAgentAvatar({
   );
 }
 
+interface DaemonRestartNoticeProps {
+  isGraceful: boolean;
+  text: string;
+  sessionId?: string | null;
+  client?: AgorClient | null;
+  isTaskRunning?: boolean;
+}
+
+function DaemonRestartNotice({
+  isGraceful,
+  text,
+  sessionId,
+  client,
+  isTaskRunning = false,
+}: DaemonRestartNoticeProps) {
+  const { token } = theme.useToken();
+  const [loading, setLoading] = useState(false);
+  const [resumed, setResumed] = useState(false);
+
+  const handleResume = async () => {
+    if (!client || !sessionId) return;
+    setLoading(true);
+    try {
+      await client.sessions.prompt(
+        sessionId,
+        'Please resume where you left off before the daemon restarted.',
+        { messageSource: 'agor' }
+      );
+      setResumed(true);
+    } catch (err) {
+      console.error('Failed to send resume prompt:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const showButton = !!client && !!sessionId && !resumed && !isTaskRunning;
+
+  return (
+    <SystemMessage
+      content={
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+          <span
+            style={{
+              color: isGraceful ? token.colorInfo : token.colorWarning,
+              flexShrink: 0,
+              marginTop: 2,
+            }}
+          >
+            {isGraceful ? <SyncOutlined /> : <WarningOutlined />}
+          </span>
+          <div style={{ fontSize: 13, flex: 1 }}>
+            <MarkdownRenderer content={text} />
+            {showButton && (
+              <Button
+                size="small"
+                type="primary"
+                loading={loading}
+                onClick={handleResume}
+                style={{ marginTop: 6 }}
+              >
+                Resume
+              </Button>
+            )}
+          </div>
+        </div>
+      }
+    />
+  );
+}
+
 // Memoized: every text block / tool block of every message in the conversation
 // re-rendered on every streaming chunk because TaskBlock's `messages` array
 // gets a fresh reference each tick. Default shallow compare is sufficient
@@ -428,23 +499,12 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
     const isGraceful = message.type === 'daemon_restart';
     const text = typeof message.content === 'string' ? message.content : '';
     return (
-      <SystemMessage
-        content={
-          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-            <span
-              style={{
-                color: isGraceful ? token.colorInfo : token.colorWarning,
-                flexShrink: 0,
-                marginTop: 2,
-              }}
-            >
-              {isGraceful ? <SyncOutlined /> : <WarningOutlined />}
-            </span>
-            <div style={{ fontSize: 13 }}>
-              <MarkdownRenderer content={text} />
-            </div>
-          </div>
-        }
+      <DaemonRestartNotice
+        isGraceful={isGraceful}
+        text={text}
+        sessionId={sessionId}
+        client={client}
+        isTaskRunning={isTaskRunning}
       />
     );
   }


### PR DESCRIPTION
## Problem

When the daemon restarts (gracefully or unexpectedly) while a session is running, startup reconciliation injects a `daemon_restart`/`daemon_crash` system message into each affected session's transcript. The message previously ended with _"Ask the agent to resume where it left off."_ — forcing the user to manually type a follow-up prompt.

## Change

**`apps/agor-daemon/src/startup.ts`**
- Removed the trailing "Ask the agent to resume where it left off." sentence from both message strings — the UI button now provides this action.

**`apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx`**
- Extracted the `daemon_restart`/`daemon_crash` render path into a new `DaemonRestartNotice` component (keeps local state out of `MessageBlockInner`).
- Added a **Resume** button (antd `Button`, `size="small"`, `type="primary"`) that calls `client.sessions.prompt(sessionId, 'Please resume where you left off before the daemon restarted.', { messageSource: 'agor' })`.
- Shows loading spinner while in flight; hides permanently after a successful send.
- Hidden if the session is already running (`isTaskRunning`) or if `client`/`sessionId` are unavailable.

## Button behaviour

| State | Button |
|---|---|
| Session idle, not yet resumed | Visible, enabled |
| Prompt in flight | Visible, loading spinner |
| Prompt sent successfully | Hidden (one-shot) |
| Session already running (`isTaskRunning`) | Hidden |
| No client / no sessionId | Hidden |

## No prop drilling needed

`sessionId` and `client` were already in `MessageBlockProps` — no changes to callers required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)