### PR TITLE
fix(mcp): preserve executor auth claims for MCP secrets

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -1,14 +1,12 @@
 import { Forbidden } from '@agor/core/feathers';
 import type { AuthenticatedParams, HookContext, Params } from '@agor/core/types';
-
-type ExecutorTokenPayload = {
-  type?: string;
-  purpose?: string;
-  session_id?: string;
-  sessionId?: string;
-  task_id?: string;
-  branch_id?: string;
-};
+import {
+  EXECUTOR_SESSION_TOKEN_PURPOSE,
+  EXECUTOR_SESSION_TOKEN_TYPE,
+  type ExecutorSessionTokenPayload,
+  getExecutorSessionTokenSessionId,
+  isExecutorSessionTokenPayload,
+} from './executor-session-token.js';
 
 type Scope = {
   sessionId?: string;
@@ -16,11 +14,11 @@ type Scope = {
   branchId?: string;
 };
 
-function scopedPayload(context: HookContext): ExecutorTokenPayload | null {
-  const params = context.params as AuthenticatedParams & ExecutorTokenPayload;
-  const payload = params.authentication?.payload as ExecutorTokenPayload | undefined;
-  if (payload?.type === 'executor-session') {
-    if (payload.purpose !== 'executor-task') {
+function scopedPayload(context: HookContext): ExecutorSessionTokenPayload | null {
+  const params = context.params as AuthenticatedParams & ExecutorSessionTokenPayload;
+  const payload = params.authentication?.payload as ExecutorSessionTokenPayload | undefined;
+  if (payload?.type === EXECUTOR_SESSION_TOKEN_TYPE) {
+    if (!isExecutorSessionTokenPayload(payload)) {
       throw new Forbidden('Executor token is not valid for this request');
     }
     return payload;
@@ -32,8 +30,8 @@ function scopedPayload(context: HookContext): ExecutorTokenPayload | null {
   // claim; normal user/API-key auth must continue through unscoped.
   if (params.authentication?.strategy === 'jwt' && params.task_id) {
     return {
-      type: 'executor-session',
-      purpose: 'executor-task',
+      type: EXECUTOR_SESSION_TOKEN_TYPE,
+      purpose: EXECUTOR_SESSION_TOKEN_PURPOSE,
       task_id: params.task_id,
       session_id: params.session_id,
       sessionId: params.sessionId,
@@ -197,7 +195,7 @@ export function executorRuntimeScopeGuard() {
     if (!payload) return context;
 
     const scope = {
-      sessionId: payload.session_id ?? payload.sessionId,
+      sessionId: getExecutorSessionTokenSessionId(payload),
       taskId: payload.task_id,
       branchId: payload.branch_id,
     };

--- a/apps/agor-daemon/src/auth/executor-session-token.ts
+++ b/apps/agor-daemon/src/auth/executor-session-token.ts
@@ -1,0 +1,30 @@
+import type { JwtPayload } from 'jsonwebtoken';
+
+export const EXECUTOR_SESSION_TOKEN_TYPE = 'executor-session';
+export const EXECUTOR_SESSION_TOKEN_PURPOSE = 'executor-task';
+
+export type ExecutorSessionTokenPayload = JwtPayload & {
+  type?: string;
+  purpose?: string;
+  session_id?: string;
+  /** @deprecated Legacy alias kept only for tokens minted before session_id became canonical. */
+  sessionId?: string;
+  task_id?: string;
+  branch_id?: string;
+};
+
+export function isExecutorSessionTokenPayload(
+  payload: unknown
+): payload is ExecutorSessionTokenPayload {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  const record = payload as ExecutorSessionTokenPayload;
+  return (
+    record.type === EXECUTOR_SESSION_TOKEN_TYPE && record.purpose === EXECUTOR_SESSION_TOKEN_PURPOSE
+  );
+}
+
+export function getExecutorSessionTokenSessionId(
+  payload: ExecutorSessionTokenPayload
+): string | undefined {
+  return payload.session_id ?? payload.sessionId;
+}

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -15,6 +15,10 @@ import type { Params, UserAuthMetadata } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import type { SessionTokenService } from '../services/session-token-service.js';
 import { markAuthenticationUserLookup } from '../services/users.js';
+import {
+  getExecutorSessionTokenSessionId,
+  isExecutorSessionTokenPayload,
+} from './executor-session-token.js';
 import { readRuntimeTenantClaim } from './runtime-tokens.js';
 import { assertUserTokenNotInvalidated, type UserAuthTokenPayload } from './token-invalidation.js';
 
@@ -158,14 +162,14 @@ export class ServiceJWTStrategy extends JWTStrategy {
     }
 
     if (payload?.type === 'executor-session') {
-      if (payload.purpose !== 'executor-task') {
+      if (!isExecutorSessionTokenPayload(payload)) {
         throw new Error('Invalid executor token purpose');
       }
       const token = authentication?.accessToken;
       if (!token || !this.sessionTokenService) {
         throw new Error('Executor token validation unavailable');
       }
-      const sessionId = payload.session_id ?? payload.sessionId;
+      const sessionId = getExecutorSessionTokenSessionId(payload);
       const sessionInfo = await this.sessionTokenService.validateToken(token, {
         sessionId,
         taskId: payload.task_id,

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -51,6 +51,22 @@ describe('tenant-owned service registration', () => {
   it('wraps gateway inbound routing in tenant database scope', () => {
     expect(TENANT_OWNED_SERVICE_PATHS).toContain('gateway');
   });
+
+  it('wraps MCP OAuth/session helper services in tenant database scope', () => {
+    expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
+      expect.arrayContaining([
+        'sessions/:id/mcp-servers',
+        'mcp-servers/discover',
+        'mcp-servers/oauth-auth-headers',
+        'mcp-servers/oauth-complete',
+        'mcp-servers/oauth-disconnect',
+        'mcp-servers/oauth-refresh',
+        'mcp-servers/oauth-start',
+        'mcp-servers/oauth-status',
+        'mcp-servers/test-oauth',
+      ])
+    );
+  });
 });
 
 describe('shouldValidateRepoEnvironmentPayload', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -385,6 +385,7 @@ export interface RegisterHooksContext {
  */
 export const TENANT_OWNED_SERVICE_PATHS = [
   'sessions',
+  'sessions/:id/mcp-servers',
   'session-relationships',
   'tasks',
   'messages',
@@ -401,6 +402,14 @@ export const TENANT_OWNED_SERVICE_PATHS = [
   'boards/:id/group-grants',
   'app-variables',
   'mcp-servers',
+  'mcp-servers/discover',
+  'mcp-servers/oauth-auth-headers',
+  'mcp-servers/oauth-complete',
+  'mcp-servers/oauth-disconnect',
+  'mcp-servers/oauth-refresh',
+  'mcp-servers/oauth-start',
+  'mcp-servers/oauth-status',
+  'mcp-servers/test-oauth',
   'card-types',
   'cards',
   'artifacts',

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -61,4 +61,14 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/requirePublicBaseUrl\s*\(/);
     expect(codeOnly).toMatch(/['"]\/mcp-servers\/oauth-callback['"]/);
   });
+
+  it('preserves tenant scope across unauthenticated OAuth callbacks', () => {
+    // Browser redirects to /mcp-servers/oauth-callback do not carry the
+    // originating Feathers auth params or tenant headers, so the pending OAuth
+    // state must capture tenant_id at flow start and re-enter that DB scope
+    // before persisting user_mcp_oauth_tokens or backfilling mcp_servers auth.
+    expect(codeOnly).toMatch(/tenantId:\s*getCurrentTenantId\s*\(\s*\)/);
+    expect(codeOnly).toMatch(/runWithTenantDatabaseScope\s*\(\s*db,\s*pendingFlow\.tenantId/);
+    expect(codeOnly).toMatch(/Missing tenant context for MCP OAuth callback/);
+  });
 });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -16,8 +16,11 @@ import {
   BoardRepository,
   BranchRepository,
   eq,
+  getCurrentTenantId,
   inArray,
+  isPostgresDatabase,
   MCPServerRepository,
+  runWithTenantDatabaseScope,
   SessionMCPServerRepository,
   type SessionMCPServerRow,
   select,
@@ -1121,6 +1124,8 @@ async function registerMCPServices(
     mcpServerId?: string;
     userId?: string;
     oauthMode?: 'per_user' | 'shared';
+    /** Tenant captured when the flow starts; browser callbacks have no auth headers. */
+    tenantId?: string;
     socketId?: string;
     createdAt: number;
     /**
@@ -1318,6 +1323,7 @@ async function registerMCPServices(
       mcpServerId: opts.mcpServerId,
       userId: opts.userId,
       oauthMode: opts.oauthMode,
+      tenantId: getCurrentTenantId(),
       socketId: opts.socketId,
       createdAt: Date.now(),
       tokenResolve,
@@ -1343,6 +1349,44 @@ async function registerMCPServices(
     }
     return base;
   }
+
+  const persistOAuthTokenForPendingFlow = async (
+    tokenResponse: OAuthTokenResponse,
+    pendingFlow: PendingOAuthFlow,
+    logPrefix: string
+  ): Promise<void> => {
+    const work = () =>
+      persistOAuthToken(
+        db,
+        tokenResponse,
+        pendingFlow.mcpUrl,
+        {
+          ...pendingFlow,
+          clientId: pendingFlow.context.clientId,
+          clientSecret: pendingFlow.context.clientSecret,
+          tokenEndpoint: pendingFlow.context.tokenEndpoint,
+        },
+        logPrefix
+      );
+
+    if (pendingFlow.tenantId) {
+      await runWithTenantDatabaseScope(db, pendingFlow.tenantId, work);
+      return;
+    }
+
+    // OAuth callbacks arrive as unauthenticated browser redirects, so they
+    // cannot re-resolve tenant scope from request auth. In Postgres/multitenant
+    // deployments, a flow without captured tenant metadata is unsafe to persist:
+    // fail closed and ask the user to restart the OAuth flow. SQLite/single-user
+    // installs do not have tenant DB scope, so they keep the legacy direct path.
+    if (isPostgresDatabase(db) && pendingFlow.mcpServerId) {
+      throw new Error(
+        'Missing tenant context for MCP OAuth callback. Please restart the OAuth flow.'
+      );
+    }
+
+    await work();
+  };
 
   // Set the OAuth callback handler
   const oauthCallbackHandler = async (req: express.Request, res: express.Response) => {
@@ -1397,18 +1441,7 @@ async function registerMCPServices(
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
-        await persistOAuthToken(
-          db,
-          tokenResponse,
-          pendingFlow.mcpUrl,
-          {
-            ...pendingFlow,
-            clientId: pendingFlow.context.clientId,
-            clientSecret: pendingFlow.context.clientSecret,
-            tokenEndpoint: pendingFlow.context.tokenEndpoint,
-          },
-          'OAuth Callback'
-        );
+        await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Callback');
 
         if (app.io) {
           const oauthEvent = {
@@ -1977,18 +2010,14 @@ async function registerMCPServices(
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
-        await persistOAuthToken(
-          db,
-          tokenResponse,
-          pendingFlow.mcpUrl,
-          {
-            ...pendingFlow,
-            clientId: pendingFlow.context.clientId,
-            clientSecret: pendingFlow.context.clientSecret,
-            tokenEndpoint: pendingFlow.context.tokenEndpoint,
-          },
-          'OAuth Complete'
-        );
+        const activeTenantId = getCurrentTenantId();
+        if (pendingFlow.tenantId && activeTenantId && pendingFlow.tenantId !== activeTenantId) {
+          throw new Error(
+            'OAuth flow belongs to a different tenant. Please restart the OAuth flow.'
+          );
+        }
+
+        await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Complete');
         return { success: true, message: 'OAuth authentication successful!', tokenObtained: true };
       } catch (error) {
         console.error('[OAuth Complete] Error:', error);

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -13,6 +13,10 @@
 
 import { getCurrentTenantId } from '@agor/core/db';
 import jwt from 'jsonwebtoken';
+import {
+  EXECUTOR_SESSION_TOKEN_PURPOSE,
+  EXECUTOR_SESSION_TOKEN_TYPE,
+} from '../auth/executor-session-token.js';
 
 const DEBUG_SESSION_TOKENS =
   process.env.AGOR_DEBUG_SESSION_TOKENS === '1' || process.env.DEBUG?.includes('session-token');
@@ -84,9 +88,8 @@ export class SessionTokenService {
     // This JWT will work seamlessly with the standard JWT strategy
     const payload = {
       sub: userId, // Standard JWT subject claim (used by Feathers for user lookup)
-      type: 'executor-session',
-      purpose: 'executor-task',
-      sessionId: sessionId, // Custom claim for session tracking
+      type: EXECUTOR_SESSION_TOKEN_TYPE,
+      purpose: EXECUTOR_SESSION_TOKEN_PURPOSE,
       session_id: sessionId,
       task_id: scope.taskId,
       branch_id: scope.branchId,

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
@@ -1,5 +1,6 @@
 import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
 import type { MCPServer } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
 import { describe, expect, it } from 'vitest';
 import {
   redactMCPServerSecrets,
@@ -94,6 +95,41 @@ describe('MCP server secret redaction', () => {
         },
       },
       session_id: 'session-a',
+    } as never;
+
+    expect(
+      shouldExposeMCPServerSecrets(executorParams, {
+        allowSessionToken: true,
+        sessionId: 'session-a',
+      })
+    ).toBe(true);
+    expect(
+      shouldExposeMCPServerSecretsForSessionToken(executorParams, { sessionId: 'session-a' })
+    ).toBe(true);
+
+    expect(
+      shouldExposeMCPServerSecrets(executorParams, {
+        allowSessionToken: true,
+        sessionId: 'session-b',
+      })
+    ).toBe(false);
+  });
+
+  it('falls back to decoding executor-session JWT claims when Feathers params lost payload metadata', () => {
+    const accessToken = jwt.sign(
+      {
+        type: 'executor-session',
+        purpose: 'executor-task',
+        session_id: 'session-a',
+      },
+      'test-secret'
+    );
+    const executorParams = {
+      provider: 'socketio',
+      authentication: {
+        strategy: 'jwt',
+        accessToken,
+      },
     } as never;
 
     expect(

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.ts
@@ -1,15 +1,18 @@
 import { redactMCPAuthSecrets } from '@agor/core/tools/mcp/auth-secrets';
 import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type { MCPServer, Params } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
+import {
+  type ExecutorSessionTokenPayload,
+  getExecutorSessionTokenSessionId,
+  isExecutorSessionTokenPayload,
+} from '../auth/executor-session-token.js';
 
 export type MCPSecretParams = Params & {
   authentication?: {
     strategy?: string;
-    payload?: {
-      type?: string;
-      session_id?: string;
-      sessionId?: string;
-    };
+    accessToken?: string;
+    payload?: ExecutorSessionTokenPayload;
   };
   user?: { role?: string; _isServiceAccount?: boolean };
   session_id?: string;
@@ -29,14 +32,35 @@ export function shouldExposeMCPServerSecretsForSessionToken(
   params?: MCPSecretParams,
   options: { sessionId?: string } = {}
 ): boolean {
-  const payload = params?.authentication?.payload;
-  const sessionId = params?.session_id ?? payload?.session_id ?? payload?.sessionId;
+  const payload = params?.authentication?.payload ?? decodeExecutorSessionPayload(params);
+  const sessionId = params?.session_id ?? getPayloadSessionId(payload);
   return (
     !!params?.provider &&
     (params.authentication?.strategy === 'session-token' || payload?.type === 'executor-session') &&
     !!sessionId &&
     (!options.sessionId || sessionId === options.sessionId)
   );
+}
+
+function decodeExecutorSessionPayload(
+  params?: MCPSecretParams
+): ExecutorSessionTokenPayload | undefined {
+  if (params?.authentication?.strategy !== 'jwt' || !params.authentication.accessToken) {
+    return undefined;
+  }
+
+  const decoded = jwt.decode(params.authentication.accessToken);
+  if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    return undefined;
+  }
+
+  if (!isExecutorSessionTokenPayload(decoded)) return undefined;
+
+  return decoded;
+}
+
+function getPayloadSessionId(payload: ExecutorSessionTokenPayload | undefined): string | undefined {
+  return payload ? getExecutorSessionTokenSessionId(payload) : undefined;
 }
 
 export function shouldExposeMCPServerSecrets(


### PR DESCRIPTION
## Summary
- Allow executor-session JWT auth claims to be recovered from the verified access token when Feathers socket params no longer carry the decoded payload.
- Keep MCP secret exposure limited to the same session-scoped executor route.
- Add regression coverage for the lost-payload path.

## Checks
- `pnpm --filter @agor/daemon typecheck`
- `pnpm --filter @agor/daemon test -- mcp-header-secrets.test.ts register-services.mcp-custom-headers.test.ts register-hooks.mcp-headers-redaction.test.ts`
- `pnpm lint -- apps/agor-daemon/src/utils/mcp-header-secrets.ts apps/agor-daemon/src/utils/mcp-header-secrets.test.ts`
