### PR TITLE
perf(agor-ui): push whole-map store subscriptions out of the always-mounted App shell

### DIFF
--- a/apps/agor-ui/src/components/App/App.rerender.test.tsx
+++ b/apps/agor-ui/src/components/App/App.rerender.test.tsx
@@ -1,0 +1,256 @@
+import type { Board, BoardComment, Branch, Session, User } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { forwardRef } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { App } from './App';
+
+// The shell's own render count. The mocked AppHeader is a plain (un-memoized)
+// function component rendered unconditionally by App, so its invocation count
+// is a faithful proxy for how many times the shell rendered.
+let shellRenders = 0;
+
+vi.mock('../AppHeader', () => ({
+  AppHeader: () => {
+    shellRenders += 1;
+    return null;
+  },
+}));
+vi.mock('../BoardAssistantPanel', () => ({
+  BoardAssistantPanel: () => null,
+}));
+vi.mock('../HomePage', () => ({
+  HomePage: () => null,
+}));
+vi.mock('../SessionCanvas', () => ({
+  SessionCanvas: forwardRef(() => null),
+}));
+vi.mock('../SessionPanel', () => ({
+  SessionPanel: () => null,
+}));
+vi.mock('../EventStreamPanel', () => ({
+  EventStreamPanel: () => null,
+}));
+vi.mock('../NewSessionButton', () => ({
+  NewSessionButton: () => null,
+}));
+vi.mock('../SettingsModal', () => ({
+  SettingsModal: () => null,
+  UserSettingsModal: () => null,
+}));
+vi.mock('../BranchModal', () => ({
+  BranchModal: () => null,
+}));
+vi.mock('../CreateDialog', () => ({
+  CreateDialog: () => null,
+}));
+vi.mock('../NewSessionModal', () => ({
+  NewSessionModal: () => null,
+}));
+vi.mock('../SessionSettingsModal', () => ({
+  SessionSettingsModal: () => null,
+}));
+vi.mock('../TerminalModal', () => ({
+  TerminalModal: () => null,
+  WEB_TERMINAL_MIN_ROLE: 'member',
+}));
+vi.mock('../ThemeEditorModal', () => ({
+  ThemeEditorModal: () => null,
+}));
+vi.mock('../EnvironmentLogsModal', () => ({
+  EnvironmentLogsModal: () => null,
+}));
+// Chime hook subscribes to socket events / audio — irrelevant here.
+vi.mock('../../hooks/useTaskCompletionChime', () => ({
+  useTaskCompletionChime: () => {},
+}));
+// react-resizable-panels needs real layout measurements (jsdom has none) and
+// throws from the imperative expand/resize handles App drives in effects.
+vi.mock('react-resizable-panels', async () => {
+  const React = await import('react');
+  const noopHandle = { collapse: () => {}, expand: () => {}, resize: () => {} };
+  const Panel = React.forwardRef<unknown, { children?: React.ReactNode }>(({ children }, ref) => {
+    React.useImperativeHandle(ref, () => noopHandle, []);
+    return <div>{children}</div>;
+  });
+  return {
+    Panel,
+    PanelGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    PanelResizeHandle: () => <div />,
+  };
+});
+
+const BOARD_ID = 'board-1';
+const board = { board_id: BOARD_ID, name: 'Board', slug: BOARD_ID } as unknown as Board;
+
+// A branch that lives on the CURRENT board (via board_objects) and one that
+// does not — patches touching the latter's entities must not wake the shell.
+const onBoardBranch = {
+  branch_id: 'wt-on-board',
+  repo_id: 'repo-1',
+  board_id: BOARD_ID,
+  name: 'on-board',
+} as unknown as Branch;
+const offBoardBranch = {
+  branch_id: 'wt-off-board',
+  repo_id: 'repo-1',
+  board_id: 'board-other',
+  name: 'off-board',
+} as unknown as Branch;
+
+const user = { user_id: 'u1', name: 'User', email: 'u@example.test' } as unknown as User;
+
+function makeSession(id: string, branchId: string, status = 'idle'): Session {
+  return {
+    session_id: id,
+    branch_id: branchId,
+    status,
+    archived: false,
+  } as unknown as Session;
+}
+
+function seedStore() {
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    boardById: new Map([[board.board_id, board]]),
+    branchById: new Map([
+      [onBoardBranch.branch_id, onBoardBranch],
+      [offBoardBranch.branch_id, offBoardBranch],
+    ]),
+    boardObjectsByBoardId: new Map([
+      [
+        BOARD_ID,
+        [
+          {
+            board_object_id: 'bo-1',
+            board_id: BOARD_ID,
+            branch_id: onBoardBranch.branch_id,
+          },
+        ],
+      ],
+    ]) as never,
+    sessionById: new Map([['s-off', makeSession('s-off', offBoardBranch.branch_id)]]),
+    sessionsByBranch: new Map([
+      [offBoardBranch.branch_id, [makeSession('s-off', offBoardBranch.branch_id)]],
+    ]),
+  });
+}
+
+function renderShell() {
+  return render(
+    <AntApp>
+      <MemoryRouter initialEntries={[`/b/${BOARD_ID}/`]}>
+        <Routes>
+          <Route
+            path="/b/:boardParam/*"
+            element={
+              <App
+                client={null}
+                user={user}
+                connected={true}
+                availableAgents={[]}
+                initialBoardId={BOARD_ID}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </AntApp>
+  );
+}
+
+describe('App shell re-render isolation on a board view', () => {
+  beforeEach(() => {
+    shellRenders = 0;
+    seedStore();
+  });
+
+  it('an irrelevant session patch does not re-render the shell', async () => {
+    renderShell();
+    await waitFor(() => {
+      expect(shellRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = shellRenders;
+
+    // Patch a session on a branch that is NOT on the current board — the
+    // shell holds no whole-map subscription, so it must stay quiet.
+    act(() => {
+      const next = new Map(agorStore.getState().sessionById);
+      next.set('s-off', makeSession('s-off', offBoardBranch.branch_id, 'running'));
+      const nextByBranch = new Map(agorStore.getState().sessionsByBranch);
+      nextByBranch.set(offBoardBranch.branch_id, [
+        makeSession('s-off', offBoardBranch.branch_id, 'running'),
+      ]);
+      agorStore.setState({ sessionById: next, sessionsByBranch: nextByBranch });
+    });
+
+    expect(shellRenders).toBe(baseline);
+  });
+
+  it('an irrelevant (other-board) comment patch does not re-render the shell', async () => {
+    renderShell();
+    await waitFor(() => {
+      expect(shellRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = shellRenders;
+
+    act(() => {
+      const comment = {
+        comment_id: 'c-other',
+        board_id: 'board-other',
+        content: 'hello @User',
+        resolved: false,
+      } as unknown as BoardComment;
+      agorStore.setState({ commentById: new Map([[comment.comment_id, comment]]) });
+    });
+
+    expect(shellRenders).toBe(baseline);
+  });
+
+  it('a current-board unresolved comment DOES re-render the shell (badge count)', async () => {
+    // Contrast case proving the narrow comment subscription is live — the
+    // isolation above is meaningful, not a dead subscription.
+    renderShell();
+    await waitFor(() => {
+      expect(shellRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = shellRenders;
+
+    act(() => {
+      const comment = {
+        comment_id: 'c-here',
+        board_id: BOARD_ID,
+        content: 'needs attention',
+        resolved: false,
+      } as unknown as BoardComment;
+      agorStore.setState({ commentById: new Map([[comment.comment_id, comment]]) });
+    });
+
+    await waitFor(() => {
+      expect(shellRenders).toBeGreaterThan(baseline);
+    });
+  });
+
+  it('a patch to a branch ON the current board re-renders the shell (canvas data)', async () => {
+    // Second contrast: boardBranches (shallow-compared derived selector)
+    // must fire when a member branch's identity changes.
+    renderShell();
+    await waitFor(() => {
+      expect(shellRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = shellRenders;
+
+    act(() => {
+      const next = new Map(agorStore.getState().branchById);
+      next.set(onBoardBranch.branch_id, { ...onBoardBranch, name: 'renamed' } as Branch);
+      agorStore.setState({ branchById: next });
+    });
+
+    await waitFor(() => {
+      expect(shellRenders).toBeGreaterThan(baseline);
+    });
+  });
+});

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -2,8 +2,6 @@ import type {
   AgorClient,
   Artifact,
   Board,
-  BoardComment,
-  BoardEntityObject,
   BoardID,
   Branch,
   CreateLocalRepoRequest,
@@ -30,7 +28,6 @@ import {
 } from 'react-resizable-panels';
 import { useLocation, useParams } from 'react-router-dom';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
-import { mapToArray } from '@/utils/mapHelpers';
 import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { useRegisterBoardSwitcher } from '../../contexts/CanvasNavigationContext';
 import { useAppNavigation } from '../../hooks/useAppNavigation';
@@ -43,23 +40,24 @@ import { useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { useTaskCompletionChime } from '../../hooks/useTaskCompletionChime';
 import { type ActiveUrlTarget, useUrlState } from '../../hooks/useUrlState';
 import { useUserLocalStorage } from '../../hooks/useUserLocalStorage';
-import { useAgorStore } from '../../store/agorStore';
+import { agorStore, shallow, useAgorStore, useStoreWithEqualityFn } from '../../store/agorStore';
 import {
+  makeBoardSelector,
+  makeBranchesForBoardSelector,
+  makeBranchSelector,
+  makeCommentMentionSelector,
+  makeRepoSelector,
+  makeSessionExistsSelector,
+  makeSessionMcpServerIdsSelector,
+  makeSessionSelector,
+  makeSessionsForBranchSelector,
+  makeUnreadCommentCountSelector,
   selectArtifactById,
   selectBoardById,
-  selectBoardObjectById,
-  selectBoardObjectsByBoardId,
+  selectBoardCount,
   selectBranchById,
-  selectCardById,
-  selectCardTypeById,
-  selectCommentById,
-  selectGatewayChannelById,
-  selectMcpServerById,
-  selectRepoById,
+  selectFirstBoardId,
   selectSessionById,
-  selectSessionMcpServerIds,
-  selectSessionsByBranch,
-  selectUserById,
 } from '../../store/selectors';
 import type { AgenticToolOption } from '../../types';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
@@ -97,6 +95,39 @@ const BoardSwitcherBridge: React.FC<{ setCurrentBoardId: (id: string) => void }>
   setCurrentBoardId,
 }) => {
   useRegisterBoardSwitcher(setCurrentBoardId);
+  return null;
+};
+
+/** Hosts the URL⇄state sync in a null-rendering child. useUrlState must
+ *  observe the whole entity maps (a deep-linked short ID resolves only once
+ *  the entity streams in), so those subscriptions live here where a patch
+ *  re-renders nothing instead of the whole shell. Effect-order note: as a
+ *  child, these effects fire before App's own — the sync is guarded by
+ *  refs/`syncingRef` and is order-insensitive within a commit. */
+const UrlStateBridge: React.FC<{
+  currentBoardId: string;
+  currentSessionId: string | null;
+  onBoardChange: (boardId: string) => void;
+  onSessionChange: (sessionId: string | null) => void;
+  onActiveUrlTargetChange: (target: ActiveUrlTarget | null) => void;
+}> = ({
+  currentBoardId,
+  currentSessionId,
+  onBoardChange,
+  onSessionChange,
+  onActiveUrlTargetChange,
+}) => {
+  useUrlState({
+    currentBoardId,
+    currentSessionId,
+    boardById: useAgorStore(selectBoardById),
+    sessionById: useAgorStore(selectSessionById),
+    branchById: useAgorStore(selectBranchById),
+    artifactById: useAgorStore(selectArtifactById),
+    onBoardChange,
+    onSessionChange,
+    onActiveUrlTargetChange,
+  });
   return null;
 };
 
@@ -199,9 +230,8 @@ export interface AppProps {
 // common no-MCP case so that downstream React.memo bailouts are not defeated.
 // Frozen at runtime; the consuming components only read it.
 const EMPTY_STRING_ARRAY: string[] = Object.freeze([] as string[]) as string[];
-const EMPTY_BOARD_OBJECTS: BoardEntityObject[] = Object.freeze(
-  [] as BoardEntityObject[]
-) as BoardEntityObject[];
+const EMPTY_BOARDS: Board[] = Object.freeze([] as Board[]) as Board[];
+const EMPTY_SESSIONS: Session[] = Object.freeze([] as Session[]) as Session[];
 
 // 320px keeps the three left-panel tabs (Assistant / All sessions / Comments)
 // on one readable line with Ant's tab padding at the 768px desktop breakpoint.
@@ -313,27 +343,11 @@ export const App: React.FC<AppProps> = ({
   webTerminalEnabled = false,
   branchStorageConfig,
 }) => {
-  // Entity maps are read straight from the store via narrow slice selectors
-  // (rather than received as props). Each selector subscribes to a single
-  // slice, so App only re-renders when that specific slice's reference changes
-  // — and the derivations below keep their exact prior logic and memoization,
-  // only their data SOURCE moves from props to the store.
-  const sessionById = useAgorStore(selectSessionById);
-  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
-  const boardById = useAgorStore(selectBoardById);
-  const boardObjectById = useAgorStore(selectBoardObjectById);
-  const boardObjectsByBoardId = useAgorStore(selectBoardObjectsByBoardId);
-  const commentById = useAgorStore(selectCommentById);
-  const cardById = useAgorStore(selectCardById);
-  const cardTypeById = useAgorStore(selectCardTypeById);
-  const repoById = useAgorStore(selectRepoById);
-  const branchById = useAgorStore(selectBranchById);
-  const userById = useAgorStore(selectUserById);
-  const mcpServerById = useAgorStore(selectMcpServerById);
-  const sessionMcpServerIds = useAgorStore(selectSessionMcpServerIds);
-  const gatewayChannelById = useAgorStore(selectGatewayChannelById);
-  const artifactById = useAgorStore(selectArtifactById);
-
+  // The always-mounted shell holds NO whole-map subscriptions. Everything it
+  // needs is either a narrow per-id / derived-scalar selector below (which
+  // stays quiet across unrelated entity patches), a call-time
+  // `agorStore.getState()` read inside a handler, or pushed down into the
+  // component that actually consumes the map (SettingsModal, UrlStateBridge).
   const { showWarning } = useThemedMessage();
   const location = useLocation();
   const routeParams = useParams<{
@@ -375,16 +389,13 @@ export const App: React.FC<AppProps> = ({
   // theme token styles. By computing the effective ID synchronously, the
   // Panel conditional evaluates to false in the *same* render, producing a
   // single-phase unmount identical to the explicit-close path.
-  const effectiveSelectedSessionId = useMemo(
-    () =>
-      !isRootHomePath &&
-      !pendingHomeNavigation &&
-      selectedSessionId &&
-      sessionById.has(selectedSessionId)
-        ? selectedSessionId
-        : null,
-    [isRootHomePath, pendingHomeNavigation, selectedSessionId, sessionById]
+  const selectedSessionExists = useAgorStore(
+    useMemo(() => makeSessionExistsSelector(selectedSessionId), [selectedSessionId])
   );
+  const effectiveSelectedSessionId =
+    !isRootHomePath && !pendingHomeNavigation && selectedSessionId && selectedSessionExists
+      ? selectedSessionId
+      : null;
 
   const [leftPanelTab, setLeftPanelTab] = useState<BoardAssistantPanelTab>('assistant');
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
@@ -395,9 +406,22 @@ export const App: React.FC<AppProps> = ({
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const handleResize = () => setViewportWidth(window.innerWidth);
+    // Debounced: viewportWidth only feeds panel min-size percentages, so
+    // re-rendering the shell on every resize tick is wasted work — the
+    // trailing value is all that matters.
+    let timer: number | null = null;
+    const handleResize = () => {
+      if (timer !== null) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        timer = null;
+        setViewportWidth(window.innerWidth);
+      }, 150);
+    };
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    return () => {
+      if (timer !== null) window.clearTimeout(timer);
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   const leftPanelMinSize = useMemo(
@@ -445,7 +469,9 @@ export const App: React.FC<AppProps> = ({
     24
   );
 
-  const currentBoard = boardById.get(currentBoardId);
+  const currentBoard = useAgorStore(
+    useMemo(() => makeBoardSelector(currentBoardId), [currentBoardId])
+  );
   const isHomeSurface = (isRootHomePath || pendingHomeNavigation) && !hasExplicitEntityTarget;
   const headerBoardId = isHomeSurface ? '' : currentBoardId;
   const headerBoard = isHomeSurface ? undefined : currentBoard;
@@ -555,11 +581,10 @@ export const App: React.FC<AppProps> = ({
 
   // Recent-board visit tracking + the id list HomePage consumes. AppHeader owns
   // its own pill derivation from the store (so it isn't fed an unstable array),
-  // and the localStorage-backed recents list keeps both in sync.
-  const { recentBoardIds, trackBoardVisit } = useRecentBoards(
-    mapToArray(boardById),
-    currentBoardId
-  );
+  // and the localStorage-backed recents list keeps both in sync. The boards arg
+  // only shapes `recentBoards`, which the shell does not consume — passing the
+  // stable empty list avoids a whole-map subscription here.
+  const { recentBoardIds, trackBoardVisit } = useRecentBoards(EMPTY_BOARDS, currentBoardId);
 
   // Persist current board to localStorage when it changes
   useEffect(() => {
@@ -596,34 +621,18 @@ export const App: React.FC<AppProps> = ({
     }
   }, [effectiveSelectedSessionId, effectiveSessionPanelSize, eventStreamPanelCollapsed]);
 
-  // URL state synchronization - bidirectional sync between URL and state
-  useUrlState({
-    currentBoardId,
-    currentSessionId: effectiveSelectedSessionId,
-    boardById,
-    sessionById,
-    branchById,
-    artifactById,
-    onBoardChange: (boardId) => {
-      setCurrentBoardIdInternal(boardId);
-    },
-    onSessionChange: (sessionId) => {
-      setSelectedSessionId(sessionId);
-    },
-    onActiveUrlTargetChange: setActiveUrlTarget,
-  });
+  // URL⇄state sync renders via UrlStateBridge (in the JSX below) so its
+  // whole-map subscriptions never wake the shell. Stable callbacks only.
+  const handleUrlBoardChange = useCallback((boardId: string) => {
+    setCurrentBoardIdInternal(boardId);
+  }, []);
 
   // Central navigation API. Every deliberate "go to X" call site routes
   // through this so the URL stays the single source of truth and the back
   // button restores prior board+session+camera. The hook reads live data
-  // via refs internally so its function identities stay stable across
-  // socket churn — important because they flow into memoized children.
-  const navigation = useAppNavigation({
-    boardById,
-    sessionById,
-    branchById,
-    artifactById,
-  });
+  // from the store at call time so its function identities stay stable
+  // across socket churn — important because they flow into memoized children.
+  const navigation = useAppNavigation();
 
   const handleHomeBoardClick = useCallback(
     (boardId: string) => navigation.goToBoard(boardId),
@@ -658,23 +667,26 @@ export const App: React.FC<AppProps> = ({
   );
 
   // If the stored board no longer exists (deleted/archived), fall back to the
-  // first board. Distinguish the two reasons `boardById` can be empty:
+  // first board. Distinguish the two reasons the board map can be empty:
   //   - Disconnected and data was never loaded, or was momentarily wiped by a
   //     stale upstream effect → treat as transient, keep the id sticky so the
   //     `/b/<id>` URL survives.
   //   - Connected with an authoritative empty set (user deleted last board) →
   //     clear the selection so we stop pointing at a tombstone.
+  // Subscribes to board-list scalars (count / first id) plus the narrow
+  // `currentBoard` read above, not the whole map.
+  const boardCount = useAgorStore(selectBoardCount);
+  const firstBoardId = useAgorStore(selectFirstBoardId);
   useEffect(() => {
-    if (boardById.size === 0) {
+    if (boardCount === 0) {
       if (!connected) return;
       if (currentBoardId) setCurrentBoardId('');
       return;
     }
-    if (currentBoardId && !boardById.has(currentBoardId)) {
-      const fallback = mapToArray(boardById)[0]?.board_id || '';
-      setCurrentBoardId(fallback);
+    if (currentBoardId && !currentBoard) {
+      setCurrentBoardId(firstBoardId || '');
     }
-  }, [boardById, currentBoardId, setCurrentBoardId, connected]);
+  }, [boardCount, firstBoardId, currentBoard, currentBoardId, setCurrentBoardId, connected]);
 
   // Recalculate default position when board changes while modal is open
   // This ensures branches spawn at the center of the new board's viewport
@@ -686,16 +698,8 @@ export const App: React.FC<AppProps> = ({
     }
   }, [currentBoardId, createDialogOpen]);
 
-  const currentBoardObjects = useMemo(
-    () =>
-      currentBoardId
-        ? boardObjectsByBoardId.get(currentBoardId) || EMPTY_BOARD_OBJECTS
-        : EMPTY_BOARD_OBJECTS,
-    [boardObjectsByBoardId, currentBoardId]
-  );
-
   // Update favicon based on session activity on current board
-  useFaviconStatus(currentBoardId, sessionsByBranch, currentBoardObjects);
+  useFaviconStatus(currentBoardId);
 
   // Check if event stream is enabled in user preferences (default: true)
   const eventStreamEnabled = user?.preferences?.eventStream?.enabled ?? true;
@@ -836,7 +840,7 @@ export const App: React.FC<AppProps> = ({
         branchName: result.branchName,
         sourceBranch: result.sourceBranch,
       },
-      { client, repoById, onCreateBranch, onUpdateBranch }
+      { client, repoById: agorStore.getState().repoById, onCreateBranch, onUpdateBranch }
     );
 
     if (!branch) {
@@ -896,22 +900,15 @@ export const App: React.FC<AppProps> = ({
     navigation.goToBranch(branch.branch_id);
   };
 
-  // Refs for the data `handleSessionClick` reads. Using refs (vs
-  // useCallback deps) keeps the handler's identity stable across
-  // socket-driven map churn — important because it flows through
-  // SessionCanvas → initialNodes deps and a flipping identity would
-  // cascade re-renders into every BranchCard. Inline `useRef(...)`
-  // rather than going through a helper so biome's
-  // `useExhaustiveDependencies` heuristic recognizes the refs as
-  // stable and doesn't false-positive on `.current.get` reads.
-  const sessionByIdRef = useRef(sessionById);
-  sessionByIdRef.current = sessionById;
-  const branchByIdRef = useRef(branchById);
-  branchByIdRef.current = branchById;
-
   const handleSessionClick = useCallback(
     (sessionId: string) => {
-      const session = sessionByIdRef.current.get(sessionId);
+      // Call-time store read: the shell no longer subscribes to the session /
+      // branch maps, so any render-time snapshot here would be stale. The
+      // handler's identity stays stable across socket churn — important
+      // because it flows through SessionCanvas → initialNodes deps and a
+      // flipping identity would cascade re-renders into every BranchCard.
+      const { sessionById, branchById } = agorStore.getState();
+      const session = sessionById.get(sessionId);
 
       // Best-effort: clear highlight flags when opening the conversation.
       // These updates may fail silently if the user lacks write permission (e.g. read-only
@@ -923,7 +920,7 @@ export const App: React.FC<AppProps> = ({
           .catch(() => {});
       }
 
-      const branch = session?.branch_id ? branchByIdRef.current.get(session.branch_id) : undefined;
+      const branch = session?.branch_id ? branchById.get(session.branch_id) : undefined;
       if (client && branch?.needs_attention) {
         client
           .service('branches')
@@ -967,10 +964,25 @@ export const App: React.FC<AppProps> = ({
     [client, user?.user_id]
   );
 
-  const selectedSession = effectiveSelectedSessionId
-    ? sessionById.get(effectiveSelectedSessionId) || null
-    : null;
-  const selectedSessionBranch = selectedSession ? branchById.get(selectedSession.branch_id) : null;
+  // Narrow per-id subscriptions: only patches to the SELECTED session (and
+  // its branch) wake the shell — those renders are needed to feed
+  // SessionPanel fresh props anyway.
+  const selectedSession =
+    useAgorStore(
+      useMemo(() => makeSessionSelector(effectiveSelectedSessionId), [effectiveSelectedSessionId])
+    ) ?? null;
+  const selectedSessionBranchId = selectedSession?.branch_id;
+  const selectedSessionBranch =
+    useAgorStore(
+      useMemo(() => makeBranchSelector(selectedSessionBranchId), [selectedSessionBranchId])
+    ) ?? null;
+  const selectedSessionMcpServerIds =
+    useAgorStore(
+      useMemo(
+        () => makeSessionMcpServerIdsSelector(effectiveSelectedSessionId),
+        [effectiveSelectedSessionId]
+      )
+    ) ?? EMPTY_STRING_ARRAY;
 
   // Sync the actual state when a session disappears (for URL, localStorage, etc.).
   // The rendering already uses effectiveSelectedSessionId so this is mostly
@@ -981,22 +993,31 @@ export const App: React.FC<AppProps> = ({
   // with the current board before clearing selection so archive/delete closes
   // the drawer and does not resurrect the card.
   useEffect(() => {
-    if (selectedSessionId && !sessionById.has(selectedSessionId)) {
+    if (selectedSessionId && !selectedSessionExists) {
       if (routeParams.sessionShortId && currentBoardId) {
         navigation.goToBoard(currentBoardId, { replace: true });
       }
       setSelectedSessionId(null);
     }
-  }, [currentBoardId, navigation, routeParams.sessionShortId, selectedSessionId, sessionById]);
+  }, [
+    currentBoardId,
+    navigation,
+    routeParams.sessionShortId,
+    selectedSessionId,
+    selectedSessionExists,
+  ]);
 
-  const sessionSettingsSession = sessionSettingsId ? sessionById.get(sessionSettingsId) : null;
+  const sessionSettingsSession =
+    useAgorStore(useMemo(() => makeSessionSelector(sessionSettingsId), [sessionSettingsId])) ??
+    null;
   const primaryAssistantId = currentBoard?.primary_assistant_id ?? null;
-  const primaryAssistantBranch = primaryAssistantId
-    ? branchById.get(primaryAssistantId)
-    : undefined;
-  const primaryAssistantRepo = primaryAssistantBranch
-    ? repoById.get(primaryAssistantBranch.repo_id)
-    : undefined;
+  const primaryAssistantBranch = useAgorStore(
+    useMemo(() => makeBranchSelector(primaryAssistantId), [primaryAssistantId])
+  );
+  const primaryAssistantRepoId = primaryAssistantBranch?.repo_id;
+  const primaryAssistantRepo = useAgorStore(
+    useMemo(() => makeRepoSelector(primaryAssistantRepoId), [primaryAssistantRepoId])
+  );
   const primaryAssistantInaccessible = Boolean(primaryAssistantId && !primaryAssistantBranch);
 
   // Preserve the historical board-switch behavior now that the panel itself
@@ -1010,50 +1031,53 @@ export const App: React.FC<AppProps> = ({
   useBoardTitle(currentBoard);
 
   // Find branch and repo for BranchModal
-  const selectedBranch = branchModalBranchId ? branchById.get(branchModalBranchId) : null;
-  const selectedBranchRepo = selectedBranch ? repoById.get(selectedBranch.repo_id) : null;
-  const branchSessions = selectedBranch ? sessionsByBranch.get(selectedBranch.branch_id) || [] : [];
+  const selectedBranch =
+    useAgorStore(useMemo(() => makeBranchSelector(branchModalBranchId), [branchModalBranchId])) ??
+    null;
+  const selectedBranchRepoId = selectedBranch?.repo_id;
+  const selectedBranchRepo =
+    useAgorStore(useMemo(() => makeRepoSelector(selectedBranchRepoId), [selectedBranchRepoId])) ??
+    null;
+  const selectedBranchId = selectedBranch?.branch_id;
+  const branchSessions =
+    useAgorStore(
+      useMemo(() => makeSessionsForBranchSelector(selectedBranchId), [selectedBranchId])
+    ) ?? EMPTY_SESSIONS;
 
   // Find branch for NewSessionModal
-  const newSessionBranch = newSessionBranchId ? branchById.get(newSessionBranchId) : null;
+  const newSessionBranch =
+    useAgorStore(useMemo(() => makeBranchSelector(newSessionBranchId), [newSessionBranchId])) ??
+    null;
 
-  // Filter branches by current board (via board_objects). Memoized so that
-  // unrelated socket churn (e.g. another user's session patch) doesn't
-  // produce a fresh array reference on every render — that array flows into
-  // SessionCanvas's `initialNodes` deps and would otherwise cascade into
-  // every BranchCard re-rendering.
-  const boardBranches = useMemo(
-    () =>
-      currentBoardObjects
-        .filter((bo: BoardEntityObject) => bo.branch_id)
-        .map((bo: BoardEntityObject) => branchById.get(bo.branch_id!))
-        .filter((wt): wt is Branch => wt !== undefined),
-    [currentBoardObjects, branchById]
+  // Branch for the environment-logs modal (open only while the id is set).
+  const logsModalBranch = useAgorStore(
+    useMemo(() => makeBranchSelector(logsModalBranchId), [logsModalBranchId])
   );
 
-  // Check if current user is mentioned in active comments. Keep this memoized so
-  // route/UI state changes do not rescan the global comments map.
-  const activeComments = useMemo(
-    () =>
-      mapToArray(commentById).filter(
-        (c: BoardComment) => c.board_id === currentBoardId && !c.resolved
-      ),
-    [commentById, currentBoardId]
+  // Branches on the current board (via board_objects), derived in the store
+  // layer with shallow equality: only membership changes or a member branch's
+  // patch produce a fresh array — unrelated socket churn keeps the reference,
+  // which matters because this flows into SessionCanvas's `initialNodes` deps
+  // and would otherwise cascade into every BranchCard re-rendering.
+  const boardBranches = useStoreWithEqualityFn(
+    agorStore,
+    useMemo(() => makeBranchesForBoardSelector(currentBoardId), [currentBoardId]),
+    shallow
   );
 
+  // Comment-derived header scalars. Subscribing to the derived number/boolean
+  // (instead of the comment map) keeps comment edits that don't change them —
+  // and all comments on other boards — from waking the shell.
   const currentUserName = user?.name || user?.email?.split('@')[0] || '';
-  const hasUserMentions =
-    !!currentUserName &&
-    activeComments.some((comment) => {
-      // Check if comment content mentions the user
-      const mentionPatterns = [
-        `@${currentUserName}`,
-        `@"${currentUserName}"`,
-        `@${user?.email}`,
-        `@"${user?.email}"`,
-      ];
-      return mentionPatterns.some((pattern) => comment.content.includes(pattern));
-    });
+  const unreadCommentsCount = useAgorStore(
+    useMemo(() => makeUnreadCommentCountSelector(currentBoardId), [currentBoardId])
+  );
+  const hasUserMentions = useAgorStore(
+    useMemo(
+      () => makeCommentMentionSelector(currentBoardId, currentUserName || undefined, user?.email),
+      [currentBoardId, currentUserName, user?.email]
+    )
+  );
 
   // Web terminal is gated by both the instance-level feature flag and the
   // user's role (`WEB_TERMINAL_MIN_ROLE`, shared with TerminalModal so the
@@ -1062,51 +1086,14 @@ export const App: React.FC<AppProps> = ({
   // terminal buttons via `{onOpenTerminal && ...}`.
   const canOpenTerminal = webTerminalEnabled && hasMinimumRole(user?.role, WEB_TERMINAL_MIN_ROLE);
 
-  // Memoize AppActionsContext value with useCallback-wrapped handlers
-  const appActionsValue = useMemo(
-    () => ({
-      onSendPrompt,
-      onFork: onForkSession,
-      onBtwFork: onBtwForkSession,
-      onSubsession: onSpawnSession,
-      onUpdateSession,
-      onDeleteSession,
-      onPermissionDecision: handlePermissionDecision,
-      onStartEnvironment,
-      onStopEnvironment,
-      onNukeEnvironment,
-      onViewLogs: (branchId: string) => setLogsModalBranchId(branchId),
-      onOpenSettings: (sessionId: string) => setSessionSettingsId(sessionId),
-      onSessionClick: handleSessionClick,
-      onOpenBranch: (branchId: string, tab?: BranchModalTab) => {
-        setBranchModalBranchId(branchId);
-        setBranchModalTab(tab);
-      },
-      onOpenTerminal: canOpenTerminal ? handleOpenTerminal : undefined,
-    }),
-    [
-      onSendPrompt,
-      onForkSession,
-      onBtwForkSession,
-      onSpawnSession,
-      onUpdateSession,
-      onDeleteSession,
-      handlePermissionDecision,
-      onStartEnvironment,
-      onStopEnvironment,
-      onNukeEnvironment,
-      handleSessionClick,
-      handleOpenTerminal,
-      canOpenTerminal,
-    ]
-  );
-
   // Stabilize the passthrough action props before they reach the memoized
-  // SessionCanvas. These arrive from AppContent as plain consts (fresh identity
-  // on every store-driven re-render); without freezing them, SessionCanvas's
-  // React.memo would re-render on every live patch even when nothing it draws
-  // changed. Every other SessionCanvas prop is already stable (memoized values,
-  // useState setters, or useCallback handlers).
+  // SessionCanvas and the AppActions context value. These arrive from
+  // AppContent as plain consts (fresh identity on every store-driven
+  // re-render); without freezing them, SessionCanvas's React.memo — and every
+  // AppActions consumer — would re-render whenever the parent re-renders,
+  // even when nothing they draw changed.
+  const stableOnSendPrompt = useStableCallback(onSendPrompt);
+  const stableOnBtwForkSession = useStableCallback(onBtwForkSession);
   const stableOnSessionUpdate = useStableCallback(onUpdateSession);
   const stableOnSessionDelete = useStableCallback(onDeleteSession);
   const stableOnForkSession = useStableCallback(onForkSession);
@@ -1117,6 +1104,58 @@ export const App: React.FC<AppProps> = ({
   const stableOnStopEnvironment = useStableCallback(onStopEnvironment);
   const stableOnNukeEnvironment = useStableCallback(onNukeEnvironment);
 
+  // Modal-opener handlers shared by the context value and panel props.
+  const handleViewLogs = useCallback((branchId: string) => setLogsModalBranchId(branchId), []);
+  const handleOpenSessionSettings = useCallback(
+    (sessionId: string) => setSessionSettingsId(sessionId),
+    []
+  );
+  const handleOpenBranchModal = useCallback((branchId: string, tab?: BranchModalTab) => {
+    setBranchModalBranchId(branchId);
+    setBranchModalTab(tab);
+  }, []);
+
+  // Memoize AppActionsContext value from identity-stable handlers only, so
+  // the provider value survives shell re-renders and context consumers stay
+  // quiet unless terminal availability actually flips.
+  const appActionsValue = useMemo(
+    () => ({
+      onSendPrompt: stableOnSendPrompt,
+      onFork: stableOnForkSession,
+      onBtwFork: stableOnBtwForkSession,
+      onSubsession: stableOnSpawnSession,
+      onUpdateSession: stableOnSessionUpdate,
+      onDeleteSession: stableOnSessionDelete,
+      onPermissionDecision: handlePermissionDecision,
+      onStartEnvironment: stableOnStartEnvironment,
+      onStopEnvironment: stableOnStopEnvironment,
+      onNukeEnvironment: stableOnNukeEnvironment,
+      onViewLogs: handleViewLogs,
+      onOpenSettings: handleOpenSessionSettings,
+      onSessionClick: handleSessionClick,
+      onOpenBranch: handleOpenBranchModal,
+      onOpenTerminal: canOpenTerminal ? handleOpenTerminal : undefined,
+    }),
+    [
+      stableOnSendPrompt,
+      stableOnForkSession,
+      stableOnBtwForkSession,
+      stableOnSpawnSession,
+      stableOnSessionUpdate,
+      stableOnSessionDelete,
+      handlePermissionDecision,
+      stableOnStartEnvironment,
+      stableOnStopEnvironment,
+      stableOnNukeEnvironment,
+      handleViewLogs,
+      handleOpenSessionSettings,
+      handleSessionClick,
+      handleOpenBranchModal,
+      handleOpenTerminal,
+      canOpenTerminal,
+    ]
+  );
+
   // Stabilize the remaining passthrough props (schedule + comment actions) and
   // the panel's inline-arrow handlers so the memoized BoardAssistantPanel's
   // React.memo bailout holds — every prop it receives stays referentially stable
@@ -1126,16 +1165,22 @@ export const App: React.FC<AppProps> = ({
   const stableOnResolveComment = useStableCallback(onResolveComment);
   const stableOnToggleReaction = useStableCallback(onToggleReaction);
   const stableOnDeleteComment = useStableCallback(onDeleteComment);
-  const handleAssistantOpenSettings = useStableCallback(
-    (branchId: string, tab?: BranchModalTab) => {
-      setBranchModalBranchId(branchId);
-      setBranchModalTab(tab);
-    }
-  );
   const handleAssistantSendComment = useStableCallback((content: string) =>
     onSendComment?.(currentBoardId || '', content)
   );
   const handleAssistantCollapse = useStableCallback(() => setCommentsPanelCollapsed(true));
+
+  // Identity-stable branch actions for EventStreamPanel (previously an inline
+  // object literal whose identity flipped on every shell render).
+  const eventStreamBranchActions = useMemo(
+    () => ({
+      onSessionClick: handleSessionClick,
+      onCreateSession: (branchId: string) => setNewSessionBranchId(branchId),
+      onOpenSettings: (branchId: string) => setBranchModalBranchId(branchId),
+      onNukeEnvironment: stableOnNukeEnvironment,
+    }),
+    [handleSessionClick, stableOnNukeEnvironment]
+  );
 
   // Header action handlers, frozen so the memoized AppHeader's React.memo bailout
   // isn't defeated by a fresh inline-arrow identity on every App re-render. Each
@@ -1173,6 +1218,13 @@ export const App: React.FC<AppProps> = ({
   return (
     <AppActionsProvider value={appActionsValue}>
       <BoardSwitcherBridge setCurrentBoardId={setCurrentBoardId} />
+      <UrlStateBridge
+        currentBoardId={currentBoardId}
+        currentSessionId={effectiveSelectedSessionId}
+        onBoardChange={handleUrlBoardChange}
+        onSessionChange={setSelectedSessionId}
+        onActiveUrlTargetChange={setActiveUrlTarget}
+      />
       <Layout style={{ height: '100vh' }}>
         <AppHeader
           user={user}
@@ -1190,9 +1242,7 @@ export const App: React.FC<AppProps> = ({
           onRetryConnection={stableOnRetryConnection}
           currentBoardName={headerBoard?.name}
           currentBoardIcon={headerBoard?.icon}
-          unreadCommentsCount={
-            activeComments.filter((c: BoardComment) => !c.parent_comment_id).length
-          }
+          unreadCommentsCount={unreadCommentsCount}
           eventStreamEnabled={eventStreamEnabled}
           hasUserMentions={hasUserMentions}
           currentBoardId={headerBoardId}
@@ -1245,7 +1295,7 @@ export const App: React.FC<AppProps> = ({
                   onForkSession={stableOnForkSession}
                   onSpawnSession={stableOnSpawnSession}
                   onArchiveOrDelete={stableOnArchiveOrDeleteBranch}
-                  onOpenSettings={handleAssistantOpenSettings}
+                  onOpenSettings={handleOpenBranchModal}
                   onOpenSessionSettings={setSessionSettingsId}
                   onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
                   onStartEnvironment={stableOnStartEnvironment}
@@ -1415,10 +1465,7 @@ export const App: React.FC<AppProps> = ({
                           session={selectedSession}
                           branch={selectedSessionBranch}
                           currentUserId={user?.user_id}
-                          sessionMcpServerIds={
-                            sessionMcpServerIds.get(effectiveSelectedSessionId) ??
-                            EMPTY_STRING_ARRAY
-                          }
+                          sessionMcpServerIds={selectedSessionMcpServerIds}
                           open={!!effectiveSelectedSessionId}
                           onClose={handleCloseSessionPanel}
                         />
@@ -1432,12 +1479,7 @@ export const App: React.FC<AppProps> = ({
                           selectedSessionId={effectiveSelectedSessionId}
                           currentBoard={currentBoard}
                           client={client}
-                          branchActions={{
-                            onSessionClick: handleSessionClick,
-                            onCreateSession: (branchId) => setNewSessionBranchId(branchId),
-                            onOpenSettings: (branchId) => setBranchModalBranchId(branchId),
-                            onNukeEnvironment,
-                          }}
+                          branchActions={eventStreamBranchActions}
                         />
                       )}
                     </Panel>
@@ -1524,15 +1566,6 @@ export const App: React.FC<AppProps> = ({
           }}
           client={client}
           currentUser={user}
-          boardById={boardById}
-          boardObjects={mapToArray(boardObjectById)}
-          repoById={repoById}
-          branchById={branchById}
-          sessionsByBranch={sessionsByBranch}
-          userById={userById}
-          mcpServerById={mcpServerById}
-          cardById={cardById}
-          cardTypeById={cardTypeById}
           activeTab={effectiveSettingsTab}
           onTabChange={(newTab) => {
             setSettingsSection(newTab as Parameters<typeof setSettingsSection>[0]);
@@ -1562,11 +1595,9 @@ export const App: React.FC<AppProps> = ({
           onDeleteUser={onDeleteUser}
           onCreateMCPServer={onCreateMCPServer}
           onDeleteMCPServer={onDeleteMCPServer}
-          gatewayChannelById={gatewayChannelById}
           onCreateGatewayChannel={onCreateGatewayChannel}
           onUpdateGatewayChannel={onUpdateGatewayChannel}
           onDeleteGatewayChannel={onDeleteGatewayChannel}
-          artifactById={artifactById}
           onUpdateArtifact={onUpdateArtifact}
           onDeleteArtifact={onDeleteArtifact}
           onCreateAssistant={() => {
@@ -1644,7 +1675,7 @@ export const App: React.FC<AppProps> = ({
           <EnvironmentLogsModal
             open={!!logsModalBranchId}
             onClose={() => setLogsModalBranchId(null)}
-            branch={branchById.get(logsModalBranchId)!}
+            branch={logsModalBranch!}
             client={client}
           />
         )}

--- a/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
+++ b/apps/agor-ui/src/components/CallbackToggleButton/CallbackTargetDisplay.tsx
@@ -3,9 +3,10 @@ import { shortId } from '@agor-live/client';
 import { DisconnectOutlined, LinkOutlined } from '@ant-design/icons';
 import { Badge, Space, Typography, theme } from 'antd';
 import type React from 'react';
+import { useMemo } from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAgorStore } from '../../store/agorStore';
-import { selectSessionById } from '../../store/selectors';
+import { makeSessionSelector } from '../../store/selectors';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 
 interface CallbackTargetDisplayProps {
@@ -42,7 +43,6 @@ export const CallbackTargetDisplay: React.FC<CallbackTargetDisplayProps> = ({
 }) => {
   const { token } = theme.useToken();
   const { onSessionClick } = useAppActions();
-  const sessionById = useAgorStore(selectSessionById);
 
   const remoteRelationship = session.remote_relationships?.as_target?.find(
     (relationship) => relationship.relationship_type === 'remote_create'
@@ -54,9 +54,12 @@ export const CallbackTargetDisplay: React.FC<CallbackTargetDisplayProps> = ({
     remoteParentId ??
     session.genealogy?.parent_session_id;
 
-  if (!targetId) return null;
+  // Subscribe to the single target session, not the whole session map — one
+  // of these renders per session footer/row, so a whole-map subscription
+  // would wake every instance on every session patch.
+  const target = useAgorStore(useMemo(() => makeSessionSelector(targetId), [targetId]));
 
-  const target = sessionById.get(targetId);
+  if (!targetId) return null;
   // Mirror CallbackToggleButton's resolution: spawned sessions default to
   // enabled unless explicitly disabled.
   const enabled = session.callback_config?.enabled ?? remoteRelationship?.callback_enabled ?? true;

--- a/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/SettingsModal.tsx
@@ -2,16 +2,12 @@ import type {
   AgorClient,
   Artifact,
   Board,
-  BoardEntityObject,
   Branch,
-  CardType,
-  CardWithType,
   CreateLocalRepoRequest,
   CreateMCPServerInput,
   CreateRepoRequest,
   CreateUserInput,
   GatewayChannel,
-  MCPServer,
   Repo,
   Session,
   UpdateUserInput,
@@ -36,8 +32,23 @@ import type { MenuProps } from 'antd';
 import { Layout, Menu, Modal, theme } from 'antd';
 import { useMemo, useState } from 'react';
 import type { BranchStorageConfig } from '@/utils/branchStorage';
+import { mapToArray } from '@/utils/mapHelpers';
 import { useServiceEnabled } from '../../hooks/useServicesConfig';
 import { SETTINGS_SECTIONS, type SettingsSection } from '../../hooks/useSettingsRoute';
+import { useAgorStore } from '../../store/agorStore';
+import {
+  selectArtifactById,
+  selectBoardById,
+  selectBoardObjectById,
+  selectBranchById,
+  selectCardById,
+  selectCardTypeById,
+  selectGatewayChannelById,
+  selectMcpServerById,
+  selectRepoById,
+  selectSessionsByBranch,
+  selectUserById,
+} from '../../store/selectors';
 import { BranchModal } from '../BranchModal';
 import type { BranchUpdate } from '../BranchModal/tabs/GeneralTab';
 import { AboutTab } from './AboutTab';
@@ -60,15 +71,6 @@ export interface SettingsModalProps {
   onClose: () => void;
   client: AgorClient | null; // Still needed for BranchModal
   currentUser?: User | null; // Current logged-in user
-  boardById: Map<string, Board>;
-  boardObjects: BoardEntityObject[];
-  repoById: Map<string, Repo>;
-  branchById: Map<string, Branch>;
-  sessionsByBranch: Map<string, Session[]>; // O(1) branch filtering
-  userById: Map<string, User>;
-  mcpServerById: Map<string, MCPServer>;
-  cardById?: Map<string, CardWithType>;
-  cardTypeById?: Map<string, CardType>;
   activeTab?: string; // Control which tab is shown when modal opens
   onTabChange?: (tabKey: string) => void;
   onCreateBoard?: (board: Partial<Board>) => void;
@@ -110,11 +112,9 @@ export interface SettingsModalProps {
   onDeleteUser?: (userId: string) => void;
   onCreateMCPServer?: (data: CreateMCPServerInput) => void;
   onDeleteMCPServer?: (serverId: string) => void;
-  gatewayChannelById?: Map<string, GatewayChannel>;
   onCreateGatewayChannel?: (data: Partial<GatewayChannel>) => void;
   onUpdateGatewayChannel?: (channelId: string, updates: Partial<GatewayChannel>) => void;
   onDeleteGatewayChannel?: (channelId: string) => void;
-  artifactById?: Map<string, Artifact>;
   onUpdateArtifact?: (artifactId: string, updates: Partial<Artifact>) => void;
   onDeleteArtifact?: (artifactId: string) => void;
   onCreateAssistant?: () => void;
@@ -126,15 +126,6 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
   onClose,
   client,
   currentUser,
-  boardById,
-  boardObjects,
-  repoById,
-  branchById,
-  sessionsByBranch,
-  userById,
-  mcpServerById,
-  cardById = new Map(),
-  cardTypeById = new Map(),
   activeTab = 'boards',
   onTabChange,
   onCreateBoard,
@@ -157,16 +148,31 @@ const SettingsModalContent: React.FC<SettingsModalProps> = ({
   onDeleteUser,
   onCreateMCPServer,
   onDeleteMCPServer,
-  gatewayChannelById = new Map(),
   onCreateGatewayChannel,
   onUpdateGatewayChannel,
   onDeleteGatewayChannel,
-  artifactById = new Map(),
   onUpdateArtifact,
   onDeleteArtifact,
   onCreateAssistant,
   branchStorageConfig,
 }) => {
+  // Entity maps come straight from the store rather than through App props:
+  // the modal only mounts while open (the exported wrapper returns null when
+  // closed), so these subscriptions cost the always-mounted shell nothing and
+  // re-render only the open modal on entity patches.
+  const boardById = useAgorStore(selectBoardById);
+  const boardObjectById = useAgorStore(selectBoardObjectById);
+  const repoById = useAgorStore(selectRepoById);
+  const branchById = useAgorStore(selectBranchById);
+  const sessionsByBranch = useAgorStore(selectSessionsByBranch);
+  const userById = useAgorStore(selectUserById);
+  const mcpServerById = useAgorStore(selectMcpServerById);
+  const cardById = useAgorStore(selectCardById);
+  const cardTypeById = useAgorStore(selectCardTypeById);
+  const gatewayChannelById = useAgorStore(selectGatewayChannelById);
+  const artifactById = useAgorStore(selectArtifactById);
+  const boardObjects = useMemo(() => mapToArray(boardObjectById), [boardObjectById]);
+
   const [selectedBranch, setSelectedBranch] = useState<Branch | null>(null);
   const [selectedRepo, setSelectedRepo] = useState<Repo | null>(null);
   const [branchSessions, setBranchSessions] = useState<Session[]>([]);

--- a/apps/agor-ui/src/hooks/useAppNavigation.ts
+++ b/apps/agor-ui/src/hooks/useAppNavigation.ts
@@ -29,22 +29,19 @@ import { artifactPath, branchPath, sessionPath } from '@agor-live/client';
 import { useCallback, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useRecenterMap } from '../contexts/CanvasNavigationContext';
+import { agorStore } from '../store/agorStore';
 import { buildBoardPath } from './useUrlState';
 
 interface UseAppNavigationOptions {
-  /** App.tsx passes its local `boardById` so URL building can prefer slugs. */
-  boardById: Map<string, { board_id: string; slug?: string }>;
-  /** Sessions, branches, and artifacts are passed in as args (rather than
-   *  read from the store) to keep this navigation hook decoupled from store
-   *  wiring and to mirror `useUrlState`'s arg-passing pattern.
-   *
-   *  Each map is optional: callers only pass what their methods need
-   *  (e.g. a Settings table that only uses `goToBranch` can omit
-   *  `sessionById` and `artifactById`). The unused maps fall back to
-   *  empty Maps. URL pushes work from the ID alone — the lookups are
-   *  only needed for the same-URL recenter fallback (re-click on the
-   *  entity that's already focused), which silently no-ops when the
-   *  map is empty. */
+  /** Callers MAY pass their own maps (a caller with fresher or filtered
+   *  data can override); any omitted map is read from `agorStore.getState()`
+   *  at call time instead. The call-time read matters: the maps are only
+   *  consulted inside the returned callbacks (URL pushes work from the ID
+   *  alone; lookups drive the same-URL recenter fallback and slug-aware
+   *  board paths), and a subscription-free consumer like the App shell
+   *  never re-renders on entity patches — so any render-time snapshot it
+   *  passed would go stale. */
+  boardById?: Map<string, { board_id: string; slug?: string }>;
   sessionById?: Map<string, Session>;
   branchById?: Map<string, Branch>;
   artifactById?: Map<string, Artifact>;
@@ -78,14 +75,12 @@ function canonical(path: string): string {
   return `${path.replace(/\/$/, '')}/`;
 }
 
-const EMPTY_MAP = new Map<string, never>();
-
 export function useAppNavigation({
   boardById,
   sessionById,
   branchById,
   artifactById,
-}: UseAppNavigationOptions): AppNavigation {
+}: UseAppNavigationOptions = {}): AppNavigation {
   const navigate = useNavigate();
   const location = useLocation();
   const recenterMap = useRecenterMap();
@@ -97,15 +92,15 @@ export function useAppNavigation({
   // created from `useRef(...)` directly) doesn't falsely flag the
   // useCallback deps below.
   //
-  // Missing optional maps fall back to a shared empty map. URL pushes
-  // work from the ID alone; the lookups are only consulted for the
-  // same-URL recenter fallback, which silently no-ops on miss.
-  const sessionByIdRef = useRef(sessionById ?? (EMPTY_MAP as Map<string, Session>));
-  sessionByIdRef.current = sessionById ?? (EMPTY_MAP as Map<string, Session>);
-  const branchByIdRef = useRef(branchById ?? (EMPTY_MAP as Map<string, Branch>));
-  branchByIdRef.current = branchById ?? (EMPTY_MAP as Map<string, Branch>);
-  const artifactByIdRef = useRef(artifactById ?? (EMPTY_MAP as Map<string, Artifact>));
-  artifactByIdRef.current = artifactById ?? (EMPTY_MAP as Map<string, Artifact>);
+  // Missing optional maps read from the store at call time (see
+  // `UseAppNavigationOptions`) — the callbacks below resolve
+  // `ref.current ?? agorStore.getState().<map>` when invoked.
+  const sessionByIdRef = useRef(sessionById);
+  sessionByIdRef.current = sessionById;
+  const branchByIdRef = useRef(branchById);
+  branchByIdRef.current = branchById;
+  const artifactByIdRef = useRef(artifactById);
+  artifactByIdRef.current = artifactById;
   const boardByIdRef = useRef(boardById);
   boardByIdRef.current = boardById;
   const locationPathnameRef = useRef(location.pathname);
@@ -124,7 +119,10 @@ export function useAppNavigation({
 
   const goToBoard = useCallback(
     (boardId: string, opts?: NavigationOpts) => {
-      pushPath(buildBoardPath(boardId, boardByIdRef.current), opts);
+      pushPath(
+        buildBoardPath(boardId, boardByIdRef.current ?? agorStore.getState().boardById),
+        opts
+      );
     },
     [pushPath]
   );
@@ -147,9 +145,9 @@ export function useAppNavigation({
         // Same-URL click on the already-open session — no history
         // transition, so the URL→state recenter effect won't run. Fall
         // back to a direct recenter via the branch when we have it.
-        const session = sessionByIdRef.current.get(sessionId);
+        const session = (sessionByIdRef.current ?? agorStore.getState().sessionById).get(sessionId);
         const branch = session?.branch_id
-          ? branchByIdRef.current.get(session.branch_id)
+          ? (branchByIdRef.current ?? agorStore.getState().branchById).get(session.branch_id)
           : undefined;
         if (branch?.board_id) {
           recenterMap(branch.branch_id, { boardId: branch.board_id });
@@ -170,7 +168,7 @@ export function useAppNavigation({
         // Same-URL fallback: no history transition, so the URL→state
         // recenter effect won't run — recenter directly when we know
         // the board.
-        const branch = branchByIdRef.current.get(branchId);
+        const branch = (branchByIdRef.current ?? agorStore.getState().branchById).get(branchId);
         if (branch?.board_id) {
           recenterMap(branchId, { boardId: branch.board_id });
         }
@@ -185,7 +183,9 @@ export function useAppNavigation({
       // impl handles the artifact-id-vs-board-object-id mismatch via
       // a data.artifactId fallback scan, so callers stay logical-id-only.
       if (!pushPath(artifactPath(artifactId as ArtifactID), opts)) {
-        const artifact = artifactByIdRef.current.get(artifactId);
+        const artifact = (artifactByIdRef.current ?? agorStore.getState().artifactById).get(
+          artifactId
+        );
         if (artifact?.board_id) {
           recenterMap(artifactId, { boardId: artifact.board_id });
         }

--- a/apps/agor-ui/src/hooks/useFaviconStatus.ts
+++ b/apps/agor-ui/src/hooks/useFaviconStatus.ts
@@ -7,20 +7,25 @@
  * - No dots: Nothing active on current board
  */
 
-import type { BoardEntityObject, Session } from '@agor-live/client';
-import { SessionStatus } from '@agor-live/client';
 import { theme } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { brandMarkHref } from '../branding/brand';
+import { agorStore, shallow, useStoreWithEqualityFn } from '../store/agorStore';
+import { makeBoardSessionActivitySelector } from '../store/selectors';
 import { createFaviconWithDot } from '../utils/faviconDot';
 
-export function useFaviconStatus(
-  currentBoardId: string | null,
-  sessionsByBranch: Map<string, Session[]>,
-  boardObjectsForCurrentBoard: BoardEntityObject[]
-) {
+export function useFaviconStatus(currentBoardId: string | null) {
   const [baseFaviconUrl] = useState(brandMarkHref());
   const { token } = theme.useToken();
+
+  // Subscribe to the two derived flags rather than the whole session /
+  // board-object maps: the favicon only changes when a flag flips, so the
+  // host component stays quiet across ordinary session churn.
+  const { hasRunning, hasReady } = useStoreWithEqualityFn(
+    agorStore,
+    useMemo(() => makeBoardSessionActivitySelector(currentBoardId), [currentBoardId]),
+    shallow
+  );
 
   useEffect(() => {
     // createFaviconWithDot is async (it decodes an <img> and rasterizes to a
@@ -37,30 +42,8 @@ export function useFaviconStatus(
       }
     };
 
-    if (!currentBoardId) {
-      // No board selected - restore default favicon
-      createFaviconWithDot(baseFaviconUrl, false, false, token.colorSuccessText).then(applyFavicon);
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    const branchesOnBoard = new Set(
-      boardObjectsForCurrentBoard.filter((obj) => obj.branch_id).map((obj) => obj.branch_id!)
-    );
-
-    // Find sessions for those branches using O(1) Map lookups
-    const sessionsOnBoard = Array.from(branchesOnBoard)
-      .flatMap((branchId) => sessionsByBranch.get(branchId!) || [])
-      .filter((s) => !s.archived);
-
-    // Determine status: check for running and ready independently
-    // Use .some() for efficient short-circuiting
-    const hasRunning = sessionsOnBoard.some((session) => session.status === SessionStatus.RUNNING);
-
-    const hasReady = sessionsOnBoard.some((session) => session.ready_for_prompt);
-
-    // Update favicon with appropriate dots
+    // Update favicon with appropriate dots (both false with no board —
+    // the selector reports no activity — restoring the default favicon).
     // White dot (lower-left) for running, green dot (lower-right) for ready
     createFaviconWithDot(baseFaviconUrl, hasRunning, hasReady, token.colorSuccessText).then(
       applyFavicon
@@ -69,11 +52,5 @@ export function useFaviconStatus(
     return () => {
       cancelled = true;
     };
-  }, [
-    currentBoardId,
-    sessionsByBranch,
-    boardObjectsForCurrentBoard,
-    baseFaviconUrl,
-    token.colorSuccessText,
-  ]);
+  }, [hasRunning, hasReady, baseFaviconUrl, token.colorSuccessText]);
 }

--- a/apps/agor-ui/src/store/selectors.ts
+++ b/apps/agor-ui/src/store/selectors.ts
@@ -11,7 +11,8 @@
  * one board's bucket: a patch to another board's objects leaves this board's
  * array reference untouched, so the subscription doesn't fire.
  */
-import type { BoardEntityObject, Session } from '@agor-live/client';
+import type { Board, BoardEntityObject, Branch, Repo, Session } from '@agor-live/client';
+import { SessionStatus } from '@agor-live/client';
 import type { AgorState } from './agorStore';
 
 export const selectSessionById = (s: AgorState) => s.sessionById;
@@ -52,7 +53,154 @@ export function makeBoardObjectsForBoardSelector(
  * card re-renders. Mirrors the canvas's prior `sessionsByBranch.get(id)` read.
  */
 export function makeSessionsForBranchSelector(
-  branchId: string
+  branchId: string | null | undefined
 ): (s: AgorState) => Session[] | undefined {
-  return (s) => s.sessionsByBranch.get(branchId);
+  return (s) => (branchId ? s.sessionsByBranch.get(branchId) : undefined);
+}
+
+// Per-id entity selectors. Same currying contract as the factories above:
+// memoize per id, and the subscription only fires when THAT entity's
+// reference changes (patches to other entities of the same type keep the
+// map entry reference-stable only for untouched ids — the maps are rebuilt
+// per write, but `get(id)` returns the same object unless id was patched).
+export function makeSessionSelector(
+  sessionId: string | null | undefined
+): (s: AgorState) => Session | undefined {
+  return (s) => (sessionId ? s.sessionById.get(sessionId) : undefined);
+}
+
+export function makeBranchSelector(
+  branchId: string | null | undefined
+): (s: AgorState) => Branch | undefined {
+  return (s) => (branchId ? s.branchById.get(branchId) : undefined);
+}
+
+export function makeBoardSelector(
+  boardId: string | null | undefined
+): (s: AgorState) => Board | undefined {
+  return (s) => (boardId ? s.boardById.get(boardId) : undefined);
+}
+
+export function makeRepoSelector(
+  repoId: string | null | undefined
+): (s: AgorState) => Repo | undefined {
+  return (s) => (repoId ? s.repoById.get(repoId) : undefined);
+}
+
+export function makeSessionExistsSelector(
+  sessionId: string | null | undefined
+): (s: AgorState) => boolean {
+  return (s) => (sessionId ? s.sessionById.has(sessionId) : false);
+}
+
+export function makeSessionMcpServerIdsSelector(
+  sessionId: string | null | undefined
+): (s: AgorState) => string[] | undefined {
+  return (s) => (sessionId ? s.sessionMcpServerIds.get(sessionId) : undefined);
+}
+
+// Primitive board-list facts for the shell's board-fallback effect: boards
+// change rarely, and subscribing to these scalars (instead of the whole map)
+// keeps high-churn entity patches from waking the subscriber.
+export const selectBoardCount = (s: AgorState) => s.boardById.size;
+export const selectFirstBoardId = (s: AgorState): string | undefined =>
+  s.boardById.keys().next().value;
+
+const EMPTY_BRANCHES: Branch[] = Object.freeze([] as Branch[]) as Branch[];
+
+/**
+ * The branches placed on one board, in board-object order. Returns a fresh
+ * array per run, so subscribe with `useStoreWithEqualityFn(..., shallow)` —
+ * the consumer then re-renders only when membership or a member branch's
+ * identity changes, not on unrelated branch/board-object patches.
+ */
+export function makeBranchesForBoardSelector(
+  boardId: string | null | undefined
+): (s: AgorState) => Branch[] {
+  return (s) => {
+    const objects = boardId ? s.boardObjectsByBoardId.get(boardId) : undefined;
+    if (!objects?.length) return EMPTY_BRANCHES;
+    const branches: Branch[] = [];
+    for (const bo of objects) {
+      if (!bo.branch_id) continue;
+      const branch = s.branchById.get(bo.branch_id);
+      if (branch) branches.push(branch);
+    }
+    return branches;
+  };
+}
+
+/**
+ * Count of unresolved top-level comments on one board (the header badge).
+ * Scalar result: comment patches elsewhere — or edits that don't change the
+ * count — leave the subscriber untouched.
+ */
+export function makeUnreadCommentCountSelector(
+  boardId: string | null | undefined
+): (s: AgorState) => number {
+  return (s) => {
+    if (!boardId) return 0;
+    let count = 0;
+    for (const c of s.commentById.values()) {
+      if (c.board_id === boardId && !c.resolved && !c.parent_comment_id) count += 1;
+    }
+    return count;
+  };
+}
+
+/**
+ * Whether any unresolved comment on the board @-mentions the user (by display
+ * name or email, quoted or bare — mirrors the comment editor's mention
+ * formats). Boolean result for the same quiet-subscription reason as above.
+ */
+export function makeCommentMentionSelector(
+  boardId: string | null | undefined,
+  userName: string | undefined,
+  userEmail: string | undefined
+): (s: AgorState) => boolean {
+  return (s) => {
+    if (!boardId || !userName) return false;
+    for (const c of s.commentById.values()) {
+      if (c.board_id !== boardId || c.resolved) continue;
+      if (c.content.includes(`@${userName}`) || c.content.includes(`@"${userName}"`)) return true;
+      if (
+        userEmail &&
+        (c.content.includes(`@${userEmail}`) || c.content.includes(`@"${userEmail}"`))
+      )
+        return true;
+    }
+    return false;
+  };
+}
+
+const NO_BOARD_ACTIVITY = Object.freeze({ hasRunning: false, hasReady: false });
+
+/**
+ * Session-activity flags for one board's favicon dots. Object result — pair
+ * with `shallow` so only flag flips (not every session patch on the board)
+ * reach the subscriber.
+ */
+export function makeBoardSessionActivitySelector(
+  boardId: string | null | undefined
+): (s: AgorState) => { hasRunning: boolean; hasReady: boolean } {
+  return (s) => {
+    if (!boardId) return NO_BOARD_ACTIVITY;
+    let hasRunning = false;
+    let hasReady = false;
+    const objects = s.boardObjectsByBoardId.get(boardId);
+    if (!objects) return NO_BOARD_ACTIVITY;
+    for (const bo of objects) {
+      if (!bo.branch_id) continue;
+      const sessions = s.sessionsByBranch.get(bo.branch_id);
+      if (!sessions) continue;
+      for (const session of sessions) {
+        if (session.archived) continue;
+        if (session.status === SessionStatus.RUNNING) hasRunning = true;
+        if (session.ready_for_prompt) hasReady = true;
+        if (hasRunning && hasReady) return { hasRunning, hasReady };
+      }
+    }
+    if (!hasRunning && !hasReady) return NO_BOARD_ACTIVITY;
+    return { hasRunning, hasReady };
+  };
 }


### PR DESCRIPTION
## Mechanism

The inner `App` shell (~1700 lines, always mounted) subscribed to **15 whole entity maps**, so a patch to any entity of any type re-rendered it. With rAF-batched store notifies (#1793) landing, the shell must be cheap at once-per-frame — this PR makes every remaining shell subscription narrow (per-id object, derived array with `shallow`, or scalar), pushes whole-map consumers down into the components that actually use them, and switches handler-internal map reads to call-time `agorStore.getState()` (render-time snapshots/refs would go stale once the shell stops re-rendering).

After this, the shell wakes only for: the selected session/branch, the current board, the current board's objects/branches (canvas data), and the current board's comment badge scalars — all data it actually renders.

## Per-item changes

**1. Whole-map subscriptions removed** (`apps/agor-ui/src/components/App/App.tsx:321-335` before)
- Selected session / branch, settings-modal session, branch-modal branch/repo/sessions, new-session branch, logs-modal branch, primary assistant branch/repo, current board: per-id curried selectors (`store/selectors.ts` — `makeSessionSelector`, `makeBranchSelector`, `makeBoardSelector`, `makeRepoSelector`, `makeSessionsForBranchSelector`, `makeSessionMcpServerIdsSelector`, `makeSessionExistsSelector`).
- `boardBranches`: `makeBranchesForBoardSelector` + `useStoreWithEqualityFn(shallow)` — replaces the `currentBoardObjects`+`branchById` memo.
- Board-fallback effect: `selectBoardCount` / `selectFirstBoardId` scalars.
- `useRecentBoards`: shell passes a stable empty list (it only consumes `recentBoardIds`/`trackBoardVisit`, which don't depend on the boards arg).
- URL⇄state sync: moved into a null-rendering `UrlStateBridge` child (same idiom as the existing `BoardSwitcherBridge`) — `useUrlState` genuinely needs whole maps to resolve deep-linked short IDs as entities stream in, so those subscriptions now wake a `null` render instead of the shell. `useUrlState` itself is untouched.
- `useAppNavigation` (`hooks/useAppNavigation.ts`): map options now optional; omitted maps read from `agorStore.getState()` at call time. Note this makes the same-URL re-click recenter fallback work for callers that previously omitted maps (tables/GlobalSearch) — previously it silently no-op'd there.
- `useFaviconStatus` (`hooks/useFaviconStatus.ts`): takes only `currentBoardId` and subscribes internally to derived `{hasRunning, hasReady}` flags (`makeBoardSessionActivitySelector` + `shallow`).
- `SettingsModal` (`components/SettingsModal/SettingsModal.tsx`): subscribes to the store itself instead of receiving 11 map props from App. The exported wrapper already returns `null` when closed, so the subscriptions exist only while the modal is open.
- `handleSessionClick` / `handleCreateAssistant`: call-time `getState()` reads (replacing render-updated refs).

**2. Board-scoped comment derivations** (`App.tsx:1038,1194` before)
- `activeComments` (full map scan → array) replaced by two scalar selectors: `makeUnreadCommentCountSelector` (badge) and `makeCommentMentionSelector` (mention flag). Comment patches on other boards, or edits that don't change the scalar, no longer wake the shell.

**3. `appActionsValue` reference stability** (`App.tsx:1066` before)
- All passthrough handlers in the context value now go through the existing `useStableCallback` (or `useCallback([])` for setState-only openers), so the `AppActionsProvider` value survives shell/parent re-renders. `EventStreamPanel`'s `branchActions` object is memoized for the same reason.

**4. `CallbackTargetDisplay`** (`components/CallbackToggleButton/CallbackTargetDisplay.tsx:45` before)
- One instance renders per session footer/row; each subscribed to the WHOLE session map. Now subscribes to the single target session via `makeSessionSelector` memoized per id.

**Stretch**: `App.tsx` resize listener debounced (150ms trailing). EventStreamPanel map narrowing skipped — App only mounts it while expanded, so the audit's "while collapsed" cost doesn't occur.

## Tests

- New `components/App/App.rerender.test.tsx` (same harness pattern as `AppHeader.rerender.test.tsx`, real store writes): pins that an **irrelevant session patch** and an **other-board comment patch** leave the shell un-rendered, with two live-subscription contrast cases (current-board comment → badge re-render; current-board branch patch → canvas-data re-render).
- Full agor-ui suite: **113 files / 720 tests pass**, including all six `*.rerender.test.tsx` suites, `useAppNavigation.test.tsx`, and `useUrlState.integration.test.tsx`.

## Gates

- `pnpm typecheck` ✅, `pnpm lint` ✅, `check:shortid` ✅, `turbo run build --filter='!@agor/docs'` ✅
- `check:multitenancy-boundaries` ❌ — **pre-existing on the base commit** (verified: identical failure output at `fbc451b4`, all flagged files are `apps/agor-daemon/*` which this PR does not touch).

## #1798 adjacency note

Sibling PR #1798 (canvas identity) also touches `App/App.tsx` around the `useStableCallback` block. This diff keeps that function untouched and its existing `stableOn*` declarations intact (only relocated above `appActionsValue` and extended with `stableOnSendPrompt`/`stableOnBtwForkSession`), so overlap is limited to that region — whichever lands second should be a small, mechanical rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)