### PR TITLE
feat(models): re-enable Claude Fable 5 in the model dropdown

### DIFF
--- a/apps/agor-daemon/src/services/claude-models.ts
+++ b/apps/agor-daemon/src/services/claude-models.ts
@@ -54,6 +54,16 @@ const CONTEXT_1M_BETA = 'context-1m-2025-08-07';
 const ONE_MILLION_TOKENS = 900_000; // threshold to detect 1M-eligible models
 
 /**
+ * Fable 5 ships a 1M context window natively — it's the default, not a beta
+ * opt-in — so it must NOT get a synthetic `[1m]` variant. That suffix maps to
+ * the `context-1m-2025-08-07` beta flag (see parseModelWithBetas), which Fable
+ * doesn't use; the bare id already is the 1M model.
+ */
+function hasNativeMillionContext(id: string): boolean {
+  return id.startsWith('claude-fable');
+}
+
+/**
  * Build the option list from the API response. Models whose
  * `max_input_tokens` >= 900k (when fetched with the 1M beta flag) get a
  * `[1m]` variant — no static allowlist required.
@@ -69,7 +79,11 @@ function toModelOptions(models: Anthropic.ModelInfo[]): ClaudeModelOption[] {
       description: undefined,
       source: 'dynamic',
     });
-    if (m.max_input_tokens && m.max_input_tokens >= ONE_MILLION_TOKENS) {
+    if (
+      m.max_input_tokens &&
+      m.max_input_tokens >= ONE_MILLION_TOKENS &&
+      !hasNativeMillionContext(m.id)
+    ) {
       options.push({
         id: `${m.id}[1m]`,
         displayName: `${m.display_name} (1M context)`,

--- a/packages/core/src/claude-cli/pricing.ts
+++ b/packages/core/src/claude-cli/pricing.ts
@@ -41,6 +41,18 @@ export interface ClaudeModelPricing {
  * entry even if Anthropic mints a `-7-1` patch revision.
  */
 const PRICING: ReadonlyArray<{ prefix: string; price: ClaudeModelPricing }> = [
+  // Fable 5 — most capable tier, priced above Opus. Cache-write is 1.25x
+  // input and cache-read is 0.1x input, matching every other entry here.
+  {
+    prefix: 'claude-fable-5',
+    price: {
+      inputPerMTok: 10,
+      outputPerMTok: 50,
+      cacheWritePerMTok: 12.5,
+      cacheReadPerMTok: 1,
+      webSearchPerRequest: 0.01,
+    },
+  },
   // Sonnet 5 introductory pricing through 2026-08-31.
   {
     prefix: 'claude-sonnet-5',
@@ -175,6 +187,9 @@ export function computeCost(
  */
 export function getContextWindowLimit(modelId: string | null | undefined): number {
   if (!modelId) return 200_000;
+  // Fable 5 ships a 1M context window natively — it's the default (and only)
+  // mode, not a beta opt-in, so the bare id already means 1M.
+  if (modelId.startsWith('claude-fable')) return 1_000_000;
   // 1M context beta — encoded as a model-id suffix in Agor; bare `claude-*`
   // ids without the `[1m]` suffix get the standard 200K window.
   if (modelId.includes('[1m]') || modelId.endsWith('-1m')) return 1_000_000;

--- a/packages/core/src/models/claude.test.ts
+++ b/packages/core/src/models/claude.test.ts
@@ -10,6 +10,6 @@ describe('AVAILABLE_CLAUDE_MODEL_ALIASES', () => {
     expect(ids).toContain('claude-opus-4-7');
     expect(ids).toContain('claude-sonnet-4-6');
     expect(ids).toContain('claude-haiku-4-5');
-    expect(ids).not.toContain('claude-fable-5');
+    expect(ids).toContain('claude-fable-5');
   });
 });

--- a/packages/core/src/models/claude.ts
+++ b/packages/core/src/models/claude.ts
@@ -24,6 +24,12 @@ export interface ClaudeModel {
  */
 export const AVAILABLE_CLAUDE_MODEL_ALIASES: ClaudeModel[] = [
   {
+    id: 'claude-fable-5',
+    displayName: 'Claude Fable 5',
+    family: 'claude-5',
+    description: 'Frontier model for complex reasoning, creative work, and agentic coding',
+  },
+  {
     id: 'claude-opus-4-8',
     displayName: 'Claude Opus 4.8',
     family: 'claude-4',


### PR DESCRIPTION
## Summary

Fable 5 is back online (available through July 7), so this restores it to the Claude model picker after it was disabled a few weeks ago.

## Changes

- **Dropdown**: add `claude-fable-5` to the static `AVAILABLE_CLAUDE_MODEL_ALIASES` fallback and flip the test guard from `not.toContain` → `toContain`. (The dynamic `/claude-models` list already surfaces it when the Anthropic Models API returns it; this fixes the static fallback + the test.)
- **Pricing** (`pricing.ts`): add Fable 5 at **$10 in / $50 out per MTok** (cache-write $12.50 = 1.25x, cache-read $1.00 = 0.1x, web-search $0.01 — matching every other row's multipliers). Without this, Fable sessions showed cost as "unknown".
- **Context window** (`getContextWindowLimit`): Fable ships a **1M** context window natively (it's the default, not a `[1m]` beta opt-in like Opus/Sonnet), so the bare id now reports 1M instead of falling through to the 200K default.
- **Dynamic service** (`claude-models.ts`): skip the synthetic `[1m]` twin for native-1M models — that suffix maps to the `context-1m-2025-08-07` beta flag Fable doesn't use, and would double-list the model.

## Notes

- Model IDs and pricing verified against the authoritative Claude API reference.