### PR TITLE
feat(presence): facepile avatar click deep-links to session or cursor position

### DIFF
--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -61,6 +61,7 @@ interface FeathersSocket extends Socket {
   data: {
     isService?: boolean;
     currentBoardId?: string;
+    currentSessionId?: string;
     lastPresenceEmitAt?: number;
     tenant?: TenantContext;
   };
@@ -483,12 +484,22 @@ export function createSocketIOConfig(
           });
         }
 
+        // Accept a short or full session ID from the client; store it so
+        // presence-updated heartbeats can carry the same value.
+        if (typeof data.sessionId === 'string' && data.sessionId) {
+          fs.data.currentSessionId = data.sessionId;
+        } else if (data.sessionId === undefined && previousBoardId !== data.boardId) {
+          // Board changed and no session ID sent — clear stale session.
+          delete fs.data.currentSessionId;
+        }
+
         const broadcastData: CursorMovedEvent = {
           userId,
           boardId: data.boardId,
           x: data.x,
           y: data.y,
           timestamp: data.timestamp,
+          ...(fs.data.currentSessionId ? { sessionId: fs.data.currentSessionId } : {}),
         };
 
         // Broadcast cursor position only to tabs actively watching this board.
@@ -508,6 +519,7 @@ export function createSocketIOConfig(
             userId,
             boardId: data.boardId,
             timestamp: data.timestamp,
+            ...(fs.data.currentSessionId ? { sessionId: fs.data.currentSessionId } : {}),
           };
           socket.broadcast.emit('presence-updated', presenceData);
           fs.data.lastPresenceEmitAt = data.timestamp;

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -14,6 +14,7 @@ import type {
   PermissionMode,
   Repo,
   Session,
+  SessionID,
   SpawnConfig,
   UpdateUserInput,
   User,
@@ -32,7 +33,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
-import { useRegisterBoardSwitcher } from '../../contexts/CanvasNavigationContext';
+import { usePanToPosition, useRegisterBoardSwitcher } from '../../contexts/CanvasNavigationContext';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useBoardTitle } from '../../hooks/useBoardTitle';
 import { useEventStream } from '../../hooks/useEventStream';
@@ -564,6 +565,8 @@ export const App: React.FC<AppProps> = ({
     artifactById,
   });
 
