### PR TITLE
fix(executor): hydrate MCP OAuth auth headers

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -1,14 +1,12 @@
 import { Forbidden } from '@agor/core/feathers';
 import type { AuthenticatedParams, HookContext, Params } from '@agor/core/types';
-
-type ExecutorTokenPayload = {
-  type?: string;
-  purpose?: string;
-  session_id?: string;
-  sessionId?: string;
-  task_id?: string;
-  branch_id?: string;
-};
+import {
+  EXECUTOR_SESSION_TOKEN_PURPOSE,
+  EXECUTOR_SESSION_TOKEN_TYPE,
+  type ExecutorSessionTokenPayload,
+  getExecutorSessionTokenSessionId,
+  isExecutorSessionTokenPayload,
+} from './executor-session-token.js';
 
 type Scope = {
   sessionId?: string;
@@ -16,11 +14,11 @@ type Scope = {
   branchId?: string;
 };
 
-function scopedPayload(context: HookContext): ExecutorTokenPayload | null {
-  const params = context.params as AuthenticatedParams & ExecutorTokenPayload;
-  const payload = params.authentication?.payload as ExecutorTokenPayload | undefined;
-  if (payload?.type === 'executor-session') {
-    if (payload.purpose !== 'executor-task') {
+function scopedPayload(context: HookContext): ExecutorSessionTokenPayload | null {
+  const params = context.params as AuthenticatedParams & ExecutorSessionTokenPayload;
+  const payload = params.authentication?.payload as ExecutorSessionTokenPayload | undefined;
+  if (payload?.type === EXECUTOR_SESSION_TOKEN_TYPE) {
+    if (!isExecutorSessionTokenPayload(payload)) {
       throw new Forbidden('Executor token is not valid for this request');
     }
     return payload;
@@ -32,8 +30,8 @@ function scopedPayload(context: HookContext): ExecutorTokenPayload | null {
   // claim; normal user/API-key auth must continue through unscoped.
   if (params.authentication?.strategy === 'jwt' && params.task_id) {
     return {
-      type: 'executor-session',
-      purpose: 'executor-task',
+      type: EXECUTOR_SESSION_TOKEN_TYPE,
+      purpose: EXECUTOR_SESSION_TOKEN_PURPOSE,
       task_id: params.task_id,
       session_id: params.session_id,
       sessionId: params.sessionId,
@@ -197,7 +195,7 @@ export function executorRuntimeScopeGuard() {
     if (!payload) return context;
 
     const scope = {
-      sessionId: payload.session_id ?? payload.sessionId,
+      sessionId: getExecutorSessionTokenSessionId(payload),
       taskId: payload.task_id,
       branchId: payload.branch_id,
     };

--- a/apps/agor-daemon/src/auth/executor-session-token.ts
+++ b/apps/agor-daemon/src/auth/executor-session-token.ts
@@ -1,0 +1,30 @@
+import type { JwtPayload } from 'jsonwebtoken';
+
+export const EXECUTOR_SESSION_TOKEN_TYPE = 'executor-session';
+export const EXECUTOR_SESSION_TOKEN_PURPOSE = 'executor-task';
+
+export type ExecutorSessionTokenPayload = JwtPayload & {
+  type?: string;
+  purpose?: string;
+  session_id?: string;
+  /** @deprecated Legacy alias kept only for tokens minted before session_id became canonical. */
+  sessionId?: string;
+  task_id?: string;
+  branch_id?: string;
+};
+
+export function isExecutorSessionTokenPayload(
+  payload: unknown
+): payload is ExecutorSessionTokenPayload {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  const record = payload as ExecutorSessionTokenPayload;
+  return (
+    record.type === EXECUTOR_SESSION_TOKEN_TYPE && record.purpose === EXECUTOR_SESSION_TOKEN_PURPOSE
+  );
+}
+
+export function getExecutorSessionTokenSessionId(
+  payload: ExecutorSessionTokenPayload
+): string | undefined {
+  return payload.session_id ?? payload.sessionId;
+}

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -15,6 +15,10 @@ import type { Params, UserAuthMetadata } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import type { SessionTokenService } from '../services/session-token-service.js';
 import { markAuthenticationUserLookup } from '../services/users.js';
+import {
+  getExecutorSessionTokenSessionId,
+  isExecutorSessionTokenPayload,
+} from './executor-session-token.js';
 import { readRuntimeTenantClaim } from './runtime-tokens.js';
 import { assertUserTokenNotInvalidated, type UserAuthTokenPayload } from './token-invalidation.js';
 
@@ -158,14 +162,14 @@ export class ServiceJWTStrategy extends JWTStrategy {
     }
 
     if (payload?.type === 'executor-session') {
-      if (payload.purpose !== 'executor-task') {
+      if (!isExecutorSessionTokenPayload(payload)) {
         throw new Error('Invalid executor token purpose');
       }
       const token = authentication?.accessToken;
       if (!token || !this.sessionTokenService) {
         throw new Error('Executor token validation unavailable');
       }
-      const sessionId = payload.session_id ?? payload.sessionId;
+      const sessionId = getExecutorSessionTokenSessionId(payload);
       const sessionInfo = await this.sessionTokenService.validateToken(token, {
         sessionId,
         taskId: payload.task_id,

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -51,6 +51,22 @@ describe('tenant-owned service registration', () => {
   it('wraps gateway inbound routing in tenant database scope', () => {
     expect(TENANT_OWNED_SERVICE_PATHS).toContain('gateway');
   });
+
+  it('wraps MCP OAuth/session helper services in tenant database scope', () => {
+    expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
+      expect.arrayContaining([
+        'sessions/:id/mcp-servers',
+        'mcp-servers/discover',
+        'mcp-servers/oauth-auth-headers',
+        'mcp-servers/oauth-complete',
+        'mcp-servers/oauth-disconnect',
+        'mcp-servers/oauth-refresh',
+        'mcp-servers/oauth-start',
+        'mcp-servers/oauth-status',
+        'mcp-servers/test-oauth',
+      ])
+    );
+  });
 });
 
 describe('shouldValidateRepoEnvironmentPayload', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -385,6 +385,7 @@ export interface RegisterHooksContext {
  */
 export const TENANT_OWNED_SERVICE_PATHS = [
   'sessions',
+  'sessions/:id/mcp-servers',
   'session-relationships',
   'tasks',
   'messages',
@@ -401,6 +402,14 @@ export const TENANT_OWNED_SERVICE_PATHS = [
   'boards/:id/group-grants',
   'app-variables',
   'mcp-servers',
+  'mcp-servers/discover',
+  'mcp-servers/oauth-auth-headers',
+  'mcp-servers/oauth-complete',
+  'mcp-servers/oauth-disconnect',
+  'mcp-servers/oauth-refresh',
+  'mcp-servers/oauth-start',
+  'mcp-servers/oauth-status',
+  'mcp-servers/test-oauth',
   'card-types',
   'cards',
   'artifacts',

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -61,4 +61,14 @@ describe('register-services OAuth callback URL regression', () => {
     expect(codeOnly).toMatch(/requirePublicBaseUrl\s*\(/);
     expect(codeOnly).toMatch(/['"]\/mcp-servers\/oauth-callback['"]/);
   });
+
+  it('preserves tenant scope across unauthenticated OAuth callbacks', () => {
+    // Browser redirects to /mcp-servers/oauth-callback do not carry the
+    // originating Feathers auth params or tenant headers, so the pending OAuth
+    // state must capture tenant_id at flow start and re-enter that DB scope
+    // before persisting user_mcp_oauth_tokens or backfilling mcp_servers auth.
+    expect(codeOnly).toMatch(/tenantId:\s*getCurrentTenantId\s*\(\s*\)/);
+    expect(codeOnly).toMatch(/runWithTenantDatabaseScope\s*\(\s*db,\s*pendingFlow\.tenantId/);
+    expect(codeOnly).toMatch(/Missing tenant context for MCP OAuth callback/);
+  });
 });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -16,8 +16,11 @@ import {
   BoardRepository,
   BranchRepository,
   eq,
+  getCurrentTenantId,
   inArray,
+  isPostgresDatabase,
   MCPServerRepository,
+  runWithTenantDatabaseScope,
   SessionMCPServerRepository,
   type SessionMCPServerRow,
   select,
@@ -1121,6 +1124,8 @@ async function registerMCPServices(
     mcpServerId?: string;
     userId?: string;
     oauthMode?: 'per_user' | 'shared';
+    /** Tenant captured when the flow starts; browser callbacks have no auth headers. */
+    tenantId?: string;
     socketId?: string;
     createdAt: number;
     /**
@@ -1318,6 +1323,7 @@ async function registerMCPServices(
       mcpServerId: opts.mcpServerId,
       userId: opts.userId,
       oauthMode: opts.oauthMode,
+      tenantId: getCurrentTenantId(),
       socketId: opts.socketId,
       createdAt: Date.now(),
       tokenResolve,
@@ -1343,6 +1349,44 @@ async function registerMCPServices(
     }
     return base;
   }
+
+  const persistOAuthTokenForPendingFlow = async (
+    tokenResponse: OAuthTokenResponse,
+    pendingFlow: PendingOAuthFlow,
+    logPrefix: string
+  ): Promise<void> => {
+    const work = () =>
+      persistOAuthToken(
+        db,
+        tokenResponse,
+        pendingFlow.mcpUrl,
+        {
+          ...pendingFlow,
+          clientId: pendingFlow.context.clientId,
+          clientSecret: pendingFlow.context.clientSecret,
+          tokenEndpoint: pendingFlow.context.tokenEndpoint,
+        },
+        logPrefix
+      );
+
+    if (pendingFlow.tenantId) {
+      await runWithTenantDatabaseScope(db, pendingFlow.tenantId, work);
+      return;
+    }
+
+    // OAuth callbacks arrive as unauthenticated browser redirects, so they
+    // cannot re-resolve tenant scope from request auth. In Postgres/multitenant
+    // deployments, a flow without captured tenant metadata is unsafe to persist:
+    // fail closed and ask the user to restart the OAuth flow. SQLite/single-user
+    // installs do not have tenant DB scope, so they keep the legacy direct path.
+    if (isPostgresDatabase(db) && pendingFlow.mcpServerId) {
+      throw new Error(
+        'Missing tenant context for MCP OAuth callback. Please restart the OAuth flow.'
+      );
+    }
+
+    await work();
+  };
 
   // Set the OAuth callback handler
   const oauthCallbackHandler = async (req: express.Request, res: express.Response) => {
@@ -1397,18 +1441,7 @@ async function registerMCPServices(
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
-        await persistOAuthToken(
-          db,
-          tokenResponse,
-          pendingFlow.mcpUrl,
-          {
-            ...pendingFlow,
-            clientId: pendingFlow.context.clientId,
-            clientSecret: pendingFlow.context.clientSecret,
-            tokenEndpoint: pendingFlow.context.tokenEndpoint,
-          },
-          'OAuth Callback'
-        );
+        await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Callback');
 
         if (app.io) {
           const oauthEvent = {
@@ -1977,18 +2010,14 @@ async function registerMCPServices(
         const tokenResponse = await completeMCPOAuthFlow(pendingFlow.context, code, state);
         pendingOAuthFlows.delete(state);
 
-        await persistOAuthToken(
-          db,
-          tokenResponse,
-          pendingFlow.mcpUrl,
-          {
-            ...pendingFlow,
-            clientId: pendingFlow.context.clientId,
-            clientSecret: pendingFlow.context.clientSecret,
-            tokenEndpoint: pendingFlow.context.tokenEndpoint,
-          },
-          'OAuth Complete'
-        );
+        const activeTenantId = getCurrentTenantId();
+        if (pendingFlow.tenantId && activeTenantId && pendingFlow.tenantId !== activeTenantId) {
+          throw new Error(
+            'OAuth flow belongs to a different tenant. Please restart the OAuth flow.'
+          );
+        }
+
+        await persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Complete');
         return { success: true, message: 'OAuth authentication successful!', tokenObtained: true };
       } catch (error) {
         console.error('[OAuth Complete] Error:', error);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2093,7 +2093,7 @@ async function registerMCPServices(
   // --------------------------------------------------------------------------
   app.use('/mcp-servers/oauth-auth-headers', {
     async create(
-      data: { mcp_server_ids: string[] },
+      data: { mcp_server_ids: string[]; executorSessionToken?: string },
       params?: AuthenticatedParams
     ): Promise<{
       headers: Record<string, { authorization?: string; error?: string }>;
@@ -2113,9 +2113,30 @@ async function registerMCPServices(
       const sessionId = (params as (AuthenticatedParams & { session_id?: string }) | undefined)
         ?.session_id;
       const trustedInternalOrService = shouldExposeMCPServerSecrets(params);
-      const trustedSessionExecutor = shouldExposeMCPServerSecretsForSessionToken(params, {
+      let trustedSessionExecutor = shouldExposeMCPServerSecretsForSessionToken(params, {
         sessionId,
       });
+      let executorSessionId = sessionId;
+      if (!trustedSessionExecutor && params?.provider && data.executorSessionToken) {
+        const executorTokenService = (
+          app as unknown as {
+            sessionTokenService?: {
+              validateToken: (
+                token: string,
+                expected?: { sessionId?: string; taskId?: string; branchId?: string }
+              ) => Promise<{ session_id: string } | null>;
+            };
+          }
+        ).sessionTokenService;
+        const sessionInfo = await executorTokenService?.validateToken(
+          data.executorSessionToken,
+          {}
+        );
+        if (sessionInfo?.session_id) {
+          executorSessionId = sessionInfo.session_id;
+          trustedSessionExecutor = true;
+        }
+      }
       if (!trustedInternalOrService && !trustedSessionExecutor) {
         throw new Forbidden('oauth-auth-headers is only available to trusted executor paths');
       }
@@ -2123,8 +2144,14 @@ async function registerMCPServices(
       const userTokenRepo = new UserMCPOAuthTokenRepository(db);
       const mcpServerRepo = new MCPServerRepository(db);
       if (trustedSessionExecutor) {
+        if (!executorSessionId) {
+          throw new Forbidden('oauth-auth-headers requires executor session scope');
+        }
         const sessionMcpRepo = new SessionMCPServerRepository(db);
-        const attachedServers = await sessionMcpRepo.listServers(sessionId as SessionID, true);
+        const attachedServers = await sessionMcpRepo.listServers(
+          executorSessionId as SessionID,
+          true
+        );
         const globalServers = await mcpServerRepo.findAll({ scope: 'global', enabled: true });
         const allowedServerIds = new Set([
           ...globalServers.map((server) => server.mcp_server_id),

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -13,6 +13,10 @@
 
 import { getCurrentTenantId } from '@agor/core/db';
 import jwt from 'jsonwebtoken';
+import {
+  EXECUTOR_SESSION_TOKEN_PURPOSE,
+  EXECUTOR_SESSION_TOKEN_TYPE,
+} from '../auth/executor-session-token.js';
 
 const DEBUG_SESSION_TOKENS =
   process.env.AGOR_DEBUG_SESSION_TOKENS === '1' || process.env.DEBUG?.includes('session-token');
@@ -84,9 +88,8 @@ export class SessionTokenService {
     // This JWT will work seamlessly with the standard JWT strategy
     const payload = {
       sub: userId, // Standard JWT subject claim (used by Feathers for user lookup)
-      type: 'executor-session',
-      purpose: 'executor-task',
-      sessionId: sessionId, // Custom claim for session tracking
+      type: EXECUTOR_SESSION_TOKEN_TYPE,
+      purpose: EXECUTOR_SESSION_TOKEN_PURPOSE,
       session_id: sessionId,
       task_id: scope.taskId,
       branch_id: scope.branchId,

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.test.ts
@@ -1,5 +1,6 @@
 import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
 import type { MCPServer } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
 import { describe, expect, it } from 'vitest';
 import {
   redactMCPServerSecrets,
@@ -94,6 +95,41 @@ describe('MCP server secret redaction', () => {
         },
       },
       session_id: 'session-a',
+    } as never;
+
+    expect(
+      shouldExposeMCPServerSecrets(executorParams, {
+        allowSessionToken: true,
+        sessionId: 'session-a',
+      })
+    ).toBe(true);
+    expect(
+      shouldExposeMCPServerSecretsForSessionToken(executorParams, { sessionId: 'session-a' })
+    ).toBe(true);
+
+    expect(
+      shouldExposeMCPServerSecrets(executorParams, {
+        allowSessionToken: true,
+        sessionId: 'session-b',
+      })
+    ).toBe(false);
+  });
+
+  it('falls back to decoding executor-session JWT claims when Feathers params lost payload metadata', () => {
+    const accessToken = jwt.sign(
+      {
+        type: 'executor-session',
+        purpose: 'executor-task',
+        session_id: 'session-a',
+      },
+      'test-secret'
+    );
+    const executorParams = {
+      provider: 'socketio',
+      authentication: {
+        strategy: 'jwt',
+        accessToken,
+      },
     } as never;
 
     expect(

--- a/apps/agor-daemon/src/utils/mcp-header-secrets.ts
+++ b/apps/agor-daemon/src/utils/mcp-header-secrets.ts
@@ -1,15 +1,18 @@
 import { redactMCPAuthSecrets } from '@agor/core/tools/mcp/auth-secrets';
 import { redactMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
 import type { MCPServer, Params } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
+import {
+  type ExecutorSessionTokenPayload,
+  getExecutorSessionTokenSessionId,
+  isExecutorSessionTokenPayload,
+} from '../auth/executor-session-token.js';
 
 export type MCPSecretParams = Params & {
   authentication?: {
     strategy?: string;
-    payload?: {
-      type?: string;
-      session_id?: string;
-      sessionId?: string;
-    };
+    accessToken?: string;
+    payload?: ExecutorSessionTokenPayload;
   };
   user?: { role?: string; _isServiceAccount?: boolean };
   session_id?: string;
@@ -29,14 +32,35 @@ export function shouldExposeMCPServerSecretsForSessionToken(
   params?: MCPSecretParams,
   options: { sessionId?: string } = {}
 ): boolean {
-  const payload = params?.authentication?.payload;
-  const sessionId = params?.session_id ?? payload?.session_id ?? payload?.sessionId;
+  const payload = params?.authentication?.payload ?? decodeExecutorSessionPayload(params);
+  const sessionId = params?.session_id ?? getPayloadSessionId(payload);
   return (
     !!params?.provider &&
     (params.authentication?.strategy === 'session-token' || payload?.type === 'executor-session') &&
     !!sessionId &&
     (!options.sessionId || sessionId === options.sessionId)
   );
+}
+
+function decodeExecutorSessionPayload(
+  params?: MCPSecretParams
+): ExecutorSessionTokenPayload | undefined {
+  if (params?.authentication?.strategy !== 'jwt' || !params.authentication.accessToken) {
+    return undefined;
+  }
+
+  const decoded = jwt.decode(params.authentication.accessToken);
+  if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    return undefined;
+  }
+
+  if (!isExecutorSessionTokenPayload(decoded)) return undefined;
+
+  return decoded;
+}
+
+function getPayloadSessionId(payload: ExecutorSessionTokenPayload | undefined): string | undefined {
+  return payload ? getExecutorSessionTokenSessionId(payload) : undefined;
 }
 
 export function shouldExposeMCPServerSecrets(

--- a/packages/executor/src/db/feathers-repositories.test.ts
+++ b/packages/executor/src/db/feathers-repositories.test.ts
@@ -2,6 +2,7 @@ import type { AgorClient } from '@agor/core/api';
 import type { SessionID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  FeathersMCPOAuthAuthHeadersRepository,
   FeathersMessagesRepository,
   FeathersSessionMCPServersRepository,
 } from './feathers-repositories';
@@ -27,6 +28,46 @@ describe('FeathersMessagesRepository', () => {
         $sort: { index: 1 },
         $limit: 10000,
       },
+    });
+  });
+});
+
+describe('FeathersMCPOAuthAuthHeadersRepository', () => {
+  it('requests OAuth auth headers through the trusted executor route', async () => {
+    const create = vi.fn().mockResolvedValue({
+      headers: {
+        'mcp-1': { authorization: 'Bearer token' },
+      },
+    });
+    const service = vi.fn((path: string) => {
+      if (path !== 'mcp-servers/oauth-auth-headers') {
+        throw new Error(`unexpected service path: ${path}`);
+      }
+      return { create };
+    });
+    const repo = new FeathersMCPOAuthAuthHeadersRepository({
+      service,
+    } as unknown as AgorClient);
+
+    const result = await repo.getAuthHeaders(['mcp-1'] as never);
+
+    expect(service).toHaveBeenCalledWith('mcp-servers/oauth-auth-headers');
+    expect(create).toHaveBeenCalledWith({ mcp_server_ids: ['mcp-1'] });
+    expect(result).toEqual({ 'mcp-1': { authorization: 'Bearer token' } });
+  });
+
+  it('includes the explicit executor session token when socket params drop JWT claims', async () => {
+    const create = vi.fn().mockResolvedValue({ headers: {} });
+    const repo = new FeathersMCPOAuthAuthHeadersRepository({
+      executorSessionToken: 'executor-jwt',
+      service: () => ({ create }),
+    } as unknown as AgorClient);
+
+    await repo.getAuthHeaders(['mcp-1'] as never);
+
+    expect(create).toHaveBeenCalledWith({
+      mcp_server_ids: ['mcp-1'],
+      executorSessionToken: 'executor-jwt',
     });
   });
 });

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -246,6 +246,38 @@ export class FeathersSessionMCPServersRepository {
   }
 }
 
+type MCPOAuthAuthHeaderResult = {
+  headers: Record<string, { authorization?: string; error?: string }>;
+};
+
+/**
+ * MCP OAuth auth headers repository - proxies to the trusted executor route.
+ *
+ * Session-scoped MCP server reads intentionally redact OAuth access tokens in
+ * normal API payloads. Executors use this narrow route to retrieve just the
+ * launch-time Authorization header for OAuth servers that are already in the
+ * session's effective MCP scope.
+ */
+export class FeathersMCPOAuthAuthHeadersRepository {
+  constructor(private client: AgorClient) {}
+
+  async getAuthHeaders(
+    mcpServerIds: MCPServerID[]
+  ): Promise<Record<string, { authorization?: string; error?: string }>> {
+    if (mcpServerIds.length === 0) return {};
+
+    const service = this.client.service('mcp-servers/oauth-auth-headers');
+    const executorSessionToken = (this.client as AgorClient & { executorSessionToken?: string })
+      .executorSessionToken;
+    const result = (await service.create({
+      mcp_server_ids: mcpServerIds,
+      ...(executorSessionToken ? { executorSessionToken } : {}),
+    })) as MCPOAuthAuthHeaderResult;
+
+    return result.headers ?? {};
+  }
+}
+
 /**
  * Users Repository - proxies to 'users' Feathers service
  */
@@ -276,6 +308,7 @@ export type BranchRepository = FeathersBranchesRepository;
 export type RepoRepository = FeathersReposRepository;
 export type MCPServerRepository = FeathersMCPServersRepository;
 export type SessionMCPServerRepository = FeathersSessionMCPServersRepository;
+export type MCPOAuthAuthHeadersRepository = FeathersMCPOAuthAuthHeadersRepository;
 export type UsersRepository = FeathersUsersRepository;
 
 /**
@@ -291,6 +324,7 @@ export function createFeathersBackedRepositories(client: AgorClient) {
     users: new FeathersUsersRepository(client),
     mcpServers: new FeathersMCPServersRepository(client),
     sessionMCP: new FeathersSessionMCPServersRepository(client),
+    mcpOAuthAuthHeaders: new FeathersMCPOAuthAuthHeadersRepository(client),
 
     // Services (direct Feathers service access)
     // SDK handlers can use these services directly with proper typing

--- a/packages/executor/src/handlers/sdk/claude.ts
+++ b/packages/executor/src/handlers/sdk/claude.ts
@@ -66,7 +66,8 @@ export async function executeClaudeCodeTask(params: {
           repos.repos,
           true, // mcpEnabled
           useNativeAuth, // Flag for Claude CLI OAuth (`claude login`)
-          repos.users
+          repos.users,
+          repos.mcpOAuthAuthHeaders
         ),
     });
   } finally {

--- a/packages/executor/src/handlers/sdk/codex.ts
+++ b/packages/executor/src/handlers/sdk/codex.ts
@@ -44,7 +44,8 @@ export async function executeCodexTask(params: {
         repos.tasksStreamingService,
         useNativeAuth, // Flag for native auth (if applicable)
         repos.mcpServers, // MCPServerRepository for global MCP server resolution
-        repos.users
+        repos.users,
+        repos.mcpOAuthAuthHeaders
       ),
   });
 }

--- a/packages/executor/src/handlers/sdk/copilot.ts
+++ b/packages/executor/src/handlers/sdk/copilot.ts
@@ -65,7 +65,8 @@ export async function executeCopilotTask(params: {
           repos.mcpServers,
           repos.users,
           permissionService,
-          repos.sessionsService
+          repos.sessionsService,
+          repos.mcpOAuthAuthHeaders
         ),
     });
   } finally {

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -210,6 +210,7 @@ async function buildCursorMcpServers(args: {
   const serversWithSource = await getMcpServersForSession(args.sessionId, {
     sessionMCPRepo: args.repos.sessionMCP,
     mcpServerRepo: args.repos.mcpServers,
+    mcpOAuthAuthHeadersRepo: args.repos.mcpOAuthAuthHeaders,
     forUserId: args.forUserId,
   });
 

--- a/packages/executor/src/handlers/sdk/gemini.ts
+++ b/packages/executor/src/handlers/sdk/gemini.ts
@@ -44,7 +44,8 @@ export async function executeGeminiTask(params: {
         repos.sessionMCP,
         true, // mcpEnabled
         useNativeAuth, // Flag to use OAuth when no API key
-        repos.users
+        repos.users,
+        repos.mcpOAuthAuthHeaders
       ),
   });
 }

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -79,7 +79,8 @@ export async function executeOpenCodeTask(params: {
       },
       repos.messagesService,
       repos.sessionMCP,
-      repos.mcpServers
+      repos.mcpServers,
+      repos.mcpOAuthAuthHeaders
     );
 
     let opencodeSessionId: string;

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.test.ts
@@ -76,4 +76,33 @@ describe('getMcpServersForSession', () => {
       'session-b',
     ]);
   });
+
+  it('hydrates OAuth access tokens through the trusted executor auth-header route', async () => {
+    const oauthServer = {
+      ...makeServer('oauth-server', 'session', 'oauth'),
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_access_token: '••••••••',
+      },
+    } as MCPServer;
+    const tokenServer = makeServer('token-server', 'global', 'token');
+    const listEffectiveServers = vi.fn().mockResolvedValue([oauthServer, tokenServer]);
+    const getAuthHeaders = vi.fn().mockResolvedValue({
+      'oauth-server': { authorization: 'Bearer real-oauth-token' },
+    });
+
+    const servers = await getMcpServersForSession('session-a' as SessionID, {
+      mcpServerRepo: { findAll: vi.fn() } as never,
+      sessionMCPRepo: { listEffectiveServers } as never,
+      mcpOAuthAuthHeadersRepo: { getAuthHeaders } as never,
+    });
+
+    expect(getAuthHeaders).toHaveBeenCalledWith(['oauth-server']);
+    const hydrated = servers.find(({ server }) => server.mcp_server_id === 'oauth-server')?.server;
+    expect(hydrated?.auth).toMatchObject({
+      type: 'oauth',
+      oauth_access_token: 'real-oauth-token',
+    });
+  });
 });

--- a/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-scoping.ts
@@ -20,6 +20,7 @@
 import { buildMCPTemplateContextFromEnv, resolveMcpServerTemplates } from '@agor/core/mcp';
 import type { MCPServer, SessionID } from '@agor/core/types';
 import type {
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   SessionMCPServerRepository,
 } from '../../db/feathers-repositories.js';
@@ -51,6 +52,13 @@ export interface MCPServerWithSource {
 export interface MCPResolutionDeps {
   sessionMCPRepo?: SessionMCPServerRepository;
   mcpServerRepo?: MCPServerRepository;
+  /**
+   * Trusted executor-only route for hydrating OAuth Authorization headers.
+   *
+   * Normal session MCP server payloads redact OAuth access tokens, so executor
+   * paths must not rely on `server.auth.oauth_access_token` being present.
+   */
+  mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository;
   /**
    * User ID to use for fetching per-user OAuth tokens.
    * When provided, MCP servers with per-user OAuth will have tokens injected.
@@ -212,6 +220,62 @@ export async function getMcpServersForSession(
       console.warn(
         `   ⚠️  Skipped ${serversSkipped} MCP server(s) due to unresolved required templates`
       );
+    }
+
+    const oauthServers = servers
+      .map(({ server }) => server)
+      .filter((server) => server.auth?.type === 'oauth');
+    if (oauthServers.length > 0) {
+      if (!deps.mcpOAuthAuthHeadersRepo) {
+        mcpDebug(
+          `   ℹ️  ${oauthServers.length} OAuth MCP server(s) resolved without executor auth-header hydrator`
+        );
+      } else {
+        try {
+          const authHeaders = await deps.mcpOAuthAuthHeadersRepo.getAuthHeaders(
+            oauthServers.map((server) => server.mcp_server_id)
+          );
+          let hydrated = 0;
+          for (let i = 0; i < servers.length; i++) {
+            const server = servers[i].server;
+            if (server.auth?.type !== 'oauth') continue;
+
+            const header = authHeaders[server.mcp_server_id];
+            const bearer = /^Bearer\s+(.+)$/i.exec(header?.authorization ?? '')?.[1];
+            if (!bearer) {
+              if (header?.error && header.error !== 'needs_reauth') {
+                console.warn(
+                  `   ⚠️  OAuth MCP server "${server.name}" auth unavailable: ${header.error}`
+                );
+              } else if (header?.error) {
+                mcpDebug(
+                  `   ℹ️  OAuth MCP server "${server.name}" auth unavailable: ${header.error}`
+                );
+              }
+              continue;
+            }
+
+            servers[i] = {
+              ...servers[i],
+              server: {
+                ...server,
+                auth: {
+                  ...server.auth,
+                  oauth_access_token: bearer,
+                },
+              },
+            };
+            hydrated++;
+          }
+          mcpDebug(`   🔐 Hydrated OAuth auth headers for ${hydrated} MCP server(s)`);
+        } catch (error) {
+          console.warn(
+            `   ⚠️  Failed to hydrate OAuth MCP auth headers: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          );
+        }
+      }
     }
 
     // Keep MCP config order stable across turns. Provider SDKs serialize MCP

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -15,6 +15,7 @@ import type { PermissionMode as ClaudeSDKPermissionMode } from '@agor/core/sdk';
 import { mapPermissionMode } from '@agor/core/utils/permission-mode-mapper';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -147,7 +148,8 @@ export class ClaudeTool implements ITool {
     reposRepo?: RepoRepository,
     mcpEnabled?: boolean,
     _useNativeAuth?: boolean, // Claude supports `claude login` OAuth, but no special handling needed in tool
-    usersRepo?: import('../../db/feathers-repositories').UsersRepository
+    usersRepo?: import('../../db/feathers-repositories').UsersRepository,
+    mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     if (messagesRepo && sessionsRepo) {
       this.promptService = new ClaudePromptService(
@@ -163,7 +165,8 @@ export class ClaudeTool implements ITool {
         reposRepo,
         messagesService,
         mcpEnabled,
-        usersRepo
+        usersRepo,
+        mcpOAuthAuthHeadersRepo
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -9,6 +9,7 @@ import { shortId } from '@agor/core/db';
 import type { PermissionMode, SDKResultMessage } from '@agor/core/sdk';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   SessionMCPServerRepository,
@@ -67,7 +68,8 @@ export class ClaudePromptService {
     private reposRepo?: import('../../db/feathers-repositories').RepoRepository,
     private messagesService?: MessagesService, // FeathersJS Messages service for creating permission requests
     private mcpEnabled?: boolean,
-    private usersRepo?: UsersRepository
+    private usersRepo?: UsersRepository,
+    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     // No client initialization needed - Agent SDK is stateless
   }
@@ -191,6 +193,7 @@ If you continue to see authentication errors, please contact your Agor administr
         messagesService: this.messagesService,
         branchesRepo: this.branchesRepo,
         usersRepo: this.usersRepo,
+        mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
         permissionLocks: this.permissionLocks,
       },
       {
@@ -357,6 +360,7 @@ If you continue to see authentication errors, please contact your Agor administr
         messagesService: this.messagesService,
         branchesRepo: this.branchesRepo,
         usersRepo: this.usersRepo,
+        mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
         permissionLocks: this.permissionLocks,
       },
       {

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -21,6 +21,7 @@ type Options = Claude.Options;
 import { getDaemonUrl, resolveUserEnvironment } from '../../config.js';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -122,6 +123,7 @@ export interface QuerySetupDeps {
   apiKey?: string;
   sessionMCPRepo?: SessionMCPServerRepository;
   mcpServerRepo?: MCPServerRepository;
+  mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository;
   permissionService?: PermissionService;
   tasksService?: TasksService;
   sessionsService?: SessionsPatchClient;
@@ -558,6 +560,7 @@ export async function setupQuery(
       const serversWithSource = await getMcpServersForSession(sessionId, {
         sessionMCPRepo: deps.sessionMCPRepo,
         mcpServerRepo: deps.mcpServerRepo,
+        mcpOAuthAuthHeadersRepo: deps.mcpOAuthAuthHeadersRepo,
         forUserId: contextUserId,
       });
 

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -11,6 +11,7 @@ import { execSync } from 'node:child_process';
 import { generateId, shortId } from '@agor/core/db';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -97,7 +98,8 @@ export class CodexTool implements ITool {
     tasksStreamingService?: TasksStreamingService,
     useNativeAuth?: boolean,
     mcpServerRepo?: MCPServerRepository,
-    usersRepo?: UsersRepository
+    usersRepo?: UsersRepository,
+    mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     this.messagesRepo = messagesRepo;
     this.sessionsRepo = sessionsRepo;
@@ -117,7 +119,8 @@ export class CodexTool implements ITool {
         mcpServerRepo,
         usersRepo,
         useNativeAuth ?? false,
-        tasksService
+        tasksService,
+        mcpOAuthAuthHeadersRepo
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -38,6 +38,7 @@ import { getDefaultCodexPermissionConfig } from '@agor/core/utils/permission-mod
 import { getDaemonUrl } from '../../config.js';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -284,7 +285,8 @@ export class CodexPromptService {
     private mcpServerRepo?: MCPServerRepository,
     _usersRepo?: UsersRepository,
     useNativeAuth: boolean = false,
-    private tasksService?: TasksService
+    private tasksService?: TasksService,
+    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     // Store API key from base-executor (already resolved with proper precedence)
     this.apiKey = apiKey || '';
@@ -635,6 +637,7 @@ export class CodexPromptService {
     const serversWithSource = await getMcpServersForSession(sessionId, {
       sessionMCPRepo: this.sessionMCPServerRepo,
       mcpServerRepo: this.mcpServerRepo,
+      mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
       forUserId,
     });
 

--- a/packages/executor/src/sdk-handlers/copilot/copilot-tool.ts
+++ b/packages/executor/src/sdk-handlers/copilot/copilot-tool.ts
@@ -15,6 +15,7 @@
 import { generateId, shortId } from '@agor/core/db';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -80,7 +81,8 @@ export class CopilotTool implements ITool {
     mcpServerRepo?: MCPServerRepository,
     usersRepo?: UsersRepository,
     permissionService?: PermissionService,
-    sessionsService?: SessionsPatchClient
+    sessionsService?: SessionsPatchClient,
+    mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     this.messagesRepo = messagesRepo;
     this.sessionsRepo = sessionsRepo;
@@ -100,7 +102,8 @@ export class CopilotTool implements ITool {
         permissionService,
         messagesService,
         tasksService,
-        sessionsService
+        sessionsService,
+        mcpOAuthAuthHeadersRepo
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/copilot/prompt-service.ts
@@ -20,6 +20,7 @@ import { CopilotClient } from '@github/copilot-sdk';
 import { getDaemonUrl } from '../../config.js';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -128,7 +129,8 @@ export class CopilotPromptService {
     permissionService?: PermissionService,
     messagesService?: MessagesService,
     tasksService?: TasksService,
-    sessionsService?: SessionsPatchClient
+    sessionsService?: SessionsPatchClient,
+    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     this.apiKey = apiKey;
     this.messagesRepo = messagesRepo;
@@ -154,6 +156,7 @@ export class CopilotPromptService {
     const serversWithSource = await getMcpServersForSession(sessionId, {
       sessionMCPRepo: this.sessionMCPServerRepo,
       mcpServerRepo: this.mcpServerRepo,
+      mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
     });
 
     const mcpServers = serversWithSource.map((s) => s.server);

--- a/packages/executor/src/sdk-handlers/gemini/gemini-tool.ts
+++ b/packages/executor/src/sdk-handlers/gemini/gemini-tool.ts
@@ -14,6 +14,7 @@ import { execSync } from 'node:child_process';
 import { generateId } from '@agor/core/db';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -72,7 +73,8 @@ export class GeminiTool implements ITool {
     sessionMCPRepo?: SessionMCPServerRepository,
     mcpEnabled?: boolean,
     useNativeAuth?: boolean, // Flag to use OAuth when no API key
-    usersRepo?: UsersRepository
+    usersRepo?: UsersRepository,
+    mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     if (messagesRepo && sessionsRepo) {
       this.promptService = new GeminiPromptService(
@@ -86,7 +88,8 @@ export class GeminiTool implements ITool {
         mcpEnabled,
         useNativeAuth,
         usersRepo,
-        this.tasksService
+        this.tasksService,
+        mcpOAuthAuthHeadersRepo
       );
     }
   }

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
@@ -26,6 +26,7 @@ import { shortId } from '@agor/core/db';
 import { getDaemonUrl } from '../../config.js';
 import type {
   BranchRepository,
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   MessagesRepository,
   RepoRepository,
@@ -114,7 +115,8 @@ export class GeminiPromptService {
     private mcpEnabled?: boolean,
     useNativeAuth?: boolean, // Flag from base-executor indicating OAuth should be used
     _usersRepo?: UsersRepository,
-    private tasksService?: TasksService
+    private tasksService?: TasksService,
+    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     this.apiKey = apiKey;
     this.useNativeAuth = useNativeAuth ?? false; // Default to false if not provided
@@ -717,6 +719,7 @@ export class GeminiPromptService {
         const serversWithSource = await getMcpServersForSession(sessionId, {
           sessionMCPRepo: this.sessionMCPRepo,
           mcpServerRepo: this.mcpServerRepo,
+          mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
           forUserId: contextUserId,
         });
 

--- a/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
+++ b/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
@@ -23,6 +23,7 @@ import type { Part as OpenCodePart } from '@opencode-ai/sdk';
 import { createOpencodeClient } from '@opencode-ai/sdk';
 import { getDaemonUrl } from '../../config.js';
 import type {
+  MCPOAuthAuthHeadersRepository,
   MCPServerRepository,
   SessionMCPServerRepository,
 } from '../../db/feathers-repositories.js';
@@ -101,7 +102,8 @@ export class OpenCodeTool implements ITool {
     config: OpenCodeConfig,
     messagesService?: MessagesService,
     sessionMCPRepo?: SessionMCPServerRepository,
-    mcpServerRepo?: MCPServerRepository
+    mcpServerRepo?: MCPServerRepository,
+    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
   ) {
     this.config = config;
     this.messagesService = messagesService;
@@ -239,6 +241,7 @@ export class OpenCodeTool implements ITool {
         const servers = await getMcpServersForSession(sessionId as SessionID, {
           sessionMCPRepo: this.sessionMCPRepo,
           mcpServerRepo: this.mcpServerRepo,
+          mcpOAuthAuthHeadersRepo: this.mcpOAuthAuthHeadersRepo,
         });
 
         for (const { server } of servers) {


### PR DESCRIPTION
## Summary
- hydrate executor MCP OAuth Authorization headers via the trusted daemon route instead of relying on redacted session MCP payloads
- include explicit executor session JWT proof on the auth-header call because Socket.io provider params can still drop JWT claims
- thread the hydrator through Codex, Claude, Gemini, OpenCode, Copilot, and Cursor MCP config paths
- add executor regression tests for OAuth header hydration and the Feathers route wrapper

## Prod smoke finding
After deploying the first cut, daemon logs showed: `Failed to hydrate OAuth MCP auth headers: oauth-auth-headers is only available to trusted executor paths`. This update mirrors the existing config/resolve-api-key pattern by sending `executorSessionToken` explicitly and validating it server-side.

## Checks
- `pnpm --filter @agor/executor test -- feathers-repositories.test.ts mcp-scoping.test.ts codex/prompt-service.test.ts claude/query-builder.test.ts`
- `pnpm --filter @agor/executor typecheck`
- `pnpm --filter @agor/daemon test -- mcp-header-secrets.test.ts register-services.mcp-custom-headers.test.ts register-hooks.test.ts`
- `pnpm --filter @agor/daemon typecheck`