### PR TITLE
perf(agor-ui): kill O(n²) canvas sync scans and node-identity churn

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -40,6 +40,7 @@ import { useFaviconStatus } from '../../hooks/useFaviconStatus';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useRecentBoards } from '../../hooks/useRecentBoards';
 import { useSettingsRoute } from '../../hooks/useSettingsRoute';
+import { useStableCallback } from '../../hooks/useStableCallback';
 import { useTaskCompletionChime } from '../../hooks/useTaskCompletionChime';
 import { type ActiveUrlTarget, useUrlState } from '../../hooks/useUrlState';
 import { useUserLocalStorage } from '../../hooks/useUserLocalStorage';
@@ -230,25 +231,6 @@ const getSessionPanelMinSizePercent = (viewportWidth: number) =>
 
 const clampPercent = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
-
-// Freeze a callback's identity for the component's lifetime while always
-// invoking the latest implementation. Several action props arrive from the
-// parent (`AppContent`) as plain consts that get a fresh identity on every
-// store-driven re-render. Passing them straight to the memoized SessionCanvas
-// would defeat its `React.memo` (and the inner BranchNode / `initialNodes`
-// memoization) on every live patch. The wrapper's identity is stable; a ref
-// keeps it delegating to the current impl, so behavior is unchanged. Preserves
-// `undefined` so optional handlers stay absent (no spurious enabled UI).
-function useStableCallback<TFn extends (...args: never[]) => unknown>(
-  callback: TFn | undefined
-): TFn | undefined {
-  const callbackRef = useRef(callback);
-  useLayoutEffect(() => {
-    callbackRef.current = callback;
-  });
-  const stable = useCallback(((...args: never[]) => callbackRef.current?.(...args)) as TFn, []);
-  return callback ? stable : undefined;
-}
 
 export const App: React.FC<AppProps> = ({
   client,

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
@@ -8,9 +8,10 @@ import type {
   Session,
 } from '@agor-live/client';
 import { act, render, waitFor } from '@testing-library/react';
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { useStableCallback } from '../../hooks/useStableCallback';
 import { EMPTY_MAPS } from '../../store/agorMaps';
 import { sessionPatched } from '../../store/agorRealtimeActions';
 import { agorStore } from '../../store/agorStore';
@@ -298,22 +299,86 @@ describe('SessionCanvas store-selector re-render isolation', () => {
     expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
     expect(cardNodeRenders).toBe(cardNodeBaseline);
   });
-});
 
