### PR TITLE
fix(ui): restore expanded-by-default session tree on board cards

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -199,7 +199,7 @@ const SessionNode = React.memo(({ data }: { data: SessionNodeData }) => {
         isPinned={data.isPinned}
         zoneName={data.zoneName}
         zoneColor={data.zoneColor}
-        defaultExpanded={Boolean(data.isActiveUrlTarget && !data.compact)}
+        defaultExpanded={!data.compact}
       />
     </div>
   );
@@ -305,7 +305,7 @@ const BranchNode = React.memo(
           zoneName={data.zoneName}
           client={data.client}
           zoneColor={data.zoneColor}
-          defaultExpanded={Boolean(data.isActiveUrlTarget && !data.compact)}
+          defaultExpanded={!data.compact}
         />
       </div>
     );


### PR DESCRIPTION
## What

Restores board `BranchCard` / `SessionNode` `defaultExpanded` to `!data.compact` — the long-standing behavior before #1783.

## Why

#1783 changed it to `Boolean(data.isActiveUrlTarget && !data.compact)`, so every card's session tree renders **collapsed** on the board except the one matching the current URL. That was premised on "expanding the session tree is the board-load cost." In prod, collapsing them did **not** fix the ~15s home→board load — which is the evidence that the expanded session tree is **not** the bottleneck. So this reverts an ineffective change that also regressed UX (users now have to click every card to see its sessions).

Kept from #1783 (harmless, complementary):
- `deferSessionDetails` panel deferral on home→board.
- `BranchSessionSections` skipping `sortSessions` / `buildSessionTree` when a section is *manually* collapsed.

## Scope

2-line change. Not a perf claim — the ~15s regression is still being investigated separately (it's a cold-mount of the whole canvas when navigating from the Home surface, which unmounts + clears the board; reproduces only on prod-scale data).

## Checks
- `vitest run SessionCanvas BranchCard BranchSessionSections` → 90 passed
- `biome check` → clean; pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)