### PR TITLE
feat(board): attention indicators in BoardSwitcher dropdown

### DIFF
--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -243,6 +243,7 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
             onBoardChange={onBoardChange || (() => {})}
             onHomeClick={onHomeClick}
             branchById={branchById}
+            sessionById={sessionById}
           />
         </div>
         {boards.length > 0 && (

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
@@ -59,6 +59,9 @@ describe('BoardSwitcher attention indicators', () => {
 
     expect(screen.getByTitle('2 branches need attention')).toBeInTheDocument();
     expect(screen.queryByTitle(/branch needs attention/)).not.toBeInTheDocument();
+    // Branch-count badges also carry explicit hover text.
+    expect(screen.getByTitle('2 branches on this board')).toBeInTheDocument();
+    expect(screen.getByTitle('1 branch on this board')).toBeInTheDocument();
   });
 
   it('shows a dot on the trigger only when a non-current board needs attention', () => {

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
@@ -1,0 +1,103 @@
+import type { Board, Branch } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { makeBranch } from '../BranchModal/testUtils';
+import { BoardSwitcher } from './BoardSwitcher';
+
+function makeBoard(overrides: Partial<Board> = {}): Board {
+  return {
+    board_id: 'board-1',
+    name: 'Board One',
+    archived: false,
+    ...overrides,
+  } as unknown as Board;
+}
+
+function renderSwitcher(boards: Board[], branches: Branch[], currentBoardId?: string) {
+  const branchById = new Map(branches.map((b) => [b.branch_id, b]));
+  return render(
+    <BoardSwitcher
+      boards={boards}
+      currentBoardId={currentBoardId}
+      onBoardChange={() => {}}
+      branchById={branchById}
+    />
+  );
+}
+
+function openDropdown() {
+  // The closed trigger shows the current board (or Home) name.
+  fireEvent.click(screen.getByRole('button'));
+}
+
+describe('BoardSwitcher attention indicators', () => {
+  it('shows an attention badge on boards with branches needing attention', () => {
+    const boards = [
+      makeBoard({ board_id: 'board-1', name: 'Alpha' }),
+      makeBoard({ board_id: 'board-2', name: 'Beta' }),
+    ];
+    const branches = [
+      makeBranch({
+        branch_id: 'br-1',
+        board_id: 'board-1',
+        needs_attention: true,
+      } as Partial<Branch>),
+      makeBranch({
+        branch_id: 'br-2',
+        board_id: 'board-1',
+        needs_attention: true,
+      } as Partial<Branch>),
+      makeBranch({
+        branch_id: 'br-3',
+        board_id: 'board-2',
+        needs_attention: false,
+      } as Partial<Branch>),
+    ];
+
+    renderSwitcher(boards, branches, 'board-2');
+    openDropdown();
+
+    expect(screen.getByTitle('2 branches need attention')).toBeInTheDocument();
+    expect(screen.queryByTitle(/branch needs attention/)).not.toBeInTheDocument();
+  });
+
+  it('shows a dot on the trigger only when a non-current board needs attention', () => {
+    const boards = [
+      makeBoard({ board_id: 'board-1', name: 'Alpha' }),
+      makeBoard({ board_id: 'board-2', name: 'Beta' }),
+    ];
+    const branches = [
+      makeBranch({
+        branch_id: 'br-1',
+        board_id: 'board-2',
+        needs_attention: true,
+      } as Partial<Branch>),
+    ];
+
+    const { unmount } = renderSwitcher(boards, branches, 'board-1');
+    expect(screen.getByTitle('Another board has branches needing attention')).toBeInTheDocument();
+    unmount();
+
+    // Same attention state, but viewing the board that owns it — no dot.
+    renderSwitcher(boards, branches, 'board-2');
+    expect(
+      screen.queryByTitle('Another board has branches needing attention')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders no attention indicators when nothing needs attention', () => {
+    const boards = [makeBoard({ board_id: 'board-1', name: 'Alpha' })];
+    const branches = [
+      makeBranch({
+        branch_id: 'br-1',
+        board_id: 'board-1',
+        needs_attention: false,
+      } as Partial<Branch>),
+    ];
+
+    renderSwitcher(boards, branches, 'board-1');
+    openDropdown();
+
+    expect(screen.queryByTitle(/attention/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
@@ -1,4 +1,4 @@
-import type { Board, Branch } from '@agor-live/client';
+import type { Board, Branch, Session } from '@agor-live/client';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { makeBranch } from '../BranchModal/testUtils';
@@ -13,14 +13,31 @@ function makeBoard(overrides: Partial<Board> = {}): Board {
   } as unknown as Board;
 }
 
-function renderSwitcher(boards: Board[], branches: Branch[], currentBoardId?: string) {
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: 'session-1',
+    branch_id: 'br-1',
+    archived: false,
+    ready_for_prompt: false,
+    ...overrides,
+  } as unknown as Session;
+}
+
+function renderSwitcher(
+  boards: Board[],
+  branches: Branch[],
+  currentBoardId?: string,
+  sessions: Session[] = []
+) {
   const branchById = new Map(branches.map((b) => [b.branch_id, b]));
+  const sessionById = new Map(sessions.map((s) => [s.session_id, s]));
   return render(
     <BoardSwitcher
       boards={boards}
       currentBoardId={currentBoardId}
       onBoardChange={() => {}}
       branchById={branchById}
+      sessionById={sessionById}
     />
   );
 }
@@ -62,6 +79,55 @@ describe('BoardSwitcher attention indicators', () => {
     // Branch-count badges also carry explicit hover text.
     expect(screen.getByTitle('2 branches on this board')).toBeInTheDocument();
     expect(screen.getByTitle('1 branch on this board')).toBeInTheDocument();
+  });
+
+  it('counts branches whose active sessions are ready for prompt', () => {
+    const boards = [makeBoard({ board_id: 'board-1', name: 'Alpha' })];
+    const branches = [
+      makeBranch({
+        branch_id: 'br-1',
+        board_id: 'board-1',
+        needs_attention: false,
+      } as Partial<Branch>),
+    ];
+    const sessions = [
+      makeSession({ session_id: 's-1', branch_id: 'br-1', ready_for_prompt: true }),
+    ];
+
+    renderSwitcher(boards, branches, 'board-1', sessions);
+    openDropdown();
+
+    expect(screen.getByTitle('1 branch needs attention')).toBeInTheDocument();
+  });
+
+  it('ignores archived sessions and archived branches', () => {
+    const boards = [makeBoard({ board_id: 'board-1', name: 'Alpha' })];
+    const branches = [
+      makeBranch({
+        branch_id: 'br-1',
+        board_id: 'board-1',
+        needs_attention: false,
+      } as Partial<Branch>),
+      makeBranch({
+        branch_id: 'br-2',
+        board_id: 'board-1',
+        needs_attention: true,
+        archived: true,
+      } as Partial<Branch>),
+    ];
+    const sessions = [
+      makeSession({
+        session_id: 's-1',
+        branch_id: 'br-1',
+        ready_for_prompt: true,
+        archived: true,
+      }),
+    ];
+
+    renderSwitcher(boards, branches, 'board-1', sessions);
+    openDropdown();
+
+    expect(screen.queryByTitle(/attention/)).not.toBeInTheDocument();
   });
 
   it('shows a dot on the trigger only when a non-current board needs attention', () => {

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -137,6 +137,7 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
               <Badge
                 count={branchCount}
                 showZero
+                title={`${branchCount} ${branchCount === 1 ? 'branch' : 'branches'} on this board`}
                 style={{ backgroundColor: isActive ? token.colorPrimary : token.colorBgTextHover }}
               />
             </Space>

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -1,4 +1,4 @@
-import type { Board, Branch } from '@agor-live/client';
+import type { Board, Branch, Session } from '@agor-live/client';
 import { DownOutlined, HomeOutlined, SearchOutlined } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
 import { Badge, Button, Divider, Dropdown, Input, Space, Typography, theme } from 'antd';
@@ -16,6 +16,7 @@ interface BoardSwitcherProps {
   onBoardChange: (boardId: string) => void;
   onHomeClick?: () => void;
   branchById: Map<string, Branch>;
+  sessionById: Map<string, Session>;
 }
 
 export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
@@ -24,6 +25,7 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
   onBoardChange,
   onHomeClick,
   branchById,
+  sessionById,
 }) => {
   const { token } = useToken();
   const [filterText, setFilterText] = useState('');
@@ -42,18 +44,29 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
     return counts;
   }, [boards, branchById]);
 
-  // Per-board count of branches flagged `needs_attention` — the same signal
-  // that drives the glow halo on branch cards, surfaced here so users can
-  // spot boards with waiting sessions without visiting each one.
+  // Per-board count of branches needing attention, surfaced here so users
+  // can spot boards with waiting work without visiting each one. A branch
+  // counts when its `needs_attention` flag is set (new branches default to
+  // true) OR any of its active (non-archived) sessions is `ready_for_prompt`
+  // — the same predicate that drives the glow halo on branch cards, so the
+  // badge and the canvas never disagree. Archived branches are hidden from
+  // boards and therefore excluded.
   const attentionCountByBoard = useMemo(() => {
+    const readyBranchIds = new Set<string>();
+    for (const session of sessionById.values()) {
+      if (session.branch_id && !session.archived && session.ready_for_prompt === true) {
+        readyBranchIds.add(session.branch_id);
+      }
+    }
     const counts = new Map<string, number>();
     for (const branch of branchById.values()) {
-      if (branch.board_id && branch.needs_attention) {
+      if (!branch.board_id || branch.archived) continue;
+      if (branch.needs_attention || readyBranchIds.has(branch.branch_id)) {
         counts.set(branch.board_id, (counts.get(branch.board_id) || 0) + 1);
       }
     }
     return counts;
-  }, [branchById]);
+  }, [branchById, sessionById]);
 
   // Attention on the *current* board is already visible on the canvas
   // itself, so the closed-trigger dot only fires for other boards.

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.tsx
@@ -42,6 +42,28 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
     return counts;
   }, [boards, branchById]);
 
+  // Per-board count of branches flagged `needs_attention` — the same signal
+  // that drives the glow halo on branch cards, surfaced here so users can
+  // spot boards with waiting sessions without visiting each one.
+  const attentionCountByBoard = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const branch of branchById.values()) {
+      if (branch.board_id && branch.needs_attention) {
+        counts.set(branch.board_id, (counts.get(branch.board_id) || 0) + 1);
+      }
+    }
+    return counts;
+  }, [branchById]);
+
+  // Attention on the *current* board is already visible on the canvas
+  // itself, so the closed-trigger dot only fires for other boards.
+  const otherBoardsNeedAttention = useMemo(() => {
+    for (const [boardId, count] of attentionCountByBoard) {
+      if (count > 0 && boardId !== currentBoardId) return true;
+    }
+    return false;
+  }, [attentionCountByBoard, currentBoardId]);
+
   const showFilter = boards.length >= FILTER_THRESHOLD;
 
   const closeDropdown = useCallback(() => {
@@ -86,6 +108,7 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
 
     return filteredBoards.map((board) => {
       const branchCount = branchCountByBoard.get(board.board_id) || 0;
+      const attentionCount = attentionCountByBoard.get(board.board_id) || 0;
       const isActive = board.board_id === currentBoardId;
       return {
         key: board.board_id,
@@ -103,17 +126,35 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
               <span style={{ fontSize: 18 }}>{board.icon || '📋'}</span>
               <Text strong={isActive}>{board.name}</Text>
             </Space>
-            <Badge
-              count={branchCount}
-              showZero
-              style={{ backgroundColor: isActive ? token.colorPrimary : token.colorBgTextHover }}
-            />
+            <Space size={6}>
+              {attentionCount > 0 && (
+                <Badge
+                  count={attentionCount}
+                  title={`${attentionCount} ${attentionCount === 1 ? 'branch needs' : 'branches need'} attention`}
+                  style={{ backgroundColor: token.colorWarning }}
+                />
+              )}
+              <Badge
+                count={branchCount}
+                showZero
+                style={{ backgroundColor: isActive ? token.colorPrimary : token.colorBgTextHover }}
+              />
+            </Space>
           </div>
         ),
         onClick: () => handleBoardClick(board.board_id),
       };
     });
-  }, [boards, currentBoardId, branchCountByBoard, handleBoardClick, token, filterText, showFilter]);
+  }, [
+    boards,
+    currentBoardId,
+    branchCountByBoard,
+    attentionCountByBoard,
+    handleBoardClick,
+    token,
+    filterText,
+    showFilter,
+  ]);
 
   const homeRow = (
     <Button
@@ -205,7 +246,14 @@ export const BoardSwitcher: React.FC<BoardSwitcherProps> = ({
         }}
       >
         <Space size={8}>
-          <span style={{ fontSize: 18 }}>{currentBoard ? currentBoard.icon || '📋' : '🏠'}</span>
+          <Badge
+            dot={otherBoardsNeedAttention}
+            color={token.colorWarning}
+            offset={[-2, 4]}
+            title={otherBoardsNeedAttention ? 'Another board has branches needing attention' : ''}
+          >
+            <span style={{ fontSize: 18 }}>{currentBoard ? currentBoard.icon || '📋' : '🏠'}</span>
+          </Badge>
           <Text strong>{currentBoard?.name || 'Home'}</Text>
         </Space>
         <DownOutlined style={{ fontSize: 12, color: token.colorTextSecondary }} />


### PR DESCRIPTION
## Summary

Surfaces "needs attention" signals in the `BoardSwitcher` dropdown so users can spot boards with waiting work without opening each one. Reuses the same predicate that drives the branch-card glow (from PR #161).

## What changed

- **Attention count badge** — each board menu item with branches needing attention gets a warning-colored count badge alongside the existing branch-count badge.
- **Trigger dot** — the closed switcher's board icon shows a dot when a *non-current* board needs attention (attention on the current board is already visible on the canvas).
- **Aligned with card glow** — the badge counts `needs_attention` OR any active (non-archived) session that is `ready_for_prompt`, matching the card-glow predicate so a board whose sessions just finished responding no longer shows glowing cards with no badge. `AppHeader` now threads the store's `sessionById` map through.
- **Explicit hover text** — the branch-count badge now has matching hover text (`"n branch(es) on this board"`) instead of AntD's bare default.

## Testing

Adds `BoardSwitcher.test.tsx` covering the badge aggregation, the ready-for-prompt predicate, and the trigger dot behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Screenshot:
<img width="1512" height="1028" alt="Screenshot 2026-07-06 at 12 29 35" src="https://github.com/user-attachments/assets/b6c4c707-6f33-4289-bf3b-34d82e3274e7" />

