### PR TITLE
fix(executor): handle terminal completion events

### DIFF
--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1164,6 +1164,380 @@ describe('CodexPromptService - tool payload mapping', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// event_msg terminal handling (issue #1749)
+//
+// New Codex rollout format emits terminal completion via `event_msg` payloads
+// with payload.type === "agent_message" or "task_complete" instead of the SDK
+// event turn.completed. Without handling these, the adapter left the task
+// running until the daemon safety-net (~15 min later) marked it failed.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('CodexPromptService - event_msg terminal handling (issue #1749)', () => {
+  function makeStreamingService() {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-mock.md');
+    serviceWithPrivates.buildMcpServersConfig = vi
+      .fn()
+      .mockResolvedValue({ servers: {}, total: 0 });
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-1',
+      branch_id: 'branch-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    });
+    mockBranchesRepo.findById.mockResolvedValue({
+      branch_id: 'branch-1',
+      path: process.cwd(),
+    });
+
+    return service;
+  }
+
+  beforeEach(() => {
+    mockInstanceCount = 0;
+    mockInstanceBaseUrls = [];
+    mockInstanceConfigs = [];
+    mockClosedInstanceIds = [];
+    mockStreamEvents = [];
+    mockStartThreadId = 'mock-thread-id';
+    delete process.env.OPENAI_BASE_URL;
+    vi.clearAllMocks();
+    appServerMocks.forkCodexThreadViaAppServer.mockReset();
+  });
+
+  it('surfaces event_msg agent_message via the actual "message" field (real rollout shape)', async () => {
+    // Actual payload shape from failed-run logs:
+    //   { type: "agent_message", message: "...", phase: "...", memory_citation: ... }
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'agent_message',
+          message: 'All changes have been applied.',
+          phase: 'completed',
+          memory_citation: null,
+        },
+      },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 5 },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const textBlocks = emitted.filter(
+      (e) =>
+        e.type === 'complete' &&
+        Array.isArray(e.content) &&
+        (e.content as Array<{ type: string; text?: string }>).some(
+          (c) => c.type === 'text' && c.text === 'All changes have been applied.'
+        )
+    );
+    expect(textBlocks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('treats event_msg task_complete (real rollout shape) as terminal success', async () => {
+    // Actual payload shape from failed-run logs:
+    //   { type: "task_complete", turn_id: "...", last_agent_message: "...",
+    //     duration_ms: 900000, time_to_first_token_ms: 1234, completed_at: "..." }
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'item.completed',
+        item: {
+          id: 'cmd-1',
+          type: 'command_execution',
+          command: 'echo hi',
+          aggregated_output: 'hi\n',
+          status: 'success',
+        },
+      },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: 'turn-abc123',
+          last_agent_message: 'Done. The script ran successfully.',
+          duration_ms: 900000,
+          time_to_first_token_ms: 1234,
+          completed_at: '2026-07-01T13:00:00Z',
+        },
+      },
+      // No turn.completed — this is the new rollout format.
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const completeEvents = emitted.filter((e) => e.type === 'complete');
+    expect(completeEvents.length).toBeGreaterThanOrEqual(1);
+
+    const last = completeEvents.at(-1);
+    expect(last?.threadId).toBe('mock-thread-id');
+
+    // last_agent_message must appear in content when no prior agent_message pushed text
+    const content = last?.content as Array<{ type: string; text?: string }>;
+    expect(
+      content.some((c) => c.type === 'text' && c.text === 'Done. The script ran successfully.')
+    ).toBe(true);
+  });
+
+  it('uses last_agent_message from task_complete when no prior agent_message event provided text', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: 'turn-xyz',
+          last_agent_message: 'Task completed successfully.',
+          duration_ms: 12000,
+          time_to_first_token_ms: 500,
+          completed_at: '2026-07-01T13:00:05Z',
+        },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const last = emitted.filter((e) => e.type === 'complete').at(-1);
+    const content = last?.content as Array<{ type: string; text?: string }>;
+    expect(
+      content.some((c) => c.type === 'text' && c.text === 'Task completed successfully.')
+    ).toBe(true);
+  });
+
+  it('does not duplicate text when agent_message already pushed the same content before task_complete', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    const finalText = 'All done!';
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'event_msg',
+        // agent_message pushes the text first
+        payload: { type: 'agent_message', message: finalText, phase: 'completed' },
+      },
+      {
+        type: 'event_msg',
+        // task_complete carries the same text in last_agent_message
+        payload: {
+          type: 'task_complete',
+          turn_id: 'turn-dup',
+          last_agent_message: finalText,
+          duration_ms: 5000,
+          time_to_first_token_ms: 200,
+          completed_at: '2026-07-01T13:00:10Z',
+        },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const finalComplete = emitted.filter((e) => e.type === 'complete').at(-1);
+    const content = finalComplete?.content as Array<{ type: string; text?: string }>;
+    // There should be exactly one text block with finalText, not two
+    const textOccurrences = content.filter((c) => c.type === 'text' && c.text === finalText);
+    expect(textOccurrences).toHaveLength(1);
+  });
+
+  it('carries event_msg token_count context snapshot into the task_complete complete event', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: { total_tokens: 30_000 },
+            model_context_window: 272_000,
+          },
+        },
+      },
+      {
+        type: 'event_msg',
+        payload: { type: 'task_complete' },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const last = emitted.filter((e) => e.type === 'complete').at(-1);
+    expect(last?.rawContextUsage).toMatchObject({
+      totalTokens: 30_000,
+      maxTokens: 272_000,
+    });
+  });
+
+  it('throws a clear actionable error when stream ends without any terminal event', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    // Stream ends with no terminal event — simulates process exit with code 0
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      { type: 'item.started', item: { id: 'cmd-1', type: 'command_execution', command: 'ls' } },
+      // Stream just ends — no turn.completed, turn.failed, task_complete, or error
+    ];
+
+    await expect(
+      (async () => {
+        for await (const _event of service.promptSessionStreaming('session-1' as any, 'go')) {
+          // drain
+        }
+      })()
+    ).rejects.toThrow('Codex stream ended without a terminal completion event');
+  });
+
+  it('does not throw when stream ends after a user-requested stop', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    // The service clears stale stop flags before streaming starts, so calling
+    // stopTask() before promptSessionStreaming() has no effect. Instead, we
+    // override the mock Codex thread to signal the stop mid-stream (between
+    // yields) — the same ordering that occurs in production when the UI calls
+    // stopTask() while events are streaming.
+    const mockCodexClient = serviceWithPrivates.codex;
+    mockCodexClient.startThread = vi.fn(() => ({
+      id: 'mock-thread-id',
+      run: vi.fn(),
+      runStreamed: vi.fn().mockResolvedValue({
+        events: (async function* () {
+          yield { type: 'turn.started' };
+          // Signal stop after the first event — before the next event is
+          // processed the for-await loop will check stopRequested and break.
+          service.stopTask('session-1' as any);
+          yield {
+            type: 'item.started',
+            item: { id: 'x', type: 'command_execution', command: 'ls' },
+          };
+          // This event is never reached because the stop check fires first.
+          yield { type: 'turn.completed', usage: {} };
+        })(),
+      }),
+    }));
+
+    const emitted: Array<Record<string, unknown>> = [];
+    await expect(
+      (async () => {
+        for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+          emitted.push(event as Record<string, unknown>);
+        }
+      })()
+    ).resolves.toBeUndefined();
+
+    expect(emitted.some((e) => e.type === 'stopped')).toBe(true);
+  });
+
+  it('ignores unknown event_msg payload types without throwing', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      { type: 'event_msg', payload: { type: 'some_future_payload_type', data: {} } },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 2 },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    expect(emitted.some((e) => e.type === 'complete')).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // MCP server config builder
 //
 // Regression coverage for the fix in this PR: every Codex MCP server config

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1320,6 +1320,39 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     ).toBe(true);
   });
 
