### PR TITLE
fix(executor): probe process liveness before failing on lost heartbeat

### DIFF
--- a/apps/agor-daemon/src/executor-tracking.test.ts
+++ b/apps/agor-daemon/src/executor-tracking.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getExecutorLiveness,
+  trackExecutorProcess,
+  untrackExecutorProcess,
+} from './executor-tracking';
+
+const SESSION_ID = '018f0000-0000-7000-8000-0000000000aa';
+
+afterEach(() => {
+  untrackExecutorProcess(SESSION_ID);
+  vi.restoreAllMocks();
+});
+
+describe('getExecutorLiveness', () => {
+  it('returns "unknown" when no PID is tracked for the session', () => {
+    expect(getExecutorLiveness(SESSION_ID)).toBe('unknown');
+  });
+
+  it('returns "alive" when the tracked process exists', () => {
+    trackExecutorProcess(SESSION_ID, 4242);
+    const kill = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    expect(getExecutorLiveness(SESSION_ID)).toBe('alive');
+    expect(kill).toHaveBeenCalledWith(4242, 0);
+  });
+
+  it('returns "dead" when the tracked process no longer exists (ESRCH)', () => {
+    trackExecutorProcess(SESSION_ID, 4242);
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('no such process') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+
+    expect(getExecutorLiveness(SESSION_ID)).toBe('dead');
+  });
+
+  it('treats EPERM as "alive" (process owned by another Unix user)', () => {
+    trackExecutorProcess(SESSION_ID, 4242);
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('operation not permitted') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+
+    expect(getExecutorLiveness(SESSION_ID)).toBe('alive');
+  });
+});

