### PR TITLE
fix(agor-ui): board-load perf (reference-stable store rebuilds) + expanded session tree + @codemirror/state dedupe

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -199,7 +199,7 @@ const SessionNode = React.memo(({ data }: { data: SessionNodeData }) => {
         isPinned={data.isPinned}
         zoneName={data.zoneName}
         zoneColor={data.zoneColor}
-        defaultExpanded={Boolean(data.isActiveUrlTarget && !data.compact)}
+        defaultExpanded={!data.compact}
       />
     </div>
   );
@@ -305,7 +305,7 @@ const BranchNode = React.memo(
           zoneName={data.zoneName}
           client={data.client}
           zoneColor={data.zoneColor}
-          defaultExpanded={Boolean(data.isActiveUrlTarget && !data.compact)}
+          defaultExpanded={!data.compact}
         />
       </div>
     );

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -19,6 +19,9 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { agorStore } from '../store/agorStore';
+// Session `patched`/`updated` writes are coalesced to one flush per frame (see
+// realtimeBatch); flush synchronously in tests that assert the post-patch store.
+import { flushRealtimeNow } from '../store/realtimeBatch';
 import { useAgorData } from './useAgorData';
 
 /**
@@ -261,7 +264,10 @@ describe('useAgorData — socket-event bailouts', () => {
 
     const beforeSessions = agorStore.getState().sessionById;
 
-    act(() => emit('sessions', 'patched', { ...session, status: 'running' }));
+    act(() => {
+      emit('sessions', 'patched', { ...session, status: 'running' });
+      flushRealtimeNow();
+    });
 
     expect(agorStore.getState().sessionById).not.toBe(beforeSessions);
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'running' });
@@ -273,13 +279,14 @@ describe('useAgorData — socket-event bailouts', () => {
     const { result } = renderHook(() => useAgorData(client));
     await waitForInitialLoad(result);
 
-    act(() =>
+    act(() => {
       emit('sessions', 'patched', {
         ...session,
         status: 'idle',
         ready_for_prompt: true,
-      })
-    );
+      });
+      flushRealtimeNow();
+    });
 
     expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({
       status: 'idle',
@@ -378,7 +385,10 @@ describe('useAgorData — socket-event bailouts', () => {
         ?.map((s) => s.session_id)
     ).toEqual(['s-1']);
 
-    act(() => emit('sessions', 'patched', { ...session, branch_id: 'b-2' }));
+    act(() => {
+      emit('sessions', 'patched', { ...session, branch_id: 'b-2' });
+      flushRealtimeNow();
+    });
 
     // Old branch bucket is cleaned up; new branch bucket holds the session.
     expect(agorStore.getState().sessionsByBranch.has('b-1')).toBe(false);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -47,6 +47,7 @@ import {
 } from '../store/agorMaps';
 import * as realtime from '../store/agorRealtimeActions';
 import { agorStore, shallow, useStoreWithEqualityFn } from '../store/agorStore';
+import { batchRealtime, flushRealtimeNow } from '../store/realtimeBatch';
 import { createInitialLoadDebugTimer, isInitialLoadDebugEnabled } from '../utils/initialLoadDebug';
 import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 import {
@@ -1094,11 +1095,25 @@ export function useAgorData(
       return;
     }
 
-    // Subscribe to session events
+    // Subscribe to session events. `patched`/`updated` are the streaming hot
+    // path (a patch per token batch), so they're coalesced to one flush per
+    // frame — without this, mounting a board into a live store (home→board)
+    // never converges. `created`/`removed` stay immediate; the patch reducer
+    // no-ops on a since-removed id, so batching can't reorder them harmfully.
     const sessionsService = client.service('sessions');
+    // Coalesce the streaming UI write, but keep the skip-apply-on-race revision
+    // bump SYNCHRONOUS — the background hydration's quiet-window guard depends on
+    // seeing the bump the instant the event lands, not a frame later. The
+    // deferred `sessionPatched` bumps again, which is harmless (the counter is
+    // monotonic; an extra bump only makes hydration more conservative).
+    const batchedSessionPatch = batchRealtime(realtime.sessionPatched);
+    const sessionPatchedBatched = (session: Session) => {
+      bumpRevision('sessions');
+      batchedSessionPatch(session);
+    };
     sessionsService.on('created', realtime.sessionCreated);
-    sessionsService.on('patched', realtime.sessionPatched);
-    sessionsService.on('updated', realtime.sessionPatched);
+    sessionsService.on('patched', sessionPatchedBatched);
+    sessionsService.on('updated', sessionPatchedBatched);
     sessionsService.on('removed', realtime.sessionRemoved);
 
     // Subscribe to board events
@@ -1340,13 +1355,16 @@ export function useAgorData(
 
     // Cleanup listeners on unmount
     return () => {
+      // Apply any frame-batched session patches before tearing down so the last
+      // streamed update isn't dropped when the workspace surface unmounts.
+      flushRealtimeNow();
       client.io.off('oauth:completed', handleOAuthCompleted);
       client.io.off('oauth:disconnected', handleOAuthDisconnected);
       client.io.off('connect', refetchSilently);
       window.removeEventListener(TOKENS_REFRESHED_EVENT, handleTokensRefreshed);
       sessionsService.removeListener('created', realtime.sessionCreated);
-      sessionsService.removeListener('patched', realtime.sessionPatched);
-      sessionsService.removeListener('updated', realtime.sessionPatched);
+      sessionsService.removeListener('patched', sessionPatchedBatched);
+      sessionsService.removeListener('updated', sessionPatchedBatched);
       sessionsService.removeListener('removed', realtime.sessionRemoved);
 
       boardsService.removeListener('created', realtime.boardCreated);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -47,7 +47,13 @@ import {
 } from '../store/agorMaps';
 import * as realtime from '../store/agorRealtimeActions';
 import { agorStore, shallow, useStoreWithEqualityFn } from '../store/agorStore';
-import { batchRealtime, flushRealtimeNow } from '../store/realtimeBatch';
+import {
+  discardRealtimeNow,
+  enqueueSessionPatch,
+  flushRealtimeNow,
+  tombstoneSession,
+  untombstoneSession,
+} from '../store/realtimeBatch';
 import { createInitialLoadDebugTimer, isInitialLoadDebugEnabled } from '../utils/initialLoadDebug';
 import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 import {
@@ -242,6 +248,9 @@ export function useAgorData(
     agorStore.getState().reset();
     resetHydrationRevisions();
     cancelAllHydrations();
+    // Drop any straggler frame-batched patches from a prior mount of the
+    // singleton so they can't flush into this instance's fresh store.
+    discardRealtimeNow();
     return null;
   });
 
@@ -999,6 +1008,9 @@ export function useAgorData(
   // and eventually apply into freshly-cleared Maps.
   useEffect(() => {
     if (client) return;
+    // Discard (don't apply) any frame-batched session patches so a queued patch
+    // can't repopulate the maps `resetMaps()` is about to clear.
+    discardRealtimeNow();
     cancelAndFailAllHydrations();
     agorStore.getState().resetMaps();
     setHasInitiallyFetched(false);
@@ -1096,25 +1108,34 @@ export function useAgorData(
     }
 
     // Subscribe to session events. `patched`/`updated` are the streaming hot
-    // path (a patch per token batch), so they're coalesced to one flush per
-    // frame — without this, mounting a board into a live store (home→board)
-    // never converges. `created`/`removed` stay immediate; the patch reducer
-    // no-ops on a since-removed id, so batching can't reorder them harmfully.
+    // path (a patch per token batch), so they're coalesced into one keyed store
+    // write per frame — without this, mounting a board into a live store
+    // (home→board) never converges. `created`/`removed` stay synchronous; the
+    // keyed queue's tombstones keep a deferred patch from resurrecting a
+    // session a synchronous `removed` just deleted (see `realtimeBatch`).
     const sessionsService = client.service('sessions');
-    // Coalesce the streaming UI write, but keep the skip-apply-on-race revision
-    // bump SYNCHRONOUS — the background hydration's quiet-window guard depends on
-    // seeing the bump the instant the event lands, not a frame later. The
-    // deferred `sessionPatched` bumps again, which is harmless (the counter is
-    // monotonic; an extra bump only makes hydration more conservative).
-    const batchedSessionPatch = batchRealtime(realtime.sessionPatched);
+    // Keep the skip-apply-on-race revision bump SYNCHRONOUS — the background
+    // hydration's quiet-window guard, and the queue's own stale-drop stamp, both
+    // depend on the bump landing the instant the event does, not a frame later.
     const sessionPatchedBatched = (session: Session) => {
       bumpRevision('sessions');
-      batchedSessionPatch(session);
+      enqueueSessionPatch(session);
     };
-    sessionsService.on('created', realtime.sessionCreated);
+    // `created` clears any tombstone (remove-then-recreate in one frame) and
+    // `removed` sets one + drops the id's queued patch, before the synchronous
+    // store write.
+    const sessionCreatedSync = (session: Session) => {
+      untombstoneSession(session.session_id);
+      realtime.sessionCreated(session);
+    };
+    const sessionRemovedSync = (session: Session) => {
+      tombstoneSession(session.session_id);
+      realtime.sessionRemoved(session);
+    };
+    sessionsService.on('created', sessionCreatedSync);
     sessionsService.on('patched', sessionPatchedBatched);
     sessionsService.on('updated', sessionPatchedBatched);
-    sessionsService.on('removed', realtime.sessionRemoved);
+    sessionsService.on('removed', sessionRemovedSync);
 
     // Subscribe to board events
     const boardsService = client.service('boards');
@@ -1355,17 +1376,19 @@ export function useAgorData(
 
     // Cleanup listeners on unmount
     return () => {
-      // Apply any frame-batched session patches before tearing down so the last
-      // streamed update isn't dropped when the workspace surface unmounts.
+      // APPLY (not discard) any frame-batched session patches here: this cleanup
+      // also runs when the effect merely re-subscribes (a dep changes), so
+      // dropping would lose live updates mid-session. The logout path discards
+      // explicitly instead (see the `client`-null effect above).
       flushRealtimeNow();
       client.io.off('oauth:completed', handleOAuthCompleted);
       client.io.off('oauth:disconnected', handleOAuthDisconnected);
       client.io.off('connect', refetchSilently);
       window.removeEventListener(TOKENS_REFRESHED_EVENT, handleTokensRefreshed);
-      sessionsService.removeListener('created', realtime.sessionCreated);
+      sessionsService.removeListener('created', sessionCreatedSync);
       sessionsService.removeListener('patched', sessionPatchedBatched);
       sessionsService.removeListener('updated', sessionPatchedBatched);
-      sessionsService.removeListener('removed', realtime.sessionRemoved);
+      sessionsService.removeListener('removed', sessionRemovedSync);
 
       boardsService.removeListener('created', realtime.boardCreated);
       boardsService.removeListener('patched', realtime.boardPatched);

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -348,9 +348,10 @@ export function useAgorData(
           () =>
             client.service('mcp-servers').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
           (list) =>
-            agorStore
-              .getState()
-              .applyMaps((prev) => ({ ...prev, mcpServerById: buildById(list, 'mcp_server_id') }))
+            agorStore.getState().applyMaps((prev) => ({
+              ...prev,
+              mcpServerById: buildById(list, 'mcp_server_id', prev.mcpServerById),
+            }))
         );
         void runHydration(
           'session-mcp-servers',
@@ -372,9 +373,10 @@ export function useAgorData(
               .service('gateway-channels')
               .findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
           (list) =>
-            agorStore
-              .getState()
-              .applyMaps((prev) => ({ ...prev, gatewayChannelById: buildById(list, 'id') }))
+            agorStore.getState().applyMaps((prev) => ({
+              ...prev,
+              gatewayChannelById: buildById(list, 'id', prev.gatewayChannelById),
+            }))
         );
         void runHydration(
           'artifacts',
@@ -407,9 +409,10 @@ export function useAgorData(
               },
             }),
           (list) =>
-            agorStore
-              .getState()
-              .applyMaps((prev) => ({ ...prev, artifactById: buildById(list, 'artifact_id') }))
+            agorStore.getState().applyMaps((prev) => ({
+              ...prev,
+              artifactById: buildById(list, 'artifact_id', prev.artifactById),
+            }))
         );
         void runHydration(
           'oauth-status',
@@ -839,7 +842,14 @@ export function useAgorData(
                 for (const [id, session] of prev.sessionById) {
                   if (session.archived && !sessions.has(id)) sessions.set(id, session);
                 }
-                const { sessionById, sessionsByBranch } = buildSessionMaps([...sessions.values()]);
+                // Reconcile against the current maps so a wholesale apply of
+                // already-loaded sessions reuses prior refs (no board-wide
+                // re-render). This is the hot path on a busy workspace: the
+                // full-session hydration lands right as the user enters a board.
+                const { sessionById, sessionsByBranch } = buildSessionMaps([...sessions.values()], {
+                  sessionById: prev.sessionById,
+                  sessionsByBranch: prev.sessionsByBranch,
+                });
                 return { ...prev, sessionById, sessionsByBranch };
               })
           );
@@ -855,9 +865,10 @@ export function useAgorData(
               // are active-only (the snapshot query is archived:false and the
               // handlers never keep an archived branch), so a wholesale replace
               // is complete.
-              agorStore
-                .getState()
-                .applyMaps((prev) => ({ ...prev, branchById: buildById(allBranches, 'branch_id') }))
+              agorStore.getState().applyMaps((prev) => ({
+                ...prev,
+                branchById: buildById(allBranches, 'branch_id', prev.branchById),
+              }))
           );
         }
 
@@ -894,9 +905,10 @@ export function useAgorData(
             ['cards'],
             () => client.service('cards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
             (allCards) =>
-              agorStore
-                .getState()
-                .applyMaps((prev) => ({ ...prev, cardById: buildById(allCards, 'card_id') }))
+              agorStore.getState().applyMaps((prev) => ({
+                ...prev,
+                cardById: buildById(allCards, 'card_id', prev.cardById),
+              }))
           );
           void runHydration(
             'board-comments',
@@ -908,7 +920,7 @@ export function useAgorData(
             (allComments) =>
               agorStore.getState().applyMaps((prev) => ({
                 ...prev,
-                commentById: buildById(allComments, 'comment_id'),
+                commentById: buildById(allComments, 'comment_id', prev.commentById),
               }))
           );
         }
@@ -925,9 +937,10 @@ export function useAgorData(
             ['boards'],
             () => client.service('boards').findAll({ query: { $limit: PAGINATION.DEFAULT_LIMIT } }),
             (allBoards) =>
-              agorStore
-                .getState()
-                .applyMaps((prev) => ({ ...prev, boardById: buildById(allBoards, 'board_id') }))
+              agorStore.getState().applyMaps((prev) => ({
+                ...prev,
+                boardById: buildById(allBoards, 'board_id', prev.boardById),
+              }))
           );
         }
 

--- a/apps/agor-ui/src/store/agorHydration.ts
+++ b/apps/agor-ui/src/store/agorHydration.ts
@@ -110,6 +110,19 @@ let liveRevisions = makeZeroCounters();
 // from the quiet-window check against `liveRevisions`. Kept strictly monotonic.
 const hydrationGeneration = makeZeroCounters();
 
+// Per-collection high-water mark of the live-write revision that the most recent
+// wholesale hydration apply was proven quiet against. A hydration applies its
+// full-set server snapshot only when no live write raced the fetch, so the
+// applied rows reflect every write up to this revision. The frame-coalesced
+// session-patch queue reads this to DROP any queued patch whose enqueue-time
+// revision is at-or-below it: that patch's effect is already contained in the
+// fresher server snapshot, so replaying it would overwrite newer state with
+// older. Any patch enqueued AFTER a hydration snapshots its baseline bumps the
+// revision during the fetch and forces that hydration to discard — so a queued
+// patch can only ever be at-or-below (stale relative to), never ahead of, an
+// apply. Reset to zero with `liveRevisions` on (re)mount.
+let lastAppliedRevision = makeZeroCounters();
+
 /**
  * Bump the live-write revision for a collection. Called by every realtime entity
  * action (and the hook's deep-link heal / OAuth handlers) that mutates one of the
@@ -118,6 +131,38 @@ const hydrationGeneration = makeZeroCounters();
  */
 export const bumpRevision = (collection: HydratedCollection): void => {
   liveRevisions[collection] += 1;
+};
+
+/**
+ * Current live-write revision for a collection. The session-patch queue stamps
+ * each enqueued entry with this (captured right after the synchronous bump) so a
+ * later hydration apply can tell which queued patches it has already subsumed.
+ */
+export const getRevision = (collection: HydratedCollection): number => liveRevisions[collection];
+
+/**
+ * Revision that the last quiet-window hydration apply for a collection was
+ * proven against. The session-patch queue drops queued entries stamped at-or-
+ * below this — their effect already lives in the fresher applied snapshot.
+ */
+export const getLastAppliedRevision = (collection: HydratedCollection): number =>
+  lastAppliedRevision[collection];
+
+/**
+ * Record that a wholesale hydration apply for `collections` landed against the
+ * given per-collection baseline revisions (the counters snapshotted before the
+ * fetch, re-proven unchanged after). Monotonic — only advances the high-water
+ * mark. Called from `runHydration` at the moment it applies.
+ */
+export const recordHydrationApply = (
+  collections: readonly HydratedCollection[],
+  baselineRevisions: readonly number[]
+): void => {
+  collections.forEach((c, i) => {
+    if (baselineRevisions[i] > lastAppliedRevision[c]) {
+      lastAppliedRevision[c] = baselineRevisions[i];
+    }
+  });
 };
 
 /**
@@ -137,6 +182,7 @@ export const bumpFirstPaintMergeRevisions = (): void => {
  */
 export const resetHydrationRevisions = (): void => {
   liveRevisions = makeZeroCounters();
+  lastAppliedRevision = makeZeroCounters();
 };
 
 /**
@@ -225,6 +271,10 @@ export async function runHydration<T>(
     if (!isCurrent()) return; // superseded while fetching
     const raced = collections.some((c, i) => liveRevisions[c] !== before[i]);
     if (!raced) {
+      // The snapshot is provably quiet against `before` — record it as the
+      // high-water mark so the session-patch queue discards any queued patch it
+      // has already subsumed, THEN apply.
+      recordHydrationApply(collections, before);
       apply(result);
       return;
     }

--- a/apps/agor-ui/src/store/agorMaps.reconcile.test.ts
+++ b/apps/agor-ui/src/store/agorMaps.reconcile.test.ts
@@ -89,4 +89,33 @@ describe('buildSessionMaps reference stability', () => {
     expect(built.sessionById.get('s1')?.session_id).toBe('s1');
     expect(built.sessionsByBranch.get('A')).toHaveLength(1);
   });
+
+  it('preserves remote surrogate rows when rebuilding against prev', () => {
+    const source = {
+      ...makeSession('source', 'A'),
+      remote_relationships: {
+        as_source: [
+          {
+            relationship_type: 'remote_create',
+            source_session_id: 'source',
+            target_session_id: 'target',
+          },
+        ],
+      },
+    } as unknown as Session;
+    const target = makeSession('target', 'B');
+    const prev = buildSessionMaps([source, target]);
+
+    const rebuilt = buildSessionMaps([{ ...source }, { ...target }], prev);
+    const sourceBucket = rebuilt.sessionsByBranch.get('A') ?? [];
+    const surrogate = sourceBucket.find(
+      (session) => session.session_id === 'target' && session.remote_surrogate
+    );
+
+    expect(surrogate).toBeDefined();
+    expect(surrogate?.branch_id).toBe('A');
+    expect(surrogate?.genealogy?.parent_session_id).toBe('source');
+    expect(surrogate?.remote_surrogate?.source_session_id).toBe('source');
+    expect(surrogate?.remote_surrogate?.target_branch_id).toBe('B');
+  });
 });

--- a/apps/agor-ui/src/store/agorMaps.reconcile.test.ts
+++ b/apps/agor-ui/src/store/agorMaps.reconcile.test.ts
@@ -1,0 +1,92 @@
+import type { Board, Session } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import { buildById, buildSessionMaps, reconcileByIdMap } from './agorMaps';
+
+// These guard the "reference-stable rebuild" contract: a wholesale rebuild of
+// already-loaded data (the background "load whole store" hydration, reconnect
+// resync) must reuse prior references so it doesn't re-render the whole board.
+// See the home→board load regression investigation.
+
+const makeSession = (id: string, branchId: string, status = 'running'): Session =>
+  ({
+    session_id: id,
+    branch_id: branchId,
+    status,
+    archived: false,
+    created_at: '2026-06-24T00:00:00.000Z',
+    last_updated: '2026-06-24T00:00:00.000Z',
+  }) as unknown as Session;
+
+const makeBoard = (id: string, name = 'Board'): Board =>
+  ({ board_id: id, name, slug: id, archived: false }) as unknown as Board;
+
+describe('reconcileByIdMap', () => {
+  it('returns the prior map when nothing changed', () => {
+    const prev = buildById([makeBoard('a'), makeBoard('b')], 'board_id');
+    const next = new Map(prev); // same refs, different map object
+    expect(reconcileByIdMap(prev, next)).toBe(prev);
+  });
+
+  it('reuses prior refs for value-equal rows and only the map identity changes', () => {
+    const a = makeBoard('a');
+    const b = makeBoard('b');
+    const prev = buildById([a, b], 'board_id');
+
+    // Fresh objects with identical values (mirrors a wholesale refetch).
+    const next = new Map([
+      ['a', makeBoard('a')],
+      ['b', makeBoard('b', 'B renamed')],
+    ]);
+    const result = reconcileByIdMap(prev, next);
+
+    expect(result).not.toBe(prev); // b changed → new map
+    expect(result.get('a')).toBe(a); // unchanged row keeps its ref
+    expect(result.get('b')).not.toBe(b); // changed row is the new ref
+    expect(result.get('b')?.name).toBe('B renamed');
+  });
+
+  it('treats added/removed keys as a change', () => {
+    const prev = buildById([makeBoard('a')], 'board_id');
+    const next = new Map([
+      ['a', makeBoard('a')],
+      ['c', makeBoard('c')],
+    ]);
+    expect(reconcileByIdMap(prev, next)).not.toBe(prev);
+  });
+});
+
+describe('buildSessionMaps reference stability', () => {
+  it('rebuilding identical data against prev returns the prior maps', () => {
+    const sessions = [makeSession('s1', 'A'), makeSession('s2', 'B')];
+    const prev = buildSessionMaps(sessions);
+
+    // Fresh session objects, identical values — the wholesale-hydration case.
+    const rebuilt = buildSessionMaps([makeSession('s1', 'A'), makeSession('s2', 'B')], prev);
+
+    expect(rebuilt.sessionById).toBe(prev.sessionById);
+    expect(rebuilt.sessionsByBranch).toBe(prev.sessionsByBranch);
+  });
+
+  it('only the changed branch bucket gets a new array; others are preserved', () => {
+    const prev = buildSessionMaps([makeSession('s1', 'A'), makeSession('s2', 'B')]);
+    const bucketABefore = prev.sessionsByBranch.get('A');
+    const bucketBBefore = prev.sessionsByBranch.get('B');
+
+    // s2 (branch B) changes status; branch A untouched.
+    const rebuilt = buildSessionMaps(
+      [makeSession('s1', 'A'), makeSession('s2', 'B', 'completed')],
+      prev
+    );
+
+    expect(rebuilt.sessionsByBranch).not.toBe(prev.sessionsByBranch); // B changed
+    expect(rebuilt.sessionsByBranch.get('A')).toBe(bucketABefore); // A bucket ref preserved
+    expect(rebuilt.sessionsByBranch.get('B')).not.toBe(bucketBBefore); // B bucket rebuilt
+    expect(rebuilt.sessionById.get('s1')).toBe(prev.sessionById.get('s1')); // unchanged session ref kept
+  });
+
+  it('behaves like a plain build when no prev is supplied', () => {
+    const built = buildSessionMaps([makeSession('s1', 'A')]);
+    expect(built.sessionById.get('s1')?.session_id).toBe('s1');
+    expect(built.sessionsByBranch.get('A')).toHaveLength(1);
+  });
+});

--- a/apps/agor-ui/src/store/agorMaps.ts
+++ b/apps/agor-ui/src/store/agorMaps.ts
@@ -115,15 +115,46 @@ export function replaceIfChanged<T extends object>(
   return next;
 }
 
+// Reconcile a freshly-built id-map against the previous one: reuse the prior
+// entity reference for every row that is value-equal, and return the PRIOR Map
+// object itself when nothing changed at all. Without this, a wholesale rebuild
+// (the background "load whole store" hydration, first-paint apply, reconnect
+// resync) mints brand-new references for every row even when the data is
+// identical — which invalidates the top-level store subscriptions and every
+// per-entity memo/selector, re-rendering the whole board for no reason. This
+// makes a wholesale apply of already-loaded data a true no-op for subscribers.
+export function reconcileByIdMap<T extends object>(
+  prev: Map<string, T> | undefined,
+  next: Map<string, T>
+): Map<string, T> {
+  if (!prev || prev.size === 0) return next;
+  let changed = prev.size !== next.size;
+  for (const [id, value] of next) {
+    const prior = prev.get(id);
+    if (prior !== undefined && (prior === value || shallowEqualEntity(prior, value))) {
+      // Reuse the prior reference so downstream `===`/memo checks stay quiet.
+      if (prior !== value) next.set(id, prior);
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : prev;
+}
+
 // Build a plain `byId` Map from a fetched list. Used by the background
 // (non-gated) fetches whose results land via their own setter rather than the
-// single atomic map-apply the essential gate performs.
-export function buildById<T>(list: readonly T[], key: keyof T): Map<string, T> {
+// single atomic map-apply the essential gate performs. Pass `prev` to preserve
+// references for unchanged rows (see `reconcileByIdMap`).
+export function buildById<T extends object>(
+  list: readonly T[],
+  key: keyof T,
+  prev?: Map<string, T>
+): Map<string, T> {
   const map = new Map<string, T>();
   for (const item of list) {
     map.set(item[key] as unknown as string, item);
   }
-  return map;
+  return reconcileByIdMap(prev, map);
 }
 
 // Group session-MCP relationship rows by session_id.
@@ -176,7 +207,10 @@ export function buildBoardObjectMaps(list: readonly BoardEntityObject[]): {
 // can open the drawer) but are kept OUT of the branch buckets (so they never
 // reappear as branch/board cards). Cross-branch remote-created sessions are
 // projected as muted surrogate children under the creating session's branch.
-export function buildSessionMaps(sessionsList: readonly Session[]): {
+export function buildSessionMaps(
+  sessionsList: readonly Session[],
+  prev?: { sessionById: Map<string, Session>; sessionsByBranch: Map<string, Session[]> }
+): {
   sessionById: Map<string, Session>;
   sessionsByBranch: Map<string, Session[]>;
 } {
@@ -215,7 +249,40 @@ export function buildSessionMaps(sessionsList: readonly Session[]): {
     }
   }
 
-  return { sessionById: sessionsById, sessionsByBranch: sessionsByBranchId };
+  if (!prev || (prev.sessionById.size === 0 && prev.sessionsByBranch.size === 0)) {
+    return { sessionById: sessionsById, sessionsByBranch: sessionsByBranchId };
+  }
+
+  // Reuse prior references for unchanged sessions and unchanged per-branch
+  // buckets so a wholesale rebuild of already-loaded data doesn't re-render the
+  // whole board. Sessions are reconciled first; buckets then remap to the
+  // reconciled refs before comparing element-wise against the prior bucket.
+  const sessionById = reconcileByIdMap(prev.sessionById, sessionsById);
+  let bucketsChanged = prev.sessionsByBranch.size !== sessionsByBranchId.size;
+  for (const [branchId, bucket] of sessionsByBranchId) {
+    let remapped = bucket;
+    for (let i = 0; i < bucket.length; i++) {
+      const canonical = sessionById.get(bucket[i].session_id);
+      if (canonical && canonical !== bucket[i]) {
+        if (remapped === bucket) remapped = bucket.slice();
+        remapped[i] = canonical;
+      }
+    }
+    const prior = prev.sessionsByBranch.get(branchId);
+    if (
+      prior &&
+      prior.length === remapped.length &&
+      prior.every((session, i) => session === remapped[i])
+    ) {
+      sessionsByBranchId.set(branchId, prior); // reuse prior array ref
+    } else {
+      sessionsByBranchId.set(branchId, remapped);
+      bucketsChanged = true;
+    }
+  }
+  const sessionsByBranch = bucketsChanged ? sessionsByBranchId : prev.sessionsByBranch;
+
+  return { sessionById, sessionsByBranch };
 }
 
 export function removeBoardObjectFromBoardBucket(

--- a/apps/agor-ui/src/store/agorMaps.ts
+++ b/apps/agor-ui/src/store/agorMaps.ts
@@ -285,6 +285,170 @@ export function buildSessionMaps(
   return { sessionById, sessionsByBranch };
 }
 
+// Apply a single `session:patched` (incl. archive) to the branch-bucket map,
+// returning `prevBuckets` unchanged when nothing moved. Split out of
+// `applySessionPatchToMaps` only for readability; it carries the branch-
+// migration cleanup, the muted remote-surrogate projection, and the content-
+// equal bail that keeps a no-op patch from minting a fresh bucket array (so a
+// `makeSessionsForBranchSelector` consumer doesn't re-render on an idempotent
+// patch). Inserts on a missing id by design — the caller's tombstone/keyed
+// queue, not this reducer, is what prevents a stale patch from resurrecting a
+// removed session.
+function applySessionPatchToBranchBuckets(
+  prevBuckets: Map<string, Session[]>,
+  session: Session,
+  oldBranchId: string | null,
+  isArchived: boolean
+): Map<string, Session[]> {
+  let changed = false;
+  const next = new Map(prevBuckets);
+  const newBranchId = session.branch_id;
+
+  const removeFromBranch = (branchId: string) => {
+    const bucket = next.get(branchId) || [];
+    const filtered = bucket.filter((s) => s.session_id !== session.session_id);
+    if (filtered.length !== bucket.length) {
+      changed = true;
+      if (filtered.length > 0) next.set(branchId, filtered);
+      else next.delete(branchId);
+    }
+  };
+
+  if (isArchived) {
+    for (const [branchId, bucket] of next) {
+      if (bucket.some((item) => item.session_id === session.session_id)) {
+        removeFromBranch(branchId);
+      }
+    }
+    return changed ? next : prevBuckets;
+  }
+
+  // Session moved between branches — drop it from the old bucket first.
+  const branchMigrated = oldBranchId && oldBranchId !== newBranchId;
+  if (branchMigrated) removeFromBranch(oldBranchId!);
+
+  const branchSessions = next.get(newBranchId) || [];
+  const index = branchSessions.findIndex((s) => s.session_id === session.session_id);
+  let sourceSessionForRemoteProjection = session;
+
+  if (index === -1) {
+    next.set(newBranchId, [...branchSessions, session]);
+    changed = true;
+  } else {
+    const mergedSession = preserveSessionRelationshipFields(session, branchSessions[index]);
+    sourceSessionForRemoteProjection = mergedSession;
+
+    // Content-equal to what we hold — leave the bucket ref untouched.
+    if (
+      branchSessions[index] === mergedSession ||
+      shallowEqualEntity(branchSessions[index], mergedSession)
+    ) {
+      return changed ? next : prevBuckets;
+    }
+
+    const updatedSessions = [...branchSessions];
+    updatedSessions[index] = mergedSession;
+    next.set(newBranchId, updatedSessions);
+    changed = true;
+
+    // Refresh any remote/surrogate projections of this session that live in
+    // other branch buckets, preserving their local tree placement.
+    for (const [branchId, bucket] of next) {
+      if (branchId === newBranchId) continue;
+
+      let bucketChanged = false;
+      const refreshedBucket = bucket.map((item) => {
+        if (item.session_id !== session.session_id) return item;
+        bucketChanged = true;
+        return {
+          ...preserveSessionRelationshipFields(session, item),
+          branch_id: item.branch_id,
+          genealogy: item.genealogy,
+          remote_surrogate: item.remote_surrogate,
+        };
+      });
+
+      if (bucketChanged) {
+        next.set(branchId, refreshedBucket);
+        changed = true;
+      }
+    }
+  }
+
+  // Project a `remote_create` source row into muted remote-surrogate children
+  // now, rather than doing relationship work during render.
+  for (const relationship of sourceSessionForRemoteProjection.remote_relationships?.as_source ??
+    []) {
+    if (relationship.relationship_type !== 'remote_create') continue;
+
+    const targetSession = findSessionInBranchBuckets(next, relationship.target_session_id);
+    if (!targetSession) continue;
+
+    const sourceBranchSessions = next.get(sourceSessionForRemoteProjection.branch_id) ?? [];
+    if (
+      sourceBranchSessions.some((candidate) => candidate.session_id === targetSession.session_id)
+    ) {
+      continue;
+    }
+
+    const remoteSurrogate = createRemoteSurrogateSession(
+      sourceSessionForRemoteProjection,
+      targetSession,
+      relationship
+    );
+    if (!remoteSurrogate) continue;
+
+    next.set(sourceSessionForRemoteProjection.branch_id, [
+      ...sourceBranchSessions,
+      remoteSurrogate,
+    ]);
+    changed = true;
+  }
+
+  return changed ? next : prevBuckets;
+}
+
+// Pure `session:patched` reducer over the whole data-map object: updates
+// `sessionById` + `sessionsByBranch` in one pass and returns `prev` untouched on
+// a no-op (so `applyMaps`' whole-object short-circuit preserves references).
+// Archive removes the session from the active maps but leaves the branch-bucket
+// pruning to the buckets helper. This is the shared reducer for BOTH the direct
+// `sessionPatched` action and the frame-coalesced flush, which composes many of
+// these into a single store write.
+export function applySessionPatchToMaps(prev: DataMaps, session: Session): DataMaps {
+  const isArchived = session.archived === true;
+  const existing = prev.sessionById.get(session.session_id);
+  const oldBranchId = existing?.branch_id ?? null;
+
+  let sessionById = prev.sessionById;
+  if (isArchived) {
+    if (existing) {
+      sessionById = new Map(prev.sessionById);
+      sessionById.delete(session.session_id);
+    }
+  } else {
+    const mergedSession = preserveSessionRelationshipFields(session, existing);
+    // Content-equal idempotent patch — keep the prior ref (safe false negative
+    // on nested fields the daemon reserializes; see `replaceIfChanged`).
+    if (!existing || !shallowEqualEntity(existing, mergedSession)) {
+      sessionById = new Map(prev.sessionById);
+      sessionById.set(session.session_id, mergedSession);
+    }
+  }
+
+  const sessionsByBranch = applySessionPatchToBranchBuckets(
+    prev.sessionsByBranch,
+    session,
+    oldBranchId,
+    isArchived
+  );
+
+  if (sessionById === prev.sessionById && sessionsByBranch === prev.sessionsByBranch) {
+    return prev;
+  }
+  return { ...prev, sessionById, sessionsByBranch };
+}
+
 export function removeBoardObjectFromBoardBucket(
   buckets: Map<string, BoardEntityObject[]>,
   boardObject: BoardEntityObject

--- a/apps/agor-ui/src/store/agorMaps.ts
+++ b/apps/agor-ui/src/store/agorMaps.ts
@@ -262,6 +262,12 @@ export function buildSessionMaps(
   for (const [branchId, bucket] of sessionsByBranchId) {
     let remapped = bucket;
     for (let i = 0; i < bucket.length; i++) {
+      // Remote surrogate rows intentionally reuse the target session id while
+      // overriding branch_id / genealogy / remote_surrogate so they render under
+      // the source branch. Do not canonicalize them back to `sessionById`, or a
+      // full-session hydration rebuild will erase the surrogate projection.
+      if (bucket[i].remote_surrogate) continue;
+
       const canonical = sessionById.get(bucket[i].session_id);
       if (canonical && canonical !== bucket[i]) {
         if (remapped === bucket) remapped = bucket.slice();

--- a/apps/agor-ui/src/store/agorRealtimeActions.ts
+++ b/apps/agor-ui/src/store/agorRealtimeActions.ts
@@ -14,12 +14,14 @@
  * bumps `sessions` too.
  *
  * IMMER breadth/depth rule applied here:
- *  - HOT single-entity `*:patched` writes → RAW reducer via `setMap`
+ *  - HOT single-map `*:patched` writes → RAW reducer via `setMap`
  *    (`new Map(prev); next.set(id, e)` through `replaceIfChanged`). No immer
  *    proxy on the hot path.
- *  - multi-map board-object index maintenance → the pure reducers
- *    (`upsertBoardObjectInMaps` / `removeBoardObjectFromMaps`) via `applyMaps`
- *    — reference-stable so the contract the tests pin holds exactly.
+ *  - multi-map maintenance (session `sessionById` + `sessionsByBranch`,
+ *    board-object index) → the pure reducers (`applySessionPatchToMaps` /
+ *    `upsertBoardObjectInMaps` / `removeBoardObjectFromMaps`) via `applyMaps`,
+ *    which commits every changed slice in ONE store notify — reference-stable so
+ *    the contract the tests pin holds exactly.
  *  - the branch-eviction CASCADE → the store's immer action
  *    (`evictBranchAndSessions`).
  */
@@ -37,12 +39,9 @@ import type {
   Session,
   User,
 } from '@agor-live/client';
-import { shallowEqualEntity } from '../utils/shallowEqual';
 import { bumpRevision } from './agorHydration';
 import {
-  createRemoteSurrogateSession,
-  findSessionInBranchBuckets,
-  preserveSessionRelationshipFields,
+  applySessionPatchToMaps,
   removeBoardObjectFromMaps,
   replaceIfChanged,
   upsertBoardObjectInMaps,
@@ -89,158 +88,11 @@ export function sessionCreated(session: Session) {
 export function sessionPatched(session: Session) {
   // Patch (incl. archive, which removes the session from the active maps) counts
   // as a live write — bump so an in-flight sessions hydration can't clobber it or
-  // resurrect an archive with a pre-archive snapshot.
+  // resurrect an archive with a pre-archive snapshot. One `applyMaps` commits
+  // both `sessionById` and `sessionsByBranch` in a single store notify; the
+  // reducer returns `prev` untouched on a no-op patch so references stay stable.
   bumpRevision('sessions');
-  const isArchived = session.archived === true;
-  // Track old branch_id for migration detection
-  let oldBranchId: string | null = null;
-
-  // Update sessionById - add/update active sessions, remove archived sessions
-  setMap('sessionById', (prev) => {
-    const existing = prev.get(session.session_id);
-
-    // Capture old branch_id before updating
-    oldBranchId = existing?.branch_id || null;
-
-    if (isArchived) {
-      if (!existing) return prev;
-      const next = new Map(prev);
-      next.delete(session.session_id);
-      return next;
-    }
-
-    const mergedSession = preserveSessionRelationshipFields(session, existing);
-
-    // Bail out on no-op patches. Feathers always emits a fresh object so
-    // `existing === session` never holds, but the daemon does emit
-    // idempotent patches (e.g. callback bookkeeping that lands at the same
-    // status). Shallow-equal misses nested fields the daemon reserializes
-    // — that's a safe false negative.
-    if (existing && shallowEqualEntity(existing, mergedSession)) return prev;
-
-    const next = new Map(prev);
-    next.set(session.session_id, mergedSession);
-    return next;
-  });
-
-  // Update sessionsByBranch - keep active sessions only
-  setMap('sessionsByBranch', (prev) => {
-    let changed = false;
-    const next = new Map(prev);
-    const newBranchId = session.branch_id;
-
-    const removeFromBranch = (branchId: string) => {
-      const bucket = next.get(branchId) || [];
-      const filtered = bucket.filter((s) => s.session_id !== session.session_id);
-      if (filtered.length !== bucket.length) {
-        changed = true;
-        if (filtered.length > 0) {
-          next.set(branchId, filtered);
-        } else {
-          next.delete(branchId);
-        }
-      }
-    };
-
-    if (isArchived) {
-      for (const [branchId, bucket] of next) {
-        if (bucket.some((item) => item.session_id === session.session_id)) {
-          removeFromBranch(branchId);
-        }
-      }
-      return changed ? next : prev;
-    }
-
-    // Session moved between branches - remove from old bucket first
-    const branchMigrated = oldBranchId && oldBranchId !== newBranchId;
-    if (branchMigrated) {
-      removeFromBranch(oldBranchId!);
-    }
-
-    const branchSessions = next.get(newBranchId) || [];
-    const index = branchSessions.findIndex((s) => s.session_id === session.session_id);
-    let sourceSessionForRemoteProjection = session;
-
-    if (index === -1) {
-      next.set(newBranchId, [...branchSessions, session]);
-    } else {
-      const mergedSession = preserveSessionRelationshipFields(session, branchSessions[index]);
-      sourceSessionForRemoteProjection = mergedSession;
-
-      // Bail out when the session is content-equal to what we already hold.
-      // Mirrors the sessionById bailout above so an idempotent patch doesn't
-      // produce a fresh branch-bucket array — preserving the reference that
-      // `makeSessionsForBranchSelector(branchId)` returns, so a BranchNode
-      // subscribed to it doesn't re-render on a no-op patch.
-      if (
-        branchSessions[index] === mergedSession ||
-        shallowEqualEntity(branchSessions[index], mergedSession)
-      ) {
-        return changed ? next : prev;
-      }
-
-      const updatedSessions = [...branchSessions];
-      updatedSessions[index] = mergedSession;
-      next.set(newBranchId, updatedSessions);
-
-      // Also update any remote/surrogate projections of this session that
-      // live in source-branch buckets. Preserve their local tree placement
-      // while refreshing status/callback_config/etc. from the canonical row.
-      for (const [branchId, bucket] of next) {
-        if (branchId === newBranchId) continue;
-
-        let bucketChanged = false;
-        const refreshedBucket = bucket.map((item) => {
-          if (item.session_id !== session.session_id) return item;
-          bucketChanged = true;
-          return {
-            ...preserveSessionRelationshipFields(session, item),
-            branch_id: item.branch_id,
-            genealogy: item.genealogy,
-            remote_surrogate: item.remote_surrogate,
-          };
-        });
-
-        if (bucketChanged) {
-          next.set(branchId, refreshedBucket);
-        }
-      }
-    }
-
-    // Remote relationships are created after the canonical target session
-    // row. The daemon then emits a patched source session with
-    // remote_relationships.as_source populated. Project that single source
-    // row into muted remote-surrogate children now, instead of doing any
-    // expensive relationship work during render.
-    for (const relationship of sourceSessionForRemoteProjection.remote_relationships?.as_source ??
-      []) {
-      if (relationship.relationship_type !== 'remote_create') continue;
-
-      const targetSession = findSessionInBranchBuckets(next, relationship.target_session_id);
-      if (!targetSession) continue;
-
-      const sourceBranchSessions = next.get(sourceSessionForRemoteProjection.branch_id) ?? [];
-      if (
-        sourceBranchSessions.some((candidate) => candidate.session_id === targetSession.session_id)
-      ) {
-        continue;
-      }
-
-      const remoteSurrogate = createRemoteSurrogateSession(
-        sourceSessionForRemoteProjection,
-        targetSession,
-        relationship
-      );
-      if (!remoteSurrogate) continue;
-
-      next.set(sourceSessionForRemoteProjection.branch_id, [
-        ...sourceBranchSessions,
-        remoteSurrogate,
-      ]);
-    }
-
-    return next;
-  });
+  applyMaps((prev) => applySessionPatchToMaps(prev, session));
 }
 
 export function sessionRemoved(session: Session) {

--- a/apps/agor-ui/src/store/realtimeBatch.test.ts
+++ b/apps/agor-ui/src/store/realtimeBatch.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { batchRealtime, flushRealtimeNow } from './realtimeBatch';
+
+describe('realtimeBatch', () => {
+  it('defers the wrapped action until the queue is flushed', () => {
+    const spy = vi.fn();
+    const handler = batchRealtime(spy);
+
+    handler('a');
+    expect(spy).not.toHaveBeenCalled(); // not applied synchronously
+
+    flushRealtimeNow();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('a');
+  });
+
+  it('coalesces a burst and preserves FIFO order across handlers', () => {
+    const calls: string[] = [];
+    const a = batchRealtime((p: string) => calls.push(`a:${p}`));
+    const b = batchRealtime((p: string) => calls.push(`b:${p}`));
+
+    a('1');
+    b('2');
+    a('3');
+    expect(calls).toEqual([]); // still queued
+
+    flushRealtimeNow();
+    expect(calls).toEqual(['a:1', 'b:2', 'a:3']);
+  });
+
+  it('flushRealtimeNow is a no-op when the queue is empty', () => {
+    expect(() => flushRealtimeNow()).not.toThrow();
+  });
+});

--- a/apps/agor-ui/src/store/realtimeBatch.test.ts
+++ b/apps/agor-ui/src/store/realtimeBatch.test.ts
@@ -1,31 +1,178 @@
-import { describe, expect, it, vi } from 'vitest';
-import { batchRealtime, flushRealtimeNow } from './realtimeBatch';
+import type { Session } from '@agor-live/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { bumpRevision, recordHydrationApply, resetHydrationRevisions } from './agorHydration';
+import { agorStore } from './agorStore';
+import {
+  discardRealtimeNow,
+  enqueueSessionPatch,
+  flushRealtimeNow,
+  tombstoneSession,
+  untombstoneSession,
+} from './realtimeBatch';
 
-describe('realtimeBatch', () => {
-  it('defers the wrapped action until the queue is flushed', () => {
-    const spy = vi.fn();
-    const handler = batchRealtime(spy);
+// The keyed session-patch queue writes through the real store, so these are
+// small integration tests: seed the store, drive the queue, assert the maps.
 
-    handler('a');
-    expect(spy).not.toHaveBeenCalled(); // not applied synchronously
+const makeSession = (overrides: Partial<Session> = {}): Session =>
+  ({
+    session_id: 's-1',
+    branch_id: 'b-1',
+    status: 'idle',
+    archived: false,
+    created_at: '2026-06-24T00:00:00.000Z',
+    ...overrides,
+  }) as unknown as Session;
+
+// Seed a session into both active maps (mirrors a `created` / hydrated row).
+function seedSession(session: Session) {
+  agorStore.getState().applyMaps((prev) => ({
+    ...prev,
+    sessionById: new Map(prev.sessionById).set(session.session_id, session),
+    sessionsByBranch: new Map(prev.sessionsByBranch).set(session.branch_id, [session]),
+  }));
+}
+
+beforeEach(() => {
+  agorStore.getState().reset();
+  resetHydrationRevisions();
+  discardRealtimeNow();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  discardRealtimeNow();
+  agorStore.getState().reset();
+  resetHydrationRevisions();
+});
+
+describe('realtimeBatch — keyed session-patch queue', () => {
+  it('defers a queued patch until the queue is flushed', () => {
+    seedSession(makeSession({ status: 'idle' }));
+
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'running' }));
+    // Not applied synchronously.
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
 
     flushRealtimeNow();
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith('a');
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'running' });
   });
 
-  it('coalesces a burst and preserves FIFO order across handlers', () => {
-    const calls: string[] = [];
-    const a = batchRealtime((p: string) => calls.push(`a:${p}`));
-    const b = batchRealtime((p: string) => calls.push(`b:${p}`));
+  it('coalesces a burst to the latest payload per id in ONE store write', () => {
+    seedSession(makeSession({ status: 'idle' }));
 
-    a('1');
-    b('2');
-    a('3');
-    expect(calls).toEqual([]); // still queued
+    let notifies = 0;
+    const unsub = agorStore.subscribe(() => {
+      notifies += 1;
+    });
+
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'running' }));
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'thinking' }));
+    bumpRevision('sessions');
+    enqueueSessionPatch(
+      makeSession({ status: 'idle', ready_for_prompt: true } as Partial<Session>)
+    );
 
     flushRealtimeNow();
-    expect(calls).toEqual(['a:1', 'b:2', 'a:3']);
+    unsub();
+
+    // Only the latest payload lands, and the whole frame is a single notify.
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({
+      status: 'idle',
+      ready_for_prompt: true,
+    });
+    expect(notifies).toBe(1);
+  });
+
+  it('a queued patch then a synchronous remove does not resurrect the session', () => {
+    seedSession(makeSession({ status: 'running' }));
+
+    // patched arrives (queued), then removed applies synchronously.
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'running' }));
+
+    tombstoneSession('s-1');
+    agorStore.getState().applyMaps((prev) => {
+      const sessionById = new Map(prev.sessionById);
+      sessionById.delete('s-1');
+      const sessionsByBranch = new Map(prev.sessionsByBranch);
+      sessionsByBranch.delete('b-1');
+      return { ...prev, sessionById, sessionsByBranch };
+    });
+
+    flushRealtimeNow();
+
+    // The tombstoned id is skipped — no resurrection in either map.
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(false);
+    expect(agorStore.getState().sessionsByBranch.has('b-1')).toBe(false);
+  });
+
+  it('created clears a tombstone so a same-frame recreate+patch applies', () => {
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'running' }));
+    tombstoneSession('s-1'); // remove
+    untombstoneSession('s-1'); // create clears the tombstone
+    seedSession(makeSession({ status: 'running' }));
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'thinking' }));
+
+    flushRealtimeNow();
+
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'thinking' });
+  });
+
+  it('flushes via the setTimeout path when the tab is hidden (rAF paused)', () => {
+    vi.useFakeTimers();
+    // jsdom's `visibilityState` lives on Document.prototype; shadow it with an
+    // own accessor and delete it after to fall back to the real getter.
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    try {
+      seedSession(makeSession({ status: 'idle' }));
+
+      bumpRevision('sessions');
+      enqueueSessionPatch(makeSession({ status: 'running' }));
+      // rAF would pause in a hidden tab; nothing applied yet.
+      expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
+
+      vi.runOnlyPendingTimers();
+      expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'running' });
+    } finally {
+      delete (document as { visibilityState?: unknown }).visibilityState;
+    }
+  });
+
+  it('drops a queued patch subsumed by a later hydration apply', () => {
+    seedSession(makeSession({ status: 'idle' }));
+
+    // A patch is enqueued (stamped with the current revision)...
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'running' }));
+
+    // ...then a hydration applies a fresher snapshot proven quiet at-or-after
+    // that revision. The queued patch is now stale.
+    recordHydrationApply(['sessions'], [1]);
+
+    flushRealtimeNow();
+
+    // The stale patch is dropped — the hydrated (idle) state stands.
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
+  });
+
+  it('discardRealtimeNow drops the pending queue without applying', () => {
+    seedSession(makeSession({ status: 'idle' }));
+
+    bumpRevision('sessions');
+    enqueueSessionPatch(makeSession({ status: 'running' }));
+
+    discardRealtimeNow();
+    flushRealtimeNow(); // nothing left to apply
+
+    expect(agorStore.getState().sessionById.get('s-1')).toMatchObject({ status: 'idle' });
   });
 
   it('flushRealtimeNow is a no-op when the queue is empty', () => {

--- a/apps/agor-ui/src/store/realtimeBatch.ts
+++ b/apps/agor-ui/src/store/realtimeBatch.ts
@@ -1,0 +1,72 @@
+/**
+ * Coalesce high-frequency realtime store updates into one flush per animation
+ * frame.
+ *
+ * Streaming agents emit a `session:patched` on every token batch. Applied
+ * synchronously — one zustand `set()` → one React notification each — they fire
+ * dozens of times per second. That is harmless once a board is mounted (each
+ * notification only re-renders the one BranchCard whose bucket changed), but it
+ * is catastrophic *while a board is mounting*: home→board mounts the whole
+ * canvas into a live, fully-hydrated store, and every mid-mount store mutation
+ * makes React re-run the in-flight render before it can settle. On a busy
+ * workspace (many agents streaming across all boards) the mount never converges
+ * — this is the ~15-20s home→board stall. A raw/direct board load doesn't hit
+ * it because its first paint is board-scoped and goes through the quiet
+ * first-paint gate.
+ *
+ * Batching defers each wrapped action to the next frame and runs the whole queue
+ * in a single task, so React batches them into ONE re-render per frame. The
+ * mount then gets whole frames to itself and settles quickly.
+ *
+ * Ordering is preserved (FIFO). Reducers already bail when their target entity
+ * is gone (`sessionPatched` no-ops when the id isn't tracked), so a batched
+ * patch can never resurrect a session that was removed synchronously in between.
+ */
+
+type Thunk = () => void;
+
+let queue: Thunk[] = [];
+let handle: number | ReturnType<typeof setTimeout> | null = null;
+
+const raf: ((cb: () => void) => number) | null =
+  typeof requestAnimationFrame === 'function' ? requestAnimationFrame : null;
+const caf: ((h: number) => void) | null =
+  typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : null;
+
+function flush(): void {
+  handle = null;
+  const batch = queue;
+  queue = [];
+  for (const run of batch) run();
+}
+
+function schedule(): void {
+  if (handle != null) return;
+  handle = raf ? raf(flush) : setTimeout(flush, 0);
+}
+
+/**
+ * Wrap a realtime action so its store write is deferred to the next coalesced
+ * flush. The returned handler is stable for the life of the wrap, so the SAME
+ * reference must be used for `service.on(...)` and `service.removeListener(...)`.
+ */
+export function batchRealtime<T>(action: (payload: T) => void): (payload: T) => void {
+  return (payload: T) => {
+    queue.push(() => action(payload));
+    schedule();
+  };
+}
+
+/**
+ * Apply any queued updates immediately. Call on teardown so a pending flush
+ * isn't lost when the subscription effect unmounts.
+ */
+export function flushRealtimeNow(): void {
+  if (handle == null && queue.length === 0) return;
+  if (handle != null) {
+    if (raf && caf) caf(handle as number);
+    else clearTimeout(handle as ReturnType<typeof setTimeout>);
+    handle = null;
+  }
+  flush();
+}

--- a/apps/agor-ui/src/store/realtimeBatch.ts
+++ b/apps/agor-ui/src/store/realtimeBatch.ts
@@ -1,6 +1,6 @@
 /**
- * Coalesce high-frequency realtime store updates into one flush per animation
- * frame.
+ * Coalesce high-frequency streaming session patches into ONE store write per
+ * animation frame.
  *
  * Streaming agents emit a `session:patched` on every token batch. Applied
  * synchronously — one zustand `set()` → one React notification each — they fire
@@ -9,64 +9,186 @@
  * is catastrophic *while a board is mounting*: home→board mounts the whole
  * canvas into a live, fully-hydrated store, and every mid-mount store mutation
  * makes React re-run the in-flight render before it can settle. On a busy
- * workspace (many agents streaming across all boards) the mount never converges
- * — this is the ~15-20s home→board stall. A raw/direct board load doesn't hit
- * it because its first paint is board-scoped and goes through the quiet
- * first-paint gate.
+ * workspace (many agents streaming across all boards) the mount never converges.
+ * A raw/direct board load doesn't hit it because its first paint is board-scoped
+ * and goes through the quiet first-paint gate.
  *
- * Batching defers each wrapped action to the next frame and runs the whole queue
- * in a single task, so React batches them into ONE re-render per frame. The
- * mount then gets whole frames to itself and settles quickly.
+ * Design — a KEYED latest-payload-per-session queue with tombstones, NOT a FIFO
+ * thunk queue. Two properties fall out of the shape:
  *
- * Ordering is preserved (FIFO). Reducers already bail when their target entity
- * is gone (`sessionPatched` no-ops when the id isn't tracked), so a batched
- * patch can never resurrect a session that was removed synchronously in between.
+ *  1. Ordering safety. `session:created`/`removed` apply SYNCHRONOUSLY (see the
+ *     wiring in `useAgorData`), while `patched`/`updated` defer to the next
+ *     flush. The patch reducer (`applySessionPatchToMaps`) INSERTS on a missing
+ *     id in both `sessionById` and `sessionsByBranch`, so a naive deferred patch
+ *     flushing after a synchronous `removed` would resurrect the deleted
+ *     session. Here `removed` drops that id's queued payload AND tombstones the
+ *     id; the flush skips tombstoned ids; `created` clears the tombstone so a
+ *     genuine remove-then-recreate within one frame still applies. Tombstones
+ *     live only until the flush that clears them — a later-frame patch can't be
+ *     stale against a same-frame remove, and cross-fetch staleness is handled by
+ *     (3). Memory is bounded to one entry per session, so a burst collapses.
+ *
+ *  2. Bounded flush work. At most one (the latest) payload per id is applied,
+ *     composed into a SINGLE `applyMaps` pass — O(1) store notifies per frame
+ *     regardless of how many patches arrived.
+ *
+ *  3. Hydration ordering. Each queued entry is stamped with the sessions
+ *     revision at enqueue time. A background hydration records the revision its
+ *     last quiet-window apply was proven against (`getLastAppliedRevision`); the
+ *     flush DROPS any queued entry stamped at-or-below it, because the applied
+ *     server snapshot already contains that patch's effect and is strictly
+ *     fresher. A patch enqueued after the hydration snapshotted would have
+ *     bumped the revision mid-fetch and forced that hydration to discard — so a
+ *     queued patch can only be stale relative to, never ahead of, an apply.
+ *
+ * Scheduling. `requestAnimationFrame` pauses in background tabs. A backgrounded
+ * tab would otherwise accumulate patches for minutes and burst on refocus, so
+ * when the document is hidden (or rAF is unavailable — SSR/tests) the flush is
+ * scheduled via `setTimeout` instead, and a `visibilitychange` re-arms a pending
+ * flush onto the scheduler that matches the new visibility state.
  */
+import type { Session } from '@agor-live/client';
+import { getLastAppliedRevision, getRevision } from './agorHydration';
+import { applySessionPatchToMaps } from './agorMaps';
+import { agorStore } from './agorStore';
 
-type Thunk = () => void;
+interface PendingPatch {
+  session: Session;
+  // Sessions revision captured right after the synchronous bump at enqueue —
+  // used by the flush to discard entries a fresher hydration already subsumed.
+  revision: number;
+}
 
-let queue: Thunk[] = [];
+// Latest queued payload per session id, and the ids removed since the last
+// flush (tombstones). Both are module-global singletons: `useAgorData` mounts
+// once, and tests reset via `discardRealtimeNow`.
+let pending = new Map<string, PendingPatch>();
+let tombstones = new Set<string>();
 let handle: number | ReturnType<typeof setTimeout> | null = null;
+let handleIsRaf = false;
+
+// Cadence for the hidden-tab / no-rAF fallback. Browsers throttle background
+// timers to ~1s regardless; a short nominal interval keeps a foreground no-rAF
+// environment (tests) responsive.
+const HIDDEN_FLUSH_INTERVAL_MS = 250;
 
 const raf: ((cb: () => void) => number) | null =
   typeof requestAnimationFrame === 'function' ? requestAnimationFrame : null;
 const caf: ((h: number) => void) | null =
   typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : null;
 
+function documentHidden(): boolean {
+  return typeof document !== 'undefined' && document.visibilityState === 'hidden';
+}
+
+function cancelHandle(): void {
+  if (handle == null) return;
+  if (handleIsRaf && caf) caf(handle as number);
+  else clearTimeout(handle as ReturnType<typeof setTimeout>);
+  handle = null;
+  handleIsRaf = false;
+}
+
+function scheduleFlush(): void {
+  if (handle != null) return;
+  if (raf && !documentHidden()) {
+    handleIsRaf = true;
+    handle = raf(flush);
+  } else {
+    handleIsRaf = false;
+    handle = setTimeout(flush, HIDDEN_FLUSH_INTERVAL_MS);
+  }
+}
+
 function flush(): void {
   handle = null;
-  const batch = queue;
-  queue = [];
-  for (const run of batch) run();
+  handleIsRaf = false;
+
+  const batch = pending;
+  const graves = tombstones;
+  // Tombstones are cleared every flush: once the frame's queue is drained, no
+  // stale patch can outlive them (a later-frame patch is not stale against a
+  // same-frame remove; cross-fetch staleness is caught by the revision guard).
+  pending = new Map();
+  tombstones = new Set();
+
+  if (batch.size === 0) return;
+
+  const lastApplied = getLastAppliedRevision('sessions');
+  const sessions: Session[] = [];
+  for (const [id, entry] of batch) {
+    if (graves.has(id)) continue; // removed synchronously this frame
+    if (entry.revision <= lastApplied) continue; // subsumed by a fresher hydration apply
+    sessions.push(entry.session);
+  }
+  if (sessions.length === 0) return;
+
+  // One store write for the whole frame: compose every surviving payload into a
+  // single `applyMaps` pass (one subscriber notify) instead of N `sessionPatched`
+  // calls each doing two `set()`s.
+  agorStore
+    .getState()
+    .applyMaps((prev) => sessions.reduce((maps, s) => applySessionPatchToMaps(maps, s), prev));
 }
 
-function schedule(): void {
-  if (handle != null) return;
-  handle = raf ? raf(flush) : setTimeout(flush, 0);
+function handleVisibilityChange(): void {
+  if (handle == null) return;
+  // A rAF armed while visible pauses when the tab backgrounds; a timeout armed
+  // while hidden should re-align to frames when the tab foregrounds. Re-arm on
+  // the scheduler that matches the new state.
+  cancelHandle();
+  scheduleFlush();
+}
+
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('visibilitychange', handleVisibilityChange);
 }
 
 /**
- * Wrap a realtime action so its store write is deferred to the next coalesced
- * flush. The returned handler is stable for the life of the wrap, so the SAME
- * reference must be used for `service.on(...)` and `service.removeListener(...)`.
+ * Queue a streaming `session:patched`/`updated`. Keeps only the latest payload
+ * per session id and stamps it with the current sessions revision (the caller
+ * bumps synchronously first, so the stamp reflects this event). Applied on the
+ * next coalesced flush.
  */
-export function batchRealtime<T>(action: (payload: T) => void): (payload: T) => void {
-  return (payload: T) => {
-    queue.push(() => action(payload));
-    schedule();
-  };
+export function enqueueSessionPatch(session: Session): void {
+  pending.set(session.session_id, { session, revision: getRevision('sessions') });
+  scheduleFlush();
 }
 
 /**
- * Apply any queued updates immediately. Call on teardown so a pending flush
- * isn't lost when the subscription effect unmounts.
+ * Tombstone a session id on synchronous `session:removed`: drop any queued patch
+ * for it and mark it so a same-frame queued patch can't resurrect it at flush.
+ * Schedules a flush so the tombstone is cleared even if no patch is queued.
+ */
+export function tombstoneSession(sessionId: string): void {
+  pending.delete(sessionId);
+  tombstones.add(sessionId);
+  scheduleFlush();
+}
+
+/**
+ * Clear a session id's tombstone on synchronous `session:created` so a genuine
+ * remove-then-recreate within one frame lets subsequent patches apply.
+ */
+export function untombstoneSession(sessionId: string): void {
+  tombstones.delete(sessionId);
+}
+
+/**
+ * Apply any queued patches immediately. Call on teardown so the last streamed
+ * update isn't dropped when the subscription effect re-runs or unmounts.
  */
 export function flushRealtimeNow(): void {
-  if (handle == null && queue.length === 0) return;
-  if (handle != null) {
-    if (raf && caf) caf(handle as number);
-    else clearTimeout(handle as ReturnType<typeof setTimeout>);
-    handle = null;
-  }
+  cancelHandle();
   flush();
+}
+
+/**
+ * Discard the pending queue and tombstones WITHOUT applying — the explicit
+ * logout/reset path, so a queued patch can't repopulate freshly-cleared maps.
+ */
+export function discardRealtimeNow(): void {
+  cancelHandle();
+  pending = new Map();
+  tombstones = new Set();
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "pnpm": {
     "overrides": {
+      "@codemirror/state": "6.7.0",
       "@codemirror/view": "6.43.0",
       "@esbuild-kit/core-utils>esbuild": "0.25.4",
       "@google/genai": "^1.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@codemirror/state': 6.7.0
   '@codemirror/view': 6.43.0
   '@esbuild-kit/core-utils>esbuild': 0.25.4
   '@google/genai': ^1.43.0
@@ -1413,9 +1414,6 @@ packages:
   '@codemirror/search@6.6.0':
     resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
 
-  '@codemirror/state@6.6.0':
-    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
-
   '@codemirror/state@6.7.0':
     resolution: {integrity: sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==}
 
@@ -2595,9 +2593,6 @@ packages:
 
   '@lydell/node-pty@1.1.0':
     resolution: {integrity: sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==}
-
-  '@marijn/find-cluster-break@1.0.2':
-    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
@@ -4553,14 +4548,14 @@ packages:
       '@codemirror/language': '>=6.0.0'
       '@codemirror/lint': '>=6.0.0'
       '@codemirror/search': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
 
   '@uiw/react-codemirror@4.25.10':
     resolution: {integrity: sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==}
     peerDependencies:
       '@babel/runtime': '>=7.11.0'
-      '@codemirror/state': '>=6.0.0'
+      '@codemirror/state': 6.7.0
       '@codemirror/theme-one-dark': '>=6.0.0'
       '@codemirror/view': 6.43.0
       codemirror: '>=6.0.0'
@@ -10041,14 +10036,14 @@ snapshots:
   '@codemirror/autocomplete@6.20.1':
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@lezer/common': 1.5.1
 
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@lezer/common': 1.5.2
 
@@ -10063,7 +10058,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
 
@@ -10073,7 +10068,7 @@ snapshots:
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
@@ -10084,7 +10079,7 @@ snapshots:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.5
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
@@ -10099,7 +10094,7 @@ snapshots:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/lang-html': 6.4.11
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.6.4
@@ -10108,7 +10103,7 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.1
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@lezer/common': 1.5.1
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
@@ -10116,7 +10111,7 @@ snapshots:
 
   '@codemirror/language@6.12.3':
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -10125,7 +10120,7 @@ snapshots:
 
   '@codemirror/lint@6.9.5':
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       crelt: 1.0.6
 
@@ -10135,10 +10130,6 @@ snapshots:
       '@codemirror/view': 6.43.0
       crelt: 1.0.7
 
-  '@codemirror/state@6.6.0':
-    dependencies:
-      '@marijn/find-cluster-break': 1.0.2
-
   '@codemirror/state@6.7.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.3
@@ -10146,13 +10137,13 @@ snapshots:
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@lezer/highlight': 1.2.3
 
   '@codemirror/view@6.43.0':
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -10179,7 +10170,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.0
       '@codemirror/view': 6.43.0
       '@codesandbox/sandpack-client': 2.19.8
       '@lezer/highlight': 1.2.3
@@ -11531,8 +11522,6 @@ snapshots:
       '@lydell/node-pty-win32-arm64': 1.1.0
       '@lydell/node-pty-win32-x64': 1.1.0
     optional: true
-
-  '@marijn/find-cluster-break@1.0.2': {}
 
   '@marijn/find-cluster-break@1.0.3': {}
 


### PR DESCRIPTION
Fixes the home→board load stall, plus two issues found along the way. Four commits, each independently revertable.

## The bug (what your tests proved)
- Direct/raw board load: paints in 1-2s.
- Home→board: 15-20s on the *same board*. First home→board after a Knowledge-Base visit is fast; the *second* is slow.

So it's not node count or mount cost — the board renders the same scoped nodes either way. The difference is **what the store is doing while the board mounts.**

## Root cause
A direct load's first paint is **board-scoped** and goes through the quiet **first-paint gate** — it mounts the canvas once, against a small, quiet store. **Home→board has no gate**: it mounts the whole canvas into a **live, fully-hydrated store** while every agent across every board streams `session:patched` (one per token). Each patch was applied **synchronously** — one zustand `set()` → one React notification — so the in-flight mount render kept getting invalidated before it could settle, and never converged. (The "2nd time slow, KB resets it" is the same mechanism: KB unmounts the workspace runtime and restarts the full-store hydration, so the *first* board visit races ahead of it while the store is still small; by the second, the full store has landed and is streaming.)

## Fixes

### 1. Coalesce streaming session patches to one flush per frame (primary)
`session:patched`/`updated` now go through `batchRealtime` — queued and flushed once per animation frame — so React does **one render per frame instead of one per token**, and the mount gets whole frames to converge. Correctness preserved: the skip-apply-on-race `bumpRevision('sessions')` stays **synchronous** (the hydration quiet-window guard needs it); only the store write defers. FIFO order kept; `sessionPatched` already no-ops on a since-removed id; pending flush is applied on teardown.

### 2. Reference-stable store rebuilds
The background "load whole store" hydration rebuilt `sessionById`/`sessionsByBranch`/every byId map from scratch — new refs for every row/bucket even when data was identical — re-rendering the whole board. Now `buildById`/`buildSessionMaps` reconcile against `prev` (reuse refs for value-equal rows, return the prior Map when unchanged), so a wholesale apply of already-loaded data is a no-op for subscribers. Directly addresses "home→board shouldn't touch objects already loaded."

### 3. Restore expanded-by-default session tree on board cards
Reverts #1783's collapse (it was premised on expansion being the cost; it isn't) — UX restoration.

### 4. Dedupe `@codemirror/state` — Fixes #1792
Two versions in the tree (6.6.0 + 6.7.0) → two module instances → broken `instanceof` → the CodeEditor crash. Pinned `@codemirror/state@6.7.0` via pnpm overrides.

## How the fix maps to the odd behavior
- **Direct load fast / home→board slow:** direct load mounts against a quiet, board-scoped store; home→board mounts into a live streaming store. Batching gives the home→board mount the same quiet frames the gate gives direct load.
- **1st fast, 2nd slow, KB resets:** timing of the full-store hydration relative to the mount. Batching makes the mount converge regardless of how fast the store is churning, so it's robust to that timing.

## Checks
- store + hooks suites: 125 passed (incl. new `realtimeBatch` and `agorMaps.reconcile` tests). Hydration skip-apply-on-race tests still green (sync revision bump preserved).
- Biome clean; pre-commit hooks passed.
- `pnpm why @codemirror/state` → single 6.7.0.

## Confidence & validation
~85% this resolves the home→board stall (it directly matches the confirmed mechanism). It's a realtime-pipeline change I can't exercise against live streaming here, so please smoke-test on prod: streaming tokens still update live, session status transitions still fire, and home→board is fast. `onlyRenderVisibleElements` (earlier #1787) was orthogonal and is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
