### PR TITLE
feat(new-session): paste/drop attachments into the initial prompt

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -25,10 +25,13 @@ import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-ro
 import { AVAILABLE_AGENTS } from './components/AgentSelectionGrid';
 import type { BranchUpdate } from './components/BranchModal/tabs/GeneralTab';
 import { ErrorBoundary, setCrashContext } from './components/ErrorBoundary';
+import { uploadFilesToSession } from './components/FileUpload/upload';
 import { ForcePasswordChangeModal } from './components/ForcePasswordChangeModal';
 import { InitialLoadingScreen } from './components/InitialLoadingScreen';
 import { LoginPage } from './components/LoginPage';
 import { OnboardingWizard } from './components/OnboardingWizard';
+import { buildPromptWithAttachments } from './components/SessionPanel/composerAttachments';
+import { getDaemonUrl } from './config/daemon';
 import { CanvasNavigationProvider } from './contexts/CanvasNavigationContext';
 import { ConnectionProvider } from './contexts/ConnectionContext';
 import { ServicesConfigContext } from './contexts/ServicesConfigContext';
@@ -636,9 +639,14 @@ function AppContent() {
         throw new Error('Branch ID is required to create a session');
       }
 
+      // Files pasted/dropped into the New Session modal ride along on the
+      // config but must never enter the session-create REST payload — strip
+      // them out and upload them once the session (and its ID) exists.
+      const { attachmentFiles, ...sessionConfig } = config;
+
       // Create the session with the branch_id
       const session = await createSession({
-        ...config,
+        ...sessionConfig,
         branch_id,
       });
 
