### PR TITLE
fix(gateway): manifest copy works in non-secure (http) contexts + inside the modal

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -426,12 +426,15 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     textarea.style.opacity = '0';
     textarea.style.pointerEvents = 'none';
     host.appendChild(textarea);
-    textarea.focus();
-    textarea.select();
-    textarea.setSelectionRange(0, text.length);
-    const ok = document.execCommand('copy');
-    host.removeChild(textarea);
-    return ok;
+    try {
+      textarea.focus();
+      textarea.select();
+      textarea.setSelectionRange(0, text.length);
+      const ok = document.execCommand('copy');
+      return ok;
+    } finally {
+      host.removeChild(textarea);
+    }
   } catch {
     return false;
   }

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -403,24 +403,34 @@ const SLACK_PROBE_FIELDS = new Set<string>([
  * unavailable (e.g. non-secure origins).
  */
 async function copyTextToClipboard(text: string): Promise<boolean> {
-  try {
-    if (navigator.clipboard?.writeText) {
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
+    try {
       await navigator.clipboard.writeText(text);
       return true;
+    } catch {
+      // Fall through to the legacy path below.
     }
-  } catch {
-    // Fall through to the legacy path below.
   }
   try {
+    // Append inside the open antd modal so the textarea lives within the
+    // modal's focus trap — appending to document.body lets the trap steal
+    // focus and clear the selection, copying an empty string. Fall back to
+    // document.body when no modal is open (edit form / other callers).
+    const host = document.querySelector('.ant-modal-wrap') ?? document.body;
     const textarea = document.createElement('textarea');
     textarea.value = text;
+    textarea.readOnly = true;
     textarea.style.position = 'fixed';
+    textarea.style.top = '0';
+    textarea.style.left = '0';
     textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
+    textarea.style.pointerEvents = 'none';
+    host.appendChild(textarea);
     textarea.focus();
     textarea.select();
+    textarea.setSelectionRange(0, text.length);
     const ok = document.execCommand('copy');
-    document.body.removeChild(textarea);
+    host.removeChild(textarea);
     return ok;
   } catch {
     return false;


### PR DESCRIPTION
## Problem

The **Copy app manifest** button in the Slack gateway setup wizard (and the edit form) silently failed — clicking it copied nothing and left the clipboard empty.

## Root cause

`copyTextToClipboard` in `GatewayChannelsTable.tsx` had two compounding issues:

1. **Secure-context gate missing.** It branched on `navigator.clipboard?.writeText`, but the dev env is served over plain `http://<ip>` — a non-secure origin where `navigator.clipboard` is unavailable. So it fell through to the legacy `execCommand('copy')` path. (Production works only because it is HTTPS.)
2. **antd modal focus-trap.** The legacy fallback appended its textarea to `document.body`, **outside** the antd `Modal`. The modal's focus trap immediately steals focus back and clears the textarea's selection, so `execCommand('copy')` copies an empty selection — and can still return truthy, so the user sees no error but an empty clipboard.

## Fix

- Gate the modern path behind `window.isSecureContext && navigator.clipboard?.writeText`.
- Harden the legacy fallback so the selection survives the modal focus trap:
  - Append the textarea inside the currently-open antd modal (`document.querySelector('.ant-modal-wrap') ?? document.body`) so it lives within the focus trap; fall back to `document.body` when no modal is open (edit form / other callers).
  - Make it `readOnly`, position it off-screen, then `focus()` + `select()` + `setSelectionRange(0, text.length)`, capture `execCommand('copy')`, remove the node, and return the result.

The same helper backs the edit-form copy button, so this fixes both. The click handler already calls `showError(...)` on a `false` return.

## Verify

- `pnpm typecheck` + `biome check` on the changed file are GREEN (pre-existing repo-wide errors in unbuilt packages / `KnowledgePage.tsx` are unrelated). Clipboard behavior can't be meaningfully unit-tested in jsdom; verified in the live http env by the orchestrator.

Refs preset-io/agor-cloud#94

🤖 Generated with [Claude Code](https://claude.com/claude-code)