### PR TITLE
feat(agor-ui): global keyboard shortcuts + command palette

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -47,6 +47,7 @@ import {
   useSessionActions,
 } from './hooks';
 import { useSurfaceBranding } from './hooks/useSurfaceBranding';
+import { KeyboardShortcutsProvider } from './keyboard';
 import { agorStore, useAgorStore } from './store/agorStore';
 import { SharedUserSettingsModal } from './surfaces/SharedUserSettingsModal';
 import type { RouteSurfaceId } from './surfaces/surfaceRegistry';
@@ -1806,13 +1807,15 @@ function AppWrapper() {
               read the canvas-nav context. The inner App component used to
               wrap its own JSX in this provider; that's been removed. */}
           <CanvasNavigationProvider>
-            {isMarketingScreenshotRoute ? (
-              <Suspense fallback={<InitialLoadingScreen message="Loading demo fixture…" />}>
-                <MarketingScreenshotPage />
-              </Suspense>
-            ) : (
-              <AppContent />
-            )}
+            <KeyboardShortcutsProvider>
+              {isMarketingScreenshotRoute ? (
+                <Suspense fallback={<InitialLoadingScreen message="Loading demo fixture…" />}>
+                  <MarketingScreenshotPage />
+                </Suspense>
+              ) : (
+                <AppContent />
+              )}
+            </KeyboardShortcutsProvider>
           </CanvasNavigationProvider>
         </ErrorBoundary>
       </AntApp>

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -43,6 +43,7 @@ import { useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { useTaskCompletionChime } from '../../hooks/useTaskCompletionChime';
 import { type ActiveUrlTarget, useUrlState } from '../../hooks/useUrlState';
 import { useUserLocalStorage } from '../../hooks/useUserLocalStorage';
+import { useKeyboardShortcut } from '../../keyboard';
 import { useAgorStore } from '../../store/agorStore';
 import {
   selectArtifactById,
@@ -65,12 +66,14 @@ import type { AgenticToolOption } from '../../types';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { createAssistantBranch } from '../../utils/assistantCreation';
 import { initializeAudioOnInteraction } from '../../utils/audio';
+import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { hasExplicitEntityRouteTarget } from '../../utils/routeTargets';
 import { startAssistantBootstrapSession } from '../../utils/startAssistantBootstrapSession';
 import { AppHeader } from '../AppHeader';
 import type { BoardAssistantPanelTab } from '../BoardAssistantPanel';
 import { BoardAssistantPanel } from '../BoardAssistantPanel';
+import { BoardSwitcherPalette } from '../BoardSwitcherPalette';
 import { BranchModal, type BranchModalTab } from '../BranchModal';
 import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
 import { CreateDialog, type CreateDialogProgress } from '../CreateDialog';
@@ -98,6 +101,37 @@ const BoardSwitcherBridge: React.FC<{ setCurrentBoardId: (id: string) => void }>
 }) => {
   useRegisterBoardSwitcher(setCurrentBoardId);
   return null;
+};
+
+/**
+ * Binds the app-level global keyboard shortcuts (new session, board switcher,
+ * MCP auth) and owns the board-switcher command palette. Lives inside
+ * `KeyboardShortcutsProvider` so it can register handlers via the context.
+ */
+const GlobalShortcuts: React.FC<{
+  boards: Board[];
+  currentBoardId?: string | null;
+  onNewSession: () => void;
+  onAuthenticateMcp: () => void;
+  onSelectBoard: (boardId: string) => void;
+  onSelectHome: () => void;
+}> = ({ boards, currentBoardId, onNewSession, onAuthenticateMcp, onSelectBoard, onSelectHome }) => {
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useKeyboardShortcut('new-session', onNewSession);
+  useKeyboardShortcut('board-switcher', () => setPaletteOpen(true));
+  useKeyboardShortcut('authenticate-mcp', onAuthenticateMcp);
+
+  return (
+    <BoardSwitcherPalette
+      open={paletteOpen}
+      boards={boards}
+      currentBoardId={currentBoardId}
+      onClose={() => setPaletteOpen(false)}
+      onSelectBoard={onSelectBoard}
+      onSelectHome={onSelectHome}
+    />
+  );
 };
 
 export interface AppProps {
@@ -334,7 +368,7 @@ export const App: React.FC<AppProps> = ({
   const gatewayChannelById = useAgorStore(selectGatewayChannelById);
   const artifactById = useAgorStore(selectArtifactById);
 
-  const { showWarning } = useThemedMessage();
+  const { showWarning, showSuccess, showInfo, showError } = useThemedMessage();
   const location = useLocation();
   const routeParams = useParams<{
     sessionShortId?: string;
@@ -1170,9 +1204,76 @@ export const App: React.FC<AppProps> = ({
   const stableOnLogout = useStableCallback(onLogout);
   const stableOnRetryConnection = useStableCallback(onRetryConnection);
 
+  // Global keyboard-shortcut handlers. Boards feed the `b` command palette;
+  // `c` opens the create dialog (mirrors NewSessionButton); `a` re-authenticates
+  // MCP servers.
+  const allBoards = useMemo(() => mapToArray(boardById), [boardById]);
+  const handleNewSessionShortcut = useStableCallback(() => {
+    setCreateDialogDefaultTab('assistant');
+    setCreateDialogOpen(true);
+  });
+
+  // Silently re-authenticate every OAuth MCP server whose token is missing or
+  // expired via the refresh endpoint (no popups). Servers that need an
+  // interactive sign-in (no refresh token / revoked grant) can't be batched
+  // because browsers block bulk OAuth popups — we report those so the user can
+  // click each pill in Settings → MCP servers.
+  const handleAuthenticateMcpShortcut = useStableCallback(async () => {
+    if (!client) return;
+    const oauthServers = mapToArray(mcpServerById).filter((s) => s.auth?.type === 'oauth');
+    if (oauthServers.length === 0) {
+      showInfo('No MCP servers require authentication.');
+      return;
+    }
+    const needing = oauthServers.filter((s) => mcpServerNeedsAuth(s, new Set<string>()));
+    if (needing.length === 0) {
+      showInfo('All MCP servers are already authenticated.');
+      return;
+    }
+
+    let refreshed = 0;
+    const needsInteractive: string[] = [];
+    await Promise.all(
+      needing.map(async (server) => {
+        const label = server.display_name || server.name;
+        try {
+          const result = (await client
+            .service('mcp-servers/oauth-refresh')
+            .create({ mcp_server_id: server.mcp_server_id })) as {
+            success: boolean;
+            error?: string;
+          };
+          if (result?.success) refreshed += 1;
+          else needsInteractive.push(label);
+        } catch {
+          needsInteractive.push(label);
+        }
+      })
+    );
+
+    if (refreshed > 0) {
+      showSuccess(`Re-authenticated ${refreshed} MCP server${refreshed === 1 ? '' : 's'}.`);
+    }
+    if (needsInteractive.length > 0) {
+      showWarning(
+        `${needsInteractive.length} MCP server${needsInteractive.length === 1 ? '' : 's'} need interactive sign-in (${needsInteractive.join(', ')}). Open Settings → MCP servers to authenticate.`
+      );
+    } else if (refreshed === 0) {
+      showError('Failed to authenticate MCP servers.');
+    }
+  });
+
   return (
     <AppActionsProvider value={appActionsValue}>
       <BoardSwitcherBridge setCurrentBoardId={setCurrentBoardId} />
+      <GlobalShortcuts
+        boards={allBoards}
+        currentBoardId={headerBoardId}
+        onNewSession={handleNewSessionShortcut}
+        onAuthenticateMcp={handleAuthenticateMcpShortcut}
+        onSelectBoard={navigation.goToBoard}
+        onSelectHome={handleHomeClick}
+      />
       <Layout style={{ height: '100vh' }}>
         <AppHeader
           user={user}

--- a/apps/agor-ui/src/components/BoardSwitcherPalette/BoardSwitcherPalette.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcherPalette/BoardSwitcherPalette.tsx
@@ -1,0 +1,162 @@
+import type { Board } from '@agor-live/client';
+import { HomeOutlined, SearchOutlined } from '@ant-design/icons';
+import { Empty, Input, type InputRef, Modal, Typography, theme } from 'antd';
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const { Text } = Typography;
+
+/** Sentinel row id for the "Home" entry (no board). */
+const HOME_ROW = '__home__';
+
+interface PaletteRow {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+interface BoardSwitcherPaletteProps {
+  open: boolean;
+  boards: Board[];
+  currentBoardId?: string | null;
+  onClose: () => void;
+  onSelectBoard: (boardId: string) => void;
+  onSelectHome?: () => void;
+}
+
+/**
+ * Keyboard-first board switcher. Opens on the `b` shortcut, filters as you
+ * type, and navigates with ↑/↓ + Enter. Complements the click-driven
+ * `BoardSwitcher` dropdown in the header rather than replacing it.
+ */
+export const BoardSwitcherPalette: React.FC<BoardSwitcherPaletteProps> = ({
+  open,
+  boards,
+  currentBoardId,
+  onClose,
+  onSelectBoard,
+  onSelectHome,
+}) => {
+  const { token } = theme.useToken();
+  const inputRef = useRef<InputRef | null>(null);
+  const [filter, setFilter] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const rows = useMemo<PaletteRow[]>(() => {
+    const boardRows: PaletteRow[] = boards
+      .filter((b) => !b.archived)
+      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
+      .map((b) => ({ key: b.board_id, label: b.name, icon: b.icon || '📋' }));
+
+    const withHome: PaletteRow[] = onSelectHome
+      ? [{ key: HOME_ROW, label: 'Home', icon: <HomeOutlined /> }, ...boardRows]
+      : boardRows;
+
+    const q = filter.trim().toLowerCase();
+    if (!q) return withHome;
+    return withHome.filter((r) => r.label.toLowerCase().includes(q));
+  }, [boards, filter, onSelectHome]);
+
+  // Reset transient state each time the palette opens, and focus the input.
+  useEffect(() => {
+    if (!open) return;
+    setFilter('');
+    setSelectedIndex(0);
+    // Defer focus until the modal's content is in the DOM.
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, [open]);
+
+  // Keep the cursor within the filtered list.
+  useEffect(() => {
+    setSelectedIndex((idx) => Math.min(idx, Math.max(rows.length - 1, 0)));
+  }, [rows.length]);
+
+  const selectRow = useCallback(
+    (row: PaletteRow | undefined) => {
+      if (!row) return;
+      if (row.key === HOME_ROW) onSelectHome?.();
+      else onSelectBoard(row.key);
+      onClose();
+    },
+    [onSelectBoard, onSelectHome, onClose]
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((idx) => Math.min(idx + 1, Math.max(rows.length - 1, 0)));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((idx) => Math.max(idx - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      selectRow(rows[selectedIndex]);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      closable={false}
+      width={460}
+      styles={{ body: { padding: 0 } }}
+      style={{ top: 120 }}
+      destroyOnHidden
+    >
+      <div style={{ padding: 12 }}>
+        <Input
+          ref={inputRef}
+          size="large"
+          placeholder="Switch board…"
+          prefix={<SearchOutlined style={{ color: token.colorTextQuaternary }} />}
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          onKeyDown={handleKeyDown}
+          variant="borderless"
+          aria-label="Switch board"
+        />
+      </div>
+      <div style={{ borderTop: `1px solid ${token.colorBorderSecondary}` }} />
+      <div style={{ maxHeight: 360, overflowY: 'auto', padding: 8 }}>
+        {rows.length === 0 ? (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No boards found" />
+        ) : (
+          rows.map((row, index) => {
+            const isActive = index === selectedIndex;
+            const isCurrent =
+              row.key === currentBoardId || (row.key === HOME_ROW && !currentBoardId);
+            return (
+              <button
+                type="button"
+                key={row.key}
+                onClick={() => selectRow(row)}
+                onMouseMove={() => setSelectedIndex(index)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  width: '100%',
+                  textAlign: 'left',
+                  padding: '8px 12px',
+                  border: 'none',
+                  borderRadius: token.borderRadiusSM,
+                  cursor: 'pointer',
+                  background: isActive ? token.colorFillSecondary : 'transparent',
+                  color: token.colorText,
+                }}
+              >
+                <span style={{ fontSize: 16, display: 'inline-flex', width: 20 }}>{row.icon}</span>
+                <Text strong={isCurrent}>{row.label}</Text>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default BoardSwitcherPalette;

--- a/apps/agor-ui/src/components/BoardSwitcherPalette/index.ts
+++ b/apps/agor-ui/src/components/BoardSwitcherPalette/index.ts
@@ -1,0 +1,1 @@
+export { BoardSwitcherPalette, default } from './BoardSwitcherPalette';

--- a/apps/agor-ui/src/keyboard/KeyboardShortcutsHelp.tsx
+++ b/apps/agor-ui/src/keyboard/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,134 @@
+import { Modal, Typography, theme } from 'antd';
+import type React from 'react';
+import { Fragment, useMemo } from 'react';
+import { formatCombo } from './matchShortcut';
+import { SHORTCUTS } from './shortcuts';
+import type { ShortcutDefinition, ShortcutGroup } from './types';
+
+const { Text } = Typography;
+
+// Render order for the grouped sections.
+const GROUP_ORDER: ShortcutGroup[] = ['General', 'Navigation', 'Actions'];
+
+const KeyCap: React.FC<{ label: string }> = ({ label }) => {
+  const { token } = theme.useToken();
+  return (
+    <kbd
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: 22,
+        height: 22,
+        padding: '0 6px',
+        fontFamily: token.fontFamilyCode,
+        fontSize: 12,
+        lineHeight: 1,
+        color: token.colorText,
+        background: token.colorFillTertiary,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: token.borderRadiusSM,
+        boxShadow: `0 1px 0 ${token.colorBorderSecondary}`,
+      }}
+    >
+      {label}
+    </kbd>
+  );
+};
+
+/** Renders the first combo of a shortcut as a row of key caps. */
+const Combo: React.FC<{ combo: string }> = ({ combo }) => {
+  const labels = useMemo(() => formatCombo(combo), [combo]);
+  return (
+    <span style={{ display: 'inline-flex', gap: 4 }}>
+      {labels.map((label) => (
+        // Labels within a single combo are unique (a combo never repeats a key).
+        <KeyCap key={label} label={label} />
+      ))}
+    </span>
+  );
+};
+
+interface KeyboardShortcutsHelpProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Discoverable help overlay listing every registered shortcut. Generated
+ * entirely from the `SHORTCUTS` registry so it can never fall out of sync with
+ * what the keyboard system actually handles.
+ */
+export const KeyboardShortcutsHelp: React.FC<KeyboardShortcutsHelpProps> = ({ open, onClose }) => {
+  const { token } = theme.useToken();
+
+  const grouped = useMemo(() => {
+    const map = new Map<ShortcutGroup, ShortcutDefinition[]>();
+    for (const shortcut of SHORTCUTS) {
+      const list = map.get(shortcut.group) ?? [];
+      list.push(shortcut);
+      map.set(shortcut.group, list);
+    }
+    return GROUP_ORDER.filter((group) => map.has(group)).map((group) => ({
+      group,
+      items: map.get(group) ?? [],
+    }));
+  }, []);
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      title="Keyboard shortcuts"
+      width={480}
+      centered
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 20, paddingTop: 8 }}>
+        {grouped.map(({ group, items }) => (
+          <div key={group}>
+            <Text
+              type="secondary"
+              style={{
+                textTransform: 'uppercase',
+                fontSize: 11,
+                letterSpacing: 0.5,
+                fontWeight: 600,
+              }}
+            >
+              {group}
+            </Text>
+            <div style={{ marginTop: 8, display: 'flex', flexDirection: 'column' }}>
+              {items.map((shortcut) => (
+                <div
+                  key={shortcut.id}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '6px 0',
+                    borderBottom: `1px solid ${token.colorBorderSecondary}`,
+                  }}
+                >
+                  <Text>{shortcut.description}</Text>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+                    {shortcut.keys.map((combo, i) => (
+                      <Fragment key={combo}>
+                        {i > 0 && (
+                          <Text type="secondary" style={{ fontSize: 12 }}>
+                            or
+                          </Text>
+                        )}
+                        <Combo combo={combo} />
+                      </Fragment>
+                    ))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Modal>
+  );
+};

--- a/apps/agor-ui/src/keyboard/KeyboardShortcutsProvider.tsx
+++ b/apps/agor-ui/src/keyboard/KeyboardShortcutsProvider.tsx
@@ -1,0 +1,132 @@
+import type React from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
+import { isEditableTarget, matchShortcut } from './matchShortcut';
+import { SHORTCUTS } from './shortcuts';
+import type { ShortcutId } from './types';
+
+type ShortcutHandler = (event: KeyboardEvent) => void;
+
+interface KeyboardShortcutsContextValue {
+  /** Register a handler for a shortcut id. Returns an unregister fn. */
+  register: (id: ShortcutId, handler: ShortcutHandler) => () => void;
+  openHelp: () => void;
+  closeHelp: () => void;
+  toggleHelp: () => void;
+  helpOpen: boolean;
+}
+
+const KeyboardShortcutsContext = createContext<KeyboardShortcutsContextValue | undefined>(
+  undefined
+);
+
+/**
+ * Owns the single global `keydown` listener, the handler registry, and the
+ * help overlay. One listener dispatches to all shortcuts (rather than N
+ * component listeners) so ordering, the editable-target guard, and
+ * `preventDefault` all live in one place.
+ *
+ * Handlers are attached with `useKeyboardShortcut(id, handler)` from any
+ * descendant; a component only handles a shortcut while it is mounted, which
+ * gives us mount-scoped shortcuts for free.
+ */
+export const KeyboardShortcutsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const handlersRef = useRef<Map<ShortcutId, ShortcutHandler>>(new Map());
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  const register = useCallback((id: ShortcutId, handler: ShortcutHandler) => {
+    handlersRef.current.set(id, handler);
+    return () => {
+      // Only clear if we still own the slot — guards against a re-registered
+      // handler being torn down by a stale cleanup.
+      if (handlersRef.current.get(id) === handler) handlersRef.current.delete(id);
+    };
+  }, []);
+
+  const openHelp = useCallback(() => setHelpOpen(true), []);
+  const closeHelp = useCallback(() => setHelpOpen(false), []);
+  const toggleHelp = useCallback(() => setHelpOpen((v) => !v), []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      // Never steal keystrokes while the user is typing.
+      if (isEditableTarget(event.target)) return;
+
+      for (const shortcut of SHORTCUTS) {
+        if (!shortcut.keys.some((combo) => matchShortcut(event, combo))) continue;
+
+        // Help toggle is owned by the provider itself.
+        if (shortcut.id === 'show-help') {
+          event.preventDefault();
+          toggleHelp();
+          return;
+        }
+
+        const handler = handlersRef.current.get(shortcut.id);
+        // No handler registered (e.g. `search`, owned by GlobalSearch) — leave
+        // the event alone so its own listener can act.
+        if (!handler) return;
+
+        event.preventDefault();
+        handler(event);
+        return;
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [toggleHelp]);
+
+  const value = useMemo<KeyboardShortcutsContextValue>(
+    () => ({ register, openHelp, closeHelp, toggleHelp, helpOpen }),
+    [register, openHelp, closeHelp, toggleHelp, helpOpen]
+  );
+
+  return (
+    <KeyboardShortcutsContext.Provider value={value}>
+      {children}
+      <KeyboardShortcutsHelp open={helpOpen} onClose={closeHelp} />
+    </KeyboardShortcutsContext.Provider>
+  );
+};
+
+export function useKeyboardShortcutsContext(): KeyboardShortcutsContextValue {
+  const ctx = useContext(KeyboardShortcutsContext);
+  if (!ctx) {
+    throw new Error('useKeyboardShortcutsContext must be used within a KeyboardShortcutsProvider');
+  }
+  return ctx;
+}
+
+/**
+ * Bind a handler to a global shortcut for as long as the calling component is
+ * mounted. Pass `enabled: false` to temporarily suspend the binding without
+ * unmounting.
+ */
+export function useKeyboardShortcut(
+  id: ShortcutId,
+  handler: ShortcutHandler,
+  enabled = true
+): void {
+  const { register } = useKeyboardShortcutsContext();
+  // Keep the latest handler in a ref so callers can pass inline closures
+  // without re-registering (and re-running the effect) on every render.
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    if (!enabled) return;
+    return register(id, (event) => handlerRef.current(event));
+  }, [id, enabled, register]);
+}

--- a/apps/agor-ui/src/keyboard/index.ts
+++ b/apps/agor-ui/src/keyboard/index.ts
@@ -1,0 +1,9 @@
+export { KeyboardShortcutsHelp } from './KeyboardShortcutsHelp';
+export {
+  KeyboardShortcutsProvider,
+  useKeyboardShortcut,
+  useKeyboardShortcutsContext,
+} from './KeyboardShortcutsProvider';
+export { formatCombo, isEditableTarget, isMac, matchShortcut, parseCombo } from './matchShortcut';
+export { SHORTCUTS, SHORTCUTS_BY_ID } from './shortcuts';
+export type { ShortcutDefinition, ShortcutGroup, ShortcutId } from './types';

--- a/apps/agor-ui/src/keyboard/matchShortcut.test.ts
+++ b/apps/agor-ui/src/keyboard/matchShortcut.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { formatCombo, isEditableTarget, matchShortcut, parseCombo } from './matchShortcut';
+
+/** Build a minimal KeyboardEvent-shaped object for the matcher. */
+function keyEvent(
+  key: string,
+  mods: Partial<Pick<KeyboardEvent, 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>> = {}
+): KeyboardEvent {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...mods,
+  } as KeyboardEvent;
+}
+
+describe('parseCombo', () => {
+  it('maps `mod` to Cmd on macOS and Ctrl elsewhere', () => {
+    expect(parseCombo('mod+k', true)).toMatchObject({ meta: true, ctrl: false, key: 'k' });
+    expect(parseCombo('mod+k', false)).toMatchObject({ meta: false, ctrl: true, key: 'k' });
+  });
+
+  it('captures the printable key and modifier flags', () => {
+    expect(parseCombo('shift+alt+d', false)).toMatchObject({
+      shift: true,
+      alt: true,
+      key: 'd',
+    });
+  });
+});
+
+describe('matchShortcut', () => {
+  it('matches a bare letter only when no modifiers are held', () => {
+    expect(matchShortcut(keyEvent('c'), 'c', true)).toBe(true);
+    // Cmd+C (copy) must NOT trigger the bare `c` shortcut.
+    expect(matchShortcut(keyEvent('c', { metaKey: true }), 'c', true)).toBe(false);
+    expect(matchShortcut(keyEvent('c', { ctrlKey: true }), 'c', false)).toBe(false);
+  });
+
+  it('is case-insensitive on the key', () => {
+    expect(matchShortcut(keyEvent('C'), 'c', true)).toBe(true);
+  });
+
+  it('honours the `mod` modifier per platform', () => {
+    expect(matchShortcut(keyEvent('k', { metaKey: true }), 'mod+k', true)).toBe(true);
+    expect(matchShortcut(keyEvent('k', { metaKey: true }), 'mod+k', false)).toBe(false);
+    expect(matchShortcut(keyEvent('k', { ctrlKey: true }), 'mod+k', false)).toBe(true);
+  });
+
+  it('matches `?` regardless of the implicit shift', () => {
+    expect(matchShortcut(keyEvent('?', { shiftKey: true }), '?', true)).toBe(true);
+    expect(matchShortcut(keyEvent('?'), '?', true)).toBe(true);
+  });
+
+  it('requires exact shift state for alphanumeric keys', () => {
+    expect(matchShortcut(keyEvent('b', { shiftKey: true }), 'b', true)).toBe(false);
+    expect(matchShortcut(keyEvent('b'), 'b', true)).toBe(true);
+  });
+});
+
+describe('isEditableTarget', () => {
+  it('detects inputs, textareas, and contenteditable regions', () => {
+    expect(isEditableTarget(document.createElement('input'))).toBe(true);
+    expect(isEditableTarget(document.createElement('textarea'))).toBe(true);
+    expect(isEditableTarget(document.createElement('select'))).toBe(true);
+
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    // jsdom doesn't derive isContentEditable from the attribute, so assert via role too.
+    const textbox = document.createElement('div');
+    textbox.setAttribute('role', 'textbox');
+    expect(isEditableTarget(textbox)).toBe(true);
+  });
+
+  it('treats plain elements and null as non-editable', () => {
+    expect(isEditableTarget(document.createElement('div'))).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('formatCombo', () => {
+  it('renders platform-appropriate modifier glyphs', () => {
+    expect(formatCombo('mod+/', true)).toEqual(['⌘', '/']);
+    expect(formatCombo('mod+/', false)).toEqual(['Ctrl', '/']);
+    expect(formatCombo('c', true)).toEqual(['C']);
+  });
+});

--- a/apps/agor-ui/src/keyboard/matchShortcut.ts
+++ b/apps/agor-ui/src/keyboard/matchShortcut.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure key-matching helpers for the keyboard-shortcut system.
+ *
+ * Combos are written in a small DSL: modifier tokens joined by `+`, with the
+ * printable key last. Recognised modifiers are `mod` (Cmd on macOS, Ctrl
+ * elsewhere), `meta`, `ctrl`, `alt`, and `shift`. Examples: `'c'`, `'?'`,
+ * `'mod+/'`, `'shift+d'`.
+ */
+
+export function isMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  // `navigator.platform` is deprecated but still the most reliable signal in
+  // browsers; fall back to the UA string for engines that have dropped it.
+  const platform = navigator.platform || navigator.userAgent || '';
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
+interface ParsedCombo {
+  meta: boolean;
+  ctrl: boolean;
+  alt: boolean;
+  shift: boolean;
+  /** Lower-cased printable key, e.g. `c`, `/`, `?`. */
+  key: string;
+}
+
+const MODIFIERS = new Set(['mod', 'meta', 'ctrl', 'control', 'alt', 'option', 'shift']);
+
+export function parseCombo(combo: string, mac = isMac()): ParsedCombo {
+  const parsed: ParsedCombo = { meta: false, ctrl: false, alt: false, shift: false, key: '' };
+  for (const rawToken of combo.split('+')) {
+    const token = rawToken.trim().toLowerCase();
+    if (!token) continue;
+    if (MODIFIERS.has(token)) {
+      switch (token) {
+        case 'mod':
+          if (mac) parsed.meta = true;
+          else parsed.ctrl = true;
+          break;
+        case 'meta':
+          parsed.meta = true;
+          break;
+        case 'ctrl':
+        case 'control':
+          parsed.ctrl = true;
+          break;
+        case 'alt':
+        case 'option':
+          parsed.alt = true;
+          break;
+        case 'shift':
+          parsed.shift = true;
+          break;
+      }
+    } else {
+      parsed.key = token;
+    }
+  }
+  return parsed;
+}
+
+/**
+ * True when the event should reach a global shortcut. Returns `false` when the
+ * user is typing into a form field, a contenteditable region, or any element
+ * with a textbox role, so shortcuts never steal keystrokes mid-edit.
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.tagName !== 'string') return false;
+  const tag = el.tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+  if (el.isContentEditable) return true;
+  const role = el.getAttribute?.('role');
+  if (role === 'textbox' || role === 'searchbox' || role === 'combobox') return true;
+  return false;
+}
+
+/** True when `event` matches the given combo exactly (all modifiers accounted for). */
+export function matchShortcut(event: KeyboardEvent, combo: string, mac = isMac()): boolean {
+  const parsed = parseCombo(combo, mac);
+  if (!parsed.key) return false;
+
+  if (event.metaKey !== parsed.meta) return false;
+  if (event.ctrlKey !== parsed.ctrl) return false;
+  if (event.altKey !== parsed.alt) return false;
+
+  const eventKey = (event.key || '').toLowerCase();
+
+  // Symbol keys that are only reachable via Shift (e.g. `?`) carry the Shift
+  // requirement implicitly, so we don't second-guess `event.shiftKey` for
+  // them. For everything else, Shift must match exactly.
+  const keyImpliesShift = parsed.key.length === 1 && !/[a-z0-9]/.test(parsed.key);
+  if (!keyImpliesShift && event.shiftKey !== parsed.shift) return false;
+
+  return eventKey === parsed.key;
+}
+
+const KEY_LABELS: Record<string, string> = {
+  '/': '/',
+  '?': '?',
+};
+
+/** Render a combo as platform-appropriate key labels, e.g. `['⌘', '/']`. */
+export function formatCombo(combo: string, mac = isMac()): string[] {
+  const labels: string[] = [];
+  for (const rawToken of combo.split('+')) {
+    const token = rawToken.trim().toLowerCase();
+    if (!token) continue;
+    switch (token) {
+      case 'mod':
+        labels.push(mac ? '⌘' : 'Ctrl');
+        break;
+      case 'meta':
+        labels.push(mac ? '⌘' : 'Win');
+        break;
+      case 'ctrl':
+      case 'control':
+        labels.push(mac ? '⌃' : 'Ctrl');
+        break;
+      case 'alt':
+      case 'option':
+        labels.push(mac ? '⌥' : 'Alt');
+        break;
+      case 'shift':
+        labels.push(mac ? '⇧' : 'Shift');
+        break;
+      default:
+        labels.push(KEY_LABELS[token] ?? token.toUpperCase());
+    }
+  }
+  return labels;
+}

--- a/apps/agor-ui/src/keyboard/shortcuts.ts
+++ b/apps/agor-ui/src/keyboard/shortcuts.ts
@@ -1,0 +1,57 @@
+import type { ShortcutDefinition } from './types';
+
+/**
+ * The canonical registry of global keyboard shortcuts.
+ *
+ * Key choices follow the GitHub / Linear convention of single-key shortcuts
+ * for actions: they're memorable, and because we suppress shortcuts while the
+ * user is typing in a field (see `isEditableTarget`), single keys never
+ * collide with browser/OS chords (which are all modifier-based). The help
+ * overlay is generated from this array, so adding a shortcut here is all it
+ * takes to make it discoverable.
+ *
+ * Note: `Cmd/Ctrl+K` (global search) lives in `GlobalSearch` because it must
+ * fire even while an input is focused; it is intentionally not registered
+ * here. It is still listed in the help overlay for completeness.
+ */
+export const SHORTCUTS: ShortcutDefinition[] = [
+  {
+    id: 'show-help',
+    keys: ['?', 'mod+/'],
+    description: 'Show keyboard shortcuts',
+    group: 'General',
+  },
+  {
+    // Owned by `GlobalSearch` (it must fire while an input is focused, which
+    // this system deliberately suppresses). Listed here purely so the overlay
+    // documents it; no handler is registered, so our matcher leaves it to
+    // GlobalSearch's own listener.
+    id: 'search',
+    keys: ['mod+k'],
+    description: 'Search everything',
+    group: 'General',
+  },
+  {
+    id: 'board-switcher',
+    keys: ['b'],
+    description: 'Switch board',
+    group: 'Navigation',
+  },
+  {
+    id: 'new-session',
+    keys: ['c'],
+    description: 'Start a new session',
+    group: 'Actions',
+  },
+  {
+    id: 'authenticate-mcp',
+    keys: ['a'],
+    description: 'Authenticate MCP servers',
+    group: 'Actions',
+  },
+];
+
+export const SHORTCUTS_BY_ID = Object.fromEntries(SHORTCUTS.map((s) => [s.id, s])) as Record<
+  ShortcutDefinition['id'],
+  ShortcutDefinition
+>;

--- a/apps/agor-ui/src/keyboard/types.ts
+++ b/apps/agor-ui/src/keyboard/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Keyboard-shortcut type definitions.
+ *
+ * The registry in `shortcuts.ts` is the single source of truth for every
+ * global shortcut: it drives both the key matching (`matchShortcut`) and the
+ * discoverable help overlay (`KeyboardShortcutsHelp`), so the two can never
+ * drift apart.
+ */
+
+/** Stable identifiers for every registered shortcut. */
+export type ShortcutId =
+  | 'new-session'
+  | 'board-switcher'
+  | 'authenticate-mcp'
+  | 'show-help'
+  | 'search';
+
+/** Grouping used to organise the help overlay into labelled sections. */
+export type ShortcutGroup = 'General' | 'Navigation' | 'Actions';
+
+export interface ShortcutDefinition {
+  id: ShortcutId;
+  /**
+   * Key combo(s) that trigger this shortcut, in the mini-DSL understood by
+   * `matchShortcut` (e.g. `'c'`, `'?'`, `'mod+/'`). The first entry is the
+   * one shown in the help overlay; extra entries are accepted aliases.
+   */
+  keys: string[];
+  /** Human-readable label shown in the help overlay. */
+  description: string;
+  group: ShortcutGroup;
+}


### PR DESCRIPTION
## Summary

Adds a small, extensible keyboard-shortcut system so common actions can be driven from the keyboard, per the request in #agor (Juliann / Evan / Daniel).

Everything is driven by a single registry (`apps/agor-ui/src/keyboard/shortcuts.ts`) that powers **both** key matching and the discoverable help overlay, so they can never drift out of sync.

## Shortcuts

| Key | Action |
| --- | --- |
| `c` | Start a new session (opens the create dialog) |
| `b` | Board switcher — command palette with filter + ↑/↓ + Enter |
| `a` | Authenticate MCP servers (bulk token refresh) |
| `?` or `⌘/Ctrl + /` | Show the keyboard-shortcuts help overlay |
| `⌘/Ctrl + K` | Search everything (documented in the overlay; still owned by `GlobalSearch`) |

**Key-choice rationale:** single-key shortcuts follow the GitHub / Linear convention. They're memorable, and because the system suppresses shortcuts while the user is typing in an `input` / `textarea` / `contenteditable` / textbox-role element, single keys never collide with browser or OS chords (which are all modifier-based). Matching is exact on modifiers, so bare `c` does **not** fire on `⌘/Ctrl+C`. `⌘` is used on macOS and `Ctrl` elsewhere (`mod` in the combo DSL).

## Design

- **`src/keyboard/`**
  - `shortcuts.ts` / `types.ts` — the registry (single source of truth).
  - `matchShortcut.ts` — pure combo parser + matcher, `isEditableTarget()` guard, platform-aware `formatCombo()`. Unit-tested.
  - `KeyboardShortcutsProvider.tsx` — installs **one** global `keydown` listener and dispatches by id. Components attach handlers with `useKeyboardShortcut(id, handler)`, so bindings are mount-scoped for free. Owns the help-overlay state.
  - `KeyboardShortcutsHelp.tsx` — the `?` overlay, generated entirely from the registry and grouped (General / Navigation / Actions).
- **`components/BoardSwitcherPalette/`** — keyboard-first board switcher modal (complements the existing click-driven header `BoardSwitcher` dropdown rather than replacing it).
- Wiring: the provider is mounted once in `src/App.tsx` (around `AppContent`); a small `GlobalShortcuts` component inside `App` binds the app-level handlers and owns the palette. The new-session handler reuses the same create-dialog flow as the existing "New session" button.

## MCP authentication — what's implemented vs. deferred

**Implemented (`a`):** re-authenticates every OAuth MCP server whose token is missing or expired by calling the existing `mcp-servers/oauth-refresh` endpoint for each, in parallel, with a summary toast. No popups, no new backend.

**Deferred / noted:** servers that need an *interactive* sign-in (no refresh token / revoked grant) can't be batched — browsers block bulk OAuth popups, and each flow needs a user gesture. Rather than half-wire that (and get popups blocked), those servers are reported by name in a warning toast so the user can sign in per-server from **Settings → MCP servers** (the existing per-pill flow). A true one-click "authenticate all" would need either a bulk backend endpoint or a dedicated multi-step consent surface.

## Tests

`matchShortcut.test.ts` (10 cases): `mod`→Cmd/Ctrl mapping, exact-modifier matching (bare `c` vs `⌘C`), case-insensitivity, `?` implicit-shift handling, editable-target detection, and platform key formatting. `pnpm typecheck` and `biome ci` pass.

## Screenshots

_Not captured — this branch's worktree has no running dev environment. The help overlay is a standard AntD `Modal` rendering styled `<kbd>` caps; the palette mirrors the existing global-search dropdown patterns._

🤖 Generated with [Claude Code](https://claude.com/claude-code)