### PR TITLE
fix(ui): home page layout fixes

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1283,16 +1283,16 @@ export const App: React.FC<AppProps> = ({
                         onCommentSelect={handleCommentSelect}
                       />
                     )}
-                    <NewSessionButton
-                      onClick={() => {
-                        const center = isHomeSurface
-                          ? null
-                          : sessionCanvasRef.current?.getViewportCenter();
-                        setNewBranchDefaultPosition(center || null);
-                        setCreateDialogDefaultTab('assistant');
-                        setCreateDialogOpen(true);
-                      }}
-                    />
+                    {!isHomeSurface && (
+                      <NewSessionButton
+                        onClick={() => {
+                          const center = sessionCanvasRef.current?.getViewportCenter();
+                          setNewBranchDefaultPosition(center || null);
+                          setCreateDialogDefaultTab('assistant');
+                          setCreateDialogOpen(true);
+                        }}
+                      />
+                    )}
                   </div>
                 </Panel>
                 {(effectiveSelectedSessionId || !eventStreamPanelCollapsed) && (

--- a/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
@@ -1,8 +1,14 @@
 import type { Board, Branch, Session } from '@agor-live/client';
-import { ClockCircleOutlined, PlusOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import {
+  ClockCircleOutlined,
+  LeftOutlined,
+  PlusOutlined,
+  RightOutlined,
+  ThunderboltOutlined,
+} from '@ant-design/icons';
 import { Button, Empty, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { formatRelativeTime } from '../../utils/time';
 import { glassCardStyle } from './homeStyles';
 import type { HomeSectionProps } from './types';
@@ -10,6 +16,7 @@ import type { HomeSectionProps } from './types';
 const { Text } = Typography;
 
 const HOME_BOARDS_LIMIT = 50;
+const BOARDS_PER_PAGE = 4;
 
 interface BoardHomeRow {
   board: Board;
@@ -169,8 +176,7 @@ export const HomeBoardsSection: React.FC<
   onBoardClick,
   onOpenCreateDialog,
 }) => {
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [columns, setColumns] = useState(4);
+  const [page, setPage] = useState(0);
 
   const rows = useMemo(() => {
     const visitRank = new Map((recentBoardIds ?? []).map((boardId, index) => [boardId, index]));
@@ -206,18 +212,11 @@ export const HomeBoardsSection: React.FC<
       .slice(0, HOME_BOARDS_LIMIT);
   }, [boardById, recentBoardIds, branchById, sessionsByBranch]);
 
-  const hasBoards = rows.length > 0;
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hasBoards is a sentinel dep — re-attaches observer when board count transitions between 0 and >0 (gridRef only mounts with boards)
-  useEffect(() => {
-    if (!gridRef.current) return;
-    const observer = new ResizeObserver(([entry]) => {
-      const w = entry.contentRect.width;
-      setColumns(w < 400 ? 1 : w < 700 ? 2 : 4);
-    });
-    observer.observe(gridRef.current);
-    return () => observer.disconnect();
-  }, [hasBoards]);
+  const totalPages = Math.max(1, Math.ceil(rows.length / BOARDS_PER_PAGE));
+  const currentPage = Math.min(page, totalPages - 1);
+  const pageStart = currentPage * BOARDS_PER_PAGE;
+  const visibleRows = rows.slice(pageStart, pageStart + BOARDS_PER_PAGE);
+  const showPager = rows.length > BOARDS_PER_PAGE;
 
   return (
     <section aria-label="Boards" style={{ marginBottom: 24 }}>
@@ -232,15 +231,40 @@ export const HomeBoardsSection: React.FC<
         <Text strong style={{ fontSize: 14 }}>
           Boards
         </Text>
-        <Button
-          type="link"
-          size="small"
-          icon={<PlusOutlined />}
-          style={{ padding: 0 }}
-          onClick={() => onOpenCreateDialog('board')}
-        >
-          New board
-        </Button>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {showPager && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <Button
+                type="text"
+                size="small"
+                icon={<LeftOutlined />}
+                aria-label="Previous boards"
+                disabled={currentPage === 0}
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+              />
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                {currentPage + 1} / {totalPages}
+              </Text>
+              <Button
+                type="text"
+                size="small"
+                icon={<RightOutlined />}
+                aria-label="Next boards"
+                disabled={currentPage >= totalPages - 1}
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              />
+            </div>
+          )}
+          <Button
+            type="link"
+            size="small"
+            icon={<PlusOutlined />}
+            style={{ padding: 0 }}
+            onClick={() => onOpenCreateDialog('board')}
+          >
+            New board
+          </Button>
+        </div>
       </div>
 
       {rows.length === 0 ? (
@@ -255,14 +279,13 @@ export const HomeBoardsSection: React.FC<
         </Empty>
       ) : (
         <div
-          ref={gridRef}
           style={{
             display: 'grid',
-            gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+            gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
             gap: 12,
           }}
         >
-          {rows.map(({ board, branches, sessions }) => (
+          {visibleRows.map(({ board, branches, sessions }) => (
             <BoardHomeCard
               key={board.board_id}
               board={board}

--- a/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
@@ -240,7 +240,7 @@ export const HomeBoardsSection: React.FC<
                 icon={<LeftOutlined />}
                 aria-label="Previous boards"
                 disabled={currentPage === 0}
-                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                onClick={() => setPage(Math.max(0, currentPage - 1))}
               />
               <Text type="secondary" style={{ fontSize: 12 }}>
                 {currentPage + 1} / {totalPages}
@@ -251,7 +251,7 @@ export const HomeBoardsSection: React.FC<
                 icon={<RightOutlined />}
                 aria-label="Next boards"
                 disabled={currentPage >= totalPages - 1}
-                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                onClick={() => setPage(Math.min(totalPages - 1, currentPage + 1))}
               />
             </div>
           )}

--- a/apps/agor-ui/src/components/HomePage/HomeKnowledgeSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeKnowledgeSection.tsx
@@ -172,6 +172,7 @@ export const HomeKnowledgeSection: React.FC<{ client: AgorClient | null; connect
             rowKey="document_id"
             dataSource={filteredDocs}
             renderItem={(doc) => <KnowledgeDocRow doc={doc} />}
+            style={{ padding: '0 12px' }}
           />
         )}
       </Card>

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -249,10 +249,19 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
           <Content
             style={{
               overflowY: 'auto',
+              display: 'flex',
+              flexDirection: 'column',
               padding: 'clamp(16px, 3vw, 28px) clamp(16px, 3vw, 32px) 80px',
             }}
           >
-            <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100%' }}>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                height: '100%',
+                minHeight: 0,
+              }}
+            >
               {/* Greeting */}
               <header
                 style={{

--- a/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
@@ -105,7 +105,7 @@ export const HomeSessionsSection: React.FC<
   return (
     <section
       aria-label={currentUserId ? 'My sessions' : 'Sessions'}
-      style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}
+      style={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 240 }}
     >
       {/* Section header */}
       <div

--- a/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
@@ -137,12 +137,13 @@ export const HomeSessionsSection: React.FC<
           body: {
             padding: 0,
             flex: 1,
-            minHeight: 240,
+            minHeight: 0,
             overflowY: 'auto',
           },
         }}
         style={{
           flex: 1,
+          minHeight: 0,
           display: 'flex',
           flexDirection: 'column',
           border: `1px solid ${token.colorBorderSecondary}`,


### PR DESCRIPTION
Four self-contained frontend fixes on the home dashboard:

- **My Sessions scrolls internally** — main column is now a bounded flex container so only the sessions card scrolls; header/onboarding/stats/Boards stay in view. Short viewports fall back to a page scroll.
- **Knowledge panel padding** — added `padding: '0 12px'` to the Knowledge list to match Team activity.
- **Boards: fixed 4-up + carousel** — removed the width-responsive `ResizeObserver` column logic; always 4 columns, paged in groups of 4 with prev/next controls when there are more than 4 boards.
- **Hide home FAB** — the floating "+" `NewSessionButton` now renders only on the board/session canvas, not on the home page (which already has a "New" button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)