### PR TITLE
fix(settings): keep saved Claude model default from reverting to Sonnet 5 (#1769)

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -19,29 +19,40 @@ vi.mock('../AgenticToolConfigForm', async () => {
 
   return {
     AgenticToolConfigForm: ({ agenticTool }: { agenticTool: AgenticToolName }) => (
-      <Form.Item name="permissionMode" label="Permission Mode">
-        <Radio.Group>
-          <Radio value="default">{agenticTool} default</Radio>
-          <Radio value="acceptEdits">{agenticTool} acceptEdits</Radio>
-          <Radio value="ask">{agenticTool} ask</Radio>
-          <Radio value="allow-all">{agenticTool} allow-all</Radio>
-        </Radio.Group>
-      </Form.Item>
+      <>
+        <Form.Item name="permissionMode" label="Permission Mode">
+          <Radio.Group>
+            <Radio value="default">{agenticTool} default</Radio>
+            <Radio value="acceptEdits">{agenticTool} acceptEdits</Radio>
+            <Radio value="ask">{agenticTool} ask</Radio>
+            <Radio value="allow-all">{agenticTool} allow-all</Radio>
+          </Radio.Group>
+        </Form.Item>
+        {/* Stand-in for ModelSelector so tests can assert the saved model alias. */}
+        <Form.Item name="model" label="Model">
+          <Radio.Group>
+            <Radio value="claude-sonnet-5">{agenticTool} model claude-sonnet-5</Radio>
+            <Radio value="claude-opus-4-8">{agenticTool} model claude-opus-4-8</Radio>
+          </Radio.Group>
+        </Form.Item>
+      </>
     ),
     buildConfigFromFormValues: (
       _tool: AgenticToolName,
-      values: { permissionMode?: string; mcpServerIds?: string[] }
+      values: { permissionMode?: string; mcpServerIds?: string[]; model?: string }
     ) => ({
       permissionMode: values.permissionMode,
       mcpServerIds: values.mcpServerIds ?? [],
+      ...(values.model ? { model: values.model } : {}),
     }),
     getClearedFormValues: () => ({ permissionMode: 'default', mcpServerIds: [] }),
     getFormValuesFromConfig: (
       _tool: AgenticToolName,
-      config?: { permissionMode?: string; mcpServerIds?: string[] }
+      config?: { permissionMode?: string; mcpServerIds?: string[]; model?: string }
     ) => ({
       permissionMode: config?.permissionMode ?? 'default',
       mcpServerIds: config?.mcpServerIds ?? [],
+      model: config?.model,
     }),
   };
 });
@@ -111,6 +122,58 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     }, ASYNC);
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByRole('heading', { name: 'Codex' })).toBeInTheDocument();
+  });
+
+  it('keeps a saved Claude model alias after the post-save re-hydration (#1769)', async () => {
+    // Stale `user` prop that never reflects the save — mirrors the realtime lag
+    // between the resolved patch and the Feathers `patched` event that refreshes
+    // the prop. Before the fix, clearing the draft after save re-ran hydration
+    // against this stale config and snapped the field back to sonnet-5.
+    const user = makeUser({
+      default_agentic_config: {
+        'claude-code': { permissionMode: 'default', mcpServerIds: [], model: 'claude-sonnet-5' },
+      },
+    });
+    const onUpdate = vi.fn(async () => {});
+    const onClose = vi.fn();
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={onClose}
+        user={user}
+        currentUser={user}
+        client={null as AgorClient | null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /claude code/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText('claude-code model claude-sonnet-5')).toBeChecked();
+    }, ASYNC);
+
+    fireEvent.click(screen.getByLabelText('claude-code model claude-opus-4-8'));
+    expect(screen.getByLabelText('claude-code model claude-opus-4-8')).toBeChecked();
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith('user-1', {
+        default_agentic_config: {
+          'claude-code': {
+            permissionMode: 'default',
+            mcpServerIds: [],
+            model: 'claude-opus-4-8',
+          },
+        },
+      });
+    }, ASYNC);
+
+    // Regression assertion: the just-saved alias must survive the post-save
+    // draft-clear even though `user` is still stale.
+    expect(screen.getByLabelText('claude-code model claude-opus-4-8')).toBeChecked();
+    expect(screen.getByLabelText('claude-code model claude-sonnet-5')).not.toBeChecked();
   });
 
   it('clears the password field after saving General settings in place', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -17,6 +17,24 @@ vi.mock('../ApiKeyFields', () => ({
 vi.mock('../AgenticToolConfigForm', async () => {
   const { Form, Radio } = await import('antd');
 
+  const MockModelSelector = ({
+    agenticTool,
+    value,
+    onChange,
+  }: {
+    agenticTool: AgenticToolName;
+    value?: { model?: string };
+    onChange?: (value: { mode: 'alias'; model: string }) => void;
+  }) => (
+    <Radio.Group
+      value={value?.model}
+      onChange={(event) => onChange?.({ mode: 'alias', model: event.target.value })}
+    >
+      <Radio value="claude-sonnet-5">{agenticTool} model claude-sonnet-5</Radio>
+      <Radio value="claude-opus-4-8">{agenticTool} model claude-opus-4-8</Radio>
+    </Radio.Group>
+  );
+
   return {
     AgenticToolConfigForm: ({ agenticTool }: { agenticTool: AgenticToolName }) => (
       <>
@@ -28,31 +46,36 @@ vi.mock('../AgenticToolConfigForm', async () => {
             <Radio value="allow-all">{agenticTool} allow-all</Radio>
           </Radio.Group>
         </Form.Item>
-        {/* Stand-in for ModelSelector so tests can assert the saved model alias. */}
-        <Form.Item name="model" label="Model">
-          <Radio.Group>
-            <Radio value="claude-sonnet-5">{agenticTool} model claude-sonnet-5</Radio>
-            <Radio value="claude-opus-4-8">{agenticTool} model claude-opus-4-8</Radio>
-          </Radio.Group>
+        {/* Stand-in for ModelSelector so tests can assert the saved modelConfig alias. */}
+        <Form.Item name="modelConfig" label="Model">
+          <MockModelSelector agenticTool={agenticTool} />
         </Form.Item>
       </>
     ),
     buildConfigFromFormValues: (
       _tool: AgenticToolName,
-      values: { permissionMode?: string; mcpServerIds?: string[]; model?: string }
+      values: {
+        permissionMode?: string;
+        mcpServerIds?: string[];
+        modelConfig?: { mode?: string; model?: string };
+      }
     ) => ({
       permissionMode: values.permissionMode,
       mcpServerIds: values.mcpServerIds ?? [],
-      ...(values.model ? { model: values.model } : {}),
+      ...(values.modelConfig ? { modelConfig: values.modelConfig } : {}),
     }),
     getClearedFormValues: () => ({ permissionMode: 'default', mcpServerIds: [] }),
     getFormValuesFromConfig: (
       _tool: AgenticToolName,
-      config?: { permissionMode?: string; mcpServerIds?: string[]; model?: string }
+      config?: {
+        permissionMode?: string;
+        mcpServerIds?: string[];
+        modelConfig?: { mode?: string; model?: string };
+      }
     ) => ({
       permissionMode: config?.permissionMode ?? 'default',
       mcpServerIds: config?.mcpServerIds ?? [],
-      model: config?.model,
+      modelConfig: config?.modelConfig,
     }),
   };
 });
@@ -131,7 +154,11 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     // against this stale config and snapped the field back to sonnet-5.
     const user = makeUser({
       default_agentic_config: {
-        'claude-code': { permissionMode: 'default', mcpServerIds: [], model: 'claude-sonnet-5' },
+        'claude-code': {
+          permissionMode: 'default',
+          mcpServerIds: [],
+          modelConfig: { mode: 'alias', model: 'claude-sonnet-5' },
+        },
       },
     });
     const onUpdate = vi.fn(async () => {});
@@ -164,7 +191,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
           'claude-code': {
             permissionMode: 'default',
             mcpServerIds: [],
-            model: 'claude-opus-4-8',
+            modelConfig: { mode: 'alias', model: 'claude-opus-4-8' },
           },
         },
       });

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -247,6 +247,18 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   // Hydrate tab-specific forms only after that tab has rendered its
   // corresponding <Form>. Calling setFieldsValue on never-mounted form
   // instances triggers Ant's "useForm is not connected" console warning.
+  //
+  // `agenticConfigDraftByTool` is intentionally NOT a dependency: it is read as
+  // a "prefer the in-progress edit over the persisted config" source, but must
+  // not itself re-trigger hydration. On tab switch the effect already re-runs
+  // (via `activeTab`) with a fresh closure over the latest draft. Including the
+  // draft in the deps caused a post-save revert (#1769): `saveAgenticConfigs`
+  // clears the draft immediately after the patch resolves, which re-ran this
+  // effect against a `user` prop that had not yet been refreshed by the realtime
+  // `patched` event — reapplying the stale/empty config and wiping the just-saved
+  // model. Reacting only to `activeTab`/`user`/`open` keeps hydration correct
+  // while leaving the saved value in place until fresh `user` data arrives.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: draft is read-only here; see comment above.
   useEffect(() => {
     if (!open || !user) return;
 
@@ -268,7 +280,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           audioPrefs?.minDurationSeconds ?? DEFAULT_AUDIO_PREFERENCES.minDurationSeconds,
       });
     }
-  }, [activeTab, agenticConfigDraftByTool, audioForm, agenticFormByTool, open, user]);
+  }, [activeTab, audioForm, agenticFormByTool, open, user]);
 
   // Rehydrate per-tool credential presence and env-var metadata from the
   // server every time the modal opens, so flags reflect the latest patch.


