### PR TITLE
fix: stabilize Sandpack inputs for artifact nodes

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
@@ -1,10 +1,10 @@
 import type { AppBoardObject, BoardObject, SandpackTemplate } from '@agor-live/client';
 import { CodeOutlined, DeleteOutlined, EyeOutlined } from '@ant-design/icons';
-import { SandpackPreview, SandpackProvider } from '@codesandbox/sandpack-react';
+import { SandpackPreview, SandpackProvider, type SandpackSetup } from '@codesandbox/sandpack-react';
 import { Button, Card, Tooltip, Typography, theme } from 'antd';
 import { useCallback, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
-import { withBodyReset } from './utils/sandpackDefaults';
+import { useStableSandpackProviderInputs } from './utils/sandpackDefaults';
 
 export interface AppNodeData {
   objectId: string;
@@ -29,6 +29,12 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
   const { token } = theme.useToken();
   const [interactMode, setInteractMode] = useState(false);
   const iframeContainerRef = useRef<HTMLDivElement>(null);
+  const sandpackInputs = useStableSandpackProviderInputs({
+    template: data.template,
+    files: data.files,
+    dependencies: data.dependencies,
+    entryFile: data.entryFile,
+  });
 
   const handleResize = useCallback(
     (_event: unknown, params: { x: number; y: number; width: number; height: number }) => {
@@ -145,13 +151,10 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
           }}
         >
           <SandpackProvider
-            template={data.template as 'react'}
-            files={withBodyReset(data.files)}
-            customSetup={data.dependencies ? { dependencies: data.dependencies } : undefined}
-            options={{
-              initMode: 'user-visible',
-              ...(data.entryFile ? { activeFile: data.entryFile } : {}),
-            }}
+            template={sandpackInputs.template as 'react'}
+            files={sandpackInputs.files}
+            customSetup={sandpackInputs.customSetup as SandpackSetup | undefined}
+            options={sandpackInputs.options}
           >
             <SandpackPreview
               style={{

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -44,7 +44,7 @@ import { useThemedMessage } from '@/utils/message';
 import { ensureSandpackCryptoSubtle } from '@/utils/sandpackCrypto';
 import { uiRouteHref } from '@/utils/uiRoutes';
 import { ArtifactConsentModal } from '../../ArtifactConsentModal/ArtifactConsentModal';
-import { withBodyReset } from './utils/sandpackDefaults';
+import { useStableSandpackProviderInputs } from './utils/sandpackDefaults';
 
 ensureSandpackCryptoSubtle();
 
@@ -69,6 +69,7 @@ export interface ArtifactNodeData {
 
 const MIN_WIDTH = 300;
 const MIN_HEIGHT = 200;
+const EMPTY_SANDPACK_FILES: Record<string, string> = {};
 
 /**
  * Eject the rendered artifact to a fresh CodeSandbox sandbox in a new tab.
@@ -176,6 +177,17 @@ export const ArtifactNode = ({
   const [error, setError] = useState<string | null>(null);
   const [consentOpen, setConsentOpen] = useState(false);
   const lastHashRef = useRef<string | null>(null);
+  const sandpackConfig = payload?.sandpack_config;
+  const sandpackOptions = sandpackConfig?.options;
+  const sandpackTemplate = (sandpackConfig?.template ?? payload?.template ?? 'react') as 'react';
+  const sandpackInputs = useStableSandpackProviderInputs({
+    template: sandpackTemplate,
+    files: payload?.files ?? EMPTY_SANDPACK_FILES,
+    customSetup: sandpackConfig?.customSetup,
+    dependencies: payload?.dependencies,
+    entryFile: payload?.entry,
+    options: sandpackOptions,
+  });
 
   // Fetch artifact payload from daemon
   const fetchPayload = useCallback(async () => {
@@ -540,15 +552,6 @@ export const ArtifactNode = ({
 
   if (!payload) return null;
 
-  const sandpackConfig = payload.sandpack_config ?? {};
-  const sandpackOptions = sandpackConfig.options ?? {};
-  const customSetup = {
-    ...(sandpackConfig.customSetup ?? {}),
-    ...(payload.dependencies && !sandpackConfig.customSetup?.dependencies
-      ? { dependencies: payload.dependencies }
-      : {}),
-  };
-  const sandpackTemplate = (sandpackConfig.template ?? payload.template) as 'react';
   const legacyBanner = payload.legacy?.is_legacy ? (
     <LegacyBanner upgradeInstructions={payload.legacy.upgrade_instructions} />
   ) : null;
@@ -611,19 +614,11 @@ export const ArtifactNode = ({
           )}
           <SandpackProvider
             key={payload.content_hash}
-            template={sandpackTemplate}
-            files={withBodyReset(payload.files)}
-            customSetup={
-              Object.keys(customSetup).length > 0 ? (customSetup as SandpackSetup) : undefined
-            }
-            theme={sandpackConfig.theme as never}
-            options={{
-              initMode: 'user-visible',
-              ...sandpackOptions,
-              ...(payload.entry && !sandpackOptions.activeFile
-                ? { activeFile: payload.entry }
-                : {}),
-            }}
+            template={sandpackInputs.template as 'react'}
+            files={sandpackInputs.files}
+            customSetup={sandpackInputs.customSetup as SandpackSetup | undefined}
+            theme={sandpackConfig?.theme as never}
+            options={sandpackInputs.options}
           >
             <SandpackPreview
               style={{

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.test.tsx
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useStableSandpackProviderInputs } from './sandpackDefaults';
+
+describe('useStableSandpackProviderInputs', () => {
+  it('keeps AppNode Sandpack props stable across equivalent parent rerenders', () => {
+    const initialProps = {
+      files: { '/App.tsx': 'export default function App() { return <div />; }' },
+      dependencies: { '@vitejs/plugin-react': '^6.0.0' },
+      entryFile: '/App.tsx',
+    };
+    const { result, rerender } = renderHook(
+      ({ files, dependencies, entryFile }) =>
+        useStableSandpackProviderInputs({
+          template: 'react',
+          files,
+          dependencies,
+          entryFile,
+        }),
+      { initialProps }
+    );
+    const first = result.current;
+
+    rerender({
+      files: { ...initialProps.files },
+      dependencies: { ...initialProps.dependencies },
+      entryFile: initialProps.entryFile,
+    });
+
+    expect(result.current.files).toBe(first.files);
+    expect(result.current.customSetup).toBe(first.customSetup);
+    expect(result.current.options).toBe(first.options);
+    expect(result.current.files['/styles.css']).toBe('body{margin:0}');
+    expect(result.current.customSetup).toEqual({ dependencies: initialProps.dependencies });
+    expect(result.current.options).toMatchObject({
+      initMode: 'user-visible',
+      activeFile: initialProps.entryFile,
+    });
+  });
+
+  it('keeps ArtifactNode Sandpack props stable across equivalent payload rerenders', () => {
+    const initialProps = {
+      files: {
+        '/src/App.tsx': 'export function App() { return <main>Hello</main>; }',
+        '/styles.css': 'body{margin:0}\nmain{padding:8px}',
+      },
+      customSetup: { devDependencies: { typescript: '^6.0.0' } },
+      dependencies: { antd: '^6.4.4' },
+      options: { visibleFiles: ['/src/App.tsx'], recompileMode: 'delayed' },
+      entryFile: '/src/App.tsx',
+    };
+    const { result, rerender } = renderHook(
+      ({ files, customSetup, dependencies, options, entryFile }) =>
+        useStableSandpackProviderInputs({
+          template: 'react',
+          files,
+          customSetup,
+          dependencies,
+          options,
+          entryFile,
+        }),
+      { initialProps }
+    );
+    const first = result.current;
+
+    rerender({
+      files: { ...initialProps.files },
+      customSetup: {
+        devDependencies: { ...initialProps.customSetup.devDependencies },
+      },
+      dependencies: { ...initialProps.dependencies },
+      options: {
+        visibleFiles: [...initialProps.options.visibleFiles],
+        recompileMode: initialProps.options.recompileMode,
+      },
+      entryFile: initialProps.entryFile,
+    });
+
+    expect(result.current.files).toBe(first.files);
+    expect(result.current.customSetup).toBe(first.customSetup);
+    expect(result.current.options).toBe(first.options);
+    expect(result.current.customSetup).toEqual({
+      devDependencies: initialProps.customSetup.devDependencies,
+      dependencies: initialProps.dependencies,
+    });
+    expect(result.current.options).toMatchObject({
+      initMode: 'user-visible',
+      activeFile: initialProps.entryFile,
+      visibleFiles: initialProps.options.visibleFiles,
+      recompileMode: 'delayed',
+    });
+  });
+
+  it('updates Sandpack props when render-affecting content changes', () => {
+    const { result, rerender } = renderHook(
+      ({ files, options }) =>
+        useStableSandpackProviderInputs({
+          template: 'react',
+          files,
+          options,
+          entryFile: '/App.tsx',
+        }),
+      {
+        initialProps: {
+          files: { '/App.tsx': 'export default function App() { return 1; }' },
+          options: { recompileMode: 'delayed' },
+        },
+      }
+    );
+    const first = result.current;
+
+    rerender({
+      files: { '/App.tsx': 'export default function App() { return 2; }' },
+      options: { recompileMode: 'immediate' },
+    });
+
+    expect(result.current.files).not.toBe(first.files);
+    expect(result.current.options).not.toBe(first.options);
+    expect(result.current.files['/App.tsx']).toContain('return 2');
+    expect(result.current.options.recompileMode).toBe('immediate');
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.test.tsx
@@ -91,6 +91,28 @@ describe('useStableSandpackProviderInputs', () => {
     });
   });
 
+  it('ignores standalone dependency churn when customSetup already owns dependencies', () => {
+    const customSetup = { dependencies: { react: '^18.3.1' } };
+    const { result, rerender } = renderHook(
+      ({ dependencies }) =>
+        useStableSandpackProviderInputs({
+          template: 'react',
+          files: { '/App.tsx': 'export default function App() { return <div />; }' },
+          customSetup,
+          dependencies,
+          entryFile: '/App.tsx',
+        }),
+      { initialProps: { dependencies: { antd: '^6.4.4' } } }
+    );
+    const first = result.current;
+
+    rerender({ dependencies: { antd: '^6.5.0' } });
+
+    expect(result.current).toBe(first);
+    expect(result.current.customSetup).toBe(first.customSetup);
+    expect(result.current.customSetup).toEqual(customSetup);
+  });
+
   it('updates Sandpack props when render-affecting content changes', () => {
     const { result, rerender } = renderHook(
       ({ files, options }) =>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.ts
@@ -1,3 +1,5 @@
+import { useRef } from 'react';
+
 /**
  * Prepend a body margin reset to Sandpack files.
  * The default React template imports /styles.css, so prepending to it
@@ -10,4 +12,86 @@ export function withBodyReset(files: Record<string, string>): Record<string, str
   const existing = files[key];
   if (existing?.includes(reset)) return files;
   return { ...files, [key]: existing ? `${reset}\n${existing}` : reset };
+}
+
+type SandpackCustomSetup = Record<string, unknown> & {
+  dependencies?: Record<string, string>;
+};
+
+type SandpackOptions = Record<string, unknown> & {
+  activeFile?: string;
+};
+
+export function useStableSandpackProviderInputs({
+  template,
+  files,
+  customSetup,
+  dependencies,
+  entryFile,
+  options,
+}: {
+  template: string;
+  files: Record<string, string>;
+  customSetup?: SandpackCustomSetup;
+  dependencies?: Record<string, string>;
+  entryFile?: string;
+  options?: SandpackOptions;
+}) {
+  const filesKey = stableValueKey(files);
+  const customSetupKey = stableValueKey(customSetup);
+  const dependenciesKey = stableValueKey(dependencies);
+  const optionsKey = stableValueKey(options);
+
+  const stableFiles = useStableComputed(filesKey, () => withBodyReset(files));
+
+  const stableCustomSetup = useStableComputed(
+    stableValueKey({ customSetupKey, dependenciesKey }),
+    () => {
+      const merged = {
+        ...(customSetup ?? {}),
+        ...(dependencies && !customSetup?.dependencies ? { dependencies } : {}),
+      };
+      return Object.keys(merged).length > 0 ? merged : undefined;
+    }
+  );
+
+  const stableOptions = useStableComputed(stableValueKey({ entryFile, optionsKey }), () => ({
+    initMode: 'user-visible',
+    ...(options ?? {}),
+    ...(entryFile && !options?.activeFile ? { activeFile: entryFile } : {}),
+  }));
+
+  return useStableComputed(
+    stableValueKey({ template, filesKey, customSetupKey, dependenciesKey, entryFile, optionsKey }),
+    () => ({
+      template,
+      files: stableFiles,
+      customSetup: stableCustomSetup,
+      options: stableOptions,
+    })
+  );
+}
+
+function useStableComputed<T>(key: string, compute: () => T): T {
+  const ref = useRef<{ key: string; value: T } | null>(null);
+  if (!ref.current || ref.current.key !== key) {
+    ref.current = { key, value: compute() };
+  }
+  return ref.current.value;
+}
+
+function stableValueKey(value: unknown): string {
+  return JSON.stringify(toStableJsonValue(value));
+}
+
+function toStableJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(toStableJsonValue);
+  if (!value || typeof value !== 'object') return value;
+
+  const stableObject: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    const entry = (value as Record<string, unknown>)[key];
+    if (entry !== undefined) stableObject[key] = toStableJsonValue(entry);
+  }
+  return stableObject;
 }

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.ts
@@ -56,7 +56,7 @@ export function useStableSandpackProviderInputs({
   );
 
   const stableOptions = useStableComputed(stableValueKey({ entryFile, optionsKey }), () => ({
-    initMode: 'user-visible',
+    initMode: 'user-visible' as const,
     ...(options ?? {}),
     ...(entryFile && !options?.activeFile ? { activeFile: entryFile } : {}),
   }));

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.ts
@@ -37,10 +37,11 @@ export function useStableSandpackProviderInputs({
   entryFile?: string;
   options?: SandpackOptions;
 }) {
-  const filesKey = stableValueKey(files);
-  const customSetupKey = stableValueKey(customSetup);
-  const dependenciesKey = stableValueKey(dependencies);
-  const optionsKey = stableValueKey(options);
+  const effectiveDependencies = customSetup?.dependencies ? undefined : dependencies;
+  const filesKey = useStableValueKey(files);
+  const customSetupKey = useStableValueKey(customSetup);
+  const dependenciesKey = useStableValueKey(effectiveDependencies);
+  const optionsKey = useStableValueKey(options);
 
   const stableFiles = useStableComputed(filesKey, () => withBodyReset(files));
 
@@ -49,7 +50,7 @@ export function useStableSandpackProviderInputs({
     () => {
       const merged = {
         ...(customSetup ?? {}),
-        ...(dependencies && !customSetup?.dependencies ? { dependencies } : {}),
+        ...(effectiveDependencies ? { dependencies: effectiveDependencies } : {}),
       };
       return Object.keys(merged).length > 0 ? merged : undefined;
     }
@@ -70,6 +71,14 @@ export function useStableSandpackProviderInputs({
       options: stableOptions,
     })
   );
+}
+
+function useStableValueKey(value: unknown): string {
+  const ref = useRef<{ value: unknown; key: string } | null>(null);
+  if (!ref.current || !Object.is(ref.current.value, value)) {
+    ref.current = { value, key: stableValueKey(value) };
+  }
+  return ref.current.key;
 }
 
 function useStableComputed<T>(key: string, compute: () => T): T {


### PR DESCRIPTION
## Linked issue

Fixes #1758

## Summary

- Stabilizes the Sandpack `files`, `customSetup`, `options`, and `template` inputs used by artifact board nodes when payload content has not changed.
- Applies the same provider-input stabilization to app board nodes, which shared the same inline Sandpack prop pattern.
- Adds focused regression coverage for stable provider inputs across equivalent rerenders and for updates when render-affecting content changes.

## Why / context

The crash report in #1758 points at `SandpackProvider -> ArtifactNode -> SessionCanvas` with React error #185 / maximum update depth exceeded. Sandpack resets provider state when key provider props change identity after mount, and ArtifactNode/AppNode were rebuilding those props inline on every parent/canvas render. Keeping unchanged Sandpack inputs referentially stable reduces reset/iframe/layout churn while preserving the existing artifact rendering behavior.

## Implementation notes

- Introduces `useStableSandpackProviderInputs` in the existing Sandpack defaults utility.
- Keeps `/styles.css` body-reset behavior, dependency/custom setup merging, entry-file selection, template selection, theme handling, trust/console/error reporting, fullscreen/eject paths, and interact-mode behavior intact.
- Leaves the existing ArtifactNode `key={payload.content_hash}` behavior in place so actual payload content changes still remount the provider as before.

## Validation / test plan

- [x] `pnpm --filter agor-ui exec vitest run src/components/SessionCanvas/canvas/utils/sandpackDefaults.test.tsx`
- [x] `pnpm exec biome check apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.ts apps/agor-ui/src/components/SessionCanvas/canvas/utils/sandpackDefaults.test.tsx`
- [x] `pnpm --filter @agor/core build && pnpm --filter @agor-live/client build && pnpm --filter agor-ui typecheck`
- [x] Commit hook ran `biome ci` on the staged TypeScript files.
- [x] Manual branch-runtime validation exercised an ArtifactNode through selection, canvas controls, keyboard refocus, resize/reflow, and route reload; no React #185 / maximum update depth / canvas white-screen crash was observed.

## Screenshots / demos

No reviewer-visible screenshot is attached because this is a stability fix with no intended visual change. Runtime validation confirmed the artifact node and Sandpack iframe remained visible after rerender/reflow/reload stress.

## Risks / rollout / rollback

Risk is limited to Sandpack rendering in ArtifactNode and AppNode. The change only stabilizes derived provider input identities for unchanged content; content changes still produce new inputs and ArtifactNode still remounts on content hash changes. Rollback is reverting this PR.

## Out of scope / follow-ups

- Does not address separate React Flow board-canvas crash reports tracked outside #1758.
- Does not rewrite the Sandpack integration, React Flow canvas ownership, artifact storage, or runtime bridge architecture.
