### PR TITLE
perf(agor-ui): progressive board mount — bound Home→board navigation cost

### DIFF
--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -16,6 +16,7 @@ import {
 } from 'antd';
 import type React from 'react';
 import { memo, useEffect, useMemo, useState } from 'react';
+import { useProgressiveMount } from '../../hooks/useProgressiveMount';
 import { useAgorStore } from '../../store/agorStore';
 import {
   selectBranchById,
@@ -206,6 +207,10 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
     [primaryAssistantBranch, sessionsByBranch]
   );
 
+  // The assistant's session tree is one of the heaviest mounts on the board
+  // surface (#1768) — hydrate it right after the canvas shell commits.
+  const sectionsReady = useProgressiveMount({ enabled: true, priority: 2 });
+
   const assistantContent = (() => {
     if (primaryAssistantBranch && primaryAssistantRepo) {
       const assistantConfig = getAssistantConfig(primaryAssistantBranch);
@@ -296,20 +301,27 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
             )}
           </div>
 
-          <BranchSessionSections
-            branch={primaryAssistantBranch}
-            sessions={assistantSessions}
-            userById={userById}
-            currentUserId={currentUserId}
-            selectedSessionId={selectedSessionId}
-            onSessionClick={onSessionClick}
-            onCreateSession={onCreateSession}
-            onForkSession={onForkSession}
-            onSpawnSession={onSpawnSession}
-            onOpenSessionSettings={onOpenSessionSettings}
-            mode="panel"
-            client={client}
-          />
+          {sectionsReady ? (
+            <BranchSessionSections
+              branch={primaryAssistantBranch}
+              sessions={assistantSessions}
+              userById={userById}
+              currentUserId={currentUserId}
+              selectedSessionId={selectedSessionId}
+              onSessionClick={onSessionClick}
+              onCreateSession={onCreateSession}
+              onForkSession={onForkSession}
+              onSpawnSession={onSpawnSession}
+              onOpenSessionSettings={onOpenSessionSettings}
+              mode="panel"
+              client={client}
+            />
+          ) : (
+            // Truthful shell while the session tree waits for its hydration slot.
+            <Typography.Text type="secondary" style={{ fontSize: 12, padding: '8px 0' }}>
+              Sessions ({assistantSessions.length})
+            </Typography.Text>
+          )}
         </div>
       );
     }

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -209,7 +209,11 @@ const BoardAssistantPanelComponent: React.FC<BoardAssistantPanelProps> = ({
 
   // The assistant's session tree is one of the heaviest mounts on the board
   // surface (#1768) — hydrate it right after the canvas shell commits.
-  const sectionsReady = useProgressiveMount({ enabled: true, priority: 2 });
+  const sectionsReady = useProgressiveMount({
+    enabled: true,
+    priority: 1,
+    resetKey: board?.board_id ?? 'no-board',
+  });
 
   const assistantContent = (() => {
     if (primaryAssistantBranch && primaryAssistantRepo) {

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -1,5 +1,5 @@
 import type { Branch, Repo, Session } from '@agor-live/client';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { theme as antdTheme, ConfigProvider } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
@@ -62,7 +62,7 @@ describe('BranchCard drag handle', () => {
     expect(onOpenTerminal).toHaveBeenCalledWith([], 'branch-1');
   });
 
-  it('uses a darker primary background surface while a branch session is executing', () => {
+  it('uses a darker primary background surface while a branch session is executing', async () => {
     const runningSession = {
       session_id: 'session-running',
       branch_id: 'branch-1',
@@ -97,8 +97,9 @@ describe('BranchCard drag handle', () => {
     expect(container.querySelector('.ant-card')?.getAttribute('style')).toContain(
       'background-color: color-mix(in srgb, rgb(1, 2, 3) 67%, rgb(10, 11, 12));'
     );
-    expect(container.querySelector('.ant-tree-title > div')).toHaveStyle({
-      width: '100%',
-    });
+    // Session sections hydrate a frame after mount (useProgressiveMount).
+    await waitFor(() =>
+      expect(container.querySelector('.ant-tree-title > div')).toHaveStyle({ width: '100%' })
+    );
   });
 });

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -13,6 +13,7 @@ import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useProgressiveMount } from '../../hooks/useProgressiveMount';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
   REACT_FLOW_NO_DRAG_CLASS,
@@ -105,6 +106,14 @@ const BranchCardComponent = ({
 }: BranchCardProps) => {
   const { token } = theme.useToken();
   const connectionDisabled = useConnectionDisabled();
+
+  // Canvas cards hydrate their session sections in chunks after the board
+  // shell commits (#1768); panel/popover surfaces render a single card, so
+  // they mount immediately.
+  const sectionsReady = useProgressiveMount({
+    enabled: !inPopover && !panelMode,
+    priority: isActiveUrlTarget || sessions.some((s) => s.session_id === selectedSessionId) ? 1 : 0,
+  });
 
   // Archive/Delete modal state
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
@@ -562,23 +571,34 @@ const BranchCardComponent = ({
 
       {/* Sessions & Scheduled Runs - composable content shared with the assistant panel */}
       <div className={REACT_FLOW_NO_DRAG_CLASS}>
-        <BranchSessionSections
-          branch={branch}
-          sessions={sessions}
-          userById={userById}
-          currentUserId={currentUserId}
-          selectedSessionId={selectedSessionId}
-          onSessionClick={onSessionClick}
-          onCreateSession={onCreateSession}
-          onForkSession={onForkSession}
-          onSpawnSession={onSpawnSession}
-          onOpenSessionSettings={onOpenSessionSettings}
-          peekedSessionIds={peekedSessionIdSet}
-          onTogglePeekSession={!inPopover && !panelMode ? handleTogglePeekSession : undefined}
-          defaultExpanded={defaultExpanded}
-          mode="card"
-          client={client}
-        />
+        {sectionsReady ? (
+          <BranchSessionSections
+            branch={branch}
+            sessions={sessions}
+            userById={userById}
+            currentUserId={currentUserId}
+            selectedSessionId={selectedSessionId}
+            onSessionClick={onSessionClick}
+            onCreateSession={onCreateSession}
+            onForkSession={onForkSession}
+            onSpawnSession={onSpawnSession}
+            onOpenSessionSettings={onOpenSessionSettings}
+            peekedSessionIds={peekedSessionIdSet}
+            onTogglePeekSession={!inPopover && !panelMode ? handleTogglePeekSession : undefined}
+            defaultExpanded={defaultExpanded}
+            mode="card"
+            client={client}
+          />
+        ) : (
+          // Truthful shell while this card waits for its hydration slot: real
+          // session count from data already in props, no fake placeholders.
+          <Typography.Text
+            type="secondary"
+            style={{ fontSize: 12, display: 'block', padding: '4px 0' }}
+          >
+            Sessions ({peekableSessions.length})
+          </Typography.Text>
+        )}
       </div>
 
       {!inPopover && !panelMode && peekedSessions.length > 0 && (

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -27,6 +27,7 @@ import { CreatedByTag } from '../metadata';
 import { IssuePill, PullRequestPill } from '../Pill';
 import { BranchSessionPeekSection } from './BranchSessionPeekSection';
 import { BranchSessionSections } from './BranchSessionSections';
+import { estimateBranchSessionSectionsHeight } from './branchCardLayout';
 
 const _BRANCH_CARD_MAX_WIDTH = 600;
 const NOTES_MAX_LENGTH = 200; // Character limit for truncated notes
@@ -66,6 +67,7 @@ interface BranchCardProps {
   defaultExpanded?: boolean;
   inPopover?: boolean; // NEW: Enable popover-optimized mode (hides board-specific controls)
   panelMode?: boolean; // Render inside side panel instead of as a draggable canvas card
+  progressiveMountKey?: string | number | null;
   /** True when this branch is the deep-link target of the current URL
    *  (`/w/<branchShort>/`). Folded together with `isFocused` (a session
    *  is open in the drawer) into a unified "selected" state — rendered
@@ -101,19 +103,27 @@ const BranchCardComponent = ({
   defaultExpanded = true,
   inPopover = false,
   panelMode = false,
+  progressiveMountKey,
   isActiveUrlTarget = false,
   client,
 }: BranchCardProps) => {
   const { token } = theme.useToken();
   const connectionDisabled = useConnectionDisabled();
 
+  const branchBoardId = (branch as { board_id?: string | null }).board_id;
+
   // Canvas cards hydrate their session sections in chunks after the board
   // shell commits (#1768); panel/popover surfaces render a single card, so
   // they mount immediately.
   const sectionsReady = useProgressiveMount({
     enabled: !inPopover && !panelMode,
-    priority: isActiveUrlTarget || sessions.some((s) => s.session_id === selectedSessionId) ? 1 : 0,
+    priority: isActiveUrlTarget || sessions.some((s) => s.session_id === selectedSessionId) ? 2 : 0,
+    resetKey: progressiveMountKey ?? branchBoardId ?? 'unassigned',
   });
+  const sessionShellMinHeight = useMemo(
+    () => estimateBranchSessionSectionsHeight(sessions, { defaultExpanded }),
+    [defaultExpanded, sessions]
+  );
 
   // Archive/Delete modal state
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
@@ -570,7 +580,10 @@ const BranchCardComponent = ({
       )}
 
       {/* Sessions & Scheduled Runs - composable content shared with the assistant panel */}
-      <div className={REACT_FLOW_NO_DRAG_CLASS}>
+      <div
+        className={REACT_FLOW_NO_DRAG_CLASS}
+        style={sectionsReady ? undefined : { minHeight: sessionShellMinHeight }}
+      >
         {sectionsReady ? (
           <BranchSessionSections
             branch={branch}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -60,6 +60,9 @@ import {
 import { ToolIcon } from '../ToolIcon';
 import { buildSessionTree, type SessionTreeNode } from './buildSessionTree';
 
+// Stable theme object so the ConfigProvider context value doesn't churn.
+const NO_MOTION_THEME = { token: { motion: false } };
+
 export type BranchSessionSectionsMode = 'card' | 'panel';
 
 export interface BranchSessionSectionsProps {
@@ -1005,7 +1008,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   }
 
   return (
-    <>
+    // Card mode disables antd motion: 30 cards animating their collapse/tree
+    // mounts multiplies board-mount commits (#1768). Panel mode keeps motion.
+    <ConfigProvider theme={isPanel ? undefined : NO_MOTION_THEME}>
       {sessionSearchBar}
       {activeSessions.length === 0 ? (
         <div
@@ -1130,6 +1135,6 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         client={client}
         userById={userById}
       />
-    </>
+    </ConfigProvider>
   );
 };

--- a/apps/agor-ui/src/components/BranchCard/branchCardLayout.ts
+++ b/apps/agor-ui/src/components/BranchCard/branchCardLayout.ts
@@ -1,0 +1,36 @@
+import type { Session } from '@agor-live/client';
+import { isGatewaySession } from '@agor-live/client';
+
+const EMPTY_SESSIONS_SHELL_HEIGHT = 72;
+const SECTION_HEADER_HEIGHT = 46;
+const SESSION_ROW_HEIGHT = 42;
+const SECTION_GAP_HEIGHT = 8;
+
+export function estimateBranchSessionSectionsHeight(
+  sessions: Session[],
+  { defaultExpanded = true }: { defaultExpanded?: boolean } = {}
+): number {
+  const activeSessions = sessions.filter((session) => !session.archived);
+  if (activeSessions.length === 0) return EMPTY_SESSIONS_SHELL_HEIGHT;
+
+  const manualCount = activeSessions.filter(
+    (session) => !session.scheduled_from_branch && !isGatewaySession(session)
+  ).length;
+  const scheduledCount = activeSessions.filter((session) => session.scheduled_from_branch).length;
+  const gatewayCount = activeSessions.filter((session) => isGatewaySession(session)).length;
+
+  let height = SECTION_GAP_HEIGHT;
+
+  if (manualCount > 0) {
+    height += SECTION_HEADER_HEIGHT;
+    if (defaultExpanded) height += manualCount * SESSION_ROW_HEIGHT;
+  } else {
+    // The card still shows a Sessions header with the New Session action when
+    // only scheduled/gateway sessions exist.
+    height += SECTION_HEADER_HEIGHT;
+  }
+  if (scheduledCount > 0) height += SECTION_HEADER_HEIGHT;
+  if (gatewayCount > 0) height += SECTION_HEADER_HEIGHT;
+
+  return height;
+}

--- a/apps/agor-ui/src/components/BranchCard/index.ts
+++ b/apps/agor-ui/src/components/BranchCard/index.ts
@@ -4,3 +4,4 @@ export type {
   BranchSessionSectionsProps,
 } from './BranchSessionSections';
 export { BranchSessionSections } from './BranchSessionSections';
+export { estimateBranchSessionSectionsHeight } from './branchCardLayout';

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -206,6 +206,7 @@ const SessionNode = React.memo(({ data }: { data: SessionNodeData }) => {
 interface BranchNodeData {
   branch: Branch;
   repo: Repo;
+  boardId?: string | null;
   userById: Map<string, User>;
   currentUserId?: string;
   onTaskClick?: (taskId: string) => void;
@@ -280,6 +281,7 @@ const BranchNode = React.memo(
           branch={data.branch}
           repo={data.repo}
           sessions={sessions}
+          progressiveMountKey={data.boardId ?? 'no-board'}
           userById={data.userById}
           currentUserId={data.currentUserId}
           selectedSessionId={data.selectedSessionId}
@@ -318,6 +320,7 @@ const BranchNode = React.memo(
     return (
       p.branch === n.branch &&
       p.repo === n.repo &&
+      p.boardId === n.boardId &&
       p.userById === n.userById &&
       p.currentUserId === n.currentUserId &&
       p.selectedSessionId === n.selectedSessionId &&
@@ -757,6 +760,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           data: {
             branch,
             repo,
+            boardId: board?.board_id ?? null,
             userById,
             currentUserId,
             selectedSessionId,

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/AppNodeLazy.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/AppNodeLazy.tsx
@@ -6,26 +6,38 @@
  * when a board actually renders an app node, rather than for every board
  * regardless of whether it has app nodes.
  *
+ * The node also stays a placeholder until it first enters the viewport, so
+ * offscreen apps don't boot the Sandpack bundler (network + CPU heavy) while
+ * the board is still painting after a navigation (#1768).
+ *
  * The fallback is a small neutral placeholder sized to fill the node so the
  * canvas doesn't jump while the Sandpack chunk downloads. The exported
  * component keeps AppNode's signature, so the `nodeTypes` map stays stable.
  */
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useRef } from 'react';
+import { useInViewportOnce } from '../../../hooks/useInViewportOnce';
 import type { AppNodeData } from './AppNode';
 import { NodeLoadingPlaceholder } from './NodeLoadingPlaceholder';
 
 const AppNodeInner = lazy(() => import('./AppNode').then((m) => ({ default: m.AppNode })));
 
-export const AppNode = (props: { data: AppNodeData; selected?: boolean }) => (
-  <Suspense
-    fallback={
-      <NodeLoadingPlaceholder
-        title={props.data.title}
-        width={props.data.width}
-        height={props.data.height}
-      />
-    }
-  >
-    <AppNodeInner {...props} />
-  </Suspense>
-);
+export const AppNode = (props: { data: AppNodeData; selected?: boolean }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const seen = useInViewportOnce(ref);
+  const placeholder = (
+    <NodeLoadingPlaceholder
+      title={props.data.title}
+      width={props.data.width}
+      height={props.data.height}
+    />
+  );
+  return (
+    <div ref={ref}>
+      {seen ? (
+        <Suspense fallback={placeholder}>{<AppNodeInner {...props} />}</Suspense>
+      ) : (
+        placeholder
+      )}
+    </div>
+  );
+};

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNodeLazy.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNodeLazy.tsx
@@ -6,10 +6,15 @@
  * chunk so it is fetched only when a board actually renders an artifact node,
  * rather than for every board regardless of whether it has artifact nodes.
  *
+ * The node also stays a placeholder until it first enters the viewport, so
+ * offscreen artifacts don't boot the Sandpack bundler (network + CPU heavy)
+ * while the board is still painting after a navigation (#1768).
+ *
  * The exported component keeps ArtifactNode's signature so the `nodeTypes`
  * map stays stable; the fallback fills the node box to avoid layout jank.
  */
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useRef } from 'react';
+import { useInViewportOnce } from '../../../hooks/useInViewportOnce';
 import type { ArtifactNodeData } from './ArtifactNode';
 import { NodeLoadingPlaceholder } from './NodeLoadingPlaceholder';
 
@@ -17,10 +22,19 @@ const ArtifactNodeInner = lazy(() =>
   import('./ArtifactNode').then((m) => ({ default: m.ArtifactNode }))
 );
 
-export const ArtifactNode = (props: { data: ArtifactNodeData; selected?: boolean }) => (
-  <Suspense
-    fallback={<NodeLoadingPlaceholder width={props.data.width} height={props.data.height} />}
-  >
-    <ArtifactNodeInner {...props} />
-  </Suspense>
-);
+export const ArtifactNode = (props: { data: ArtifactNodeData; selected?: boolean }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const seen = useInViewportOnce(ref);
+  const placeholder = (
+    <NodeLoadingPlaceholder width={props.data.width} height={props.data.height} />
+  );
+  return (
+    <div ref={ref}>
+      {seen ? (
+        <Suspense fallback={placeholder}>{<ArtifactNodeInner {...props} />}</Suspense>
+      ) : (
+        placeholder
+      )}
+    </div>
+  );
+};

--- a/apps/agor-ui/src/hooks/useInViewportOnce.test.tsx
+++ b/apps/agor-ui/src/hooks/useInViewportOnce.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useInViewportOnce } from './useInViewportOnce';
+
+type ObserverCallback = ConstructorParameters<typeof IntersectionObserver>[0];
+
+function Probe() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const seen = useInViewportOnce(ref);
+  return <div ref={ref}>{seen ? 'seen' : 'hidden'}</div>;
+}
+
+describe('useInViewportOnce', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('latches true after the element intersects and disconnects on cleanup', async () => {
+    let callback: ObserverCallback | undefined;
+    const disconnect = vi.fn();
+
+    class MockIntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = '';
+      readonly thresholds = [];
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = disconnect;
+      takeRecords = vi.fn(() => []);
+
+      constructor(cb: ObserverCallback) {
+        callback = cb;
+      }
+    }
+
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
+    const { unmount } = render(<Probe />);
+
+    expect(screen.getByText('hidden')).toBeInTheDocument();
+
+    callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+
+    await waitFor(() => expect(screen.getByText('seen')).toBeInTheDocument());
+
+    unmount();
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/hooks/useInViewportOnce.ts
+++ b/apps/agor-ui/src/hooks/useInViewportOnce.ts
@@ -1,0 +1,31 @@
+/**
+ * useInViewportOnce — true once the referenced element has intersected the
+ * viewport. Used to keep heavy embeds (Sandpack artifact/app nodes) from
+ * booting while offscreen — e.g. during a board navigation (#1768) — without
+ * unmounting them again when the user scrolls away.
+ */
+import { type RefObject, useEffect, useState } from 'react';
+
+export function useInViewportOnce(ref: RefObject<Element | null>, margin = '200px'): boolean {
+  const [seen, setSeen] = useState(false);
+
+  useEffect(() => {
+    if (seen) return;
+    const el = ref.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setSeen(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) setSeen(true);
+      },
+      { rootMargin: margin }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [seen, ref, margin]);
+
+  return seen;
+}

--- a/apps/agor-ui/src/hooks/useProgressiveMount.test.tsx
+++ b/apps/agor-ui/src/hooks/useProgressiveMount.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProgressiveMount } from './useProgressiveMount';
+
+function Probe({ enabled, resetKey = 'board-a' }: { enabled: boolean; resetKey?: string }) {
+  const ready = useProgressiveMount({ enabled, resetKey });
+  return <div>{ready ? 'ready' : 'deferred'}</div>;
+}
+
+describe('useProgressiveMount', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      setTimeout(() => callback(0), 0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('forces ready when deferral is disabled after a component was queued', async () => {
+    const { rerender } = render(<Probe enabled />);
+
+    expect(screen.getByText('deferred')).toBeInTheDocument();
+
+    rerender(<Probe enabled={false} />);
+
+    await waitFor(() => expect(screen.getByText('ready')).toBeInTheDocument());
+  });
+
+  it('replays deferral synchronously when the reset key changes', async () => {
+    const { rerender } = render(<Probe enabled resetKey="board-a" />);
+
+    await waitFor(() => expect(screen.getByText('ready')).toBeInTheDocument());
+
+    rerender(<Probe enabled resetKey="board-b" />);
+
+    expect(screen.getByText('deferred')).toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText('ready')).toBeInTheDocument());
+  });
+});

--- a/apps/agor-ui/src/hooks/useProgressiveMount.ts
+++ b/apps/agor-ui/src/hooks/useProgressiveMount.ts
@@ -58,11 +58,21 @@ function schedulePump(): void {
 export function useProgressiveMount({
   enabled,
   priority = 0,
+  resetKey = 'default',
 }: {
   enabled: boolean;
   priority?: number;
+  /**
+   * Logical surface key for this mount request. Changing it replays deferral
+   * for reused component instances (for example, same branch node across boards).
+   */
+  resetKey?: string | number | null;
 }): boolean {
-  const [ready, setReady] = useState(!enabled);
+  const [state, setState] = useState(() => ({ ready: !enabled, resetKey }));
+
+  // If the key changed, compute the visible value from the new key immediately
+  // instead of rendering one frame with the previous board's granted state.
+  const ready = state.resetKey === resetKey ? state.ready : !enabled;
 
   // Enqueue-time priority via ref: a later priority flip must not re-enqueue
   // (losing queue position) or re-run the effect.
@@ -70,13 +80,28 @@ export function useProgressiveMount({
   priorityRef.current = priority;
 
   useEffect(() => {
-    if (ready) return;
+    if (state.resetKey !== resetKey) {
+      setState({ ready: !enabled, resetKey });
+      return;
+    }
+
+    if (!enabled) {
+      if (!state.ready) setState({ ready: true, resetKey });
+      return;
+    }
+
+    if (state.ready) return;
+
     let cancelled = false;
     const entry: PendingMount = {
       priority: priorityRef.current,
       seq: seqCounter++,
       fire: () => {
-        if (!cancelled) setReady(true);
+        if (!cancelled) {
+          setState((current) =>
+            current.resetKey === resetKey ? { ready: true, resetKey } : current
+          );
+        }
       },
     };
     pending.push(entry);
@@ -85,7 +110,7 @@ export function useProgressiveMount({
       cancelled = true;
       pending = pending.filter((e) => e !== entry);
     };
-  }, [ready]);
+  }, [enabled, resetKey, state.ready, state.resetKey]);
 
   return ready;
 }

--- a/apps/agor-ui/src/hooks/useProgressiveMount.ts
+++ b/apps/agor-ui/src/hooks/useProgressiveMount.ts
@@ -1,0 +1,91 @@
+/**
+ * useProgressiveMount — chunked mount scheduler for expensive card internals.
+ *
+ * Problem (#1768): navigating Home → board mounts every BranchCard's session
+ * sections inside the same router transition. On a board with dozens of
+ * branches that is a multi-second render before the canvas ever paints.
+ *
+ * Cards call this hook instead of mounting their heavy internals directly.
+ * The first render returns `false` (the card renders a lightweight shell),
+ * then a shared module-level queue releases mounts in small chunks — one
+ * chunk per frame — so the canvas shell commits first and detail hydration
+ * never blocks a single frame for long. Higher `priority` mounts first
+ * (e.g. the URL-target card).
+ */
+import { useEffect, useRef, useState } from 'react';
+
+// 3 sections per frame keeps each hydration commit well under a frame budget
+// in production while still fully hydrating a 30-card board in ~10 frames.
+const CHUNK_SIZE = 3;
+
+interface PendingMount {
+  priority: number;
+  seq: number;
+  fire: () => void;
+}
+
+let pending: PendingMount[] = [];
+let pumpScheduled = false;
+let seqCounter = 0;
+
+function pump(): void {
+  pumpScheduled = false;
+  if (pending.length === 0) return;
+  // Highest priority first; FIFO within the same priority.
+  pending.sort((a, b) => b.priority - a.priority || a.seq - b.seq);
+  const batch = pending.splice(0, CHUNK_SIZE);
+  for (const item of batch) item.fire();
+  if (pending.length > 0) schedulePump();
+}
+
+function schedulePump(): void {
+  if (pumpScheduled) return;
+  pumpScheduled = true;
+  if (typeof requestAnimationFrame === 'function') {
+    // rAF → macrotask: let the browser paint the chunk just committed before
+    // the next chunk mounts.
+    requestAnimationFrame(() => setTimeout(pump, 0));
+  } else {
+    setTimeout(pump, 0);
+  }
+}
+
+/**
+ * Returns `true` once this consumer's mount slot has been granted.
+ * `enabled: false` opts out of deferral entirely (always returns `true`) —
+ * used by surfaces that render a single instance (side panel, popover).
+ */
+export function useProgressiveMount({
+  enabled,
+  priority = 0,
+}: {
+  enabled: boolean;
+  priority?: number;
+}): boolean {
+  const [ready, setReady] = useState(!enabled);
+
+  // Enqueue-time priority via ref: a later priority flip must not re-enqueue
+  // (losing queue position) or re-run the effect.
+  const priorityRef = useRef(priority);
+  priorityRef.current = priority;
+
+  useEffect(() => {
+    if (ready) return;
+    let cancelled = false;
+    const entry: PendingMount = {
+      priority: priorityRef.current,
+      seq: seqCounter++,
+      fire: () => {
+        if (!cancelled) setReady(true);
+      },
+    };
+    pending.push(entry);
+    schedulePump();
+    return () => {
+      cancelled = true;
+      pending = pending.filter((e) => e !== entry);
+    };
+  }, [ready]);
+
+  return ready;
+}


### PR DESCRIPTION
## Linked issue

Fixes #1768

## Root cause

Home→board felt frozen because the click cold-mounts the entire board surface inside one router transition: every `BranchCard` mounts its full `BranchSessionSections` (expanded Collapse + session Tree + markdown), and the `BoardAssistantPanel` mounts its primary-assistant session tree (a single instance costing 400–480ms per render pass on a busy workspace). On a 29-branch board this produced 8–14 commits over 2.5–4s (dev profile) before the first canvas node reached the DOM — ~90% of commit time was `BranchSessionSections × 29`. Controlled experiments ruled out the alternatives: clicking after hydration fully settled was equally slow, pausing WebSocket delivery during the transition changed nothing, and Home→empty-board took 277ms — the cost tracks board content, not data fetching or Home unmount.

## Changes

1. **`useProgressiveMount`** (new hook): a shared chunked grant queue (3 mounts per frame, priority-ordered, URL-target/selected card first). `BranchCard` (card mode only) and `BoardAssistantPanel` render a truthful `Sessions (N)` shell — real count from props, no fake placeholders — until granted, so the canvas shell is the only thing the navigation waits on. Panel/popover single-card surfaces are exempt and mount immediately.
2. **Motion off for card-mode sections**: `ConfigProvider token.motion: false` (module-const theme) around card-mode `BranchSessionSections`; 30 cards animating collapse/tree mounts multiplied board-mount commits. The side panel keeps animations.
3. **`useInViewportOnce`** (new hook): Sandpack `ArtifactNodeLazy`/`AppNodeLazy` stay placeholders until first scrolled into view, so offscreen embeds no longer boot the CodeSandbox bundler (hundreds of CDN requests observed in the sandbox trace) during navigation.

## Performance (Home → 29-branch board, dev build, repeatable protocol)

| Metric | Before | After |
| --- | ---: | ---: |
| Click → board canvas + nodes visible | 3455 / 3476 / 3759 ms | **863–1024 ms** |
| Worst long animation frame | 3120–3365 ms | ~1300 ms |
| Full section hydration | all upfront (blocking) | progressive, ~4.5s, 3 cards/frame |

Remaining pre-paint commit is the canvas shell itself (~430ms: 28 card headers + notes markdown).

## Validation

- `pnpm vitest run` on BranchCard / SessionCanvas rerender / HomePage rerender / BoardAssistantPanel suites — 9 files, 32 tests pass. `BranchCard.drag.test.tsx` updated to await deferred hydration.
- `biome check` clean on all touched files.
- Manual pass on a 29-branch board: assistant panel tree, card sessions, zones, peek sections, fork/spawn modal all intact; sections fill in over ~2–3s with the navigated-to card first.

## Risks / notes

- Cards briefly show a `Sessions (N)` line before their tree hydrates (~1–2s window in dev, shorter in prod); count is real data, and priority order fills the visible/target card first.
- Card-mode session sections no longer animate expand/collapse on mount (deliberate; panel mode unchanged).
- `useProgressiveMount`'s queue is module-level and shared across surfaces; a board switch mid-hydration re-enqueues behind in-flight grants. Acceptable for now — grants drain at 3/frame — but worth scoping per-surface if more consumers appear.

## Out of scope / follow-ups

- The `sessions` background hydration retry loop re-fetches the full sessions table every few seconds on busy workspaces (visible in the issue's trace as periodic WS floods) — separate issue worth filing.
- `/artifacts/<id>/sandpack-error` took 1.85s server-side in the sandbox trace.