### PR TITLE
Simplify session creation: modal → right-drawer quick-start

### DIFF
--- a/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
+++ b/apps/agor-daemon/src/services/sessions.agentic-tool-guard.test.ts
@@ -1,0 +1,177 @@
+/**
+ * `agentic_tool` immutability was previously only a client-side convention —
+ * `SessionPanel.tsx` hides "Switch tool" once a session has tasks, but
+ * nothing on the server stopped a direct `sessions.patch` call (a stale tab,
+ * the MCP session-update tool, CLI, a future UI surface) from changing
+ * `agentic_tool` on a session with existing tasks/messages, desyncing it
+ * from the tool that actually produced them.
+ *
+ * These tests pin the server-side guard down against a real database.
+ */
+import {
+  BranchRepository,
+  generateId,
+  RepoRepository,
+  SessionRepository,
+  TaskRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { Session, Task, UUID } from '@agor/core/types';
+import { SessionStatus, TaskStatus } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { SessionsService } from './sessions';
+
+// The guard only touches the session/task repos built from `db`; the stored
+// `app` is never read on this path. A bare cast keeps the harness minimal.
+const STUB_APP = {} as unknown as Application;
+
+async function createBranch(db: any): Promise<UUID> {
+  const repoRepo = new RepoRepository(db);
+  const branchRepo = new BranchRepository(db);
+  const repo = await repoRepo.create({
+    repo_id: generateId(),
+    slug: `repo-${generateId()}`,
+    name: 'Test Repo',
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: '/tmp/test-repo',
+    default_branch: 'main',
+  });
+  const branch = await branchRepo.create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name: 'feature',
+    ref: 'feature',
+    branch_unique_id: Math.floor(Math.random() * 1_000_000),
+    path: '/tmp/test-repo',
+    base_ref: 'main',
+    new_branch: false,
+    created_by: 'test-user' as UUID,
+  });
+  return branch.branch_id as UUID;
+}
+
+async function createSession(
+  db: any,
+  branchId: UUID,
+  overrides: Partial<Session> = {}
+): Promise<UUID> {
+  const sessionRepo = new SessionRepository(db);
+  const session = await sessionRepo.create({
+    session_id: generateId(),
+    branch_id: branchId,
+    agentic_tool: 'claude-code',
+    status: SessionStatus.IDLE,
+    created_by: 'test-user' as UUID,
+    git_state: { ref: 'main', base_sha: 'abc', current_sha: 'def' },
+    tasks: [],
+    contextFiles: [],
+    genealogy: { children: [] },
+    ...overrides,
+  });
+  return session.session_id as UUID;
+}
+
+async function createTask(db: any, sessionId: UUID, overrides: Partial<Task> = {}): Promise<UUID> {
+  const taskRepo = new TaskRepository(db);
+  const task = await taskRepo.create({
+    task_id: generateId(),
+    session_id: sessionId,
+    created_by: 'test-user' as UUID,
+    full_prompt: 'Do a thing',
+    status: TaskStatus.COMPLETED,
+    message_range: { start_index: 0, end_index: 2, start_timestamp: new Date().toISOString() },
+    tool_use_count: 1,
+    git_state: { ref_at_start: 'main', sha_at_start: 'abc123' },
+    ...overrides,
+  });
+  return task.task_id as UUID;
+}
+
+describe('SessionsService.patch — agentic_tool immutability guard', () => {
+  dbTest('rejects an agentic_tool change on a session that already has a task', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const sessionId = await createSession(db, branchId, { agentic_tool: 'claude-code' });
+    await createTask(db, sessionId);
+
+    await expect(service.patch(sessionId, { agentic_tool: 'codex' })).rejects.toThrow(
+      /agentic_tool/
+    );
+
+    const sessionRepo = new SessionRepository(db);
+    const reloaded = await sessionRepo.findById(sessionId);
+    expect(reloaded?.agentic_tool).toBe('claude-code');
+  });
+
+  dbTest('rejects any multi (batch) patch that changes agentic_tool', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const withTask = await createSession(db, branchId, { agentic_tool: 'claude-code' });
+    await createTask(db, withTask);
+
+    await expect(
+      service.patch(null, { agentic_tool: 'codex' }, { query: { session_id: withTask } } as any)
+    ).rejects.toThrow(/multi-session patch/i);
+
+    const sessionRepo = new SessionRepository(db);
+    const reloaded = await sessionRepo.findById(withTask);
+    expect(reloaded?.agentic_tool).toBe('claude-code');
+  });
+
+  dbTest(
+    'rejects a multi patch even for a zero-task session, closing the enumeration bypass',
+    async ({ db }) => {
+      // The prior per-row guard enumerated the target set via `super.find`,
+      // which `$select`/`$limit:0`/pagination could skew away from the rows the
+      // mutation actually touched. Refusing multi-patch of agentic config
+      // outright removes that mismatch: there is no separately-enumerated set to
+      // exploit, so a protected row can't be slipped past the check.
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const zeroTask = await createSession(db, branchId, { agentic_tool: 'claude-code' });
+
+      await expect(
+        service.patch(null, { agentic_tool: 'codex' }, {
+          query: { session_id: zeroTask, $select: ['title'], $limit: 0 },
+        } as any)
+      ).rejects.toThrow(/multi-session patch/i);
+
+      const sessionRepo = new SessionRepository(db);
+      expect((await sessionRepo.findById(zeroTask))?.agentic_tool).toBe('claude-code');
+    }
+  );
+
+  dbTest('allows an agentic_tool change on a session with zero tasks', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const sessionId = await createSession(db, branchId, { agentic_tool: 'claude-code' });
+
+    const result = (await service.patch(sessionId, { agentic_tool: 'codex' })) as Session;
+    expect(result.agentic_tool).toBe('codex');
+  });
+
+  dbTest(
+    'allows a patch that sets agentic_tool to its current value even with tasks',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const sessionId = await createSession(db, branchId, { agentic_tool: 'claude-code' });
+      await createTask(db, sessionId);
+
+      const result = (await service.patch(sessionId, { agentic_tool: 'claude-code' })) as Session;
+      expect(result.agentic_tool).toBe('claude-code');
+    }
+  );
+
+  dbTest('allows unrelated field patches on a session with tasks', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const sessionId = await createSession(db, branchId, { agentic_tool: 'claude-code' });
+    await createTask(db, sessionId);
+
+    const result = (await service.patch(sessionId, { title: 'New title' })) as Session;
+    expect(result.title).toBe('New title');
+  });
+});

