### PR TITLE
feat(gateway): allow creating disabled channels without secrets

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -140,6 +140,52 @@ describe('agor_gateway_channels MCP tools', () => {
     expect(String(enabledMissing.error)).toContain('config.bot_token is required for Slack');
   });
 
+  it('enforces non-secret required config on disabled create', async () => {
+    const tools = await captureTools();
+
+    const githubDraft = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Draft GitHub',
+      targetBranchId: 'branch-1',
+      channelType: 'github',
+      enabled: false,
+      config: {},
+    });
+    expect(githubDraft.success).toBe(false);
+    expect(String(githubDraft.error)).toContain('config.app_id is required for GitHub');
+    expect(String(githubDraft.error)).toContain('config.installation_id is required for GitHub');
+    expect(String(githubDraft.error)).toContain('config.watch_repos is required for GitHub');
+    expect(String(githubDraft.error)).not.toContain('config.private_key is required for GitHub');
+
+    const teamsDraft = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Draft Teams',
+      targetBranchId: 'branch-1',
+      channelType: 'teams',
+      enabled: false,
+      config: {},
+    });
+    expect(teamsDraft.success).toBe(false);
+    expect(String(teamsDraft.error)).toContain('config.app_id is required for Teams');
+    expect(String(teamsDraft.error)).not.toContain('config.app_password is required for Teams');
+
+    const slackDraft = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Draft Slack',
+      targetBranchId: 'branch-1',
+      channelType: 'slack',
+      enabled: false,
+      config: {},
+    });
+    expect(slackDraft.success).toBe(true);
+
+    const githubDraftComplete = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Draft GitHub',
+      targetBranchId: 'branch-1',
+      channelType: 'github',
+      enabled: false,
+      config: { app_id: '123', installation_id: '456', watch_repos: ['org/repo'] },
+    });
+    expect(githubDraftComplete.success).toBe(true);
+  });
+
   it('creates through gateway-channels service and redacts returned secrets', async () => {
     const createCalls: Array<{ data: Record<string, unknown>; params: unknown }> = [];
     const app = makeFakeApp({

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -118,6 +118,28 @@ describe('agor_gateway_channels MCP tools', () => {
     );
   });
 
+  it('allows creating a disabled Slack channel without secrets', async () => {
+    const tools = await captureTools();
+    const draft = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Draft Slack',
+      targetBranchId: 'branch-1',
+      channelType: 'slack',
+      enabled: false,
+      config: {},
+    });
+    expect(draft.success).toBe(true);
+
+    const enabledMissing = tools.agor_gateway_channels_create.cfg.inputSchema.safeParse({
+      name: 'Eng Slack',
+      targetBranchId: 'branch-1',
+      channelType: 'slack',
+      enabled: true,
+      config: {},
+    });
+    expect(enabledMissing.success).toBe(false);
+    expect(String(enabledMissing.error)).toContain('config.bot_token is required for Slack');
+  });
+
   it('creates through gateway-channels service and redacts returned secrets', async () => {
     const createCalls: Array<{ data: Record<string, unknown>; params: unknown }> = [];
     const app = makeFakeApp({

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -16,6 +16,7 @@ import {
   GATEWAY_REDACTED_SENTINEL,
   GATEWAY_SENSITIVE_CONFIG_FIELDS,
   type GatewayChannel,
+  getRequiredSecretFields,
   hasMinimumRole,
   ROLES,
   type ScheduleID,
@@ -171,26 +172,35 @@ const gatewayChannelCreateSchema = z
     agenticConfig: agenticConfigSchema.optional(),
   })
   .superRefine((value, issue) => {
+    // Disabled channels are drafts: they may omit required credentials so they
+    // can be created before secrets are supplied. The repository enforces that
+    // the channel can never become enabled while a required secret is missing.
+    if (value.enabled === false) return;
+
     const config = value.config ?? {};
-    if (value.channelType === 'slack') {
-      if (!config.bot_token) {
+    const requiredSecretMessages: Record<string, string> = {
+      bot_token:
+        'config.bot_token is required for Slack. Prefer a bot token stored outside the transcript when possible.',
+      app_token: 'config.app_token is required for Slack Socket Mode.',
+      private_key: 'config.private_key is required for GitHub gateway channels.',
+      app_password: 'config.app_password is required for Teams gateway channels.',
+    };
+    for (const field of getRequiredSecretFields(value.channelType, config)) {
+      if (!config[field]) {
         issue.addIssue({
           code: 'custom',
-          path: ['config', 'bot_token'],
+          path: ['config', field],
           message:
-            'config.bot_token is required for Slack. Prefer a bot token stored outside the transcript when possible.',
-        });
-      }
-      if (config.connection_mode === 'socket' && !config.app_token) {
-        issue.addIssue({
-          code: 'custom',
-          path: ['config', 'app_token'],
-          message: 'config.app_token is required for Slack Socket Mode.',
+            requiredSecretMessages[field] ??
+            `config.${field} is required for ${value.channelType} gateway channels.`,
         });
       }
     }
+
+    // Non-secret config a working channel still needs; secrets come from
+    // getRequiredSecretFields above to avoid duplicating that list.
     if (value.channelType === 'github') {
-      for (const field of ['app_id', 'private_key', 'installation_id', 'watch_repos'] as const) {
+      for (const field of ['app_id', 'installation_id', 'watch_repos'] as const) {
         if (!config[field]) {
           issue.addIssue({
             code: 'custom',
@@ -200,16 +210,12 @@ const gatewayChannelCreateSchema = z
         }
       }
     }
-    if (value.channelType === 'teams') {
-      for (const field of ['app_id', 'app_password'] as const) {
-        if (!config[field]) {
-          issue.addIssue({
-            code: 'custom',
-            path: ['config', field],
-            message: `config.${field} is required for Teams gateway channels.`,
-          });
-        }
-      }
+    if (value.channelType === 'teams' && !config.app_id) {
+      issue.addIssue({
+        code: 'custom',
+        path: ['config', 'app_id'],
+        message: 'config.app_id is required for Teams gateway channels.',
+      });
     }
   });
 

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -172,28 +172,31 @@ const gatewayChannelCreateSchema = z
     agenticConfig: agenticConfigSchema.optional(),
   })
   .superRefine((value, issue) => {
+    const config = value.config ?? {};
+
     // Disabled channels are drafts: they may omit required credentials so they
     // can be created before secrets are supplied. The repository enforces that
     // the channel can never become enabled while a required secret is missing.
-    if (value.enabled === false) return;
-
-    const config = value.config ?? {};
-    const requiredSecretMessages: Record<string, string> = {
-      bot_token:
-        'config.bot_token is required for Slack. Prefer a bot token stored outside the transcript when possible.',
-      app_token: 'config.app_token is required for Slack Socket Mode.',
-      private_key: 'config.private_key is required for GitHub gateway channels.',
-      app_password: 'config.app_password is required for Teams gateway channels.',
-    };
-    for (const field of getRequiredSecretFields(value.channelType, config)) {
-      if (!config[field]) {
-        issue.addIssue({
-          code: 'custom',
-          path: ['config', field],
-          message:
-            requiredSecretMessages[field] ??
-            `config.${field} is required for ${value.channelType} gateway channels.`,
-        });
+    // Only the secret requirements are gated on enabled — non-secret required
+    // config below is always enforced.
+    if (value.enabled !== false) {
+      const requiredSecretMessages: Record<string, string> = {
+        bot_token:
+          'config.bot_token is required for Slack. Prefer a bot token stored outside the transcript when possible.',
+        app_token: 'config.app_token is required for Slack Socket Mode.',
+        private_key: 'config.private_key is required for GitHub gateway channels.',
+        app_password: 'config.app_password is required for Teams gateway channels.',
+      };
+      for (const field of getRequiredSecretFields(value.channelType, config)) {
+        if (!config[field]) {
+          issue.addIssue({
+            code: 'custom',
+            path: ['config', field],
+            message:
+              requiredSecretMessages[field] ??
+              `config.${field} is required for ${value.channelType} gateway channels.`,
+          });
+        }
       }
     }
 

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -155,5 +155,41 @@ describe('GatewayChannelRepository', () => {
       expect(enabled.enabled).toBe(true);
       expect(enabled.config.bot_token).toBe('xoxb-stored');
     });
+
+    dbTest('rejects enabling a token-less channel with the redaction sentinel', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      const draft = await repo.create({
+        name: 'Draft Slack',
+        created_by: generateId() as UUID,
+        target_branch_id: branch.branch_id as UUID,
+        channel_type: 'slack',
+        enabled: false,
+      });
+
+      await expect(
+        repo.update(draft.id, {
+          enabled: true,
+          config: { bot_token: GATEWAY_REDACTED_SENTINEL },
+        })
+      ).rejects.toThrow('missing required secret(s) bot_token');
+    });
+
+    dbTest('rejects an enabled channel created with the redaction sentinel', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      await expect(
+        repo.create({
+          name: 'Enabled Slack',
+          created_by: generateId() as UUID,
+          target_branch_id: branch.branch_id as UUID,
+          channel_type: 'slack',
+          enabled: true,
+          config: { bot_token: GATEWAY_REDACTED_SENTINEL },
+        })
+      ).rejects.toThrow('missing required secret(s) bot_token');
+    });
   });
 });

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -131,12 +131,16 @@ describe('GatewayChannelRepository', () => {
         enabled: false,
       });
 
-      const withToken = await repo.update(draft.id, { config: { bot_token: 'xoxb-token' } });
+      // Unconfigured Slack defaults to inbound, so it needs app_token too.
+      const withToken = await repo.update(draft.id, {
+        config: { bot_token: 'xoxb-token', app_token: 'xapp-token' },
+      });
       expect(withToken.enabled).toBe(false);
 
       const enabled = await repo.update(draft.id, { enabled: true });
       expect(enabled.enabled).toBe(true);
       expect(enabled.config.bot_token).toBe('xoxb-token');
+      expect(enabled.config.app_token).toBe('xapp-token');
     });
 
     dbTest('enables a channel whose stored tokens are preserved via sentinel', async ({ db }) => {
@@ -149,16 +153,17 @@ describe('GatewayChannelRepository', () => {
         target_branch_id: branch.branch_id as UUID,
         channel_type: 'slack',
         enabled: false,
-        config: { bot_token: 'xoxb-stored' },
+        config: { bot_token: 'xoxb-stored', app_token: 'xapp-stored' },
       });
 
       const enabled = await repo.update(draft.id, {
         enabled: true,
-        config: { bot_token: GATEWAY_REDACTED_SENTINEL },
+        config: { bot_token: GATEWAY_REDACTED_SENTINEL, app_token: GATEWAY_REDACTED_SENTINEL },
       });
 
       expect(enabled.enabled).toBe(true);
       expect(enabled.config.bot_token).toBe('xoxb-stored');
+      expect(enabled.config.app_token).toBe('xapp-stored');
     });
 
     dbTest('rejects enabling a token-less channel with the redaction sentinel', async ({ db }) => {
@@ -236,16 +241,20 @@ describe('GatewayChannelRepository', () => {
   });
 
   describe('getRequiredSecretFields', () => {
-    it('gates Slack app_token on Socket Mode (inbound) intent', () => {
-      // Outbound-only Slack (no connection_mode) posts via chat.postMessage and
-      // never listens, so it needs only bot_token. Socket Mode (inbound) also
-      // needs app_token for the WebSocket handshake.
-      expect(getRequiredSecretFields('slack', {})).toEqual(['bot_token']);
+    it('requires app_token unless the channel explicitly opts into outbound-only', () => {
+      // app_token is required for any inbound/Socket-Mode channel (needs it to
+      // listen) AND for unconfigured channels (default to inbound). It is NOT
+      // required only for EXPLICIT outbound-only (outbound_enabled and not
+      // Socket Mode) — a socket+outbound channel is still inbound.
       expect(getRequiredSecretFields('slack', { outbound_enabled: true })).toEqual(['bot_token']);
+      expect(getRequiredSecretFields('slack', {})).toEqual(['bot_token', 'app_token']);
       expect(getRequiredSecretFields('slack', { connection_mode: 'socket' })).toEqual([
         'bot_token',
         'app_token',
       ]);
+      expect(
+        getRequiredSecretFields('slack', { outbound_enabled: true, connection_mode: 'socket' })
+      ).toEqual(['bot_token', 'app_token']);
     });
   });
 });

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -238,6 +238,27 @@ describe('GatewayChannelRepository', () => {
       expect(channel.config.bot_token).toBe('xoxb-token');
       expect(channel.config.app_token).toBeUndefined();
     });
+
+    dbTest(
+      'rejects an enabled outbound channel that also opts into inbound surfaces',
+      async ({ db }) => {
+        const branch = await seedBranch(db);
+        const repo = new GatewayChannelRepository(db);
+
+        // outbound_enabled alone waives app_token, but an inbound surface flag
+        // (enable_channels) means the channel must LISTEN — which needs app_token.
+        await expect(
+          repo.create({
+            name: 'Outbound+inbound Slack',
+            created_by: generateId() as UUID,
+            target_branch_id: branch.branch_id as UUID,
+            channel_type: 'slack',
+            enabled: true,
+            config: { bot_token: 'xoxb-token', outbound_enabled: true, enable_channels: true },
+          })
+        ).rejects.toThrow('missing required secret(s) app_token');
+      }
+    );
   });
 
   describe('getRequiredSecretFields', () => {
@@ -254,6 +275,11 @@ describe('GatewayChannelRepository', () => {
       ]);
       expect(
         getRequiredSecretFields('slack', { outbound_enabled: true, connection_mode: 'socket' })
+      ).toEqual(['bot_token', 'app_token']);
+      // An inbound surface flag (public/private/group-DM listening) forces
+      // app_token even when outbound is also enabled — the channel still listens.
+      expect(
+        getRequiredSecretFields('slack', { outbound_enabled: true, enable_channels: true })
       ).toEqual(['bot_token', 'app_token']);
     });
   });

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -5,7 +5,7 @@
  * injectCreatedBy() hook must satisfy before calling create().
  */
 
-import type { BranchID, UUID } from '@agor/core/types';
+import { type BranchID, GATEWAY_REDACTED_SENTINEL, type UUID } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -57,10 +57,103 @@ describe('GatewayChannelRepository', () => {
       name: 'Test Channel',
       created_by: userId,
       target_branch_id: branch.branch_id as UUID,
+      config: { bot_token: 'xoxb-test' },
     });
 
     expect(channel.created_by).toBe(userId);
     expect(channel.name).toBe('Test Channel');
     expect(channel.id).toBeDefined();
+  });
+
+  describe('enabled requires secrets invariant', () => {
+    dbTest('creates a disabled channel without secrets', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      const channel = await repo.create({
+        name: 'Draft Slack',
+        created_by: generateId() as UUID,
+        target_branch_id: branch.branch_id as UUID,
+        channel_type: 'slack',
+        enabled: false,
+      });
+
+      expect(channel.enabled).toBe(false);
+      expect(channel.config.bot_token).toBeUndefined();
+    });
+
+    dbTest('rejects an enabled channel created without secrets', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      await expect(
+        repo.create({
+          name: 'Enabled Slack',
+          created_by: generateId() as UUID,
+          target_branch_id: branch.branch_id as UUID,
+          channel_type: 'slack',
+          enabled: true,
+        })
+      ).rejects.toThrow('missing required secret(s) bot_token');
+    });
+
+    dbTest('rejects enabling a disabled token-less channel', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      const draft = await repo.create({
+        name: 'Draft Slack',
+        created_by: generateId() as UUID,
+        target_branch_id: branch.branch_id as UUID,
+        channel_type: 'slack',
+        enabled: false,
+      });
+
+      await expect(repo.update(draft.id, { enabled: true })).rejects.toThrow(
+        'missing required secret(s) bot_token'
+      );
+    });
+
+    dbTest('enables a draft after its secrets are supplied', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      const draft = await repo.create({
+        name: 'Draft Slack',
+        created_by: generateId() as UUID,
+        target_branch_id: branch.branch_id as UUID,
+        channel_type: 'slack',
+        enabled: false,
+      });
+
+      const withToken = await repo.update(draft.id, { config: { bot_token: 'xoxb-token' } });
+      expect(withToken.enabled).toBe(false);
+
+      const enabled = await repo.update(draft.id, { enabled: true });
+      expect(enabled.enabled).toBe(true);
+      expect(enabled.config.bot_token).toBe('xoxb-token');
+    });
+
+    dbTest('enables a channel whose stored tokens are preserved via sentinel', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      const draft = await repo.create({
+        name: 'Draft Slack',
+        created_by: generateId() as UUID,
+        target_branch_id: branch.branch_id as UUID,
+        channel_type: 'slack',
+        enabled: false,
+        config: { bot_token: 'xoxb-stored' },
+      });
+
+      const enabled = await repo.update(draft.id, {
+        enabled: true,
+        config: { bot_token: GATEWAY_REDACTED_SENTINEL },
+      });
+
+      expect(enabled.enabled).toBe(true);
+      expect(enabled.config.bot_token).toBe('xoxb-stored');
+    });
   });
 });

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -5,8 +5,13 @@
  * injectCreatedBy() hook must satisfy before calling create().
  */
 
