### PR TITLE
fix(env): forward tenant params on env patched emit so cards live-update (#1750)

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -159,6 +159,10 @@ function createServiceHarness() {
     get: vi.fn(async () => ({ repo_id: 'repo-1', local_path: '/tmp/repo', unix_group: null })),
   };
 
+  // The `branches` self-reference is used by updateEnvironment to manually
+  // emit the `patched` event (this.patch bypasses Feathers auto-dispatch).
+  const branchesService = { find: vi.fn(async () => []), emit: vi.fn() };
+
   const app = {
     sessionTokenService: {
       generateToken: vi.fn(async () => 'executor-token'),
@@ -167,14 +171,14 @@ function createServiceHarness() {
       if (path === 'board-objects') return boardObjectsService;
       if (path === 'sessions') return sessionsService;
       if (path === 'boards') return { get: vi.fn(async () => ({ objects: {} })) };
-      if (path === 'branches') return { find: vi.fn(async () => []) };
+      if (path === 'branches') return branchesService;
       if (path === 'repos') return reposService;
       throw new Error(`Unknown service: ${path}`);
     },
   } as unknown as Application;
 
   const service = new BranchesService(createTenantScopeTestDb() as never, app);
-  return { service, boardObjectsService, sessionsService };
+  return { service, boardObjectsService, sessionsService, branchesService };
 }
 
 async function runInTestTenantScope<T>(work: () => Promise<T>): Promise<T> {
@@ -583,6 +587,53 @@ describe('BranchesService environment start async behavior', () => {
         }),
       }),
       undefined
