### PR TITLE
fix(daemon): scope startup stuck-idle sweep to actually-interrupted sessions

### DIFF
--- a/apps/agor-daemon/src/startup.test.ts
+++ b/apps/agor-daemon/src/startup.test.ts
@@ -1,8 +1,20 @@
 import { createTenantScopedDatabaseProxy, MissingTenantDatabaseScopeError } from '@agor/core/db';
+import type { Session, Task } from '@agor/core/types';
+import { SessionStatus, TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { cleanupOrphanStatuses, type StartupContext } from './startup.js';
 
-function makeStartupContextWithGuardedDb() {
+interface StartupFixtures {
+  orphanedTasks?: Task[];
+  queuedTasks?: Task[];
+  /** Returned by the IDLE + ready_for_prompt=false sweep query */
+  idleNotReadySessions?: Session[];
+  /** Lookup table for tasksService.get / sessionsService.get */
+  tasksById?: Record<string, Task>;
+  sessionsById?: Record<string, Session>;
+}
+
+function makeStartupContextWithGuardedDb(fixtures: StartupFixtures = {}) {
   const baseDb = {
     run: vi.fn(),
     marker: vi.fn(() => 'scoped'),
@@ -16,20 +28,44 @@ function makeStartupContextWithGuardedDb() {
   const tasksService = {
     getOrphaned: vi.fn(async () => {
       touchDb();
-      return [];
+      return fixtures.orphanedTasks ?? [];
     }),
-    find: vi.fn(async () => {
+    find: vi.fn(async (params: { query?: { status?: string } }) => {
       touchDb();
+      if (params?.query?.status === TaskStatus.QUEUED) {
+        return { data: fixtures.queuedTasks ?? [] };
+      }
       return { data: [] };
+    }),
+    get: vi.fn(async (id: string) => {
+      touchDb();
+      const task = fixtures.tasksById?.[id];
+      if (!task) {
+        throw new Error(`Task not found: ${id}`);
+      }
+      return task;
     }),
     patch: vi.fn(),
   };
   const sessionsService = {
-    find: vi.fn(async () => {
+    find: vi.fn(async (params: { query?: { status?: string; ready_for_prompt?: boolean } }) => {
       touchDb();
+      if (
+        params?.query?.status === SessionStatus.IDLE &&
+        params?.query?.ready_for_prompt === false
+      ) {
+        return { data: fixtures.idleNotReadySessions ?? [] };
+      }
       return { data: [] };
     }),
-    get: vi.fn(),
+    get: vi.fn(async (id: string) => {
+      touchDb();
+      const session = fixtures.sessionsById?.[id];
+      if (!session) {
+        throw new Error(`Session not found: ${id}`);
+      }
+      return session;
+    }),
     patch: vi.fn(),
   };
   const services = new Map<string, unknown>([
@@ -59,7 +95,27 @@ function makeStartupContextWithGuardedDb() {
     terminalsService: null,
   } as unknown as StartupContext;
 
-  return { ctx, baseDb };
+  return { ctx, baseDb, tasksService, sessionsService };
+}
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    task_id: 'task-1',
+    session_id: 'session-1',
+    status: TaskStatus.RUNNING,
+    created_at: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  } as Task;
+}
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    session_id: 'session-1',
+    status: SessionStatus.IDLE,
+    ready_for_prompt: false,
+    tasks: [],
+    ...overrides,
+  } as Session;
 }
 
 describe('startup tenant database scope', () => {
@@ -82,5 +138,105 @@ describe('startup tenant database scope', () => {
       MissingTenantDatabaseScopeError
     );
     expect(baseDb.marker).not.toHaveBeenCalled();
+  });
+});
+
+describe('stuck-idle sweep (IDLE + ready_for_prompt=false)', () => {
+  it('unblocks an interrupted session whose latest task was orphan-stopped this boot', async () => {
+    // Kill-during-stop race: stop path wrote status=idle but died before
+    // ready_for_prompt=true; the executing task is orphaned at boot.
+    const task = makeTask({ task_id: 'task-1', session_id: 'session-1' });
+    const session = makeSession({
+      session_id: 'session-1',
+      tasks: ['task-1'] as Session['tasks'],
+    });
+    const { ctx, sessionsService } = makeStartupContextWithGuardedDb({
+      orphanedTasks: [task],
+      idleNotReadySessions: [session],
+      sessionsById: { 'session-1': session },
+    });
+
+    await cleanupOrphanStatuses(ctx);
+
+    expect(sessionsService.patch).toHaveBeenCalledWith(
+      'session-1',
+      { ready_for_prompt: true },
+      expect.anything()
+    );
+  });
+
+  it('unblocks a session whose latest task is still in a non-terminal state', async () => {
+    // Daemon died between task creation and executor start — task row exists
+    // in a pre-executor state that neither the orphan nor queue pass touched.
+    const task = makeTask({
+      task_id: 'task-2',
+      session_id: 'session-2',
+      status: TaskStatus.CREATED,
+    });
+    const session = makeSession({
+      session_id: 'session-2',
+      tasks: ['task-2'] as Session['tasks'],
+    });
+    const { ctx, sessionsService } = makeStartupContextWithGuardedDb({
+      idleNotReadySessions: [session],
+      tasksById: { 'task-2': task },
+    });
+
+    await cleanupOrphanStatuses(ctx);
+
+    expect(sessionsService.patch).toHaveBeenCalledWith(
+      'session-2',
+      { ready_for_prompt: true },
+      expect.anything()
+    );
+  });
+
+  it('leaves a read session untouched across daemon restarts (latest task terminal)', async () => {
+    // The normal resting state of a read/acknowledged session: the UI patched
+    // ready_for_prompt=false on open, and its latest task completed long ago.
+    const task = makeTask({
+      task_id: 'task-3',
+      session_id: 'session-3',
+      status: TaskStatus.COMPLETED,
+    });
+    const session = makeSession({
+      session_id: 'session-3',
+      tasks: ['task-3'] as Session['tasks'],
+    });
+    const { ctx, sessionsService } = makeStartupContextWithGuardedDb({
+      idleNotReadySessions: [session],
+      tasksById: { 'task-3': task },
+    });
+
+    // Two consecutive boots — the session must never be re-flagged unread.
+    await cleanupOrphanStatuses(ctx);
+    await cleanupOrphanStatuses(ctx);
+
+    expect(sessionsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('leaves a session with no tasks untouched', async () => {
+    const session = makeSession({ session_id: 'session-4', tasks: [] as Session['tasks'] });
+    const { ctx, sessionsService } = makeStartupContextWithGuardedDb({
+      idleNotReadySessions: [session],
+    });
+
+    await cleanupOrphanStatuses(ctx);
+
+    expect(sessionsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the latest task row cannot be loaded', async () => {
+    const session = makeSession({
+      session_id: 'session-5',
+      tasks: ['task-missing'] as Session['tasks'],
+    });
+    const { ctx, sessionsService } = makeStartupContextWithGuardedDb({
+      idleNotReadySessions: [session],
+    });
+
+    await cleanupOrphanStatuses(ctx);
+
+    expect(sessionsService.patch).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -21,7 +21,7 @@ import {
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Id, Paginated, Session, SessionID, Task, TenantContext } from '@agor/core/types';
-import { SessionStatus, TaskStatus } from '@agor/core/types';
+import { isTerminalTaskStatus, SessionStatus, TaskStatus } from '@agor/core/types';
 import type { Application, SessionsServiceImpl, TasksServiceImpl } from './declarations.js';
 import { ExecutorHeartbeatSupervisor } from './services/executor-heartbeat-supervisor.js';
 import type { GatewayService } from './services/gateway.js';
@@ -270,26 +270,57 @@ async function cleanupOrphanStatusesInTenantScope(
     }
   }
 
-  // Fix sessions that are IDLE but not promptable — this happens when the
-  // daemon is killed while a session is mid-execution and the stop path set
-  // status=idle without setting ready_for_prompt=true, or when the executor
-  // exit raced with the stop endpoint and left ready_for_prompt=false. IDLE +
-  // ready_for_prompt=false is never a legitimate persistent state.
-  const stuckIdleResult = (await sessionsService.find({
+  // Fix sessions that are IDLE but not promptable *because a kill interrupted
+  // them* — the daemon died during the stop path after writing status=idle but
+  // before writing ready_for_prompt=true, or the executor exit raced the stop
+  // endpoint. IDLE + ready_for_prompt=false is NOT inherently orphaned state:
+  // the UI also uses ready_for_prompt as the unread/attention flag (opening a
+  // conversation patches it false, branch cards highlight while it's true —
+  // see SessionPromptState in @agor/core/types), so it is the normal resting
+  // state of every read session. Discriminate by the session's most recent
+  // task: only sessions whose latest task was non-terminal at boot (just
+  // orphan-stopped / queue-wiped above, or still in an executing state) were
+  // actually interrupted; read sessions have a terminal latest task from a
+  // previous run and must be left untouched.
+  const bootInterruptedTaskIds = new Set<string>([
+    ...orphanedTasks.map((t: Task) => t.task_id as string),
+    ...queuedTasks.map((t: Task) => t.task_id as string),
+  ]);
+
+  const idleNotReadyResult = (await sessionsService.find({
     query: { status: SessionStatus.IDLE, ready_for_prompt: false, $limit: 1000 },
     ...startupParams,
   })) as unknown as Paginated<Session>;
-  const stuckIdleSessions = stuckIdleResult.data;
 
-  if (stuckIdleSessions.length > 0) {
-    for (const session of stuckIdleSessions) {
-      await app
-        .service('sessions')
-        .patch(session.session_id, { ready_for_prompt: true }, startupParams as never);
-      startupDebug(
-        `   ✓ Unblocked stuck-idle session ${shortId(session.session_id)} (ready_for_prompt was false)`
-      );
+  const stuckIdleSessions: Session[] = [];
+  for (const session of idleNotReadyResult.data) {
+    // Sessions maintain an ordered task-ID list; the last entry is the most
+    // recent task (same convention as injectRestartNotices below).
+    const latestTaskId = session.tasks?.at(-1);
+    if (!latestTaskId) {
+      continue; // never ran a task — nothing was interrupted
     }
+
+    let wasInterrupted = bootInterruptedTaskIds.has(latestTaskId as string);
+    if (!wasInterrupted) {
+      try {
+        const latestTask = await tasksService.get(latestTaskId, startupParams as never);
+        wasInterrupted = !isTerminalTaskStatus(latestTask.status);
+      } catch {
+        // Task row missing/unreadable — fail closed: don't re-flag the session.
+      }
+    }
+    if (!wasInterrupted) {
+      continue;
+    }
+
+    stuckIdleSessions.push(session);
+    await app
+      .service('sessions')
+      .patch(session.session_id, { ready_for_prompt: true }, startupParams as never);
+    startupDebug(
+      `   ✓ Unblocked stuck-idle session ${shortId(session.session_id)} (ready_for_prompt was false, latest task interrupted)`
+    );
   }
 
   const cleanupParts: string[] = [


### PR DESCRIPTION
## The regression

Commit 41e8d091 (first shipped in **0.23.1**) added a fourth orphan-cleanup pass to daemon startup that finds every session in `status=idle, ready_for_prompt=false` and patches it to `ready_for_prompt=true`, on the premise that "IDLE + ready_for_prompt=false is never a legitimate persistent state."

That premise is wrong because `ready_for_prompt` is overloaded. Besides being an execution-state signal (task start → `false`, task complete → `true`), the UI uses it as the **unread/attention indicator**:

- Opening a conversation patches it to `false` — "mark as read" (`App.tsx`)
- Branch cards highlight while any session on the branch has it `true` (`BranchCard.tsx`)
- The doc comment on `SessionPromptState` in `packages/core/src/types/session.ts` explicitly warns the flag "is intentionally not equivalent to promptability: the UI also uses it as an attention/acknowledgement flag."

So `idle + ready_for_prompt=false` is the normal resting state of **every read/acknowledged session**.

## User impact

On every daemon restart, every read idle session (capped at 1000/boot) was re-flagged unread, lighting up all branch cards on all boards. On the reporting instance, **518 sessions were mass-flagged** after upgrading to 0.23.1.

Note the sweep wasn't even needed for promptability: `sessionCanStartTask` treats any `idle` session as promptable regardless of the flag, so the "stuck" state never blocked prompting — the only user-visible effect of the sweep was the unread spam.

## The fix

The original race-fix intent is preserved: a kill during the stop path (or an executor-exit/stop race) can strand a session at `idle + ready_for_prompt=false` with its in-flight work never acknowledged. The sweep now discriminates on the session's **most recent task**:

- **Flip** only sessions whose latest task was non-terminal at boot — i.e. it was just orphan-stopped or queue-wiped by the earlier cleanup passes in the same startup, or is still in an executing/pre-executor state (`created`). These are the genuinely interrupted sessions.
- **Leave untouched** sessions whose latest task is terminal (`completed`/`failed`/`stopped`/`timed_out`) — the read-session population — plus sessions with no tasks at all, and sessions whose latest task row can't be loaded (fail closed, never re-flag).

This works because the interrupted population is fully identifiable at this point in startup: pass 1 (`getOrphaned`) has already stopped every executing task and pass 2 has wiped the queue, so "latest task ∈ tasks transitioned this boot" ∪ "latest task still non-terminal" covers exactly the race the original commit targeted, and provably excludes read sessions (their latest task has been terminal since a previous daemon run).

## Tests

Extended `apps/agor-daemon/src/startup.test.ts` with fixture-driven coverage of both populations:

- interrupted session (latest task orphan-stopped this boot) → unblocked
- interrupted session (latest task still non-terminal, e.g. `created`) → unblocked
- read session (latest task `completed`) → untouched across **two** consecutive simulated boots
- session with no tasks → untouched
- latest task row missing → fail closed, untouched

`pnpm typecheck`, `biome check`, and the full daemon unit suite (1396 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)