### PR TITLE
Fix scoped Unix sync for group membership changes

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -662,15 +662,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
-  const membershipGroupIdFromContext = (context: HookContext): string | undefined => {
+  const membershipGroupIdFromContext = (context: HookContext): GroupID | undefined => {
     const resultGroupId = (context.result as { group_id?: unknown } | undefined)?.group_id;
-    if (typeof resultGroupId === 'string' && resultGroupId.length > 0) return resultGroupId;
+    if (typeof resultGroupId === 'string' && resultGroupId.length > 0) {
+      return resultGroupId as GroupID;
+    }
     const dataGroupId = (context.data as { group_id?: unknown } | undefined)?.group_id;
-    if (typeof dataGroupId === 'string' && dataGroupId.length > 0) return dataGroupId;
+    if (typeof dataGroupId === 'string' && dataGroupId.length > 0) return dataGroupId as GroupID;
     const queryGroupId = context.params.query?.group_id;
-    if (typeof queryGroupId === 'string' && queryGroupId.length > 0) return queryGroupId;
+    if (typeof queryGroupId === 'string' && queryGroupId.length > 0) return queryGroupId as GroupID;
     const routeGroupId = context.params.route?.groupId;
-    if (typeof routeGroupId === 'string' && routeGroupId.length > 0) return routeGroupId;
+    if (typeof routeGroupId === 'string' && routeGroupId.length > 0) return routeGroupId as GroupID;
     return undefined;
   };
 
@@ -687,9 +689,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       return context;
     }
 
