### PR TITLE
fix(ui): avoid board canvas rebuilds on session patches

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
@@ -229,6 +229,7 @@ describe('SessionCanvas store-selector re-render isolation', () => {
       expect(cardNodeRenders).toBeGreaterThanOrEqual(1);
     });
 
+    const canvasBaseline = sessionCanvasRenders;
     const branchBBaseline = branchCardRenders.get('B') ?? 0;
     const branchABaseline = branchCardRenders.get('A') ?? 0;
     const cardNodeBaseline = cardNodeRenders;
@@ -242,9 +243,11 @@ describe('SessionCanvas store-selector re-render isolation', () => {
       expect(branchCardRenders.get('A') ?? 0).toBeGreaterThan(branchABaseline);
     });
 
-    // The win: branch B's card and the board-object-derived card node are
-    // untouched because their selector inputs (branch B's session bucket; this
-    // board's board-object array) kept the same reference across the patch.
+    // The win: the session patch is handled inside the affected BranchNode's
+    // per-branch subscription. SessionCanvas itself does not subscribe to the
+    // whole sessionsByBranch map, so React Flow's controlled node array is not
+    // rebuilt for every streaming session patch.
+    expect(sessionCanvasRenders).toBe(canvasBaseline);
     expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
     expect(cardNodeRenders).toBe(cardNodeBaseline);
   });

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -10,6 +10,7 @@ import type {
   Branch,
   BranchID,
   CardWithType,
+  MCPServer,
   Repo,
   Session,
   SpawnConfig,
@@ -362,6 +363,63 @@ const EMPTY_BOARD_ENTITY_OBJECTS: BoardEntityObject[] = Object.freeze(
   [] as BoardEntityObject[]
 ) as BoardEntityObject[];
 
+interface BranchZoneTriggerModalProps {
+  modal: {
+    branchId: BranchID;
+    zoneName: string;
+    zoneId: string;
+    trigger: ZoneTrigger;
+  };
+  client: AgorClient | null;
+  branches: Branch[];
+  board: Board | null;
+  availableAgents: AgenticToolOption[];
+  mcpServerById: Map<string, MCPServer>;
+  currentUser: User | null;
+  onCancel: () => void;
+  onExecute: React.ComponentProps<typeof ZoneTriggerModal>['onExecute'];
+}
+
+// The zone-trigger modal needs the full sessionsByBranch map to offer source
+// session choices, but that map changes on every streaming session patch. Keep
+// that subscription behind this tiny conditional child so the main canvas does
+// not rebuild every React Flow node while the modal is closed.
+const BranchZoneTriggerModal = React.memo(
+  ({
+    modal,
+    client,
+    branches,
+    board,
+    availableAgents,
+    mcpServerById,
+    currentUser,
+    onCancel,
+    onExecute,
+  }: BranchZoneTriggerModalProps) => {
+    const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+
+    return (
+      <ZoneTriggerModal
+        open={true}
+        onCancel={onCancel}
+        client={client}
+        branchId={modal.branchId}
+        branch={branches.find((wt) => wt.branch_id === modal.branchId)}
+        sessionsByBranch={sessionsByBranch}
+        zoneName={modal.zoneName}
+        trigger={modal.trigger}
+        boardName={board?.name}
+        boardDescription={board?.description}
+        boardCustomContext={board?.custom_context}
+        availableAgents={availableAgents}
+        mcpServerById={mcpServerById}
+        currentUser={currentUser}
+        onExecute={onExecute}
+      />
+    );
+  }
+);
+
 const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
   (
     {
@@ -406,7 +464,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // Entity state via narrow store subscriptions. Each whole-map selector is a
     // stable module-level reference, so a slice only re-renders the canvas when
     // its own reference changes (idempotent writes are short-circuited upstream).
-    const sessionsByBranch = useAgorStore(selectSessionsByBranch);
     const repoById = useAgorStore(selectRepoById);
     const branchById = useAgorStore(selectBranchById);
     const commentById = useAgorStore(selectCommentById);
@@ -594,13 +651,10 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const { getBoardObjectNodes, batchUpdateObjectPositions, deleteObject } = useBoardObjects({
       board,
       client,
-      sessionsByBranch,
-      branches,
       boardObjectsForBoard,
       setNodes,
       deletedObjectsRef,
       eraserMode: activeTool === 'eraser',
-      selectedSessionId,
       activeUrlTargetArtifactId,
       onEditMarkdown: handleEditMarkdownNote,
     });
@@ -2785,18 +2839,12 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
         {/* Branch Zone Trigger Modal */}
         {branchTriggerModal && (
-          <ZoneTriggerModal
-            open={true}
+          <BranchZoneTriggerModal
+            modal={branchTriggerModal}
             onCancel={() => setBranchTriggerModal(null)}
             client={client}
-            branchId={branchTriggerModal.branchId}
-            branch={branches.find((wt) => wt.branch_id === branchTriggerModal.branchId)}
-            sessionsByBranch={sessionsByBranch}
-            zoneName={branchTriggerModal.zoneName}
-            trigger={branchTriggerModal.trigger}
-            boardName={board?.name}
-            boardDescription={board?.description}
-            boardCustomContext={board?.custom_context}
+            branches={branches}
+            board={board}
             availableAgents={availableAgents}
             mcpServerById={mcpServerById}
             currentUser={currentUserId ? userById.get(currentUserId) || null : null}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -70,7 +70,7 @@ interface ZoneNodeData {
   x: number;
   y: number;
   trigger?: BoardObject extends { type: 'zone'; trigger?: infer T } ? T : never;
-  sessionCount?: number;
+  pinnedItemCount?: number;
   onUpdate?: (objectId: string, objectData: BoardObject) => void;
   onDelete?: (objectId: string, deleteAssociatedSessions: boolean) => void;
   onReorder?: (objectId: string, op: LayerOp) => void;
@@ -923,7 +923,7 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           }
         }}
         zoneName={data.label}
-        sessionCount={data.sessionCount || 0}
+        pinnedItemCount={data.pinnedItemCount || 0}
       />
     </>
   );

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Modal for confirming zone deletion with options for handling associated sessions
+ * Modal for confirming zone deletion with options for handling associated pinned items
  */
 
 import { Modal, Radio, theme } from 'antd';
@@ -11,7 +11,7 @@ interface DeleteZoneModalProps {
   onCancel: () => void;
   onConfirm: (deleteAssociatedSessions: boolean) => void;
   zoneName: string;
-  sessionCount: number;
+  pinnedItemCount: number;
 }
 
 export const DeleteZoneModal = ({
@@ -19,7 +19,7 @@ export const DeleteZoneModal = ({
   onCancel,
   onConfirm,
   zoneName,
-  sessionCount,
+  pinnedItemCount,
 }: DeleteZoneModalProps) => {
   const { token } = theme.useToken();
   const [deleteAssociatedSessions, setDeleteAssociatedSessions] = useState(false);
@@ -47,10 +47,10 @@ export const DeleteZoneModal = ({
       <div style={{ marginBottom: 16 }}>
         <p style={{ margin: 0, marginBottom: 16 }}>Are you sure you want to delete this zone?</p>
 
-        {sessionCount > 0 && (
+        {pinnedItemCount > 0 && (
           <>
             <p style={{ margin: 0, marginBottom: 16, color: token.colorTextSecondary }}>
-              This zone has {sessionCount} pinned session{sessionCount !== 1 ? 's' : ''}.
+              This zone has {pinnedItemCount} pinned item{pinnedItemCount !== 1 ? 's' : ''}.
             </p>
 
             <Radio.Group
@@ -60,22 +60,22 @@ export const DeleteZoneModal = ({
               <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                 <Radio value={false}>
                   <div>
-                    <div style={{ fontWeight: 500 }}>Unpin sessions (keep on board)</div>
+                    <div style={{ fontWeight: 500 }}>Unpin items (keep on board)</div>
                     <div style={{ fontSize: 12, color: token.colorTextSecondary }}>
-                      Sessions will remain on the board at their current positions
+                      Pinned items will remain on the board at their current positions
                     </div>
                   </div>
                 </Radio>
                 <Radio value={true} disabled>
                   <div>
                     <div style={{ fontWeight: 500 }}>
-                      Delete pinned sessions too{' '}
+                      Delete pinned items too{' '}
                       <span style={{ fontSize: 11, color: token.colorTextTertiary }}>
                         [coming soon]
                       </span>
                     </div>
                     <div style={{ fontSize: 12, color: token.colorTextSecondary }}>
-                      Remove sessions from board entirely
+                      Remove pinned items from board entirely
                     </div>
                   </div>
                 </Radio>
@@ -84,9 +84,9 @@ export const DeleteZoneModal = ({
           </>
         )}
 
-        {sessionCount === 0 && (
+        {pinnedItemCount === 0 && (
           <p style={{ margin: 0, color: token.colorTextSecondary }}>
-            This zone has no pinned sessions.
+            This zone has no pinned items.
           </p>
         )}
       </div>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
@@ -51,8 +51,6 @@ function renderReorder(board: Board, client: unknown) {
       useBoardObjects({
         board,
         client: client as never,
-        sessionsByBranch: new Map(),
-        branches: [],
         boardObjectsForBoard: [],
         setNodes: vi.fn(),
         deletedObjectsRef: { current: new Set<string>() },

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -2,15 +2,8 @@
  * Hook for managing board objects (text labels, zones, etc.)
  */
 
-import type {
-  AgorClient,
-  Board,
-  BoardEntityObject,
-  BoardObject,
-  Branch,
-  Session,
-} from '@agor-live/client';
-import { useCallback, useMemo, useRef } from 'react';
+import type { AgorClient, Board, BoardEntityObject, BoardObject } from '@agor-live/client';
+import { useCallback, useRef } from 'react';
 import type { Node } from 'reactflow';
 import { useThemedMessage } from '../../../utils/message';
 import {
@@ -23,13 +16,10 @@ import {
 interface UseBoardObjectsProps {
   board: Board | null;
   client: AgorClient | null;
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
-  branches: Branch[];
   boardObjectsForBoard: BoardEntityObject[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   deletedObjectsRef: React.MutableRefObject<Set<string>>;
   eraserMode?: boolean;
-  selectedSessionId?: string | null;
   /** Artifact ID currently targeted by an `/a/<…>/` deep link. Used to
    *  flag the matching ArtifactNode so it can render the dashed
    *  "selected" outline. */
@@ -40,13 +30,10 @@ interface UseBoardObjectsProps {
 export const useBoardObjects = ({
   board,
   client,
-  sessionsByBranch,
-  branches,
   boardObjectsForBoard,
   setNodes,
   deletedObjectsRef,
   eraserMode = false,
-  selectedSessionId,
   activeUrlTargetArtifactId,
   onEditMarkdown,
 }: UseBoardObjectsProps) => {
@@ -56,24 +43,10 @@ export const useBoardObjects = ({
 
   const { showError } = useThemedMessage();
 
-  // Stabilize board.objects reference using deep equality comparison
-  // This prevents unnecessary re-renders when board object changes but content is identical
-  const boardObjectsJson = board?.objects ? JSON.stringify(board.objects) : null;
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Intentionally using JSON serialization for deep equality
-  const boardObjects = useMemo(() => board?.objects, [boardObjectsJson]);
-
-  // Get session IDs for this board (branch-centric model)
-  const _boardSessionIds = useMemo(() => {
-    if (!board) return [];
-    const boardBranchIds = branches
-      .filter((w) => w.board_id === board.board_id)
-      .map((w) => w.branch_id);
-
-    // Use O(1) Map lookups to get sessions for each branch
-    return boardBranchIds
-      .flatMap((branchId) => sessionsByBranch.get(branchId) || [])
-      .map((s) => s.session_id);
-  }, [board, branches, sessionsByBranch]);
+  // Use the board object's reference directly. The store already preserves
+  // unchanged board references, and serializing every object on every canvas
+  // render is prohibitively expensive on large boards.
+  const boardObjects = board?.objects;
 
   /**
    * Update an existing board object
@@ -356,17 +329,16 @@ export const useBoardObjects = ({
           };
         }
 
-        // Calculate branch count for this zone (branch-centric model)
-        let sessionCount = 0;
+        // Count entities pinned to this zone via board_objects.zone_id.
+        // Deliberately avoid subscribing the whole canvas to sessionsByBranch:
+        // streaming session patches are high-frequency and should only update
+        // the affected BranchCard's per-branch selector, not rebuild every
+        // React Flow node on the board.
+        let pinnedItemCount = 0;
         if (objectData.type === 'zone') {
-          // Count branches pinned to this zone via board_objects.zone_id
           for (const boardObj of boardObjectsForBoard) {
-            if (boardObj.zone_id === objectId) {
-              // Count sessions in this branch using O(1) Map lookup
-              const branchSessions = boardObj.branch_id
-                ? sessionsByBranch.get(boardObj.branch_id) || []
-                : [];
-              sessionCount += branchSessions.length;
+            if (boardObj.zone_id === objectId && (boardObj.branch_id || boardObj.card_id)) {
+              pinnedItemCount += 1;
             }
           }
         }
@@ -408,7 +380,7 @@ export const useBoardObjects = ({
             x: objectData.x, // Include position in data for updates
             y: objectData.y,
             trigger: objectData.type === 'zone' ? objectData.trigger : undefined,
-            sessionCount,
+            pinnedItemCount,
             onUpdate: handleUpdateObject,
             onDelete: deleteZone,
             onReorder: reorderObject,
@@ -416,9 +388,8 @@ export const useBoardObjects = ({
         };
       });
   }, [
-    boardObjects, // Use stabilized boardObjects instead of board?.objects
+    boardObjects,
     boardObjectsForBoard,
-    sessionsByBranch,
     handleUpdateObject,
     deleteZone,
     deleteObject,


### PR DESCRIPTION
## Summary
- stop SessionCanvas from subscribing to the hot sessionsByBranch map while rendering the board
- move the zone-trigger modal's sessionsByBranch subscription behind a conditional child so it is only active while the modal is open
- remove per-render JSON.stringify stabilization of board.objects and count pinned zone items from board-object placement data
- add a render-churn regression assertion that session patches do not re-render SessionCanvas / rebuild React Flow nodes

## Checks
- pnpm --filter agor-ui test -- SessionCanvas.rerender.test.tsx BranchCard.rerender.test.tsx useBoardObjects.test.tsx
- pnpm exec biome check apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx

## Note
- pnpm --filter agor-ui typecheck is currently blocked in this fresh worktree because @agor-live/client / @agor/core generated workspace entrypoints are missing.