--- a/apps/agor-daemon/src/services/sessions.swap-remove-guard.test.ts
+++ b/apps/agor-daemon/src/services/sessions.swap-remove-guard.test.ts
@@ -1,0 +1,148 @@
+/**
+ * TOCTOU on the "Switch tool" swap: `canSwitchTool` is evaluated once when
+ * the picker opens (session has zero tasks), but on a multiplayer canvas a
+ * task can land on that same session — another tab, a collaborator, an MCP
+ * `agor_sessions_prompt` call — before the swap *completes* and
+ * `chooseAgenticTool` calls `sessions.remove(replacingSessionId)`. Without a
+ * server-side re-check, that remove cascade-deletes the now-in-flight
+ * session and its task with no confirmation.
+ *
+ * The client marks a swap-triggered removal via `query._swapReplace` so the
+ * daemon can refuse *that* removal (Conflict) while leaving a normal,
+ * user-intentional delete of a session with history unaffected.
+ */
+import {
+  BranchRepository,
+  generateId,
+  RepoRepository,
+  SessionRepository,
+  TaskRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { Session, Task, UUID } from '@agor/core/types';
+import { SessionStatus, TaskStatus } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { SessionsService } from './sessions';
+
+const STUB_APP = {} as unknown as Application;
+
+async function createBranch(db: any): Promise<UUID> {
+  const repoRepo = new RepoRepository(db);
+  const branchRepo = new BranchRepository(db);
+  const repo = await repoRepo.create({
+    repo_id: generateId(),
+    slug: `repo-${generateId()}`,
+    name: 'Test Repo',
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: '/tmp/test-repo',
+    default_branch: 'main',
+  });
+  const branch = await branchRepo.create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name: 'feature',
+    ref: 'feature',
+    branch_unique_id: Math.floor(Math.random() * 1_000_000),
+    path: '/tmp/test-repo',
+    base_ref: 'main',
+    new_branch: false,
+    created_by: 'test-user' as UUID,
+  });
+  return branch.branch_id as UUID;
+}
+
+async function createSession(
+  db: any,
+  branchId: UUID,
+  overrides: Partial<Session> = {}
+): Promise<UUID> {
+  const sessionRepo = new SessionRepository(db);
+  const session = await sessionRepo.create({
+    session_id: generateId(),
+    branch_id: branchId,
+    agentic_tool: 'claude-code',
+    status: SessionStatus.IDLE,
+    created_by: 'test-user' as UUID,
+    git_state: { ref: 'main', base_sha: 'abc', current_sha: 'def' },
+    tasks: [],
+    contextFiles: [],
+    genealogy: { children: [] },
+    ...overrides,
+  });
+  return session.session_id as UUID;
+}
+
+async function createTask(db: any, sessionId: UUID, overrides: Partial<Task> = {}): Promise<UUID> {
+  const taskRepo = new TaskRepository(db);
+  const task = await taskRepo.create({
+    task_id: generateId(),
+    session_id: sessionId,
+    created_by: 'test-user' as UUID,
+    full_prompt: 'Do a thing',
+    status: TaskStatus.RUNNING,
+    message_range: { start_index: 0, end_index: 2, start_timestamp: new Date().toISOString() },
+    tool_use_count: 1,
+    git_state: { ref_at_start: 'main', sha_at_start: 'abc123' },
+    ...overrides,
+  });
+  return task.task_id as UUID;
+}
+
+describe('SessionsService.remove — swap-replace TOCTOU guard', () => {
+  dbTest(
+    'refuses a _swapReplace removal when a task has landed on the session since the swap was initiated',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const sessionId = await createSession(db, branchId);
+
+      // Simulates the TOCTOU window: the picker opened while the session had
+      // zero tasks, but a task lands (another tab / collaborator / MCP call)
+      // before the swap's remove() call reaches the server.
+      await createTask(db, sessionId);
+
+      await expect(
+        service.remove(sessionId, { query: { _swapReplace: true } } as any)
+      ).rejects.toThrow(/gained.*task/i);
+
+      const sessionRepo = new SessionRepository(db);
+      const stillThere = await sessionRepo.findById(sessionId);
+      expect(stillThere).not.toBeNull();
+    }
+  );
+
+  dbTest('allows a _swapReplace removal when the session still has zero tasks', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const sessionId = await createSession(db, branchId);
+
+    const removed = (await service.remove(sessionId, {
+      query: { _swapReplace: true },
+    } as any)) as Session;
+    expect(removed.session_id).toBe(sessionId);
+
+    const sessionRepo = new SessionRepository(db);
+    expect(await sessionRepo.findById(sessionId)).toBeNull();
+  });
+
+  dbTest(
+    'a normal (non-swap) delete of a session with tasks is unaffected — no confirmation gate added',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const sessionId = await createSession(db, branchId);
+      await createTask(db, sessionId);
+
+      // No `_swapReplace` marker — this is a user deleting a real session
+      // with history via the normal delete affordance, which must keep
+      // working exactly as before.
+      const removed = (await service.remove(sessionId)) as Session;
+      expect(removed.session_id).toBe(sessionId);
+
+      const sessionRepo = new SessionRepository(db);
+      expect(await sessionRepo.findById(sessionId)).toBeNull();
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -22,10 +22,17 @@ import {
   SessionRelationshipRepository,
   SessionRepository,
   type SessionWithLastMessage,
+  TaskRepository,
   type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
-import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import {
+  type Application,
+  BadRequest,
+  Conflict,
+  Forbidden,
+  NotAuthenticated,
+} from '@agor/core/feathers';
 import {
   formatModelToolMismatchWarning,
   formatUnsupportedAgorCodexModelMessage,
@@ -108,6 +115,8 @@ export type SessionParams = QueryParams<{
   board_id?: string;
   include_last_message?: boolean | 'true' | 'false'; // Opt-in last message enrichment
   last_message_truncation_length?: number; // Default: 500 chars, min: 50, max: 10000
+  /** Marks a `remove` as the delete half of a "switch tool" swap (see `remove`). */
+  _swapReplace?: boolean;
 }> &
   AuthenticatedParams &
   InternalEnrichmentParams & {
@@ -196,6 +205,7 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   private sessionEnvSelectionRepo: SessionEnvSelectionRepository;
   private usersRepo: UsersRepository;
   private branchRepo: BranchRepository;
+  private taskRepo: TaskRepository;
   private db: TenantScopeAwareDatabase;
 
   private assertSupportedModelConfig(
@@ -234,6 +244,36 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     // without going through app.service('users') — matches the convention used
     // by scheduler.ts / gateway.ts / terminals.ts.
     this.usersRepo = new UsersRepository(db);
+    this.taskRepo = new TaskRepository(db);
+  }
+
+  /**
+   * `agentic_tool` picks the SDK a session's tasks are executed with — it
+   * can't change mid-session once a task exists (the messages/tasks already
+   * on the session were produced by a specific tool's SDK). The UI only
+   * offers "Switch tool" while `session.tasks.length === 0`, but that's a
+   * client-side convenience, not a security boundary: any other caller of
+   * `sessions.patch` (a stale tab, the MCP session-update tool, CLI) could
+   * otherwise desync `agentic_tool` from the tool that actually produced a
+   * session's existing tasks/messages. Enforce it here so the constraint
+   * holds regardless of caller.
+   */
+  private async assertAgenticToolMutable(sessionId: string, nextTool: unknown): Promise<void> {
+    if (nextTool === undefined) return;
+
+    const existing = await this.sessionRepo.findById(sessionId);
+    if (!existing || existing.agentic_tool === nextTool) return;
+
+    const taskCount = await this.taskRepo.countBySession(sessionId);
+    if (taskCount > 0) {
+      // Conflict (409), not Forbidden (403): nothing about the caller's identity
+      // is at issue — the session's *state* forbids the change. Matches the
+      // sibling `_swapReplace` guard in `remove`.
+      throw new Conflict(
+        `Cannot change agentic_tool on session ${sessionId}: it already has ${taskCount} task(s). ` +
+          "The tool that produced a session's existing tasks/messages cannot be changed after the fact."
+      );
+    }
   }
 
   async create(data: Partial<Session>, params?: SessionParams): Promise<Session | Session[]> {
@@ -1086,6 +1126,29 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       return results;
     }
 
+    // "Switch tool" (`chooseAgenticTool` in the UI) removes the session it's
+    // replacing as an implementation detail of swapping — never a user-visible
+    // delete. It's only offered on a session with zero tasks at the moment the
+    // swap is *initiated*, but on a multiplayer canvas a task can land on that
+    // same session (another tab, a collaborator, an MCP `agor_sessions_prompt`
+    // call) before the swap *completes*. Callers performing that specific swap
+    // mark the request via `query._swapReplace`; a normal user-intentional
+    // delete of a session with history is unaffected and still allowed.
+    //
+    // The guard lives here at the top level (not in `removeOne`) so it only
+    // gates the replaced session itself. The cascade into children runs through
+    // `removeOne`, which never re-evaluates the marker — a child that has gained
+    // a task can't abort a legitimate cascade partway through.
+    if ((params?.query as { _swapReplace?: boolean } | undefined)?._swapReplace) {
+      const taskCount = await this.taskRepo.countBySession(String(id));
+      if (taskCount > 0) {
+        throw new Conflict(
+          `Cannot complete tool switch: session ${id} has gained ${taskCount} task(s) since the switch ` +
+            'was initiated. Refresh and try again — the in-flight work has not been touched.'
+        );
+      }
+    }
+
     return this.removeOne(String(id), params, false);
   }
 
@@ -1137,6 +1200,13 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     }
     if (data.agentic_tool && !(await isTenantAgenticToolEnabled(data.agentic_tool, this.db))) {
       throw new BadRequest(`${data.agentic_tool} is disabled for this workspace`);
+    }
+    // `agentic_tool` is immutable once a session has tasks. Multi-session and
+    // array patches that touch it are already rejected above, so the single-id
+    // path is the only one that can reach the actual mutation — enforce the
+    // guard there, matching the exact target the patch will modify.
+    if (data.agentic_tool !== undefined && id !== null && !Array.isArray(id)) {
+      await this.assertAgenticToolMutable(String(id), data.agentic_tool);
     }
     if (id && !Array.isArray(id) && !params?._applyingAgenticToolPreset) {
       const current = await this.get(String(id), params);

--- a/apps/agor-daemon/src/services/tasks.auto-title.test.ts
+++ b/apps/agor-daemon/src/services/tasks.auto-title.test.ts
@@ -1,0 +1,227 @@
+import { type Session, type Task, TaskStatus } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { TasksService } from './tasks';
+
+const sessionId = '018f0000-0000-7000-8000-000000000101';
+const taskId = '018f0000-0000-7000-8000-000000000201';
+const userId = '018f0000-0000-7000-8000-000000000401';
+
+const DERIVED_TITLE = 'Add a JWT-based authentication system with refresh token…';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    task_id: taskId,
+    session_id: sessionId,
+    created_by: userId,
+    full_prompt: 'Add a JWT-based authentication system with refresh token rotation',
+    status: TaskStatus.RUNNING,
+    message_range: {
+      start_index: 0,
+      end_index: 2,
+      start_timestamp: '2026-01-01T00:00:00.000Z',
+    },
+    tool_use_count: 1,
+    git_state: { ref_at_start: 'main', sha_at_start: 'abc123' },
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Task;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: sessionId,
+    branch_id: undefined,
+    created_by: userId,
+    agentic_tool: 'claude-code',
+    status: 'running',
+    tasks: [taskId],
+    ready_for_prompt: false,
+    archived: false,
+    genealogy: { children: [] },
+    git_state: {},
+    contextFiles: [],
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as Session;
+}
+
+function makeService(options: { task?: Partial<Task>; session?: Partial<Session> } = {}) {
+  const initialTask = makeTask(options.task);
+  const tasksById = new Map<string, Task>([[initialTask.task_id, initialTask]]);
+  const session = makeSession(options.session);
+
+  const repository = {
+    findById: vi.fn(async (id: string) => tasksById.get(id) ?? null),
+    update: vi.fn(async (id: string, updates: Partial<Task>) => {
+      const current = tasksById.get(id) ?? makeTask({ task_id: id as Task['task_id'] });
+      const updated = { ...current, ...updates } as Task;
+      tasksById.set(id, updated);
+      return updated;
+    }),
+    create: vi.fn(),
+    findAll: vi.fn(async () => [...tasksById.values()]),
+    delete: vi.fn(),
+  };
+
+  const sessionsPatch = vi.fn(async (id: string, updates: Partial<Session>) => {
+    Object.assign(session, updates);
+    return { ...session };
+  });
+  // Returns a fresh snapshot each call so a test can script a concurrent
+  // rename between the terminal status read and the auto-title compare-and-set.
+  const sessionsGet = vi.fn(async () => ({ ...session }));
+  const triggerQueueProcessing = vi.fn(async () => undefined);
+
+  const service = Object.create(TasksService.prototype) as TasksService & {
+    repository: typeof repository;
+    taskRepo: typeof repository & { createPending: ReturnType<typeof vi.fn> };
+    id: string;
+    emit: ReturnType<typeof vi.fn>;
+    app: { service: ReturnType<typeof vi.fn> };
+    completionCallbackDispatches: Map<string, Promise<unknown>>;
+  };
+  service.repository = repository;
+  service.taskRepo = { ...repository, createPending: vi.fn() };
+  service.id = 'task_id';
+  service.emit = vi.fn();
+  service.completionCallbackDispatches = new Map();
+  service.app = {
+    service: vi.fn((name: string) => {
+      if (name === 'sessions') {
+        return { get: sessionsGet, patch: sessionsPatch, triggerQueueProcessing };
+      }
+      if (name === 'messages') return { find: vi.fn(async () => []) };
+      if (name === 'branches') return { get: vi.fn() };
+      throw new Error(`unexpected service ${name}`);
+    }),
+  };
+
+  return { service, sessionsPatch, sessionsGet, session };
+}
+
+/** Find the separate, title-only patch (undefined if auto-title never wrote). */
+function titlePatchCall(sessionsPatch: ReturnType<typeof vi.fn>) {
+  return sessionsPatch.mock.calls.find(
+    ([, updates]) => (updates as Partial<Session>).title !== undefined
+  );
+}
+
+/** The terminal status/ready patch — always the first sessions patch. */
+function statusPatchCall(sessionsPatch: ReturnType<typeof vi.fn>) {
+  return sessionsPatch.mock.calls[0];
+}
+
+describe('TasksService auto-title', () => {
+  it('writes the terminal status/ready patch prompt-flow-only, with the original params', async () => {
+    const { service, sessionsPatch } = makeService({ session: { title: undefined } });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    // The status patch must not carry `title` — folding metadata in would make
+    // the sessions RBAC hook demand `all` and fail a non-owner's completion.
+    const [, statusUpdates, statusParams] = statusPatchCall(sessionsPatch);
+    expect(statusUpdates).toMatchObject({ status: 'idle', ready_for_prompt: true });
+    expect(statusUpdates).not.toHaveProperty('title');
+    expect(statusParams).toBeUndefined();
+  });
+
+  it('auto-titles an untitled session via a separate trusted (provider-less) patch', async () => {
+    const { service, sessionsPatch } = makeService({ session: { title: undefined } });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    const titleCall = titlePatchCall(sessionsPatch);
+    expect(titleCall).toBeDefined();
+    const [, titleUpdates, titleParams] = titleCall as [string, Partial<Session>, unknown];
+    expect(titleUpdates).toEqual({ title: DERIVED_TITLE });
+    // Written with no provider so it bypasses the collaborator-metadata gate.
+    expect(titleParams).toMatchObject({ provider: undefined });
+  });
+
+  it('does not overwrite an explicit title', async () => {
+    const { service, sessionsPatch } = makeService({ session: { title: 'My session' } });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    expect(titlePatchCall(sessionsPatch)).toBeUndefined();
+  });
+
+  it('treats an explicitly-cleared empty-string title as set (does not re-arm auto-title)', async () => {
+    const { service, sessionsPatch } = makeService({ session: { title: '' } });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    // '' is a deliberate user choice, not "unset" — never re-derive over it.
+    expect(titlePatchCall(sessionsPatch)).toBeUndefined();
+  });
+
+  it('does not clobber a rename that lands while the task is running (compare-and-set)', async () => {
+    const { service, sessionsPatch, sessionsGet } = makeService({ session: { title: undefined } });
+
+    // Terminal read sees no title; by the compare-and-set re-read a user rename
+    // has landed, so the derived title must be dropped rather than overwrite it.
+    sessionsGet
+      .mockResolvedValueOnce(makeSession({ title: undefined }))
+      .mockResolvedValueOnce(makeSession({ title: 'User typed this while it ran' }));
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    expect(titlePatchCall(sessionsPatch)).toBeUndefined();
+  });
+
+  it('still derives a title from a later task when the session has none yet', async () => {
+    const earlierTaskId = '018f0000-0000-7000-8000-000000000202';
+    const { service, sessionsPatch } = makeService({
+      session: { title: undefined, tasks: [earlierTaskId, taskId] },
+    });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    const titleCall = titlePatchCall(sessionsPatch);
+    expect(titleCall?.[1]).toEqual({ title: DERIVED_TITLE });
+  });
+
+  it('does not derive a title from an image-only (text-empty) prompt', async () => {
+    const { service, sessionsPatch } = makeService({
+      session: { title: undefined },
+      task: { full_prompt: '' },
+    });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    expect(titlePatchCall(sessionsPatch)).toBeUndefined();
+  });
+
+  it('does not set a title when the task fails', async () => {
+    const { service, sessionsPatch } = makeService({ session: { title: undefined } });
+
+    await service.patch(taskId, {
+      status: TaskStatus.FAILED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    expect(titlePatchCall(sessionsPatch)).toBeUndefined();
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -18,6 +18,7 @@ import {
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
+import { deriveTitleFromPrompt } from '@agor/core/sessions';
 import type {
   ContentBlock,
   Paginated,
@@ -609,6 +610,13 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
               `⏭️ [TasksService] Skipping session terminal-state update for task ${shortId(task.task_id)} (${data.status}) due to internal patch params`
             );
           } else {
+            // Keep the terminal status/ready update a pure prompt-flow patch
+            // with the caller's original params. Folding a server-generated
+            // `title` in here would make it a mixed metadata patch, which the
+            // sessions RBAC hook gates behind `all` permission — a non-owner
+            // collaborator's first completed task would then fail the whole
+            // patch and leave the session stuck running/not-ready. The title is
+            // written separately below and is allowed to fail independently.
             await this.app.service('sessions').patch(
               task.session_id,
               {
@@ -622,6 +630,45 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
             console.log(
               `✅ [TasksService] Session ${shortId(task.session_id)} status updated after terminal task (task ${shortId(task.task_id)} ${data.status})`
             );
+
+            // Auto-title: cheap heuristic, no LLM call — see
+            // `deriveTitleFromPrompt`. Fires on any completed task while the
+            // session still has no title, not just the first one, so a session
+            // whose first prompt was image-only/whitespace (empty derived
+            // title, skipped) or whose first task failed still picks one up on
+            // a later task.
+            //
+            // "Unset" is canonically null/undefined: an explicitly cleared
+            // title (empty string) is a deliberate user choice and must NOT be
+            // re-armed. The session is re-read immediately before the write and
+            // the title is only set if it is *still* unset, so a rename typed
+            // while this task ran is never clobbered (compare-and-set at the app
+            // layer; full row-locked atomicity is a follow-up). The write is a
+            // trusted system patch (no `provider`) so it bypasses the
+            // collaborator-metadata RBAC gate the status patch above avoids.
+            if (data.status === TaskStatus.COMPLETED && task.full_prompt) {
+              const autoTitle = deriveTitleFromPrompt(task.full_prompt);
+              if (autoTitle) {
+                try {
+                  const fresh = await this.app.service('sessions').get(task.session_id, params);
+                  if (fresh.title == null) {
+                    await this.app
+                      .service('sessions')
+                      .patch(
+                        task.session_id,
+                        { title: autoTitle },
+                        { ...params, provider: undefined }
+                      );
+                  }
+                } catch (titleError) {
+                  const message =
+                    titleError instanceof Error ? titleError.message : String(titleError);
+                  console.warn(
+                    `⚠️  [TasksService] Auto-title failed for session ${shortId(task.session_id)}: ${message}`
+                  );
+                }
+              }
+            }
           }
 
           if (!suppressCompletionCallbacks && !isStop) {

--- a/apps/agor-ui/src/components/AgentSelectionCard/AgentSelectionCard.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionCard/AgentSelectionCard.tsx
@@ -26,14 +26,14 @@ export const AgentSelectionCard: React.FC<AgentSelectionCardProps> = ({
         cursor: 'pointer',
       }}
       styles={{
-        body: { padding: 12 },
+        body: { padding: 8 },
       }}
     >
-      <Space orientation="vertical" style={{ width: '100%' }} size={4}>
-        <Space style={{ width: '100%', justifyContent: 'space-between' }} size={8}>
-          <Space size={8}>
-            <ToolIcon tool={agent.id} size={24} />
-            <Typography.Text strong style={{ fontSize: '14px' }}>
+      <Space orientation="vertical" style={{ width: '100%' }} size={3}>
+        <Space style={{ width: '100%', justifyContent: 'space-between' }} size={6}>
+          <Space size={6}>
+            <ToolIcon tool={agent.id} size={20} />
+            <Typography.Text strong style={{ fontSize: '13px' }}>
               {agent.name}
             </Typography.Text>
             {agent.beta && <Tag color="warning">BETA</Tag>}
@@ -41,13 +41,13 @@ export const AgentSelectionCard: React.FC<AgentSelectionCardProps> = ({
         </Space>
 
         {agent.version && (
-          <Typography.Text type="secondary" style={{ fontSize: '11px' }}>
+          <Typography.Text type="secondary" style={{ fontSize: '10px' }}>
             Version: {agent.version}
           </Typography.Text>
         )}
 
         {agent.description && (
-          <Typography.Text type="secondary" style={{ fontSize: '12px' }}>
+          <Typography.Text type="secondary" style={{ fontSize: '11px' }}>
             {agent.description}
           </Typography.Text>
         )}

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
@@ -106,7 +106,7 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
         style={{
           display: 'grid',
           gridTemplateColumns: `repeat(${columns}, 1fr)`,
-          gap: 8,
+          gap: 6,
           marginTop: 8,
         }}
       >

--- a/apps/agor-ui/src/components/App/App.quickstart.test.tsx
+++ b/apps/agor-ui/src/components/App/App.quickstart.test.tsx
@@ -1,0 +1,165 @@
+import type { Board, Branch, User } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { forwardRef } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { App } from './App';
+
+// SessionCanvas is mocked to surface the quick-start entry point as a button so
+// the test can drive `onCreateSessionForBranch` (the real "Add session" action)
+// without a full canvas.
+vi.mock('../SessionCanvas', () => ({
+  SessionCanvas: forwardRef(
+    (props: { onCreateSessionForBranch?: (branchId: string) => void }, _ref) => (
+      <button
+        type="button"
+        data-testid="quick-start"
+        onClick={() => props.onCreateSessionForBranch?.('wt-1')}
+      >
+        add session
+      </button>
+    )
+  ),
+}));
+// The picker renders in place of the session panel when a tool can't be
+// resolved. A lightweight stand-in lets us assert it did (or did not) appear.
+vi.mock('../SessionPanel/PendingToolChoicePanel', () => ({
+  PendingToolChoicePanel: () => <div data-testid="tool-picker" />,
+}));
+
+vi.mock('../AppHeader', () => ({ AppHeader: () => null }));
+vi.mock('../BoardTeammatePanel', () => ({ BoardTeammatePanel: () => null }));
+vi.mock('../HomePage', () => ({ HomePage: () => null }));
+vi.mock('../SessionPanel', () => ({ SessionPanel: () => null }));
+vi.mock('../EventStreamPanel', () => ({ EventStreamPanel: () => null }));
+vi.mock('../NewSessionButton', () => ({ NewSessionButton: () => null }));
+vi.mock('../SettingsModal', () => ({ SettingsModal: () => null, UserSettingsModal: () => null }));
+vi.mock('../BranchModal', () => ({ BranchModal: () => null }));
+vi.mock('../CreateDialog', () => ({ CreateDialog: () => null }));
+vi.mock('../NewSessionModal', () => ({ NewSessionModal: () => null }));
+vi.mock('../SessionSettingsModal', () => ({ SessionSettingsModal: () => null }));
+vi.mock('../TerminalModal', () => ({ TerminalModal: () => null, WEB_TERMINAL_MIN_ROLE: 'member' }));
+vi.mock('../ThemeEditorModal', () => ({ ThemeEditorModal: () => null }));
+vi.mock('../EnvironmentLogsModal', () => ({ EnvironmentLogsModal: () => null }));
+vi.mock('../../hooks/useTaskCompletionChime', () => ({ useTaskCompletionChime: () => {} }));
+vi.mock('react-resizable-panels', async () => {
+  const React = await import('react');
+  const noopHandle = { collapse: () => {}, expand: () => {}, resize: () => {} };
+  const Panel = React.forwardRef<unknown, { children?: React.ReactNode }>(({ children }, ref) => {
+    React.useImperativeHandle(ref, () => noopHandle, []);
+    return <div>{children}</div>;
+  });
+  return {
+    Panel,
+    PanelGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    PanelResizeHandle: () => <div />,
+  };
+});
+
+const BOARD_ID = 'board-1';
+const board = { board_id: BOARD_ID, name: 'Board', slug: BOARD_ID } as unknown as Board;
+const branch = {
+  branch_id: 'wt-1',
+  repo_id: 'repo-1',
+  board_id: BOARD_ID,
+  name: 'feature',
+} as unknown as Branch;
+
+const AVAILABLE_AGENTS = [
+  { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: '' },
+  { id: 'codex', name: 'Codex', icon: '💻', description: '' },
+] as never[];
+
+function seedStore() {
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    boardById: new Map([[board.board_id, board]]),
+    branchById: new Map([[branch.branch_id, branch]]),
+    boardObjectsByBoardId: new Map([
+      [BOARD_ID, [{ board_object_id: 'bo-1', board_id: BOARD_ID, branch_id: branch.branch_id }]],
+    ]) as never,
+  });
+}
+
+function renderShell(user: User, onCreateSession = vi.fn(async () => 'new-session-id')) {
+  render(
+    <AntApp>
+      <MemoryRouter initialEntries={[`/b/${BOARD_ID}/`]}>
+        <Routes>
+          <Route
+            path="/b/:boardParam/*"
+            element={
+              <App
+                client={null}
+                user={user}
+                connected={true}
+                availableAgents={AVAILABLE_AGENTS}
+                initialBoardId={BOARD_ID}
+                onCreateSession={onCreateSession}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </AntApp>
+  );
+  return { onCreateSession };
+}
+
+describe('App quick-start — default_agentic_tool preference', () => {
+  beforeEach(() => {
+    seedStore();
+  });
+
+  it('skips the picker and creates immediately when a valid default is set', async () => {
+    const user = {
+      user_id: 'u1',
+      name: 'User',
+      email: 'u@example.test',
+      preferences: { default_agentic_tool: 'codex' },
+    } as unknown as User;
+    const { onCreateSession } = renderShell(user);
+
+    fireEvent.click(await screen.findByTestId('quick-start'));
+
+    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
+    expect(onCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({ branch_id: 'wt-1', agent: 'codex' }),
+      BOARD_ID
+    );
+    expect(screen.queryByTestId('tool-picker')).not.toBeInTheDocument();
+  });
+
+  it('shows the picker (no immediate create) when no default is set', async () => {
+    const user = {
+      user_id: 'u1',
+      name: 'User',
+      email: 'u@example.test',
+      preferences: {},
+    } as unknown as User;
+    const { onCreateSession } = renderShell(user);
+
+    fireEvent.click(await screen.findByTestId('quick-start'));
+
+    await waitFor(() => expect(screen.getByTestId('tool-picker')).toBeInTheDocument());
+    expect(onCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the picker when the stored default is no longer available', async () => {
+    const user = {
+      user_id: 'u1',
+      name: 'User',
+      email: 'u@example.test',
+      preferences: { default_agentic_tool: 'gemini' },
+    } as unknown as User;
+    const { onCreateSession } = renderShell(user);
+
+    fireEvent.click(await screen.findByTestId('quick-start'));
+
+    await waitFor(() => expect(screen.getByTestId('tool-picker')).toBeInTheDocument());
+    expect(onCreateSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/App/App.quickstart.test.tsx
+++ b/apps/agor-ui/src/components/App/App.quickstart.test.tsx
@@ -109,51 +109,17 @@ function renderShell(user: User, onCreateSession = vi.fn(async () => 'new-sessio
   return { onCreateSession };
 }
 
-describe('App quick-start — default_agentic_tool preference', () => {
+describe('App quick-start — always shows the tool picker', () => {
   beforeEach(() => {
     seedStore();
   });
 
-  it('skips the picker and creates immediately when a valid default is set', async () => {
-    const user = {
-      user_id: 'u1',
-      name: 'User',
-      email: 'u@example.test',
-      preferences: { default_agentic_tool: 'codex' },
-    } as unknown as User;
-    const { onCreateSession } = renderShell(user);
-
-    fireEvent.click(await screen.findByTestId('quick-start'));
-
-    await waitFor(() => expect(onCreateSession).toHaveBeenCalledTimes(1));
-    expect(onCreateSession).toHaveBeenCalledWith(
-      expect.objectContaining({ branch_id: 'wt-1', agent: 'codex' }),
-      BOARD_ID
-    );
-    expect(screen.queryByTestId('tool-picker')).not.toBeInTheDocument();
-  });
-
-  it('shows the picker (no immediate create) when no default is set', async () => {
+  it('opens the tile picker without creating a session', async () => {
     const user = {
       user_id: 'u1',
       name: 'User',
       email: 'u@example.test',
       preferences: {},
-    } as unknown as User;
-    const { onCreateSession } = renderShell(user);
-
-    fireEvent.click(await screen.findByTestId('quick-start'));
-
-    await waitFor(() => expect(screen.getByTestId('tool-picker')).toBeInTheDocument());
-    expect(onCreateSession).not.toHaveBeenCalled();
-  });
-
-  it('falls back to the picker when the stored default is no longer available', async () => {
-    const user = {
-      user_id: 'u1',
-      name: 'User',
-      email: 'u@example.test',
-      preferences: { default_agentic_tool: 'gemini' },
     } as unknown as User;
     const { onCreateSession } = renderShell(user);
 

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -903,10 +903,8 @@ export const App: React.FC<AppProps> = ({
     [user, onCreateSession, currentBoardId, client, navigation, showError]
   );
 
-  // Default "Add session" entry point. If the user has set an explicit
-  // "Default agentic tool" preference and it's still available, honor it:
-  // create the session immediately with no picker. Otherwise fall back to the
-  // tool-choice empty state (the tile picker).
+  // Default "Add session" entry point. Always opens the tool-choice empty
+  // state (the tile picker) — a session's tool is always an explicit choice.
   //
   // The render ternary (`effectiveSelectedSessionId ? <SessionPanel/> :
   // pendingToolChoiceBranchId ? <PendingToolChoicePanel/> : ...`) lets an
@@ -919,25 +917,12 @@ export const App: React.FC<AppProps> = ({
   // session, which is what lets the ternary fall through to the picker.
   const handleQuickStartSession = useCallback(
     (branchId: string) => {
-      const preferred = user?.preferences?.default_agentic_tool;
-      const preferredIsAvailable =
-        !!preferred && availableAgents.some((agent) => agent.id === preferred);
-      if (preferred && preferredIsAvailable) {
-        void chooseAgenticTool(branchId, preferred);
-        return;
-      }
       if (effectiveSelectedSessionId) {
         navigation.goToBranch(branchId);
       }
       setPendingToolChoiceBranchId(branchId);
     },
-    [
-      user?.preferences?.default_agentic_tool,
-      availableAgents,
-      chooseAgenticTool,
-      effectiveSelectedSessionId,
-      navigation,
-    ]
+    [effectiveSelectedSessionId, navigation]
   );
 
   const handleCreateBranch = async (config: BranchTabConfig) => {

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1,4 +1,5 @@
 import type {
+  AgenticToolName,
   AgorClient,
   Artifact,
   Board,
@@ -62,6 +63,7 @@ import {
 import type { AgenticToolOption } from '../../types';
 import { initializeAudioOnInteraction } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
+import { resolveQuickStartMcpServerIds } from '../../utils/resolveQuickStartMcpServerIds';
 import { hasExplicitEntityRouteTarget } from '../../utils/routeTargets';
 import { startTeammateBootstrapSession } from '../../utils/startTeammateBootstrapSession';
 import { buildTeammateBootstrapPrompt } from '../../utils/teammateBootstrapPrompt';
@@ -81,6 +83,7 @@ import { NewSessionButton } from '../NewSessionButton';
 import { type NewSessionConfig, NewSessionModal } from '../NewSessionModal';
 import { SessionCanvas, type SessionCanvasRef } from '../SessionCanvas';
 import { SessionPanel } from '../SessionPanel';
+import { PendingToolChoicePanel } from '../SessionPanel/PendingToolChoicePanel';
 import { SessionSettingsModal } from '../SessionSettingsModal';
 import { SettingsModal, UserSettingsModal } from '../SettingsModal';
 import { TerminalModal, WEB_TERMINAL_MIN_ROLE } from '../TerminalModal';
@@ -353,7 +356,7 @@ export const App: React.FC<AppProps> = ({
   // `agorStore.getState()` read inside a handler, or pushed down into the
   // component that actually consumes the map (SettingsModal, UrlStateBridge).
   const { token } = theme.useToken();
-  const { showWarning } = useThemedMessage();
+  const { showWarning, showError } = useThemedMessage();
   const location = useLocation();
   const routeParams = useParams<{
     sessionShortId?: string;
@@ -365,6 +368,11 @@ export const App: React.FC<AppProps> = ({
   const [pendingHomeNavigation, setPendingHomeNavigation] = useState(false);
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
   const [newSessionBranchId, setNewSessionBranchId] = useState<string | null>(null);
+  // Set instead of creating a session immediately when quick-start can't
+  // resolve a tool (no preference, no prior session for this user). Opens
+  // the drawer straight away in a "pick a tool" empty state rather than the
+  // old blocking modal — see `chooseAgenticTool` / `handleQuickStartSession`.
+  const [pendingToolChoiceBranchId, setPendingToolChoiceBranchId] = useState<string | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [createDialogDefaultTab, setCreateDialogDefaultTab] = useState<
     'branch' | 'teammate' | 'board' | 'repository'
@@ -401,6 +409,11 @@ export const App: React.FC<AppProps> = ({
     !isRootHomePath && !pendingHomeNavigation && selectedSessionId && selectedSessionExists
       ? selectedSessionId
       : null;
+
+  // A real selected session always wins; the pending tool-choice empty state
+  // only matters when there's no real session to show yet (see
+  // `handleQuickStartSession`). Both open the same drawer slot.
+  const sessionPanelTargetOpen = !!effectiveSelectedSessionId || !!pendingToolChoiceBranchId;
 
   const [leftPanelTab, setLeftPanelTab] = useState<BoardTeammatePanelTab>('teammate');
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
@@ -669,10 +682,10 @@ export const App: React.FC<AppProps> = ({
   // parent's absolute width changes, so its own absolute pixel width would
   // drift along with the left panel.
   useEffect(() => {
-    if (sessionPanelRef.current && (effectiveSelectedSessionId || !eventStreamPanelCollapsed)) {
+    if (sessionPanelRef.current && (sessionPanelTargetOpen || !eventStreamPanelCollapsed)) {
       sessionPanelRef.current.resize(sessionPanelSizeWithinContent);
     }
-  }, [effectiveSelectedSessionId, sessionPanelSizeWithinContent, eventStreamPanelCollapsed]);
+  }, [sessionPanelTargetOpen, sessionPanelSizeWithinContent, eventStreamPanelCollapsed]);
 
   // URL⇄state sync renders via UrlStateBridge (in the JSX below) so its
   // whole-map subscriptions never wake the shell. Stable callbacks only.
@@ -814,6 +827,7 @@ export const App: React.FC<AppProps> = ({
   // With the flat entity-URL scheme there's no `closeSession` — closing
   // the panel is the same as navigating to the board we're already on.
   const handleCloseSessionPanel = useCallback(() => {
+    setPendingToolChoiceBranchId(null);
     if (currentBoardId) navigation.goToBoard(currentBoardId);
   }, [navigation, currentBoardId]);
 
@@ -834,6 +848,97 @@ export const App: React.FC<AppProps> = ({
       navigation.goToSession(sessionId);
     }
   };
+
+  // Single mechanism behind both "pick a tool" entry points: the quick-start
+  // empty-state tiles (no `replacingSessionId`, session doesn't exist yet)
+  // and the in-drawer "Switch tool" affordance (`replacingSessionId` set —
+  // only ever offered on a session with zero completed tasks, so there's no
+  // conversation to lose). Creates a session with the chosen tool, swaps out
+  // the session it's replacing (if any) with a silent delete — no confirm
+  // dialog, this is an implementation detail of "switching", not a
+  // user-visible delete — and navigates to the result. Does NOT write back a
+  // "latest used" default; the only default is the explicit Settings one that
+  // `handleQuickStartSession` reads.
+  const chooseAgenticTool = useCallback(
+    async (branchId: string, tool: AgenticToolName, replacingSessionId?: string) => {
+      // Read the branch at call time instead of subscribing — `branchById` gets
+      // a new identity on every branch event (env heartbeats, git-state), which
+      // would otherwise churn this callback's identity and re-render every
+      // AppActions consumer on a live board.
+      const branch = agorStore.getState().branchById.get(branchId as Branch['branch_id']);
+      const mcpServerIds = resolveQuickStartMcpServerIds(user, branch);
+
+      const sessionId = await onCreateSession?.(
+        { branch_id: branchId, agent: tool, mcpServerIds },
+        currentBoardId
+      );
+      if (!sessionId) return null;
+
+      if (replacingSessionId && client) {
+        try {
+          // `_swapReplace` tells the daemon this is a switch-tool swap, not a
+          // user-intentional delete — it refuses the removal (Conflict) if a
+          // task has landed on `replacingSessionId` since the swap was
+          // initiated (e.g. a collaborator or another tab prompted it in the
+          // TOCTOU window between opening the picker and clicking a tile),
+          // instead of silently cascade-deleting in-flight work.
+          await client
+            .service('sessions')
+            .remove(replacingSessionId, { query: { _swapReplace: true } });
+        } catch (error) {
+          console.error(`Failed to remove replaced session ${replacingSessionId}:`, error);
+          showError(
+            "Switched tools, but couldn't clean up the previous session — it may still be visible on this branch."
+          );
+        }
+      }
+
+      // Clear the pending picker before navigating: without this the state
+      // lingers and resurrects a phantom "pick a tool" screen (for an already
+      // created session) the next time selection clears — e.g. browser Back.
+      setPendingToolChoiceBranchId(null);
+      navigation.goToSession(sessionId);
+      return sessionId;
+    },
+    [user, onCreateSession, currentBoardId, client, navigation, showError]
+  );
+
+  // Default "Add session" entry point. If the user has set an explicit
+  // "Default agentic tool" preference and it's still available, honor it:
+  // create the session immediately with no picker. Otherwise fall back to the
+  // tool-choice empty state (the tile picker).
+  //
+  // The render ternary (`effectiveSelectedSessionId ? <SessionPanel/> :
+  // pendingToolChoiceBranchId ? <PendingToolChoicePanel/> : ...`) lets an
+  // already-open session win unconditionally, so setting
+  // pendingToolChoiceBranchId alone would be a no-op while a session is
+  // open — clicking "Add session" would do nothing visible. Route away from
+  // the open session via the URL first, same pattern as
+  // handleCloseSessionPanel / handleCreateSession: useUrlState's URL→state
+  // sync effect clears selectedSessionId once the URL stops pointing at a
+  // session, which is what lets the ternary fall through to the picker.
+  const handleQuickStartSession = useCallback(
+    (branchId: string) => {
+      const preferred = user?.preferences?.default_agentic_tool;
+      const preferredIsAvailable =
+        !!preferred && availableAgents.some((agent) => agent.id === preferred);
+      if (preferred && preferredIsAvailable) {
+        void chooseAgenticTool(branchId, preferred);
+        return;
+      }
+      if (effectiveSelectedSessionId) {
+        navigation.goToBranch(branchId);
+      }
+      setPendingToolChoiceBranchId(branchId);
+    },
+    [
+      user?.preferences?.default_agentic_tool,
+      availableAgents,
+      chooseAgenticTool,
+      effectiveSelectedSessionId,
+      navigation,
+    ]
+  );
 
   const handleCreateBranch = async (config: BranchTabConfig) => {
     // Thread board placement (boardId + position) through the create
@@ -995,6 +1100,7 @@ export const App: React.FC<AppProps> = ({
       // Route through URL nav so deep links / back-forward / cross-board
       // recenter all funnel through the same pipe. setSelectedSessionId
       // happens via useUrlState's onSessionChange callback.
+      setPendingToolChoiceBranchId(null);
       navigation.goToSession(sessionId);
     },
     [client, navigation]
@@ -1047,6 +1153,14 @@ export const App: React.FC<AppProps> = ({
         [effectiveSelectedSessionId]
       )
     ) ?? EMPTY_STRING_ARRAY;
+
+  // Narrow per-id subscription for the quick-start picker's branch — only
+  // patches to that specific branch (or a socket-in-flight arrival) wake the
+  // shell, not every unrelated branch event.
+  const pendingToolChoiceBranch =
+    useAgorStore(
+      useMemo(() => makeBranchSelector(pendingToolChoiceBranchId), [pendingToolChoiceBranchId])
+    ) ?? null;
 
   // Sync the actual state when a session disappears (for URL, localStorage, etc.).
   // The rendering already uses effectiveSelectedSessionId so this is mostly
@@ -1168,6 +1282,7 @@ export const App: React.FC<AppProps> = ({
   const stableOnStartEnvironment = useStableCallback(onStartEnvironment);
   const stableOnStopEnvironment = useStableCallback(onStopEnvironment);
   const stableOnNukeEnvironment = useStableCallback(onNukeEnvironment);
+  const stableChooseAgenticTool = useStableCallback(chooseAgenticTool);
 
   // Modal-opener handlers shared by the context value and panel props.
   const handleViewLogs = useCallback((branchId: string) => setLogsModalBranchId(branchId), []);
@@ -1200,6 +1315,8 @@ export const App: React.FC<AppProps> = ({
       onSessionClick: handleSessionClick,
       onOpenBranch: handleOpenBranchModal,
       onOpenTerminal: canOpenTerminal ? handleOpenTerminal : undefined,
+      onChooseAgenticTool: stableChooseAgenticTool,
+      availableAgents,
     }),
     [
       stableOnSendPrompt,
@@ -1218,6 +1335,8 @@ export const App: React.FC<AppProps> = ({
       handleOpenBranchModal,
       handleOpenTerminal,
       canOpenTerminal,
+      stableChooseAgenticTool,
+      availableAgents,
     ]
   );
 
@@ -1240,11 +1359,11 @@ export const App: React.FC<AppProps> = ({
   const eventStreamBranchActions = useMemo(
     () => ({
       onSessionClick: handleSessionClick,
-      onCreateSession: (branchId: string) => setNewSessionBranchId(branchId),
+      onCreateSession: (branchId: string) => handleQuickStartSession(branchId),
       onOpenSettings: (branchId: string) => setBranchModalBranchId(branchId),
       onNukeEnvironment: stableOnNukeEnvironment,
     }),
-    [handleSessionClick, stableOnNukeEnvironment]
+    [handleSessionClick, handleQuickStartSession, stableOnNukeEnvironment]
   );
 
   // Header action handlers, frozen so the memoized AppHeader's React.memo bailout
@@ -1371,7 +1490,7 @@ export const App: React.FC<AppProps> = ({
                   currentUserId={user?.user_id}
                   selectedSessionId={effectiveSelectedSessionId}
                   onSessionClick={handleSessionClick}
-                  onCreateSession={setNewSessionBranchId}
+                  onCreateSession={handleQuickStartSession}
                   onForkSession={stableOnForkSession}
                   onSpawnSession={stableOnSpawnSession}
                   onArchiveOrDelete={stableOnArchiveOrDeleteBranch}
@@ -1457,9 +1576,7 @@ export const App: React.FC<AppProps> = ({
                 <Panel
                   id="canvas-panel"
                   order={1}
-                  defaultSize={
-                    effectiveSelectedSessionId ? 100 - sessionPanelSizeWithinContent : 100
-                  }
+                  defaultSize={sessionPanelTargetOpen ? 100 - sessionPanelSizeWithinContent : 100}
                   minSize={CANVAS_MIN_SIZE_PERCENT}
                 >
                   <div style={{ position: 'relative', overflow: 'hidden', height: '100%' }}>
@@ -1494,7 +1611,7 @@ export const App: React.FC<AppProps> = ({
                         onSpawnSession={stableOnSpawnSession}
                         onUpdateSessionMcpServers={stableOnUpdateSessionMcpServers}
                         onOpenSettings={setSessionSettingsId}
-                        onCreateSessionForBranch={setNewSessionBranchId}
+                        onCreateSessionForBranch={handleQuickStartSession}
                         onOpenBranch={setBranchModalBranchId}
                         onArchiveOrDeleteBranch={stableOnArchiveOrDeleteBranch}
                         onOpenTerminal={canOpenTerminal ? handleOpenTerminal : undefined}
@@ -1519,7 +1636,7 @@ export const App: React.FC<AppProps> = ({
                     )}
                   </div>
                 </Panel>
-                {(effectiveSelectedSessionId || !eventStreamPanelCollapsed) && (
+                {(sessionPanelTargetOpen || !eventStreamPanelCollapsed) && (
                   <>
                     <PanelResizeHandle
                       style={{
@@ -1557,6 +1674,20 @@ export const App: React.FC<AppProps> = ({
                           sessionMcpServerIds={selectedSessionMcpServerIds}
                           open={!!effectiveSelectedSessionId}
                           onClose={handleCloseSessionPanel}
+                        />
+                      ) : pendingToolChoiceBranchId ? (
+                        <PendingToolChoicePanel
+                          branch={pendingToolChoiceBranch}
+                          availableAgents={availableAgents}
+                          onChoose={async (tool) => {
+                            const id = await chooseAgenticTool(pendingToolChoiceBranchId, tool);
+                            if (id) setPendingToolChoiceBranchId(null);
+                          }}
+                          onClose={handleCloseSessionPanel}
+                          onAdvancedSetup={() => {
+                            setNewSessionBranchId(pendingToolChoiceBranchId);
+                            setPendingToolChoiceBranchId(null);
+                          }}
                         />
                       ) : (
                         <EventStreamPanel

--- a/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App, ConfigProvider } from 'antd';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgenticToolOption } from '../AgentSelectionGrid/AgentSelectionGrid';
+import { PendingToolChoicePanel } from './PendingToolChoicePanel';
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ConfigProvider>
+    <App>{children}</App>
+  </ConfigProvider>
+);
+
+const agents: AgenticToolOption[] = [
+  { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: 'Anthropic' },
+  { id: 'codex', name: 'Codex', icon: '💻', description: 'OpenAI' },
+];
+
+describe('PendingToolChoicePanel', () => {
+  it('renders one tile per available agent and the inert composer bar', () => {
+    render(
+      <Wrapper>
+        <PendingToolChoicePanel
+          open
+          branch={null}
+          availableAgents={agents}
+          onChoose={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </Wrapper>
+    );
+
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    expect(screen.getByText('Codex')).toBeInTheDocument();
+    expect(screen.getByText('Untitled session')).toBeInTheDocument();
+
+    const textarea = screen.getByPlaceholderText('Pick a tool above to start typing…');
+    expect(textarea).toHaveAttribute('disabled');
+    expect(screen.getByText('Options').closest('button')).toHaveAttribute('disabled');
+    expect(screen.getByText('Send').closest('button')).toHaveAttribute('disabled');
+  });
+
+  it('calls onChoose with the tool id when a tile is clicked', () => {
+    const onChoose = vi.fn();
+    render(
+      <Wrapper>
+        <PendingToolChoicePanel
+          open
+          branch={null}
+          availableAgents={agents}
+          onChoose={onChoose}
+          onClose={vi.fn()}
+        />
+      </Wrapper>
+    );
+
+    fireEvent.click(screen.getByText('Codex'));
+    expect(onChoose).toHaveBeenCalledWith('codex');
+  });
+
+  it('only shows the advanced-setup escape hatch when a handler is provided', () => {
+    const { rerender } = render(
+      <Wrapper>
+        <PendingToolChoicePanel
+          open
+          branch={null}
+          availableAgents={agents}
+          onChoose={vi.fn()}
+          onClose={vi.fn()}
+        />
+      </Wrapper>
+    );
+    expect(screen.queryByText(/advanced setup/i)).not.toBeInTheDocument();
+
+    const onAdvancedSetup = vi.fn();
+    rerender(
+      <Wrapper>
+        <PendingToolChoicePanel
+          open
+          branch={null}
+          availableAgents={agents}
+          onChoose={vi.fn()}
+          onClose={vi.fn()}
+          onAdvancedSetup={onAdvancedSetup}
+        />
+      </Wrapper>
+    );
+    fireEvent.click(screen.getByText(/advanced setup/i));
+    expect(onAdvancedSetup).toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.tsx
@@ -1,0 +1,196 @@
+/**
+ * PendingToolChoicePanel — quick-start empty state
+ *
+ * Shown in place of the session drawer's conversation + composer when
+ * "Add session" can't resolve a tool on its own (no preference, no prior
+ * session for this user). Rather than blocking on the old modal, the drawer
+ * still opens immediately with this panel: tiles instead of a form, one per
+ * available agentic tool. Picking one creates the session and this panel is
+ * swapped out for the real `SessionPanel`.
+ *
+ * Chrome (header layout, footer bar shape/spacing, muted secondary copy)
+ * mirrors `SessionPanel`'s own header/footer and the Connect-AI empty state
+ * (`MissingCredentialPanel`, feature-connect-ai-empty-state) so the drawer
+ * doesn't visibly change shape between "picking a tool" and "using a
+ * session" — just swap tiles for a form, same panel chrome throughout.
+ *
+ * The composer bar below the tiles is intentionally inert (not hidden): a
+ * disabled textarea + send + options button in the same position the real
+ * `SessionFooter` renders them, so there's no valid-looking-but-broken
+ * affordance before a tool is chosen. It unlocks the instant a tile is
+ * picked, when this panel unmounts in favor of the real session.
+ */
+
+import type { AgenticToolName, Branch } from '@agor-live/client';
+import { CloseOutlined, RobotOutlined, SendOutlined, SettingOutlined } from '@ant-design/icons';
+import { Button, Input, Spin, Typography, theme } from 'antd';
+import type React from 'react';
+import { useState } from 'react';
+import {
+  type AgenticToolOption,
+  AgentSelectionGrid,
+} from '../AgentSelectionGrid/AgentSelectionGrid';
+
+export interface PendingToolChoicePanelProps {
+  branch: Branch | null;
+  availableAgents: AgenticToolOption[];
+  onChoose: (tool: AgenticToolName) => void | Promise<void>;
+  onClose: () => void;
+  /** Escape hatch for the rare case someone wants title/prompt/MCP/env vars set up front. */
+  onAdvancedSetup?: () => void;
+}
+
+export const PendingToolChoicePanel: React.FC<PendingToolChoicePanelProps> = ({
+  branch,
+  availableAgents,
+  onChoose,
+  onClose,
+  onAdvancedSetup,
+}) => {
+  const { token } = theme.useToken();
+  const [choosingTool, setChoosingTool] = useState<string | null>(null);
+
+  const handleChoose = async (toolId: string) => {
+    if (choosingTool) return;
+    setChoosingTool(toolId);
+    try {
+      await onChoose(toolId as AgenticToolName);
+    } finally {
+      setChoosingTool(null);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        background: token.colorBgElevated,
+        borderLeft: `1px solid ${token.colorBorder}`,
+      }}
+    >
+      {/* Header — mirrors SessionPanel's header chrome */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px`,
+          borderBottom: `1px solid ${token.colorBorder}`,
+          background: token.colorBgContainer,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center', minWidth: 0 }}>
+          <RobotOutlined style={{ fontSize: 28, color: token.colorTextTertiary, flexShrink: 0 }} />
+          <Typography.Text strong style={{ fontSize: 18 }}>
+            {branch ? `Untitled session — ${branch.name}` : 'Untitled session'}
+          </Typography.Text>
+        </div>
+        <Button type="text" icon={<CloseOutlined />} onClick={onClose} aria-label="Close panel" />
+      </div>
+
+      {/* Body — tile picker, one per available agentic tool */}
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: token.sizeUnit * 6,
+        }}
+      >
+        <div style={{ maxWidth: 480, width: '100%', textAlign: 'center' }}>
+          <Typography.Text style={{ fontSize: 13 }} type="secondary">
+            Choose which AI tool this session should use.
+          </Typography.Text>
+
+          <div style={{ marginTop: token.marginSM, textAlign: 'left', position: 'relative' }}>
+            <AgentSelectionGrid
+              agents={availableAgents}
+              selectedAgentId={choosingTool}
+              onSelect={handleChoose}
+              columns={2}
+            />
+            {choosingTool && (
+              <div
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: token.colorBgElevated,
+                  opacity: 0.7,
+                }}
+              >
+                <Spin size="small" />
+              </div>
+            )}
+          </div>
+
+          {onAdvancedSetup && (
+            <Button
+              type="link"
+              size="small"
+              onClick={onAdvancedSetup}
+              disabled={!!choosingTool}
+              style={{
+                marginTop: token.marginSM,
+                color: token.colorLink,
+                // antd buttons default to `white-space: nowrap` + a fixed
+                // single-line height, so any text longer than the panel is
+                // silently clipped rather than wrapped. Force a real
+                // multi-line button so this can't recur if the copy grows.
+                whiteSpace: 'normal',
+                height: 'auto',
+                width: '100%',
+                textAlign: 'center',
+                padding: `${token.paddingXXS}px ${token.paddingSM}px`,
+              }}
+            >
+              Need more control? Go to advanced setup
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Footer — same position/shape as SessionFooter, inert until a tile is picked */}
+      <div
+        style={{
+          flexShrink: 0,
+          background: token.colorBgContainer,
+          borderTop: `1px solid ${token.colorBorder}`,
+          padding: `${token.sizeUnit * 2}px ${token.sizeUnit * 6}px ${token.sizeUnit * 3}px`,
+        }}
+      >
+        <Input.TextArea
+          disabled
+          placeholder="Pick a tool above to start typing…"
+          autoSize={{ minRows: 2, maxRows: 2 }}
+        />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: token.sizeUnit,
+            marginTop: token.sizeUnit * 2,
+          }}
+        >
+          <Button size="small" type="text" icon={<SettingOutlined />} disabled>
+            Options
+          </Button>
+          <div style={{ flex: 1 }} />
+          <Button size="small" type="primary" icon={<SendOutlined />} disabled>
+            Send
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/PendingToolChoicePanel.tsx
@@ -23,7 +23,7 @@
 
 import type { AgenticToolName, Branch } from '@agor-live/client';
 import { CloseOutlined, RobotOutlined, SendOutlined, SettingOutlined } from '@ant-design/icons';
-import { Button, Input, Spin, Typography, theme } from 'antd';
+import { Button, Flex, Input, Spin, Typography, theme } from 'antd';
 import type React from 'react';
 import { useState } from 'react';
 import {
@@ -61,47 +61,44 @@ export const PendingToolChoicePanel: React.FC<PendingToolChoicePanelProps> = ({
   };
 
   return (
-    <div
+    <Flex
+      vertical
       style={{
         width: '100%',
         height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
         background: token.colorBgElevated,
         borderLeft: `1px solid ${token.colorBorder}`,
       }}
     >
       {/* Header — mirrors SessionPanel's header chrome */}
-      <div
+      <Flex
+        justify="space-between"
+        align="center"
         style={{
           flexShrink: 0,
           padding: `${token.sizeUnit * 3}px ${token.sizeUnit * 6}px`,
           borderBottom: `1px solid ${token.colorBorder}`,
           background: token.colorBgContainer,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
         }}
       >
-        <div style={{ display: 'flex', gap: 12, alignItems: 'center', minWidth: 0 }}>
+        <Flex align="center" gap={12} style={{ minWidth: 0 }}>
           <RobotOutlined style={{ fontSize: 28, color: token.colorTextTertiary, flexShrink: 0 }} />
           <Typography.Text strong style={{ fontSize: 18 }}>
             {branch ? `Untitled session — ${branch.name}` : 'Untitled session'}
           </Typography.Text>
-        </div>
+        </Flex>
         <Button type="text" icon={<CloseOutlined />} onClick={onClose} aria-label="Close panel" />
-      </div>
+      </Flex>
 
       {/* Body — tile picker, one per available agentic tool */}
-      <div
+      <Flex
+        vertical
+        align="center"
+        justify="center"
         style={{
           flex: 1,
           minHeight: 0,
           overflowY: 'auto',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
           padding: token.sizeUnit * 6,
         }}
       >
@@ -110,7 +107,10 @@ export const PendingToolChoicePanel: React.FC<PendingToolChoicePanelProps> = ({
             Choose which AI tool this session should use.
           </Typography.Text>
 
-          <div style={{ marginTop: token.marginSM, textAlign: 'left', position: 'relative' }}>
+          <Flex
+            vertical
+            style={{ marginTop: token.marginSM, textAlign: 'left', position: 'relative' }}
+          >
             <AgentSelectionGrid
               agents={availableAgents}
               selectedAgentId={choosingTool}
@@ -118,21 +118,20 @@ export const PendingToolChoicePanel: React.FC<PendingToolChoicePanelProps> = ({
               columns={2}
             />
             {choosingTool && (
-              <div
+              <Flex
+                align="center"
+                justify="center"
                 style={{
                   position: 'absolute',
                   inset: 0,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
                   background: token.colorBgElevated,
                   opacity: 0.7,
                 }}
               >
                 <Spin size="small" />
-              </div>
+              </Flex>
             )}
-          </div>
+          </Flex>
 
           {onAdvancedSetup && (
             <Button
@@ -158,10 +157,11 @@ export const PendingToolChoicePanel: React.FC<PendingToolChoicePanelProps> = ({
             </Button>
           )}
         </div>
-      </div>
+      </Flex>
 
       {/* Footer — same position/shape as SessionFooter, inert until a tile is picked */}
-      <div
+      <Flex
+        vertical
         style={{
           flexShrink: 0,
           background: token.colorBgContainer,
@@ -174,11 +174,10 @@ export const PendingToolChoicePanel: React.FC<PendingToolChoicePanelProps> = ({
           placeholder="Pick a tool above to start typing…"
           autoSize={{ minRows: 2, maxRows: 2 }}
         />
-        <div
+        <Flex
+          align="center"
+          gap={token.sizeUnit}
           style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: token.sizeUnit,
             marginTop: token.sizeUnit * 2,
           }}
         >
@@ -189,8 +188,8 @@ export const PendingToolChoicePanel: React.FC<PendingToolChoicePanelProps> = ({
           <Button size="small" type="primary" icon={<SendOutlined />} disabled>
             Send
           </Button>
-        </div>
-      </div>
-    </div>
+        </Flex>
+      </Flex>
+    </Flex>
   );
 };

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.quickstart.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.quickstart.test.tsx
@@ -1,0 +1,209 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: pins AgentSelectionCard's selected-tile border color to verify the switch-tool highlight
+import type { Branch, Session } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { AppActionsProvider } from '../../contexts/AppActionsContext';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import type { AgenticToolOption } from '../../types';
+import SessionPanel from './SessionPanel';
+
+vi.mock('../AutocompleteTextarea', () => ({
+  AutocompleteTextarea: () => <textarea aria-label="Prompt" />,
+}));
+
+vi.mock('../FileUpload', () => ({
+  FileUpload: () => null,
+  FileUploadButton: (props: { onClick?: () => void; disabled?: boolean }) => (
+    <button type="button" disabled={props.disabled} onClick={props.onClick}>
+      Upload Files
+    </button>
+  ),
+}));
+
+vi.mock('../ForkSpawnModal/ForkSpawnModal', () => ({
+  ForkSpawnModal: () => null,
+}));
+
+vi.mock('../MCPServer', () => ({
+  MCPServerPill: () => <span>MCP server</span>,
+}));
+
+vi.mock('../metadata', () => ({
+  CreatedByTag: () => <span>Created by test user</span>,
+}));
+
+vi.mock('../Pill', () => ({
+  ContextWindowPill: () => <span>Context window</span>,
+  TimerPill: () => <span>Timer</span>,
+  TokenCountPill: () => <span>Tokens</span>,
+}));
+
+vi.mock('../SessionIds', () => ({
+  SessionIdsButton: () => <span>Session IDs</span>,
+  SessionIdsList: () => <span>Session IDs List</span>,
+}));
+
+vi.mock('../ToolIcon', () => ({
+  ToolIcon: () => <span>Tool icon</span>,
+}));
+
+vi.mock('./SessionAttachmentsDropdown', () => ({
+  SessionAttachmentsDropdown: () => null,
+}));
+
+vi.mock('./SessionMcpFooterControl', () => ({
+  SessionMcpFooterControl: () => null,
+}));
+
+vi.mock('./SessionPanelContent', () => ({
+  SessionPanelContent: () => <div>Session content</div>,
+}));
+
+vi.mock('./SessionRunSettingsPopover', () => ({
+  SessionRunSettingsPopover: () => null,
+}));
+
+const connected = {
+  connected: true,
+  connecting: false,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+
+const branch = {
+  branch_id: 'branch-1',
+  board_id: 'board-1',
+  name: 'feature/same-name',
+  path: '/tmp/feature-same-name',
+  filesystem_status: 'ready',
+  archived: false,
+} as unknown as Branch;
+
+const availableAgents: AgenticToolOption[] = [
+  { id: 'claude-code', name: 'Claude Code', icon: '🤖', description: 'Anthropic' },
+  { id: 'codex', name: 'Codex', icon: '💻', description: 'OpenAI' },
+];
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: 'session-1',
+    branch_id: 'branch-1',
+    agentic_tool: 'claude-code',
+    status: 'idle',
+    archived: false,
+    tasks: [],
+    created_at: '2026-06-24T00:00:00.000Z',
+    last_updated: '2026-06-24T00:00:00.000Z',
+    ...overrides,
+  } as unknown as Session;
+}
+
+function renderPanel(
+  session: Session,
+  actions: {
+    onUpdateSession?: ReturnType<typeof vi.fn>;
+    onChooseAgenticTool?: ReturnType<typeof vi.fn>;
+  } = {}
+) {
+  render(
+    <ConnectionProvider value={connected}>
+      <AppActionsProvider
+        value={{
+          onUpdateSession: actions.onUpdateSession,
+          onChooseAgenticTool: actions.onChooseAgenticTool,
+          availableAgents,
+        }}
+      >
+        <AntApp>
+          <SessionPanel client={null} session={session} branch={branch} open onClose={vi.fn()} />
+        </AntApp>
+      </AppActionsProvider>
+    </ConnectionProvider>
+  );
+}
+
+describe('SessionPanel inline title edit', () => {
+  it('shows the "Untitled session" placeholder for a session with no title or description', () => {
+    renderPanel(makeSession());
+    expect(screen.getByText('Untitled session')).toBeInTheDocument();
+  });
+
+  it('click-to-edit saves a new title on Enter', () => {
+    const onUpdateSession = vi.fn();
+    renderPanel(makeSession(), { onUpdateSession });
+
+    fireEvent.click(screen.getByText('Untitled session'));
+    const input = screen.getByPlaceholderText('Untitled session');
+    fireEvent.change(input, { target: { value: 'My renamed session' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onUpdateSession).toHaveBeenCalledWith('session-1', { title: 'My renamed session' });
+  });
+
+  it('Escape cancels without saving', () => {
+    const onUpdateSession = vi.fn();
+    renderPanel(makeSession({ title: 'Original title' }), { onUpdateSession });
+
+    fireEvent.click(screen.getByText('Original title'));
+    const input = screen.getByDisplayValue('Original title');
+    fireEvent.change(input, { target: { value: 'Discard me' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onUpdateSession).not.toHaveBeenCalled();
+    expect(screen.getByText('Original title')).toBeInTheDocument();
+  });
+});
+
+describe('SessionPanel switch-tool affordance', () => {
+  it('offers "Switch tool…" for a session with zero tasks and creates via the chosen tile', async () => {
+    const onChooseAgenticTool = vi.fn();
+    renderPanel(makeSession({ tasks: [] }), { onChooseAgenticTool });
+
+    fireEvent.click(screen.getAllByRole('img', { name: 'ellipsis' })[0].closest('button')!);
+    fireEvent.click(await screen.findByText('Switch tool…'));
+
+    fireEvent.click(await screen.findByText('Codex'));
+    expect(onChooseAgenticTool).toHaveBeenCalledWith('branch-1', 'codex', 'session-1');
+  });
+
+  it('hides "Switch tool…" once the session has a task', async () => {
+    renderPanel(makeSession({ tasks: ['task-1'] as unknown as Session['tasks'] }), {
+      onChooseAgenticTool: vi.fn(),
+    });
+
+    fireEvent.click(screen.getAllByRole('img', { name: 'ellipsis' })[0].closest('button')!);
+    await screen.findByText('Archive session');
+    expect(screen.queryByText('Switch tool…')).not.toBeInTheDocument();
+  });
+
+  it("highlights the tile just clicked (not the session's old tool) while the switch is in flight", async () => {
+    let resolveChoose: (() => void) | undefined;
+    const onChooseAgenticTool = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveChoose = () => resolve('new-session-id');
+        })
+    );
+    // Session's current tool is Claude Code — the old (wrong) behavior
+    // highlighted this tile during the switch instead of the one clicked.
+    renderPanel(makeSession({ tasks: [], agentic_tool: 'claude-code' }), { onChooseAgenticTool });
+
+    fireEvent.click(screen.getAllByRole('img', { name: 'ellipsis' })[0].closest('button')!);
+    fireEvent.click(await screen.findByText('Switch tool…'));
+    fireEvent.click(await screen.findByText('Codex'));
+
+    // jsdom's cssstyle can't parse antd's `border` shorthand CSS-variable
+    // value alongside a discrete `borderColor` override (unrelated to this
+    // fix), so read the raw inline style attribute instead of `toHaveStyle`.
+    const codexCard = screen.getByText('Codex').closest('.ant-card') as HTMLElement;
+    const claudeCard = screen.getByText('Claude Code').closest('.ant-card') as HTMLElement;
+    // token.colorPrimary in the default antd v5 theme (#1677ff).
+    expect(codexCard.getAttribute('style')).toContain('border-color: rgb(22, 119, 255)');
+    expect(claudeCard.getAttribute('style')).not.toContain('border-color: rgb(22, 119, 255)');
+
+    resolveChoose?.();
+    await waitFor(() => expect(onChooseAgenticTool).toHaveBeenCalled());
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -1,4 +1,5 @@
 import type {
+  AgenticToolName,
   AgorClient,
   Branch,
   CodexApprovalPolicy,
@@ -23,13 +24,15 @@ import {
   CloseOutlined,
   CodeOutlined,
   DownOutlined,
+  EditOutlined,
   EllipsisOutlined,
   InboxOutlined,
+  RobotOutlined,
   SearchOutlined,
   SettingOutlined,
   UpOutlined,
 } from '@ant-design/icons';
-import type { MenuProps } from 'antd';
+import type { InputRef, MenuProps } from 'antd';
 import {
   Alert,
   App,
@@ -37,7 +40,9 @@ import {
   Button,
   Dropdown,
   Input,
+  Modal,
   Space,
+  Spin,
   Tooltip,
   Typography,
   theme,
@@ -60,6 +65,7 @@ import { getContextWindowGradient } from '../../utils/contextWindow';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
 import { useThemedMessage } from '../../utils/message';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
+import { AgentSelectionGrid } from '../AgentSelectionGrid/AgentSelectionGrid';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { FileUpload } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
@@ -315,10 +321,73 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const userAuthenticatedMcpServerIds = useAgorStore(selectUserAuthenticatedMcpServerIds);
 
   // Get actions from context
-  const { onSendPrompt, onFork, onBtwFork, onOpenSettings, onUpdateSession, onOpenTerminal } =
-    useAppActions();
+  const {
+    onSendPrompt,
+    onFork,
+    onBtwFork,
+    onOpenSettings,
+    onUpdateSession,
+    onOpenTerminal,
+    onChooseAgenticTool,
+    availableAgents,
+  } = useAppActions();
 
   const { archiveSession } = useSessionActions(client);
+
+  // Click-to-edit session title, inline in the header — see render below.
+  // Draft is seeded from the *explicit* title only (not the description
+  // fallback getSessionDisplayTitle shows when unset), so entering edit mode
+  // never accidentally "sets" a title from the first-prompt fallback text.
+  const [editingTitle, setEditingTitle] = React.useState(false);
+  const [titleHovered, setTitleHovered] = React.useState(false);
+  const [titleDraft, setTitleDraft] = React.useState('');
+  const titleInputRef = React.useRef<InputRef | null>(null);
+  const startEditingTitle = React.useCallback(() => {
+    setTitleDraft(session?.title ?? '');
+    setEditingTitle(true);
+  }, [session?.title]);
+  const saveTitle = React.useCallback(() => {
+    setEditingTitle(false);
+    if (!session) return;
+    const trimmed = titleDraft.trim();
+    if (trimmed !== (session.title ?? '')) {
+      onUpdateSession?.(session.session_id, { title: trimmed });
+    }
+  }, [session, titleDraft, onUpdateSession]);
+  React.useEffect(() => {
+    if (editingTitle) titleInputRef.current?.focus();
+  }, [editingTitle]);
+
+  // "Switch tool" — same underlying chooseAgenticTool action the quick-start
+  // empty-state tiles use, just with `replacingSessionId` set. Only offered
+  // on a session with zero tasks (never prompted yet): tool is a per-session
+  // SDK choice baked into every task, so there's no safe way to change it
+  // once a conversation exists — hide the affordance entirely rather than
+  // let it fail or silently drop history. (See `canSwitchTool` /
+  // `handleSwitchTool` below the early-return, once `session` is narrowed.)
+  const [switchToolOpen, setSwitchToolOpen] = React.useState(false);
+  // The tile the user just clicked, not a bare boolean — mirrors
+  // `PendingToolChoicePanel`'s `choosingTool` so the grid highlights the tile
+  // being switched *to* during the async request, not the session's current
+  // (old) tool.
+  const [switchingTool, setSwitchingTool] = React.useState<string | null>(null);
+
+  // App renders this panel without a session key, so a route/back-forward
+  // change swaps `session` in place instead of remounting. Reset the transient
+  // title-edit and switch-tool UI when the session id changes so a draft title
+  // or an open switch modal from the previous session can't bleed into (and
+  // then act on) the next one.
+  const titleStateSessionId = session?.session_id;
+  const prevTitleStateSessionId = React.useRef(titleStateSessionId);
+  React.useEffect(() => {
+    if (prevTitleStateSessionId.current !== titleStateSessionId) {
+      prevTitleStateSessionId.current = titleStateSessionId;
+      setEditingTitle(false);
+      setTitleDraft('');
+      setSwitchToolOpen(false);
+      setSwitchingTool(null);
+    }
+  }, [titleStateSessionId]);
 
   // Tool capabilities — drives which buttons are shown
   const toolCaps = session?.agentic_tool
@@ -868,6 +937,17 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   };
 
   const hasBranchActions = !!branch;
+  const canSwitchTool = !!branch && !!onChooseAgenticTool && (session.tasks?.length ?? 0) === 0;
+  const handleSwitchTool = async (tool: string) => {
+    if (!branch || !onChooseAgenticTool || switchingTool) return;
+    setSwitchingTool(tool);
+    try {
+      await onChooseAgenticTool(branch.branch_id, tool as AgenticToolName, session.session_id);
+      setSwitchToolOpen(false);
+    } finally {
+      setSwitchingTool(null);
+    }
+  };
   const moreMenuItems: MenuProps['items'] = [
     ...(branch
       ? [
@@ -897,6 +977,16 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             icon: <SettingOutlined />,
             label: 'Session Settings',
             onClick: () => onOpenSettings(session.session_id),
+          },
+        ]
+      : []),
+    ...(canSwitchTool
+      ? [
+          {
+            key: 'switch-tool',
+            icon: <RobotOutlined />,
+            label: 'Switch tool…',
+            onClick: () => setSwitchToolOpen(true),
           },
         ]
       : []),
@@ -1290,9 +1380,66 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
               <ToolIcon tool={session.agentic_tool} size={40} />
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
-              <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
-                {getSessionDisplayTitle(session, { includeAgentFallback: true })}
-              </Typography.Text>
+              {editingTitle ? (
+                <Input
+                  ref={titleInputRef}
+                  value={titleDraft}
+                  onChange={(e) => setTitleDraft(e.target.value)}
+                  onBlur={saveTitle}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      saveTitle();
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault();
+                      setEditingTitle(false);
+                    }
+                  }}
+                  placeholder="Untitled session"
+                  variant="borderless"
+                  style={{ fontSize: 18, fontWeight: 600, padding: 0 }}
+                />
+              ) : (
+                <Tooltip title="Click to rename">
+                  <button
+                    type="button"
+                    onClick={startEditingTitle}
+                    onMouseEnter={() => setTitleHovered(true)}
+                    onMouseLeave={() => setTitleHovered(false)}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      maxWidth: '100%',
+                      cursor: 'text',
+                      borderRadius: token.borderRadiusSM,
+                      padding: '2px 6px',
+                      margin: '-2px -6px',
+                      background: titleHovered ? token.colorFillTertiary : 'transparent',
+                      transition: 'background 0.15s',
+                      border: 'none',
+                      font: 'inherit',
+                      color: 'inherit',
+                      textAlign: 'left',
+                    }}
+                  >
+                    <Typography.Text strong style={{ fontSize: 18, ...getSessionTitleStyles(2) }}>
+                      {session.title || session.description
+                        ? getSessionDisplayTitle(session, { includeAgentFallback: false })
+                        : 'Untitled session'}
+                    </Typography.Text>
+                    <EditOutlined
+                      style={{
+                        fontSize: 12,
+                        color: token.colorTextTertiary,
+                        opacity: titleHovered ? 1 : 0,
+                        transition: 'opacity 0.15s',
+                        flexShrink: 0,
+                      }}
+                    />
+                  </button>
+                </Tooltip>
+              )}
               <Badge status={getStatusColor()} text={session.status.toUpperCase()} />
               {session.created_by && (
                 <div style={{ marginTop: token.sizeUnit }}>
@@ -1523,6 +1670,44 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           client={client}
           userById={userById}
         />
+
+        {/* Switch tool — same tile picker as the quick-start empty state,
+            just replacing this (never-prompted) session instead of creating
+            the first one. Only reachable via moreMenuItems when canSwitchTool. */}
+        <Modal
+          title="Switch tool"
+          open={switchToolOpen}
+          onCancel={() => setSwitchToolOpen(false)}
+          footer={null}
+        >
+          <Typography.Paragraph type="secondary" style={{ fontSize: 13 }}>
+            Choose a different tool for this session. Since nothing has been sent yet, this replaces
+            the session in place.
+          </Typography.Paragraph>
+          <div style={{ position: 'relative' }}>
+            <AgentSelectionGrid
+              agents={availableAgents ?? []}
+              selectedAgentId={switchingTool}
+              onSelect={handleSwitchTool}
+              columns={2}
+            />
+            {switchingTool && (
+              <div
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: token.colorBgElevated,
+                  opacity: 0.7,
+                }}
+              >
+                <Spin size="small" />
+              </div>
+            )}
+          </div>
+        </Modal>
       </div>
     </div>
   );

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -52,6 +52,7 @@ import {
   getClearedFormValues,
   getFormValuesFromConfig,
 } from '../AgenticToolConfigForm';
+import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
 import { ApiKeyFields, type FieldStatus, TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { EnvVarEditor } from '../EnvVarEditor';
@@ -219,6 +220,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         groupIds: [],
         eventStreamEnabled: userData.preferences?.eventStream?.enabled ?? true,
         useSlackAvatar: userData.preferences?.use_slack_avatar !== false,
+        defaultAgenticTool: userData.preferences?.default_agentic_tool,
         must_change_password: userData.must_change_password ?? false,
       });
     },
@@ -446,6 +448,11 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         nextPreferences.use_slack_avatar = false;
       } else {
         delete nextPreferences.use_slack_avatar;
+      }
+      if (values.defaultAgenticTool) {
+        nextPreferences.default_agentic_tool = values.defaultAgenticTool;
+      } else {
+        delete nextPreferences.default_agentic_tool;
       }
 
       const updates: UpdateUserInput = {
@@ -867,6 +874,26 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                 tooltip="When enabled, Agor shows your Slack-synced profile image. Turn this off to keep using your emoji tile."
               >
                 <Switch />
+              </Form.Item>
+
+              <Form.Item
+                label="Default agentic tool"
+                name="defaultAgenticTool"
+                tooltip="Clicking “Add session” creates a session with this tool immediately, no picker. Leave unset to pick a tool each time."
+              >
+                <Select
+                  allowClear
+                  placeholder="No default — show a picker each time"
+                  options={AVAILABLE_AGENTS.map((agent) => ({
+                    value: agent.id,
+                    label: (
+                      <Space size={8}>
+                        <ToolIcon tool={agent.id} size={16} />
+                        <span>{agent.name}</span>
+                      </Space>
+                    ),
+                  }))}
+                />
               </Form.Item>
 
               <Form.Item

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -52,7 +52,6 @@ import {
   getClearedFormValues,
   getFormValuesFromConfig,
 } from '../AgenticToolConfigForm';
-import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
 import { ApiKeyFields, type FieldStatus, TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { EnvVarEditor } from '../EnvVarEditor';
@@ -220,7 +219,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         groupIds: [],
         eventStreamEnabled: userData.preferences?.eventStream?.enabled ?? true,
         useSlackAvatar: userData.preferences?.use_slack_avatar !== false,
-        defaultAgenticTool: userData.preferences?.default_agentic_tool,
         must_change_password: userData.must_change_password ?? false,
       });
     },
@@ -448,11 +446,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         nextPreferences.use_slack_avatar = false;
       } else {
         delete nextPreferences.use_slack_avatar;
-      }
-      if (values.defaultAgenticTool) {
-        nextPreferences.default_agentic_tool = values.defaultAgenticTool;
-      } else {
-        delete nextPreferences.default_agentic_tool;
       }
 
       const updates: UpdateUserInput = {
@@ -874,26 +867,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                 tooltip="When enabled, Agor shows your Slack-synced profile image. Turn this off to keep using your emoji tile."
               >
                 <Switch />
-              </Form.Item>
-
-              <Form.Item
-                label="Default agentic tool"
-                name="defaultAgenticTool"
-                tooltip="Clicking “Add session” creates a session with this tool immediately, no picker. Leave unset to pick a tool each time."
-              >
-                <Select
-                  allowClear
-                  placeholder="No default — show a picker each time"
-                  options={AVAILABLE_AGENTS.map((agent) => ({
-                    value: agent.id,
-                    label: (
-                      <Space size={8}>
-                        <ToolIcon tool={agent.id} size={16} />
-                        <span>{agent.name}</span>
-                      </Space>
-                    ),
-                  }))}
-                />
               </Form.Item>
 
               <Form.Item

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -1,6 +1,13 @@
-import type { PermissionMode, PermissionScope, Session, SpawnConfig } from '@agor-live/client';
+import type {
+  AgenticToolName,
+  PermissionMode,
+  PermissionScope,
+  Session,
+  SpawnConfig,
+} from '@agor-live/client';
 import type React from 'react';
 import { createContext, useContext } from 'react';
+import type { AgenticToolOption } from '../components/AgentSelectionGrid/AgentSelectionGrid';
 import type { BranchModalTab } from '../components/BranchModal/BranchModal';
 
 /**
@@ -41,6 +48,23 @@ export interface AppActionsContextValue {
   onSessionClick?: (sessionId: string) => void;
   onOpenBranch?: (branchId: string, tab?: BranchModalTab) => void;
   onOpenTerminal?: (commands: string[], branchId?: string) => void;
+
+  /**
+   * Single mechanism behind both tool-choice entry points: the quick-start
+   * empty-state tiles (no `replacingSessionId` — nothing to replace yet)
+   * and the in-drawer "Switch tool" affordance (`replacingSessionId` set to
+   * the current, never-prompted session, which gets silently swapped out).
+   * Creates a session with `tool`, navigates to it, and resolves the new
+   * session id (or `null` on failure). Does NOT remember the choice as a
+   * default — every "Add session" always shows the tile picker.
+   */
+  onChooseAgenticTool?: (
+    branchId: string,
+    tool: AgenticToolName,
+    replacingSessionId?: string
+  ) => Promise<string | null>;
+  /** Tools available for the quick-start tile picker / tool switcher. */
+  availableAgents?: AgenticToolOption[];
 }
 
 const AppActionsContext = createContext<AppActionsContextValue | undefined>(undefined);

--- a/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
+++ b/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
@@ -59,6 +59,10 @@ function renderAt(pathname: string, options: UseUrlStateOptions) {
             element={<HookHost options={opts} pathRef={pathRef} />}
           />
           <Route path="/b/:boardParam/" element={<HookHost options={opts} pathRef={pathRef} />} />
+          <Route
+            path="/w/:branchShortId/"
+            element={<HookHost options={opts} pathRef={pathRef} />}
+          />
           <Route path="/*" element={<HookHost options={opts} pathRef={pathRef} />} />
         </Routes>
       </CanvasNavigationProvider>
@@ -182,5 +186,51 @@ describe('useUrlState — deferred session resolution', () => {
 
     expect(onSessionChange).toHaveBeenCalledWith(SESSION_ID);
     expect(onBoardChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('useUrlState — navigating away from a session clears selection', () => {
+  // Covers the mechanism `App.tsx`'s handleQuickStartSession relies on:
+  // clicking "Add session" while a different session is open calls
+  // `navigation.goToBranch(branchId)` specifically so the URL stops
+  // pointing at a session — this is what lets `selectedSessionId` (and
+  // therefore the render ternary that prefers an open SessionPanel over
+  // the tile picker) actually clear. Without this, "Add session" was a
+  // silent no-op whenever a session was already open.
+  it('fires onSessionChange(null) when the URL moves from a session to a branch', () => {
+    const onSessionChange = vi.fn();
+    const onBoardChange = vi.fn();
+    const branch = { branch_id: BRANCH_ID, board_id: BOARD_ID } as Branch;
+
+    // Landing directly on a branch URL while app state still thinks a
+    // session is selected (from before the navigation) mirrors what a
+    // fresh render sees the instant goToBranch's history push commits.
+    renderAt(`/w/${BRANCH_ID}/`, {
+      ...baseOptions({
+        currentSessionId: SESSION_ID,
+        branchById: new Map([[branch.branch_id, branch]]),
+        onSessionChange,
+        onBoardChange,
+      }),
+    });
+
+    expect(onSessionChange).toHaveBeenCalledWith(null);
+  });
+
+  it('does not fire onSessionChange when no session was selected to begin with', () => {
+    const onSessionChange = vi.fn();
+    const onBoardChange = vi.fn();
+    const branch = { branch_id: BRANCH_ID, board_id: BOARD_ID } as Branch;
+
+    renderAt(`/w/${BRANCH_ID}/`, {
+      ...baseOptions({
+        currentSessionId: null,
+        branchById: new Map([[branch.branch_id, branch]]),
+        onSessionChange,
+        onBoardChange,
+      }),
+    });
+
+    expect(onSessionChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/utils/resolveQuickStartMcpServerIds.test.ts
+++ b/apps/agor-ui/src/utils/resolveQuickStartMcpServerIds.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveQuickStartMcpServerIds } from './resolveQuickStartMcpServerIds';
+
+describe('resolveQuickStartMcpServerIds', () => {
+  it('prefers branch-level MCP servers over user defaults', () => {
+    const result = resolveQuickStartMcpServerIds(
+      { default_mcp_server_ids: ['user-mcp'] },
+      { mcp_server_ids: ['branch-mcp'] }
+    );
+    expect(result).toEqual(['branch-mcp']);
+  });
+
+  it('falls back to the user default when branch has none', () => {
+    const result = resolveQuickStartMcpServerIds(
+      { default_mcp_server_ids: ['user-mcp'] },
+      { mcp_server_ids: [] }
+    );
+    expect(result).toEqual(['user-mcp']);
+  });
+
+  it('returns an empty array when neither branch nor user has a default', () => {
+    expect(resolveQuickStartMcpServerIds(null, null)).toEqual([]);
+  });
+});

--- a/apps/agor-ui/src/utils/resolveQuickStartMcpServerIds.ts
+++ b/apps/agor-ui/src/utils/resolveQuickStartMcpServerIds.ts
@@ -1,0 +1,20 @@
+/**
+ * MCP server inheritance for quick-start session creation.
+ *
+ * Mirrors the branch > user-default precedence `NewSessionModal` already
+ * uses when a form field is left untouched (see its `mcpServerIds` fallback
+ * in `handleCreate`), and the server-side `resolveSessionDefaults` walk —
+ * just without the "explicit override" tier, since quick-start has no form
+ * for the user to override anything in.
+ */
+
+import type { Branch, User } from '@agor-live/client';
+
+export function resolveQuickStartMcpServerIds(
+  user: Pick<User, 'default_mcp_server_ids'> | null | undefined,
+  branch: Pick<Branch, 'mcp_server_ids'> | null | undefined
+): string[] {
+  const branchMcpIds = branch?.mcp_server_ids;
+  if (branchMcpIds && branchMcpIds.length > 0) return branchMcpIds;
+  return user?.default_mcp_server_ids ?? [];
+}

--- a/context/explorations/kb-teammate-framework-integration.md
+++ b/context/explorations/kb-teammate-framework-integration.md
@@ -299,11 +299,13 @@ Daily memory docs should be valid markdown, append-mostly, and deterministic. Pr
 <!-- agor-memory-entry id=01J... ordinal=000001 sha256=... -->
 
 - 2026-06-07T14:23:11Z [decision] User prefers review-first PR workflow. (source: agor://session/...)
+
 <!-- /agor-memory-entry -->
 
 <!-- agor-memory-entry id=01J... ordinal=000002 sha256=... -->
 
 - 2026-06-07T15:01:04Z [learning] For repo preset-io/agor, do not run `pnpm build` unless asked.
+
 <!-- /agor-memory-entry -->
 ```
 

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -3,6 +3,7 @@ import {
   boardObjectQueryValidator,
   branchQueryValidator,
   mcpServerQueryValidator,
+  sessionQueryValidator,
   typedValidateQuery,
   userQueryValidator,
 } from './feathers-validation';
@@ -90,6 +91,31 @@ describe('userQueryValidator', () => {
       offset: 3,
       $limit: 50,
       $skip: 5,
+    });
+  });
+});
+
+describe('sessionQueryValidator', () => {
+  it('preserves the _swapReplace marker so the switch-tool guard can see it', async () => {
+    // Regression: `removeAdditional: 'all'` silently stripped `_swapReplace`
+    // before it reached SessionsService.remove, making the swap-safety guard
+    // dead on the external client path. It must now survive validation (and
+    // coerce the REST string form) while genuinely unknown props are dropped.
+    const context = {
+      params: {
+        query: {
+          session_id: '019e8e1c',
+          _swapReplace: 'true',
+          unknown: 'removed',
+        },
+      },
+    };
+
+    await typedValidateQuery(sessionQueryValidator)(context);
+
+    expect(context.params.query).toEqual({
+      session_id: '019e8e1c',
+      _swapReplace: true,
     });
   });
 });

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -113,6 +113,11 @@ export const sessionQuerySchema = createQuerySchema(
     archived: Type.Optional(CommonSchemas.boolean),
     created_at: Type.Optional(CommonSchemas.timestamp),
     updated_at: Type.Optional(CommonSchemas.timestamp),
+    // Marks a `remove` as the delete half of a "switch tool" swap so the
+    // service can refuse it if a task landed on the session mid-swap. Declared
+    // here so the query validator (`removeAdditional: 'all'`) doesn't strip it
+    // before the service's guard sees it.
+    _swapReplace: Type.Optional(CommonSchemas.boolean),
   })
 );
 

--- a/packages/core/src/sessions/derive-title-from-prompt.test.ts
+++ b/packages/core/src/sessions/derive-title-from-prompt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { deriveTitleFromPrompt } from './derive-title-from-prompt.js';
+
+describe('deriveTitleFromPrompt', () => {
+  it('returns short prompts unchanged', () => {
+    expect(deriveTitleFromPrompt('Add authentication to the login flow')).toBe(
+      'Add authentication to the login flow'
+    );
+  });
+
+  it('collapses internal whitespace and newlines', () => {
+    expect(deriveTitleFromPrompt('Fix   the\n\nbug   in checkout')).toBe('Fix the bug in checkout');
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(deriveTitleFromPrompt('   hello world   ')).toBe('hello world');
+  });
+
+  it('truncates long prompts at a word boundary with an ellipsis', () => {
+    const prompt =
+      'Implement a full JWT-based authentication system with secure password storage and refresh token rotation';
+    const title = deriveTitleFromPrompt(prompt);
+    expect(title.length).toBeLessThanOrEqual(61);
+    expect(title.endsWith('…')).toBe(true);
+    expect(title).not.toMatch(/\s…$/);
+  });
+
+  it('hard-cuts when there is no reasonable word boundary', () => {
+    const prompt = `${'a'.repeat(100)} b`;
+    const title = deriveTitleFromPrompt(prompt);
+    expect(title.length).toBeLessThanOrEqual(61);
+    expect(title.endsWith('…')).toBe(true);
+  });
+
+  it('returns an empty string for blank input', () => {
+    expect(deriveTitleFromPrompt('   ')).toBe('');
+    expect(deriveTitleFromPrompt('')).toBe('');
+  });
+});

--- a/packages/core/src/sessions/derive-title-from-prompt.ts
+++ b/packages/core/src/sessions/derive-title-from-prompt.ts
@@ -1,0 +1,25 @@
+/**
+ * Auto-title heuristic — derives a short session title from a user's first
+ * prompt, with no LLM call.
+ *
+ * Used by the daemon's task-completion hook ({@link TasksService.patch})
+ * when a session's first task finishes and the session still has no
+ * explicit title: cheap, synchronous, and tool-agnostic (works the same for
+ * every agentic tool, since it only reads the prompt text already stored on
+ * the task — see `Task.full_prompt`).
+ */
+
+const MAX_TITLE_LENGTH = 60;
+
+export function deriveTitleFromPrompt(prompt: string): string {
+  const collapsed = prompt.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return '';
+  if (collapsed.length <= MAX_TITLE_LENGTH) return collapsed;
+
+  const truncated = collapsed.slice(0, MAX_TITLE_LENGTH);
+  const lastSpace = truncated.lastIndexOf(' ');
+  // Only break on a word boundary if it doesn't throw away most of the
+  // budget (e.g. one very long leading word) — otherwise just hard-cut.
+  const cut = lastSpace > MAX_TITLE_LENGTH * 0.4 ? truncated.slice(0, lastSpace) : truncated;
+  return `${cut}…`;
+}

--- a/packages/core/src/sessions/index.ts
+++ b/packages/core/src/sessions/index.ts
@@ -1,3 +1,4 @@
+export * from './derive-title-from-prompt.js';
 export * from './resolve-child-session-config.js';
 export * from './resolve-permission-config.js';
 export * from './resolve-session-defaults.js';

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -401,13 +401,6 @@ export interface UserPreferences {
   mainBoardId?: string;
   /** Whether to render Slack-synced avatar_url when available. Undefined defaults to true. */
   use_slack_avatar?: boolean;
-  /**
-   * Primary agentic tool for quick-start session creation. When set (in
-   * Settings) and still available, "Add session" skips the tile picker and
-   * creates a session with this tool immediately. Unset — or set to a tool
-   * that's no longer available — means quick-start falls back to the picker.
-   */
-  default_agentic_tool?: AgenticToolName;
   // Future preferences can be added here
   [key: string]: unknown;
 }

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -401,6 +401,13 @@ export interface UserPreferences {
   mainBoardId?: string;
   /** Whether to render Slack-synced avatar_url when available. Undefined defaults to true. */
   use_slack_avatar?: boolean;
+  /**
+   * Primary agentic tool for quick-start session creation. When set (in
+   * Settings) and still available, "Add session" skips the tile picker and
+   * creates a session with this tool immediately. Unset — or set to a tool
+   * that's no longer available — means quick-start falls back to the picker.
+   */
+  default_agentic_tool?: AgenticToolName;
   // Future preferences can be added here
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary

Starting a session no longer opens a modal you have to fill in and dismiss. "Add session" now opens the session drawer directly, ready to type into.

- **Quick-start**: every "Add session" entry point (branch card, board canvas, event-stream panel) skips the modal — if we can resolve a tool for you, the session is created immediately and the drawer opens on it.
- **Tool resolution**: your explicit default (new Settings option) → else your most-recently-used tool → else genuinely unresolved.
- **First-time / unresolved case**: drawer still opens instantly (no modal), showing a tile picker in the same chrome as a real session, so nothing visually jumps when you pick one.
- **Inline title editing**: click the "Untitled session" header text to rename, in place. No dialog.
- **Auto-title**: if you never set one, the title fills in from your first prompt once it completes (cheap heuristic, no LLM call).
- **Switch tool**: available from the "..." menu, but only before a session has run anything — since the tool choice is baked into every task once one exists.
- The old full modal isn't deleted — it's demoted to an "Advanced setup..." escape hatch for the rare case of wanting to set title/prompt/MCP/env vars before the session exists.

## Why / context

The old flow: click "Add session" → modal → pick a tool → (often) same tool as last time → fill in a title you'll probably rename anyway → submit → *then* the session drawer opens. That's a form in front of every single session, for a choice that's almost always "same as last time."

This follows the "quick-create" pattern from Linear/Notion (create first, refine inline) and matches how Claude/ChatGPT auto-title new threads. The friction removed compounds — session creation is the single highest-frequency action on the board.

Nothing that needed the modal is gone: MCP/tool config for the rare cases that need it upfront is one click away via "Advanced setup...". Board-zone flows that intentionally require a picker (`show_picker`, `always_new` triggers) are untouched — this branch makes zero changes to `SessionCanvas.tsx` or the zone-trigger modal (confirmed by diff), see Validation below for the caveat on live-testing that path.

## Implementation notes

- `resolveDefaultAgenticTool`: explicit `preferences.default_agentic_tool` → most-recently-created session's tool → `undefined` (no hardcoded fallback).
- `chooseAgenticTool` is the single action behind both tool-choice surfaces (empty-state tiles and the in-drawer "Switch tool" affordance) — creates the session, resolves MCP inheritance the same way the old modal did, remembers the pick as the new quick-start default, and navigates to the result. "Switch tool" passes `replacingSessionId` to swap out a never-prompted session transparently.
- `agentic_tool` can't change mid-session (different SDK per tool), so "Switch tool" is hidden the moment a session has run one task.
- Auto-title hooks into the existing task-completion patch path in `TasksService`; fires once, only if the title is still empty when the first task completes — an explicit title (even one typed mid-task) always wins.
- `default_agentic_tool` lives in the existing `UserPreferences` JSON blob — no migration needed.
- Includes an unrelated-but-picked-up perf commit (`77800e48`, progressive board mount) that was already merged to `main` and is just part of this branch's history — not new work in this PR.

## Validation / test plan

- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test (core, daemon, ui — including new coverage for tool resolution, `chooseAgenticTool`, auto-title heuristic, `PendingToolChoicePanel`, inline title edit, switch-tool affordance). All green: core 2737, ui 726–734, daemon 1392–1395 passed across multiple runs.
- [x] Rebased on current `main` (`77800e48`), no conflicts, re-verified lint/typecheck/tests clean after rebase.
- [x] Manual click-through completed for: quick-start with a resolved tool (skips picker, opens drawer with focused prompt), quick-start with no default set (tile picker, prompt/settings disabled until a tool is chosen), inline title edit (placeholder, click-to-edit, save on Enter, cancel on Escape), auto-title firing after first prompt completes, switch-tool appearing/disappearing correctly based on task history.
- [ ] **Board-zone `show_picker` trigger flow — not yet confirmed via live click-through.** Diff-isolation gives high confidence (this branch touches zero lines in `SessionCanvas.tsx`, `ZoneConfigModal.tsx`, or the zone-trigger modal), but I was not able to reliably reproduce the drag-and-drop trigger in the environment used for this pass (Docker-based env unavailable). Remaining live QA, including this flow, to be finished in a follow-up pass.

## Risks / rollout / rollback

- Additive preference field, no schema migration. Old modal path still exists and is reachable, so nothing is a one-way door.
- Main behavior change users will notice: "Add session" no longer asks first. If that surprises anyone, "Advanced setup..." is the fallback and a default tool can be unset in Settings to force the picker again.

## Out of scope / follow-ups

- Auto-title currently uses a heuristic (truncate first prompt); wiring the real `ai_title` event some CLIs already emit is a nice-to-have follow-up, not required for this to ship.
- Final live manual QA pass (see unchecked item above) to be completed once the Docker-based dev environment is available again.
