### PR TITLE
fix(auth): stop swapping machine-token logins for short-lived browser tokens

### DIFF
--- a/apps/agor-daemon/src/auth/issue-browser-tokens-hook.test.ts
+++ b/apps/agor-daemon/src/auth/issue-browser-tokens-hook.test.ts
@@ -90,6 +90,39 @@ test('local login receives a browser access + refresh token pair', async () => {
   expect(refreshPayload.sub).toBe('user-1');
 });
 
+test('api-key login (no JWT payload) receives a browser access + refresh token pair', async () => {
+  const context = makeContext(undefined, 'api-key');
+
+  const result = (await makeHook()(context)).result;
+
+  expect(result.accessToken).not.toBe(ORIGINAL_TOKEN);
+  expect(result.refreshToken).toEqual(expect.any(String));
+  expectRedactedUser(result.user);
+
+  const accessPayload = verifyToken(result.accessToken);
+  expect(accessPayload.type).toBe('access');
+  expect(accessPayload.sub).toBe('user-1');
+});
+
+test('params.tenant tenant_id propagates into both minted tokens', async () => {
+  const context = makeContext(undefined, 'local');
+  context.params = { tenant: { tenant_id: 'tenant-1' } };
+
+  const result = (await makeHook()(context)).result;
+
+  expect(verifyToken(result.accessToken).tenant_id).toBe('tenant-1');
+  expect(verifyToken(result.refreshToken).tenant_id).toBe('tenant-1');
+});
+
+test('user.tenant_id is the fallback tenant claim when params carry no tenant', async () => {
+  const context = makeContext(undefined, 'local');
+  context.result.user = { ...makeUser(), tenant_id: 'tenant-2' };
+
+  const result = (await makeHook()(context)).result;
+
+  expect(verifyToken(result.accessToken).tenant_id).toBe('tenant-2');
+});
+
 test('browser jwt re-auth (payload.type=access) still receives a fresh token pair', async () => {
   const context = makeContext('access');
 

--- a/apps/agor-daemon/src/auth/issue-browser-tokens-hook.test.ts
+++ b/apps/agor-daemon/src/auth/issue-browser-tokens-hook.test.ts
@@ -1,0 +1,118 @@
+import jwt from 'jsonwebtoken';
+import { expect, test } from 'vitest';
+import { createIssueBrowserTokensHook } from './issue-browser-tokens-hook';
+import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from './runtime-tokens';
+
+const JWT_SECRET = 'issue-browser-tokens-hook-test-secret';
+const ACCESS_TOKEN_TTL = '15m';
+const REFRESH_TOKEN_TTL = '30d';
+const ORIGINAL_TOKEN = 'original-machine-token';
+
+function makeHook() {
+  return createIssueBrowserTokensHook({
+    jwtSecret: JWT_SECRET,
+    accessTokenTtl: ACCESS_TOKEN_TTL,
+    refreshTokenTtl: REFRESH_TOKEN_TTL,
+    tenantClaim: 'tenant_id',
+  });
+}
+
+function makeUser() {
+  return {
+    user_id: 'user-1',
+    email: 'user@example.com',
+    tokens_valid_after: new Date(0),
+    password: 'hashed-secret',
+  };
+}
+
+function makeContext(payloadType?: string, strategy = 'jwt') {
+  return {
+    params: {},
+    result: {
+      accessToken: ORIGINAL_TOKEN,
+      user: makeUser(),
+      authentication: {
+        strategy,
+        ...(payloadType ? { payload: { sub: 'user-1', type: payloadType } } : {}),
+      },
+    },
+  };
+}
+
+function verifyToken(token: string) {
+  return jwt.verify(token, JWT_SECRET, {
+    issuer: RUNTIME_JWT_ISSUER,
+    audience: RUNTIME_JWT_AUDIENCE,
+  }) as Record<string, unknown>;
+}
+
+function expectRedactedUser(user: unknown): void {
+  expect(user).not.toHaveProperty('tokens_valid_after');
+  expect(user).not.toHaveProperty('password');
+}
+
+test('executor-session login keeps its original access token and gets no refresh token', async () => {
+  const context = makeContext('executor-session');
+
+  const result = (await makeHook()(context)).result;
+
+  expect(result.accessToken).toBe(ORIGINAL_TOKEN);
+  expect(result).not.toHaveProperty('refreshToken');
+  expectRedactedUser(result.user);
+});
+
+test('service login keeps its original access token and gets no refresh token', async () => {
+  const context = makeContext('service');
+
+  const result = (await makeHook()(context)).result;
+
+  expect(result.accessToken).toBe(ORIGINAL_TOKEN);
+  expect(result).not.toHaveProperty('refreshToken');
+  expectRedactedUser(result.user);
+});
+
+test('local login receives a browser access + refresh token pair', async () => {
+  const context = makeContext(undefined, 'local');
+
+  const result = (await makeHook()(context)).result;
+
+  expect(result.accessToken).not.toBe(ORIGINAL_TOKEN);
+  expect(result.refreshToken).toEqual(expect.any(String));
+  expectRedactedUser(result.user);
+
+  const accessPayload = verifyToken(result.accessToken);
+  expect(accessPayload.type).toBe('access');
+  expect(accessPayload.sub).toBe('user-1');
+
+  const refreshPayload = verifyToken(result.refreshToken);
+  expect(refreshPayload.type).toBe('refresh');
+  expect(refreshPayload.sub).toBe('user-1');
+});
+
+test('browser jwt re-auth (payload.type=access) still receives a fresh token pair', async () => {
+  const context = makeContext('access');
+
+  const result = (await makeHook()(context)).result;
+
+  expect(result.accessToken).not.toBe(ORIGINAL_TOKEN);
+  expect(result.refreshToken).toEqual(expect.any(String));
+  expectRedactedUser(result.user);
+
+  const accessPayload = verifyToken(result.accessToken);
+  expect(accessPayload.type).toBe('access');
+  expect(accessPayload.sub).toBe('user-1');
+});
+
+test('result without a user is left untouched', async () => {
+  const context = {
+    params: {},
+    result: { accessToken: ORIGINAL_TOKEN, authentication: { strategy: 'jwt' } },
+  };
+
+  const result = (await makeHook()(context)).result;
+
+  expect(result.accessToken).toBe(ORIGINAL_TOKEN);
+  expect(result).not.toHaveProperty('refreshToken');
+  expect(result).not.toHaveProperty('user');
+});

--- a/apps/agor-daemon/src/auth/issue-browser-tokens-hook.ts
+++ b/apps/agor-daemon/src/auth/issue-browser-tokens-hook.ts
@@ -1,0 +1,74 @@
+import type { SignOptions } from 'jsonwebtoken';
+import { issueRuntimeTokenPair, runtimeTenantClaims } from './runtime-tokens.js';
+import { authTokenIssuedAtClaim } from './token-invalidation.js';
+import { redactUserAuthMetadata } from './user-redaction.js';
+
+/**
+ * JWT payload types that identify machine credentials (executor sockets,
+ * service-to-service calls) rather than an interactive browser client.
+ */
+const MACHINE_TOKEN_TYPES = new Set(['executor-session', 'service']);
+
+export interface IssueBrowserTokensHookOptions {
+  jwtSecret: string;
+  accessTokenTtl: SignOptions['expiresIn'];
+  refreshTokenTtl: SignOptions['expiresIn'];
+  tenantClaim: string;
+  debug?: (...args: unknown[]) => void;
+}
+
+/**
+ * After-create hook for the authentication service: replace the strategy's
+ * access token with a browser access token and attach a refresh token.
+ *
+ * Machine-token logins (executor-session / service JWTs) are exempt from the
+ * swap. Feathers stores the login result's accessToken on the socket
+ * connection and re-verifies it on every subsequent service call, so swapping
+ * a machine credential for a short-TTL browser token would kill any
+ * long-running executor connection the moment the browser TTL elapses — even
+ * though the machine token itself is still valid. Machine logins also must
+ * not receive long-lived refresh tokens meant for interactive clients.
+ *
+ * User redaction applies on every path that returns a user.
+ */
+export function createIssueBrowserTokensHook(options: IssueBrowserTokensHookOptions) {
+  const { jwtSecret, accessTokenTtl, refreshTokenTtl, tenantClaim, debug } = options;
+
+  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS context type not fully typed
+  return async (context: any) => {
+    debug?.('✅ Authentication succeeded:', {
+      strategy: context.result?.authentication?.strategy,
+      hasUser: !!context.result?.user,
+      user_id: context.result?.user?.user_id,
+      hasAccessToken: !!context.result?.accessToken,
+    });
+
+    if (!context.result?.user) {
+      return context;
+    }
+
+    const payloadType = context.result.authentication?.payload?.type;
+    if (typeof payloadType === 'string' && MACHINE_TOKEN_TYPES.has(payloadType)) {
+      context.result.user = redactUserAuthMetadata(context.result.user);
+      return context;
+    }
+
+    const tenantId =
+      context.params?.tenant?.tenant_id ??
+      (context.result.user as { tenant_id?: string }).tenant_id;
+    const tokens = issueRuntimeTokenPair(
+      context.result.user,
+      jwtSecret,
+      accessTokenTtl,
+      refreshTokenTtl,
+      {
+        ...authTokenIssuedAtClaim(Date.now(), context.result.user),
+        ...runtimeTenantClaims(tenantId, tenantClaim),
+      }
+    );
+    context.result.accessToken = tokens.accessToken;
+    context.result.refreshToken = tokens.refreshToken;
+    context.result.user = redactUserAuthMetadata(context.result.user);
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -72,17 +72,15 @@ import {
 import { NotFoundError } from '@agor/core/utils/errors';
 import type { Request } from 'express';
 import { rateLimit } from 'express-rate-limit';
+import { createIssueBrowserTokensHook } from './auth/issue-browser-tokens-hook.js';
 import { createLaunchAuthService, resolvePublicLaunchAuthSettings } from './auth/launch-auth.js';
 import { createRefreshTokenService } from './auth/refresh-token-service.js';
 import {
   issueRuntimeToken,
-  issueRuntimeTokenPair,
   RUNTIME_JWT_AUDIENCE,
   RUNTIME_JWT_ISSUER,
-  runtimeTenantClaims,
 } from './auth/runtime-tokens.js';
 import { authTokenIssuedAtClaim } from './auth/token-invalidation.js';
-import { redactUserAuthMetadata } from './auth/user-redaction.js';
 import type {
   BoardsServiceImpl,
   BranchesServiceImpl,
@@ -437,41 +435,21 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   };
 
   // Hook: Issue browser access + refresh tokens with millisecond issue time.
+  // Machine-token logins (executor-session / service) keep their original
+  // token — see createIssueBrowserTokensHook for why.
   // Rate limiting is enforced by express-rate-limit middleware mounted on
   // `/authentication` above — by the time we reach this hook the limiter
   // has already 429'd any over-quota request.
   authService.hooks({
     after: {
       create: [
-        // biome-ignore lint/suspicious/noExplicitAny: FeathersJS context type not fully typed
-        async (context: any) => {
-          authEventDebug('✅ Authentication succeeded:', {
-            strategy: context.result?.authentication?.strategy,
-            hasUser: !!context.result?.user,
-            user_id: context.result?.user?.user_id,
-            hasAccessToken: !!context.result?.accessToken,
-          });
-
-          if (context.result?.user) {
-            const tenantId =
-              context.params?.tenant?.tenant_id ??
-              (context.result.user as { tenant_id?: string }).tenant_id;
-            const tokens = issueRuntimeTokenPair(
-              context.result.user,
-              jwtSecret,
-              ACCESS_TOKEN_TTL,
-              REFRESH_TOKEN_TTL,
-              {
-                ...authTokenIssuedAtClaim(Date.now(), context.result.user),
-                ...runtimeTenantClaims(tenantId, tenantTokenClaim),
-              }
-            );
-            context.result.accessToken = tokens.accessToken;
-            context.result.refreshToken = tokens.refreshToken;
-            context.result.user = redactUserAuthMetadata(context.result.user);
-          }
-          return context;
-        },
+        createIssueBrowserTokensHook({
+          jwtSecret,
+          accessTokenTtl: ACCESS_TOKEN_TTL,
+          refreshTokenTtl: REFRESH_TOKEN_TTL,
+          tenantClaim: tenantTokenClaim,
+          debug: authEventDebug,
+        }),
       ],
     },
   });


### PR DESCRIPTION
## Problem

Any session with a single turn longer than ~15 minutes gets marked failed with **"Executor heartbeat lost"**, even though the executor process is alive and working. This is the root cause behind the long-standing "sessions fail after ~15 minutes" reports (#1809), and the 15-minute boundary previously investigated in #1677 / #1753.

## Root cause

The executor authenticates its Feathers socket **once at spawn** with a 24-hour executor-session JWT (`SessionTokenService.generateToken`, payload `type: 'executor-session'`) via `client.authenticate({strategy: 'jwt', accessToken})` in `packages/executor/src/services/feathers-client.ts`.

That login flows through the authentication service's after-create hook in `apps/agor-daemon/src/register-routes.ts`, which ran on **every** successful `authentication.create` whose result has a user — and unconditionally **replaced** `context.result.accessToken` with a freshly minted browser access token (`ACCESS_TOKEN_TTL = '15m'`), plus a 30-day `refreshToken`.

Feathers v5's `JWTStrategy.handleConnection('login')` stores the **login result's** token as `connection.authentication.accessToken` and re-verifies it on every subsequent socket service call. So the executor's socket connection ends up carrying a 15-minute browser token instead of its 24-hour machine token. At exactly login+900s, every executor→daemon write starts failing with `NotAuthenticated: jwt expired` — task heartbeat patches (`packages/executor/src/executor-heartbeat.ts`), the `canUseTool` permission flow, and the terminal task-status patch. The daemon's `ExecutorHeartbeatSupervisor` then marks the task failed ~30–40s later.

Key details:

- The socket never disconnects — so the executor's reconnect/re-auth logic never triggers. The connection is "up" but its stored credential is expired.
- Executor-session tokens are genuinely 24h (verified in instance config); only the swapped-in browser token expires.
- The swap also clobbered the task-scoped connection payload that `persistExecutorJwtPayloadOnConnection` (`apps/agor-daemon/src/auth/service-jwt-strategy.ts`) deliberately persists.

## Evidence

journalctl on a production instance: executor daemon writes start failing `NotAuthenticated: jwt expired` at **exactly executor start + 900s** across 5 sampled executors, followed by "Executor heartbeat lost" ~30–40s later. Executor↔daemon traffic is localhost, ruling out proxy/LB transport rotation as the cause.

## Fix

The hook now skips both the token swap and the refresh-token issuance when the authenticated credential is a machine token — discriminated by `context.result.authentication?.payload?.type` being `'executor-session'` or `'service'` (payload types set by `ServiceJWTStrategy` / the token minters).

All other paths keep current behavior exactly: `local` password logins, browser jwt re-auth (payload `type: 'access'` or no payload), and api-key logins still receive the access+refresh pair. `redactUserAuthMetadata` is still applied on every path that returns a user, including the new machine-token path.

The hook body is extracted from `register-routes.ts` into a named, unit-testable factory: `createIssueBrowserTokensHook` in `apps/agor-daemon/src/auth/issue-browser-tokens-hook.ts`; registration in `register-routes.ts` stays thin.

## Tests

New colocated unit tests in `apps/agor-daemon/src/auth/issue-browser-tokens-hook.test.ts`:

- executor-session login → access token is the **identity** of the original token, no `refreshToken` property, user redacted
- service login → same
- local login → fresh pair issued, decoded access token has `type: 'access'` and `sub === user_id`, refresh token has `type: 'refresh'`, user redacted
- browser jwt re-auth (payload `type: 'access'`) → pair still issued
- result without a user → hook is a no-op

Gate: `turbo typecheck --filter=@agor/daemon` ✅, `biome check` on touched files ✅, full `@agor/daemon` vitest suite ✅ (1407 passed, 31 skipped).

## Notes

- This also stops issuing 30-day refresh tokens to machine logins — executor/service credentials had no business receiving browser refresh tokens.
- Explains the 15-minute boundary investigated in #1677 / #1753 and the failures reported in #1809.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