+    );
+  });
+
+  it('emits patched with a hook-shaped publish context carrying tenant params (regression #1750)', async () => {
+    const { service, branchesService } = createServiceHarness();
+    const branch = {
+      branch_id: 'wt-env-emit' as BranchID,
+      repo_id: 'repo-1',
+      name: 'wt-env-emit',
+      path: '/tmp/wt-env-emit',
+      created_by: 'user-1' as UUID,
+      branch_unique_id: 1,
+      environment_instance: { status: 'starting' },
+    };
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    vi.spyOn(service, 'patch').mockImplementation(async (_id, data) => {
+      return { ...branch, ...(data as object) } as never;
+    });
+
+    // Background transitions (health-monitor start→running, executor
+    // stop/nuke→stopped) call updateEnvironment with the tenant params. The
+    // manual emit MUST forward a HookContext-shaped third arg — Feathers passes
+    // it through UNCHANGED as the publish `hook`, so raw params (or nothing)
+    // leaves the publish handler without `context.path`/`context.params.tenant`
+    // and it suppresses the event to service-only sockets under
+    // `mode: required_from_auth`, leaving the env card spinner stuck.
+    const params = { tenant: { tenant_id: 'tenant-1', source: 'auth_claim' } };
+    await service.updateEnvironment(branch.branch_id, { status: 'running' }, params as never);
+
+    expect(branchesService.emit).toHaveBeenCalledTimes(1);
+    const [event, payload, hook] = branchesService.emit.mock.calls[0];
+    expect(event).toBe('patched');
+    expect(payload).toEqual(
+      expect.objectContaining({
+        branch_id: branch.branch_id,
+        environment_instance: expect.objectContaining({ status: 'running' }),
+      })
+    );
+    // Load-bearing: publish context needs path (branch RBAC scoping) and
+    // params.tenant (tenant channel resolution), not raw params.
+    expect(hook).toEqual(
+      expect.objectContaining({
+        path: 'branches',
+        event: 'patched',
+        id: branch.branch_id,
+        params,
+      })
     );
   });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -64,6 +64,7 @@ import { DrizzleService, type Query } from '../adapters/drizzle';
 import { buildBranchCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { ensureCanControlBranchEnvironment } from '../utils/branch-authorization.js';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
+import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { resolveGitImpersonationForBranch } from '../utils/git-impersonation.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
 import {
@@ -1824,8 +1825,20 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     // this.patch() calls the raw implementation and bypasses Feathers event
     // dispatch, so the patched event is not automatically emitted. Emit it
-    // manually so WebSocket clients receive the environment status update.
-    this.app.service('branches').emit?.('patched', branch);
+    // manually — with a correctly-shaped publish context carrying the tenant
+    // params — so the realtime publish handler can route it to the tenant's
+    // browser clients. Background transitions (health-monitor start→running,
+    // executor stop/nuke→stopped) fire outside any request scope, so the tenant
+    // must come from `resolvedParams` here or the event is suppressed and the
+    // env card spinner hangs until a manual refresh. See #1750 and
+    // emitServiceEvent for why the hook shape matters.
+    emitServiceEvent(this.app, {
+      path: 'branches',
+      event: 'patched',
+      data: branch,
+      params: resolvedParams,
+      id,
+    });
 
     return branch;
   }

--- a/apps/agor-daemon/src/utils/emit-service-event.test.ts
+++ b/apps/agor-daemon/src/utils/emit-service-event.test.ts
@@ -1,0 +1,65 @@
+import type { Application } from '@agor/core/feathers';
+import { describe, expect, it, vi } from 'vitest';
+import { emitServiceEvent } from './emit-service-event';
+
+function makeApp(emit: (name: string, data: unknown, hook: unknown) => void) {
+  const service = { emit };
+  return {
+    app: {
+      service: vi.fn(() => service),
+    } as unknown as Application,
+    service,
+  };
+}
+
+describe('emitServiceEvent', () => {
+  it('emits a HookContext-shaped third arg so the publish handler can scope the event', () => {
+    const emit = vi.fn();
+    const { app } = makeApp(emit);
+    const params = { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } };
+    const data = { branch_id: 'b1', environment_instance: { status: 'running' } };
+
+    emitServiceEvent(app, {
+      path: 'branches',
+      event: 'patched',
+      data,
+      params: params as never,
+      id: 'b1',
+    });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    const [event, payload, hook] = emit.mock.calls[0];
+    expect(event).toBe('patched');
+    expect(payload).toBe(data);
+    // The third arg is passed UNCHANGED by Feathers as the publish `hook`, so
+    // it must carry path (RBAC scoping) and params (tenant resolution).
+    expect(hook).toMatchObject({
+      path: 'branches',
+      event: 'patched',
+      method: 'patch',
+      id: 'b1',
+      params,
+      result: data,
+    });
+    expect((hook as { app: unknown }).app).toBe(app);
+  });
+
+  it('infers the CRUD method from the event name and defaults params to an object', () => {
+    const emit = vi.fn();
+    const { app } = makeApp(emit);
+
+    emitServiceEvent(app, { path: 'boards', event: 'created', data: { id: 'x' } });
+
+    const hook = emit.mock.calls[0][2];
+    expect(hook).toMatchObject({ path: 'boards', method: 'create', params: {} });
+  });
+
+  it('honors an explicit method override', () => {
+    const emit = vi.fn();
+    const { app } = makeApp(emit);
+
+    emitServiceEvent(app, { path: 'branches', event: 'custom', data: {}, method: 'get' });
+
+    expect(emit.mock.calls[0][2]).toMatchObject({ method: 'get' });
+  });
+});

