### PR TITLE
fix(agor-ui): dedupe @codemirror/state so CodeEditor stops crashing

### DIFF
--- a/apps/agor-ui/src/components/CodeEditor/CodeEditor.inner.tsx
+++ b/apps/agor-ui/src/components/CodeEditor/CodeEditor.inner.tsx
@@ -7,13 +7,19 @@
  *
  * Split out into its own module so Vite can code-split the ~150KB of CM6
  * into its own chunk that only loads when an editor is actually rendered.
+ *
+ * All language packages are imported statically so they land in the same
+ * async chunk as @codemirror/state. A nested dynamic import() would create a
+ * second async chunk boundary that causes Rollup to duplicate @codemirror/state
+ * across chunks, breaking its instanceof checks at runtime.
  */
 import { json } from '@codemirror/lang-json';
+import { markdown } from '@codemirror/lang-markdown';
 import { yaml } from '@codemirror/lang-yaml';
 import { oneDark } from '@codemirror/theme-one-dark';
 import CodeMirror from '@uiw/react-codemirror';
 import type React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
 
 export type CodeEditorLanguage = 'json' | 'yaml' | 'markdown';
@@ -36,9 +42,24 @@ export interface CodeEditorInnerProps {
 // avoids taking a direct dep on `@codemirror/state` (which is transitive).
 type LanguageExtensionFactory = typeof json;
 
+// Markdown is configured with codeLanguages so fenced code blocks get
+// syntax highlighting for yaml/json. Wrapped in a factory to match the
+// shape of the other entries and to defer the extension object creation
+// until the editor first renders.
+const markdownWithCodeLanguages: LanguageExtensionFactory = () =>
+  markdown({
+    codeLanguages: (info) => {
+      const languageName = info.trim().split(/\s+/, 1)[0]?.toLowerCase();
+      if (languageName === 'yaml' || languageName === 'yml') return yaml().language;
+      if (languageName === 'json') return json().language;
+      return null;
+    },
+  });
+
 const LANGUAGE_EXTENSIONS: Partial<Record<CodeEditorLanguage, LanguageExtensionFactory>> = {
   json,
   yaml,
+  markdown: markdownWithCodeLanguages,
 };
 
 const CodeEditorInner: React.FC<CodeEditorInnerProps> = ({
@@ -55,44 +76,11 @@ const CodeEditorInner: React.FC<CodeEditorInnerProps> = ({
   // `isDark` is the canonical dark/light signal from ThemeContext — already
   // accounts for `themeMode === 'custom'` rendering dark.
   const { isDark } = useTheme();
-  const [markdownExtensionFactory, setMarkdownExtensionFactory] =
-    useState<LanguageExtensionFactory | null>(null);
-
-  useEffect(() => {
-    if (language !== 'markdown' || markdownExtensionFactory) return;
-
-    let cancelled = false;
-    import('@codemirror/lang-markdown')
-      .then(({ markdown }) => {
-        const createMarkdownWithCodeLanguages = () =>
-          markdown({
-            codeLanguages: (info) => {
-              const languageName = info.trim().split(/\s+/, 1)[0]?.toLowerCase();
-              if (languageName === 'yaml' || languageName === 'yml') return yaml().language;
-              if (languageName === 'json') return json().language;
-              return null;
-            },
-          });
-        if (!cancelled) {
-          setMarkdownExtensionFactory(
-            () => createMarkdownWithCodeLanguages as LanguageExtensionFactory
-          );
-        }
-      })
-      .catch((error) => {
-        console.error('Failed to load CodeMirror markdown highlighting.', error);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [language, markdownExtensionFactory]);
 
   const extensions = useMemo(() => {
-    const extensionFactory =
-      language === 'markdown' ? markdownExtensionFactory : LANGUAGE_EXTENSIONS[language];
+    const extensionFactory = LANGUAGE_EXTENSIONS[language];
     return extensionFactory ? [extensionFactory()] : [];
-  }, [language, markdownExtensionFactory]);
+  }, [language]);
 
   // ~20px per row is a close-enough match to Ant's TextArea sizing so editors
   // don't jump visibly when call sites migrate from `rows={14}` textareas.

--- a/apps/agor-ui/vite.config.ts
+++ b/apps/agor-ui/vite.config.ts
@@ -49,6 +49,12 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    // Guard against @codemirror/state being duplicated across async chunks.
+    // manualChunks forces CM6 packages into the 'editor' chunk, but a nested
+    // dynamic import() inside that chunk can still cause Rollup to emit a
+    // second copy of @codemirror/state (breaking instanceof checks). Dedupe
+    // pins all resolutions to the same singleton regardless of chunk layout.
+    dedupe: ['@codemirror/state', '@codemirror/view'],
   },
 
   // Mark Node.js-only packages as external so they're not bundled
@@ -64,7 +70,14 @@ export default defineConfig({
           if (!id.includes('node_modules')) return undefined;
           if (id.includes('@ant-design') || /\/antd\//.test(id)) return 'antd';
           if (id.includes('reactflow')) return 'reactflow';
-          if (id.includes('@uiw/react-codemirror') || id.includes('@codemirror/')) return 'editor';
+          // Keep the entire CM6 + lezer graph together so @codemirror/state
+          // is never split across chunks (lezer packages are CM6 peer deps).
+          if (
+            id.includes('@uiw/react-codemirror') ||
+            id.includes('@codemirror/') ||
+            id.includes('@lezer/')
+          )
+            return 'editor';
           if (id.includes('react-syntax-highlighter')) return 'syntax';
           if (id.includes('emoji-picker-react') || id.includes('emojibase')) return 'emoji';
           if (id.includes('@tsparticles/')) return 'particles';


### PR DESCRIPTION
## Summary

- **Symptom**: Opening the Edit Board Settings modal → Advanced tab (or any first `<CodeEditor>` mount) crashed the React tree with _"Unrecognized extension value in extension set … This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks."_
- **Root cause**: The nested `import('@codemirror/lang-markdown')` inside `CodeEditor.inner.tsx` created a second async chunk boundary. Combined with the `manualChunks` rule in `vite.config.ts` that forces `@codemirror/state` into the `editor` chunk, Rollup emitted a duplicate copy of `@codemirror/state` in the markdown sub-chunk. Two module instances → broken instanceof. Regression introduced in #1577 (lazy-load Phase 2).
- **Fix**:
  1. **`CodeEditor.inner.tsx`**: import `markdown` statically alongside `json`/`yaml`. Remove the `useState`/`useEffect` dynamic-import loader. The markdown `codeLanguages` config (yaml/json syntax highlighting in fenced blocks) is preserved via a module-level factory. All CM6 packages now land in the single `CodeEditor.inner` async chunk, which imports `@codemirror/state` from the `editor` chunk — no duplication.
  2. **`vite.config.ts`**: add `resolve.dedupe: ['@codemirror/state', '@codemirror/view']` as belt-and-suspenders against future regressions; broaden the `editor` manualChunk matcher to include `@lezer/` (CM6 peer deps) so the whole CM6 graph stays together.

## Verification

- Built with `vite build` (bypassing pre-existing TS errors in unrelated files).
- Grepped `dist/assets/*.js` for `"Unrecognized extension value"` — appears in **exactly 1 chunk** (`editor-*.js`). Before this fix it appeared in 2 chunks.
- `CodeEditor.inner-*.js` chunk confirmed to contain **0** copies of the `@codemirror/state` error string — it imports from the `editor` chunk rather than bundling its own copy.
- `pnpm --filter agor-ui lint` passes clean (biome, 575 files, no fixes applied).
- No new TypeScript errors in CodeEditor files.

## Test plan

- [ ] Open Edit Board Settings → Advanced tab — YAML editor should render without error-boundary crash
- [ ] Open any other `<CodeEditor language="markdown">` surface — markdown highlighting should work normally
- [ ] Confirm no chunk duplication: `grep -l "Unrecognized extension value" dist/assets/*.js` returns exactly 1 file after a production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)