@@ -663,8 +671,43 @@ function AppContent() {
 
         showSuccess('Session created!');
 
-        // If there's an initial prompt, send it to the agent
-        if (config.initialPrompt?.trim()) {
+        // Upload any pasted/dropped files to the freshly created session, then
+        // fold their server paths into the initial prompt. A screenshot with no
+        // typed text is valid — the attachment block becomes the message — so we
+        // send whenever there is prompt text OR at least one attachment.
+        const trimmedPrompt = config.initialPrompt?.trim() ?? '';
+        if (attachmentFiles?.length) {
+          try {
+            const uploaded = await uploadFilesToSession({
+              sessionId: session.session_id,
+              daemonUrl: getDaemonUrl(),
+              files: attachmentFiles,
+              notifyAgent: false,
+            });
+            const finalPrompt = buildPromptWithAttachments(
+              config.initialPrompt ?? '',
+              uploaded.files.map((file) => file.path)
+            );
+            if (finalPrompt.trim()) {
+              await handleSendPrompt(session.session_id, finalPrompt, config.permissionMode);
+            }
+          } catch (error) {
+            // Never silently drop the user's words: surface the upload failure
+            // but still send the text-only prompt so their typing isn't lost.
+            showError(
+              `Failed to upload attachments: ${
+                error instanceof Error ? error.message : String(error)
+              }`
+            );
+            if (trimmedPrompt) {
+              await handleSendPrompt(
+                session.session_id,
+                config.initialPrompt,
+                config.permissionMode
+              );
+            }
+          }
+        } else if (trimmedPrompt) {
           await handleSendPrompt(session.session_id, config.initialPrompt, config.permissionMode);
         }
 

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.test.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Regression test for late attachment intake during session creation.
+ *
+ * Bug: after clicking "Create Session" the modal stays open for the whole
+ * async create -> upload -> prompt cycle, but `attachmentFiles` was already
+ * captured when the click fired. Files pasted/dropped in that window were
+ * added to the tray yet silently never uploaded. The fix wires
+ * `filesDropDisabled={isCreating}` on the initial-prompt AutocompleteTextarea
+ * so file intake is refused while a session is being created.
+ *
+ * This test pins that wiring end to end: a paste is accepted before creation
+ * but refused once `isCreating` is latched by an in-flight onCreate.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NewSessionModal } from './NewSessionModal';
+
+// Stand-in for AutocompleteTextarea: exposes `filesDropDisabled` as a data
+// attribute and offers a paste trigger that mirrors the real component's gate
+// (AutocompleteTextarea.tsx: `if (filesDropDisabled) return;`). The real
+// component's own gating is covered by AutocompleteTextarea.test.tsx.
+vi.mock('../AutocompleteTextarea', () => ({
+  AutocompleteTextarea: ({
+    value,
+    onChange,
+    onFilesDrop,
+    filesDropDisabled,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+    onFilesDrop?: (files: File[]) => void;
+    filesDropDisabled?: boolean;
+    placeholder?: string;
+  }) => (
+    <div>
+      <textarea
+        data-testid="prompt-textarea"
+        data-files-drop-disabled={String(!!filesDropDisabled)}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button
+        type="button"
+        data-testid="simulate-paste"
+        onClick={() => {
+          if (filesDropDisabled) return;
+          onFilesDrop?.([new File(['notes'], 'notes.txt', { type: 'text/plain' })]);
+        }}
+      >
+        paste
+      </button>
+    </div>
+  ),
+}));
+
+// Heavy children that need a live client/store are irrelevant to this test.
+vi.mock('../AgentSelectionGrid/AgentSelectionGrid', () => ({
+  AgentSelectionGrid: () => <div data-testid="agent-grid" />,
+}));
+vi.mock('../MCPServerSelect', () => ({
+  SessionMcpServersField: () => <div data-testid="mcp-servers-field" />,
+}));
+vi.mock('../AgenticToolConfigForm', async () => {
+  const actual = await vi.importActual<typeof import('../AgenticToolConfigForm')>(
+    '../AgenticToolConfigForm'
+  );
+  return { ...actual, AgenticToolConfigForm: () => <div data-testid="agentic-tool-config" /> };
+});
+
+vi.mock('../../store/agorStore', () => ({
+  useAgorStore: (selector: (state: unknown) => unknown) =>
+    selector({ userById: new Map(), mcpServerById: new Map() }),
+}));
+vi.mock('../../utils/message', () => ({
+  useThemedMessage: () => ({ showError: vi.fn() }),
+}));
+
+// Antd Modal mount + async validateFields cycles brush against vitest's 5s
+// default on slower runners (see ForkSpawnModal.test.tsx).
+describe('NewSessionModal attachment intake', { timeout: 10_000 }, () => {
+  it('refuses file intake while a session is being created', async () => {
+    // onCreate never resolves, so the modal stays open with isCreating latched.
+    const onCreate = vi.fn(() => new Promise<void>(() => {}));
+
+    render(
+      <NewSessionModal
+        open
+        onClose={vi.fn()}
+        onCreate={onCreate}
+        availableAgents={[]}
+        branchId="branch-1"
+        client={null}
+      />
+    );
+
+    const removeButtons = () => screen.queryAllByRole('button', { name: /^Remove/ });
+
+    // Intake is enabled before creation: a paste adds one tray item.
+    expect(screen.getByTestId('prompt-textarea')).toHaveAttribute(
+      'data-files-drop-disabled',
+      'false'
+    );
+    fireEvent.click(screen.getByTestId('simulate-paste'));
+    expect(removeButtons()).toHaveLength(1);
+
+    // Start creation; isCreating latches because onCreate never resolves.
+    fireEvent.click(screen.getByRole('button', { name: 'Create Session' }));
+    await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('prompt-textarea')).toHaveAttribute(
+        'data-files-drop-disabled',
+        'true'
+      )
+    );
+
+    // A late paste during creation is refused: no new tray item is added.
+    fireEvent.click(screen.getByTestId('simulate-paste'));
+    expect(removeButtons()).toHaveLength(1);
+  });
+});

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -27,6 +27,12 @@ import { SessionEnvVarsSelector } from '../SessionEnvVarsSelector';
 import { SessionAttachmentTray } from '../SessionPanel/SessionAttachmentTray';
 import { useComposerAttachments } from '../SessionPanel/useComposerAttachments';
 
