### PR TITLE
perf(agor-ui): isolate transcript streaming re-renders to the streamed message

### DIFF
--- a/apps/agor-ui/src/components/ConversationView/ConversationView.rerender.test.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.rerender.test.tsx
@@ -1,0 +1,204 @@
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Render counters ──────────────────────────────────────────────────────────
+// MessageBlock is the per-message leaf of the transcript. Counting its renders
+// per message_id (through the REAL TaskBlock + real streaming grouping hooks)
+// pins the streaming-isolation contract: a chunk for task X must not touch
+// message subtrees of other tasks — nor untouched messages of task X itself.
+const messageRenders = new Map<string, number>();
+
+vi.mock('../MessageBlock', async () => {
+  const React = await import('react');
+  return {
+    __esModule: true,
+    // Memoized like the real MessageBlock — the pin is that props (above all
+    // `message`) keep their identity, which is exactly what lets the real,
+    // markdown-heavy MessageBlock bail out during streaming.
+    MessageBlock: React.memo(({ message }: { message: { message_id: string } }) => {
+      messageRenders.set(message.message_id, (messageRenders.get(message.message_id) || 0) + 1);
+      return <div data-testid={`msg-${message.message_id}`} />;
+    }),
+  };
+});
+
+// use-stick-to-bottom owns scroll physics that jsdom can't exercise; the
+// existing ConversationView.test.tsx covers that wiring. Stub it here so the
+// isolation test doesn't depend on layout behavior.
+vi.mock('use-stick-to-bottom', () => ({
+  useStickToBottom: () => ({
+    scrollRef: () => {},
+    contentRef: () => {},
+    scrollToBottom: () => {},
+    stopScroll: () => {},
+    state: { escapedFromLock: false, isAtBottom: true },
+  }),
+}));
+
+// Controlled reactive-session feed: `emitReactiveState` swaps the state object
+// the way a real streaming notify does (fresh top-level object per event).
+let emitReactiveState: (state: unknown) => void = () => {};
+let initialReactiveState: unknown = null;
+
+// Identity-stable like the real shared handle — a fresh handle per render
+// would itself defeat the load/unload useCallbacks under test.
+const mockReactiveHandle = {
+  loadTaskMessages: async () => {},
+  unloadTaskMessages: () => {},
+  resync: async () => {},
+};
+
+vi.mock('../../hooks/useSharedReactiveSession', async () => {
+  const React = await import('react');
+  return {
+    useSharedReactiveSession: () => {
+      const [state, setState] = React.useState(initialReactiveState);
+      emitReactiveState = setState;
+      return { handle: mockReactiveHandle, state };
+    },
+  };
+});
+
+import { ConversationView } from './ConversationView';
+
+const SESSION_ID = 'session-1';
+
+function makeTask(id: string, status: string): any {
+  return {
+    task_id: id,
+    session_id: SESSION_ID,
+    full_prompt: `prompt ${id}`,
+    status,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    created_by: 'user-1',
+    message_range: null,
+    normalized_sdk_response: null,
+    computed_context_window: 0,
+    git_state: {},
+  };
+}
+
+function makeMessage(id: string, taskId: string, index: number): any {
+  return {
+    message_id: id,
+    session_id: SESSION_ID,
+    task_id: taskId,
+    role: 'assistant',
+    content: `text of ${id}`,
+    index,
+    timestamp: '2026-07-01T00:00:01.000Z',
+  };
+}
+
+function makeStreamingMessage(id: string, taskId: string, content: string): any {
+  return {
+    message_id: id,
+    session_id: SESSION_ID,
+    task_id: taskId,
+    role: 'assistant',
+    content,
+    thinkingContent: '',
+    timestamp: '2026-07-01T00:00:02.000Z',
+    isStreaming: true,
+    index: 99,
+  };
+}
+
+function makeState(overrides: Record<string, unknown>): any {
+  return {
+    sessionId: SESSION_ID,
+    session: null,
+    tasks: [],
+    messagesByTask: new Map(),
+    queuedTasks: [],
+    streamingMessages: new Map(),
+    toolsByTask: new Map(),
+    loadedTaskIds: new Set(),
+    connected: true,
+    loading: false,
+    error: null,
+    terminal: false,
+    lastSyncedAt: null,
+    ...overrides,
+  };
+}
+
+describe('ConversationView streaming re-render isolation', () => {
+  const taskA = makeTask('task-a', 'completed');
+  const taskB = makeTask('task-b', 'running');
+  const tasks = [taskA, taskB];
+  const msgA1 = makeMessage('msg-a1', 'task-a', 0);
+  const msgA2 = makeMessage('msg-a2', 'task-a', 1);
+  const msgB1 = makeMessage('msg-b1', 'task-b', 0);
+  const messagesByTask = new Map([
+    ['task-a', [msgA1, msgA2]],
+    ['task-b', [msgB1]],
+  ]);
+  const loadedTaskIds = new Set(['task-a', 'task-b']);
+
+  function baseState(streamingMessages: Map<string, unknown>) {
+    return makeState({ tasks, messagesByTask, loadedTaskIds, streamingMessages });
+  }
+
+  beforeEach(() => {
+    messageRenders.clear();
+  });
+
+  it('a streaming chunk for task B does not re-render task A message blocks (nor settled task B ones)', () => {
+    const streamB = makeStreamingMessage('stream-b', 'task-b', 'partial');
+    initialReactiveState = baseState(new Map([['stream-b', streamB]]));
+
+    render(
+      <ConversationView
+        client={null}
+        sessionId={SESSION_ID as any}
+        sessionModel="model"
+        forceExpandAll
+      />
+    );
+
+    expect(screen.getByTestId('msg-stream-b')).toBeInTheDocument();
+    const baseline = new Map(messageRenders);
+    expect(baseline.get('msg-a1')).toBeGreaterThanOrEqual(1);
+
+    // A chunk lands for task B: the reactive session replaces the state object
+    // and the streamingMessages map, cloning ONLY the streamed entry — every
+    // other message object keeps its identity (mirrors onStreamingChunk).
+    act(() => {
+      emitReactiveState(
+        baseState(new Map([['stream-b', { ...streamB, content: 'partial plus more' }]]))
+      );
+    });
+
+    // Only the streamed message re-rendered.
+    expect(messageRenders.get('stream-b')).toBe((baseline.get('stream-b') || 0) + 1);
+    // Task A's subtree — and task B's settled message — stayed quiet.
+    expect(messageRenders.get('msg-a1')).toBe(baseline.get('msg-a1'));
+    expect(messageRenders.get('msg-a2')).toBe(baseline.get('msg-a2'));
+    expect(messageRenders.get('msg-b1')).toBe(baseline.get('msg-b1'));
+  });
+
+  it('a reactive notify with identical streaming content re-renders no message blocks', () => {
+    const streamB = makeStreamingMessage('stream-b', 'task-b', 'partial');
+    initialReactiveState = baseState(new Map([['stream-b', streamB]]));
+
+    render(
+      <ConversationView
+        client={null}
+        sessionId={SESSION_ID as any}
+        sessionModel="model"
+        forceExpandAll
+      />
+    );
+    const baseline = new Map(messageRenders);
+
+    // Same entries, fresh Map identity — e.g. an unrelated field changed on the
+    // reactive state. The stable-ref grouping must absorb the Map churn.
+    act(() => {
+      emitReactiveState(baseState(new Map([['stream-b', streamB]])));
+    });
+
+    expect(messageRenders).toEqual(baseline);
+  });
+});

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -24,6 +24,9 @@ import { TaskBlock } from '../TaskBlock';
 
 const { Text } = Typography;
 const EMPTY_STREAMING_MESSAGES = new Map();
