### PR TITLE
fix(ui): branch chip in session panel fills available width before truncating

### DIFF
--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -131,6 +131,7 @@ export function BranchHeaderPill({
         </>
       )}
       <span
+        title={branch.name}
         style={{
           fontFamily: token.fontFamilyCode,
           fontSize: token.fontSizeSM,

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -202,7 +202,7 @@ export function BranchHeaderPill({
       ? `${repo.slug} / ${branch.name} · Open branch settings`
       : 'Open branch settings';
   const identityLinkStyle: React.CSSProperties = {
-    display: 'inline-flex',
+    display: 'flex',
     alignItems: 'center',
     gap: 4,
     padding: compact ? '0 6px' : '0 8px',
@@ -228,6 +228,8 @@ export function BranchHeaderPill({
         display: 'flex',
         alignItems: 'stretch',
         cursor: 'default',
+        width: '100%',
+        minWidth: 0,
       }}
     >
       {/* Section 1: Repo + Branch — click opens either the supplied identity URL or the branch modal. */}

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -134,7 +134,8 @@ export function BranchHeaderPill({
         style={{
           fontFamily: token.fontFamilyCode,
           fontSize: token.fontSizeSM,
-          maxWidth: compact ? 220 : 180,
+          flex: 1,
+          minWidth: 0,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
@@ -208,6 +209,8 @@ export function BranchHeaderPill({
     height: PILL_HEIGHT,
     color: 'inherit',
     textDecoration: 'none',
+    flex: 1,
+    minWidth: 0,
   };
   const isInternalIdentityLink = identityLink?.startsWith('/');
 
@@ -221,7 +224,7 @@ export function BranchHeaderPill({
         padding: 0,
         overflow: 'hidden',
         lineHeight: `${PILL_HEIGHT}px`,
-        display: 'inline-flex',
+        display: 'flex',
         alignItems: 'stretch',
         cursor: 'default',
       }}
@@ -251,6 +254,8 @@ export function BranchHeaderPill({
               border: 'none',
               color: 'inherit',
               font: 'inherit',
+              flex: 1,
+              minWidth: 0,
             }}
           >
             {identityContent}
@@ -268,6 +273,7 @@ export function BranchHeaderPill({
             padding: '0 4px',
             height: PILL_HEIGHT,
             borderLeft: `1px solid ${token.colorBorderSecondary}`,
+            flexShrink: 0,
           }}
         >
           {hasConfig ? (
@@ -443,6 +449,7 @@ export function BranchHeaderPill({
           padding: '0 3px',
           height: PILL_HEIGHT,
           borderLeft: `1px solid ${token.colorBorderSecondary}`,
+          flexShrink: 0,
         }}
       >
         <Tooltip title={`Sessions${sessionCount != null ? ` (${sessionCount})` : ''}`}>

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -135,16 +135,18 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             <Space size={8} wrap style={{ flex: 1 }}>
               {/* Unified Branch Pill */}
               {branch && repo && (
-                <BranchHeaderPill
-                  repo={repo}
-                  branch={branch}
-                  onOpenBranch={onOpenBranch}
-                  onStartEnvironment={onStartEnvironment}
-                  onStopEnvironment={onStopEnvironment}
-                  onNukeEnvironment={onNukeEnvironment}
-                  onViewLogs={onViewLogs}
-                  identityLink={sessionPath(session.session_id)}
-                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <BranchHeaderPill
+                    repo={repo}
+                    branch={branch}
+                    onOpenBranch={onOpenBranch}
+                    onStartEnvironment={onStartEnvironment}
+                    onStopEnvironment={onStopEnvironment}
+                    onNukeEnvironment={onNukeEnvironment}
+                    onViewLogs={onViewLogs}
+                    identityLink={sessionPath(session.session_id)}
+                  />
+                </div>
               )}
               {/* Issue and PR Pills */}
               {branch?.issue_url && (


### PR DESCRIPTION
## Summary

The branch chip in the session panel header was truncating the branch name too early (hard-capped at a fixed pixel width) rather than filling the available container width first.

**Root cause:** The `BranchHeaderPill` `Tag` used `display: inline-flex` (shrinks to content) and the branch name `<span>` had a hardcoded `maxWidth: 180/220` regardless of available space.

## Changes

### `BranchHeaderPill.tsx` (component — affects all usage sites)

- `Tag` container: `display: inline-flex` → `display: flex` so it expands to fill its block width
- Identity link/button (Section 1): added `flex: 1; minWidth: 0` so it takes remaining space after the icon sections
- Branch name `<span>`: replaced `maxWidth: 180/220` with `flex: 1; minWidth: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap` — truncates based on actual available space, not a fixed cap
- Branch name `<span>`: added native `title={branch.name}` attribute so hovering always reveals the full name
- Env controls section (Section 2): added `flexShrink: 0` — icons don't compress
- Shortcut icons section (Section 3): added `flexShrink: 0` — icons don't compress

### `SessionPanelContent.tsx` (session panel header — primary usage site)

Wrapped `BranchHeaderPill` in `<div style={{ flex: 1, minWidth: 0 }}>` so that the Ant Design `Space` flex item gives the chip full available width to expand into.

## Usage sites audited

| Site | Location | Treatment |
|------|----------|-----------|
| **Session panel header** | `SessionPanelContent.tsx:137` | Added `flex: 1; minWidth: 0` wrapper div — chip now fills the header row |
| **Board assistant panel** | `BoardAssistantPanel.tsx:263` | Component-level fix applies (no hardcoded maxWidth); no fill-width wrapper added since this is a tag-cloud layout (`Space wrap`) alongside CreatedByTag/IssuePill/PullRequestPill — filling the row there would push siblings to the next line |

## Test plan

- [ ] Open any session in the left panel — branch chip should stretch to fill the header row width
- [ ] Long branch names truncate with ellipsis at the right edge (not at ~180px into the row)
- [ ] Hovering the truncated branch name shows the full name via native tooltip
- [ ] The env controls and shortcut icons on the right remain at fixed size and don't compress
- [ ] Board assistant panel chip (compact mode) still renders correctly alongside other pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)