### PR TITLE
feat(onboarding): resumable conversational /onboarding agent

### DIFF
--- a/apps/agor-daemon/src/onboarding/index.ts
+++ b/apps/agor-daemon/src/onboarding/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Onboarding-agent module barrel.
+ *
+ * See `./trigger.ts` and `./kickoff-prompt.ts` for the design rationale -
+ * there is no dedicated onboarding session/agent type, just a
+ * system-authored prompt queued through the existing prompt path.
+ */
+
+export type { OnboardingKickoffPromptInput, OnboardingTriggerReason } from './kickoff-prompt.js';
+export { buildOnboardingKickoffPrompt } from './kickoff-prompt.js';
+export type {
+  OnboardingTriggerApp,
+  TriggerOnboardingInput,
+  TriggerOnboardingResult,
+} from './trigger.js';
+export {
+  ONBOARDING_KNOWLEDGE_DOC_PATH,
+  onboardingNamespaceSlug,
+  triggerOnboarding,
+} from './trigger.js';

--- a/apps/agor-daemon/src/onboarding/kickoff-prompt.test.ts
+++ b/apps/agor-daemon/src/onboarding/kickoff-prompt.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the onboarding kickoff prompt builder.
+ *
+ * These assert the prompt actually encodes the behavioral contract this
+ * feature depends on - since the "onboarding agent" IS this prompt text,
+ * a regression here is a regression in the product, not just a string
+ * change.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildOnboardingKickoffPrompt } from './kickoff-prompt';
+
+const baseInput = {
+  namespaceSlug: 'onboarding-abc12345',
+  docPath: 'progress.md',
+};
+
+describe('buildOnboardingKickoffPrompt', () => {
+  it('embeds the exact namespace slug and doc path so the agent never has to guess its own scope', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toContain('onboarding-abc12345');
+    expect(prompt).toContain('progress.md');
+  });
+
+  it('never frames AI-connection as a step, and never instructs a credential check', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt.toLowerCase()).not.toMatch(/step 1.*connect.*ai/);
+    expect(prompt).toContain('is already connected');
+    expect(prompt).not.toContain('agor_users_get_current');
+  });
+
+  it('lists exactly the 2 core + 4 optional steps, keyed by stable ids', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    for (const stepId of [
+      'repo_branch',
+      'first_prompt',
+      'board_zone',
+      'invite_or_assistant',
+      'mcp_connection',
+      'first_artifact',
+    ]) {
+      expect(prompt).toContain(stepId);
+    }
+  });
+
+  it('instructs picking a subset of optional steps rather than running all of them', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toMatch(/pick 1-3/);
+    expect(prompt).toMatch(/never (run|track) all four|never mechanically/);
+  });
+
+  it('instructs combining first_prompt and first_artifact when the work has a visual output', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toMatch(/judgment call/i);
+    expect(prompt).toContain('agor_artifacts_publish');
+  });
+
+  it('never instructs calling AskUserQuestion', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toMatch(/never call it/);
+    expect(prompt).toContain('AskUserQuestion');
+  });
+
+  it('mirrors the env_vars widget dismissal phrasing for whole-flow dismissal', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toContain(
+      "don't re-request immediately - ask whether to proceed without, or move on to other work."
+    );
+  });
+
+  it('caps the todo list at 5 items and excludes AI-connection from it', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toMatch(/<=5-item/);
+    expect(prompt).toMatch(/never an "AI connected" entry/);
+  });
+
+  it('deep-links to Settings > MCP Servers instead of building an inline capture', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toContain('/settings/mcp/');
+    expect(prompt).toContain('agor_mcp_servers_list');
+  });
+
+  it('varies the trigger framing between auto and manual, and manual overrides a prior dismissal', () => {
+    const autoPrompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    const manualPrompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'manual' });
+    expect(autoPrompt).not.toEqual(manualPrompt);
+    expect(manualPrompt).toMatch(/overrides a prior dismissal/);
+  });
+
+  it('instructs writing progress immediately, not batching or speculating', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toMatch(/not batched, not speculative/);
+    expect(prompt).toContain('expectedVersion');
+  });
+
+  it('instructs no internal-mechanics narration', () => {
+    const prompt = buildOnboardingKickoffPrompt({ ...baseInput, reason: 'auto' });
+    expect(prompt).toMatch(/do not narrate/i);
+  });
+});

--- a/apps/agor-daemon/src/onboarding/kickoff-prompt.ts
+++ b/apps/agor-daemon/src/onboarding/kickoff-prompt.ts
@@ -1,0 +1,106 @@
+/**
+ * Onboarding-agent kickoff prompt.
+ *
+ * There is no `.claude/commands/onboarding.md` and no `AskUserQuestion` in
+ * this codebase (the latter is disallowed at the SDK layer - see
+ * `packages/executor/src/sdk-handlers/claude/constants.ts`). So "the
+ * onboarding agent" is not a distinct agent type or session kind - it is
+ * this one system-authored instructional prompt, queued into an ordinary
+ * session via the same `/sessions/:id/prompt` path the `env_vars` widget's
+ * auto-resume already uses (see `../widgets/submissions.ts`).
+ *
+ * The daemon resolves the calling user's private Knowledge namespace/doc
+ * path before building this prompt (see `./trigger.ts`) and embeds it
+ * verbatim, so the agent never has to guess or look up its own scope.
+ */
+
+export type OnboardingTriggerReason = 'auto' | 'manual';
+
+export interface OnboardingKickoffPromptInput {
+  reason: OnboardingTriggerReason;
+  namespaceSlug: string;
+  docPath: string;
+}
+
+export function buildOnboardingKickoffPrompt({
+  reason,
+  namespaceSlug,
+  docPath,
+}: OnboardingKickoffPromptInput): string {
+  const reasonLine =
+    reason === 'auto'
+      ? 'Trigger: the user just connected an AI provider and finished the setup wizard. This is the first time this walkthrough has ever fired for them.'
+      : 'Trigger: the user explicitly asked to (re)open the setup walkthrough via the "Setup guide" button. Honor this even if your saved state says the whole flow was previously dismissed - an explicit request always overrides a prior dismissal.';
+
+  return `### Agor setup walkthrough
+
+${reasonLine}
+
+You are not a separate "onboarding bot" - you are this session's agent, briefly guiding the person through getting real value out of Agor. Read the whole brief below, then act on it. Do not narrate any of this to the user (no "let me check your progress..." - just do it, then speak naturally from the result).
+
+## Before you say anything
+
+1. Ensure your private progress store exists (idempotent, safe to call every time): call \`agor_kb_namespace_put\` with slug "${namespaceSlug}", kind "user", visibilityDefault "private". Then call \`agor_kb_get\` for namespace "${namespaceSlug}", path "${docPath}".
+   - If the document does not exist, this is a brand-new user: create it in your first write (see "Writing progress" below) with empty step state.
+   - If it exists, read its \`metadata\`: \`{ dismissed, steps: { [stepId]: { status: 'done'|'skipped', updated_at } }, current_step, last_interaction_at }\`. Absence of a step's key means not started.
+2. Since you're able to talk to the user at all, an AI provider is already connected - that is this flow's precondition, not something you check, track, or mention as a step. Never present "connect an AI provider" as step 1 or as a todo item. Do not call any credential-check tool for this.
+3. If \`dismissed: true\` and this trigger's reason is "auto", stop here - do not send an opening message at all, this shouldn't have fired (belt-and-braces; the daemon already checks this before queuing you). If reason is "manual", proceed regardless - that's an explicit re-invocation and always wins over a prior dismissal.
+
+## The steps (2 core + a menu of 4 optional - pick 1-3 of the optional ones, never run all four mechanically, never track AI connection)
+
+1. **repo_branch** (core) - point Agor at a repo and create a first branch. Introduce "branch" only here, in one or two sentences: it's a first-class git working directory on its own branch with its own dev environment, one per feature/PR. Skip silently if the user already has a repo and branch (check before asking).
+2. **first_prompt** (core) - the "aha" moment: get the user to actually run a real prompt in a session. Don't just describe this - draft the concrete next action (e.g. "want to just try asking it to \`<something plausible for their repo>\`?") and guide them into doing it for real, not hypothetically.
+3. **board_zone** (optional, lower priority) - help them understand/create a board and, if relevant, a zone. Introduce these terms only here: a board is the spatial canvas where branches live as cards; a zone is a region on a board with an optional prompt template that fires when a branch is dropped in.
+4. **invite_or_assistant** (optional, lower priority) - invite a teammate, or set up a persistent assistant (a companion agent with its own memory and identity living in a branch). Offer this as a choice in plain text, not a forced sequence.
+5. **mcp_connection** (optional, lower priority) - connect an MCP server (Slack, GitHub, Linear/Shortcut, etc.) for richer context. Introduce "MCP" only here: pluggable capabilities/integrations your agent can use, beyond what's built in. Check \`agor_mcp_servers_list\` first - if one is already configured, skip silently. MCP server setup is a Settings-page/OAuth flow, not something you can do inline - don't invent a form for it. Point the user at it with a short markdown link to \`/settings/mcp/\` and one sentence on why it's useful for their situation (e.g. "connecting Slack would let your agent read/post to channels while it works").
+6. **first_artifact** (optional, lower priority) - see or create a first Artifact. Introduce "Artifact" only here: a live app or preview a session can produce, visible as a card on the board. Check \`agor_artifacts_list\` for the branch/board first - if one already exists, just point them at it (board card, or the \`/a/<id>/\` fullscreen link) instead of making a new one. Otherwise you can genuinely build one yourself with \`agor_artifacts_publish\` if the moment calls for it - this is a real tool, not a deep link.
+
+**Judgment call, not a script:** steps 2 and 6 are very often the same moment. If the user's first real prompt (step 2) is naturally something with a visible output - a small UI, a preview, a little tool - steer it toward producing one and publish it as an Artifact right there with \`agor_artifacts_publish\`, so the "aha" moment and the Artifact intro land together instead of as two separate asks. Only treat them as genuinely separate steps if what the user wants to build for their first prompt has no sensible visual output.
+
+Ask early (plain conversational text, not a forced form) what the user actually wants to do first, and let that answer both reorder the core steps and tell you which 1-3 of the four optional steps are actually relevant to them - don't mechanically march through all four. The numbered list above is a default ordering/menu, not a script. Bias toward doing: if a step reduces to one concrete action (pick a repo, type a prompt), guide them straight into doing it rather than explaining first and asking permission after.
+
+Introduce any Agor term (branch, board, zone, assistant, environment, Knowledge, MCP, Artifact, Cards) only at the moment it's relevant, in one or two sentences, never as a front-loaded glossary. Don't assume familiarity with git worktrees or coding agents, but don't condescend if the user's own replies show they already know this stuff - read their level from how they talk and match it.
+
+Remember the hard constraint regardless of which optional steps you pick: no more than 5 active steps in the todo list at once (2 core + at most 3 optional), and in practice 1-2 optional steps is usually the right amount - pick by relevance, not by trying to maximize coverage.
+
+## Opening message (only when this is truly the first turn - skip if resuming, see below)
+
+Two to three sentences max, then move straight into the first relevant step or ask what they want to do first:
+- Say briefly what this is (a quick, optional walkthrough to get real value out of Agor).
+- Make clear it's dismissible any time.
+- Say how to bring it back (the "Setup guide" affordance in the session panel).
+- Then immediately continue into step 1 (or ask what they'd like to tackle first) - don't stop and wait after the intro.
+
+## Resuming (any step already has state)
+
+Skip a warm reintroduction. Greet with a one-line status plus a next-step offer, e.g. "Last time you got your first branch set up - want to run your first real prompt, or is something else on your mind?" Never mechanically announce "skipping step 2" - just continue from wherever they actually are, using the same silent-skip rule for anything already done or already true in the workspace.
+
+## Progress display
+
+Call \`TodoWrite\` to keep an always-visible, <=5-item list of only the in-scope steps above (never an "AI connected" entry). Update it as steps complete or get skipped - this is the same inline task-list rendering Agor already uses elsewhere, no separate UI.
+
+## Structured choices
+
+\`AskUserQuestion\` does not work in this environment - never call it. When a choice is genuinely structured (e.g. "which repo"), inline it as plain text options (A/B/C or a short list) and let the user reply as a normal next turn. Don't force structure onto something a normal sentence and reply would handle better - this is a conversation, not a form.
+
+## Credentials mid-flow
+
+You have an \`env_vars\` widget tool available. Only reach for it if a real credential need comes up organically (e.g. a private repo needs an access token, or a teammate invite needs an integration token) - it is not tied to any scripted step here.
+
+## Writing progress (do this immediately after each true completion, not batched, not speculative)
+
+Call \`agor_kb_put\` (or \`agor_kb_edit\` if the doc already exists - use \`expectedVersion\` from your last read to avoid clobbering a concurrent write) against namespace "${namespaceSlug}", path "${docPath}", kind "memory", visibility "private". Merge into \`metadata.steps[stepId] = { status: 'done'|'skipped', updated_at: <ISO timestamp> }\`, and update \`metadata.current_step\` and \`metadata.last_interaction_at\` on every turn where the user is actively engaged with the flow, so a killed/reopened session resumes from the true state, not a stale one. Treat every write as idempotent - re-checking existing state before writing, so a retried trigger never duplicates progress or re-sends the opening message.
+
+## Skip vs. dismiss
+
+- **Skip one step**: move on, persist \`status: 'skipped'\` for that step id, don't auto-re-ask it later. It's still reachable if the user brings it up on their own, or if you notice they did it anyway outside this flow (e.g. connected a second repo unprompted) - in that case just mark it done next time you check state, don't contradict what already happened.
+- **Dismiss the whole flow**: persist \`dismissed: true\`, stop entirely, and say something like: "Sounds good - I'll stay out of it. You can bring this back any time via the setup guide button in this panel." Do not auto-re-trigger after this. Mirror this exact non-looping convention Agor already uses for its env-var request widget: don't re-request immediately - ask whether to proceed without, or move on to other work.
+
+## Off-topic interruptions
+
+If the user asks something unrelated mid-step, answer it fully and naturally first. Then offer to resume: "want to keep going with setup, or good for now?" Keep \`metadata.current_step\` bookmarked so "resume" continues the right step rather than restarting.
+
+## Completion
+
+When all in-scope steps are done or skipped, or the user dismisses, send one consistent closing note: what they can do next in Agor, and that setup can always be reopened later via the re-entry point. Don't repeat this closing message on every subsequent visit - only when a run of the flow actually concludes.`;
+}

--- a/apps/agor-daemon/src/onboarding/trigger.test.ts
+++ b/apps/agor-daemon/src/onboarding/trigger.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for the onboarding-agent trigger.
+ *
+ * Covers the contract this module exists to enforce:
+ *   - `auto` queues when the user's progress document doesn't exist yet
+ *     AND the credential actually resolves (live check, not just "a
+ *     session exists")
+ *   - `auto` does NOT queue when the credential does not resolve - this is
+ *     the fix for firing the kickoff into a session that cannot execute
+ *     anything yet
+ *   - `auto` no-ops once the progress document already exists (idempotent
+ *     - no duplicate opening message), and does so WITHOUT even running
+ *     the live credential check (cheap existence check short-circuits first)
+ *   - `manual` always queues, even when the document exists (an explicit
+ *     re-invocation overrides a prior dismissal) and skips the live
+ *     credential check entirely (an open session is already known-good)
+ *   - the queued task carries `onboarding_trigger` + `system_authored`
+ *     metadata via the existing `/sessions/:id/prompt` path
+ *
+ * `createCheckAuthService` is mocked at the module boundary rather than
+ * exercised for real: this file's job is to test *trigger.ts's* decision
+ * logic (does it call the live check, and does it respect the result?),
+ * not to re-test `check-auth.ts`'s own provider-probing internals, which
+ * belong in that module's own tests.
+ */
+
+import {
+  type Database,
+  generateId,
+  KnowledgeDocumentRepository,
+  KnowledgeNamespaceRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { AgenticToolName, SessionID, User, UserID } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { beforeEach, describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import {
+  ONBOARDING_KNOWLEDGE_DOC_PATH,
+  type OnboardingTriggerApp,
+  onboardingNamespaceSlug,
+  triggerOnboarding,
+} from './trigger';
+
+const checkAuthMock = vi.hoisted(() => ({
+  create: vi.fn(async () => ({ authenticated: true, method: 'api-key' as const })),
+}));
+
+vi.mock('../services/check-auth.js', () => ({
+  createCheckAuthService: () => checkAuthMock,
+}));
+
+const SOME_TOOL = 'claude-code' as AgenticToolName;
+
+interface MockCall {
+  data: unknown;
+  params: unknown;
+}
+
+function makeMockApp() {
+  const calls: MockCall[] = [];
+  const app: OnboardingTriggerApp = {
+    service(name: string) {
+      if (name !== '/sessions/:id/prompt') {
+        throw new Error(`Mock app has no service '${name}'`);
+      }
+      return {
+        async create(data: unknown, params?: unknown) {
+          calls.push({ data, params });
+          return { task_id: 'task-mock' };
+        },
+      };
+    },
+  };
+  return { app, calls };
+}
+
+async function seedUser(db: Database, label: string): Promise<User> {
+  const users = new UsersRepository(db);
+  return users.create({
+    user_id: generateId() as UserID,
+    email: `${label}-${Date.now()}-${Math.random()}@test.local`,
+    name: label,
+    role: ROLES.MEMBER,
+  }) as Promise<User>;
+}
+
+/** Seed a progress document exactly where `triggerOnboarding` expects to find it. */
+async function seedProgressDocument(db: Database, userId: UserID): Promise<void> {
+  const namespace = await new KnowledgeNamespaceRepository(db).create({
+    slug: onboardingNamespaceSlug(userId),
+    display_name: 'Onboarding',
+    kind: 'user',
+    owner_user_id: userId,
+    visibility_default: 'private',
+    created_by: userId,
+  });
+  await new KnowledgeDocumentRepository(db).create({
+    namespace_id: namespace.namespace_id,
+    path: ONBOARDING_KNOWLEDGE_DOC_PATH,
+    title: 'Onboarding progress',
+    kind: 'memory',
+    visibility: 'private',
+    status: 'published',
+    edit_policy: 'owner',
+    content_text: '# Onboarding progress',
+    created_by: userId,
+  });
+}
+
+describe('triggerOnboarding', () => {
+  beforeEach(() => {
+    checkAuthMock.create.mockReset();
+    checkAuthMock.create.mockResolvedValue({ authenticated: true, method: 'api-key' });
+  });
+
+  dbTest('auto queues the kickoff prompt when the credential resolves', async ({ db }) => {
+    const { app, calls } = makeMockApp();
+    const userId = (await seedUser(db, 'new-user')).user_id as UserID;
+
+    const result = await triggerOnboarding(app, db, {
+      sessionId: generateId() as SessionID,
+      userId,
+      callerUserId: userId,
+      agenticTool: SOME_TOOL,
+      reason: 'auto',
+    });
+
+    expect(result).toEqual({ queued: true, reason: 'auto' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].data).toMatchObject({
+      messageSource: 'agor',
+      metadata: { system_authored: true, onboarding_trigger: 'auto' },
+    });
+    expect((calls[0].data as { prompt: string }).prompt).toContain(onboardingNamespaceSlug(userId));
+    expect(checkAuthMock.create).toHaveBeenCalledWith(
+      { tool: SOME_TOOL },
+      expect.objectContaining({ user: expect.objectContaining({ user_id: userId }) })
+    );
+  });
+
+  dbTest(
+    'auto does NOT queue when the credential does not actually resolve, even though a session exists',
+    async ({ db }) => {
+      checkAuthMock.create.mockResolvedValue({
+        authenticated: false,
+        method: 'none',
+        hint: 'not configured',
+      });
+      const { app, calls } = makeMockApp();
+      const userId = (await seedUser(db, 'no-credential-user')).user_id as UserID;
+
+      // Simulates the "Continue without key" wizard path, or a rejected
+      // key from "Save & Continue": a session exists (the caller always
+      // has one by the time it calls this), but nothing actually
+      // authenticates. This is the exact case that used to slip through
+      // when the trigger only checked "did the wizard run a
+      // credential-setting button", not "does a credential really work".
+      const result = await triggerOnboarding(app, db, {
+        sessionId: generateId() as SessionID,
+        userId,
+        callerUserId: userId,
+        agenticTool: SOME_TOOL,
+        reason: 'auto',
+      });
+
+      expect(result).toEqual({ queued: false, reason: 'auto' });
+      expect(calls).toHaveLength(0);
+    }
+  );
+
+  dbTest(
+    'auto no-ops once the progress document already exists, without even running the live check',
+    async ({ db }) => {
+      const { app, calls } = makeMockApp();
+      const userId = (await seedUser(db, 'returning-user')).user_id as UserID;
+      await seedProgressDocument(db, userId);
+
+      const result = await triggerOnboarding(app, db, {
+        sessionId: generateId() as SessionID,
+        userId,
+        callerUserId: userId,
+        agenticTool: SOME_TOOL,
+        reason: 'auto',
+      });
+
+      expect(result).toEqual({ queued: false, reason: 'auto' });
+      expect(calls).toHaveLength(0);
+      expect(checkAuthMock.create).not.toHaveBeenCalled();
+    }
+  );
+
+  dbTest('manual always queues, even when the progress document exists', async ({ db }) => {
+    const { app, calls } = makeMockApp();
+    const userId = (await seedUser(db, 'dismissed-user')).user_id as UserID;
+    await seedProgressDocument(db, userId);
+
+    const result = await triggerOnboarding(app, db, {
+      sessionId: generateId() as SessionID,
+      userId,
+      callerUserId: userId,
+      agenticTool: SOME_TOOL,
+      reason: 'manual',
+    });
+
+    expect(result).toEqual({ queued: true, reason: 'manual' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].data).toMatchObject({
+      metadata: { system_authored: true, onboarding_trigger: 'manual' },
+    });
+    expect(checkAuthMock.create).not.toHaveBeenCalled();
+  });
+
+  dbTest(
+    'manual always queues even when the credential would not resolve - explicit request wins',
+    async ({ db }) => {
+      checkAuthMock.create.mockResolvedValue({ authenticated: false, method: 'none' });
+      const { app, calls } = makeMockApp();
+      const userId = (await seedUser(db, 'manual-no-credential-user')).user_id as UserID;
+
+      const result = await triggerOnboarding(app, db, {
+        sessionId: generateId() as SessionID,
+        userId,
+        callerUserId: userId,
+        agenticTool: SOME_TOOL,
+        reason: 'manual',
+      });
+
+      expect(result).toEqual({ queued: true, reason: 'manual' });
+      expect(calls).toHaveLength(1);
+    }
+  );
+
+  dbTest('two users get independent namespace slugs', async ({ db }) => {
+    const { app, calls } = makeMockApp();
+    const userA = (await seedUser(db, 'user-a')).user_id as UserID;
+    const userB = (await seedUser(db, 'user-b')).user_id as UserID;
+
+    await triggerOnboarding(app, db, {
+      sessionId: generateId() as SessionID,
+      userId: userA,
+      callerUserId: userA,
+      agenticTool: SOME_TOOL,
+      reason: 'auto',
+    });
+    await triggerOnboarding(app, db, {
+      sessionId: generateId() as SessionID,
+      userId: userB,
+      callerUserId: userB,
+      agenticTool: SOME_TOOL,
+      reason: 'auto',
+    });
+
+    expect(calls).toHaveLength(2);
+    const slugA = onboardingNamespaceSlug(userA);
+    const slugB = onboardingNamespaceSlug(userB);
+    expect(slugA).not.toEqual(slugB);
+    expect((calls[0].data as { prompt: string }).prompt).toContain(slugA);
+    expect((calls[1].data as { prompt: string }).prompt).toContain(slugB);
+  });
+});

--- a/apps/agor-daemon/src/onboarding/trigger.ts
+++ b/apps/agor-daemon/src/onboarding/trigger.ts
@@ -1,0 +1,173 @@
+/**
+ * Onboarding-agent trigger.
+ *
+ * Queues the kickoff prompt (`./kickoff-prompt.ts`) into an existing session
+ * via the same `/sessions/:id/prompt` path the `env_vars` widget's
+ * auto-resume uses (see `../widgets/submissions.ts`). No new session/agent
+ * type - this just decides *whether* to queue and builds the prompt text.
+ *
+ * Two callers:
+ *   - `reason: 'auto'` - the Onboarding Wizard, right after it creates (or
+ *     reuses) the user's assistant session. A session existing is NOT the
+ *     same thing as AI being connected - "Continue without key" also
+ *     creates a session, with no credential at all. So this path performs
+ *     a LIVE credential-resolution check (`createCheckAuthService`, the
+ *     same probe the wizard's own "Test Connection" button and Settings
+ *     use) immediately before queuing, and no-ops silently if it fails.
+ *     This is the fallback described in the PRD §3: Feature 1
+ *     (`feature-connect-ai-empty-state`) isn't merged yet, so there's no
+ *     "credential resolution succeeded" event to hook into server-side
+ *     today - reusing its underlying check is the next best thing. Once
+ *     Feature 1 merges, its own success event is the better long-term
+ *     hook (see PRD §3) - this call site is the one to revisit then.
+ *     Also idempotent on the Knowledge existence check: no-ops if this
+ *     user's progress document already exists.
+ *   - `reason: 'manual'` - the "Setup guide" re-entry affordance. Always
+ *     queues, no live re-check - an explicit click from inside an already
+ *     -open session means that session is already known to work.
+ */
+
+import { KnowledgeDocumentRepository, shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
+import type { AgenticToolName, AuthenticatedParams, SessionID, UserID } from '@agor/core/types';
+import { buildOnboardingKickoffPrompt, type OnboardingTriggerReason } from './kickoff-prompt.js';
+
+export const ONBOARDING_KNOWLEDGE_DOC_PATH = 'progress.md';
+
+export function onboardingNamespaceSlug(userId: UserID): string {
+  return `onboarding-${shortId(userId)}`;
+}
+
+export interface OnboardingTriggerApp {
+  service(name: string): {
+    create(data: unknown, params?: unknown): Promise<unknown>;
+  };
+}
+
+export interface TriggerOnboardingInput {
+  sessionId: SessionID;
+  /** The user this onboarding progress document belongs to (session creator). */
+  userId: UserID;
+  /** The user attributed as the author of the queued task (usually the same as `userId`). */
+  callerUserId: UserID;
+  /**
+   * The session's agentic tool, used only by the `auto` path's live
+   * credential-resolution check. Ignored for `manual`.
+   */
+  agenticTool: AgenticToolName;
+  reason: OnboardingTriggerReason;
+}
+
+export interface TriggerOnboardingResult {
+  queued: boolean;
+  reason: OnboardingTriggerReason;
+}
+
+/**
+ * Per-user in-process serialization of concurrent `auto` existence checks.
+ * Mirrors `inFlightResolutions` in `../widgets/submissions.ts`: a second
+ * caller waits for the first check to settle, then runs its own fresh
+ * check rather than trusting the first's result. That's a deliberate,
+ * narrow guarantee - this function never writes the progress document
+ * itself (only the agent does, once it actually responds), so two truly
+ * simultaneous `auto` calls can still both see "not found" and both queue.
+ * Acceptable for single-daemon deployments; the same trade-off is accepted
+ * in the widget resolver this mirrors.
+ */
+const inFlightAutoTriggers = new Map<string, Promise<boolean>>();
+
+async function alreadyTriggered(db: TenantScopeAwareDatabase, userId: UserID): Promise<boolean> {
+  const repo = new KnowledgeDocumentRepository(db);
+  const existing = await repo.findByNamespaceSlugAndPath(
+    onboardingNamespaceSlug(userId),
+    ONBOARDING_KNOWLEDGE_DOC_PATH
+  );
+  return existing !== null;
+}
+
+export async function triggerOnboarding(
+  app: OnboardingTriggerApp,
+  db: TenantScopeAwareDatabase,
+  input: TriggerOnboardingInput
+): Promise<TriggerOnboardingResult> {
+  const { sessionId, userId, callerUserId, agenticTool, reason } = input;
+
+  if (reason === 'auto') {
+    const key = String(userId);
+    // If another `auto` check for this user is already in flight, wait for
+    // it to settle before running our own - this is what actually closes
+    // the race (two calls landing back-to-back before either check
+    // resolves). It does NOT make the two calls share a result: each still
+    // performs its own fresh existence check afterward, which is correct
+    // since the progress document isn't written by this function at all
+    // (the agent writes it later, once it actually responds) - see the
+    // module comment on `inFlightAutoTriggers`.
+    const inFlight = inFlightAutoTriggers.get(key);
+    if (inFlight) {
+      await inFlight.catch(() => {});
+    }
+    const check = alreadyTriggered(db, userId);
+    inFlightAutoTriggers.set(key, check);
+    let exists: boolean;
+    try {
+      exists = await check;
+    } finally {
+      if (inFlightAutoTriggers.get(key) === check) {
+        inFlightAutoTriggers.delete(key);
+      }
+    }
+    if (exists) return { queued: false, reason };
+
+    // Cheap existence check passed - now do the expensive, authoritative
+    // part: actually confirm the credential resolves, the same live probe
+    // "Test Connection" uses. A session existing (even one just created by
+    // the wizard) does not mean AI is connected - "Continue without key"
+    // creates a session with nothing to authenticate with at all. Firing
+    // the kickoff prompt into a session that cannot execute would just
+    // surface as a raw CLI passthrough error, defeating the entire point
+    // of treating "AI connected" as this flow's precondition.
+    //
+    // Dynamic import deliberately, not a static top-level one:
+    // `check-auth.ts` pulls in the Claude SDK (for its CLI-auth probe),
+    // which is otherwise never touched by anything importing this module
+    // (`register-routes.ts` -> `trigger.ts`). A static import here would
+    // make every consumer of `register-routes.ts` eagerly load that chain
+    // at module-evaluation time - harmless in the running daemon, but it
+    // widened the blast radius of an unrelated, pre-existing ESM
+    // resolution issue in this package's Vitest setup (confirmed by
+    // diffing full-suite runs with/without this change) to test files
+    // that have nothing to do with onboarding.
+    const { createCheckAuthService } = await import('../services/check-auth.js');
+    const authResult = await createCheckAuthService(db).create(
+      { tool: agenticTool },
+      // Internal trusted call - createCheckAuthService only ever reads
+      // `params.user.user_id`, so the other AuthenticatedUser fields are
+      // irrelevant here; cast rather than fabricate values that mean
+      // nothing in this context.
+      { user: { user_id: userId } } as unknown as AuthenticatedParams
+    );
+    if (!authResult.authenticated) return { queued: false, reason };
+  }
+
+  const prompt = buildOnboardingKickoffPrompt({
+    reason,
+    namespaceSlug: onboardingNamespaceSlug(userId),
+    docPath: ONBOARDING_KNOWLEDGE_DOC_PATH,
+  });
+
+  await app.service('/sessions/:id/prompt').create(
+    {
+      prompt,
+      messageSource: 'agor',
+      metadata: {
+        system_authored: true,
+        onboarding_trigger: reason,
+      },
+    },
+    {
+      user: { user_id: callerUserId },
+      route: { id: sessionId },
+    }
+  );
+
+  return { queued: true, reason };
+}

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -92,6 +92,8 @@ import type {
   TasksServiceImpl,
 } from './declarations.js';
 import { killExecutorProcess } from './executor-tracking.js';
+import type { OnboardingTriggerReason } from './onboarding/kickoff-prompt.js';
+import { triggerOnboarding } from './onboarding/trigger.js';
 import type { GatewayService } from './services/gateway.js';
 import {
   ScheduleBusyError,
@@ -221,7 +223,7 @@ export interface RegisterRoutesContext {
   /**
    * Resolved build info (sha + builtAt). Surfaced on /health so the UI can
    * detect FE/BE drift after a deploy. The SHA is the canonical version
-   * signal for the version-sync banner — see setup/build-info.ts.
+   * signal for the version-sync banner - see setup/build-info.ts.
    */
   DAEMON_BUILD_INFO: import('./setup/build-info.js').BuildInfo;
   servicesConfig: DaemonServicesConfig;
@@ -286,7 +288,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   /**
    * Schedule fn in a new event-loop tick with a fresh tenant DB scope.
-   * Always use this instead of bare setImmediate inside route/service code —
+   * Always use this instead of bare setImmediate inside route/service code -
    * bare setImmediate inherits the active transaction ALS store, while a plain
    * ALS exit loses Postgres RLS tenant context for session/task lookups.
    */
@@ -333,11 +335,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     authStrategiesArray.push('session-token');
   }
 
-  // Access token TTL — short by design. The /authentication/refresh route
+  // Access token TTL - short by design. The /authentication/refresh route
   // (and the after-hook below) issues a 30-day refresh token so users stay
   // logged in across browser restarts; the access token itself stays
   // short-lived so that a leaked one expires quickly. Both the auth-service
-  // config AND the refresh endpoint MUST use this constant — if they drift,
+  // config AND the refresh endpoint MUST use this constant - if they drift,
   // the refresh path silently downgrades the security of the auth path.
   const ACCESS_TOKEN_TTL = '15m';
   const REFRESH_TOKEN_TTL = '30d';
@@ -392,7 +394,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   //
   // Mounted at `/authentication` so it covers BOTH the Feathers auth service
   // (POST /authentication) and the custom refresh endpoint
-  // (POST /authentication/refresh) — Express's path-prefix matching means
+  // (POST /authentication/refresh) - Express's path-prefix matching means
   // a single middleware handles both, and the keyGenerator branches on the
   // sub-path to choose the right composite key.
   const AUTH_RATE_LIMIT_MAX = 50;
@@ -401,13 +403,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const authRateLimiter = rateLimit({
     windowMs: AUTH_RATE_LIMIT_WINDOW_MS,
     limit: AUTH_RATE_LIMIT_MAX,
-    // Modern IETF draft-7 headers (RateLimit-*) — clients can back off.
+    // Modern IETF draft-7 headers (RateLimit-*) - clients can back off.
     standardHeaders: 'draft-7',
     // Drop the legacy X-RateLimit-* set; they're noisy and non-standard.
     legacyHeaders: false,
     // Composite key on (ip, email). For the refresh sub-path the body has
     // no email, so we bucket purely by IP. Trust only Express's resolved
-    // `req.ip` (which respects `app.set('trust proxy', n)`) — never
+    // `req.ip` (which respects `app.set('trust proxy', n)`) - never
     // X-Forwarded-For directly.
     keyGenerator: (req: Request): string => buildAuthRateLimitKey(req),
     message: 'Too many authentication attempts. Please try again in 15 minutes.',
@@ -437,7 +439,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   // Hook: Issue browser access + refresh tokens with millisecond issue time.
   // Rate limiting is enforced by express-rate-limit middleware mounted on
-  // `/authentication` above — by the time we reach this hook the limiter
+  // `/authentication` above - by the time we reach this hook the limiter
   // has already 429'd any over-quota request.
   authService.hooks({
     after: {
@@ -822,7 +824,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
    * Closes the existing `cli-<short>` tab (if any) and re-spawns `claude`
    * inside a fresh tab against the same JSONL. The session's
    * `cli_state.watcher_offset` is preserved so the watcher resumes
-   * tailing from wherever it left off — no events are lost across the
+   * tailing from wherever it left off - no events are lost across the
    * restart.
    *
    * Use this when claude has crashed / been Ctrl-C'd inside the pane,
@@ -843,7 +845,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           );
         }
         const targetUserId = session.created_by;
-        if (!targetUserId) throw new Error('Session has no created_by — cannot route restart');
+        if (!targetUserId) throw new Error('Session has no created_by - cannot route restart');
         if (
           params.provider &&
           !canControlCliSession({
@@ -865,7 +867,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         //    ("Session ID … is already in use") when the new spawn
         //    fires. `pkill -f` against the argv pattern is the reliable
         //    kill. Match BOTH `--session-id <X>` (first launch) and
-        //    `--resume <X>` (post-restart spawn) — same code path
+        //    `--resume <X>` (post-restart spawn) - same code path
         //    `buildClaudeCliSpawn` emits.
         try {
           const { spawn: spawnProc } = await import('node:child_process');
@@ -877,7 +879,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           await new Promise<void>((resolve) => {
             killProc.on('exit', () => resolve());
             killProc.on('error', () => resolve());
-            // Defensive cap — pkill should be <100ms.
+            // Defensive cap - pkill should be <100ms.
             setTimeout(() => {
               try {
                 killProc.kill();
@@ -899,14 +901,14 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         //   - `close` only closed the focused tab (one of potentially
         //     several duplicates from earlier racing executors), so
         //     the subsequent `create` would see surviving siblings
-        //     and auto-converse to `focus` — restart "succeeded" but
+        //     and auto-converse to `focus` - restart "succeeded" but
         //     claude never actually respawned.
         //   - The 800ms timer was a guess against an uncoordinated
         //     race between executors.
         //
         // With `forceRecreate: true` the executor closes EVERY tab
         // matching `tabName` first, then issues `new-tab --layout`
-        // with the freshly-built claude argv — atomic in the
+        // with the freshly-built claude argv - atomic in the
         // executor's tab-event loop. No timer, no surviving stale
         // tab, no auto-converse. Restart actually restarts.
         const branch = (await app.service('branches').get(session.branch_id, params)) as {
@@ -946,13 +948,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   );
 
   /**
-   * Per-session "turn" lock — single source of truth for "who's allowed to
+   * Per-session "turn" lock - single source of truth for "who's allowed to
    * spawn an executor for this session right now" mutual exclusion. Shared
    * by `/sessions/:id/prompt`'s idle branch, `/tasks/:id/run`, and the
    * queue processor's drain loop. See `utils/session-turn-lock.ts`.
    *
    * Without this, two concurrent prompts on the same idle session could
-   * both observe `status === 'idle'` and both spawn executors — a race
+   * both observe `status === 'idle'` and both spawn executors - a race
    * that pre-dates the `/tasks/:id/run` route but is now fixed across all
    * three entry points.
    */
@@ -1011,7 +1013,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   }
 
   /**
-   * spawnTaskExecutor — sole transition point for `tasks.status` going from
+   * spawnTaskExecutor - sole transition point for `tasks.status` going from
    * `created` / `queued` → `running`.
    *
    * Both the IDLE branch of POST /sessions/:id/prompt and the queued-task
@@ -1025,7 +1027,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
    *     before the executor process is forked. Without this, any crash
    *     during executor startup loses the prompt from the chat transcript
    *     even though `tasks.full_prompt` still has the text. Gated by
-   *     `config.execution.daemon_writes_user_message` (kill switch — see
+   *     `config.execution.daemon_writes_user_message` (kill switch - see
    *     §5.E of `docs/never-lose-prompt-design.md`).
    *   - `task.metadata.is_agor_callback` / `task.metadata.source` are
    *     re-stamped onto the new message so the UI's callback styling
@@ -1080,7 +1082,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       params
     )) as Task;
 
-    // Alt D — write the user-message row before spawning. Gated by kill switch.
+    // Alt D - write the user-message row before spawning. Gated by kill switch.
     // The executor's createUserMessage has a skip-if-exists guard so a duplicate
     // write is harmless if the daemon path is enabled.
     if (config.execution?.daemon_writes_user_message !== false) {
@@ -1091,7 +1093,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           messageMetadata.is_agor_callback = true;
         }
         // Prefer task.metadata.source (set when the task was queued) over
-        // the request's messageSource — the latter applies only to the
+        // the request's messageSource - the latter applies only to the
         // current draining tick, the former to where the prompt originated.
         const source = task.metadata?.source ?? options.messageSource;
         if (source) {
@@ -1111,7 +1113,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         });
         await app.service('messages').create(userMessage, params);
       } catch (msgErr) {
-        // Don't fail the spawn — the executor's createUserMessage fallback
+        // Don't fail the spawn - the executor's createUserMessage fallback
         // (with skip-if-exists) will write the row when it connects.
         console.warn(
           `⚠️  [Daemon] Failed to write initial user-message row for task ${shortId(task.task_id)} (executor will retry):`,
@@ -1171,7 +1173,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     if (session.agentic_tool === 'claude-code-cli') {
       // Hand the task off to the watcher BEFORE we PTY-inject. The watcher
       // claims this task on the next `user_message` JSONL line and links
-      // every subsequent assistant/tool message to it — then closes it on
+      // every subsequent assistant/tool message to it - then closes it on
       // `turn_end`. Without this stash, the watcher would mint a *new*
       // task on that user line and we'd end up with two task rows per
       // turn (the empty one from /prompt + the one the watcher minted).
@@ -1185,7 +1187,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         try {
           const targetUserId = session.created_by;
           if (!targetUserId) {
-            throw new Error('CLI session has no created_by — cannot route PTY injection');
+            throw new Error('CLI session has no created_by - cannot route PTY injection');
           }
           const channel = `user/${targetUserId}/terminal`;
           const tabName = `cli-${shortId(session.session_id)}`;
@@ -1212,7 +1214,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
           // Append \r so the REPL submits. Zellij forwards raw bytes
           // unchanged to claude's pseudo-tty. If the user is currently
-          // mid-typing into the REPL, the bytes interleave — documented
+          // mid-typing into the REPL, the bytes interleave - documented
           // race per the analysis doc § Blind spot #2.
           const payload = `${promptForExecutor}\r`;
           io?.to(channel).emit('terminal:input', { userId: targetUserId, input: payload });
@@ -1251,7 +1253,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     }
 
     // Background spawn + failure handling. Returning the patched Task to the
-    // caller before this resolves matches the previous behavior — the HTTP
+    // caller before this resolves matches the previous behavior - the HTTP
     // response should not block on the executor process being live.
     // deferInFreshTenantScope uses a fresh DB connection and tenant RLS scope
     // instead of inheriting a stale committed transaction.
@@ -1299,7 +1301,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         // prompt and silence even though the task list reads FAILED.
         try {
           // Recompute the next index instead of trusting `messageStartIndex
-          // + 1` — the daemon-write user-message above is wrapped in a
+          // + 1` - the daemon-write user-message above is wrapped in a
           // try/catch and may have been swallowed, leaving a gap at
           // `messageStartIndex`. countMessages always reports the live row
           // count, so it lands the system error at the true tail whether
@@ -1355,7 +1357,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
            * Optional extra task metadata merged onto the queued/created task.
            * Used by internal callers (e.g. widget submissions) to stamp
            * traceability fields like `system_authored` / `widget_id`.
-           * External callers receive no validation on this field — it's
+           * External callers receive no validation on this field - it's
            * trusted because the route is RBAC-gated.
            */
           metadata?: Partial<import('@agor/core/types').TaskMetadata>;
@@ -1438,7 +1440,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           async () => {
             let lockedSession = await sessionsService.get(id, params);
             if (lockedSession.status === SessionStatus.STOPPING) {
-              // The earlier STOPPING check was against pre-lock state — re-check
+              // The earlier STOPPING check was against pre-lock state - re-check
               // here so a session that entered STOPPING while we waited for our
               // turn doesn't accept a prompt.
               throw new Error('Cannot send prompt: session is currently stopping');
@@ -1541,12 +1543,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Task run endpoint
   //
   // Explicit executor trigger for an already-created task. Lets pure-REST
-  // harnesses (Python, Go, shell+curl — anything without an MCP client) drive
+  // harnesses (Python, Go, shell+curl - anything without an MCP client) drive
   // the executor by POSTing a Task row first (`POST /tasks`) and then poking
   // it awake here. Wraps `spawnTaskExecutor` via `runExistingTask` (status
-  // revalidation) under `withSessionTurnLock` — the same shared session-level
+  // revalidation) under `withSessionTurnLock` - the same shared session-level
   // mutex that `/sessions/:id/prompt`'s idle branch and the queue drainer
-  // also acquire — so the on-the-wire effect is identical to "create a task
+  // also acquire - so the on-the-wire effect is identical to "create a task
   // and run it now."
   //
   // Only CREATED tasks on IDLE sessions are accepted. QUEUED tasks are
@@ -1579,7 +1581,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
 
         // Only CREATED tasks may be triggered. QUEUED tasks must drain in
-        // queue-position order via the queue processor — running them out of
+        // queue-position order via the queue processor - running them out of
         // order would violate the invariant documented in
         // `context/concepts/task-queueing.md`. Terminal/in-flight states are
         // rejected so the caller doesn't try to revive a finished task or
@@ -1588,7 +1590,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           const hint =
             task.status === TaskStatus.QUEUED
               ? `Queued tasks drain automatically in queue-position order ` +
-                `when the session becomes idle — wait for it, or stop the ` +
+                `when the session becomes idle - wait for it, or stop the ` +
                 `currently running task to free the queue.`
               : `Only 'created' tasks may be triggered.`;
           throw new Conflict(
@@ -1596,12 +1598,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           );
         }
 
-        // Branch RBAC — defense in depth. Without this, a member with
+        // Branch RBAC - defense in depth. Without this, a member with
         // 'view' permission could trigger execution; the eventual
         // `tasks.patch` inside spawnTaskExecutor would still 403 via the
         // `ensureCanPromptInSession` hook, but only after we'd done extra
         // work and emitted partial state. Mirrors the upload route's
-        // pattern (~L1467) and `ensureCanPromptInSession` semantics —
+        // pattern (~L1467) and `ensureCanPromptInSession` semantics -
         // including the service-account / no-provider bypasses so executor
         // callbacks aren't held to the same checks as user requests.
         const isInternalCall = !params.provider;
@@ -1646,12 +1648,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         // spawning. This is what closes the race against concurrent
         // /tasks/:id/run on different tasks of the same session, against
         // /sessions/:id/prompt's idle branch, and against the queue
-        // drainer — they all serialize through `sessionTurnLocks`.
+        // drainer - they all serialize through `sessionTurnLocks`.
         return await withSessionTurnLock(
           sessionTurnLocks,
           task.session_id,
           async () => {
-            // Re-read session state inside the lock — it may have flipped to
+            // Re-read session state inside the lock - it may have flipped to
             // RUNNING while we waited for our turn.
             const session = await reconcileSessionPromptStateIfStuck(
               await sessionsService.get(task.session_id, params),
@@ -1666,7 +1668,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             if (!sessionCanStartTask(session.status, session.ready_for_prompt)) {
               throw new Conflict(
                 `Cannot run task ${shortId(taskId)}: session is '${session.status}'. ` +
-                  `To enqueue a prompt on a busy session, POST to /sessions/:id/prompt instead — ` +
+                  `To enqueue a prompt on a busy session, POST to /sessions/:id/prompt instead - ` +
                   `it creates and queues a task atomically.`
               );
             }
@@ -1719,7 +1721,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
            */
           parentPermissionMode?: import('@agor/core/types').PermissionMode;
           // Remaining fields are spawn-subsession context (incl. the *child*
-          // session's permissionMode/modelConfig/etc) — see
+          // session's permissionMode/modelConfig/etc) - see
           // `SpawnSubsessionContext` in @agor/core for the shape.
           [key: string]: unknown;
         },
@@ -1735,7 +1737,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           '@agor/core/templates/spawn-subsession-template'
         );
         // Render the meta-prompt against the child-session config (the rest
-        // of `data`). `parentPermissionMode` is intentionally excluded — it's
+        // of `data`). `parentPermissionMode` is intentionally excluded - it's
         // the parent's send-mode, not part of the template.
         const { parentPermissionMode, ...spawnContext } = data;
         const metaPrompt = renderSpawnSubsessionPrompt(
@@ -1759,7 +1761,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Zone-trigger fire endpoint (always_new behaviour)
   //
   // Daemon is the source of truth for the zone's trigger template / agent /
-  // label — the UI only sends the zone id. The shared
+  // label - the UI only sends the zone id. The shared
   // `fireAlwaysNewZoneTrigger` helper (also used by the MCP
   // `agor_branches_set_zone(triggerTemplate: true)` always_new branch)
   // does render → validate → resolve defaults → create session → attach MCPs
@@ -1802,7 +1804,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (zoneObj.trigger?.behavior !== 'always_new') {
           // This endpoint is the always_new server-side action. show_picker
           // zones flow through the modal-driven explicit-target path, not this
-          // route — refuse instead of silently creating a session.
+          // route - refuse instead of silently creating a session.
           throw new BadRequest(
             `Zone "${zoneObj.label}" trigger behaviour is "${zoneObj.trigger?.behavior}", expected "always_new"`
           );
@@ -2069,7 +2071,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       next();
       // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
     }) as any,
-    // Cheap pre-multer Content-Length check — short-circuits before we spend
+    // Cheap pre-multer Content-Length check - short-circuits before we spend
     // time writing oversize uploads to disk.
     // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
     enforceTotalUploadSize() as any,
@@ -2077,7 +2079,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     // biome-ignore lint/suspicious/noExplicitAny: Express 5 + multer type compatibility
     uploadMiddleware.array('files', 10) as any,
     // Defence-in-depth aggregate-size check using the actual file sizes that
-    // multer wrote — catches Content-Length-spoofing clients.
+    // multer wrote - catches Content-Length-spoofing clients.
     // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
     enforceParsedTotalUploadSize() as any,
     // biome-ignore lint/suspicious/noExplicitAny: Express 5 type compatibility
@@ -2158,12 +2160,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   );
 
   // ============================================================================
-  // Queue listing — task-centric (was message-centric pre-never-lose-prompt).
+  // Queue listing - task-centric (was message-centric pre-never-lose-prompt).
   // The queue is the set of tasks with status='queued', ranked by
   // queue_position. Each queued task carries the full prompt + metadata; on
   // drain it transitions queued → running via spawnTaskExecutor.
   //
-  // Enqueueing goes through `POST /sessions/:id/prompt` — the daemon decides
+  // Enqueueing goes through `POST /sessions/:id/prompt` - the daemon decides
   // run-vs-queue based on session state and reports it back via `task.status`.
   // ============================================================================
 
@@ -2191,13 +2193,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
-  // Queue processing implementation — task-centric. Acquires the shared
+  // Queue processing implementation - task-centric. Acquires the shared
   // `sessionTurnLocks` (declared near the top of registerRoutes) so the
   // drainer can't race `/sessions/:id/prompt` or `/tasks/:id/run` for the
   // same session. The retry-on-existing-lock indirection (vs. a plain
   // `withSessionTurnLock` wrapper) preserves the original "if drain is in
   // flight, schedule a retry instead of stacking concurrent drainers"
-  // semantics — important because callbacks can fire processNextQueuedTask
+  // semantics - important because callbacks can fire processNextQueuedTask
   // from arbitrary points in the lifecycle.
   const queueRetryScheduled = new Set<SessionID>();
 
@@ -2220,7 +2222,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
       if (outcome === 'timeout') {
         console.error(
-          `❌ [Queue] Session ${shortId(sessionId)}: turn lock held >${LOCK_WAIT_TIMEOUT_MS / 1000}s — ` +
+          `❌ [Queue] Session ${shortId(sessionId)}: turn lock held >${LOCK_WAIT_TIMEOUT_MS / 1000}s - ` +
             `holder may be stuck on a broken DB connection. Skipping this drain trigger; ` +
             `the next natural trigger (user prompt or task completion) will retry.`
         );
@@ -2327,7 +2329,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       return;
     }
 
-    // Re-read the task — defend against the case where it was already drained
+    // Re-read the task - defend against the case where it was already drained
     // by a concurrent caller, or removed by an admin via DELETE /tasks/:id.
     const stillQueued = await taskRepo.findById(nextTask.task_id);
     if (!stillQueued || stillQueued.status !== TaskStatus.QUEUED) {
@@ -2513,6 +2515,48 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   );
 
   // ============================================================================
+  // Onboarding-agent trigger endpoint
+  //
+  // Queues the onboarding kickoff prompt into an existing session - no new
+  // session/agent type, this just decides whether to fire and builds the
+  // prompt text. See `./onboarding/trigger.ts`.
+  // ============================================================================
+
+  registerAuthenticatedRoute(
+    app,
+    '/sessions/:id/onboarding/trigger',
+    {
+      async create(data: { reason?: OnboardingTriggerReason }, params: RouteParams) {
+        const sessionId = params.route?.id;
+        if (!sessionId) throw new Error('Session ID required');
+        if (!params.user?.user_id) {
+          throw new NotAuthenticated('Authentication required to trigger onboarding');
+        }
+        if (data?.reason !== 'auto' && data?.reason !== 'manual') {
+          throw new Error("reason must be 'auto' or 'manual'");
+        }
+
+        const session = await sessionsService.get(sessionId, params);
+        if (session.created_by !== params.user.user_id) {
+          throw new Forbidden('You can only trigger onboarding for your own sessions');
+        }
+
+        return triggerOnboarding(app, db, {
+          sessionId: session.session_id,
+          userId: session.created_by as UUID,
+          callerUserId: params.user.user_id as UUID,
+          agenticTool: session.agentic_tool,
+          reason: data.reason,
+        });
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'trigger onboarding' },
+    },
+    requireAuth
+  );
+
+  // ============================================================================
   // Tasks custom routes
   // ============================================================================
 
@@ -2616,11 +2660,11 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           pull_request_url?: string;
           boardId: string;
           /** Explicit board position. Omit to let the service compute a
-           *  smart default — preferred for MCP/agent callers. The UI
+           *  smart default - preferred for MCP/agent callers. The UI
            *  passes the viewport center so the new card lands where the
            *  user invoked the dialog. */
           position?: { x: number; y: number };
-          // Branch storage model — see context/explorations/clone-redesign.md.
+          // Branch storage model - see context/explorations/clone-redesign.md.
           storage_mode?: 'worktree' | 'clone';
           clone_depth?: number;
         },
@@ -2777,7 +2821,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           const id = params.route?.id;
           if (!id) throw new Error('Comment ID required');
           if (!data.content) throw new Error('content required');
-          // Always attribute the reply to the authenticated caller — never trust
+          // Always attribute the reply to the authenticated caller - never trust
           // a client-supplied `created_by`. `requireAuth` upstream guarantees
           // `params.user.user_id`.
           const callerId = (params as { user?: { user_id?: string } }).user?.user_id;
@@ -3088,7 +3132,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // ============================================================================
   // Pre-#1253 callers fired a single per-branch schedule via this route.
   // Now that a branch can have N schedules, the unambiguous case is "exactly
-  // one schedule on this branch" — we forward to that schedule's run-now.
+  // one schedule on this branch" - we forward to that schedule's run-now.
   // Zero or multiple → 400 with a pointer to /schedules/:id/run-now.
   app.use('/branches/:id/execute-schedule-now', {
     async create(_data: unknown, params: RouteParams) {
@@ -3241,7 +3285,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     if (!user) {
       throw new NotAuthenticated('Authentication required');
     }
-    // Fast-path for service accounts — skip the session lookup entirely.
+    // Fast-path for service accounts - skip the session lookup entirely.
     if (user._isServiceAccount) return;
 
     const session = await sessionsService.get(sessionId, { provider: undefined });
@@ -3434,13 +3478,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Session env selections (v0.5 env-var-access)
   //
   // Routes:
-  //   GET    /sessions/:id/env-selections           — list selected env var names
-  //   POST   /sessions/:id/env-selections           — add one: { envVarName }
-  //   DELETE /sessions/:id/env-selections/:name     — remove one
-  //   PATCH  /sessions/:id/env-selections           — replace all: { envVarNames: [] }
+  //   GET    /sessions/:id/env-selections           - list selected env var names
+  //   POST   /sessions/:id/env-selections           - add one: { envVarName }
+  //   DELETE /sessions/:id/env-selections/:name     - remove one
+  //   PATCH  /sessions/:id/env-selections           - replace all: { envVarNames: [] }
   //
   // RBAC: only the session's creator or a global admin/superadmin may mutate.
-  // Branch `all` permission does NOT grant access — selections expose the
+  // Branch `all` permission does NOT grant access - selections expose the
   // creator's private credentials to the executor process.
   // ============================================================================
 
@@ -3473,7 +3517,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     app,
     '/sessions/:id/env-selections',
     {
-      // GET returns the selected env var names as a plain `string[]` — both
+      // GET returns the selected env var names as a plain `string[]` - both
       // the comment above and the UI consumer expect names, not full rows.
       async find(params: RouteParams): Promise<string[]> {
         const id = params.route?.id;
@@ -3559,7 +3603,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         timestamp: Date.now(),
         version: DAEMON_VERSION,
         // Build identity for the version-sync banner (apps/agor-ui ConnectionStatus).
-        // SHA precedence is resolved at startup — see setup/build-info.ts.
+        // SHA precedence is resolved at startup - see setup/build-info.ts.
         // Tabs capture this SHA on first connect and prompt a refresh whenever
         // a later handshake reports a different value. 'dev' disables the check.
         buildSha: DAEMON_BUILD_INFO.sha,
@@ -3666,7 +3710,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             managedEnvsExecutionMode:
               config.execution?.managed_envs_execution_mode ?? MANAGED_ENV_EXECUTION_MODE_DEFAULT,
           },
-          // Resolved security posture — admins can confirm in Settings → About
+          // Resolved security posture - admins can confirm in Settings → About
           // which CSP/CORS policy the daemon booted with, without tailing logs
           // or reading response headers by hand. Keep the shape tight: the
           // full CSP header value is the one piece operators actually need
@@ -3838,7 +3882,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   for (const name of SERVICE_GROUP_NAMES) {
     if (!mappedGroups.has(name)) {
       console.warn(
-        `[services] Service group '${name}' has no path mapping — tier hooks will not apply`
+        `[services] Service group '${name}' has no path mapping - tier hooks will not apply`
       );
     }
   }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -590,6 +590,27 @@ export function OnboardingWizard({
             onStatusChange: setOperationText,
           }));
 
+        // Fire-and-forget: always call this after every session
+        // creation/reuse, regardless of which LLM-step button got here
+        // ("Save & Continue", "Continue with Codex CLI auth", or
+        // "Continue without key" - the last of these creates a session
+        // with no credential at all). The daemon route performs a LIVE
+        // credential-resolution check before actually queuing the kickoff
+        // prompt, so this is always safe to call - it just silently
+        // no-ops when there is nothing to talk to the user about yet.
+        // Wrapped in an async IIFE (not just `.catch()`) so a synchronous
+        // throw from `client.service(...)` itself can't escape and fail
+        // wizard completion - this must never block or break setup.
+        void (async () => {
+          try {
+            await client?.service(`sessions/${sessionId}/onboarding/trigger`).create({
+              reason: 'auto',
+            });
+          } catch (err) {
+            console.warn('[OnboardingWizard] Failed to trigger onboarding agent:', err);
+          }
+        })();
+
         setSetupStage('done');
         setOperationText('Opening your assistant…');
         onComplete({ branchId: branch.branch_id, sessionId, boardId, path: 'assistant' });

--- a/apps/agor-ui/src/components/SessionPanel/OnboardingDiscoveryBanner.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/OnboardingDiscoveryBanner.tsx
@@ -1,0 +1,29 @@
+import { CompassOutlined } from '@ant-design/icons';
+import { Alert } from 'antd';
+import type React from 'react';
+
+export interface OnboardingDiscoveryBannerProps {
+  onDismiss: () => void;
+}
+
+/**
+ * One-time discovery banner for a user's first session ever - points at the
+ * "Setup guide" toolbar button (see SessionPanel.tsx) since a brand-new,
+ * non-technical user has no way to otherwise know that affordance exists.
+ * Separate concern from onboarding flow progress itself: dismissing this
+ * banner does not touch the onboarding Knowledge document, and starting or
+ * dismissing the onboarding flow does not touch this banner's own state.
+ */
+export const OnboardingDiscoveryBanner: React.FC<OnboardingDiscoveryBannerProps> = ({
+  onDismiss,
+}) => (
+  <Alert
+    type="info"
+    showIcon
+    icon={<CompassOutlined />}
+    closable
+    onClose={onDismiss}
+    title="New here? Use the Setup guide (compass icon above) anytime to get set up."
+    style={{ marginBottom: 12 }}
+  />
+);

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.onboarding.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.onboarding.test.tsx
@@ -1,0 +1,277 @@
+import type { AgorClient, Branch, Session, User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppActionsProvider } from '../../contexts/AppActionsContext';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { agorStore } from '../../store/agorStore';
+import SessionPanel from './SessionPanel';
+
+vi.mock('../AutocompleteTextarea', () => ({
+  AutocompleteTextarea: () => <textarea aria-label="Prompt" />,
+}));
+
+vi.mock('../FileUpload', () => ({
+  FileUpload: () => null,
+  FileUploadButton: (props: { onClick?: () => void; disabled?: boolean }) => (
+    <button type="button" disabled={props.disabled} onClick={props.onClick}>
+      Upload Files
+    </button>
+  ),
+}));
+
+vi.mock('../ForkSpawnModal/ForkSpawnModal', () => ({
+  ForkSpawnModal: () => null,
+}));
+
+vi.mock('../MCPServer', () => ({
+  MCPServerPill: () => <span>MCP server</span>,
+}));
+
+vi.mock('../metadata', () => ({
+  CreatedByTag: () => <span>Created by test user</span>,
+}));
+
+vi.mock('../Pill', () => ({
+  ContextWindowPill: () => <span>Context window</span>,
+  TimerPill: () => <span>Timer</span>,
+  TokenCountPill: () => <span>Tokens</span>,
+}));
+
+vi.mock('../SessionIds', () => ({
+  SessionIdsButton: () => <span>Session IDs</span>,
+  SessionIdsList: () => <span>Session IDs List</span>,
+}));
+
+vi.mock('../ToolIcon', () => ({
+  ToolIcon: () => <span>Tool icon</span>,
+}));
+
+vi.mock('./SessionAttachmentsDropdown', () => ({
+  SessionAttachmentsDropdown: () => null,
+}));
+
+vi.mock('./SessionMcpFooterControl', () => ({
+  SessionMcpFooterControl: () => null,
+}));
+
+vi.mock('./SessionPanelContent', () => ({
+  SessionPanelContent: () => <div>Session content</div>,
+}));
+
+vi.mock('./SessionRunSettingsPopover', () => ({
+  SessionRunSettingsPopover: () => null,
+}));
+
+vi.mock('../../hooks/useSharedReactiveSession', () => ({
+  useSharedReactiveSession: () => ({ handle: null, state: { tasks: [] } }),
+}));
+
+const connected = {
+  connected: true,
+  connecting: false,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+
+const branch = {
+  branch_id: 'branch-1',
+  board_id: 'board-1',
+  name: 'feature/onboarding',
+  path: '/tmp/feature-onboarding',
+  filesystem_status: 'ready',
+  archived: false,
+} as unknown as Branch;
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: 'session-1',
+    branch_id: 'branch-1',
+    title: 'Onboarding session',
+    agentic_tool: 'claude-code-cli',
+    status: 'idle',
+    archived: false,
+    created_by: 'user-1',
+    created_at: '2026-06-24T00:00:00.000Z',
+    last_updated: '2026-06-24T00:00:00.000Z',
+    ...overrides,
+  } as unknown as Session;
+}
+
+function makeClient(): {
+  client: AgorClient;
+  createMock: ReturnType<typeof vi.fn>;
+  patchUserMock: ReturnType<typeof vi.fn>;
+} {
+  const createMock = vi.fn().mockResolvedValue({ queued: true, reason: 'manual' });
+  const patchUserMock = vi.fn().mockResolvedValue({});
+  const taskEvents = { on: vi.fn(), off: vi.fn() };
+  const client = {
+    service: vi.fn((name: string) => {
+      if (name === 'tasks') return taskEvents;
+      if (name === 'sessions/session-1/onboarding/trigger') {
+        return { create: createMock };
+      }
+      if (name === 'users') {
+        return { patch: patchUserMock };
+      }
+      return { create: createMock, find: vi.fn().mockResolvedValue({ data: [] }) };
+    }),
+  } as unknown as AgorClient;
+  return { client, createMock, patchUserMock };
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    user_id: 'user-1',
+    email: 'user-1@test.local',
+    name: 'Test User',
+    role: 'member',
+    ...overrides,
+  } as unknown as User;
+}
+
+function renderPanel({
+  client,
+  session = makeSession(),
+  currentUserId,
+}: {
+  client: AgorClient | null;
+  session?: Session;
+  currentUserId?: string;
+}) {
+  return render(
+    <ConnectionProvider value={connected}>
+      <AppActionsProvider value={{}}>
+        <AntApp>
+          <SessionPanel
+            client={client}
+            session={session}
+            branch={branch}
+            currentUserId={currentUserId}
+            open
+            onClose={vi.fn()}
+          />
+        </AntApp>
+      </AppActionsProvider>
+    </ConnectionProvider>
+  );
+}
+
+beforeEach(() => {
+  agorStore.getState().reset();
+});
+
+describe('SessionPanel onboarding re-entry affordance', () => {
+  it('shows the Setup guide button for the session owner', () => {
+    const { client } = makeClient();
+    renderPanel({ client, currentUserId: 'user-1' });
+
+    expect(screen.getByRole('img', { name: 'compass' })).toBeInTheDocument();
+  });
+
+  it('hides the Setup guide button when viewing someone else session', () => {
+    const { client } = makeClient();
+    renderPanel({ client, currentUserId: 'user-2' });
+
+    expect(screen.queryByRole('img', { name: 'compass' })).not.toBeInTheDocument();
+  });
+
+  it('hides the Setup guide button when there is no known current user', () => {
+    const { client } = makeClient();
+    renderPanel({ client });
+
+    expect(screen.queryByRole('img', { name: 'compass' })).not.toBeInTheDocument();
+  });
+
+  it('triggers onboarding with reason manual when clicked', async () => {
+    const { client, createMock } = makeClient();
+    renderPanel({ client, currentUserId: 'user-1' });
+
+    fireEvent.click(screen.getByRole('img', { name: 'compass' }).closest('button')!);
+
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalledWith({ reason: 'manual' });
+    });
+  });
+});
+
+const BANNER_TEXT = /New here\? Use the Setup guide/;
+
+describe('SessionPanel discovery banner', () => {
+  it('shows the banner when this is the only session the user has ever created', () => {
+    const { client } = makeClient();
+    agorStore
+      .getState()
+      .setMap('sessionById', new Map([[makeSession().session_id, makeSession()]]));
+    agorStore.getState().setMap('userById', new Map([['user-1', makeUser()]]));
+    renderPanel({ client, currentUserId: 'user-1' });
+
+    expect(screen.getByText(BANNER_TEXT)).toBeInTheDocument();
+  });
+
+  it('hides the banner when the user already has other sessions', () => {
+    const { client } = makeClient();
+    const first = makeSession({ session_id: 'session-0' });
+    const current = makeSession();
+    agorStore.getState().setMap(
+      'sessionById',
+      new Map([
+        [first.session_id, first],
+        [current.session_id, current],
+      ])
+    );
+    agorStore.getState().setMap('userById', new Map([['user-1', makeUser()]]));
+    renderPanel({ client, currentUserId: 'user-1' });
+
+    expect(screen.queryByText(BANNER_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('hides the banner once already dismissed', () => {
+    const { client } = makeClient();
+    agorStore
+      .getState()
+      .setMap('sessionById', new Map([[makeSession().session_id, makeSession()]]));
+    agorStore
+      .getState()
+      .setMap(
+        'userById',
+        new Map([['user-1', makeUser({ preferences: { setupGuideBannerDismissed: true } })]])
+      );
+    renderPanel({ client, currentUserId: 'user-1' });
+
+    expect(screen.queryByText(BANNER_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('hides the banner when there is no known current user', () => {
+    const { client } = makeClient();
+    agorStore
+      .getState()
+      .setMap('sessionById', new Map([[makeSession().session_id, makeSession()]]));
+    renderPanel({ client });
+
+    expect(screen.queryByText(BANNER_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('persists dismissal to user preferences and hides immediately on close', async () => {
+    const { client, patchUserMock } = makeClient();
+    agorStore
+      .getState()
+      .setMap('sessionById', new Map([[makeSession().session_id, makeSession()]]));
+    agorStore.getState().setMap('userById', new Map([['user-1', makeUser()]]));
+    const { container } = renderPanel({ client, currentUserId: 'user-1' });
+
+    expect(screen.getByText(BANNER_TEXT)).toBeInTheDocument();
+    const closeIcon = container.querySelector('.ant-alert-close-icon');
+    expect(closeIcon).toBeTruthy();
+    fireEvent.click(closeIcon!);
+
+    expect(screen.queryByText(BANNER_TEXT)).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(patchUserMock).toHaveBeenCalledWith('user-1', {
+        preferences: { setupGuideBannerDismissed: true },
+      });
+    });
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -22,6 +22,7 @@ import {
   AimOutlined,
   CloseOutlined,
   CodeOutlined,
+  CompassOutlined,
   EllipsisOutlined,
   InboxOutlined,
   SettingOutlined,
@@ -35,7 +36,7 @@ import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useSessionActions } from '../../hooks/useSessionActions';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
-import { useAgorStore } from '../../store/agorStore';
+import { agorStore, useAgorStore } from '../../store/agorStore';
 import {
   selectMcpServerById,
   selectUserAuthenticatedMcpServerIds,
@@ -58,6 +59,7 @@ import {
   getLatestComposerPromptText,
   isBlockingComposerAttachment,
 } from './composerAttachments';
+import { OnboardingDiscoveryBanner } from './OnboardingDiscoveryBanner';
 import type { SessionAttachmentItem } from './SessionAttachmentsDropdown';
 import { SessionAttachmentsDropdown } from './SessionAttachmentsDropdown';
 import { SessionAttachmentTray } from './SessionAttachmentTray';
@@ -70,7 +72,7 @@ import { useComposerAttachments } from './useComposerAttachments';
 export type { PermissionMode };
 
 // ---------------------------------------------------------------------------
-// PromptInput — thin wrapper around AutocompleteTextarea that keeps the typed
+// PromptInput - thin wrapper around AutocompleteTextarea that keeps the typed
 // text in *local* state so that keystrokes never trigger a parent re-render.
 // The parent reads/clears the value imperatively via a ref.
 // ---------------------------------------------------------------------------
@@ -295,7 +297,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 
   const { archiveSession } = useSessionActions(client);
 
-  // Tool capabilities — drives which buttons are shown
+  // Tool capabilities - drives which buttons are shown
   const toolCaps = session?.agentic_tool
     ? AGENTIC_TOOL_CAPABILITIES[session.agentic_tool]
     : undefined;
@@ -337,14 +339,14 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   }, []);
 
   // Input value lives entirely inside PromptInput (local state).
-  // The parent reads it imperatively via promptRef / inputValueRef — no
+  // The parent reads it imperatively via promptRef / inputValueRef - no
   // parent re-renders on keystrokes.
   const promptRef = React.useRef<PromptInputHandle>(null);
   const inputValueRef = React.useRef(session ? getDraft(session.session_id) : '');
   const [hasInput, setHasInput] = React.useState(() => !!inputValueRef.current.trim());
   const handleHasInputChange = React.useCallback((v: boolean) => setHasInput(v), []);
 
-  // getDefaultPermissionMode imported from @agor-live/client — canonical
+  // getDefaultPermissionMode imported from @agor-live/client - canonical
   // per-tool defaults live in core's `getDefaultPermissionMode`. The local
   // shadow that used to live here was stale (missing gemini/opencode/copilot)
   // and silently drifted from the core definition.
@@ -602,6 +604,28 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     setEffortLevel(session?.model_config?.effort || 'high');
   }, [session?.model_config?.effort]);
 
+  // "First session ever" is approximated as "the store currently has
+  // exactly one session created by this user, and it's this one" - the
+  // best available proxy without a dedicated first-login flag (there
+  // isn't one on the User type). Read imperatively via `agorStore.getState()`
+  // rather than a reactive `useAgorStore` selector: this file deliberately
+  // avoids subscribing to the live sessions slice (see the comment above
+  // the `userById`/`mcpServerById` selectors) so streaming session patches
+  // elsewhere in the app don't re-render this panel. Recomputed only when
+  // the viewed session or user actually changes, not on every store update.
+  const [isFirstSessionEver, setIsFirstSessionEver] = React.useState(false);
+  React.useEffect(() => {
+    const sessionId = session?.session_id;
+    if (!currentUserId || !sessionId) {
+      setIsFirstSessionEver(false);
+      return;
+    }
+    const ownSessions = Array.from(agorStore.getState().sessionById.values()).filter(
+      (s) => s.created_by === currentUserId
+    );
+    setIsFirstSessionEver(ownSessions.length === 1 && ownSessions[0]?.session_id === sessionId);
+  }, [session?.session_id, currentUserId]);
+
   // When there's no session, render nothing (panel is collapsed to zero).
   // When open=false, we still render the component tree (hidden) so that
   // antd's CSS-in-JS doesn't garbage-collect component styles.
@@ -630,6 +654,40 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         }
       },
     });
+  };
+
+  const handleTriggerOnboarding = async () => {
+    if (!client || connectionDisabled) {
+      showError('Cannot start the setup guide while disconnected from the daemon.');
+      return;
+    }
+    try {
+      await client
+        .service(`sessions/${session.session_id}/onboarding/trigger`)
+        .create({ reason: 'manual' });
+      showSuccess('Setup guide is on its way in this session.');
+    } catch (error) {
+      showError(error instanceof Error ? error.message : 'Failed to start the setup guide');
+    }
+  };
+
+  const currentUser = currentUserId ? (userById.get(currentUserId) ?? null) : null;
+  const discoveryBannerDismissed = currentUser?.preferences?.setupGuideBannerDismissed === true;
+  const showDiscoveryBanner = isFirstSessionEver && !discoveryBannerDismissed && !!currentUserId;
+
+  const handleDismissDiscoveryBanner = async () => {
+    // Optimistic - hide immediately regardless of persistence outcome; a
+    // failed patch just means it may reappear next session, which is a
+    // fine degrade for a one-time tip, not worth blocking the UI over.
+    setIsFirstSessionEver(false);
+    if (!client || !currentUserId || !currentUser) return;
+    try {
+      await client.service('users').patch(currentUserId, {
+        preferences: { ...currentUser.preferences, setupGuideBannerDismissed: true },
+      });
+    } catch (error) {
+      console.warn('[SessionPanel] Failed to persist discovery banner dismissal:', error);
+    }
   };
 
   const hasBranchActions = !!branch;
@@ -762,7 +820,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       // function ConversationView exposed via onScrollRef.
       if (composerStillOwnsSend) scrollToBottom?.();
     } catch (error) {
-      console.error('Composer send failed — keeping prompt and files in composer:', error);
+      console.error('Composer send failed - keeping prompt and files in composer:', error);
       showError(error instanceof Error ? error.message : 'Failed to send prompt');
     } finally {
       composerSendInFlightRef.current = false;
@@ -808,7 +866,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       // leaves the typed prompt intact for the user to retry.
       promptRef.current?.clear();
     } catch (error) {
-      console.error('Fork failed — keeping prompt in compose box:', error);
+      console.error('Fork failed - keeping prompt in compose box:', error);
     }
   };
 
@@ -833,7 +891,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       await onBtwFork?.(session.session_id, promptToSend);
       promptRef.current?.clear();
     } catch (error) {
-      console.error('BTW fork failed — keeping prompt in compose box:', error);
+      console.error('BTW fork failed - keeping prompt in compose box:', error);
     }
   };
 
@@ -857,7 +915,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     // `parentPermissionMode` is the *parent* session's permission mode for the
     // forwarding prompt; the spawn config's `permissionMode` is rendered into
     // the meta-prompt as the *child* session's intended mode. They're distinct
-    // — don't reuse one for the other.
+    // - don't reuse one for the other.
     const spawnConfig =
       typeof config === 'string'
         ? { userPrompt: config }
@@ -946,7 +1004,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       };
       // Honor the advisor selector's clear action. `model_config` is
       // column-replaced on patch, so we must DELETE the key when the user clears
-      // it (allowClear → undefined) — the spread above would otherwise silently
+      // it (allowClear → undefined) - the spread above would otherwise silently
       // carry the previous value forward (root cause of "no way to turn it off").
       if (newConfig.advisorModel) {
         nextConfig.advisorModel = newConfig.advisorModel;
@@ -1147,6 +1205,11 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           </Space>
           <Space size={4}>
             <SessionAttachmentsDropdown items={attachmentItems} />
+            {currentUserId && session.created_by === currentUserId && (
+              <Tooltip title="Setup guide">
+                <Button type="text" icon={<CompassOutlined />} onClick={handleTriggerOnboarding} />
+              </Tooltip>
+            )}
             <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
               <Tooltip title="More actions">
                 <Button type="text" icon={<EllipsisOutlined />} />
@@ -1174,6 +1237,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px 0`,
         }}
       >
+        {showDiscoveryBanner && (
+          <OnboardingDiscoveryBanner onDismiss={handleDismissDiscoveryBanner} />
+        )}
         <SessionPanelContent
           client={client}
           session={session}
@@ -1195,7 +1261,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           setCliViewMode={setCliViewMode}
         />
 
-        {/* Footer — rendered outside SessionPanelContent so that
+        {/* Footer - rendered outside SessionPanelContent so that
             keystroke-driven re-renders don't propagate to ConversationView.
             Hidden for CLI sessions in 'terminal' view because the embedded
             `claude` REPL has its own input prompt; the Agor textarea is
@@ -1223,7 +1289,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           }}
         />
 
-        {/* Fork modal — opened when Fork button is clicked with an empty textarea */}
+        {/* Fork modal - opened when Fork button is clicked with an empty textarea */}
         <ForkSpawnModal
           open={forkModalOpen}
           action="fork"

--- a/docs/internal/onboarding-agent-prd-2026-07-01.md
+++ b/docs/internal/onboarding-agent-prd-2026-07-01.md
@@ -1,0 +1,156 @@
+# /onboarding - Resumable Conversational Onboarding Agent - PRD
+
+**Status:** Canonical spec for the `feature-onboarding-agent` branch. Supersedes prior scattered chat instructions in that session.
+**Branch:** `feature-onboarding-agent`
+**Date:** 2026-07-01
+
+---
+
+## 1. Background
+
+Agor is a self-hosted, multiplayer command center for orchestrating AI coding agents on isolated git branches, with a spatial 2D board UI. Core terminology to use consistently in all copy and code:
+
+- **Branch** - the unit of work in Agor. A first-class git working directory on its own branch with its own dev environment. Conventionally one branch per feature/PR.
+- **Session** - an agent conversation, tied to a branch. Sessions can fork (sibling) or spawn (child).
+- **Task** - a single prompt-and-execution within a session.
+- **Board** - the spatial canvas where branches live as cards.
+- **Zone** - a region on a board with an optional prompt template that fires when a branch is dropped in.
+- **Assistant** - a persistent AI companion living in a branch, with its own memory and identity.
+- **Environment** - the running dev server instance for a branch.
+- **Knowledge** - the built-in searchable markdown knowledge base, used here for durable state.
+- **MCP** - a pluggable integration/capability your agent can use (e.g. Slack, GitHub, Shortcut).
+- **Cards** - how branches are represented visually on a board.
+- **Artifact** - a live app/preview a session can produce, visible on the board.
+
+A multi-step Onboarding Wizard already exists and runs on first open, but investigation found it's a single "Assistant" bootstrap flow in this codebase (not the originally assumed 5-step Clone/Board/Branch/API-Keys/Launch wizard) - "API key skipped" is inferred live via `agor_users_get_current`, not read from stored wizard step state. This feature fills the gap: a persistent, resumable, conversational onboarding agent living in the chat, dismissable and re-invocable, that picks up exactly where a user left off.
+
+This flow is meant to trigger after "Feature 1" (a separate in-flight "Connect AI" empty state feature, branch `feature-connect-ai-empty-state`, not yet merged) succeeds. Since that branch isn't merged into `main` yet, this flow can't literally hook into Feature 1's event today - see the Trigger section below for the required fallback.
+
+## 2. Investigation findings already confirmed
+
+Reference only - re-verify if anything here seems stale by the time it's read.
+
+1. No real custom slash commands exist in Agor's chat UI. `/onboarding` is implemented as a server-authored system prompt queued via the same `/sessions/:id/prompt` mechanism the `env_vars` widget's auto-resume already uses.
+2. `AskUserQuestion` is fully disallowed in this codebase - all structured choices must be plain conversational text, not a structured prompt call.
+3. Knowledge persistence: per-user private Knowledge namespace (e.g. `onboarding-<shortId(userId)>`), one `kind: 'memory'` document (`progress.md`), step state keyed by string id in `metadata` (not a fixed array) so new steps can append later without a schema change. Created by the agent itself on first write, not pre-provisioned server-side.
+4. Manual re-entry affordance: new "Setup guide" icon button in the `SessionPanel` toolbar, matching the existing `Button type="text"` + `Tooltip` idiom already used for other toolbar actions (e.g. "More actions", "Close Panel").
+5. `env_vars` widget's dismissal convention (three terminal states: `submitted`, `dismissed`, `already_present`; non-looping after dismissal - ask before re-requesting rather than auto-re-prompting) is the pattern to mirror for both single-step skip and whole-flow dismiss.
+
+If any of these turn out to be wrong on re-check, note the correction explicitly rather than silently reverting to the original spec's assumption.
+
+## 3. Trigger (activation precondition, not a flow step)
+
+The flow's precondition is "AI credential confirmed resolved" for that user - not merely "the Onboarding Wizard created the user's assistant session." A session can exist without a working AI credential (that's precisely the bug Feature 1 fixes - today a session with no resolved credential shows a raw CLI passthrough error when the user tries to prompt it). If the onboarding kickoff prompt fires before a credential resolves, the kickoff message itself could hit that same broken path.
+
+- Prefer hooking the trigger into wherever credential resolution success already happens server-side today (e.g. wherever a session's first successful model call happens, or wherever credential resolution is checked) - not session-creation time.
+- If no such clean hook exists yet in `main`, fall back to a live resolution check (reuse whatever logic Feature 1's empty-state check uses, or its underlying function) immediately before firing the kickoff, rather than assuming "wizard ran" implies "credential resolved."
+- Once Feature 1 merges, the long-term correct hook is its own success event (user completes the empty-state CTA) - note this explicitly as a documented follow-up integration point in the PR description, don't block on it.
+
+## 4. Step list (canonical - replaces any earlier step list)
+
+**"Connect an AI provider" is explicitly NOT an in-flow step.** It cannot be, because this agent only exists inside a working chat session, which cannot run without AI already connected - trying to track it as a done/skipped/not-started step is a logical contradiction. It is purely the activation trigger described above. Do not include it in the Knowledge state schema, the todo list, or the opening message's step framing.
+
+Core steps (near-always active unless already done):
+
+1. Point Agor at a repo and create a first branch.
+2. Run a first real prompt in a session - the "aha" moment.
+
+Optional steps (agent picks 1-3 of these based on early conversational read of what the user wants, or what's most relevant - not run mechanically every time):
+
+3. Create/understand a board and a zone.
+4. Invite a teammate, or set up a persistent assistant.
+5. Connect an MCP server (e.g. Slack, GitHub, Shortcut) for richer context. Investigation should confirm today's actual connection flow (Settings page vs. inline) - if it's Settings/OAuth-based rather than something with an inline capture widget, deep-link there (mirroring how Feature 1 deep-links to Settings -> Agentic Tools) rather than building a new capture widget (out of scope per Non-goals).
+6. See/create a first artifact. Investigation should confirm how artifacts currently surface in the UI (board, session view) so the agent points the user at the right existing place rather than building anything new.
+
+**Judgment call:** steps 2 and 6 can be the same moment if it fits naturally - if the user's first real prompt would naturally produce a visible artifact (e.g. a small UI/preview task), nudge them toward that framing so the "aha" moment and the artifact introduction happen together, rather than forcing two separate asks.
+
+**Hard constraint, still in force:** no more than 3-5 _active_ steps in any single flow run (2 core + up to 3 of the 4 optional).
+
+## 5. Conversation design requirements
+
+- Introduce a term (Branch, Board, Zone, Assistant, Environment, Knowledge, MCP, Cards, Artifact) only at the moment it's relevant to the step at hand, in 1-2 sentences - never front-load a glossary. Assume no prior familiarity with git worktrees or coding agents, but don't condescend to users who clearly have that background - read it from how they respond.
+- Bias toward doing, not describing: if a step can be completed by one concrete action, guide the user straight into doing it. Generate the next concrete action immediately rather than waiting on "what next."
+- Opening message: 2-3 sentences max. Say what this is, that it's optional/dismissible, how to bring it back later, then move straight into the first relevant step or question.
+- Tone: collaborative and competent, like a teammate who's done this many times - not a corporate wizard, not falsely enthusiastic, not robotic. Match Agor's existing product copy voice if inferable; default direct and slightly informal.
+
+## 6. Interaction and state requirements
+
+- **Persistence:** per-user, private, `memory`-tagged Knowledge document (per finding #3 above). Must survive across sessions, days, devices.
+- **Resumability:** read state first, before saying anything substantive, on every trigger. Skip done steps silently - no mechanical "skipping step 2" narration. Greet returning users with a one-line status ("last time you got your first branch set up - want to run your first prompt, or is something else on your mind?").
+- **Short-circuit already-satisfied steps:** if a step's precondition is already true when reached, skip it silently - mirrors `env_vars` widget's `already_present` behavior.
+- **Off-topic interruptions:** answer fully and naturally, then offer to resume ("want to keep going with setup, or good for now?"). Bookmark the current step internally so resume is accurate.
+- **Skip vs. dismiss:** skipping a single step persists as skipped, doesn't auto-re-ask, but is still reachable if the user brings it up manually. Dismissing the whole flow persists and stops all auto-triggering - only re-enterable via explicit re-invocation. Mirror the `env_vars` widget's exact non-looping dismissal convention (don't re-request immediately - ask whether to proceed without, or move on).
+- **Progress visibility:** Agor's existing inline Todo List rendering, always visible, never more than 5 items.
+- **Completion:** one consistent closing message for "all steps done" or "flow dismissed," leaving the user clear on what's next and that setup can be reopened later.
+
+## 7. Discovery banner (new UI chrome)
+
+- One-time, dismissable banner shown on a user's first session ever (or the best available proxy if "first session ever" can't be cleanly detected - state which proxy and why).
+- Points at the re-entry affordance ("Setup guide" button / confirmed equivalent). Rationale: solves discoverability even though the button/mechanism exists, since a brand-new user has no way to know it's there otherwise.
+- Dismissal persists per-user, separate from onboarding flow progress itself (a user can dismiss this banner without ever starting or dismissing the onboarding flow). Check whether Agor already has a per-user UI-dismissal mechanism (e.g. via the `users` domain) to reuse before inventing new persistence or overloading the onboarding Knowledge doc.
+- Component: Ant Design's existing dismissable alert/banner pattern, matching whatever's already used elsewhere in the app for one-time notices - not a new visual treatment.
+- Copy: one short sentence plus a dismiss control. Example: "New here? Use the Setup guide anytime to get set up." (adjust wording to match the real affordance).
+
+## 8. Claude-agent-specific best practices
+
+- Do NOT use `AskUserQuestion` (confirmed disallowed in this codebase, finding #2) - use plain conversational text for all structured choices instead.
+- One step or sub-decision per agent turn - don't stack unrelated asks.
+- Write to Knowledge immediately after a step's true completion is confirmed, not speculatively or batched.
+- Every write should be idempotent - a retried/duplicated trigger should not create duplicate Knowledge entries or double-fire the opening message. Check existing state before writing new state.
+- Never narrate internal mechanics to the user ("I'm now checking your Knowledge state...") - do the check, then speak naturally based on the result.
+
+## 9. UI/component requirements
+
+- Most of this feature lives inside the existing chat transcript (text, inline Todo Lists) - no new visual components needed there.
+- New UI chrome, both must be Ant Design components matching Agor's existing patterns exactly, no new component library or custom styling divergence:
+  - The "Setup guide" re-entry button in `SessionPanel` toolbar (matches existing `Button type="text"` + `Tooltip` idiom).
+  - The discovery banner (matches existing dismissable alert/banner pattern in the app).
+
+## 10. Edge cases to explicitly handle
+
+- User re-invokes the flow while a whole-flow dismissal is on record - respect it as an explicit request, resume from stored progress, don't treat it as contradicting the dismissal.
+- Two team members on the same board, each with independent onboarding progress - state must be scoped per-user, not per-board or per-session.
+- Step list/state schema should be appendable later without redesign (string-keyed metadata, not a fixed array - see finding #3).
+- User skips a step, then later organically does that thing anyway outside the flow (e.g. connects a second MCP server unprompted) - don't contradict or re-ask about something already done if the conversation re-enters that area.
+- Onboarding wizard was never run at all (e.g. self-hosted setups) - flow must still degrade gracefully, not assume wizard-specific state exists.
+
+## 11. Explicit non-goals
+
+- No new general-purpose widget types (confirmations, OAuth-connect flows, pickers). Only the `env_vars` widget exists today - reuse it for the credential step specifically; drive everything else through conversational text and inline Todo Lists (no `AskUserQuestion` per finding #2).
+- Do not duplicate or replace the existing Onboarding Wizard.
+- Do not modify credential storage, MCP token issuance, or Scheduler internals.
+- Do not build analytics/instrumentation dashboards - just keep the state schema clean enough to be queryable for that later.
+
+## 12. Testing / verification
+
+- Full flow start to finish as a new user with nothing pre-configured, including the "aha" first-prompt step actually succeeding.
+- Kill/reopen a session mid-flow - confirm resumption reflects true progress, no duplicate opening messages, no lost state.
+- Skip-one-step, then dismiss-whole-flow, then manually re-invoke - confirm each behaves per spec, especially that dismiss doesn't auto-re-trigger and manual re-invocation overrides a prior dismissal.
+- Off-topic interruption mid-step - confirm the agent answers fully, then correctly offers/executes resumption.
+- "Already satisfied" short-circuit - confirm the flow degrades gracefully if the wizard never ran, and that steps skip silently when already true.
+- Trigger-timing correctness: confirm the kickoff does NOT fire before a credential is confirmed resolved (not merely after the wizard runs).
+- Discovery banner: confirm it shows once on first session, never again after dismissal, and dismissal is scoped per-user.
+- Two different users on the same workspace/board - confirm state isolation.
+- Run this repo's lint/typecheck/build/test commands and confirm clean.
+- Read the full opening message and step transitions as a first-time, non-technical user - confirm nothing assumes un-introduced prior knowledge.
+
+## 13. Definition of done
+
+- Re-entry affordance reliably re-opens the flow from correct, true state at any time.
+- A brand-new user is offered the flow automatically once their AI credential is confirmed resolved (not merely once a session/wizard exists), with a warm, correctly-oriented opening message.
+- Core steps (repo+branch, first prompt) plus up to 3 relevant optional steps work end-to-end, including the user genuinely completing a first real prompt.
+- Progress is visibly shown, persists correctly across sessions/days, distinguishes done/skipped/not-started per user, and does not track AI-connection as an in-flow step.
+- Skip and dismiss behave per spec, including non-looping after dismissal.
+- Off-topic interruptions handled gracefully with correct resumption.
+- Discovery banner shows once per user, on first session, dismissable, never reappears after dismissal.
+- No duplicate/contradictory behavior re-entering a partially-complete flow.
+- Lint/typecheck/build/tests all pass.
+
+## 14. Org conventions for this repo
+
+- No em dashes anywhere in copy, docs, or PR text - use a short dash (-) instead.
+- No `Co-Authored-By` lines in any commit.
+- Run lint, typecheck, build, and test locally before pushing; batch fixes into sensible commits.
+- Open the PR as a draft, no exceptions.
+- No self-attribution or "generated by" language in the PR description.
+- Pre-existing/unrelated CI failures are out of scope - note them and stop, don't expand scope.

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -10,7 +10,7 @@ export const TaskStatus = {
   STOPPING: 'stopping', // Stop requested, waiting for SDK to halt
   AWAITING_PERMISSION: 'awaiting_permission',
   AWAITING_INPUT: 'awaiting_input', // Legacy / pre-#1177: AskUserQuestion was disallowed at the SDK; new tasks never enter this state, kept for historical rows
-  TIMED_OUT: 'timed_out', // Permission/input request timed out, executor exited — user must re-prompt
+  TIMED_OUT: 'timed_out', // Permission/input request timed out, executor exited - user must re-prompt
   COMPLETED: 'completed',
   FAILED: 'failed',
   STOPPED: 'stopped', // User-requested stop (distinct from failed)
@@ -20,7 +20,7 @@ export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 
 /**
  * Structured metadata attached to a task. All fields are optional, but the
- * ones that are present are load-bearing — typing them here prevents drift
+ * ones that are present are load-bearing - typing them here prevents drift
  * between the daemon (which writes them) and the UI/services that read them.
  *
  * - `is_agor_callback`: marks a task whose prompt was synthesized by the
@@ -34,7 +34,7 @@ export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
  *   callback owner and `queued_by_user_id` is set to the same value but
  *   the field carries semantic intent rather than ownership).
  * - `child_session_id` / `child_task_id`: lineage breadcrumbs for callback
- *   tasks — the child session/task whose completion produced this prompt.
+ *   tasks - the child session/task whose completion produced this prompt.
  */
 export interface TaskMetadata {
   is_agor_callback?: boolean;
@@ -65,6 +65,14 @@ export interface TaskMetadata {
    * this prompt. Links the task back to the originating widget for audit.
    */
   widget_id?: MessageID;
+  /**
+   * Marks a task queued by the onboarding-agent trigger (see
+   * `apps/agor-daemon/src/onboarding/`). `auto` fires from the Onboarding
+   * Wizard once a credential is actually resolved; `manual` fires from the
+   * re-entry affordance in the session panel. Lets the UI label these
+   * prompts distinctly, same idea as `widget_id` for widget auto-resume.
+   */
+  onboarding_trigger?: 'auto' | 'manual';
 }
 
 /**
@@ -112,7 +120,7 @@ export function isTaskExecuting(task: TaskExecutionState): boolean {
  * Source depends on the agentic tool:
  * - Claude Code: derived from the Claude Agent SDK `getContextUsage()` response.
  * - Codex: extracted from the Codex CLI's `event_msg/token_count.last_token_usage`
- *   payload — see `extractCodexContextSnapshotFromEvent` in the executor.
+ *   payload - see `extractCodexContextSnapshotFromEvent` in the executor.
  *
  * `percentage` is the value the source tool itself reports/displays for
  * "Context XX% used" (i.e. for Codex it is baseline-adjusted to match the
@@ -149,7 +157,7 @@ export interface Task {
 
   /**
    * Structured metadata for the task. Fields here are load-bearing for
-   * auth, lineage, and UI styling — see the per-field comments. When a
+   * auth, lineage, and UI styling - see the per-field comments. When a
    * QUEUED task transitions to RUNNING and a user-message row is written,
    * `is_agor_callback` and `source` are copied onto the new message.metadata
    * so the UI styling for callbacks survives the queue → run hop.
@@ -222,10 +230,10 @@ export interface Task {
   //    Codex CLI event_msg/token_count last_token_usage). This is the common
   //    case and is what UI consumers should rely on.
   // 2. Otherwise the tool's `computeContextWindow()` fallback (per-tool
-  //    heuristic — see tool.interface.ts).
+  //    heuristic - see tool.interface.ts).
   //
   // For display percentages, prefer `contextUsageSnapshot.percentage` over
-  // recomputing here — Codex applies a baseline subtraction that does NOT
+  // recomputing here - Codex applies a baseline subtraction that does NOT
   // equal raw `computed_context_window / contextWindowLimit`.
   computed_context_window?: number;
 


### PR DESCRIPTION
## Summary

Adds a persistent, resumable, conversational onboarding agent that lives in the chat - triggered automatically once a user's AI credential is confirmed resolved, and re-invocable at any time via a "Setup guide" button. Fills the gap left by the existing Onboarding Wizard, whose API-key step is skippable and which has no ongoing way to pick setup back up.

Full spec: [`docs/internal/onboarding-agent-prd-2026-07-01.md`](docs/internal/onboarding-agent-prd-2026-07-01.md) - canonical source of truth for this feature, written and reconciled against actual codebase investigation rather than assumptions.

## What this is, architecturally

No new agent/session type, no new widget type, no slash command (investigation found no real custom-slash-command mechanism in this codebase's chat UI). The "onboarding agent" is a server-authored system prompt (`apps/agor-daemon/src/onboarding/kickoff-prompt.ts`) queued into an ordinary session via the same `/sessions/:id/prompt` path the `env_vars` widget's auto-resume already uses.

**Trigger.** A session existing does not mean AI is connected - "Continue without key" in the wizard creates a session with no credential at all, and firing the kickoff into that session would just surface a raw CLI passthrough error. So the automatic trigger (`apps/agor-daemon/src/onboarding/trigger.ts`) performs a live credential-resolution check (`createCheckAuthService`, the same probe "Test Connection" uses) immediately before queuing, not just "did the wizard run." This is called after every wizard session creation/reuse, and no-ops silently when nothing actually authenticates yet.

**Step list.** "Connect an AI provider" is explicitly *not* a step - it's the activation precondition (see PRD §3-4). Core steps: point Agor at a repo and create a first branch, then run a first real prompt (the "aha" moment). Optional menu (agent picks 1-3 based on the conversation, never runs all of them mechanically): board/zone, invite a teammate or set up a persistent assistant, connect an MCP server (deep-links to Settings, since that's an OAuth/form flow, not something to build inline), see/create a first Artifact (the agent can genuinely build one via `agor_artifacts_publish` and land it in the same moment as the first prompt, when the requested work has a visible output).

**Persistence.** Per-user private Knowledge namespace (`onboarding-<shortId(userId)>`), one `kind: 'memory'` document (`progress.md`), step state keyed by string id in `metadata` so new steps can be appended later without a schema change. Created by the agent itself on first write.

**Discovery banner.** One-time, dismissable Ant Design `Alert` shown on a user's first session ever, pointing at the "Setup guide" button - solves discoverability for a brand-new user who has no way to otherwise know that affordance exists. "First session ever" is approximated client-side (no dedicated first-login flag exists on the `User` type) as "the store currently has exactly one session created by this user, and it's this one." Dismissal persists to `user.preferences` (the same per-user JSON blob already used for audio settings), kept separate from onboarding flow progress itself.

## Deviations from the original spec, forced by what's actually in this codebase

- **No real slash commands.** `/onboarding` is a triggered system prompt, not a `.claude/commands/onboarding.md` file - there's no existing mechanism to seed such a file into every branch worktree without polluting users' own project repos.
- **`AskUserQuestion` is fully disallowed** at the SDK layer in this codebase. All structured choices in the kickoff prompt are specified as plain conversational text, never a structured tool call.
- **The Onboarding Wizard is a single "Assistant" bootstrap flow**, not the originally assumed 5-step Clone/Board/Branch/API-Keys/Launch wizard. "API key skipped" is inferred live rather than read from stored wizard state.
- **PRD placement.** Saved to `docs/internal/onboarding-agent-prd-2026-07-01.md` rather than the originally suggested `docs/onboarding-agent-prd.md` - `docs/internal/` is this repo's actual convention for dated design/spec docs (matches `in-conversation-widgets-design-2026-05-19.md` and similar); the root `docs/` folder holds only two older, un-dated files.
- **Feature 1 follow-up (documented, not blocking).** This flow is meant to trigger after "Feature 1" (a separate in-flight "Connect AI" empty state, branch `feature-connect-ai-empty-state`) succeeds. That branch isn't merged yet, so there's no "credential resolution succeeded" event to hook into server-side today - the live `createCheckAuthService` check is the fallback. Once Feature 1 merges, its own success event is the better long-term hook; the call site to revisit is documented directly in `trigger.ts`.

## Testing

- `apps/agor-daemon/src/onboarding/trigger.test.ts` and `kickoff-prompt.test.ts` - idempotency, the live-credential-check gating (including the specific regression case: wizard ran but nothing actually authenticates), manual-always-overrides-dismissal, per-user namespace isolation.
- `apps/agor-ui/.../SessionPanel.onboarding.test.tsx` - Setup guide button visibility/ownership, discovery banner first-session detection and dismissal persistence.
- Full lint, typecheck, test, and build clean for both `apps/agor-daemon` and `apps/agor-ui`.

## Non-goals honored

No new general-purpose widget types, no changes to credential storage/MCP token issuance/Scheduler internals, no duplication of the existing Onboarding Wizard, no analytics dashboards (state schema is structured cleanly enough to be queryable for that later).