### PR TITLE
fix(ui): preserve session tree collapse state

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -1,10 +1,8 @@
 import type { Branch, Session, User } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { App as AntApp } from 'antd';
 import type React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
-import { BranchSessionSections } from './BranchSessionSections';
 
 vi.mock('antd', async (importOriginal) => {
   const actual = await importOriginal<typeof import('antd')>();
@@ -44,6 +42,11 @@ vi.mock('antd', async (importOriginal) => {
     Tree: MockTree,
   };
 });
+
+const [{ App: AntApp }, { BranchSessionSections }] = await Promise.all([
+  import('antd'),
+  import('./BranchSessionSections'),
+]);
 
 const branch = {
   branch_id: 'branch-1',

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -277,4 +277,81 @@ describe('BranchSessionSections', () => {
 
     expect(screen.getByText('Child session')).toBeInTheDocument();
   });
+
+  it('keeps a manually collapsed parent collapsed when it loses and regains children', async () => {
+    const parentSession = makeManualSession({
+      session_id: 'session-parent',
+      title: 'Parent session',
+      genealogy: { children: ['session-child-1'] },
+    });
+    const firstChild = makeManualSession({
+      session_id: 'session-child-1',
+      title: 'First child',
+      genealogy: { parent_session_id: 'session-parent', children: [] },
+    });
+    const secondChild = makeManualSession({
+      session_id: 'session-child-2',
+      title: 'Second child',
+      genealogy: { parent_session_id: 'session-parent', children: [] },
+    });
+
+    const { rerender } = renderSections({ sessions: [parentSession, firstChild] });
+
+    expect(screen.getByText('First child')).toBeInTheDocument();
+
+    fireEvent.click(getSessionTreeToggle('Parent session'));
+
+    await waitFor(() => expect(screen.queryByText('First child')).not.toBeInTheDocument());
+
+    rerender(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <AntApp>
+          <BranchSessionSections
+            branch={branch}
+            sessions={[{ ...parentSession, genealogy: { children: [] } }]}
+            userById={new Map<string, User>()}
+            onSessionClick={vi.fn()}
+            onCreateSession={vi.fn()}
+            client={null}
+          />
+        </AntApp>
+      </ConnectionProvider>
+    );
+
+    rerender(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <AntApp>
+          <BranchSessionSections
+            branch={branch}
+            sessions={[
+              { ...parentSession, genealogy: { children: ['session-child-2'] } },
+              secondChild,
+            ]}
+            userById={new Map<string, User>()}
+            onSessionClick={vi.fn()}
+            onCreateSession={vi.fn()}
+            client={null}
+          />
+        </AntApp>
+      </ConnectionProvider>
+    );
+
+    expect(screen.queryByText('Second child')).not.toBeInTheDocument();
+  });
 });

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -82,6 +82,24 @@ function makeManualSession(
   } as unknown as Session;
 }
 