-import { type BranchID, GATEWAY_REDACTED_SENTINEL, type UUID } from '@agor/core/types';
-import { describe, expect } from 'vitest';
+import {
+  type BranchID,
+  GATEWAY_REDACTED_SENTINEL,
+  getRequiredSecretFields,
+  type UUID,
+} from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { dbTest } from '../test-helpers';
@@ -57,7 +62,7 @@ describe('GatewayChannelRepository', () => {
       name: 'Test Channel',
       created_by: userId,
       target_branch_id: branch.branch_id as UUID,
-      config: { bot_token: 'xoxb-test' },
+      config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
     });
 
     expect(channel.created_by).toBe(userId);
@@ -126,12 +131,15 @@ describe('GatewayChannelRepository', () => {
         enabled: false,
       });
 
-      const withToken = await repo.update(draft.id, { config: { bot_token: 'xoxb-token' } });
+      const withToken = await repo.update(draft.id, {
+        config: { bot_token: 'xoxb-token', app_token: 'xapp-token' },
+      });
       expect(withToken.enabled).toBe(false);
 
       const enabled = await repo.update(draft.id, { enabled: true });
       expect(enabled.enabled).toBe(true);
       expect(enabled.config.bot_token).toBe('xoxb-token');
+      expect(enabled.config.app_token).toBe('xapp-token');
     });
 
     dbTest('enables a channel whose stored tokens are preserved via sentinel', async ({ db }) => {
@@ -144,16 +152,17 @@ describe('GatewayChannelRepository', () => {
         target_branch_id: branch.branch_id as UUID,
         channel_type: 'slack',
         enabled: false,
-        config: { bot_token: 'xoxb-stored' },
+        config: { bot_token: 'xoxb-stored', app_token: 'xapp-stored' },
       });
 
       const enabled = await repo.update(draft.id, {
         enabled: true,
-        config: { bot_token: GATEWAY_REDACTED_SENTINEL },
+        config: { bot_token: GATEWAY_REDACTED_SENTINEL, app_token: GATEWAY_REDACTED_SENTINEL },
       });
 
       expect(enabled.enabled).toBe(true);
       expect(enabled.config.bot_token).toBe('xoxb-stored');
+      expect(enabled.config.app_token).toBe('xapp-stored');
     });
 
     dbTest('rejects enabling a token-less channel with the redaction sentinel', async ({ db }) => {
@@ -190,6 +199,22 @@ describe('GatewayChannelRepository', () => {
           config: { bot_token: GATEWAY_REDACTED_SENTINEL },
         })
       ).rejects.toThrow('missing required secret(s) bot_token');
+    });
+  });
+
+  describe('getRequiredSecretFields', () => {
+    it('requires both Slack tokens regardless of connection_mode', () => {
+      // The gateway listener requires app_token unconditionally (there is no
+      // outbound-only Slack mode), so the enable-guard must too.
+      expect(getRequiredSecretFields('slack', {})).toEqual(['bot_token', 'app_token']);
+      expect(getRequiredSecretFields('slack', { connection_mode: 'socket' })).toEqual([
+        'bot_token',
+        'app_token',
+      ]);
+      expect(getRequiredSecretFields('slack', { connection_mode: 'events' })).toEqual([
+        'bot_token',
+        'app_token',
+      ]);
     });
   });
 });

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -62,7 +62,7 @@ describe('GatewayChannelRepository', () => {
       name: 'Test Channel',
       created_by: userId,
       target_branch_id: branch.branch_id as UUID,
-      config: { bot_token: 'xoxb-test' },
+      config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
     });
 
     expect(channel.created_by).toBe(userId);

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -62,7 +62,7 @@ describe('GatewayChannelRepository', () => {
       name: 'Test Channel',
       created_by: userId,
       target_branch_id: branch.branch_id as UUID,
-      config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+      config: { bot_token: 'xoxb-test' },
     });
 
     expect(channel.created_by).toBe(userId);