### PR DESCRIPTION
Closes #1769.

## Problem

In **User Settings → Agentic Tools → Claude Code → Defaults**, selecting a Claude model alias (e.g. `claude-opus-4-8`) and clicking **Save** appeared to revert the selection back to Sonnet 5.

## Confirmed root cause

The value *is* persisted correctly — the form resets its own displayed value right after saving, so it only looks reverted.

- The tab-hydration effect in `UserSettingsModal.tsx` listed `agenticConfigDraftByTool` in its dependency array.
- `saveAgenticConfigs` clears the draft for the saved tool immediately after the patch resolves.
- Clearing the draft re-ran the hydration effect, which re-reads from the `user` prop's `default_agentic_config`. The `user` prop hadn't yet been refreshed by the realtime Feathers `patched` event, so hydration reapplied the **stale/empty** config and wiped the just-saved `modelConfig`.
- `ModelSelector` displays `value?.model || fallbackModel`, so an emptied field silently shows its fallback — the first entry in the live Anthropic models list, i.e. **Sonnet 5**. Hence the apparent revert.

(Verified the daemon patch persists `modelConfig` correctly via `apps/agor-daemon/src/services/users.ts`, so this was purely a client-side re-hydration race.)

## Fix

Drop `agenticConfigDraftByTool` from the hydration effect's dependency array. The draft is still *read* (preferred over the persisted config when present), but clearing it no longer re-triggers hydration. The effect still re-runs on `activeTab` / `user` / `open` changes with a fresh closure over the latest draft, so tab-switch hydration is unaffected.

Chosen over the alternatives (reordering the draft-clear to wait for a refreshed `user`, or one-shot hydration) as the least invasive change that removes the race at its source. A code comment documents the reasoning.

## Testing

- Added a regression test in `UserSettingsModal.test.tsx` that saves a model alias against a deliberately **stale** `user` prop and asserts the selection survives the post-save re-hydration.
- `pnpm test src/components/SettingsModal/UserSettingsModal.test.tsx` → **4/4 pass**
- `pnpm lint` (biome) on the changed files → **clean**
- `turbo run typecheck --filter=agor-ui` → **pass**

## Follow-up (not in this PR)

Consider making the `ModelSelector` fallback "honest" — distinguishing "no selection (showing recommended default)" from a real stored value — so a cleared field can never masquerade as a saved one. Filed as a hardening idea; out of scope for this targeted fix.
