### PR TITLE
Fix SessionCanvas zone select update loop

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -101,6 +101,7 @@ import {
 } from './canvas/utils/coordinateTransforms';
 import { getValidZoneParentId, sanitizeOrphanedNodeParents } from './canvas/utils/nodeParentUtils';
 import { ZoneTriggerModal } from './canvas/ZoneTriggerModal';
+import { ZONE_BASE_Z_INDEX, ZONE_SELECTED_Z_INDEX } from './canvas/zIndex';
 
 interface SessionCanvasProps {
   board: Board | null;
@@ -1408,16 +1409,25 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         if (selectChanges.length > 0) {
           setNodes((currentNodes) => {
             // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
-            const zoneIds = new Set(selectChanges.map((c: any) => c.id));
-            const hasZoneChange = currentNodes.some((n) => n.type === 'zone' && zoneIds.has(n.id));
-            if (!hasZoneChange) return currentNodes;
-            return currentNodes.map((n) => {
+            const zoneSelectById = new Map(selectChanges.map((c: any) => [c.id, c]));
+            let changed = false;
+            const nextNodes = currentNodes.map((n) => {
               if (n.type !== 'zone') return n;
               // biome-ignore lint/suspicious/noExplicitAny: React Flow change event types are not exported
-              const change = selectChanges.find((c: any) => c.id === n.id);
-              if (change) return { ...n, zIndex: change.selected ? 101 : 100 };
-              return n;
+              const change = zoneSelectById.get(n.id) as any;
+              if (!change) return n;
+
+              const nextZIndex = change.selected ? ZONE_SELECTED_Z_INDEX : ZONE_BASE_Z_INDEX;
+              if (n.zIndex === nextZIndex) return n;
+
+              changed = true;
+              return { ...n, zIndex: nextZIndex };
             });
+
+            // React Flow can emit select changes while reconciling the controlled
+            // nodes prop. Returning the same array for no-op zIndex transitions
+            // avoids a controlled-update feedback loop (React #185).
+            return changed ? nextNodes : currentNodes;
           });
         }
 
@@ -2012,7 +2022,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               type: 'zone',
               position,
               // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
-              zIndex: 100, // Zones behind branches and comments
+              zIndex: ZONE_BASE_Z_INDEX, // Zones behind branches and comments
               style: { width, height },
               data: {
                 objectId,

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -334,6 +334,21 @@ describe('SessionCanvas zoom shortcuts', () => {
         // Guard returns currentNodes unchanged so React can bail out on re-render
         expect(result).toBe(mockNodes);
       });
+
+      it('returns the same node array reference when zone zIndex is already current', () => {
+        const { onNodesChange } = renderCanvas(null);
+        setNodesUnsafeSpy.mockClear();
+
+        act(() => onNodesChange([{ type: 'select', id: 'zone-1', selected: true }]));
+
+        const updater = getLastSetNodesUpdater();
+        expect(updater).toBeDefined();
+        const mockNodes = [{ id: 'zone-1', type: 'zone', zIndex: 101 }];
+        const result = updater!(mockNodes);
+        // No-op select echoes from React Flow must not allocate a fresh nodes
+        // array, or controlled ReactFlow can re-emit selection indefinitely.
+        expect(result).toBe(mockNodes);
+      });
     });
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -12,6 +12,7 @@ import type {
 } from '@agor-live/client';
 import { useCallback, useMemo, useRef } from 'react';
 import type { Node } from 'reactflow';
+import { ZONE_BASE_Z_INDEX } from './zIndex';
 
 interface UseBoardObjectsProps {
   board: Board | null;
@@ -308,7 +309,7 @@ export const useBoardObjects = ({
           // Locked zones are never draggable. Unlocked zones inherit from
           // canvas-level nodesDraggable (mutationGate.canMutate).
           ...(isLocked ? { draggable: false } : {}),
-          zIndex: 100, // Zones behind branches and comments
+          zIndex: ZONE_BASE_Z_INDEX, // Zones behind branches and comments
           className: eraserMode ? 'eraser-mode' : undefined,
           // Set dimensions both as direct props (for collision detection) and style (for rendering)
           width: objectData.width,
@@ -369,7 +370,7 @@ export const useBoardObjects = ({
           type: 'zone',
           position: { x, y },
           // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
-          zIndex: 100, // Zones behind branches and comments
+          zIndex: ZONE_BASE_Z_INDEX, // Zones behind branches and comments
           style: {
             width,
             height,

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/zIndex.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/zIndex.ts
@@ -1,0 +1,2 @@
+export const ZONE_BASE_Z_INDEX = 100;
+export const ZONE_SELECTED_Z_INDEX = ZONE_BASE_Z_INDEX + 1;


### PR DESCRIPTION
Closes #1738
Closes #1723
Closes #1724

## Triage conclusion
- **#1738 actionability:** Treating #1738 as a real, actionable bug rather than a one-off transient report. I could not replay the exact production user interaction from the crash report alone, but the signature is specific: React error #185 means "Maximum update depth exceeded", and the stack is in ReactFlow/SessionCanvas. The code path had a plausible controlled-component feedback loop: zone selection handling always allocated a fresh nodes array/object even when the requested z-index was already applied.
- **#1723/#1724 relationship:** They are **not duplicates of #1738**. #1723 and #1724 are both build `851b2621` CodeMirror crashes with `Unrecognized extension value... multiple instances of @codemirror/state`, rooted in `editor-*.js` / `CodeEditor.inner-*`. #1738 is build `fdcaf0f1`, React error #185, rooted in `reactflow-*.js` / `SessionCanvas-*`. Same user/board area, different build, error, bundle, and component stack.
- **#1723/#1724 status:** Those CodeMirror crashes were already fixed on `main` by #1712 / commit `a6cde5b1` (`fix(agor-ui): dedupe @codemirror/state so CodeEditor stops crashing`). The crash reports came from build `851b2621`, which predates that fix. This PR intentionally carries the closing keywords for #1723/#1724 so all three open crash-report issues close together, while the only new code change here is the #1738 ReactFlow loop guard.

## Summary
- Avoid allocating new SessionCanvas node arrays for no-op zone select z-index echoes.
- Preserve z-index raise/lower behavior only when it actually changes.
- Add regression coverage for no-op zone select updates.

## Tests
- `pnpm --filter agor-ui test -- SessionCanvas.zoom.test.tsx`
- `pnpm exec biome check apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx`