### PR TITLE
fix(assistant-panel): replace collapsed knob with a persistent icon rail

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -92,6 +92,7 @@ import {
   getToggleBoardPanelState,
 } from './boardPanelActions';
 import {
+  capSessionSizeForCanvasMin,
   getContentPanelWidthPercent,
   toContentRelativePercent,
   toViewportRelativePercent,
@@ -218,6 +219,9 @@ const LEFT_PANEL_MAX_SIZE_PERCENT = 45;
 const SESSION_PANEL_MIN_WIDTH_PX = 360;
 const SESSION_PANEL_MAX_SIZE_PERCENT = 75;
 const SESSION_PANEL_MIN_SIZE_FLOOR_PERCENT = 15;
+// Matches the canvas panel's own `minSize` below — kept as one constant so
+// the two cannot drift apart.
+const CANVAS_MIN_SIZE_PERCENT = 20;
 // Width of the persistent icon rail (AssistantPanelRail) shown in place of
 // the panel when collapsed. Replaces the old 0px-collapse + floating
 // reopen-knob pattern (see issue agor-cloud#123).
@@ -570,18 +574,20 @@ export const App: React.FC<AppProps> = ({
     SESSION_PANEL_MAX_SIZE_PERCENT
   );
   // react-resizable-panels sizes the nested `canvas-session` PanelGroup's
-  // panels relative to the content panel, not the viewport — convert.
-  const sessionPanelSizeWithinContent = toContentRelativePercent(
-    effectiveSessionPanelSize,
-    contentPanelWidthPercent
+  // panels relative to the content panel, not the viewport — convert. Both
+  // the default and max are further capped so the canvas panel can always
+  // keep its own `minSize` (CANVAS_MIN_SIZE_PERCENT).
+  const sessionPanelSizeWithinContent = capSessionSizeForCanvasMin(
+    toContentRelativePercent(effectiveSessionPanelSize, contentPanelWidthPercent),
+    CANVAS_MIN_SIZE_PERCENT
   );
-  const sessionPanelMinSizeWithinContent = toContentRelativePercent(
-    sessionPanelMinSize,
-    contentPanelWidthPercent
+  const sessionPanelMaxSizeWithinContent = capSessionSizeForCanvasMin(
+    toContentRelativePercent(SESSION_PANEL_MAX_SIZE_PERCENT, contentPanelWidthPercent),
+    CANVAS_MIN_SIZE_PERCENT
   );
-  const sessionPanelMaxSizeWithinContent = toContentRelativePercent(
-    SESSION_PANEL_MAX_SIZE_PERCENT,
-    contentPanelWidthPercent
+  const sessionPanelMinSizeWithinContent = Math.min(
+    toContentRelativePercent(sessionPanelMinSize, contentPanelWidthPercent),
+    sessionPanelMaxSizeWithinContent
   );
   const sessionPanelRef = useRef<ImperativePanelHandle>(null);
   const leftPanelResizeDraggingRef = useRef(false);
@@ -1415,7 +1421,7 @@ export const App: React.FC<AppProps> = ({
                   defaultSize={
                     effectiveSelectedSessionId ? 100 - sessionPanelSizeWithinContent : 100
                   }
-                  minSize={20}
+                  minSize={CANVAS_MIN_SIZE_PERCENT}
                 >
                   <div style={{ position: 'relative', overflow: 'hidden', height: '100%' }}>
                     {isHomeSurface ? (

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -19,8 +19,7 @@ import type {
   User,
 } from '@agor-live/client';
 import { hasMinimumRole, PermissionScope } from '@agor-live/client';
-import { LeftOutlined, RightOutlined } from '@ant-design/icons';
-import { Layout, Tooltip, Upload } from 'antd';
+import { Layout, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   type ImperativePanelHandle,
@@ -70,7 +69,7 @@ import { hasExplicitEntityRouteTarget } from '../../utils/routeTargets';
 import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { AppHeader } from '../AppHeader';
 import type { BoardAssistantPanelTab } from '../BoardAssistantPanel';
-import { BoardAssistantPanel } from '../BoardAssistantPanel';
+import { AssistantPanelRail, BoardAssistantPanel } from '../BoardAssistantPanel';
 import { BranchModal, type BranchModalTab } from '../BranchModal';
 import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
 import { CreateDialog, type CreateDialogProgress } from '../CreateDialog';
@@ -87,7 +86,11 @@ import { SessionSettingsModal } from '../SessionSettingsModal';
 import { SettingsModal, UserSettingsModal } from '../SettingsModal';
 import { TerminalModal, WEB_TERMINAL_MIN_ROLE } from '../TerminalModal';
 import { ThemeEditorModal } from '../ThemeEditorModal';
-import { getShowCommentsPanelState, getToggleBoardPanelState } from './boardPanelActions';
+import {
+  getSelectAssistantPanelTabState,
+  getShowCommentsPanelState,
+  getToggleBoardPanelState,
+} from './boardPanelActions';
 
 const { Content } = Layout;
 
@@ -210,11 +213,16 @@ const LEFT_PANEL_MAX_SIZE_PERCENT = 45;
 const SESSION_PANEL_MIN_WIDTH_PX = 360;
 const SESSION_PANEL_MAX_SIZE_PERCENT = 75;
 const SESSION_PANEL_MIN_SIZE_FLOOR_PERCENT = 15;
-const LEFT_PANEL_TOGGLE_HIT_SIZE_PX = 44;
-const LEFT_PANEL_TOGGLE_KNOB_SIZE_PX = 30;
+// Width of the persistent icon rail (AssistantPanelRail) shown in place of
+// the panel when collapsed. Replaces the old 0px-collapse + floating
+// reopen-knob pattern (see issue agor-cloud#123).
+const LEFT_PANEL_RAIL_WIDTH_PX = 56;
 
 const getLeftPanelMinSizePercent = (viewportWidth: number) =>
   Math.min(LEFT_PANEL_MAX_SIZE_PERCENT, (LEFT_PANEL_MIN_WIDTH_PX / viewportWidth) * 100);
+
+const getLeftPanelRailSizePercent = (viewportWidth: number) =>
+  (LEFT_PANEL_RAIL_WIDTH_PX / viewportWidth) * 100;
 
 // Express the session panel's 360px minimum through the panel sizing system
 // (a percentage of the current viewport) rather than a CSS px `minWidth`, which
@@ -405,6 +413,11 @@ export const App: React.FC<AppProps> = ({
     [viewportWidth]
   );
 
+  const leftPanelRailSize = useMemo(
+    () => getLeftPanelRailSizePercent(viewportWidth),
+    [viewportWidth]
+  );
+
   const sessionPanelMinSize = useMemo(
     () => getSessionPanelMinSizePercent(viewportWidth),
     [viewportWidth]
@@ -509,6 +522,11 @@ export const App: React.FC<AppProps> = ({
     isHomeSurface ||
     isLeavingHomeSurface ||
     homeExitSidePanelDeferred;
+  // The rail only makes sense when there's a board to open the panel onto,
+  // and stays hidden entirely while a modal-first flow suppresses the panel
+  // (suppressLeftPanel) — same gating the old floating knob used.
+  const leftPanelRailVisible = leftPanelCollapsed && !!currentBoard && !suppressLeftPanel;
+  const leftPanelCollapsedSize = leftPanelRailVisible ? leftPanelRailSize : 0;
 
   // Ref for programmatically controlling the comments panel
   const commentsPanelRef = useRef<ImperativePanelHandle>(null);
@@ -736,6 +754,15 @@ export const App: React.FC<AppProps> = ({
   const handleOpenCommentsPanel = useCallback(() => {
     applyLeftPanelState(getShowCommentsPanelState({ collapsed: true, activeTab: 'assistant' }));
   }, [applyLeftPanelState]);
+
+  // Shared by every AssistantPanelRail button: expand the panel onto
+  // whichever tab was clicked.
+  const handleSelectAssistantPanelTab = useCallback(
+    (tab: BoardAssistantPanelTab) => {
+      applyLeftPanelState(getSelectAssistantPanelTabState(tab));
+    },
+    [applyLeftPanelState]
+  );
 
   const handleCommentSelect = useCallback((commentId: string | null) => {
     // Toggle selection: if clicking same comment, deselect
@@ -1040,6 +1067,11 @@ export const App: React.FC<AppProps> = ({
       ),
     [commentById, currentBoardId]
   );
+  // Shared between AppHeader's comments button and the collapsed rail's
+  // Comments item so both surfaces carry the same badge.
+  const unreadCommentsCount = activeComments.filter(
+    (c: BoardComment) => !c.parent_comment_id
+  ).length;
 
   const currentUserName = user?.name || user?.email?.split('@')[0] || '';
   const hasUserMentions =
@@ -1190,9 +1222,7 @@ export const App: React.FC<AppProps> = ({
           onRetryConnection={stableOnRetryConnection}
           currentBoardName={headerBoard?.name}
           currentBoardIcon={headerBoard?.icon}
-          unreadCommentsCount={
-            activeComments.filter((c: BoardComment) => !c.parent_comment_id).length
-          }
+          unreadCommentsCount={unreadCommentsCount}
           eventStreamEnabled={eventStreamEnabled}
           hasUserMentions={hasUserMentions}
           currentBoardId={headerBoardId}
@@ -1223,13 +1253,27 @@ export const App: React.FC<AppProps> = ({
               order={1}
               ref={commentsPanelRef}
               collapsible
-              defaultSize={leftPanelCollapsed ? 0 : effectiveCommentsPanelSize}
-              collapsedSize={0}
-              minSize={leftPanelCollapsed ? 0 : leftPanelMinSize}
+              defaultSize={leftPanelCollapsed ? leftPanelCollapsedSize : effectiveCommentsPanelSize}
+              collapsedSize={leftPanelCollapsedSize}
+              minSize={leftPanelCollapsed ? leftPanelCollapsedSize : leftPanelMinSize}
               maxSize={LEFT_PANEL_MAX_SIZE_PERCENT}
-              style={{ minWidth: leftPanelCollapsed ? 0 : LEFT_PANEL_MIN_WIDTH_PX }}
+              style={{
+                minWidth: leftPanelCollapsed
+                  ? leftPanelRailVisible
+                    ? LEFT_PANEL_RAIL_WIDTH_PX
+                    : 0
+                  : LEFT_PANEL_MIN_WIDTH_PX,
+              }}
             >
-              {!leftPanelCollapsed && (
+              {leftPanelCollapsed ? (
+                leftPanelRailVisible && (
+                  <AssistantPanelRail
+                    onSelectTab={handleSelectAssistantPanelTab}
+                    unreadCommentsCount={unreadCommentsCount}
+                    hasUserMentions={hasUserMentions}
+                  />
+                )
+              ) : (
                 <BoardAssistantPanel
                   client={client}
                   board={currentBoard || null}
@@ -1296,7 +1340,9 @@ export const App: React.FC<AppProps> = ({
             <Panel
               id="content-panel"
               order={2}
-              defaultSize={leftPanelCollapsed ? 100 : 100 - effectiveCommentsPanelSize}
+              defaultSize={
+                leftPanelCollapsed ? 100 - leftPanelCollapsedSize : 100 - effectiveCommentsPanelSize
+              }
               minSize={40}
             >
               <PanelGroup
@@ -1446,59 +1492,6 @@ export const App: React.FC<AppProps> = ({
               </PanelGroup>
             </Panel>
           </PanelGroup>
-          {currentBoard && (
-            <Tooltip
-              title={leftPanelCollapsed ? 'Open side panel' : 'Close side panel'}
-              placement="right"
-              getPopupContainer={() => document.body}
-            >
-              <button
-                type="button"
-                aria-label={leftPanelCollapsed ? 'Open side panel' : 'Close side panel'}
-                onClick={() => setCommentsPanelCollapsed(!commentsPanelCollapsed)}
-                style={{
-                  position: 'absolute',
-                  top: '50%',
-                  left: leftPanelCollapsed ? 0 : `calc(${effectiveCommentsPanelSize}% + 2px)`,
-                  transform: 'translate(-50%, -50%)',
-                  width: LEFT_PANEL_TOGGLE_HIT_SIZE_PX,
-                  height: LEFT_PANEL_TOGGLE_HIT_SIZE_PX,
-                  padding: 0,
-                  border: 0,
-                  background: 'transparent',
-                  cursor: 'pointer',
-                  pointerEvents: 'auto',
-                  zIndex: 20,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <span
-                  aria-hidden="true"
-                  style={{
-                    width: LEFT_PANEL_TOGGLE_KNOB_SIZE_PX,
-                    height: LEFT_PANEL_TOGGLE_KNOB_SIZE_PX,
-                    borderRadius: '50%',
-                    border: '1px solid var(--ant-color-border)',
-                    background: 'var(--ant-color-bg-container)',
-                    boxShadow: '0 1px 4px rgba(0,0,0,0.18)',
-                    color: 'var(--ant-color-text)',
-                    cursor: 'pointer',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  {leftPanelCollapsed ? (
-                    <RightOutlined style={{ fontSize: 12 }} />
-                  ) : (
-                    <LeftOutlined style={{ fontSize: 12 }} />
-                  )}
-                </span>
-              </button>
-            </Tooltip>
-          )}
         </Content>
         {/* Invisible mount of antd Upload so its CSS-in-JS styles stay
               registered even after the SessionPanel (which contains FileUpload)

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -91,6 +91,11 @@ import {
   getShowCommentsPanelState,
   getToggleBoardPanelState,
 } from './boardPanelActions';
+import {
+  getContentPanelWidthPercent,
+  toContentRelativePercent,
+  toViewportRelativePercent,
+} from './panelSizing';
 
 const { Content } = Layout;
 
@@ -536,7 +541,23 @@ export const App: React.FC<AppProps> = ({
     LEFT_PANEL_MAX_SIZE_PERCENT
   );
 
-  // Session panel size persistence (percentage of available width), scoped per user.
+  // Width of the middle content panel (canvas + session panel), as a
+  // percentage of the full viewport — whatever's left once the left
+  // assistant/comments panel (rail or fully expanded) takes its share. The
+  // session panel's own size is persisted relative to the viewport (below),
+  // so this is the conversion factor used to translate that into the
+  // content-relative percentage react-resizable-panels expects — keeping the
+  // session panel's absolute pixel width stable whenever the left panel
+  // toggles or resizes.
+  const contentPanelWidthPercent = getContentPanelWidthPercent(
+    leftPanelCollapsed,
+    leftPanelCollapsedSize,
+    effectiveCommentsPanelSize
+  );
+
+  // Session panel size persistence: percentage of the FULL VIEWPORT (not of
+  // the content panel), scoped per user, so the chat panel's absolute pixel
+  // width doesn't change when the left panel collapses to a rail or back.
   const [sessionPanelSize, setSessionPanelSize] = useUserLocalStorage<number>(
     user?.user_id,
     'panel:right:size',
@@ -547,6 +568,20 @@ export const App: React.FC<AppProps> = ({
     sessionPanelSize,
     sessionPanelMinSize,
     SESSION_PANEL_MAX_SIZE_PERCENT
+  );
+  // react-resizable-panels sizes the nested `canvas-session` PanelGroup's
+  // panels relative to the content panel, not the viewport — convert.
+  const sessionPanelSizeWithinContent = toContentRelativePercent(
+    effectiveSessionPanelSize,
+    contentPanelWidthPercent
+  );
+  const sessionPanelMinSizeWithinContent = toContentRelativePercent(
+    sessionPanelMinSize,
+    contentPanelWidthPercent
+  );
+  const sessionPanelMaxSizeWithinContent = toContentRelativePercent(
+    SESSION_PANEL_MAX_SIZE_PERCENT,
+    contentPanelWidthPercent
   );
   const sessionPanelRef = useRef<ImperativePanelHandle>(null);
   const leftPanelResizeDraggingRef = useRef(false);
@@ -608,11 +643,17 @@ export const App: React.FC<AppProps> = ({
     }
   }, [effectiveCommentsPanelSize, leftPanelCollapsed]);
 
+  // Re-resize whenever the content-relative size changes — including when
+  // the left panel toggles or resizes and shifts contentPanelWidthPercent,
+  // which sessionPanelSizeWithinContent is derived from. Without this, the
+  // session panel keeps the same content-relative percentage while its
+  // parent's absolute width changes, so its own absolute pixel width would
+  // drift along with the left panel.
   useEffect(() => {
     if (sessionPanelRef.current && (effectiveSelectedSessionId || !eventStreamPanelCollapsed)) {
-      sessionPanelRef.current.resize(effectiveSessionPanelSize);
+      sessionPanelRef.current.resize(sessionPanelSizeWithinContent);
     }
-  }, [effectiveSelectedSessionId, effectiveSessionPanelSize, eventStreamPanelCollapsed]);
+  }, [effectiveSelectedSessionId, sessionPanelSizeWithinContent, eventStreamPanelCollapsed]);
 
   // URL state synchronization - bidirectional sync between URL and state
   useUrlState({
@@ -1337,14 +1378,7 @@ export const App: React.FC<AppProps> = ({
                 }
               }}
             />
-            <Panel
-              id="content-panel"
-              order={2}
-              defaultSize={
-                leftPanelCollapsed ? 100 - leftPanelCollapsedSize : 100 - effectiveCommentsPanelSize
-              }
-              minSize={40}
-            >
+            <Panel id="content-panel" order={2} defaultSize={contentPanelWidthPercent} minSize={40}>
               <PanelGroup
                 id="canvas-session"
                 direction="horizontal"
@@ -1352,13 +1386,25 @@ export const App: React.FC<AppProps> = ({
                 onLayout={(sizes) => {
                   // Persist only user drag updates so panel open/close and
                   // programmatic restores do not overwrite the user's preference.
+                  // sizes[1] is content-relative (react-resizable-panels sizes
+                  // panels relative to their own PanelGroup) — convert back to
+                  // viewport-relative before persisting, matching the frame
+                  // sessionPanelSize is stored in.
                   if (
                     effectiveSelectedSessionId &&
                     rightPanelResizeDraggingRef.current &&
                     sizes.length === 2
                   ) {
+                    const viewportRelativeSize = toViewportRelativePercent(
+                      sizes[1],
+                      contentPanelWidthPercent
+                    );
                     setSessionPanelSize(
-                      clampPercent(sizes[1], sessionPanelMinSize, SESSION_PANEL_MAX_SIZE_PERCENT)
+                      clampPercent(
+                        viewportRelativeSize,
+                        sessionPanelMinSize,
+                        SESSION_PANEL_MAX_SIZE_PERCENT
+                      )
                     );
                   }
                 }}
@@ -1366,7 +1412,9 @@ export const App: React.FC<AppProps> = ({
                 <Panel
                   id="canvas-panel"
                   order={1}
-                  defaultSize={effectiveSelectedSessionId ? 100 - effectiveSessionPanelSize : 100}
+                  defaultSize={
+                    effectiveSelectedSessionId ? 100 - sessionPanelSizeWithinContent : 100
+                  }
                   minSize={20}
                 >
                   <div style={{ position: 'relative', overflow: 'hidden', height: '100%' }}>
@@ -1451,9 +1499,9 @@ export const App: React.FC<AppProps> = ({
                       id="session-panel"
                       order={2}
                       ref={sessionPanelRef}
-                      defaultSize={effectiveSessionPanelSize}
-                      minSize={sessionPanelMinSize}
-                      maxSize={SESSION_PANEL_MAX_SIZE_PERCENT}
+                      defaultSize={sessionPanelSizeWithinContent}
+                      minSize={sessionPanelMinSizeWithinContent}
+                      maxSize={sessionPanelMaxSizeWithinContent}
                     >
                       {effectiveSelectedSessionId ? (
                         <SessionPanel

--- a/apps/agor-ui/src/components/App/boardPanelActions.test.ts
+++ b/apps/agor-ui/src/components/App/boardPanelActions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { getShowCommentsPanelState, getToggleBoardPanelState } from './boardPanelActions';
+import {
+  getSelectAssistantPanelTabState,
+  getShowCommentsPanelState,
+  getToggleBoardPanelState,
+} from './boardPanelActions';
 
 describe('board panel navbar actions', () => {
   it('opens a closed panel on the Comments tab from Show comments tab', () => {
@@ -27,6 +31,17 @@ describe('board panel navbar actions', () => {
     expect(getToggleBoardPanelState({ collapsed: false, activeTab: 'comments' })).toEqual({
       collapsed: true,
       activeTab: 'comments',
+    });
+  });
+
+  it.each([
+    'assistant',
+    'all-sessions',
+    'comments',
+  ] as const)('opens a closed panel on the %s tab when its rail button is clicked', (tab) => {
+    expect(getSelectAssistantPanelTabState(tab)).toEqual({
+      collapsed: false,
+      activeTab: tab,
     });
   });
 });

--- a/apps/agor-ui/src/components/App/boardPanelActions.ts
+++ b/apps/agor-ui/src/components/App/boardPanelActions.ts
@@ -24,3 +24,12 @@ export const getToggleBoardPanelState = (state: BoardLeftPanelState): BoardLeftP
     collapsed: true,
   };
 };
+
+// Used by every AssistantPanelRail button when the panel is collapsed:
+// expand onto whichever tab was clicked.
+export const getSelectAssistantPanelTabState = (
+  tab: BoardAssistantPanelTab
+): BoardLeftPanelState => ({
+  collapsed: false,
+  activeTab: tab,
+});

--- a/apps/agor-ui/src/components/App/panelSizing.test.ts
+++ b/apps/agor-ui/src/components/App/panelSizing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  capSessionSizeForCanvasMin,
   getContentPanelWidthPercent,
   toContentRelativePercent,
   toViewportRelativePercent,
@@ -74,5 +75,21 @@ describe('viewport <-> content relative percent conversion', () => {
 
   it('clamps viewport-relative percent to [0, 100]', () => {
     expect(toViewportRelativePercent(150, 90)).toBe(100);
+  });
+});
+
+describe('capSessionSizeForCanvasMin', () => {
+  it('caps the session panel so the canvas panel keeps its minSize when the left panel is expanded', () => {
+    // Chat pinned at 75% of the viewport (its max); left panel expanded to
+    // 24%, leaving a 76%-wide content panel — converting to content-relative
+    // asks for ~98.7%, which would starve the canvas below its 20% minimum.
+    const contentPanelWidthPercent = getContentPanelWidthPercent(false, 4, 24);
+    const sessionContentRelativePercent = toContentRelativePercent(75, contentPanelWidthPercent);
+
+    expect(capSessionSizeForCanvasMin(sessionContentRelativePercent, 20)).toBeLessThanOrEqual(80);
+  });
+
+  it('passes the size through unchanged when it already leaves the canvas its minimum', () => {
+    expect(capSessionSizeForCanvasMin(50, 20)).toBe(50);
   });
 });

--- a/apps/agor-ui/src/components/App/panelSizing.test.ts
+++ b/apps/agor-ui/src/components/App/panelSizing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getContentPanelWidthPercent,
+  toContentRelativePercent,
+  toViewportRelativePercent,
+} from './panelSizing';
+
+describe('getContentPanelWidthPercent', () => {
+  it('subtracts the rail width from the viewport when collapsed', () => {
+    expect(getContentPanelWidthPercent(true, 4, 24)).toBe(96);
+  });
+
+  it('subtracts the expanded left panel width when open', () => {
+    expect(getContentPanelWidthPercent(false, 4, 24)).toBe(76);
+  });
+});
+
+describe('viewport <-> content relative percent conversion', () => {
+  it('converts a viewport-relative size into a larger content-relative size when the content panel is narrower than the viewport', () => {
+    // Session panel wants 30% of the viewport; content panel is only 76%
+    // of the viewport (left panel expanded to 24%) — so within its own
+    // parent, the session panel must claim a bigger share.
+    expect(toContentRelativePercent(30, 76)).toBeCloseTo(39.4736, 3);
+  });
+
+  it('round-trips back to the original viewport-relative percent', () => {
+    const contentPanelWidthPercent = 76;
+    const viewportRelativePercent = 30;
+    const contentRelativePercent = toContentRelativePercent(
+      viewportRelativePercent,
+      contentPanelWidthPercent
+    );
+    expect(toViewportRelativePercent(contentRelativePercent, contentPanelWidthPercent)).toBeCloseTo(
+      viewportRelativePercent,
+      5
+    );
+  });
+
+  it('keeps the absolute (viewport-relative) session panel size constant when the left panel collapses to a rail', () => {
+    // Left panel expanded (24% of viewport) vs collapsed to a 4%-wide rail.
+    // A session panel pinned at 30% of the viewport should convert to two
+    // different content-relative percentages that both resolve back to the
+    // same 30% of the viewport — i.e. the same absolute pixel width.
+    const viewportRelativePercent = 30;
+    const expandedContentWidth = getContentPanelWidthPercent(false, 4, 24);
+    const collapsedContentWidth = getContentPanelWidthPercent(true, 4, 24);
+
+    const expandedContentRelative = toContentRelativePercent(
+      viewportRelativePercent,
+      expandedContentWidth
+    );
+    const collapsedContentRelative = toContentRelativePercent(
+      viewportRelativePercent,
+      collapsedContentWidth
+    );
+
+    expect(toViewportRelativePercent(expandedContentRelative, expandedContentWidth)).toBeCloseTo(
+      viewportRelativePercent,
+      5
+    );
+    expect(toViewportRelativePercent(collapsedContentRelative, collapsedContentWidth)).toBeCloseTo(
+      viewportRelativePercent,
+      5
+    );
+  });
+
+  it('returns 0 instead of NaN/Infinity when the content panel has no width', () => {
+    expect(toContentRelativePercent(30, 0)).toBe(0);
+  });
+
+  it('clamps content-relative percent to [0, 100]', () => {
+    expect(toContentRelativePercent(90, 10)).toBe(100);
+  });
+
+  it('clamps viewport-relative percent to [0, 100]', () => {
+    expect(toViewportRelativePercent(150, 90)).toBe(100);
+  });
+});

--- a/apps/agor-ui/src/components/App/panelSizing.ts
+++ b/apps/agor-ui/src/components/App/panelSizing.ts
@@ -31,3 +31,14 @@ export const toViewportRelativePercent = (
   contentRelativePercent: number,
   contentPanelWidthPercent: number
 ) => clamp((contentRelativePercent * contentPanelWidthPercent) / 100, 0, 100);
+
+// The session panel shares the content panel with the canvas, which enforces
+// its own `minSize`. A content-relative session size only bounded to [0, 100]
+// can ask for more room than leaves the canvas its minimum; react-resizable-
+// panels then clamps the layout and the session panel visibly jumps when the
+// left panel toggles. Cap the session panel's content-relative percentage so
+// the canvas always keeps at least `canvasMinPercent`.
+export const capSessionSizeForCanvasMin = (
+  sessionContentRelativePercent: number,
+  canvasMinPercent: number
+) => Math.min(sessionContentRelativePercent, 100 - canvasMinPercent);

--- a/apps/agor-ui/src/components/App/panelSizing.ts
+++ b/apps/agor-ui/src/components/App/panelSizing.ts
@@ -1,0 +1,33 @@
+// Pure width math for the resizable App layout panels. Extracted so it's
+// unit-testable without mounting the full App component tree.
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+// Width of the middle "content" panel (canvas + session panel) as a
+// percentage of the full viewport — whatever's left once the left
+// assistant/comments panel (rail or fully expanded) takes its share.
+export const getContentPanelWidthPercent = (
+  leftPanelCollapsed: boolean,
+  leftPanelCollapsedSize: number,
+  leftPanelExpandedSize: number
+) => 100 - (leftPanelCollapsed ? leftPanelCollapsedSize : leftPanelExpandedSize);
+
+// The session/chat panel's persisted size is expressed as a percentage of
+// the full viewport (so its absolute pixel width doesn't change when the
+// left panel toggles between rail and expanded), but react-resizable-panels
+// needs sizes expressed relative to each panel's own immediate parent — the
+// content panel. These two functions convert between the two frames. Both
+// clamp to [0, 100] and guard the divide so a momentarily-zero content width
+// doesn't produce NaN/Infinity.
+export const toContentRelativePercent = (
+  viewportRelativePercent: number,
+  contentPanelWidthPercent: number
+) =>
+  contentPanelWidthPercent > 0
+    ? clamp((viewportRelativePercent / contentPanelWidthPercent) * 100, 0, 100)
+    : 0;
+
+export const toViewportRelativePercent = (
+  contentRelativePercent: number,
+  contentPanelWidthPercent: number
+) => clamp((contentRelativePercent * contentPanelWidthPercent) / 100, 0, 100);

--- a/apps/agor-ui/src/components/BoardAssistantPanel/AssistantPanelRail.test.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/AssistantPanelRail.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AssistantPanelRail } from './AssistantPanelRail';
+
+describe('AssistantPanelRail', () => {
+  it('renders one button per tab, fully visible (no clipped floating knob)', () => {
+    render(<AssistantPanelRail onSelectTab={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Assistant' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sessions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Comments' })).toBeInTheDocument();
+  });
+
+  it('opens the Assistant tab when its button is clicked', () => {
+    const onSelectTab = vi.fn();
+    render(<AssistantPanelRail onSelectTab={onSelectTab} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assistant' }));
+
+    expect(onSelectTab).toHaveBeenCalledExactlyOnceWith('assistant');
+  });
+
+  it('opens the All sessions tab when its button is clicked', () => {
+    const onSelectTab = vi.fn();
+    render(<AssistantPanelRail onSelectTab={onSelectTab} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sessions' }));
+
+    expect(onSelectTab).toHaveBeenCalledExactlyOnceWith('all-sessions');
+  });
+
+  it('opens the Comments tab when its button is clicked', () => {
+    const onSelectTab = vi.fn();
+    render(<AssistantPanelRail onSelectTab={onSelectTab} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Comments' }));
+
+    expect(onSelectTab).toHaveBeenCalledExactlyOnceWith('comments');
+  });
+
+  it('shows no unread badge on Comments when the count is zero', () => {
+    render(<AssistantPanelRail onSelectTab={vi.fn()} unreadCommentsCount={0} />);
+
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('shows the unread badge on Comments when there are unread comments', () => {
+    render(<AssistantPanelRail onSelectTab={vi.fn()} unreadCommentsCount={3} />);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/BoardAssistantPanel/AssistantPanelRail.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/AssistantPanelRail.tsx
@@ -1,5 +1,5 @@
 import { CommentOutlined, RobotOutlined, UnorderedListOutlined } from '@ant-design/icons';
-import { Badge, Tooltip, theme } from 'antd';
+import { Badge, theme } from 'antd';
 import type React from 'react';
 import { memo } from 'react';
 import type { BoardAssistantPanelTab } from './BoardAssistantPanel';
@@ -48,36 +48,35 @@ const AssistantPanelRailComponent: React.FC<AssistantPanelRailProps> = ({
     >
       {RAIL_ITEMS.map((item) => {
         const button = (
-          <Tooltip key={item.key} title={item.label} placement="right">
-            <button
-              type="button"
-              aria-label={item.label}
-              onClick={() => onSelectTab(item.key)}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 2,
-                width: 48,
-                padding: '8px 2px',
-                border: 0,
-                borderRadius: token.borderRadius,
-                background: 'transparent',
-                color: token.colorText,
-                cursor: 'pointer',
-              }}
-              onMouseEnter={(e) => {
-                (e.currentTarget as HTMLButtonElement).style.background = token.colorFillTertiary;
-              }}
-              onMouseLeave={(e) => {
-                (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
-              }}
-            >
-              <span style={{ fontSize: 18, lineHeight: 1 }}>{item.icon}</span>
-              <span style={{ fontSize: 10, lineHeight: 1.2 }}>{item.label}</span>
-            </button>
-          </Tooltip>
+          <button
+            key={item.key}
+            type="button"
+            aria-label={item.label}
+            onClick={() => onSelectTab(item.key)}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 2,
+              width: 48,
+              padding: '8px 2px',
+              border: 0,
+              borderRadius: token.borderRadius,
+              background: 'transparent',
+              color: token.colorText,
+              cursor: 'pointer',
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.background = token.colorFillTertiary;
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
+            }}
+          >
+            <span style={{ fontSize: 18, lineHeight: 1 }}>{item.icon}</span>
+            <span style={{ fontSize: 10, lineHeight: 1.2 }}>{item.label}</span>
+          </button>
         );
 
         if (item.key !== 'comments') return button;

--- a/apps/agor-ui/src/components/BoardAssistantPanel/AssistantPanelRail.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/AssistantPanelRail.tsx
@@ -1,0 +1,104 @@
+import { CommentOutlined, RobotOutlined, UnorderedListOutlined } from '@ant-design/icons';
+import { Badge, Tooltip, theme } from 'antd';
+import type React from 'react';
+import { memo } from 'react';
+import type { BoardAssistantPanelTab } from './BoardAssistantPanel';
+
+interface RailItem {
+  key: BoardAssistantPanelTab;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const RAIL_ITEMS: RailItem[] = [
+  { key: 'assistant', label: 'Assistant', icon: <RobotOutlined /> },
+  { key: 'all-sessions', label: 'Sessions', icon: <UnorderedListOutlined /> },
+  { key: 'comments', label: 'Comments', icon: <CommentOutlined /> },
+];
+
+export interface AssistantPanelRailProps {
+  onSelectTab: (tab: BoardAssistantPanelTab) => void;
+  unreadCommentsCount?: number;
+  hasUserMentions?: boolean;
+}
+
+// Collapsed-state replacement for the old floating reopen knob (issue #123):
+// a persistent, always-fully-visible icon rail rather than a half-clipped,
+// low-contrast circle floating at the panel edge.
+const AssistantPanelRailComponent: React.FC<AssistantPanelRailProps> = ({
+  onSelectTab,
+  unreadCommentsCount = 0,
+  hasUserMentions = false,
+}) => {
+  const { token } = theme.useToken();
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 4,
+        paddingTop: 12,
+        background: token.colorBgContainer,
+        borderRight: `1px solid ${token.colorBorderSecondary}`,
+      }}
+    >
+      {RAIL_ITEMS.map((item) => {
+        const button = (
+          <Tooltip key={item.key} title={item.label} placement="right">
+            <button
+              type="button"
+              aria-label={item.label}
+              onClick={() => onSelectTab(item.key)}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 2,
+                width: 48,
+                padding: '8px 2px',
+                border: 0,
+                borderRadius: token.borderRadius,
+                background: 'transparent',
+                color: token.colorText,
+                cursor: 'pointer',
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = token.colorFillTertiary;
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
+              }}
+            >
+              <span style={{ fontSize: 18, lineHeight: 1 }}>{item.icon}</span>
+              <span style={{ fontSize: 10, lineHeight: 1.2 }}>{item.label}</span>
+            </button>
+          </Tooltip>
+        );
+
+        if (item.key !== 'comments') return button;
+
+        return (
+          <Badge
+            key={item.key}
+            count={unreadCommentsCount}
+            offset={[-10, 10]}
+            style={{
+              backgroundColor: hasUserMentions ? token.colorError : token.colorPrimaryBgHover,
+            }}
+          >
+            {button}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+};
+
+export const AssistantPanelRail = memo(AssistantPanelRailComponent);
+
+export default AssistantPanelRail;

--- a/apps/agor-ui/src/components/BoardAssistantPanel/index.ts
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/index.ts
@@ -1,2 +1,3 @@
+export { AssistantPanelRail } from './AssistantPanelRail';
 export type { BoardAssistantPanelTab } from './BoardAssistantPanel';
 export { BoardAssistantPanel, default } from './BoardAssistantPanel';


### PR DESCRIPTION
## Summary

Fixes https://github.com/preset-io/agor-cloud/issues/123 ("Agent tab: the expand affordance is hard to see"). Note: that issue was filed against `agor-cloud`, but the panel it describes lives in this repo (`agor/apps/agor-ui`) — the fix is here.

- The left assistant/comments panel used to collapse to 0px width with a small floating circular knob as the only way to reopen it. That knob was clipped almost in half by the viewport edge (`left: 0` + `translateX(-50%)`) and used low-contrast neutral tokens that blended into the canvas background.
- Replaced it with `AssistantPanelRail`: a persistent, always-fully-visible 56px icon rail shown while the panel is collapsed, with one stacked icon+label button per tab (Assistant, Sessions, Comments — Slack-nav style). Clicking a button expands the panel directly onto that tab.
- The Comments rail item carries the same unread-count badge (and mention-highlight color) that `AppHeader`'s "Show comments tab" button already has.
- Deleted the old floating knob entirely; the panel's own in-tab-bar "Collapse panel" button is unchanged.
- `AppHeader`'s "Show comments tab" button is left as-is — it's still a useful global comments shortcut regardless of panel state.

Before:
<img width="429" height="817" alt="image" src="https://github.com/user-attachments/assets/d2da64b7-1bb3-4102-a700-e41b664563b5" />

After:

<img width="429" height="817" alt="image" src="https://github.com/user-attachments/assets/8e50919d-640e-454d-9f96-75bc48ad48ea" />


## Test plan

- [x] `pnpm lint` (apps/agor-ui) — clean
- [x] `pnpm typecheck` (apps/agor-ui) — clean
- [x] `pnpm test` (apps/agor-ui) — 665 tests passing, including new coverage: rail renders all 3 buttons, each button opens the correct tab, unread badge shows/hides correctly
- [ ] Manual browser verification — not completed in this session (no browser automation tooling available in the sandbox); recommend a quick manual pass on the deployed preview before merging: collapse the panel, confirm the rail is fully visible with no clipping, click each icon to confirm it opens the right tab.

## Follow-up: session panel width jump

Manual testing of this PR found that collapsing/expanding the left rail also resized the right session panel (its stored size was a percentage of the content panel, which grows/shrinks with the left panel, rather than of the full viewport). Fixed in a follow-up commit: the session panel's persisted size is now viewport-relative and converted to/from the content-panel-relative percentage `react-resizable-panels` needs. Verified with Playwright against the live dev environment: session panel width stayed within ~1px (Playwright layout rounding) across collapse, expand, and dragging the left panel's own resize handle — all previously produced a large, evident jump.

- [x] Manual browser verification — completed against the branch's dev environment: rail is fully visible (not clipped) on collapse, each of the 3 rail buttons opens the correct tab, unread badge shows on Comments, and the session panel width fix above was confirmed with pixel measurements before/after each interaction.