--- a/apps/agor-daemon/src/executor-tracking.ts
+++ b/apps/agor-daemon/src/executor-tracking.ts
@@ -25,6 +25,42 @@ export function untrackExecutorProcess(sessionId: string): void {
 }
 
 /**
+ * Liveness of a session's tracked executor process.
+ *
+ * - `alive`   — a PID is tracked and the OS confirms the process exists.
+ * - `dead`    — a PID is tracked but the process no longer exists (ESRCH).
+ * - `unknown` — no PID is tracked (e.g. never spawned here, or the daemon
+ *               restarted and lost its in-memory map). Callers should fall
+ *               back to their prior heuristics in this case.
+ */
+export type ExecutorLiveness = 'alive' | 'dead' | 'unknown';
+
+/**
+ * Probe whether a session's executor process is still running.
+ *
+ * Uses signal 0 (`process.kill(pid, 0)`), which performs an existence/permission
+ * check without delivering a signal. In insulated/strict Unix modes the executor
+ * runs as a different user, so the daemon may lack permission to signal it — that
+ * surfaces as `EPERM`, which still proves the process exists, so we treat it as
+ * `alive`. Only `ESRCH` (no such process) is treated as `dead`.
+ */
+export function getExecutorLiveness(sessionId: string): ExecutorLiveness {
+  const proc = executorProcesses.get(sessionId);
+  if (!proc) return 'unknown';
+
+  try {
+    process.kill(proc.pid, 0);
+    return 'alive';
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM: process exists but is owned by another user — still alive.
+    if (code === 'EPERM') return 'alive';
+    // ESRCH (or anything else we can't interpret as "exists"): treat as dead.
+    return 'dead';
+  }
+}
+
+/**
  * Kill an executor process for a session using Unix signals.
  *
  * Phase 1: SIGTERM (allows graceful shutdown — executor's SIGTERM handler

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
@@ -4,37 +4,54 @@ import {
   ExecutorHeartbeatSupervisor,
 } from './executor-heartbeat-supervisor';
 
-describe('ExecutorHeartbeatSupervisor', () => {
-  it('marks active tasks failed when latest heartbeat is stale', async () => {
-    const staleTask = {
-      task_id: '018f0000-0000-7000-8000-000000000001',
-      session_id: '018f0000-0000-7000-8000-000000000002',
-      status: 'running',
-      last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
-    };
-    const failForLostHeartbeat = vi.fn().mockResolvedValue({});
-    const app = {
+const BASE_CONFIG = {
+  enabled: true,
+  interval_ms: 1000,
+  stale_after_ms: 3000,
+  callback: { command_template: null, timeout_ms: 3000 },
+} as const;
+
+function makeStaleTask(overrides: Record<string, unknown> = {}) {
+  return {
+    task_id: '018f0000-0000-7000-8000-000000000001',
+    session_id: '018f0000-0000-7000-8000-000000000002',
+    status: 'running',
+    last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeApp(
+  task: Record<string, unknown>,
+  failForLostHeartbeat = vi.fn().mockResolvedValue({})
+) {
+  return {
+    app: {
       service: (name: string) => {
         if (name === 'tasks') {
           return {
-            getActiveWithExecutorHeartbeat: vi.fn().mockResolvedValue([staleTask]),
-            get: vi.fn().mockResolvedValue(staleTask),
+            getActiveWithExecutorHeartbeat: vi.fn().mockResolvedValue([task]),
+            get: vi.fn().mockResolvedValue(task),
             failForLostHeartbeat,
           };
         }
         throw new Error(`unknown service ${name}`);
       },
-    } as any;
+    } as any,
+    failForLostHeartbeat,
+  };
+}
+
+describe('ExecutorHeartbeatSupervisor', () => {
+  it('fails a stale task when the executor process is confirmed dead', async () => {
+    const staleTask = makeStaleTask();
+    const { app, failForLostHeartbeat } = makeApp(staleTask);
 
     const supervisor = new ExecutorHeartbeatSupervisor({
       app,
-      config: {
-        enabled: true,
-        interval_ms: 1000,
-        stale_after_ms: 3000,
-        callback: { command_template: null, timeout_ms: 3000 },
-      },
+      config: { ...BASE_CONFIG },
       now: () => new Date('2026-01-01T00:00:05.000Z'),
+      checkExecutorLiveness: () => 'dead',
     });
 
     await supervisor.checkOnce();
@@ -45,14 +62,60 @@ describe('ExecutorHeartbeatSupervisor', () => {
     });
   });
 
+  it('fails a stale task when the executor PID is unknown (preserves reaping of orphans)', async () => {
+    const staleTask = makeStaleTask();
+    const { app, failForLostHeartbeat } = makeApp(staleTask);
+
+    const supervisor = new ExecutorHeartbeatSupervisor({
+      app,
+      config: { ...BASE_CONFIG },
+      now: () => new Date('2026-01-01T00:00:05.000Z'),
+      checkExecutorLiveness: () => 'unknown',
+    });
+
+    await supervisor.checkOnce();
+
+    expect(failForLostHeartbeat).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fail a stale task while the executor process is still alive', async () => {
+    const staleTask = makeStaleTask();
+    const { app, failForLostHeartbeat } = makeApp(staleTask);
+
+    const supervisor = new ExecutorHeartbeatSupervisor({
+      app,
+      config: { ...BASE_CONFIG },
+      now: () => new Date('2026-01-01T00:00:05.000Z'),
+      checkExecutorLiveness: () => 'alive',
+    });
+
+    await supervisor.checkOnce();
+
+    expect(failForLostHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fail when a long synchronous tool call starves the heartbeat but the process is alive', async () => {
+    // Heartbeat is extremely stale (executor was busy in a long tool call and
+    // could not emit) yet the OS reports the process alive — must not be reaped.
+    const staleTask = makeStaleTask({ last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z' });
+    const { app, failForLostHeartbeat } = makeApp(staleTask);
+
+    const supervisor = new ExecutorHeartbeatSupervisor({
+      app,
+      config: { ...BASE_CONFIG },
+      now: () => new Date('2026-01-01T00:10:00.000Z'), // 10 minutes later
+      checkExecutorLiveness: () => 'alive',
+    });
+
+    await supervisor.checkOnce();
+
+    expect(failForLostHeartbeat).not.toHaveBeenCalled();
+  });
+
   it('skips tasks that refreshed before failure', async () => {
-    const task = {
-      task_id: '018f0000-0000-7000-8000-000000000001',
-      session_id: '018f0000-0000-7000-8000-000000000002',
-      status: 'running',
-      last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
-    };
+    const task = makeStaleTask();
     const tasksPatch = vi.fn();
+    const failForLostHeartbeat = vi.fn();
     const app = {
       service: (name: string) => ({
         getActiveWithExecutorHeartbeat: vi.fn().mockResolvedValue([task]),
@@ -61,21 +124,19 @@ describe('ExecutorHeartbeatSupervisor', () => {
           last_executor_heartbeat_at: '2026-01-01T00:00:04.500Z',
         }),
         patch: name === 'tasks' ? tasksPatch : vi.fn(),
+        failForLostHeartbeat,
       }),
     } as any;
 
     const supervisor = new ExecutorHeartbeatSupervisor({
       app,
-      config: {
-        enabled: true,
-        interval_ms: 1000,
-        stale_after_ms: 3000,
-        callback: { command_template: null, timeout_ms: 3000 },
-      },
+      config: { ...BASE_CONFIG },
       now: () => new Date('2026-01-01T00:00:05.000Z'),
+      checkExecutorLiveness: () => 'dead',
     });
 
     await supervisor.checkOnce();
     expect(tasksPatch).not.toHaveBeenCalled();
+    expect(failForLostHeartbeat).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
@@ -1,6 +1,7 @@
 import type { ResolvedExecutorHeartbeatConfig } from '@agor/core/config';
 import { shortId } from '@agor/core/db';
 import type { Application, TasksServiceImpl } from '../declarations.js';
+import { type ExecutorLiveness, getExecutorLiveness } from '../executor-tracking.js';
 
 export const EXECUTOR_HEARTBEAT_LOST_MESSAGE =
   'Executor heartbeat lost; the executor may have crashed or disconnected.';
@@ -10,6 +11,12 @@ export interface ExecutorHeartbeatSupervisorOptions {
   config: ResolvedExecutorHeartbeatConfig;
   tickIntervalMs?: number;
   now?: () => Date;
+  /**
+   * Probe whether a session's executor process is still running. Injectable for
+   * tests; defaults to the daemon's in-memory PID tracker. A stale heartbeat is
+   * only allowed to fail a task when the executor process is NOT confirmed alive.
+   */
+  checkExecutorLiveness?: (sessionId: string) => ExecutorLiveness;
 }
 
 export class ExecutorHeartbeatSupervisor {
@@ -17,10 +24,12 @@ export class ExecutorHeartbeatSupervisor {
   private running = false;
   private readonly tickIntervalMs: number;
   private readonly now: () => Date;
+  private readonly checkExecutorLiveness: (sessionId: string) => ExecutorLiveness;
 
   constructor(private options: ExecutorHeartbeatSupervisorOptions) {
     this.tickIntervalMs = options.tickIntervalMs ?? Math.min(options.config.interval_ms, 30_000);
     this.now = options.now ?? (() => new Date());
+    this.checkExecutorLiveness = options.checkExecutorLiveness ?? getExecutorLiveness;
   }
 
   start(): void {
@@ -56,12 +65,29 @@ export class ExecutorHeartbeatSupervisor {
           if (!Number.isFinite(currentHeartbeatMs)) continue;
           if (nowMs - currentHeartbeatMs <= this.options.config.stale_after_ms) continue;
 
+          // Liveness gate: a stale heartbeat alone does NOT mean the executor
+          // crashed. A busy-but-alive executor (heavy git/build/test work, host
+          // load) can simply be late writing its heartbeat. Only fail when the
+          // OS confirms the executor process is gone. If we still have a live
+          // PID, skip — the heartbeat will catch up. `unknown` (no tracked PID,
+          // e.g. after a daemon restart that orphaned the executor) falls
+          // through to the timestamp-based reap, preserving prior behavior.
+          const liveness = this.checkExecutorLiveness(task.session_id);
+          if (liveness === 'alive') {
+            console.warn(
+              `[executor-heartbeat] Task ${shortId(task.task_id)} heartbeat is stale ` +
+                `(${nowMs - currentHeartbeatMs}ms old) but executor process is alive; skipping failure`
+            );
+            continue;
+          }
+
           await tasksService.failForLostHeartbeat(task.task_id, {
             completed_at: this.now().toISOString(),
             error_message: EXECUTOR_HEARTBEAT_LOST_MESSAGE,
           });
           console.warn(
-            `[executor-heartbeat] Marked task ${shortId(task.task_id)} failed after stale heartbeat (${nowMs - currentHeartbeatMs}ms old)`
+            `[executor-heartbeat] Marked task ${shortId(task.task_id)} failed after stale heartbeat ` +
+              `(${nowMs - currentHeartbeatMs}ms old, executor process ${liveness})`
           );
         } catch (error) {
           console.warn(

--- a/packages/core/src/config/executor-heartbeat.test.ts
+++ b/packages/core/src/config/executor-heartbeat.test.ts
@@ -3,22 +3,34 @@ import { getDefaultConfig } from './config-manager';
 import { resolveExecutorHeartbeatConfig } from './executor-heartbeat';
 
 describe('resolveExecutorHeartbeatConfig', () => {
-  it('defaults to enabled with a 10s interval and conservative stale threshold', () => {
+  it('defaults to enabled with a 10s interval and forgiving stale threshold', () => {
     expect(resolveExecutorHeartbeatConfig()).toEqual({
       enabled: true,
       interval_ms: 10_000,
-      stale_after_ms: 30_000,
+      stale_after_ms: 90_000,
       callback: { command_template: null, timeout_ms: 3_000 },
     });
   });
 
-  it('defaults stale_after_ms to max(3 * interval_ms, 30000)', () => {
+  it('defaults stale_after_ms to max(3 * interval_ms, 90000)', () => {
+    // Below the 90s floor: clamped up.
     expect(
       resolveExecutorHeartbeatConfig({ executor_heartbeat: { interval_ms: 20_000 } }).stale_after_ms
-    ).toBe(60_000);
+    ).toBe(90_000);
     expect(
       resolveExecutorHeartbeatConfig({ executor_heartbeat: { interval_ms: 1_000 } }).stale_after_ms
-    ).toBe(30_000);
+    ).toBe(90_000);
+    // Above the floor: 3 * interval wins.
+    expect(
+      resolveExecutorHeartbeatConfig({ executor_heartbeat: { interval_ms: 40_000 } }).stale_after_ms
+    ).toBe(120_000);
+  });
+
+  it('honors an explicit stale_after_ms override', () => {
+    expect(
+      resolveExecutorHeartbeatConfig({ executor_heartbeat: { stale_after_ms: 15_000 } })
+        .stale_after_ms
+    ).toBe(15_000);
   });
 
   it('includes executor heartbeat defaults in getDefaultConfig', () => {

--- a/packages/core/src/config/executor-heartbeat.ts
+++ b/packages/core/src/config/executor-heartbeat.ts
@@ -1,7 +1,12 @@
 import type { AgorExecutionSettings } from './types';
 
 export const EXECUTOR_HEARTBEAT_DEFAULT_INTERVAL_MS = 10_000;
-export const EXECUTOR_HEARTBEAT_MIN_STALE_AFTER_MS = 30_000;
+// Minimum grace period before a stale heartbeat is even considered for failure.
+// Kept forgiving (90s) so a busy-but-alive executor under heavy git/build/test
+// work or host load is not mistaken for a crash. The daemon additionally probes
+// the executor process's liveness before failing, so this is a floor, not the
+// sole safeguard. Fully overridable via `execution.executor_heartbeat.stale_after_ms`.
+export const EXECUTOR_HEARTBEAT_MIN_STALE_AFTER_MS = 90_000;
 export const EXECUTOR_HEARTBEAT_DEFAULT_CALLBACK_TIMEOUT_MS = 3_000;
 
 export interface ResolvedExecutorHeartbeatConfig {

--- a/packages/executor/src/executor-heartbeat.ts
+++ b/packages/executor/src/executor-heartbeat.ts
@@ -16,6 +16,24 @@ export interface ExecutorHeartbeatHandle {
 
 const DEFAULT_INTERVAL_MS = 10_000;
 
+/**
+ * Emit a periodic liveness heartbeat for a running task.
+ *
+ * Design notes on starvation (see issue #1809):
+ * - The heartbeat runs on its own `setInterval`, independent of the tool's
+ *   async work. Tool execution (git/build/test, SDK streaming) is asynchronous
+ *   subprocess/socket I/O, so it yields the event loop and the timer keeps
+ *   firing on schedule.
+ * - The `inFlight` guard only skips *overlapping* emits (e.g. a slow patch); it
+ *   never blocks the timer itself, so a slow write cannot stall future ticks.
+ * - A pathological CPU-bound *synchronous* tool call could still delay any
+ *   main-thread timer in Node. That is why the daemon no longer treats a late
+ *   heartbeat as proof of death: before failing a task it probes the executor
+ *   OS process directly (`process.kill(pid, 0)`), which cannot be starved by
+ *   anything happening inside the executor's event loop. The emitted heartbeat
+ *   is a fast-path liveness refresh; the process probe is the authoritative,
+ *   unblockable signal.
+ */
 export function startExecutorHeartbeat(options: ExecutorHeartbeatOptions): ExecutorHeartbeatHandle {
   const enabled = options.enabled ?? true;
   if (!enabled) {


### PR DESCRIPTION
## Problem

`ExecutorHeartbeatSupervisor` marked a task/session `failed` purely because no executor heartbeat landed within `stale_after_ms` (default `max(3 × interval, 30s)` = 30s). A **busy-but-alive** executor — heavy git/build/test work, or host load — was indistinguishable from a crashed one, so healthy sessions that did real, committed work got reaped and mislabeled `failed` with:

> Executor heartbeat lost; the executor may have crashed or disconnected.

## Fix

**1. Liveness gate before failing (primary).**
Before calling `failForLostHeartbeat`, the supervisor now probes the executor's OS process via a new `getExecutorLiveness(sessionId)` helper on the existing in-memory PID tracker (`executor-tracking.ts`), which does `process.kill(pid, 0)`:

| Liveness | Meaning | Action |
| --- | --- | --- |
| `alive` | PID tracked, process exists (incl. `EPERM` = owned by another Unix user in insulated/strict mode) | **skip — do not fail** |
| `dead` | PID tracked, `ESRCH` (no such process) | fail (preserves crash detection) |
| `unknown` | No tracked PID (e.g. daemon restarted and orphaned the executor) | fall through to the prior timestamp-based reap |

The probe runs on the **daemon** and cannot be starved by anything happening in the executor's event loop, so it is the authoritative, **unblockable** liveness signal.

**2. Unblockable heartbeat (verified/documented).**
The executor heartbeat already runs on an independent `unref`'d `setInterval`; its `inFlight` guard only skips *overlapping* emits and never stalls the timer. Because a pathological CPU-bound synchronous tool call could still delay *any* main-thread timer in Node, we no longer treat a late heartbeat as proof of death — the daemon-side process probe (above) is the guarantee. This reasoning is now documented in `packages/executor/src/executor-heartbeat.ts`.

**3. More forgiving default (hardening).**
Raised the stale floor from **30s → 90s** (`EXECUTOR_HEARTBEAT_MIN_STALE_AFTER_MS`). Still fully overridable via `execution.executor_heartbeat.stale_after_ms`.

## Before / after

- **Before:** last heartbeat + 30s with no update → task/session `failed`, regardless of whether the executor was still running.
- **After:** a stale heartbeat only fails the task when the OS confirms the executor process is gone (or when no PID is tracked, preserving orphan reaping). A live executor is left alone and its heartbeat catches up.

## Tests

- `stale + live PID → not failed` (includes a 10-minute heartbeat-starvation case)
- `stale + dead PID → failed` (preserves current crash behavior)
- `stale + unknown PID → failed` (preserves orphan reaping after daemon restart)
- `getExecutorLiveness` branches: alive / dead (ESRCH) / unknown / EPERM→alive
- Updated config defaults test for the 90s floor + explicit-override case

Test/lint/typecheck run locally (daemon + core): all green, biome clean, `tsc --noEmit` clean.

## Deferred follow-up

Surfacing heartbeat-lost tasks that already produced committed work as `interrupted` rather than `failed` was intentionally skipped: the task status enum has no clean `interrupted` state today (`queued/created/running/stopping/awaiting_permission/awaiting_input/timed_out/completed/failed/stopped`). Worth a dedicated change if that status is added.

Closes #1809

🤖 Generated with [Claude Code](https://claude.com/claude-code)