### PR TITLE
fix(mcp): preserve tenant scope for OAuth flows

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -51,6 +51,22 @@ describe('tenant-owned service registration', () => {
   it('wraps gateway inbound routing in tenant database scope', () => {
     expect(TENANT_OWNED_SERVICE_PATHS).toContain('gateway');
   });
+
+  it('wraps MCP OAuth/session helper services in tenant database scope', () => {
+    expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
+      expect.arrayContaining([
+        'sessions/:id/mcp-servers',
+        'mcp-servers/discover',
+        'mcp-servers/oauth-auth-headers',
+        'mcp-servers/oauth-complete',
+        'mcp-servers/oauth-disconnect',
+        'mcp-servers/oauth-refresh',
+        'mcp-servers/oauth-start',
+        'mcp-servers/oauth-status',
+        'mcp-servers/test-oauth',
+      ])
+    );
+  });
 });
 
 describe('shouldValidateRepoEnvironmentPayload', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -385,6 +385,7 @@ export interface RegisterHooksContext {
  */
 export const TENANT_OWNED_SERVICE_PATHS = [
   'sessions',
+  'sessions/:id/mcp-servers',
   'session-relationships',
   'tasks',
   'messages',
@@ -401,6 +402,14 @@ export const TENANT_OWNED_SERVICE_PATHS = [
   'boards/:id/group-grants',
   'app-variables',
   'mcp-servers',
+  'mcp-servers/discover',
+  'mcp-servers/oauth-auth-headers',
+  'mcp-servers/oauth-complete',
+  'mcp-servers/oauth-disconnect',
+  'mcp-servers/oauth-refresh',
+  'mcp-servers/oauth-start',
+  'mcp-servers/oauth-status',
+  'mcp-servers/test-oauth',
   'card-types',
   'cards',
   'artifacts',

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -61,4 +61,14 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/requirePublicBaseUrl\s*\(/);
     expect(codeOnly).toMatch(/['"]\/mcp-servers\/oauth-callback['"]/);
   });
+
+  it('preserves tenant scope across unauthenticated OAuth callbacks', () => {
+    // Browser redirects to /mcp-servers/oauth-callback do not carry the
+    // originating Feathers auth params or tenant headers, so the pending OAuth
+    // state must capture tenant_id at flow start and re-enter that DB scope
+    // before persisting user_mcp_oauth_tokens or backfilling mcp_servers auth.
+    expect(codeOnly).toMatch(/tenantId:\s*getCurrentTenantId\s*\(\s*\)/);
+    expect(codeOnly).toMatch(/runWithTenantDatabaseScope\s*\(\s*db,\s*pendingFlow\.tenantId/);
+    expect(codeOnly).toMatch(/Missing tenant context for MCP OAuth callback/);
+  });
 });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -16,8 +16,11 @@ import {
   BoardRepository,
   BranchRepository,
   eq,
+  getCurrentTenantId,
   inArray,
+  isPostgresDatabase,
   MCPServerRepository,
+  runWithTenantDatabaseScope,
   SessionMCPServerRepository,
   type SessionMCPServerRow,
   select,
@@ -1121,6 +1124,8 @@ async function registerMCPServices(
     mcpServerId?: string;
     userId?: string;
     oauthMode?: 'per_user' | 'shared';
+    /** Tenant captured when the flow starts; browser callbacks have no auth headers. */
+    tenantId?: string;
     socketId?: string;
     createdAt: number;
     /**
@@ -1318,6 +1323,7 @@ async function registerMCPServices(
       mcpServerId: opts.mcpServerId,
       userId: opts.userId,
       oauthMode: opts.oauthMode,
+      tenantId: getCurrentTenantId(),
       socketId: opts.socketId,
       createdAt: Date.now(),
       tokenResolve,
@@ -1343,6 +1349,44 @@ async function registerMCPServices(
     }
     return base;
   }
+
+  const persistOAuthTokenForPendingFlow = async (
+    tokenResponse: OAuthTokenResponse,
+    pendingFlow: PendingOAuthFlow,
+    logPrefix: string
+  ): Promise<void> => {
+    const work = () =>
+      persistOAuthToken(
+        db,
+        tokenResponse,
+        pendingFlow.mcpUrl,
+        {
+          ...pendingFlow,
+          clientId: pendingFlow.context.clientId,
+          clientSecret: pendingFlow.context.clientSecret,
+          tokenEndpoint: pendingFlow.context.tokenEndpoint,
+        },
+        logPrefix
+      );
+
+    if (pendingFlow.tenantId) {
+      await runWithTenantDatabaseScope(db, pendingFlow.tenantId, work);
+      return;
+    }
+
+    // OAuth callbacks arrive as unauthenticated browser redirects, so they
+    // cannot re-resolve tenant scope from request auth. In Postgres/multitenant
+    // deployments, a flow without captured tenant metadata is unsafe to persist:
+    // fail closed and ask the user to restart the OAuth flow. SQLite/single-user
+    // installs do not have tenant DB scope, so they keep the legacy direct path.
+    if (isPostgresDatabase(db) && pendingFlow.mcpServerId) {
+      throw new Error(
+        'Missing tenant context for MCP OAuth callback. Please restart the OAuth flow.'
+      );
+    }
+
+    await work();
+  };
 
   // Set the OAuth callback handler
   const oauthCallbackHandler = async (req: express.Request, res: express.Response) => {
@@ -1397,18 +1441,7 @@ async function registerMCPServices(
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
-        await persistOAuthToken(
-          db,
-          tokenResponse,
-          pendingFlow.mcpUrl,
-          {
-            ...pendingFlow,
-            clientId: pendingFlow.context.clientId,
-            clientSecret: pendingFlow.context.clientSecret,
-            tokenEndpoint: pendingFlow.context.tokenEndpoint,
-          },
-          'OAuth Callback'
-        );
+        await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Callback');
 
         if (app.io) {
           const oauthEvent = {
@@ -1977,18 +2010,14 @@ async function registerMCPServices(
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
-        await persistOAuthToken(
-          db,
-          tokenResponse,
-          pendingFlow.mcpUrl,
-          {
-            ...pendingFlow,
-            clientId: pendingFlow.context.clientId,
-            clientSecret: pendingFlow.context.clientSecret,
-            tokenEndpoint: pendingFlow.context.tokenEndpoint,
-          },
-          'OAuth Complete'
-        );
+        const activeTenantId = getCurrentTenantId();
+        if (pendingFlow.tenantId && activeTenantId && pendingFlow.tenantId !== activeTenantId) {
+          throw new Error(
+            'OAuth flow belongs to a different tenant. Please restart the OAuth flow.'
+          );
+        }
+
+        await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Complete');
         return { success: true, message: 'OAuth authentication successful!', tokenObtained: true };
       } catch (error) {
         console.error('[OAuth Complete] Error:', error);


### PR DESCRIPTION
## Summary
- add tenant DB hooks for nested session MCP resolution and MCP OAuth helper services
- capture tenant_id when starting daemon-side MCP OAuth flows
- re-enter captured tenant DB scope before OAuth callback/manual completion persists tokens or backfills token endpoints
- fail closed for Postgres OAuth callbacks that lack captured tenant context

## Tests
- `pnpm --filter @agor/daemon test -- register-hooks.test.ts register-services.oauth-callback.test.ts register-services.mcp-custom-headers.test.ts register-services.mcp-discover.test.ts`
- `pnpm --filter @agor/daemon typecheck`
- `git diff --check`

Note: `node scripts/check-multitenancy-boundaries.mjs` still fails on existing baseline entries unrelated to this change (`branches.test.ts`, `tenant-db-scope.test.ts`, `widgets/env-vars/index.ts`).