-    const branchIds = await branchRepository.findExplicitFsAccessBranchIdsForGroup(
-      groupId as GroupID
-    );
+    const branchIds = await branchRepository.findExplicitFsAccessBranchIdsForGroup(groupId);
     if (branchIds.length === 0) return context;
     console.log(
       `[Unix Integration] Queueing group membership permission sync for ${branchIds.length} branch(es) granted to group ${shortId(groupId)}`

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -661,19 +661,34 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
-  const syncUnixAccessForAllBranches = async (
+  const membershipGroupIdFromContext = (context: HookContext): string | undefined => {
+    const resultGroupId = (context.result as { group_id?: unknown } | undefined)?.group_id;
+    if (typeof resultGroupId === 'string' && resultGroupId.length > 0) return resultGroupId;
+    const dataGroupId = (context.data as { group_id?: unknown } | undefined)?.group_id;
+    if (typeof dataGroupId === 'string' && dataGroupId.length > 0) return dataGroupId;
+    const queryGroupId = context.params.query?.group_id;
+    if (typeof queryGroupId === 'string' && queryGroupId.length > 0) return queryGroupId;
+    const routeGroupId = context.params.route?.groupId;
+    if (typeof routeGroupId === 'string' && routeGroupId.length > 0) return routeGroupId;
+    return undefined;
+  };
+
+  const syncUnixAccessForGroupGrantedBranches = async (
     context: HookContext,
     logPrefix: string
   ): Promise<HookContext> => {
     if (!executionMode.unixFsIsolationEnabled) return context;
-    const branches = await branchRepository.findAll({ includeArchived: false });
-    for (const branch of branches) {
-      syncBranchUnixAccess(
-        branch.branch_id as BranchID,
-        logPrefix,
-        context.params as Partial<AuthenticatedParams>
-      );
-      await invalidateRealtimeBranchAccess(branch.branch_id);
+    const groupId = membershipGroupIdFromContext(context);
+    if (!groupId) return context;
+
+    const branchIds = await branchRepository.findExplicitFsAccessBranchIdsForGroup(groupId);
+    if (branchIds.length === 0) return context;
+    console.log(
+      `[Unix Integration] Queueing group membership permission sync for ${branchIds.length} branch(es) granted to group ${shortId(groupId)}`
+    );
+    for (const branchId of branchIds) {
+      syncBranchUnixAccess(branchId, logPrefix, context.params as Partial<AuthenticatedParams>);
+      await invalidateRealtimeBranchAccess(branchId);
     }
     return context;
   };
@@ -1862,12 +1877,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       create: [
         clearRealtimeBranchVisibility,
         (context: HookContext) =>
-          syncUnixAccessForAllBranches(context, '[Executor/group-memberships.create]'),
+          syncUnixAccessForGroupGrantedBranches(context, '[Executor/group-memberships.create]'),
       ],
       remove: [
         clearRealtimeBranchVisibility,
         (context: HookContext) =>
-          syncUnixAccessForAllBranches(context, '[Executor/group-memberships.remove]'),
+          syncUnixAccessForGroupGrantedBranches(context, '[Executor/group-memberships.remove]'),
       ],
     },
   });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -57,6 +57,7 @@ import type {
   BoardID,
   Branch,
   BranchID,
+  GroupID,
   HookContext,
   MCPServer,
   Paginated,
@@ -679,9 +680,16 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   ): Promise<HookContext> => {
     if (!executionMode.unixFsIsolationEnabled) return context;
     const groupId = membershipGroupIdFromContext(context);
-    if (!groupId) return context;
+    if (!groupId) {
+      console.warn(
+        `[Unix Integration] Could not resolve group_id for ${context.path}.${context.method}; skipping group membership permission sync`
+      );
+      return context;
+    }
 
-    const branchIds = await branchRepository.findExplicitFsAccessBranchIdsForGroup(groupId);
+    const branchIds = await branchRepository.findExplicitFsAccessBranchIdsForGroup(
+      groupId as GroupID
+    );
     if (branchIds.length === 0) return context;
     console.log(
       `[Unix Integration] Queueing group membership permission sync for ${branchIds.length} branch(es) granted to group ${shortId(groupId)}`

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -1247,6 +1247,108 @@ describe('BranchRepository findExplicitFsAccessUserIds', () => {
   );
 });
 
+describe('BranchRepository findExplicitFsAccessBranchIdsForGroup', () => {
+  dbTest(
+    'scopes membership-driven filesystem syncs to direct and board-aligned group grants',
+    async ({ db }) => {
+      const repoRepo = new RepoRepository(db);
+      const boardRepo = new BoardRepository(db);
+      const branchRepo = new BranchRepository(db);
+      const groupRepo = new GroupRepository(db);
+      const usersRepo = new UsersRepository(db);
+      const repo = await repoRepo.create(createRepoData({ slug: 'group-fs-branches-repo' }));
+      const creatorId = generateId() as UUID;
+      await usersRepo.create({
+        user_id: creatorId,
+        email: 'creator-group-fs-branches@example.com',
+      });
+      const group = await groupRepo.create({ name: 'Group FS Branches', created_by: creatorId });
+
+      const direct = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          name: 'group-fs-direct',
+          branch_unique_id: 9401,
+          created_by: creatorId,
+        })
+      );
+      await groupRepo.upsertBranchGrant({
+        branch_id: direct.branch_id,
+        group_id: group.group_id,
+        can: 'session',
+        fs_access: 'write',
+        created_by: creatorId,
+      });
+
+      const board = await boardRepo.create({
+        board_id: generateId(),
+        name: 'Group FS Board',
+        created_by: creatorId,
+        access_mode: 'shared',
+      });
+      await groupRepo.upsertBoardGrant({
+        board_id: board.board_id,
+        group_id: group.group_id,
+        can: 'view',
+        fs_access: 'read',
+        created_by: creatorId,
+      });
+      const aligned = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          name: 'group-fs-board-aligned',
+          branch_unique_id: 9402,
+          created_by: creatorId,
+          permission_source: 'board',
+        })
+      );
+      const override = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          name: 'group-fs-board-override',
+          branch_unique_id: 9403,
+          created_by: creatorId,
+          permission_source: 'override',
+        })
+      );
+
+      const appOnly = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          name: 'group-app-only',
+          branch_unique_id: 9404,
+          created_by: creatorId,
+        })
+      );
+      await groupRepo.upsertBranchGrant({
+        branch_id: appOnly.branch_id,
+        group_id: group.group_id,
+        can: 'prompt',
+        fs_access: 'none',
+        created_by: creatorId,
+      });
+
+      const branchIds = await branchRepo.findExplicitFsAccessBranchIdsForGroup(group.group_id);
+      expect(branchIds).toEqual(expect.arrayContaining([direct.branch_id, aligned.branch_id]));
+      expect(branchIds).not.toEqual(
+        expect.arrayContaining([override.branch_id, appOnly.branch_id])
+      );
+    }
+  );
+
+  dbTest('returns no branches for groups without filesystem grants', async ({ db }) => {
+    const branchRepo = new BranchRepository(db);
+    const groupRepo = new GroupRepository(db);
+    const group = await groupRepo.create({ name: 'No FS Grants' });
+
+    await expect(branchRepo.findExplicitFsAccessBranchIdsForGroup(group.group_id)).resolves.toEqual(
+      []
+    );
+  });
+});
+
 describe('BranchRepository.findAssistantBranches', () => {
   dbTest(
     'finds marker assistants and enabled-schedule legacy assistants without scanning all branches',

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -1279,6 +1279,20 @@ describe('BranchRepository findExplicitFsAccessBranchIdsForGroup', () => {
         fs_access: 'write',
         created_by: creatorId,
       });
+      const defaultFsAccess = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          name: 'group-fs-default-read',
+          branch_unique_id: 9405,
+          created_by: creatorId,
+        })
+      );
+      await groupRepo.upsertBranchGrant({
+        branch_id: defaultFsAccess.branch_id,
+        group_id: group.group_id,
+        can: 'view',
+        created_by: creatorId,
+      });
 
       const board = await boardRepo.create({
         board_id: generateId(),
@@ -1329,11 +1343,57 @@ describe('BranchRepository findExplicitFsAccessBranchIdsForGroup', () => {
         fs_access: 'none',
         created_by: creatorId,
       });
+      const privateBoard = await boardRepo.create({
+        board_id: generateId(),
+        name: 'Private Group FS Board',
+        created_by: creatorId,
+        access_mode: 'private',
+      });
+      await groupRepo.upsertBoardGrant({
+        board_id: privateBoard.board_id,
+        group_id: group.group_id,
+        can: 'all',
+        fs_access: 'write',
+        created_by: creatorId,
+      });
+      const privateBoardBranch = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          board_id: privateBoard.board_id,
+          name: 'group-fs-private-board',
+          branch_unique_id: 9406,
+          created_by: creatorId,
+          permission_source: 'board',
+        })
+      );
+      const archivedBranch = await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id,
+          name: 'group-fs-archived',
+          branch_unique_id: 9407,
+          created_by: creatorId,
+        })
+      );
+      await groupRepo.upsertBranchGrant({
+        branch_id: archivedBranch.branch_id,
+        group_id: group.group_id,
+        can: 'session',
+        fs_access: 'write',
+        created_by: creatorId,
+      });
+      await branchRepo.update(archivedBranch.branch_id, { archived: true });
 
       const branchIds = await branchRepo.findExplicitFsAccessBranchIdsForGroup(group.group_id);