+function getSessionTreeToggle(sessionTitle: string): HTMLElement {
+  const mockedToggle = screen.queryByLabelText(
+    new RegExp(`(collapse|expand) ${sessionTitle}`, 'i')
+  );
+  if (mockedToggle) return mockedToggle;
+
+  const titleElement = screen.getByText(sessionTitle);
+  const treeNode = titleElement.closest('.ant-tree-treenode');
+  const switcher = treeNode?.querySelector<HTMLElement>(
+    ':scope > .ant-tree-switcher:not(.ant-tree-switcher-noop)'
+  );
+  if (!switcher) {
+    throw new Error(`Unable to find tree toggle for ${sessionTitle}`);
+  }
+
+  return switcher;
+}
+
 function renderSections(props: Partial<React.ComponentProps<typeof BranchSessionSections>> = {}) {
   return render(
     <ConnectionProvider
@@ -188,7 +206,7 @@ describe('BranchSessionSections', () => {
 
     expect(screen.getByText('Child session')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText(/collapse parent session/i));
+    fireEvent.click(getSessionTreeToggle('Parent session'));
 
     await waitFor(() => expect(screen.queryByText('Child session')).not.toBeInTheDocument());
 
@@ -216,7 +234,6 @@ describe('BranchSessionSections', () => {
       </ConnectionProvider>
     );
 
-    expect(screen.getByLabelText(/expand parent session/i)).toBeInTheDocument();
     expect(screen.queryByText('Child session')).not.toBeInTheDocument();
   });
 
@@ -258,7 +275,6 @@ describe('BranchSessionSections', () => {
       </ConnectionProvider>
     );
 
-    expect(screen.getByLabelText(/collapse parent session/i)).toBeInTheDocument();
     expect(screen.getByText('Child session')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -1,10 +1,49 @@
 import type { Branch, Session, User } from '@agor-live/client';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import { BranchSessionSections } from './BranchSessionSections';
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+
+  const MockTree = ({ treeData, expandedKeys = [], onExpand, titleRender }: any) => {
+    const expandedKeySet = new Set(expandedKeys);
+
+    const renderNodes = (nodes: any[]) =>
+      nodes.map((node) => {
+        const hasChildren = Boolean(node.children?.length);
+        const expanded = expandedKeySet.has(node.key);
+        const nextExpandedKeys = expanded
+          ? expandedKeys.filter((key: React.Key) => key !== node.key)
+          : [...expandedKeys, node.key];
+        const title = titleRender ? titleRender(node) : node.title;
+
+        return (
+          <div key={node.key}>
+            {hasChildren && (
+              <button
+                type="button"
+                aria-label={`${expanded ? 'Collapse' : 'Expand'} ${node.session.title}`}
+                onClick={() => onExpand?.(nextExpandedKeys)}
+              />
+            )}
+            {title}
+            {hasChildren && expanded && <div>{renderNodes(node.children)}</div>}
+          </div>
+        );
+      });
+
+    return <div role="tree">{renderNodes(treeData)}</div>;
+  };
+
+  return {
+    ...actual,
+    Tree: MockTree,
+  };
+});
 
 const branch = {
   branch_id: 'branch-1',
@@ -118,5 +157,105 @@ describe('BranchSessionSections', () => {
     expect(screen.queryByText('Archived parent')).not.toBeInTheDocument();
     expect(screen.getByText('Visible child')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('keeps a manually collapsed parent collapsed after selecting another session', async () => {
+    const parentSession = makeManualSession({
+      session_id: 'session-parent',
+      title: 'Parent session',
+      genealogy: { children: ['session-child'] },
+    });
+    const childSession = makeManualSession({
+      session_id: 'session-child',
+      title: 'Child session',
+      genealogy: { parent_session_id: 'session-parent', children: [] },
+    });
+    const otherSession = makeManualSession({
+      session_id: 'session-other',
+      title: 'Other session',
+    });
+    const sessions = [parentSession, childSession, otherSession];
+    const onSessionClick = vi.fn();
+
+    const { rerender } = renderSections({
+      sessions,
+      selectedSessionId: 'session-parent',
+      onSessionClick,
+    });
+
+    expect(screen.getByText('Child session')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText(/collapse parent session/i));
+
+    await waitFor(() => expect(screen.queryByText('Child session')).not.toBeInTheDocument());
+
+    rerender(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <AntApp>
+          <BranchSessionSections
+            branch={branch}
+            sessions={sessions.map((session) => ({ ...session }))}
+            userById={new Map<string, User>()}
+            selectedSessionId="session-other"
+            onSessionClick={onSessionClick}
+            onCreateSession={vi.fn()}
+            client={null}
+          />
+        </AntApp>
+      </ConnectionProvider>
+    );
+
+    expect(screen.getByLabelText(/expand parent session/i)).toBeInTheDocument();
+    expect(screen.queryByText('Child session')).not.toBeInTheDocument();
+  });
+
+  it('expands a session when it newly gains children', () => {
+    const parentSession = makeManualSession({
+      session_id: 'session-parent',
+      title: 'Parent session',
+    });
+    const childSession = makeManualSession({
+      session_id: 'session-child',
+      title: 'Child session',
+      genealogy: { parent_session_id: 'session-parent', children: [] },
+    });
+
+    const { rerender } = renderSections({ sessions: [parentSession] });
+
+    expect(screen.queryByText('Child session')).not.toBeInTheDocument();
+
+    rerender(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <AntApp>
+          <BranchSessionSections
+            branch={branch}
+            sessions={[{ ...parentSession }, childSession]}
+            userById={new Map<string, User>()}
+            onSessionClick={vi.fn()}
+            onCreateSession={vi.fn()}
+            client={null}
+          />
+        </AntApp>
+      </ConnectionProvider>
+    );
+
+    expect(screen.getByLabelText(/collapse parent session/i)).toBeInTheDocument();
+    expect(screen.getByText('Child session')).toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -7,7 +7,7 @@ import { ConnectionProvider } from '../../contexts/ConnectionContext';
 vi.mock('antd', async (importOriginal) => {
   const actual = await importOriginal<typeof import('antd')>();
 
-  const MockTree = ({ treeData, expandedKeys = [], onExpand, titleRender }: any) => {
+  const MockTree = ({ treeData, expandedKeys = [], onExpand, switcherIcon, titleRender }: any) => {
     const expandedKeySet = new Set(expandedKeys);
 
     const renderNodes = (nodes: any[]) =>
@@ -19,15 +19,23 @@ vi.mock('antd', async (importOriginal) => {
           : [...expandedKeys, node.key];
         const title = titleRender ? titleRender(node) : node.title;
 
+        const renderedSwitcher = switcherIcon?.({
+          eventKey: node.key,
+          expanded,
+          isLeaf: !hasChildren,
+          session: node.session,
+        });
+
         return (
           <div key={node.key}>
-            {hasChildren && (
-              <button
-                type="button"
-                aria-label={`${expanded ? 'Collapse' : 'Expand'} ${node.session.title}`}
-                onClick={() => onExpand?.(nextExpandedKeys)}
-              />
-            )}
+            {hasChildren &&
+              (renderedSwitcher ?? (
+                <button
+                  type="button"
+                  aria-label={`${expanded ? 'Collapse' : 'Expand'} ${node.session.title}`}
+                  onClick={() => onExpand?.(nextExpandedKeys)}
+                />
+              ))}
             {title}
             {hasChildren && expanded && <div>{renderNodes(node.children)}</div>}
           </div>
@@ -237,6 +245,68 @@ describe('BranchSessionSections', () => {
     expect(screen.queryByText('Child session')).not.toBeInTheDocument();
   });
 
+  it('keeps a manually collapsed nested ancestor collapsed after selecting another session', async () => {
+    const rootSession = makeManualSession({
+      session_id: 'session-root',
+      title: 'Root session',
+      genealogy: { children: ['session-nested-parent'] },
+    });
+    const nestedParentSession = makeManualSession({
+      session_id: 'session-nested-parent',
+      title: 'Nested parent',
+      genealogy: { parent_session_id: 'session-root', children: ['session-nested-child'] },
+    });
+    const nestedChildSession = makeManualSession({
+      session_id: 'session-nested-child',
+      title: 'Nested child',
+      genealogy: { parent_session_id: 'session-nested-parent', children: [] },
+    });
+    const otherSession = makeManualSession({
+      session_id: 'session-other',
+      title: 'Other session',
+    });
+    const sessions = [rootSession, nestedParentSession, nestedChildSession, otherSession];
+
+    const { rerender } = renderSections({
+      sessions,
+      selectedSessionId: 'session-root',
+    });
+
+    expect(screen.getByText('Nested child')).toBeInTheDocument();
+
+    fireEvent.click(getSessionTreeToggle('Nested parent'));
+
+    await waitFor(() => expect(screen.queryByText('Nested child')).not.toBeInTheDocument());
+
+    rerender(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <AntApp>
+          <BranchSessionSections
+            branch={branch}
+            sessions={sessions.map((session) => ({ ...session }))}
+            userById={new Map<string, User>()}
+            selectedSessionId="session-other"
+            onSessionClick={vi.fn()}
+            onCreateSession={vi.fn()}
+            client={null}
+          />
+        </AntApp>
+      </ConnectionProvider>
+    );
+
+    expect(screen.getByText('Nested parent')).toBeInTheDocument();
+    expect(screen.queryByText('Nested child')).not.toBeInTheDocument();
+    expect(getSessionTreeToggle('Nested parent')).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('expands a session when it newly gains children', () => {
     const parentSession = makeManualSession({
       session_id: 'session-parent',
@@ -325,6 +395,8 @@ describe('BranchSessionSections', () => {
         </AntApp>
       </ConnectionProvider>
     );
+
+    expect(screen.queryByLabelText(/(collapse|expand) parent session/i)).not.toBeInTheDocument();
 
     rerender(
       <ConnectionProvider

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -257,6 +257,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   });
   const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
   const previousExpandableKeysRef = useRef<Set<React.Key> | null>(null);
+  const manuallyCollapsedKeysRef = useRef<Set<React.Key>>(new Set());
   const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const [sort, setSort] = useLocalStorage<SessionSort>(SESSION_SORT_STORAGE_KEY, 'recent');
@@ -506,17 +507,22 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   useEffect(() => {
     const expandableKeySet = new Set(expandableKeys);
     const previousExpandableKeys = previousExpandableKeysRef.current;
+    const manuallyCollapsedKeys = manuallyCollapsedKeysRef.current;
 
     setExpandedKeys((previousExpandedKeys) => {
       if (!previousExpandableKeys) {
-        return expandableKeys;
+        return expandableKeys.filter((key) => !manuallyCollapsedKeys.has(key));
       }
 
       const nextExpandedKeys = previousExpandedKeys.filter((key) => expandableKeySet.has(key));
       const nextExpandedKeySet = new Set(nextExpandedKeys);
 
       for (const key of expandableKeys) {
-        if (!previousExpandableKeys.has(key) && !nextExpandedKeySet.has(key)) {
+        if (
+          !previousExpandableKeys.has(key) &&
+          !nextExpandedKeySet.has(key) &&
+          !manuallyCollapsedKeys.has(key)
+        ) {
           nextExpandedKeys.push(key);
           nextExpandedKeySet.add(key);
         }
@@ -527,6 +533,27 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
     previousExpandableKeysRef.current = expandableKeySet;
   }, [expandableKeys]);
+
+  const handleSessionTreeExpand = useCallback((keys: React.Key[]) => {
+    setExpandedKeys((previousKeys) => {
+      const nextKeys = [...keys];
+      const previousKeySet = new Set(previousKeys);
+      const nextKeySet = new Set(nextKeys);
+
+      for (const key of previousKeySet) {
+        if (!nextKeySet.has(key)) {
+          manuallyCollapsedKeysRef.current.add(key);
+        }
+      }
+      for (const key of nextKeySet) {
+        if (!previousKeySet.has(key)) {
+          manuallyCollapsedKeysRef.current.delete(key);
+        }
+      }
+
+      return nextKeys;
+    });
+  }, []);
 
   const sessionRowStyle = (session: Session): React.CSSProperties => {
     const isSessionSelected = session.session_id === selectedSessionId;
@@ -709,11 +736,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           aria-expanded={expanded}
           onClick={(event) => {
             event.stopPropagation();
-            setExpandedKeys((previousKeys) =>
-              previousKeys.includes(key)
-                ? previousKeys.filter((expandedKey) => expandedKey !== key)
-                : [...previousKeys, key]
-            );
+            setExpandedKeys((previousKeys) => {
+              if (previousKeys.includes(key)) {
+                manuallyCollapsedKeysRef.current.add(key);
+                return previousKeys.filter((expandedKey) => expandedKey !== key);
+              }
+
+              manuallyCollapsedKeysRef.current.delete(key);
+              return [...previousKeys, key];
+            });
           }}
           style={{
             border: 0,
@@ -793,7 +824,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         className="agor-flat-tree"
         treeData={sessionTreeData}
         expandedKeys={expandedKeys}
-        onExpand={(keys) => setExpandedKeys(keys as React.Key[])}
+        onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[])}
         showLine
         switcherIcon={renderTreeSwitcherIcon}
         showIcon={false}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -14,7 +14,9 @@ import {
   EyeOutlined,
   LinkOutlined,
   MessageOutlined,
+  MinusSquareOutlined,
   PlusOutlined,
+  PlusSquareOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import {
@@ -684,6 +686,51 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     );
   };
 
+  const renderTreeSwitcherIcon = useCallback(
+    (nodeProps: {
+      eventKey?: React.Key;
+      expanded?: boolean;
+      isLeaf?: boolean;
+      session?: Session;
+    }) => {
+      const key = nodeProps.eventKey;
+      if (nodeProps.isLeaf || key == null) return null;
+
+      const expanded = Boolean(nodeProps.expanded);
+      const sessionTitle = nodeProps.session
+        ? getSessionDisplayTitle(nodeProps.session, { includeAgentFallback: true })
+        : 'session';
+      const Icon = expanded ? MinusSquareOutlined : PlusSquareOutlined;
+
+      return (
+        <button
+          type="button"
+          aria-label={`${expanded ? 'Collapse' : 'Expand'} ${sessionTitle}`}
+          aria-expanded={expanded}
+          onClick={(event) => {
+            event.stopPropagation();
+            setExpandedKeys((previousKeys) =>
+              previousKeys.includes(key)
+                ? previousKeys.filter((expandedKey) => expandedKey !== key)
+                : [...previousKeys, key]
+            );
+          }}
+          style={{
+            border: 0,
+            background: 'transparent',
+            padding: 0,
+            lineHeight: 0,
+            cursor: 'pointer',
+            color: 'inherit',
+          }}
+        >
+          <Icon />
+        </button>
+      );
+    },
+    []
+  );
+
   const renderSessionNode = (node: SessionTreeNode) => {
     const session = node.session;
     const isActive = isSessionExecuting(session);
@@ -748,6 +795,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         expandedKeys={expandedKeys}
         onExpand={(keys) => setExpandedKeys(keys as React.Key[])}
         showLine
+        switcherIcon={renderTreeSwitcherIcon}
         showIcon={false}
         blockNode
         selectable={false}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -31,7 +31,7 @@ import {
   theme,
 } from 'antd';
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useServiceEnabled } from '../../hooks/useServicesConfig';
@@ -254,6 +254,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     session: null,
   });
   const [expandedKeys, setExpandedKeys] = useState<React.Key[]>([]);
+  const previousExpandableKeysRef = useRef<Set<React.Key> | null>(null);
   const [archivingSessionIds, setArchivingSessionIds] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const [sort, setSort] = useLocalStorage<SessionSort>(SESSION_SORT_STORAGE_KEY, 'recent');
@@ -464,6 +465,20 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     () => buildSessionTree(sortedManualSessions),
     [sortedManualSessions]
   );
+  const expandableKeys = useMemo(() => {
+    const collectKeysWithChildren = (nodes: SessionTreeNode[]): React.Key[] => {
+      const keys: React.Key[] = [];
+      for (const node of nodes) {
+        if (node.children && node.children.length > 0) {
+          keys.push(node.key);
+          keys.push(...collectKeysWithChildren(node.children));
+        }
+      }
+      return keys;
+    };
+
+    return collectKeysWithChildren(sessionTreeData);
+  }, [sessionTreeData]);
   const searchResults = useMemo(
     () =>
       isPanel && searchActive
@@ -487,19 +502,29 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const isSessionFailed = (session: Session): boolean => session.status === SessionStatus.FAILED;
 
   useEffect(() => {
-    const collectKeysWithChildren = (nodes: SessionTreeNode[]): React.Key[] => {
-      const keys: React.Key[] = [];
-      for (const node of nodes) {
-        if (node.children && node.children.length > 0) {
-          keys.push(node.key);
-          keys.push(...collectKeysWithChildren(node.children));
+    const expandableKeySet = new Set(expandableKeys);
+    const previousExpandableKeys = previousExpandableKeysRef.current;
+
+    setExpandedKeys((previousExpandedKeys) => {
+      if (!previousExpandableKeys) {
+        return expandableKeys;
+      }
+
+      const nextExpandedKeys = previousExpandedKeys.filter((key) => expandableKeySet.has(key));
+      const nextExpandedKeySet = new Set(nextExpandedKeys);
+
+      for (const key of expandableKeys) {
+        if (!previousExpandableKeys.has(key) && !nextExpandedKeySet.has(key)) {
+          nextExpandedKeys.push(key);
+          nextExpandedKeySet.add(key);
         }
       }
-      return keys;
-    };
 
-    setExpandedKeys(collectKeysWithChildren(sessionTreeData));
-  }, [sessionTreeData]);
+      return nextExpandedKeys;
+    });
+
+    previousExpandableKeysRef.current = expandableKeySet;
+  }, [expandableKeys]);
 
   const sessionRowStyle = (session: Session): React.CSSProperties => {
     const isSessionSelected = session.session_id === selectedSessionId;


### PR DESCRIPTION
## Linked issue

Fixes #1756

## Summary

- Preserve manual expand/collapse state in the session tree when selecting another session.
- Keep initial expandable session nodes expanded by default.
- Auto-expand only sessions that newly gain children, without reopening nodes the user manually collapsed.

## Why / context

Selecting a different session rebuilt the tree data and reset expanded keys to every expandable parent. That caused manually collapsed parent sessions to re-expand, hiding the user's chosen tree state.

## Implementation notes

- Tracks the previous set of expandable tree nodes so existing collapsed parents are not re-added on ordinary rerenders.
- Prunes expanded keys for removed/non-expandable nodes.
- Adds newly expandable parents to the expanded set so newly created child sessions still become visible by default.
- Keeps the change local to `BranchSessionSections` and its focused component coverage; no backend genealogy data changes.

## Validation / test plan

- [x] Focused component tests cover a manually collapsed parent staying collapsed after selecting another session.
- [x] Focused component tests cover a parent expanding when it newly gains children.
- [x] Touched UI files pass formatter/linter checks.
- [x] Diff hygiene check passes.
- [x] Live rendered branch UI validation confirmed that collapsing a parent with children, selecting a sibling session, and returning to the tree keeps that parent collapsed with children hidden.
- [ ] Broad UI typecheck: not passing in this checkout because generated package declarations for local workspace packages are unresolved; the focused tests and touched-file checks above passed.

## Screenshots / demos

No PR-visible screenshots attached. The interaction was validated in a live rendered branch UI: the parent initially showed children, collapsed on user action, and remained collapsed after selecting another session.

## Risks / rollout / rollback

Low-risk local UI state fix. Rollback is reverting the `BranchSessionSections` state handling and regression tests.

## Out of scope / follow-ups

- No persistence across browser reloads.
- No changes to session genealogy data, sorting, search, scheduled sessions, gateway sessions, or tree styling.