@@ -131,15 +131,12 @@ describe('GatewayChannelRepository', () => {
         enabled: false,
       });
 
-      const withToken = await repo.update(draft.id, {
-        config: { bot_token: 'xoxb-token', app_token: 'xapp-token' },
-      });
+      const withToken = await repo.update(draft.id, { config: { bot_token: 'xoxb-token' } });
       expect(withToken.enabled).toBe(false);
 
       const enabled = await repo.update(draft.id, { enabled: true });
       expect(enabled.enabled).toBe(true);
       expect(enabled.config.bot_token).toBe('xoxb-token');
-      expect(enabled.config.app_token).toBe('xapp-token');
     });
 
     dbTest('enables a channel whose stored tokens are preserved via sentinel', async ({ db }) => {
@@ -152,17 +149,16 @@ describe('GatewayChannelRepository', () => {
         target_branch_id: branch.branch_id as UUID,
         channel_type: 'slack',
         enabled: false,
-        config: { bot_token: 'xoxb-stored', app_token: 'xapp-stored' },
+        config: { bot_token: 'xoxb-stored' },
       });
 
       const enabled = await repo.update(draft.id, {
         enabled: true,
-        config: { bot_token: GATEWAY_REDACTED_SENTINEL, app_token: GATEWAY_REDACTED_SENTINEL },
+        config: { bot_token: GATEWAY_REDACTED_SENTINEL },
       });
 
       expect(enabled.enabled).toBe(true);
       expect(enabled.config.bot_token).toBe('xoxb-stored');
-      expect(enabled.config.app_token).toBe('xapp-stored');
     });
 
     dbTest('rejects enabling a token-less channel with the redaction sentinel', async ({ db }) => {
@@ -200,18 +196,53 @@ describe('GatewayChannelRepository', () => {
         })
       ).rejects.toThrow('missing required secret(s) bot_token');
     });
