### PR TITLE
feat(gateway): bind outbound emit + Slack reads to the calling session's branch

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -1,6 +1,7 @@
 import {
   BranchRepository,
   GatewayChannelRepository,
+  SessionRepository,
   ThreadSessionMapRepository,
 } from '@agor/core/db';
 import {
@@ -37,7 +38,11 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean;
 }>;
 
-async function captureTools(role: 'admin' | 'member' = 'admin', app = makeFakeApp({})) {
+async function captureTools(
+  role: 'admin' | 'member' = 'admin',
+  app = makeFakeApp({}),
+  sessionId: string | null = 'sess-1'
+) {
   const { registerGatewayChannelTools } = await import('./gateway-channels.js');
   const tools: Record<string, { cfg: any; handler: ToolHandler }> = {};
   const fakeServer = {
@@ -49,11 +54,22 @@ async function captureTools(role: 'admin' | 'member' = 'admin', app = makeFakeAp
     app: app as any,
     db: {} as any,
     userId: 'user-1' as any,
-    sessionId: 'sess-1' as any,
+    ...(sessionId ? { sessionId: sessionId as any } : {}),
     authenticatedUser: { user_id: 'user-1', role } as any,
     baseServiceParams: { authenticated: true, user: { user_id: 'user-1', role } } as any,
   });
   return tools;
+}
+
+/**
+ * The caller session used for session-branch binding: ctx.sessionId ('sess-1')
+ * resolves to a session on the given branch. null simulates a stale/missing
+ * session, which the binding must treat as fail-closed.
+ */
+function spyCallerSessionBranch(branchId: string | null) {
+  return vi
+    .spyOn(SessionRepository.prototype, 'findById')
+    .mockResolvedValue((branchId ? { session_id: 'sess-1', branch_id: branchId } : null) as any);
 }
 
 const slackChannel = {
@@ -518,6 +534,7 @@ describe('agor_gateway_channels MCP tools', () => {
       ],
     }));
     vi.mocked(getConnector).mockReturnValue({ fetchThreadHistory } as any);
+    spyCallerSessionBranch('branch-1');
     vi.spyOn(ThreadSessionMapRepository.prototype, 'findBySession').mockResolvedValue(
       threadMapping as any
     );
@@ -600,6 +617,7 @@ describe('agor_gateway_channels MCP tools', () => {
       ],
     }));
     vi.mocked(getConnector).mockReturnValue({ fetchThreadHistory } as any);
+    spyCallerSessionBranch('branch-1');
     vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(slackChannel as any);
     vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
     vi.spyOn(BranchRepository.prototype, 'isOwner').mockResolvedValue(false);
