### PR TITLE
fix(agor-ui): reduce home to board navigation jank

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -449,6 +449,38 @@ export const App: React.FC<AppProps> = ({
   const isHomeSurface = (isRootHomePath || pendingHomeNavigation) && !hasExplicitEntityTarget;
   const headerBoardId = isHomeSurface ? '' : currentBoardId;
   const headerBoard = isHomeSurface ? undefined : currentBoard;
+  const wasHomeSurfaceRef = useRef(isHomeSurface);
+  const isLeavingHomeSurface = wasHomeSurfaceRef.current && !isHomeSurface;
+  const [homeExitSidePanelDeferred, setHomeExitSidePanelDeferred] = useState(false);
+  const [homeExitPanelDetailsDeferred, setHomeExitPanelDetailsDeferred] = useState(false);
+
+  useLayoutEffect(() => {
+    if (isLeavingHomeSurface) {
+      setHomeExitSidePanelDeferred(true);
+      setHomeExitPanelDetailsDeferred(true);
+    }
+    wasHomeSurfaceRef.current = isHomeSurface;
+  }, [isLeavingHomeSurface, isHomeSurface]);
+
+  useEffect(() => {
+    if (!homeExitSidePanelDeferred) return;
+    const timer = window.setTimeout(() => {
+      setHomeExitSidePanelDeferred(false);
+    }, 1200);
+    return () => window.clearTimeout(timer);
+  }, [homeExitSidePanelDeferred]);
+
+  useEffect(() => {
+    if (!homeExitPanelDetailsDeferred) return;
+    const timer = window.setTimeout(() => {
+      setHomeExitPanelDetailsDeferred(false);
+    }, 4000);
+    return () => window.clearTimeout(timer);
+  }, [homeExitPanelDetailsDeferred]);
+
+  const handleDeferredDetailsHydrated = useCallback(() => {
+    setHomeExitPanelDetailsDeferred(false);
+  }, []);
 
   // Home is route-authoritative. Do not clear board/session state while the
   // old `/b/...` URL is still active — that creates a transient no-board
@@ -471,7 +503,12 @@ export const App: React.FC<AppProps> = ({
     selectedSessionId,
   ]);
 
-  const leftPanelCollapsed = commentsPanelCollapsed || suppressLeftPanel || isHomeSurface;
+  const leftPanelCollapsed =
+    commentsPanelCollapsed ||
+    suppressLeftPanel ||
+    isHomeSurface ||
+    isLeavingHomeSurface ||
+    homeExitSidePanelDeferred;
 
   // Ref for programmatically controlling the comments panel
   const commentsPanelRef = useRef<ImperativePanelHandle>(null);
@@ -587,6 +624,26 @@ export const App: React.FC<AppProps> = ({
     branchById,
     artifactById,
   });
+
+  const handleHomeBoardClick = useCallback(
+    (boardId: string) => navigation.goToBoard(boardId),
+    [navigation]
+  );
+
+  const handleHomeBranchClick = useCallback(
+    (branchId: string) => navigation.goToBranch(branchId),
+    [navigation]
+  );
+
+  const handleHomeOpenCreateDialog = useCallback(
+    (tab?: 'branch' | 'assistant' | 'board' | 'repository', boardId?: string) => {
+      if (boardId) navigation.goToBoard(boardId);
+      setNewBranchDefaultPosition(null);
+      setCreateDialogDefaultTab(tab || 'assistant');
+      setCreateDialogOpen(true);
+    },
+    [navigation]
+  );
 
   // Wrapper to update board ID (updates both state and URL via hook)
   // Also closes conversation panel when switching to a different board
@@ -974,9 +1031,14 @@ export const App: React.FC<AppProps> = ({
     [currentBoardObjects, branchById]
   );
 
-  // Check if current user is mentioned in active comments
-  const activeComments = mapToArray(commentById).filter(
-    (c: BoardComment) => c.board_id === currentBoardId && !c.resolved
+  // Check if current user is mentioned in active comments. Keep this memoized so
+  // route/UI state changes do not rescan the global comments map.
+  const activeComments = useMemo(
+    () =>
+      mapToArray(commentById).filter(
+        (c: BoardComment) => c.board_id === currentBoardId && !c.resolved
+      ),
+    [commentById, currentBoardId]
   );
 
   const currentUserName = user?.name || user?.email?.split('@')[0] || '';
@@ -1199,6 +1261,8 @@ export const App: React.FC<AppProps> = ({
                   hoveredCommentId={hoveredCommentId}
                   selectedCommentId={selectedCommentId}
                   onCollapse={handleAssistantCollapse}
+                  deferSessionDetails={homeExitPanelDetailsDeferred}
+                  onDeferredDetailsHydrated={handleDeferredDetailsHydrated}
                 />
               )}
             </Panel>
@@ -1266,15 +1330,10 @@ export const App: React.FC<AppProps> = ({
                         connected={connected}
                         recentBoardIds={recentBoardIds}
                         currentUserId={user?.user_id}
-                        onBoardClick={navigation.goToBoard}
-                        onBranchClick={navigation.goToBranch}
+                        onBoardClick={handleHomeBoardClick}
+                        onBranchClick={handleHomeBranchClick}
                         onSessionClick={handleSessionClick}
-                        onOpenCreateDialog={(tab, boardId) => {
-                          if (boardId) navigation.goToBoard(boardId);
-                          setNewBranchDefaultPosition(null);
-                          setCreateDialogDefaultTab(tab);
-                          setCreateDialogOpen(true);
-                        }}
+                        onOpenCreateDialog={handleHomeOpenCreateDialog}
                         onOpenSettings={openSettings}
                       />
                     ) : (

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Empty,
   Select,
+  Skeleton,
   Space,
   Spin,
   Tabs,
@@ -15,7 +16,7 @@ import {
   theme,
 } from 'antd';
 import type React from 'react';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import {
   selectBranchById,
@@ -72,6 +73,8 @@ interface BoardAssistantPanelProps {
   hoveredCommentId?: string | null;
   selectedCommentId?: string | null;
   onCollapse?: () => void;
+  deferSessionDetails?: boolean;
+  onDeferredDetailsHydrated?: () => void;
   client: AgorClient | null;
 }
 
@@ -98,6 +101,8 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
   hoveredCommentId,
   selectedCommentId,
   onCollapse,
+  deferSessionDetails = false,
+  onDeferredDetailsHydrated,
   client,
 }) => {
   const { token } = theme.useToken();
@@ -109,13 +114,6 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
   const repoById = useAgorStore(selectRepoById);
   const userById = useAgorStore(selectUserById);
   const commentById = useAgorStore(selectCommentById);
-  // Derive the board-scoped comment list and board objects locally: comments
-  // only render when a board is selected, so filtering by `board.board_id`
-  // scopes them to that board.
-  const comments = useMemo(
-    () => mapToArray(commentById).filter((c) => c.board_id === board?.board_id),
-    [commentById, board?.board_id]
-  );
   const boardObjects = board?.objects;
   const defaultTab: BoardAssistantPanelTab = primaryAssistantInaccessible
     ? 'all-sessions'
@@ -124,10 +122,52 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
     useState<BoardAssistantPanelTab>(defaultTab);
   const isControlled = controlledActiveTab !== undefined;
   const activeTab = controlledActiveTab ?? uncontrolledActiveTab;
+  const [sessionDetailsHydrated, setSessionDetailsHydrated] = useState(() => !deferSessionDetails);
+  useEffect(() => {
+    setSessionDetailsHydrated(!deferSessionDetails);
+  }, [deferSessionDetails]);
+
+  const hydrateDeferredDetails = useCallback(() => {
+    if (sessionDetailsHydrated) return;
+    setSessionDetailsHydrated(true);
+    onDeferredDetailsHydrated?.();
+  }, [onDeferredDetailsHydrated, sessionDetailsHydrated]);
+
+  useEffect(() => {
+    if (!deferSessionDetails || sessionDetailsHydrated) return;
+
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleCallbackId: number | undefined;
+    const hydrate = () => hydrateDeferredDetails();
+
+    if ('requestIdleCallback' in window) {
+      idleCallbackId = window.requestIdleCallback(hydrate, { timeout: 2500 });
+    } else {
+      fallbackTimer = globalThis.setTimeout(hydrate, 2000);
+    }
+
+    return () => {
+      if (idleCallbackId !== undefined) window.cancelIdleCallback?.(idleCallbackId);
+      if (fallbackTimer !== undefined) window.clearTimeout(fallbackTimer);
+    };
+  }, [deferSessionDetails, hydrateDeferredDetails, sessionDetailsHydrated]);
+
   const setActiveTab = (tab: BoardAssistantPanelTab) => {
+    hydrateDeferredDetails();
     setUncontrolledActiveTab(tab);
     onTabChange?.(tab);
   };
+
+  // Derive board comments only when the comments tab is actually visible. The
+  // default assistant tab does not need to scan the global comment map during
+  // Home → board navigation.
+  const comments = useMemo(
+    () =>
+      activeTab === 'comments'
+        ? mapToArray(commentById).filter((c) => c.board_id === board?.board_id)
+        : [],
+    [activeTab, commentById, board?.board_id]
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset the tab when switching boards, even if the default tab string is unchanged.
   useEffect(() => {
@@ -137,29 +177,29 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
     }
   }, [defaultTab, board?.board_id, isControlled, onTabChange]);
 
-  const assistantOptions = useMemo(
-    () =>
-      Array.from(branchById.values())
-        .filter((branch) => isAssistant(branch) && !branch.archived)
-        .sort((a, b) => {
-          const aConfig = getAssistantConfig(a);
-          const bConfig = getAssistantConfig(b);
-          return (aConfig?.displayName ?? a.name).localeCompare(bConfig?.displayName ?? b.name);
-        })
-        .map((branch) => {
-          const config = getAssistantConfig(branch);
-          const repo = repoById.get(branch.repo_id);
-          const label = config?.displayName ?? branch.name;
-          return {
-            value: branch.branch_id,
-            label,
-            searchText: `${label} ${branch.name} ${repo?.slug ?? ''}`,
-            branch,
-            repo,
-          };
-        }),
-    [branchById, repoById]
-  );
+  const assistantOptions = useMemo(() => {
+    if (primaryAssistantBranch || primaryAssistantInaccessible) return [];
+
+    return Array.from(branchById.values())
+      .filter((branch) => isAssistant(branch) && !branch.archived)
+      .sort((a, b) => {
+        const aConfig = getAssistantConfig(a);
+        const bConfig = getAssistantConfig(b);
+        return (aConfig?.displayName ?? a.name).localeCompare(bConfig?.displayName ?? b.name);
+      })
+      .map((branch) => {
+        const config = getAssistantConfig(branch);
+        const repo = repoById.get(branch.repo_id);
+        const label = config?.displayName ?? branch.name;
+        return {
+          value: branch.branch_id,
+          label,
+          searchText: `${label} ${branch.name} ${repo?.slug ?? ''}`,
+          branch,
+          repo,
+        };
+      });
+  }, [branchById, primaryAssistantBranch, primaryAssistantInaccessible, repoById]);
   const [selectedAssistantId, setSelectedAssistantId] = useState<string | undefined>();
   const [assigningAssistant, setAssigningAssistant] = useState(false);
 
@@ -296,20 +336,40 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
             )}
           </div>
 
-          <BranchSessionSections
-            branch={primaryAssistantBranch}
-            sessions={assistantSessions}
-            userById={userById}
-            currentUserId={currentUserId}
-            selectedSessionId={selectedSessionId}
-            onSessionClick={onSessionClick}
-            onCreateSession={onCreateSession}
-            onForkSession={onForkSession}
-            onSpawnSession={onSpawnSession}
-            onOpenSessionSettings={onOpenSessionSettings}
-            mode="panel"
-            client={client}
-          />
+          {sessionDetailsHydrated ? (
+            <BranchSessionSections
+              branch={primaryAssistantBranch}
+              sessions={assistantSessions}
+              userById={userById}
+              currentUserId={currentUserId}
+              selectedSessionId={selectedSessionId}
+              onSessionClick={onSessionClick}
+              onCreateSession={onCreateSession}
+              onForkSession={onForkSession}
+              onSpawnSession={onSpawnSession}
+              onOpenSessionSettings={onOpenSessionSettings}
+              defaultExpanded={false}
+              mode="panel"
+              client={client}
+            />
+          ) : (
+            <div style={{ paddingTop: 8 }}>
+              <Space direction="vertical" size={8} style={{ width: '100%' }}>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Loading sessions…
+                </Typography.Text>
+                <Skeleton active paragraph={{ rows: 3 }} title={false} />
+                <Button
+                  size="small"
+                  type="link"
+                  onClick={hydrateDeferredDetails}
+                  style={{ padding: 0 }}
+                >
+                  Show now
+                </Button>
+              </Space>
+            </div>
+          )}
         </div>
       );
     }
@@ -395,14 +455,20 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
             label: 'All sessions',
             children: board ? (
               <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
-                <BoardSessionList
-                  board={board}
-                  currentBoardId={board.board_id}
-                  branchById={branchById}
-                  repoById={repoById}
-                  sessionsByBranch={sessionsByBranch}
-                  onSessionClick={onSessionClick}
-                />
+                {sessionDetailsHydrated ? (
+                  <BoardSessionList
+                    board={board}
+                    currentBoardId={board.board_id}
+                    branchById={branchById}
+                    repoById={repoById}
+                    sessionsByBranch={sessionsByBranch}
+                    onSessionClick={onSessionClick}
+                  />
+                ) : (
+                  <div style={{ padding: 16 }}>
+                    <Skeleton active paragraph={{ rows: 4 }} title={false} />
+                  </div>
+                )}
               </div>
             ) : (
               <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No board selected" />

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -61,6 +61,11 @@ import { ToolIcon } from '../ToolIcon';
 import { buildSessionTree, type SessionTreeNode } from './buildSessionTree';
 
 export type BranchSessionSectionsMode = 'card' | 'panel';
+type CollapseKey = string | number;
+type RemoteRelationshipRef = {
+  relationship_type?: string;
+  source_session_id?: string;
+};
 
 export interface BranchSessionSectionsProps {
   branch: Branch;
@@ -259,6 +264,39 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const [sort, setSort] = useLocalStorage<SessionSort>(SESSION_SORT_STORAGE_KEY, 'recent');
 
   const isPanel = mode === 'panel';
+  const [openSectionKeys, setOpenSectionKeys] = useState<CollapseKey[]>(() =>
+    defaultExpanded ? ['sessions'] : []
+  );
+  const isManualSessionsOpen = openSectionKeys.includes('sessions');
+  const isScheduledRunsOpen = openSectionKeys.includes('scheduled-runs');
+  const isGatewaySessionsOpen = openSectionKeys.includes('gateway-sessions');
+  const updateSectionOpenState = useCallback(
+    (sectionKey: CollapseKey, keys: CollapseKey | CollapseKey[]) => {
+      const sectionIsOpen = Array.isArray(keys) ? keys.includes(sectionKey) : keys === sectionKey;
+      setOpenSectionKeys((currentKeys) => {
+        const alreadyOpen = currentKeys.includes(sectionKey);
+        if (sectionIsOpen) return alreadyOpen ? currentKeys : [...currentKeys, sectionKey];
+        return alreadyOpen ? currentKeys.filter((key) => key !== sectionKey) : currentKeys;
+      });
+    },
+    []
+  );
+  const handleManualSessionsChange = useCallback(
+    (keys: CollapseKey | CollapseKey[]) => updateSectionOpenState('sessions', keys),
+    [updateSectionOpenState]
+  );
+  const handleScheduledRunsChange = useCallback(
+    (keys: CollapseKey | CollapseKey[]) => updateSectionOpenState('scheduled-runs', keys),
+    [updateSectionOpenState]
+  );
+  const handleGatewaySessionsChange = useCallback(
+    (keys: CollapseKey | CollapseKey[]) => updateSectionOpenState('gateway-sessions', keys),
+    [updateSectionOpenState]
+  );
+  useEffect(() => {
+    if (!defaultExpanded) return;
+    setOpenSectionKeys((keys) => (keys.includes('sessions') ? keys : [...keys, 'sessions']));
+  }, [defaultExpanded]);
   const peekedIds = peekedSessionIds ?? new Set<string>();
   const trimmedSearchQuery = searchQuery.trim();
   const searchActive = isSessionSearchActive(trimmedSearchQuery);
@@ -275,7 +313,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     return (
       session.remote_surrogate?.relationship ??
       session.remote_relationships?.as_target?.find(
-        (relationship) => relationship.relationship_type === 'remote_create'
+        (relationship: RemoteRelationshipRef) => relationship.relationship_type === 'remote_create'
       )
     );
   }, []);
@@ -285,7 +323,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       if (session.remote_surrogate) return undefined;
 
       const relationshipParentId = session.remote_relationships?.as_target?.find(
-        (relationship) => relationship.relationship_type === 'remote_create'
+        (relationship: RemoteRelationshipRef) => relationship.relationship_type === 'remote_create'
       )?.source_session_id;
       if (relationshipParentId) return relationshipParentId;
 
@@ -457,12 +495,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     [gatewayEnabled, gatewaySessions, manualSessions, scheduledSessions, schedulerEnabled]
   );
   const sortedManualSessions = useMemo(
-    () => sortSessions(manualSessions, sort),
-    [manualSessions, sort]
+    () => (isManualSessionsOpen ? sortSessions(manualSessions, sort) : []),
+    [isManualSessionsOpen, manualSessions, sort]
   );
   const sessionTreeData = useMemo(
-    () => buildSessionTree(sortedManualSessions),
-    [sortedManualSessions]
+    () => (isManualSessionsOpen ? buildSessionTree(sortedManualSessions) : []),
+    [isManualSessionsOpen, sortedManualSessions]
   );
   const searchResults = useMemo(
     () =>
@@ -487,6 +525,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const isSessionFailed = (session: Session): boolean => session.status === SessionStatus.FAILED;
 
   useEffect(() => {
+    if (!isManualSessionsOpen) return;
+
     const collectKeysWithChildren = (nodes: SessionTreeNode[]): React.Key[] => {
       const keys: React.Key[] = [];
       for (const node of nodes) {
@@ -499,7 +539,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     };
 
     setExpandedKeys(collectKeysWithChildren(sessionTreeData));
-  }, [sessionTreeData]);
+  }, [isManualSessionsOpen, sessionTreeData]);
 
   const sessionRowStyle = (session: Session): React.CSSProperties => {
     const isSessionSelected = session.session_id === selectedSessionId;
@@ -715,7 +755,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     );
   };
 