+  const panToPosition = usePanToPosition();
+
   // Wrapper to update board ID (updates both state and URL via hook)
   // Also closes conversation panel when switching to a different board
   const setCurrentBoardId = useCallback(
@@ -1073,9 +1076,21 @@ export const App: React.FC<AppProps> = ({
   const handleOpenUserSettings = useStableCallback(() => setUserSettingsOpen(true));
   const handleOpenThemeEditor = useStableCallback(() => setThemeEditorOpen(true));
   const handleHeaderUserClick = useStableCallback(
-    (_userId: string, boardId?: BoardID, _cursor?: { x: number; y: number }) => {
-      // Navigate to the user's board (pushes history, so the back button
-      // returns to the previous board).
+    (
+      _userId: string,
+      boardId?: BoardID,
+      cursor?: { x: number; y: number },
+      sessionId?: SessionID
+    ) => {
+      // Priority: session > cursor position > board.
+      if (sessionId) {
+        navigation.goToSession(sessionId);
+        return;
+      }
+      if (cursor && boardId) {
+        panToPosition(cursor.x, cursor.y, { boardId });
+        return;
+      }
       if (boardId) {
         navigation.goToBoard(boardId);
       }

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -29,7 +29,7 @@ import {
   PanelGroup,
   PanelResizeHandle,
 } from 'react-resizable-panels';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
 import { mapToArray } from '@/utils/mapHelpers';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
@@ -321,6 +321,7 @@ export const App: React.FC<AppProps> = ({
   const artifactById = useAgorStore(selectArtifactById);
 
   const { showWarning } = useThemedMessage();
+  const navigate = useNavigate();
   const location = useLocation();
   const routeParams = useParams<{
     sessionShortId?: string;
@@ -341,6 +342,13 @@ export const App: React.FC<AppProps> = ({
     y: number;
   } | null>(null);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+
+  // Watch mode: observing another user's session/cursor without relocating
+  // self-presence. `watchHomeUrl` captures the URL at entry so exit is exact.
+  const [watchedUserId, setWatchedUserId] = useState<string | null>(null);
+  const [watchHomeUrl, setWatchHomeUrl] = useState<string | null>(null);
+  const isWatchMode = watchedUserId !== null;
+
   // Active URL deep-link target (branch or artifact). Folds into the
   // unified dashed "selected" outline alongside `selectedSessionId` —
   // both answer "what am I looking at right now?" so they share one
@@ -1077,21 +1085,46 @@ export const App: React.FC<AppProps> = ({
   const handleOpenThemeEditor = useStableCallback(() => setThemeEditorOpen(true));
   const handleHeaderUserClick = useStableCallback(
     (
-      _userId: string,
+      userId: string,
       boardId?: BoardID,
       cursor?: { x: number; y: number },
       sessionId?: SessionID
     ) => {
-      // Priority: session > cursor position > board.
+      // Self-click: exit watch mode and restore home location.
+      if (userId === user?.user_id) {
+        if (isWatchMode && watchHomeUrl) {
+          navigate(watchHomeUrl);
+          setWatchedUserId(null);
+          setWatchHomeUrl(null);
+        }
+        return;
+      }
+
+      // Toggle off: clicking the already-watched user exits watch mode.
+      if (watchedUserId === userId) {
+        if (watchHomeUrl) {
+          navigate(watchHomeUrl);
+        }
+        setWatchedUserId(null);
+        setWatchHomeUrl(null);
+        return;
+      }
+
+      // Enter watch mode (or switch watch target to a different user).
+      // Snapshot home URL only if not already watching anyone — switching
+      // targets mid-watch should not overwrite the original home.
+      if (!isWatchMode) {
+        setWatchHomeUrl(location.pathname);
+      }
+      setWatchedUserId(userId);
+
+      // Navigate the viewport to where the watched user is.
+      // Priority: session they're in > cursor position > their board.
       if (sessionId) {
         navigation.goToSession(sessionId);
-        return;
-      }
-      if (cursor && boardId) {
+      } else if (cursor && boardId) {
         panToPosition(cursor.x, cursor.y, { boardId });
-        return;
-      }
-      if (boardId) {
+      } else if (boardId) {
         navigation.goToBoard(boardId);
       }
     }
@@ -1130,6 +1163,7 @@ export const App: React.FC<AppProps> = ({
           onUserClick={handleHeaderUserClick}
           instanceLabel={instanceLabel}
           instanceDescription={instanceDescription}
+          watchedUserId={watchedUserId ?? undefined}
         />
         <Content style={{ position: 'relative', overflow: 'hidden', display: 'flex' }}>
           <PanelGroup
@@ -1296,6 +1330,7 @@ export const App: React.FC<AppProps> = ({
                         onOpenCommentsPanel={handleOpenCommentsPanel}
                         onCommentHover={setHoveredCommentId}
                         onCommentSelect={handleCommentSelect}
+                        cursorTrackingPaused={isWatchMode}
                       />
                     )}
                     <NewSessionButton

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -1,4 +1,4 @@
-import type { ActiveUser, AgorClient, Board, BoardID, User } from '@agor-live/client';
+import type { ActiveUser, AgorClient, Board, BoardID, SessionID, User } from '@agor-live/client';
 import {
   ApiOutlined,
   BulbOutlined,
@@ -62,8 +62,9 @@ export interface AppHeaderProps {
   onUserClick?: (
     userId: string,
     boardId?: BoardID,
-    cursorPosition?: { x: number; y: number }
-  ) => void; // Navigate to user's board
+    cursorPosition?: { x: number; y: number },
+    sessionId?: SessionID
+  ) => void; // Navigate to user's board/session
   /** Instance label for deployment identification (displayed as a Tag) */
   instanceLabel?: string;
   /** Instance description (markdown) shown in popover around the instance label */

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -65,6 +65,8 @@ export interface AppHeaderProps {
     cursorPosition?: { x: number; y: number },
     sessionId?: SessionID
   ) => void; // Navigate to user's board/session
+  /** User currently being observed in watch mode — wired to facepile for visual treatment. */
+  watchedUserId?: string;
   /** Instance label for deployment identification (displayed as a Tag) */
   instanceLabel?: string;
   /** Instance description (markdown) shown in popover around the instance label */
@@ -135,6 +137,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   onUserClick,
   instanceLabel,
   instanceDescription,
+  watchedUserId,
 }) => {
   const { token } = theme.useToken();
   const navigate = useNavigate();
@@ -290,6 +293,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
           onUserClick={onUserClick}
           staticActiveUsers={staticActiveUsers}
           maxVisible={presenceMaxVisible}
+          watchedUserId={watchedUserId}
         />
         <GlobalSearch
           currentUserId={currentUserId}

--- a/apps/agor-ui/src/components/AppHeader/GlobalPresenceFacepile.tsx
+++ b/apps/agor-ui/src/components/AppHeader/GlobalPresenceFacepile.tsx
@@ -1,4 +1,4 @@
-import type { ActiveUser, AgorClient, Board, BoardID, User } from '@agor-live/client';
+import type { ActiveUser, AgorClient, Board, BoardID, SessionID, User } from '@agor-live/client';
 import { Divider } from 'antd';
 import { useMemo } from 'react';
 import { PRESENCE_CONFIG } from '../../config/presence';
@@ -14,7 +14,8 @@ interface GlobalPresenceFacepileProps {
   onUserClick?: (
     userId: string,
     boardId?: BoardID,
-    cursorPosition?: { x: number; y: number }
+    cursorPosition?: { x: number; y: number },
+    sessionId?: SessionID
   ) => void;
   /** Demo/screenshot-only override: render a fixed facepile without live socket presence. */
   staticActiveUsers?: ActiveUser[];

--- a/apps/agor-ui/src/components/AppHeader/GlobalPresenceFacepile.tsx
+++ b/apps/agor-ui/src/components/AppHeader/GlobalPresenceFacepile.tsx
@@ -21,6 +21,8 @@ interface GlobalPresenceFacepileProps {
   staticActiveUsers?: ActiveUser[];
   /** Optional screenshot/demo composition override. Omit to preserve the product default cap. */
   maxVisible?: number;
+  /** User currently being observed in watch mode. */
+  watchedUserId?: string;
 }
 
 export const GlobalPresenceFacepile: React.FC<GlobalPresenceFacepileProps> = ({
@@ -32,6 +34,7 @@ export const GlobalPresenceFacepile: React.FC<GlobalPresenceFacepileProps> = ({
   onUserClick,
   staticActiveUsers,
   maxVisible = 5,
+  watchedUserId,
 }) => {
   const { activeUsers } = usePresence({
     client,
@@ -64,6 +67,7 @@ export const GlobalPresenceFacepile: React.FC<GlobalPresenceFacepileProps> = ({
       <Facepile
         activeUsers={allActiveUsers}
         currentUserId={currentUser?.user_id}
+        watchedUserId={watchedUserId}
         maxVisible={maxVisible}
         boardById={boardById}
         onUserClick={onUserClick}

--- a/apps/agor-ui/src/components/Facepile/Facepile.tsx
+++ b/apps/agor-ui/src/components/Facepile/Facepile.tsx
@@ -7,7 +7,7 @@
  * so no Map lookup is needed for this component.
  */
 
-import type { ActiveUser, Board, BoardID } from '@agor-live/client';
+import type { ActiveUser, Board, BoardID, SessionID } from '@agor-live/client';
 import { Avatar, Tooltip, theme } from 'antd';
 import type { CSSProperties } from 'react';
 import { slackAvatarRadius, UserIdentityAvatar } from '../UserIdentityAvatar';
@@ -20,7 +20,8 @@ export interface FacepileProps {
   onUserClick?: (
     userId: string,
     boardId?: BoardID,
-    cursorPosition?: { x: number; y: number }
+    cursorPosition?: { x: number; y: number },
+    sessionId?: SessionID
   ) => void;
   boardById?: Map<string, Board>; // For looking up board names
   style?: CSSProperties;
@@ -49,11 +50,17 @@ export const Facepile: React.FC<FacepileProps> = ({
 
   return (
     <div className="facepile" style={style}>
-      {visibleUsers.map(({ user, cursor, boardId }) => {
+      {visibleUsers.map(({ user, cursor, boardId, sessionId }) => {
         const board = boardId && boardById ? boardById.get(boardId) : null;
         const boardName = board?.name || 'Unknown Board';
         const boardIcon = board?.icon || '📋';
         const canClick = onUserClick && boardId;
+
+        const clickHint = sessionId
+          ? 'Click to open their session'
+          : cursor
+            ? 'Click to go to their location'
+            : 'Click to go to board';
 
         return (
           <Tooltip
@@ -68,7 +75,7 @@ export const Facepile: React.FC<FacepileProps> = ({
                 )}
                 {canClick && (
                   <div style={{ fontSize: '11px', opacity: 0.7, marginTop: '4px' }}>
-                    Click to go to board
+                    {clickHint}
                   </div>
                 )}
               </div>
@@ -82,7 +89,7 @@ export const Facepile: React.FC<FacepileProps> = ({
                 }}
                 onClick={() => {
                   if (canClick) {
-                    onUserClick(user.user_id, boardId, cursor);
+                    onUserClick(user.user_id, boardId, cursor, sessionId);
                   }
                 }}
               />

--- a/apps/agor-ui/src/components/Facepile/Facepile.tsx
+++ b/apps/agor-ui/src/components/Facepile/Facepile.tsx
@@ -16,6 +16,9 @@ import './Facepile.css';
 export interface FacepileProps {
   activeUsers: ActiveUser[];
   currentUserId?: string;
+  /** User currently being observed in watch mode. When set, that avatar gets a
+   *  visual ring and the current user's avatar becomes a "return home" control. */
+  watchedUserId?: string;
   maxVisible?: number;
   onUserClick?: (
     userId: string,
@@ -32,12 +35,16 @@ export interface FacepileProps {
  */
 export const Facepile: React.FC<FacepileProps> = ({
   activeUsers,
+  currentUserId,
+  watchedUserId,
   maxVisible = 5,
   onUserClick,
   boardById,
   style,
 }) => {
   const { token } = theme.useToken();
+
+  const isWatchMode = !!watchedUserId;
 
   // Show first N users, with overflow count
   const visibleUsers = activeUsers.slice(0, maxVisible);
@@ -51,16 +58,42 @@ export const Facepile: React.FC<FacepileProps> = ({
   return (
     <div className="facepile" style={style}>
       {visibleUsers.map(({ user, cursor, boardId, sessionId }) => {
+        const isSelf = user.user_id === currentUserId;
+        const isWatched = user.user_id === watchedUserId;
         const board = boardId && boardById ? boardById.get(boardId) : null;
         const boardName = board?.name || 'Unknown Board';
         const boardIcon = board?.icon || '📋';
-        const canClick = onUserClick && boardId;
 
-        const clickHint = sessionId
-          ? 'Click to open their session'
-          : cursor
-            ? 'Click to go to their location'
-            : 'Click to go to board';
+        // Own avatar is always clickable (to exit watch mode when watching)
+        const canClick = isSelf ? isWatchMode : !!(onUserClick && boardId);
+
+        let clickHint: string;
+        if (isSelf && isWatchMode) {
+          clickHint = 'Click to return to your workspace';
+        } else if (isWatched) {
+          clickHint = 'Watching — click to stop';
+        } else if (sessionId) {
+          clickHint = 'Click to open their session';
+        } else if (cursor) {
+          clickHint = 'Click to go to their location';
+        } else {
+          clickHint = 'Click to go to board';
+        }
+
+        // Watched avatar: blue ring. Own avatar in watch mode: orange ring.
+        const ringStyle: CSSProperties = isWatched
+          ? {
+              outline: `2px solid ${token.colorPrimary}`,
+              outlineOffset: '2px',
+              borderRadius: slackAvatarRadius(40),
+            }
+          : isSelf && isWatchMode
+            ? {
+                outline: `2px solid ${token.colorWarning}`,
+                outlineOffset: '2px',
+                borderRadius: slackAvatarRadius(40),
+              }
+            : {};
 
         return (
           <Tooltip
@@ -68,7 +101,7 @@ export const Facepile: React.FC<FacepileProps> = ({
             title={
               <div>
                 <div>{user.name || user.email}</div>
-                {boardId && (
+                {boardId && !isSelf && (
                   <div style={{ fontSize: '11px', opacity: 0.7, marginTop: '4px' }}>
                     {boardIcon} {boardName}
                   </div>
@@ -81,14 +114,18 @@ export const Facepile: React.FC<FacepileProps> = ({
               </div>
             }
           >
-            <span>
+            <span style={ringStyle}>
               <UserIdentityAvatar
                 user={user}
                 style={{
                   cursor: canClick ? 'pointer' : 'default',
+                  display: 'block',
                 }}
                 onClick={() => {
-                  if (canClick) {
+                  if (isSelf && isWatchMode) {
+                    // Self-click exits watch mode; handler checks isSelf
+                    onUserClick?.(user.user_id, boardId, cursor, sessionId);
+                  } else if (canClick && onUserClick && boardId) {
                     onUserClick(user.user_id, boardId, cursor, sessionId);
                   }
                 }}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -154,6 +154,9 @@ interface SessionCanvasProps {
   staticCursorScale?: number;
   /** Optional host-controlled height for embedded/demo canvases. Defaults to full viewport. */
   height?: React.CSSProperties['height'];
+  /** When true, suspend cursor-move emissions so watch-mode viewport changes
+   *  are not broadcast as if the user relocated to a different board. */
+  cursorTrackingPaused?: boolean;
 }
 
 export interface SessionCanvasRef {
@@ -398,6 +401,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       staticCursors,
       staticCursorScale,
       height = '100vh',
+      cursorTrackingPaused = false,
     }: SessionCanvasProps,
     ref
   ) => {
@@ -1007,11 +1011,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
     // Cursor tracking hook — include selectedSessionId so observers can
     // deep-link to the user's current session via the facepile.
+    // Paused while in watch mode so the observer's presence is not broadcast
+    // on the watched user's board.
     useCursorTracking({
       client,
       boardId: board?.board_id as BoardID | null,
       reactFlowInstance: reactFlowInstanceRef.current,
-      enabled: !!board && !!client && !staticCursors,
+      enabled: !!board && !!client && !staticCursors && !cursorTrackingPaused,
       sessionId: selectedSessionId ?? null,
     });
 

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -56,7 +56,9 @@ import { shortId } from '@agor-live/client';
 import { mapToArray } from '@/utils/mapHelpers';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
 import {
+  useConsumePendingPan,
   useConsumePendingRecenter,
+  useRegisterPanToPosition,
   useRegisterRecenter,
 } from '../../contexts/CanvasNavigationContext';
 import { useMutationGate } from '../../contexts/ConnectionContext';
@@ -990,12 +992,27 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
     const consumePendingRecenter = useConsumePendingRecenter();
 
-    // Cursor tracking hook
+    // Register pan-to-position so callers (e.g. facepile click) can pan to
+    // arbitrary flow coordinates without going through a node id.
+    const panToPosition = useCallback((x: number, y: number): boolean => {
+      const instance = reactFlowInstanceRef.current;
+      if (!instance) return false;
+      instance.setCenter(x, y, { zoom: instance.getZoom(), duration: 400 });
+      return true;
+    }, []);
+
+    useRegisterPanToPosition(panToPosition);
+
+    const consumePendingPan = useConsumePendingPan();
+
+    // Cursor tracking hook — include selectedSessionId so observers can
+    // deep-link to the user's current session via the facepile.
     useCursorTracking({
       client,
       boardId: board?.board_id as BoardID | null,
       reactFlowInstance: reactFlowInstanceRef.current,
       enabled: !!board && !!client && !staticCursors,
+      sessionId: selectedSessionId ?? null,
     });
 
     // Create comment nodes from spatial comments
@@ -1386,6 +1403,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           lastFitBoardIdRef.current = board?.board_id ?? null;
           return;
         }
+        // Cross-board cursor pan: if a facepile click requested a pan to
+        // flow coordinates on this board, honor it instead of fitView.
+        const pendingPan = consumePendingPan();
+        if (pendingPan && panToPosition(pendingPan.x, pendingPan.y)) {
+          lastFitBoardIdRef.current = board?.board_id ?? null;
+          return;
+        }
         reactFlowInstanceRef.current?.fitView({
           padding: 0.2, // 20% padding around nodes
           minZoom: 0.1, // Allow zooming out far enough to see widely-spaced nodes
@@ -1397,7 +1421,15 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       }, 100);
 
       return () => clearTimeout(timer);
-    }, [isReactFlowReady, nodes.length, board?.board_id, consumePendingRecenter, recenterOnNode]);
+    }, [
+      isReactFlowReady,
+      nodes.length,
+      board?.board_id,
+      consumePendingRecenter,
+      recenterOnNode,
+      consumePendingPan,
+      panToPosition,
+    ]);
 
     // Intercept onNodesChange to detect resize events
     const onNodesChange = useCallback(

--- a/apps/agor-ui/src/contexts/CanvasNavigationContext.tsx
+++ b/apps/agor-ui/src/contexts/CanvasNavigationContext.tsx
@@ -33,9 +33,16 @@ import {
 export type RecenterMapFn = (nodeId: string) => boolean;
 export type RecenterOpts = { boardId?: string };
 export type BoardSwitcherFn = (boardId: string) => void;
+export type PanToPositionFn = (x: number, y: number) => boolean;
 
 interface PendingRecenter {
   nodeId: string;
+  expiresAt: number;
+}
+
+interface PendingPan {
+  x: number;
+  y: number;
   expiresAt: number;
 }
 
@@ -43,6 +50,8 @@ interface CanvasNavigationContextValue {
   recenterRef: React.MutableRefObject<RecenterMapFn | null>;
   boardSwitcherRef: React.MutableRefObject<BoardSwitcherFn | null>;
   pendingRef: React.MutableRefObject<PendingRecenter | null>;
+  panToPositionRef: React.MutableRefObject<PanToPositionFn | null>;
+  pendingPanRef: React.MutableRefObject<PendingPan | null>;
 }
 
 // Pending recenter has a short TTL so a stale stash doesn't fire when a user
@@ -57,7 +66,12 @@ export function CanvasNavigationProvider({ children }: { children: ReactNode }) 
   const recenterRef = useRef<RecenterMapFn | null>(null);
   const boardSwitcherRef = useRef<BoardSwitcherFn | null>(null);
   const pendingRef = useRef<PendingRecenter | null>(null);
-  const value = useMemo(() => ({ recenterRef, boardSwitcherRef, pendingRef }), []);
+  const panToPositionRef = useRef<PanToPositionFn | null>(null);
+  const pendingPanRef = useRef<PendingPan | null>(null);
+  const value = useMemo(
+    () => ({ recenterRef, boardSwitcherRef, pendingRef, panToPositionRef, pendingPanRef }),
+    []
+  );
   return (
     <CanvasNavigationContext.Provider value={value}>{children}</CanvasNavigationContext.Provider>
   );
@@ -120,6 +134,54 @@ export function useRecenterMap(): (nodeId: string, opts?: RecenterOpts) => boole
       if (opts?.boardId && ctx.boardSwitcherRef.current) {
         ctx.pendingRef.current = {
           nodeId,
+          expiresAt: Date.now() + PENDING_TTL_MS,
+        };
+        ctx.boardSwitcherRef.current(opts.boardId);
+        return true;
+      }
+      return false;
+    },
+    [ctx]
+  );
+}
+
+/** SessionCanvas registers its setCenter implementation so callers can pan to
+ *  arbitrary flow coordinates (e.g. a remote user's cursor position). */
+export function useRegisterPanToPosition(fn: PanToPositionFn): void {
+  useRegisterRef(useContext(CanvasNavigationContext)?.panToPositionRef, fn);
+}
+
+/** SessionCanvas drains a pending coordinate pan after a board switch loads. */
+export function useConsumePendingPan(): () => { x: number; y: number } | null {
+  const ctx = useContext(CanvasNavigationContext);
+  return useCallback(() => {
+    const pending = ctx?.pendingPanRef.current;
+    if (!pending) return null;
+    if (Date.now() > pending.expiresAt) {
+      ctx!.pendingPanRef.current = null;
+      return null;
+    }
+    ctx!.pendingPanRef.current = null;
+    return { x: pending.x, y: pending.y };
+  }, [ctx]);
+}
+
+/** Consumer hook — pan the canvas to flow coordinates (x, y).
+ *  Handles cross-board: if the target is on a different board, switches first
+ *  and lets SessionCanvas drain the pending pan on mount. */
+export function usePanToPosition(): (x: number, y: number, opts?: { boardId?: string }) => boolean {
+  const ctx = useContext(CanvasNavigationContext);
+  return useCallback(
+    (x: number, y: number, opts?: { boardId?: string }) => {
+      if (!ctx) return false;
+      // Try synchronous pan first (canvas is already showing the right board).
+      const sync = ctx.panToPositionRef.current?.(x, y);
+      if (sync) return true;
+      // Cross-board: stash + switch board so the new SessionCanvas drains it.
+      if (opts?.boardId && ctx.boardSwitcherRef.current) {
+        ctx.pendingPanRef.current = {
+          x,
+          y,
           expiresAt: Date.now() + PENDING_TTL_MS,
         };
         ctx.boardSwitcherRef.current(opts.boardId);

--- a/apps/agor-ui/src/hooks/useCursorTracking.ts
+++ b/apps/agor-ui/src/hooks/useCursorTracking.ts
@@ -14,6 +14,9 @@ interface UseCursorTrackingOptions {
   boardId: BoardID | null;
   reactFlowInstance: ReactFlowInstance | null;
   enabled?: boolean;
+  /** Current session the user is viewing; included in cursor-move events so
+   *  other clients can deep-link to it via the facepile. */
+  sessionId?: string | null;
 }
 
 /**
@@ -23,7 +26,12 @@ interface UseCursorTrackingOptions {
  * @returns Callback to manually emit cursor position (rarely needed)
  */
 export function useCursorTracking(options: UseCursorTrackingOptions) {
-  const { client, boardId, reactFlowInstance, enabled = true } = options;
+  const { client, boardId, reactFlowInstance, enabled = true, sessionId } = options;
+  // Mirror sessionId into a ref so emitCursorPosition always reads the current
+  // value without needing it in the dependency array (which would force the
+  // callback to be recreated on every session change and tear down mousemove).
+  const sessionIdRef = useRef(sessionId ?? null);
+  sessionIdRef.current = sessionId ?? null;
 
   // Pause cursor tracking when tab is hidden to save CPU
   const [isTabVisible, setIsTabVisible] = useState(
@@ -72,6 +80,7 @@ export function useCursorTracking(options: UseCursorTrackingOptions) {
                 x: latest.x,
                 y: latest.y,
                 timestamp: Date.now(),
+                ...(sessionIdRef.current ? { sessionId: sessionIdRef.current } : {}),
               };
               client.io.emit('cursor-move', event);
               lastEmitRef.current = Date.now();
@@ -87,6 +96,7 @@ export function useCursorTracking(options: UseCursorTrackingOptions) {
         x,
         y,
         timestamp: now,
+        ...(sessionIdRef.current ? { sessionId: sessionIdRef.current } : {}),
       };
 
       client.io.emit('cursor-move', event);

--- a/apps/agor-ui/src/hooks/usePresence.ts
+++ b/apps/agor-ui/src/hooks/usePresence.ts
@@ -14,6 +14,7 @@ import type {
   BoardID,
   CursorMovedEvent,
   PresenceUpdatedEvent,
+  SessionID,
   User,
 } from '@agor-live/client';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -66,7 +67,7 @@ export function usePresence(options: UsePresenceOptions): UsePresenceResult {
   >(new Map());
 
   const [presenceMap, setPresenceMap] = useState<
-    Map<string, { boardId: BoardID; x?: number; y?: number; timestamp: number }>
+    Map<string, { boardId: BoardID; x?: number; y?: number; timestamp: number; sessionId?: string }>
   >(new Map());
 
   useEffect(() => {
@@ -127,6 +128,7 @@ export function usePresence(options: UsePresenceOptions): UsePresenceResult {
           x: event.x,
           y: event.y,
           timestamp: event.timestamp,
+          sessionId: event.sessionId,
         };
 
         // Update presence map (for facepile)
@@ -175,6 +177,7 @@ export function usePresence(options: UsePresenceOptions): UsePresenceResult {
       const presenceData = {
         boardId: event.boardId,
         timestamp: event.timestamp,
+        sessionId: event.sessionId,
       };
 
       setPresenceMap((prev) => {
@@ -329,6 +332,7 @@ export function usePresence(options: UsePresenceOptions): UsePresenceResult {
         user,
         lastSeen: presence.timestamp,
         boardId: presence.boardId,
+        sessionId: presence.sessionId as SessionID | undefined,
         cursor:
           typeof presence.x === 'number' && typeof presence.y === 'number'
             ? {

--- a/packages/core/src/types/presence.ts
+++ b/packages/core/src/types/presence.ts
@@ -1,6 +1,6 @@
 // src/types/presence.ts
 
-import type { BoardID } from './id';
+import type { BoardID, SessionID } from './id';
 import type { User } from './user';
 
 /**
@@ -11,6 +11,8 @@ export interface CursorMoveEvent {
   x: number; // React Flow viewport coordinates
   y: number; // React Flow viewport coordinates
   timestamp: number;
+  /** Short or full session ID the client is currently viewing, if any. */
+  sessionId?: string;
 }
 
 /**
@@ -22,6 +24,8 @@ export interface CursorMovedEvent {
   x: number;
   y: number;
   timestamp: number;
+  /** Session the emitting user is currently viewing, if any. */
+  sessionId?: string;
 }
 
 /**
@@ -35,6 +39,8 @@ export interface PresenceUpdatedEvent {
   userId: string;
   boardId: BoardID;
   timestamp: number;
+  /** Session the emitting user is currently viewing, if any. */
+  sessionId?: string;
 }
 
 /**
@@ -62,6 +68,7 @@ export interface ActiveUser {
   user: User;
   lastSeen: number;
   boardId?: BoardID; // Which board the user is currently viewing
+  sessionId?: SessionID; // Session the user is currently viewing, if any
   cursor?: {
     x: number;
     y: number;


### PR DESCRIPTION
## Summary

Clicking a presence facepile avatar in the top bar now enters a non-destructive **watch mode** that follows the user you clicked — without overwriting where *you* are working.

### Core concepts

| Concept | What it is |
|---------|-----------|
| **Self-presence** | Where I'm working — broadcast to others, never mutated by watching |
| **Watch mode** | Transient view overlay — follows another user without relocating me |

### Click behavior

| Who you click | What happens |
|--------------|-------------|
| Another user (not watching yet) | Snapshot home URL → enter watch mode → navigate viewport to their session / cursor / board |
| Another user (already watching them) | Toggle off — exit watch mode, restore home |
| Another user (watching someone else) | Switch watch target (home snapshot preserved) |
| **Your own avatar** while watching | Exit watch mode, restore home |
| Your own avatar (not watching) | No-op |

### Navigation priority when entering watch mode

1. User is in a **session** → `goToSession(sessionId)` (opens `/s/<short>/`)
2. User has a **live cursor** → `panToPosition(x, y, { boardId })` (canvas pan; cross-board aware)
3. User is on a **board** → `goToBoard(boardId)` (fallback — previous behavior)

### Visual affordances (Facepile)

- **Watched user's avatar**: blue ring (`colorPrimary`) — tooltip "Watching — click to stop"
- **Own avatar while watching**: orange ring (`colorWarning`) — tooltip "Click to return to your workspace"
- **Tooltips on other users**: "Click to open their session" / "Click to go to their location" / "Click to go to board" depending on available context

### Presence broadcast gating

During watch mode, `useCursorTracking` is **paused** (via `cursorTrackingPaused` prop on SessionCanvas). This prevents cursor-move events from being emitted on the watched user's board — others continue to see your presence icon in the facepile from your last real location (5-minute timeout), but your cursor does not appear on the watched board.

### Home restore

The current URL (`location.pathname`) is snapshot at watch-mode entry. Exit navigates directly back to that URL — instant and exact (board + session state round-trips through the URL).

## Design decisions

**Why URL navigation for watch, not a shadow state?** The existing URL→state sync (`useUrlState`) already drives board/session rendering. Reusing it means the watched user's session panel renders for free, React Flow recenters correctly, and the back button works naturally through watch hops. The tradeoff is that the URL briefly reflects the watched location — acceptable since it restores cleanly.

**Why pause cursor tracking rather than re-broadcast home location?** Continuously emitting the home coordinates from watch mode would require a separate "fake" cursor emitter running in parallel, adding complexity. Pausing is simpler: observers lose your moving cursor during watch (acceptable) but still see your presence avatar (no flickering from the facepile).

## What changed (15 files across 2 commits)

**Commit 1 — sessionId substrate:**
- `packages/core/src/types/presence.ts` — `sessionId?` on `CursorMoveEvent`, `CursorMovedEvent`, `PresenceUpdatedEvent`, `ActiveUser`
- `apps/agor-daemon/src/setup/socketio.ts` — store/emit `sessionId` per socket
- `apps/agor-ui/src/hooks/useCursorTracking.ts` — emit `sessionId` in cursor events
- `apps/agor-ui/src/hooks/usePresence.ts` — track and expose `sessionId` on `ActiveUser`
- `apps/agor-ui/src/contexts/CanvasNavigationContext.tsx` — `usePanToPosition` + cross-board pending pan
- `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx` — register pan-to-position; drain pending pan on board load; pass `selectedSessionId` to cursor tracking
- `apps/agor-ui/src/components/Facepile/Facepile.tsx` — pass `sessionId` in click handler; contextual tooltip text
- `apps/agor-ui/src/components/AppHeader/{AppHeader,GlobalPresenceFacepile}.tsx` — thread `sessionId` through click chain

**Commit 2 — watch mode:**
- `apps/agor-ui/src/components/App/App.tsx` — `watchedUserId` + `watchHomeUrl` state; `handleHeaderUserClick` watch mode logic; `isWatchMode` → `cursorTrackingPaused`; `watchedUserId` → AppHeader
- `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx` — `cursorTrackingPaused` prop
- `apps/agor-ui/src/components/Facepile/Facepile.tsx` — `watchedUserId` prop; ring styles; self-avatar click-to-exit
- `apps/agor-ui/src/components/AppHeader/{AppHeader,GlobalPresenceFacepile}.tsx` — thread `watchedUserId`

## Test plan

- [ ] **Session watch**: Two users online; User A opens a session. User B clicks A's avatar → viewport moves to A's session; A's avatar gets a blue ring; B's own avatar gets an orange ring with "return" tooltip
- [ ] **Cursor watch**: User A on a board (no session). User B clicks A's avatar → canvas pans to A's cursor position
- [ ] **Cross-board watch**: A is on a different board → clicking A's avatar switches B to A's board then pans
- [ ] **Exit via watched avatar**: B clicks A's blue-ringed avatar again → returns to B's original board/session
- [ ] **Exit via own avatar**: B (watching) clicks own orange-ringed avatar → same restore
- [ ] **Switch target**: B is watching A; B clicks C's avatar → switches watch to C, home snapshot unchanged
- [ ] **Self-presence not broadcast**: While B watches A, B moves mouse on A's board → B's cursor does NOT appear for A or others on A's board
- [ ] **Fallback**: User with no boardId → click is no-op (graceful)
- [ ] **Biome lint**: `biome check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)