+  it('treats event_msg turn_complete alias as terminal success', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'turn_complete',
+          turn_id: 'turn-v2',
+          last_agent_message: 'Done via turn_complete.',
+        },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const last = emitted.filter((e) => e.type === 'complete').at(-1);
+    const content = last?.content as Array<{ type: string; text?: string }>;
+    expect(content.some((c) => c.type === 'text' && c.text === 'Done via turn_complete.')).toBe(
+      true
+    );
+  });
+
   it('uses last_agent_message from task_complete when no prior agent_message event provided text', async () => {
     const service = makeStreamingService();
     const serviceWithPrivates = service as any;
@@ -1401,6 +1434,44 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     // There should be exactly one text block with finalText, not two.
     const textOccurrences = content.filter((c) => c.type === 'text' && c.text === finalText);
     expect(textOccurrences).toHaveLength(1);
+  });
+
+  it('preserves distinct agent_message and last_agent_message text blocks', async () => {
+    const service = makeStreamingService();
+    const serviceWithPrivates = service as any;
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'event_msg',
+        payload: { type: 'agent_message', message: 'Progress update.', phase: 'running' },
+      },
+      {
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: 'turn-final',
+          last_agent_message: 'Final answer.',
+        },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const finalComplete = emitted.filter((e) => e.type === 'complete').at(-1);
+    const content = finalComplete?.content as Array<{ type: string; text?: string }>;
+    expect(content.filter((c) => c.type === 'text').map((c) => c.text)).toEqual([
+      'Progress update.',
+      'Final answer.',
+    ]);
   });
 
   it('carries event_msg token_count context snapshot into the task_complete complete event', async () => {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1393,9 +1393,12 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
       emitted.push(event as Record<string, unknown>);
     }
 
-    const finalComplete = emitted.filter((e) => e.type === 'complete').at(-1);
+    const completeEvents = emitted.filter((e) => e.type === 'complete');
+    expect(completeEvents).toHaveLength(1);
+
+    const finalComplete = completeEvents.at(-1);
     const content = finalComplete?.content as Array<{ type: string; text?: string }>;
-    // There should be exactly one text block with finalText, not two
+    // There should be exactly one text block with finalText, not two.
     const textOccurrences = content.filter((c) => c.type === 'text' && c.text === finalText);
     expect(textOccurrences).toHaveLength(1);
   });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -1262,12 +1262,6 @@ export class CodexPromptService {
                     : '';
             if (text) {
               currentMessage.push({ type: 'text', text });
-              yield {
-                type: 'complete',
-                content: [{ type: 'text', text }],
-                threadId: thread.id || '',
-                resolvedModel,
-              };
             }
             continue;
           }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -1266,7 +1266,7 @@ export class CodexPromptService {
             continue;
           }
 