+// Default-param `= new Map()` would mint a fresh Map on every render and
+// defeat every TaskBlock's React.memo whenever the prop is omitted.
+const EMPTY_USER_MAP = new Map<string, User>();
 // Shared empty-array sentinel so TaskBlock's `taskMessages` prop keeps a stable
 // reference for tasks whose messages haven't been loaded — otherwise `|| []`
 // would mint a fresh array on every render and thrash TaskBlock's React.memo.
@@ -130,7 +133,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     sessionId,
     agentic_tool,
     sessionModel,
-    userById = new Map(),
+    userById = EMPTY_USER_MAP,
     currentUserId,
     onScrollRef,
     onPermissionDecision,

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.rerender.test.tsx
@@ -1,0 +1,236 @@
+import type { Branch, Session, Task, User } from '@agor-live/client';
+import { act, render, waitFor } from '@testing-library/react';
+import { App as AntdApp } from 'antd';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppActionsProvider } from '../../contexts/AppActionsContext';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+
+// ── Render counters ──────────────────────────────────────────────────────────
+// ToolIcon renders inline in SessionPanel's header on every panel render;
+// SessionFooter is replaced by a memoized counting stub that sees the EXACT
+// props SessionPanel passes. Together they pin the contract: reactive-session
+// notifies that don't change footer-relevant data re-render the panel but must
+// leave every footer prop identity-stable, so the memo boundary holds.
+let sessionPanelRenders = 0;
+let sessionFooterRenders = 0;
+
+vi.mock('../ToolIcon', () => ({
+  __esModule: true,
+  ToolIcon: () => {
+    sessionPanelRenders += 1;
+    return <div data-testid="tool-icon" />;
+  },
+}));
+
+vi.mock('./SessionFooter', async () => {
+  const React = await import('react');
+  return {
+    __esModule: true,
+    SessionFooter: React.memo(() => {
+      sessionFooterRenders += 1;
+      return <div data-testid="session-footer" />;
+    }),
+  };
+});
+
+// Controlled reactive-session feed (SessionPanel subscribes for `tasks`).
+// Emitting a fresh state object mirrors what every streaming chunk notify
+// does to the panel.
+let emitReactiveState: (state: unknown) => void = () => {};
+let initialReactiveState: unknown = null;
+
+vi.mock('../../hooks/useSharedReactiveSession', async () => {
+  const React = await import('react');
+  return {
+    useSharedReactiveSession: () => {
+      const [state, setState] = React.useState(initialReactiveState);
+      emitReactiveState = setState;
+      return { handle: null, state };
+    },
+  };
+});
+
+// Heavy children not under test — same stubs as SessionPanel.rerender.test.tsx.
+vi.mock('./SessionPanelContent', () => ({
+  __esModule: true,
+  SessionPanelContent: () => <div data-testid="session-panel-content" />,
+}));
+vi.mock('./SessionAttachmentsDropdown', () => ({
+  __esModule: true,
+  SessionAttachmentsDropdown: () => null,
+}));
+vi.mock('../AutocompleteTextarea', () => ({
+  __esModule: true,
+  AutocompleteTextarea: () => null,
+}));
+vi.mock('../ForkSpawnModal/ForkSpawnModal', () => ({
+  __esModule: true,
+  ForkSpawnModal: () => null,
+}));
+vi.mock('../FileUpload', () => ({
+  __esModule: true,
+  FileUpload: () => null,
+  FileUploadButton: () => null,
+}));
+vi.mock('../SessionIds', () => ({
+  __esModule: true,
+  SessionIdsButton: () => null,
+  SessionIdsList: () => null,
+}));
+vi.mock('../MCPServer', () => ({
+  __esModule: true,
+  MCPServerPill: () => null,
+}));
+vi.mock('../metadata', () => ({
+  __esModule: true,
+  CreatedByTag: () => null,
+}));
+
+import { SessionPanel } from './index';
+
+const SESSION_ID = 'sA';
+const USER_ID = 'user-1';
+
+const session = {
+  session_id: SESSION_ID,
+  branch_id: 'A',
+  status: 'running',
+  agentic_tool: 'claude-code',
+  archived: false,
+  created_at: '2026-07-01T00:00:00.000Z',
+  last_updated: '2026-07-01T00:00:00.000Z',
+} as unknown as Session;
+
+const branch = { branch_id: 'A', repo_id: 'repo-1', name: 'A' } as unknown as Branch;
+const user = { user_id: USER_ID, name: 'User' } as unknown as User;
+
+const EMPTY_MCP_IDS: string[] = [];
+const CONNECTION_VALUE = {
+  connected: true,
+  connecting: false,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+const APP_ACTIONS = {};
+
+function makeTask(id: string, overrides: Record<string, unknown> = {}): Task {
+  return {
+    task_id: id,
+    session_id: SESSION_ID,
+    status: 'running',
+    full_prompt: 'prompt',
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    git_state: {},
+    ...overrides,
+  } as unknown as Task;
+}
+
+function makeReactiveState(tasks: Task[]): unknown {
+  return {
+    sessionId: SESSION_ID,
+    tasks,
+    messagesByTask: new Map(),
+    streamingMessages: new Map(),
+    loadedTaskIds: new Set(),
+    loading: false,
+    error: null,
+    terminal: false,
+    lastSyncedAt: null,
+  };
+}
+
+function renderPanel(ui: ReactNode) {
+  return render(
+    <AntdApp>
+      <ConnectionProvider value={CONNECTION_VALUE}>
+        <AppActionsProvider value={APP_ACTIONS}>{ui}</AppActionsProvider>
+      </ConnectionProvider>
+    </AntdApp>
+  );
+}
+
+describe('SessionFooter re-render isolation from streaming notifies', () => {
+  beforeEach(() => {
+    sessionPanelRenders = 0;
+    sessionFooterRenders = 0;
+    agorStore.setState({ ...EMPTY_MAPS, userById: new Map([[USER_ID, user]]) });
+  });
+
+  it('a reactive notify that keeps `tasks` identity re-renders the panel but not the footer', async () => {
+    const tasks = [makeTask('task-1')];
+    initialReactiveState = makeReactiveState(tasks);
+
+    renderPanel(
+      <SessionPanel
+        client={null}
+        session={session}
+        branch={branch}
+        currentUserId={USER_ID}
+        sessionMcpServerIds={EMPTY_MCP_IDS}
+        open={true}
+        onClose={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(sessionFooterRenders).toBeGreaterThanOrEqual(1));
+    const panelBaseline = sessionPanelRenders;
+    const footerBaseline = sessionFooterRenders;
+
+    // Streaming chunk: fresh state object, same tasks array — the only slice
+    // of reactive state the panel derives footer props from.
+    act(() => {
+      emitReactiveState(makeReactiveState(tasks));
+    });
+
+    expect(sessionPanelRenders).toBeGreaterThan(panelBaseline);
+    expect(sessionFooterRenders).toBe(footerBaseline);
+  });
+
+  it('a notify that changes task token usage DOES re-render the footer', async () => {
+    initialReactiveState = makeReactiveState([makeTask('task-1')]);
+
+    renderPanel(
+      <SessionPanel
+        client={null}
+        session={session}
+        branch={branch}
+        currentUserId={USER_ID}
+        sessionMcpServerIds={EMPTY_MCP_IDS}
+        open={true}
+        onClose={() => {}}
+      />
+    );
+
+    await waitFor(() => expect(sessionFooterRenders).toBeGreaterThanOrEqual(1));
+    const footerBaseline = sessionFooterRenders;
+
+    // Contrast case proving the counter is wired: a task patch that lands new
+    // token usage replaces the tasks array → tokenBreakdown changes → the
+    // footer legitimately re-renders.
+    act(() => {
+      emitReactiveState(
+        makeReactiveState([
+          makeTask('task-1', {
+            normalized_sdk_response: {
+              tokenUsage: {
+                totalTokens: 100,
+                inputTokens: 60,
+                outputTokens: 40,
+                cacheReadTokens: 0,
+                cacheCreationTokens: 0,
+              },
+              costUsd: 0.01,
+            },
+          }),
+        ])
+      );
+    });
+
+    await waitFor(() => expect(sessionFooterRenders).toBeGreaterThan(footerBaseline));
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -95,7 +95,12 @@ export interface SessionFooterProps {
   promptInputSlot: React.ReactNode;
 }
 
-export const SessionFooter: React.FC<SessionFooterProps> = ({
+// Memoized: the panel re-renders once per animation frame while its session
+// streams (reactive-session notifies), and this footer is a large subtree of
+// dropdowns/popovers that doesn't depend on per-chunk state. SessionPanel
+// keeps every prop identity-stable across those renders (stable handler
+// wrappers, memoized slot/config objects) so the bailout actually holds.
+const SessionFooterInner: React.FC<SessionFooterProps> = ({
   session,
   footerTimerTask,
   tokenBreakdown,
@@ -1570,3 +1575,6 @@ export const SessionFooter: React.FC<SessionFooterProps> = ({
     </div>
   );
 };
+
+export const SessionFooter = React.memo(SessionFooterInner);
+SessionFooter.displayName = 'SessionFooter';

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -275,6 +275,11 @@ PromptInput.displayName = 'PromptInput';
 
 // ---------------------------------------------------------------------------
 
+// Stable fallback so renders before the reactive session hydrates don't mint
+// a fresh array — the memos deriving footer props from `tasks` (and through
+// them the memoized SessionFooter) key on its identity.
+const EMPTY_TASKS: Task[] = [];
+
 export interface SessionPanelProps {
   client: AgorClient | null;
   session: Session | null;
@@ -411,7 +416,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     reactiveOptions: { taskHydration: 'none' },
   });
 
-  const tasks = reactiveSessionState?.tasks || [];
+  const tasks = reactiveSessionState?.tasks || EMPTY_TASKS;
   const attachmentInputRef = React.useRef<HTMLInputElement>(null);
   const bodyRef = React.useRef<HTMLDivElement | null>(null);
   // Search observes only the conversation region, not the whole body: the
@@ -674,6 +679,163 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   }, [searchOpen]);
 
+  const isRunning =
+    session?.status === SessionStatus.RUNNING || session?.status === SessionStatus.STOPPING;
+  const isStopping = session?.status === SessionStatus.STOPPING;
+
+  // SessionFooter is memoized, but its handlers close over per-render state
+  // and are defined below the null-session early return, so they can't be
+  // useCallback'd directly. Freeze the identities the footer sees with
+  // lifetime-stable wrappers that delegate to the latest implementations via
+  // a ref (re-pointed each render, right where the impls are defined).
+  const footerHandlersRef = React.useRef<{
+    onModelConfigChange: (config: ModelConfig) => void;
+    onSendPrompt: () => void;
+    onStop: () => void;
+    onFork: () => void;
+    onBtwSend: () => void;
+    onSpawnOpen: () => void;
+    onAttachFiles: () => void;
+    onUploadOpen: () => void;
+    onEffortChange: (v: EffortLevel) => void;
+    onPermissionModeChange: (v: PermissionMode) => void;
+    onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) => void;
+  } | null>(null);
+  const stableFooterHandlers = React.useMemo(
+    () => ({
+      onModelConfigChange: (config: ModelConfig) =>
+        footerHandlersRef.current?.onModelConfigChange(config),
+      onSendPrompt: () => footerHandlersRef.current?.onSendPrompt(),
+      onStop: () => footerHandlersRef.current?.onStop(),
+      onFork: () => footerHandlersRef.current?.onFork(),
+      onBtwSend: () => footerHandlersRef.current?.onBtwSend(),
+      onSpawnOpen: () => footerHandlersRef.current?.onSpawnOpen(),
+      onAttachFiles: () => footerHandlersRef.current?.onAttachFiles(),
+      onUploadOpen: () => footerHandlersRef.current?.onUploadOpen(),
+      onEffortChange: (v: EffortLevel) => footerHandlersRef.current?.onEffortChange(v),
+      onPermissionModeChange: (v: PermissionMode) =>
+        footerHandlersRef.current?.onPermissionModeChange(v),
+      onCodexPermissionChange: (sandbox: CodexSandboxMode, approval: CodexApprovalPolicy) =>
+        footerHandlersRef.current?.onCodexPermissionChange(sandbox, approval),
+    }),
+    []
+  );
+
+  const modelLabel =
+    session?.model_config?.model &&
+    session.agentic_tool === 'opencode' &&
+    session.model_config.provider
+      ? `${session.model_config.provider}/${session.model_config.model}`
+      : session?.model_config?.model;
+  const modelConfig: ModelConfig | undefined = React.useMemo(
+    () =>
+      session?.model_config?.model
+        ? {
+            mode: session.model_config.mode || 'alias',
+            model: session.model_config.model,
+            provider: session.model_config.provider,
+            advisorModel: session.model_config.advisorModel,
+          }
+        : undefined,
+    [
+      session?.model_config?.mode,
+      session?.model_config?.model,
+      session?.model_config?.provider,
+      session?.model_config?.advisorModel,
+    ]
+  );
+
+  // The composer subtree only depends on composer/draft state — memoize it so
+  // ordinary SessionPanel re-renders (reactive-session notifies, store
+  // patches) hand the memoized SessionFooter a reference-stable slot.
+  const sessionCustomContext = session?.custom_context as Record<string, unknown> | undefined;
+  const promptInputSlot = React.useMemo(() => {
+    if (!session) return null;
+    return (
+      <SessionComposerDropZone
+        disabled={composerAttachmentUploading}
+        onDragActiveChange={setComposerDropActive}
+        onFilesDrop={addComposerAttachments}
+      >
+        {composerAttachmentValidationError && (
+          <Alert
+            type="error"
+            showIcon
+            message={composerAttachmentValidationError}
+            style={{ marginBottom: 0, borderRadius: token.borderRadius }}
+          />
+        )}
+        <SessionAttachmentTray
+          attachments={composerAttachments}
+          disabled={composerAttachmentUploading}
+          onRemove={removeComposerAttachment}
+        />
+        <PromptInput
+          ref={promptRef}
+          sessionId={session.session_id}
+          getDraft={getDraft}
+          saveDraft={saveDraft}
+          deleteDraft={deleteDraft}
+          onHasInputChange={handleHasInputChange}
+          inputValueRef={inputValueRef}
+          onSubmit={stableFooterHandlers.onSendPrompt}
+          hasExternalInput={hasComposerAttachments}
+          placeholder={
+            isRunning
+              ? 'Queue here… @ for mentions, : for emoji'
+              : 'Prompt here… @ for mentions, : for emoji'
+          }
+          autoSize={{ minRows: 1, maxRows: 10 }}
+          client={client}
+          userById={userById}
+          onFilesDrop={addComposerAttachments}
+          filesDropDisabled={composerAttachmentUploading}
+          showFilesDropOverlay={false}
+          suppressEmptyHighlight={composerDropActive}
+          slashCommands={
+            Array.isArray(sessionCustomContext?.slash_commands)
+              ? sessionCustomContext.slash_commands
+              : undefined
+          }
+          skills={
+            Array.isArray(sessionCustomContext?.skills) ? sessionCustomContext.skills : undefined
+          }
+        />
+        <input
+          ref={attachmentInputRef}
+          type="file"
+          accept={getComposerUploadAccept()}
+          multiple
+          disabled={composerAttachmentUploading}
+          style={{ display: 'none' }}
+          onChange={(event) => {
+            addComposerAttachments(Array.from(event.target.files ?? []));
+            event.target.value = '';
+          }}
+        />
+      </SessionComposerDropZone>
+    );
+  }, [
+    session,
+    sessionCustomContext,
+    composerAttachmentUploading,
+    composerAttachmentValidationError,
+    composerAttachments,
+    composerDropActive,
+    hasComposerAttachments,
+    isRunning,
+    client,
+    userById,
+    addComposerAttachments,
+    removeComposerAttachment,
+    getDraft,
+    saveDraft,
+    deleteDraft,
+    handleHasInputChange,
+    stableFooterHandlers,
+    token.borderRadius,
+  ]);
+
   // When there's no session, render nothing (panel is collapsed to zero).
   // When open=false, we still render the component tree (hidden) so that
   // antd's CSS-in-JS doesn't garbage-collect component styles.
@@ -745,10 +907,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       onClick: handleArchive,
     },
   ];
-
-  const isRunning =
-    session.status === SessionStatus.RUNNING || session.status === SessionStatus.STOPPING;
-  const isStopping = session.status === SessionStatus.STOPPING;
 
   const openAdvancedUpload = (initialFiles: File[] = []) => {
     if (composerAttachmentUploadingRef.current) return;
@@ -1044,20 +1202,22 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
-  const modelLabel =
-    session.model_config?.model &&
-    session.agentic_tool === 'opencode' &&
-    session.model_config.provider
-      ? `${session.model_config.provider}/${session.model_config.model}`
-      : session.model_config?.model;
-  const modelConfig: ModelConfig | undefined = session.model_config?.model
-    ? {
-        mode: session.model_config.mode || 'alias',
-        model: session.model_config.model,
-        provider: session.model_config.provider,
-        advisorModel: session.model_config.advisorModel,
-      }
-    : undefined;
+  // Re-point the stable footer wrappers at this render's implementations.
+  // Render-phase ref write (instead of the usual useLayoutEffect) because the
+  // impls above only exist when `session` is non-null, past the early return.
+  footerHandlersRef.current = {
+    onModelConfigChange: handleModelConfigChange,
+    onSendPrompt: handleSendPrompt,
+    onStop: handleStop,
+    onFork: handleFork,
+    onBtwSend: handleBtwSend,
+    onSpawnOpen: handleSpawnOpen,
+    onAttachFiles: () => attachmentInputRef.current?.click(),
+    onUploadOpen: () => openAdvancedUpload(),
+    onEffortChange: handleEffortChange,
+    onPermissionModeChange: handlePermissionModeChange,
+    onCodexPermissionChange: handleCodexPermissionChange,
+  };
 
   const sessionFooter = (
     <SessionFooter
@@ -1086,82 +1246,19 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       client={client}
       modelLabel={modelLabel}
       modelConfig={modelConfig}
-      onModelConfigChange={handleModelConfigChange}
+      onModelConfigChange={stableFooterHandlers.onModelConfigChange}
       onOpenSessionSettings={onOpenSettings}
-      onSendPrompt={handleSendPrompt}
-      onStop={handleStop}
-      onFork={handleFork}
-      onBtwSend={handleBtwSend}
-      onSpawnOpen={handleSpawnOpen}
-      onAttachFiles={() => attachmentInputRef.current?.click()}
-      onUploadOpen={() => openAdvancedUpload()}
-      onEffortChange={handleEffortChange}
-      onPermissionModeChange={handlePermissionModeChange}
-      onCodexPermissionChange={handleCodexPermissionChange}
-      promptInputSlot={
-        <SessionComposerDropZone
-          disabled={composerAttachmentUploading}
-          onDragActiveChange={setComposerDropActive}
-          onFilesDrop={addComposerAttachments}
-        >
-          {composerAttachmentValidationError && (
-            <Alert
-              type="error"
-              showIcon
-              message={composerAttachmentValidationError}
-              style={{ marginBottom: 0, borderRadius: token.borderRadius }}
-            />
-          )}
-          <SessionAttachmentTray
-            attachments={composerAttachments}
-            disabled={composerAttachmentUploading}
-            onRemove={removeComposerAttachment}
-          />
-          <PromptInput
-            ref={promptRef}
-            sessionId={session.session_id}
-            getDraft={getDraft}
-            saveDraft={saveDraft}
-            deleteDraft={deleteDraft}
-            onHasInputChange={handleHasInputChange}
-            inputValueRef={inputValueRef}
-            onSubmit={handleSendPrompt}
-            hasExternalInput={hasComposerAttachments}
-            placeholder={
-              isRunning
-                ? 'Queue here… @ for mentions, : for emoji'
-                : 'Prompt here… @ for mentions, : for emoji'
-            }
-            autoSize={{ minRows: 1, maxRows: 10 }}
-            client={client}
-            userById={userById}
-            onFilesDrop={addComposerAttachments}
-            filesDropDisabled={composerAttachmentUploading}
-            showFilesDropOverlay={false}
-            suppressEmptyHighlight={composerDropActive}
-            slashCommands={(() => {
-              const ctx = session?.custom_context as Record<string, unknown> | undefined;
-              return Array.isArray(ctx?.slash_commands) ? ctx.slash_commands : undefined;
-            })()}
-            skills={(() => {
-              const ctx = session?.custom_context as Record<string, unknown> | undefined;
-              return Array.isArray(ctx?.skills) ? ctx.skills : undefined;
-            })()}
-          />
-          <input
-            ref={attachmentInputRef}
-            type="file"
-            accept={getComposerUploadAccept()}
-            multiple
-            disabled={composerAttachmentUploading}
-            style={{ display: 'none' }}
-            onChange={(event) => {
-              addComposerAttachments(Array.from(event.target.files ?? []));
-              event.target.value = '';
-            }}
-          />
-        </SessionComposerDropZone>
-      }
+      onSendPrompt={stableFooterHandlers.onSendPrompt}
+      onStop={stableFooterHandlers.onStop}
+      onFork={stableFooterHandlers.onFork}
+      onBtwSend={stableFooterHandlers.onBtwSend}
+      onSpawnOpen={stableFooterHandlers.onSpawnOpen}
+      onAttachFiles={stableFooterHandlers.onAttachFiles}
+      onUploadOpen={stableFooterHandlers.onUploadOpen}
+      onEffortChange={stableFooterHandlers.onEffortChange}
+      onPermissionModeChange={stableFooterHandlers.onPermissionModeChange}
+      onCodexPermissionChange={stableFooterHandlers.onCodexPermissionChange}
+      promptInputSlot={promptInputSlot}
     />
   );
 

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -31,7 +31,7 @@ import {
 } from '@ant-design/icons';
 import { Bubble } from '@ant-design/x';
 import { Collapse, Flex, Spin, Typography, theme } from 'antd';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { getContextWindowGradient } from '../../utils/contextWindow';
 import { AgentChain } from '../AgentChain';
 import { AgorAvatar } from '../AgorAvatar';
@@ -54,6 +54,10 @@ import { TaskStatusIcon } from '../TaskStatusIcon';
 import { ToolIcon } from '../ToolIcon';
 
 const { Paragraph } = Typography;
+
+// Default-param `= new Map()` would mint a fresh Map per render and defeat
+// the MessageBlock memos below whenever the prop is omitted.
+const EMPTY_USER_MAP = new Map<string, User>();
 
 /**
  * Block types for rendering
@@ -345,12 +349,32 @@ function groupMessagesIntoBlocks(messages: Message[]): Block[] {
   return blocks;
 }
 
+/**
+ * Identity key for reconciling a block across renders — mirrors the React
+ * `key` each block type renders with.
+ */
+function getBlockKey(block: Block): string {
+  return block.type === 'message'
+    ? `m:${block.message.message_id}`
+    : `${block.type}:${block.messages[0]?.message_id || 'unknown'}`;
+}
+
+/** Same composition: identical message references in identical order. */
+function blocksHaveSameMessages(a: Block, b: Block): boolean {
+  if (a.type !== b.type) return false;
+  if (a.type === 'message' && b.type === 'message') return a.message === b.message;
+  const aMessages = (a as { messages: Message[] }).messages;
+  const bMessages = (b as { messages: Message[] }).messages;
+  if (aMessages.length !== bMessages.length) return false;
+  return aMessages.every((msg, i) => msg === bMessages[i]);
+}
+
 export const TaskBlock = React.memo<TaskBlockProps>(
   ({
     task,
     agentic_tool,
     sessionModel,
-    userById = new Map(),
+    userById = EMPTY_USER_MAP,
     currentUserId,
     isExpanded,
     onExpandChange,
@@ -408,8 +432,24 @@ export const TaskBlock = React.memo<TaskBlockProps>(
       );
     }, [taskMessages, streamingForTask, streamingMessages]);
 
-    // Group messages into blocks
-    const blocks = useMemo(() => groupMessagesIntoBlocks(messages), [messages]);
+    // Group messages into blocks, then reconcile against the previous render:
+    // a streaming chunk rebuilds `messages` (new array identity) every frame,
+    // but only the streamed message's block actually changed. Reusing the
+    // previous block objects — and crucially their `messages` arrays, which
+    // are minted fresh by groupMessagesIntoBlocks — keeps the props of the
+    // memoized AgentChain/CompactionBlock children reference-stable, so the
+    // untouched (often large) tool-chain subtrees bail out of re-rendering.
+    const prevBlocksRef = useRef<Block[]>([]);
+    const blocks = useMemo(() => {
+      const next = groupMessagesIntoBlocks(messages);
+      const prevByKey = new Map(prevBlocksRef.current.map((b) => [getBlockKey(b), b]));
+      const reconciled = next.map((block) => {
+        const prev = prevByKey.get(getBlockKey(block));
+        return prev && blocksHaveSameMessages(prev, block) ? prev : block;
+      });
+      prevBlocksRef.current = reconciled;
+      return reconciled;
+    }, [messages]);
 
     // Index of the last agent-chain block — used for isLatest so that a streaming
     // text bubble appearing after the chain doesn't prematurely collapse it
@@ -599,7 +639,12 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                     </div>
                   )}
 
-                  {/* Render all blocks (messages and agent chains) */}
+                  {/* Render all blocks (messages and agent chains). Each block
+                      gets a `data-conversation-block` wrapper: in-session
+                      search's MutationObserver keys off these boundaries to
+                      tell structural transcript changes (new message/chain,
+                      task hydration) apart from per-frame streaming churn
+                      inside a block. */}
                   {!messagesLoading &&
                     blocks.map((block, blockIndex) => {
                       if (block.type === 'message') {
@@ -624,11 +669,9 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                         // Render SDK status messages (rate limit, API wait, etc.) with dedicated component
                         if (isSdkStatusMessage(block.message)) {
                           return (
-                            <RateLimitBlock
-                              key={block.message.message_id}
-                              message={block.message}
-                              agentic_tool={agentic_tool}
-                            />
+                            <div key={block.message.message_id} data-conversation-block>
+                              <RateLimitBlock message={block.message} agentic_tool={agentic_tool} />
+                            </div>
                           );
                         }
 
@@ -638,44 +681,47 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           blockIndex === blocks.length - 1;
 
                         return (
-                          <MessageBlock
-                            key={block.message.message_id}
-                            message={block.message}
-                            agentic_tool={agentic_tool}
-                            userById={userById}
-                            currentUserId={task.created_by}
-                            isTaskRunning={task.status === TaskStatus.RUNNING}
-                            sessionId={sessionId}
-                            onPermissionDecision={onPermissionDecision}
-                            isFirstPendingPermission={isFirstPending}
-                            isLatestMessage={isLatestMessage}
-                            taskId={task.task_id}
-                            assistantEmoji={assistantEmoji}
-                            client={client}
-                          />
+                          <div key={block.message.message_id} data-conversation-block>
+                            <MessageBlock
+                              message={block.message}
+                              agentic_tool={agentic_tool}
+                              userById={userById}
+                              currentUserId={task.created_by}
+                              isTaskRunning={task.status === TaskStatus.RUNNING}
+                              sessionId={sessionId}
+                              onPermissionDecision={onPermissionDecision}
+                              isFirstPendingPermission={isFirstPending}
+                              isLatestMessage={isLatestMessage}
+                              taskId={task.task_id}
+                              assistantEmoji={assistantEmoji}
+                              client={client}
+                            />
+                          </div>
                         );
                       }
                       if (block.type === 'agent-chain') {
                         // Use first message ID as key for agent chain
                         const blockKey = `agent-chain-${block.messages[0]?.message_id || 'unknown'}`;
                         return (
-                          <AgentChain
-                            key={blockKey}
-                            messages={block.messages}
-                            isTaskRunning={task.status === TaskStatus.RUNNING}
-                            isLatest={isLatestTask && blockIndex === lastAgentChainIndex}
-                          />
+                          <div key={blockKey} data-conversation-block>
+                            <AgentChain
+                              messages={block.messages}
+                              isTaskRunning={task.status === TaskStatus.RUNNING}
+                              isLatest={isLatestTask && blockIndex === lastAgentChainIndex}
+                            />
+                          </div>
                         );
                       }
                       if (block.type === 'compaction') {
                         // Render compaction block with aggregated messages
                         const blockKey = `compaction-${block.messages[0]?.message_id || 'unknown'}`;
                         return (
-                          <CompactionBlock
-                            key={blockKey}
-                            messages={block.messages}
-                            agentic_tool={agentic_tool}
-                          />
+                          <div key={blockKey} data-conversation-block>
+                            <CompactionBlock
+                              messages={block.messages}
+                              agentic_tool={agentic_tool}
+                            />
+                          </div>
                         );
                       }
                       return null;
@@ -684,9 +730,12 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                   {/* Keep latest TODO visible even after completion (Claude parity). */}
                   <StickyTodoRenderer messages={messages} taskStatus={task.status} />
 
-                  {/* Show typing indicator whenever task is actively running */}
+                  {/* Show typing indicator whenever task is actively running.
+                      Marked as a conversation block so its unmount at stream
+                      end gives search one final structural re-scan that picks
+                      up the finished message text. */}
                   {task.status === TaskStatus.RUNNING && (
-                    <div style={{ margin: `${token.sizeUnit}px 0` }}>
+                    <div data-conversation-block style={{ margin: `${token.sizeUnit}px 0` }}>
                       <Bubble
                         placement="start"
                         avatar={

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -359,6 +359,20 @@ function getBlockKey(block: Block): string {
     : `${block.type}:${block.messages[0]?.message_id || 'unknown'}`;
 }
 
+/**
+ * Marker value for a block's `data-conversation-block` wrapper. In-session
+ * search re-scans on the 'streaming' → 'settled' attribute flip: a message
+ * that finishes streaming settles inside the SAME wrapper node (same key), so
+ * without the flip its final text would only become findable at the next
+ * block mount/unmount.
+ */
+function getBlockMarker(block: Block): 'streaming' | 'settled' {
+  const messages = block.type === 'message' ? [block.message] : block.messages;
+  return messages.some((m) => (m as { isStreaming?: boolean }).isStreaming === true)
+    ? 'streaming'
+    : 'settled';
+}
+
 /** Same composition: identical message references in identical order. */
 function blocksHaveSameMessages(a: Block, b: Block): boolean {
   if (a.type !== b.type) return false;
@@ -643,8 +657,8 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                       gets a `data-conversation-block` wrapper: in-session
                       search's MutationObserver keys off these boundaries to
                       tell structural transcript changes (new message/chain,
-                      task hydration) apart from per-frame streaming churn
-                      inside a block. */}
+                      task hydration, a block settling after streaming) apart
+                      from per-frame streaming churn inside a block. */}
                   {!messagesLoading &&
                     blocks.map((block, blockIndex) => {
                       if (block.type === 'message') {
@@ -669,7 +683,10 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                         // Render SDK status messages (rate limit, API wait, etc.) with dedicated component
                         if (isSdkStatusMessage(block.message)) {
                           return (
-                            <div key={block.message.message_id} data-conversation-block>
+                            <div
+                              key={block.message.message_id}
+                              data-conversation-block={getBlockMarker(block)}
+                            >
                               <RateLimitBlock message={block.message} agentic_tool={agentic_tool} />
                             </div>
                           );
@@ -681,7 +698,10 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           blockIndex === blocks.length - 1;
 
                         return (
-                          <div key={block.message.message_id} data-conversation-block>
+                          <div
+                            key={block.message.message_id}
+                            data-conversation-block={getBlockMarker(block)}
+                          >
                             <MessageBlock
                               message={block.message}
                               agentic_tool={agentic_tool}
@@ -703,7 +723,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                         // Use first message ID as key for agent chain
                         const blockKey = `agent-chain-${block.messages[0]?.message_id || 'unknown'}`;
                         return (
-                          <div key={blockKey} data-conversation-block>
+                          <div key={blockKey} data-conversation-block={getBlockMarker(block)}>
                             <AgentChain
                               messages={block.messages}
                               isTaskRunning={task.status === TaskStatus.RUNNING}
@@ -716,7 +736,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                         // Render compaction block with aggregated messages
                         const blockKey = `compaction-${block.messages[0]?.message_id || 'unknown'}`;
                         return (
-                          <div key={blockKey} data-conversation-block>
+                          <div key={blockKey} data-conversation-block={getBlockMarker(block)}>
                             <CompactionBlock
                               messages={block.messages}
                               agentic_tool={agentic_tool}

--- a/apps/agor-ui/src/hooks/useSessionSearch.test.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { getMatchOffsets } from './useSessionSearch';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getMatchOffsets,
+  isStructuralMutation,
+  REBUILD_DEBOUNCE_MS,
+  useSessionSearch,
+} from './useSessionSearch';
 
 describe('getMatchOffsets', () => {
   it('returns nothing for empty or whitespace-only queries', () => {
@@ -27,5 +33,145 @@ describe('getMatchOffsets', () => {
     const text = 'the quick brown fox';
     const [start, end] = getMatchOffsets(text, 'quick')[0];
     expect(text.slice(start, end)).toBe('quick');
+  });
+});
+
+// ── isStructuralMutation ─────────────────────────────────────────────────────
+
+function makeRecord(partial: Partial<MutationRecord>): MutationRecord {
+  return {
+    type: 'childList',
+    addedNodes: [] as unknown as NodeList,
+    removedNodes: [] as unknown as NodeList,
+    attributeName: null,
+    ...partial,
+  } as unknown as MutationRecord;
+}
+
+function blockEl(marker = 'settled'): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-conversation-block', marker);
+  return el;
+}
+
+describe('isStructuralMutation', () => {
+  it('re-scans when a conversation block mounts', () => {
+    expect(
+      isStructuralMutation([makeRecord({ addedNodes: [blockEl()] as unknown as NodeList })])
+    ).toBe(true);
+  });
+
+  it('re-scans when an added subtree contains a task block boundary', () => {
+    const wrapper = document.createElement('div');
+    const task = document.createElement('div');
+    task.setAttribute('data-task-block', 'task-1');
+    wrapper.appendChild(task);
+    expect(
+      isStructuralMutation([makeRecord({ addedNodes: [wrapper] as unknown as NodeList })])
+    ).toBe(true);
+  });
+
+  it('re-scans when a conversation block unmounts (typing indicator at stream end)', () => {
+    expect(
+      isStructuralMutation([makeRecord({ removedNodes: [blockEl()] as unknown as NodeList })])
+    ).toBe(true);
+  });
+
+  it('ignores text/inline churn inside an existing block', () => {
+    const span = document.createElement('span');
+    span.textContent = 'streamed word';
+    const text = document.createTextNode('more streamed text');
+    expect(
+      isStructuralMutation([
+        makeRecord({ addedNodes: [span, text] as unknown as NodeList }),
+        makeRecord({ type: 'characterData' }),
+      ])
+    ).toBe(false);
+  });
+
+  it("re-scans on the block marker's streaming → settled attribute flip", () => {
+    expect(
+      isStructuralMutation([
+        makeRecord({ type: 'attributes', attributeName: 'data-conversation-block' }),
+      ])
+    ).toBe(true);
+  });
+
+  it('ignores attribute mutations other than the block marker', () => {
+    expect(isStructuralMutation([makeRecord({ type: 'attributes', attributeName: 'class' })])).toBe(
+      false
+    );
+  });
+});
+
+// ── streaming-settle rescan (hook + DOM) ─────────────────────────────────────
+
+class HighlightStub {
+  priority = 0;
+  // biome-ignore lint/complexity/noUselessConstructor: mirrors the DOM Highlight signature
+  constructor(..._ranges: Range[]) {}
+}
+
+describe('useSessionSearch streaming-settle rescan', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // jsdom ships neither the CSS Custom Highlight API nor CSS.highlights;
+    // without them the hook degrades to no-op scanning, so stub the registry.
+    (globalThis as { Highlight?: unknown }).Highlight = HighlightStub;
+    (globalThis as { CSS?: { highlights?: unknown } }).CSS = {
+      ...(globalThis as { CSS?: object }).CSS,
+      highlights: new Map(),
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    container.remove();
+    delete (globalThis as { Highlight?: unknown }).Highlight;
+  });
+
+  /** Let the MutationObserver microtask deliver, then run the debounce out. */
+  async function flushObserverAndDebounce() {
+    await act(async () => {
+      await Promise.resolve();
+      vi.advanceTimersByTime(REBUILD_DEBOUNCE_MS + 10);
+    });
+  }
+
+  it('a query matching only late-streamed text is found when the message settles', async () => {
+    const block = document.createElement('div');
+    block.setAttribute('data-conversation-block', 'streaming');
+    const textNode = document.createTextNode('hello ');
+    block.appendChild(textNode);
+    container.appendChild(block);
+
+    const ref = { current: container };
+    const { result } = renderHook(() => useSessionSearch(ref));
+
+    act(() => {
+      result.current.openSearch();
+    });
+    act(() => {
+      result.current.setQuery('needle');
+    });
+    await flushObserverAndDebounce();
+    expect(result.current.totalMatches).toBe(0);
+
+    // The match streams in as character churn inside the existing block —
+    // deliberately NOT a re-scan trigger (that's the per-frame cost this
+    // hook avoids), so the count must stay stale for now.
+    textNode.data = 'hello needle';
+    await flushObserverAndDebounce();
+    expect(result.current.totalMatches).toBe(0);
+
+    // Stream end: the message settles in place and TaskBlock flips the wrapper
+    // marker. That alone — no mounts/unmounts — must make the text findable.
+    block.setAttribute('data-conversation-block', 'settled');
+    await flushObserverAndDebounce();
+    expect(result.current.totalMatches).toBe(1);
   });
 });

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -3,7 +3,7 @@ import { escapeRegExp } from '../components/HighlightMatch/HighlightMatch';
 
 const HIGHLIGHT_NAME = 'agor-search';
 const CURRENT_HIGHLIGHT_NAME = 'agor-search-current';
-const REBUILD_DEBOUNCE_MS = 160;
+export const REBUILD_DEBOUNCE_MS = 160;
 
 export interface SessionSearchColors {
   /** Base color for every match (rendered translucent). */
@@ -87,9 +87,18 @@ function buildRanges(container: HTMLElement, query: string): Range[] {
  * TreeWalker re-scan per animation frame is exactly the cost this avoids.
  */
 const STRUCTURAL_BLOCK_SELECTOR = '[data-task-block], [data-conversation-block]';
+const BLOCK_MARKER_ATTRIBUTE = 'data-conversation-block';
 
 export function isStructuralMutation(records: MutationRecord[]): boolean {
   for (const record of records) {
+    // A message that finishes streaming settles *in place*: same wrapper node,
+    // marker value flips 'streaming' → 'settled' (see TaskBlock). That's the
+    // one boundary change with no childList signal, and it's exactly when the
+    // fully-streamed text must become findable.
+    if (record.type === 'attributes') {
+      if (record.attributeName === BLOCK_MARKER_ATTRIBUTE) return true;
+      continue;
+    }
     if (record.type !== 'childList') continue;
     for (const nodes of [record.addedNodes, record.removedNodes]) {
       for (const node of nodes) {
@@ -270,13 +279,19 @@ export function useSessionSearch(
     // mutations aren't observed and intra-block childList churn is filtered
     // out: while an agent streams, both fire once per frame, and each reset of
     // the debounce both starves the pending scan and queues a full-transcript
-    // TreeWalker pass per quiet gap. Text still streaming when the last
-    // structural scan ran becomes searchable at the next boundary change (new
-    // block, or the typing indicator unmounting at stream end).
+    // TreeWalker pass per quiet gap. Boundary changes that DO re-scan: a block
+    // mounting/unmounting (childList) and a block's marker value flipping when
+    // its message finishes streaming (attribute) — so late-streamed text is
+    // findable at message completion, not at the next mount.
     const observer = new MutationObserver((records) => {
       if (isStructuralMutation(records)) scheduleRebuild(false);
     });
-    observer.observe(container, { childList: true, subtree: true });
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [BLOCK_MARKER_ATTRIBUTE],
+    });
 
     return () => {
       observer.disconnect();

--- a/apps/agor-ui/src/hooks/useSessionSearch.ts
+++ b/apps/agor-ui/src/hooks/useSessionSearch.ts
@@ -79,6 +79,31 @@ function buildRanges(container: HTMLElement, query: string): Range[] {
   return ranges;
 }
 
+/**
+ * Transcript boundaries that mark a *structural* change worth a re-scan:
+ * a task mounting/unmounting, task hydration, or a new message/agent-chain
+ * block appearing. Mutations inside an existing block (per-frame streaming
+ * markdown growth) don't move these boundaries and are ignored — a full
+ * TreeWalker re-scan per animation frame is exactly the cost this avoids.
+ */
+const STRUCTURAL_BLOCK_SELECTOR = '[data-task-block], [data-conversation-block]';
+
+export function isStructuralMutation(records: MutationRecord[]): boolean {
+  for (const record of records) {
+    if (record.type !== 'childList') continue;
+    for (const nodes of [record.addedNodes, record.removedNodes]) {
+      for (const node of nodes) {
+        if (node.nodeType !== Node.ELEMENT_NODE) continue;
+        const el = node as Element;
+        if (el.matches(STRUCTURAL_BLOCK_SELECTOR) || el.querySelector(STRUCTURAL_BLOCK_SELECTOR)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 function scrollRangeIntoView(range: Range) {
   const node = range.startContainer;
   const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
@@ -241,8 +266,17 @@ export function useSessionSearch(
 
     scheduleRebuild(true);
 
-    const observer = new MutationObserver(() => scheduleRebuild(false));
-    observer.observe(container, { childList: true, subtree: true, characterData: true });
+    // Only block-level structural changes reschedule the scan. Character-level
+    // mutations aren't observed and intra-block childList churn is filtered
+    // out: while an agent streams, both fire once per frame, and each reset of
+    // the debounce both starves the pending scan and queues a full-transcript
+    // TreeWalker pass per quiet gap. Text still streaming when the last
+    // structural scan ran becomes searchable at the next boundary change (new
+    // block, or the typing indicator unmounting at stream end).
+    const observer = new MutationObserver((records) => {
+      if (isStructuralMutation(records)) scheduleRebuild(false);
+    });
+    observer.observe(container, { childList: true, subtree: true });
 
     return () => {
       observer.disconnect();


### PR DESCRIPTION
While an agent streams, the transcript is the surface users watch — and today every chunk re-evaluates far more of it than necessary. With store-side rAF batching (#1793) landing, updates arrive once per frame; this PR makes one frame's work small: a chunk for task X now invalidates only the streamed message's subtree.

## What changed

### 1. Streaming chunk isolation — only the streamed message re-renders

- **`TaskBlock.tsx:426-444`** — `groupMessagesIntoBlocks` minted fresh block objects and `messages` arrays on every chunk, handing the memoized `AgentChain`/`CompactionBlock` children new array identities and defeating their `React.memo` for the whole streaming task. The `blocks` memo now reconciles against the previous render (`getBlockKey` + `blocksHaveSameMessages`, `TaskBlock.tsx:355-378`) and reuses prior block objects when their message references are unchanged — untouched tool-chain subtrees bail out while the streamed block still updates every frame.
- **`ConversationView.tsx:30-33`, `TaskBlock.tsx:60-62`** — the `userById = new Map()` default params minted a fresh Map per render, defeating every `TaskBlock`/`MessageBlock` memo whenever the prop was omitted. Replaced with module-level `EMPTY_USER_MAP` constants.
- Cross-task routing (`useStreamingMessagesByTask` → `ConversationView.tsx:241`) keeps per-task Map entries reference-stable when their messages didn't change; that path is now pinned by tests so regressions can't silently reintroduce cross-task invalidation.

### 2. `SessionFooter` memoized behind identity-stable props

`SessionPanel` re-renders once per frame while its session streams (reactive-session notify), and the footer is a ~1.5k-line subtree of dropdowns/popovers that doesn't depend on per-chunk state.

- **`SessionFooter.tsx:98-103`** — wrapped in `React.memo`.
- **`SessionPanel.tsx:689-726`** — footer handlers close over per-render state and are defined past the null-session early return, so they can't be `useCallback`'d; they now flow through lifetime-stable wrappers delegating to the latest impls via a ref (re-pointed each render at `SessionPanel.tsx:1005-1019`).
- **`SessionPanel.tsx:734-750, 756-831`** — `modelConfig` and the composer `promptInputSlot` are memoized on their actual deps instead of being rebuilt inline per render.
- **`SessionPanel.tsx:288-291, 424`** — stable `EMPTY_TASKS` fallback so pre-hydration renders don't churn `tokenBreakdown`/`footerTimerTask` identities.

### 3. In-session search: structural-only re-scans

- **`useSessionSearch.ts:87-110, 273-284`** — the MutationObserver rescheduled a full-transcript TreeWalker re-scan on every streaming mutation; because each mutation resets the 160 ms debounce, continuous streaming starved the pending scan and then paid a full scan on every quiet gap. The observer no longer watches `characterData` and only reschedules when a childList mutation adds/removes a block boundary (`[data-task-block]` / `[data-conversation-block]`). The 160 ms debounce for query changes is unchanged.
- **`TaskBlock.tsx:650-656, 745-751`** — each rendered block (and the typing indicator) carries `data-conversation-block`, so new messages, task hydration, and stream end still trigger a re-scan; text still streaming when the last scan ran becomes searchable at the next boundary change (at the latest, the typing indicator unmounting at stream end).

### Tests

- `ConversationView.rerender.test.tsx` — through the **real** `TaskBlock` + grouping hooks: a streaming chunk for task B re-renders only the streamed message (task A's MessageBlocks and task B's settled ones stay quiet); a notify with identical streaming content re-renders no message blocks.
- `SessionFooter.rerender.test.tsx` — a reactive notify that keeps `tasks` identity re-renders the panel but not the footer; a token-usage change does (contrast case proving the counter is wired).

Streaming text still renders live once per frame with identical visuals; auto-scroll (#1655) wiring in `use-stick-to-bottom` is untouched and its existing tests pass unchanged.

## Gates

- `pnpm typecheck`, `pnpm lint`, `pnpm check:shortid`, `turbo run build --filter='!@agor/docs'` — green. `check:multitenancy-boundaries` fails identically on the pristine base commit (daemon files this PR doesn't touch) — pre-existing on main.
- agor-ui suites: SessionPanel / ConversationView / MessageBlock / useSessionSearch (78 tests) and all `*.rerender.test.tsx` (10 files, 35 tests) — green.

## Follow-up: transcript windowing (not in this PR)

The transcript remains unvirtualized: a long session mounts hundreds of markdown/tool trees even though only a screenful is visible. This PR makes frames cheap, but mount cost and memory still scale with session length. Shape of the follow-up, which needs UX decisions first:

- **Task-level windowing, not message-level** — tasks are already collapsible units with stable identities; render placeholders (measured/estimated heights) for off-viewport tasks and mount real content only for the window around the viewport ± overscan.
- **use-stick-to-bottom interplay** — the library pins via a persistent ResizeObserver on the content element; placeholder→content swaps change heights and must not fight the bottom lock (swap while pinned only from the bottom up, suppress re-pin during upward backfill).
- **Scroll anchoring** — preserve position when content above the viewport materializes (height cache keyed by task_id + message count, scroll-offset compensation on swap).
- **Search interplay** — in-session search force-expands all tasks today; windowing needs a search-time full-mount escape hatch or an off-DOM text index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
