### PR TITLE
feat(session-panel): in-session search

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -207,6 +207,7 @@ const EMPTY_BOARD_OBJECTS: BoardEntityObject[] = Object.freeze(
 // on one readable line with Ant's tab padding at the 768px desktop breakpoint.
 const LEFT_PANEL_MIN_WIDTH_PX = 320;
 const LEFT_PANEL_MAX_SIZE_PERCENT = 45;
+const SESSION_PANEL_MIN_WIDTH_PX = 360;
 const LEFT_PANEL_TOGGLE_HIT_SIZE_PX = 44;
 const LEFT_PANEL_TOGGLE_KNOB_SIZE_PX = 30;
 
@@ -1323,6 +1324,7 @@ export const App: React.FC<AppProps> = ({
                       defaultSize={effectiveSessionPanelSize}
                       minSize={15}
                       maxSize={75}
+                      style={{ minWidth: SESSION_PANEL_MIN_WIDTH_PX }}
                     >
                       {effectiveSelectedSessionId ? (
                         <SessionPanel

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -208,11 +208,25 @@ const EMPTY_BOARD_OBJECTS: BoardEntityObject[] = Object.freeze(
 const LEFT_PANEL_MIN_WIDTH_PX = 320;
 const LEFT_PANEL_MAX_SIZE_PERCENT = 45;
 const SESSION_PANEL_MIN_WIDTH_PX = 360;
+const SESSION_PANEL_MAX_SIZE_PERCENT = 75;
+const SESSION_PANEL_MIN_SIZE_FLOOR_PERCENT = 15;
 const LEFT_PANEL_TOGGLE_HIT_SIZE_PX = 44;
 const LEFT_PANEL_TOGGLE_KNOB_SIZE_PX = 30;
 
 const getLeftPanelMinSizePercent = (viewportWidth: number) =>
   Math.min(LEFT_PANEL_MAX_SIZE_PERCENT, (LEFT_PANEL_MIN_WIDTH_PX / viewportWidth) * 100);
+
+// Express the session panel's 360px minimum through the panel sizing system
+// (a percentage of the current viewport) rather than a CSS px `minWidth`, which
+// fights react-resizable-panels' percentage layout on narrow viewports.
+const getSessionPanelMinSizePercent = (viewportWidth: number) =>
+  Math.min(
+    SESSION_PANEL_MAX_SIZE_PERCENT,
+    Math.max(
+      SESSION_PANEL_MIN_SIZE_FLOOR_PERCENT,
+      (SESSION_PANEL_MIN_WIDTH_PX / viewportWidth) * 100
+    )
+  );
 
 const clampPercent = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
@@ -391,6 +405,11 @@ export const App: React.FC<AppProps> = ({
     [viewportWidth]
   );
 
+  const sessionPanelMinSize = useMemo(
+    () => getSessionPanelMinSizePercent(viewportWidth),
+    [viewportWidth]
+  );
+
   // Settings modal state via URL routing
   const {
     isOpen: settingsRouteOpen,
@@ -469,7 +488,11 @@ export const App: React.FC<AppProps> = ({
     50
   );
 
-  const effectiveSessionPanelSize = clampPercent(sessionPanelSize, 15, 75);
+  const effectiveSessionPanelSize = clampPercent(
+    sessionPanelSize,
+    sessionPanelMinSize,
+    SESSION_PANEL_MAX_SIZE_PERCENT
+  );
   const sessionPanelRef = useRef<ImperativePanelHandle>(null);
   const leftPanelResizeDraggingRef = useRef(false);
   const rightPanelResizeDraggingRef = useRef(false);
@@ -1224,7 +1247,9 @@ export const App: React.FC<AppProps> = ({
                     rightPanelResizeDraggingRef.current &&
                     sizes.length === 2
                   ) {
-                    setSessionPanelSize(clampPercent(sizes[1], 15, 75));
+                    setSessionPanelSize(
+                      clampPercent(sizes[1], sessionPanelMinSize, SESSION_PANEL_MAX_SIZE_PERCENT)
+                    );
                   }
                 }}
               >
@@ -1322,9 +1347,8 @@ export const App: React.FC<AppProps> = ({
                       order={2}
                       ref={sessionPanelRef}
                       defaultSize={effectiveSessionPanelSize}
-                      minSize={15}
-                      maxSize={75}
-                      style={{ minWidth: SESSION_PANEL_MIN_WIDTH_PX }}
+                      minSize={sessionPanelMinSize}
+                      maxSize={SESSION_PANEL_MAX_SIZE_PERCENT}
                     >
                       {effectiveSelectedSessionId ? (
                         <SessionPanel

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -117,6 +117,11 @@ export interface ConversationViewProps {
    * Emoji override for assistant avatar in message bubbles
    */
   assistantEmoji?: string;
+
+  /**
+   * When true, all task blocks are force-expanded (used by in-session search)
+   */
+  forceExpandAll?: boolean;
 }
 
 export const ConversationView = React.memo<ConversationViewProps>(
@@ -136,6 +141,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     isActive = true,
     genealogy,
     assistantEmoji,
+    forceExpandAll = false,
   }) => {
     const { token } = theme.useToken();
     const [copied, copy] = useCopyToClipboard();
@@ -479,7 +485,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
               sessionModel={sessionModel}
               userById={userById}
               currentUserId={currentUserId}
-              isExpanded={expandedTaskIds.has(task.task_id)}
+              isExpanded={forceExpandAll || expandedTaskIds.has(task.task_id)}
               onExpandChange={handleTaskExpandChange}
               sessionId={sessionId}
               onPermissionDecision={onPermissionDecision}

--- a/apps/agor-ui/src/components/HighlightMatch/HighlightMatch.tsx
+++ b/apps/agor-ui/src/components/HighlightMatch/HighlightMatch.tsx
@@ -39,9 +39,6 @@ export const HighlightMatch: React.FC<HighlightMatchProps> = ({
             style={{
               backgroundColor: token.colorWarning,
               color: 'rgba(0, 0, 0, 0.88)',
-              padding: `0 ${token.paddingXXS}px`,
-              borderRadius: token.borderRadiusSM,
-              fontWeight: 600,
             }}
           >
             {part}

--- a/apps/agor-ui/src/components/HighlightMatch/HighlightMatch.tsx
+++ b/apps/agor-ui/src/components/HighlightMatch/HighlightMatch.tsx
@@ -55,6 +55,6 @@ export const HighlightMatch: React.FC<HighlightMatchProps> = ({
   );
 };
 
-function escapeRegExp(value: string): string {
+export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -36,6 +36,7 @@ import {
   Badge,
   Button,
   Dropdown,
+  Empty,
   Input,
   Space,
   Tooltip,
@@ -416,6 +417,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     setQuery,
     totalMatches,
     currentMatch,
+    searchPending,
     openSearch,
     closeSearch,
     goNext,
@@ -1164,101 +1166,28 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           background: token.colorBgContainer,
         }}
       >
+        {/* Row 1: icon + title + action buttons — always unchanged */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
           <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
             <div style={{ flexShrink: 0 }}>
               <ToolIcon tool={session.agentic_tool} size={40} />
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ marginBottom: 4 }}>
-                <Typography.Text
-                  strong
-                  style={{
-                    fontSize: 18,
-                    ...getSessionTitleStyles(2),
-                  }}
-                >
-                  {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-                </Typography.Text>
-                {!searchOpen && (
-                  <Badge
-                    status={getStatusColor()}
-                    text={session.status.toUpperCase()}
-                    style={{ marginLeft: 12 }}
-                  />
-                )}
-              </div>
-              {searchOpen ? (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <SearchOutlined
-                    style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }}
-                  />
-                  <Input
-                    ref={(el) => {
-                      searchInputRef.current = el?.input ?? null;
-                    }}
-                    value={query}
-                    onChange={(e) => {
-                      setQuery(e.target.value);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
-                      if (e.key === 'Escape') closeSearch();
-                    }}
-                    placeholder="Search session..."
-                    variant="borderless"
-                    style={{ flex: 1, padding: 0 }}
-                    size="small"
-                  />
-                  {query && (
-                    <Typography.Text
-                      type="secondary"
-                      style={{
-                        fontSize: 12,
-                        whiteSpace: 'nowrap',
-                        minWidth: 44,
-                        textAlign: 'right',
-                        fontVariantNumeric: 'tabular-nums',
-                      }}
-                    >
-                      {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : 'no results'}
-                    </Typography.Text>
-                  )}
-                  {!query && (
-                    <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                      Esc to close
-                    </Typography.Text>
-                  )}
-                  {totalMatches > 1 && (
-                    <Space size={2}>
-                      <Tooltip title="Previous (Shift+Enter)">
-                        <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
-                      </Tooltip>
-                      <Tooltip title="Next (Enter)">
-                        <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
-                      </Tooltip>
-                    </Space>
-                  )}
-                  <Tooltip title="Close search (Esc)">
-                    <Button
-                      type="text"
-                      size="small"
-                      icon={<CloseOutlined />}
-                      onClick={closeSearch}
-                    />
-                  </Tooltip>
-                </div>
-              ) : (
-                session.created_by && (
-                  <div>
-                    <CreatedByTag
-                      createdBy={session.created_by}
-                      currentUserId={currentUserId}
-                      userById={userById}
-                      prefix="Created by"
-                    />
-                  </div>
-                )
+              <Typography.Text
+                strong
+                style={{
+                  fontSize: 18,
+                  ...getSessionTitleStyles(2),
+                }}
+              >
+                {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+              </Typography.Text>
+              {!searchOpen && (
+                <Badge
+                  status={getStatusColor()}
+                  text={session.status.toUpperCase()}
+                  style={{ marginLeft: 12 }}
+                />
               )}
             </div>
           </div>
@@ -1282,6 +1211,72 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </Tooltip>
           </Space>
         </div>
+        {/* Row 2: full-width search bar OR indented created-by */}
+        {searchOpen ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: token.sizeUnit }}>
+            <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
+            <Input
+              ref={(el) => {
+                searchInputRef.current = el?.input ?? null;
+              }}
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                if (e.key === 'Escape') closeSearch();
+              }}
+              placeholder="Search session..."
+              variant="borderless"
+              style={{ flex: 1, padding: 0 }}
+              size="small"
+            />
+            {query && (
+              <Typography.Text
+                type="secondary"
+                style={{
+                  fontSize: 12,
+                  whiteSpace: 'nowrap',
+                  minWidth: 44,
+                  textAlign: 'right',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
+              </Typography.Text>
+            )}
+            {!query && (
+              <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                Esc to close
+              </Typography.Text>
+            )}
+            {totalMatches > 1 && (
+              <Space size={2}>
+                <Tooltip title="Previous (Shift+Enter)">
+                  <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                </Tooltip>
+                <Tooltip title="Next (Enter)">
+                  <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                </Tooltip>
+              </Space>
+            )}
+            <Tooltip title="Close search (Esc)">
+              <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+            </Tooltip>
+          </div>
+        ) : (
+          session.created_by && (
+            <div style={{ marginLeft: 52, marginTop: token.sizeUnit }}>
+              <CreatedByTag
+                createdBy={session.created_by}
+                currentUserId={currentUserId}
+                userById={userById}
+                prefix="Created by"
+              />
+            </div>
+          )
+        )}
       </div>
 
       {/* Body - Scrollable content */}
@@ -1296,23 +1291,20 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           position: 'relative',
         }}
       >
-        {searchOpen && query.trim() && totalMatches === 0 && (
+        {searchOpen && query.trim() && totalMatches === 0 && !searchPending && (
           <div
             style={{
               position: 'absolute',
               inset: 0,
               display: 'flex',
-              flexDirection: 'column',
               alignItems: 'center',
               justifyContent: 'center',
-              gap: token.sizeUnit * 2,
               zIndex: 10,
               pointerEvents: 'none',
               background: `${token.colorBgContainer}cc`,
             }}
           >
-            <SearchOutlined style={{ fontSize: 32, color: token.colorTextTertiary }} />
-            <Typography.Text type="secondary">No results for &ldquo;{query}&rdquo;</Typography.Text>
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={`No results for "${query}"`} />
           </div>
         )}
         <SessionPanelContent

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1206,7 +1206,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             style={{
               display: 'flex',
               alignItems: 'center',
-              marginTop: token.sizeUnit,
+              marginTop: 2,
               marginLeft: 52,
             }}
           >

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -423,7 +423,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     goNext,
     goPrev,
   } = useSessionSearch(bodyRef, {
-    highlight: `${token.colorWarning}66`,
+    highlight: token.colorWarning,
     current: token.colorWarning,
     currentText: 'rgba(0,0,0,0.88)',
   });

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1154,9 +1154,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         }}
       >
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-          <Space size={12} align="start" style={{ flex: 1 }}>
-            <ToolIcon tool={session.agentic_tool} size={40} />
-            <div style={{ flex: 1 }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
+            <div style={{ flexShrink: 0 }}><ToolIcon tool={session.agentic_tool} size={40} /></div>
+            <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ marginBottom: 4 }}>
                 <Typography.Text
                   strong
@@ -1226,7 +1226,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                 )
               )}
             </div>
-          </Space>
+          </div>
           <Space size={4}>
             <SessionAttachmentsDropdown items={attachmentItems} />
             <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1211,74 +1211,76 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </Tooltip>
           </Space>
         </div>
-        {/* Row 2: always rendered at fixed height to prevent header jump */}
-        <div
-          style={{ display: 'flex', alignItems: 'center', marginTop: token.sizeUnit, height: 24 }}
-        >
-          {searchOpen ? (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
-              <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
-              <Input
-                ref={(el) => {
-                  searchInputRef.current = el?.input ?? null;
-                }}
-                value={query}
-                onChange={(e) => {
-                  setQuery(e.target.value);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
-                  if (e.key === 'Escape') closeSearch();
-                }}
-                placeholder="Search session..."
-                variant="borderless"
-                style={{ flex: 1, padding: 0 }}
-                size="small"
-              />
-              {query && (
-                <Typography.Text
-                  type="secondary"
-                  style={{
-                    fontSize: 12,
-                    whiteSpace: 'nowrap',
-                    minWidth: 44,
-                    textAlign: 'right',
-                    fontVariantNumeric: 'tabular-nums',
+        {/* Row 2: search bar (when open) or created-by (when available) */}
+        {(searchOpen || session.created_by) && (
+          <div style={{ display: 'flex', alignItems: 'center', marginTop: token.sizeUnit }}>
+            {searchOpen ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
+                <SearchOutlined
+                  style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }}
+                />
+                <Input
+                  ref={(el) => {
+                    searchInputRef.current = el?.input ?? null;
                   }}
-                >
-                  {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
-                </Typography.Text>
-              )}
-              {!query && (
-                <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                  Esc to close
-                </Typography.Text>
-              )}
-              {totalMatches > 1 && (
-                <Space size={2}>
-                  <Tooltip title="Previous (Shift+Enter)">
-                    <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
-                  </Tooltip>
-                  <Tooltip title="Next (Enter)">
-                    <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
-                  </Tooltip>
-                </Space>
-              )}
-              <Tooltip title="Close search (Esc)">
-                <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
-              </Tooltip>
-            </div>
-          ) : session.created_by ? (
-            <div style={{ marginLeft: 52 }}>
-              <CreatedByTag
-                createdBy={session.created_by}
-                currentUserId={currentUserId}
-                userById={userById}
-                prefix="Created by"
-              />
-            </div>
-          ) : null}
-        </div>
+                  value={query}
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                    if (e.key === 'Escape') closeSearch();
+                  }}
+                  placeholder="Search session..."
+                  variant="borderless"
+                  style={{ flex: 1, padding: 0 }}
+                  size="small"
+                />
+                {query && (
+                  <Typography.Text
+                    type="secondary"
+                    style={{
+                      fontSize: 12,
+                      whiteSpace: 'nowrap',
+                      minWidth: 44,
+                      textAlign: 'right',
+                      fontVariantNumeric: 'tabular-nums',
+                    }}
+                  >
+                    {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
+                  </Typography.Text>
+                )}
+                {!query && (
+                  <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                    Esc to close
+                  </Typography.Text>
+                )}
+                {totalMatches > 1 && (
+                  <Space size={2}>
+                    <Tooltip title="Previous (Shift+Enter)">
+                      <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                    </Tooltip>
+                    <Tooltip title="Next (Enter)">
+                      <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                    </Tooltip>
+                  </Space>
+                )}
+                <Tooltip title="Close search (Esc)">
+                  <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+                </Tooltip>
+              </div>
+            ) : (
+              <div style={{ marginLeft: 52 }}>
+                <CreatedByTag
+                  createdBy={session.created_by}
+                  currentUserId={currentUserId}
+                  userById={userById}
+                  prefix="Created by"
+                />
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1174,9 +1174,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
                 {getSessionDisplayTitle(session, { includeAgentFallback: true })}
               </Typography.Text>
-              {!searchOpen && (
-                <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
-              )}
+              <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
             </div>
           </div>
           <Space size={4}>
@@ -1199,9 +1197,17 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </Tooltip>
           </Space>
         </div>
-        {/* Row 2: full-width search bar, only when open */}
-        {searchOpen && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+        {/* Row 2: search bar — always in DOM, animates in/out */}
+        <div
+          style={{
+            overflow: 'hidden',
+            maxHeight: searchOpen ? '36px' : '0px',
+            opacity: searchOpen ? 1 : 0,
+            marginTop: searchOpen ? '4px' : '0px',
+            transition: 'max-height 0.15s ease, opacity 0.12s ease, margin-top 0.15s ease',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
             <Input
               ref={(el) => {
@@ -1253,7 +1259,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
             </Tooltip>
           </div>
-        )}
+        </div>
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1166,56 +1166,39 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           background: token.colorBgContainer,
         }}
       >
-        {/* Row 1: icon + title + action buttons — always unchanged */}
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
-            <div style={{ flexShrink: 0 }}>
-              <ToolIcon tool={session.agentic_tool} size={40} />
-            </div>
-            <div style={{ flex: 1, minWidth: 0 }}>
+        {/* Row 1: always single row — search bar appears inline when open */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div style={{ flexShrink: 0 }}>
+            <ToolIcon tool={session.agentic_tool} size={40} />
+          </div>
+          {searchOpen ? (
+            <>
               <Typography.Text
                 strong
                 style={{
                   fontSize: 18,
-                  ...getSessionTitleStyles(2),
+                  maxWidth: 140,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  display: 'block',
+                  flexShrink: 0,
                 }}
               >
                 {getSessionDisplayTitle(session, { includeAgentFallback: true })}
               </Typography.Text>
-              {!searchOpen && (
-                <Badge
-                  status={getStatusColor()}
-                  text={session.status.toUpperCase()}
-                  style={{ marginLeft: 12 }}
-                />
-              )}
-            </div>
-          </div>
-          <Space size={4}>
-            <SessionAttachmentsDropdown items={attachmentItems} />
-            <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
-              <Tooltip title="More actions">
-                <Button type="text" icon={<EllipsisOutlined />} />
-              </Tooltip>
-            </Dropdown>
-            <Tooltip title="Search session (Cmd+F)">
-              <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
-            </Tooltip>
-            <Tooltip title="Close Panel">
-              <Button
-                type="text"
-                icon={<CloseOutlined />}
-                onClick={onClose}
-                style={{ marginLeft: token.sizeUnit }}
-              />
-            </Tooltip>
-          </Space>
-        </div>
-        {/* Row 2: search bar (when open) or created-by (when available) */}
-        {(searchOpen || session.created_by) && (
-          <div style={{ display: 'flex', alignItems: 'center', marginTop: token.sizeUnit }}>
-            {searchOpen ? (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
+              <div
+                style={{
+                  flex: 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  background: token.colorFillAlter,
+                  borderRadius: token.borderRadius,
+                  padding: '0 8px',
+                  minWidth: 0,
+                }}
+              >
                 <SearchOutlined
                   style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }}
                 />
@@ -1269,16 +1252,56 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                   <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
                 </Tooltip>
               </div>
-            ) : (
-              <div style={{ marginLeft: 52 }}>
-                <CreatedByTag
-                  createdBy={session.created_by}
-                  currentUserId={currentUserId}
-                  userById={userById}
-                  prefix="Created by"
-                />
-              </div>
-            )}
+            </>
+          ) : (
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <Typography.Text
+                strong
+                style={{
+                  fontSize: 18,
+                  ...getSessionTitleStyles(2),
+                }}
+              >
+                {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+              </Typography.Text>
+              <Badge
+                status={getStatusColor()}
+                text={session.status.toUpperCase()}
+                style={{ marginLeft: 12 }}
+              />
+            </div>
+          )}
+          {!searchOpen && (
+            <Space size={4}>
+              <SessionAttachmentsDropdown items={attachmentItems} />
+              <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
+                <Tooltip title="More actions">
+                  <Button type="text" icon={<EllipsisOutlined />} />
+                </Tooltip>
+              </Dropdown>
+              <Tooltip title="Search session (Cmd+F)">
+                <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
+              </Tooltip>
+            </Space>
+          )}
+          <Tooltip title="Close Panel">
+            <Button
+              type="text"
+              icon={<CloseOutlined />}
+              onClick={onClose}
+              style={{ marginLeft: searchOpen ? 0 : token.sizeUnit }}
+            />
+          </Tooltip>
+        </div>
+        {/* Row 2: created-by only when not searching */}
+        {!searchOpen && session.created_by && (
+          <div style={{ marginTop: token.sizeUnit, marginLeft: 52 }}>
+            <CreatedByTag
+              createdBy={session.created_by}
+              currentUserId={currentUserId}
+              userById={userById}
+              prefix="Created by"
+            />
           </div>
         )}
       </div>

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1165,9 +1165,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           background: token.colorBgContainer,
         }}
       >
-        {/* Row 1: icon + title + badge + action buttons */}
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
+        {/* Row 1: icon + title + badge + actions, center-aligned */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'center', flex: 1, minWidth: 0 }}>
             <div style={{ flexShrink: 0 }}>
               <ToolIcon tool={session.agentic_tool} size={40} />
             </div>
@@ -1175,67 +1175,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
                 {getSessionDisplayTitle(session, { includeAgentFallback: true })}
               </Typography.Text>
-              {searchOpen ? (
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
-                  <SearchOutlined
-                    style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }}
-                  />
-                  <Input
-                    ref={(el) => {
-                      searchInputRef.current = el?.input ?? null;
-                    }}
-                    value={query}
-                    onChange={(e) => {
-                      setQuery(e.target.value);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
-                      if (e.key === 'Escape') closeSearch();
-                    }}
-                    placeholder="Search session..."
-                    variant="borderless"
-                    style={{ flex: 1, padding: 0 }}
-                    size="small"
-                  />
-                  {query && (
-                    <Typography.Text
-                      type="secondary"
-                      style={{
-                        fontSize: 12,
-                        whiteSpace: 'nowrap',
-                        minWidth: 44,
-                        textAlign: 'right',
-                        fontVariantNumeric: 'tabular-nums',
-                      }}
-                    >
-                      {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
-                    </Typography.Text>
-                  )}
-                  {!query && (
-                    <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                      Esc to close
-                    </Typography.Text>
-                  )}
-                  {totalMatches > 1 && (
-                    <Space size={2}>
-                      <Tooltip title="Previous (Shift+Enter)">
-                        <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
-                      </Tooltip>
-                      <Tooltip title="Next (Enter)">
-                        <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
-                      </Tooltip>
-                    </Space>
-                  )}
-                  <Tooltip title="Close search (Esc)">
-                    <Button
-                      type="text"
-                      size="small"
-                      icon={<CloseOutlined />}
-                      onClick={closeSearch}
-                    />
-                  </Tooltip>
-                </div>
-              ) : (
+              {!searchOpen && (
                 <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
               )}
             </div>
@@ -1260,6 +1200,61 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </Tooltip>
           </Space>
         </div>
+        {/* Row 2: full-width search bar, only when open */}
+        {searchOpen && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 2 }}>
+            <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
+            <Input
+              ref={(el) => {
+                searchInputRef.current = el?.input ?? null;
+              }}
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                if (e.key === 'Escape') closeSearch();
+              }}
+              placeholder="Search session..."
+              variant="borderless"
+              style={{ flex: 1, padding: 0 }}
+              size="small"
+            />
+            {query && (
+              <Typography.Text
+                type="secondary"
+                style={{
+                  fontSize: 12,
+                  whiteSpace: 'nowrap',
+                  minWidth: 44,
+                  textAlign: 'right',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
+              </Typography.Text>
+            )}
+            {!query && (
+              <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                Esc to close
+              </Typography.Text>
+            )}
+            {totalMatches > 1 && (
+              <Space size={2}>
+                <Tooltip title="Previous (Shift+Enter)">
+                  <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                </Tooltip>
+                <Tooltip title="Next (Enter)">
+                  <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                </Tooltip>
+              </Space>
+            )}
+            <Tooltip title="Close search (Esc)">
+              <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+            </Tooltip>
+          </div>
+        )}
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -409,7 +409,11 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     closeSearch,
     goNext,
     goPrev,
-  } = useSessionSearch(bodyRef);
+  } = useSessionSearch(bodyRef, {
+    highlight: `${token.colorWarning}66`,
+    current: token.colorWarning,
+    currentText: 'rgba(0,0,0,0.88)',
+  });
   const composerSessionIdentityRef = React.useRef<{
     sessionId: SessionID | null;
     generation: number;
@@ -1254,8 +1258,30 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           display: 'flex',
           flexDirection: 'column',
           padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px 0`,
+          position: 'relative',
         }}
       >
+        {searchOpen && query.trim() && totalMatches === 0 && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: token.sizeUnit * 2,
+              zIndex: 10,
+              pointerEvents: 'none',
+              background: `${token.colorBgContainer}cc`,
+            }}
+          >
+            <SearchOutlined style={{ fontSize: 32, color: token.colorTextTertiary }} />
+            <Typography.Text type="secondary">
+              No results for &ldquo;{query}&rdquo;
+            </Typography.Text>
+          </div>
+        )}
         <SessionPanelContent
           client={client}
           session={session}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1175,7 +1175,67 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
                 {getSessionDisplayTitle(session, { includeAgentFallback: true })}
               </Typography.Text>
-              {!searchOpen && (
+              {searchOpen ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
+                  <SearchOutlined
+                    style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }}
+                  />
+                  <Input
+                    ref={(el) => {
+                      searchInputRef.current = el?.input ?? null;
+                    }}
+                    value={query}
+                    onChange={(e) => {
+                      setQuery(e.target.value);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                      if (e.key === 'Escape') closeSearch();
+                    }}
+                    placeholder="Search session..."
+                    variant="borderless"
+                    style={{ flex: 1, padding: 0 }}
+                    size="small"
+                  />
+                  {query && (
+                    <Typography.Text
+                      type="secondary"
+                      style={{
+                        fontSize: 12,
+                        whiteSpace: 'nowrap',
+                        minWidth: 44,
+                        textAlign: 'right',
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    >
+                      {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
+                    </Typography.Text>
+                  )}
+                  {!query && (
+                    <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                      Esc to close
+                    </Typography.Text>
+                  )}
+                  {totalMatches > 1 && (
+                    <Space size={2}>
+                      <Tooltip title="Previous (Shift+Enter)">
+                        <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                      </Tooltip>
+                      <Tooltip title="Next (Enter)">
+                        <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                      </Tooltip>
+                    </Space>
+                  )}
+                  <Tooltip title="Close search (Esc)">
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<CloseOutlined />}
+                      onClick={closeSearch}
+                    />
+                  </Tooltip>
+                </div>
+              ) : (
                 <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
               )}
             </div>
@@ -1200,70 +1260,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </Tooltip>
           </Space>
         </div>
-        {/* Row 2: search bar, only when open */}
-        {searchOpen && (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              marginTop: 2,
-              marginLeft: 52,
-            }}
-          >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
-              <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
-              <Input
-                ref={(el) => {
-                  searchInputRef.current = el?.input ?? null;
-                }}
-                value={query}
-                onChange={(e) => {
-                  setQuery(e.target.value);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
-                  if (e.key === 'Escape') closeSearch();
-                }}
-                placeholder="Search session..."
-                variant="borderless"
-                style={{ flex: 1, padding: 0 }}
-                size="small"
-              />
-              {query && (
-                <Typography.Text
-                  type="secondary"
-                  style={{
-                    fontSize: 12,
-                    whiteSpace: 'nowrap',
-                    minWidth: 44,
-                    textAlign: 'right',
-                    fontVariantNumeric: 'tabular-nums',
-                  }}
-                >
-                  {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
-                </Typography.Text>
-              )}
-              {!query && (
-                <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                  Esc to close
-                </Typography.Text>
-              )}
-              {totalMatches > 1 && (
-                <Space size={2}>
-                  <Tooltip title="Previous (Shift+Enter)">
-                    <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
-                  </Tooltip>
-                  <Tooltip title="Next (Enter)">
-                    <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
-                  </Tooltip>
-                </Space>
-              )}
-              <Tooltip title="Close search (Esc)">
-                <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
-              </Tooltip>
-            </div>
-          </div>
-        )}
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -36,7 +36,6 @@ import {
   Badge,
   Button,
   Dropdown,
-  Empty,
   Input,
   Space,
   Tooltip,
@@ -1282,7 +1281,39 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               background: `${token.colorBgContainer}cc`,
             }}
           >
-            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={`No results for "${query}"`} />
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                padding: '28px 16px',
+                gap: 6,
+              }}
+            >
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: '50%',
+                  background: token.colorFillTertiary,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  marginBottom: 2,
+                }}
+              >
+                <SearchOutlined style={{ fontSize: 16, color: token.colorTextTertiary }} />
+              </div>
+              <Typography.Text strong style={{ fontSize: 13 }}>
+                No results
+              </Typography.Text>
+              <Typography.Text
+                type="secondary"
+                style={{ fontSize: 12, textAlign: 'center', lineHeight: 1.5, maxWidth: 200 }}
+              >
+                Nothing matched <Typography.Text code>{query}</Typography.Text>
+              </Typography.Text>
+            </div>
           </div>
         )}
         <SessionPanelContent

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1211,63 +1211,65 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </Tooltip>
           </Space>
         </div>
-        {/* Row 2: full-width search bar OR indented created-by */}
-        {searchOpen ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: token.sizeUnit }}>
-            <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
-            <Input
-              ref={(el) => {
-                searchInputRef.current = el?.input ?? null;
-              }}
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
-                if (e.key === 'Escape') closeSearch();
-              }}
-              placeholder="Search session..."
-              variant="borderless"
-              style={{ flex: 1, padding: 0 }}
-              size="small"
-            />
-            {query && (
-              <Typography.Text
-                type="secondary"
-                style={{
-                  fontSize: 12,
-                  whiteSpace: 'nowrap',
-                  minWidth: 44,
-                  textAlign: 'right',
-                  fontVariantNumeric: 'tabular-nums',
+        {/* Row 2: always rendered at fixed height to prevent header jump */}
+        <div
+          style={{ display: 'flex', alignItems: 'center', marginTop: token.sizeUnit, height: 24 }}
+        >
+          {searchOpen ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
+              <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
+              <Input
+                ref={(el) => {
+                  searchInputRef.current = el?.input ?? null;
                 }}
-              >
-                {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
-              </Typography.Text>
-            )}
-            {!query && (
-              <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                Esc to close
-              </Typography.Text>
-            )}
-            {totalMatches > 1 && (
-              <Space size={2}>
-                <Tooltip title="Previous (Shift+Enter)">
-                  <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
-                </Tooltip>
-                <Tooltip title="Next (Enter)">
-                  <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
-                </Tooltip>
-              </Space>
-            )}
-            <Tooltip title="Close search (Esc)">
-              <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
-            </Tooltip>
-          </div>
-        ) : (
-          session.created_by && (
-            <div style={{ marginLeft: 52, marginTop: token.sizeUnit }}>
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                  if (e.key === 'Escape') closeSearch();
+                }}
+                placeholder="Search session..."
+                variant="borderless"
+                style={{ flex: 1, padding: 0 }}
+                size="small"
+              />
+              {query && (
+                <Typography.Text
+                  type="secondary"
+                  style={{
+                    fontSize: 12,
+                    whiteSpace: 'nowrap',
+                    minWidth: 44,
+                    textAlign: 'right',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
+                </Typography.Text>
+              )}
+              {!query && (
+                <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                  Esc to close
+                </Typography.Text>
+              )}
+              {totalMatches > 1 && (
+                <Space size={2}>
+                  <Tooltip title="Previous (Shift+Enter)">
+                    <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                  </Tooltip>
+                  <Tooltip title="Next (Enter)">
+                    <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                  </Tooltip>
+                </Space>
+              )}
+              <Tooltip title="Close search (Esc)">
+                <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+              </Tooltip>
+            </div>
+          ) : session.created_by ? (
+            <div style={{ marginLeft: 52 }}>
               <CreatedByTag
                 createdBy={session.created_by}
                 currentUserId={currentUserId}
@@ -1275,8 +1277,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                 prefix="Created by"
               />
             </div>
-          )
-        )}
+          ) : null}
+        </div>
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1334,7 +1334,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           isOpen={open}
           cliViewMode={cliViewMode}
           setCliViewMode={setCliViewMode}
-          forceExpandAll={searchOpen}
+          forceExpandAll={searchOpen && query.trim().length > 0}
         />
 
         {/* Footer — rendered outside SessionPanelContent so that

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -64,6 +64,7 @@ import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { FileUpload } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
 import type { ModelConfig } from '../ModelSelector';
+import { CreatedByTag } from '../metadata';
 import { getUrlDisplayLabel } from '../Pill/url-helpers';
 import { ToolIcon } from '../ToolIcon';
 import {
@@ -82,6 +83,11 @@ import { useComposerAttachments } from './useComposerAttachments';
 
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
+
+// The find shortcut is Cmd+F on mac, Ctrl+F elsewhere — label it correctly.
+const IS_MAC =
+  typeof navigator !== 'undefined' && /Mac|iPhone|iPad/i.test(navigator.platform ?? '');
+const FIND_SHORTCUT_LABEL = IS_MAC ? 'Cmd+F' : 'Ctrl+F';
 
 // ---------------------------------------------------------------------------
 // PromptInput — thin wrapper around AutocompleteTextarea that keeps the typed
@@ -647,6 +653,17 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     return () => window.removeEventListener('keydown', handler);
   }, [searchOpen, open, openSearch, closeSearch]);
 
+  // Reset search when switching sessions — stale ranges/counts belong to the
+  // previous conversation's DOM.
+  const prevSearchSessionIdRef = React.useRef(session?.session_id ?? null);
+  React.useEffect(() => {
+    const id = session?.session_id ?? null;
+    if (prevSearchSessionIdRef.current !== id) {
+      prevSearchSessionIdRef.current = id;
+      closeSearch();
+    }
+  }, [session?.session_id, closeSearch]);
+
   React.useEffect(() => {
     if (searchOpen) {
       setTimeout(() => searchInputRef.current?.focus(), 30);
@@ -1175,6 +1192,16 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                 {getSessionDisplayTitle(session, { includeAgentFallback: true })}
               </Typography.Text>
               <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
+              {session.created_by && (
+                <div style={{ marginTop: token.sizeUnit }}>
+                  <CreatedByTag
+                    createdBy={session.created_by}
+                    currentUserId={currentUserId}
+                    userById={userById}
+                    prefix="Created by"
+                  />
+                </div>
+              )}
             </div>
           </div>
           <Space size={4}>
@@ -1184,7 +1211,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                 <Button type="text" icon={<EllipsisOutlined />} />
               </Tooltip>
             </Dropdown>
-            <Tooltip title="Search session (Cmd+F)">
+            <Tooltip title={`Search session (${FIND_SHORTCUT_LABEL})`}>
               <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
             </Tooltip>
             <Tooltip title="Close Panel">

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -414,6 +414,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const tasks = reactiveSessionState?.tasks || [];
   const attachmentInputRef = React.useRef<HTMLInputElement>(null);
   const bodyRef = React.useRef<HTMLDivElement | null>(null);
+  // Search observes only the conversation region, not the whole body: the
+  // no-results overlay, footer, and modals are `bodyRef` children, so observing
+  // `bodyRef` would let the overlay's own mount/unmount retrigger the scan.
+  const conversationRef = React.useRef<HTMLDivElement | null>(null);
   const searchInputRef = React.useRef<HTMLInputElement | null>(null);
   const {
     searchOpen,
@@ -426,7 +430,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     closeSearch,
     goNext,
     goPrev,
-  } = useSessionSearch(bodyRef, {
+  } = useSessionSearch(conversationRef, {
     highlight: token.colorWarning,
     current: token.colorWarning,
     currentText: 'rgba(0,0,0,0.88)',
@@ -1349,27 +1353,38 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </div>
           </div>
         )}
-        <SessionPanelContent
-          client={client}
-          session={session}
-          branch={branch}
-          currentUserId={currentUserId}
-          sessionMcpServerIds={sessionMcpServerIds}
-          scrollToBottom={scrollToBottom}
-          scrollToTop={scrollToTop}
-          setScrollToBottom={setScrollToBottom}
-          setScrollToTop={setScrollToTop}
-          queuedTasks={queuedTasks}
-          setQueuedTasks={setQueuedTasks}
-          spawnModalOpen={spawnModalOpen}
-          setSpawnModalOpen={setSpawnModalOpen}
-          onSpawnModalConfirm={handleSpawnModalConfirm}
-          inputValueRef={inputValueRef}
-          isOpen={open}
-          cliViewMode={cliViewMode}
-          setCliViewMode={setCliViewMode}
-          forceExpandAll={searchOpen && query.trim().length > 0}
-        />
+        <div
+          ref={conversationRef}
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          <SessionPanelContent
+            client={client}
+            session={session}
+            branch={branch}
+            currentUserId={currentUserId}
+            sessionMcpServerIds={sessionMcpServerIds}
+            scrollToBottom={scrollToBottom}
+            scrollToTop={scrollToTop}
+            setScrollToBottom={setScrollToBottom}
+            setScrollToTop={setScrollToTop}
+            queuedTasks={queuedTasks}
+            setQueuedTasks={setQueuedTasks}
+            spawnModalOpen={spawnModalOpen}
+            setSpawnModalOpen={setSpawnModalOpen}
+            onSpawnModalConfirm={handleSpawnModalConfirm}
+            inputValueRef={inputValueRef}
+            isOpen={open}
+            cliViewMode={cliViewMode}
+            setCliViewMode={setCliViewMode}
+            forceExpandAll={searchOpen && query.trim().length > 0}
+          />
+        </div>
 
         {/* Footer — rendered outside SessionPanelContent so that
             keystroke-driven re-renders don't propagate to ConversationView.

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1165,7 +1165,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           background: token.colorBgContainer,
         }}
       >
-        {/* Row 1: icon + title + action buttons — never changes */}
+        {/* Row 1: icon + title + badge + action buttons */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
           <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
             <div style={{ flexShrink: 0 }}>
@@ -1175,6 +1175,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
                 {getSessionDisplayTitle(session, { includeAgentFallback: true })}
               </Typography.Text>
+              {!searchOpen && (
+                <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
+              )}
             </div>
           </div>
           <Space size={4}>
@@ -1197,17 +1200,16 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </Tooltip>
           </Space>
         </div>
-        {/* Row 2: always rendered at fixed height — status badge or search bar */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            marginTop: token.sizeUnit,
-            marginLeft: 52,
-            height: 24,
-          }}
-        >
-          {searchOpen ? (
+        {/* Row 2: search bar, only when open */}
+        {searchOpen && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              marginTop: token.sizeUnit,
+              marginLeft: 52,
+            }}
+          >
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
               <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
               <Input
@@ -1260,10 +1262,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                 <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
               </Tooltip>
             </div>
-          ) : (
-            <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
-          )}
-        </div>
+          </div>
+        )}
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -65,7 +65,6 @@ import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { FileUpload } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
 import type { ModelConfig } from '../ModelSelector';
-import { CreatedByTag } from '../metadata';
 import { getUrlDisplayLabel } from '../Pill/url-helpers';
 import { ToolIcon } from '../ToolIcon';
 import {
@@ -1166,144 +1165,105 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           background: token.colorBgContainer,
         }}
       >
-        {/* Row 1: always single row — search bar appears inline when open */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-          <div style={{ flexShrink: 0 }}>
-            <ToolIcon tool={session.agentic_tool} size={40} />
-          </div>
-          {searchOpen ? (
-            <>
-              <Typography.Text
-                strong
-                style={{
-                  fontSize: 18,
-                  maxWidth: 140,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  display: 'block',
-                  flexShrink: 0,
-                }}
-              >
-                {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-              </Typography.Text>
-              <div
-                style={{
-                  flex: 1,
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 6,
-                  background: token.colorFillAlter,
-                  borderRadius: token.borderRadius,
-                  padding: '0 8px',
-                  minWidth: 0,
-                }}
-              >
-                <SearchOutlined
-                  style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }}
-                />
-                <Input
-                  ref={(el) => {
-                    searchInputRef.current = el?.input ?? null;
-                  }}
-                  value={query}
-                  onChange={(e) => {
-                    setQuery(e.target.value);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
-                    if (e.key === 'Escape') closeSearch();
-                  }}
-                  placeholder="Search session..."
-                  variant="borderless"
-                  style={{ flex: 1, padding: 0 }}
-                  size="small"
-                />
-                {query && (
-                  <Typography.Text
-                    type="secondary"
-                    style={{
-                      fontSize: 12,
-                      whiteSpace: 'nowrap',
-                      minWidth: 44,
-                      textAlign: 'right',
-                      fontVariantNumeric: 'tabular-nums',
-                    }}
-                  >
-                    {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
-                  </Typography.Text>
-                )}
-                {!query && (
-                  <Typography.Text type="secondary" style={{ fontSize: 11 }}>
-                    Esc to close
-                  </Typography.Text>
-                )}
-                {totalMatches > 1 && (
-                  <Space size={2}>
-                    <Tooltip title="Previous (Shift+Enter)">
-                      <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
-                    </Tooltip>
-                    <Tooltip title="Next (Enter)">
-                      <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
-                    </Tooltip>
-                  </Space>
-                )}
-                <Tooltip title="Close search (Esc)">
-                  <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
-                </Tooltip>
-              </div>
-            </>
-          ) : (
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <Typography.Text
-                strong
-                style={{
-                  fontSize: 18,
-                  ...getSessionTitleStyles(2),
-                }}
-              >
-                {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-              </Typography.Text>
-              <Badge
-                status={getStatusColor()}
-                text={session.status.toUpperCase()}
-                style={{ marginLeft: 12 }}
-              />
+        {/* Row 1: icon + title + action buttons — never changes */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
+            <div style={{ flexShrink: 0 }}>
+              <ToolIcon tool={session.agentic_tool} size={40} />
             </div>
-          )}
-          {!searchOpen && (
-            <Space size={4}>
-              <SessionAttachmentsDropdown items={attachmentItems} />
-              <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
-                <Tooltip title="More actions">
-                  <Button type="text" icon={<EllipsisOutlined />} />
-                </Tooltip>
-              </Dropdown>
-              <Tooltip title="Search session (Cmd+F)">
-                <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
-              </Tooltip>
-            </Space>
-          )}
-          <Tooltip title="Close Panel">
-            <Button
-              type="text"
-              icon={<CloseOutlined />}
-              onClick={onClose}
-              style={{ marginLeft: searchOpen ? 0 : token.sizeUnit }}
-            />
-          </Tooltip>
-        </div>
-        {/* Row 2: created-by only when not searching */}
-        {!searchOpen && session.created_by && (
-          <div style={{ marginTop: token.sizeUnit, marginLeft: 52 }}>
-            <CreatedByTag
-              createdBy={session.created_by}
-              currentUserId={currentUserId}
-              userById={userById}
-              prefix="Created by"
-            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
+                {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+              </Typography.Text>
+            </div>
           </div>
-        )}
+          <Space size={4}>
+            <SessionAttachmentsDropdown items={attachmentItems} />
+            <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
+              <Tooltip title="More actions">
+                <Button type="text" icon={<EllipsisOutlined />} />
+              </Tooltip>
+            </Dropdown>
+            <Tooltip title="Search session (Cmd+F)">
+              <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
+            </Tooltip>
+            <Tooltip title="Close Panel">
+              <Button
+                type="text"
+                icon={<CloseOutlined />}
+                onClick={onClose}
+                style={{ marginLeft: token.sizeUnit }}
+              />
+            </Tooltip>
+          </Space>
+        </div>
+        {/* Row 2: always rendered at fixed height — status badge or search bar */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginTop: token.sizeUnit,
+            marginLeft: 52,
+            height: 24,
+          }}
+        >
+          {searchOpen ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, width: '100%' }}>
+              <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
+              <Input
+                ref={(el) => {
+                  searchInputRef.current = el?.input ?? null;
+                }}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                  if (e.key === 'Escape') closeSearch();
+                }}
+                placeholder="Search session..."
+                variant="borderless"
+                style={{ flex: 1, padding: 0 }}
+                size="small"
+              />
+              {query && (
+                <Typography.Text
+                  type="secondary"
+                  style={{
+                    fontSize: 12,
+                    whiteSpace: 'nowrap',
+                    minWidth: 44,
+                    textAlign: 'right',
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : ''}
+                </Typography.Text>
+              )}
+              {!query && (
+                <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                  Esc to close
+                </Typography.Text>
+              )}
+              {totalMatches > 1 && (
+                <Space size={2}>
+                  <Tooltip title="Previous (Shift+Enter)">
+                    <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                  </Tooltip>
+                  <Tooltip title="Next (Enter)">
+                    <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                  </Tooltip>
+                </Space>
+              )}
+              <Tooltip title="Close search (Esc)">
+                <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+              </Tooltip>
+            </div>
+          ) : (
+            <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
+          )}
+        </div>
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -22,12 +22,15 @@ import {
   AimOutlined,
   CloseOutlined,
   CodeOutlined,
+  DownOutlined,
   EllipsisOutlined,
   InboxOutlined,
+  SearchOutlined,
   SettingOutlined,
+  UpOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Alert, App, Badge, Button, Dropdown, Space, Tooltip, Typography, theme } from 'antd';
+import { Alert, App, Badge, Button, Dropdown, Input, Space, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
@@ -65,6 +68,7 @@ import { SessionComposerDropZone } from './SessionComposerDropZone';
 import { SessionFooter } from './SessionFooter';
 import { SessionPanelContent } from './SessionPanelContent';
 import { useComposerAttachments } from './useComposerAttachments';
+import { useSessionSearch } from '../../hooks/useSessionSearch';
 
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
@@ -393,6 +397,19 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const tasks = reactiveSessionState?.tasks || [];
   const attachmentInputRef = React.useRef<HTMLInputElement>(null);
+  const bodyRef = React.useRef<HTMLDivElement | null>(null);
+  const searchInputRef = React.useRef<HTMLInputElement | null>(null);
+  const {
+    searchOpen,
+    query,
+    setQuery,
+    totalMatches,
+    currentMatch,
+    openSearch,
+    closeSearch,
+    goNext,
+    goPrev,
+  } = useSessionSearch(bodyRef);
   const composerSessionIdentityRef = React.useRef<{
     sessionId: SessionID | null;
     generation: number;
@@ -601,6 +618,25 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   React.useEffect(() => {
     setEffortLevel(session?.model_config?.effort || 'high');
   }, [session?.model_config?.effort]);
+
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f' && open) {
+        e.preventDefault();
+        if (!searchOpen) openSearch();
+        else searchInputRef.current?.focus();
+      }
+      if (e.key === 'Escape' && searchOpen) closeSearch();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [searchOpen, open, openSearch, closeSearch]);
+
+  React.useEffect(() => {
+    if (searchOpen) {
+      setTimeout(() => searchInputRef.current?.focus(), 30);
+    }
+  }, [searchOpen]);
 
   // When there's no session, render nothing (panel is collapsed to zero).
   // When open=false, we still render the component tree (hidden) so that
@@ -1113,59 +1149,102 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           background: token.colorBgContainer,
         }}
       >
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-          <Space size={12} align="start" style={{ flex: 1 }}>
-            <ToolIcon tool={session.agentic_tool} size={40} />
-            <div style={{ flex: 1 }}>
-              <div style={{ marginBottom: 4 }}>
-                <Typography.Text
-                  strong
-                  style={{
-                    fontSize: 18,
-                    ...getSessionTitleStyles(2),
-                  }}
-                >
-                  {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-                </Typography.Text>
-                <Badge
-                  status={getStatusColor()}
-                  text={session.status.toUpperCase()}
-                  style={{ marginLeft: 12 }}
-                />
-              </div>
-              {session.created_by && (
-                <div>
-                  <CreatedByTag
-                    createdBy={session.created_by}
-                    currentUserId={currentUserId}
-                    userById={userById}
-                    prefix="Created by"
+        {searchOpen ? (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
+            <Input
+              ref={(el) => { searchInputRef.current = el?.input ?? null; }}
+              value={query}
+              onChange={(e) => { setQuery(e.target.value); }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                if (e.key === 'Escape') closeSearch();
+              }}
+              placeholder="Search session…"
+              variant="borderless"
+              style={{ flex: 1, padding: 0 }}
+            />
+            {query && (
+              <Typography.Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap', minWidth: 44, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : 'no results'}
+              </Typography.Text>
+            )}
+            {!query && (
+              <Typography.Text type="secondary" style={{ fontSize: 11 }}>Esc to close</Typography.Text>
+            )}
+            {totalMatches > 1 && (
+              <Space size={2}>
+                <Tooltip title="Previous (⇧↵)">
+                  <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                </Tooltip>
+                <Tooltip title="Next (↵)">
+                  <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                </Tooltip>
+              </Space>
+            )}
+            <Tooltip title="Close search (Esc)">
+              <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+            </Tooltip>
+          </div>
+        ) : (
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <Space size={12} align="start" style={{ flex: 1 }}>
+              <ToolIcon tool={session.agentic_tool} size={40} />
+              <div style={{ flex: 1 }}>
+                <div style={{ marginBottom: 4 }}>
+                  <Typography.Text
+                    strong
+                    style={{
+                      fontSize: 18,
+                      ...getSessionTitleStyles(2),
+                    }}
+                  >
+                    {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+                  </Typography.Text>
+                  <Badge
+                    status={getStatusColor()}
+                    text={session.status.toUpperCase()}
+                    style={{ marginLeft: 12 }}
                   />
                 </div>
-              )}
-            </div>
-          </Space>
-          <Space size={4}>
-            <SessionAttachmentsDropdown items={attachmentItems} />
-            <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
-              <Tooltip title="More actions">
-                <Button type="text" icon={<EllipsisOutlined />} />
+                {session.created_by && (
+                  <div>
+                    <CreatedByTag
+                      createdBy={session.created_by}
+                      currentUserId={currentUserId}
+                      userById={userById}
+                      prefix="Created by"
+                    />
+                  </div>
+                )}
+              </div>
+            </Space>
+            <Space size={4}>
+              <SessionAttachmentsDropdown items={attachmentItems} />
+              <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
+                <Tooltip title="More actions">
+                  <Button type="text" icon={<EllipsisOutlined />} />
+                </Tooltip>
+              </Dropdown>
+              <Tooltip title="Search session (⌘F)">
+                <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
               </Tooltip>
-            </Dropdown>
-            <Tooltip title="Close Panel">
-              <Button
-                type="text"
-                icon={<CloseOutlined />}
-                onClick={onClose}
-                style={{ marginLeft: token.sizeUnit }}
-              />
-            </Tooltip>
-          </Space>
-        </div>
+              <Tooltip title="Close Panel">
+                <Button
+                  type="text"
+                  icon={<CloseOutlined />}
+                  onClick={onClose}
+                  style={{ marginLeft: token.sizeUnit }}
+                />
+              </Tooltip>
+            </Space>
+          </div>
+        )}
       </div>
 
       {/* Body - Scrollable content */}
       <div
+        ref={bodyRef}
         style={{
           flex: 1,
           overflow: 'hidden',
@@ -1193,6 +1272,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           isOpen={open}
           cliViewMode={cliViewMode}
           setCliViewMode={setCliViewMode}
+          forceExpandAll={searchOpen}
         />
 
         {/* Footer — rendered outside SessionPanelContent so that

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1149,65 +1149,68 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           background: token.colorBgContainer,
         }}
       >
-        {searchOpen ? (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
-            <Input
-              ref={(el) => { searchInputRef.current = el?.input ?? null; }}
-              value={query}
-              onChange={(e) => { setQuery(e.target.value); }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
-                if (e.key === 'Escape') closeSearch();
-              }}
-              placeholder="Search session…"
-              variant="borderless"
-              style={{ flex: 1, padding: 0 }}
-            />
-            {query && (
-              <Typography.Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap', minWidth: 44, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
-                {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : 'no results'}
-              </Typography.Text>
-            )}
-            {!query && (
-              <Typography.Text type="secondary" style={{ fontSize: 11 }}>Esc to close</Typography.Text>
-            )}
-            {totalMatches > 1 && (
-              <Space size={2}>
-                <Tooltip title="Previous (⇧↵)">
-                  <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
-                </Tooltip>
-                <Tooltip title="Next (↵)">
-                  <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
-                </Tooltip>
-              </Space>
-            )}
-            <Tooltip title="Close search (Esc)">
-              <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
-            </Tooltip>
-          </div>
-        ) : (
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-            <Space size={12} align="start" style={{ flex: 1 }}>
-              <ToolIcon tool={session.agentic_tool} size={40} />
-              <div style={{ flex: 1 }}>
-                <div style={{ marginBottom: 4 }}>
-                  <Typography.Text
-                    strong
-                    style={{
-                      fontSize: 18,
-                      ...getSessionTitleStyles(2),
-                    }}
-                  >
-                    {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-                  </Typography.Text>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <Space size={12} align="start" style={{ flex: 1 }}>
+            <ToolIcon tool={session.agentic_tool} size={40} />
+            <div style={{ flex: 1 }}>
+              <div style={{ marginBottom: 4 }}>
+                <Typography.Text
+                  strong
+                  style={{
+                    fontSize: 18,
+                    ...getSessionTitleStyles(2),
+                  }}
+                >
+                  {getSessionDisplayTitle(session, { includeAgentFallback: true })}
+                </Typography.Text>
+                {!searchOpen && (
                   <Badge
                     status={getStatusColor()}
                     text={session.status.toUpperCase()}
                     style={{ marginLeft: 12 }}
                   />
+                )}
+              </div>
+              {searchOpen ? (
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
+                  <Input
+                    ref={(el) => { searchInputRef.current = el?.input ?? null; }}
+                    value={query}
+                    onChange={(e) => { setQuery(e.target.value); }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
+                      if (e.key === 'Escape') closeSearch();
+                    }}
+                    placeholder="Search session..."
+                    variant="borderless"
+                    style={{ flex: 1, padding: 0 }}
+                    size="small"
+                  />
+                  {query && (
+                    <Typography.Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap', minWidth: 44, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                      {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : 'no results'}
+                    </Typography.Text>
+                  )}
+                  {!query && (
+                    <Typography.Text type="secondary" style={{ fontSize: 11 }}>Esc to close</Typography.Text>
+                  )}
+                  {totalMatches > 1 && (
+                    <Space size={2}>
+                      <Tooltip title="Previous (Shift+Enter)">
+                        <Button type="text" size="small" icon={<UpOutlined />} onClick={goPrev} />
+                      </Tooltip>
+                      <Tooltip title="Next (Enter)">
+                        <Button type="text" size="small" icon={<DownOutlined />} onClick={goNext} />
+                      </Tooltip>
+                    </Space>
+                  )}
+                  <Tooltip title="Close search (Esc)">
+                    <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+                  </Tooltip>
                 </div>
-                {session.created_by && (
+              ) : (
+                session.created_by && (
                   <div>
                     <CreatedByTag
                       createdBy={session.created_by}
@@ -1216,30 +1219,30 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                       prefix="Created by"
                     />
                   </div>
-                )}
-              </div>
-            </Space>
-            <Space size={4}>
-              <SessionAttachmentsDropdown items={attachmentItems} />
-              <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
-                <Tooltip title="More actions">
-                  <Button type="text" icon={<EllipsisOutlined />} />
-                </Tooltip>
-              </Dropdown>
-              <Tooltip title="Search session (⌘F)">
-                <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
+                )
+              )}
+            </div>
+          </Space>
+          <Space size={4}>
+            <SessionAttachmentsDropdown items={attachmentItems} />
+            <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
+              <Tooltip title="More actions">
+                <Button type="text" icon={<EllipsisOutlined />} />
               </Tooltip>
-              <Tooltip title="Close Panel">
-                <Button
-                  type="text"
-                  icon={<CloseOutlined />}
-                  onClick={onClose}
-                  style={{ marginLeft: token.sizeUnit }}
-                />
-              </Tooltip>
-            </Space>
-          </div>
-        )}
+            </Dropdown>
+            <Tooltip title="Search session (Cmd+F)">
+              <Button type="text" icon={<SearchOutlined />} onClick={openSearch} />
+            </Tooltip>
+            <Tooltip title="Close Panel">
+              <Button
+                type="text"
+                icon={<CloseOutlined />}
+                onClick={onClose}
+                style={{ marginLeft: token.sizeUnit }}
+              />
+            </Tooltip>
+          </Space>
+        </div>
       </div>
 
       {/* Body - Scrollable content */}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -30,13 +30,25 @@ import {
   UpOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Alert, App, Badge, Button, Dropdown, Input, Space, Tooltip, Typography, theme } from 'antd';
+import {
+  Alert,
+  App,
+  Badge,
+  Button,
+  Dropdown,
+  Input,
+  Space,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import React from 'react';
 import { getDaemonUrl } from '../../config/daemon';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useSessionActions } from '../../hooks/useSessionActions';
+import { useSessionSearch } from '../../hooks/useSessionSearch';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { useAgorStore } from '../../store/agorStore';
 import {
@@ -68,7 +80,6 @@ import { SessionComposerDropZone } from './SessionComposerDropZone';
 import { SessionFooter } from './SessionFooter';
 import { SessionPanelContent } from './SessionPanelContent';
 import { useComposerAttachments } from './useComposerAttachments';
-import { useSessionSearch } from '../../hooks/useSessionSearch';
 
 // Re-export PermissionMode from SDK for convenience
 export type { PermissionMode };
@@ -1155,7 +1166,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       >
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
           <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flex: 1, minWidth: 0 }}>
-            <div style={{ flexShrink: 0 }}><ToolIcon tool={session.agentic_tool} size={40} /></div>
+            <div style={{ flexShrink: 0 }}>
+              <ToolIcon tool={session.agentic_tool} size={40} />
+            </div>
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ marginBottom: 4 }}>
                 <Typography.Text
@@ -1177,11 +1190,17 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               </div>
               {searchOpen ? (
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                  <SearchOutlined style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }} />
+                  <SearchOutlined
+                    style={{ color: token.colorPrimary, fontSize: 14, flexShrink: 0 }}
+                  />
                   <Input
-                    ref={(el) => { searchInputRef.current = el?.input ?? null; }}
+                    ref={(el) => {
+                      searchInputRef.current = el?.input ?? null;
+                    }}
                     value={query}
-                    onChange={(e) => { setQuery(e.target.value); }}
+                    onChange={(e) => {
+                      setQuery(e.target.value);
+                    }}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') e.shiftKey ? goPrev() : goNext();
                       if (e.key === 'Escape') closeSearch();
@@ -1192,12 +1211,23 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                     size="small"
                   />
                   {query && (
-                    <Typography.Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap', minWidth: 44, textAlign: 'right', fontVariantNumeric: 'tabular-nums' }}>
+                    <Typography.Text
+                      type="secondary"
+                      style={{
+                        fontSize: 12,
+                        whiteSpace: 'nowrap',
+                        minWidth: 44,
+                        textAlign: 'right',
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    >
                       {totalMatches > 0 ? `${currentMatch + 1} / ${totalMatches}` : 'no results'}
                     </Typography.Text>
                   )}
                   {!query && (
-                    <Typography.Text type="secondary" style={{ fontSize: 11 }}>Esc to close</Typography.Text>
+                    <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+                      Esc to close
+                    </Typography.Text>
                   )}
                   {totalMatches > 1 && (
                     <Space size={2}>
@@ -1210,7 +1240,12 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
                     </Space>
                   )}
                   <Tooltip title="Close search (Esc)">
-                    <Button type="text" size="small" icon={<CloseOutlined />} onClick={closeSearch} />
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<CloseOutlined />}
+                      onClick={closeSearch}
+                    />
                   </Tooltip>
                 </div>
               ) : (
@@ -1277,9 +1312,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             }}
           >
             <SearchOutlined style={{ fontSize: 32, color: token.colorTextTertiary }} />
-            <Typography.Text type="secondary">
-              No results for &ldquo;{query}&rdquo;
-            </Typography.Text>
+            <Typography.Text type="secondary">No results for &ldquo;{query}&rdquo;</Typography.Text>
           </div>
         )}
         <SessionPanelContent

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -45,6 +45,8 @@ export interface SessionPanelContentProps {
    *  Tabs bar inline above the panel; when omitted, the parent is
    *  expected to render the bar itself (legacy header-level placement). */
   setCliViewMode?: (mode: 'terminal' | 'conversation') => void;
+  /** When true, all task blocks are force-expanded (used by in-session search) */
+  forceExpandAll?: boolean;
 }
 
 export const SessionPanelContent = React.memo<SessionPanelContentProps>(
@@ -66,6 +68,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     isOpen,
     cliViewMode = 'terminal',
     setCliViewMode,
+    forceExpandAll = false,
   }) => {
     const { token } = theme.useToken();
     const { showSuccess, showError } = useThemedMessage();
@@ -325,6 +328,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             assistantEmoji={
               branch && isAssistant(branch) ? getAssistantConfig(branch)?.emoji : undefined
             }
+            forceExpandAll={forceExpandAll}
           />
         </div>
 

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -562,200 +562,202 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     );
 
     return (
-      <Collapse
-        activeKey={isExpanded ? ['task-content'] : []}
-        onChange={(keys) => onExpandChange(task.task_id, keys.length > 0)}
-        expandIcon={() => null}
-        style={{ background: 'transparent', margin: `${token.sizeUnit * 3}px 0` }}
-        items={[
-          {
-            key: 'task-content',
-            label: taskHeader,
-            styles: {
-              header: {
-                padding: token.sizeUnit * 2,
-                alignItems: 'flex-start',
-                background: taskHeaderGradient || 'transparent',
-                borderRadius: isExpanded ? '8px 8px 0 0' : 8,
+      <div data-task-block={task.task_id}>
+        <Collapse
+          activeKey={isExpanded ? ['task-content'] : []}
+          onChange={(keys) => onExpandChange(task.task_id, keys.length > 0)}
+          expandIcon={() => null}
+          style={{ background: 'transparent', margin: `${token.sizeUnit * 3}px 0` }}
+          items={[
+            {
+              key: 'task-content',
+              label: taskHeader,
+              styles: {
+                header: {
+                  padding: token.sizeUnit * 2,
+                  alignItems: 'flex-start',
+                  background: taskHeaderGradient || 'transparent',
+                  borderRadius: isExpanded ? '8px 8px 0 0' : 8,
+                },
+                body: {
+                  background: 'transparent',
+                  padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 2}px`,
+                },
               },
-              body: {
-                background: 'transparent',
-                padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 2}px`,
-              },
-            },
-            children: (
-              <div style={{ paddingTop: token.sizeUnit }}>
-                {/* Show loading spinner while fetching messages */}
-                {messagesLoading && (
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'center',
-                      padding: `${token.sizeUnit * 2}px 0`,
-                    }}
-                  >
-                    <Spin size="small" />
-                  </div>
-                )}
+              children: (
+                <div style={{ paddingTop: token.sizeUnit }}>
+                  {/* Show loading spinner while fetching messages */}
+                  {messagesLoading && (
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        padding: `${token.sizeUnit * 2}px 0`,
+                      }}
+                    >
+                      <Spin size="small" />
+                    </div>
+                  )}
 
-                {/* Render all blocks (messages and agent chains) */}
-                {!messagesLoading &&
-                  blocks.map((block, blockIndex) => {
-                    if (block.type === 'message') {
-                      // Find if this is a permission request and if it's the first pending one
-                      const isPermissionRequest = block.message.type === 'permission_request';
-                      let isFirstPending = false;
+                  {/* Render all blocks (messages and agent chains) */}
+                  {!messagesLoading &&
+                    blocks.map((block, blockIndex) => {
+                      if (block.type === 'message') {
+                        // Find if this is a permission request and if it's the first pending one
+                        const isPermissionRequest = block.message.type === 'permission_request';
+                        let isFirstPending = false;
 
-                      if (isPermissionRequest) {
-                        const content = block.message.content as PermissionRequestContent;
-                        if (content.status === PermissionStatus.PENDING) {
-                          // Check if this is the first pending permission request
-                          isFirstPending = !blocks.slice(0, blockIndex).some((b) => {
-                            if (b.type === 'message' && b.message.type === 'permission_request') {
-                              const c = b.message.content as PermissionRequestContent;
-                              return c.status === PermissionStatus.PENDING;
-                            }
-                            return false;
-                          });
+                        if (isPermissionRequest) {
+                          const content = block.message.content as PermissionRequestContent;
+                          if (content.status === PermissionStatus.PENDING) {
+                            // Check if this is the first pending permission request
+                            isFirstPending = !blocks.slice(0, blockIndex).some((b) => {
+                              if (b.type === 'message' && b.message.type === 'permission_request') {
+                                const c = b.message.content as PermissionRequestContent;
+                                return c.status === PermissionStatus.PENDING;
+                              }
+                              return false;
+                            });
+                          }
                         }
-                      }
 
-                      // Render SDK status messages (rate limit, API wait, etc.) with dedicated component
-                      if (isSdkStatusMessage(block.message)) {
+                        // Render SDK status messages (rate limit, API wait, etc.) with dedicated component
+                        if (isSdkStatusMessage(block.message)) {
+                          return (
+                            <RateLimitBlock
+                              key={block.message.message_id}
+                              message={block.message}
+                              agentic_tool={agentic_tool}
+                            />
+                          );
+                        }
+
+                        // Check if this is the latest agent message (last message block)
+                        const isLatestMessage =
+                          block.message.role === MessageRole.ASSISTANT &&
+                          blockIndex === blocks.length - 1;
+
                         return (
-                          <RateLimitBlock
+                          <MessageBlock
                             key={block.message.message_id}
                             message={block.message}
+                            agentic_tool={agentic_tool}
+                            userById={userById}
+                            currentUserId={task.created_by}
+                            isTaskRunning={task.status === TaskStatus.RUNNING}
+                            sessionId={sessionId}
+                            onPermissionDecision={onPermissionDecision}
+                            isFirstPendingPermission={isFirstPending}
+                            isLatestMessage={isLatestMessage}
+                            taskId={task.task_id}
+                            assistantEmoji={assistantEmoji}
+                            client={client}
+                          />
+                        );
+                      }
+                      if (block.type === 'agent-chain') {
+                        // Use first message ID as key for agent chain
+                        const blockKey = `agent-chain-${block.messages[0]?.message_id || 'unknown'}`;
+                        return (
+                          <AgentChain
+                            key={blockKey}
+                            messages={block.messages}
+                            isTaskRunning={task.status === TaskStatus.RUNNING}
+                            isLatest={isLatestTask && blockIndex === lastAgentChainIndex}
+                          />
+                        );
+                      }
+                      if (block.type === 'compaction') {
+                        // Render compaction block with aggregated messages
+                        const blockKey = `compaction-${block.messages[0]?.message_id || 'unknown'}`;
+                        return (
+                          <CompactionBlock
+                            key={blockKey}
+                            messages={block.messages}
                             agentic_tool={agentic_tool}
                           />
                         );
                       }
+                      return null;
+                    })}
 
-                      // Check if this is the latest agent message (last message block)
-                      const isLatestMessage =
-                        block.message.role === MessageRole.ASSISTANT &&
-                        blockIndex === blocks.length - 1;
+                  {/* Keep latest TODO visible even after completion (Claude parity). */}
+                  <StickyTodoRenderer messages={messages} taskStatus={task.status} />
 
-                      return (
-                        <MessageBlock
-                          key={block.message.message_id}
-                          message={block.message}
-                          agentic_tool={agentic_tool}
-                          userById={userById}
-                          currentUserId={task.created_by}
-                          isTaskRunning={task.status === TaskStatus.RUNNING}
-                          sessionId={sessionId}
-                          onPermissionDecision={onPermissionDecision}
-                          isFirstPendingPermission={isFirstPending}
-                          isLatestMessage={isLatestMessage}
-                          taskId={task.task_id}
-                          assistantEmoji={assistantEmoji}
-                          client={client}
-                        />
-                      );
-                    }
-                    if (block.type === 'agent-chain') {
-                      // Use first message ID as key for agent chain
-                      const blockKey = `agent-chain-${block.messages[0]?.message_id || 'unknown'}`;
-                      return (
-                        <AgentChain
-                          key={blockKey}
-                          messages={block.messages}
-                          isTaskRunning={task.status === TaskStatus.RUNNING}
-                          isLatest={isLatestTask && blockIndex === lastAgentChainIndex}
-                        />
-                      );
-                    }
-                    if (block.type === 'compaction') {
-                      // Render compaction block with aggregated messages
-                      const blockKey = `compaction-${block.messages[0]?.message_id || 'unknown'}`;
-                      return (
-                        <CompactionBlock
-                          key={blockKey}
-                          messages={block.messages}
-                          agentic_tool={agentic_tool}
-                        />
-                      );
-                    }
-                    return null;
-                  })}
+                  {/* Show typing indicator whenever task is actively running */}
+                  {task.status === TaskStatus.RUNNING && (
+                    <div style={{ margin: `${token.sizeUnit}px 0` }}>
+                      <Bubble
+                        placement="start"
+                        avatar={
+                          assistantEmoji ? (
+                            <AgorAvatar>{assistantEmoji}</AgorAvatar>
+                          ) : agentic_tool ? (
+                            <ToolIcon tool={agentic_tool} size={32} />
+                          ) : (
+                            <AgorAvatar
+                              icon={<RobotOutlined />}
+                              style={{ backgroundColor: token.colorSuccess }}
+                            />
+                          )
+                        }
+                        loading={true}
+                        content=""
+                        variant="outlined"
+                      />
+                    </div>
+                  )}
 
-                {/* Keep latest TODO visible even after completion (Claude parity). */}
-                <StickyTodoRenderer messages={messages} taskStatus={task.status} />
-
-                {/* Show typing indicator whenever task is actively running */}
-                {task.status === TaskStatus.RUNNING && (
-                  <div style={{ margin: `${token.sizeUnit}px 0` }}>
-                    <Bubble
-                      placement="start"
-                      avatar={
-                        assistantEmoji ? (
-                          <AgorAvatar>{assistantEmoji}</AgorAvatar>
-                        ) : agentic_tool ? (
-                          <ToolIcon tool={agentic_tool} size={32} />
-                        ) : (
-                          <AgorAvatar
-                            icon={<RobotOutlined />}
-                            style={{ backgroundColor: token.colorSuccess }}
-                          />
-                        )
-                      }
-                      loading={true}
-                      content=""
-                      variant="outlined"
-                    />
-                  </div>
-                )}
-
-                {/* Show commit message if available */}
-                {task.git_state.commit_message && (
-                  <div
-                    style={{
-                      marginTop: token.sizeUnit * 1.5,
-                      padding: `${token.sizeUnit * 0.75}px ${token.sizeUnit * 1.25}px`,
-                      background: 'rgba(0, 0, 0, 0.02)',
-                      borderRadius: token.borderRadius,
-                    }}
-                  >
-                    <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-                      <GithubOutlined /> Commit:{' '}
-                    </Typography.Text>
-                    <Typography.Text code style={{ fontSize: 11 }}>
-                      {typeof task.git_state.commit_message === 'string'
-                        ? task.git_state.commit_message
-                        : JSON.stringify(task.git_state.commit_message)}
-                    </Typography.Text>
-                  </div>
-                )}
-
-                {/* Show report if available */}
-                {task.report && (
-                  <div style={{ marginTop: token.sizeUnit * 1.5 }}>
-                    <Tag icon={<FileTextOutlined />} color="green">
-                      Task Report
-                    </Tag>
-                    <Paragraph
+                  {/* Show commit message if available */}
+                  {task.git_state.commit_message && (
+                    <div
                       style={{
-                        marginTop: token.sizeUnit,
-                        padding: token.sizeUnit * 1.5,
-                        background: 'rgba(82, 196, 26, 0.05)',
-                        border: `1px solid ${token.colorSuccessBorder}`,
+                        marginTop: token.sizeUnit * 1.5,
+                        padding: `${token.sizeUnit * 0.75}px ${token.sizeUnit * 1.25}px`,
+                        background: 'rgba(0, 0, 0, 0.02)',
                         borderRadius: token.borderRadius,
-                        fontSize: 13,
-                        whiteSpace: 'pre-wrap',
                       }}
                     >
-                      {typeof task.report === 'string'
-                        ? task.report
-                        : JSON.stringify(task.report, null, 2)}
-                    </Paragraph>
-                  </div>
-                )}
-              </div>
-            ),
-          },
-        ]}
-      />
+                      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                        <GithubOutlined /> Commit:{' '}
+                      </Typography.Text>
+                      <Typography.Text code style={{ fontSize: 11 }}>
+                        {typeof task.git_state.commit_message === 'string'
+                          ? task.git_state.commit_message
+                          : JSON.stringify(task.git_state.commit_message)}
+                      </Typography.Text>
+                    </div>
+                  )}
+
+                  {/* Show report if available */}
+                  {task.report && (
+                    <div style={{ marginTop: token.sizeUnit * 1.5 }}>
+                      <Tag icon={<FileTextOutlined />} color="green">
+                        Task Report
+                      </Tag>
+                      <Paragraph
+                        style={{
+                          marginTop: token.sizeUnit,
+                          padding: token.sizeUnit * 1.5,
+                          background: 'rgba(82, 196, 26, 0.05)',
+                          border: `1px solid ${token.colorSuccessBorder}`,
+                          borderRadius: token.borderRadius,
+                          fontSize: 13,
+                          whiteSpace: 'pre-wrap',
+                        }}
+                      >
+                        {typeof task.report === 'string'
+                          ? task.report
+                          : JSON.stringify(task.report, null, 2)}
+                      </Paragraph>
+                    </div>
+                  )}
+                </div>
+              ),
+            },
+          ]}
+        />
+      </div>
     );
   }
 );

--- a/apps/agor-ui/src/hooks/useSessionSearch.test.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getMatchOffsets } from './useSessionSearch';
+
+describe('getMatchOffsets', () => {
+  it('returns nothing for empty or whitespace-only queries', () => {
+    expect(getMatchOffsets('hello world', '')).toEqual([]);
+    expect(getMatchOffsets('hello world', '   ')).toEqual([]);
+    expect(getMatchOffsets('', 'hello')).toEqual([]);
+  });
+
+  it('finds every non-overlapping, case-insensitive match', () => {
+    expect(getMatchOffsets('Foo foo FOO', 'foo')).toEqual([
+      [0, 3],
+      [4, 7],
+      [8, 11],
+    ]);
+  });
+
+  it('treats regex metacharacters in the query literally', () => {
+    expect(getMatchOffsets('a.b a.b axb', 'a.b')).toEqual([
+      [0, 3],
+      [4, 7],
+    ]);
+  });
+
+  it('reports offsets that slice back to the matched substring', () => {
+    const text = 'the quick brown fox';
+    const [start, end] = getMatchOffsets(text, 'quick')[0];
+    expect(text.slice(start, end)).toBe('quick');
+  });
+});

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -1,98 +1,102 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { escapeRegExp } from '../components/HighlightMatch/HighlightMatch';
 
-const MARK_CLASS = 'agor-search-highlight';
+const HIGHLIGHT_NAME = 'agor-search';
+const CURRENT_HIGHLIGHT_NAME = 'agor-search-current';
+const REBUILD_DEBOUNCE_MS = 160;
 
-function escapeRegex(s: string) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+export interface SessionSearchColors {
+  /** Base color for every match (rendered translucent). */
+  highlight: string;
+  /** Solid color for the active match. */
+  current: string;
+  /** Text color painted over the active match. */
+  currentText: string;
 }
 
-function clearMarks(container: HTMLElement) {
-  container.querySelectorAll(`.${MARK_CLASS}`).forEach((mark) => {
-    const parent = mark.parentNode;
-    if (!parent) return;
-    parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
-    parent.normalize();
-  });
+// Structural view over the CSS Custom Highlight API so this compiles regardless
+// of whether the installed TS DOM lib ships the (recent) `Highlight` types.
+type CSSHighlight = { priority: number };
+type CSSHighlightCtor = new (...ranges: Range[]) => CSSHighlight;
+interface HighlightRegistryLike {
+  set(name: string, highlight: CSSHighlight): void;
+  delete(name: string): void;
 }
 
-function buildMarks(container: HTMLElement, query: string, highlightColor: string): HTMLElement[] {
-  clearMarks(container);
+function getHighlightApi(): { create: CSSHighlightCtor; registry: HighlightRegistryLike } | null {
+  if (typeof window === 'undefined') return null;
+  const global = window as unknown as {
+    Highlight?: CSSHighlightCtor;
+    CSS?: { highlights?: HighlightRegistryLike };
+  };
+  if (typeof global.Highlight !== 'function' || !global.CSS?.highlights) return null;
+  return { create: global.Highlight, registry: global.CSS.highlights };
+}
+
+/**
+ * Case-insensitive, non-overlapping match offsets of `query` within `text`.
+ * Pure so the range-building logic stays unit-testable without a DOM.
+ */
+export function getMatchOffsets(text: string, query: string): Array<[number, number]> {
+  if (!text || !query.trim()) return [];
+  const regex = new RegExp(escapeRegExp(query), 'gi');
+  const offsets: Array<[number, number]> = [];
+  let match = regex.exec(text);
+  while (match !== null) {
+    offsets.push([match.index, match.index + match[0].length]);
+    // Guard against a zero-length match wedging the loop.
+    if (match.index === regex.lastIndex) regex.lastIndex += 1;
+    match = regex.exec(text);
+  }
+  return offsets;
+}
+
+function buildRanges(container: HTMLElement, query: string): Range[] {
   if (!query.trim()) return [];
-
-  const regex = new RegExp(escapeRegex(query), 'gi');
-  const marks: HTMLElement[] = [];
 
   const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
       const el = node.parentElement;
       if (!el) return NodeFilter.FILTER_REJECT;
-      const tag = el.tagName.toLowerCase();
-      if (tag === 'script' || tag === 'style' || el.classList.contains(MARK_CLASS)) {
-        return NodeFilter.FILTER_REJECT;
-      }
-      return NodeFilter.FILTER_ACCEPT;
+      const tag = el.tagName;
+      if (tag === 'SCRIPT' || tag === 'STYLE') return NodeFilter.FILTER_REJECT;
+      return node.nodeValue?.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
     },
   });
 
-  const textNodes: Text[] = [];
-  let next = walker.nextNode();
-  while (next) {
-    textNodes.push(next as Text);
-    next = walker.nextNode();
-  }
-
-  for (const textNode of textNodes) {
-    const text = textNode.textContent || '';
-    if (!regex.test(text)) {
-      regex.lastIndex = 0;
-      continue;
+  const ranges: Range[] = [];
+  let node = walker.nextNode();
+  while (node) {
+    const text = node.nodeValue ?? '';
+    for (const [start, end] of getMatchOffsets(text, query)) {
+      const range = document.createRange();
+      range.setStart(node, start);
+      range.setEnd(node, end);
+      ranges.push(range);
     }
-    regex.lastIndex = 0;
-    const frag = document.createDocumentFragment();
-    let last = 0;
-    let m = regex.exec(text);
-    while (m !== null) {
-      if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
-      const mark = document.createElement('mark');
-      mark.className = MARK_CLASS;
-      mark.textContent = m[0];
-      mark.style.cssText = `background:${highlightColor};color:rgba(0,0,0,0.88);border-radius:3px;padding:0 1px;`;
-      frag.appendChild(mark);
-      marks.push(mark);
-      last = regex.lastIndex;
-      m = regex.exec(text);
-    }
-    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
-    textNode.parentNode?.replaceChild(frag, textNode);
+    node = walker.nextNode();
   }
-  return marks;
+  return ranges;
 }
 
-function paintMark(
-  mark: HTMLElement,
-  current: boolean,
-  colors: { highlight: string; current: string; currentText: string }
-) {
-  if (current) {
-    mark.style.background = colors.current;
-    mark.style.color = colors.currentText;
-    mark.style.boxShadow = `0 0 0 2px ${colors.current}`;
-    mark.style.outline = 'none';
-    mark.style.outlineOffset = '0';
-  } else {
-    mark.style.background = colors.highlight;
-    mark.style.color = 'rgba(0,0,0,0.88)';
-    mark.style.boxShadow = 'none';
-    mark.style.outline = 'none';
-  }
+function scrollRangeIntoView(range: Range) {
+  const node = range.startContainer;
+  const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+  el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
 }
 
+/**
+ * In-drawer find. Highlights matches with the CSS Custom Highlight API — text
+ * nodes are read-only (ranges only), so React's tree is never mutated and
+ * streaming/hydrating re-renders stay safe. Where the API is unavailable the
+ * hook degrades to navigation without visible highlighting.
+ */
 export function useSessionSearch(
   containerRef: React.RefObject<HTMLElement | null>,
-  colors?: { highlight: string; current: string; currentText: string }
+  colors?: SessionSearchColors
 ) {
   const resolvedColors = colors ?? {
-    highlight: 'rgba(250,173,20,0.4)',
+    highlight: '#faad14',
     current: '#faad14',
     currentText: 'rgba(0,0,0,0.88)',
   };
@@ -102,21 +106,79 @@ export function useSessionSearch(
   const [totalMatches, setTotalMatches] = useState(0);
   const [currentMatch, setCurrentMatch] = useState(0);
   const [searchPending, setSearchPending] = useState(false);
-  const marksRef = useRef<HTMLElement[]>([]);
-  const hiddenBlocksRef = useRef<HTMLElement[]>([]);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const resolvedColorsRef = useRef(resolvedColors);
-  resolvedColorsRef.current = resolvedColors;
 
-  const setCurrent = useCallback((idx: number, marks: HTMLElement[]) => {
-    marks.forEach((m, i) => {
-      paintMark(m, i === idx, resolvedColorsRef.current);
-    });
-    marks[idx]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-    setCurrentMatch(idx);
+  const apiRef = useRef<ReturnType<typeof getHighlightApi>>(null);
+  const styleElRef = useRef<HTMLStyleElement | null>(null);
+  const rangesRef = useRef<Range[]>([]);
+  const currentIndexRef = useRef(0);
+  const queryRef = useRef(query);
+  queryRef.current = query;
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const applyHighlights = useCallback((ranges: Range[], currentIdx: number) => {
+    const api = apiRef.current;
+    if (!api) return;
+    if (ranges.length === 0) {
+      api.registry.delete(HIGHLIGHT_NAME);
+      api.registry.delete(CURRENT_HIGHLIGHT_NAME);
+      return;
+    }
+    api.registry.set(HIGHLIGHT_NAME, new api.create(...ranges));
+    const current = ranges[currentIdx];
+    if (current) {
+      const highlight = new api.create(current);
+      // Paint the active match on top of the base highlight.
+      highlight.priority = 1;
+      api.registry.set(CURRENT_HIGHLIGHT_NAME, highlight);
+    } else {
+      api.registry.delete(CURRENT_HIGHLIGHT_NAME);
+    }
   }, []);
 
+  const clearHighlights = useCallback(() => {
+    const api = apiRef.current;
+    if (api) {
+      api.registry.delete(HIGHLIGHT_NAME);
+      api.registry.delete(CURRENT_HIGHLIGHT_NAME);
+    }
+    rangesRef.current = [];
+  }, []);
+
+  const runSearch = useCallback(
+    (scrollToCurrent: boolean) => {
+      const container = containerRef.current;
+      if (!container || !apiRef.current) {
+        setTotalMatches(0);
+        setSearchPending(false);
+        return;
+      }
+      const ranges = buildRanges(container, queryRef.current);
+      rangesRef.current = ranges;
+      const idx = ranges.length === 0 ? 0 : Math.min(currentIndexRef.current, ranges.length - 1);
+      currentIndexRef.current = idx;
+      applyHighlights(ranges, idx);
+      setTotalMatches(ranges.length);
+      setCurrentMatch(idx);
+      setSearchPending(false);
+      if (scrollToCurrent && ranges[idx]) scrollRangeIntoView(ranges[idx]);
+    },
+    [containerRef, applyHighlights]
+  );
+
+  const setCurrent = useCallback(
+    (idx: number) => {
+      const ranges = rangesRef.current;
+      if (!ranges.length) return;
+      currentIndexRef.current = idx;
+      applyHighlights(ranges, idx);
+      setCurrentMatch(idx);
+      if (ranges[idx]) scrollRangeIntoView(ranges[idx]);
+    },
+    [applyHighlights]
+  );
+
   const openSearch = useCallback(() => {
+    currentIndexRef.current = 0;
     setSearchOpen(true);
     setQuery('');
     setTotalMatches(0);
@@ -124,72 +186,81 @@ export function useSessionSearch(
   }, []);
 
   const closeSearch = useCallback(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    if (containerRef.current) clearMarks(containerRef.current);
-    marksRef.current = [];
-    hiddenBlocksRef.current.forEach((el) => {
-      el.style.display = '';
-    });
-    hiddenBlocksRef.current = [];
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    clearHighlights();
+    currentIndexRef.current = 0;
     setSearchOpen(false);
     setQuery('');
     setTotalMatches(0);
     setCurrentMatch(0);
     setSearchPending(false);
-  }, [containerRef]);
+  }, [clearHighlights]);
 
+  // Detect the Custom Highlight API once and register the ::highlight() stylesheet.
+  useEffect(() => {
+    const api = getHighlightApi();
+    apiRef.current = api;
+    if (!api) return;
+    const style = document.createElement('style');
+    styleElRef.current = style;
+    document.head.appendChild(style);
+    return () => {
+      style.remove();
+      styleElRef.current = null;
+      api.registry.delete(HIGHLIGHT_NAME);
+      api.registry.delete(CURRENT_HIGHLIGHT_NAME);
+    };
+  }, []);
+
+  // ::highlight() only accepts a handful of properties (no box-shadow/border),
+  // so the active match is distinguished by a solid fill over the translucent base.
+  useEffect(() => {
+    const style = styleElRef.current;
+    if (!style) return;
+    style.textContent = `::highlight(${HIGHLIGHT_NAME}){background-color:color-mix(in srgb, ${resolvedColors.highlight} 40%, transparent);}::highlight(${CURRENT_HIGHLIGHT_NAME}){background-color:${resolvedColors.current};color:${resolvedColors.currentText};}`;
+  }, [resolvedColors.highlight, resolvedColors.current, resolvedColors.currentText]);
+
+  // Rebuild on query change and re-scan when the conversation mutates while open:
+  // lazy task hydration, streaming updates, etc. all land after the initial scan.
+  // `query` is a deliberate trigger — typing doesn't mutate the DOM, so the
+  // observer never fires for it; runSearch reads the latest value via queryRef.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: query re-runs the effect on typing; value is read via queryRef
   useEffect(() => {
     if (!searchOpen) return;
-    if (timerRef.current) clearTimeout(timerRef.current);
-    setSearchPending(true);
-    timerRef.current = setTimeout(() => {
-      if (!containerRef.current) return;
+    const container = containerRef.current;
+    if (!container || !apiRef.current) return;
 
-      // Restore any previously hidden blocks before re-running
-      hiddenBlocksRef.current.forEach((el) => {
-        el.style.display = '';
-      });
-      hiddenBlocksRef.current = [];
+    // A new query starts from the first match.
+    currentIndexRef.current = 0;
 
-      const marks = buildMarks(containerRef.current, query, resolvedColorsRef.current.highlight);
-      marksRef.current = marks;
-      setTotalMatches(marks.length);
-      setCurrentMatch(0);
-
-      if (marks.length > 0) {
-        setCurrent(0, marks);
-        // Hide task blocks with no matches
-        const allBlocks = Array.from(
-          containerRef.current.querySelectorAll<HTMLElement>('[data-task-block]')
-        );
-        const matchedBlocks = new Set(
-          marks.map((m) => m.closest('[data-task-block]')).filter(Boolean)
-        );
-        hiddenBlocksRef.current = allBlocks.filter((b) => !matchedBlocks.has(b));
-        hiddenBlocksRef.current.forEach((el) => {
-          el.style.display = 'none';
-        });
-      }
-      setSearchPending(false);
-    }, 160);
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
+    const scheduleRebuild = (scrollToCurrent: boolean) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      setSearchPending(true);
+      debounceRef.current = setTimeout(() => runSearch(scrollToCurrent), REBUILD_DEBOUNCE_MS);
     };
-  }, [query, searchOpen, containerRef, setCurrent]);
+
+    scheduleRebuild(true);
+
+    const observer = new MutationObserver(() => scheduleRebuild(false));
+    observer.observe(container, { childList: true, subtree: true, characterData: true });
+
+    return () => {
+      observer.disconnect();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, searchOpen, containerRef, runSearch]);
 
   const goNext = useCallback(() => {
-    const marks = marksRef.current;
-    if (!marks.length) return;
-    const next = (currentMatch + 1) % marks.length;
-    setCurrent(next, marks);
-  }, [currentMatch, setCurrent]);
+    const total = rangesRef.current.length;
+    if (!total) return;
+    setCurrent((currentIndexRef.current + 1) % total);
+  }, [setCurrent]);
 
   const goPrev = useCallback(() => {
-    const marks = marksRef.current;
-    if (!marks.length) return;
-    const prev = (currentMatch - 1 + marks.length) % marks.length;
-    setCurrent(prev, marks);
-  }, [currentMatch, setCurrent]);
+    const total = rangesRef.current.length;
+    if (!total) return;
+    setCurrent((currentIndexRef.current - 1 + total) % total);
+  }, [setCurrent]);
 
   return {
     searchOpen,

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -76,11 +76,13 @@ function paintMark(
   if (current) {
     mark.style.background = colors.current;
     mark.style.color = colors.currentText;
-    mark.style.outline = `2px solid ${colors.current}`;
-    mark.style.outlineOffset = '1px';
+    mark.style.boxShadow = `0 0 0 2px ${colors.current}`;
+    mark.style.outline = 'none';
+    mark.style.outlineOffset = '0';
   } else {
     mark.style.background = colors.highlight;
     mark.style.color = 'rgba(0,0,0,0.88)';
+    mark.style.boxShadow = 'none';
     mark.style.outline = 'none';
   }
 }

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -100,6 +100,7 @@ export function useSessionSearch(
   const [totalMatches, setTotalMatches] = useState(0);
   const [currentMatch, setCurrentMatch] = useState(0);
   const marksRef = useRef<HTMLElement[]>([]);
+  const hiddenBlocksRef = useRef<HTMLElement[]>([]);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const resolvedColorsRef = useRef(resolvedColors);
   resolvedColorsRef.current = resolvedColors;
@@ -123,6 +124,10 @@ export function useSessionSearch(
     if (timerRef.current) clearTimeout(timerRef.current);
     if (containerRef.current) clearMarks(containerRef.current);
     marksRef.current = [];
+    hiddenBlocksRef.current.forEach((el) => {
+      el.style.display = '';
+    });
+    hiddenBlocksRef.current = [];
     setSearchOpen(false);
     setQuery('');
     setTotalMatches(0);
@@ -134,11 +139,32 @@ export function useSessionSearch(
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       if (!containerRef.current) return;
+
+      // Restore any previously hidden blocks before re-running
+      hiddenBlocksRef.current.forEach((el) => {
+        el.style.display = '';
+      });
+      hiddenBlocksRef.current = [];
+
       const marks = buildMarks(containerRef.current, query, resolvedColorsRef.current.highlight);
       marksRef.current = marks;
       setTotalMatches(marks.length);
       setCurrentMatch(0);
-      if (marks.length > 0) setCurrent(0, marks);
+
+      if (marks.length > 0) {
+        setCurrent(0, marks);
+        // Hide task blocks with no matches
+        const allBlocks = Array.from(
+          containerRef.current.querySelectorAll<HTMLElement>('[data-task-block]')
+        );
+        const matchedBlocks = new Set(
+          marks.map((m) => m.closest('[data-task-block]')).filter(Boolean)
+        );
+        hiddenBlocksRef.current = allBlocks.filter((b) => !matchedBlocks.has(b));
+        hiddenBlocksRef.current.forEach((el) => {
+          el.style.display = 'none';
+        });
+      }
     }, 160);
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const MARK_CLASS = 'agor-search-highlight';
+
+function escapeRegex(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function clearMarks(container: HTMLElement) {
+  container.querySelectorAll(`.${MARK_CLASS}`).forEach((mark) => {
+    const parent = mark.parentNode;
+    if (!parent) return;
+    parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
+    parent.normalize();
+  });
+}
+
+function buildMarks(container: HTMLElement, query: string): HTMLElement[] {
+  clearMarks(container);
+  if (!query.trim()) return [];
+
+  const regex = new RegExp(escapeRegex(query), 'gi');
+  const marks: HTMLElement[] = [];
+
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const el = node.parentElement;
+      if (!el) return NodeFilter.FILTER_REJECT;
+      const tag = el.tagName.toLowerCase();
+      if (tag === 'script' || tag === 'style' || el.classList.contains(MARK_CLASS)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  const textNodes: Text[] = [];
+  let n: Text | null;
+  while ((n = walker.nextNode() as Text | null)) textNodes.push(n);
+
+  for (const textNode of textNodes) {
+    const text = textNode.textContent || '';
+    if (!regex.test(text)) { regex.lastIndex = 0; continue; }
+    regex.lastIndex = 0;
+    const frag = document.createDocumentFragment();
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(text)) !== null) {
+      if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
+      const mark = document.createElement('mark');
+      mark.className = MARK_CLASS;
+      mark.textContent = m[0];
+      mark.style.cssText = 'background:rgba(252,211,77,0.35);color:inherit;border-radius:3px;padding:0 1px;';
+      frag.appendChild(mark);
+      marks.push(mark);
+      last = regex.lastIndex;
+    }
+    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+    textNode.parentNode?.replaceChild(frag, textNode);
+  }
+  return marks;
+}
+
+function paintMark(mark: HTMLElement, current: boolean) {
+  if (current) {
+    mark.style.background = '#f97316';
+    mark.style.color = '#fff';
+    mark.style.outline = '2px solid #f97316';
+    mark.style.outlineOffset = '1px';
+  } else {
+    mark.style.background = 'rgba(252,211,77,0.35)';
+    mark.style.color = 'inherit';
+    mark.style.outline = 'none';
+  }
+}
+
+export function useSessionSearch(containerRef: React.RefObject<HTMLElement | null>) {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [totalMatches, setTotalMatches] = useState(0);
+  const [currentMatch, setCurrentMatch] = useState(0);
+  const marksRef = useRef<HTMLElement[]>([]);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const setCurrent = useCallback((idx: number, marks: HTMLElement[]) => {
+    marks.forEach((m, i) => paintMark(m, i === idx));
+    marks[idx]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    setCurrentMatch(idx);
+  }, []);
+
+  const openSearch = useCallback(() => {
+    setSearchOpen(true);
+    setQuery('');
+    setTotalMatches(0);
+    setCurrentMatch(0);
+  }, []);
+
+  const closeSearch = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (containerRef.current) clearMarks(containerRef.current);
+    marksRef.current = [];
+    setSearchOpen(false);
+    setQuery('');
+    setTotalMatches(0);
+    setCurrentMatch(0);
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (!searchOpen) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      if (!containerRef.current) return;
+      const marks = buildMarks(containerRef.current, query);
+      marksRef.current = marks;
+      setTotalMatches(marks.length);
+      setCurrentMatch(0);
+      if (marks.length > 0) setCurrent(0, marks);
+    }, 160);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [query, searchOpen, containerRef, setCurrent]);
+
+  const goNext = useCallback(() => {
+    const marks = marksRef.current;
+    if (!marks.length) return;
+    const next = (currentMatch + 1) % marks.length;
+    setCurrent(next, marks);
+  }, [currentMatch, setCurrent]);
+
+  const goPrev = useCallback(() => {
+    const marks = marksRef.current;
+    if (!marks.length) return;
+    const prev = (currentMatch - 1 + marks.length) % marks.length;
+    setCurrent(prev, marks);
+  }, [currentMatch, setCurrent]);
+
+  return { searchOpen, query, setQuery, totalMatches, currentMatch, openSearch, closeSearch, goNext, goPrev };
+}

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -99,6 +99,7 @@ export function useSessionSearch(
   const [query, setQuery] = useState('');
   const [totalMatches, setTotalMatches] = useState(0);
   const [currentMatch, setCurrentMatch] = useState(0);
+  const [searchPending, setSearchPending] = useState(false);
   const marksRef = useRef<HTMLElement[]>([]);
   const hiddenBlocksRef = useRef<HTMLElement[]>([]);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -132,11 +133,13 @@ export function useSessionSearch(
     setQuery('');
     setTotalMatches(0);
     setCurrentMatch(0);
+    setSearchPending(false);
   }, [containerRef]);
 
   useEffect(() => {
     if (!searchOpen) return;
     if (timerRef.current) clearTimeout(timerRef.current);
+    setSearchPending(true);
     timerRef.current = setTimeout(() => {
       if (!containerRef.current) return;
 
@@ -165,6 +168,7 @@ export function useSessionSearch(
           el.style.display = 'none';
         });
       }
+      setSearchPending(false);
     }, 160);
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
@@ -191,6 +195,7 @@ export function useSessionSearch(
     setQuery,
     totalMatches,
     currentMatch,
+    searchPending,
     openSearch,
     closeSearch,
     goNext,

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -35,17 +35,23 @@ function buildMarks(container: HTMLElement, query: string, highlightColor: strin
   });
 
   const textNodes: Text[] = [];
-  let n: Text | null;
-  while ((n = walker.nextNode() as Text | null)) textNodes.push(n);
+  let next = walker.nextNode();
+  while (next) {
+    textNodes.push(next as Text);
+    next = walker.nextNode();
+  }
 
   for (const textNode of textNodes) {
     const text = textNode.textContent || '';
-    if (!regex.test(text)) { regex.lastIndex = 0; continue; }
+    if (!regex.test(text)) {
+      regex.lastIndex = 0;
+      continue;
+    }
     regex.lastIndex = 0;
     const frag = document.createDocumentFragment();
     let last = 0;
-    let m: RegExpExecArray | null;
-    while ((m = regex.exec(text)) !== null) {
+    let m = regex.exec(text);
+    while (m !== null) {
       if (m.index > last) frag.appendChild(document.createTextNode(text.slice(last, m.index)));
       const mark = document.createElement('mark');
       mark.className = MARK_CLASS;
@@ -54,6 +60,7 @@ function buildMarks(container: HTMLElement, query: string, highlightColor: strin
       frag.appendChild(mark);
       marks.push(mark);
       last = regex.lastIndex;
+      m = regex.exec(text);
     }
     if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
     textNode.parentNode?.replaceChild(frag, textNode);
@@ -98,7 +105,9 @@ export function useSessionSearch(
   resolvedColorsRef.current = resolvedColors;
 
   const setCurrent = useCallback((idx: number, marks: HTMLElement[]) => {
-    marks.forEach((m, i) => paintMark(m, i === idx, resolvedColorsRef.current));
+    marks.forEach((m, i) => {
+      paintMark(m, i === idx, resolvedColorsRef.current);
+    });
     marks[idx]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
     setCurrentMatch(idx);
   }, []);
@@ -131,7 +140,9 @@ export function useSessionSearch(
       setCurrentMatch(0);
       if (marks.length > 0) setCurrent(0, marks);
     }, 160);
-    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
   }, [query, searchOpen, containerRef, setCurrent]);
 
   const goNext = useCallback(() => {
@@ -148,5 +159,15 @@ export function useSessionSearch(
     setCurrent(prev, marks);
   }, [currentMatch, setCurrent]);
 
-  return { searchOpen, query, setQuery, totalMatches, currentMatch, openSearch, closeSearch, goNext, goPrev };
+  return {
+    searchOpen,
+    query,
+    setQuery,
+    totalMatches,
+    currentMatch,
+    openSearch,
+    closeSearch,
+    goNext,
+    goPrev,
+  };
 }

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -15,7 +15,7 @@ function clearMarks(container: HTMLElement) {
   });
 }
 
-function buildMarks(container: HTMLElement, query: string): HTMLElement[] {
+function buildMarks(container: HTMLElement, query: string, highlightColor: string): HTMLElement[] {
   clearMarks(container);
   if (!query.trim()) return [];
 
@@ -50,7 +50,7 @@ function buildMarks(container: HTMLElement, query: string): HTMLElement[] {
       const mark = document.createElement('mark');
       mark.className = MARK_CLASS;
       mark.textContent = m[0];
-      mark.style.cssText = 'background:rgba(252,211,77,0.35);color:inherit;border-radius:3px;padding:0 1px;';
+      mark.style.cssText = `background:${highlightColor};color:rgba(0,0,0,0.88);border-radius:3px;padding:0 1px;`;
       frag.appendChild(mark);
       marks.push(mark);
       last = regex.lastIndex;
@@ -61,29 +61,44 @@ function buildMarks(container: HTMLElement, query: string): HTMLElement[] {
   return marks;
 }
 
-function paintMark(mark: HTMLElement, current: boolean) {
+function paintMark(
+  mark: HTMLElement,
+  current: boolean,
+  colors: { highlight: string; current: string; currentText: string }
+) {
   if (current) {
-    mark.style.background = '#f97316';
-    mark.style.color = '#fff';
-    mark.style.outline = '2px solid #f97316';
+    mark.style.background = colors.current;
+    mark.style.color = colors.currentText;
+    mark.style.outline = `2px solid ${colors.current}`;
     mark.style.outlineOffset = '1px';
   } else {
-    mark.style.background = 'rgba(252,211,77,0.35)';
-    mark.style.color = 'inherit';
+    mark.style.background = colors.highlight;
+    mark.style.color = 'rgba(0,0,0,0.88)';
     mark.style.outline = 'none';
   }
 }
 
-export function useSessionSearch(containerRef: React.RefObject<HTMLElement | null>) {
+export function useSessionSearch(
+  containerRef: React.RefObject<HTMLElement | null>,
+  colors?: { highlight: string; current: string; currentText: string }
+) {
+  const resolvedColors = colors ?? {
+    highlight: 'rgba(250,173,20,0.4)',
+    current: '#faad14',
+    currentText: 'rgba(0,0,0,0.88)',
+  };
+
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [totalMatches, setTotalMatches] = useState(0);
   const [currentMatch, setCurrentMatch] = useState(0);
   const marksRef = useRef<HTMLElement[]>([]);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resolvedColorsRef = useRef(resolvedColors);
+  resolvedColorsRef.current = resolvedColors;
 
   const setCurrent = useCallback((idx: number, marks: HTMLElement[]) => {
-    marks.forEach((m, i) => paintMark(m, i === idx));
+    marks.forEach((m, i) => paintMark(m, i === idx, resolvedColorsRef.current));
     marks[idx]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
     setCurrentMatch(idx);
   }, []);
@@ -110,7 +125,7 @@ export function useSessionSearch(containerRef: React.RefObject<HTMLElement | nul
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       if (!containerRef.current) return;
-      const marks = buildMarks(containerRef.current, query);
+      const marks = buildMarks(containerRef.current, query, resolvedColorsRef.current.highlight);
       marksRef.current = marks;
       setTotalMatches(marks.length);
       setCurrentMatch(0);


### PR DESCRIPTION
## Summary

- Adds Cmd+F search to the right session drawer — DOM-based TreeWalker, no prop threading, works across all collapsible TaskBlocks (force-expands on open)
- Search bar slots into header row 2 (where "Created by" sits) so title and action buttons are always visible and header height is unchanged
- Highlights use `token.colorWarning` amber to match the existing `HighlightMatch` / GlobalSearch behavior; current match gets solid amber with outline, non-current at 40% opacity
- No-results state shows a frosted overlay with empty-state icon in the session body
- Session panel enforces 360px CSS min-width so layout doesn't collapse at narrow sizes
- Search input fills the full available header width (replaced Ant Design `Space` wrapper, which silently blocked `flex: 1` via `.ant-space-item` divs, with a plain flex div)


https://github.com/user-attachments/assets/5325b9aa-d8c9-4f2f-9564-f2804b90aa7a


## Test plan

- [ ] Open any session drawer, press Cmd+F (or Ctrl+F) — search bar appears in header row 2, title remains visible
- [ ] Type a query — matches highlight in amber throughout the session (including inside collapsed sections, which auto-expand)
- [ ] Use Enter / Shift+Enter or the arrow buttons to cycle through matches; current match scrolls into view
- [ ] Press Esc or click X — search closes, highlights clear, sections return to their previous collapsed state
- [ ] Type a query with no matches — frosted empty-state overlay appears in the body
- [ ] Drag the right panel to a very narrow width — panel stops at ~360px and doesn't collapse further
- [ ] Search input stretches to fill the header left-side width at all panel sizes