### PR TITLE
Clarify Slack gateway reply routing

### DIFF
--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -270,6 +270,9 @@ describe('GatewayService Slack thread catch-up', () => {
       triggerTs: '103.000000',
     });
     const prompt = promptCreate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain(
+      'Any assistant message you send in this current Agor session is streamed back directly to the Slack conversation'
+    );
     expect(prompt).toContain('**Slack context**');
     expect(prompt).toContain('### Previous thread messages');
     expect(prompt).toContain('missed context');
@@ -317,7 +320,10 @@ describe('GatewayService Slack thread catch-up', () => {
     });
 
     expect(result).toMatchObject({ success: true, sessionId: 'sess-1', created: false });
-    expect(promptCreate.mock.calls[0][0].prompt).toBe('please answer');
+    expect(promptCreate.mock.calls[0][0].prompt).toContain(
+      'Any assistant message you send in this current Agor session is streamed back directly to the Slack conversation'
+    );
+    expect(promptCreate.mock.calls[0][0].prompt).toContain('please answer');
     expect(threadMapRepo.updateMetadata).not.toHaveBeenCalledWith(
       'map-1',
       expect.objectContaining({

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -280,6 +280,14 @@ function oneLineForPrompt(text: string, maxChars = 900): string {
   return `${normalized.slice(0, Math.max(0, maxChars - 1))}…`;
 }
 
+const SLACK_GATEWAY_REPLY_NOTE =
+  'Note: Any assistant message you send in this current Agor session is streamed back directly to the Slack conversation. Only use outbound gateway tools when you intentionally need to start a separate thread, DM, or message.';
+
+function prependSlackGatewayReplyNote(prompt: string): string {
+  if (prompt.includes(SLACK_GATEWAY_REPLY_NOTE)) return prompt;
+  return `${SLACK_GATEWAY_REPLY_NOTE}\n\n${prompt}`;
+}
+
 function formatSlackCatchUpPrompt(args: {
   channel: GatewayChannel;
   threadId: string;
@@ -2159,6 +2167,10 @@ export class GatewayService {
         if (contextPrefix) {
           promptText = contextPrefix + promptText;
         }
+      }
+
+      if (channel.channel_type === 'slack') {
+        promptText = prependSlackGatewayReplyNote(promptText);
       }
 
       // Prepend MCP auth warning to the initial prompt so the agent is aware


### PR DESCRIPTION
## Summary
- Add a Slack gateway prompt note clarifying that assistant replies in the current Agor session route back to Slack.
- Keep outbound gateway tools reserved for intentionally starting separate threads/DMs/messages.
- Update gateway tests for the injected note.

## Checks
- ✅ `pnpm i`
- ⚠️ `pnpm check` — typecheck/lint/shortid passed, then failed in `check:multitenancy-boundaries` on existing baseline issues:
  - `apps/agor-daemon/src/services/branches.test.ts`
  - `apps/agor-daemon/src/utils/tenant-db-scope.test.ts`
  - `apps/agor-daemon/src/widgets/env-vars/index.ts`
- ✅ `pnpm --filter @agor/daemon test -- src/services/gateway.test.ts`