### PR TITLE
perf(agor-ui): narrow home page store subscriptions to stop session-patch rerender storms

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -20,7 +20,7 @@ import type {
 } from '@agor-live/client';
 import { boardPath, ENTITY_PATH_SEGMENTS, sessionPath } from '@agor-live/client';
 import { Alert, App as AntApp, ConfigProvider } from 'antd';
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AVAILABLE_AGENTS } from './components/AgentSelectionGrid';
 import type { BranchUpdate } from './components/BranchModal/tabs/GeneralTab';
@@ -315,6 +315,13 @@ function AppContent() {
   // ConnectionStatus (amber tag with a refresh tooltip) and AboutTab (debug
   // rows). Mounted exactly once so all consumers share the same baseline.
   const { capturedSha, currentSha, outOfSync } = useServerVersion(client);
+
+  // Referentially stable context value: without the memo, every App render
+  // hands consumers a fresh object and defeats their own memoization.
+  const connectionContextValue = useMemo(
+    () => ({ connected, connecting, outOfSync, capturedSha, currentSha }),
+    [connected, connecting, outOfSync, capturedSha, currentSha]
+  );
 
   const directSessionIdFromPath = location.pathname.match(/^\/s\/([^/]+)\/?$/)?.[1] ?? null;
 
@@ -1654,7 +1661,7 @@ function AppContent() {
   // Render main app
   return (
     <ServicesConfigContext.Provider value={servicesConfig}>
-      <ConnectionProvider value={{ connected, connecting, outOfSync, capturedSha, currentSha }}>
+      <ConnectionProvider value={connectionContextValue}>
         {/* Force Password Change Modal - shown when user.must_change_password is true */}
         <ForcePasswordChangeModal
           open={!!currentUser?.must_change_password}

--- a/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
@@ -20,11 +20,18 @@ import {
 } from 'antd';
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectBoardById,
+  selectBranchById,
+  selectSessionById,
+  selectUserById,
+} from '../../store/selectors';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime } from '../../utils/time';
 import { AssistantPill, BoardPill, BranchPill, SessionPill, UserPill } from '../Pill';
 import { glassCardStyle } from './homeStyles';
-import type { HomeSectionProps } from './types';
+import type { HomePageProps } from './types';
 
 const { Text } = Typography;
 
@@ -69,25 +76,12 @@ const ActivityFeedItem: React.FC<{
 };
 
 export const HomeActivitySection: React.FC<
-  Pick<
-    HomeSectionProps,
-    | 'branchById'
-    | 'boardById'
-    | 'sessionById'
-    | 'userById'
-    | 'onBoardClick'
-    | 'onBranchClick'
-    | 'onSessionClick'
-  >
-> = ({
-  branchById,
-  boardById,
-  sessionById,
-  userById,
-  onBoardClick,
-  onBranchClick,
-  onSessionClick,
-}) => {
+  Pick<HomePageProps, 'onBoardClick' | 'onBranchClick' | 'onSessionClick'>
+> = ({ onBoardClick, onBranchClick, onSessionClick }) => {
+  const branchById = useAgorStore(selectBranchById);
+  const boardById = useAgorStore(selectBoardById);
+  const sessionById = useAgorStore(selectSessionById);
+  const userById = useAgorStore(selectUserById);
   const { token } = theme.useToken();
   const cardGlassStyle = glassCardStyle(token);
   const [filter, setFilter] = useState<ActivityFilter>('all');

--- a/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
@@ -8,20 +8,29 @@ import {
 } from '@ant-design/icons';
 import { Button, Empty, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectBranchById, selectSessionsByBranch } from '../../store/selectors';
 import { formatRelativeTime } from '../../utils/time';
 import { glassCardStyle } from './homeStyles';
-import type { HomeSectionProps } from './types';
+import type { HomePageProps } from './types';
 
 const { Text } = Typography;
 
 const HOME_BOARDS_LIMIT = 50;
 const BOARDS_PER_PAGE = 4;
 
+/**
+ * Everything below `board` is a primitive so the memo'd card bails out of
+ * re-renders unless ITS board's display data actually changed — passing the
+ * per-board branch/session arrays instead would defeat the memo (they're
+ * rebuilt fresh on every derivation pass).
+ */
 interface BoardHomeRow {
   board: Board;
-  branches: Branch[];
-  sessions: Session[];
+  branchCount: number;
+  activeCount: number;
+  latestSessionAt: Session['last_updated'] | null;
   latest: number;
   visitRank: number;
 }
@@ -54,28 +63,27 @@ const activeSessions = (sessions: Session[]) =>
       s.status === 'running' || s.status === 'awaiting_permission' || s.status === 'awaiting_input'
   );
 
-const BoardHomeCard: React.FC<{
+const BoardHomeCard = memo(function BoardHomeCard({
+  board,
+  branchCount,
+  activeCount,
+  latestSessionAt,
+  onBoardClick,
+}: {
   board: Board;
-  branches: Branch[];
-  sessions: Session[];
-  onClick: () => void;
-}> = ({ board, branches, sessions, onClick }) => {
+  branchCount: number;
+  activeCount: number;
+  latestSessionAt: Session['last_updated'] | null;
+  onBoardClick: (boardId: string) => void;
+}) {
   const { token } = theme.useToken();
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
-  const activeCount = activeSessions(sessions).length;
-  const latestSession = useMemo(
-    () =>
-      [...sessions].sort(
-        (a, b) => new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime()
-      )[0],
-    [sessions]
-  );
 
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={() => onBoardClick(board.board_id)}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onFocus={() => setFocused(true)}
@@ -135,7 +143,7 @@ const BoardHomeCard: React.FC<{
           </Tooltip>
           <div style={{ display: 'flex', gap: 10 }}>
             <Text type="secondary" style={{ fontSize: 12 }}>
-              {branches.length} branch{branches.length !== 1 ? 'es' : ''}
+              {branchCount} branch{branchCount !== 1 ? 'es' : ''}
             </Text>
             {activeCount > 0 && (
               <Text type="secondary" style={{ fontSize: 12 }}>
@@ -147,8 +155,8 @@ const BoardHomeCard: React.FC<{
           <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             <ClockCircleOutlined style={{ fontSize: 11, color: token.colorTextSecondary }} />
             <Text type="secondary" style={{ fontSize: 12 }}>
-              {latestSession
-                ? `Last session ${formatRelativeTime(latestSession.last_updated)}`
+              {latestSessionAt
+                ? `Last session ${formatRelativeTime(latestSessionAt)}`
                 : 'No sessions yet'}
             </Text>
           </div>
@@ -156,26 +164,14 @@ const BoardHomeCard: React.FC<{
       </div>
     </button>
   );
-};
+});
 
 export const HomeBoardsSection: React.FC<
-  Pick<
-    HomeSectionProps,
-    | 'boardById'
-    | 'recentBoardIds'
-    | 'branchById'
-    | 'sessionsByBranch'
-    | 'onBoardClick'
-    | 'onOpenCreateDialog'
-  >
-> = ({
-  boardById,
-  recentBoardIds = [],
-  branchById,
-  sessionsByBranch,
-  onBoardClick,
-  onOpenCreateDialog,
-}) => {
+  Pick<HomePageProps, 'recentBoardIds' | 'onBoardClick' | 'onOpenCreateDialog'>
+> = ({ recentBoardIds = [], onBoardClick, onOpenCreateDialog }) => {
+  const boardById = useAgorStore(selectBoardById);
+  const branchById = useAgorStore(selectBranchById);
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
   const [page, setPage] = useState(0);
 
   const rows = useMemo(() => {
@@ -190,15 +186,25 @@ export const HomeBoardsSection: React.FC<
         const sessions = branches.flatMap(
           (branch) => visibleSessionsByBranch.get(branch.branch_id) ?? []
         );
+        let latestSessionAt: BoardHomeRow['latestSessionAt'] = null;
+        let latestSessionTime = Number.NEGATIVE_INFINITY;
+        for (const session of sessions) {
+          const time = new Date(session.last_updated).getTime();
+          if (time > latestSessionTime) {
+            latestSessionTime = time;
+            latestSessionAt = session.last_updated;
+          }
+        }
         const latest = Math.max(
           new Date(board.last_updated).getTime(),
           ...branches.map((branch) => new Date(branch.updated_at || branch.created_at).getTime()),
-          ...sessions.map((session) => new Date(session.last_updated).getTime())
+          latestSessionTime
         );
         return {
           board,
-          branches,
-          sessions,
+          branchCount: branches.length,
+          activeCount: activeSessions(sessions).length,
+          latestSessionAt,
           latest: Number.isFinite(latest) ? latest : 0,
           visitRank: visitRank.get(board.board_id) ?? Number.POSITIVE_INFINITY,
         };
@@ -285,13 +291,14 @@ export const HomeBoardsSection: React.FC<
             gap: 12,
           }}
         >
-          {visibleRows.map(({ board, branches, sessions }) => (
+          {visibleRows.map(({ board, branchCount, activeCount, latestSessionAt }) => (
             <BoardHomeCard
               key={board.board_id}
               board={board}
-              branches={branches}
-              sessions={sessions}
-              onClick={() => onBoardClick(board.board_id)}
+              branchCount={branchCount}
+              activeCount={activeCount}
+              latestSessionAt={latestSessionAt}
+              onBoardClick={onBoardClick}
             />
           ))}
         </div>

--- a/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
@@ -47,6 +47,8 @@ function renderHome() {
         onBoardClick={() => {}}
         onBranchClick={() => {}}
         onSessionClick={() => {}}
+        onOpenCreateDialog={() => {}}
+        onOpenSettings={() => {}}
       />
     </MemoryRouter>
   );
@@ -77,8 +79,8 @@ describe('HomePage store-selector re-render isolation', () => {
   });
 
   it('a session patch does not re-render HomePage', async () => {
-    // Seed BEFORE the baseline so the patch below can't flip a derived value
-    // HomePage does select (the onboarding "hasSessions" boolean).
+    // Seed BEFORE the baseline so the patch below flips nothing derived
+    // anywhere in the subtree (e.g. the onboarding gate's "hasSessions").
     agorStore.setState({ sessionById: new Map([[session.session_id, session]]) });
     renderHome();
 
@@ -153,6 +155,8 @@ const STABLE_HOME_PROPS = {
   currentUserId: 'u1',
   onBoardClick: noop,
   onBranchClick: noop,
+  onOpenCreateDialog: noop,
+  onOpenSettings: noop,
 } as const;
 
 // Parent harness rendering the REAL memo'd HomePage the way App does. The

--- a/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.rerender.test.tsx
@@ -1,4 +1,4 @@
-import type { Board } from '@agor-live/client';
+import type { Board, Session } from '@agor-live/client';
 import { act, render, waitFor } from '@testing-library/react';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -29,6 +29,15 @@ vi.mock('./HomeKnowledgeSection', () => ({
 }));
 
 const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as unknown as Board;
+
+const session = {
+  session_id: 'session-1',
+  status: 'completed',
+  archived: false,
+  genealogy: {},
+  agentic_tool: 'claude',
+  last_updated: '2026-07-01T10:00:00.000Z',
+} as unknown as Session;
 
 function renderHome() {
   return render(
@@ -62,6 +71,31 @@ describe('HomePage store-selector re-render isolation', () => {
     // its subscriptions stay quiet and it does not re-render.
     act(() => {
       agorStore.setState({ commentById: new Map([['c-1', { board_id: 'board-1' } as never]]) });
+    });
+
+    expect(homeRenders).toBe(baseline);
+  });
+
+  it('a session patch does not re-render HomePage', async () => {
+    // Seed BEFORE the baseline so the patch below can't flip a derived value
+    // HomePage does select (the onboarding "hasSessions" boolean).
+    agorStore.setState({ sessionById: new Map([[session.session_id, session]]) });
+    renderHome();
+
+    await waitFor(() => {
+      expect(homeRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = homeRenders;
+
+    // A streaming-style patch: same session, new object identity. HomePage
+    // selects no session-shaped slice (sections subscribe themselves), so the
+    // page must stay quiet.
+    act(() => {
+      agorStore.setState({
+        sessionById: new Map([
+          [session.session_id, { ...session, description: 'streamed token' } as Session],
+        ]),
+      });
     });
 
     expect(homeRenders).toBe(baseline);

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -32,6 +32,94 @@ const NEW_MENU_ITEMS: MenuProps['items'] = [
   { key: 'board', label: 'New board', icon: <AppstoreOutlined /> },
 ];
 
+/**
+ * Gate around OnboardingCard that owns the onboarding-progress subscription,
+ * so its per-notification cost (including a session scan for `hasSessions`)
+ * exists ONLY while the card can appear. HomePage unmounts this once the card
+ * is dismissed — the common case for established users — leaving the page
+ * with zero onboarding subscription cost; when every step is done it renders
+ * nothing while parked on the (rarely notified) shallow-equal booleans.
+ */
+const HomeOnboarding: React.FC<{
+  currentUserId?: string;
+  onNewSession: () => void;
+  onOpenCreateDialog: HomePageProps['onOpenCreateDialog'];
+  onOpenSettings: HomePageProps['onOpenSettings'];
+  onDismiss: () => void;
+}> = ({ currentUserId, onNewSession, onOpenCreateDialog, onOpenSettings, onDismiss }) => {
+  // Booleans with shallow equality: entity patches only re-render this gate
+  // when a step actually flips (e.g. first repo connected). `sessionById`
+  // keeps archived sessions around for deep links, so `hasSessions` must
+  // filter !archived (and scope to the current user when known); `.some`
+  // exits the scan at the first match.
+  const { hasBoards, hasRepos, hasMcp, hasTeammates, hasSessions } = useStoreWithEqualityFn(
+    agorStore,
+    (state) => ({
+      hasBoards: state.boardById.size > 0,
+      hasRepos: state.repoById.size > 0,
+      hasMcp: state.mcpServerById.size > 0,
+      hasTeammates: state.userById.size > 1,
+      hasSessions: Array.from(state.sessionById.values()).some(
+        (s) => !s.archived && (!currentUserId || s.created_by === currentUserId)
+      ),
+    }),
+    shallow
+  );
+
+  const steps = useMemo(() => {
+    return [
+      {
+        id: 'repo',
+        label: 'Connect a repository',
+        done: hasRepos,
+        cta: 'Connect →',
+        onClick: () => onOpenSettings('repos'),
+      },
+      {
+        id: 'board',
+        label: 'Create your first board',
+        done: hasBoards,
+        cta: 'Create →',
+        onClick: () => onOpenCreateDialog('board'),
+      },
+      {
+        id: 'session',
+        label: 'Launch an AI session',
+        done: hasSessions,
+        cta: 'Start →',
+        onClick: onNewSession,
+      },
+      {
+        id: 'mcp',
+        label: 'Configure MCP tools',
+        done: hasMcp,
+        cta: 'Set up →',
+        onClick: () => onOpenSettings('mcp'),
+      },
+      {
+        id: 'invite',
+        label: 'Invite a teammate',
+        done: hasTeammates,
+        cta: 'Invite →',
+        onClick: () => onOpenSettings('users'),
+      },
+    ];
+  }, [
+    hasBoards,
+    hasRepos,
+    hasMcp,
+    hasTeammates,
+    hasSessions,
+    onOpenCreateDialog,
+    onOpenSettings,
+    onNewSession,
+  ]);
+
+  if (steps.every((s) => s.done)) return null;
+
+  return <OnboardingCard steps={steps} onDismiss={onDismiss} />;
+};
+
 export const HomePage = memo(function HomePage(props: HomePageProps) {
   const { token } = theme.useToken();
   const homeBackground = DEFAULT_BACKGROUNDS[isDarkTheme(token) ? 'dark' : 'light'];
@@ -162,74 +250,6 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
     props.onOpenCreateDialog(createType, selectedBoardId);
   }, [props.onOpenCreateDialog, createType, selectedBoardId]);
 
-  // Booleans with shallow equality: entity patches only re-render HomePage
-  // when a step actually flips (e.g. first repo connected), not on every
-  // write to the underlying maps.
-  const { hasBoards, hasRepos, hasMcp, hasTeammates, hasSessions } = useStoreWithEqualityFn(
-    agorStore,
-    (state) => ({
-      hasBoards: state.boardById.size > 0,
-      hasRepos: state.repoById.size > 0,
-      hasMcp: state.mcpServerById.size > 0,
-      hasTeammates: state.userById.size > 1,
-      hasSessions: Array.from(state.sessionById.values()).some(
-        (s) => !s.archived && (!props.currentUserId || s.created_by === props.currentUserId)
-      ),
-    }),
-    shallow
-  );
-
-  const onboardingSteps = useMemo(() => {
-    return [
-      {
-        id: 'repo',
-        label: 'Connect a repository',
-        done: hasRepos,
-        cta: 'Connect →',
-        onClick: () => props.onOpenSettings('repos'),
-      },
-      {
-        id: 'board',
-        label: 'Create your first board',
-        done: hasBoards,
-        cta: 'Create →',
-        onClick: () => props.onOpenCreateDialog('board'),
-      },
-      {
-        id: 'session',
-        label: 'Launch an AI session',
-        done: hasSessions,
-        cta: 'Start →',
-        onClick: handleNewSession,
-      },
-      {
-        id: 'mcp',
-        label: 'Configure MCP tools',
-        done: hasMcp,
-        cta: 'Set up →',
-        onClick: () => props.onOpenSettings('mcp'),
-      },
-      {
-        id: 'invite',
-        label: 'Invite a teammate',
-        done: hasTeammates,
-        cta: 'Invite →',
-        onClick: () => props.onOpenSettings('users'),
-      },
-    ];
-  }, [
-    hasBoards,
-    hasRepos,
-    hasMcp,
-    hasTeammates,
-    hasSessions,
-    props.onOpenCreateDialog,
-    props.onOpenSettings,
-    handleNewSession,
-  ]);
-
-  const showOnboardingCard = !onboardingHidden && onboardingSteps.some((s) => !s.done);
-
   return (
     <>
       <div style={{ height: '100%', overflow: 'hidden', background: homeBackground }}>
@@ -287,10 +307,13 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
                 </Dropdown>
               </header>
 
-              {/* Get started onboarding card */}
-              {showOnboardingCard && (
-                <OnboardingCard
-                  steps={onboardingSteps}
+              {/* Get started onboarding card — gate unmounted once dismissed */}
+              {!onboardingHidden && (
+                <HomeOnboarding
+                  currentUserId={props.currentUserId}
+                  onNewSession={handleNewSession}
+                  onOpenCreateDialog={props.onOpenCreateDialog}
+                  onOpenSettings={props.onOpenSettings}
                   onDismiss={() => {
                     localStorage.setItem(ONBOARDING_HIDDEN_KEY, 'true');
                     setOnboardingHidden(true);

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -1,20 +1,11 @@
-import type { SessionStatus } from '@agor-live/client';
 import { AppstoreOutlined, BranchesOutlined, PlusOutlined, RobotOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Button, Dropdown, Layout, Modal, Segmented, Select, Typography, theme } from 'antd';
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
-import { useAgorStore } from '../../store/agorStore';
-import {
-  selectBoardById,
-  selectBranchById,
-  selectMcpServerById,
-  selectRepoById,
-  selectSessionById,
-  selectSessionsByBranch,
-  selectUserById,
-} from '../../store/selectors';
+import { agorStore, shallow, useAgorStore, useStoreWithEqualityFn } from '../../store/agorStore';
+import { selectBoardById } from '../../store/selectors';
 import { isDarkTheme } from '../../utils/theme';
 import { HomeActivitySection } from './HomeActivitySection';
 import { HomeBoardsSection } from './HomeBoardsSection';
@@ -35,8 +26,6 @@ const SIDEBAR_DEFAULT = 340;
 const SIDEBAR_MIN = 240;
 const SIDEBAR_MAX_RATIO = 0.5;
 
-const AWAITING_STATUSES = new Set<SessionStatus>(['awaiting_permission', 'awaiting_input']);
-
 const NEW_MENU_ITEMS: MenuProps['items'] = [
   { key: 'assistant', label: 'New assistant', icon: <RobotOutlined /> },
   { key: 'branch', label: 'New branch', icon: <BranchesOutlined /> },
@@ -47,20 +36,21 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
   const { token } = theme.useToken();
   const homeBackground = DEFAULT_BACKGROUNDS[isDarkTheme(token) ? 'dark' : 'light'];
 
+  // HomePage deliberately subscribes to NOTHING session-shaped: sections that
+  // display session data subscribe themselves, so a streaming session patch
+  // wakes only those sections — never this whole page. Boards are the one
+  // whole-map subscription left (board options + default board for the create
+  // modal); board patches are rare.
   const boardById = useAgorStore(selectBoardById);
-  const branchById = useAgorStore(selectBranchById);
-  const repoById = useAgorStore(selectRepoById);
-  const sessionById = useAgorStore(selectSessionById);
-  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
-  const userById = useAgorStore(selectUserById);
-  const mcpServerById = useAgorStore(selectMcpServerById);
 
   const [onboardingHidden, setOnboardingHidden] = useState(
     () => localStorage.getItem(ONBOARDING_HIDDEN_KEY) === 'true'
   );
 
-  const currentUser = props.currentUserId ? userById.get(props.currentUserId) : null;
-  const username = currentUser?.name || 'there';
+  const currentUserName = useAgorStore((s) =>
+    props.currentUserId ? s.userById.get(props.currentUserId)?.name : undefined
+  );
+  const username = currentUserName || 'there';
 
   // Resizable sidebar
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
@@ -135,17 +125,6 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
   // Tear down an in-progress drag if the page unmounts mid-drag.
   useEffect(() => () => dragCleanupRef.current?.(), []);
 
-  const waitingSessions = useMemo(
-    () =>
-      Array.from(sessionById.values()).filter(
-        (s) =>
-          !s.archived &&
-          AWAITING_STATUSES.has(s.status) &&
-          (!props.currentUserId || s.created_by === props.currentUserId)
-      ),
-    [sessionById, props.currentUserId]
-  );
-
   const defaultBoardId = useMemo(() => {
     const firstRecent = (props.recentBoardIds ?? []).find(
       (id) => boardById.get(id)?.archived === false
@@ -183,14 +162,24 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
     props.onOpenCreateDialog(createType, selectedBoardId);
   }, [props.onOpenCreateDialog, createType, selectedBoardId]);
 
+  // Booleans with shallow equality: entity patches only re-render HomePage
+  // when a step actually flips (e.g. first repo connected), not on every
+  // write to the underlying maps.
+  const { hasBoards, hasRepos, hasMcp, hasTeammates, hasSessions } = useStoreWithEqualityFn(
+    agorStore,
+    (state) => ({
+      hasBoards: state.boardById.size > 0,
+      hasRepos: state.repoById.size > 0,
+      hasMcp: state.mcpServerById.size > 0,
+      hasTeammates: state.userById.size > 1,
+      hasSessions: Array.from(state.sessionById.values()).some(
+        (s) => !s.archived && (!props.currentUserId || s.created_by === props.currentUserId)
+      ),
+    }),
+    shallow
+  );
+
   const onboardingSteps = useMemo(() => {
-    const hasBoards = boardById.size > 0;
-    const hasRepos = repoById.size > 0;
-    const hasMcp = (mcpServerById?.size ?? 0) > 0;
-    const hasTeammates = userById.size > 1;
-    const hasSessions = Array.from(sessionById.values()).some(
-      (s) => !s.archived && (!props.currentUserId || s.created_by === props.currentUserId)
-    );
     return [
       {
         id: 'repo',
@@ -229,12 +218,11 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
       },
     ];
   }, [
-    boardById,
-    sessionById,
-    repoById,
-    userById,
-    mcpServerById,
-    props.currentUserId,
+    hasBoards,
+    hasRepos,
+    hasMcp,
+    hasTeammates,
+    hasSessions,
     props.onOpenCreateDialog,
     props.onOpenSettings,
     handleNewSession,
@@ -310,26 +298,17 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
                 />
               )}
 
-              {/* Jump back in — awaiting sessions */}
-              {waitingSessions.length > 0 && (
-                <JumpBackInSection
-                  sessions={waitingSessions}
-                  onSessionClick={props.onSessionClick}
-                />
-              )}
+              {/* Jump back in — awaiting sessions (renders nothing when none) */}
+              <JumpBackInSection
+                currentUserId={props.currentUserId}
+                onSessionClick={props.onSessionClick}
+              />
 
               {/* Workspace stats */}
-              <HomeStatsBar
-                sessionById={sessionById}
-                currentUserId={props.currentUserId}
-                teamSize={userById.size}
-              />
+              <HomeStatsBar currentUserId={props.currentUserId} />
 
               {/* My Sessions — flex: 1 fills remaining viewport height */}
               <HomeSessionsSection
-                sessionById={sessionById}
-                branchById={branchById}
-                boardById={boardById}
                 currentUserId={props.currentUserId}
                 onSessionClick={props.onSessionClick}
               />
@@ -337,10 +316,7 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
               {/* Boards grid */}
               <div style={{ marginTop: 24 }}>
                 <HomeBoardsSection
-                  boardById={boardById}
                   recentBoardIds={props.recentBoardIds}
-                  branchById={branchById}
-                  sessionsByBranch={sessionsByBranch}
                   onBoardClick={props.onBoardClick}
                   onOpenCreateDialog={props.onOpenCreateDialog}
                 />
@@ -421,10 +397,6 @@ export const HomePage = memo(function HomePage(props: HomePageProps) {
                 }}
               >
                 <HomeActivitySection
-                  branchById={branchById}
-                  boardById={boardById}
-                  sessionById={sessionById}
-                  userById={userById}
                   onBoardClick={props.onBoardClick}
                   onBranchClick={props.onBranchClick}
                   onSessionClick={props.onSessionClick}

--- a/apps/agor-ui/src/components/HomePage/HomeSections.rerender.test.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeSections.rerender.test.tsx
@@ -1,0 +1,166 @@
+import type { Board, Branch, Session } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { getSessionDisplayTitle } from '../../utils/sessionTitle';
+import { formatRelativeTime } from '../../utils/time';
+import { HomeBoardsSection } from './HomeBoardsSection';
+import { HomeSessionsSection } from './HomeSessionsSection';
+
+// Both leaf components (HomeSessionRow / BoardHomeCard) are memo'd module
+// internals, so their render counts are observed through utils each calls
+// exactly once per render body: getSessionDisplayTitle(session) for a session
+// row, formatRelativeTime(latestSessionAt) for a board card. Wrapping the real
+// implementations keeps rendering behavior identical while exposing call
+// counts keyed by argument identity.
+vi.mock('../../utils/sessionTitle', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../utils/sessionTitle')>();
+  return { ...mod, getSessionDisplayTitle: vi.fn(mod.getSessionDisplayTitle) };
+});
+vi.mock('../../utils/time', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../../utils/time')>();
+  return { ...mod, formatRelativeTime: vi.fn(mod.formatRelativeTime) };
+});
+
+const noop = () => {};
+
+const makeSession = (id: string, lastUpdated: string, extra?: object) =>
+  ({
+    session_id: id,
+    title: `Session ${id}`,
+    status: 'completed',
+    archived: false,
+    genealogy: {},
+    agentic_tool: 'claude',
+    last_updated: lastUpdated,
+    ...extra,
+  }) as unknown as Session;
+
+const titleRendersFor = (session: Session) =>
+  vi.mocked(getSessionDisplayTitle).mock.calls.filter(([arg]) => arg === session).length;
+
+const timeRendersWith = (timestamp: string) =>
+  vi.mocked(formatRelativeTime).mock.calls.filter(([arg]) => arg === timestamp).length;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  agorStore.setState({ ...EMPTY_MAPS });
+});
+
+describe('HomeSessionsSection row re-render isolation', () => {
+  it('patching one session leaves the other rows un-rendered', async () => {
+    const s1 = makeSession('s-1', '2026-07-01T10:00:00.000Z');
+    const s2 = makeSession('s-2', '2026-07-01T09:00:00.000Z');
+    agorStore.setState({
+      sessionById: new Map([
+        [s1.session_id, s1],
+        [s2.session_id, s2],
+      ]),
+    });
+
+    render(<HomeSessionsSection onSessionClick={noop} />);
+
+    await waitFor(() => {
+      expect(titleRendersFor(s2)).toBeGreaterThanOrEqual(1);
+    });
+    const s2Baseline = titleRendersFor(s2);
+
+    // Streaming-style patch to s1: new object identity, s2 untouched. The
+    // section re-renders (it displays session data), but only s1's row may
+    // re-render — s2's row keeps every prop reference and bails out.
+    const s1Patched = { ...s1, status: 'running' } as Session;
+    act(() => {
+      agorStore.setState({
+        sessionById: new Map([
+          [s1.session_id, s1Patched],
+          [s2.session_id, s2],
+        ]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(titleRendersFor(s1Patched)).toBeGreaterThanOrEqual(1);
+    });
+    expect(titleRendersFor(s2)).toBe(s2Baseline);
+  });
+});
+
+describe('HomeBoardsSection card re-render isolation', () => {
+  it('a session patch on one board leaves the other boards’ cards un-rendered', async () => {
+    const timeA = '2026-07-01T10:00:00.000Z';
+    const timeAPatched = '2026-07-01T10:05:00.000Z';
+    const timeB = '2026-06-30T08:00:00.000Z';
+
+    const boardA = {
+      board_id: 'b-A',
+      name: 'Alpha',
+      archived: false,
+      last_updated: '2026-06-01T00:00:00.000Z',
+    } as unknown as Board;
+    const boardB = {
+      board_id: 'b-B',
+      name: 'Beta',
+      archived: false,
+      last_updated: '2026-06-01T00:00:00.000Z',
+    } as unknown as Board;
+    const branchA = {
+      branch_id: 'br-A',
+      board_id: 'b-A',
+      archived: false,
+      name: 'br-a',
+      created_at: '2026-06-01T00:00:00.000Z',
+    } as unknown as Branch;
+    const branchB = {
+      branch_id: 'br-B',
+      board_id: 'b-B',
+      archived: false,
+      name: 'br-b',
+      created_at: '2026-06-01T00:00:00.000Z',
+    } as unknown as Branch;
+    const sessionA = makeSession('s-A', timeA, { branch_id: 'br-A' });
+    const sessionB = makeSession('s-B', timeB, { branch_id: 'br-B' });
+    // Shared across both setState calls: the store's realtime writer preserves
+    // untouched branch buckets by reference, and this test mirrors that.
+    const branchBSessions = [sessionB];
+
+    agorStore.setState({
+      boardById: new Map([
+        [boardA.board_id, boardA],
+        [boardB.board_id, boardB],
+      ]),
+      branchById: new Map([
+        [branchA.branch_id, branchA],
+        [branchB.branch_id, branchB],
+      ]),
+      sessionsByBranch: new Map([
+        ['br-A', [sessionA]],
+        ['br-B', branchBSessions],
+      ]),
+    });
+
+    render(<HomeBoardsSection onBoardClick={noop} onOpenCreateDialog={noop} />);
+
+    await waitFor(() => {
+      expect(timeRendersWith(timeB)).toBeGreaterThanOrEqual(1);
+    });
+    const boardBBaseline = timeRendersWith(timeB);
+
+    // Patch board A's streaming session. Board B's derived card props are all
+    // unchanged (same board object, same session bucket), so its card bails.
+    act(() => {
+      agorStore.setState({
+        sessionsByBranch: new Map([
+          ['br-A', [{ ...sessionA, last_updated: timeAPatched } as Session]],
+          ['br-B', branchBSessions],
+        ]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(timeRendersWith(timeAPatched)).toBeGreaterThanOrEqual(1);
+    });
+    expect(timeRendersWith(timeB)).toBe(boardBBaseline);
+  });
+});

--- a/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeSessionsSection.tsx
@@ -2,8 +2,10 @@ import type { Board, Branch, Session } from '@agor-live/client';
 import { ForkOutlined } from '@ant-design/icons';
 import { Card, Empty, List, Space, Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useAgorStore } from '../../store/agorStore';
+import { selectBoardById, selectBranchById, selectSessionById } from '../../store/selectors';
 import {
   isSessionSearchActive,
   SESSION_SORT_STORAGE_KEY,
@@ -17,18 +19,25 @@ import { BoardPill, BranchPill } from '../Pill';
 import { SessionSearchToolbar } from '../SessionSearchControls';
 import { glassCardStyle } from './homeStyles';
 import { StatusDot } from './StatusDot';
-import type { HomeSectionProps } from './types';
+import type { HomePageProps } from './types';
 
 const { Text } = Typography;
 
 const HOME_SESSIONS_LIMIT = 100;
 
-const HomeSessionRow: React.FC<{
+// Memo'd so a patch to one session leaves every other row's DOM untouched:
+// unaffected rows keep their entity references and bail out of the re-render.
+const HomeSessionRow = memo(function HomeSessionRow({
+  session,
+  branch,
+  board,
+  onSessionClick,
+}: {
   session: Session;
   branch?: Branch;
   board?: Board;
-  onClick: () => void;
-}> = ({ session, branch, board, onClick }) => {
+  onSessionClick: (sessionId: string) => void;
+}) {
   const { token } = theme.useToken();
   const title = getSessionDisplayTitle(session, { includeAgentFallback: true });
   const isForked = !!(
@@ -39,7 +48,7 @@ const HomeSessionRow: React.FC<{
 
   return (
     <List.Item
-      onClick={onClick}
+      onClick={() => onSessionClick(session.session_id)}
       style={{
         cursor: 'pointer',
         padding: '8px 14px',
@@ -75,15 +84,15 @@ const HomeSessionRow: React.FC<{
       )}
     </List.Item>
   );
-};
+});
 
 export const HomeSessionsSection: React.FC<
-  Pick<
-    HomeSectionProps,
-    'sessionById' | 'branchById' | 'boardById' | 'currentUserId' | 'onSessionClick'
-  >
-> = ({ sessionById, branchById, boardById, currentUserId, onSessionClick }) => {
+  Pick<HomePageProps, 'currentUserId' | 'onSessionClick'>
+> = ({ currentUserId, onSessionClick }) => {
   const { token } = theme.useToken();
+  const sessionById = useAgorStore(selectSessionById);
+  const branchById = useAgorStore(selectBranchById);
+  const boardById = useAgorStore(selectBoardById);
   const [searchQuery, setSearchQuery] = useState('');
   const [sort, setSort] = useLocalStorage<SessionSort>(SESSION_SORT_STORAGE_KEY, 'recent');
   const allSessions = useMemo(
@@ -169,7 +178,7 @@ export const HomeSessionsSection: React.FC<
                   session={session}
                   branch={branch}
                   board={board}
-                  onClick={() => onSessionClick(session.session_id)}
+                  onSessionClick={onSessionClick}
                 />
               );
             }}

--- a/apps/agor-ui/src/components/HomePage/HomeStatsBar.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeStatsBar.tsx
@@ -1,8 +1,8 @@
-import type { Session } from '@agor-live/client';
 import { RiseOutlined, TeamOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { agorStore, shallow, useAgorStore, useStoreWithEqualityFn } from '../../store/agorStore';
 import { glassCardStyle } from './homeStyles';
 
 const { Text } = Typography;
@@ -76,10 +76,8 @@ const StatCard: React.FC<{
 };
 
 export const HomeStatsBar: React.FC<{
-  sessionById: Map<string, Session>;
   currentUserId?: string;
-  teamSize?: number;
-}> = ({ sessionById, currentUserId, teamSize }) => {
+}> = ({ currentUserId }) => {
   const { token } = theme.useToken();
   const [now, setNow] = useState(() => Date.now());
 
@@ -88,45 +86,54 @@ export const HomeStatsBar: React.FC<{
     return () => clearInterval(id);
   }, []);
 
-  const { activeTeammates, myThisWeek, runningNow, activeThisWeek } = useMemo(() => {
-    const weekAgo = now - 7 * 24 * 60 * 60 * 1000;
+  const teamSize = useAgorStore((s) => s.userById.size);
 
-    const activeUserIds = new Set<string>();
-    let myThisWeek = 0;
-    let runningNow = 0;
-    let activeThisWeek = 0;
+  // Derived counts with shallow equality: session patches that don't change
+  // any count (e.g. streaming updates to an already-active session) leave the
+  // stats bar un-rendered.
+  const { activeTeammates, myThisWeek, runningNow, activeThisWeek } = useStoreWithEqualityFn(
+    agorStore,
+    (state) => {
+      const weekAgo = now - 7 * 24 * 60 * 60 * 1000;
 
-    for (const s of sessionById.values()) {
-      if (s.archived) continue;
+      const activeUserIds = new Set<string>();
+      let myThisWeek = 0;
+      let runningNow = 0;
+      let activeThisWeek = 0;
 
-      const updatedAt = s.last_updated
-        ? new Date(s.last_updated).getTime()
-        : s.created_at
-          ? new Date(s.created_at).getTime()
-          : Number.NaN;
+      for (const s of state.sessionById.values()) {
+        if (s.archived) continue;
 
-      if (s.status === 'running') {
-        runningNow++;
-      }
+        const updatedAt = s.last_updated
+          ? new Date(s.last_updated).getTime()
+          : s.created_at
+            ? new Date(s.created_at).getTime()
+            : Number.NaN;
 
-      if (!Number.isNaN(updatedAt) && updatedAt > weekAgo) {
-        activeThisWeek++;
-        if (s.created_by) activeUserIds.add(s.created_by);
-        if (s.created_by === currentUserId) {
-          myThisWeek++;
+        if (s.status === 'running') {
+          runningNow++;
+        }
+
+        if (!Number.isNaN(updatedAt) && updatedAt > weekAgo) {
+          activeThisWeek++;
+          if (s.created_by) activeUserIds.add(s.created_by);
+          if (s.created_by === currentUserId) {
+            myThisWeek++;
+          }
         }
       }
-    }
 
-    return {
-      activeTeammates: activeUserIds.size,
-      myThisWeek,
-      runningNow,
-      activeThisWeek,
-    };
-  }, [sessionById, currentUserId, now]);
+      return {
+        activeTeammates: activeUserIds.size,
+        myThisWeek,
+        runningNow,
+        activeThisWeek,
+      };
+    },
+    shallow
+  );
 
-  const isMultiUser = (teamSize ?? 0) > 1;
+  const isMultiUser = teamSize > 1;
   const weekValue =
     isMultiUser && currentUserId && activeThisWeek > 0
       ? `${myThisWeek}/${activeThisWeek}`

--- a/apps/agor-ui/src/components/HomePage/JumpBackInSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/JumpBackInSection.tsx
@@ -1,8 +1,9 @@
-import type { Session } from '@agor-live/client';
+import type { Session, SessionStatus } from '@agor-live/client';
 import { ThunderboltOutlined } from '@ant-design/icons';
 import { Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useState } from 'react';
+import { agorStore, shallow, useStoreWithEqualityFn } from '../../store/agorStore';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime } from '../../utils/time';
 import { glassCardStyle } from './homeStyles';
@@ -12,8 +13,10 @@ const { Text } = Typography;
 
 const JUMP_LIMIT = 5;
 
+const AWAITING_STATUSES = new Set<SessionStatus>(['awaiting_permission', 'awaiting_input']);
+
 interface JumpBackInSectionProps {
-  sessions: Session[];
+  currentUserId?: string;
   onSessionClick: (sessionId: string) => void;
 }
 
@@ -61,12 +64,33 @@ const JumpBackInRow: React.FC<{
 };
 
 export const JumpBackInSection: React.FC<JumpBackInSectionProps> = ({
-  sessions,
+  currentUserId,
   onSessionClick,
 }) => {
   const { token } = theme.useToken();
+  // Shallow equality on the derived array: session patches that don't change
+  // the awaiting set (element identities) leave this section un-rendered.
+  const sessions = useStoreWithEqualityFn(
+    agorStore,
+    (state) => {
+      const waiting: Session[] = [];
+      for (const session of state.sessionById.values()) {
+        if (
+          !session.archived &&
+          AWAITING_STATUSES.has(session.status) &&
+          (!currentUserId || session.created_by === currentUserId)
+        ) {
+          waiting.push(session);
+        }
+      }
+      return waiting;
+    },
+    shallow
+  );
   const visibleSessions = sessions.slice(0, JUMP_LIMIT);
   const hiddenCount = sessions.length - visibleSessions.length;
+
+  if (sessions.length === 0) return null;
 
   return (
     <div style={{ marginBottom: 24 }}>

--- a/apps/agor-ui/src/components/HomePage/types.ts
+++ b/apps/agor-ui/src/components/HomePage/types.ts
@@ -1,5 +1,5 @@
 import type { KnowledgeDocument as CoreKnowledgeDocument } from '@agor/core/types';
-import type { AgorClient, Board, Branch, MCPServer, Repo, Session, User } from '@agor-live/client';
+import type { AgorClient } from '@agor-live/client';
 
 export interface HomePageProps {
   client: AgorClient | null;
@@ -15,24 +15,6 @@ export interface HomePageProps {
   ) => void;
   onOpenSettings: (section: 'repos' | 'mcp' | 'users') => void;
 }
-
-/**
- * Entity maps the home sub-sections consume. HomePage reads these from the
- * store and drills them into its sections, so they're typed separately from
- * HomePageProps (which carries only HomePage's own props).
- */
-export interface HomeEntityMaps {
-  boardById: Map<string, Board>;
-  branchById: Map<string, Branch>;
-  repoById: Map<string, Repo>;
-  sessionById: Map<string, Session>;
-  sessionsByBranch: Map<string, Session[]>;
-  userById: Map<string, User>;
-  mcpServerById?: Map<string, MCPServer>;
-}
-
-/** Props available to home sub-sections: HomePage's own props plus entity maps. */
-export type HomeSectionProps = HomePageProps & HomeEntityMaps;
 
 export interface KnowledgeDocument
   extends Omit<CoreKnowledgeDocument, 'created_at' | 'updated_at' | 'archived_at'> {


### PR DESCRIPTION
## Mechanism

Streaming agents patch `sessionById` roughly once per token (once per frame after #1793). `HomePage.tsx` subscribed to **seven whole entity maps** (`HomePage.tsx:50-56` before this change), and whole-map selectors hand subscribers a new `Map` reference on every entity patch — so every token re-rendered the entire home page and recomputed `waitingSessions` (full session scan), `boardOptions`, and `onboardingSteps` (walks 5 maps), because their `useMemo`s were keyed on whole maps. List rows compounded it: `HomeSessionRow` and `BoardHomeCard` were un-memo'd and received fresh inline `onClick` closures per row per render. Separately, `App.tsx:1657` passed `ConnectionProvider` a fresh object literal every outer-App render, defeating every context consumer's memoization.

## What changed

**HomePage subscribes to nothing session-shaped** (`HomePage.tsx:50-55`). It keeps one whole-map subscription (`boardById`, rare writes, feeds the create-modal board options) plus two narrow derived reads: current user name (primitive) and the five onboarding booleans via `useStoreWithEqualityFn` + `shallow`, so entity patches only wake the page when a step actually flips.

**Sections own their data** with subscriptions scoped to what they display:
- `HomeSessionsSection.tsx` / `HomeActivitySection.tsx` / `HomeBoardsSection.tsx` subscribe to the maps they render from; a session patch wakes only them, not the page.
- `HomeStatsBar.tsx` derives its four counts behind `shallow` — a streaming patch that doesn't change any count leaves it un-rendered.
- `JumpBackInSection.tsx` derives the awaiting-session array behind `shallow` (element identities stable across unrelated patches) and renders `null` when empty.

**Leaf memoization with stable callbacks:**
- `HomeSessionRow` is `memo`'d and takes the id-keyed `onSessionClick` directly (`HomeSessionsSection.tsx:26`, `:168-173`) — no inline closure in the list map. Patching one session re-renders only that row.
- `BoardHomeCard` is `memo`'d and takes primitives (`branchCount`, `activeCount`, `latestSessionAt`) computed in the section's derivation pass, plus `onBoardClick` (`HomeBoardsSection.tsx:66`, `:177-211`) — passing the per-board arrays would have defeated the memo since they're rebuilt fresh each pass.

**App shell:** `ConnectionProvider` value is now `useMemo`'d (`App.tsx:319-325`), keyed on the five connection fields.

`HomeEntityMaps`/`HomeSectionProps` prop-drilling types deleted (`types.ts`); sections `Pick` from `HomePageProps`.

## Test coverage

- `HomePage.rerender.test.tsx` — new pin: a streaming-style session patch does **not** re-render HomePage (alongside the existing pins: unselected-slice isolation, boards-patch liveness contrast, memo/prop-stability bailout).
- `HomeSections.rerender.test.tsx` (new) — row/card-level pins using argument-identity spies on `getSessionDisplayTitle`/`formatRelativeTime`: patching one session leaves other rows un-rendered; a session patch on one board leaves other boards' cards un-rendered (with liveness contrast on the patched row/card in both).

All 7 rerender suites pass (24 tests).

## Gate results

- `pnpm typecheck` + `pnpm lint` + `pnpm check:shortid` + `turbo run build --filter='!@agor/docs'` — green.
- `pnpm check:multitenancy-boundaries` fails **on the clean base commit** (fbc451b4) with identical daemon-file baseline drift (verified via `git stash` → run → pop); this UI-only diff doesn't touch it.
- `pnpm --filter agor-ui test -- --run rerender` — 7 files, 24 tests, all pass.

## Not included (follow-up finding)

`components/App/App.tsx:321-335` subscribes to 15 whole maps at the app-shell level — same mechanism, planned as a separate mechanical pushdown so this PR stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)