-      expect(branchIds).toEqual(expect.arrayContaining([direct.branch_id, aligned.branch_id]));
+      expect(branchIds).toEqual(
+        expect.arrayContaining([direct.branch_id, defaultFsAccess.branch_id, aligned.branch_id])
+      );
       expect(branchIds).not.toEqual(
-        expect.arrayContaining([override.branch_id, appOnly.branch_id])
+        expect.arrayContaining([
+          override.branch_id,
+          appOnly.branch_id,
+          privateBoardBranch.branch_id,
+          archivedBranch.branch_id,
+        ])
       );
     }
   );
@@ -1342,6 +1402,40 @@ describe('BranchRepository findExplicitFsAccessBranchIdsForGroup', () => {
     const branchRepo = new BranchRepository(db);
     const groupRepo = new GroupRepository(db);
     const group = await groupRepo.create({ name: 'No FS Grants' });
+
+    await expect(branchRepo.findExplicitFsAccessBranchIdsForGroup(group.group_id)).resolves.toEqual(
+      []
+    );
+  });
+
+  dbTest('returns no branches for archived groups', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const groupRepo = new GroupRepository(db);
+    const usersRepo = new UsersRepository(db);
+    const repo = await repoRepo.create(createRepoData({ slug: 'archived-group-fs-branches-repo' }));
+    const creatorId = generateId() as UUID;
+    await usersRepo.create({
+      user_id: creatorId,
+      email: 'creator-archived-group-fs-branches@example.com',
+    });
+    const group = await groupRepo.create({ name: 'Archived Group FS', created_by: creatorId });
+    const branch = await branchRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        name: 'archived-group-fs-branch',
+        branch_unique_id: 9408,
+        created_by: creatorId,
+      })
+    );
+    await groupRepo.upsertBranchGrant({
+      branch_id: branch.branch_id,
+      group_id: group.group_id,
+      can: 'session',
+      fs_access: 'write',
+      created_by: creatorId,
+    });
+    await groupRepo.update(group.group_id, { archived: true });
 
     await expect(branchRepo.findExplicitFsAccessBranchIdsForGroup(group.group_id)).resolves.toEqual(
       []

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -999,6 +999,78 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     return Array.from(userIds);
   }
 