@@ -637,6 +655,7 @@ describe('agor_gateway_channels MCP tools', () => {
   });
 
   it('denies mapped explicit Slack thread history without branch all permission', async () => {
+    spyCallerSessionBranch('branch-1');
     vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(slackChannel as any);
     vi.spyOn(ThreadSessionMapRepository.prototype, 'findByChannelAndThread').mockResolvedValue(
       threadMapping as any
@@ -657,6 +676,7 @@ describe('agor_gateway_channels MCP tools', () => {
   });
 
   it('denies unmapped explicit Slack thread history to non-admins even with branch all permission', async () => {
+    spyCallerSessionBranch('branch-1');
     vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(slackChannel as any);
     vi.spyOn(ThreadSessionMapRepository.prototype, 'findByChannelAndThread').mockResolvedValue(
       null
@@ -684,6 +704,7 @@ describe('agor_gateway_channels MCP tools', () => {
       messages: [],
     }));
     vi.mocked(getConnector).mockReturnValue({ fetchThreadHistory } as any);
+    spyCallerSessionBranch('branch-1');
     vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(slackChannel as any);
     vi.spyOn(ThreadSessionMapRepository.prototype, 'findByChannelAndThread').mockResolvedValue(
       null
@@ -710,6 +731,7 @@ describe('agor_gateway_channels MCP tools', () => {
   });
 
   it('rejects Slack history for non-Slack gateway mappings before connector use', async () => {
+    spyCallerSessionBranch('branch-1');
     vi.spyOn(ThreadSessionMapRepository.prototype, 'findBySession').mockResolvedValue(
       threadMapping as any
     );
@@ -803,6 +825,210 @@ describe('agor_gateway_channels MCP tools', () => {
       target: 'thread:C123:171234.000100',
     });
     expect(existingThread.success).toBe(false);
+  });
+});
+
+describe('gateway session branch binding (MCP)', () => {
+  const outboundChannelBranch1 = {
+    ...slackChannel,
+    id: 'chan-b1',
+    target_branch_id: 'branch-1',
+    config: { ...slackChannel.config, outbound_enabled: true, default_outbound_target: '#eng' },
+  };
+  const outboundChannelBranch2 = {
+    ...slackChannel,
+    id: 'chan-b2',
+    target_branch_id: 'branch-2',
+    config: { ...slackChannel.config, outbound_enabled: true },
+  };
+
+  function spyOutboundChannels() {
+    vi.spyOn(GatewayChannelRepository.prototype, 'findAll').mockResolvedValue([
+      outboundChannelBranch1,
+      outboundChannelBranch2,
+    ] as any);
+    vi.spyOn(BranchRepository.prototype, 'findById').mockImplementation(
+      async (id) => ({ branch_id: id, name: `wt-${id}`, others_can: 'view' }) as any
+    );
+  }
+
+  it('emit inputSchema rejects injected session/user attribution fields', async () => {
+    const tools = await captureTools('member', makeFakeApp({ gateway: { emitMessage: vi.fn() } }));
+
+    for (const extra of [
+      { emittedBySessionId: 'sess-evil' },
+      { sessionId: 'sess-evil' },
+      { emittedByUserId: 'user-evil' },
+    ]) {
+      const parsed = tools.agor_gateway_emit_message.cfg.inputSchema.safeParse({
+        gatewayChannelId: 'chan-1',
+        message: 'Hello',
+        ...extra,
+      });
+      expect(parsed.success).toBe(false);
+    }
+  });
+
+  it('scopes outbound targets to the calling session branch even for admins', async () => {
+    spyCallerSessionBranch('branch-1');
+    spyOutboundChannels();
+
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_outbound_targets_list.handler({});
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.channels).toHaveLength(1);
+    expect(payload.channels[0]).toMatchObject({
+      gateway_channel_id: 'chan-b1',
+      target_branch_id: 'branch-1',
+    });
+    expect(payload.hint).toBeUndefined();
+  });
+
+  it('returns empty with a binding note when branchId conflicts with the session branch', async () => {
+    spyCallerSessionBranch('branch-1');
+    spyOutboundChannels();
+
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_outbound_targets_list.handler({
+      branchId: 'branch-2',
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.channels).toEqual([]);
+    expect(payload.binding).toContain("scoped to the calling session's branch");
+  });
+
+  it('keeps unscoped outbound targets for callers without session context', async () => {
+    const sessionSpy = spyCallerSessionBranch('branch-1');
+    spyOutboundChannels();
+
+    const tools = await captureTools('admin', makeFakeApp({}), null);
+    const result = await tools.agor_gateway_outbound_targets_list.handler({});
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(
+      payload.channels.map((c: { gateway_channel_id: string }) => c.gateway_channel_id)
+    ).toEqual(['chan-b1', 'chan-b2']);
+    expect(sessionSpy).not.toHaveBeenCalled();
+  });
+
+  it('hints when no outbound channel targets the session branch', async () => {
+    spyCallerSessionBranch('branch-3');
+    spyOutboundChannels();
+
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_outbound_targets_list.handler({});
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.channels).toEqual([]);
+    expect(payload.hint).toContain('No outbound-enabled channel targets');
+  });
+
+  it('fails closed when the calling session cannot be loaded', async () => {
+    spyCallerSessionBranch(null);
+    spyOutboundChannels();
+
+    const tools = await captureTools('admin');
+    await expect(tools.agor_gateway_outbound_targets_list.handler({})).rejects.toThrow(
+      'calling session not found'
+    );
+  });
+
+  it('denies session-mapped thread history across branches even for admins', async () => {
+    spyCallerSessionBranch('branch-1');
+    vi.spyOn(ThreadSessionMapRepository.prototype, 'findBySession').mockResolvedValue({
+      ...threadMapping,
+      branch_id: 'branch-2',
+    } as any);
+    const sessionsGet = vi.fn(async () => ({ session_id: 'sess-42', branch_id: 'branch-2' }));
+
+    const tools = await captureTools('admin', makeFakeApp({ sessions: { get: sessionsGet } }));
+    const error: Error = await tools.agor_gateway_slack_thread_history_get
+      .handler({ sessionId: 'sess-42' })
+      .then(() => {
+        throw new Error('expected thread history read to be denied');
+      })
+      .catch((err: Error) => err);
+
+    expect(error.message).toContain('Gateway read denied');
+    expect(error.message).not.toContain('branch-2');
+    expect(getConnector).not.toHaveBeenCalled();
+  });
+
+  it('denies session-mapped thread history when the channel was retargeted to another branch', async () => {
+    spyCallerSessionBranch('branch-1');
+    vi.spyOn(ThreadSessionMapRepository.prototype, 'findBySession').mockResolvedValue({
+      ...threadMapping,
+      branch_id: 'branch-1',
+    } as any);
+    vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue({
+      ...slackChannel,
+      target_branch_id: 'branch-2',
+    } as any);
+    const sessionsGet = vi.fn(async () => ({ session_id: 'sess-42', branch_id: 'branch-1' }));
+
+    const tools = await captureTools('admin', makeFakeApp({ sessions: { get: sessionsGet } }));
+    const error: Error = await tools.agor_gateway_slack_thread_history_get
+      .handler({ sessionId: 'sess-42' })
+      .then(() => {
+        throw new Error('expected thread history read to be denied');
+      })
+      .catch((err: Error) => err);
+
+    expect(error.message).toContain('Gateway read denied');
+    expect(error.message).not.toContain('branch-2');
+    expect(getConnector).not.toHaveBeenCalled();
+  });
+
+  it('denies explicit thread history when the channel targets another branch, even for admins', async () => {
+    spyCallerSessionBranch('branch-1');
+    vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue({
+      ...slackChannel,
+      target_branch_id: 'branch-2',
+    } as any);
+    const findMapping = vi.spyOn(ThreadSessionMapRepository.prototype, 'findByChannelAndThread');
+
+    const tools = await captureTools('admin');
+    await expect(
+      tools.agor_gateway_slack_thread_history_get.handler({
+        gatewayChannelId: 'chan-1',
+        threadId: 'C123-171234.000100',
+      })
+    ).rejects.toThrow('Gateway read denied');
+
+    expect(findMapping).not.toHaveBeenCalled();
+    expect(getConnector).not.toHaveBeenCalled();
+  });
+
+  it('keeps the no-session admin path for unmapped explicit thread reads', async () => {
+    const fetchThreadHistory = vi.fn(async () => ({
+      threadId: 'C123-171234.000100',
+      channel: 'C123',
+      thread_ts: '171234.000100',
+      has_more: false,
+      messages: [],
+    }));
+    vi.mocked(getConnector).mockReturnValue({ fetchThreadHistory } as any);
+    const sessionSpy = spyCallerSessionBranch('branch-1');
+    vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(slackChannel as any);
+    vi.spyOn(ThreadSessionMapRepository.prototype, 'findByChannelAndThread').mockResolvedValue(
+      null
+    );
+    vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+
+    const tools = await captureTools('admin', makeFakeApp({}), null);
+    const result = await tools.agor_gateway_slack_thread_history_get.handler({
+      gatewayChannelId: 'chan-1',
+      threadId: 'C123-171234.000100',
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(sessionSpy).not.toHaveBeenCalled();
+    expect(payload.thread).toMatchObject({
+      source: 'explicit',
+      thread_id: 'C123-171234.000100',
+    });
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -48,6 +48,32 @@ function requireAdmin(ctx: McpContext, action: string): void {
   }
 }
 
+/**
+ * Session-context gateway calls are hard-bound to the calling session's
+ * branch, with no admin-role bypass — agent sessions run as admin users, so a
+ * role bypass would let any session use another assistant's channel. Callers
+ * without session context (personal API keys) keep the user-permission model.
+ * Fails closed when a session ID is present but the session cannot be loaded.
+ */
+async function resolveCallerSessionBranchId(ctx: McpContext): Promise<BranchID | null> {
+  if (!ctx.sessionId) return null;
+  const session = await new SessionRepository(ctx.db).findById(ctx.sessionId);
+  if (!session) {
+    throw new Error('Gateway access denied: calling session not found');
+  }
+  return session.branch_id as BranchID;
+}
+
+/**
+ * Deliberately never echoes the target's branch, so a denied read cannot be
+ * used to enumerate which branch a foreign channel or thread serves.
+ */
+function sessionBranchReadDeniedError(): Error {
+  return new Error(
+    "Gateway read denied: this Slack thread belongs to a gateway channel targeting a different branch than the calling session's. Sessions can read Slack thread history only through gateway channels whose target branch matches their own."
+  );
+}
+
 async function canUseGatewayOutbound(
   ctx: McpContext,
   branchRepo: BranchRepository,
@@ -389,6 +415,7 @@ async function resolveSlackThreadHistoryTarget(
   const channelRepo = new GatewayChannelRepository(ctx.db);
   const threadMapRepo = new ThreadSessionMapRepository(ctx.db);
   const branchRepo = new BranchRepository(ctx.db);
+  const callerSessionBranchId = await resolveCallerSessionBranchId(ctx);
 
   if (args.sessionId) {
     const session = (await ctx.app
@@ -401,9 +428,15 @@ async function resolveSlackThreadHistoryTarget(
     if (!mapping) {
       throw new Error(`No gateway thread mapping found for session ${session.session_id}.`);
     }
+    if (callerSessionBranchId && mapping.branch_id !== callerSessionBranchId) {
+      throw sessionBranchReadDeniedError();
+    }
     const channel = await channelRepo.findById(mapping.channel_id);
     if (!channel) {
       throw new Error(`Gateway channel not found for session mapping ${mapping.id}.`);
+    }
+    if (callerSessionBranchId && channel.target_branch_id !== callerSessionBranchId) {
+      throw sessionBranchReadDeniedError();
     }
     const branch = await branchRepo.findById(mapping.branch_id);
     return {
@@ -419,6 +452,9 @@ async function resolveSlackThreadHistoryTarget(
   const channel = await channelRepo.findById(args.gatewayChannelId as string);
   if (!channel) {
     throw new Error(`Gateway channel not found: ${args.gatewayChannelId}`);
+  }
+  if (callerSessionBranchId && channel.target_branch_id !== callerSessionBranchId) {
+    throw sessionBranchReadDeniedError();
   }
   const mapping = await threadMapRepo.findByChannelAndThread(channel.id, args.threadId as string);
   if (mapping) {
@@ -789,7 +825,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     'agor_gateway_outbound_targets_list',
     {
       description:
-        'List Slack gateway outbound targets the caller can use. Returns only outbound-enabled channels where the caller has branch all permission or admin access. Secrets and inbound channel keys are never returned.',
+        "List Slack gateway outbound targets the caller can use. Returns only outbound-enabled channels where the caller has branch all permission or admin access; when called from a session, results are additionally scoped to channels targeting the session's branch. Secrets and inbound channel keys are never returned.",
       annotations: { readOnlyHint: true },
       inputSchema: z.strictObject({
         branchId: mcpOptionalId('branchId', 'Branch', 'Filter by target branch ID.'),
@@ -804,8 +840,17 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     async (args) => {
       const channelRepo = new GatewayChannelRepository(ctx.db);
       const branchRepo = new BranchRepository(ctx.db);
+      const callerSessionBranchId = await resolveCallerSessionBranchId(ctx);
       const branchFilter = args.branchId ? await branchRepo.findById(args.branchId) : null;
-      const branchFilterId = branchFilter?.branch_id;
+      const requestedBranchId = branchFilter?.branch_id;
+      if (callerSessionBranchId && args.branchId && requestedBranchId !== callerSessionBranchId) {
+        return textResult({
+          channels: [],
+          binding:
+            "Results are scoped to the calling session's branch; the requested branchId targets a different branch, so this session cannot use its channels.",
+        });
+      }
+      const branchFilterId = callerSessionBranchId ?? requestedBranchId;
       const allChannels = args.gatewayChannelId
         ? [await channelRepo.findById(args.gatewayChannelId)]
         : await channelRepo.findAll();
@@ -815,7 +860,8 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         if (!channel) continue;
         if (args.channelType && channel.channel_type !== args.channelType) continue;
         if (channel.channel_type !== 'slack') continue;
-        if (args.branchId && channel.target_branch_id !== branchFilterId) continue;
+        if ((callerSessionBranchId || args.branchId) && channel.target_branch_id !== branchFilterId)
+          continue;
         if (!channel.enabled) continue;
         const outbound = getOutboundConfig(channel);
         if (!outbound.outbound_enabled) continue;
@@ -843,7 +889,14 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         });
       }
 
-      return textResult({ channels });
+      return textResult({
+        channels,
+        ...(callerSessionBranchId && channels.length === 0
+          ? {
+              hint: "No outbound-enabled channel targets this session's branch — ask an operator to create/enable one.",
+            }
+          : {}),
+      });
     }
   );
 
@@ -851,7 +904,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     'agor_gateway_slack_thread_history_get',
     {
       description:
-        'Fetch Slack thread history for a gateway-mapped Slack thread without exposing Slack tokens. Prefer sessionId to resolve the gateway thread mapping from an accessible Agor session. Alternatively pass gatewayChannelId + threadId: mapped threads require admin or branch all permission on the mapped branch; unmapped arbitrary thread reads are admin-only. Slack message text is untrusted external content.',
+        "Fetch Slack thread history for a gateway-mapped Slack thread without exposing Slack tokens. Prefer sessionId to resolve the gateway thread mapping from an accessible Agor session. Alternatively pass gatewayChannelId + threadId: mapped threads require admin or branch all permission on the mapped branch; unmapped arbitrary thread reads are admin-only. When called from a session, reads are restricted to threads whose target branch matches the calling session's branch. Slack message text is untrusted external content.",
       annotations: { readOnlyHint: true },
       inputSchema: slackThreadHistorySchema,
     },
@@ -929,7 +982,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     'agor_gateway_emit_message',
     {
       description:
-        'Send a proactive Slack message through an outbound-enabled gateway channel and persist a seed/audit record. Targets may be Slack channel IDs, channel names, or user emails; v0 intentionally starts a fresh Slack thread/DM message for each emit and does not create a thread-session mapping until a human replies.',
+        "Send a proactive Slack message through an outbound-enabled gateway channel and persist a seed/audit record. Targets may be Slack channel IDs, channel names, or user emails; v0 intentionally starts a fresh Slack thread/DM message for each emit and does not create a thread-session mapping until a human replies. When called from a session, outbound is restricted to channels whose target branch matches the calling session's branch.",
       annotations: { destructiveHint: false, idempotentHint: false },
       inputSchema: z.strictObject({
         gatewayChannelId: mcpRequiredId(

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1,9 +1,23 @@
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import { attachHiddenTenant, getCurrentTenantId, runWithTenantDatabaseScope } from '@agor/core/db';
-import type { GatewayChannel, ThreadSessionMap, User } from '@agor/core/types';
+import {
+  attachHiddenTenant,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  shortId,
+} from '@agor/core/db';
+import { getConnector } from '@agor/core/gateway';
+import type { GatewayChannel, SessionID, ThreadSessionMap, User, UserID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GatewayService, tenantIdFromGatewayChannel } from './gateway.js';
+
+vi.mock('@agor/core/gateway', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/gateway')>();
+  return {
+    ...actual,
+    getConnector: vi.fn(),
+  };
+});
 
 const user: User = {
   user_id: 'user-1',
@@ -121,6 +135,10 @@ function makeGatewayHarness(args: {
 
   return { service, promptCreate, sessionsCreate, channelRepo, threadMapRepo };
 }
+
+afterEach(() => {
+  vi.mocked(getConnector).mockReset();
+});
 
 describe('gateway tenant metadata helpers', () => {
   it('extracts non-enumerable tenant metadata from gateway channel DTOs', () => {
@@ -641,5 +659,138 @@ describe('GatewayService Slack streaming', () => {
       recipientTeamId: undefined,
     });
     expect(service.wasTaskStreamedToSlack?.('task-1')).toBe(true);
+  });
+});
+
+describe('GatewayService outbound emit session branch binding', () => {
+  const outboundChannel: GatewayChannel = {
+    ...slackChannel,
+    id: 'chan-outbound',
+    config: {
+      bot_token: 'xoxb-test',
+      outbound_enabled: true,
+      default_outbound_target: 'channel:C123',
+    },
+  } as unknown as GatewayChannel;
+
+  function makeEmitHarness(args: { session?: { session_id: string; branch_id: string } | null }) {
+    const { service } = makeGatewayHarness({ channel: outboundChannel });
+    const sendSlackMessage = vi.fn(async () => ({
+      ts: '200.000100',
+      channel: 'C123',
+      thread_ts: '200.000100',
+      permalink: null,
+    }));
+    vi.mocked(getConnector).mockReturnValue({ sendSlackMessage } as never);
+    const outboundRepo = {
+      create: vi.fn(async (data: Record<string, unknown>) => ({ id: 'out-1', ...data })),
+      findUnconsumedByChannelAndThread: vi.fn(async () => null),
+    };
+    const sessionRepo = { findById: vi.fn(async () => args.session ?? null) };
+    const branchRepo = {
+      findById: vi.fn(async () => ({
+        branch_id: outboundChannel.target_branch_id,
+        others_can: 'view',
+      })),
+      isOwner: vi.fn(async () => false),
+      resolveUserPermission: vi.fn(async () => 'view'),
+    };
+    (service as unknown as { outboundRepo: unknown }).outboundRepo = outboundRepo;
+    (service as unknown as { sessionRepo: unknown }).sessionRepo = sessionRepo;
+    (service as unknown as { branchRepo: unknown }).branchRepo = branchRepo;
+    return { service, sendSlackMessage, outboundRepo, sessionRepo, branchRepo };
+  }
+
+  type EmitData = Parameters<GatewayService['emitMessage']>[0];
+
+  function emitData(overrides: Partial<EmitData> = {}): EmitData {
+    return {
+      gatewayChannelId: 'chan-outbound',
+      message: 'ship update',
+      emittedByUserId: 'user-1' as UserID,
+      userRole: 'admin',
+      ...overrides,
+    };
+  }
+
+  it('allows a same-branch session emit and keeps session attribution on the audit row', async () => {
+    const { service, sendSlackMessage, outboundRepo } = makeEmitHarness({
+      session: { session_id: 'sess-1', branch_id: 'branch-1' },
+    });
+
+    const result = await service.emitMessage(
+      emitData({ emittedBySessionId: 'sess-1' as SessionID })
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      gateway_outbound_message_id: 'out-1',
+      gateway_channel_id: 'chan-outbound',
+    });
+    expect(sendSlackMessage).toHaveBeenCalledTimes(1);
+    expect(outboundRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ emitted_by_session_id: 'sess-1' })
+    );
+  });
+
+  it('denies a cross-branch session emit even with admin role, before any Slack send', async () => {
+    const { service, sendSlackMessage, outboundRepo, sessionRepo } = makeEmitHarness({
+      session: { session_id: 'sess-1', branch_id: 'branch-2' },
+    });
+
+    await expect(
+      service.emitMessage(emitData({ emittedBySessionId: 'sess-1' as SessionID }))
+    ).rejects.toThrow(/Gateway outbound denied/);
+    expect(sessionRepo.findById).toHaveBeenCalledWith('sess-1');
+    expect(sendSlackMessage).not.toHaveBeenCalled();
+    expect(outboundRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('names the session branch but never the channel target branch in the denial', async () => {
+    const { service } = makeEmitHarness({
+      session: { session_id: 'sess-1', branch_id: 'branch-2' },
+    });
+
+    const error: Error = await service
+      .emitMessage(emitData({ emittedBySessionId: 'sess-1' as SessionID }))
+      .then(() => {
+        throw new Error('expected emit to be denied');
+      })
+      .catch((err: Error) => err);
+
+    expect(error.message).toContain(shortId('sess-1'));
+    expect(error.message).toContain(shortId('branch-2'));
+    expect(error.message).not.toContain(outboundChannel.target_branch_id);
+    expect(error.message).not.toContain(shortId(outboundChannel.target_branch_id));
+  });
+
+  it('fails closed when the emitting session cannot be found', async () => {
+    const { service, sendSlackMessage, outboundRepo } = makeEmitHarness({ session: null });
+
+    await expect(
+      service.emitMessage(emitData({ emittedBySessionId: 'sess-gone' as SessionID }))
+    ).rejects.toThrow('Gateway outbound denied: emitting session not found');
+    expect(sendSlackMessage).not.toHaveBeenCalled();
+    expect(outboundRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps admin access for calls without session context', async () => {
+    const { service, sendSlackMessage, sessionRepo } = makeEmitHarness({});
+
+    const result = await service.emitMessage(emitData());
+
+    expect(result).toMatchObject({ success: true });
+    expect(sessionRepo.findById).not.toHaveBeenCalled();
+    expect(sendSlackMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies no-session members without branch all permission', async () => {
+    const { service, sendSlackMessage, branchRepo } = makeEmitHarness({});
+
+    await expect(service.emitMessage(emitData({ userRole: 'member' }))).rejects.toThrow(
+      'Insufficient branch permission'
+    );
+    expect(branchRepo.resolveUserPermission).toHaveBeenCalled();
+    expect(sendSlackMessage).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -16,6 +16,7 @@ import {
   MCPServerRepository,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
+  SessionRepository,
   shortId,
   type TenantScopeAwareDatabase,
   ThreadSessionMapRepository,
@@ -106,6 +107,12 @@ interface EmitGatewayMessageData {
   target?: string;
   purpose?: string;
   emittedByUserId: UserID;
+  /**
+   * Trust contract: must be sourced from verified auth context (MCP
+   * ctx.sessionId), never from tool/user input. When set, the outbound emit is
+   * hard-bound to the session's branch — it is denied unless the session's
+   * branch matches the channel's target branch, regardless of user role.
+   */
   emittedBySessionId?: SessionID;
   emittedByTaskId?: string;
   emittedByScheduleId?: string;
@@ -546,6 +553,7 @@ export class GatewayService {
   private threadMapRepo: ThreadSessionMapRepository;
   private outboundRepo: GatewayOutboundMessageRepository;
   private branchRepo: BranchRepository;
+  private sessionRepo: SessionRepository;
   private usersRepo: UsersRepository;
 
   private mcpServerRepo: MCPServerRepository;
@@ -594,6 +602,7 @@ export class GatewayService {
     this.threadMapRepo = new ThreadSessionMapRepository(db);
     this.outboundRepo = new GatewayOutboundMessageRepository(db);
     this.branchRepo = new BranchRepository(db);
+    this.sessionRepo = new SessionRepository(db);
     this.usersRepo = new UsersRepository(db);
 
     this.mcpServerRepo = new MCPServerRepository(db);
@@ -1331,6 +1340,28 @@ export class GatewayService {
     }
   }
 
+  /**
+   * Session-context emits are hard-bound to the session's branch, with no
+   * admin-role bypass — agent sessions run as admin users, so a role bypass
+   * would let any session impersonate another assistant's channel. The error
+   * deliberately never echoes the channel's target branch, so a denied emit
+   * cannot be used to enumerate which branch a foreign channel serves.
+   */
+  private async ensureSessionBranchBoundToChannel(
+    channel: GatewayChannel,
+    sessionId: SessionID
+  ): Promise<void> {
+    const session = await this.sessionRepo.findById(sessionId);
+    if (!session) {
+      throw new Error('Gateway outbound denied: emitting session not found');
+    }
+    if (session.branch_id !== channel.target_branch_id) {
+      throw new Error(
+        `Gateway outbound denied: session ${shortId(sessionId)} runs on branch ${shortId(session.branch_id)}, but this channel targets a different branch. Sessions can emit only through gateway channels whose target branch matches their own. Call agor_gateway_outbound_targets_list to see usable channels.`
+      );
+    }
+  }
+
   private async ensureCanEmitFromChannel(
     channel: GatewayChannel,
     userId: UserID,
@@ -1374,6 +1405,9 @@ export class GatewayService {
       throw new Error('Gateway outbound is disabled for this channel');
     }
 
+    if (data.emittedBySessionId) {
+      await this.ensureSessionBranchBoundToChannel(channel, data.emittedBySessionId);
+    }
     await this.ensureCanEmitFromChannel(channel, data.emittedByUserId, data.userRole);
 
     const target =

--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -95,6 +95,10 @@ Slack DM                    Agor Daemon                    Agent
 
 The outbound routing is a lightweight after-hook on message creation. For sessions without a gateway mapping (the vast majority), it's a single database lookup that returns immediately — effectively a no-op.
 
+### Outbound branch binding
+
+Proactive outbound emits (`agor_gateway_emit_message`) and Slack thread history reads made from a session are bound to that session's own branch: the gateway channel's target branch must match the calling session's branch, and there is no admin-role bypass. `agor_gateway_outbound_targets_list` only returns channels a session can actually use. Calls made without session context (personal API keys) follow the regular user-permission model instead.
+
 ## Slack thread behavior
 
 In Slack channels, Agor uses a hard mention rule:


### PR DESCRIPTION
## The bug (confused deputy)

Gateway channels each have a `target_branch_id`, and inbound routing is branch-scoped — but **outbound was not**. `agor_gateway_emit_message` takes an explicit `gatewayChannelId`, and its only authorization (`ensureCanEmitFromChannel`) early-returns for admin role, otherwise checking the *user's* permission on the *channel's* branch. Nothing tied the **calling session's** branch to the channel. Since assistant sessions run as admin users, any session could call `agor_gateway_outbound_targets_list`, discover another assistant's channel, and emit through it — impersonating that assistant's Slack bot. The same leak applied to reads via `agor_gateway_slack_thread_history_get`.

## The fix

Whenever the caller has session context (`ctx.sessionId` present — always true for agent sessions), outbound emit and Slack thread reads now require `session.branch_id === channel.target_branch_id`:

- **`GatewayService.emitMessage`** — when `emittedBySessionId` is set (server-derived from MCP `ctx.sessionId`, never tool input; the input zod schema is strict and rejects injected attribution fields), a new `ensureSessionBranchBoundToChannel` check runs **before** `ensureCanEmitFromChannel`, with **no admin-role bypass** (agents *are* admins — a bypass would make the fix a no-op; this is deliberate). Fails closed if the session can't be loaded. The denial message names the caller's branch but never echoes the channel's target branch (anti-enumeration).
- **`agor_gateway_slack_thread_history_get`** — both the `sessionId`-mapping path and the explicit `gatewayChannelId`+`threadId` path deny cross-branch reads for session-context callers, with the same anti-enumeration property. Existing admin/`'all'`-permission checks are unchanged for no-session callers.
- **`agor_gateway_outbound_targets_list`** — results are force-scoped to the calling session's branch (even for admins). A conflicting `args.branchId` returns `channels: []` plus a binding note (no throw); an empty result includes a hint to ask an operator.
- Calls **without** session context (personal API keys `agor_sk_`, i.e. human operators) keep today's user-permission model unchanged. No escape hatch in v1.

Tests cover: same-branch emit success with session attribution on the audit row; cross-branch emit denied *while admin* with no Slack send and no audit row; fail-closed on missing session; unchanged no-session admin/member paths; strict-schema rejection of injected `emittedBySessionId`/`sessionId`; targets-list scoping/conflict/hint/no-session cases; and thread-history cross-branch denial (mapped + explicit) alongside unchanged no-session admin reads.

## CI note

`check:multitenancy-boundaries` is pre-existing-red on `main` (4 benign hits: 3 in daemon test files that drive tenant scope / flush macrotasks, plus one type-only `Database` import in `widgets/env-vars/index.ts`) — all unchanged by this PR. It is a known-unrelated failure the team merges over; this PR deliberately does not modify the shared check script.

## Stacking

**Stacked on #1745** (#1743 ← #1745 ← this). Base is `gateway-token-widget`, not `main`; this will be rebased onto `main` after #1743/#1745 merge.

## Residual risks (known, out of scope)

- (a) An agent could `agor_sessions_create` a session **on the victim branch** and have it emit — that's a separate authorization layer and the emit is then correctly attributed to a session genuinely on that branch; out of scope here.
- (b) Human personal-API-key callers without a session header keep the user-permission model **by design**.
- (c) REST `sessions.patch` `branch_id` re-parenting is a human-only surface; a possible one-line follow-up is adding `branch_id` to `ensureSessionImmutability`.
- (d) `config.allowed_emitter_branch_ids` is the designated future escape-hatch extension point if cross-branch emits ever need to be sanctioned per channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
