### PR TITLE
feat(agor-ui): eject session from sidebar onto board canvas

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -35,9 +35,9 @@ import { useRegisterBoardSwitcher } from '../../contexts/CanvasNavigationContext
 import type { NewSessionConfig, SessionCreationResult } from '../../domain/sessionCreation';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useBoardTitle } from '../../hooks/useBoardTitle';
+import { useEjectedSessions } from '../../hooks/useEjectedSessions';
 import { useEventStream } from '../../hooks/useEventStream';
 import { useFaviconStatus } from '../../hooks/useFaviconStatus';
-import { useEjectedSessions } from '../../hooks/useEjectedSessions';
 import { findFrameworkRepo } from '../../hooks/useFrameworkRepo';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useRecentBoards } from '../../hooks/useRecentBoards';
@@ -431,8 +431,13 @@ export const App: React.FC<AppProps> = ({
 
   // Ejected session positions — stored in localStorage per user+board. Sessions in
   // this map render as interactive canvas nodes instead of opening in the sidebar.
-  const { ejectedSessions, ejectSession, updateEjectedPosition, redockSession, closeEjectedSession } =
-    useEjectedSessions(user?.user_id, currentBoardId);
+  const {
+    ejectedSessions,
+    ejectSession,
+    updateEjectedPosition,
+    redockSession,
+    closeEjectedSession,
+  } = useEjectedSessions(user?.user_id, currentBoardId);
 
   // Ref so handleSessionClick (a stable useCallback) can read ejectedSessions
   // without being included in its dependency array and breaking referential stability.
@@ -1794,6 +1799,11 @@ export const App: React.FC<AppProps> = ({
                               open={!!effectiveSelectedSessionId}
                               onClose={handleCloseSessionPanel}
                               uploadPolicy={uploadPolicy}
+                              onEject={
+                                effectiveSelectedSessionId
+                                  ? () => handleEjectSession(effectiveSelectedSessionId)
+                                  : undefined
+                              }
                             />
                           </div>
                         </Flex>
@@ -1809,11 +1819,6 @@ export const App: React.FC<AppProps> = ({
                             setNewSessionBranchId(pendingToolChoiceBranchId);
                             setPendingToolChoiceBranchId(null);
                           }}
-                          onEject={
-                            effectiveSelectedSessionId
-                              ? () => handleEjectSession(effectiveSelectedSessionId)
-                              : undefined
-                          }
                         />
                       ) : (
                         <EventStreamPanel

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -37,6 +37,7 @@ import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useBoardTitle } from '../../hooks/useBoardTitle';
 import { useEventStream } from '../../hooks/useEventStream';
 import { useFaviconStatus } from '../../hooks/useFaviconStatus';
+import { useEjectedSessions } from '../../hooks/useEjectedSessions';
 import { findFrameworkRepo } from '../../hooks/useFrameworkRepo';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useRecentBoards } from '../../hooks/useRecentBoards';
@@ -422,6 +423,26 @@ export const App: React.FC<AppProps> = ({
   const activeUrlTargetArtifactId =
     activeUrlTarget?.kind === 'artifact' ? activeUrlTarget.id : null;
 
+  // currentBoardId must be declared before useEjectedSessions (which is scoped per board)
+  // and before effectiveSelectedSessionId (which excludes ejected sessions).
+  // Initialize current board only from explicit route/bootstrap state. Home (`/`)
+  // is a valid no-board route, so do not auto-select localStorage/first board.
+  const [currentBoardId, setCurrentBoardIdInternal] = useState(() => initialBoardId || '');
+
+  // Ejected session positions — stored in localStorage per user+board. Sessions in
+  // this map render as interactive canvas nodes instead of opening in the sidebar.
+  const { ejectedSessions, ejectSession, updateEjectedPosition, redockSession, closeEjectedSession } =
+    useEjectedSessions(user?.user_id, currentBoardId);
+
+  // Ref so handleSessionClick (a stable useCallback) can read ejectedSessions
+  // without being included in its dependency array and breaking referential stability.
+  const ejectedSessionsRef = useRef(ejectedSessions);
+  ejectedSessionsRef.current = ejectedSessions;
+
+  // Ref so eject/redock handlers can read currentBoardId without capturing a stale value.
+  const currentBoardIdRef = useRef(currentBoardId);
+  currentBoardIdRef.current = currentBoardId;
+
   // Synchronously derive the effective session selection. When a session is
   // archived/deleted, it vanishes from sessionById. Without this, there is a
   // two-phase unmount: first SessionPanel renders null (session gone but
@@ -436,8 +457,14 @@ export const App: React.FC<AppProps> = ({
   const selectedSessionExists = useAgorStore(
     useMemo(() => makeSessionExistsSelector(selectedSessionId), [selectedSessionId])
   );
+  // Ejected sessions are excluded so they stay on the canvas rather than
+  // opening in the sidebar drawer when navigated to via URL.
   const effectiveSelectedSessionId =
-    !isRootHomePath && !pendingHomeNavigation && selectedSessionId && selectedSessionExists
+    !isRootHomePath &&
+    !pendingHomeNavigation &&
+    selectedSessionId &&
+    selectedSessionExists &&
+    !ejectedSessions[selectedSessionId]
       ? selectedSessionId
       : null;
 
@@ -510,10 +537,6 @@ export const App: React.FC<AppProps> = ({
 
   // Handle external user settings modal control (e.g., from onboarding "Configure API Keys")
   const effectiveUserSettingsOpen = userSettingsOpen || !!openUserSettings;
-
-  // Initialize current board only from explicit route/bootstrap state. Home (`/`)
-  // is a valid no-board route, so do not auto-select localStorage/first board.
-  const [currentBoardId, setCurrentBoardIdInternal] = useState(() => initialBoardId || '');
 
   // Initialize comments panel state from localStorage (collapsed by default)
   const [commentsPanelCollapsed, setCommentsPanelCollapsed] = useLocalStorage<boolean>(
@@ -866,6 +889,37 @@ export const App: React.FC<AppProps> = ({
     if (currentBoardId) navigation.goToBoard(currentBoardId);
   }, [navigation, currentBoardId]);
 
+  // Eject a session from the sidebar drawer onto the board canvas as a live node.
+  // Position is derived from the viewport center plus a small offset per existing ejected count.
+  const handleEjectSession = useCallback(
+    (sessionId: string) => {
+      const center = sessionCanvasRef.current?.getViewportCenter() ?? { x: 200, y: 100 };
+      const ejectedCount = Object.keys(ejectedSessionsRef.current).length;
+      const offset = ejectedCount * 40;
+      ejectSession(sessionId, { x: center.x - 300 + offset, y: center.y - 350 + offset });
+      // Close the sidebar drawer — the session now lives on the canvas.
+      if (currentBoardIdRef.current) navigation.goToBoard(currentBoardIdRef.current);
+    },
+    [ejectSession, navigation]
+  );
+
+  // Move an ejected session back into the sidebar drawer.
+  const handleRedockSession = useCallback(
+    (sessionId: string) => {
+      redockSession(sessionId);
+      navigation.goToSession(sessionId);
+    },
+    [redockSession, navigation]
+  );
+
+  // Close an ejected session without re-docking. Next click opens it in the drawer.
+  const handleCloseEjectedSession = useCallback(
+    (sessionId: string) => {
+      closeEjectedSession(sessionId);
+    },
+    [closeEjectedSession]
+  );
+
   const handleCloseTerminal = () => {
     setTerminalOpen(false);
     setTerminalCommands([]);
@@ -1121,6 +1175,10 @@ export const App: React.FC<AppProps> = ({
 
   const handleSessionClick = useCallback(
     (sessionId: string) => {
+      // If the session is already ejected onto the canvas, don't also open it in the drawer.
+      // The ejected node is its own live panel.
+      if (ejectedSessionsRef.current[sessionId]) return;
+
       // Call-time store read: the shell no longer subscribes to the session /
       // branch maps, so any render-time snapshot here would be stale. The
       // handler's identity stays stable across socket churn — important
@@ -1677,6 +1735,10 @@ export const App: React.FC<AppProps> = ({
                         onOpenCommentsPanel={handleOpenCommentsPanel}
                         onCommentHover={setHoveredCommentId}
                         onCommentSelect={handleCommentSelect}
+                        ejectedSessions={ejectedSessions}
+                        onEjectSessionRedock={handleRedockSession}
+                        onEjectSessionClose={handleCloseEjectedSession}
+                        onUpdateEjectedPosition={updateEjectedPosition}
                       />
                     )}
                     {!isHomeSurface && (
@@ -1747,6 +1809,11 @@ export const App: React.FC<AppProps> = ({
                             setNewSessionBranchId(pendingToolChoiceBranchId);
                             setPendingToolChoiceBranchId(null);
                           }}
+                          onEject={
+                            effectiveSelectedSessionId
+                              ? () => handleEjectSession(effectiveSelectedSessionId)
+                              : undefined
+                          }
                         />
                       ) : (
                         <EventStreamPanel

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1613,7 +1613,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       if (isDraggingRef.current) return;
 
       setNodes((currentNodes) => {
-        const { zones, markdown, branches, cards, apps, ejected } = partitionNodesByType(currentNodes);
+        const { zones, markdown, branches, cards, apps, ejected } =
+          partitionNodesByType(currentNodes);
 
         // Comment parents are branches or zones; branches take precedence on id
         // collision (insertion order below makes them overwrite).
@@ -1666,7 +1667,15 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           return newNode;
         });
 
-        return applyZOrder(zones, markdown, branches, cards, commentsWithLocalPositions, apps, ejected);
+        return applyZOrder(
+          zones,
+          markdown,
+          branches,
+          cards,
+          commentsWithLocalPositions,
+          apps,
+          ejected
+        );
       });
     }, [commentNodes, setNodes, applyZOrder, partitionNodesByType]);
 

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -87,6 +87,7 @@ import SessionCard from '../SessionCard';
 import { AppNode } from './canvas/AppNodeLazy';
 import { ArtifactNode } from './canvas/ArtifactNodeLazy';
 import { CommentNode, ZoneNode } from './canvas/BoardObjectNodes';
+import EjectedSessionNode, { type EjectedSessionNodeData } from './canvas/EjectedSessionNode';
 import { MarkdownNode } from './canvas/MarkdownNode';
 import { RemoteCursorLayer, type StaticRemoteCursor } from './canvas/RemoteCursorLayer';
 import { useBoardObjects } from './canvas/useBoardObjects';
@@ -152,6 +153,18 @@ interface SessionCanvasProps {
   staticCursorScale?: number;
   /** Optional host-controlled height for embedded/demo canvases. Defaults to full viewport. */
   height?: React.CSSProperties['height'];
+  /**
+   * Map of ejected session IDs → canvas positions. Sessions in this map are
+   * rendered as interactive `ejectedSessionNode` nodes instead of in the sidebar.
+   * Persisted in localStorage by `useEjectedSessions` in App.tsx.
+   */
+  ejectedSessions?: Record<string, { x: number; y: number }>;
+  /** Called when the user re-docks an ejected session back to the sidebar. */
+  onEjectSessionRedock?: (sessionId: string) => void;
+  /** Called when the user closes an ejected session without re-docking. */
+  onEjectSessionClose?: (sessionId: string) => void;
+  /** Called when an ejected session node is dragged to persist its new position. */
+  onUpdateEjectedPosition?: (sessionId: string, position: { x: number; y: number }) => void;
 }
 
 export interface SessionCanvasRef {
@@ -354,6 +367,7 @@ const nodeTypes = {
   markdown: MarkdownNode,
   appNode: AppNode,
   artifactNode: ArtifactNode,
+  ejectedSessionNode: EjectedSessionNode,
 };
 
 const EMPTY_BOARD_ENTITY_OBJECTS: BoardEntityObject[] = Object.freeze(
@@ -452,6 +466,10 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       staticCursors,
       staticCursorScale,
       height = '100vh',
+      ejectedSessions = {},
+      onEjectSessionRedock,
+      onEjectSessionClose,
+      onUpdateEjectedPosition,
     }: SessionCanvasProps,
     ref
   ) => {
@@ -1040,6 +1058,27 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       warnInvalidZoneRef,
     ]);
 
+    // Build ejected session nodes from the ejectedSessions map passed in from App.tsx.
+    // These render as full interactive panels on the canvas (no backend persistence needed).
+    const ejectedSessionNodes: Node[] = useMemo(() => {
+      return Object.entries(ejectedSessions).map(([sessionId, position]) => ({
+        id: `ejected-${sessionId}`,
+        type: 'ejectedSessionNode',
+        dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
+        position,
+        zIndex: 600, // Above branches (500), below comments (1000)
+        width: 600,
+        height: 700,
+        data: {
+          sessionId,
+          client,
+          currentUserId,
+          onRedock: onEjectSessionRedock ?? (() => {}),
+          onClose: onEjectSessionClose ?? (() => {}),
+        } satisfies EjectedSessionNodeData,
+      }));
+    }, [ejectedSessions, client, currentUserId, onEjectSessionRedock, onEjectSessionClose]);
+
     // No edges needed for branch-centric boards
     // (Session genealogy is visualized within BranchCard, not as canvas edges)
     const initialEdges: Edge[] = useMemo(() => [], []);
@@ -1417,6 +1456,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         if (node.type === 'comment') return token.colorText;
         if (node.type === 'markdown') return `${token.colorText}B3`;
         if (node.type === 'zone') return `${token.colorText}66`;
+        if (node.type === 'ejectedSessionNode') return token.colorPrimary;
         if (node.type === 'cardNode') {
           const cardData = node.data as CardNodeData;
           return cardData.card?.effective_color || token.colorPrimaryBorder;
@@ -1452,6 +1492,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       const cards: Node[] = [];
       const apps: Node[] = [];
       const comments: Node[] = [];
+      const ejected: Node[] = [];
       for (const node of nodes) {
         switch (node.type) {
           case 'zone':
@@ -1473,13 +1514,16 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           case 'comment':
             comments.push(node);
             break;
+          case 'ejectedSessionNode':
+            ejected.push(node);
+            break;
         }
       }
-      return { zones, markdown, branches, cards, apps, comments };
+      return { zones, markdown, branches, cards, apps, comments, ejected };
     }, []);
 
     // Helper: Apply consistent z-ordering to nodes
-    // Z-order: zones < branches/cards < apps/artifacts < markdown < comments
+    // Z-order: zones < branches/cards < apps/artifacts < markdown < ejected < comments
     const applyZOrder = useCallback(
       (
         zones: Node[],
@@ -1487,10 +1531,11 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         branches: Node[],
         cards: Node[],
         comments: Node[],
-        apps: Node[] = []
+        apps: Node[] = [],
+        ejected: Node[] = []
       ) => {
         return sanitizeOrphanedNodeParents(
-          [...zones, ...branches, ...cards, ...apps, ...markdown, ...comments],
+          [...zones, ...branches, ...cards, ...apps, ...markdown, ...ejected, ...comments],
           { onOrphan: onOrphanedParent }
         );
       },
@@ -1510,7 +1555,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       const boardObjectNodes = getBoardObjectNodes();
 
       setNodes((currentNodes) => {
-        const { comments } = partitionNodesByType(currentNodes);
+        const { comments, ejected } = partitionNodesByType(currentNodes);
         const currentNodesById = new Map(currentNodes.map((n) => [n.id, n]));
 
         const zones = boardObjectNodes
@@ -1551,7 +1596,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         const updatedBranches = applyLocalPositions(initialNodes, currentNodesById, zones);
         const updatedCards = applyLocalPositions(cardNodes, currentNodesById, zones);
 
-        return applyZOrder(zones, markdown, updatedBranches, updatedCards, comments, apps);
+        return applyZOrder(zones, markdown, updatedBranches, updatedCards, comments, apps, ejected);
       });
     }, [
       initialNodes,
@@ -1568,7 +1613,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       if (isDraggingRef.current) return;
 
       setNodes((currentNodes) => {
-        const { zones, markdown, branches, cards, apps } = partitionNodesByType(currentNodes);
+        const { zones, markdown, branches, cards, apps, ejected } = partitionNodesByType(currentNodes);
 
         // Comment parents are branches or zones; branches take precedence on id
         // collision (insertion order below makes them overwrite).
@@ -1621,9 +1666,38 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           return newNode;
         });
 
-        return applyZOrder(zones, markdown, branches, cards, commentsWithLocalPositions, apps);
+        return applyZOrder(zones, markdown, branches, cards, commentsWithLocalPositions, apps, ejected);
       });
     }, [commentNodes, setNodes, applyZOrder, partitionNodesByType]);
+
+    // Sync EJECTED SESSION nodes separately. Position is owned by localStorage
+    // (via ejectedSessionNodes prop); apply localPositionsRef overrides to prevent
+    // flicker while a drag is in-flight waiting for the localStorage write to round-trip.
+    useEffect(() => {
+      if (isDraggingRef.current) return;
+
+      setNodes((currentNodes) => {
+        const { zones, markdown, branches, cards, apps, comments } =
+          partitionNodesByType(currentNodes);
+
+        const updatedEjected = ejectedSessionNodes.map((newNode) => {
+          const localPosition = localPositionsRef.current[newNode.id];
+          if (localPosition) {
+            const positionConfirmed =
+              Math.abs(localPosition.x - newNode.position.x) <= 1 &&
+              Math.abs(localPosition.y - newNode.position.y) <= 1;
+            if (positionConfirmed) {
+              delete localPositionsRef.current[newNode.id];
+              return newNode;
+            }
+            return { ...newNode, position: localPosition };
+          }
+          return newNode;
+        });
+
+        return applyZOrder(zones, markdown, branches, cards, comments, apps, updatedEjected);
+      });
+    }, [ejectedSessionNodes, setNodes, applyZOrder, partitionNodesByType]);
 
     // Sync edges
     useEffect(() => {
@@ -1799,10 +1873,21 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // Handle node drag end - persist layout to board (debounced)
     const handleNodeDragStop: NodeDragHandler = useCallback(
       (_event, node) => {
-        if (!board || !client || !reactFlowInstanceRef.current) return;
-
         // Reset dragging flag immediately to allow node sync effects to run
         isDraggingRef.current = false;
+
+        // Ejected session nodes are client-side only — persist to localStorage and return.
+        // No board_object update needed.
+        if (node.type === 'ejectedSessionNode') {
+          const absolutePos = node.positionAbsolute || node.position;
+          localPositionsRef.current[node.id] = { x: absolutePos.x, y: absolutePos.y };
+          // Extract sessionId from node id (format: `ejected-<sessionId>`)
+          const sessionId = node.id.replace(/^ejected-/, '');
+          onUpdateEjectedPosition?.(sessionId, { x: absolutePos.x, y: absolutePos.y });
+          return;
+        }
+
+        if (!board || !client || !reactFlowInstanceRef.current) return;
 
         // Track final position locally
         // IMPORTANT: Store ABSOLUTE position, not relative!
@@ -2157,6 +2242,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         boardObjectByCard,
         commentById,
         setNodes,
+        onUpdateEjectedPosition,
       ]
     );
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/EjectedSessionNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/EjectedSessionNode.tsx
@@ -1,0 +1,145 @@
+import type { AgorClient } from '@agor-live/client';
+import { CloseOutlined, ShrinkOutlined } from '@ant-design/icons';
+import { Button, Space, Tooltip, theme } from 'antd';
+import React from 'react';
+import { useAgorStore } from '../../../store/agorStore';
+import {
+  selectBranchById,
+  selectSessionById,
+  selectSessionMcpServerIds,
+} from '../../../store/selectors';
+import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
+import {
+  REACT_FLOW_DRAG_HANDLE_CLASS,
+  REACT_FLOW_NO_DRAG_CLASS,
+} from '../../../utils/reactFlowDragClasses';
+import SessionPanel from '../../SessionPanel/SessionPanel';
+import { ToolIcon } from '../../ToolIcon';
+
+const EMPTY_STRING_ARRAY: string[] = Object.freeze([] as string[]) as string[];
+
+export interface EjectedSessionNodeData {
+  sessionId: string;
+  client: AgorClient | null;
+  currentUserId?: string;
+  /** Called when the user clicks "Re-dock" — removes from canvas and opens in sidebar. */
+  onRedock: (sessionId: string) => void;
+  /** Called when the user clicks "Close" — removes from canvas; next click opens in sidebar. */
+  onClose: (sessionId: string) => void;
+}
+
+/**
+ * ReactFlow node that renders a full interactive session panel on the board canvas.
+ *
+ * Drag handle: the top strip (className="drag-handle").
+ * Content area: SessionPanel with `isEjected={true}`, which adds drag handle class
+ * to the panel header and stop-wheel propagation to the body.
+ *
+ * All realtime subscriptions, draft persistence, and prompt input are handled
+ * by SessionPanel itself — identical to the sidebar variant.
+ */
+const EjectedSessionNode: React.FC<{ data: EjectedSessionNodeData }> = ({ data }) => {
+  const { token } = theme.useToken();
+
+  // Read live data directly from the store — no prop drilling needed.
+  const sessionById = useAgorStore(selectSessionById);
+  const branchById = useAgorStore(selectBranchById);
+  const sessionMcpServerIds = useAgorStore(selectSessionMcpServerIds);
+
+  const session = sessionById.get(data.sessionId) ?? null;
+  const branch = session ? (branchById.get(session.branch_id) ?? null) : null;
+  const mcpServerIds = sessionMcpServerIds.get(data.sessionId) ?? EMPTY_STRING_ARRAY;
+
+  // Session was deleted/archived while ejected — render nothing.
+  if (!session) return null;
+
+  return (
+    <div
+      style={{
+        width: 600,
+        height: 700,
+        display: 'flex',
+        flexDirection: 'column',
+        background: token.colorBgElevated,
+        border: `2px solid ${token.colorPrimaryBorder}`,
+        borderRadius: token.borderRadiusLG,
+        boxShadow: token.boxShadowSecondary,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Drag-handle title bar — dragging this moves the node */}
+      <div
+        className={REACT_FLOW_DRAG_HANDLE_CLASS}
+        style={{
+          flexShrink: 0,
+          padding: '4px 8px',
+          background: token.colorPrimaryBg,
+          borderBottom: `1px solid ${token.colorPrimaryBorder}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: 'grab',
+          userSelect: 'none',
+          minWidth: 0,
+        }}
+      >
+        <Space size={6} style={{ minWidth: 0, flex: 1, overflow: 'hidden' }}>
+          <ToolIcon tool={session.agentic_tool} size={14} />
+          <span
+            style={{
+              fontSize: 12,
+              color: token.colorTextSecondary,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+          </span>
+        </Space>
+        {/* Buttons must not initiate drag (nodrag class) */}
+        <Space size={2} className={REACT_FLOW_NO_DRAG_CLASS}>
+          <Tooltip title="Re-dock to sidebar" mouseEnterDelay={0.5}>
+            <Button
+              type="text"
+              size="small"
+              icon={<ShrinkOutlined />}
+              onClick={() => data.onRedock(data.sessionId)}
+              style={{ color: token.colorTextSecondary }}
+            />
+          </Tooltip>
+          <Tooltip title="Close" mouseEnterDelay={0.5}>
+            <Button
+              type="text"
+              size="small"
+              icon={<CloseOutlined />}
+              onClick={() => data.onClose(data.sessionId)}
+              style={{ color: token.colorTextSecondary }}
+            />
+          </Tooltip>
+        </Space>
+      </div>
+
+      {/* Full session panel — same component as the sidebar, just sized differently */}
+      <div
+        className={REACT_FLOW_NO_DRAG_CLASS}
+        style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}
+        // Prevent canvas wheel-zoom from triggering while scrolling conversation
+        onWheel={(e) => e.stopPropagation()}
+      >
+        <SessionPanel
+          client={data.client}
+          session={session}
+          branch={branch}
+          currentUserId={data.currentUserId}
+          sessionMcpServerIds={mcpServerIds}
+          open={true}
+          isEjected={true}
+          onClose={() => data.onRedock(data.sessionId)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(EjectedSessionNode);

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/EjectedSessionNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/EjectedSessionNode.tsx
@@ -8,11 +8,11 @@ import {
   selectSessionById,
   selectSessionMcpServerIds,
 } from '../../../store/selectors';
-import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
   REACT_FLOW_NO_DRAG_CLASS,
 } from '../../../utils/reactFlowDragClasses';
+import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
 import SessionPanel from '../../SessionPanel/SessionPanel';
 import { ToolIcon } from '../../ToolIcon';
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -28,10 +28,12 @@ import {
   DownOutlined,
   EditOutlined,
   EllipsisOutlined,
+  ExpandAltOutlined,
   InboxOutlined,
   RobotOutlined,
   SearchOutlined,
   SettingOutlined,
+  ShrinkOutlined,
   UpOutlined,
 } from '@ant-design/icons';
 import type { InputRef, MenuProps } from 'antd';
@@ -75,6 +77,10 @@ import {
   type MarketplacePromptSuggestionState,
   subscribeMarketplacePromptState,
 } from '../../utils/marketplaceOAuthPrompt';
+import {
+  REACT_FLOW_DRAG_HANDLE_CLASS,
+  REACT_FLOW_NO_DRAG_CLASS,
+} from '../../utils/reactFlowDragClasses';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { deletePromptDraft, getPromptDraft, savePromptDraft } from '../../utils/promptDrafts';
@@ -309,6 +315,20 @@ export interface SessionPanelProps {
   open: boolean;
   onClose: () => void;
   uploadPolicy?: import('@agor/core/types').UploadIngressPolicy;
+  /**
+   * When provided, an "eject to board" button appears in the header.
+   * Only used in sidebar/drawer mode (not when already ejected).
+   */
+  onEject?: () => void;
+  /**
+   * When true, the panel is rendered inside a ReactFlow canvas node.
+   * - The header gets the drag-handle class so the node can be dragged by it.
+   * - The body gets wheel-stop propagation so scrolling the conversation
+   *   doesn't accidentally zoom the canvas.
+   * - The left border is suppressed (the node container provides its own border).
+   * - `onClose` becomes "Re-dock to sidebar" in the header button.
+   */
+  isEjected?: boolean;
 }
 
 const SessionPanel: React.FC<SessionPanelProps> = ({
@@ -320,6 +340,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   open,
   onClose,
   uploadPolicy,
+  onEject,
+  isEjected = false,
 }) => {
   const { token } = theme.useToken();
   const { modal } = App.useApp();
@@ -1660,16 +1682,20 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         display: open ? 'flex' : 'none',
         flexDirection: 'column',
         background: token.colorBgElevated,
-        borderLeft: `1px solid ${token.colorBorder}`,
+        // Suppress the left border when ejected — the node container provides its own.
+        borderLeft: isEjected ? 'none' : `1px solid ${token.colorBorder}`,
       }}
     >
-      {/* Header */}
+      {/* Header — becomes drag-handle when ejected so the user can move the canvas node */}
       <div
+        className={isEjected ? REACT_FLOW_DRAG_HANDLE_CLASS : undefined}
         style={{
           flexShrink: 0,
           padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px`,
           borderBottom: `1px solid ${token.colorBorder}`,
           background: token.colorBgContainer,
+          cursor: isEjected ? 'grab' : undefined,
+          userSelect: isEjected ? 'none' : undefined,
         }}
       >
         {/* Row 1: icon + title + badge + actions, center-aligned */}
@@ -1752,7 +1778,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               )}
             </div>
           </div>
-          <Space size={4}>
+          <Space size={4} className={isEjected ? REACT_FLOW_NO_DRAG_CLASS : undefined}>
             <SessionAttachmentsDropdown items={attachmentItems} />
             <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
               <Tooltip title="More actions">
@@ -1767,14 +1793,35 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                 onClick={openSearch}
               />
             </Tooltip>
-            <Tooltip title="Close Panel">
-              <Button
-                type="text"
-                icon={<CloseOutlined />}
-                onClick={onClose}
-                style={{ marginLeft: token.sizeUnit }}
-              />
-            </Tooltip>
+            {onEject && !isEjected && (
+              <Tooltip title="Pop out to board">
+                <Button
+                  type="text"
+                  icon={<ExpandAltOutlined />}
+                  onClick={onEject}
+                  style={{ marginLeft: token.sizeUnit }}
+                />
+              </Tooltip>
+            )}
+            {isEjected ? (
+              <Tooltip title="Re-dock to sidebar">
+                <Button
+                  type="text"
+                  icon={<ShrinkOutlined />}
+                  onClick={onClose}
+                  style={{ marginLeft: token.sizeUnit }}
+                />
+              </Tooltip>
+            ) : (
+              <Tooltip title="Close Panel">
+                <Button
+                  type="text"
+                  icon={<CloseOutlined />}
+                  onClick={onClose}
+                  style={{ marginLeft: token.sizeUnit }}
+                />
+              </Tooltip>
+            )}
           </Space>
         </div>
         {/* Row 2: search bar — always in DOM, animates in/out */}
@@ -1845,6 +1892,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       {/* Body - Scrollable content */}
       <div
         ref={bodyRef}
+        className={isEjected ? REACT_FLOW_NO_DRAG_CLASS : undefined}
         style={{
           flex: 1,
           overflow: 'hidden',
@@ -1853,6 +1901,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px 0`,
           position: 'relative',
         }}
+        // Prevent canvas wheel-zoom while scrolling the conversation or typing
+        onWheel={isEjected ? (e) => e.stopPropagation() : undefined}
       >
         {searchOpen && query.trim() && totalMatches === 0 && !searchPending && (
           <div

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -77,13 +77,13 @@ import {
   type MarketplacePromptSuggestionState,
   subscribeMarketplacePromptState,
 } from '../../utils/marketplaceOAuthPrompt';
+import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
+import { useThemedMessage } from '../../utils/message';
+import { deletePromptDraft, getPromptDraft, savePromptDraft } from '../../utils/promptDrafts';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
   REACT_FLOW_NO_DRAG_CLASS,
 } from '../../utils/reactFlowDragClasses';
-import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
-import { useThemedMessage } from '../../utils/message';
-import { deletePromptDraft, getPromptDraft, savePromptDraft } from '../../utils/promptDrafts';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AgentSelectionGrid } from '../AgentSelectionGrid/AgentSelectionGrid';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';

--- a/apps/agor-ui/src/hooks/useEjectedSessions.ts
+++ b/apps/agor-ui/src/hooks/useEjectedSessions.ts
@@ -1,0 +1,82 @@
+import { useCallback } from 'react';
+import { useLocalStorage } from './useLocalStorage';
+
+export type EjectedSessionPositions = Record<string, { x: number; y: number }>;
+
+/**
+ * Persists ejected session canvas positions in localStorage, scoped per user+board.
+ *
+ * Ejected sessions are removed from the right-panel drawer and rendered as
+ * full interactive nodes on the board canvas instead. Each session maintains
+ * its own realtime subscription, draft persistence, and prompt input.
+ *
+ * Key: `agor:ejected:<userId>:<boardId>` — scoped so switching boards shows
+ * only the ejected sessions belonging to that board.
+ */
+export function useEjectedSessions(
+  userId: string | undefined,
+  boardId: string
+): {
+  ejectedSessions: EjectedSessionPositions;
+  ejectSession: (sessionId: string, position: { x: number; y: number }) => void;
+  updateEjectedPosition: (sessionId: string, position: { x: number; y: number }) => void;
+  redockSession: (sessionId: string) => void;
+  closeEjectedSession: (sessionId: string) => void;
+} {
+  const storageKey =
+    userId && boardId ? `agor:ejected:${userId}:${boardId}` : 'agor:ejected:anon:';
+
+  const [ejectedSessions, setEjectedSessions] = useLocalStorage<EjectedSessionPositions>(
+    storageKey,
+    {}
+  );
+
+  const ejectSession = useCallback(
+    (sessionId: string, position: { x: number; y: number }) => {
+      setEjectedSessions((prev) => ({ ...prev, [sessionId]: position }));
+    },
+    [setEjectedSessions]
+  );
+
+  const updateEjectedPosition = useCallback(
+    (sessionId: string, position: { x: number; y: number }) => {
+      setEjectedSessions((prev) => {
+        if (!prev[sessionId]) return prev;
+        return { ...prev, [sessionId]: position };
+      });
+    },
+    [setEjectedSessions]
+  );
+
+  /** Remove from ejected set so the caller can open the session in the drawer. */
+  const redockSession = useCallback(
+    (sessionId: string) => {
+      setEjectedSessions((prev) => {
+        const next = { ...prev };
+        delete next[sessionId];
+        return next;
+      });
+    },
+    [setEjectedSessions]
+  );
+
+  /** Close without re-docking: removes from canvas; next click opens in drawer. */
+  const closeEjectedSession = useCallback(
+    (sessionId: string) => {
+      setEjectedSessions((prev) => {
+        const next = { ...prev };
+        delete next[sessionId];
+        return next;
+      });
+    },
+    [setEjectedSessions]
+  );
+
+  return {
+    ejectedSessions,
+    ejectSession,
+    updateEjectedPosition,
+    redockSession,
+    closeEjectedSession,
+  };
+}

--- a/apps/agor-ui/src/hooks/useEjectedSessions.ts
+++ b/apps/agor-ui/src/hooks/useEjectedSessions.ts
@@ -23,8 +23,7 @@ export function useEjectedSessions(
   redockSession: (sessionId: string) => void;
   closeEjectedSession: (sessionId: string) => void;
 } {
-  const storageKey =
-    userId && boardId ? `agor:ejected:${userId}:${boardId}` : 'agor:ejected:anon:';
+  const storageKey = userId && boardId ? `agor:ejected:${userId}:${boardId}` : 'agor:ejected:anon:';
 
   const [ejectedSessions, setEjectedSessions] = useLocalStorage<EjectedSessionPositions>(
     storageKey,


### PR DESCRIPTION
## Summary

Requested by Evan (Agor admin). Implements the "session eject" feature: a button in the SessionPanel drawer header that pops an open session out onto the board canvas as a live, interactive node.

- **Eject button (↗)** in the SessionPanel header moves the session from the sidebar drawer onto the board canvas as a full-size interactive card
- **Ejected card** shows the identical session UI (transcript + prompt input + model footer) — `SessionPanel` is reused with `isEjected={true}`, not forked
- **Re-dock button** moves the card back to the sidebar; **Close button** dismisses the canvas node without re-docking (next click opens in the sidebar as usual)
- **Multiple sessions** can be ejected simultaneously; each has its own live realtime subscription, draft persistence, and prompt input
- **Position persists** across page refresh via localStorage, scoped per user+board (`agor:ejected:<userId>:<boardId>`)
- Ejected nodes integrate with the existing ReactFlow canvas: draggable via the title-bar handle, wheel-scroll protected inside the body, visible in the minimap

## Architecture decisions

**Client-side persistence (localStorage) for v1** — no DB migration, no backend changes, ships immediately. Each user's ejected positions are stored locally and survive page refreshes. Multi-device sync or admin-visible ejected state would require a `board_objects` column or separate table; that can be layered on later when the demand is clear.

**Reuse `SessionPanel`, don't fork it** — added two props (`onEject?: () => void`, `isEjected?: boolean`) that toggle drag-handle CSS and button layout. The underlying `SessionPanelContent`, `PromptInput`, and `SessionFooter` are completely shared.

**No double-mount** — `effectiveSelectedSessionId` excludes ejected session IDs so the sidebar never opens for an already-ejected session; `handleSessionClick` has a ref-based early-return guard for the same reason.

**Third sync effect for ejected nodes** — matches the pattern of the existing board-objects and comment sync effects, preserving ejected nodes through WebSocket churn. `handleNodeDragStop` detects `ejectedSessionNode` type and persists to localStorage instead of `board-objects`.

## Changed files

| File | Change |
|------|--------|
| `apps/agor-ui/src/hooks/useEjectedSessions.ts` | New hook — localStorage-backed positions, functional updater form |
| `apps/agor-ui/src/components/SessionCanvas/canvas/EjectedSessionNode.tsx` | New ReactFlow node component wrapping `SessionPanel` |
| `apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx` | `onEject` + `isEjected` props; drag-handle/nodrag CSS; wheel guard |
| `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx` | `ejectedSessionNode` type, third sync effect, drag-stop early return, minimap color |
| `apps/agor-ui/src/components/App/App.tsx` | Hook wiring, eject/redock/close handlers, `onEject` → SessionPanel, props → SessionCanvas |

## Follow-ups / punted

- **Server-side persistence** — multi-device sync; store positions in `board_objects` with a new `ejected_session_id` FK
- **Resize handle** — ejected nodes are fixed 600×700; could allow per-session resize
- **Keyboard shortcut** — `E` to eject/re-dock the active session
- **Scroll-into-view** when re-docking (canvas recenter to the session's branch card)

## Test plan

- [ ] Open a session in the sidebar drawer → click ↗ "Pop out to board" → session disappears from drawer, appears as a node on the canvas at viewport center
- [ ] Drag the ejected node → position is saved to localStorage → refresh page → node is in the same position
- [ ] Eject a second session simultaneously → both nodes are live with independent prompts
- [ ] Click "Re-dock" on an ejected node → node disappears, session re-opens in the sidebar drawer
- [ ] Click "Close" on an ejected node → node disappears, next click on that session opens it in the drawer
- [ ] Click on a branch card session that is currently ejected → nothing happens (no duplicate in sidebar)
- [ ] Navigate to `/s/<id>/` URL for an ejected session → sidebar stays closed, ejected node stays on canvas
- [ ] Scroll conversation inside ejected node → canvas does NOT zoom
- [ ] Eject session, switch boards, switch back → ejected node is gone (localStorage is per-board)

🤖 Generated with [Claude Code](https://claude.com/claude-code)