+const PASTE_SHORTCUT =
+  typeof navigator !== 'undefined' &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || '')
+    ? '⌘V'
+    : 'Ctrl+V';
+
 export interface NewSessionConfig {
   branch_id: string; // Required - sessions are always created from a branch
   agent: string;
@@ -258,7 +264,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
           <AutocompleteTextarea
             value={form.getFieldValue('initialPrompt') || ''}
             onChange={(value) => form.setFieldValue('initialPrompt', value)}
-            placeholder="e.g., Build a JWT authentication system with secure password storage... (type @ for autocomplete, or ⌘V / Ctrl+V to paste a screenshot)"
+            placeholder={`e.g., Build a JWT authentication system with secure password storage... (type @ for autocomplete, or ${PASTE_SHORTCUT} to paste a screenshot)`}
             autoSize={{ minRows: 4, maxRows: 8 }}
             client={client}
             sessionId={null}

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -272,6 +272,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
             enableKnowledgeMentions
             kbLinkTarget="absolute-route"
             onFilesDrop={addAttachments}
+            filesDropDisabled={isCreating}
           />
         </Form.Item>
         {attachments.length > 0 && (

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -14,6 +14,7 @@ import { Alert, Collapse, Form, Input, Modal, Typography } from 'antd';
 import { useEffect, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { selectMcpServerById, selectUserById } from '../../store/selectors';
+import { useThemedMessage } from '../../utils/message';
 import { AgenticToolConfigForm, getFormValuesFromConfig } from '../AgenticToolConfigForm';
 import {
   type AgenticToolOption,
@@ -23,6 +24,8 @@ import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { SessionMcpServersField } from '../MCPServerSelect';
 import type { ModelConfig } from '../ModelSelector';
 import { SessionEnvVarsSelector } from '../SessionEnvVarsSelector';
+import { SessionAttachmentTray } from '../SessionPanel/SessionAttachmentTray';
+import { useComposerAttachments } from '../SessionPanel/useComposerAttachments';
 
 export interface NewSessionConfig {
   branch_id: string; // Required - sessions are always created from a branch
@@ -43,6 +46,12 @@ export interface NewSessionConfig {
    * session's executor process once it is created.
    */
   envVarNames?: string[];
+  /**
+   * Raw files pasted/dropped into the initial prompt before the session
+   * exists. Uploaded to the new session after creation, then folded into the
+   * initial prompt. Never included in the session-create REST payload.
+   */
+  attachmentFiles?: File[];
 }
 
 export interface NewSessionModalProps {
@@ -71,9 +80,12 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
   const mcpServerById = useAgorStore(selectMcpServerById);
   const userById = useAgorStore(selectUserById);
   const [form] = Form.useForm();
+  const { showError } = useThemedMessage();
   const [selectedAgent, setSelectedAgent] = useState<string>('claude-code');
   const [isCreating, setIsCreating] = useState(false);
   const [envVarNames, setEnvVarNames] = useState<string[]>([]);
+  const { attachments, addAttachments, removeAttachment, clearAttachments } =
+    useComposerAttachments({ sessionId: null, showError });
   const isFormValid = !!selectedAgent;
 
   // Reset form when modal opens, using user defaults if available
@@ -86,6 +98,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
     setSelectedAgent('claude-code');
     setIsCreating(false); // Reset creating state when modal opens
     setEnvVarNames([]);
+    clearAttachments();
 
     // Get default config for the selected agent
     const agentDefaults = currentUser?.default_agentic_config?.['claude-code'];
@@ -158,6 +171,8 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
         mcpServerIds: values.mcpServerIds ?? fallbackMcpServerIds,
         permissionMode,
         envVarNames: envVarNames.length > 0 ? envVarNames : undefined,
+        attachmentFiles:
+          attachments.length > 0 ? attachments.map((attachment) => attachment.file) : undefined,
       };
 
       if (selectedAgent === 'codex') {
@@ -183,6 +198,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
 
   const handleCancel = () => {
     form.resetFields();
+    clearAttachments();
     onClose();
   };
 
@@ -249,6 +265,12 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
             userById={userById}
             enableKnowledgeMentions
             kbLinkTarget="absolute-route"
+            onFilesDrop={addAttachments}
+          />
+          <SessionAttachmentTray
+            attachments={attachments}
+            onRemove={removeAttachment}
+            disabled={isCreating}
           />
         </Form.Item>
 

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -258,7 +258,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
           <AutocompleteTextarea
             value={form.getFieldValue('initialPrompt') || ''}
             onChange={(value) => form.setFieldValue('initialPrompt', value)}
-            placeholder="e.g., Build a JWT authentication system with secure password storage... (type @ for autocomplete)"
+            placeholder="e.g., Build a JWT authentication system with secure password storage... (type @ for autocomplete, or ⌘V / Ctrl+V to paste a screenshot)"
             autoSize={{ minRows: 4, maxRows: 8 }}
             client={client}
             sessionId={null}
@@ -268,11 +268,15 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
             onFilesDrop={addAttachments}
           />
         </Form.Item>
-        <SessionAttachmentTray
-          attachments={attachments}
-          onRemove={removeAttachment}
-          disabled={isCreating}
-        />
+        {attachments.length > 0 && (
+          <div style={{ padding: '8px 0' }}>
+            <SessionAttachmentTray
+              attachments={attachments}
+              onRemove={removeAttachment}
+              disabled={isCreating}
+            />
+          </div>
+        )}
 
         {/* MCP Servers — first-class field, mirrors SessionSettingsModal */}
         <SessionMcpServersField mcpServerById={mcpServerById} />

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -267,12 +267,12 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
             kbLinkTarget="absolute-route"
             onFilesDrop={addAttachments}
           />
-          <SessionAttachmentTray
-            attachments={attachments}
-            onRemove={removeAttachment}
-            disabled={isCreating}
-          />
         </Form.Item>
+        <SessionAttachmentTray
+          attachments={attachments}
+          onRemove={removeAttachment}
+          disabled={isCreating}
+        />
 
         {/* MCP Servers — first-class field, mirrors SessionSettingsModal */}
         <SessionMcpServersField mcpServerById={mcpServerById} />


### PR DESCRIPTION
## What

The New Session modal's **Initial Prompt** textarea now supports pasting screenshots and dragging/dropping files — the same capability the in-session conversation composer already has. Previously paste/drop did nothing there because the modal never passed `onFilesDrop` to `<AutocompleteTextarea>`.

## How

Reuses the existing composer pieces verbatim — no new upload/validation logic:

- `NewSessionModal` wires `useComposerAttachments({ sessionId: null, showError })`, passes `onFilesDrop={addAttachments}` to the textarea, and renders `<SessionAttachmentTray>` beneath it. The pending raw files are carried up on the create config as `attachmentFiles`.
- Because no session exists yet, files are **not** uploaded in the modal. `handleCreateSession` (App.tsx) strips `attachmentFiles` out of the config **before** it enters the session-create REST payload, then after the session exists follows the same ordering as the in-session composer: **create → upload to the new session → `buildPromptWithAttachments` → send**.

## Edge cases

- A screenshot with **no typed text** is a valid message — the send condition was widened to also fire when attachments are present (the attachment block becomes the message).
- **Graceful degradation:** if the upload throws, an error toast is shown but the text-only initial prompt is still sent, so the user's typed words are never silently dropped.
- Existing size/MIME limits and validation are untouched; attachments clear on modal open/cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)