### PR TITLE
Ping/mention collaborators inside a session (non-agent messages)

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/messages.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.test.ts
@@ -245,6 +245,25 @@ describe('agor_messages_list MCP tool', () => {
     expect(mockAllSpy).toHaveBeenCalled();
   });
 
+  it('always excludes mention (ping) messages from agent-facing results', async () => {
+    const handler = await registerAndGetHandler({ userId: 'user-1' });
+
+    await handler({ sessionId: 'sess-0001', includeToolCalls: true });
+
+    expect(mockWhereSpy).toHaveBeenCalledTimes(1);
+    // Drizzle SQL fragments are circular; flatten to text to assert on content
+    // without depending on their internal shape.
+    const seen = new WeakSet();
+    const flattened = JSON.stringify(mockWhereSpy.mock.calls[0]?.[0], (_key, v) => {
+      if (typeof v === 'object' && v !== null) {
+        if (seen.has(v)) return undefined;
+        seen.add(v);
+      }
+      return v;
+    });
+    expect(flattened).toContain("!= 'mention'");
+  });
+
   it('sets next_offset to the raw rows consumed for the returned page', async () => {
     mockAllSpy.mockResolvedValue([row(0), row(1), row(2)]);
     const handler = await registerAndGetHandler({ userId: 'user-1' });

--- a/apps/agor-daemon/src/mcp/tools/messages.ts
+++ b/apps/agor-daemon/src/mcp/tools/messages.ts
@@ -152,6 +152,11 @@ export function registerMessageTools(server: McpServer, ctx: McpContext): void {
         );
       }
 
+      // Pings ('mention' messages) are human-to-human notes, never part of the
+      // agent's own conversation — exclude unconditionally so the agent can't
+      // read them back through this tool either.
+      conditions.push(sql`${messagesTable.type} != 'mention'`);
+
       // Search: parse "term1 term2 | term3 term4" into (t1 AND t2) OR (t3 AND t4)
       if (search) {
         const orGroups = search.split(/\s*\|\s*/).map((group) => {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -233,13 +233,12 @@ import {
   deferWithSessionQueueTenantScope,
   runWithSessionQueueTenantScope,
 } from './utils/session-queue-tenant-scope.js';
-import { findHostTaskForSession } from './utils/session-tasks.js';
 import { stopSessionPreserveQueue } from './utils/session-stop.js';
 import {
   sessionCanStartTask,
   shouldReconcileSessionPromptState,
 } from './utils/session-task-state.js';
-import { findActiveTasksForSession } from './utils/session-tasks.js';
+import { findActiveTasksForSession, findHostTaskForSession } from './utils/session-tasks.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { bindStopRouteRepositories } from './utils/stop-route-repositories.js';
 import { formatStructuredLog, structuredLogErrorCode } from './utils/structured-log.js';

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -233,6 +233,7 @@ import {
   deferWithSessionQueueTenantScope,
   runWithSessionQueueTenantScope,
 } from './utils/session-queue-tenant-scope.js';
+import { findHostTaskForSession } from './utils/session-tasks.js';
 import { stopSessionPreserveQueue } from './utils/session-stop.js';
 import {
   sessionCanStartTask,
@@ -820,7 +821,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     sessionsService,
     boardsService,
     branchRepository,
-    usersRepository: _usersRepository,
+    usersRepository,
     sessionsRepository,
     sessionMCPServersService,
     sessionEnvSelectionsService,
@@ -2219,6 +2220,72 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     },
     {
       create: { role: ROLES.MEMBER, action: 'execute prompts' },
+    },
+    requireAuth
+  );
+
+  // ============================================================================
+  // Ping endpoint
+  //
+  // A "ping" is a human-to-human note in the conversation stream — Slack-style
+  // `@collaborator what do you think?`. Unlike /sessions/:id/prompt, this path
+  // NEVER creates/queues a Task and NEVER spawns the executor: it only writes
+  // a `type: 'mention'` message via the same messages service used elsewhere,
+  // so the same RBAC hooks (ensureCanPromptInSession) apply. Structurally this
+  // guarantees the ping can't reach the agent — no Task means the executor is
+  // never invoked with it. It's also excluded from the agent-facing
+  // `agor_messages_list` MCP tool (see mcp/tools/messages.ts) so the agent
+  // can't read it back that way either.
+  // ============================================================================
+
+  registerAuthenticatedRoute(
+    app,
+    '/sessions/:id/ping',
+    {
+      async create(data: { text: string; mentioned_user_ids?: string[] }, params: RouteParams) {
+        const id = params.route?.id;
+        if (!id) throw new Error('Session ID required');
+        const text = data.text?.trim();
+        if (!text) throw new Error('Ping text required');
+        if (!params.user?.user_id) {
+          throw new NotAuthenticated('Authentication required to ping a session');
+        }
+
+        const session = await sessionsService.get(id, params);
+
+        // Resolve mentioned user ids, silently dropping any that don't
+        // resolve to a real user (best-effort — the ping still posts).
+        const requestedMentionIds = Array.from(new Set(data.mentioned_user_ids ?? []));
+        const mentions: UserID[] = [];
+        for (const userId of requestedMentionIds) {
+          const user = await usersRepository.findById(userId);
+          if (user) mentions.push(user.user_id as UserID);
+        }
+
+        // Attach to the session's host task (mirrors the widget_request
+        // pattern) so the transcript renderer — which loads messages by
+        // task_id — picks it up. Sessions with no tasks yet (never prompted)
+        // have no host task; the ping is still stored but won't render until
+        // the session has at least one task.
+        const hostTask = await findHostTaskForSession(app, session.session_id, params);
+
+        const created = await appendSystemMessage({
+          app,
+          db,
+          sessionId: session.session_id,
+          taskId: hostTask?.task_id,
+          content: text,
+          type: 'mention',
+          role: MessageRole.USER,
+          metadata: { mentions },
+          params,
+        });
+
+        return created;
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'ping session collaborators' },
     },
     requireAuth
   );

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2277,7 +2277,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           content: text,
           type: 'mention',
           role: MessageRole.USER,
-          metadata: { mentions },
+          metadata: { mentions, author_user_id: params.user.user_id as UserID },
           params,
         });
 

--- a/apps/agor-daemon/src/utils/append-system-message.ts
+++ b/apps/agor-daemon/src/utils/append-system-message.ts
@@ -33,7 +33,10 @@ export interface AppendSystemMessageOptions {
   /** Falls back to the first 200 chars of string content when omitted */
   contentPreview?: string;
   /** Defaults to 'system' */
-  type?: Extract<MessageType, 'system' | 'daemon_restart' | 'daemon_crash' | 'widget_request'>;
+  type?: Extract<
+    MessageType,
+    'system' | 'daemon_restart' | 'daemon_crash' | 'widget_request' | 'mention'
+  >;
   /** Defaults to MessageRole.SYSTEM */
   role?: Message['role'];
   metadata?: Message['metadata'];

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1420,6 +1420,24 @@ function AppContent() {
     }
   };
 
+  // Handle send ping - human-to-human note, never reaches the agent
+  const handleSendPing = async (
+    sessionId: string,
+    text: string,
+    mentionedUserIds?: string[]
+  ): Promise<boolean> => {
+    if (!client) return false;
+
+    try {
+      await client.sessions.ping(sessionId, text, mentionedUserIds);
+      return true;
+    } catch (error) {
+      showError(`Failed to send ping: ${error instanceof Error ? error.message : String(error)}`);
+      console.error('Ping error:', error);
+      return false;
+    }
+  };
+
   // Handle update session
   const handleUpdateSession = async (sessionId: string, updates: Partial<Session>) => {
     const authority = appAuthorityGuard.begin();
@@ -2188,6 +2206,7 @@ function AppContent() {
       onBtwForkSession={handleBtwForkSession}
       onSpawnSession={handleSpawnSession}
       onSendPrompt={handleSendPrompt}
+      onSendPing={handleSendPing}
       onUpdateSession={handleUpdateSession}
       onDeleteSession={handleDeleteSession}
       onCreateBoard={handleCreateBoard}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -189,6 +189,11 @@ export interface AppProps {
     prompt: string,
     permissionMode?: PermissionMode
   ) => boolean | undefined | Promise<boolean | undefined>;
+  onSendPing?: (
+    sessionId: string,
+    text: string,
+    mentionedUserIds?: string[]
+  ) => boolean | undefined | Promise<boolean | undefined>;
   onUpdateSession?: (sessionId: string, updates: Partial<Session>) => void;
   onDeleteSession?: (sessionId: string) => void;
   onCreateBoard?: (board: Partial<Board>) => Promise<Board | null>;
@@ -336,6 +341,7 @@ export const App: React.FC<AppProps> = ({
   onBtwForkSession,
   onSpawnSession,
   onSendPrompt,
+  onSendPing,
   onUpdateSession,
   onDeleteSession,
   onCreateBoard,
@@ -1314,6 +1320,50 @@ export const App: React.FC<AppProps> = ({
   // terminal buttons via `{onOpenTerminal && ...}`.
   const canOpenTerminal = webTerminalEnabled && hasMinimumRole(user?.role, WEB_TERMINAL_MIN_ROLE);
 
+<<<<<<< HEAD
+=======
+  // Memoize AppActionsContext value with useCallback-wrapped handlers
+  const appActionsValue = useMemo(
+    () => ({
+      onSendPrompt,
+      onSendPing,
+      onFork: onForkSession,
+      onBtwFork: onBtwForkSession,
+      onSubsession: onSpawnSession,
+      onUpdateSession,
+      onDeleteSession,
+      onPermissionDecision: handlePermissionDecision,
+      onStartEnvironment,
+      onStopEnvironment,
+      onNukeEnvironment,
+      onViewLogs: (branchId: string) => setLogsModalBranchId(branchId),
+      onOpenSettings: (sessionId: string) => setSessionSettingsId(sessionId),
+      onSessionClick: handleSessionClick,
+      onOpenBranch: (branchId: string, tab?: BranchModalTab) => {
+        setBranchModalBranchId(branchId);
+        setBranchModalTab(tab);
+      },
+      onOpenTerminal: canOpenTerminal ? handleOpenTerminal : undefined,
+    }),
+    [
+      onSendPrompt,
+      onSendPing,
+      onForkSession,
+      onBtwForkSession,
+      onSpawnSession,
+      onUpdateSession,
+      onDeleteSession,
+      handlePermissionDecision,
+      onStartEnvironment,
+      onStopEnvironment,
+      onNukeEnvironment,
+      handleSessionClick,
+      handleOpenTerminal,
+      canOpenTerminal,
+    ]
+  );
+
+>>>>>>> 25fbfd852 (feat(ui): add Ping compose action to session composer)
   // Stabilize the passthrough action props before they reach the memoized
   // SessionCanvas and the AppActions context value. These arrive from
   // AppContent as plain consts (fresh identity on every store-driven

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1320,50 +1320,6 @@ export const App: React.FC<AppProps> = ({
   // terminal buttons via `{onOpenTerminal && ...}`.
   const canOpenTerminal = webTerminalEnabled && hasMinimumRole(user?.role, WEB_TERMINAL_MIN_ROLE);
 
-<<<<<<< HEAD
-=======
-  // Memoize AppActionsContext value with useCallback-wrapped handlers
-  const appActionsValue = useMemo(
-    () => ({
-      onSendPrompt,
-      onSendPing,
-      onFork: onForkSession,
-      onBtwFork: onBtwForkSession,
-      onSubsession: onSpawnSession,
-      onUpdateSession,
-      onDeleteSession,
-      onPermissionDecision: handlePermissionDecision,
-      onStartEnvironment,
-      onStopEnvironment,
-      onNukeEnvironment,
-      onViewLogs: (branchId: string) => setLogsModalBranchId(branchId),
-      onOpenSettings: (sessionId: string) => setSessionSettingsId(sessionId),
-      onSessionClick: handleSessionClick,
-      onOpenBranch: (branchId: string, tab?: BranchModalTab) => {
-        setBranchModalBranchId(branchId);
-        setBranchModalTab(tab);
-      },
-      onOpenTerminal: canOpenTerminal ? handleOpenTerminal : undefined,
-    }),
-    [
-      onSendPrompt,
-      onSendPing,
-      onForkSession,
-      onBtwForkSession,
-      onSpawnSession,
-      onUpdateSession,
-      onDeleteSession,
-      handlePermissionDecision,
-      onStartEnvironment,
-      onStopEnvironment,
-      onNukeEnvironment,
-      handleSessionClick,
-      handleOpenTerminal,
-      canOpenTerminal,
-    ]
-  );
-
->>>>>>> 25fbfd852 (feat(ui): add Ping compose action to session composer)
   // Stabilize the passthrough action props before they reach the memoized
   // SessionCanvas and the AppActions context value. These arrive from
   // AppContent as plain consts (fresh identity on every store-driven
@@ -1371,6 +1327,7 @@ export const App: React.FC<AppProps> = ({
   // AppActions consumer — would re-render whenever the parent re-renders,
   // even when nothing they draw changed.
   const stableOnSendPrompt = useStableCallback(onSendPrompt);
+  const stableOnSendPing = useStableCallback(onSendPing);
   const stableOnBtwForkSession = useStableCallback(onBtwForkSession);
   const stableOnSessionUpdate = useStableCallback(onUpdateSession);
   const stableOnSessionDelete = useStableCallback(onDeleteSession);
@@ -1400,6 +1357,7 @@ export const App: React.FC<AppProps> = ({
   const appActionsValue = useMemo(
     () => ({
       onSendPrompt: stableOnSendPrompt,
+      onSendPing: stableOnSendPing,
       onFork: stableOnForkSession,
       onBtwFork: stableOnBtwForkSession,
       onSubsession: stableOnSpawnSession,
@@ -1423,6 +1381,7 @@ export const App: React.FC<AppProps> = ({
     }),
     [
       stableOnSendPrompt,
+      stableOnSendPing,
       stableOnForkSession,
       stableOnBtwForkSession,
       stableOnSpawnSession,

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
@@ -281,6 +281,39 @@ describe('AutocompleteTextarea', () => {
     expect(kbDocumentsFind).not.toHaveBeenCalled();
   });
 
+  it('quotes multi-word user mentions and fires onMentionSelect', async () => {
+    const onMentionSelect = vi.fn();
+    const userById = new Map([
+      ['user-1', { user_id: 'user-1', name: 'Jane Smith', email: 'jane@example.com' } as never],
+    ]);
+
+    const Harness = () => {
+      const [value, setValue] = useState('');
+      return (
+        <AutocompleteTextarea
+          value={value}
+          onChange={setValue}
+          placeholder="Prompt"
+          client={null}
+          sessionId={null}
+          userById={userById}
+          onMentionSelect={onMentionSelect}
+        />
+      );
+    };
+    render(<Harness />);
+    const textarea = screen.getByPlaceholderText('Prompt') as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: '@Jane', selectionStart: 5 } });
+
+    fireEvent.click(await screen.findByText(/Jane Smith/));
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('@"Jane Smith" ');
+    });
+    expect(onMentionSelect).toHaveBeenCalledWith('user-1', '@"Jane Smith"');
+  });
+
   it('routes pasted image files through file drop handling with screenshot names', () => {
     const { textarea, onFilesDrop } = renderFilePasteTextarea();
     const imageFile = new File(['image'], 'clipboard.png', { type: 'image/png' });

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -47,6 +47,7 @@ interface FileResult {
 }
 
 interface UserResult {
+  userId: string;
   name: string;
   email: string;
   type: 'user';
@@ -120,8 +121,18 @@ interface AutocompleteTextareaProps {
   kbLinkTarget?: KbLinkTarget;
   /** Draw attention to the textarea while it is empty. */
   highlightWhenEmpty?: boolean;
+<<<<<<< HEAD
   /** Style overrides for the underlying Ant Design textarea control. */
   textareaStyle?: React.CSSProperties;
+=======
+  /**
+   * Fires when a user is chosen from the `@` autocomplete, with the userId
+   * and the exact `@name` / `@"name"` text inserted into the textarea. Lets
+   * callers (e.g. the ping composer) track mentioned user ids without
+   * re-parsing free text.
+   */
+  onMentionSelect?: (userId: string, insertedText: string) => void;
+>>>>>>> 25fbfd852 (feat(ui): add Ping compose action to session composer)
 }
 
 // Minimum characters required after : before showing emoji picker (like Slack)
@@ -381,7 +392,11 @@ export const AutocompleteTextarea = React.forwardRef<
       kbDocs,
       kbLinkTarget = 'stable-uri',
       highlightWhenEmpty = false,
+<<<<<<< HEAD
       textareaStyle,
+=======
+      onMentionSelect,
+>>>>>>> 25fbfd852 (feat(ui): add Ping compose action to session composer)
     },
     ref
   ) => {
@@ -623,6 +638,7 @@ export const AutocompleteTextarea = React.forwardRef<
         // If no query, show all users (up to MAX_USER_RESULTS)
         if (!searchQuery.trim()) {
           return allUsers.slice(0, MAX_USER_RESULTS).map((u: User) => ({
+            userId: u.user_id,
             name: u.name || u.email,
             email: u.email,
             type: 'user' as const,
@@ -639,6 +655,7 @@ export const AutocompleteTextarea = React.forwardRef<
           )
           .slice(0, MAX_USER_RESULTS)
           .map((u: User) => ({
+            userId: u.user_id,
             name: u.name || u.email,
             email: u.email,
             type: 'user' as const,
@@ -929,8 +946,10 @@ export const AutocompleteTextarea = React.forwardRef<
           // File selection
           insertText = `@${quoteIfNeeded(item.path)}`;
         } else {
-          // User selection
-          insertText = `@${item.name}`;
+          // User selection. Quote multi-word names so the highlight regex
+          // (and any downstream mention parsing) captures the whole name.
+          insertText = `@${quoteIfNeeded(item.name)}`;
+          onMentionSelect?.(item.userId, insertText);
         }
 
         const newValue =
@@ -960,7 +979,7 @@ export const AutocompleteTextarea = React.forwardRef<
           textareaRef.current.current?.focus();
         }, 0);
       },
-      [triggerIndex, value, onChange, kbLinkTarget]
+      [triggerIndex, value, onChange, kbLinkTarget, onMentionSelect]
     );
 
     /**

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -121,10 +121,8 @@ interface AutocompleteTextareaProps {
   kbLinkTarget?: KbLinkTarget;
   /** Draw attention to the textarea while it is empty. */
   highlightWhenEmpty?: boolean;
-<<<<<<< HEAD
   /** Style overrides for the underlying Ant Design textarea control. */
   textareaStyle?: React.CSSProperties;
-=======
   /**
    * Fires when a user is chosen from the `@` autocomplete, with the userId
    * and the exact `@name` / `@"name"` text inserted into the textarea. Lets
@@ -132,7 +130,6 @@ interface AutocompleteTextareaProps {
    * re-parsing free text.
    */
   onMentionSelect?: (userId: string, insertedText: string) => void;
->>>>>>> 25fbfd852 (feat(ui): add Ping compose action to session composer)
 }
 
 // Minimum characters required after : before showing emoji picker (like Slack)
@@ -392,11 +389,8 @@ export const AutocompleteTextarea = React.forwardRef<
       kbDocs,
       kbLinkTarget = 'stable-uri',
       highlightWhenEmpty = false,
-<<<<<<< HEAD
       textareaStyle,
-=======
       onMentionSelect,
->>>>>>> 25fbfd852 (feat(ui): add Ping compose action to session composer)
     },
     ref
   ) => {

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -22,7 +22,7 @@ import {
   shortId,
   type User,
 } from '@agor-live/client';
-import { RobotOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons';
+import { CommentOutlined, RobotOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons';
 import { Bubble } from '@ant-design/x';
 import { Button, Tooltip, theme } from 'antd';
 
@@ -312,6 +312,62 @@ function DaemonRestartNotice({
   );
 }
 
+interface PingNoteProps {
+  message: Message;
+  userById: Map<string, User>;
+}
+
+/**
+ * Renders a `type === 'mention'` message — a human-to-human note posted via
+ * the composer's "Ping" action. Styled to read as a comment between
+ * collaborators, not as agent output: it never enters the agent's context
+ * (see MessageType docs / mcp/tools/messages.ts).
+ */
+function PingNote({ message, userById }: PingNoteProps) {
+  const { token } = theme.useToken();
+  const authorId = message.metadata?.author_user_id;
+  const author = authorId ? userById.get(authorId) : undefined;
+  const mentionIds = message.metadata?.mentions ?? [];
+  const mentionedUsers = mentionIds.map((id) => userById.get(id)).filter((u): u is User => !!u);
+  const text = typeof message.content === 'string' ? message.content : '';
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 8,
+        border: `1px solid ${token.colorInfoBorder}`,
+        borderRadius: token.borderRadiusLG,
+        padding: '8px 12px',
+        margin: '8px 0',
+        background: token.colorInfoBg,
+      }}
+    >
+      <UserIdentityAvatar user={author} size={24} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: token.colorInfo,
+            marginBottom: 4,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+          }}
+        >
+          <CommentOutlined />
+          {author?.name || author?.email || 'Someone'} pinged
+          {mentionedUsers.length > 0 &&
+            ` ${mentionedUsers.map((u) => u.name || u.email).join(', ')}`}
+        </div>
+        <MarkdownRenderer content={text} />
+      </div>
+    </div>
+  );
+}
+
 // Memoized: every text block / tool block of every message in the conversation
 // re-rendered on every streaming chunk because TaskBlock's `messages` array
 // gets a fresh reference each tick. Default shallow compare is sufficient
@@ -400,6 +456,12 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
         <WidgetBlock message={message} client={client} />
       </div>
     );
+  }
+
+  // Ping — human-to-human note posted via the composer's "Ping" action.
+  // Never sent to the agent (see MessageType docs).
+  if (message.type === 'mention') {
+    return <PingNote message={message} userById={userById} />;
   }
 
   // Check if this is a Task tool prompt or result (agent-generated, but has user role)

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -15,6 +15,7 @@ import {
   BranchesOutlined,
   ClockCircleOutlined,
   CloseOutlined,
+  CommentOutlined,
   EllipsisOutlined,
   ExclamationCircleOutlined,
   ForkOutlined,
@@ -101,6 +102,8 @@ export interface SessionFooterProps {
   onModelConfigCommit: (config: ModelConfig) => void;
   onOpenSessionSettings?: (sessionId: string) => void;
   onSendPrompt: () => void;
+  /** Post a human-to-human ping note. Omit to hide the Ping button entirely. */
+  onSendPing?: () => void;
   onStop: () => void;
   onFork: () => void;
   onBtwSend: () => void;
@@ -149,6 +152,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   onModelConfigCommit,
   onOpenSessionSettings,
   onSendPrompt,
+  onSendPing,
   onStop,
   onFork,
   onBtwSend,
@@ -265,6 +269,9 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   const btwForkDisabled = connectionDisabled || !hasInput || composerAttachmentsPresent;
   const spawnDisabled = connectionDisabled || isRunning || composerAttachmentsPresent;
   const sendDisabled = connectionDisabled || composerAttachmentUploading || !hasInput;
+  // Pings never touch the executor, so unlike sendDisabled they don't care
+  // about composerAttachmentUploading (attachments aren't sent with a ping).
+  const pingDisabled = connectionDisabled || !hasInput;
 
   const sectionHeaderStyle: React.CSSProperties = {
     padding: '6px 12px 3px',
@@ -1722,6 +1729,21 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                   disabled={connectionDisabled || !isRunning || stopRequestInFlight}
                 >
                   Stop
+                </Button>
+              </Tooltip>
+            )}
+            {onSendPing && (
+              <Tooltip title="Post a note to collaborators — not sent to the agent">
+                <Button
+                  size="small"
+                  type="text"
+                  aria-label="Ping collaborators"
+                  icon={<CommentOutlined />}
+                  onClick={onSendPing}
+                  disabled={pingDisabled}
+                  data-testid="ping-bar-btn"
+                >
+                  Ping
                 </Button>
               </Tooltip>
             )}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -121,6 +121,13 @@ export interface PromptInputHandle {
   getValue: () => string;
   clear: () => void;
   insertText: (text: string) => void;
+  /**
+   * User ids mentioned via the `@` autocomplete since the last clear(),
+   * filtered down to mentions whose inserted `@name` text is still present
+   * in the current value (so deleting a mention drops it). Used by the ping
+   * compose action — see `handleSendPing`.
+   */
+  getMentionedUserIds: () => string[];
 }
 
 interface PromptInputProps {
@@ -175,6 +182,13 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
     const [value, setValue] = React.useState(() => getDraft(sessionId));
     const valueRef = React.useRef(value);
     const textareaElementRef = React.useRef<HTMLTextAreaElement | null>(null);
+    // userId -> inserted "@name" text, tracked as the user types/selects
+    // mentions. Cleared on submit/session-switch alongside the draft.
+    const mentionsRef = React.useRef<Map<string, string>>(new Map());
+
+    const handleMentionSelect = React.useCallback((userId: string, insertedText: string) => {
+      mentionsRef.current.set(userId, insertedText);
+    }, []);
 
     // Keep refs in sync (zero-cost, no re-render)
     valueRef.current = value;
@@ -212,6 +226,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
           }
           setValue('');
           deleteDraft(sessionId);
+          mentionsRef.current.clear();
         },
         insertText: (text: string) => {
           setValue((prev) => {
@@ -220,6 +235,12 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
             inputValueRef.current = nextValue;
             return nextValue;
           });
+        },
+        getMentionedUserIds: () => {
+          const currentValue = textareaElementRef.current?.value ?? valueRef.current;
+          return Array.from(mentionsRef.current.entries())
+            .filter(([, insertedText]) => currentValue.includes(insertedText))
+            .map(([userId]) => userId);
         },
       }),
       [sessionId, deleteDraft, inputValueRef]
@@ -231,6 +252,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
       if (prevSessionId.current !== sessionId) {
         saveDraft(prevSessionId.current, valueRef.current);
         setValue(getDraft(sessionId));
+        mentionsRef.current.clear();
         prevSessionId.current = sessionId;
       }
     }, [sessionId, saveDraft, getDraft]);
@@ -284,6 +306,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
         enableKnowledgeMentions
         kbLinkTarget="absolute-route"
         highlightWhenEmpty
+        onMentionSelect={handleMentionSelect}
       />
     );
   }
@@ -346,6 +369,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   // Get actions from context
   const {
     onSendPrompt,
+    onSendPing,
     onFork,
     onBtwFork,
     onOpenSettings,
@@ -1312,6 +1336,42 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
+  // Post a ping — a human-to-human note, never sent to the agent. Shares the
+  // composer textarea with handleSendPrompt (including the send-in-flight
+  // guard) but skips attachments/permission mode entirely since it never
+  // reaches the executor.
+  const handleSendPing = async () => {
+    const sendStartComposerIdentity = composerSessionIdentityRef.current;
+    if (composerSendInFlightRef.current === sendStartComposerIdentity || connectionDisabled) {
+      return;
+    }
+
+    composerSendInFlightRef.current = sendStartComposerIdentity;
+    try {
+      const sendStartSessionId = session.session_id;
+      const value = promptRef.current?.getValue() ?? '';
+      if (!value.trim()) return;
+
+      if (!onSendPing) {
+        showError('Cannot send ping from this view.');
+        return;
+      }
+
+      const mentionedUserIds = promptRef.current?.getMentionedUserIds() ?? [];
+      const sendResult = await onSendPing(sendStartSessionId, value, mentionedUserIds);
+      if (sendResult === false) return;
+
+      promptRef.current?.clear();
+    } catch (error) {
+      console.error('Ping send failed — keeping text in composer:', error);
+      showError(error instanceof Error ? error.message : 'Failed to send ping');
+    } finally {
+      if (composerSendInFlightRef.current === sendStartComposerIdentity) {
+        composerSendInFlightRef.current = null;
+      }
+    }
+  };
+
   const handleStop = async () => {
     if (!session || !client || connectionDisabled || stopRequestInFlight) return;
 
@@ -1639,6 +1699,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       onModelConfigCommit={stableFooterHandlers.onModelConfigCommit}
       onOpenSessionSettings={onOpenSettings}
       onSendPrompt={stableFooterHandlers.onSendPrompt}
+      onSendPing={onSendPing ? handleSendPing : undefined}
       onStop={stableFooterHandlers.onStop}
       onFork={stableFooterHandlers.onFork}
       onBtwSend={stableFooterHandlers.onBtwSend}

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -23,6 +23,15 @@ export interface AppActionsContextValue {
     prompt: string,
     permissionMode?: PermissionMode
   ) => boolean | undefined | Promise<boolean | undefined>;
+  /**
+   * Post a human-to-human "ping" note — never sent to the agent, never
+   * creates a Task. See `client.sessions.ping` / `POST /sessions/:id/ping`.
+   */
+  onSendPing?: (
+    sessionId: string,
+    text: string,
+    mentionedUserIds?: string[]
+  ) => boolean | undefined | Promise<boolean | undefined>;
   onFork?: (sessionId: string, prompt: string) => Promise<void>;
   onBtwFork?: (sessionId: string, prompt: string) => Promise<void>;
   onSubsession?: (sessionId: string, config: string | Partial<SpawnConfig>) => Promise<void>;

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -161,12 +161,34 @@ export interface SessionInitializationResult {
   task?: Task;
 }
 
+/**
+ * Body shape for `POST /sessions/:id/ping` — a human-to-human note in the
+ * conversation stream (Slack-style `@collaborator ...`). Unlike `prompt()`,
+ * this never creates a Task or invokes the agent; it only writes a
+ * `type: 'mention'` message. See `context/` / PR description for the design
+ * rationale (composer action vs. `@`-prefix heuristic).
+ */
+export interface SessionPingRequest {
+  text: string;
+  mentioned_user_ids?: string[];
+}
+
+export interface SessionPingOptions {
+  params?: Params;
+}
+
 export interface SessionsClientHelpers {
   prompt(sessionId: string, prompt: string, options?: SessionPromptOptions): Promise<Task>;
   initialize(
     sessionId: string,
     options: SessionInitializationOptions
   ): Promise<SessionInitializationResult>;
+  ping(
+    sessionId: string,
+    text: string,
+    mentionedUserIds?: string[],
+    options?: SessionPingOptions
+  ): Promise<Message>;
 }
 
 /**
@@ -1398,6 +1420,20 @@ function extendSessionsHelpers(client: AgorClient): void {
         .service(`sessions/${sessionId}/initialize`)
         .create(request, params);
       return response as SessionInitializationResult;
+    },
+    ping: async (
+      sessionId: string,
+      text: string,
+      mentionedUserIds?: string[],
+      options?: SessionPingOptions
+    ) => {
+      const response = await client
+        .service(`sessions/${sessionId}/ping`)
+        .create(
+          { text, mentioned_user_ids: mentionedUserIds } as SessionPingRequest,
+          options?.params
+        );
+      return response as Message;
     },
   };
 

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -541,6 +541,7 @@ export const messages = pgTable(
         'daemon_restart',
         'daemon_crash',
         'widget_request',
+        'mention',
       ],
     }).notNull(),
     role: text('role', {

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -505,6 +505,7 @@ export const messages = sqliteTable(
         'daemon_restart',
         'daemon_crash',
         'widget_request',
+        'mention',
       ],
     }).notNull(),
     role: text('role', {

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -282,6 +282,15 @@ export interface Message {
     mentions?: UserID[];
 
     /**
+     * The user who posted this message. Only populated on `type ===
+     * 'mention'` messages — Message has no general `created_by` column, and
+     * ordinary user/assistant messages are attributed to the session's
+     * current viewer instead. Pings need explicit attribution because any
+     * collaborator with session access can post one.
+     */
+    author_user_id?: UserID;
+
+    /**
      * Marks the user-role message / task as having been authored by the
      * daemon on behalf of the user, rather than typed by a human.
      * Used by widget auto-resume prompts (see `widget_id`) and other

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PersistedAgenticToolName } from './agentic-tool';
-import type { MessageID, SessionID, TaskID } from './id';
+import type { MessageID, SessionID, TaskID, UserID } from './id';
 import type { WidgetMessageMetadata } from './widget';
 
 /**
@@ -46,6 +46,7 @@ export const MESSAGE_TYPE_VALUES = [
   'daemon_restart',
   'daemon_crash',
   'widget_request',
+  'mention',
 ] as const;
 
 export type MessageType = (typeof MESSAGE_TYPE_VALUES)[number];
@@ -270,6 +271,15 @@ export interface Message {
      * messages. Discriminated by `widget_type`; see `types/widget.ts`.
      */
     widget?: WidgetMessageMetadata;
+
+    /**
+     * @mentioned user IDs. Only populated on `type === 'mention'` messages
+     * (the ping/comment compose action — see `context/explorations/` or PR
+     * description for design). Mirrors `BoardComment.mentions`. These
+     * messages are human-to-human notes: never dispatched to the agent and
+     * excluded from agent-facing message search (see mcp/tools/messages.ts).
+     */
+    mentions?: UserID[];
 
     /**
      * Marks the user-role message / task as having been authored by the


### PR DESCRIPTION
## Summary

Adds a Slack-like "ping" — bring a collaborator's attention to something inside a session without prompting the agent. A ping is a human-to-human note: it shows up in the conversation stream and is visible to session viewers, but it never enters the agent's context and never triggers a run.

**Design decision (why not the `@`-prefix heuristic):** the composer's `@` is already an overloaded autocomplete trigger for files/users/KB references whose results *do* go to the agent (e.g. `@file.ts explain this`). Inferring "this is a ping, not a prompt" from a leading `@` would collide with that and be fragile. Instead, intent is explicit via a distinct **Ping** button next to Send in the composer's action bar. It reuses the existing `@`-user autocomplete to pick who to mention.

## What's in scope

- **New `mention` `MessageType`** (`packages/core/src/types/message.ts`), stored via the existing messages pipeline. Mentioned user ids + author live in `message.metadata` (mirrors `BoardComment.mentions`). No DB migration needed — the `enum` option on a text column is TS-level only (per `context/guides/creating-database-migrations.md`).
- **`POST /sessions/:id/ping`** (`apps/agor-daemon/src/register-routes.ts`) — a sibling to `/sessions/:id/prompt` that writes the message via the same messages-service RBAC hooks, but **never creates/queues a Task and never spawns the executor**. Since none of the agent executors (Claude/Codex/Gemini/Copilot) read conversation context from Agor's message table — they resume from their own native session files — never creating a Task is sufficient to structurally guarantee a ping can't reach the agent.
- **Excluded from `agor_messages_list`** (the agent-facing MCP tool), closing the one remaining path an agent could otherwise read a ping back through.
- **Composer UI**: a "Ping" button in `SessionFooter`, wired through `AppActionsContext` → `client.sessions.ping()`. Tracks `@mentioned` users via a new `onMentionSelect` callback on `AutocompleteTextarea` (also fixes a latent bug where multi-word mention names weren't quoted).
- **Distinct rendering**: pings render as a comment-styled note (author + mentioned collaborators + text), not as agent output.
- Tests: MCP tool exclusion is unconditional, mention quoting/callback behavior in `AutocompleteTextarea`.

## Explicitly out of scope (follow-ups)

- **Slack DM on mention** via the gateway (mention → look up email → `openDmByEmail`/`sendSlackMessage`). Feasible, left for a fast-follow.
- **Cross-session notification center / unread badges.** For this PR, the ping simply appears live in the session view (same Socket.io/Feathers event path as any other message) — no new notification infrastructure.
- Editing/deleting pings.

## Test plan

- [x] `pnpm typecheck` across `@agor/core`, `@agor/daemon`, `agor-ui`, `@agor-live/client`
- [x] `biome check` clean on all changed files
- [x] Existing daemon/UI test suites for touched files pass (register-hooks, widgets/submissions, messages MCP tool, SessionPanel send, SessionFooter, AutocompleteTextarea)
- [x] New tests: `agor_messages_list` unconditionally excludes `mention` messages; `AutocompleteTextarea` quotes multi-word mentions and fires `onMentionSelect`
- [ ] Manual smoke test in a running dev environment (not run in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)