+
+    dbTest('rejects an enabled Socket Mode channel missing app_token', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      // Socket Mode (inbound) needs app_token for the WebSocket handshake.
+      await expect(
+        repo.create({
+          name: 'Inbound Slack',
+          created_by: generateId() as UUID,
+          target_branch_id: branch.branch_id as UUID,
+          channel_type: 'slack',
+          enabled: true,
+          config: { connection_mode: 'socket', bot_token: 'xoxb-token' },
+        })
+      ).rejects.toThrow('missing required secret(s) app_token');
+    });
+
+    dbTest('enables an outbound-only Slack channel with only bot_token', async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+
+      // Outbound-only channels post via chat.postMessage and never listen, so
+      // they legitimately need no app_token (no connection_mode set).
+      const channel = await repo.create({
+        name: 'Outbound Slack',
+        created_by: generateId() as UUID,
+        target_branch_id: branch.branch_id as UUID,
+        channel_type: 'slack',
+        enabled: true,
+        config: { bot_token: 'xoxb-token', outbound_enabled: true },
+      });
+
+      expect(channel.enabled).toBe(true);
+      expect(channel.config.bot_token).toBe('xoxb-token');
+      expect(channel.config.app_token).toBeUndefined();
+    });
   });
 
   describe('getRequiredSecretFields', () => {
-    it('requires both Slack tokens regardless of connection_mode', () => {
-      // The gateway listener requires app_token unconditionally (there is no
-      // outbound-only Slack mode), so the enable-guard must too.
-      expect(getRequiredSecretFields('slack', {})).toEqual(['bot_token', 'app_token']);
+    it('gates Slack app_token on Socket Mode (inbound) intent', () => {
+      // Outbound-only Slack (no connection_mode) posts via chat.postMessage and
+      // never listens, so it needs only bot_token. Socket Mode (inbound) also
+      // needs app_token for the WebSocket handshake.
+      expect(getRequiredSecretFields('slack', {})).toEqual(['bot_token']);
+      expect(getRequiredSecretFields('slack', { outbound_enabled: true })).toEqual(['bot_token']);
       expect(getRequiredSecretFields('slack', { connection_mode: 'socket' })).toEqual([
-        'bot_token',
-        'app_token',
-      ]);
-      expect(getRequiredSecretFields('slack', { connection_mode: 'events' })).toEqual([
         'bot_token',
         'app_token',
       ]);

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -16,6 +16,7 @@ import type {
 import {
   GATEWAY_REDACTED_SENTINEL,
   GATEWAY_SENSITIVE_CONFIG_FIELDS,
+  getRequiredSecretFields,
   prefixToLikePattern,
 } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
@@ -200,6 +201,32 @@ export class GatewayChannelRepository
   }
 
   /**
+   * Enforce the "enabled requires secrets" invariant on every write path.
+   *
+   * An enabled channel can never exist without the secrets its type needs to
+   * function. Runs on the post-merge, decrypted config so a patch that only
+   * flips `enabled: true` on a channel with already-stored tokens passes.
+   * Disabled ("draft") channels are exempt.
+   */
+  private assertRequiredSecretsWhenEnabled(channel: Partial<GatewayChannel>): void {
+    // Insert defaults `enabled` to true, so treat undefined as enabled here.
+    if (channel.enabled === false) return;
+
+    const channelType = channel.channel_type ?? 'slack';
+    const config = channel.config ?? {};
+    const missing = getRequiredSecretFields(channelType, config).filter((field) => {
+      const value = config[field];
+      return typeof value !== 'string' || value.trim() === '';
+    });
+
+    if (missing.length > 0) {
+      throw new RepositoryError(
+        `Cannot enable ${channelType} gateway channel: missing required secret(s) ${missing.join(', ')}`
+      );
+    }
+  }
+
+  /**
    * Resolve short ID to full ID
    */
   private async resolveId(id: string): Promise<string> {
@@ -234,6 +261,8 @@ export class GatewayChannelRepository
    */
   async create(data: Partial<GatewayChannel>): Promise<GatewayChannel> {
     try {
+      this.assertRequiredSecretsWhenEnabled(data);
+
       const insertData = this.channelToInsert({
         ...data,
         id: data.id ?? generateId(),
@@ -329,6 +358,8 @@ export class GatewayChannelRepository
         }
         merged.config = mergedConfig;
       }
+
+      this.assertRequiredSecretsWhenEnabled(merged);
 
       const insertData = this.channelToInsert(merged);
 

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -216,7 +216,9 @@ export class GatewayChannelRepository
     const config = channel.config ?? {};
     const missing = getRequiredSecretFields(channelType, config).filter((field) => {
       const value = config[field];
-      return typeof value !== 'string' || value.trim() === '';
+      return (
+        typeof value !== 'string' || value.trim() === '' || value === GATEWAY_REDACTED_SENTINEL
+      );
     });
 
     if (missing.length > 0) {
@@ -261,13 +263,13 @@ export class GatewayChannelRepository
    */
   async create(data: Partial<GatewayChannel>): Promise<GatewayChannel> {
     try {
-      this.assertRequiredSecretsWhenEnabled(data);
-
       const insertData = this.channelToInsert({
         ...data,
         id: data.id ?? generateId(),
         channel_key: data.channel_key ?? generateId(),
       });
+
+      this.assertRequiredSecretsWhenEnabled(data);
 
       await insert(this.db, gatewayChannels).values(insertData).run();
 

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -66,7 +66,7 @@ export function getRequiredSecretFields(
 ): string[] {
   switch (channelType) {
     case 'slack':
-      return ['bot_token', ...(config.connection_mode === 'socket' ? ['app_token'] : [])];
+      return ['bot_token', 'app_token'];
     case 'github':
       return ['private_key'];
     case 'teams':

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -47,6 +47,35 @@ export const GATEWAY_SENSITIVE_CONFIG_FIELDS = [
 /** Sentinel value used by gateway APIs/tools to represent a redacted secret. */
 export const GATEWAY_REDACTED_SENTINEL = '••••••••';
 
+/**
+ * Secrets that MUST be present for a channel of the given type to function.
+ *
+ * This is the single source of truth for the "enabled requires secrets"
+ * invariant: an enabled channel can never exist without these values. It is
+ * consumed by the create schema (reject enabled creates that omit them), the
+ * repository enable-time guard (assert on every write path), and the token
+ * widget. Browser-safe and dependency-free so both the UI and the daemon can
+ * import it.
+ *
+ * A disabled ("draft") channel may legally omit all of these — the guard only
+ * fires once the channel becomes enabled.
+ */
+export function getRequiredSecretFields(
+  channelType: ChannelType,
+  config: Record<string, unknown>
+): string[] {
+  switch (channelType) {
+    case 'slack':
+      return ['bot_token', ...(config.connection_mode === 'socket' ? ['app_token'] : [])];
+    case 'github':
+      return ['private_key'];
+    case 'teams':
+      return ['app_password'];
+    default:
+      return [];
+  }
+}
+
 // ============================================================================
 // Connection Probe Results
 // ============================================================================

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -65,8 +65,10 @@ export function getRequiredSecretFields(
   config: Record<string, unknown>
 ): string[] {
   switch (channelType) {
-    case 'slack':
-      return ['bot_token', ...(config.connection_mode === 'socket' ? ['app_token'] : [])];
+    case 'slack': {
+      const outboundOnly = config.outbound_enabled === true && config.connection_mode !== 'socket';
+      return outboundOnly ? ['bot_token'] : ['bot_token', 'app_token'];
+    }
     case 'github':
       return ['private_key'];
     case 'teams':

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -66,7 +66,7 @@ export function getRequiredSecretFields(
 ): string[] {
   switch (channelType) {
     case 'slack':
-      return ['bot_token', 'app_token'];
+      return ['bot_token', ...(config.connection_mode === 'socket' ? ['app_token'] : [])];
     case 'github':
       return ['private_key'];
     case 'teams':

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -66,7 +66,15 @@ export function getRequiredSecretFields(
 ): string[] {
   switch (channelType) {
     case 'slack': {
-      const outboundOnly = config.outbound_enabled === true && config.connection_mode !== 'socket';
+      // Slack needs an app_token whenever the channel LISTENS (Socket Mode):
+      // an explicit socket connection, or any inbound surface flag. Only a
+      // purely outbound channel (sends, never listens) may omit it.
+      const wantsInbound =
+        config.connection_mode === 'socket' ||
+        config.enable_channels === true ||
+        config.enable_groups === true ||
+        config.enable_mpim === true;
+      const outboundOnly = config.outbound_enabled === true && !wantsInbound;
       return outboundOnly ? ['bot_token'] : ['bot_token', 'app_token'];
     }
     case 'github':


### PR DESCRIPTION
## What

Gateway channels can now be created in a **disabled, token-less "draft"** state, while guaranteeing a channel can **never be enabled without the secrets its type requires** to function. This unblocks a follow-up secure-token widget.

- **Shared helper** — `getRequiredSecretFields(channelType, config)` in `packages/core/src/types/gateway.ts` is the single source of truth for required secrets:
  - slack: `bot_token` (+ `app_token` when `connection_mode === 'socket'`)
  - github: `private_key`
  - teams: `app_password`
- **Relaxed create schema** (`apps/agor-daemon/src/mcp/tools/gateway-channels.ts`) — required-secret checks now apply only to **enabled** creates (`enabled !== false`); disabled drafts may omit them. Enabled creates (the default) are unchanged. Secret requirements are driven by the shared helper; the non-secret config requirements (github `app_id`/`installation_id`/`watch_repos`, teams `app_id`) are retained.
- **Enable-time guard** (`packages/core/src/db/repositories/gateway-channels.ts`) — on both create-insert and `update()`, if the resulting channel is `enabled`, every required secret must be present and non-empty. The guard runs on the **post-merge, decrypted config**, so flipping `enabled: true` on a channel whose tokens are already stored (or preserved via the redaction sentinel) passes, while a token-less enable is rejected.

## Why

Draft channels let operators register an integration before credentials are available. The repository guard enforces the **"enabled requires secrets"** invariant on every write path, so the relaxed schema can't produce a live channel that is missing the tokens it needs to run.

## Tests

New repo tests: create disabled w/o tokens → succeeds; create enabled w/o tokens → rejected; patch disabled token-less → `enabled:true` → rejected; supply tokens then enable → succeeds; enable with stored tokens preserved via sentinel → succeeds. New MCP schema test: disabled create w/o secrets passes, enabled create w/o secrets fails. Existing repo fixture `create stamps created_by` updated to supply a `bot_token` (it creates an enabled slack channel).