### PR TITLE
perf(agor-ui): cheapen home-page per-event derivations + keep glass hover repaint-static

### DIFF
--- a/apps/agor-ui/src/components/AppHeader/AppHeader.rerender.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.rerender.test.tsx
@@ -1,4 +1,4 @@
-import type { Board, Repo, User } from '@agor-live/client';
+import type { Board, Repo, Session, User } from '@agor-live/client';
 import { act, render, waitFor } from '@testing-library/react';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -56,6 +56,16 @@ vi.mock('./GlobalPresenceFacepile', () => ({
 
 const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as unknown as Board;
 const repo = { repo_id: 'repo-1', name: 'repo', slug: 'repo' } as unknown as Repo;
+const session = {
+  session_id: 'session-1',
+  status: 'running',
+  archived: false,
+  genealogy: {},
+  agentic_tool: 'claude',
+  branch_id: 'branch-1',
+  created_by: 'u1',
+  last_updated: '2026-07-01T10:00:00.000Z',
+} as unknown as Session;
 
 function renderHeader(node: React.ReactNode) {
   return render(
@@ -84,6 +94,30 @@ describe('AppHeader store-selector re-render isolation', () => {
     // so its subscriptions stay quiet and it does not re-render.
     act(() => {
       agorStore.setState({ repoById: new Map([[repo.repo_id, repo]]) });
+    });
+
+    expect(headerRenders).toBe(baseline);
+  });
+
+  it('a session patch does not re-render the header', async () => {
+    // Seed a session BEFORE the baseline so the patch below flips nothing the
+    // header derives. `sessionById` feeds ONLY GlobalSearch, which now owns that
+    // subscription in a memo'd leaf — so a streaming-style session patch (new
+    // object identity) must wake GlobalSearch, never the header chrome.
+    agorStore.setState({ sessionById: new Map([[session.session_id, session]]) });
+    renderHeader(<AppHeader />);
+
+    await waitFor(() => {
+      expect(headerRenders).toBeGreaterThanOrEqual(1);
+    });
+    const baseline = headerRenders;
+
+    act(() => {
+      agorStore.setState({
+        sessionById: new Map([
+          [session.session_id, { ...session, status: 'completed' } as Session],
+        ]),
+      });
     });
 
     expect(headerRenders).toBe(baseline);

--- a/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeader.tsx
@@ -14,21 +14,14 @@ import { BRAND, brandMarkHref } from '../../branding/brand';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useRecentBoards } from '../../hooks/useRecentBoards';
 import { useAgorStore } from '../../store/agorStore';
-import {
-  selectArtifactById,
-  selectBoardById,
-  selectBranchById,
-  selectMcpServerById,
-  selectSessionById,
-  selectUserById,
-} from '../../store/selectors';
+import { selectBoardById, selectBranchById, selectUserById } from '../../store/selectors';
 import { BoardSwitcher } from '../BoardSwitcher';
 import { BrandLogo } from '../BrandLogo';
 import { ConnectionStatus } from '../ConnectionStatus';
-import { GlobalSearch } from '../GlobalSearch';
 import { GlobalUserMenu } from '../GlobalUserMenu';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { ThemeSwitcher } from '../ThemeSwitcher';
+import { AppHeaderGlobalSearch } from './AppHeaderGlobalSearch';
 import { GlobalPresenceFacepile } from './GlobalPresenceFacepile';
 
 const { Header } = Layout;
@@ -148,9 +141,6 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
   const boardById = useAgorStore(selectBoardById);
   const userById = useAgorStore(selectUserById);
   const branchById = useAgorStore(selectBranchById);
-  const sessionById = useAgorStore(selectSessionById);
-  const artifactById = useAgorStore(selectArtifactById);
-  const mcpServerById = useAgorStore(selectMcpServerById);
   const boards = useMemo(() => mapToArray(boardById), [boardById]);
   const presenceUsers = useMemo(() => mapToArray(userById), [userById]);
   // Derive the recent-board pills here (not as a prop): the source array is the
@@ -290,13 +280,10 @@ const AppHeaderInner: React.FC<AppHeaderProps> = ({
           staticActiveUsers={staticActiveUsers}
           maxVisible={presenceMaxVisible}
         />
-        <GlobalSearch
+        <AppHeaderGlobalSearch
           currentUserId={currentUserId}
-          sessionById={sessionById}
           branchById={branchById}
-          artifactById={artifactById}
           boardById={boardById}
-          mcpServerById={mcpServerById}
           onSettingsClick={onSettingsClick}
         />
         <Divider orientation="vertical" style={{ height: 32, margin: '0 8px' }} />

--- a/apps/agor-ui/src/components/AppHeader/AppHeaderGlobalSearch.tsx
+++ b/apps/agor-ui/src/components/AppHeader/AppHeaderGlobalSearch.tsx
@@ -1,0 +1,45 @@
+import type { Board, Branch } from '@agor-live/client';
+import { memo } from 'react';
+import { useAgorStore } from '../../store/agorStore';
+import { selectArtifactById, selectMcpServerById, selectSessionById } from '../../store/selectors';
+import { GlobalSearch } from '../GlobalSearch';
+
+interface AppHeaderGlobalSearchProps {
+  currentUserId?: string;
+  branchById: Map<string, Branch>;
+  boardById: Map<string, Board>;
+  onSettingsClick?: () => void;
+}
+
+/**
+ * Owns the entity maps that ONLY GlobalSearch consumes — sessions, artifacts and
+ * MCP servers. `sessionById` in particular is the highest-churn slice in the
+ * store (a patch per streamed token). Subscribing to it HERE, in a memo'd leaf,
+ * means a session patch wakes only GlobalSearch — not the whole AppHeader and
+ * its board switcher / presence facepile chrome. `branchById` and `boardById`
+ * are read by other header chrome too, so they stay subscribed in AppHeader and
+ * arrive as props (their references only change on the rarer branch/board
+ * patches). GlobalSearch receives the exact same live maps as before.
+ */
+export const AppHeaderGlobalSearch = memo(function AppHeaderGlobalSearch({
+  currentUserId,
+  branchById,
+  boardById,
+  onSettingsClick,
+}: AppHeaderGlobalSearchProps) {
+  const sessionById = useAgorStore(selectSessionById);
+  const artifactById = useAgorStore(selectArtifactById);
+  const mcpServerById = useAgorStore(selectMcpServerById);
+
+  return (
+    <GlobalSearch
+      currentUserId={currentUserId}
+      sessionById={sessionById}
+      branchById={branchById}
+      artifactById={artifactById}
+      boardById={boardById}
+      mcpServerById={mcpServerById}
+      onSettingsClick={onSettingsClick}
+    />
+  );
+});

--- a/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeActivitySection.tsx
@@ -1,4 +1,4 @@
-import type { Branch, Session } from '@agor-live/client';
+import type { Board, Branch, Session, User } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
 import {
   BranchesOutlined,
@@ -19,7 +19,7 @@ import {
   theme,
 } from 'antd';
 import type React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import {
   selectBoardById,
@@ -27,6 +27,7 @@ import {
   selectSessionById,
   selectUserById,
 } from '../../store/selectors';
+import { getTimeMs } from '../../utils/entityTime';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime } from '../../utils/time';
 import { AssistantPill, BoardPill, BranchPill, SessionPill, UserPill } from '../Pill';
@@ -40,19 +41,161 @@ const HOME_ACTIVITY_LIMIT = 100;
 type ActivityFilter = 'all' | 'branches' | 'sessions' | 'assistants';
 type ActivityEventType = Exclude<ActivityFilter, 'all'>;
 
+// `t` is the numeric sort key, parsed once via the shared memoized util so the
+// comparator never touches `new Date` — the whole feed is rebuilt on every
+// store notify, and a Date-per-comparison there was the hot path.
 interface ActivityEvent {
   id: string;
   type: ActivityEventType;
   dttm: string | Date;
+  t: number;
   entityId: string;
 }
 
-const ActivityFeedItem: React.FC<{
-  icon: React.ReactNode;
-  message: React.ReactNode;
-  time?: string | Date | null;
-}> = ({ icon, message, time }) => {
+type ActivityCallbacks = Pick<HomePageProps, 'onBoardClick' | 'onBranchClick' | 'onSessionClick'>;
+
+// Module-level constants: passing referentially-stable style objects keeps the
+// pills (and the memo'd rows below) from churning on unrelated store notifies.
+const CLICKABLE_PILL_STYLE: React.CSSProperties = { cursor: 'pointer', marginInlineEnd: 0 };
+const SESSION_PILL_STYLE: React.CSSProperties = {
+  ...CLICKABLE_PILL_STYLE,
+  display: 'inline-flex',
+  alignItems: 'center',
+  paddingInline: 6,
+};
+
+const activityIcon = (type: ActivityEventType): React.ReactNode => {
+  if (type === 'sessions') return <UnorderedListOutlined />;
+  if (type === 'assistants') return <RobotOutlined />;
+  return <BranchesOutlined />;
+};
+
+/**
+ * One activity row. Receives the already-resolved entity object references
+ * (session/branch/board/user) plus stable callbacks, and builds its message
+ * content HERE — so a store notify re-renders only the rows whose entities
+ * actually changed. Because these props are entity references (not the whole
+ * maps), `memo` bails out for every unaffected row: a single session:patched no
+ * longer rebuilds all 100 rows.
+ */
+const ActivityRow = memo(function ActivityRow({
+  type,
+  dttm,
+  session,
+  branch,
+  board,
+  actor,
+  onBoardClick,
+  onBranchClick,
+  onSessionClick,
+}: ActivityCallbacks & {
+  type: ActivityEventType;
+  dttm: string | Date;
+  session?: Session;
+  branch?: Branch;
+  board?: Board;
+  actor?: User;
+}) {
   const { token } = theme.useToken();
+
+  let message: React.ReactNode = null;
+
+  if (type === 'sessions') {
+    if (!session) return null;
+    const sessionTitle = getSessionDisplayTitle(session, {
+      includeAgentFallback: true,
+      includeIdFallback: true,
+    });
+    const verb =
+      Math.abs(getTimeMs(session, 'last_updated') - getTimeMs(session, 'created_at')) < 1000
+        ? 'started'
+        : 'updated';
+
+    message = (
+      <Space size={4} wrap>
+        {actor ? <UserPill user={actor} compact /> : <Text strong>Someone</Text>}
+        <Text type="secondary">{verb}</Text>
+        <Popover
+          trigger="hover"
+          title={<Text style={{ maxWidth: 320, display: 'block' }}>{sessionTitle}</Text>}
+          content={
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              {session.agentic_tool} · {session.status.replaceAll('_', ' ')}
+            </Text>
+          }
+        >
+          <SessionPill
+            ariaLabel={sessionTitle}
+            title={sessionTitle}
+            onClick={() => onSessionClick(session.session_id)}
+            style={SESSION_PILL_STYLE}
+          />
+        </Popover>
+        {branch && (
+          <>
+            <Text type="secondary">in</Text>
+            <BranchPill
+              branch={branch.name}
+              compact
+              onClick={() => onBranchClick(branch.branch_id)}
+            />
+          </>
+        )}
+        {board && (
+          <>
+            <Text type="secondary">on</Text>
+            <BoardPill
+              board={board}
+              compact
+              onClick={() => onBoardClick(board.board_id)}
+              style={CLICKABLE_PILL_STYLE}
+            />
+          </>
+        )}
+      </Space>
+    );
+  } else {
+    if (!branch) return null;
+    const assistant = type === 'assistants';
+    const assistantConfig = getAssistantConfig(branch);
+    const branchLabel = assistantConfig?.displayName ?? branch.name;
+
+    message = (
+      <Space size={4} wrap>
+        {actor ? <UserPill user={actor} compact /> : <Text strong>Someone</Text>}
+        <Text type="secondary">created</Text>
+        {assistant ? (
+          <AssistantPill
+            name={branchLabel}
+            emoji={assistantConfig?.emoji}
+            compact
+            title={branch.name}
+            onClick={() => onBranchClick(branch.branch_id)}
+            style={CLICKABLE_PILL_STYLE}
+          />
+        ) : (
+          <BranchPill
+            branch={branchLabel}
+            compact
+            title={branch.name}
+            onClick={() => onBranchClick(branch.branch_id)}
+          />
+        )}
+        {board && (
+          <>
+            <Text type="secondary">on</Text>
+            <BoardPill
+              board={board}
+              compact
+              onClick={() => onBoardClick(board.board_id)}
+              style={CLICKABLE_PILL_STYLE}
+            />
+          </>
+        )}
+      </Space>
+    );
+  }
+
   return (
     <List.Item style={{ padding: '10px 0' }}>
       <Space align="start">
@@ -60,24 +203,26 @@ const ActivityFeedItem: React.FC<{
           size="small"
           style={{ background: token.colorFillSecondary, color: token.colorText }}
         >
-          {icon}
+          {activityIcon(type)}
         </Avatar>
         <div>
           <div>{message}</div>
-          {time && (
+          {dttm && (
             <Text type="secondary" style={{ fontSize: 12 }}>
-              {formatRelativeTime(time)}
+              {formatRelativeTime(dttm)}
             </Text>
           )}
         </div>
       </Space>
     </List.Item>
   );
-};
+});
 
-export const HomeActivitySection: React.FC<
-  Pick<HomePageProps, 'onBoardClick' | 'onBranchClick' | 'onSessionClick'>
-> = ({ onBoardClick, onBranchClick, onSessionClick }) => {
+export const HomeActivitySection: React.FC<ActivityCallbacks> = ({
+  onBoardClick,
+  onBranchClick,
+  onSessionClick,
+}) => {
   const branchById = useAgorStore(selectBranchById);
   const boardById = useAgorStore(selectBoardById);
   const sessionById = useAgorStore(selectSessionById);
@@ -85,181 +230,36 @@ export const HomeActivitySection: React.FC<
   const { token } = theme.useToken();
   const cardGlassStyle = glassCardStyle(token);
   const [filter, setFilter] = useState<ActivityFilter>('all');
-  const clickablePillStyle = useMemo<React.CSSProperties>(
-    () => ({
-      cursor: 'pointer',
-      marginInlineEnd: 0,
-    }),
-    []
-  );
-
-  const branchMessage = useCallback(
-    (branch: Branch, assistant: boolean) => {
-      const board = branch.board_id ? boardById.get(branch.board_id) : undefined;
-      const actor = userById.get(branch.created_by);
-      const assistantConfig = getAssistantConfig(branch);
-      const branchLabel = assistantConfig?.displayName ?? branch.name;
-
-      return (
-        <Space size={4} wrap>
-          {actor ? <UserPill user={actor} compact /> : <Text strong>Someone</Text>}
-          <Text type="secondary">created</Text>
-          {assistant ? (
-            <AssistantPill
-              name={branchLabel}
-              emoji={assistantConfig?.emoji}
-              compact
-              title={branch.name}
-              onClick={() => onBranchClick(branch.branch_id)}
-              style={clickablePillStyle}
-            />
-          ) : (
-            <BranchPill
-              branch={branchLabel}
-              compact
-              title={branch.name}
-              onClick={() => onBranchClick(branch.branch_id)}
-            />
-          )}
-          {board && (
-            <>
-              <Text type="secondary">on</Text>
-              <BoardPill
-                board={board}
-                compact
-                onClick={() => onBoardClick(board.board_id)}
-                style={clickablePillStyle}
-              />
-            </>
-          )}
-        </Space>
-      );
-    },
-    [boardById, clickablePillStyle, onBoardClick, onBranchClick, userById]
-  );
-
-  const sessionMessage = useCallback(
-    (session: Session) => {
-      const branch = branchById.get(session.branch_id);
-      const board = branch?.board_id ? boardById.get(branch.board_id) : undefined;
-      const actor = userById.get(session.created_by);
-      const sessionTitle = getSessionDisplayTitle(session, {
-        includeAgentFallback: true,
-        includeIdFallback: true,
-      });
-      const createdAt = new Date(session.created_at).getTime();
-      const updatedAt = new Date(session.last_updated).getTime();
-      const verb = Math.abs(updatedAt - createdAt) < 1000 ? 'started' : 'updated';
-
-      return (
-        <Space size={4} wrap>
-          {actor ? <UserPill user={actor} compact /> : <Text strong>Someone</Text>}
-          <Text type="secondary">{verb}</Text>
-          <Popover
-            trigger="hover"
-            title={<Text style={{ maxWidth: 320, display: 'block' }}>{sessionTitle}</Text>}
-            content={
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                {session.agentic_tool} · {session.status.replaceAll('_', ' ')}
-              </Text>
-            }
-          >
-            <SessionPill
-              ariaLabel={sessionTitle}
-              title={sessionTitle}
-              onClick={() => onSessionClick(session.session_id)}
-              style={{
-                ...clickablePillStyle,
-                display: 'inline-flex',
-                alignItems: 'center',
-                paddingInline: 6,
-              }}
-            />
-          </Popover>
-          {branch && (
-            <>
-              <Text type="secondary">in</Text>
-              <BranchPill
-                branch={branch.name}
-                compact
-                onClick={() => onBranchClick(branch.branch_id)}
-              />
-            </>
-          )}
-          {board && (
-            <>
-              <Text type="secondary">on</Text>
-              <BoardPill
-                board={board}
-                compact
-                onClick={() => onBoardClick(board.board_id)}
-                style={clickablePillStyle}
-              />
-            </>
-          )}
-        </Space>
-      );
-    },
-    [
-      boardById,
-      branchById,
-      onBoardClick,
-      onBranchClick,
-      onSessionClick,
-      clickablePillStyle,
-      userById,
-    ]
-  );
 
   const items = useMemo(() => {
-    const events: ActivityEvent[] = [
-      ...Array.from(branchById.values())
-        .filter((branch) => !branch.archived)
-        .map((branch): ActivityEvent => {
-          const assistant = isAssistant(branch);
-          return {
-            id: `branch:${branch.branch_id}`,
-            type: assistant ? 'assistants' : 'branches',
-            dttm: branch.created_at,
-            entityId: branch.branch_id,
-          };
-        }),
-      ...Array.from(sessionById.values())
-        .filter((session) => !session.archived)
-        .map(
-          (session): ActivityEvent => ({
-            id: `session:${session.session_id}`,
-            type: 'sessions',
-            dttm: session.last_updated,
-            entityId: session.session_id,
-          })
-        ),
-    ];
+    const events: ActivityEvent[] = [];
+    for (const branch of branchById.values()) {
+      if (branch.archived) continue;
+      const assistant = isAssistant(branch);
+      events.push({
+        id: `branch:${branch.branch_id}`,
+        type: assistant ? 'assistants' : 'branches',
+        dttm: branch.created_at,
+        t: getTimeMs(branch, 'created_at'),
+        entityId: branch.branch_id,
+      });
+    }
+    for (const session of sessionById.values()) {
+      if (session.archived) continue;
+      events.push({
+        id: `session:${session.session_id}`,
+        type: 'sessions',
+        dttm: session.last_updated,
+        t: getTimeMs(session, 'last_updated'),
+        entityId: session.session_id,
+      });
+    }
 
     return events
       .filter((event) => filter === 'all' || event.type === filter)
-      .sort((a, b) => new Date(b.dttm).getTime() - new Date(a.dttm).getTime())
+      .sort((a, b) => b.t - a.t)
       .slice(0, HOME_ACTIVITY_LIMIT);
   }, [branchById, sessionById, filter]);
-
-  const renderActivityIcon = useCallback((event: ActivityEvent) => {
-    if (event.type === 'sessions') return <UnorderedListOutlined />;
-    if (event.type === 'assistants') return <RobotOutlined />;
-    return <BranchesOutlined />;
-  }, []);
-
-  const renderActivityMessage = useCallback(
-    (event: ActivityEvent): React.ReactNode => {
-      if (event.type === 'sessions') {
-        const session = sessionById.get(event.entityId);
-        return session ? sessionMessage(session) : null;
-      }
-
-      const branch = branchById.get(event.entityId);
-      return branch ? branchMessage(branch, event.type === 'assistants') : null;
-    },
-    [branchById, branchMessage, sessionById, sessionMessage]
-  );
 
   return (
     <section
@@ -343,13 +343,38 @@ export const HomeActivitySection: React.FC<
             rowKey="id"
             dataSource={items}
             renderItem={(item) => {
-              const message = renderActivityMessage(item);
-              if (!message) return null;
+              if (item.type === 'sessions') {
+                const session = sessionById.get(item.entityId);
+                const branch = session ? branchById.get(session.branch_id) : undefined;
+                const board = branch?.board_id ? boardById.get(branch.board_id) : undefined;
+                const actor = session ? userById.get(session.created_by) : undefined;
+                return (
+                  <ActivityRow
+                    type="sessions"
+                    dttm={item.dttm}
+                    session={session}
+                    branch={branch}
+                    board={board}
+                    actor={actor}
+                    onBoardClick={onBoardClick}
+                    onBranchClick={onBranchClick}
+                    onSessionClick={onSessionClick}
+                  />
+                );
+              }
+              const branch = branchById.get(item.entityId);
+              const board = branch?.board_id ? boardById.get(branch.board_id) : undefined;
+              const actor = branch ? userById.get(branch.created_by) : undefined;
               return (
-                <ActivityFeedItem
-                  icon={renderActivityIcon(item)}
-                  message={message}
-                  time={item.dttm}
+                <ActivityRow
+                  type={item.type}
+                  dttm={item.dttm}
+                  branch={branch}
+                  board={board}
+                  actor={actor}
+                  onBoardClick={onBoardClick}
+                  onBranchClick={onBranchClick}
+                  onSessionClick={onSessionClick}
                 />
               );
             }}

--- a/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeBoardsSection.tsx
@@ -11,8 +11,9 @@ import type React from 'react';
 import { memo, useMemo, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById, selectBranchById, selectSessionsByBranch } from '../../store/selectors';
+import { getTimeMs } from '../../utils/entityTime';
 import { formatRelativeTime } from '../../utils/time';
-import { glassCardStyle } from './homeStyles';
+import { glassSurfaceStyle } from './homeStyles';
 import type { HomePageProps } from './types';
 
 const { Text } = Typography;
@@ -46,12 +47,26 @@ const groupBranchesByBoard = (branchById: Map<string, Branch>): Map<string, Bran
   return grouped;
 };
 
+// Keyed by the per-branch session bucket array reference. The store preserves
+// untouched buckets by reference across patches, so a session:patched on one
+// branch leaves every other branch's filtered result cached — no re-filter of
+// the whole workspace on every notify.
+const visibleSessionsCache = new WeakMap<Session[], Session[]>();
+
+const filterVisibleSessions = (sessions: Session[]): Session[] => {
+  const cached = visibleSessionsCache.get(sessions);
+  if (cached) return cached;
+  const visible = sessions.filter((session) => !session.archived);
+  visibleSessionsCache.set(sessions, visible);
+  return visible;
+};
+
 const groupVisibleSessionsByBranch = (
   sessionsByBranch: Map<string, Session[]>
 ): Map<string, Session[]> => {
   const grouped = new Map<string, Session[]>();
   for (const [branchId, sessions] of sessionsByBranch) {
-    const visibleSessions = sessions.filter((session) => !session.archived);
+    const visibleSessions = filterVisibleSessions(sessions);
     if (visibleSessions.length > 0) grouped.set(branchId, visibleSessions);
   }
   return grouped;
@@ -81,88 +96,104 @@ const BoardHomeCard = memo(function BoardHomeCard({
   const [focused, setFocused] = useState(false);
 
   return (
-    <button
-      type="button"
-      onClick={() => onBoardClick(board.board_id)}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onFocus={() => setFocused(true)}
-      onBlur={() => setFocused(false)}
-      style={{
-        display: 'block',
-        width: '100%',
-        height: '100%',
-        textAlign: 'left',
-        border: `1px solid ${hovered ? token.colorPrimary : token.colorBorderSecondary}`,
-        borderRadius: token.borderRadiusLG,
-        padding: '12px 14px',
-        cursor: 'pointer',
-        ...glassCardStyle(token, 0.3),
-        boxShadow: hovered
-          ? `${token.boxShadowSecondary}, inset 0 1px 0 rgba(255, 255, 255, 0.12)`
-          : undefined,
-        outline: focused ? `2px solid ${token.colorPrimary}` : undefined,
-        outlineOffset: focused ? 2 : undefined,
-        transition: 'border-color 0.2s, box-shadow 0.2s',
-        fontFamily: 'inherit',
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
-        {/* Board icon */}
-        <div
-          style={{
-            width: 36,
-            height: 36,
-            borderRadius: 8,
-            background: token.colorFillTertiary,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: 20,
-            flexShrink: 0,
-          }}
-        >
-          {board.icon || '📋'}
-        </div>
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      {/* Static blurred glass fill on its own layer, painted behind the
+          interactive button. Hover/focus never touch this element, so its
+          expensive backdrop-filter is never re-blurred. */}
+      <span
+        aria-hidden
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: token.borderRadiusLG,
+          ...glassSurfaceStyle(token, 0.3),
+          pointerEvents: 'none',
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => onBoardClick(board.board_id)}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        style={{
+          position: 'relative',
+          display: 'block',
+          width: '100%',
+          height: '100%',
+          textAlign: 'left',
+          border: `1px solid ${hovered ? token.colorPrimary : token.colorBorderSecondary}`,
+          borderRadius: token.borderRadiusLG,
+          padding: '12px 14px',
+          cursor: 'pointer',
+          background: 'transparent',
+          boxShadow: hovered
+            ? `${token.boxShadowSecondary}, inset 0 1px 0 rgba(255, 255, 255, 0.12)`
+            : undefined,
+          outline: focused ? `2px solid ${token.colorPrimary}` : undefined,
+          outlineOffset: focused ? 2 : undefined,
+          transition: 'border-color 0.2s, box-shadow 0.2s',
+          fontFamily: 'inherit',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
+          {/* Board icon */}
+          <div
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 8,
+              background: token.colorFillTertiary,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 20,
+              flexShrink: 0,
+            }}
+          >
+            {board.icon || '📋'}
+          </div>
 
-        {/* Name + meta — all aligned under each other, to the right of the icon */}
-        <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <Tooltip title={board.name}>
-            <Text
-              strong
-              style={{
-                fontSize: 14,
-                display: 'block',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {board.name}
-            </Text>
-          </Tooltip>
-          <div style={{ display: 'flex', gap: 10 }}>
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              {branchCount} branch{branchCount !== 1 ? 'es' : ''}
-            </Text>
-            {activeCount > 0 && (
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                <ThunderboltOutlined style={{ marginRight: 2 }} />
-                {activeCount} active
+          {/* Name + meta — all aligned under each other, to the right of the icon */}
+          <div style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <Tooltip title={board.name}>
+              <Text
+                strong
+                style={{
+                  fontSize: 14,
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {board.name}
               </Text>
-            )}
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <ClockCircleOutlined style={{ fontSize: 11, color: token.colorTextSecondary }} />
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              {latestSessionAt
-                ? `Last session ${formatRelativeTime(latestSessionAt)}`
-                : 'No sessions yet'}
-            </Text>
+            </Tooltip>
+            <div style={{ display: 'flex', gap: 10 }}>
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                {branchCount} branch{branchCount !== 1 ? 'es' : ''}
+              </Text>
+              {activeCount > 0 && (
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  <ThunderboltOutlined style={{ marginRight: 2 }} />
+                  {activeCount} active
+                </Text>
+              )}
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <ClockCircleOutlined style={{ fontSize: 11, color: token.colorTextSecondary }} />
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                {latestSessionAt
+                  ? `Last session ${formatRelativeTime(latestSessionAt)}`
+                  : 'No sessions yet'}
+              </Text>
+            </div>
           </div>
         </div>
-      </div>
-    </button>
+      </button>
+    </div>
   );
 });
 
@@ -189,15 +220,17 @@ export const HomeBoardsSection: React.FC<
         let latestSessionAt: BoardHomeRow['latestSessionAt'] = null;
         let latestSessionTime = Number.NEGATIVE_INFINITY;
         for (const session of sessions) {
-          const time = new Date(session.last_updated).getTime();
+          const time = getTimeMs(session, 'last_updated');
           if (time > latestSessionTime) {
             latestSessionTime = time;
             latestSessionAt = session.last_updated;
           }
         }
         const latest = Math.max(
-          new Date(board.last_updated).getTime(),
-          ...branches.map((branch) => new Date(branch.updated_at || branch.created_at).getTime()),
+          getTimeMs(board, 'last_updated'),
+          ...branches.map((branch) =>
+            getTimeMs(branch, branch.updated_at ? 'updated_at' : 'created_at')
+          ),
           latestSessionTime
         );
         return {

--- a/apps/agor-ui/src/components/HomePage/HomePage.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomePage.tsx
@@ -4,7 +4,13 @@ import { Button, Dropdown, Layout, Modal, Segmented, Select, Typography, theme }
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
-import { agorStore, shallow, useAgorStore, useStoreWithEqualityFn } from '../../store/agorStore';
+import {
+  type AgorState,
+  agorStore,
+  shallow,
+  useAgorStore,
+  useStoreWithEqualityFn,
+} from '../../store/agorStore';
 import { selectBoardById } from '../../store/selectors';
 import { isDarkTheme } from '../../utils/theme';
 import { HomeActivitySection } from './HomeActivitySection';
@@ -25,6 +31,15 @@ const SIDEBAR_STORAGE_KEY = 'agor:homepage-sidebar-width';
 const SIDEBAR_DEFAULT = 340;
 const SIDEBAR_MIN = 240;
 const SIDEBAR_MAX_RATIO = 0.5;
+
+// Direct map-value iteration with an early exit — avoids materializing an array
+// of every session on each store notify just to test for one visible match.
+function hasVisibleSession(sessionById: AgorState['sessionById'], currentUserId?: string): boolean {
+  for (const s of sessionById.values()) {
+    if (!s.archived && (!currentUserId || s.created_by === currentUserId)) return true;
+  }
+  return false;
+}
 
 const NEW_MENU_ITEMS: MenuProps['items'] = [
   { key: 'assistant', label: 'New assistant', icon: <RobotOutlined /> },
@@ -59,9 +74,7 @@ const HomeOnboarding: React.FC<{
       hasRepos: state.repoById.size > 0,
       hasMcp: state.mcpServerById.size > 0,
       hasTeammates: state.userById.size > 1,
-      hasSessions: Array.from(state.sessionById.values()).some(
-        (s) => !s.archived && (!currentUserId || s.created_by === currentUserId)
-      ),
+      hasSessions: hasVisibleSession(state.sessionById, currentUserId),
     }),
     shallow
   );

--- a/apps/agor-ui/src/components/HomePage/HomeSections.rerender.test.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeSections.rerender.test.tsx
@@ -5,6 +5,7 @@ import { EMPTY_MAPS } from '../../store/agorMaps';
 import { agorStore } from '../../store/agorStore';
 import { getSessionDisplayTitle } from '../../utils/sessionTitle';
 import { formatRelativeTime } from '../../utils/time';
+import { HomeActivitySection } from './HomeActivitySection';
 import { HomeBoardsSection } from './HomeBoardsSection';
 import { HomeSessionsSection } from './HomeSessionsSection';
 
@@ -70,6 +71,51 @@ describe('HomeSessionsSection row re-render isolation', () => {
     // Streaming-style patch to s1: new object identity, s2 untouched. The
     // section re-renders (it displays session data), but only s1's row may
     // re-render — s2's row keeps every prop reference and bails out.
+    const s1Patched = { ...s1, status: 'running' } as Session;
+    act(() => {
+      agorStore.setState({
+        sessionById: new Map([
+          [s1.session_id, s1Patched],
+          [s2.session_id, s2],
+        ]),
+      });
+    });
+
+    await waitFor(() => {
+      expect(titleRendersFor(s1Patched)).toBeGreaterThanOrEqual(1);
+    });
+    expect(titleRendersFor(s2)).toBe(s2Baseline);
+  });
+});
+
+describe('HomeActivitySection row re-render isolation', () => {
+  it('patching one session leaves the other activity rows un-rendered', async () => {
+    const s1 = makeSession('s-1', '2026-07-01T10:00:00.000Z', {
+      created_at: '2026-07-01T10:00:00.000Z',
+    });
+    const s2 = makeSession('s-2', '2026-07-01T09:00:00.000Z', {
+      created_at: '2026-07-01T09:00:00.000Z',
+    });
+    agorStore.setState({
+      sessionById: new Map([
+        [s1.session_id, s1],
+        [s2.session_id, s2],
+      ]),
+    });
+
+    render(<HomeActivitySection onBoardClick={noop} onBranchClick={noop} onSessionClick={noop} />);
+
+    await waitFor(() => {
+      expect(titleRendersFor(s2)).toBeGreaterThanOrEqual(1);
+    });
+    const s2Baseline = titleRendersFor(s2);
+
+    // Streaming-style patch to s1: new object identity, same last_updated (so
+    // feed order is unchanged), s2 untouched. The section re-renders (it builds
+    // the feed from sessions), but each row is a memo'd component fed resolved
+    // entity refs — so only s1's row rebuilds its message. If the row weren't
+    // memo'd (or its message builders depended on the whole maps, as before),
+    // s2's row would re-render too and this would fail.
     const s1Patched = { ...s1, status: 'running' } as Session;
     act(() => {
       agorStore.setState({

--- a/apps/agor-ui/src/components/HomePage/HomeStatsBar.tsx
+++ b/apps/agor-ui/src/components/HomePage/HomeStatsBar.tsx
@@ -3,6 +3,7 @@ import { Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
 import { useEffect, useState } from 'react';
 import { agorStore, shallow, useAgorStore, useStoreWithEqualityFn } from '../../store/agorStore';
+import { getTimeMs } from '../../utils/entityTime';
 import { glassCardStyle } from './homeStyles';
 
 const { Text } = Typography;
@@ -104,11 +105,8 @@ export const HomeStatsBar: React.FC<{
       for (const s of state.sessionById.values()) {
         if (s.archived) continue;
 
-        const updatedAt = s.last_updated
-          ? new Date(s.last_updated).getTime()
-          : s.created_at
-            ? new Date(s.created_at).getTime()
-            : Number.NaN;
+        const lastUpdated = getTimeMs(s, 'last_updated');
+        const updatedAt = Number.isNaN(lastUpdated) ? getTimeMs(s, 'created_at') : lastUpdated;
 
         if (s.status === 'running') {
           runningNow++;

--- a/apps/agor-ui/src/components/HomePage/homeStyles.ts
+++ b/apps/agor-ui/src/components/HomePage/homeStyles.ts
@@ -37,8 +37,23 @@ export const glassCardStyle = (
   token: ReturnType<typeof theme.useToken>['token'],
   alpha = 0.3
 ): React.CSSProperties => ({
+  ...glassSurfaceStyle(token, alpha),
+  boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.12)',
+});
+
+/**
+ * The tinted, blurred glass fill WITHOUT any box-shadow. Split out from
+ * `glassCardStyle` so an interactive card can paint this on a static, never-
+ * mutated layer while hover/focus affordances (border, shadow, outline) live on
+ * a separate sibling element. `backdrop-filter: blur(20px)` is expensive to
+ * repaint, so toggling styles on a layer that carries it forces the whole blur
+ * to be recomputed on every hover; keeping this fill static avoids that.
+ */
+export const glassSurfaceStyle = (
+  token: ReturnType<typeof theme.useToken>['token'],
+  alpha = 0.3
+): React.CSSProperties => ({
   background: withAlpha(token.colorBgContainer, alpha),
   backdropFilter: 'blur(20px) saturate(180%)',
   WebkitBackdropFilter: 'blur(20px) saturate(180%)',
-  boxShadow: 'inset 0 1px 0 rgba(255, 255, 255, 0.12)',
 });

--- a/apps/agor-ui/src/utils/entityTime.ts
+++ b/apps/agor-ui/src/utils/entityTime.ts
@@ -1,0 +1,33 @@
+/**
+ * Memoized timestamp parsing for immutable store entities.
+ *
+ * Sessions, branches and boards are replaced by a fresh object on every patch,
+ * never mutated in place. That makes them safe WeakMap keys: a parsed epoch
+ * stays valid for the lifetime of the object, and the entry is collected when
+ * the object is replaced. The home page re-derives its feeds on every store
+ * notify (one per streamed token on busy instances), so parsing the same
+ * `new Date(entity.field)` on every comparison and every scan dominated the
+ * frame. Here each (entity, field) is parsed once and reused thereafter.
+ */
+
+const cache = new WeakMap<object, Record<string, number>>();
+
+/**
+ * Epoch milliseconds for `entity[field]`, parsed at most once per object.
+ * Returns `NaN` for a missing/invalid value (same as `new Date(x).getTime()`),
+ * and caches that result too so repeat lookups stay allocation-free.
+ */
+export function getTimeMs(entity: object | null | undefined, field: string): number {
+  if (!entity) return Number.NaN;
+  let fields = cache.get(entity);
+  if (!fields) {
+    fields = {};
+    cache.set(entity, fields);
+  }
+  const cached = fields[field];
+  if (cached !== undefined) return cached;
+  const raw = (entity as Record<string, unknown>)[field];
+  const value = raw ? new Date(raw as string | number | Date).getTime() : Number.NaN;
+  fields[field] = value;
+  return value;
+}

--- a/apps/agor-ui/src/utils/sessionSearch.ts
+++ b/apps/agor-ui/src/utils/sessionSearch.ts
@@ -4,6 +4,7 @@ import {
   type Session,
   tokenizeSearchQuery,
 } from '@agor-live/client';
+import { getTimeMs } from './entityTime';
 import { getSessionDisplayTitle } from './sessionTitle';
 
 export const SESSION_SORT_STORAGE_KEY = 'agor:session-sort';
@@ -92,7 +93,7 @@ export function scoreSession(session: Session, query: string, now = Date.now()):
   // session appear in search results.
   if (score === 0) return 0;
 
-  const updatedAt = new Date(session.last_updated).getTime();
+  const updatedAt = getTimeMs(session, 'last_updated');
   if (Number.isFinite(updatedAt)) {
     const ageDays = Math.max(0, (now - updatedAt) / 86_400_000);
     score += Math.round(SCORE_WEIGHTS.RECENCY_MAX * Math.exp(-ageDays));
@@ -175,11 +176,11 @@ export function sortSessions(sessions: Session[], sort: SessionSort): Session[] 
 }
 
 function compareByRecent(a: Session, b: Session): number {
-  return new Date(b.last_updated).getTime() - new Date(a.last_updated).getTime();
+  return getTimeMs(b, 'last_updated') - getTimeMs(a, 'last_updated');
 }
 
 function compareByOldest(a: Session, b: Session): number {
-  return new Date(a.last_updated).getTime() - new Date(b.last_updated).getTime();
+  return getTimeMs(a, 'last_updated') - getTimeMs(b, 'last_updated');
 }
 
 function compareByTitle(a: Session, b: Session): number {


### PR DESCRIPTION
## Why

On busy instances the daemon streams `session:patched` continuously. Even batched to one store notify per animation frame, the home page did **O(all-entities)** work on every notify, and hovering the board cards forced repaints of `backdrop-filter: blur(20px)` glass surfaces. A Chrome trace showed ~1s frames. This is a pure perf PR — no visible behavior, ordering, or visual change.

Two mechanisms dominated:

1. **Per-notify re-derivation.** Sort comparators and selector scans parsed `new Date(entity.field)` on every comparison, and `HomeActivitySection` rebuilt + re-rendered 100 unmemoized rows from all branches+sessions on every patch (its message builders were `useCallback`s keyed on whole maps, so their identity churned each patch and every row rebuilt).
2. **Blur invalidation.** Hover/focus toggled `border`/`boxShadow` on the same element that carried `backdrop-filter`, forcing the whole 20px blur to be recomputed on each hover.

## What changed

- **`utils/entityTime.ts` (new).** `getTimeMs(entity, field)` — a module-level `WeakMap`-memoized timestamp parse. Store entities are immutable (replaced on patch), so a parsed epoch stays valid for the object's lifetime and is GC'd with it. Every home-page timestamp parse now routes through this, eliminating `new Date()` from sort comparators and per-notify scans.
- **`HomeActivitySection.tsx`.** Events now carry a numeric sort key `t` computed once; the comparator subtracts numbers. Rendering is restructured around a `React.memo` `ActivityRow` that receives resolved entity refs (session/branch/board/user) plus stable callbacks and builds its message **inside** the row — so a store notify re-renders only rows whose entities changed. Exact visual output, ordering, filtering, and Segmented-filter behavior preserved.
- **`utils/sessionSearch.ts`.** `compareByRecent`/`compareByOldest` and the recency boost in `scoreSession` use `getTimeMs` instead of parsing dates per comparison.
- **`HomeBoardsSection.tsx`.** Row derivation uses `getTimeMs`; a module-level `WeakMap` (keyed by the reference-stable per-branch session bucket) caches the visible-session filter so untouched branches aren't re-filtered every notify. `BoardHomeCard` memo bailouts unchanged.
- **`HomeStatsBar.tsx`.** Selector uses `getTimeMs` for the last-updated/created-at fallback.
- **`HomePage.tsx`.** The `HomeOnboarding` `hasSessions` gate iterates `sessionById.values()` directly with an early exit instead of materializing `Array.from(...).some(...)` on every notify.
- **`AppHeader.tsx` + `AppHeaderGlobalSearch.tsx` (new).** AppHeader subscribed to six whole maps and re-rendered on every entity patch org-wide. The three maps only GlobalSearch consumes — `sessionById` (highest churn), `artifactById`, `mcpServerById` — now live in a memo'd `AppHeaderGlobalSearch` leaf, so a session patch wakes only GlobalSearch, never the board switcher / presence chrome. `boardById`/`branchById`/`userById` (read by other chrome, rare churn) stay subscribed in AppHeader and pass through as props. GlobalSearch receives the exact same live maps as before.
- **`homeStyles.ts` + `BoardHomeCard`.** Split `glassSurfaceStyle` (tinted blur, no shadow) out of `glassCardStyle`. `BoardHomeCard` now paints the blur on a static sibling `<span>` layer behind the interactive `<button>`; hover/focus border/shadow/outline live on the button (no `backdrop-filter`), so the blur layer's paint never invalidates. Pixel-parity with the prior hover/focus look — border, shadow, outline values are unchanged and the button paints above the blur.

## Tests

- `HomeSections.rerender.test.tsx` — new guard: a session patch re-renders only the affected activity row, not the others (verified fails-on-revert by temporarily unwrapping the row `memo`: the untouched row rendered twice).
- `AppHeader.rerender.test.tsx` — new guard: a session patch does not re-render the header after the subscription narrowing.

## Gate results

- `pnpm typecheck` — clean
- `pnpm lint` (biome) — clean
- Rerender test files — 13 passed
- Full agor-ui suite — 746 passed / 118 files (one pre-existing flaky modal-timing test failed once, passed on rerun; unrelated to this change)