-          if (payloadType === 'task_complete') {
+          if (payloadType === 'task_complete' || payloadType === 'turn_complete') {
             // Terminal completion event from new Codex rollout format.
             // Treat as equivalent to turn.completed.
             threadId = thread.id || '';
@@ -1276,15 +1276,17 @@ export class CodexPromptService {
             const contextUsage =
               latestContextUsage ?? (await extractLatestContextUsageFromRollout(thread.id || ''));
 
-            // Synthesize final assistant text from last_agent_message only when
-            // no text block was already pushed by a preceding agent_message event.
-            // Avoids duplication when both payloads carry the same text.
-            const hasTextContent = currentMessage.some((block) => block.type === 'text');
+            // Synthesize final assistant text from last_agent_message unless
+            // a preceding agent_message event already pushed the same text.
+            // This preserves distinct progress/final messages without duplicating.
             const lastAgentMessage =
               typeof eventPayload?.last_agent_message === 'string'
                 ? eventPayload.last_agent_message
                 : '';
-            if (!hasTextContent && lastAgentMessage) {
+            const hasSameTextContent = currentMessage.some(
+              (block) => block.type === 'text' && block.text === lastAgentMessage
+            );
+            if (lastAgentMessage && !hasSameTextContent) {
               currentMessage.push({ type: 'text', text: lastAgentMessage });
             }
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -1216,6 +1216,7 @@ export class CodexPromptService {
       let latestContextUsage: ContextUsageSnapshot | undefined;
 
       let eventCount = 0;
+      let didStop = false;
 
       for await (const event of events) {
         eventCount++;
@@ -1225,6 +1226,7 @@ export class CodexPromptService {
         if (this.stopRequested.get(sessionId)) {
           console.log(`🛑 Stop requested for session ${sessionId}, breaking event loop`);
           this.stopRequested.delete(sessionId);
+          didStop = true;
           // Yield stopped event so caller knows execution was stopped early
           yield {
             type: 'stopped',
@@ -1234,12 +1236,83 @@ export class CodexPromptService {
         }
 
         if ((event as { type?: string }).type === 'event_msg') {
-          // Codex emits token_count as generic event_msg payloads.
-          // Capture the latest snapshot so turn.completed can return context usage.
-          const contextSnapshot = extractCodexContextSnapshotFromEvent(event);
-          if (contextSnapshot) {
-            latestContextUsage = contextSnapshot;
+          const eventPayload = (event as { payload?: Record<string, unknown> }).payload;
+          const payloadType = eventPayload?.type;
+
+          if (payloadType === 'token_count') {
+            // Codex emits token_count as generic event_msg payloads.
+            // Capture the latest snapshot so turn.completed can return context usage.
+            const contextSnapshot = extractCodexContextSnapshotFromEvent(event);
+            if (contextSnapshot) {
+              latestContextUsage = contextSnapshot;
+            }
+            continue;
           }
+
+          if (payloadType === 'agent_message') {
+            // New Codex rollout format: final assistant text surfaces via event_msg
+            // rather than an item.completed(agent_message) item.
+            const text =
+              typeof eventPayload?.content === 'string'
+                ? eventPayload.content
+                : typeof eventPayload?.text === 'string'
+                  ? eventPayload.text
+                  : typeof eventPayload?.message === 'string'
+                    ? eventPayload.message
+                    : '';
+            if (text) {
+              currentMessage.push({ type: 'text', text });
+              yield {
+                type: 'complete',
+                content: [{ type: 'text', text }],
+                threadId: thread.id || '',
+                resolvedModel,
+              };
+            }
+            continue;
+          }
+
+          if (payloadType === 'task_complete') {
+            // Terminal completion event from new Codex rollout format.
+            // Treat as equivalent to turn.completed.
+            threadId = thread.id || '';
+            const taskCompleteUsage = extractCodexTokenUsage(
+              (eventPayload?.usage ?? eventPayload?.token_usage) as unknown
+            );
+            const contextUsage =
+              latestContextUsage ?? (await extractLatestContextUsageFromRollout(thread.id || ''));
+
+            // Synthesize final assistant text from last_agent_message only when
+            // no text block was already pushed by a preceding agent_message event.
+            // Avoids duplication when both payloads carry the same text.
+            const hasTextContent = currentMessage.some((block) => block.type === 'text');
+            const lastAgentMessage =
+              typeof eventPayload?.last_agent_message === 'string'
+                ? eventPayload.last_agent_message
+                : '';
+            if (!hasTextContent && lastAgentMessage) {
+              currentMessage.push({ type: 'text', text: lastAgentMessage });
+            }
+
+            codexDebug(
+              `✅ [Codex] task_complete event_msg received for session ${shortId(sessionId)}`
+            );
+
+            yield {
+              type: 'complete',
+              content: currentMessage,
+              toolUses: allToolUses.length > 0 ? allToolUses : undefined,
+              threadId,
+              resolvedModel,
+              usage: taskCompleteUsage,
+              rawContextUsage: contextUsage,
+            };
+
+            return;
+          }
+
+          // Unknown event_msg payload type — ignore silently.
+          codexDebug(`[Codex] Unknown event_msg payload type: ${String(payloadType)}`);
           continue;
         }
 
@@ -1443,6 +1516,18 @@ export class CodexPromptService {
             // Ignore other event types silently
             break;
         }
+      }
+
+      // If we reach here without returning, the stream ended.
+      // A user-requested stop is a valid early exit; anything else means Codex
+      // exited without emitting a terminal event (turn.completed / task_complete),
+      // which is the bug described in issue #1749.
+      if (!didStop) {
+        throw new Error(
+          'Codex stream ended without a terminal completion event (turn.completed or task_complete). ' +
+            'The Codex process may have exited unexpectedly (check the executor logs for exit code 0 clues). ' +
+            'This is usually resolved by retrying the prompt; if it persists, restart the session.'
+        );
       }
     } catch (error) {
       // Check if this is an AbortError from AbortController.abort()

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -1291,7 +1291,7 @@ export class CodexPromptService {
             }
 
             codexDebug(
-              `✅ [Codex] task_complete event_msg received for session ${shortId(sessionId)}`
+              `✅ [Codex] terminal event_msg (${payloadType}) received for session ${shortId(sessionId)}`
             );
 
             yield {
@@ -1516,11 +1516,11 @@ export class CodexPromptService {
 
       // If we reach here without returning, the stream ended.
       // A user-requested stop is a valid early exit; anything else means Codex
-      // exited without emitting a terminal event (turn.completed / task_complete),
+      // exited without emitting a terminal event (turn.completed / task_complete / turn_complete),
       // which is the bug described in issue #1749.
       if (!didStop) {
         throw new Error(
-          'Codex stream ended without a terminal completion event (turn.completed or task_complete). ' +
+          'Codex stream ended without a terminal completion event (turn.completed, task_complete, or turn_complete). ' +
             'The Codex process may have exited unexpectedly (check the executor logs for exit code 0 clues). ' +
             'This is usually resolved by retrying the prompt; if it persists, restart the session.'
         );


### PR DESCRIPTION
## Linked issue

Fixes #1749

## Summary

- Recognize terminal `event_msg` completion payloads in the executor stream.
- Persist final assistant text from `agent_message` and `task_complete.last_agent_message` without duplicating it.
- Add focused coverage for current rollout payload shapes and stream-end failure behavior.

## Why / context

Some sessions were being marked failed after the underlying stream had already emitted a successful terminal event. The adapter only treated `turn.completed` as terminal success, so newer `event_msg.task_complete` payloads left the Agor task in `running` until the executor exited and the daemon safety net marked it failed.

This showed up to users as an apparent ~15-minute stop/failure. In the representative failing run, the underlying stream emitted `task_complete` after about 10 minutes, but Agor ignored that terminal event and kept the task marked `running`. A few minutes later, around the 15-minute mark from task start, the executor process closed while Agor still considered the task active. The daemon then applied its safety-net behavior and marked the still-running task failed with an error such as `Executor exited unexpectedly with code 0` or, in some races, heartbeat lost. The 15-minute timing was therefore a symptom of the stream/process lifecycle after the missed terminal event, not an intentional Agor task timeout.

## Implementation notes

- `event_msg.token_count` still updates context usage as before.
- `event_msg.agent_message` is surfaced as assistant text when present.
- `event_msg.task_complete` now returns terminal success and carries the latest context snapshot.
- If the stream ends without `turn.completed`, `task_complete`, `turn.failed`, `error`, or a user stop, the executor throws a clear terminal-event error instead of falling through silently.
- Pending todo items are not auto-marked complete; the UI continues to reflect only persisted todo-list updates.

## Validation / test plan

- [x] `pnpm --filter @agor/executor test -- src/sdk-handlers/codex/prompt-service.test.ts` — 38/38 passed
- [x] Pre-commit `biome ci --no-errors-on-unmatched --files-ignore-unknown=true` passed for changed files

## Screenshots / demos

Not applicable; executor behavior and tests only.

## Risks / rollout / rollback

Risk is limited to executor stream handling for the affected SDK path. Rollback is reverting this commit, which restores the previous terminal-event behavior.

## Out of scope / follow-ups

Live end-to-end validation with a real session using the patched daemon is still recommended before marking the issue fully closed.