-// Mirror of AppContent's `useStableCallback`: freeze a handler's identity across
-// renders while delegating to the latest impl via a ref. This is the exact
-// mechanism AppContent uses to keep SessionCanvas's action handlers stable, so
-// reproducing it here exercises the real prop-stabilization contract.
-function useStableCallback<TFn extends (...args: never[]) => unknown>(
-  callback: TFn | undefined
-): TFn | undefined {
-  const callbackRef = useRef(callback);
-  useLayoutEffect(() => {
-    callbackRef.current = callback;
+  it('a repoById patch that leaves displayed repos untouched does not re-render branch cards', async () => {
+    render(
+      <ConnectionProvider value={CONNECTION_VALUE}>
+        <SessionCanvas board={board} client={null} branches={BRANCHES} />
+      </ConnectionProvider>
+    );
+
+    await waitFor(() => {
+      expect(branchCardRenders.get('A')).toBeGreaterThanOrEqual(1);
+      expect(branchCardRenders.get('B')).toBeGreaterThanOrEqual(1);
+    });
+
+    const canvasBaseline = sessionCanvasRenders;
+    const branchABaseline = branchCardRenders.get('A') ?? 0;
+    const branchBBaseline = branchCardRenders.get('B') ?? 0;
+
+    // A repo that is not on the board is added: the map reference changes (so
+    // the canvas re-renders and rebuilds its node array) but each displayed
+    // branch's repo object keeps its identity.
+    act(() => {
+      agorStore.setState({
+        repoById: new Map([
+          [REPO_ID, repo],
+          ['repo-2', { repo_id: 'repo-2', name: 'other', slug: 'other' } as unknown as Repo],
+        ]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(sessionCanvasRenders).toBeGreaterThan(canvasBaseline);
+    });
+
+    // BranchNode's areEqual holds field-by-field (same branch, same repo
+    // object, stable handlers), so no branch card pays for the map churn.
+    expect(branchCardRenders.get('A') ?? 0).toBe(branchABaseline);
+    expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
   });
-  const stable = useCallback(((...args: never[]) => callbackRef.current?.(...args)) as TFn, []);
-  return callback ? stable : undefined;
-}
+
+  it('board-object churn with unchanged values does not re-render branch cards', async () => {
+    render(
+      <ConnectionProvider value={CONNECTION_VALUE}>
+        <SessionCanvas board={board} client={null} branches={BRANCHES} />
+      </ConnectionProvider>
+    );
+
+    await waitFor(() => {
+      expect(branchCardRenders.get('A')).toBeGreaterThanOrEqual(1);
+      expect(branchCardRenders.get('B')).toBeGreaterThanOrEqual(1);
+    });
+
+    const canvasBaseline = sessionCanvasRenders;
+    const branchABaseline = branchCardRenders.get('A') ?? 0;
+    const branchBBaseline = branchCardRenders.get('B') ?? 0;
+
+    // Fresh array/object references with identical values — the placement maps
+    // derived from them rebuild, which is exactly what would hand every branch
+    // node a fresh `onUnpin` identity if that handler were not stabilized.
+    act(() => {
+      agorStore.setState({
+        boardObjectsByBoardId: new Map([
+          [
+            BOARD_ID,
+            boardObjects.map(
+              (object) =>
+                ({ ...object, position: { ...object.position } }) as unknown as BoardEntityObject
+            ),
+          ],
+        ]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(sessionCanvasRenders).toBeGreaterThan(canvasBaseline);
+    });
+
+    expect(branchCardRenders.get('A') ?? 0).toBe(branchABaseline);
+    expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
+  });
+});
 
 // Lets a test trigger a parent re-render without touching SessionCanvas's props.
 let triggerParentRerender: () => void = () => {};

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
@@ -6,6 +6,7 @@ import type {
   CardWithType,
   Repo,
   Session,
+  User,
 } from '@agor-live/client';
 import { act, render, waitFor } from '@testing-library/react';
 import { useState } from 'react';
@@ -377,6 +378,46 @@ describe('SessionCanvas store-selector re-render isolation', () => {
 
     expect(branchCardRenders.get('A') ?? 0).toBe(branchABaseline);
     expect(branchCardRenders.get('B') ?? 0).toBe(branchBBaseline);
+  });
+
+  it('a userById patch re-renders branch cards WITHOUT rebuilding node data (documented contract)', async () => {
+    render(
+      <ConnectionProvider value={CONNECTION_VALUE}>
+        <SessionCanvas board={board} client={null} branches={BRANCHES} />
+      </ConnectionProvider>
+    );
+
+    await waitFor(() => {
+      expect(branchCardRenders.get('A')).toBeGreaterThanOrEqual(1);
+      expect(branchCardRenders.get('B')).toBeGreaterThanOrEqual(1);
+      expect(cardNodeRenders).toBeGreaterThanOrEqual(1);
+    });
+
+    const branchABaseline = branchCardRenders.get('A') ?? 0;
+    const branchBBaseline = branchCardRenders.get('B') ?? 0;
+    const cardNodeBaseline = cardNodeRenders;
+
+    act(() => {
+      agorStore.setState({
+        userById: new Map([['user-x', { user_id: 'user-x', username: 'x' } as unknown as User]]),
+      });
+    });
+
+    // Documented contract, the weaker of the two possible pins: BranchNode
+    // subscribes to the WHOLE user map (BranchCard renders arbitrary users —
+    // session and message authors resolved deep inside its session tree — so
+    // the set of relevant user ids is not derivable at subscription time, and
+    // a narrower per-branch selector is not mechanical). Any user-map change
+    // therefore re-renders every branch card...
+    await waitFor(() => {
+      expect(branchCardRenders.get('A') ?? 0).toBeGreaterThan(branchABaseline);
+      expect(branchCardRenders.get('B') ?? 0).toBeGreaterThan(branchBBaseline);
+    });
+
+    // ...but the map lives outside node `data`, so the node array is NOT
+    // rebuilt: card nodes (which do not consume users) keep their `data`
+    // references and stay un-rendered.
+    expect(cardNodeRenders).toBe(cardNodeBaseline);
   });
 });
 

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -62,6 +62,7 @@ import {
 } from '../../contexts/CanvasNavigationContext';
 import { useMutationGate } from '../../contexts/ConnectionContext';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
+import { useStableCallback } from '../../hooks/useStableCallback';
 import { useAgorStore } from '../../store/agorStore';
 import {
   makeBoardObjectsForBoardSelector,
@@ -209,7 +210,6 @@ interface BranchNodeData {
   branch: Branch;
   repo: Repo;
   boardId?: string | null;
-  userById: Map<string, User>;
   currentUserId?: string;
   onTaskClick?: (taskId: string) => void;
   onSessionClick?: (sessionId: string) => void;
@@ -277,6 +277,12 @@ const BranchNode = React.memo(
       [data.branch.branch_id]
     );
     const sessions = useAgorStore(sessionsSelector) ?? EMPTY_SESSIONS;
+    // Sourced from the store rather than carried in `data`: BranchCard reads
+    // arbitrary users (session/message authors), so the whole map is the
+    // narrowest mechanical slice. Keeping it out of `data` keeps the map out
+    // of the parent's node-building dependencies, so a user patch updates the
+    // affected cards without rebuilding every node's `data` on the board.
+    const userById = useAgorStore(selectUserById);
     return (
       <div className="branch-node">
         <BranchCard
@@ -284,7 +290,7 @@ const BranchNode = React.memo(
           repo={data.repo}
           sessions={sessions}
           progressiveMountKey={data.boardId ?? 'no-board'}
-          userById={data.userById}
+          userById={userById}
           currentUserId={data.currentUserId}
           selectedSessionId={data.selectedSessionId}
           isActiveUrlTarget={data.isActiveUrlTarget}
@@ -323,7 +329,6 @@ const BranchNode = React.memo(
       p.branch === n.branch &&
       p.repo === n.repo &&
       p.boardId === n.boardId &&
-      p.userById === n.userById &&
       p.currentUserId === n.currentUserId &&
       p.selectedSessionId === n.selectedSessionId &&
       p.isActiveUrlTarget === n.isActiveUrlTarget &&
@@ -673,7 +678,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         }
       });
       return labels;
-    }, [board]);
+    }, [board?.objects]);
 
     const warnedInvalidZoneRefsRef = useRef<Set<string>>(new Set());
     const warnInvalidZoneRef = useCallback(
@@ -695,62 +700,62 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       []
     );
 
-    // Handler to unpin a branch from its zone
-    const handleUnpinBranch = useCallback(
-      async (branchId: string) => {
-        if (!board || !client) return;
+    // Handler to unpin a branch from its zone. Identity-stabilized because it
+    // feeds every branch node's `data.onUnpin`: a fresh identity (its closure
+    // reads `board` and the placement map, which change on every board patch)
+    // would defeat BranchNode's areEqual for all branches at once.
+    const handleUnpinBranch = useStableCallback(async (branchId: string) => {
+      if (!board || !client) return;
 
-        // Find the board_object for this branch
-        const boardObject = boardObjectByBranch.get(branchId);
+      // Find the board_object for this branch
+      const boardObject = boardObjectByBranch.get(branchId);
 
-        if (!boardObject?.zone_id) {
-          return;
-        }
+      if (!boardObject?.zone_id) {
+        return;
+      }
 
-        // Get zone position from board.objects
-        const zone = board.objects?.[boardObject.zone_id];
+      // Get zone position from board.objects
+      const zone = board.objects?.[boardObject.zone_id];
 
-        if (!zone) {
-          console.error('Cannot unpin: zone not found', {
-            zoneId: boardObject.zone_id,
-          });
-          return;
-        }
-
-        // Calculate absolute position from relative position
-        // Branch's position is relative to zone when pinned, so add zone's position
-        const absoluteX = boardObject.position.x + zone.x;
-        const absoluteY = boardObject.position.y + zone.y;
-
-        // Optimistically store absolute position in localPositionsRef
-        // This will be used by the node sync effect until WebSocket confirms
-        localPositionsRef.current[branchId] = {
-          x: absoluteX,
-          y: absoluteY,
-        };
-
-        // Trigger immediate React Flow update
-        setNodes((currentNodes) =>
-          currentNodes.map((node) => {
-            if (node.id === branchId) {
-              return {
-                ...node,
-                position: { x: absoluteX, y: absoluteY },
-                parentId: undefined, // Remove parent relationship
-              };
-            }
-            return node;
-          })
-        );
-
-        // Update with absolute position and clear zone_id
-        await client.service('board-objects').patch(boardObject.object_id, {
-          position: { x: absoluteX, y: absoluteY },
-          zone_id: null, // null serializes correctly, undefined gets stripped
+      if (!zone) {
+        console.error('Cannot unpin: zone not found', {
+          zoneId: boardObject.zone_id,
         });
-      },
-      [board, client, boardObjectByBranch, setNodes]
-    );
+        return;
+      }
+
+      // Calculate absolute position from relative position
+      // Branch's position is relative to zone when pinned, so add zone's position
+      const absoluteX = boardObject.position.x + zone.x;
+      const absoluteY = boardObject.position.y + zone.y;
+
+      // Optimistically store absolute position in localPositionsRef
+      // This will be used by the node sync effect until WebSocket confirms
+      localPositionsRef.current[branchId] = {
+        x: absoluteX,
+        y: absoluteY,
+      };
+
+      // Trigger immediate React Flow update
+      setNodes((currentNodes) =>
+        currentNodes.map((node) => {
+          if (node.id === branchId) {
+            return {
+              ...node,
+              position: { x: absoluteX, y: absoluteY },
+              parentId: undefined, // Remove parent relationship
+            };
+          }
+          return node;
+        })
+      );
+
+      // Update with absolute position and clear zone_id
+      await client.service('board-objects').patch(boardObject.object_id, {
+        position: { x: absoluteX, y: absoluteY },
+        zone_id: null, // null serializes correctly, undefined gets stripped
+      });
+    });
 
     // Convert branches to React Flow nodes (branch-centric approach)
     const initialNodes: Node[] = useMemo(() => {
@@ -816,7 +821,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             branch,
             repo,
             boardId: board?.board_id ?? null,
-            userById,
             currentUserId,
             selectedSessionId,
             isActiveUrlTarget: branch.branch_id === activeUrlTargetBranchId,
@@ -846,7 +850,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
       return nodes;
     }, [
-      board,
+      board?.objects,
+      board?.board_id,
       branches,
       primaryAssistantId,
       boardObjectByBranch,
@@ -871,53 +876,48 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       handleUnpinBranch,
       zoneLabels,
       warnInvalidZoneRef,
-      userById,
       client,
     ]);
 
-    // Handler to open card modal
-    const handleCardClick = useCallback(
-      (cardId: string) => {
-        const card = cardById.get(cardId);
-        if (card) {
-          setSelectedCard(card);
-          setCardModalOpen(true);
-        }
-      },
-      [cardById]
-    );
+    // Handler to open card modal. Identity-stabilized so card-map churn does
+    // not hand every card node a fresh `data.onClick`.
+    const handleCardClick = useStableCallback((cardId: string) => {
+      const card = cardById.get(cardId);
+      if (card) {
+        setSelectedCard(card);
+        setCardModalOpen(true);
+      }
+    });
 
-    // Handler to unpin a card from its zone
-    const handleUnpinCard = useCallback(
-      async (cardId: string) => {
-        if (!board || !client) return;
-        const boardObject = boardObjectByCard.get(cardId);
-        if (!boardObject?.zone_id) return;
+    // Handler to unpin a card from its zone. Identity-stabilized for the same
+    // reason as handleUnpinBranch.
+    const handleUnpinCard = useStableCallback(async (cardId: string) => {
+      if (!board || !client) return;
+      const boardObject = boardObjectByCard.get(cardId);
+      if (!boardObject?.zone_id) return;
 
-        const zone = board.objects?.[boardObject.zone_id];
-        if (!zone) return;
+      const zone = board.objects?.[boardObject.zone_id];
+      if (!zone) return;
 
-        const absoluteX = boardObject.position.x + zone.x;
-        const absoluteY = boardObject.position.y + zone.y;
+      const absoluteX = boardObject.position.x + zone.x;
+      const absoluteY = boardObject.position.y + zone.y;
 
-        localPositionsRef.current[`card-${cardId}`] = { x: absoluteX, y: absoluteY };
+      localPositionsRef.current[`card-${cardId}`] = { x: absoluteX, y: absoluteY };
 
-        setNodes((currentNodes) =>
-          currentNodes.map((node) => {
-            if (node.id === `card-${cardId}`) {
-              return { ...node, position: { x: absoluteX, y: absoluteY }, parentId: undefined };
-            }
-            return node;
-          })
-        );
+      setNodes((currentNodes) =>
+        currentNodes.map((node) => {
+          if (node.id === `card-${cardId}`) {
+            return { ...node, position: { x: absoluteX, y: absoluteY }, parentId: undefined };
+          }
+          return node;
+        })
+      );
 
-        await client.service('board-objects').patch(boardObject.object_id, {
-          position: { x: absoluteX, y: absoluteY },
-          zone_id: null,
-        });
-      },
-      [board, client, boardObjectByCard, setNodes]
-    );
+      await client.service('board-objects').patch(boardObject.object_id, {
+        position: { x: absoluteX, y: absoluteY },
+        zone_id: null,
+      });
+    });
 
     // Build card nodes from board_objects that have card_id set
     const cardNodes: Node[] = useMemo(() => {
@@ -963,7 +963,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
       return nodes;
     }, [
-      board,
+      board?.objects,
       boardObjectByCard,
       cardById,
       zoneLabels,

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1178,19 +1178,26 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onCommentSelect,
     ]);
 
-    // Helper: Apply local position overrides to a set of incoming nodes (branches or cards)
+    // Helper: Apply local position overrides to a set of incoming nodes (branches or cards).
+    // Lookups go through Maps so a full board sync stays O(n) instead of
+    // O(n²) per-node array scans.
     const applyLocalPositions = useCallback(
-      (incomingNodes: Node[], currentNodes: Node[], zoneNodes: Node[]) => {
+      (incomingNodes: Node[], currentNodesById: Map<string, Node>, zoneNodes: Node[]) => {
+        // Incoming nodes take precedence over zones on id collision (insertion
+        // order below makes them overwrite), matching parent resolution that
+        // consults incoming nodes first.
+        const parentById = new Map<string, Node>();
+        for (const node of zoneNodes) parentById.set(node.id, node);
+        for (const node of incomingNodes) parentById.set(node.id, node);
+
         return incomingNodes.map((newNode) => {
-          const existingNode = currentNodes.find((n) => n.id === newNode.id);
+          const existingNode = currentNodesById.get(newNode.id);
           const localPosition = localPositionsRef.current[newNode.id];
 
           if (localPosition) {
             let incomingAbsolutePosition = newNode.position;
             if (newNode.parentId) {
-              const parentNode = [...incomingNodes, ...zoneNodes].find(
-                (n) => n.id === newNode.parentId
-              );
+              const parentNode = parentById.get(newNode.parentId);
               if (parentNode) {
                 incomingAbsolutePosition = relativeToAbsolute(
                   newNode.position,
@@ -1214,9 +1221,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
             let positionToUse = localPosition;
             if (newNode.parentId) {
-              const parentNode = [...incomingNodes, ...zoneNodes].find(
-                (n) => n.id === newNode.parentId
-              );
+              const parentNode = parentById.get(newNode.parentId);
               if (parentNode) {
                 positionToUse = absoluteToRelative(localPosition, parentNode.position);
               }
@@ -1272,16 +1277,39 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       ]
     );
 
-    // Helper: Partition nodes by type
+    // Helper: Partition nodes by type in a single pass (this runs inside every
+    // node-sync setNodes updater, so per-type .filter sweeps add up on large boards)
     const partitionNodesByType = useCallback((nodes: Node[]) => {
-      return {
-        zones: nodes.filter((n) => n.type === 'zone'),
-        markdown: nodes.filter((n) => n.type === 'markdown'),
-        branches: nodes.filter((n) => n.type === 'branchNode'),
-        cards: nodes.filter((n) => n.type === 'cardNode'),
-        apps: nodes.filter((n) => n.type === 'appNode' || n.type === 'artifactNode'),
-        comments: nodes.filter((n) => n.type === 'comment'),
-      };
+      const zones: Node[] = [];
+      const markdown: Node[] = [];
+      const branches: Node[] = [];
+      const cards: Node[] = [];
+      const apps: Node[] = [];
+      const comments: Node[] = [];
+      for (const node of nodes) {
+        switch (node.type) {
+          case 'zone':
+            zones.push(node);
+            break;
+          case 'markdown':
+            markdown.push(node);
+            break;
+          case 'branchNode':
+            branches.push(node);
+            break;
+          case 'cardNode':
+            cards.push(node);
+            break;
+          case 'appNode':
+          case 'artifactNode':
+            apps.push(node);
+            break;
+          case 'comment':
+            comments.push(node);
+            break;
+        }
+      }
+      return { zones, markdown, branches, cards, apps, comments };
     }, []);
 
     // Helper: Apply consistent z-ordering to nodes
@@ -1317,11 +1345,12 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
       setNodes((currentNodes) => {
         const { comments } = partitionNodesByType(currentNodes);
+        const currentNodesById = new Map(currentNodes.map((n) => [n.id, n]));
 
         const zones = boardObjectNodes
           .filter((n) => n.type === 'zone' && !deletedObjectsRef.current.has(n.id))
           .map((newZone) => {
-            const existingZone = currentNodes.find((n) => n.id === newZone.id);
+            const existingZone = currentNodesById.get(newZone.id);
             // Honor the persisted/default base order from board data (`newZone`),
             // and re-apply the +1 selection bump if the zone is currently
             // selected. Reading the base from `newZone` (not the stale runtime
@@ -1338,7 +1367,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         const markdown = boardObjectNodes
           .filter((n) => n.type === 'markdown' && !deletedObjectsRef.current.has(n.id))
           .map((newMarkdown) => {
-            const existingMarkdown = currentNodes.find((n) => n.id === newMarkdown.id);
+            const existingMarkdown = currentNodesById.get(newMarkdown.id);
             return { ...newMarkdown, selected: existingMarkdown?.selected };
           });
 
@@ -1349,12 +1378,12 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               !deletedObjectsRef.current.has(n.id)
           )
           .map((newApp) => {
-            const existingApp = currentNodes.find((n) => n.id === newApp.id);
+            const existingApp = currentNodesById.get(newApp.id);
             return { ...newApp, selected: existingApp?.selected };
           });
 
-        const updatedBranches = applyLocalPositions(initialNodes, currentNodes, zones);
-        const updatedCards = applyLocalPositions(cardNodes, currentNodes, zones);
+        const updatedBranches = applyLocalPositions(initialNodes, currentNodesById, zones);
+        const updatedCards = applyLocalPositions(cardNodes, currentNodesById, zones);
 
         return applyZOrder(zones, markdown, updatedBranches, updatedCards, comments, apps);
       });
@@ -1375,6 +1404,12 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       setNodes((currentNodes) => {
         const { zones, markdown, branches, cards, apps } = partitionNodesByType(currentNodes);
 
+        // Comment parents are branches or zones; branches take precedence on id
+        // collision (insertion order below makes them overwrite).
+        const parentById = new Map<string, Node>();
+        for (const node of zones) parentById.set(node.id, node);
+        for (const node of branches) parentById.set(node.id, node);
+
         // Apply local position overrides to comment nodes (to prevent flicker during drag)
         const commentsWithLocalPositions = commentNodes.map((newNode) => {
           const localPosition = localPositionsRef.current[newNode.id];
@@ -1384,7 +1419,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             // If node has parentId, position is relative to parent - must convert to absolute
             let incomingAbsolutePosition = newNode.position;
             if (newNode.parentId) {
-              const parentNode = [...branches, ...zones].find((n) => n.id === newNode.parentId);
+              const parentNode = parentById.get(newNode.parentId);
               if (parentNode) {
                 incomingAbsolutePosition = relativeToAbsolute(
                   newNode.position,
@@ -1408,7 +1443,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             // If node now has parentId, convert local absolute position to relative
             let positionToUse = localPosition;
             if (newNode.parentId) {
-              const parentNode = [...branches, ...zones].find((n) => n.id === newNode.parentId);
+              const parentNode = parentById.get(newNode.parentId);
               if (parentNode) {
                 positionToUse = absoluteToRelative(localPosition, parentNode.position);
               }

--- a/apps/agor-ui/src/hooks/index.ts
+++ b/apps/agor-ui/src/hooks/index.ts
@@ -22,4 +22,5 @@ export * from './useServicesConfig';
 export * from './useSessionActions';
 export * from './useSettingsRoute';
 export * from './useSharedReactiveSession';
+export * from './useStableCallback';
 export * from './useUrlState';

--- a/apps/agor-ui/src/hooks/useStableCallback.ts
+++ b/apps/agor-ui/src/hooks/useStableCallback.ts
@@ -1,0 +1,26 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Freeze a callback's identity for the component's lifetime while always
+ * invoking the latest implementation. Handlers that close over frequently
+ * changing state (store maps, live-patched entities) get a fresh identity on
+ * every render; passing them into memoized children — or into React Flow node
+ * `data` compared by a custom `areEqual` — defeats those memo boundaries on
+ * every live patch. The wrapper's identity is stable; a ref keeps it
+ * delegating to the current impl, so behavior is unchanged. Preserves
+ * `undefined` so optional handlers stay absent (no spurious enabled UI).
+ */
+export function useStableCallback<TFn extends (...args: never[]) => unknown>(callback: TFn): TFn;
+export function useStableCallback<TFn extends (...args: never[]) => unknown>(
+  callback: TFn | undefined
+): TFn | undefined;
+export function useStableCallback<TFn extends (...args: never[]) => unknown>(
+  callback: TFn | undefined
+): TFn | undefined {
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+  const stable = useCallback(((...args: never[]) => callbackRef.current?.(...args)) as TFn, []);
+  return callback ? stable : undefined;
+}


### PR DESCRIPTION
## Mechanism

Two independent hotspots made the board canvas scale badly with board size (prod boards: 300+ objects, 50+ branches, many concurrently-streaming sessions). Split into two commits for revertability.

### Commit 1 — algorithmic: O(n²) → O(n) in the sync effects (f644717d)

The node-sync and comment-sync effects ran per-node linear scans over the full node array:

- `applyLocalPositions` did `currentNodes.find()` per incoming node and `[...incomingNodes, ...zoneNodes].find()` per parent lookup (`SessionCanvas.tsx:1177-1237` pre-change). Called twice per node-sync run (branches + cards).
- The zone/markdown/app merges each did `currentNodes.find()` per board object (`SessionCanvas.tsx:1320,1337,1348` pre-change).
- `partitionNodesByType` swept the array with six `.filter()` passes per call (`SessionCanvas.tsx:1272-1281` pre-change), invoked from **both** sync effects → 12 passes per update cycle.

Now: one `currentNodesById` map per sync run shared by all merges and both `applyLocalPositions` calls, a parent map built once per invocation, and a single-pass partition. For a 300-node board a node-sync run drops from ~300×300 ≈ 90k node comparisons (plus 12 full-array filter sweeps) to ~4 O(n) passes with O(1) lookups — and these effects fire on every session/branch/board-object patch, i.e. continuously while sessions stream.

### Commit 2 — identity: make BranchNode's areEqual actually hold (29e6f8ef)

`BranchNode`'s custom `areEqual` (`SessionCanvas.tsx:319-355`) only pays off if the fields inside a rebuilt node `data` keep their identities. Three things broke that:

- `handleUnpinBranch` / `handleUnpinCard` / `handleCardClick` closed over `board` and the derived placement/card maps, so **any** board-object or card patch minted fresh callbacks → fresh `data.onUnpin`/`data.onClick` for every node → every BranchCard re-rendered. They're now frozen with `useStableCallback` (extracted from `App.tsx` into `src/hooks/useStableCallback.ts`, now shared by both) and read live state through a ref.
- `userById` (whole map) was carried through node `data` and listed in the `initialNodes` memo deps, so any user patch rebuilt every node's `data` and failed `areEqual` for all branches. `BranchNode` now reads it from the store directly (`SessionCanvas.tsx:285-291`), the same pattern as its per-branch session subscription. BranchCard reads arbitrary users (session/message authors), so the whole map is the narrowest mechanical slice — a patch to a displayed user still re-renders (correct), but no longer rebuilds the node array.
- The node-build memos depended on the whole `board` while reading only `board?.objects`; deps narrowed accordingly (`SessionCanvas.tsx:851,975`, `zoneLabels` at `:678`).

## Test coverage

`SessionCanvas.rerender.test.tsx` grows three pins (80 total in the SessionCanvas suites, all green):

- **repoById churn** (new map ref, unchanged repo objects — i.e. a patch to a repo not on the board) does not re-render branch cards.
- **board-object churn** (fresh refs, identical values) does not re-render branch cards — mutation-verified: this test **fails** against the pre-fix SessionCanvas (unstabilized `onUnpin`) and passes with it.

- **user-map churn** pins the documented contract (see Known residuals): branch cards re-render, but the node array is not rebuilt — card nodes stay quiet. 80/80 total.

## Gates

- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm check:shortid` ✅ · `turbo run build` ✅
- agor-ui tests: full suite 718/718 ✅ (SessionCanvas suites 79/79, incl. the new pins)
- ⚠️ `pnpm check` as a whole fails on `check:multitenancy-boundaries` — **pre-existing on the base commit** (fbc451b4, current main tip): 5 daemon files violate the script's own inline baseline. Verified identical failure on a pristine checkout; CI does not run this script (`ci.yml` runs lint/build/typecheck/tests). Not touched here — daemon scope belongs to other open work.

## Known residuals

`BranchNode` subscribes to the whole `userById` map: BranchCard renders arbitrary users (session and message authors resolved deep inside its session tree), so the relevant user-id set is not derivable at subscription time and a narrower per-branch selector is not mechanical. Any real user-map change therefore re-renders every mounted branch card — but no longer rebuilds any node `data` (the map lives outside the node-build pipeline). Pinned as a documented contract in `SessionCanvas.rerender.test.tsx`; per-branch derived user slices are a possible follow-up.

## Notes for concurrent PRs

- Does **not** touch the store write layer (`useAgorData.ts`, `agorMaps.ts`, `agorRealtimeActions.ts`, `agorHydration.ts`) — #1793's territory.
- Touches `SessionCanvas.tsx`, so #1789 (progressive board mount) will need a rebase in one direction or the other.
