### PR TITLE
perf(ui): virtualize board canvas to cut home→board cold-mount load

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
@@ -23,6 +23,9 @@ import SessionCanvas from './SessionCanvas';
 // board-object-derived card node.
 const branchCardRenders = new Map<string, number>();
 let cardNodeRenders = 0;
+// Captures the props last passed to the (mocked) ReactFlow so tests can assert
+// on canvas-level configuration such as viewport virtualization.
+let lastReactFlowProps: { onlyRenderVisibleElements?: boolean } | null = null;
 // SessionCanvas's own render count. The mocked ReactFlow below renders exactly
 // once per SessionCanvas render, so its invocation count is a faithful proxy —
 // it lets us assert the memo+selector boundary protects the WHOLE canvas, not
@@ -74,8 +77,10 @@ vi.mock('reactflow', async () => {
       nodes?: Array<{ id: string; type: string; data: unknown }>;
       nodeTypes?: Record<string, React.ComponentType<{ data: unknown }>>;
       children?: React.ReactNode;
+      onlyRenderVisibleElements?: boolean;
     }) => {
       sessionCanvasRenders += 1;
+      lastReactFlowProps = props;
       return (
         <div data-testid="react-flow">
           {props.nodes?.map((node) => {
@@ -202,8 +207,25 @@ describe('SessionCanvas store-selector re-render isolation', () => {
     branchCardRenders.clear();
     cardNodeRenders = 0;
     sessionCanvasRenders = 0;
+    lastReactFlowProps = null;
     agorStore.setState({ ...EMPTY_MAPS });
     seedStore();
+  });
+
+  it('enables ReactFlow viewport virtualization (onlyRenderVisibleElements)', async () => {
+    // Regression guard for the home→board cold-mount perf fix: without viewport
+    // virtualization, entering a large board from Home mounts every BranchCard
+    // and boots every Sandpack artifact at once (~15s). See SessionCanvas.tsx.
+    render(
+      <ConnectionProvider value={CONNECTION_VALUE}>
+        <SessionCanvas board={board} client={null} branches={BRANCHES} />
+      </ConnectionProvider>
+    );
+
+    await waitFor(() => {
+      expect(lastReactFlowProps).not.toBeNull();
+    });
+    expect(lastReactFlowProps?.onlyRenderVisibleElements).toBe(true);
   });
 
   it('a session:patched for branch A does not re-render branch B card nor the board-object card node', async () => {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2495,6 +2495,19 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             nodesConnectable={false}
             elementsSelectable={true}
             elevateNodesOnSelect={false}
+            // Viewport virtualization. Entering a board from Home is a COLD mount
+            // of the whole graph (Home unmounts SessionCanvas), so without this
+            // every BranchCard and every Sandpack artifact/app node mounts — and
+            // each artifact boots its own Sandpack sandbox (babel transpile +
+            // iframe) — all at once. That is the dominant cost of the ~15s
+            // home→board load on large boards. Culling to on-viewport nodes keeps
+            // the fiber tree (and the offscreen Sandpack boots) proportional to
+            // what actually fits on screen; on a large board fitView clamps to
+            // minZoom (0.1) and the content overflows the window, so most nodes
+            // are offscreen and never mount until scrolled into view. DOM-only
+            // culling: `instance.getNodes()`, fitView, and edge routing all read
+            // node geometry from the store, so logic is unaffected.
+            onlyRenderVisibleElements={true}
             // Two-finger scrolling to pan when in select mode (Figma-style)
             // Also allow click-drag to pan since selection box isn't useful here
             // Disable all panning when actively drawing a zone to prevent interference


### PR DESCRIPTION
## Problem

Navigating **home → a large board** via the navbar board-switcher takes ~15s, but hitting **back** (or opening a session on the same board) is instant.

## Root cause

The homepage redesign (#1591, sessions-first Home) made Home a **separate surface**. In `components/App/App.tsx` the canvas is rendered as `{isHomeSurface ? <HomePage/> : <SessionCanvas/>}`, so **Home unmounts SessionCanvas**. Entering a board from Home is therefore a **cold mount of the entire React Flow graph** — every `BranchCard` and every Sandpack artifact/app node mounts at once, and each artifact boots its own Sandpack sandbox (babel transpile + iframe + browserfs). Back-button / session navigation keeps `!isHomeSurface`, so the canvas never unmounts → instant. Cost scales with board size → ~15s on large boards.

Two amplifiers:
1. `<ReactFlow>` had no viewport virtualization, so the *whole* graph lived in the fiber tree (this is what makes React DevTools' `updateFiberRecursively`/`updateVirtualChildrenRecursively` walk — the flame chart in the DevTools trace — so expensive).
2. Every artifact/app node boots Sandpack on mount (a separate transpiler renderer process was visible in the trace).

Note: data hydration does **not** re-run on navigation (`fetchData` deps are `[client, directSessionId, enabled]`; board scope is resolved from the URL only at mount), so this is a component-mount cost, not a store re-sync.

## Fix

- **Enable `onlyRenderVisibleElements`** on `<ReactFlow>`. On a large board, `fitView` clamps to `minZoom` (0.1) and the content overflows the window, so most nodes are offscreen and are culled — their `BranchCard`s and Sandpack boots never mount until scrolled into view. DOM-only culling: `instance.getNodes()`, `fitView`, and edge routing all read node geometry from the store, so app logic is unaffected.
- **Memoize `activeComments`** so it isn't re-derived (and re-scanned by `hasUserMentions`) on every App render during the load burst.
- **Regression test** asserting viewport virtualization stays enabled.

## Checks

- `vitest run SessionCanvas BranchCard useBoardObjects` → 91 passed (incl. new test)
- `biome check` on changed files → clean
- Full `tsc` typecheck is blocked by the missing generated `@agor-live/client` dist in this worktree (every error is `Cannot find module '@agor-live/client'`) — pre-existing, unrelated to these changes.

## Suggested follow-ups (not in this PR)

- **Viewport/zoom-size-gated Sandpack boot**: defer `<SandpackProvider>` in `ArtifactNode`/`AppNode` until the node is on-screen *and* large enough (`width*zoom ≥ ~140px`), latched. Handles the case where a board fully fits on screen at low zoom (all nodes "visible" but tiny). Careful: pre-`fitView` the viewport is zoom=1, which would boot everything — the gate must key off the settled/post-fit zoom.
- **Keep SessionCanvas mounted across Home** (overlay HomePage instead of unmounting) so repeat home→board visits are instant like back-button.
- **Instrumentation**: add a `performance.mark`/`measure` around SessionCanvas mount→first fitView, and count Sandpack boots per board load, to quantify before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)