--- a/apps/agor-daemon/src/utils/emit-service-event.ts
+++ b/apps/agor-daemon/src/utils/emit-service-event.ts
@@ -1,0 +1,78 @@
+import type { Application } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+
+const DEFAULT_EVENT_METHOD: Record<string, string> = {
+  created: 'create',
+  updated: 'update',
+  patched: 'patch',
+  removed: 'remove',
+};
+
+export type ManualServiceEvent = {
+  /**
+   * Service path the event belongs to (e.g. `'branches'`). Load-bearing: the
+   * realtime publish handler keys tenant + branch/session RBAC scoping off
+   * `context.path`.
+   */
+  path: string;
+  /**
+   * Service event name. Typically one of `created` | `updated` | `patched` |
+   * `removed` (the method is inferred from these), but any custom event string
+   * is supported — pass `method` to set the inferred CRUD method for those.
+   */
+  event: string;
+  /** Record to broadcast (becomes both the event payload and `hook.result`). */
+  data: unknown;
+  /**
+   * Request params carrying tenant/connection context. Load-bearing: without a
+   * resolvable tenant here (or an ambient tenant DB scope), multi-tenant
+   * publishing suppresses the event to service-only sockets.
+   */
+  params?: HookContext['params'];
+  /** Optional record id (publisher uses it as a branch-id fallback and for logging). */
+  id?: HookContext['id'];
+  /** Overrides the CRUD method inferred from `event`. */
+  method?: string;
+};
+
+/**
+ * Manually emit a Feathers service event with a correctly-shaped publish
+ * context.
+ *
+ * Some services persist through a raw adapter path (e.g. an overridden
+ * `patch()` that calls `super.patch()`), which bypasses Feathers' automatic
+ * event dispatch — so those call sites must emit the service event by hand.
+ *
+ * The shape of the emit matters. Feathers' transport-commons publish listener
+ * passes the THIRD `emit` argument through UNCHANGED as the publish `hook`, and
+ * only synthesizes a fake `{ path, service, app, result }` when that argument
+ * is absent (`@feathersjs/transport-commons` `channels/index.ts`). Automatic
+ * events, by contrast, emit the full HookContext (`@feathersjs/feathers`
+ * `events.ts`). So both malformed shapes lose something the global publish
+ * handler (`configureRealtimePublish`) needs:
+ *   - passing NO third arg gets a synthesized `path`, but no `context.params`
+ *     (no tenant/connection context), and
+ *   - passing raw params as the third arg carries `context.params`-looking data
+ *     at the wrong nesting AND loses `path` (Feathers won't synthesize it once a
+ *     third arg is present).
+ * Either way the handler can't resolve the tenant channel (multi-tenancy)
+ * and/or the branch/session RBAC scope, so it degrades to global-scope
+ * broadcast or service-only suppression.
+ *
+ * Build the hook shape once, here, so call sites can't drift on it.
+ */
+export function emitServiceEvent(app: Application, event: ManualServiceEvent): void {
+  const service = app.service(event.path as never) as unknown as {
+    emit?: (name: string, data: unknown, hook: Partial<HookContext>) => void;
+  };
+  service.emit?.(event.event, event.data, {
+    app,
+    service,
+    path: event.path,
+    method: event.method ?? DEFAULT_EVENT_METHOD[event.event] ?? 'patch',
+    event: event.event,
+    id: event.id,
+    result: event.data,
+    params: event.params ?? {},
+  } as Partial<HookContext>);
+}

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -145,6 +145,49 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([service]);
   });
 
