### PR TITLE
fix(env): avoid stale tenant scope in health monitor timers

### DIFF
--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { ENVIRONMENT } from '@agor/core/config';
+import { getCurrentTenantId, tenantDatabaseScope } from '@agor/core/db';
 import type { Branch } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HealthMonitor } from './health-monitor';
@@ -159,6 +160,46 @@ describe('HealthMonitor tenant context', () => {
     expect(branches.checkHealth).toHaveBeenCalledWith('branch-tenant-a', {
       tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
     });
+    monitor.cleanup();
+  });
+
+  it('does not let health-check timers inherit the caller tenant DB scope', async () => {
+    const branches = new BranchServiceMock();
+    const ambientTenantIds: Array<string | undefined> = [];
+    branches.get.mockImplementation(async (branchId: string) => {
+      ambientTenantIds.push(getCurrentTenantId());
+      return makeBranch({
+        branch_id: branchId,
+        tenant_id: 'tenant-a',
+        environment_instance: { status: 'running' },
+      });
+    });
+    branches.checkHealth.mockImplementation(async () => {
+      ambientTenantIds.push(getCurrentTenantId());
+    });
+
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      defaultParams: { tenant: { tenant_id: 'default', source: 'static' } },
+    });
+
+    tenantDatabaseScope.run(
+      { kind: 'tenant', tenantId: 'stale-transaction', db: {} as never },
+      () => {
+        branches.emit(
+          'patched',
+          makeBranch({
+            branch_id: 'branch-tenant-a',
+            tenant_id: 'tenant-a',
+            environment_instance: { status: 'running' },
+          })
+        );
+      }
+    );
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(1));
+
+    expect(ambientTenantIds).toEqual([undefined, undefined]);
     monitor.cleanup();
   });
 });

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -15,6 +15,7 @@ import { ENVIRONMENT } from '@agor/core/config';
 import {
   BranchRepository,
   getHiddenTenantId,
+  runWithoutTenantDatabaseScope,
   runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
   shortId,
@@ -161,21 +162,30 @@ export class HealthMonitor {
     this.stopMonitoring(branchId);
     if (params) this.branchParams.set(branchId, params);
 
-    // Wait grace period before first check
-    setTimeout(() => {
-      if (this.isShuttingDown) return;
-
-      // Perform first health check
-      this.checkHealth(branchId);
-
-      // Set up periodic health checks
-      const interval = setInterval(() => {
+    // Wait grace period before first check.
+    //
+    // Health monitoring is often started from inside tenant-scoped service
+    // hooks or startup discovery. Timers inherit AsyncLocalStorage, including
+    // the active tenant DB transaction; by the time the timer fires that
+    // transaction has usually committed. Schedule outside the current tenant
+    // DB scope so every check enters a fresh scope through the branches service
+    // hooks using the stored tenant params.
+    runWithoutTenantDatabaseScope(() => {
+      setTimeout(() => {
         if (this.isShuttingDown) return;
-        this.checkHealth(branchId);
-      }, ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS);
 
-      this.intervals.set(branchId, interval);
-    }, ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+        // Perform first health check
+        this.checkHealth(branchId);
+
+        // Set up periodic health checks
+        const interval = setInterval(() => {
+          if (this.isShuttingDown) return;
+          this.checkHealth(branchId);
+        }, ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS);
+
+        this.intervals.set(branchId, interval);
+      }, ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- schedule health-monitor timers outside the current tenant DB scope so they do not inherit stale transaction AsyncLocalStorage
- keep per-branch tenant params and let branch service hooks enter a fresh tenant scope for each health check
- add regression coverage for timer scope leakage

## Validation
- pnpm --filter @agor/daemon test -- health-monitor.test.ts
- pnpm --filter @agor/daemon typecheck

## Context
Observed `onboarding-test-sophie` stuck in `starting` even though `http://10.33.92.175:14130/` was healthy. Daemon logs showed background health checks failing with stale transaction errors such as `SAVEPOINT can only be used in transaction blocks`; a manual `/branches/:id/health` call succeeded and transitioned the branch to `running`.