+  /**
+   * Find non-archived branches whose explicit filesystem access set can change
+   * when membership in the given group changes.
+   *
+   * This scopes Unix permission resyncs to branch-level grants for the group and
+   * board-aligned branches on shared boards that grant the group filesystem
+   * access. App-only grants (`fs_access = 'none'`) are intentionally excluded
+   * because membership changes for those grants do not require branch-folder
+   * mutation.
+   */
+  async findExplicitFsAccessBranchIdsForGroup(groupId: string): Promise<BranchID[]> {
+    const directRows = await select(this.db, { branch_id: branchGroupGrants.branch_id })
+      .from(branchGroupGrants)
+      .innerJoin(branches, eq(branches.branch_id, branchGroupGrants.branch_id))
+      .innerJoin(
+        groups,
+        and(eq(groups.group_id, branchGroupGrants.group_id), eq(groups.archived, false))
+      )
+      .where(
+        and(
+          eq(branchGroupGrants.group_id, groupId),
+          eq(branches.archived, false),
+          inArray(
+            sql`coalesce(${branchGroupGrants.fs_access}, 'read')`,
+            FS_ACCESS_BRANCH_PERMISSIONS
+          )
+        )
+      )
+      .all();
+
+    const boardRows = await select(this.db, { branch_id: branches.branch_id })
+      .from(boardGroupGrants)
+      .innerJoin(
+        groups,
+        and(eq(groups.group_id, boardGroupGrants.group_id), eq(groups.archived, false))
+      )
+      .innerJoin(
+        boards,
+        and(
+          eq(boards.board_id, boardGroupGrants.board_id),
+          eq(sql`coalesce(${jsonExtract(this.db, boards.data, 'access_mode')}, 'shared')`, 'shared')
+        )
+      )
+      .innerJoin(
+        branches,
+        and(
+          eq(branches.board_id, boardGroupGrants.board_id),
+          eq(branches.permission_source, 'board'),
+          eq(branches.archived, false)
+        )
+      )
+      .where(
+        and(
+          eq(boardGroupGrants.group_id, groupId),
+          inArray(
+            sql`coalesce(${boardGroupGrants.fs_access}, 'read')`,
+            FS_ACCESS_BRANCH_PERMISSIONS
+          )
+        )
+      )
+      .all();
+
+    const branchIds = new Set<BranchID>();
+    for (const row of directRows as Array<{ branch_id: string }>) {
+      branchIds.add(row.branch_id as BranchID);
+    }
+    for (const row of boardRows as Array<{ branch_id: string }>) {
+      branchIds.add(row.branch_id as BranchID);
+    }
+    return Array.from(branchIds);
+  }
+
   async findBoardAlignedBranches(boardId: BoardID): Promise<Branch[]> {
     const rows = await select(this.db)
       .from(branches)

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -11,6 +11,7 @@ import type {
   BranchFsAccessLevel,
   BranchID,
   EffectiveBranchAccess,
+  GroupID,
   SessionStatus,
   UUID,
 } from '@agor/core/types';
@@ -1003,13 +1004,12 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
    * Find non-archived branches whose explicit filesystem access set can change
    * when membership in the given group changes.
    *
-   * This scopes Unix permission resyncs to branch-level grants for the group and
-   * board-aligned branches on shared boards that grant the group filesystem
-   * access. App-only grants (`fs_access = 'none'`) are intentionally excluded
-   * because membership changes for those grants do not require branch-folder
-   * mutation.
+   * Keep this inverse lookup in lockstep with findExplicitFsAccessUserIds():
+   * both encode which group grants materialize into branch-folder access.
+   * App-only grants (`fs_access = 'none'`) are intentionally excluded because
+   * membership changes for those grants do not require branch-folder mutation.
    */
-  async findExplicitFsAccessBranchIdsForGroup(groupId: string): Promise<BranchID[]> {
+  async findExplicitFsAccessBranchIdsForGroup(groupId: GroupID): Promise<BranchID[]> {
     const directRows = await select(this.db, { branch_id: branchGroupGrants.branch_id })
       .from(branchGroupGrants)
       .innerJoin(branches, eq(branches.branch_id, branchGroupGrants.branch_id))


### PR DESCRIPTION
Closes #1741.

## Summary

- Scope `group-memberships.create/remove` Unix resyncs to branches affected by the changed group instead of all non-archived branches.
- Resolve affected branches from:
  - direct branch group grants with filesystem access
  - shared-board group grants for board-aligned branches with filesystem access
- Skip app-only grants (`fs_access: none`) and groups with no filesystem grants, so newly-created groups with no grants queue zero branch syncs.

## DB vs filesystem decision

Group membership changes are already represented in the DB, and app/RBAC access is resolved dynamically from membership and grant rows. Therefore, membership changes do **not** require branch-folder mutation for app-only permission changes.

Filesystem mutation is still required when Unix filesystem isolation is enabled and the changed group has a filesystem-impacting grant. In that case, the branch Unix group membership must be reconciled so users added to or removed from the RBAC group gain or lose OS-level access. This PR limits that filesystem work to the branches where such a grant can affect the explicit filesystem access set.

## Tests / checks

- `pnpm i` ✅
- `pnpm --filter @agor/core test -- src/db/repositories/branches.test.ts` ✅
- `pnpm exec biome check apps/agor-daemon/src/register-hooks.ts packages/core/src/db/repositories/branches.ts packages/core/src/db/repositories/branches.test.ts` ✅
- `pnpm check` ⚠️ ran typecheck/build/lint/shortid successfully, then failed at `check:multitenancy-boundaries` due unrelated existing baseline violations:
  - `apps/agor-daemon/src/services/health-monitor.test.ts`
  - `apps/agor-daemon/src/services/branches.test.ts`
  - `apps/agor-daemon/src/utils/tenant-db-scope.test.ts`
  - `apps/agor-daemon/src/widgets/env-vars/index.ts`