+  it('routes a manual emit to the tenant channel when the hook context carries params.tenant (regression #1750)', async () => {
+    // Background env transitions (health-monitor / executor completion) run
+    // outside any request AND outside an ambient tenant DB scope, so the tenant
+    // must be resolvable from the emitted hook's params. This is exactly the
+    // context shape emitServiceEvent() builds for the branches `patched` emit.
+    const tenantUser = user('tenant-user');
+    const otherTenantUser = user('other-tenant-user');
+    const app = makeApp(
+      [{ user: tenantUser }, { user: otherTenantUser }],
+      {},
+      {
+        authenticated: [{ user: tenantUser }, { user: otherTenantUser }],
+        'tenant:tenant-a': [{ user: tenantUser }],
+        'tenant:tenant-b': [{ user: otherTenantUser }],
+      }
+    );
+    const r = repos({ branch: branch('b1'), permissions: {} });
+    configureRealtimePublish({
+      app,
+      branchRbacEnabled: false,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as any,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    // No ambient tenant DB scope here — tenant resolves purely from the hook.
+    const channel = await app.runPublish(
+      { branch_id: 'b1' },
+      {
+        path: 'branches',
+        method: 'patch',
+        event: 'patched',
+        id: 'b1',
+        params: { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
+      }
+    );
+
+    expect(channel.connections).toEqual([{ user: tenantUser }]);
+  });
+
   it('uses ambient tenant database scope for internal/manual emits without params tenant', async () => {
     const tenantUser = user('tenant-user');
     const otherTenantUser = user('other-tenant-user');


### PR DESCRIPTION
## Linked issue

Fixes #1750

## Summary

- Add a shared `emitServiceEvent(app, {...})` helper (`apps/agor-daemon/src/utils/emit-service-event.ts`) that emits a Feathers service event with a **correctly-shaped `HookContext`** (`path` + `params`), so the global realtime publish handler can scope it.
- Use it for the `branches` `patched` emit in `updateEnvironment` (`branches.ts`), passing `resolvedParams` so the tenant is resolvable.
- Tests: helper unit tests, a `configureRealtimePublish` test proving a manual emit routes to the tenant channel when the hook carries `params.tenant` (no ambient scope), and an updated branches regression test asserting the emitted hook shape.

## Why / context

The env card spinner never cleared on status transitions (`start→running`, `stop/nuke→stopped`) until a manual page refresh.

`updateEnvironment` persists via `this.patch()`, an override that calls `super.patch()` and therefore **bypasses Feathers' automatic event dispatch**, so it emits the `patched` event manually. The emit passed no publish context.

The load-bearing detail (verified in installed Feathers source): transport-commons' publish listener passes the **third `emit` argument through unchanged** as the publish `hook` (`@feathersjs/transport-commons` `channels/index.ts:67-71`), and only synthesizes a fake `{ path, service, app, result }` when that arg is **absent**. Automatic events, by contrast, emit the full `HookContext` (`@feathersjs/feathers` `events.ts:18`). So a manual emit that passes **raw params — or nothing —** leaves `configureRealtimePublish` without a usable `context.path` / `context.params`. Under `multi_tenancy.mode: required_from_auth` it then can't resolve the tenant channel and suppresses the event to **service-only sockets**; browsers never receive it.

This hits the terminal transitions users wait on, which for `kind`/executor env variants are applied by background paths **outside any request scope** — and, since #1737, **outside any ambient tenant DB scope**:
- `start→running` — flipped by the health-monitor timer.
- `stop/nuke→stopped` — the executor path early-returns at `stopping`; the terminal write lands from an async executor-completion path.

Because those paths have no ambient tenant scope, the tenant must come from the emitted hook's `params`. The helper supplies exactly that.

A hard refresh fixes it because the initial `findAll` re-reads status directly, bypassing websockets.

> Note: an earlier revision of this PR passed `resolvedParams` as the raw third arg. That is **not** a valid publish context (Feathers does not wrap it into `context.params`), so it did not actually resolve the tenant and it dropped the fake hook's `path`. This revision fixes the shape via the helper. Thanks to the review that caught it.

## Implementation notes

- The helper centralizes the hook shape so call sites can't drift on it, and documents the Feathers semantics inline.
- Scope kept to the #1750 path. Other manual `emit(...)` call sites in the daemon (e.g. the `boards` emits in `branches.ts:743/965/975`, and sites in `register-hooks.ts` / `register-routes.ts`) share the same context-less shape and should be migrated to `emitServiceEvent` in a follow-up audit — see below.
- Review focus: the Feathers third-arg → publish `hook` mapping, and that `resolvedParams` carries `.tenant` on the background caller paths (health monitor / executor RPC).

## Validation / test plan

- [x] `emit-service-event.test.ts` — helper emits a `HookContext`-shaped third arg (path/params/method/id).
- [x] `realtime-publish.test.ts` — a `branches patched` event whose hook carries `params.tenant` routes to the tenant channel under `required_from_auth` **without** ambient scope (previously would be suppressed).
- [x] `branches.test.ts` — updated regression test asserts the emitted hook shape (`path: 'branches'`, `params.tenant`). Verified it **fails** when the emit shape is reverted to raw params.
- [x] `vitest run` on the three files — 69 passed. `tsc --noEmit` (agor-daemon) — clean. Pre-commit hooks — passed.
- [ ] Manual validation pending on a `required_from_auth` deployment: start/stop/nuke a `kind` env and confirm the card clears the spinner without a refresh.

## Risks / rollout / rollback

- Low risk. Adds a helper and a properly-shaped context to one emit; no schema/API/config changes. In `mode: static` behavior is unchanged (tenant resolves to the static id regardless).
- Rollback: revert this commit.

## Out of scope / follow-ups

- **Audit other manual service emits** for the same context-less shape and migrate them to `emitServiceEvent` (`branches.ts:743/965/975`, `register-hooks.ts`, `register-routes.ts`, `register-services.ts:299`).
- The reporter's secondary observation — a lag (~10 min) before the executor `stop/nuke` path writes `stopped` (status not derived from tracked-pid liveness). That reconciliation path is separate from this event-delivery fix.