-  const sessionListContent = (
+  const sessionListContent = isManualSessionsOpen ? (
     <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
       <Tree
         className="agor-flat-tree"
@@ -730,7 +770,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         titleRender={renderSessionNode}
       />
     </ConfigProvider>
-  );
+  ) : null;
 
   const sessionListHeader = (
     <div
@@ -794,7 +834,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     </div>
   );
 
-  const scheduledRunsContent = (
+  const scheduledRunsContent = isScheduledRunsOpen ? (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       {scheduledSessions.map((session) => {
         const isActive = isSessionExecuting(session);
@@ -842,7 +882,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         );
       })}
     </div>
-  );
+  ) : null;
 
   const gatewaySessionsHeader = (
     <div
@@ -866,7 +906,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     </div>
   );
 
-  const gatewaySessionsContent = (
+  const gatewaySessionsContent = isGatewaySessionsOpen ? (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       {gatewaySessions.map((session) => {
         const gatewaySource = getGatewaySource(session);
@@ -937,7 +977,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         );
       })}
     </div>
-  );
+  ) : null;
 
   const sessionSearchBar =
     isPanel && activeSessions.length > 0 ? (
@@ -1062,7 +1102,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         <>
           {manualSessions.length > 0 ? (
             <Collapse
-              defaultActiveKey={defaultExpanded ? ['sessions'] : []}
+              activeKey={openSectionKeys}
+              onChange={handleManualSessionsChange}
               items={[
                 {
                   key: 'sessions',
@@ -1082,7 +1123,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
           {schedulerEnabled && scheduledSessions.length > 0 && (
             <Collapse
-              defaultActiveKey={[]}
+              activeKey={openSectionKeys}
+              onChange={handleScheduledRunsChange}
               items={[
                 {
                   key: 'scheduled-runs',
@@ -1100,7 +1142,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
           {gatewayEnabled && gatewaySessions.length > 0 && (
             <Collapse
-              defaultActiveKey={[]}
+              activeKey={openSectionKeys}
+              onChange={handleGatewaySessionsChange}
               items={[
                 {
                   key: 'gateway-sessions',

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -173,6 +173,7 @@ interface SessionNodeData {
   parentZoneId?: string;
   zoneName?: string;
   zoneColor?: string;
+  isActiveUrlTarget?: boolean;
 }
 
 // Shared empty array for branches that have no sessions. Without this, a
@@ -197,7 +198,7 @@ const SessionNode = React.memo(({ data }: { data: SessionNodeData }) => {
         isPinned={data.isPinned}
         zoneName={data.zoneName}
         zoneColor={data.zoneColor}
-        defaultExpanded={!data.compact}
+        defaultExpanded={Boolean(data.isActiveUrlTarget && !data.compact)}
       />
     </div>
   );
@@ -303,7 +304,7 @@ const BranchNode = React.memo(
           zoneName={data.zoneName}
           client={data.client}
           zoneColor={data.zoneColor}
-          defaultExpanded={!data.compact}
+          defaultExpanded={Boolean(data.isActiveUrlTarget && !data.compact)}
         />
       </div>
     );

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -76,23 +76,22 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
   const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
 
-  // Calculate session count per board (branch-centric model)
+  // Calculate session count per board (branch-centric model). Build the
+  // board buckets once so opening Settings is O(branches + sessions) instead
+  // of O(boards × branches).
   const boardSessionCounts = useMemo(() => {
     const counts = new Map<string, number>();
 
+    for (const branch of branchById.values()) {
+      if (!branch.board_id) continue;
+      counts.set(
+        branch.board_id,
+        (counts.get(branch.board_id) ?? 0) + (sessionsByBranch.get(branch.branch_id)?.length ?? 0)
+      );
+    }
+
     for (const board of boardById.values()) {
-      const boardBranchIds: string[] = [];
-      for (const branch of branchById.values()) {
-        if (branch.board_id === board.board_id) {
-          boardBranchIds.push(branch.branch_id);
-        }
-      }
-
-      const sessionCount = boardBranchIds.flatMap(
-        (branchId) => sessionsByBranch.get(branchId) || []
-      ).length;
-
-      counts.set(board.board_id, sessionCount);
+      if (!counts.has(board.board_id)) counts.set(board.board_id, 0);
     }
 
     return counts;

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -121,7 +121,7 @@ export interface SettingsModalProps {
   branchStorageConfig?: BranchStorageConfig;
 }
 
-export const SettingsModal: React.FC<SettingsModalProps> = ({
+const SettingsModalContent: React.FC<SettingsModalProps> = ({
   open,
   onClose,
   client,
@@ -566,4 +566,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
       />
     </Modal>
   );
+};
+
+export const SettingsModal: React.FC<SettingsModalProps> = (props) => {
+  if (!props.open) return null;
+  return <SettingsModalContent {...props} />;
 };


### PR DESCRIPTION
## Linked issue

Fixes #1768

## Summary

- Render the board/canvas before heavier assistant and session details on Home → board navigation.
- Keep branch cards real on first paint, while deferring session tree construction until sections are opened.
- Avoid hidden Settings work and reduce board session-count computation cost.
- Add lightweight/idle hydration for assistant session details without requiring users to click to load them.

## What was broken

Home → board navigation was doing too much synchronous UI work immediately after the click.

From the user's point of view, the route changed but the browser appeared frozen for multiple seconds before the board became usable. This was especially visible after starting from Home because Home is now a much heavier surface than it used to be.

The important point is that this was not a single `BranchCard` regression. `BranchCard` showed up in profiling because it is part of the first board render, but the actual problem was the transition as a whole: leaving a heavy Home page and immediately mounting a heavy board page caused too much work to land in the same main-thread window.

## Why it was happening

The regression came from several recent changes combining with older eager-render behavior:

1. **Home became a heavier dashboard.** The redesigned Home surface reads and derives data for sessions, boards, stats, onboarding, jump-back-in rows, activity, knowledge/sidebar content, and other summary UI. Navigating away from Home now starts from a much busier React/store state than the old lightweight landing page.
2. **More state is read through global store selectors.** This is useful for live updates, but it also means newly mounted surfaces can immediately consume large maps and derive view state during navigation.
3. **Board mount still assumed it could eagerly render details.** On the first board commit, branch cards could sort/build/render full session trees, scheduled sessions, gateway sessions, and related metadata even though the user only needs the board shell first.
4. **Assistant/sidebar details mounted on the same critical path.** The canvas, branch cards, assistant context, comments/session data, and sidebar details were all competing to render before the board felt ready.
5. **Some hidden UI still did real work.** Closed Settings content and board/session count derivations added avoidable pressure outside the visible path.

Those costs stacked into a multi-second main-thread block: the app navigated, then React had to build too much UI before the browser could paint the board.

## Approach

This PR changes the route transition priority instead of hiding important UI:

1. **Paint the board first.** The canvas and real branch-card shells are the first priority.
2. **Keep visible UI truthful.** Branch cards are not replaced with fake/black placeholders; headers and counts render immediately.
3. **Delay expensive details, not important context.** Session trees, scheduled/gateway session bodies, comments/session-heavy side-panel content, and assistant details hydrate after first paint, during idle time, or when the user opens the relevant section/tab.
4. **Avoid hidden work.** Closed Settings content and hidden comments/assistant-option derivations no longer run on the initial navigation path.

The intended UX is: click Home → board, see the board quickly, then heavier details fill in automatically. “Show now” is only an escape hatch if a user wants to force the deferred panel details sooner; it is not required during normal use.

## Why this improves performance

The fix reduces the amount of work React must complete before the first useful board paint.

Before, a single navigation had to mount the canvas, expand branch/session details, prepare assistant/sidebar details, and run unrelated hidden derivations. After this change, the browser can paint the board once the essential shell is ready, then continue hydrating lower-priority details after the critical path has completed.

That directly targets the measured symptom: long main-thread tasks during Home → board navigation.

## Implementation notes

- Home → board now temporarily defers assistant/sidebar session details so the canvas can paint first.
- `BoardAssistantPanel` skips hidden comments/assistant-option derivations unless those UI paths are visible/needed, and hydrates deferred session details during idle time with a timeout fallback.
- `BranchSessionSections` controls collapse state and only builds/sorts/renders manual, scheduled, and gateway session details when the relevant section is open.
- `SessionCanvas` starts branch/session detail expansion only for the active URL target instead of expanding every branch card on first board commit.
- `SettingsModal` returns `null` while closed, and `BoardsTable` counts board sessions in a single pass over branches/sessions.

## Validation / test plan

- [x] `git diff --check`
- [x] `pnpm exec biome check apps/agor-ui/src/components/App/App.tsx apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx`
- [x] Commit hook / lint-staged biome check passed on staged files.
- [x] Local browser performance measurement on `http://localhost:5174`, Home → board.
- [x] Manual UX pass completed locally: Home → board, board refresh, branch session expansion, assistant/session/comments surfaces.
- [ ] `pnpm -C apps/agor-ui typecheck` is still blocked by existing repo-wide declaration/type issues, primarily missing `@agor-live/client` declarations and pre-existing `SessionCanvas` unknown-object errors.

Performance tracking:

| Scenario | Before | After |
| --- | ---: | ---: |
| Home → board canvas visible | 2654.2ms | 458.7ms |
| Home → board nodes visible | 2726.8ms | 473.0ms |
| Home → board worst long task | 1876ms | 375ms |
| Home → board worst frame gap | 2166.8ms | 384ms |
| Home → Settings modal visible | ~768ms baseline | ~100–161ms after |

The final Home → board measurement was taken after the review fixes for stable deferred-detail callbacks and independent collapse state.

## Screenshots / demos

No screenshots attached. The behavior is visible locally by opening Home and navigating to a board: the board/canvas paints first, real branch cards are visible immediately, and heavier session/sidebar details hydrate afterward.

## Risks / rollout / rollback

- Branch-card session sections now start collapsed unless they are the active URL target; users can expand the sections to load details.
- Assistant/session details hydrate automatically after the board paint; the “Show now” action remains an escape hatch, not a required step.
- Rollback is limited to the UI changes in this PR.

## Out of scope / follow-ups

- Deeper profiling of the remaining ~350–375ms delayed React task when the assistant/sidebar hydrates.
- Broader Home dashboard selector/summary optimization; this PR focuses on the Home → board navigation path.
