### PR TITLE
feat: add links organizer UI and assistant promotion

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -81,7 +81,10 @@ import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
-import { ingestParsedLinksAfterMessageCreate } from './services/links.js';
+import {
+  associateUploadLinksAfterMessageCreate,
+  ingestParsedLinksAfterMessageCreate,
+} from './services/links.js';
 import { linksHooks } from './services/links-hooks.js';
 import {
   isRemoteRelationshipsEnrichedResult,
@@ -750,7 +753,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
     },
     after: {
-      create: [gatewayRouteHook, ingestParsedLinksAfterMessageCreate(app)],
+      create: [
+        gatewayRouteHook,
+        ingestParsedLinksAfterMessageCreate(app),
+        associateUploadLinksAfterMessageCreate(app),
+      ],
       patch: [
         async (context: HookContext<Board>) => {
           // Detect permission resolution and notify executor via IPC

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1113,43 +1113,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           type: isCallback ? 'system' : 'user',
           metadata: Object.keys(messageMetadata).length > 0 ? messageMetadata : undefined,
         });
-        const createdMessage = (await app
-          .service('messages')
-          .create(userMessage, params)) as Message;
-        const uploadLinkIds = Array.isArray(task.metadata?.upload_link_ids)
-          ? task.metadata.upload_link_ids.filter(
-              (id): id is NonNullable<typeof id> => typeof id === 'string'
-            )
-          : [];
-        if (uploadLinkIds.length > 0) {
-          const linksService = app.service('links');
-          await Promise.all(
-            uploadLinkIds.map(async (linkId) => {
-              try {
-                const link = (await linksService.get(linkId, {
-                  ...params,
-                  provider: undefined,
-                } as Params)) as Link;
-                if (
-                  link.session_id !== task.session_id ||
-                  link.source !== 'upload' ||
-                  link.source_message_id
-                ) {
-                  return;
-                }
-                await linksService.patch(linkId, { source_message_id: createdMessage.message_id }, {
-                  ...params,
-                  provider: undefined,
-                } as Params);
-              } catch (linkErr) {
-                console.warn(
-                  `⚠️  [Daemon] Failed to associate upload link ${String(linkId).slice(0, 8)} with message ${shortId(createdMessage.message_id)}:`,
-                  linkErr
-                );
-              }
-            })
-          );
-        }
+        await app.service('messages').create(userMessage, params);
       } catch (msgErr) {
         // Don't fail the spawn — the executor's createUserMessage fallback
         // (with skip-if-exists) will write the row when it connects.

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -43,6 +43,7 @@ import type {
   AuthenticatedParams,
   DaemonServicesConfig,
   HookContext,
+  Link,
   LinkCreate,
   Message,
   MessageSource,
@@ -94,6 +95,8 @@ import type {
 } from './declarations.js';
 import { killExecutorProcess } from './executor-tracking.js';
 import type { GatewayService } from './services/gateway.js';
+import { registerLinkContentRoute } from './services/link-content.js';
+import { LinkPromotionService, type LinksServiceForPromotion } from './services/link-promotion.js';
 import {
   ScheduleBusyError,
   ScheduleNotReadyError,
@@ -1110,7 +1113,43 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           type: isCallback ? 'system' : 'user',
           metadata: Object.keys(messageMetadata).length > 0 ? messageMetadata : undefined,
         });
-        await app.service('messages').create(userMessage, params);
+        const createdMessage = (await app
+          .service('messages')
+          .create(userMessage, params)) as Message;
+        const uploadLinkIds = Array.isArray(task.metadata?.upload_link_ids)
+          ? task.metadata.upload_link_ids.filter(
+              (id): id is NonNullable<typeof id> => typeof id === 'string'
+            )
+          : [];
+        if (uploadLinkIds.length > 0) {
+          const linksService = app.service('links');
+          await Promise.all(
+            uploadLinkIds.map(async (linkId) => {
+              try {
+                const link = (await linksService.get(linkId, {
+                  ...params,
+                  provider: undefined,
+                } as Params)) as Link;
+                if (
+                  link.session_id !== task.session_id ||
+                  link.source !== 'upload' ||
+                  link.source_message_id
+                ) {
+                  return;
+                }
+                await linksService.patch(linkId, { source_message_id: createdMessage.message_id }, {
+                  ...params,
+                  provider: undefined,
+                } as Params);
+              } catch (linkErr) {
+                console.warn(
+                  `⚠️  [Daemon] Failed to associate upload link ${String(linkId).slice(0, 8)} with message ${shortId(createdMessage.message_id)}:`,
+                  linkErr
+                );
+              }
+            })
+          );
+        }
       } catch (msgErr) {
         // Don't fail the spawn — the executor's createUserMessage fallback
         // (with skip-if-exists) will write the row when it connects.
@@ -1838,6 +1877,27 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   );
 
   // ============================================================================
+  // Uploaded link content endpoint
+  // ============================================================================
+
+  registerLinkContentRoute(app);
+
+  registerAuthenticatedRoute(
+    app,
+    '/links/:id/promote',
+    new LinkPromotionService({
+      linksService: app.service('links') as unknown as LinksServiceForPromotion,
+      branchRepository,
+      branchRbacEnabled,
+      superadminOpts,
+    }),
+    {
+      create: { role: ROLES.MEMBER, action: 'promote links to assistant' },
+    },
+    requireAuth
+  );
+
+  // ============================================================================
   // File upload endpoint
   // ============================================================================
 
@@ -1972,10 +2032,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         created_by: (params.user?.user_id as UUID | undefined) ?? null,
       }));
 
+      const createdUploadLinks: Link[] = [];
       if (uploadLinks.length > 0) {
-        await app
+        const created = (await app
           .service('links')
-          .create(uploadLinks, { ...params, provider: undefined } as Params);
+          .create(uploadLinks, { ...params, provider: undefined } as Params)) as Link | Link[];
+        createdUploadLinks.push(...(Array.isArray(created) ? created : [created]));
       }
 
       let notificationError: string | null = null;
@@ -1994,7 +2056,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             route: { id: sessionId },
             user: params.user,
           };
-          await promptService.create({ prompt: promptText }, promptParams);
+          await promptService.create(
+            {
+              prompt: promptText,
+              metadata:
+                createdUploadLinks.length > 0
+                  ? { upload_link_ids: createdUploadLinks.map((link) => link.link_id) }
+                  : undefined,
+            },
+            promptParams
+          );
         } catch (error) {
           console.error('❌ [Upload Handler] Failed to notify agent:', error);
           notificationError =

--- a/apps/agor-daemon/src/services/link-content.test.ts
+++ b/apps/agor-daemon/src/services/link-content.test.ts
@@ -1,12 +1,15 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { Forbidden } from '@agor/core/feathers';
 import type { Link } from '@agor/core/types';
-import { describe, expect, it } from 'vitest';
+import type { Request, Response } from 'express';
+import { describe, expect, it, vi } from 'vitest';
 import {
   chooseLinkContentDisposition,
   contentDispositionHeader,
   LinkContentError,
+  registerLinkContentRoute,
   resolveUploadedLinkContentFile,
 } from './link-content';
 
@@ -114,5 +117,70 @@ describe('link content route helpers', () => {
     expect(contentDispositionHeader('attachment', 'report "q1".pdf')).toContain(
       'attachment; filename="report _q1_.pdf"'
     );
+  });
+
+  it('requires bearer auth before resolving link content', async () => {
+    let handler: (req: Request, res: Response) => Promise<void> = async () => {};
+    const app = {
+      get: vi.fn((_path: string, routeHandler: typeof handler) => {
+        handler = routeHandler;
+      }),
+      service: vi.fn(),
+    };
+    registerLinkContentRoute(app as never);
+    const json = vi.fn();
+    const status = vi.fn(() => ({ json }));
+
+    await handler(
+      { headers: {}, params: { linkId: 'link-1' }, query: {} } as unknown as Request,
+      { status } as unknown as Response
+    );
+
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    expect(app.service).not.toHaveBeenCalledWith('links');
+  });
+
+  it('propagates link visibility/RBAC denials from links.get', async () => {
+    let handler: (req: Request, res: Response) => Promise<void> = async () => {};
+    const linksGet = vi.fn(async () => {
+      throw new Forbidden('Link not visible');
+    });
+    const app = {
+      get: vi.fn((_path: string, routeHandler: typeof handler) => {
+        handler = routeHandler;
+      }),
+      service: vi.fn((pathName: string) => {
+        if (pathName === 'authentication') {
+          return {
+            create: vi.fn(async () => ({
+              user: { user_id: 'user-1' },
+              authentication: { strategy: 'jwt' },
+            })),
+          };
+        }
+        if (pathName === 'links') return { get: linksGet };
+        throw new Error(`Unexpected service: ${pathName}`);
+      }),
+    };
+    registerLinkContentRoute(app as never);
+    const json = vi.fn();
+    const status = vi.fn(() => ({ json }));
+
+    await handler(
+      {
+        headers: { authorization: 'Bearer token' },
+        params: { linkId: 'link-1' },
+        query: {},
+      } as unknown as Request,
+      { status } as unknown as Response
+    );
+
+    expect(linksGet).toHaveBeenCalledWith(
+      'link-1',
+      expect.objectContaining({ provider: 'rest', user: { user_id: 'user-1' } })
+    );
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith({ error: 'Link not visible' });
   });
 });

--- a/apps/agor-daemon/src/services/link-content.test.ts
+++ b/apps/agor-daemon/src/services/link-content.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { Link } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import {
+  chooseLinkContentDisposition,
+  contentDispositionHeader,
+  LinkContentError,
+  resolveUploadedLinkContentFile,
+} from './link-content';
+
+async function withTempUploads<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-link-content-'));
+  try {
+    return await fn(root);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+function link(patch: Partial<Link>): Link {
+  return {
+    link_id: 'link-1' as Link['link_id'],
+    branch_id: null,
+    session_id: 'session-1' as Link['session_id'],
+    kind: 'document',
+    source: 'upload',
+    file_path: null,
+    target_key: 'file:test',
+    is_pinned: false,
+    title: null,
+    mime_type: 'text/plain',
+    metadata: null,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-01T00:00:00.000Z',
+    ...patch,
+  } as Link;
+}
+
+describe('link content route helpers', () => {
+  it('resolves uploaded files only when the real path remains inside the upload root', async () => {
+    await withTempUploads(async (root) => {
+      const filePath = path.join(root, 'note.txt');
+      await fs.writeFile(filePath, 'hello');
+
+      const resolved = await resolveUploadedLinkContentFile(
+        link({ file_path: filePath, title: 'note.txt', mime_type: 'text/plain' }),
+        root
+      );
+
+      expect(resolved).toMatchObject({
+        path: await fs.realpath(filePath),
+        size: 5,
+        mimeType: 'text/plain',
+      });
+    });
+  });
+
+  it('rejects traversal, out-of-root paths, and symlinks', async () => {
+    await withTempUploads(async (root) => {
+      const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-link-outside-'));
+      try {
+        const outsideFile = path.join(outsideDir, 'secret.txt');
+        await fs.writeFile(outsideFile, 'secret');
+
+        await expect(
+          resolveUploadedLinkContentFile(link({ file_path: outsideFile }), root)
+        ).rejects.toMatchObject({ status: 403 });
+
+        const symlinkPath = path.join(root, 'secret-link.txt');
+        await fs.symlink(outsideFile, symlinkPath);
+        await expect(
+          resolveUploadedLinkContentFile(link({ file_path: symlinkPath }), root)
+        ).rejects.toMatchObject({ status: 403 });
+      } finally {
+        await fs.rm(outsideDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('allows inline only for safe preview MIME types within caps', () => {
+    expect(
+      chooseLinkContentDisposition({
+        requestedDisposition: 'inline',
+        mimeType: 'image/png',
+        size: 10,
+      })
+    ).toBe('inline');
+    expect(
+      chooseLinkContentDisposition({
+        requestedDisposition: 'inline',
+        mimeType: 'text/markdown',
+        size: 10,
+      })
+    ).toBe('inline');
+    expect(
+      chooseLinkContentDisposition({
+        requestedDisposition: 'attachment',
+        mimeType: 'application/pdf',
+        size: 10,
+      })
+    ).toBe('attachment');
+    expect(() =>
+      chooseLinkContentDisposition({
+        requestedDisposition: 'inline',
+        mimeType: 'application/pdf',
+        size: 10,
+      })
+    ).toThrow(LinkContentError);
+  });
+
+  it('emits attachment-safe content disposition filenames', () => {
+    expect(contentDispositionHeader('attachment', 'report "q1".pdf')).toContain(
+      'attachment; filename="report _q1_.pdf"'
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/link-content.ts
+++ b/apps/agor-daemon/src/services/link-content.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Application } from '@agor/core/feathers';
+import type { AuthenticatedParams, Link, Params } from '@agor/core/types';
+import type { Request, Response } from 'express';
+import { ALLOWED_UPLOAD_MIME_TYPES, getUploadDirectory } from '../utils/upload.js';
+
+export const INLINE_IMAGE_MIME_TYPES: ReadonlySet<string> = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+export const INLINE_TEXT_MIME_TYPES: ReadonlySet<string> = new Set(['text/plain', 'text/markdown']);
+
+export const MAX_INLINE_IMAGE_SIZE = 10 * 1024 * 1024;
+export const MAX_INLINE_TEXT_SIZE = 1024 * 1024;
+
+export class LinkContentError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export interface ResolvedLinkContentFile {
+  path: string;
+  size: number;
+  mimeType: string;
+  filename: string;
+}
+
+function normalizeMimeType(value?: string | null): string {
+  return (value ?? '').split(';')[0].trim().toLowerCase();
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function encodeContentDispositionValue(value: string): string {
+  return encodeURIComponent(value)
+    .replace(/['()]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replace(/\*/g, '%2A');
+}
+
+export function safeContentFilename(link: Pick<Link, 'title' | 'file_path' | 'metadata'>): string {
+  const metadata = link.metadata && typeof link.metadata === 'object' ? link.metadata : {};
+  const metadataName =
+    typeof metadata.originalName === 'string'
+      ? metadata.originalName
+      : typeof metadata.filename === 'string'
+        ? metadata.filename
+        : null;
+  const fallback =
+    link.title || metadataName || (link.file_path ? path.basename(link.file_path) : 'download');
+  const basename = path
+    .basename(fallback)
+    .replace(/[\r\n"\\]/g, '_')
+    .trim();
+  return basename || 'download';
+}
+
+export function contentDispositionHeader(
+  disposition: 'inline' | 'attachment',
+  filename: string
+): string {
+  const safeName = filename.replace(/[\r\n"\\]/g, '_') || 'download';
+  const encoded = encodeContentDispositionValue(safeName);
+  return `${disposition}; filename="${safeName}"; filename*=UTF-8''${encoded}`;
+}
+
+export function chooseLinkContentDisposition(args: {
+  requestedDisposition?: unknown;
+  mimeType: string;
+  size: number;
+}): 'inline' | 'attachment' {
+  const requested = args.requestedDisposition === 'inline' ? 'inline' : 'attachment';
+  const mimeType = normalizeMimeType(args.mimeType);
+
+  if (!ALLOWED_UPLOAD_MIME_TYPES.has(mimeType)) {
+    throw new LinkContentError(415, 'Unsupported file type');
+  }
+
+  if (requested !== 'inline') return 'attachment';
+
+  if (INLINE_IMAGE_MIME_TYPES.has(mimeType)) {
+    if (args.size > MAX_INLINE_IMAGE_SIZE) {
+      throw new LinkContentError(413, 'File is too large to preview inline');
+    }
+    return 'inline';
+  }
+
+  if (INLINE_TEXT_MIME_TYPES.has(mimeType)) {
+    if (args.size > MAX_INLINE_TEXT_SIZE) {
+      throw new LinkContentError(413, 'File is too large to preview inline');
+    }
+    return 'inline';
+  }
+
+  throw new LinkContentError(415, 'File type is not previewable inline');
+}
+
+export async function resolveUploadedLinkContentFile(
+  link: Pick<Link, 'source' | 'file_path' | 'mime_type' | 'title' | 'metadata'>,
+  uploadRoot = getUploadDirectory()
+): Promise<ResolvedLinkContentFile> {
+  if (link.source !== 'upload' || !link.file_path) {
+    throw new LinkContentError(404, 'File content not found');
+  }
+
+  const uploadRootReal = await fs.realpath(uploadRoot).catch(() => {
+    throw new LinkContentError(404, 'File content not found');
+  });
+
+  const candidatePath = path.isAbsolute(link.file_path)
+    ? path.resolve(link.file_path)
+    : path.resolve(uploadRoot, link.file_path);
+
+  const lstat = await fs.lstat(candidatePath).catch(() => {
+    throw new LinkContentError(404, 'File content not found');
+  });
+
+  if (lstat.isSymbolicLink()) {
+    throw new LinkContentError(403, 'File content not available');
+  }
+  if (!lstat.isFile()) {
+    throw new LinkContentError(404, 'File content not found');
+  }
+
+  const fileReal = await fs.realpath(candidatePath).catch(() => {
+    throw new LinkContentError(404, 'File content not found');
+  });
+
+  if (!isPathInside(uploadRootReal, fileReal)) {
+    throw new LinkContentError(403, 'File content not available');
+  }
+
+  const mimeType = normalizeMimeType(link.mime_type);
+  if (!ALLOWED_UPLOAD_MIME_TYPES.has(mimeType)) {
+    throw new LinkContentError(415, 'Unsupported file type');
+  }
+
+  return {
+    path: fileReal,
+    size: lstat.size,
+    mimeType,
+    filename: safeContentFilename(link),
+  };
+}
+
+async function authenticateBearerRequest(
+  app: Application,
+  req: Request
+): Promise<AuthenticatedParams> {
+  const authHeader = req.headers.authorization;
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.substring(7) : null;
+  if (!token) throw new LinkContentError(401, 'Authentication required');
+
+  const authService = app.service('authentication') as unknown as {
+    create(data: {
+      strategy: 'jwt';
+      accessToken: string;
+    }): Promise<{ user?: unknown; authentication?: unknown }>;
+  };
+  const result = await authService.create({ strategy: 'jwt', accessToken: token }).catch(() => {
+    throw new LinkContentError(401, 'Authentication required');
+  });
+
+  return {
+    user: result.user,
+    provider: 'rest',
+    authentication: result.authentication,
+  } as AuthenticatedParams;
+}
+
+export function registerLinkContentRoute(app: Application): void {
+  // biome-ignore lint/suspicious/noExplicitAny: Express route method is not represented on Feathers Application.
+  (app as any).get('/link-content/:linkId', async (req: Request, res: Response) => {
+    try {
+      const params = await authenticateBearerRequest(app, req);
+      const link = (await app.service('links').get(req.params.linkId, params as Params)) as Link;
+      const file = await resolveUploadedLinkContentFile(link);
+      const disposition = chooseLinkContentDisposition({
+        requestedDisposition: req.query.disposition,
+        mimeType: file.mimeType,
+        size: file.size,
+      });
+
+      res.setHeader('Content-Type', file.mimeType);
+      res.setHeader('Content-Length', String(file.size));
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('Cache-Control', 'private, no-store');
+      res.setHeader('Content-Disposition', contentDispositionHeader(disposition, file.filename));
+      res.sendFile(file.path);
+    } catch (error) {
+      const status = error instanceof LinkContentError ? error.status : 500;
+      const message = error instanceof Error ? error.message : 'Failed to load file content';
+      res.status(status).json({ error: status >= 500 ? 'Failed to load file content' : message });
+    }
+  });
+}

--- a/apps/agor-daemon/src/services/link-content.ts
+++ b/apps/agor-daemon/src/services/link-content.ts
@@ -198,7 +198,16 @@ export function registerLinkContentRoute(app: Application): void {
       res.setHeader('Content-Disposition', contentDispositionHeader(disposition, file.filename));
       res.sendFile(file.path);
     } catch (error) {
-      const status = error instanceof LinkContentError ? error.status : 500;
+      const status =
+        error instanceof LinkContentError
+          ? error.status
+          : typeof (error as { code?: unknown }).code === 'number'
+            ? ((error as { code: number }).code ?? 500)
+            : typeof (error as { status?: unknown }).status === 'number'
+              ? ((error as { status: number }).status ?? 500)
+              : typeof (error as { statusCode?: unknown }).statusCode === 'number'
+                ? ((error as { statusCode: number }).statusCode ?? 500)
+                : 500;
       const message = error instanceof Error ? error.message : 'Failed to load file content';
       res.status(status).json({ error: status >= 500 ? 'Failed to load file content' : message });
     }

--- a/apps/agor-daemon/src/services/link-promotion.test.ts
+++ b/apps/agor-daemon/src/services/link-promotion.test.ts
@@ -5,9 +5,9 @@ import {
   SessionRepository,
   UsersRepository,
 } from '@agor/core/db';
-import type { Branch, BranchID, SessionID, UUID } from '@agor/core/types';
+import type { Branch, BranchID, Link, SessionID, UUID } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import type { Database } from '../../../../packages/core/src/db/client';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { generateId } from '../../../../packages/core/src/lib/ids';
@@ -256,6 +256,67 @@ describe('promoteLinkToAssistant', () => {
           } as never,
         })
       ).rejects.toThrow(/all' permission/);
+    }
+  );
+
+  dbTest(
+    'loads the source with caller params and creates assistant copy internally',
+    async ({ db }) => {
+      const assistant = await seedBranch(db, { assistant: true });
+      const source = {
+        link_id: generateId(),
+        branch_id: null,
+        session_id: generateId(),
+        source_message_id: null,
+        kind: 'url',
+        source: 'manual',
+        url: 'https://example.com/visible-source',
+        ref_uri: null,
+        file_path: null,
+        target_key: 'url:https://example.com/visible-source',
+        is_pinned: false,
+        title: 'Visible source',
+        mime_type: null,
+        metadata: null,
+        created_by: null,
+        created_at: '2026-07-06T00:00:00.000Z',
+        updated_at: '2026-07-06T00:00:00.000Z',
+      } as Link;
+      const get = vi.fn(async () => source);
+      const create = vi.fn(async (data: unknown) => ({
+        ...source,
+        ...data,
+        link_id: generateId(),
+      }));
+      const params = {
+        provider: 'rest',
+        user: { user_id: generateId(), role: ROLES.MEMBER },
+        tenant: { tenant_id: 'tenant-a' },
+      } as never;
+
+      await promoteLinkToAssistant(
+        {
+          linksService: { get, create },
+          branchRepository: new BranchRepository(db),
+          branchRbacEnabled: false,
+          superadminOpts: { allowSuperadmin: true },
+        },
+        {
+          sourceLinkId: source.link_id,
+          assistantBranchId: assistant.branch_id,
+          params,
+        }
+      );
+
+      expect(get).toHaveBeenCalledWith(source.link_id, params);
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branch_id: assistant.branch_id,
+          url: source.url,
+          is_pinned: true,
+        }),
+        expect.objectContaining({ provider: undefined, tenant: { tenant_id: 'tenant-a' } })
+      );
     }
   );
 });

--- a/apps/agor-daemon/src/services/link-promotion.test.ts
+++ b/apps/agor-daemon/src/services/link-promotion.test.ts
@@ -1,0 +1,261 @@
+import {
+  BranchRepository,
+  LinksRepository,
+  RepoRepository,
+  SessionRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Branch, BranchID, SessionID, UUID } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import type { Database } from '../../../../packages/core/src/db/client';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { generateId } from '../../../../packages/core/src/lib/ids';
+import { promoteLinkToAssistant } from './link-promotion';
+import { LinksService } from './links';
+
+async function seedUser(db: Database, userId: UUID, email: string) {
+  await new UsersRepository(db).create({ user_id: userId, email, name: email });
+}
+
+async function seedRepo(db: Database) {
+  return new RepoRepository(db).create({
+    repo_id: generateId() as UUID,
+    slug: `link-promotion-repo-${generateId()}`,
+    name: 'Link Promotion Repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/example/repo.git',
+    local_path: `/tmp/${generateId()}`,
+    default_branch: 'main',
+  });
+}
+
+async function seedBranch(
+  db: Database,
+  options: {
+    createdBy?: UUID;
+    assistant?: boolean;
+    othersCan?: Branch['others_can'];
+  } = {}
+) {
+  const repo = await seedRepo(db);
+  return new BranchRepository(db).create({
+    branch_id: generateId() as BranchID,
+    repo_id: repo.repo_id,
+    name: options.assistant ? `assistant-${generateId()}` : `branch-${generateId()}`,
+    ref: 'refs/heads/test',
+    branch_unique_id: 1,
+    path: `/tmp/${generateId()}`,
+    created_by: options.createdBy ?? ('owner' as UUID),
+    permission_source: 'override',
+    others_can: options.othersCan ?? 'view',
+    custom_context: options.assistant
+      ? { assistant: { kind: 'assistant', displayName: 'Assistant' } }
+      : undefined,
+  });
+}
+
+async function seedSession(db: Database, branchId: BranchID, createdBy: UUID = 'owner' as UUID) {
+  return new SessionRepository(db).create({
+    session_id: generateId() as SessionID,
+    branch_id: branchId,
+    created_by: createdBy,
+    tasks: [],
+    genealogy: { children: [] },
+  });
+}
+
+function promotionDeps(db: Database, branchRbacEnabled = false) {
+  return {
+    linksService: new LinksService(db),
+    branchRepository: new BranchRepository(db),
+    branchRbacEnabled,
+    superadminOpts: { allowSuperadmin: true },
+  };
+}
+
+describe('promoteLinkToAssistant', () => {
+  dbTest(
+    'copies a session URL link into the assistant branch pinned and keeps the source',
+    async ({ db }) => {
+      const sourceBranch = await seedBranch(db);
+      const assistant = await seedBranch(db, { assistant: true });
+      const session = await seedSession(db, sourceBranch.branch_id);
+      const source = await new LinksRepository(db).create({
+        session_id: session.session_id,
+        kind: 'url',
+        source: 'parsed',
+        url: 'https://example.com/docs',
+        title: 'Docs',
+        metadata: { sourceNote: 'keep' },
+      });
+
+      const promoted = await promoteLinkToAssistant(promotionDeps(db), {
+        sourceLinkId: source.link_id,
+        assistantBranchId: assistant.branch_id,
+      });
+
+      expect(promoted.link_id).not.toBe(source.link_id);
+      expect(promoted.branch_id).toBe(assistant.branch_id);
+      expect(promoted.session_id).toBeNull();
+      expect(promoted.url).toBe(source.url);
+      expect(promoted.source).toBe('manual');
+      expect(promoted.is_pinned).toBe(true);
+      expect(promoted.metadata).toMatchObject({
+        sourceNote: 'keep',
+        promoted_from_link_id: source.link_id,
+        promoted_from_owner: { session_id: session.session_id },
+      });
+
+      expect(await new LinksRepository(db).findById(source.link_id)).toMatchObject({
+        session_id: session.session_id,
+        is_pinned: false,
+      });
+    }
+  );
+
+  dbTest(
+    'copies ref and uploaded file links without browser-created file payloads',
+    async ({ db }) => {
+      const sourceBranch = await seedBranch(db);
+      const assistant = await seedBranch(db, { assistant: true });
+      const session = await seedSession(db, sourceBranch.branch_id);
+      const repo = new LinksRepository(db);
+      const refSource = await repo.create({
+        session_id: session.session_id,
+        kind: 'kb_ref',
+        source: 'parsed',
+        ref_uri: 'agor://kb/team/runbook.md',
+        title: 'Runbook',
+      });
+      const fileSource = await repo.create({
+        session_id: session.session_id,
+        kind: 'document',
+        source: 'upload',
+        file_path: '/home/agor/.agor/uploads/session/spec.pdf',
+        title: 'spec.pdf',
+        mime_type: 'application/pdf',
+      });
+
+      const promotedRef = await promoteLinkToAssistant(promotionDeps(db), {
+        sourceLinkId: refSource.link_id,
+        assistantBranchId: assistant.branch_id,
+      });
+      const promotedFile = await promoteLinkToAssistant(promotionDeps(db), {
+        sourceLinkId: fileSource.link_id,
+        assistantBranchId: assistant.branch_id,
+      });
+
+      expect(promotedRef).toMatchObject({
+        branch_id: assistant.branch_id,
+        ref_uri: refSource.ref_uri,
+        source: 'manual',
+        is_pinned: true,
+      });
+      expect(promotedFile).toMatchObject({
+        branch_id: assistant.branch_id,
+        file_path: fileSource.file_path,
+        source: 'upload',
+        kind: 'document',
+        mime_type: 'application/pdf',
+        is_pinned: true,
+      });
+    }
+  );
+
+  dbTest('dedupes assistant copies by target_key and re-pins an existing copy', async ({ db }) => {
+    const sourceBranch = await seedBranch(db);
+    const assistant = await seedBranch(db, { assistant: true });
+    const session = await seedSession(db, sourceBranch.branch_id);
+    const repo = new LinksRepository(db);
+    const source = await repo.create({
+      session_id: session.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/repeat#ignored',
+    });
+
+    const first = await promoteLinkToAssistant(promotionDeps(db), {
+      sourceLinkId: source.link_id,
+      assistantBranchId: assistant.branch_id,
+    });
+    await new LinksService(db).patch(first.link_id, { is_pinned: false });
+    const second = await promoteLinkToAssistant(promotionDeps(db), {
+      sourceLinkId: source.link_id,
+      assistantBranchId: assistant.branch_id,
+    });
+
+    expect(second.link_id).toBe(first.link_id);
+    expect(second.is_pinned).toBe(true);
+    expect(await repo.findAll({ branchId: assistant.branch_id })).toHaveLength(1);
+  });
+
+  dbTest('removing the assistant copy leaves the original source link intact', async ({ db }) => {
+    const sourceBranch = await seedBranch(db);
+    const assistant = await seedBranch(db, { assistant: true });
+    const session = await seedSession(db, sourceBranch.branch_id);
+    const repo = new LinksRepository(db);
+    const source = await repo.create({
+      session_id: session.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/remove-copy',
+    });
+    const promoted = await promoteLinkToAssistant(promotionDeps(db), {
+      sourceLinkId: source.link_id,
+      assistantBranchId: assistant.branch_id,
+    });
+
+    await new LinksService(db).remove(promoted.link_id);
+
+    expect(await repo.findById(promoted.link_id)).toBeNull();
+    expect(await repo.findById(source.link_id)).toMatchObject({ link_id: source.link_id });
+  });
+
+  dbTest('rejects non-assistant targets', async ({ db }) => {
+    const sourceBranch = await seedBranch(db);
+    const nonAssistant = await seedBranch(db);
+    const session = await seedSession(db, sourceBranch.branch_id);
+    const source = await new LinksRepository(db).create({
+      session_id: session.session_id,
+      kind: 'url',
+      source: 'manual',
+      url: 'https://example.com/not-assistant',
+    });
+
+    await expect(
+      promoteLinkToAssistant(promotionDeps(db), {
+        sourceLinkId: source.link_id,
+        assistantBranchId: nonAssistant.branch_id,
+      })
+    ).rejects.toThrow(/not an assistant/);
+  });
+
+  dbTest(
+    'requires all permission on the target assistant when branch RBAC is enabled',
+    async ({ db }) => {
+      const caller = generateId() as UUID;
+      await seedUser(db, caller, 'promoter@example.com');
+      const sourceBranch = await seedBranch(db, { othersCan: 'view' });
+      const assistant = await seedBranch(db, { assistant: true, othersCan: 'view' });
+      const session = await seedSession(db, sourceBranch.branch_id);
+      const source = await new LinksRepository(db).create({
+        session_id: session.session_id,
+        kind: 'url',
+        source: 'manual',
+        url: 'https://example.com/rbac',
+      });
+
+      await expect(
+        promoteLinkToAssistant(promotionDeps(db, true), {
+          sourceLinkId: source.link_id,
+          assistantBranchId: assistant.branch_id,
+          params: {
+            provider: 'rest',
+            user: { user_id: caller, role: ROLES.MEMBER },
+          } as never,
+        })
+      ).rejects.toThrow(/all' permission/);
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/link-promotion.ts
+++ b/apps/agor-daemon/src/services/link-promotion.ts
@@ -1,0 +1,202 @@
+import type { BranchRepository } from '@agor/core/db';
+import { BadRequest, Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
+import type {
+  AuthenticatedParams,
+  Branch,
+  BranchID,
+  Link,
+  LinkCreate,
+  Params,
+  UUID,
+} from '@agor/core/types';
+import { isAssistant, ROLES } from '@agor/core/types';
+import { ensureMinimumRole } from '../utils/authorization.js';
+import { PERMISSION_RANK, resolveBranchPermission } from '../utils/branch-authorization.js';
+
+export interface LinkPromotionRequest {
+  target?: 'assistant';
+  assistant_branch_id?: BranchID | string;
+}
+
+export interface LinkPromotionParams extends AuthenticatedParams {
+  route?: {
+    id?: string;
+  };
+}
+
+export interface LinksServiceForPromotion {
+  get(id: string, params?: Params): Promise<Link>;
+  create(data: Partial<LinkCreate>, params?: Params): Promise<Link | Link[]>;
+}
+
+export interface PromoteLinkToAssistantDeps {
+  linksService: LinksServiceForPromotion;
+  branchRepository: BranchRepository;
+  branchRbacEnabled: boolean;
+  superadminOpts: { allowSuperadmin: boolean };
+}
+
+function getSourceOwner(link: Link): { branch_id: BranchID } | { session_id: Link['session_id'] } {
+  if (link.branch_id) return { branch_id: link.branch_id };
+  return { session_id: link.session_id };
+}
+
+function getSourceTarget(
+  link: Link
+):
+  | Pick<LinkCreate, 'url'>
+  | Pick<LinkCreate, 'ref_uri' | 'target_object_type' | 'target_object_id'>
+  | Pick<LinkCreate, 'file_path'> {
+  if (link.url) return { url: link.url };
+  if (link.ref_uri) {
+    return {
+      ref_uri: link.ref_uri,
+      target_object_type: link.target_object_type ?? null,
+      target_object_id: link.target_object_id ?? null,
+    };
+  }
+  if (link.file_path) return { file_path: link.file_path };
+  throw new BadRequest('Source link has no promotable target');
+}
+
+async function ensureCanMutateAssistantBranch(args: {
+  branch: Branch;
+  branchRepository: BranchRepository;
+  branchRbacEnabled: boolean;
+  params: LinkPromotionParams | undefined;
+  superadminOpts: { allowSuperadmin: boolean };
+}): Promise<void> {
+  const { branch, branchRepository, branchRbacEnabled, params, superadminOpts } = args;
+
+  if (!isAssistant(branch)) {
+    throw new BadRequest('Target branch is not an assistant branch');
+  }
+
+  if (!branchRbacEnabled || !params?.provider) return;
+  if (params.user?._isServiceAccount) return;
+
+  const user = params.user;
+  if (!user) throw new NotAuthenticated('Authentication required');
+
+  const isOwner = await branchRepository.isOwner(branch.branch_id, user.user_id as UUID);
+  const branchPermission = await branchRepository.resolveUserPermission(
+    branch,
+    user.user_id as UUID
+  );
+  const effectiveLevel = resolveBranchPermission(
+    branch,
+    user.user_id as UUID,
+    isOwner,
+    user.role,
+    superadminOpts.allowSuperadmin,
+    branchPermission
+  );
+
+  if (PERMISSION_RANK[effectiveLevel] >= PERMISSION_RANK.all) return;
+
+  throw new Forbidden(
+    `You need 'all' permission to promote links to this assistant. You have '${effectiveLevel}' permission.`
+  );
+}
+
+function buildPromotedMetadata(args: {
+  source: Link;
+  promotedAt: string;
+  promotedBy?: UUID | null;
+}): Link['metadata'] {
+  const sourceMetadata =
+    args.source.metadata &&
+    typeof args.source.metadata === 'object' &&
+    !Array.isArray(args.source.metadata)
+      ? args.source.metadata
+      : {};
+
+  return {
+    ...sourceMetadata,
+    promoted_from_link_id: args.source.link_id,
+    promoted_from_owner: getSourceOwner(args.source),
+    promoted_at: args.promotedAt,
+    promoted_by: args.promotedBy ?? null,
+  };
+}
+
+export async function promoteLinkToAssistant(
+  deps: PromoteLinkToAssistantDeps,
+  input: {
+    sourceLinkId: string;
+    assistantBranchId: string;
+    params?: LinkPromotionParams;
+  }
+): Promise<Link> {
+  const { linksService, branchRepository, branchRbacEnabled, superadminOpts } = deps;
+  const { sourceLinkId, assistantBranchId, params } = input;
+
+  if (!sourceLinkId) throw new BadRequest('Source link ID is required');
+  if (!assistantBranchId) throw new BadRequest('assistant_branch_id is required');
+
+  ensureMinimumRole(params, ROLES.MEMBER, 'promote links to assistant');
+
+  const source = await linksService.get(sourceLinkId, params as Params);
+  const assistantBranch = await branchRepository.findById(assistantBranchId);
+  if (!assistantBranch) throw new NotFound(`Assistant branch not found: ${assistantBranchId}`);
+
+  await ensureCanMutateAssistantBranch({
+    branch: assistantBranch,
+    branchRepository,
+    branchRbacEnabled,
+    params,
+    superadminOpts,
+  });
+
+  const promotedAt = new Date().toISOString();
+  const promotedBy = (params?.user?.user_id as UUID | undefined) ?? null;
+  const target = getSourceTarget(source);
+  const promoted = await linksService.create(
+    {
+      branch_id: assistantBranch.branch_id,
+      session_id: null,
+      source_message_id: null,
+      kind: source.kind,
+      source: source.file_path ? source.source : 'manual',
+      ...target,
+      is_pinned: true,
+      title: source.title ?? null,
+      mime_type: source.mime_type ?? null,
+      metadata: buildPromotedMetadata({ source, promotedAt, promotedBy }),
+      created_by: promotedBy,
+    },
+    { ...(params as Params), provider: undefined }
+  );
+
+  return Array.isArray(promoted) ? promoted[0] : promoted;
+}
+
+export class LinkPromotionService {
+  constructor(
+    private deps: Omit<PromoteLinkToAssistantDeps, 'linksService'> & {
+      linksService: LinksServiceForPromotion;
+    }
+  ) {}
+
+  async create(data: LinkPromotionRequest, params?: LinkPromotionParams): Promise<Link> {
+    const sourceLinkId = params?.route?.id;
+    if (!sourceLinkId) throw new BadRequest('Source link ID is required');
+    if (data?.target && data.target !== 'assistant') {
+      throw new BadRequest(`Unsupported promotion target: ${String(data.target)}`);
+    }
+
+    return promoteLinkToAssistant(
+      {
+        linksService: this.deps.linksService,
+        branchRepository: this.deps.branchRepository,
+        branchRbacEnabled: this.deps.branchRbacEnabled,
+        superadminOpts: this.deps.superadminOpts,
+      },
+      {
+        sourceLinkId,
+        assistantBranchId: String(data?.assistant_branch_id ?? ''),
+        params,
+      }
+    );
+  }
+}

--- a/apps/agor-daemon/src/services/link-promotion.ts
+++ b/apps/agor-daemon/src/services/link-promotion.ts
@@ -151,22 +151,23 @@ export async function promoteLinkToAssistant(
   const promotedAt = new Date().toISOString();
   const promotedBy = (params?.user?.user_id as UUID | undefined) ?? null;
   const target = getSourceTarget(source);
-  const promoted = await linksService.create(
-    {
-      branch_id: assistantBranch.branch_id,
-      session_id: null,
-      source_message_id: null,
-      kind: source.kind,
-      source: source.file_path ? source.source : 'manual',
-      ...target,
-      is_pinned: true,
-      title: source.title ?? null,
-      mime_type: source.mime_type ?? null,
-      metadata: buildPromotedMetadata({ source, promotedAt, promotedBy }),
-      created_by: promotedBy,
-    },
-    { ...(params as Params), provider: undefined }
-  );
+  const promotedDraft = {
+    branch_id: assistantBranch.branch_id,
+    session_id: null,
+    source_message_id: null,
+    kind: source.kind,
+    source: source.file_path ? source.source : 'manual',
+    ...target,
+    is_pinned: true,
+    title: source.title ?? null,
+    mime_type: source.mime_type ?? null,
+    metadata: buildPromotedMetadata({ source, promotedAt, promotedBy }),
+    created_by: promotedBy,
+  } as Partial<LinkCreate>;
+  const promoted = await linksService.create(promotedDraft, {
+    ...(params as Params),
+    provider: undefined,
+  });
 
   return Array.isArray(promoted) ? promoted[0] : promoted;
 }

--- a/apps/agor-daemon/src/services/links.test.ts
+++ b/apps/agor-daemon/src/services/links.test.ts
@@ -4,6 +4,7 @@ import {
   MessagesRepository,
   RepoRepository,
   SessionRepository,
+  TaskRepository,
   UsersRepository,
 } from '@agor/core/db';
 import type { BranchID, Link, Message, MessageID, SessionID, UUID } from '@agor/core/types';
@@ -11,7 +12,12 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Database } from '../../../../packages/core/src/db/client';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { generateId } from '../../../../packages/core/src/lib/ids';
-import { ingestParsedLinksAfterMessageCreate, LINKS_SERVICE_METHODS, LinksService } from './links';
+import {
+  associateUploadLinksAfterMessageCreate,
+  ingestParsedLinksAfterMessageCreate,
+  LINKS_SERVICE_METHODS,
+  LinksService,
+} from './links';
 
 async function seedUser(db: Database, userId: UUID, email: string) {
   await new UsersRepository(db).create({ user_id: userId, email, name: email });
@@ -236,6 +242,135 @@ describe('LinksService', () => {
         tenant,
         authentication: { payload: { tenant_id: 'tenant-a' } },
       })
+    );
+  });
+
+  dbTest('associates task upload links from the message-create hook', async ({ db }) => {
+    const branch = await seedBranch(db, 'view');
+    const session = await seedSession(db, branch.branch_id);
+    const task = await new TaskRepository(db).create({
+      session_id: session.session_id,
+      created_by: 'owner' as UUID,
+      full_prompt: '',
+      metadata: {
+        upload_link_ids: [],
+      },
+    });
+    const upload = await new LinksRepository(db).create({
+      session_id: session.session_id,
+      kind: 'document',
+      source: 'upload',
+      file_path: '/home/agor/.agor/uploads/session/spec.pdf',
+      mime_type: 'application/pdf',
+    });
+    const parsed = await new LinksRepository(db).create({
+      session_id: session.session_id,
+      kind: 'url',
+      source: 'parsed',
+      url: 'https://example.com/not-upload',
+    });
+    const otherSession = await seedSession(db, branch.branch_id);
+    const otherUpload = await new LinksRepository(db).create({
+      session_id: otherSession.session_id,
+      kind: 'document',
+      source: 'upload',
+      file_path: '/home/agor/.agor/uploads/other/spec.pdf',
+      mime_type: 'application/pdf',
+    });
+    await new TaskRepository(db).update(task.task_id, {
+      metadata: {
+        upload_link_ids: [upload.link_id, parsed.link_id, otherUpload.link_id],
+      },
+    });
+
+    const linksService = new LinksService(db);
+    const app = {
+      service: vi.fn((path: string) => {
+        if (path === 'links') return linksService;
+        if (path === 'tasks') {
+          return {
+            get: (id: string) => new TaskRepository(db).findById(id),
+          };
+        }
+        throw new Error(`Unexpected service: ${path}`);
+      }),
+    };
+    const hook = associateUploadLinksAfterMessageCreate(app as never);
+    const message = {
+      message_id: generateId() as MessageID,
+      session_id: session.session_id,
+      task_id: task.task_id,
+      type: 'user',
+      role: 'user',
+      index: 0,
+      timestamp: new Date().toISOString(),
+      content_preview: '',
+      content: '',
+    } as Message;
+    await new MessagesRepository(db).create(message);
+
+    await hook({ result: message, params: { provider: 'rest' } } as never);
+
+    await expect(new LinksRepository(db).findById(upload.link_id)).resolves.toMatchObject({
+      source_message_id: message.message_id,
+    });
+    await expect(new LinksRepository(db).findById(parsed.link_id)).resolves.toMatchObject({
+      source_message_id: null,
+    });
+    await expect(new LinksRepository(db).findById(otherUpload.link_id)).resolves.toMatchObject({
+      source_message_id: null,
+    });
+  });
+
+  it('uses internal provider context when associating upload links', async () => {
+    const taskId = generateId();
+    const message = {
+      message_id: generateId() as MessageID,
+      session_id: generateId() as SessionID,
+      task_id: taskId,
+      type: 'user',
+      role: 'user',
+      index: 0,
+      timestamp: new Date().toISOString(),
+      content_preview: '',
+      content: '',
+    } as Message;
+    const getTask = vi.fn(async () => ({
+      task_id: taskId,
+      metadata: { upload_link_ids: ['link-1'] },
+    }));
+    const getLink = vi.fn(async () => ({
+      link_id: 'link-1',
+      session_id: message.session_id,
+      source: 'upload',
+      source_message_id: null,
+    }));
+    const patchLink = vi.fn(async () => ({}));
+    const app = {
+      service: vi.fn((path: string) => {
+        if (path === 'tasks') return { get: getTask };
+        if (path === 'links') return { get: getLink, patch: patchLink };
+        throw new Error(`Unexpected service: ${path}`);
+      }),
+    };
+
+    await associateUploadLinksAfterMessageCreate(app as never)({
+      result: message,
+      params: { provider: 'rest', tenant: { tenant_id: 'tenant-a' } },
+    } as never);
+
+    expect(getTask).toHaveBeenCalledWith(
+      taskId,
+      expect.objectContaining({ provider: undefined, tenant: { tenant_id: 'tenant-a' } })
+    );
+    expect(getLink).toHaveBeenCalledWith(
+      'link-1',
+      expect.objectContaining({ provider: undefined, tenant: { tenant_id: 'tenant-a' } })
+    );
+    expect(patchLink).toHaveBeenCalledWith(
+      'link-1',
+      { source_message_id: message.message_id },
+      expect.objectContaining({ provider: undefined, tenant: { tenant_id: 'tenant-a' } })
     );
   });
 });

--- a/apps/agor-daemon/src/services/links.ts
+++ b/apps/agor-daemon/src/services/links.ts
@@ -22,9 +22,10 @@ import type {
   Params,
   QueryParams,
   SessionID,
+  Task,
   UUID,
 } from '@agor/core/types';
-import { extractLinksFromMessage } from '@agor/core/types';
+import { extractLinksFromMessage, shortId } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
 
 export const LINKS_SERVICE_METHODS = ['find', 'get', 'create', 'patch', 'remove'] as const;
@@ -151,6 +152,84 @@ export function ingestParsedLinksAfterMessageCreate(app: Application) {
         provider: undefined,
       } as Params);
     }
+    return context;
+  };
+}
+
+function uploadLinkIdsFromTask(task: Pick<Task, 'metadata'> | null | undefined): string[] {
+  const ids = task?.metadata?.upload_link_ids;
+  if (!Array.isArray(ids)) return [];
+  const result: string[] = [];
+  for (const id of ids) {
+    if (typeof id === 'string' && id.length > 0) result.push(id);
+  }
+  return result;
+}
+
+export async function associateUploadLinksWithMessage(
+  app: Application,
+  message: Message,
+  params?: Params
+): Promise<void> {
+  if (!message.task_id) return;
+
+  const task = (await app
+    .service('tasks')
+    .get(message.task_id, {
+      ...params,
+      provider: undefined,
+    } as Params)
+    .catch((err: unknown) => {
+      console.warn(
+        `⚠️  [Links] Failed to load task ${shortId(message.task_id as string)} for upload link association:`,
+        err
+      );
+      return null;
+    })) as Task | null;
+  const uploadLinkIds = uploadLinkIdsFromTask(task);
+  if (uploadLinkIds.length === 0) return;
+
+  const linksService = app.service('links') as unknown as {
+    get(id: string, params?: Params): Promise<Link>;
+    patch(id: string, data: Partial<Link>, params?: Params): Promise<Link | Link[]>;
+  };
+
+  await Promise.all(
+    uploadLinkIds.map(async (linkId) => {
+      try {
+        const link = await linksService.get(linkId, {
+          ...params,
+          provider: undefined,
+        } as Params);
+        if (
+          link.session_id !== message.session_id ||
+          link.source !== 'upload' ||
+          link.source_message_id
+        ) {
+          return;
+        }
+        await linksService.patch(linkId, { source_message_id: message.message_id }, {
+          ...params,
+          provider: undefined,
+        } as Params);
+      } catch (linkErr) {
+        console.warn(
+          `⚠️  [Links] Failed to associate upload link ${String(linkId).slice(0, 8)} with message ${shortId(message.message_id)}:`,
+          linkErr
+        );
+      }
+    })
+  );
+}
+
+export function associateUploadLinksAfterMessageCreate(app: Application) {
+  return async (context: HookContext): Promise<HookContext> => {
+    const messages = normalizeCreatedMessages(context.result);
+    if (messages.length === 0) return context;
+
+    await Promise.all(
+      messages.map((message) => associateUploadLinksWithMessage(app, message, context.params))
+    );
     return context;
   };
 }

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1302,6 +1302,7 @@ export const App: React.FC<AppProps> = ({
                           session={selectedSession}
                           branch={selectedSessionBranch}
                           currentUserId={user?.user_id}
+                          primaryAssistantId={primaryAssistantId}
                           sessionMcpServerIds={
                             sessionMcpServerIds.get(effectiveSelectedSessionId) ??
                             EMPTY_STRING_ARRAY

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.test.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.test.tsx
@@ -1,26 +1,86 @@
-import type { Board } from '@agor-live/client';
-import { render, screen } from '@testing-library/react';
+import type { AgorClient, Board, Branch, Link, Repo } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ComponentProps } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { BoardAssistantPanel } from './BoardAssistantPanel';
 
 const board = { board_id: 'board-1' } as Board;
+const assistantBranch = {
+  branch_id: 'assistant-1',
+  repo_id: 'repo-1',
+  name: 'assistant',
+  custom_context: { assistant: { kind: 'assistant', displayName: 'Helper' } },
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+} as Branch;
+const assistantRepo = {
+  repo_id: 'repo-1',
+  slug: 'agor',
+  name: 'Agor',
+  repo_type: 'local',
+} as Repo;
+
+function makePinnedLink(index: number): Link {
+  return {
+    link_id: `link-${index}`,
+    branch_id: assistantBranch.branch_id,
+    session_id: null,
+    title: `Link ${index}`,
+    url: `https://example.com/${index}`,
+    kind: 'url',
+    source: 'manual',
+    target_key: `url:https://example.com/${index}`,
+    is_pinned: true,
+    created_at: `2026-01-01T00:00:0${index}.000Z`,
+    updated_at: `2026-01-01T00:00:0${index}.000Z`,
+  } as Link;
+}
+
+function makeClient(links: Link[]): AgorClient {
+  const linksService = {
+    find: vi.fn().mockResolvedValue({ data: links }),
+    patch: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return {
+    service: vi.fn((name: string) => {
+      if (name === 'links') return linksService;
+      throw new Error(`Unexpected service ${name}`);
+    }),
+  } as unknown as AgorClient;
+}
 
 const renderPanel = (props: Partial<ComponentProps<typeof BoardAssistantPanel>> = {}) =>
   render(
-    <AntApp>
-      <BoardAssistantPanel
-        board={board}
-        activeTab="comments"
-        onTabChange={vi.fn()}
-        primaryAssistantInaccessible={false}
-        onSessionClick={vi.fn()}
-        client={null}
-        {...props}
-      />
-    </AntApp>
+    <MemoryRouter>
+      <AntApp>
+        <BoardAssistantPanel
+          board={board}
+          activeTab="comments"
+          onTabChange={vi.fn()}
+          primaryAssistantInaccessible={false}
+          onSessionClick={vi.fn()}
+          client={null}
+          {...props}
+        />
+      </AntApp>
+    </MemoryRouter>
   );
+
+const renderAssistantPanel = (
+  links: Link[],
+  props: Partial<ComponentProps<typeof BoardAssistantPanel>> = {}
+) =>
+  renderPanel({
+    activeTab: 'assistant',
+    primaryAssistantBranch: assistantBranch,
+    primaryAssistantRepo: assistantRepo,
+    client: makeClient(links),
+    ...props,
+  });
 
 describe('BoardAssistantPanel controlled tabs', () => {
   it('does not reset a controlled Comments tab to the default tab on mount', () => {
@@ -30,5 +90,40 @@ describe('BoardAssistantPanel controlled tabs', () => {
 
     expect(screen.getByRole('tab', { name: 'Comments' })).toHaveAttribute('aria-selected', 'true');
     expect(onTabChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('BoardAssistantPanel assistant pinned links', () => {
+  it('shows six pinned links inline without a more affordance at the limit', async () => {
+    renderAssistantPanel(Array.from({ length: 6 }, (_, index) => makePinnedLink(index + 1)));
+
+    expect(await screen.findByText('Link 1')).toBeInTheDocument();
+    expect(screen.getByText('Link 6')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /\+\d+ more/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the hidden pinned link count above the inline limit', async () => {
+    renderAssistantPanel(Array.from({ length: 8 }, (_, index) => makePinnedLink(index + 1)));
+
+    expect(await screen.findByText('Link 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+2 more' })).toBeInTheDocument();
+    expect(screen.queryByText('Link 7')).not.toBeInTheDocument();
+    expect(screen.queryByText('Link 8')).not.toBeInTheDocument();
+  });
+
+  it('opens the assistant branch modal on the Links tab when clicking more', async () => {
+    const onOpenSettings = vi.fn();
+    renderAssistantPanel(
+      Array.from({ length: 7 }, (_, index) => makePinnedLink(index + 1)),
+      {
+        onOpenSettings,
+      }
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: '+1 more' }));
+
+    await waitFor(() => {
+      expect(onOpenSettings).toHaveBeenCalledWith(assistantBranch.branch_id, 'links');
+    });
   });
 });

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -45,7 +45,7 @@ import { CreatedByTag } from '../metadata';
 import { IssuePill, PullRequestPill } from '../Pill';
 
 export type BoardAssistantPanelTab = 'assistant' | 'all-sessions' | 'comments';
-const ASSISTANT_PINNED_LINK_INLINE_LIMIT = 3;
+const ASSISTANT_PINNED_LINK_INLINE_LIMIT = 6;
 
 function AssistantPinnedLinksBlock({
   links,
@@ -53,12 +53,14 @@ function AssistantPinnedLinksBlock({
   error,
   onTogglePinned,
   pinningLinkId,
+  onOpenMore,
 }: {
   links: Link[];
   loading: boolean;
   error: string | null;
   onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
   pinningLinkId?: string | null;
+  onOpenMore?: () => void;
 }) {
   const { token } = theme.useToken();
   const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
@@ -74,6 +76,7 @@ function AssistantPinnedLinksBlock({
     () => pinnedItems.slice(0, ASSISTANT_PINNED_LINK_INLINE_LIMIT),
     [pinnedItems]
   );
+  const hiddenCount = pinnedItems.length - inlineItems.length;
 
   if (!loading && !error && pinnedItems.length === 0) return null;
 
@@ -124,6 +127,21 @@ function AssistantPinnedLinksBlock({
                 pinning={item.linkId === pinningLinkId}
               />
             ))}
+            {hiddenCount > 0 && (
+              <Button
+                type="link"
+                size="small"
+                onClick={onOpenMore}
+                style={{
+                  alignSelf: 'flex-start',
+                  height: 24,
+                  padding: `0 ${token.sizeUnit * 1.5}px`,
+                  fontSize: 12,
+                }}
+              >
+                +{hiddenCount} more
+              </Button>
+            )}
           </Space>
         ) : loading ? (
           <Typography.Text type="secondary" style={{ fontSize: 12 }}>
@@ -494,6 +512,7 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
             error={assistantLinksError}
             onTogglePinned={handleToggleAssistantPinned}
             pinningLinkId={assistantPinningLinkId}
+            onOpenMore={() => onOpenSettings?.(primaryAssistantBranch.branch_id, 'links')}
           />
 
           <BranchSessionSections

--- a/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
+++ b/apps/agor-ui/src/components/BoardAssistantPanel/BoardAssistantPanel.tsx
@@ -1,6 +1,6 @@
-import type { AgorClient, Board, Branch, Repo, SpawnConfig } from '@agor-live/client';
+import type { AgorClient, Board, Branch, Link, Repo, SpawnConfig } from '@agor-live/client';
 import { getAssistantConfig, isAssistant } from '@agor-live/client';
-import { LeftOutlined, RobotOutlined } from '@ant-design/icons';
+import { LeftOutlined, PushpinFilled, RobotOutlined } from '@ant-design/icons';
 import {
   Alert,
   App as AntApp,
@@ -30,11 +30,111 @@ import { BranchHeaderPill } from '../BranchHeaderPill';
 import { BoardSessionList } from '../BranchListDrawer';
 import type { BranchModalTab } from '../BranchModal';
 import { CommentsPanel } from '../CommentsPanel';
+import {
+  buildLinkDisplayItems,
+  isBranchOwnedLink,
+  type LinkDisplayItem,
+  normalizeLinkFindResult,
+  reconcilePinnedBranchLink,
+  removeLinkById,
+} from '../Links/linkDisplay';
+import { dispatchLinkMutation, listenForLinkMutations } from '../Links/linkEvents';
+import { LinkPreviewModal, LinkRow, useLinkFileActions } from '../Links/SessionLinksControl';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { CreatedByTag } from '../metadata';
 import { IssuePill, PullRequestPill } from '../Pill';
 
 export type BoardAssistantPanelTab = 'assistant' | 'all-sessions' | 'comments';
+const ASSISTANT_PINNED_LINK_INLINE_LIMIT = 3;
+
+function AssistantPinnedLinksBlock({
+  links,
+  loading,
+  error,
+  onTogglePinned,
+  pinningLinkId,
+}: {
+  links: Link[];
+  loading: boolean;
+  error: string | null;
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  pinningLinkId?: string | null;
+}) {
+  const { token } = theme.useToken();
+  const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
+  const items = useMemo(
+    () =>
+      buildLinkDisplayItems({ links, includeBranchLinks: false }).filter(
+        (item) => item.ownerScope === 'branch'
+      ),
+    [links]
+  );
+  const pinnedItems = useMemo(() => items.filter((item) => item.isPinned), [items]);
+  const inlineItems = useMemo(
+    () => pinnedItems.slice(0, ASSISTANT_PINNED_LINK_INLINE_LIMIT),
+    [pinnedItems]
+  );
+
+  if (!loading && !error && pinnedItems.length === 0) return null;
+
+  return (
+    <>
+      <div
+        style={{
+          margin: `${token.sizeUnit}px 0 ${token.sizeUnit * 3}px`,
+          padding: `${token.sizeUnit * 0.5}px 0 ${token.sizeUnit * 2}px`,
+          borderBottom: `1px dashed ${token.colorBorderSecondary}`,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: token.sizeUnit,
+            marginBottom: pinnedItems.length > 0 || loading || error ? token.sizeUnit : 0,
+          }}
+        >
+          <PushpinFilled style={{ color: token.colorTextTertiary, fontSize: 11 }} />
+          <Typography.Text type="secondary" style={{ fontSize: 12, fontWeight: 600 }}>
+            Pinned links
+          </Typography.Text>
+          {pinnedItems.length > 0 && (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              {pinnedItems.length}
+            </Typography.Text>
+          )}
+          {loading && <Spin size="small" style={{ marginLeft: 'auto' }} />}
+        </div>
+
+        {error ? (
+          <Typography.Text type="danger" style={{ fontSize: 12 }}>
+            {error}
+          </Typography.Text>
+        ) : inlineItems.length > 0 ? (
+          <Space direction="vertical" size={2} style={{ width: '100%' }}>
+            {inlineItems.map((item) => (
+              <LinkRow
+                key={item.key}
+                item={item}
+                compact
+                onPreview={openPreview}
+                onDownload={downloadItem}
+                onTogglePinned={onTogglePinned}
+                busy={item.linkId === busyLinkId}
+                pinning={item.linkId === pinningLinkId}
+              />
+            ))}
+          </Space>
+        ) : loading ? (
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            Loading assistant links…
+          </Typography.Text>
+        ) : null}
+      </div>
+      <LinkPreviewModal preview={preview} onClose={() => setPreview(null)} />
+    </>
+  );
+}
 
 interface BoardAssistantPanelProps {
   board: Board | null;
@@ -206,6 +306,98 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
     [primaryAssistantBranch, sessionsByBranch]
   );
 
+  const assistantBranchId = primaryAssistantBranch?.branch_id;
+  const [assistantLinks, setAssistantLinks] = useState<Link[]>([]);
+  const [assistantLinksLoading, setAssistantLinksLoading] = useState(false);
+  const [assistantLinksError, setAssistantLinksError] = useState<string | null>(null);
+  const [assistantPinningLinkId, setAssistantPinningLinkId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!client || !assistantBranchId) {
+      setAssistantLinks([]);
+      setAssistantLinksLoading(false);
+      setAssistantLinksError(null);
+      return;
+    }
+
+    let active = true;
+    const linksService = client.service('links');
+
+    const upsertAssistantLink = (link: Link) => {
+      setAssistantLinks((prev) => reconcilePinnedBranchLink(prev, link, assistantBranchId));
+    };
+
+    const removeAssistantLink = (link: Link) => {
+      setAssistantLinks((prev) => removeLinkById(prev, link));
+    };
+
+    const fetchAssistantLinks = async () => {
+      setAssistantLinksLoading(true);
+      setAssistantLinksError(null);
+      try {
+        const result = await linksService.find({
+          query: { branch_id: assistantBranchId, is_pinned: true, $limit: 20 },
+        });
+        if (active) {
+          setAssistantLinks(
+            normalizeLinkFindResult(result).filter(
+              (link) => isBranchOwnedLink(link, assistantBranchId) && link.is_pinned
+            )
+          );
+        }
+      } catch (error) {
+        if (!active) return;
+        console.error('[BoardAssistantPanel] Failed to fetch assistant links:', error);
+        setAssistantLinks([]);
+        setAssistantLinksError(
+          error instanceof Error ? error.message : 'Failed to load assistant links'
+        );
+      } finally {
+        if (active) setAssistantLinksLoading(false);
+      }
+    };
+
+    fetchAssistantLinks();
+    linksService.on('created', upsertAssistantLink);
+    linksService.on('patched', upsertAssistantLink);
+    linksService.on('updated', upsertAssistantLink);
+    linksService.on('removed', removeAssistantLink);
+    const stopListeningForLocalMutations = listenForLinkMutations(({ link, mutation }) => {
+      if (mutation === 'removed') {
+        removeAssistantLink(link);
+      } else {
+        upsertAssistantLink(link);
+      }
+    });
+
+    return () => {
+      active = false;
+      linksService.off('created', upsertAssistantLink);
+      linksService.off('patched', upsertAssistantLink);
+      linksService.off('updated', upsertAssistantLink);
+      linksService.off('removed', removeAssistantLink);
+      stopListeningForLocalMutations();
+    };
+  }, [assistantBranchId, client]);
+
+  const handleToggleAssistantPinned = async (item: LinkDisplayItem) => {
+    if (!client || !assistantBranchId || !item.linkId || assistantPinningLinkId) return;
+    setAssistantPinningLinkId(item.linkId);
+    try {
+      const updated = await client.service('links').patch(item.linkId, {
+        is_pinned: !item.isPinned,
+      });
+      setAssistantLinks((prev) => reconcilePinnedBranchLink(prev, updated, assistantBranchId));
+      dispatchLinkMutation({ link: updated, mutation: 'patched' });
+    } catch (error) {
+      message.error(
+        `Failed to update pin: ${error instanceof Error ? error.message : String(error)}`
+      );
+    } finally {
+      setAssistantPinningLinkId(null);
+    }
+  };
+
   const assistantContent = (() => {
     if (primaryAssistantBranch && primaryAssistantRepo) {
       const assistantConfig = getAssistantConfig(primaryAssistantBranch);
@@ -295,6 +487,14 @@ export const BoardAssistantPanel: React.FC<BoardAssistantPanelProps> = ({
               </div>
             )}
           </div>
+
+          <AssistantPinnedLinksBlock
+            links={assistantLinks}
+            loading={assistantLinksLoading}
+            error={assistantLinksError}
+            onTogglePinned={handleToggleAssistantPinned}
+            pinningLinkId={assistantPinningLinkId}
+          />
 
           <BranchSessionSections
             branch={primaryAssistantBranch}

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -1,4 +1,4 @@
-import type { AgorClient, Branch, Repo, Session, SpawnConfig, User } from '@agor-live/client';
+import type { AgorClient, Branch, Link, Repo, Session, SpawnConfig, User } from '@agor-live/client';
 import { getAssistantConfig, isAssistant, isSessionExecuting } from '@agor-live/client';
 import {
   BranchesOutlined,
@@ -13,6 +13,7 @@ import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useThemedMessage } from '../../utils/message';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
   REACT_FLOW_NO_DRAG_CLASS,
@@ -21,6 +22,16 @@ import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { ArchiveActionButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import { EnvironmentPill } from '../EnvironmentPill';
+import {
+  buildLinkDisplayItems,
+  isBranchOwnedLink,
+  type LinkDisplayItem,
+  normalizeLinkFindResult,
+  reconcilePinnedBranchLink,
+  removeLinkById,
+} from '../Links/linkDisplay';
+import { dispatchLinkMutation, listenForLinkMutations } from '../Links/linkEvents';
+import { LinkPreviewModal, LinkRow, useLinkFileActions } from '../Links/SessionLinksControl';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { CreatedByTag } from '../metadata';
 import { IssuePill, PullRequestPill } from '../Pill';
@@ -30,6 +41,67 @@ import { BranchSessionSections } from './BranchSessionSections';
 const _BRANCH_CARD_MAX_WIDTH = 600;
 const NOTES_MAX_LENGTH = 200; // Character limit for truncated notes
 const PEEK_SESSIONS_STORAGE_KEY_PREFIX = 'agor:branch-card:peeked-session-ids:';
+const BRANCH_CARD_PINNED_LINK_INLINE_LIMIT = 6;
+
+function BranchCardPinnedLinksBlock({
+  items,
+  onTogglePinned,
+  pinningLinkId,
+}: {
+  items: LinkDisplayItem[];
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  pinningLinkId?: string | null;
+}) {
+  const { token } = theme.useToken();
+  const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
+  const inlineItems = useMemo(() => items.slice(0, BRANCH_CARD_PINNED_LINK_INLINE_LIMIT), [items]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <>
+      <div
+        data-testid="branch-card-pinned-links"
+        className={REACT_FLOW_NO_DRAG_CLASS}
+        style={{
+          margin: `${token.sizeUnit}px 0 ${token.sizeUnit * 3}px`,
+          padding: `${token.sizeUnit * 0.5}px 0 ${token.sizeUnit * 2}px`,
+          borderBottom: `1px dashed ${token.colorBorderSecondary}`,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: token.sizeUnit,
+            marginBottom: token.sizeUnit,
+          }}
+        >
+          <PushpinFilled style={{ color: token.colorTextTertiary, fontSize: 11 }} />
+          <Typography.Text type="secondary" style={{ fontSize: 12, fontWeight: 600 }}>
+            Pinned links
+          </Typography.Text>
+        </div>
+
+        <Space direction="vertical" size={2} style={{ width: '100%' }}>
+          {inlineItems.map((item) => (
+            <LinkRow
+              key={item.key}
+              item={item}
+              compact
+              onPreview={openPreview}
+              onDownload={downloadItem}
+              onTogglePinned={onTogglePinned}
+              busy={item.linkId === busyLinkId}
+              pinning={item.linkId === pinningLinkId}
+            />
+          ))}
+        </Space>
+      </div>
+      <LinkPreviewModal preview={preview} onClose={() => setPreview(null)} />
+    </>
+  );
+}
 
 interface BranchCardProps {
   branch: Branch;
@@ -104,10 +176,13 @@ const BranchCardComponent = ({
   client,
 }: BranchCardProps) => {
   const { token } = theme.useToken();
+  const { showError } = useThemedMessage();
   const connectionDisabled = useConnectionDisabled();
 
   // Archive/Delete modal state
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
+  const [pinnedBranchLinks, setPinnedBranchLinks] = useState<Link[]>([]);
+  const [pinningLinkId, setPinningLinkId] = useState<string | null>(null);
 
   // Notes expansion state
   const [notesExpanded, setNotesExpanded] = useState(false);
@@ -174,6 +249,95 @@ const BranchCardComponent = ({
       updatePeekedSessionIds(next);
     },
     [peekedSessionIdSet, peekedSessionIds, updatePeekedSessionIds]
+  );
+
+  useEffect(() => {
+    if (!client || !branch.branch_id) {
+      setPinnedBranchLinks([]);
+      return;
+    }
+
+    let active = true;
+    const linksService = client.service('links');
+
+    const upsertBranchPinnedLink = (link: Link) => {
+      setPinnedBranchLinks((prev) => reconcilePinnedBranchLink(prev, link, branch.branch_id));
+    };
+
+    const removeBranchLink = (link: Link) => {
+      setPinnedBranchLinks((prev) => removeLinkById(prev, link));
+    };
+
+    const fetchPinnedLinks = async () => {
+      try {
+        const result = await linksService.find({
+          query: { branch_id: branch.branch_id, is_pinned: true, $limit: 20 },
+        });
+        if (active) {
+          setPinnedBranchLinks(
+            normalizeLinkFindResult(result).filter(
+              (link) => isBranchOwnedLink(link, branch.branch_id) && link.is_pinned
+            )
+          );
+        }
+      } catch (error) {
+        if (!active) return;
+        console.error('[BranchCard] Failed to fetch pinned links:', error);
+        setPinnedBranchLinks([]);
+      }
+    };
+
+    fetchPinnedLinks();
+    linksService.on('created', upsertBranchPinnedLink);
+    linksService.on('patched', upsertBranchPinnedLink);
+    linksService.on('updated', upsertBranchPinnedLink);
+    linksService.on('removed', removeBranchLink);
+    const stopListeningForLocalMutations = listenForLinkMutations(({ link, mutation }) => {
+      if (mutation === 'removed') {
+        removeBranchLink(link);
+      } else {
+        upsertBranchPinnedLink(link);
+      }
+    });
+
+    return () => {
+      active = false;
+      linksService.off('created', upsertBranchPinnedLink);
+      linksService.off('patched', upsertBranchPinnedLink);
+      linksService.off('updated', upsertBranchPinnedLink);
+      linksService.off('removed', removeBranchLink);
+      stopListeningForLocalMutations();
+    };
+  }, [branch.branch_id, client]);
+
+  const pinnedBranchLinkItems = useMemo(
+    () =>
+      buildLinkDisplayItems({
+        links: pinnedBranchLinks,
+        includeBranchLinks: false,
+      }).filter((item) => item.ownerScope === 'branch' && item.isPinned),
+    [pinnedBranchLinks]
+  );
+
+  const handleToggleLinkPinned = useCallback(
+    async (item: LinkDisplayItem) => {
+      if (!client || !item.linkId || pinningLinkId) return;
+      setPinningLinkId(item.linkId);
+      try {
+        const updated = await client.service('links').patch(item.linkId, {
+          is_pinned: !item.isPinned,
+        });
+        setPinnedBranchLinks((prev) => reconcilePinnedBranchLink(prev, updated, branch.branch_id));
+        dispatchLinkMutation({ link: updated, mutation: 'patched' });
+      } catch (error) {
+        showError(
+          `Failed to update pin: ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        setPinningLinkId(null);
+      }
+    },
+    [branch.branch_id, client, pinningLinkId, showError]
   );
 
   // Filter out archived sessions from board card display
@@ -547,6 +711,14 @@ const BranchCardComponent = ({
             </Button>
           )}
         </div>
+      )}
+
+      {pinnedBranchLinkItems.length > 0 && (
+        <BranchCardPinnedLinksBlock
+          items={pinnedBranchLinkItems}
+          onTogglePinned={handleToggleLinkPinned}
+          pinningLinkId={pinningLinkId}
+        />
       )}
 
       {/* Sessions & Scheduled Runs - composable content shared with the assistant panel */}

--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -11,6 +11,7 @@ import { EnvironmentTab } from './tabs/EnvironmentTab';
 import { FilesTab } from './tabs/FilesTab';
 import { GeneralTab } from './tabs/GeneralTab';
 import { KnowledgeTab } from './tabs/KnowledgeTab';
+import { LinksTab } from './tabs/LinksTab';
 import { PermissionsTab } from './tabs/PermissionsTab';
 import { ScheduleTab } from './tabs/ScheduleTab';
 import { SessionsTab } from './tabs/SessionsTab';
@@ -23,6 +24,7 @@ export type BranchModalTab =
   | 'sessions'
   | 'environment'
   | 'files'
+  | 'links'
   | 'permissions'
   | 'schedule';
 
@@ -205,6 +207,17 @@ export const BranchModal: React.FC<BranchModalProps> = ({
       key: 'files',
       label: 'Files',
       children: <FilesTab branch={branch} client={client} />,
+    },
+    {
+      key: 'links',
+      label: 'Links',
+      children: (
+        <LinksTab
+          branch={branch}
+          client={client}
+          assistantBranchId={branchBoard?.primary_assistant_id ?? null}
+        />
+      ),
     },
     // Permissions tab — shown for RBAC-capable admins/owners. Keep it visible
     // while owner data is loading so confirmed owners do not see the tab

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -817,7 +817,7 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
                         '--agor-link-icon-color': disabled
                           ? token.colorTextDisabled
                           : token.colorTextTertiary,
-                        '--agor-link-row-hover-bg': token.colorFillQuaternary,
+                        '--agor-link-row-hover-bg': 'transparent',
                         '--agor-link-row-hover-color': token.colorPrimary,
                         borderColor: token.colorBorderSecondary,
                         borderRadius: token.borderRadius,

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -1,13 +1,9 @@
 import type { AgorClient, Branch, Link } from '@agor-live/client';
 import {
-  DownloadOutlined,
   EllipsisOutlined,
-  ExportOutlined,
-  EyeOutlined,
   GithubOutlined,
   PushpinFilled,
   PushpinOutlined,
-  RightOutlined,
   StopOutlined,
 } from '@ant-design/icons';
 import type { MenuProps } from 'antd';
@@ -25,7 +21,7 @@ import {
 } from 'antd';
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { useThemedMessage } from '../../../utils/message';
 import {
   LinkImagePreviewModal,
@@ -279,103 +275,6 @@ function BranchTitle({
   );
 }
 
-function BranchAction({
-  item,
-  busy = false,
-  onPreview,
-  onDownload,
-}: {
-  item: LinkDisplayItem;
-  busy?: boolean;
-  onPreview: (item: LinkDisplayItem) => void;
-  onDownload: (item: LinkDisplayItem) => void;
-}) {
-  const { token } = theme.useToken();
-  const title = getCompactLinkDisplayName(item);
-  const contentAction = getLinkContentAction(item);
-  const disabledReason = getUnavailableReason(item);
-  const iconLinkStyle: React.CSSProperties = {
-    width: 24,
-    height: 24,
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
-    borderRadius: token.borderRadiusSM,
-  };
-
-  if (contentAction) {
-    return (
-      <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
-        <Button
-          className="agor-action-link-affordance"
-          type="text"
-          size="small"
-          loading={busy}
-          aria-label={`${contentAction === 'preview' ? 'Preview' : 'Download'} ${title}`}
-          icon={contentAction === 'preview' ? <EyeOutlined /> : <DownloadOutlined />}
-          onClick={() => {
-            if (contentAction === 'preview') onPreview(item);
-            else onDownload(item);
-          }}
-          style={{
-            width: 24,
-            minWidth: 24,
-            height: 24,
-            padding: 0,
-            color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
-          }}
-        />
-      </Tooltip>
-    );
-  }
-
-  if (item.href && item.navigation === 'spa') {
-    return (
-      <Tooltip title="Open link">
-        <RouterLink
-          className="agor-action-link-affordance"
-          aria-label="Open link"
-          to={item.href}
-          style={iconLinkStyle}
-        >
-          <RightOutlined />
-        </RouterLink>
-      </Tooltip>
-    );
-  }
-
-  if (item.href) {
-    return (
-      <Tooltip title="Open link">
-        <a
-          className="agor-action-link-affordance"
-          aria-label="Open link"
-          href={item.href}
-          target="_blank"
-          rel="noreferrer"
-          style={iconLinkStyle}
-        >
-          <ExportOutlined />
-        </a>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Tooltip title={disabledReason ?? 'No route available'}>
-      <span
-        className="agor-action-link-affordance"
-        role="img"
-        aria-label={`No route available for ${title}`}
-        style={{ ...iconLinkStyle, color: token.colorTextDisabled }}
-      >
-        <StopOutlined />
-      </span>
-    </Tooltip>
-  );
-}
-
 function BranchStatusPill({
   item,
   onTogglePinned,
@@ -496,8 +395,13 @@ function BranchAssistantPromotionAction({
   );
 }
 
+function shouldIgnoreRowActivation(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && Boolean(target.closest('a,button,[role="button"]'));
+}
+
 const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranchId = null }) => {
   const { token } = theme.useToken();
+  const navigate = useNavigate();
   const { showError } = useThemedMessage();
   const [links, setLinks] = useState<Link[]>([]);
   const [loading, setLoading] = useState(true);
@@ -669,6 +573,28 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
     [busyLinkId, showError]
   );
 
+  const openItem = useCallback(
+    (item: LinkDisplayItem) => {
+      const contentAction = getLinkContentAction(item);
+      if (contentAction === 'preview') {
+        openPreview(item);
+        return;
+      }
+      if (contentAction === 'download') {
+        void downloadItem(item);
+        return;
+      }
+      if (item.href && item.navigation === 'spa') {
+        navigate(item.href);
+        return;
+      }
+      if (item.href) {
+        window.open(item.href, '_blank', 'noopener,noreferrer');
+      }
+    },
+    [downloadItem, navigate, openPreview]
+  );
+
   const handleTogglePinned = useCallback(
     async (item: LinkDisplayItem) => {
       if (!client || !item.linkId || pinningLinkId) return;
@@ -808,7 +734,19 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
                   <List.Item
                     className="agor-action-link-row"
                     key={item.key}
+                    role={disabled ? undefined : 'link'}
+                    tabIndex={disabled ? -1 : 0}
                     aria-disabled={disabled || undefined}
+                    onClick={(event) => {
+                      if (disabled || shouldIgnoreRowActivation(event.target)) return;
+                      openItem(item);
+                    }}
+                    onKeyDown={(event) => {
+                      if (disabled || shouldIgnoreRowActivation(event.target)) return;
+                      if (event.key !== 'Enter' && event.key !== ' ') return;
+                      event.preventDefault();
+                      openItem(item);
+                    }}
                     style={
                       {
                         '--agor-link-title-color': disabled
@@ -821,17 +759,11 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
                         '--agor-link-row-hover-color': token.colorPrimary,
                         borderColor: token.colorBorderSecondary,
                         borderRadius: token.borderRadius,
+                        cursor: disabled ? 'default' : 'pointer',
                         paddingRight: token.sizeSM,
                       } as React.CSSProperties
                     }
                     actions={[
-                      <BranchAction
-                        key="open"
-                        item={item}
-                        busy={item.linkId === busyLinkId}
-                        onPreview={openPreview}
-                        onDownload={downloadItem}
-                      />,
                       <BranchStatusPill
                         key="state"
                         item={item}

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -147,13 +147,16 @@ function BranchGlyph({ item, disabled = false }: { item: LinkDisplayItem; disabl
   const isGitHubLink = item.category === 'issue' || item.category === 'pr';
   return (
     <span
+      className="agor-action-link-icon"
       aria-hidden="true"
       style={{
         width: 28,
         height: 28,
         borderRadius: token.borderRadiusLG,
         background: token.colorFillTertiary,
-        color: disabled ? token.colorTextDisabled : token.colorTextTertiary,
+        color: disabled
+          ? token.colorTextDisabled
+          : `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -210,14 +213,21 @@ function BranchTitle({
   const contentAction = getLinkContentAction(item);
   const disabled = Boolean(getUnavailableReason(item));
   const style: React.CSSProperties = {
-    color: disabled ? token.colorTextDisabled : token.colorPrimary,
+    color: disabled
+      ? token.colorTextDisabled
+      : `var(--agor-link-title-color, ${token.colorPrimary})`,
     fontWeight: 600,
     lineHeight: 1.25,
   };
 
   if (item.href && item.navigation === 'spa') {
     return (
-      <RouterLink to={item.href} style={{ ...style, textDecoration: 'none' }} title={title}>
+      <RouterLink
+        className="agor-action-link-title"
+        to={item.href}
+        style={{ ...style, textDecoration: 'none' }}
+        title={title}
+      >
         {title}
       </RouterLink>
     );
@@ -226,6 +236,7 @@ function BranchTitle({
   if (item.href) {
     return (
       <a
+        className="agor-action-link-title"
         href={item.href}
         target="_blank"
         rel="noreferrer"
@@ -240,6 +251,7 @@ function BranchTitle({
   if (contentAction) {
     return (
       <button
+        className="agor-action-link-title"
         type="button"
         onClick={() => {
           if (contentAction === 'preview') onPreview(item);
@@ -288,7 +300,7 @@ function BranchAction({
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    color: token.colorTextTertiary,
+    color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
     borderRadius: token.borderRadiusSM,
   };
 
@@ -296,6 +308,7 @@ function BranchAction({
     return (
       <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
         <Button
+          className="agor-action-link-affordance"
           type="text"
           size="small"
           loading={busy}
@@ -310,7 +323,7 @@ function BranchAction({
             minWidth: 24,
             height: 24,
             padding: 0,
-            color: token.colorTextTertiary,
+            color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
           }}
         />
       </Tooltip>
@@ -320,7 +333,12 @@ function BranchAction({
   if (item.href && item.navigation === 'spa') {
     return (
       <Tooltip title="Open link">
-        <RouterLink aria-label="Open link" to={item.href} style={iconLinkStyle}>
+        <RouterLink
+          className="agor-action-link-affordance"
+          aria-label="Open link"
+          to={item.href}
+          style={iconLinkStyle}
+        >
           <RightOutlined />
         </RouterLink>
       </Tooltip>
@@ -331,6 +349,7 @@ function BranchAction({
     return (
       <Tooltip title="Open link">
         <a
+          className="agor-action-link-affordance"
           aria-label="Open link"
           href={item.href}
           target="_blank"
@@ -346,6 +365,7 @@ function BranchAction({
   return (
     <Tooltip title={disabledReason ?? 'No route available'}>
       <span
+        className="agor-action-link-affordance"
         role="img"
         aria-label={`No route available for ${title}`}
         style={{ ...iconLinkStyle, color: token.colorTextDisabled }}
@@ -786,8 +806,24 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
                 const targetLabel = getLinkDisplaySecondaryLabel(item);
                 return (
                   <List.Item
+                    className="agor-action-link-row"
                     key={item.key}
-                    style={{ borderColor: token.colorBorderSecondary, paddingRight: token.sizeSM }}
+                    aria-disabled={disabled || undefined}
+                    style={
+                      {
+                        '--agor-link-title-color': disabled
+                          ? token.colorTextDisabled
+                          : token.colorPrimary,
+                        '--agor-link-icon-color': disabled
+                          ? token.colorTextDisabled
+                          : token.colorTextTertiary,
+                        '--agor-link-row-hover-bg': token.colorFillQuaternary,
+                        '--agor-link-row-hover-color': token.colorPrimary,
+                        borderColor: token.colorBorderSecondary,
+                        borderRadius: token.borderRadius,
+                        paddingRight: token.sizeSM,
+                      } as React.CSSProperties
+                    }
                     actions={[
                       <BranchAction
                         key="open"

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -43,7 +43,6 @@ import {
   compareLinkDisplayItemsBySort,
   getCompactLinkDisplayName,
   getLinkCategoryCounts,
-  getLinkCategorySummary,
   getLinkDisplayGlyphLabel,
   getLinkDisplaySecondaryLabel,
   isBranchOwnedLink,
@@ -699,29 +698,6 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
         data-testid="branch-links-tab"
       >
         <Space direction="vertical" size={token.sizeMD} style={{ width: '100%' }}>
-          <div
-            style={{
-              position: 'sticky',
-              top: 0,
-              zIndex: 1,
-              background: token.colorBgElevated,
-              padding: `0 ${token.paddingLG}px ${token.sizeXS}px`,
-            }}
-          >
-            <Typography.Title level={5} style={{ margin: 0 }}>
-              Branch links
-            </Typography.Title>
-            <Typography.Text type="secondary">
-              Durable resources owned by this branch. Session-owned pins stay promoted in session
-              headers, not on the branch card.
-            </Typography.Text>
-            {items.length > 0 && (
-              <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
-                {getLinkCategorySummary(items)}
-              </Typography.Text>
-            )}
-          </div>
-
           {error && (
             <div style={{ padding: `0 ${token.paddingLG}px` }}>
               <Alert title="Error" description={error} type="error" showIcon />

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -13,8 +13,10 @@ import {
   Dropdown,
   Empty,
   List,
+  Select,
   Space,
   Spin,
+  Tabs,
   Tooltip,
   Typography,
   theme,
@@ -38,12 +40,20 @@ import {
 } from '../../Links/linkContent';
 import {
   buildLinkDisplayItems,
+  compareLinkDisplayItemsBySort,
   getCompactLinkDisplayName,
+  getLinkCategoryCounts,
+  getLinkCategorySummary,
   getLinkDisplayGlyphLabel,
   getLinkDisplaySecondaryLabel,
   isBranchOwnedLink,
-  type LinkDisplayCategory,
+  isFileLinkDisplayItem,
+  LINK_CATEGORY_TAB_LABELS,
+  LINK_SORT_LABELS,
+  type LinkCategoryTabKey,
   type LinkDisplayItem,
+  type LinkSortKey,
+  matchesLinkCategoryTab,
   normalizeLinkFindResult,
   removeLinkById,
   upsertLinkById,
@@ -61,22 +71,8 @@ interface LinksTabProps {
   assistantBranchId?: string | null;
 }
 
-const DOCUMENT_CATEGORIES = new Set<LinkDisplayCategory>([
-  'pdf',
-  'spreadsheet',
-  'csv',
-  'document',
-  'markdown',
-  'text',
-  'code',
-  'json',
-  'log',
-]);
-
 function isFileItem(item: LinkDisplayItem): boolean {
-  return (
-    item.category === 'image' || Boolean(item.filePath) || DOCUMENT_CATEGORIES.has(item.category)
-  );
+  return isFileLinkDisplayItem(item);
 }
 
 function getUnavailableReason(item: LinkDisplayItem): string | null {
@@ -94,7 +90,7 @@ function getTypeLabel(item: LinkDisplayItem): string {
     case 'knowledge':
       return 'Knowledge';
     case 'url':
-      return 'Saved URL';
+      return 'Link';
     case 'image':
       return 'Image';
     case 'pdf':
@@ -287,7 +283,7 @@ function BranchStatusPill({
   const { token } = theme.useToken();
   const title = getCompactLinkDisplayName(item);
   const canTogglePin = Boolean(item.linkId);
-  const label = item.isPinned ? 'pinned' : 'saved';
+  const label = item.isPinned ? 'Pinned' : 'Branch';
   const actionLabel = item.isPinned ? 'Unpin from branch card' : 'Pin to branch card';
   return (
     <Tooltip title={canTogglePin ? actionLabel : label}>
@@ -309,8 +305,8 @@ function BranchStatusPill({
           padding: '0 8px',
           border: 0,
           borderRadius: token.borderRadiusSM,
-          background: item.isPinned ? token.colorPrimaryBg : token.colorFillTertiary,
-          color: item.isPinned ? token.colorPrimary : token.colorTextSecondary,
+          background: item.isPinned ? token.colorWarningBg : token.colorFillTertiary,
+          color: item.isPinned ? token.colorWarning : token.colorTextSecondary,
           fontSize: 12,
           cursor: canTogglePin && !pinning ? 'pointer' : 'default',
           opacity: pinning ? 0.55 : 1,
@@ -412,6 +408,8 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
   const [busyLinkId, setBusyLinkId] = useState<string | null>(null);
   const [previewTarget, setPreviewTarget] = useState<LinkImagePreviewTarget | null>(null);
   const [markdownTarget, setMarkdownTarget] = useState<LinkMarkdownPreviewTarget | null>(null);
+  const [activeCategory, setActiveCategory] = useState<LinkCategoryTabKey>('all');
+  const [sortOrder, setSortOrder] = useState<LinkSortKey>('az');
 
   useEffect(() => {
     if (!client) {
@@ -542,6 +540,22 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
   const assistantPromotionLinks = assistantBranchId === branch.branch_id ? links : assistantLinks;
 
   const items = useMemo(() => buildLinkDisplayItems({ branch, links }), [branch, links]);
+  const categoryCounts = useMemo(() => getLinkCategoryCounts(items), [items]);
+  const categoryTabs = useMemo(
+    () =>
+      (['all', 'files', 'links', 'knowledge', 'issues'] as const).map((key) => ({
+        key,
+        label: `${LINK_CATEGORY_TAB_LABELS[key]} ${categoryCounts[key]}`,
+      })),
+    [categoryCounts]
+  );
+  const visibleItems = useMemo(
+    () =>
+      items
+        .filter((item) => matchesLinkCategoryTab(item, activeCategory))
+        .sort((a, b) => compareLinkDisplayItemsBySort(a, b, sortOrder)),
+    [activeCategory, items, sortOrder]
+  );
 
   const openPreview = useCallback((item: LinkDisplayItem) => {
     if (!item.linkId) return;
@@ -703,6 +717,11 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
               Durable resources owned by this branch. Session-owned pins stay promoted in session
               headers, not on the branch card.
             </Typography.Text>
+            {items.length > 0 && (
+              <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+                {getLinkCategorySummary(items)}
+              </Typography.Text>
+            )}
           </div>
 
           {error && (
@@ -723,106 +742,142 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
               <Spin />
             </div>
           ) : items.length > 0 ? (
-            <List
-              style={{ padding: `0 ${token.paddingLG}px` }}
-              dataSource={items}
-              renderItem={(item) => {
-                const disabledReason = getUnavailableReason(item);
-                const disabled = Boolean(disabledReason);
-                const targetLabel = getLinkDisplaySecondaryLabel(item);
-                return (
-                  <List.Item
-                    className="agor-action-link-row"
-                    key={item.key}
-                    role={disabled ? undefined : 'link'}
-                    tabIndex={disabled ? -1 : 0}
-                    aria-disabled={disabled || undefined}
-                    onClick={(event) => {
-                      if (disabled || shouldIgnoreRowActivation(event.target)) return;
-                      openItem(item);
-                    }}
-                    onKeyDown={(event) => {
-                      if (disabled || shouldIgnoreRowActivation(event.target)) return;
-                      if (event.key !== 'Enter' && event.key !== ' ') return;
-                      event.preventDefault();
-                      openItem(item);
-                    }}
-                    style={
-                      {
-                        '--agor-link-title-color': disabled
-                          ? token.colorTextDisabled
-                          : token.colorPrimary,
-                        '--agor-link-icon-color': disabled
-                          ? token.colorTextDisabled
-                          : token.colorTextTertiary,
-                        '--agor-link-row-hover-bg': 'transparent',
-                        '--agor-link-row-hover-color': token.colorPrimary,
-                        borderColor: token.colorBorderSecondary,
-                        borderRadius: token.borderRadius,
-                        cursor: disabled ? 'default' : 'pointer',
-                        paddingRight: token.sizeSM,
-                      } as React.CSSProperties
-                    }
-                    actions={[
-                      <BranchStatusPill
-                        key="state"
-                        item={item}
-                        onTogglePinned={handleTogglePinned}
-                        pinning={item.linkId === pinningLinkId}
-                      />,
-                      <BranchAssistantPromotionAction
-                        key="assistant"
-                        item={item}
-                        assistantBranchId={assistantBranchId}
-                        assistantLinks={assistantPromotionLinks}
-                        sourceBranchId={branch.branch_id}
-                        busyKey={assistantPromotionBusyKey}
-                        onPromote={handlePromoteToAssistant}
-                        onRemove={handleRemoveFromAssistant}
-                      />,
-                    ]}
-                  >
-                    <List.Item.Meta
-                      avatar={<BranchGlyph item={item} disabled={disabled} />}
-                      title={
-                        <span
-                          style={{
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            gap: token.sizeXS,
-                            minWidth: 0,
-                          }}
-                        >
-                          <BranchTitle
+            <Space direction="vertical" size={token.sizeMD} style={{ width: '100%' }}>
+              <div style={{ padding: `0 ${token.paddingLG}px` }}>
+                <Tabs
+                  className="agor-link-category-tabs"
+                  activeKey={activeCategory}
+                  items={categoryTabs}
+                  onChange={(key) => setActiveCategory(key as LinkCategoryTabKey)}
+                />
+                <Space size={token.sizeXS} style={{ marginTop: token.sizeSM }}>
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                    Sort
+                  </Typography.Text>
+                  <Select<LinkSortKey>
+                    size="small"
+                    value={sortOrder}
+                    options={(Object.keys(LINK_SORT_LABELS) as LinkSortKey[]).map((key) => ({
+                      value: key,
+                      label: LINK_SORT_LABELS[key],
+                    }))}
+                    onChange={setSortOrder}
+                    style={{ width: 128 }}
+                  />
+                </Space>
+              </div>
+              {visibleItems.length > 0 ? (
+                <List
+                  style={{ padding: `0 ${token.paddingLG}px` }}
+                  dataSource={visibleItems}
+                  renderItem={(item) => {
+                    const disabledReason = getUnavailableReason(item);
+                    const disabled = Boolean(disabledReason);
+                    const targetLabel = getLinkDisplaySecondaryLabel(item);
+                    return (
+                      <List.Item
+                        className="agor-action-link-row"
+                        key={item.key}
+                        role={disabled ? undefined : 'link'}
+                        tabIndex={disabled ? -1 : 0}
+                        aria-disabled={disabled || undefined}
+                        onClick={(event) => {
+                          if (disabled || shouldIgnoreRowActivation(event.target)) return;
+                          openItem(item);
+                        }}
+                        onKeyDown={(event) => {
+                          if (disabled || shouldIgnoreRowActivation(event.target)) return;
+                          if (event.key !== 'Enter' && event.key !== ' ') return;
+                          event.preventDefault();
+                          openItem(item);
+                        }}
+                        style={
+                          {
+                            '--agor-link-title-color': disabled
+                              ? token.colorTextDisabled
+                              : token.colorPrimary,
+                            '--agor-link-icon-color': disabled
+                              ? token.colorTextDisabled
+                              : token.colorTextTertiary,
+                            '--agor-link-row-hover-bg': 'transparent',
+                            '--agor-link-row-hover-color': token.colorPrimary,
+                            borderColor: token.colorBorderSecondary,
+                            borderRadius: token.borderRadius,
+                            cursor: disabled ? 'default' : 'pointer',
+                            paddingRight: token.sizeSM,
+                          } as React.CSSProperties
+                        }
+                        actions={[
+                          <BranchStatusPill
+                            key="state"
                             item={item}
-                            onPreview={openPreview}
-                            onDownload={downloadItem}
-                          />
-                          <BranchTypePill item={item} />
-                        </span>
-                      }
-                      description={
-                        <span>
-                          {targetLabel && (
-                            <Typography.Text type="secondary" ellipsis style={{ display: 'block' }}>
-                              {targetLabel}
-                            </Typography.Text>
-                          )}
-                          {disabledReason && (
-                            <Typography.Text
-                              type="warning"
-                              style={{ display: 'block', fontSize: 12, marginTop: 2 }}
+                            onTogglePinned={handleTogglePinned}
+                            pinning={item.linkId === pinningLinkId}
+                          />,
+                          <BranchAssistantPromotionAction
+                            key="assistant"
+                            item={item}
+                            assistantBranchId={assistantBranchId}
+                            assistantLinks={assistantPromotionLinks}
+                            sourceBranchId={branch.branch_id}
+                            busyKey={assistantPromotionBusyKey}
+                            onPromote={handlePromoteToAssistant}
+                            onRemove={handleRemoveFromAssistant}
+                          />,
+                        ]}
+                      >
+                        <List.Item.Meta
+                          avatar={<BranchGlyph item={item} disabled={disabled} />}
+                          title={
+                            <span
+                              style={{
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                                gap: token.sizeXS,
+                                minWidth: 0,
+                              }}
                             >
-                              {disabledReason}
-                            </Typography.Text>
-                          )}
-                        </span>
-                      }
-                    />
-                  </List.Item>
-                );
-              }}
-            />
+                              <BranchTitle
+                                item={item}
+                                onPreview={openPreview}
+                                onDownload={downloadItem}
+                              />
+                              <BranchTypePill item={item} />
+                            </span>
+                          }
+                          description={
+                            <span>
+                              {targetLabel && (
+                                <Typography.Text
+                                  type="secondary"
+                                  ellipsis
+                                  style={{ display: 'block' }}
+                                >
+                                  {targetLabel}
+                                </Typography.Text>
+                              )}
+                              {disabledReason && (
+                                <Typography.Text
+                                  type="warning"
+                                  style={{ display: 'block', fontSize: 12, marginTop: 2 }}
+                                >
+                                  {disabledReason}
+                                </Typography.Text>
+                              )}
+                            </span>
+                          }
+                        />
+                      </List.Item>
+                    );
+                  }}
+                />
+              ) : (
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description="No links match this view."
+                />
+              )}
+            </Space>
           ) : (
             <Empty
               image={Empty.PRESENTED_IMAGE_SIMPLE}

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -1,0 +1,878 @@
+import type { AgorClient, Branch, Link } from '@agor-live/client';
+import {
+  DownloadOutlined,
+  EllipsisOutlined,
+  ExportOutlined,
+  EyeOutlined,
+  GithubOutlined,
+  PushpinFilled,
+  PushpinOutlined,
+  RightOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
+import type { MenuProps } from 'antd';
+import {
+  Alert,
+  Button,
+  Dropdown,
+  Empty,
+  List,
+  Space,
+  Spin,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import type React from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import { useThemedMessage } from '../../../utils/message';
+import {
+  LinkImagePreviewModal,
+  type LinkImagePreviewTarget,
+} from '../../Links/LinkImagePreviewModal';
+import {
+  LinkMarkdownPreviewModal,
+  type LinkMarkdownPreviewTarget,
+} from '../../Links/LinkMarkdownPreviewModal';
+import {
+  downloadLinkContent,
+  getLinkContentAction,
+  getLinkPreviewKind,
+} from '../../Links/linkContent';
+import {
+  buildLinkDisplayItems,
+  getCompactLinkDisplayName,
+  getLinkDisplayGlyphLabel,
+  getLinkDisplaySecondaryLabel,
+  isBranchOwnedLink,
+  type LinkDisplayCategory,
+  type LinkDisplayItem,
+  normalizeLinkFindResult,
+  removeLinkById,
+  upsertLinkById,
+} from '../../Links/linkDisplay';
+import { dispatchLinkMutation, listenForLinkMutations } from '../../Links/linkEvents';
+import {
+  findAssistantLinkForTarget,
+  getAssistantPromotionState,
+  promoteLinkToAssistant,
+} from '../../Links/linkPromotion';
+
+interface LinksTabProps {
+  branch: Branch;
+  client: AgorClient | null;
+  assistantBranchId?: string | null;
+}
+
+const DOCUMENT_CATEGORIES = new Set<LinkDisplayCategory>([
+  'pdf',
+  'spreadsheet',
+  'csv',
+  'document',
+  'markdown',
+  'text',
+  'code',
+  'json',
+  'log',
+]);
+
+function isFileItem(item: LinkDisplayItem): boolean {
+  return (
+    item.category === 'image' || Boolean(item.filePath) || DOCUMENT_CATEGORIES.has(item.category)
+  );
+}
+
+function getUnavailableReason(item: LinkDisplayItem): string | null {
+  if (item.href || getLinkContentAction(item)) return null;
+  if (isFileItem(item)) return 'No preview/download route is available yet.';
+  return 'No safe route is available for this item yet.';
+}
+
+function getTypeLabel(item: LinkDisplayItem): string {
+  switch (item.category) {
+    case 'issue':
+      return 'Issue';
+    case 'pr':
+      return 'PR';
+    case 'knowledge':
+      return 'Knowledge';
+    case 'url':
+      return 'Saved URL';
+    case 'image':
+      return 'Image';
+    case 'pdf':
+    case 'spreadsheet':
+    case 'csv':
+    case 'document':
+    case 'markdown':
+    case 'text':
+    case 'code':
+    case 'json':
+    case 'log':
+      return 'Doc';
+    case 'internal':
+      return 'Ref';
+    default:
+      return 'Link';
+  }
+}
+
+function getTypePillColors(item: LinkDisplayItem): { background: string; color: string } {
+  switch (item.category) {
+    case 'issue':
+    case 'pr':
+    case 'url':
+      return { background: 'rgba(22, 119, 255, 0.16)', color: '#69b1ff' };
+    case 'knowledge':
+      return { background: 'rgba(114, 46, 209, 0.18)', color: '#b37feb' };
+    case 'image':
+    case 'pdf':
+    case 'spreadsheet':
+    case 'csv':
+    case 'document':
+    case 'markdown':
+    case 'text':
+    case 'code':
+    case 'json':
+    case 'log':
+      return { background: 'rgba(83, 29, 171, 0.18)', color: '#d3adf7' };
+    default:
+      return { background: 'rgba(255, 255, 255, 0.06)', color: 'rgba(255, 255, 255, 0.78)' };
+  }
+}
+
+function BranchGlyph({ item, disabled = false }: { item: LinkDisplayItem; disabled?: boolean }) {
+  const { token } = theme.useToken();
+  const isGitHubLink = item.category === 'issue' || item.category === 'pr';
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 28,
+        height: 28,
+        borderRadius: token.borderRadiusLG,
+        background: token.colorFillTertiary,
+        color: disabled ? token.colorTextDisabled : token.colorTextTertiary,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 10,
+        fontWeight: 800,
+        letterSpacing: 0.2,
+        flex: '0 0 auto',
+      }}
+    >
+      {disabled ? (
+        <StopOutlined style={{ fontSize: 13 }} />
+      ) : isGitHubLink ? (
+        <GithubOutlined style={{ fontSize: 13 }} />
+      ) : (
+        getLinkDisplayGlyphLabel(item.category)
+      )}
+    </span>
+  );
+}
+
+function BranchTypePill({ item }: { item: LinkDisplayItem }) {
+  const { token } = theme.useToken();
+  const colors = getTypePillColors(item);
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        borderRadius: token.borderRadiusSM,
+        padding: '1px 8px',
+        background: colors.background,
+        color: colors.color,
+        fontSize: 12,
+        lineHeight: 1.35,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {getTypeLabel(item)}
+    </span>
+  );
+}
+
+function BranchTitle({
+  item,
+  onPreview,
+  onDownload,
+}: {
+  item: LinkDisplayItem;
+  onPreview: (item: LinkDisplayItem) => void;
+  onDownload: (item: LinkDisplayItem) => void;
+}) {
+  const { token } = theme.useToken();
+  const title = getCompactLinkDisplayName(item);
+  const contentAction = getLinkContentAction(item);
+  const disabled = Boolean(getUnavailableReason(item));
+  const style: React.CSSProperties = {
+    color: disabled ? token.colorTextDisabled : token.colorPrimary,
+    fontWeight: 600,
+    lineHeight: 1.25,
+  };
+
+  if (item.href && item.navigation === 'spa') {
+    return (
+      <RouterLink to={item.href} style={{ ...style, textDecoration: 'none' }} title={title}>
+        {title}
+      </RouterLink>
+    );
+  }
+
+  if (item.href) {
+    return (
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noreferrer"
+        style={{ ...style, textDecoration: 'none' }}
+        title={title}
+      >
+        {title}
+      </a>
+    );
+  }
+
+  if (contentAction) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          if (contentAction === 'preview') onPreview(item);
+          else onDownload(item);
+        }}
+        style={{
+          ...style,
+          border: 0,
+          background: 'transparent',
+          padding: 0,
+          cursor: 'pointer',
+          textAlign: 'left',
+        }}
+        title={title}
+      >
+        {title}
+      </button>
+    );
+  }
+
+  return (
+    <Typography.Text disabled style={style} title={title}>
+      {title}
+    </Typography.Text>
+  );
+}
+
+function BranchAction({
+  item,
+  busy = false,
+  onPreview,
+  onDownload,
+}: {
+  item: LinkDisplayItem;
+  busy?: boolean;
+  onPreview: (item: LinkDisplayItem) => void;
+  onDownload: (item: LinkDisplayItem) => void;
+}) {
+  const { token } = theme.useToken();
+  const title = getCompactLinkDisplayName(item);
+  const contentAction = getLinkContentAction(item);
+  const disabledReason = getUnavailableReason(item);
+  const iconLinkStyle: React.CSSProperties = {
+    width: 24,
+    height: 24,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: token.colorTextTertiary,
+    borderRadius: token.borderRadiusSM,
+  };
+
+  if (contentAction) {
+    return (
+      <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
+        <Button
+          type="text"
+          size="small"
+          loading={busy}
+          aria-label={`${contentAction === 'preview' ? 'Preview' : 'Download'} ${title}`}
+          icon={contentAction === 'preview' ? <EyeOutlined /> : <DownloadOutlined />}
+          onClick={() => {
+            if (contentAction === 'preview') onPreview(item);
+            else onDownload(item);
+          }}
+          style={{
+            width: 24,
+            minWidth: 24,
+            height: 24,
+            padding: 0,
+            color: token.colorTextTertiary,
+          }}
+        />
+      </Tooltip>
+    );
+  }
+
+  if (item.href && item.navigation === 'spa') {
+    return (
+      <Tooltip title="Open link">
+        <RouterLink aria-label="Open link" to={item.href} style={iconLinkStyle}>
+          <RightOutlined />
+        </RouterLink>
+      </Tooltip>
+    );
+  }
+
+  if (item.href) {
+    return (
+      <Tooltip title="Open link">
+        <a
+          aria-label="Open link"
+          href={item.href}
+          target="_blank"
+          rel="noreferrer"
+          style={iconLinkStyle}
+        >
+          <ExportOutlined />
+        </a>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip title={disabledReason ?? 'No route available'}>
+      <span
+        role="img"
+        aria-label={`No route available for ${title}`}
+        style={{ ...iconLinkStyle, color: token.colorTextDisabled }}
+      >
+        <StopOutlined />
+      </span>
+    </Tooltip>
+  );
+}
+
+function BranchStatusPill({
+  item,
+  onTogglePinned,
+  pinning = false,
+}: {
+  item: LinkDisplayItem;
+  onTogglePinned: (item: LinkDisplayItem) => void | Promise<void>;
+  pinning?: boolean;
+}) {
+  const { token } = theme.useToken();
+  const title = getCompactLinkDisplayName(item);
+  const canTogglePin = Boolean(item.linkId);
+  const label = item.isPinned ? 'pinned' : 'saved';
+  const actionLabel = item.isPinned ? 'Unpin from branch card' : 'Pin to branch card';
+  return (
+    <Tooltip title={canTogglePin ? actionLabel : label}>
+      <button
+        type="button"
+        disabled={!canTogglePin || pinning}
+        aria-label={`${canTogglePin ? actionLabel : label} ${title}`}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onTogglePinned(item);
+        }}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 6,
+          height: 24,
+          padding: '0 8px',
+          border: 0,
+          borderRadius: token.borderRadiusSM,
+          background: item.isPinned ? token.colorPrimaryBg : token.colorFillTertiary,
+          color: item.isPinned ? token.colorPrimary : token.colorTextSecondary,
+          fontSize: 12,
+          cursor: canTogglePin && !pinning ? 'pointer' : 'default',
+          opacity: pinning ? 0.55 : 1,
+        }}
+      >
+        {item.isPinned ? <PushpinFilled /> : <PushpinOutlined />}
+        {label}
+      </button>
+    </Tooltip>
+  );
+}
+
+function BranchAssistantPromotionAction({
+  item,
+  assistantBranchId,
+  assistantLinks,
+  sourceBranchId,
+  busyKey,
+  onPromote,
+  onRemove,
+}: {
+  item: LinkDisplayItem;
+  assistantBranchId?: string | null;
+  assistantLinks: Link[];
+  sourceBranchId: string;
+  busyKey?: string | null;
+  onPromote: (item: LinkDisplayItem) => void | Promise<void>;
+  onRemove: (item: LinkDisplayItem) => void | Promise<void>;
+}) {
+  const { token } = theme.useToken();
+  const state = getAssistantPromotionState({
+    item,
+    assistantBranchId,
+    assistantLinks,
+    sourceBranchId,
+  });
+  const busy = busyKey === (state.assistantLink?.link_id ?? item.linkId ?? item.key);
+  const menuItems: MenuProps['items'] = [
+    {
+      key: state.isPromoted ? 'remove-assistant' : 'promote-assistant',
+      label: state.actionLabel,
+      disabled: !state.canUseAssistantPromotion || busy,
+      title: state.unavailableReason ?? undefined,
+    },
+  ];
+
+  return (
+    <Tooltip title={state.unavailableReason ?? 'Assistant link actions'}>
+      <Dropdown
+        trigger={['click']}
+        menu={{
+          items: menuItems,
+          onClick: ({ domEvent }) => {
+            domEvent.preventDefault();
+            domEvent.stopPropagation();
+            if (!state.canUseAssistantPromotion || busy) return;
+            if (state.isPromoted) void onRemove(item);
+            else void onPromote(item);
+          },
+        }}
+      >
+        <Button
+          type="text"
+          size="small"
+          loading={busy}
+          aria-label={`Assistant actions for ${getCompactLinkDisplayName(item)}`}
+          icon={<EllipsisOutlined />}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+          style={{
+            width: 24,
+            minWidth: 24,
+            height: 24,
+            padding: 0,
+            color: token.colorTextTertiary,
+          }}
+        />
+      </Dropdown>
+    </Tooltip>
+  );
+}
+
+const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranchId = null }) => {
+  const { token } = theme.useToken();
+  const { showError } = useThemedMessage();
+  const [links, setLinks] = useState<Link[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pinningLinkId, setPinningLinkId] = useState<string | null>(null);
+  const [assistantLinks, setAssistantLinks] = useState<Link[]>([]);
+  const [assistantPromotionBusyKey, setAssistantPromotionBusyKey] = useState<string | null>(null);
+  const [busyLinkId, setBusyLinkId] = useState<string | null>(null);
+  const [previewTarget, setPreviewTarget] = useState<LinkImagePreviewTarget | null>(null);
+  const [markdownTarget, setMarkdownTarget] = useState<LinkMarkdownPreviewTarget | null>(null);
+
+  useEffect(() => {
+    if (!client) {
+      setLinks([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let active = true;
+    const linksService = client.service('links');
+    const branchId = branch.branch_id;
+
+    const upsertBranchLink = (link: Link) => {
+      setLinks((prev) => {
+        if (isBranchOwnedLink(link, branchId)) return upsertLinkById(prev, link);
+        return removeLinkById(prev, link);
+      });
+    };
+
+    const removeBranchLink = (link: Link) => {
+      setLinks((prev) => removeLinkById(prev, link));
+    };
+
+    const fetchLinks = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await linksService.find({
+          query: { branch_id: branchId, $limit: 200 },
+        });
+        if (!active) return;
+        setLinks(
+          normalizeLinkFindResult(result).filter((link) => isBranchOwnedLink(link, branchId))
+        );
+      } catch (err) {
+        if (!active) return;
+        console.error('[BranchLinksTab] Failed to fetch links:', err);
+        setError('Could not load branch links');
+        setLinks([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+
+    void fetchLinks();
+    linksService.on('created', upsertBranchLink);
+    linksService.on('patched', upsertBranchLink);
+    linksService.on('updated', upsertBranchLink);
+    linksService.on('removed', removeBranchLink);
+    const stopListeningForLocalMutations = listenForLinkMutations(({ link, mutation }) => {
+      if (mutation === 'removed') {
+        removeBranchLink(link);
+      } else {
+        upsertBranchLink(link);
+      }
+    });
+
+    return () => {
+      active = false;
+      linksService.off('created', upsertBranchLink);
+      linksService.off('patched', upsertBranchLink);
+      linksService.off('updated', upsertBranchLink);
+      linksService.off('removed', removeBranchLink);
+      stopListeningForLocalMutations();
+    };
+  }, [branch.branch_id, client]);
+
+  useEffect(() => {
+    if (!client || !assistantBranchId || assistantBranchId === branch.branch_id) {
+      setAssistantLinks([]);
+      return;
+    }
+
+    let active = true;
+    const linksService = client.service('links');
+
+    const upsertAssistantLink = (link: Link) => {
+      setAssistantLinks((prev) => {
+        if (isBranchOwnedLink(link, assistantBranchId)) return upsertLinkById(prev, link);
+        return removeLinkById(prev, link);
+      });
+    };
+
+    const removeAssistantLink = (link: Link) => {
+      setAssistantLinks((prev) => removeLinkById(prev, link));
+    };
+
+    const fetchAssistantLinks = async () => {
+      try {
+        const result = await linksService.find({
+          query: { branch_id: assistantBranchId, $limit: 200 },
+        });
+        if (active) {
+          setAssistantLinks(
+            normalizeLinkFindResult(result).filter((link) =>
+              isBranchOwnedLink(link, assistantBranchId)
+            )
+          );
+        }
+      } catch (err) {
+        if (!active) return;
+        console.error('[BranchLinksTab] Failed to fetch assistant links:', err);
+        setAssistantLinks([]);
+      }
+    };
+
+    void fetchAssistantLinks();
+    linksService.on('created', upsertAssistantLink);
+    linksService.on('patched', upsertAssistantLink);
+    linksService.on('updated', upsertAssistantLink);
+    linksService.on('removed', removeAssistantLink);
+    const stopListeningForLocalMutations = listenForLinkMutations(({ link, mutation }) => {
+      if (mutation === 'removed') removeAssistantLink(link);
+      else upsertAssistantLink(link);
+    });
+
+    return () => {
+      active = false;
+      linksService.off('created', upsertAssistantLink);
+      linksService.off('patched', upsertAssistantLink);
+      linksService.off('updated', upsertAssistantLink);
+      linksService.off('removed', removeAssistantLink);
+      stopListeningForLocalMutations();
+    };
+  }, [assistantBranchId, branch.branch_id, client]);
+
+  const assistantPromotionLinks = assistantBranchId === branch.branch_id ? links : assistantLinks;
+
+  const items = useMemo(() => buildLinkDisplayItems({ branch, links }), [branch, links]);
+
+  const openPreview = useCallback((item: LinkDisplayItem) => {
+    if (!item.linkId) return;
+    const previewKind = getLinkPreviewKind(item);
+    const target = {
+      linkId: item.linkId,
+      title: getCompactLinkDisplayName(item),
+      subtitle: getLinkDisplaySecondaryLabel(item),
+    };
+    if (previewKind === 'image') {
+      setPreviewTarget(target);
+    } else if (previewKind === 'markdown' || previewKind === 'text') {
+      setMarkdownTarget(target);
+    }
+  }, []);
+
+  const downloadItem = useCallback(
+    async (item: LinkDisplayItem) => {
+      if (!item.linkId || busyLinkId) return;
+      setBusyLinkId(item.linkId);
+      try {
+        await downloadLinkContent(item.linkId, getCompactLinkDisplayName(item));
+      } catch (err) {
+        showError(err instanceof Error ? err.message : 'Download failed');
+      } finally {
+        setBusyLinkId(null);
+      }
+    },
+    [busyLinkId, showError]
+  );
+
+  const handleTogglePinned = useCallback(
+    async (item: LinkDisplayItem) => {
+      if (!client || !item.linkId || pinningLinkId) return;
+      setPinningLinkId(item.linkId);
+      try {
+        const updated = await client.service('links').patch(item.linkId, {
+          is_pinned: !item.isPinned,
+        });
+        setLinks((prev) => {
+          if (isBranchOwnedLink(updated, branch.branch_id)) return upsertLinkById(prev, updated);
+          return removeLinkById(prev, updated);
+        });
+        dispatchLinkMutation({ link: updated, mutation: 'patched' });
+      } catch (err) {
+        showError(`Failed to update pin: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        setPinningLinkId(null);
+      }
+    },
+    [branch.branch_id, client, pinningLinkId, showError]
+  );
+
+  const handlePromoteToAssistant = useCallback(
+    async (item: LinkDisplayItem) => {
+      if (!client || !assistantBranchId || !item.linkId || assistantPromotionBusyKey) return;
+      setAssistantPromotionBusyKey(item.linkId);
+      try {
+        const promoted = await promoteLinkToAssistant({
+          client,
+          sourceLinkId: item.linkId,
+          assistantBranchId,
+        });
+        if (assistantBranchId === branch.branch_id) {
+          setLinks((prev) => upsertLinkById(prev, promoted));
+        } else {
+          setAssistantLinks((prev) => upsertLinkById(prev, promoted));
+        }
+        dispatchLinkMutation({ link: promoted, mutation: 'patched' });
+      } catch (err) {
+        showError(`Failed to promote link: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        setAssistantPromotionBusyKey(null);
+      }
+    },
+    [assistantBranchId, assistantPromotionBusyKey, branch.branch_id, client, showError]
+  );
+
+  const handleRemoveFromAssistant = useCallback(
+    async (item: LinkDisplayItem) => {
+      if (!client || !assistantBranchId || assistantPromotionBusyKey) return;
+      const assistantLink =
+        assistantBranchId === branch.branch_id && item.linkId
+          ? links.find((link) => link.link_id === item.linkId)
+          : findAssistantLinkForTarget(item, assistantPromotionLinks);
+      if (!assistantLink) return;
+      setAssistantPromotionBusyKey(assistantLink.link_id);
+      try {
+        const removed = (await client.service('links').remove(assistantLink.link_id)) as Link;
+        if (assistantBranchId === branch.branch_id) {
+          setLinks((prev) => removeLinkById(prev, assistantLink));
+        } else {
+          setAssistantLinks((prev) => removeLinkById(prev, assistantLink));
+        }
+        dispatchLinkMutation({ link: removed, mutation: 'removed' });
+      } catch (err) {
+        showError(
+          `Failed to remove assistant link: ${err instanceof Error ? err.message : String(err)}`
+        );
+      } finally {
+        setAssistantPromotionBusyKey(null);
+      }
+    },
+    [
+      assistantBranchId,
+      assistantPromotionBusyKey,
+      assistantPromotionLinks,
+      branch.branch_id,
+      client,
+      links,
+      showError,
+    ]
+  );
+
+  return (
+    <>
+      <LinkImagePreviewModal target={previewTarget} onClose={() => setPreviewTarget(null)} />
+      <LinkMarkdownPreviewModal target={markdownTarget} onClose={() => setMarkdownTarget(null)} />
+      <div
+        style={{ width: '100%', height: '70vh', overflowY: 'auto' }}
+        data-testid="branch-links-tab"
+      >
+        <Space direction="vertical" size={token.sizeMD} style={{ width: '100%' }}>
+          <div
+            style={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 1,
+              background: token.colorBgElevated,
+              padding: `0 ${token.paddingLG}px ${token.sizeXS}px`,
+            }}
+          >
+            <Typography.Title level={5} style={{ margin: 0 }}>
+              Branch links
+            </Typography.Title>
+            <Typography.Text type="secondary">
+              Durable resources owned by this branch. Session-owned pins stay promoted in session
+              headers, not on the branch card.
+            </Typography.Text>
+          </div>
+
+          {error && (
+            <div style={{ padding: `0 ${token.paddingLG}px` }}>
+              <Alert title="Error" description={error} type="error" showIcon />
+            </div>
+          )}
+
+          {loading ? (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minHeight: 180,
+              }}
+            >
+              <Spin />
+            </div>
+          ) : items.length > 0 ? (
+            <List
+              style={{ padding: `0 ${token.paddingLG}px` }}
+              dataSource={items}
+              renderItem={(item) => {
+                const disabledReason = getUnavailableReason(item);
+                const disabled = Boolean(disabledReason);
+                const targetLabel = getLinkDisplaySecondaryLabel(item);
+                return (
+                  <List.Item
+                    key={item.key}
+                    style={{ borderColor: token.colorBorderSecondary, paddingRight: token.sizeSM }}
+                    actions={[
+                      <BranchAction
+                        key="open"
+                        item={item}
+                        busy={item.linkId === busyLinkId}
+                        onPreview={openPreview}
+                        onDownload={downloadItem}
+                      />,
+                      <BranchStatusPill
+                        key="state"
+                        item={item}
+                        onTogglePinned={handleTogglePinned}
+                        pinning={item.linkId === pinningLinkId}
+                      />,
+                      <BranchAssistantPromotionAction
+                        key="assistant"
+                        item={item}
+                        assistantBranchId={assistantBranchId}
+                        assistantLinks={assistantPromotionLinks}
+                        sourceBranchId={branch.branch_id}
+                        busyKey={assistantPromotionBusyKey}
+                        onPromote={handlePromoteToAssistant}
+                        onRemove={handleRemoveFromAssistant}
+                      />,
+                    ]}
+                  >
+                    <List.Item.Meta
+                      avatar={<BranchGlyph item={item} disabled={disabled} />}
+                      title={
+                        <span
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: token.sizeXS,
+                            minWidth: 0,
+                          }}
+                        >
+                          <BranchTitle
+                            item={item}
+                            onPreview={openPreview}
+                            onDownload={downloadItem}
+                          />
+                          <BranchTypePill item={item} />
+                        </span>
+                      }
+                      description={
+                        <span>
+                          {targetLabel && (
+                            <Typography.Text type="secondary" ellipsis style={{ display: 'block' }}>
+                              {targetLabel}
+                            </Typography.Text>
+                          )}
+                          {disabledReason && (
+                            <Typography.Text
+                              type="warning"
+                              style={{ display: 'block', fontSize: 12, marginTop: 2 }}
+                            >
+                              {disabledReason}
+                            </Typography.Text>
+                          )}
+                        </span>
+                      }
+                    />
+                  </List.Item>
+                );
+              }}
+            />
+          ) : (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No durable branch links yet. Add branch-owned links here when they should persist with the branch."
+            />
+          )}
+        </Space>
+      </div>
+    </>
+  );
+};
+
+export const LinksTab = memo(LinksTabInner, (prevProps, nextProps) => {
+  return (
+    prevProps.client === nextProps.client &&
+    prevProps.branch.branch_id === nextProps.branch.branch_id &&
+    prevProps.branch.issue_url === nextProps.branch.issue_url &&
+    prevProps.branch.pull_request_url === nextProps.branch.pull_request_url &&
+    prevProps.assistantBranchId === nextProps.assistantBranchId
+  );
+});

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -205,9 +205,7 @@ function BranchTitle({
   const contentAction = getLinkContentAction(item);
   const disabled = Boolean(getUnavailableReason(item));
   const style: React.CSSProperties = {
-    color: disabled
-      ? token.colorTextDisabled
-      : `var(--agor-link-title-color, ${token.colorPrimary})`,
+    color: disabled ? token.colorTextDisabled : `var(--agor-link-title-color, ${token.colorText})`,
     fontWeight: 600,
     lineHeight: 1.25,
   };
@@ -795,7 +793,7 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
                           {
                             '--agor-link-title-color': disabled
                               ? token.colorTextDisabled
-                              : token.colorPrimary,
+                              : token.colorText,
                             '--agor-link-icon-color': disabled
                               ? token.colorTextDisabled
                               : token.colorTextTertiary,

--- a/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/LinksTab.tsx
@@ -724,7 +724,7 @@ const LinksTabInner: React.FC<LinksTabProps> = ({ branch, client, assistantBranc
                   items={categoryTabs}
                   onChange={(key) => setActiveCategory(key as LinkCategoryTabKey)}
                 />
-                <Space size={token.sizeXS} style={{ marginTop: token.sizeSM }}>
+                <Space size={token.sizeXS} style={{ marginTop: token.sizeMD }}>
                   <Typography.Text type="secondary" style={{ fontSize: 12 }}>
                     Sort
                   </Typography.Text>

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -10,7 +10,14 @@
  * - Auto-scrolling to latest content
  */
 
-import type { AgorClient, Message, PermissionScope, SessionID, User } from '@agor-live/client';
+import type {
+  AgorClient,
+  Link,
+  Message,
+  PermissionScope,
+  SessionID,
+  User,
+} from '@agor-live/client';
 import { shortId, TaskStatus } from '@agor-live/client';
 import { BranchesOutlined, CopyOutlined, ForkOutlined } from '@ant-design/icons';
 import { Alert, Button, Spin, Typography, theme } from 'antd';
@@ -117,6 +124,11 @@ export interface ConversationViewProps {
    * Emoji override for assistant avatar in message bubbles
    */
   assistantEmoji?: string;
+
+  /**
+   * Uploaded image links keyed by the user message that introduced them.
+   */
+  attachmentLinksByMessageId?: Map<string, Link[]>;
 }
 
 export const ConversationView = React.memo<ConversationViewProps>(
@@ -136,6 +148,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     isActive = true,
     genealogy,
     assistantEmoji,
+    attachmentLinksByMessageId,
   }) => {
     const { token } = theme.useToken();
     const [copied, copy] = useCopyToClipboard();
@@ -496,6 +509,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
               assistantEmoji={assistantEmoji}
               isLatestTask={taskIndex === tasks.length - 1}
               client={client}
+              attachmentLinksByMessageId={attachmentLinksByMessageId}
             />
           ))}
         </div>

--- a/apps/agor-ui/src/components/Links/LinkAttachmentCard.test.tsx
+++ b/apps/agor-ui/src/components/Links/LinkAttachmentCard.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { targetForLinkAttachment } from './LinkAttachmentCard';
+
+describe('targetForLinkAttachment', () => {
+  it('only returns external targets for absolute http(s) URLs', () => {
+    expect(targetForLinkAttachment({ url: 'https://example.com/file.png' })).toEqual({
+      href: 'https://example.com/file.png',
+      navigation: 'external',
+    });
+    expect(targetForLinkAttachment({ url: 'http://example.com/file.png' })).toEqual({
+      href: 'http://example.com/file.png',
+      navigation: 'external',
+    });
+    expect(targetForLinkAttachment({ url: 'javascript:alert(1)' })).toBeNull();
+    expect(targetForLinkAttachment({ url: 'data:text/html,<script>alert(1)</script>' })).toBeNull();
+    expect(targetForLinkAttachment({ url: 'blob:https://example.com/id' })).toBeNull();
+    expect(targetForLinkAttachment({ url: 'https://%' })).toBeNull();
+    expect(targetForLinkAttachment({ url: '/relative/path' })).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/Links/LinkAttachmentCard.test.tsx
+++ b/apps/agor-ui/src/components/Links/LinkAttachmentCard.test.tsx
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { targetForLinkAttachment } from './LinkAttachmentCard';
 
 describe('targetForLinkAttachment', () => {
+  it('routes path-addressed KB refs and leaves opaque KB refs unrouted', () => {
+    expect(targetForLinkAttachment({ refUri: 'agor://kb/global/guides/architecture.md' })).toEqual({
+      href: '/kb/global/guides/architecture.md',
+      navigation: 'spa',
+    });
+    expect(targetForLinkAttachment({ refUri: 'agor://kb/team/runbooks/one%20two.md' })).toEqual({
+      href: '/kb/team/runbooks/one%20two.md',
+      navigation: 'spa',
+    });
+    expect(targetForLinkAttachment({ refUri: 'agor://kb/document/0190a000' })).toBeNull();
+    expect(targetForLinkAttachment({ refUri: 'agor://kb/unit/0190a000' })).toBeNull();
+  });
+
   it('only returns external targets for absolute http(s) URLs', () => {
     expect(targetForLinkAttachment({ url: 'https://example.com/file.png' })).toEqual({
       href: 'https://example.com/file.png',

--- a/apps/agor-ui/src/components/Links/LinkAttachmentCard.tsx
+++ b/apps/agor-ui/src/components/Links/LinkAttachmentCard.tsx
@@ -11,11 +11,11 @@ import {
 } from '@ant-design/icons';
 import { Tooltip, Typography, theme } from 'antd';
 import type React from 'react';
-import { buildKnowledgeRoutePath } from '../../utils/knowledgeRoutes';
 import { useThemedMessage } from '../../utils/message';
 import type { LinkImagePreviewTarget } from './LinkImagePreviewModal';
 import { LinkImageThumbnail } from './LinkImageThumbnail';
 import { downloadLinkContent, getSafeLinkContentLabel } from './linkContent';
+import { routeForKnowledgeRefUri } from './linkDisplay';
 
 export interface LinkAttachmentTarget {
   href: string;
@@ -67,11 +67,7 @@ const extensionFromPath = (value?: string | null): string => {
 };
 
 export function routeForKnowledgeUri(uri?: string | null, basePath = '/kb'): string | null {
-  if (!uri?.startsWith(KNOWLEDGE_PREFIX)) return null;
-  const rest = uri.slice(KNOWLEDGE_PREFIX.length);
-  const [namespaceSlug, ...pathParts] = rest.split('/').filter(Boolean);
-  if (!namespaceSlug || namespaceSlug === 'document') return null;
-  return buildKnowledgeRoutePath(basePath, namespaceSlug, pathParts.join('/'));
+  return routeForKnowledgeRefUri(uri, basePath);
 }
 
 export function targetForLinkAttachment(args: {

--- a/apps/agor-ui/src/components/Links/LinkAttachmentCard.tsx
+++ b/apps/agor-ui/src/components/Links/LinkAttachmentCard.tsx
@@ -1,4 +1,4 @@
-import type { LinkKind, LinkSource } from '@agor-live/client';
+import { getSafeWebUrl, type LinkKind, type LinkSource } from '@agor-live/client';
 import {
   BookOutlined,
   CodeOutlined,
@@ -82,7 +82,8 @@ export function targetForLinkAttachment(args: {
     const route = routeForKnowledgeUri(args.refUri);
     return route ? { href: route, navigation: 'spa' } : null;
   }
-  if (args.url) return { href: args.url, navigation: 'external' };
+  const safeUrl = getSafeWebUrl(args.url);
+  if (safeUrl) return { href: safeUrl, navigation: 'external' };
   return null;
 }
 

--- a/apps/agor-ui/src/components/Links/LinkAttachmentCard.tsx
+++ b/apps/agor-ui/src/components/Links/LinkAttachmentCard.tsx
@@ -1,0 +1,477 @@
+import type { LinkKind, LinkSource } from '@agor-live/client';
+import {
+  BookOutlined,
+  CodeOutlined,
+  DownloadOutlined,
+  FileExcelOutlined,
+  FileImageOutlined,
+  FileOutlined,
+  FilePdfOutlined,
+  FileTextOutlined,
+} from '@ant-design/icons';
+import { Tooltip, Typography, theme } from 'antd';
+import type React from 'react';
+import { buildKnowledgeRoutePath } from '../../utils/knowledgeRoutes';
+import { useThemedMessage } from '../../utils/message';
+import type { LinkImagePreviewTarget } from './LinkImagePreviewModal';
+import { LinkImageThumbnail } from './LinkImageThumbnail';
+import { downloadLinkContent, getSafeLinkContentLabel } from './linkContent';
+
+export interface LinkAttachmentTarget {
+  href: string;
+  navigation: 'spa' | 'external';
+}
+
+export interface LinkAttachmentCardProps {
+  kind?: LinkKind | null;
+  source?: LinkSource | 'branch' | 'fixture' | string | null;
+  linkId?: string | null;
+  title: string;
+  subtitle?: string | null;
+  url?: string | null;
+  refUri?: string | null;
+  filePath?: string | null;
+  mimeType?: string | null;
+  ownerLabel?: string | null;
+  stateLabel?: string | null;
+  disabledReason?: string | null;
+  compact?: boolean;
+  onDark?: boolean;
+  imageThumbnail?: boolean;
+  onOpenImage?: (target: LinkImagePreviewTarget) => void;
+  onOpenMarkdown?: (target: LinkImagePreviewTarget) => void;
+  onOpenTarget?: (target: LinkAttachmentTarget) => void;
+  actions?: React.ReactNode;
+}
+
+type AttachmentCategory =
+  | 'knowledge'
+  | 'image'
+  | 'pdf'
+  | 'spreadsheet'
+  | 'csv'
+  | 'document'
+  | 'markdown'
+  | 'text'
+  | 'code'
+  | 'json'
+  | 'log'
+  | 'unknown';
+
+const KNOWLEDGE_PREFIX = 'agor://kb/';
+
+const extensionFromPath = (value?: string | null): string => {
+  const cleaned = (value ?? '').split(/[?#]/)[0]?.split('/').pop() ?? '';
+  const dot = cleaned.lastIndexOf('.');
+  return dot >= 0 ? cleaned.slice(dot + 1).toLowerCase() : '';
+};
+
+export function routeForKnowledgeUri(uri?: string | null, basePath = '/kb'): string | null {
+  if (!uri?.startsWith(KNOWLEDGE_PREFIX)) return null;
+  const rest = uri.slice(KNOWLEDGE_PREFIX.length);
+  const [namespaceSlug, ...pathParts] = rest.split('/').filter(Boolean);
+  if (!namespaceSlug || namespaceSlug === 'document') return null;
+  return buildKnowledgeRoutePath(basePath, namespaceSlug, pathParts.join('/'));
+}
+
+export function targetForLinkAttachment(args: {
+  url?: string | null;
+  refUri?: string | null;
+}): LinkAttachmentTarget | null {
+  if (args.refUri?.startsWith(KNOWLEDGE_PREFIX)) {
+    const route = routeForKnowledgeUri(args.refUri);
+    return route ? { href: route, navigation: 'spa' } : null;
+  }
+  if (args.url) return { href: args.url, navigation: 'external' };
+  return null;
+}
+
+export function canUseLinkContentRoute(args: {
+  source?: LinkSource | 'branch' | 'fixture' | string | null;
+  linkId?: string | null;
+  filePath?: string | null;
+}): boolean {
+  return args.source === 'upload' && Boolean(args.linkId) && Boolean(args.filePath);
+}
+
+export function inferLinkAttachmentCategory(args: {
+  kind?: LinkKind | string | null;
+  mimeType?: string | null;
+  title?: string | null;
+  filePath?: string | null;
+  refUri?: string | null;
+}): AttachmentCategory {
+  if (args.kind === 'kb_ref' || args.refUri?.startsWith(KNOWLEDGE_PREFIX)) return 'knowledge';
+  if (args.kind === 'image' || args.mimeType?.startsWith('image/')) return 'image';
+
+  const mime = args.mimeType?.split(';')[0]?.trim().toLowerCase() ?? '';
+  const ext = extensionFromPath(args.filePath) || extensionFromPath(args.title);
+
+  if (mime === 'application/pdf' || ext === 'pdf') return 'pdf';
+  if (mime === 'text/csv' || ['csv', 'tsv'].includes(ext)) return 'csv';
+  if (
+    mime.includes('spreadsheet') ||
+    mime.includes('excel') ||
+    ['xls', 'xlsx', 'ods'].includes(ext)
+  ) {
+    return 'spreadsheet';
+  }
+  if (
+    mime.includes('wordprocessingml') ||
+    mime === 'application/msword' ||
+    ['doc', 'docx', 'rtf', 'odt'].includes(ext)
+  ) {
+    return 'document';
+  }
+  if (mime === 'application/json' || ext === 'json') return 'json';
+  if (ext === 'log') return 'log';
+  if (['md', 'markdown'].includes(ext) || mime === 'text/markdown') return 'markdown';
+  if (mime.startsWith('text/') || ['txt', 'adoc', 'rst'].includes(ext)) return 'text';
+  if (
+    [
+      'js',
+      'jsx',
+      'ts',
+      'tsx',
+      'py',
+      'rb',
+      'go',
+      'rs',
+      'java',
+      'c',
+      'cc',
+      'cpp',
+      'h',
+      'hpp',
+      'css',
+      'scss',
+      'html',
+      'xml',
+      'yaml',
+      'yml',
+      'toml',
+      'sql',
+      'sh',
+      'zsh',
+    ].includes(ext)
+  ) {
+    return 'code';
+  }
+  return 'unknown';
+}
+
+export function canPreviewMarkdownLinkAttachment(args: {
+  source?: LinkSource | 'branch' | 'fixture' | string | null;
+  linkId?: string | null;
+  kind?: LinkKind | string | null;
+  mimeType?: string | null;
+  title?: string | null;
+  filePath?: string | null;
+  refUri?: string | null;
+}): boolean {
+  const category = inferLinkAttachmentCategory(args);
+  return canUseLinkContentRoute(args) && (category === 'markdown' || category === 'text');
+}
+
+export function canDownloadLinkAttachment(args: {
+  source?: LinkSource | 'branch' | 'fixture' | string | null;
+  linkId?: string | null;
+  filePath?: string | null;
+}): boolean {
+  return canUseLinkContentRoute(args);
+}
+
+function visualForCategory(category: AttachmentCategory) {
+  switch (category) {
+    case 'knowledge':
+      return { label: 'KB', color: '#722ed1', icon: <BookOutlined /> };
+    case 'image':
+      return { label: 'IMG', color: '#1677ff', icon: <FileImageOutlined /> };
+    case 'pdf':
+      return { label: 'PDF', color: '#cf1322', icon: <FilePdfOutlined /> };
+    case 'spreadsheet':
+      return { label: 'XLS', color: '#389e0d', icon: <FileExcelOutlined /> };
+    case 'csv':
+      return { label: 'CSV', color: '#389e0d', icon: <FileExcelOutlined /> };
+    case 'document':
+      return { label: 'DOC', color: '#0958d9', icon: <FileTextOutlined /> };
+    case 'markdown':
+      return { label: 'MD', color: '#531dab', icon: <FileTextOutlined /> };
+    case 'text':
+      return { label: 'TXT', color: '#531dab', icon: <FileTextOutlined /> };
+    case 'json':
+      return { label: 'JSON', color: '#d46b08', icon: <CodeOutlined /> };
+    case 'log':
+      return { label: 'LOG', color: '#ad6800', icon: <FileTextOutlined /> };
+    case 'code':
+      return { label: 'CODE', color: '#08979c', icon: <CodeOutlined /> };
+    default:
+      return { label: 'FILE', color: '#595959', icon: <FileOutlined /> };
+  }
+}
+
+export function getLinkAttachmentKindLabel(args: {
+  kind?: LinkKind | string | null;
+  mimeType?: string | null;
+  title?: string | null;
+  filePath?: string | null;
+  refUri?: string | null;
+}): string {
+  const category = inferLinkAttachmentCategory(args);
+  return visualForCategory(category).label;
+}
+
+export const LinkAttachmentGlyph: React.FC<{
+  kind?: LinkKind | string | null;
+  mimeType?: string | null;
+  title?: string | null;
+  filePath?: string | null;
+  refUri?: string | null;
+  disabled?: boolean;
+  onDark?: boolean;
+  size?: 'sm' | 'md';
+}> = ({
+  kind,
+  mimeType,
+  title,
+  filePath,
+  refUri,
+  disabled = false,
+  onDark = false,
+  size = 'md',
+}) => {
+  const { token } = theme.useToken();
+  const visual = visualForCategory(
+    inferLinkAttachmentCategory({ kind, mimeType, title, filePath, refUri })
+  );
+  const dimension = size === 'sm' ? 28 : 38;
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: dimension,
+        height: dimension,
+        borderRadius: token.borderRadiusLG,
+        background: 'transparent',
+        color: onDark
+          ? 'rgba(255, 255, 255, 0.78)'
+          : disabled
+            ? token.colorTextSecondary
+            : token.colorTextTertiary,
+        border: `1px solid ${onDark ? 'rgba(255, 255, 255, 0.26)' : token.colorBorderSecondary}`,
+        display: 'inline-flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        lineHeight: 1,
+        flex: '0 0 auto',
+      }}
+    >
+      {size === 'sm' ? (
+        <span style={{ fontSize: 10, fontWeight: 800, letterSpacing: 0.2 }}>{visual.label}</span>
+      ) : (
+        <>
+          <span style={{ fontSize: 15 }}>{visual.icon}</span>
+          <span style={{ fontSize: 9, fontWeight: 700, marginTop: 3 }}>{visual.label}</span>
+        </>
+      )}
+    </span>
+  );
+};
+
+export const LinkAttachmentCard: React.FC<LinkAttachmentCardProps> = ({
+  kind,
+  source,
+  linkId,
+  title,
+  subtitle,
+  url,
+  refUri,
+  filePath,
+  mimeType,
+  ownerLabel,
+  stateLabel,
+  disabledReason,
+  compact = false,
+  onDark = false,
+  imageThumbnail = false,
+  onOpenImage,
+  onOpenMarkdown,
+  onOpenTarget,
+  actions,
+}) => {
+  const { token } = theme.useToken();
+  const { showError } = useThemedMessage();
+  const target = targetForLinkAttachment({ url, refUri });
+  const canPreviewImage =
+    kind === 'image' && source === 'upload' && Boolean(linkId) && !disabledReason;
+  const canPreviewMarkdown =
+    canPreviewMarkdownLinkAttachment({ source, linkId, kind, mimeType, title, filePath, refUri }) &&
+    !disabledReason;
+  const canDownload =
+    canDownloadLinkAttachment({ source, linkId, filePath }) &&
+    !canPreviewImage &&
+    !canPreviewMarkdown;
+  const disabled =
+    Boolean(disabledReason) || (!canPreviewImage && !canPreviewMarkdown && !canDownload && !target);
+  const reason =
+    disabledReason ??
+    (!target && !canPreviewImage && !canPreviewMarkdown && !canDownload
+      ? 'Preview/download unavailable'
+      : null);
+  const description = getSafeLinkContentLabel(subtitle ?? refUri ?? url ?? filePath);
+  const metaParts = [ownerLabel, stateLabel, reason].filter(Boolean).join(' · ');
+
+  if (imageThumbnail && canPreviewImage && linkId && onOpenImage) {
+    return (
+      <LinkImageThumbnail
+        linkId={linkId}
+        title={title}
+        subtitle={description}
+        onOpen={onOpenImage}
+      />
+    );
+  }
+
+  const open = (event: React.MouseEvent | React.KeyboardEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (disabled) return;
+    if (canPreviewImage && linkId && onOpenImage) {
+      onOpenImage({ linkId, title, subtitle: description });
+      return;
+    }
+    if (canPreviewMarkdown && linkId && onOpenMarkdown) {
+      onOpenMarkdown({ linkId, title, subtitle: description });
+      return;
+    }
+    if (target) onOpenTarget?.(target);
+    if (canDownload && linkId) {
+      downloadLinkContent(linkId, title).catch((err) => {
+        showError(err instanceof Error ? err.message : 'Download failed');
+      });
+    }
+  };
+
+  const onKeyDown: React.KeyboardEventHandler<HTMLButtonElement> = (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    open(event);
+  };
+
+  return (
+    <Tooltip title={reason ?? description ?? title} mouseEnterDelay={0.6}>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label={disabled ? `${title}: ${reason}` : `Open ${title}`}
+        onClick={open}
+        onKeyDown={onKeyDown}
+        style={{
+          width: compact ? '100%' : 'min(100%, 360px)',
+          maxWidth: '100%',
+          border: `1px solid ${
+            onDark
+              ? 'rgba(255, 255, 255, 0.16)'
+              : disabled
+                ? token.colorBorderSecondary
+                : token.colorBorder
+          }`,
+          borderRadius: token.borderRadiusLG,
+          background: onDark
+            ? 'rgba(255, 255, 255, 0.09)'
+            : disabled
+              ? token.colorFillQuaternary
+              : token.colorBgContainer,
+          color: onDark ? 'rgba(255, 255, 255, 0.92)' : token.colorText,
+          cursor: disabled ? 'not-allowed' : canPreviewImage ? 'zoom-in' : 'pointer',
+          padding: compact ? `${token.paddingXXS + 2}px ${token.paddingXS}px` : token.paddingSM,
+          font: 'inherit',
+          textAlign: 'left',
+          display: 'flex',
+          alignItems: 'center',
+          gap: token.sizeSM,
+          opacity: 1,
+        }}
+      >
+        <LinkAttachmentGlyph
+          kind={kind}
+          mimeType={mimeType}
+          title={title}
+          filePath={filePath}
+          refUri={refUri}
+          disabled={disabled}
+          onDark={onDark}
+          size={compact ? 'sm' : 'md'}
+        />
+        <span style={{ minWidth: 0, flex: 1 }}>
+          <Typography.Text
+            strong={!compact}
+            ellipsis
+            style={{
+              display: 'block',
+              color: onDark
+                ? 'rgba(255, 255, 255, 0.94)'
+                : disabled
+                  ? token.colorTextSecondary
+                  : token.colorText,
+              fontSize: compact ? 13 : undefined,
+              minWidth: 0,
+            }}
+          >
+            {title}
+          </Typography.Text>
+          {description && (
+            <Typography.Text
+              ellipsis
+              style={{
+                display: 'block',
+                color: onDark ? 'rgba(255, 255, 255, 0.62)' : token.colorTextSecondary,
+                fontSize: compact ? 11 : 12,
+              }}
+            >
+              {description}
+            </Typography.Text>
+          )}
+          {metaParts && (
+            <Typography.Text
+              ellipsis
+              style={{
+                display: 'block',
+                marginTop: compact ? 0 : 4,
+                color: onDark ? 'rgba(255, 255, 255, 0.58)' : token.colorTextTertiary,
+                fontSize: 11,
+              }}
+            >
+              {metaParts}
+            </Typography.Text>
+          )}
+        </span>
+        {(canDownload || actions) && (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: token.sizeXXS }}>
+            {canDownload && linkId && (
+              <Tooltip title="Download file">
+                <span
+                  aria-hidden
+                  style={{
+                    width: 24,
+                    height: 24,
+                    borderRadius: 999,
+                    color: onDark ? 'rgba(255, 255, 255, 0.78)' : token.colorTextSecondary,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: 'pointer',
+                    flex: '0 0 auto',
+                  }}
+                >
+                  <DownloadOutlined />
+                </span>
+              </Tooltip>
+            )}
+            {actions && <span onClick={(event) => event.stopPropagation()}>{actions}</span>}
+          </span>
+        )}
+      </button>
+    </Tooltip>
+  );
+};

--- a/apps/agor-ui/src/components/Links/LinkImagePreviewModal.tsx
+++ b/apps/agor-ui/src/components/Links/LinkImagePreviewModal.tsx
@@ -1,0 +1,106 @@
+import { Alert, Modal, Spin, Typography, theme } from 'antd';
+import React from 'react';
+import { fetchLinkObjectUrl, getSafeLinkContentLabel, type LinkContentTarget } from './linkContent';
+
+export type LinkImagePreviewTarget = LinkContentTarget;
+
+interface LinkImagePreviewModalProps {
+  target: LinkImagePreviewTarget | null;
+  onClose: () => void;
+}
+
+export async function fetchLinkImageObjectUrl(linkId: string): Promise<string> {
+  return fetchLinkObjectUrl(linkId, { accept: 'image/png, image/jpeg, image/gif, image/webp' });
+}
+
+export const LinkImagePreviewModal: React.FC<LinkImagePreviewModalProps> = ({
+  target,
+  onClose,
+}) => {
+  const { token } = theme.useToken();
+  const [objectUrl, setObjectUrl] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const safeSubtitle = getSafeLinkContentLabel(target?.subtitle);
+
+  React.useEffect(() => {
+    if (!target) {
+      setObjectUrl(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    let createdUrl: string | null = null;
+    setLoading(true);
+    setError(null);
+    setObjectUrl(null);
+
+    fetchLinkImageObjectUrl(target.linkId)
+      .then((url) => {
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        createdUrl = url;
+        setObjectUrl(url);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Preview failed');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [target]);
+
+  return (
+    <Modal
+      open={Boolean(target)}
+      title={target?.title ?? 'Image preview'}
+      onCancel={onClose}
+      footer={null}
+      width="min(960px, 92vw)"
+      destroyOnHidden
+    >
+      <div data-testid="link-image-preview-modal">
+        {safeSubtitle && (
+          <Typography.Text type="secondary" ellipsis style={{ display: 'block', marginBottom: 12 }}>
+            {safeSubtitle}
+          </Typography.Text>
+        )}
+        {loading && (
+          <div style={{ display: 'grid', placeItems: 'center', minHeight: 260 }}>
+            <Spin tip="Loading image preview…" />
+          </div>
+        )}
+        {error && <Alert type="warning" showIcon message={error} />}
+        {objectUrl && !error && (
+          <div
+            style={{
+              display: 'grid',
+              placeItems: 'center',
+              background: token.colorFillQuaternary,
+              borderRadius: token.borderRadiusLG,
+              padding: token.paddingSM,
+              maxHeight: '72vh',
+              overflow: 'auto',
+            }}
+          >
+            <img
+              data-testid="link-image-preview-image"
+              src={objectUrl}
+              alt={target?.title ?? 'Uploaded image preview'}
+              style={{ maxWidth: '100%', maxHeight: '68vh', objectFit: 'contain' }}
+            />
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/apps/agor-ui/src/components/Links/LinkImageThumbnail.test.tsx
+++ b/apps/agor-ui/src/components/Links/LinkImageThumbnail.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LinkImageThumbnail } from './LinkImageThumbnail';
+
+describe('LinkImageThumbnail', () => {
+  it('does not download image content before click-to-preview', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const onOpen = vi.fn();
+
+    render(
+      <LinkImageThumbnail
+        linkId="link-1"
+        title="screenshot.png"
+        subtitle="/home/agor/.agor/uploads/screenshot.png"
+        onOpen={onOpen}
+      />
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('Click to preview')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /open image preview for screenshot\.png/i })
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalledWith({
+      linkId: 'link-1',
+      title: 'screenshot.png',
+      subtitle: 'screenshot.png',
+    });
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/apps/agor-ui/src/components/Links/LinkImageThumbnail.tsx
+++ b/apps/agor-ui/src/components/Links/LinkImageThumbnail.tsx
@@ -1,0 +1,137 @@
+import { FileImageOutlined } from '@ant-design/icons';
+import { Alert, Spin, Tooltip, Typography, theme } from 'antd';
+import React from 'react';
+import { fetchLinkImageObjectUrl, type LinkImagePreviewTarget } from './LinkImagePreviewModal';
+import { getSafeLinkContentLabel } from './linkContent';
+
+interface LinkImageThumbnailProps {
+  linkId: string;
+  title: string;
+  subtitle?: string | null;
+  onOpen: (target: LinkImagePreviewTarget) => void;
+}
+
+export const LinkImageThumbnail: React.FC<LinkImageThumbnailProps> = ({
+  linkId,
+  title,
+  subtitle,
+  onOpen,
+}) => {
+  const { token } = theme.useToken();
+  const [objectUrl, setObjectUrl] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let createdUrl: string | null = null;
+    setLoading(true);
+    setError(null);
+    setObjectUrl(null);
+
+    fetchLinkImageObjectUrl(linkId)
+      .then((url) => {
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        createdUrl = url;
+        setObjectUrl(url);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Preview failed');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [linkId]);
+
+  const safeSubtitle = getSafeLinkContentLabel(subtitle);
+
+  const handleOpen = (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!objectUrl || error) return;
+    onOpen({ linkId, title, subtitle: safeSubtitle });
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={!objectUrl || Boolean(error)}
+      aria-label={`Open image preview for ${title}`}
+      onClick={handleOpen}
+      style={{
+        display: 'block',
+        width: 'fit-content',
+        maxWidth: 320,
+        marginTop: token.sizeUnit,
+        padding: 0,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: token.borderRadiusLG,
+        background: token.colorBgContainer,
+        overflow: 'hidden',
+        cursor: objectUrl && !error ? 'zoom-in' : 'default',
+        color: token.colorText,
+        font: 'inherit',
+        textAlign: 'left',
+      }}
+    >
+      <div
+        style={{
+          width: 260,
+          minHeight: 120,
+          maxHeight: 180,
+          display: 'grid',
+          placeItems: 'center',
+          background: token.colorFillQuaternary,
+        }}
+      >
+        {loading && <Spin size="small" />}
+        {error && (
+          <Alert
+            type="warning"
+            showIcon
+            message="Preview unavailable"
+            description={error}
+            style={{ margin: token.marginXS, maxWidth: 240 }}
+          />
+        )}
+        {objectUrl && !error && (
+          <img
+            src={objectUrl}
+            alt={title}
+            style={{
+              display: 'block',
+              maxWidth: 320,
+              maxHeight: 180,
+              width: 'auto',
+              height: 'auto',
+              objectFit: 'contain',
+            }}
+          />
+        )}
+      </div>
+      <Tooltip title={safeSubtitle || title} mouseEnterDelay={0.6}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: token.sizeXS,
+            padding: `${token.paddingXXS}px ${token.paddingXS}px`,
+          }}
+        >
+          <FileImageOutlined style={{ color: token.colorTextSecondary, flexShrink: 0 }} />
+          <Typography.Text ellipsis style={{ maxWidth: 230, fontSize: token.fontSizeSM }}>
+            {title}
+          </Typography.Text>
+        </div>
+      </Tooltip>
+    </button>
+  );
+};

--- a/apps/agor-ui/src/components/Links/LinkImageThumbnail.tsx
+++ b/apps/agor-ui/src/components/Links/LinkImageThumbnail.tsx
@@ -1,7 +1,7 @@
 import { FileImageOutlined } from '@ant-design/icons';
-import { Alert, Spin, Tooltip, Typography, theme } from 'antd';
-import React from 'react';
-import { fetchLinkImageObjectUrl, type LinkImagePreviewTarget } from './LinkImagePreviewModal';
+import { Tooltip, Typography, theme } from 'antd';
+import type React from 'react';
+import type { LinkImagePreviewTarget } from './LinkImagePreviewModal';
 import { getSafeLinkContentLabel } from './linkContent';
 
 interface LinkImageThumbnailProps {
@@ -18,52 +18,17 @@ export const LinkImageThumbnail: React.FC<LinkImageThumbnailProps> = ({
   onOpen,
 }) => {
   const { token } = theme.useToken();
-  const [objectUrl, setObjectUrl] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
-  const [loading, setLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    let cancelled = false;
-    let createdUrl: string | null = null;
-    setLoading(true);
-    setError(null);
-    setObjectUrl(null);
-
-    fetchLinkImageObjectUrl(linkId)
-      .then((url) => {
-        if (cancelled) {
-          URL.revokeObjectURL(url);
-          return;
-        }
-        createdUrl = url;
-        setObjectUrl(url);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Preview failed');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-      if (createdUrl) URL.revokeObjectURL(createdUrl);
-    };
-  }, [linkId]);
-
   const safeSubtitle = getSafeLinkContentLabel(subtitle);
 
   const handleOpen = (event: React.MouseEvent) => {
     event.preventDefault();
     event.stopPropagation();
-    if (!objectUrl || error) return;
     onOpen({ linkId, title, subtitle: safeSubtitle });
   };
 
   return (
     <button
       type="button"
-      disabled={!objectUrl || Boolean(error)}
       aria-label={`Open image preview for ${title}`}
       onClick={handleOpen}
       style={{
@@ -76,7 +41,7 @@ export const LinkImageThumbnail: React.FC<LinkImageThumbnailProps> = ({
         borderRadius: token.borderRadiusLG,
         background: token.colorBgContainer,
         overflow: 'hidden',
-        cursor: objectUrl && !error ? 'zoom-in' : 'default',
+        cursor: 'zoom-in',
         color: token.colorText,
         font: 'inherit',
         textAlign: 'left',
@@ -92,30 +57,20 @@ export const LinkImageThumbnail: React.FC<LinkImageThumbnailProps> = ({
           background: token.colorFillQuaternary,
         }}
       >
-        {loading && <Spin size="small" />}
-        {error && (
-          <Alert
-            type="warning"
-            showIcon
-            message="Preview unavailable"
-            description={error}
-            style={{ margin: token.marginXS, maxWidth: 240 }}
-          />
-        )}
-        {objectUrl && !error && (
-          <img
-            src={objectUrl}
-            alt={title}
-            style={{
-              display: 'block',
-              maxWidth: 320,
-              maxHeight: 180,
-              width: 'auto',
-              height: 'auto',
-              objectFit: 'contain',
-            }}
-          />
-        )}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: token.sizeXS,
+            color: token.colorTextTertiary,
+          }}
+        >
+          <FileImageOutlined style={{ fontSize: 28 }} />
+          <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+            Click to preview
+          </Typography.Text>
+        </div>
       </div>
       <Tooltip title={safeSubtitle || title} mouseEnterDelay={0.6}>
         <div

--- a/apps/agor-ui/src/components/Links/LinkMarkdownPreviewModal.tsx
+++ b/apps/agor-ui/src/components/Links/LinkMarkdownPreviewModal.tsx
@@ -1,0 +1,87 @@
+import { Alert, Modal, Spin, Typography } from 'antd';
+import React from 'react';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import {
+  fetchLinkMarkdownText,
+  getSafeLinkContentLabel,
+  type LinkContentTarget,
+} from './linkContent';
+
+export type LinkMarkdownPreviewTarget = LinkContentTarget;
+
+interface LinkMarkdownPreviewModalProps {
+  target: LinkMarkdownPreviewTarget | null;
+  onClose: () => void;
+}
+
+export const LinkMarkdownPreviewModal: React.FC<LinkMarkdownPreviewModalProps> = ({
+  target,
+  onClose,
+}) => {
+  const [content, setContent] = React.useState<string>('');
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const safeSubtitle = getSafeLinkContentLabel(target?.subtitle);
+
+  React.useEffect(() => {
+    if (!target) {
+      setContent('');
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setContent('');
+
+    fetchLinkMarkdownText(target.linkId)
+      .then((text) => {
+        if (!cancelled) setContent(text);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Preview failed');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [target]);
+
+  return (
+    <Modal
+      open={Boolean(target)}
+      title={target?.title ?? 'Markdown preview'}
+      onCancel={onClose}
+      footer={null}
+      width={900}
+      destroyOnHidden
+      styles={{
+        body: {
+          maxHeight: '70vh',
+          overflowY: 'auto',
+          padding: 24,
+        },
+      }}
+    >
+      <div data-testid="link-markdown-preview-modal">
+        {safeSubtitle && (
+          <Typography.Text type="secondary" ellipsis style={{ display: 'block', marginBottom: 12 }}>
+            {safeSubtitle}
+          </Typography.Text>
+        )}
+        {loading && (
+          <div style={{ display: 'grid', placeItems: 'center', minHeight: 220 }}>
+            <Spin tip="Loading markdown preview…" />
+          </div>
+        )}
+        {error && <Alert type="warning" showIcon message={error} />}
+        {!loading && !error && content && <MarkdownRenderer content={content} />}
+      </div>
+    </Modal>
+  );
+};

--- a/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
+++ b/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
@@ -234,12 +234,11 @@ export const PromotedPinnedLinks: React.FC<PromotedPinnedLinksProps> = ({
                         : token.colorText,
                     '--agor-link-chip-accent-color': disabled
                       ? token.colorTextDisabled
-                      : isBranchCard
-                        ? token.colorTextTertiary
-                        : token.colorPrimary,
+                      : token.colorTextTertiary,
                     '--agor-link-chip-hover-bg': token.colorPrimaryBgHover,
                     '--agor-link-chip-hover-border': token.colorPrimaryBorderHover,
                     '--agor-link-chip-hover-color': token.colorPrimary,
+                    '--agor-link-chip-hover-accent-color': token.colorTextTertiary,
                     height: chipHeight,
                     minWidth: 0,
                     maxWidth: chipMaxWidth,

--- a/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
+++ b/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
@@ -209,6 +209,7 @@ export const PromotedPinnedLinks: React.FC<PromotedPinnedLinksProps> = ({
               mouseEnterDelay={0.45}
             >
               <button
+                className="agor-action-link-chip"
                 type="button"
                 disabled={disabled}
                 aria-label={
@@ -218,42 +219,59 @@ export const PromotedPinnedLinks: React.FC<PromotedPinnedLinksProps> = ({
                   event.stopPropagation();
                   openItem(item);
                 }}
-                style={{
-                  height: chipHeight,
-                  minWidth: 0,
-                  maxWidth: chipMaxWidth,
-                  border: `1px solid ${disabled ? token.colorBorderSecondary : token.colorPrimaryBorder}`,
-                  borderRadius: 999,
-                  background: disabled ? token.colorFillQuaternary : token.colorPrimaryBg,
-                  color: disabled ? token.colorTextDisabled : token.colorText,
-                  cursor: disabled ? 'not-allowed' : canPreviewImage(item) ? 'zoom-in' : 'pointer',
-                  padding: `0 ${token.paddingXS}px`,
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 5,
-                  font: 'inherit',
-                  lineHeight: 1,
-                  flex: '0 1 auto',
-                }}
-              >
-                <PushpinFilled
-                  style={{
-                    color: disabled
+                style={
+                  {
+                    '--agor-link-chip-bg': disabled
+                      ? token.colorFillQuaternary
+                      : token.colorPrimaryBg,
+                    '--agor-link-chip-border': disabled
+                      ? token.colorBorderSecondary
+                      : token.colorPrimaryBorder,
+                    '--agor-link-chip-color': disabled
+                      ? token.colorTextDisabled
+                      : isBranchCard
+                        ? token.colorTextSecondary
+                        : token.colorText,
+                    '--agor-link-chip-accent-color': disabled
                       ? token.colorTextDisabled
                       : isBranchCard
                         ? token.colorTextTertiary
                         : token.colorPrimary,
+                    '--agor-link-chip-hover-bg': token.colorPrimaryBgHover,
+                    '--agor-link-chip-hover-border': token.colorPrimary,
+                    '--agor-link-chip-hover-color': token.colorPrimary,
+                    height: chipHeight,
+                    minWidth: 0,
+                    maxWidth: chipMaxWidth,
+                    border: '1px solid var(--agor-link-chip-border)',
+                    borderRadius: 999,
+                    cursor: disabled
+                      ? 'not-allowed'
+                      : canPreviewImage(item)
+                        ? 'zoom-in'
+                        : 'pointer',
+                    padding: `0 ${token.paddingXS}px`,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    font: 'inherit',
+                    lineHeight: 1,
+                    flex: '0 1 auto',
+                  } as React.CSSProperties
+                }
+              >
+                <PushpinFilled
+                  className="agor-action-link-affordance"
+                  style={{
+                    color: 'var(--agor-link-chip-accent-color)',
                     fontSize: isBranchCard ? 10 : 11,
                   }}
                 />
                 <span
+                  className="agor-action-link-icon"
                   style={{
                     width: 14,
-                    color: disabled
-                      ? token.colorTextDisabled
-                      : isBranchCard
-                        ? token.colorTextTertiary
-                        : token.colorPrimary,
+                    color: 'var(--agor-link-chip-accent-color)',
                     display: 'inline-flex',
                     alignItems: 'center',
                     justifyContent: 'center',
@@ -263,15 +281,12 @@ export const PromotedPinnedLinks: React.FC<PromotedPinnedLinksProps> = ({
                   {getIcon(item, disabled)}
                 </span>
                 <Typography.Text
+                  className={disabled ? undefined : 'agor-action-link-title'}
                   ellipsis
                   style={{
                     fontSize: isBranchCard ? 11 : 12,
                     maxWidth: chipMaxWidth - 50,
-                    color: disabled
-                      ? token.colorTextDisabled
-                      : isBranchCard
-                        ? token.colorTextSecondary
-                        : token.colorText,
+                    color: 'var(--agor-link-chip-color)',
                   }}
                 >
                   {item.name.replace(/^(Issue|PR|Knowledge|Saved URL):\s*/i, '')}

--- a/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
+++ b/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
@@ -1,0 +1,314 @@
+import {
+  BookOutlined,
+  FileImageOutlined,
+  FileTextOutlined,
+  GithubOutlined,
+  GlobalOutlined,
+  LinkOutlined,
+  PushpinFilled,
+  StopOutlined,
+} from '@ant-design/icons';
+import { Button, Tooltip, Typography, theme } from 'antd';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useThemedMessage } from '../../utils/message';
+import {
+  canDownloadLinkAttachment,
+  canPreviewMarkdownLinkAttachment,
+  type LinkAttachmentTarget,
+  targetForLinkAttachment,
+} from './LinkAttachmentCard';
+import { LinkImagePreviewModal, type LinkImagePreviewTarget } from './LinkImagePreviewModal';
+import {
+  LinkMarkdownPreviewModal,
+  type LinkMarkdownPreviewTarget,
+} from './LinkMarkdownPreviewModal';
+import { downloadLinkContent, getSafeLinkContentLabel } from './linkContent';
+
+export interface PromotedPinnedLinkItem {
+  key: string;
+  name: string;
+  url?: string | null;
+  refUri?: string | null;
+  filePath?: string | null;
+  mimeType?: string | null;
+  linkId?: string | null;
+  kind?: string | null;
+  source?: string | null;
+  disabled?: boolean;
+  note?: string | null;
+}
+
+interface PromotedPinnedLinksProps {
+  items: PromotedPinnedLinkItem[];
+  max?: number;
+  variant?: 'session-header' | 'branch-card';
+  overflowLabel?: string;
+  onOverflow?: () => void;
+  onOpenTarget?: (target: LinkAttachmentTarget) => void;
+  empty?: React.ReactNode;
+  'data-testid'?: string;
+}
+
+function canPreviewImage(item: PromotedPinnedLinkItem): boolean {
+  return (
+    item.kind === 'image' && item.source === 'upload' && Boolean(item.linkId) && !item.disabled
+  );
+}
+
+function canPreviewMarkdown(item: PromotedPinnedLinkItem): boolean {
+  return canPreviewMarkdownLinkAttachment({
+    source: item.source,
+    linkId: item.linkId,
+    kind: item.kind,
+    mimeType: item.mimeType,
+    title: item.name,
+    filePath: item.filePath,
+    refUri: item.refUri,
+  });
+}
+
+function canDownloadFile(item: PromotedPinnedLinkItem): boolean {
+  return (
+    canDownloadLinkAttachment({
+      source: item.source,
+      linkId: item.linkId,
+      filePath: item.filePath,
+    }) &&
+    !canPreviewImage(item) &&
+    !canPreviewMarkdown(item)
+  );
+}
+
+function disabledReasonForItem(item: PromotedPinnedLinkItem): string | null {
+  if (item.disabled) return item.note || 'Preview/download unavailable';
+  if (canPreviewImage(item)) return null;
+  if (canPreviewMarkdown(item) || canDownloadFile(item)) return null;
+  if (item.source === 'upload' || item.filePath || item.kind === 'image') {
+    return item.note || 'Preview/download unavailable';
+  }
+  if (!targetForLinkAttachment({ url: item.url, refUri: item.refUri })) {
+    return 'No safe route is available for this item yet.';
+  }
+  return null;
+}
+
+function getTargetDisplay(item: PromotedPinnedLinkItem): string {
+  if (item.url) {
+    try {
+      const parsed = new URL(item.url);
+      return `${parsed.hostname}${parsed.pathname}`;
+    } catch {
+      return item.url;
+    }
+  }
+  if (item.refUri) return item.refUri;
+  if (item.filePath) return getSafeLinkContentLabel(item.filePath) || item.name;
+  return item.name;
+}
+
+function getIcon(item: PromotedPinnedLinkItem, disabled: boolean): React.ReactNode {
+  if (disabled) return <StopOutlined />;
+  if (item.kind === 'kb_ref' || item.refUri?.startsWith('agor://kb/')) return <BookOutlined />;
+  if (item.kind === 'image') return <FileImageOutlined />;
+  if (item.kind === 'document' || item.filePath) return <FileTextOutlined />;
+  const target = item.url ?? item.refUri ?? '';
+  try {
+    const { hostname } = new URL(target);
+    if (hostname === 'github.com' || hostname.endsWith('.github.com')) return <GithubOutlined />;
+  } catch {
+    // ignore non-URL targets
+  }
+  return item.kind === 'url' ? <GlobalOutlined /> : <LinkOutlined />;
+}
+
+export const PromotedPinnedLinks: React.FC<PromotedPinnedLinksProps> = ({
+  items,
+  max = 3,
+  variant = 'session-header',
+  overflowLabel,
+  onOverflow,
+  onOpenTarget,
+  empty = null,
+  'data-testid': dataTestId,
+}) => {
+  const { token } = theme.useToken();
+  const navigate = useNavigate();
+  const { showError } = useThemedMessage();
+  const [previewTarget, setPreviewTarget] = React.useState<LinkImagePreviewTarget | null>(null);
+  const [markdownTarget, setMarkdownTarget] = React.useState<LinkMarkdownPreviewTarget | null>(
+    null
+  );
+
+  if (items.length === 0) return <>{empty}</>;
+
+  const visibleItems = items.slice(0, max);
+  const hiddenCount = Math.max(0, items.length - visibleItems.length);
+  const isBranchCard = variant === 'branch-card';
+
+  const openAttachmentTarget = (target: LinkAttachmentTarget) => {
+    if (onOpenTarget) {
+      onOpenTarget(target);
+      return;
+    }
+    if (target.navigation === 'spa') {
+      navigate(target.href);
+      return;
+    }
+    window.open(target.href, '_blank', 'noopener,noreferrer');
+  };
+
+  const openItem = (item: PromotedPinnedLinkItem) => {
+    if (canPreviewImage(item) && item.linkId) {
+      setPreviewTarget({ linkId: item.linkId, title: item.name, subtitle: getTargetDisplay(item) });
+      return;
+    }
+    if (canPreviewMarkdown(item) && item.linkId) {
+      setMarkdownTarget({
+        linkId: item.linkId,
+        title: item.name,
+        subtitle: getTargetDisplay(item),
+      });
+      return;
+    }
+    if (canDownloadFile(item) && item.linkId) {
+      downloadLinkContent(item.linkId, item.name).catch((err) => {
+        showError(err instanceof Error ? err.message : 'Download failed');
+      });
+      return;
+    }
+    const target = targetForLinkAttachment({ url: item.url, refUri: item.refUri });
+    if (!target || disabledReasonForItem(item)) return;
+    openAttachmentTarget(target);
+  };
+
+  const chipHeight = isBranchCard ? 22 : 26;
+  const chipMaxWidth = isBranchCard ? 118 : 156;
+
+  return (
+    <>
+      <div
+        data-testid={dataTestId}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: token.sizeXXS,
+          minWidth: 0,
+          flexWrap: 'nowrap',
+          overflow: 'hidden',
+          maxWidth: isBranchCard ? '100%' : 500,
+        }}
+      >
+        {visibleItems.map((item) => {
+          const disabledReason = disabledReasonForItem(item);
+          const disabled = Boolean(disabledReason);
+          return (
+            <Tooltip
+              key={item.key}
+              title={disabledReason ?? `${item.name} · ${getTargetDisplay(item)}`}
+              mouseEnterDelay={0.45}
+            >
+              <button
+                type="button"
+                disabled={disabled}
+                aria-label={
+                  disabled ? `${item.name}: ${disabledReason}` : `Open pinned ${item.name}`
+                }
+                onClick={(event) => {
+                  event.stopPropagation();
+                  openItem(item);
+                }}
+                style={{
+                  height: chipHeight,
+                  minWidth: 0,
+                  maxWidth: chipMaxWidth,
+                  border: `1px solid ${disabled ? token.colorBorderSecondary : token.colorPrimaryBorder}`,
+                  borderRadius: 999,
+                  background: disabled ? token.colorFillQuaternary : token.colorPrimaryBg,
+                  color: disabled ? token.colorTextDisabled : token.colorText,
+                  cursor: disabled ? 'not-allowed' : canPreviewImage(item) ? 'zoom-in' : 'pointer',
+                  padding: `0 ${token.paddingXS}px`,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 5,
+                  font: 'inherit',
+                  lineHeight: 1,
+                  flex: '0 1 auto',
+                }}
+              >
+                <PushpinFilled
+                  style={{
+                    color: disabled
+                      ? token.colorTextDisabled
+                      : isBranchCard
+                        ? token.colorTextTertiary
+                        : token.colorPrimary,
+                    fontSize: isBranchCard ? 10 : 11,
+                  }}
+                />
+                <span
+                  style={{
+                    width: 14,
+                    color: disabled
+                      ? token.colorTextDisabled
+                      : isBranchCard
+                        ? token.colorTextTertiary
+                        : token.colorPrimary,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flex: '0 0 auto',
+                  }}
+                >
+                  {getIcon(item, disabled)}
+                </span>
+                <Typography.Text
+                  ellipsis
+                  style={{
+                    fontSize: isBranchCard ? 11 : 12,
+                    maxWidth: chipMaxWidth - 50,
+                    color: disabled
+                      ? token.colorTextDisabled
+                      : isBranchCard
+                        ? token.colorTextSecondary
+                        : token.colorText,
+                  }}
+                >
+                  {item.name.replace(/^(Issue|PR|Knowledge|Saved URL):\s*/i, '')}
+                </Typography.Text>
+              </button>
+            </Tooltip>
+          );
+        })}
+        {hiddenCount > 0 && (
+          <Tooltip
+            title={
+              overflowLabel ?? `${hiddenCount} more pinned link${hiddenCount === 1 ? '' : 's'}`
+            }
+          >
+            <Button
+              size="small"
+              type="text"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOverflow?.();
+              }}
+              style={{
+                height: chipHeight,
+                minWidth: isBranchCard ? 30 : 34,
+                padding: `0 ${token.paddingXXS}px`,
+                borderRadius: 999,
+                color: token.colorPrimary,
+                flex: '0 0 auto',
+              }}
+            >
+              +{hiddenCount}
+            </Button>
+          </Tooltip>
+        )}
+      </div>
+      <LinkImagePreviewModal target={previewTarget} onClose={() => setPreviewTarget(null)} />
+      <LinkMarkdownPreviewModal target={markdownTarget} onClose={() => setMarkdownTarget(null)} />
+    </>
+  );
+};

--- a/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
+++ b/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
@@ -237,8 +237,8 @@ export const PromotedPinnedLinks: React.FC<PromotedPinnedLinksProps> = ({
                       : isBranchCard
                         ? token.colorTextTertiary
                         : token.colorPrimary,
-                    '--agor-link-chip-hover-bg': token.colorPrimaryBgHover,
-                    '--agor-link-chip-hover-border': token.colorPrimary,
+                    '--agor-link-chip-hover-bg': token.colorPrimaryBg,
+                    '--agor-link-chip-hover-border': token.colorPrimaryBorder,
                     '--agor-link-chip-hover-color': token.colorPrimary,
                     height: chipHeight,
                     minWidth: 0,

--- a/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
+++ b/apps/agor-ui/src/components/Links/PromotedPinnedLinks.tsx
@@ -237,8 +237,8 @@ export const PromotedPinnedLinks: React.FC<PromotedPinnedLinksProps> = ({
                       : isBranchCard
                         ? token.colorTextTertiary
                         : token.colorPrimary,
-                    '--agor-link-chip-hover-bg': token.colorPrimaryBg,
-                    '--agor-link-chip-hover-border': token.colorPrimaryBorder,
+                    '--agor-link-chip-hover-bg': token.colorPrimaryBgHover,
+                    '--agor-link-chip-hover-border': token.colorPrimaryBorderHover,
                     '--agor-link-chip-hover-color': token.colorPrimary,
                     height: chipHeight,
                     minWidth: 0,

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.test.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { LinkDisplayItem } from './linkDisplay';
+import { LinkRow } from './SessionLinksControl';
+
+const uploadMarkdownItem: LinkDisplayItem = {
+  key: 'link-1',
+  name: 'notes.md',
+  targetKey: 'file:notes.md',
+  category: 'markdown',
+  source: 'upload',
+  ownerScope: 'session',
+  isPinned: true,
+  filePath: 'notes.md',
+  linkId: 'link-1',
+};
+
+describe('LinkRow', () => {
+  it('keeps the body preview action separate from the pin action', () => {
+    const onPreview = vi.fn();
+    const onDownload = vi.fn();
+    const onTogglePinned = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <LinkRow
+          item={uploadMarkdownItem}
+          onPreview={onPreview}
+          onDownload={onDownload}
+          onTogglePinned={onTogglePinned}
+        />
+      </MemoryRouter>
+    );
+
+    const previewButtons = screen.getAllByRole('button', { name: /preview notes\.md/i });
+    expect(previewButtons).toHaveLength(2);
+
+    fireEvent.click(previewButtons[0]);
+    expect(onPreview).toHaveBeenCalledTimes(1);
+    expect(onDownload).not.toHaveBeenCalled();
+    expect(onTogglePinned).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /unpin from session notes\.md/i }));
+    expect(onPreview).toHaveBeenCalledTimes(1);
+    expect(onTogglePinned).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(previewButtons[1]);
+    expect(onPreview).toHaveBeenCalledTimes(2);
+    expect(onTogglePinned).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.test.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.test.tsx
@@ -33,10 +33,9 @@ describe('LinkRow', () => {
       </MemoryRouter>
     );
 
-    const previewButtons = screen.getAllByRole('button', { name: /preview notes\.md/i });
-    expect(previewButtons).toHaveLength(2);
+    const previewButton = screen.getByRole('button', { name: /preview notes\.md/i });
 
-    fireEvent.click(previewButtons[0]);
+    fireEvent.click(previewButton);
     expect(onPreview).toHaveBeenCalledTimes(1);
     expect(onDownload).not.toHaveBeenCalled();
     expect(onTogglePinned).not.toHaveBeenCalled();
@@ -45,7 +44,7 @@ describe('LinkRow', () => {
     expect(onPreview).toHaveBeenCalledTimes(1);
     expect(onTogglePinned).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(previewButtons[1]);
+    fireEvent.click(previewButton);
     expect(onPreview).toHaveBeenCalledTimes(2);
     expect(onTogglePinned).toHaveBeenCalledTimes(1);
   });

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
@@ -1,12 +1,8 @@
 import {
-  DownloadOutlined,
-  ExportOutlined,
-  EyeOutlined,
   GithubOutlined,
   LinkOutlined,
   PushpinFilled,
   PushpinOutlined,
-  RightOutlined,
   StopOutlined,
 } from '@ant-design/icons';
 import {
@@ -191,7 +187,6 @@ export function LinkRow({
   onPreview,
   onDownload,
   onTogglePinned,
-  busy = false,
   pinning = false,
 }: {
   item: LinkDisplayItem;
@@ -232,24 +227,6 @@ export function LinkRow({
     </Tooltip>
   ) : null;
 
-  const actionButton = contentAction ? (
-    <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
-      <Button
-        type="text"
-        size="small"
-        loading={busy}
-        aria-label={`${contentAction === 'preview' ? 'Preview' : 'Download'} ${title}`}
-        icon={contentAction === 'preview' ? <EyeOutlined /> : <DownloadOutlined />}
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          if (contentAction === 'preview') onPreview?.(item);
-          else onDownload?.(item);
-        }}
-        style={{ color: 'var(--agor-link-icon-color)', flex: '0 0 auto' }}
-      />
-    </Tooltip>
-  ) : null;
 
   const showPassivePinIndicator = item.isPinned && !canTogglePin;
   const isActionable = Boolean(item.href || contentAction);
@@ -292,19 +269,6 @@ export function LinkRow({
           </Typography.Text>
         )}
       </span>
-      {item.href ? (
-        item.navigation === 'spa' ? (
-          <RightOutlined
-            className="agor-action-link-affordance"
-            style={{ color: 'var(--agor-link-icon-color)', fontSize: 12 }}
-          />
-        ) : (
-          <ExportOutlined
-            className="agor-action-link-affordance"
-            style={{ color: 'var(--agor-link-icon-color)', fontSize: 12 }}
-          />
-        )
-      ) : null}
     </span>
   );
 
@@ -384,7 +348,6 @@ export function LinkRow({
     >
       {mainTarget}
       {pinActionButton}
-      {actionButton}
     </span>
   );
 
@@ -723,6 +686,38 @@ function TypePill({ item, compact = false }: { item: LinkDisplayItem; compact?: 
   );
 }
 
+
+function shouldIgnoreRowActivation(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && Boolean(target.closest('a,button,[role="button"]'));
+}
+
+function activateLinkItem(
+  item: LinkDisplayItem,
+  navigate: (to: string) => void,
+  onPreview?: (item: LinkDisplayItem) => void,
+  onDownload?: (item: LinkDisplayItem) => void,
+  onNavigate?: () => void
+) {
+  const contentAction = getLinkContentAction(item);
+  if (contentAction === 'preview') {
+    onPreview?.(item);
+    return;
+  }
+  if (contentAction === 'download') {
+    onDownload?.(item);
+    return;
+  }
+  if (item.href && item.navigation === 'spa') {
+    onNavigate?.();
+    navigate(item.href);
+    return;
+  }
+  if (item.href) {
+    onNavigate?.();
+    window.open(item.href, '_blank', 'noopener,noreferrer');
+  }
+}
+
 function activateContentAction(
   item: LinkDisplayItem,
   onPreview?: (item: LinkDisplayItem) => void,
@@ -834,108 +829,6 @@ function TitleTarget({
   );
 }
 
-function ActionControl({
-  item,
-  onPreview,
-  onDownload,
-  onNavigate,
-  busy = false,
-}: {
-  item: LinkDisplayItem;
-  onPreview?: (item: LinkDisplayItem) => void;
-  onDownload?: (item: LinkDisplayItem) => void;
-  onNavigate?: () => void;
-  busy?: boolean;
-}) {
-  const { token } = theme.useToken();
-  const title = getCompactLinkDisplayName(item);
-  const contentAction = getLinkContentAction(item);
-  const disabledReason = getUnavailableReason(item);
-  const iconLinkStyle: React.CSSProperties = {
-    width: 22,
-    height: 22,
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
-    borderRadius: token.borderRadiusSM,
-  };
-
-  if (contentAction) {
-    return (
-      <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
-        <Button
-          className="agor-action-link-affordance"
-          type="text"
-          size="small"
-          loading={busy}
-          aria-label={`${contentAction === 'preview' ? 'Preview' : 'Download'} ${title}`}
-          icon={contentAction === 'preview' ? <EyeOutlined /> : <DownloadOutlined />}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            activateContentAction(item, onPreview, onDownload);
-          }}
-          style={{
-            width: 22,
-            minWidth: 22,
-            height: 22,
-            padding: 0,
-            color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
-          }}
-        />
-      </Tooltip>
-    );
-  }
-
-  if (item.href && item.navigation === 'spa') {
-    return (
-      <Tooltip title="Open link">
-        <RouterLink
-          className="agor-action-link-affordance"
-          aria-label="Open link"
-          to={item.href}
-          onClick={onNavigate}
-          style={iconLinkStyle}
-        >
-          <RightOutlined />
-        </RouterLink>
-      </Tooltip>
-    );
-  }
-
-  if (item.href) {
-    return (
-      <Tooltip title="Open link">
-        <a
-          className="agor-action-link-affordance"
-          aria-label="Open link"
-          href={item.href}
-          target="_blank"
-          rel="noreferrer"
-          onClick={onNavigate}
-          style={iconLinkStyle}
-        >
-          <ExportOutlined />
-        </a>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Tooltip title={disabledReason ?? 'No route available'}>
-      <span
-        className="agor-action-link-affordance"
-        role="img"
-        aria-label={`No route available for ${title}`}
-        style={{ ...iconLinkStyle, color: token.colorTextDisabled }}
-      >
-        <StopOutlined />
-      </span>
-    </Tooltip>
-  );
-}
-
 function PinAction({
   item,
   onTogglePinned,
@@ -986,31 +879,43 @@ function QuickLinkRow({
   onPreview,
   onDownload,
   onNavigate,
-  busy = false,
 }: {
   item: LinkDisplayItem;
   onPreview?: (item: LinkDisplayItem) => void;
   onDownload?: (item: LinkDisplayItem) => void;
   onNavigate?: () => void;
-  busy?: boolean;
 }) {
   const { token } = theme.useToken();
+  const navigate = useNavigate();
   const disabled = Boolean(getUnavailableReason(item));
   return (
     <div
       className="agor-action-link-row"
+      role={disabled ? undefined : 'link'}
+      tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled || undefined}
+      onClick={(event) => {
+        if (disabled || shouldIgnoreRowActivation(event.target)) return;
+        activateLinkItem(item, navigate, onPreview, onDownload, onNavigate);
+      }}
+      onKeyDown={(event) => {
+        if (disabled || shouldIgnoreRowActivation(event.target)) return;
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        activateLinkItem(item, navigate, onPreview, onDownload, onNavigate);
+      }}
       style={
         {
           '--agor-link-icon-color': disabled ? token.colorTextDisabled : token.colorTextTertiary,
           '--agor-link-row-hover-bg': 'transparent',
           '--agor-link-row-hover-color': token.colorPrimary,
           display: 'grid',
-          gridTemplateColumns: '34px minmax(0, 1fr) 52px 28px',
+          gridTemplateColumns: '34px minmax(0, 1fr) 52px',
           columnGap: token.sizeSM,
           alignItems: 'center',
           minWidth: 0,
           minHeight: 58,
+          cursor: disabled ? 'default' : 'pointer',
           padding: `${token.sizeXS}px ${token.sizeXS}px`,
           borderRadius: token.borderRadius,
         } as React.CSSProperties
@@ -1040,13 +945,6 @@ function QuickLinkRow({
         </Typography.Text>
       </span>
       <TypePill item={item} compact />
-      <ActionControl
-        item={item}
-        onPreview={onPreview}
-        onDownload={onDownload}
-        onNavigate={onNavigate}
-        busy={busy}
-      />
     </div>
   );
 }
@@ -1057,7 +955,6 @@ function ManagementLinkRow({
   onDownload,
   onTogglePinned,
   onNavigate,
-  busy = false,
   pinning = false,
 }: {
   item: LinkDisplayItem;
@@ -1065,22 +962,36 @@ function ManagementLinkRow({
   onDownload?: (item: LinkDisplayItem) => void;
   onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
   onNavigate?: () => void;
-  busy?: boolean;
   pinning?: boolean;
 }) {
   const { token } = theme.useToken();
+  const navigate = useNavigate();
   const targetLabel = getLinkDisplaySecondaryLabel(item);
   const disabledReason = getUnavailableReason(item);
   const disabled = Boolean(disabledReason);
   return (
     <div
+      role={disabled ? undefined : 'link'}
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+      onClick={(event) => {
+        if (disabled || shouldIgnoreRowActivation(event.target)) return;
+        activateLinkItem(item, navigate, onPreview, onDownload, onNavigate);
+      }}
+      onKeyDown={(event) => {
+        if (disabled || shouldIgnoreRowActivation(event.target)) return;
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        activateLinkItem(item, navigate, onPreview, onDownload, onNavigate);
+      }}
       style={{
         display: 'grid',
-        gridTemplateColumns: 'minmax(0, 1.35fr) minmax(110px, 0.45fr) 94px 28px 24px',
+        gridTemplateColumns: 'minmax(0, 1.35fr) minmax(110px, 0.45fr) 94px 24px',
         columnGap: token.sizeMD,
         alignItems: 'center',
         padding: `${token.sizeSM}px 0`,
         borderBottom: `1px solid ${token.colorBorderSecondary}`,
+        cursor: disabled ? 'default' : 'pointer',
         minWidth: 0,
       }}
     >
@@ -1117,13 +1028,6 @@ function ManagementLinkRow({
         {getScopeDomainLabel(item)}
       </Typography.Text>
       <TypePill item={item} />
-      <ActionControl
-        item={item}
-        onPreview={onPreview}
-        onDownload={onDownload}
-        onNavigate={onNavigate}
-        busy={busy}
-      />
       <PinAction item={item} onTogglePinned={onTogglePinned} pinning={pinning} />
     </div>
   );
@@ -1359,7 +1263,7 @@ export const LinksManagementDrawer: React.FC<LinksManagementDrawerProps> = ({
   width = 720,
 }) => {
   const { token } = theme.useToken();
-  const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
+  const { preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
   const [activeFilter, setActiveFilter] = useState<LinkManagementFilter>('all');
 
   const sortedItems = useMemo(() => [...items].sort(compareManagementItems), [items]);
@@ -1427,7 +1331,6 @@ export const LinksManagementDrawer: React.FC<LinksManagementDrawerProps> = ({
                     onDownload={downloadItem}
                     onTogglePinned={onTogglePinned}
                     onNavigate={onClose}
-                    busy={item.linkId === busyLinkId}
                     pinning={item.linkId === pinningLinkId}
                   />
                 ))}
@@ -1460,7 +1363,7 @@ export const SessionLinksControl: React.FC<SessionLinksControlProps> = ({
   const { token } = theme.useToken();
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
+  const { preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
   const quickItems = useMemo(() => selectQuickItems(items, quickLimit), [items, quickLimit]);
   const hiddenCount = Math.max(items.length - quickItems.length, 0);
 
@@ -1517,7 +1420,6 @@ export const SessionLinksControl: React.FC<SessionLinksControlProps> = ({
               onPreview={handlePreview}
               onDownload={handleDownload}
               onNavigate={closePopover}
-              busy={item.linkId === busyLinkId}
             />
           ))}
         </div>

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
@@ -1,0 +1,1507 @@
+import {
+  DownloadOutlined,
+  ExportOutlined,
+  EyeOutlined,
+  GithubOutlined,
+  LinkOutlined,
+  PushpinFilled,
+  PushpinOutlined,
+  RightOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
+import {
+  Badge,
+  Button,
+  Drawer,
+  Empty,
+  Modal,
+  Popover,
+  Segmented,
+  Space,
+  Spin,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { getAuthHeaders } from '../../utils/authHeaders';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import {
+  getLinkContentAction,
+  getLinkContentUrl,
+  getLinkPreviewKind,
+  type LinkPreviewKind,
+} from './linkContent';
+import {
+  getCompactLinkDisplayName,
+  getLinkDisplayGlyphLabel,
+  getLinkDisplaySecondaryLabel,
+  type LinkDisplayCategory,
+  type LinkDisplayItem,
+} from './linkDisplay';
+
+const QUICK_LINK_LIMIT = 7;
+
+export interface SessionLinksControlProps {
+  items: LinkDisplayItem[];
+  loading?: boolean;
+  error?: string | null;
+  quickLimit?: number;
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  pinningLinkId?: string | null;
+}
+
+export interface PinnedLinksStripProps {
+  items: LinkDisplayItem[];
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  pinningLinkId?: string | null;
+  label?: string;
+  'data-testid'?: string;
+}
+
+export interface LinksManagementDrawerProps {
+  items: LinkDisplayItem[];
+  open: boolean;
+  onClose: () => void;
+  title?: React.ReactNode;
+  emptyDescription?: React.ReactNode;
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  pinningLinkId?: string | null;
+  width?: number | string;
+}
+
+type PreviewState = {
+  item: LinkDisplayItem;
+  kind: LinkPreviewKind;
+  loading: boolean;
+  error?: string | null;
+  text?: string;
+  objectUrl?: string;
+};
+
+export function LinkGlyph({ item }: { item: LinkDisplayItem }) {
+  const { token } = theme.useToken();
+  const isGitHubLink = item.category === 'issue' || item.category === 'pr';
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 34,
+        height: 24,
+        borderRadius: token.borderRadiusSM,
+        background: token.colorFillTertiary,
+        color: token.colorTextSecondary,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: 0.2,
+        flex: '0 0 auto',
+      }}
+    >
+      {isGitHubLink ? (
+        <GithubOutlined style={{ fontSize: 14 }} />
+      ) : (
+        getLinkDisplayGlyphLabel(item.category)
+      )}
+    </span>
+  );
+}
+
+function SmallLinkGlyph({ item, disabled = false }: { item: LinkDisplayItem; disabled?: boolean }) {
+  const { token } = theme.useToken();
+  const isGitHubLink = item.category === 'issue' || item.category === 'pr';
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 24,
+        height: 24,
+        borderRadius: token.borderRadiusLG,
+        background: token.colorFillTertiary,
+        color: disabled ? token.colorTextDisabled : token.colorTextTertiary,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 10,
+        fontWeight: 800,
+        letterSpacing: 0.2,
+        flex: '0 0 auto',
+      }}
+    >
+      {disabled ? (
+        <StopOutlined style={{ fontSize: 13 }} />
+      ) : isGitHubLink ? (
+        <GithubOutlined style={{ fontSize: 13 }} />
+      ) : (
+        getLinkDisplayGlyphLabel(item.category)
+      )}
+    </span>
+  );
+}
+
+async function fetchLinkContent(item: LinkDisplayItem, disposition: 'inline' | 'attachment') {
+  if (!item.linkId) throw new Error('Missing link id');
+  const response = await fetch(getLinkContentUrl(item.linkId, disposition), {
+    headers: getAuthHeaders(),
+  });
+  if (!response.ok) {
+    let message = `Failed to load file (${response.status})`;
+    try {
+      const body = await response.json();
+      if (typeof body.error === 'string') message = body.error;
+    } catch {
+      // Response may be plain text/HTML from an intermediary; keep status fallback.
+    }
+    throw new Error(message);
+  }
+  return response;
+}
+
+function triggerBlobDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function getPinActionLabel(item: LinkDisplayItem): string {
+  if (item.ownerScope === 'branch') {
+    return item.isPinned ? 'Unpin from branch card' : 'Pin to branch card';
+  }
+  return item.isPinned ? 'Unpin from session' : 'Pin in session';
+}
+
+export function LinkRow({
+  item,
+  compact = false,
+  inline = false,
+  onPreview,
+  onDownload,
+  onTogglePinned,
+  busy = false,
+  pinning = false,
+}: {
+  item: LinkDisplayItem;
+  compact?: boolean;
+  inline?: boolean;
+  onPreview?: (item: LinkDisplayItem) => void;
+  onDownload?: (item: LinkDisplayItem) => void;
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  busy?: boolean;
+  pinning?: boolean;
+}) {
+  const { token } = theme.useToken();
+  const title = getCompactLinkDisplayName(item);
+  const targetLabel = getLinkDisplaySecondaryLabel(item);
+  const contentAction = getLinkContentAction(item);
+  const pinActionLabel = getPinActionLabel(item);
+  const canTogglePin = Boolean(item.linkId && onTogglePinned);
+
+  const pinActionButton = canTogglePin ? (
+    <Tooltip title={pinActionLabel}>
+      <Button
+        type="text"
+        size="small"
+        loading={pinning}
+        aria-label={`${pinActionLabel} ${title}`}
+        icon={item.isPinned ? <PushpinFilled /> : <PushpinOutlined />}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onTogglePinned?.(item);
+        }}
+        style={{
+          color: item.isPinned ? token.colorWarning : token.colorTextTertiary,
+          flex: '0 0 auto',
+        }}
+      />
+    </Tooltip>
+  ) : null;
+
+  const actionButton = contentAction ? (
+    <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
+      <Button
+        type="text"
+        size="small"
+        loading={busy}
+        aria-label={`${contentAction === 'preview' ? 'Preview' : 'Download'} ${title}`}
+        icon={contentAction === 'preview' ? <EyeOutlined /> : <DownloadOutlined />}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (contentAction === 'preview') onPreview?.(item);
+          else onDownload?.(item);
+        }}
+        style={{ color: token.colorTextTertiary, flex: '0 0 auto' }}
+      />
+    </Tooltip>
+  ) : null;
+
+  const showPassivePinIndicator = item.isPinned && !canTogglePin;
+
+  const linkBody = (
+    <span
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: token.sizeUnit * 2,
+        minWidth: 0,
+        flex: '1 1 auto',
+      }}
+    >
+      <LinkGlyph item={item} />
+      <span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <span style={{ display: 'flex', alignItems: 'center', gap: token.sizeUnit, minWidth: 0 }}>
+          <Typography.Text ellipsis style={{ lineHeight: 1.25, flex: 1 }}>
+            {title}
+          </Typography.Text>
+          {showPassivePinIndicator && (
+            <Tooltip title="Pinned">
+              <PushpinFilled
+                style={{ color: token.colorWarning, fontSize: 11, flex: '0 0 auto' }}
+              />
+            </Tooltip>
+          )}
+        </span>
+        {!compact && targetLabel && (
+          <Typography.Text type="secondary" ellipsis style={{ fontSize: 12, lineHeight: 1.2 }}>
+            {targetLabel}
+          </Typography.Text>
+        )}
+      </span>
+      {item.href ? (
+        item.navigation === 'spa' ? (
+          <RightOutlined style={{ color: token.colorTextTertiary, fontSize: 12 }} />
+        ) : (
+          <ExportOutlined style={{ color: token.colorTextTertiary, fontSize: 12 }} />
+        )
+      ) : null}
+    </span>
+  );
+
+  const commonStyle: React.CSSProperties = {
+    color: token.colorText,
+    textDecoration: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    minWidth: 0,
+    flex: inline ? '0 1 auto' : '1 1 auto',
+    borderRadius: token.borderRadiusSM,
+    maxWidth: inline ? '100%' : undefined,
+  };
+
+  const nonNavigableStyle: React.CSSProperties = {
+    ...commonStyle,
+    color: contentAction ? token.colorText : token.colorTextSecondary,
+    cursor: 'default',
+  };
+
+  const mainTarget =
+    item.href && item.navigation === 'spa' ? (
+      <RouterLink to={item.href} style={commonStyle} title={title}>
+        {linkBody}
+      </RouterLink>
+    ) : item.href ? (
+      <a href={item.href} target="_blank" rel="noreferrer" style={commonStyle} title={title}>
+        {linkBody}
+      </a>
+    ) : (
+      <span
+        aria-disabled={contentAction ? undefined : true}
+        style={nonNavigableStyle}
+        title={title}
+      >
+        {linkBody}
+      </span>
+    );
+
+  const row = (
+    <span
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: token.sizeUnit * 2,
+        minWidth: 0,
+        width: inline ? 'auto' : '100%',
+        padding: compact
+          ? `${token.sizeUnit}px ${token.sizeUnit * 1.5}px`
+          : `${token.sizeUnit}px 0`,
+      }}
+    >
+      {mainTarget}
+      {pinActionButton}
+      {actionButton}
+    </span>
+  );
+
+  return row;
+}
+
+export function useLinkFileActions() {
+  const [busyLinkId, setBusyLinkId] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (preview?.objectUrl) URL.revokeObjectURL(preview.objectUrl);
+    };
+  }, [preview?.objectUrl]);
+
+  const openPreview = async (item: LinkDisplayItem) => {
+    const kind = getLinkPreviewKind(item);
+    if (!kind) return;
+    setPreview({ item, kind, loading: true });
+    setBusyLinkId(item.linkId ?? null);
+    try {
+      const response = await fetchLinkContent(item, 'inline');
+      if (kind === 'image') {
+        const objectUrl = URL.createObjectURL(await response.blob());
+        setPreview({ item, kind, loading: false, objectUrl });
+      } else {
+        setPreview({ item, kind, loading: false, text: await response.text() });
+      }
+    } catch (err) {
+      setPreview({
+        item,
+        kind,
+        loading: false,
+        error: err instanceof Error ? err.message : 'Failed to load preview',
+      });
+    } finally {
+      setBusyLinkId(null);
+    }
+  };
+
+  const downloadItem = async (item: LinkDisplayItem) => {
+    setBusyLinkId(item.linkId ?? null);
+    try {
+      const response = await fetchLinkContent(item, 'attachment');
+      triggerBlobDownload(await response.blob(), getCompactLinkDisplayName(item));
+    } catch (err) {
+      setPreview({
+        item,
+        kind: 'text',
+        loading: false,
+        error: err instanceof Error ? err.message : 'Failed to download file',
+      });
+    } finally {
+      setBusyLinkId(null);
+    }
+  };
+
+  return { busyLinkId, preview, setPreview, openPreview, downloadItem };
+}
+
+export function LinkPreviewModal({
+  preview,
+  onClose,
+}: {
+  preview: PreviewState | null;
+  onClose: () => void;
+}) {
+  const { token } = theme.useToken();
+  return (
+    <Modal
+      title={preview ? getCompactLinkDisplayName(preview.item) : 'Preview'}
+      open={!!preview}
+      onCancel={onClose}
+      footer={<Button onClick={onClose}>Close</Button>}
+      width={preview?.kind === 'image' ? 840 : 900}
+    >
+      {preview?.loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: token.paddingXL }}>
+          <Spin />
+        </div>
+      ) : preview?.error ? (
+        <Typography.Text type="danger">{preview.error}</Typography.Text>
+      ) : preview?.kind === 'image' && preview.objectUrl ? (
+        <img
+          src={preview.objectUrl}
+          alt={getCompactLinkDisplayName(preview.item)}
+          style={{ maxWidth: '100%', maxHeight: '70vh', display: 'block', margin: '0 auto' }}
+        />
+      ) : preview?.kind === 'markdown' ? (
+        <div style={{ maxHeight: '70vh', overflowY: 'auto' }}>
+          <MarkdownRenderer content={preview.text ?? ''} />
+        </div>
+      ) : preview?.kind === 'text' ? (
+        <pre
+          style={{
+            maxHeight: '70vh',
+            overflow: 'auto',
+            margin: 0,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            color: token.colorText,
+          }}
+        >
+          {preview.text ?? ''}
+        </pre>
+      ) : null}
+    </Modal>
+  );
+}
+
+type LinkManagementFilter =
+  | 'all'
+  | 'branch'
+  | 'session'
+  | 'files'
+  | 'knowledge'
+  | 'issues'
+  | 'pinned';
+
+const LINK_DOCUMENT_CATEGORIES = new Set<LinkDisplayCategory>([
+  'pdf',
+  'spreadsheet',
+  'csv',
+  'document',
+  'markdown',
+  'text',
+  'code',
+  'json',
+  'log',
+]);
+
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralLabel}`;
+}
+
+function isFileDisplayItem(item: LinkDisplayItem): boolean {
+  return (
+    item.category === 'image' ||
+    Boolean(item.filePath) ||
+    LINK_DOCUMENT_CATEGORIES.has(item.category)
+  );
+}
+
+function isKnowledgeDisplayItem(item: LinkDisplayItem): boolean {
+  return item.category === 'knowledge' || Boolean(item.refUri?.startsWith('agor://kb/'));
+}
+
+function isIssuePrDisplayItem(item: LinkDisplayItem): boolean {
+  return item.category === 'issue' || item.category === 'pr';
+}
+
+function matchesManagementFilter(item: LinkDisplayItem, filter: LinkManagementFilter): boolean {
+  switch (filter) {
+    case 'branch':
+      return item.ownerScope === 'branch';
+    case 'session':
+      return item.ownerScope === 'session';
+    case 'files':
+      return isFileDisplayItem(item);
+    case 'knowledge':
+      return isKnowledgeDisplayItem(item);
+    case 'issues':
+      return isIssuePrDisplayItem(item);
+    case 'pinned':
+      return item.isPinned;
+    default:
+      return true;
+  }
+}
+
+function compareManagementItems(a: LinkDisplayItem, b: LinkDisplayItem): number {
+  if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+  const nameOrder = getCompactLinkDisplayName(a).localeCompare(
+    getCompactLinkDisplayName(b),
+    undefined,
+    { sensitivity: 'base' }
+  );
+  if (nameOrder !== 0) return nameOrder;
+  return a.key.localeCompare(b.key);
+}
+
+function getQuickCategoryRank(item: LinkDisplayItem): number {
+  if (item.category === 'issue') return 0;
+  if (item.category === 'pr') return 1;
+  if (isKnowledgeDisplayItem(item)) return 2;
+  if (item.category === 'url' || item.category === 'internal') return 3;
+  if (isFileDisplayItem(item)) return 4;
+  return 5;
+}
+
+function compareQuickItems(a: LinkDisplayItem, b: LinkDisplayItem): number {
+  if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+  const createdOrder = (a.createdAt ?? '').localeCompare(b.createdAt ?? '');
+  if (createdOrder !== 0) return createdOrder;
+  const categoryOrder = getQuickCategoryRank(a) - getQuickCategoryRank(b);
+  if (categoryOrder !== 0) return categoryOrder;
+  const nameOrder = getCompactLinkDisplayName(a).localeCompare(
+    getCompactLinkDisplayName(b),
+    undefined,
+    { sensitivity: 'base' }
+  );
+  if (nameOrder !== 0) return nameOrder;
+  return a.key.localeCompare(b.key);
+}
+
+function selectQuickItems(items: LinkDisplayItem[], limit: number): LinkDisplayItem[] {
+  const ordered = [...items].sort(compareQuickItems);
+  if (limit < 5) return ordered.slice(0, limit);
+
+  const files = ordered.filter(isFileDisplayItem);
+  const fileReserve = files.length > 0 ? Math.min(2, files.length, Math.max(1, limit - 5)) : 0;
+  const nonFiles = ordered.filter((item) => !isFileDisplayItem(item));
+  const selected = nonFiles.slice(0, Math.max(0, limit - fileReserve));
+  const selectedKeys = new Set(selected.map((item) => item.key));
+  selected.push(
+    ...files.filter((item) => !selectedKeys.has(item.key)).slice(0, limit - selected.length)
+  );
+  return selected;
+}
+
+function getSummary(items: LinkDisplayItem[]): string {
+  const pinnedCount = items.filter((item) => item.isPinned).length;
+  const fileCount = items.filter(isFileDisplayItem).length;
+  return `${plural(items.length, 'link')} · ${plural(pinnedCount, 'pinned', 'pinned')} · ${plural(fileCount, 'file')}`;
+}
+
+function getTypeLabel(item: LinkDisplayItem): string {
+  switch (item.category) {
+    case 'issue':
+      return 'Issue';
+    case 'pr':
+      return 'PR';
+    case 'knowledge':
+      return 'KB';
+    case 'image':
+      return 'Image';
+    case 'pdf':
+    case 'spreadsheet':
+    case 'csv':
+    case 'document':
+    case 'markdown':
+    case 'text':
+    case 'code':
+    case 'json':
+    case 'log':
+      return 'Doc';
+    case 'url':
+      return 'URL';
+    case 'internal':
+      return 'Ref';
+    default:
+      return 'Link';
+  }
+}
+
+function getDomain(value?: string): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+function getSourceOrDomainLabel(item: LinkDisplayItem): string {
+  const domain = getDomain(item.url);
+  if (domain) return domain;
+  if (isKnowledgeDisplayItem(item)) return 'Knowledge';
+  if (item.source === 'upload' || item.filePath) return 'Upload';
+  return item.ownerScope === 'branch' ? 'Branch' : 'This session';
+}
+
+function getScopeDomainLabel(item: LinkDisplayItem): string {
+  const ownerLabel = item.ownerScope === 'branch' ? 'Branch' : 'This session';
+  const sourceOrDomain = getSourceOrDomainLabel(item);
+  return sourceOrDomain === ownerLabel ? ownerLabel : `${ownerLabel} · ${sourceOrDomain}`;
+}
+
+function getQuickSecondaryLabel(item: LinkDisplayItem): string {
+  return getScopeDomainLabel(item);
+}
+
+function getUnavailableReason(item: LinkDisplayItem): string | null {
+  if (item.href || getLinkContentAction(item)) return null;
+  if (isFileDisplayItem(item)) return 'Preview/download not available yet.';
+  return 'No safe route is available for this item yet.';
+}
+
+function getTypePillColors(item: LinkDisplayItem): { background: string; color: string } {
+  switch (item.category) {
+    case 'issue':
+    case 'pr':
+      return { background: 'rgba(22, 119, 255, 0.16)', color: '#69b1ff' };
+    case 'knowledge':
+      return { background: 'rgba(114, 46, 209, 0.18)', color: '#b37feb' };
+    case 'image':
+      return { background: 'rgba(83, 29, 171, 0.18)', color: '#d3adf7' };
+    case 'pdf':
+    case 'spreadsheet':
+    case 'csv':
+    case 'document':
+    case 'markdown':
+    case 'text':
+    case 'code':
+    case 'json':
+    case 'log':
+      return { background: 'rgba(83, 29, 171, 0.18)', color: '#d3adf7' };
+    default:
+      return { background: 'rgba(255, 255, 255, 0.06)', color: 'rgba(255, 255, 255, 0.78)' };
+  }
+}
+
+function TypePill({ item, compact = false }: { item: LinkDisplayItem; compact?: boolean }) {
+  const { token } = theme.useToken();
+  const colors = getTypePillColors(item);
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: compact ? 'flex-end' : 'flex-start',
+        minWidth: compact ? 34 : 66,
+        maxWidth: compact ? 44 : 88,
+        borderRadius: token.borderRadiusSM,
+        padding: compact ? 0 : '2px 8px',
+        background: compact ? 'transparent' : colors.background,
+        color: compact ? token.colorTextTertiary : colors.color,
+        fontSize: 12,
+        lineHeight: 1.25,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {getTypeLabel(item)}
+    </span>
+  );
+}
+
+function activateContentAction(
+  item: LinkDisplayItem,
+  onPreview?: (item: LinkDisplayItem) => void,
+  onDownload?: (item: LinkDisplayItem) => void
+) {
+  const contentAction = getLinkContentAction(item);
+  if (contentAction === 'preview') onPreview?.(item);
+  else if (contentAction === 'download') onDownload?.(item);
+}
+
+function getPinnedChipActionLabel(item: LinkDisplayItem): string {
+  const contentAction = getLinkContentAction(item);
+  if (contentAction === 'preview') return 'Preview pinned';
+  if (contentAction === 'download') return 'Download pinned';
+  return 'Open pinned';
+}
+
+function getPinnedChipTitle(item: LinkDisplayItem): string {
+  return getCompactLinkDisplayName(item).replace(/^(Issue|PR|Knowledge|Saved URL):\s*/i, '');
+}
+
+function TitleTarget({
+  item,
+  accent = false,
+  onPreview,
+  onDownload,
+  onNavigate,
+}: {
+  item: LinkDisplayItem;
+  accent?: boolean;
+  onPreview?: (item: LinkDisplayItem) => void;
+  onDownload?: (item: LinkDisplayItem) => void;
+  onNavigate?: () => void;
+}) {
+  const { token } = theme.useToken();
+  const title = getCompactLinkDisplayName(item);
+  const contentAction = getLinkContentAction(item);
+  const disabled = Boolean(getUnavailableReason(item));
+  const baseStyle: React.CSSProperties = {
+    display: 'block',
+    minWidth: 0,
+    maxWidth: '100%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    fontWeight: 600,
+    fontSize: 13,
+    lineHeight: 1.25,
+    color: disabled ? token.colorTextDisabled : accent ? token.colorPrimary : token.colorText,
+  };
+
+  if (item.href && item.navigation === 'spa') {
+    return (
+      <RouterLink
+        to={item.href}
+        onClick={onNavigate}
+        style={{ ...baseStyle, textDecoration: 'none' }}
+        title={title}
+      >
+        {title}
+      </RouterLink>
+    );
+  }
+
+  if (item.href) {
+    return (
+      <a
+        href={item.href}
+        target="_blank"
+        rel="noreferrer"
+        onClick={onNavigate}
+        style={{ ...baseStyle, textDecoration: 'none' }}
+        title={title}
+      >
+        {title}
+      </a>
+    );
+  }
+
+  if (contentAction) {
+    return (
+      <button
+        type="button"
+        onClick={() => activateContentAction(item, onPreview, onDownload)}
+        style={{
+          ...baseStyle,
+          border: 0,
+          background: 'transparent',
+          padding: 0,
+          cursor: 'pointer',
+          textAlign: 'left',
+        }}
+        title={title}
+      >
+        {title}
+      </button>
+    );
+  }
+
+  return (
+    <Typography.Text disabled ellipsis style={baseStyle} title={title}>
+      {title}
+    </Typography.Text>
+  );
+}
+
+function ActionControl({
+  item,
+  onPreview,
+  onDownload,
+  onNavigate,
+  busy = false,
+}: {
+  item: LinkDisplayItem;
+  onPreview?: (item: LinkDisplayItem) => void;
+  onDownload?: (item: LinkDisplayItem) => void;
+  onNavigate?: () => void;
+  busy?: boolean;
+}) {
+  const { token } = theme.useToken();
+  const title = getCompactLinkDisplayName(item);
+  const contentAction = getLinkContentAction(item);
+  const disabledReason = getUnavailableReason(item);
+  const iconLinkStyle: React.CSSProperties = {
+    width: 22,
+    height: 22,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: token.colorTextTertiary,
+    borderRadius: token.borderRadiusSM,
+  };
+
+  if (contentAction) {
+    return (
+      <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
+        <Button
+          type="text"
+          size="small"
+          loading={busy}
+          aria-label={`${contentAction === 'preview' ? 'Preview' : 'Download'} ${title}`}
+          icon={contentAction === 'preview' ? <EyeOutlined /> : <DownloadOutlined />}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            activateContentAction(item, onPreview, onDownload);
+          }}
+          style={{
+            width: 22,
+            minWidth: 22,
+            height: 22,
+            padding: 0,
+            color: token.colorTextTertiary,
+          }}
+        />
+      </Tooltip>
+    );
+  }
+
+  if (item.href && item.navigation === 'spa') {
+    return (
+      <Tooltip title="Open link">
+        <RouterLink
+          aria-label="Open link"
+          to={item.href}
+          onClick={onNavigate}
+          style={iconLinkStyle}
+        >
+          <RightOutlined />
+        </RouterLink>
+      </Tooltip>
+    );
+  }
+
+  if (item.href) {
+    return (
+      <Tooltip title="Open link">
+        <a
+          aria-label="Open link"
+          href={item.href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={onNavigate}
+          style={iconLinkStyle}
+        >
+          <ExportOutlined />
+        </a>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip title={disabledReason ?? 'No route available'}>
+      <span
+        role="img"
+        aria-label={`No route available for ${title}`}
+        style={{ ...iconLinkStyle, color: token.colorTextDisabled }}
+      >
+        <StopOutlined />
+      </span>
+    </Tooltip>
+  );
+}
+
+function PinAction({
+  item,
+  onTogglePinned,
+  pinning = false,
+}: {
+  item: LinkDisplayItem;
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  pinning?: boolean;
+}) {
+  const { token } = theme.useToken();
+  const title = getCompactLinkDisplayName(item);
+  const canTogglePin = Boolean(item.linkId && onTogglePinned);
+  if (!canTogglePin && !item.isPinned) return <span aria-hidden />;
+  const label = canTogglePin ? getPinActionLabel(item) : 'Pinned';
+  return (
+    <Tooltip title={label}>
+      <button
+        type="button"
+        aria-label={`${label} ${title}`}
+        disabled={!canTogglePin || pinning}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onTogglePinned?.(item);
+        }}
+        style={{
+          width: 22,
+          height: 22,
+          border: 0,
+          background: 'transparent',
+          padding: 0,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: canTogglePin && !pinning ? 'pointer' : 'default',
+          color: item.isPinned ? token.colorPrimary : token.colorTextQuaternary,
+          opacity: pinning ? 0.55 : 1,
+        }}
+      >
+        {item.isPinned ? <PushpinFilled /> : <PushpinOutlined />}
+      </button>
+    </Tooltip>
+  );
+}
+
+function QuickLinkRow({
+  item,
+  onPreview,
+  onDownload,
+  onNavigate,
+  busy = false,
+}: {
+  item: LinkDisplayItem;
+  onPreview?: (item: LinkDisplayItem) => void;
+  onDownload?: (item: LinkDisplayItem) => void;
+  onNavigate?: () => void;
+  busy?: boolean;
+}) {
+  const { token } = theme.useToken();
+  const disabled = Boolean(getUnavailableReason(item));
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '34px minmax(0, 1fr) 52px 28px',
+        columnGap: token.sizeSM,
+        alignItems: 'center',
+        minWidth: 0,
+        minHeight: 58,
+        padding: `${token.sizeXS}px ${token.sizeXS}px`,
+      }}
+    >
+      <SmallLinkGlyph item={item} disabled={disabled} />
+      <span
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: token.sizeXXS,
+          minWidth: 0,
+        }}
+      >
+        <TitleTarget
+          item={item}
+          onPreview={onPreview}
+          onDownload={onDownload}
+          onNavigate={onNavigate}
+        />
+        <Typography.Text
+          type="secondary"
+          ellipsis
+          style={{ display: 'block', fontSize: 12, lineHeight: 1.35 }}
+        >
+          {getQuickSecondaryLabel(item)}
+        </Typography.Text>
+      </span>
+      <TypePill item={item} compact />
+      <ActionControl
+        item={item}
+        onPreview={onPreview}
+        onDownload={onDownload}
+        onNavigate={onNavigate}
+        busy={busy}
+      />
+    </div>
+  );
+}
+
+function ManagementLinkRow({
+  item,
+  onPreview,
+  onDownload,
+  onTogglePinned,
+  onNavigate,
+  busy = false,
+  pinning = false,
+}: {
+  item: LinkDisplayItem;
+  onPreview?: (item: LinkDisplayItem) => void;
+  onDownload?: (item: LinkDisplayItem) => void;
+  onTogglePinned?: (item: LinkDisplayItem) => void | Promise<void>;
+  onNavigate?: () => void;
+  busy?: boolean;
+  pinning?: boolean;
+}) {
+  const { token } = theme.useToken();
+  const targetLabel = getLinkDisplaySecondaryLabel(item);
+  const disabledReason = getUnavailableReason(item);
+  const disabled = Boolean(disabledReason);
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1.35fr) minmax(110px, 0.45fr) 94px 28px 24px',
+        columnGap: token.sizeMD,
+        alignItems: 'center',
+        padding: `${token.sizeSM}px 0`,
+        borderBottom: `1px solid ${token.colorBorderSecondary}`,
+        minWidth: 0,
+      }}
+    >
+      <span style={{ display: 'flex', gap: token.sizeSM, minWidth: 0, alignItems: 'flex-start' }}>
+        <SmallLinkGlyph item={item} disabled={disabled} />
+        <span style={{ minWidth: 0, flex: 1 }}>
+          <TitleTarget
+            item={item}
+            accent
+            onPreview={onPreview}
+            onDownload={onDownload}
+            onNavigate={onNavigate}
+          />
+          {targetLabel && (
+            <Typography.Text
+              type="secondary"
+              ellipsis
+              style={{ display: 'block', fontSize: 12, lineHeight: 1.25 }}
+            >
+              {targetLabel}
+            </Typography.Text>
+          )}
+          {disabledReason && (
+            <Typography.Text
+              type="warning"
+              style={{ display: 'block', fontSize: 12, marginTop: 2 }}
+            >
+              {disabledReason}
+            </Typography.Text>
+          )}
+        </span>
+      </span>
+      <Typography.Text type="secondary" ellipsis style={{ fontSize: 12 }}>
+        {getScopeDomainLabel(item)}
+      </Typography.Text>
+      <TypePill item={item} />
+      <ActionControl
+        item={item}
+        onPreview={onPreview}
+        onDownload={onDownload}
+        onNavigate={onNavigate}
+        busy={busy}
+      />
+      <PinAction item={item} onTogglePinned={onTogglePinned} pinning={pinning} />
+    </div>
+  );
+}
+
+export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
+  items,
+  onTogglePinned,
+  pinningLinkId = null,
+  label = 'Pinned',
+  'data-testid': dataTestId,
+}) => {
+  const { token } = theme.useToken();
+  const navigate = useNavigate();
+  const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
+
+  if (items.length === 0) return null;
+
+  const openItem = (item: LinkDisplayItem) => {
+    const contentAction = getLinkContentAction(item);
+    if (contentAction === 'preview') {
+      void openPreview(item);
+      return;
+    }
+    if (contentAction === 'download') {
+      void downloadItem(item);
+      return;
+    }
+    if (item.href && item.navigation === 'spa') {
+      navigate(item.href);
+      return;
+    }
+    if (item.href) {
+      window.open(item.href, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  return (
+    <>
+      <div
+        data-testid={dataTestId}
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: token.sizeSM,
+          flexWrap: 'wrap',
+          minWidth: 0,
+          marginBottom: 0,
+          padding: `${token.paddingXXS + 2}px ${token.paddingXS}px`,
+        }}
+      >
+        <Typography.Text
+          type="secondary"
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            letterSpacing: 0.2,
+            flex: '0 0 auto',
+            paddingTop: 4,
+          }}
+        >
+          {label}
+        </Typography.Text>
+        <div
+          data-testid={dataTestId ? `${dataTestId}-links` : undefined}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: token.sizeXXS,
+            flexWrap: 'wrap',
+            minWidth: 0,
+            flex: '1 1 0',
+          }}
+        >
+          {items.map((item) => {
+            const disabledReason = getUnavailableReason(item);
+            const disabled = Boolean(disabledReason);
+            const title = getPinnedChipTitle(item);
+            const canTogglePin = Boolean(item.linkId && onTogglePinned);
+            const pinActionLabel = canTogglePin ? getPinActionLabel(item) : 'Pinned';
+            const isBusy = item.linkId === busyLinkId;
+            const isPinning = item.linkId === pinningLinkId;
+            const secondaryLabel = getLinkDisplaySecondaryLabel(item);
+            const tooltipTitle = disabledReason
+              ? disabledReason
+              : secondaryLabel
+                ? `${title} · ${secondaryLabel}`
+                : title;
+            return (
+              <Tooltip key={item.key} title={tooltipTitle} mouseEnterDelay={0.45}>
+                <span
+                  style={{
+                    height: 26,
+                    minWidth: 0,
+                    maxWidth: 156,
+                    border: `1px solid ${
+                      disabled ? token.colorBorderSecondary : token.colorPrimaryBorder
+                    }`,
+                    borderRadius: 999,
+                    background: disabled ? token.colorFillQuaternary : token.colorPrimaryBg,
+                    color: disabled ? token.colorTextDisabled : token.colorText,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    lineHeight: 1,
+                    flex: '0 1 auto',
+                    opacity: isBusy ? 0.65 : 1,
+                    overflow: 'hidden',
+                  }}
+                >
+                  <button
+                    type="button"
+                    disabled={!canTogglePin || isPinning}
+                    aria-label={`${pinActionLabel} ${title}`}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onTogglePinned?.(item);
+                    }}
+                    style={{
+                      width: 20,
+                      height: 24,
+                      border: 0,
+                      background: 'transparent',
+                      color: disabled ? token.colorTextDisabled : token.colorPrimary,
+                      cursor: canTogglePin && !isPinning ? 'pointer' : 'default',
+                      padding: '0 0 0 8px',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flex: '0 0 auto',
+                      opacity: isPinning ? 0.55 : 1,
+                    }}
+                  >
+                    <PushpinFilled style={{ fontSize: 11 }} />
+                  </button>
+                  <button
+                    type="button"
+                    disabled={disabled || isBusy}
+                    aria-label={
+                      disabled
+                        ? `${title}: ${disabledReason}`
+                        : `${getPinnedChipActionLabel(item)} ${title}`
+                    }
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      openItem(item);
+                    }}
+                    style={{
+                      minWidth: 0,
+                      border: 0,
+                      background: 'transparent',
+                      color: 'inherit',
+                      cursor: disabled || isBusy ? 'not-allowed' : 'pointer',
+                      padding: `0 ${token.paddingXS}px 0 0`,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 5,
+                      font: 'inherit',
+                      lineHeight: 1,
+                      flex: '1 1 auto',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        width: 18,
+                        color: disabled ? token.colorTextDisabled : token.colorPrimary,
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flex: '0 0 auto',
+                        fontSize: item.category === 'issue' || item.category === 'pr' ? 13 : 9,
+                        fontWeight: 800,
+                        letterSpacing: 0.2,
+                      }}
+                    >
+                      {item.category === 'issue' || item.category === 'pr' ? (
+                        <GithubOutlined />
+                      ) : (
+                        getLinkDisplayGlyphLabel(item.category)
+                      )}
+                    </span>
+                    <Typography.Text
+                      ellipsis
+                      style={{
+                        fontSize: 12,
+                        maxWidth: 96,
+                        color: disabled ? token.colorTextDisabled : token.colorText,
+                      }}
+                    >
+                      {title}
+                    </Typography.Text>
+                  </button>
+                </span>
+              </Tooltip>
+            );
+          })}
+        </div>
+      </div>
+      <LinkPreviewModal preview={preview} onClose={() => setPreview(null)} />
+    </>
+  );
+};
+
+export const LinksManagementDrawer: React.FC<LinksManagementDrawerProps> = ({
+  items,
+  open,
+  onClose,
+  title = 'Manage links',
+  emptyDescription = 'No links yet',
+  onTogglePinned,
+  pinningLinkId = null,
+  width = 720,
+}) => {
+  const { token } = theme.useToken();
+  const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
+  const [activeFilter, setActiveFilter] = useState<LinkManagementFilter>('all');
+
+  const sortedItems = useMemo(() => [...items].sort(compareManagementItems), [items]);
+  const visibleItems = useMemo(
+    () => sortedItems.filter((item) => matchesManagementFilter(item, activeFilter)),
+    [activeFilter, sortedItems]
+  );
+  const filterOptions = useMemo(
+    () => [
+      { label: `All ${items.length}`, value: 'all' as const },
+      {
+        label: `Branch ${items.filter((item) => item.ownerScope === 'branch').length}`,
+        value: 'branch' as const,
+      },
+      {
+        label: `This session ${items.filter((item) => item.ownerScope === 'session').length}`,
+        value: 'session' as const,
+      },
+      { label: `Files ${items.filter(isFileDisplayItem).length}`, value: 'files' as const },
+      {
+        label: `Knowledge ${items.filter(isKnowledgeDisplayItem).length}`,
+        value: 'knowledge' as const,
+      },
+      {
+        label: `Issues/PRs ${items.filter(isIssuePrDisplayItem).length}`,
+        value: 'issues' as const,
+      },
+      { label: `Pinned ${items.filter((item) => item.isPinned).length}`, value: 'pinned' as const },
+    ],
+    [items]
+  );
+
+  return (
+    <>
+      <Drawer
+        title={title}
+        extra={
+          <Typography.Text type="secondary" style={{ fontSize: 13 }}>
+            {getSummary(items)}
+          </Typography.Text>
+        }
+        open={open}
+        onClose={onClose}
+        width={width}
+        styles={{ body: { paddingTop: token.sizeLG } }}
+      >
+        {items.length > 0 ? (
+          <Space direction="vertical" size={token.sizeLG} style={{ width: '100%' }}>
+            <div data-testid="links-management-filter-row">
+              <Segmented<LinkManagementFilter>
+                size="middle"
+                value={activeFilter}
+                options={filterOptions}
+                onChange={setActiveFilter}
+              />
+            </div>
+
+            {visibleItems.length > 0 ? (
+              <div>
+                {visibleItems.map((item) => (
+                  <ManagementLinkRow
+                    key={item.key}
+                    item={item}
+                    onPreview={openPreview}
+                    onDownload={downloadItem}
+                    onTogglePinned={onTogglePinned}
+                    onNavigate={onClose}
+                    busy={item.linkId === busyLinkId}
+                    pinning={item.linkId === pinningLinkId}
+                  />
+                ))}
+              </div>
+            ) : (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="No links match your filters"
+              />
+            )}
+          </Space>
+        ) : (
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={emptyDescription} />
+        )}
+      </Drawer>
+
+      <LinkPreviewModal preview={preview} onClose={() => setPreview(null)} />
+    </>
+  );
+};
+
+export const SessionLinksControl: React.FC<SessionLinksControlProps> = ({
+  items,
+  loading = false,
+  error = null,
+  quickLimit = QUICK_LINK_LIMIT,
+  onTogglePinned,
+  pinningLinkId = null,
+}) => {
+  const { token } = theme.useToken();
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const { busyLinkId, preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
+  const quickItems = useMemo(() => selectQuickItems(items, quickLimit), [items, quickLimit]);
+  const hiddenCount = Math.max(items.length - quickItems.length, 0);
+
+  if (!loading && !error && items.length === 0) return null;
+
+  const openDrawer = () => {
+    setPopoverOpen(false);
+    setDrawerOpen(true);
+  };
+
+  const handlePreview = (item: LinkDisplayItem) => {
+    setPopoverOpen(false);
+    openPreview(item);
+  };
+
+  const handleDownload = (item: LinkDisplayItem) => {
+    setPopoverOpen(false);
+    downloadItem(item);
+  };
+
+  const closePopover = () => setPopoverOpen(false);
+
+  const popoverContent = (
+    <div style={{ width: 312 }} data-testid="links-organizer-popover">
+      <div>
+        <Typography.Text strong>Links</Typography.Text>
+        <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+          {getSummary(items)}
+        </Typography.Text>
+      </div>
+
+      {error ? (
+        <Typography.Text
+          type="danger"
+          style={{ display: 'block', fontSize: 12, marginTop: token.sizeSM }}
+        >
+          {error}
+        </Typography.Text>
+      ) : quickItems.length > 0 ? (
+        <div
+          style={{
+            display: 'grid',
+            gap: token.sizeXS,
+            marginTop: token.sizeMD,
+            maxHeight: 308,
+            overflowY: 'auto',
+            paddingRight: 2,
+          }}
+        >
+          {quickItems.map((item) => (
+            <QuickLinkRow
+              key={item.key}
+              item={item}
+              onPreview={handlePreview}
+              onDownload={handleDownload}
+              onNavigate={closePopover}
+              busy={item.linkId === busyLinkId}
+            />
+          ))}
+        </div>
+      ) : (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No links yet"
+          style={{ margin: `${token.sizeSM}px 0` }}
+        />
+      )}
+
+      <div
+        style={{
+          borderTop: `1px solid ${token.colorBorderSecondary}`,
+          marginTop: token.sizeMD,
+          paddingTop: token.sizeMD,
+        }}
+      >
+        <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+          {hiddenCount > 0 ? `+${hiddenCount} more in ` : ''}
+          <Button
+            type="link"
+            size="small"
+            onClick={openDrawer}
+            style={{ padding: 0, height: 'auto', fontSize: 12 }}
+          >
+            Manage links
+          </Button>
+        </Typography.Text>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <Popover
+        content={popoverContent}
+        trigger="click"
+        placement="bottomRight"
+        open={popoverOpen}
+        onOpenChange={setPopoverOpen}
+      >
+        <Tooltip title="Links">
+          <Badge count={items.length || 0} color={token.colorPrimary} size="small" offset={[-4, 4]}>
+            <Button
+              type="text"
+              aria-label="Links"
+              loading={loading}
+              icon={<LinkOutlined style={{ color: token.colorPrimary }} />}
+            />
+          </Badge>
+        </Tooltip>
+      </Popover>
+
+      <LinksManagementDrawer
+        items={items}
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        onTogglePinned={onTogglePinned}
+        pinningLinkId={pinningLinkId}
+      />
+
+      <LinkPreviewModal preview={preview} onClose={() => setPreview(null)} />
+    </>
+  );
+};

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
@@ -368,7 +368,7 @@ export function LinkRow({
         {
           '--agor-link-title-color': isActionable ? token.colorText : token.colorTextSecondary,
           '--agor-link-icon-color': token.colorTextTertiary,
-          '--agor-link-row-hover-bg': token.colorFillQuaternary,
+          '--agor-link-row-hover-bg': 'transparent',
           '--agor-link-row-hover-color': token.colorPrimary,
           display: 'flex',
           alignItems: 'center',
@@ -1003,7 +1003,7 @@ function QuickLinkRow({
       style={
         {
           '--agor-link-icon-color': disabled ? token.colorTextDisabled : token.colorTextTertiary,
-          '--agor-link-row-hover-bg': token.colorFillQuaternary,
+          '--agor-link-row-hover-bg': 'transparent',
           '--agor-link-row-hover-color': token.colorPrimary,
           display: 'grid',
           gridTemplateColumns: '34px minmax(0, 1fr) 52px 28px',
@@ -1231,8 +1231,8 @@ export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
                       '--agor-link-chip-accent-color': disabled
                         ? token.colorTextDisabled
                         : token.colorPrimary,
-                      '--agor-link-chip-hover-bg': token.colorPrimaryBgHover,
-                      '--agor-link-chip-hover-border': token.colorPrimary,
+                      '--agor-link-chip-hover-bg': token.colorPrimaryBg,
+                      '--agor-link-chip-hover-border': token.colorPrimaryBorder,
                       '--agor-link-chip-hover-color': token.colorPrimary,
                       height: 26,
                       minWidth: 0,

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
@@ -86,13 +86,14 @@ export function LinkGlyph({ item }: { item: LinkDisplayItem }) {
   const isGitHubLink = item.category === 'issue' || item.category === 'pr';
   return (
     <span
+      className="agor-action-link-icon"
       aria-hidden="true"
       style={{
         width: 34,
         height: 24,
         borderRadius: token.borderRadiusSM,
         background: token.colorFillTertiary,
-        color: token.colorTextSecondary,
+        color: `var(--agor-link-icon-color, ${token.colorTextSecondary})`,
         border: `1px solid ${token.colorBorderSecondary}`,
         display: 'inline-flex',
         alignItems: 'center',
@@ -117,13 +118,16 @@ function SmallLinkGlyph({ item, disabled = false }: { item: LinkDisplayItem; dis
   const isGitHubLink = item.category === 'issue' || item.category === 'pr';
   return (
     <span
+      className="agor-action-link-icon"
       aria-hidden="true"
       style={{
         width: 24,
         height: 24,
         borderRadius: token.borderRadiusLG,
         background: token.colorFillTertiary,
-        color: disabled ? token.colorTextDisabled : token.colorTextTertiary,
+        color: disabled
+          ? token.colorTextDisabled
+          : `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -209,6 +213,7 @@ export function LinkRow({
   const pinActionButton = canTogglePin ? (
     <Tooltip title={pinActionLabel}>
       <Button
+        className="agor-action-link-affordance"
         type="text"
         size="small"
         loading={pinning}
@@ -241,12 +246,13 @@ export function LinkRow({
           if (contentAction === 'preview') onPreview?.(item);
           else onDownload?.(item);
         }}
-        style={{ color: token.colorTextTertiary, flex: '0 0 auto' }}
+        style={{ color: 'var(--agor-link-icon-color)', flex: '0 0 auto' }}
       />
     </Tooltip>
   ) : null;
 
   const showPassivePinIndicator = item.isPinned && !canTogglePin;
+  const isActionable = Boolean(item.href || contentAction);
 
   const linkBody = (
     <span
@@ -261,7 +267,15 @@ export function LinkRow({
       <LinkGlyph item={item} />
       <span style={{ minWidth: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
         <span style={{ display: 'flex', alignItems: 'center', gap: token.sizeUnit, minWidth: 0 }}>
-          <Typography.Text ellipsis style={{ lineHeight: 1.25, flex: 1 }}>
+          <Typography.Text
+            className={isActionable ? 'agor-action-link-title' : undefined}
+            ellipsis
+            style={{
+              color: 'var(--agor-link-title-color)',
+              lineHeight: 1.25,
+              flex: 1,
+            }}
+          >
             {title}
           </Typography.Text>
           {showPassivePinIndicator && (
@@ -280,9 +294,15 @@ export function LinkRow({
       </span>
       {item.href ? (
         item.navigation === 'spa' ? (
-          <RightOutlined style={{ color: token.colorTextTertiary, fontSize: 12 }} />
+          <RightOutlined
+            className="agor-action-link-affordance"
+            style={{ color: 'var(--agor-link-icon-color)', fontSize: 12 }}
+          />
         ) : (
-          <ExportOutlined style={{ color: token.colorTextTertiary, fontSize: 12 }} />
+          <ExportOutlined
+            className="agor-action-link-affordance"
+            style={{ color: 'var(--agor-link-icon-color)', fontSize: 12 }}
+          />
         )
       ) : null}
     </span>
@@ -302,7 +322,12 @@ export function LinkRow({
   const nonNavigableStyle: React.CSSProperties = {
     ...commonStyle,
     color: contentAction ? token.colorText : token.colorTextSecondary,
-    cursor: 'default',
+    cursor: contentAction ? 'pointer' : 'default',
+    border: 0,
+    background: 'transparent',
+    padding: 0,
+    font: 'inherit',
+    textAlign: 'left',
   };
 
   const mainTarget =
@@ -314,28 +339,48 @@ export function LinkRow({
       <a href={item.href} target="_blank" rel="noreferrer" style={commonStyle} title={title}>
         {linkBody}
       </a>
-    ) : (
-      <span
-        aria-disabled={contentAction ? undefined : true}
+    ) : contentAction ? (
+      <button
+        type="button"
+        aria-label={`${contentAction === 'preview' ? 'Preview' : 'Download'} ${title}`}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (contentAction === 'preview') onPreview?.(item);
+          else onDownload?.(item);
+        }}
         style={nonNavigableStyle}
         title={title}
       >
+        {linkBody}
+      </button>
+    ) : (
+      <span aria-disabled style={nonNavigableStyle} title={title}>
         {linkBody}
       </span>
     );
 
   const row = (
     <span
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: token.sizeUnit * 2,
-        minWidth: 0,
-        width: inline ? 'auto' : '100%',
-        padding: compact
-          ? `${token.sizeUnit}px ${token.sizeUnit * 1.5}px`
-          : `${token.sizeUnit}px 0`,
-      }}
+      className="agor-action-link-row"
+      aria-disabled={isActionable ? undefined : true}
+      style={
+        {
+          '--agor-link-title-color': isActionable ? token.colorText : token.colorTextSecondary,
+          '--agor-link-icon-color': token.colorTextTertiary,
+          '--agor-link-row-hover-bg': token.colorFillQuaternary,
+          '--agor-link-row-hover-color': token.colorPrimary,
+          display: 'flex',
+          alignItems: 'center',
+          gap: token.sizeUnit * 2,
+          minWidth: 0,
+          width: inline ? 'auto' : '100%',
+          borderRadius: token.borderRadiusSM,
+          padding: compact
+            ? `${token.sizeUnit}px ${token.sizeUnit * 1.5}px`
+            : `${token.sizeUnit}px 0`,
+        } as React.CSSProperties
+      }
     >
       {mainTarget}
       {pinActionButton}
@@ -726,12 +771,15 @@ function TitleTarget({
     fontWeight: 600,
     fontSize: 13,
     lineHeight: 1.25,
-    color: disabled ? token.colorTextDisabled : accent ? token.colorPrimary : token.colorText,
+    color: disabled
+      ? token.colorTextDisabled
+      : `var(--agor-link-title-color, ${accent ? token.colorPrimary : token.colorText})`,
   };
 
   if (item.href && item.navigation === 'spa') {
     return (
       <RouterLink
+        className="agor-action-link-title"
         to={item.href}
         onClick={onNavigate}
         style={{ ...baseStyle, textDecoration: 'none' }}
@@ -745,6 +793,7 @@ function TitleTarget({
   if (item.href) {
     return (
       <a
+        className="agor-action-link-title"
         href={item.href}
         target="_blank"
         rel="noreferrer"
@@ -760,6 +809,7 @@ function TitleTarget({
   if (contentAction) {
     return (
       <button
+        className="agor-action-link-title"
         type="button"
         onClick={() => activateContentAction(item, onPreview, onDownload)}
         style={{
@@ -807,7 +857,7 @@ function ActionControl({
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    color: token.colorTextTertiary,
+    color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
     borderRadius: token.borderRadiusSM,
   };
 
@@ -815,6 +865,7 @@ function ActionControl({
     return (
       <Tooltip title={contentAction === 'preview' ? 'Preview' : 'Download'}>
         <Button
+          className="agor-action-link-affordance"
           type="text"
           size="small"
           loading={busy}
@@ -830,7 +881,7 @@ function ActionControl({
             minWidth: 22,
             height: 22,
             padding: 0,
-            color: token.colorTextTertiary,
+            color: `var(--agor-link-icon-color, ${token.colorTextTertiary})`,
           }}
         />
       </Tooltip>
@@ -841,6 +892,7 @@ function ActionControl({
     return (
       <Tooltip title="Open link">
         <RouterLink
+          className="agor-action-link-affordance"
           aria-label="Open link"
           to={item.href}
           onClick={onNavigate}
@@ -856,6 +908,7 @@ function ActionControl({
     return (
       <Tooltip title="Open link">
         <a
+          className="agor-action-link-affordance"
           aria-label="Open link"
           href={item.href}
           target="_blank"
@@ -872,6 +925,7 @@ function ActionControl({
   return (
     <Tooltip title={disabledReason ?? 'No route available'}>
       <span
+        className="agor-action-link-affordance"
         role="img"
         aria-label={`No route available for ${title}`}
         style={{ ...iconLinkStyle, color: token.colorTextDisabled }}
@@ -944,15 +998,23 @@ function QuickLinkRow({
   const disabled = Boolean(getUnavailableReason(item));
   return (
     <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: '34px minmax(0, 1fr) 52px 28px',
-        columnGap: token.sizeSM,
-        alignItems: 'center',
-        minWidth: 0,
-        minHeight: 58,
-        padding: `${token.sizeXS}px ${token.sizeXS}px`,
-      }}
+      className="agor-action-link-row"
+      aria-disabled={disabled || undefined}
+      style={
+        {
+          '--agor-link-icon-color': disabled ? token.colorTextDisabled : token.colorTextTertiary,
+          '--agor-link-row-hover-bg': token.colorFillQuaternary,
+          '--agor-link-row-hover-color': token.colorPrimary,
+          display: 'grid',
+          gridTemplateColumns: '34px minmax(0, 1fr) 52px 28px',
+          columnGap: token.sizeSM,
+          alignItems: 'center',
+          minWidth: 0,
+          minHeight: 58,
+          padding: `${token.sizeXS}px ${token.sizeXS}px`,
+          borderRadius: token.borderRadius,
+        } as React.CSSProperties
+      }
     >
       <SmallLinkGlyph item={item} disabled={disabled} />
       <span
@@ -1153,24 +1215,39 @@ export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
             return (
               <Tooltip key={item.key} title={tooltipTitle} mouseEnterDelay={0.45}>
                 <span
-                  style={{
-                    height: 26,
-                    minWidth: 0,
-                    maxWidth: 156,
-                    border: `1px solid ${
-                      disabled ? token.colorBorderSecondary : token.colorPrimaryBorder
-                    }`,
-                    borderRadius: 999,
-                    background: disabled ? token.colorFillQuaternary : token.colorPrimaryBg,
-                    color: disabled ? token.colorTextDisabled : token.colorText,
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 5,
-                    lineHeight: 1,
-                    flex: '0 1 auto',
-                    opacity: isBusy ? 0.65 : 1,
-                    overflow: 'hidden',
-                  }}
+                  className="agor-action-link-chip"
+                  aria-disabled={disabled || undefined}
+                  style={
+                    {
+                      '--agor-link-chip-bg': disabled
+                        ? token.colorFillQuaternary
+                        : token.colorPrimaryBg,
+                      '--agor-link-chip-border': disabled
+                        ? token.colorBorderSecondary
+                        : token.colorPrimaryBorder,
+                      '--agor-link-chip-color': disabled
+                        ? token.colorTextDisabled
+                        : token.colorText,
+                      '--agor-link-chip-accent-color': disabled
+                        ? token.colorTextDisabled
+                        : token.colorPrimary,
+                      '--agor-link-chip-hover-bg': token.colorPrimaryBgHover,
+                      '--agor-link-chip-hover-border': token.colorPrimary,
+                      '--agor-link-chip-hover-color': token.colorPrimary,
+                      height: 26,
+                      minWidth: 0,
+                      maxWidth: 156,
+                      border: '1px solid var(--agor-link-chip-border)',
+                      borderRadius: 999,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 5,
+                      lineHeight: 1,
+                      flex: '0 1 auto',
+                      opacity: isBusy ? 0.65 : 1,
+                      overflow: 'hidden',
+                    } as React.CSSProperties
+                  }
                 >
                   <button
                     type="button"
@@ -1186,7 +1263,7 @@ export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
                       height: 24,
                       border: 0,
                       background: 'transparent',
-                      color: disabled ? token.colorTextDisabled : token.colorPrimary,
+                      color: 'var(--agor-link-chip-accent-color)',
                       cursor: canTogglePin && !isPinning ? 'pointer' : 'default',
                       padding: '0 0 0 8px',
                       display: 'inline-flex',
@@ -1215,7 +1292,7 @@ export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
                       minWidth: 0,
                       border: 0,
                       background: 'transparent',
-                      color: 'inherit',
+                      color: 'var(--agor-link-chip-color)',
                       cursor: disabled || isBusy ? 'not-allowed' : 'pointer',
                       padding: `0 ${token.paddingXS}px 0 0`,
                       display: 'inline-flex',
@@ -1229,9 +1306,10 @@ export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
                   >
                     <span
                       aria-hidden="true"
+                      className="agor-action-link-icon"
                       style={{
                         width: 18,
-                        color: disabled ? token.colorTextDisabled : token.colorPrimary,
+                        color: 'var(--agor-link-chip-accent-color)',
                         display: 'inline-flex',
                         alignItems: 'center',
                         justifyContent: 'center',
@@ -1248,11 +1326,12 @@ export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
                       )}
                     </span>
                     <Typography.Text
+                      className={disabled ? undefined : 'agor-action-link-title'}
                       ellipsis
                       style={{
                         fontSize: 12,
                         maxWidth: 96,
-                        color: disabled ? token.colorTextDisabled : token.colorText,
+                        color: 'var(--agor-link-chip-color)',
                       }}
                     >
                       {title}

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
@@ -227,7 +227,6 @@ export function LinkRow({
     </Tooltip>
   ) : null;
 
-
   const showPassivePinIndicator = item.isPinned && !canTogglePin;
   const isActionable = Boolean(item.href || contentAction);
 
@@ -685,7 +684,6 @@ function TypePill({ item, compact = false }: { item: LinkDisplayItem; compact?: 
     </span>
   );
 }
-
 
 function shouldIgnoreRowActivation(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && Boolean(target.closest('a,button,[role="button"]'));

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
@@ -921,6 +921,7 @@ function ManagementLinkRow({
   const disabled = Boolean(disabledReason);
   return (
     <div
+      className="agor-action-link-row"
       role={disabled ? undefined : 'link'}
       tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled || undefined}
@@ -934,16 +935,22 @@ function ManagementLinkRow({
         event.preventDefault();
         activateLinkItem(item, navigate, onPreview, onDownload, onNavigate);
       }}
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'minmax(0, 1.35fr) minmax(110px, 0.45fr) 94px 24px',
-        columnGap: token.sizeMD,
-        alignItems: 'center',
-        padding: `${token.sizeSM}px 0`,
-        borderBottom: `1px solid ${token.colorBorderSecondary}`,
-        cursor: disabled ? 'default' : 'pointer',
-        minWidth: 0,
-      }}
+      style={
+        {
+          '--agor-link-title-color': disabled ? token.colorTextDisabled : token.colorText,
+          '--agor-link-icon-color': disabled ? token.colorTextDisabled : token.colorTextTertiary,
+          '--agor-link-row-hover-bg': 'transparent',
+          '--agor-link-row-hover-color': token.colorPrimary,
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1.35fr) minmax(110px, 0.45fr) 94px 24px',
+          columnGap: token.sizeMD,
+          alignItems: 'center',
+          padding: `${token.sizeSM}px 0`,
+          borderBottom: `1px solid ${token.colorBorderSecondary}`,
+          cursor: disabled ? 'default' : 'pointer',
+          minWidth: 0,
+        } as React.CSSProperties
+      }
     >
       <span style={{ display: 'flex', gap: token.sizeSM, minWidth: 0, alignItems: 'flex-start' }}>
         <SmallLinkGlyph item={item} disabled={disabled} />
@@ -1084,10 +1091,11 @@ export const PinnedLinksStrip: React.FC<PinnedLinksStripProps> = ({
                         : token.colorText,
                       '--agor-link-chip-accent-color': disabled
                         ? token.colorTextDisabled
-                        : token.colorPrimary,
+                        : token.colorTextTertiary,
                       '--agor-link-chip-hover-bg': token.colorPrimaryBg,
                       '--agor-link-chip-hover-border': token.colorPrimaryBorder,
                       '--agor-link-chip-hover-color': token.colorPrimary,
+                      '--agor-link-chip-hover-accent-color': token.colorTextTertiary,
                       height: 26,
                       minWidth: 0,
                       maxWidth: 156,

--- a/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
+++ b/apps/agor-ui/src/components/Links/SessionLinksControl.tsx
@@ -12,9 +12,10 @@ import {
   Empty,
   Modal,
   Popover,
-  Segmented,
+  Select,
   Space,
   Spin,
+  Tabs,
   Tooltip,
   Typography,
   theme,
@@ -31,11 +32,23 @@ import {
   type LinkPreviewKind,
 } from './linkContent';
 import {
+  compareLinkDisplayItemsBySort,
   getCompactLinkDisplayName,
+  getLinkCategoryCounts,
+  getLinkCategorySummary,
   getLinkDisplayGlyphLabel,
   getLinkDisplaySecondaryLabel,
-  type LinkDisplayCategory,
+  isFileLinkDisplayItem,
+  isKnowledgeLinkDisplayItem,
+  LINK_CATEGORY_TAB_LABELS,
+  LINK_OWNER_FILTER_LABELS,
+  LINK_SORT_LABELS,
+  type LinkCategoryTabKey,
   type LinkDisplayItem,
+  type LinkOwnerFilterKey,
+  type LinkSortKey,
+  matchesLinkCategoryTab,
+  matchesLinkOwnerFilter,
 } from './linkDisplay';
 
 const QUICK_LINK_LIMIT = 7;
@@ -458,75 +471,16 @@ export function LinkPreviewModal({
   );
 }
 
-type LinkManagementFilter =
-  | 'all'
-  | 'branch'
-  | 'session'
-  | 'files'
-  | 'knowledge'
-  | 'issues'
-  | 'pinned';
-
-const LINK_DOCUMENT_CATEGORIES = new Set<LinkDisplayCategory>([
-  'pdf',
-  'spreadsheet',
-  'csv',
-  'document',
-  'markdown',
-  'text',
-  'code',
-  'json',
-  'log',
-]);
-
-function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : pluralLabel}`;
-}
+type LinkManagementCategory = LinkCategoryTabKey;
+type LinkManagementSourceFilter = LinkOwnerFilterKey;
+type LinkManagementSort = LinkSortKey;
 
 function isFileDisplayItem(item: LinkDisplayItem): boolean {
-  return (
-    item.category === 'image' ||
-    Boolean(item.filePath) ||
-    LINK_DOCUMENT_CATEGORIES.has(item.category)
-  );
+  return isFileLinkDisplayItem(item);
 }
 
 function isKnowledgeDisplayItem(item: LinkDisplayItem): boolean {
-  return item.category === 'knowledge' || Boolean(item.refUri?.startsWith('agor://kb/'));
-}
-
-function isIssuePrDisplayItem(item: LinkDisplayItem): boolean {
-  return item.category === 'issue' || item.category === 'pr';
-}
-
-function matchesManagementFilter(item: LinkDisplayItem, filter: LinkManagementFilter): boolean {
-  switch (filter) {
-    case 'branch':
-      return item.ownerScope === 'branch';
-    case 'session':
-      return item.ownerScope === 'session';
-    case 'files':
-      return isFileDisplayItem(item);
-    case 'knowledge':
-      return isKnowledgeDisplayItem(item);
-    case 'issues':
-      return isIssuePrDisplayItem(item);
-    case 'pinned':
-      return item.isPinned;
-    default:
-      return true;
-  }
-}
-
-function compareManagementItems(a: LinkDisplayItem, b: LinkDisplayItem): number {
-  if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
-  const nameOrder = getCompactLinkDisplayName(a).localeCompare(
-    getCompactLinkDisplayName(b),
-    undefined,
-    { sensitivity: 'base' }
-  );
-  if (nameOrder !== 0) return nameOrder;
-  return a.key.localeCompare(b.key);
+  return isKnowledgeLinkDisplayItem(item);
 }
 
 function getQuickCategoryRank(item: LinkDisplayItem): number {
@@ -569,9 +523,7 @@ function selectQuickItems(items: LinkDisplayItem[], limit: number): LinkDisplayI
 }
 
 function getSummary(items: LinkDisplayItem[]): string {
-  const pinnedCount = items.filter((item) => item.isPinned).length;
-  const fileCount = items.filter(isFileDisplayItem).length;
-  return `${plural(items.length, 'link')} · ${plural(pinnedCount, 'pinned', 'pinned')} · ${plural(fileCount, 'file')}`;
+  return getLinkCategorySummary(items);
 }
 
 function getTypeLabel(item: LinkDisplayItem): string {
@@ -734,7 +686,7 @@ function getPinnedChipActionLabel(item: LinkDisplayItem): string {
 }
 
 function getPinnedChipTitle(item: LinkDisplayItem): string {
-  return getCompactLinkDisplayName(item).replace(/^(Issue|PR|Knowledge|Saved URL):\s*/i, '');
+  return getCompactLinkDisplayName(item).replace(/^(Issue|PR|Knowledge|Link|URL):\s*/i, '');
 }
 
 function TitleTarget({
@@ -862,7 +814,7 @@ function PinAction({
           alignItems: 'center',
           justifyContent: 'center',
           cursor: canTogglePin && !pinning ? 'pointer' : 'default',
-          color: item.isPinned ? token.colorPrimary : token.colorTextQuaternary,
+          color: item.isPinned ? token.colorWarning : token.colorTextQuaternary,
           opacity: pinning ? 0.55 : 1,
         }}
       >
@@ -1262,36 +1214,30 @@ export const LinksManagementDrawer: React.FC<LinksManagementDrawerProps> = ({
 }) => {
   const { token } = theme.useToken();
   const { preview, setPreview, openPreview, downloadItem } = useLinkFileActions();
-  const [activeFilter, setActiveFilter] = useState<LinkManagementFilter>('all');
+  const [activeCategory, setActiveCategory] = useState<LinkManagementCategory>('all');
+  const [sourceFilter, setSourceFilter] = useState<LinkManagementSourceFilter>('all');
+  const [sortOrder, setSortOrder] = useState<LinkManagementSort>('az');
 
-  const sortedItems = useMemo(() => [...items].sort(compareManagementItems), [items]);
-  const visibleItems = useMemo(
-    () => sortedItems.filter((item) => matchesManagementFilter(item, activeFilter)),
-    [activeFilter, sortedItems]
+  const sortedItems = useMemo(
+    () => [...items].sort((a, b) => compareLinkDisplayItemsBySort(a, b, sortOrder)),
+    [items, sortOrder]
   );
-  const filterOptions = useMemo(
-    () => [
-      { label: `All ${items.length}`, value: 'all' as const },
-      {
-        label: `Branch ${items.filter((item) => item.ownerScope === 'branch').length}`,
-        value: 'branch' as const,
-      },
-      {
-        label: `This session ${items.filter((item) => item.ownerScope === 'session').length}`,
-        value: 'session' as const,
-      },
-      { label: `Files ${items.filter(isFileDisplayItem).length}`, value: 'files' as const },
-      {
-        label: `Knowledge ${items.filter(isKnowledgeDisplayItem).length}`,
-        value: 'knowledge' as const,
-      },
-      {
-        label: `Issues/PRs ${items.filter(isIssuePrDisplayItem).length}`,
-        value: 'issues' as const,
-      },
-      { label: `Pinned ${items.filter((item) => item.isPinned).length}`, value: 'pinned' as const },
-    ],
-    [items]
+  const visibleItems = useMemo(
+    () =>
+      sortedItems.filter(
+        (item) =>
+          matchesLinkCategoryTab(item, activeCategory) && matchesLinkOwnerFilter(item, sourceFilter)
+      ),
+    [activeCategory, sourceFilter, sortedItems]
+  );
+  const categoryCounts = useMemo(() => getLinkCategoryCounts(items), [items]);
+  const categoryTabs = useMemo(
+    () =>
+      (['all', 'files', 'links', 'knowledge', 'issues'] as const).map((key) => ({
+        key,
+        label: `${LINK_CATEGORY_TAB_LABELS[key]} ${categoryCounts[key]}`,
+      })),
+    [categoryCounts]
   );
 
   return (
@@ -1310,14 +1256,48 @@ export const LinksManagementDrawer: React.FC<LinksManagementDrawerProps> = ({
       >
         {items.length > 0 ? (
           <Space direction="vertical" size={token.sizeLG} style={{ width: '100%' }}>
-            <div data-testid="links-management-filter-row">
-              <Segmented<LinkManagementFilter>
-                size="middle"
-                value={activeFilter}
-                options={filterOptions}
-                onChange={setActiveFilter}
+            <div data-testid="links-management-category-row">
+              <Tabs
+                className="agor-link-category-tabs"
+                activeKey={activeCategory}
+                items={categoryTabs}
+                onChange={(key) => setActiveCategory(key as LinkManagementCategory)}
               />
             </div>
+            <Space wrap size={token.sizeSM} style={{ width: '100%' }}>
+              <Space size={token.sizeXS}>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Sort
+                </Typography.Text>
+                <Select<LinkManagementSort>
+                  size="small"
+                  value={sortOrder}
+                  options={(Object.keys(LINK_SORT_LABELS) as LinkManagementSort[]).map((key) => ({
+                    value: key,
+                    label: LINK_SORT_LABELS[key],
+                  }))}
+                  onChange={setSortOrder}
+                  style={{ width: 128 }}
+                />
+              </Space>
+              <Space size={token.sizeXS}>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Location
+                </Typography.Text>
+                <Select<LinkManagementSourceFilter>
+                  size="small"
+                  value={sourceFilter}
+                  options={(
+                    Object.keys(LINK_OWNER_FILTER_LABELS) as LinkManagementSourceFilter[]
+                  ).map((key) => ({
+                    value: key,
+                    label: LINK_OWNER_FILTER_LABELS[key],
+                  }))}
+                  onChange={setSourceFilter}
+                  style={{ width: 142 }}
+                />
+              </Space>
+            </Space>
 
             {visibleItems.length > 0 ? (
               <div>
@@ -1466,7 +1446,7 @@ export const SessionLinksControl: React.FC<SessionLinksControlProps> = ({
               type="text"
               aria-label="Links"
               loading={loading}
-              icon={<LinkOutlined style={{ color: token.colorPrimary }} />}
+              icon={<LinkOutlined style={{ color: token.colorTextSecondary }} />}
             />
           </Badge>
         </Tooltip>

--- a/apps/agor-ui/src/components/Links/linkContent.ts
+++ b/apps/agor-ui/src/components/Links/linkContent.ts
@@ -1,0 +1,172 @@
+import { getDaemonUrl } from '../../config/daemon';
+import { getAgorAccessToken } from '../../utils/authHeaders';
+import type { LinkDisplayCategory, LinkDisplayItem } from './linkDisplay';
+
+export interface LinkContentTarget {
+  linkId: string;
+  title: string;
+  subtitle?: string | null;
+}
+
+export type LinkContentDisposition = 'inline' | 'attachment';
+export type LinkContentAction = 'preview' | 'download';
+export type LinkPreviewKind = 'image' | 'markdown' | 'text';
+
+const PREVIEW_CATEGORIES: Partial<Record<LinkDisplayCategory, LinkPreviewKind>> = {
+  image: 'image',
+  markdown: 'markdown',
+  text: 'text',
+};
+
+const DOWNLOAD_CATEGORIES = new Set<LinkDisplayCategory>([
+  'pdf',
+  'spreadsheet',
+  'csv',
+  'document',
+  'code',
+  'json',
+  'log',
+]);
+
+export function getLinkContentPath(
+  linkId: string,
+  disposition: LinkContentDisposition = 'attachment'
+): string {
+  const encodedId = encodeURIComponent(linkId);
+  return `/link-content/${encodedId}?disposition=${disposition}`;
+}
+
+export function getLinkContentUrl(
+  linkId: string,
+  disposition: LinkContentDisposition = 'attachment',
+  daemonUrl = getDaemonUrl()
+): string {
+  return `${daemonUrl.replace(/\/$/, '')}${getLinkContentPath(linkId, disposition)}`;
+}
+
+export function getLinkPreviewKind(item: LinkDisplayItem): LinkPreviewKind | null {
+  if (item.source !== 'upload' || !item.linkId || !item.filePath) return null;
+  return PREVIEW_CATEGORIES[item.category] ?? null;
+}
+
+export function getLinkContentAction(item: LinkDisplayItem): LinkContentAction | null {
+  if (getLinkPreviewKind(item)) return 'preview';
+  if (
+    item.source === 'upload' &&
+    item.linkId &&
+    item.filePath &&
+    DOWNLOAD_CATEGORIES.has(item.category)
+  ) {
+    return 'download';
+  }
+  return null;
+}
+
+function isLocalFilePathLike(value: string): boolean {
+  return (
+    value.startsWith('/') ||
+    value.startsWith('~/') ||
+    value.startsWith('./') ||
+    value.startsWith('../') ||
+    /^[a-zA-Z]:[\\/]/.test(value) ||
+    value.includes('\\')
+  );
+}
+
+function basenameFromPathLike(value: string): string {
+  const withoutQuery = value.split(/[?#]/)[0] ?? value;
+  const parts = withoutQuery.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1) || value;
+}
+
+export function getSafeLinkContentLabel(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith('agor://')) return trimmed;
+  try {
+    // Preserve URLs; callers already decide whether a URL is safe to open.
+    // This helper only avoids surfacing daemon-local filesystem paths.
+    new URL(trimmed);
+    return trimmed;
+  } catch {
+    // Not a fully-qualified URL.
+  }
+  return isLocalFilePathLike(trimmed) ? basenameFromPathLike(trimmed) : trimmed;
+}
+
+async function fetchLinkContent(
+  linkId: string,
+  options?: { disposition?: LinkContentDisposition; download?: boolean; accept?: string }
+): Promise<Response> {
+  const token = getAgorAccessToken();
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (options?.accept) headers.Accept = options.accept;
+
+  const disposition = options?.download ? 'attachment' : (options?.disposition ?? 'inline');
+  const response = await fetch(getLinkContentUrl(linkId, disposition), { headers });
+  if (!response.ok) {
+    let message = `Link content request failed (${response.status})`;
+    try {
+      const body = (await response.json()) as { error?: unknown };
+      if (typeof body.error === 'string') message = body.error;
+    } catch {
+      // ignore non-JSON error bodies
+    }
+    throw new Error(message);
+  }
+  return response;
+}
+
+export async function fetchLinkObjectUrl(
+  linkId: string,
+  options?: { download?: boolean; accept?: string }
+): Promise<string> {
+  const response = await fetchLinkContent(linkId, options);
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}
+
+export async function fetchLinkMarkdownText(linkId: string): Promise<string> {
+  const response = await fetchLinkContent(linkId, {
+    disposition: 'inline',
+    accept: 'text/markdown, text/plain;q=0.9',
+  });
+  return response.text();
+}
+
+function fallbackDownloadFilename(title: string): string {
+  return title.replace(/[\r\n"\\/:*?<>|]/g, '_').slice(0, 180) || 'download';
+}
+
+function filenameFromContentDisposition(value: string | null): string | null {
+  if (!value) return null;
+  const encoded = value.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
+  if (encoded) {
+    try {
+      return decodeURIComponent(encoded);
+    } catch {
+      return encoded;
+    }
+  }
+  return value.match(/filename="([^"]+)"/i)?.[1] ?? null;
+}
+
+export async function downloadLinkContent(linkId: string, title: string): Promise<void> {
+  const response = await fetchLinkContent(linkId, {
+    download: true,
+    accept: 'application/octet-stream',
+  });
+  const blob = await response.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download =
+    filenameFromContentDisposition(response.headers.get('Content-Disposition')) ??
+    fallbackDownloadFilename(title);
+  anchor.rel = 'noopener';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+}

--- a/apps/agor-ui/src/components/Links/linkDisplay.test.ts
+++ b/apps/agor-ui/src/components/Links/linkDisplay.test.ts
@@ -71,6 +71,22 @@ describe('link display KB routing', () => {
     expect(targetForLinkDisplay({ refUri: 'agor://kb/document/0190a000' })).toBeNull();
   });
 
+  it('only creates external targets for absolute http(s) URLs', () => {
+    expect(targetForLinkDisplay({ url: 'https://example.com/docs?q=1#top' })).toEqual({
+      href: 'https://example.com/docs?q=1#top',
+      navigation: 'external',
+    });
+    expect(targetForLinkDisplay({ url: 'http://example.com/docs' })).toEqual({
+      href: 'http://example.com/docs',
+      navigation: 'external',
+    });
+    expect(targetForLinkDisplay({ url: 'javascript:alert(1)' })).toBeNull();
+    expect(targetForLinkDisplay({ url: 'data:text/html,<script>alert(1)</script>' })).toBeNull();
+    expect(targetForLinkDisplay({ url: 'blob:https://example.com/id' })).toBeNull();
+    expect(targetForLinkDisplay({ url: 'https://%' })).toBeNull();
+    expect(targetForLinkDisplay({ url: '/relative/path' })).toBeNull();
+  });
+
   it('keeps KB document refs visible even when they are not directly routable', () => {
     const refUri = 'agor://kb/document/0190a000-0000-7000-8000-0000000000aa';
     const item = linkToDisplayItem(
@@ -88,6 +104,25 @@ describe('link display KB routing', () => {
       category: 'knowledge',
       refUri,
       href: undefined,
+    });
+  });
+
+  it('keeps unsafe persisted URL rows visible but without navigable hrefs', () => {
+    const item = linkToDisplayItem(
+      makeLink({
+        link_id: 'link-unsafe-url' as Link['link_id'],
+        kind: 'url',
+        source: 'manual',
+        url: 'javascript:alert(1)',
+      })
+    );
+
+    expect(item).toMatchObject({
+      name: 'URL: alert(1)',
+      category: 'url',
+      url: 'javascript:alert(1)',
+      href: undefined,
+      navigation: undefined,
     });
   });
 });

--- a/apps/agor-ui/src/components/Links/linkDisplay.test.ts
+++ b/apps/agor-ui/src/components/Links/linkDisplay.test.ts
@@ -3,13 +3,17 @@ import { normalizeRefTargetKey, normalizeUrlTargetKey } from '@agor-live/client'
 import { describe, expect, it } from 'vitest';
 import {
   buildLinkDisplayItems,
+  compareLinkDisplayItemsBySort,
   getCompactLinkDisplayName,
+  getLinkCategoryCounts,
+  getLinkCategorySummary,
   getLinkDisplayCategory,
   getLinkDisplayGlyphLabel,
   getLinkDisplayPillLabel,
   getLinkDisplaySecondaryLabel,
   type LinkDisplayItem,
   linkToDisplayItem,
+  matchesLinkCategoryTab,
   routeForKnowledgeRefUri,
   sortLinkDisplayItems,
   targetForLinkDisplay,
@@ -231,12 +235,50 @@ describe('link display categories', () => {
     expect(getLinkDisplayPillLabel('issue')).toBe('Issue');
     expect(getLinkDisplayPillLabel('pr')).toBe('PR');
     expect(getLinkDisplayPillLabel('knowledge')).toBe('Knowledge');
-    expect(getLinkDisplayPillLabel('url')).toBe('Saved URL');
+    expect(getLinkDisplayPillLabel('url')).toBe('Link');
     expect(getLinkDisplayPillLabel('image')).toBe('Image');
     expect(getLinkDisplayPillLabel('document')).toBe('Doc');
     expect(getLinkDisplayPillLabel('spreadsheet')).toBe('XLS');
     expect(getLinkDisplayPillLabel('csv')).toBe('CSV');
     expect(getLinkDisplayPillLabel('markdown')).toBe('MD');
+  });
+
+  it('splits organizer categories into tabs without losing ordinary web links', () => {
+    const items: LinkDisplayItem[] = [
+      item('web', 'Docs', false),
+      { ...item('kb', 'Knowledge', false), category: 'knowledge', refUri: 'agor://kb/team/doc.md' },
+      { ...item('file', 'Plan', false), category: 'pdf', filePath: '/uploads/plan.pdf' },
+      { ...item('pr', 'PR', false), category: 'pr' },
+    ];
+
+    expect(getLinkCategoryCounts(items)).toEqual({
+      all: 4,
+      files: 1,
+      links: 1,
+      knowledge: 1,
+      issues: 1,
+    });
+    expect(matchesLinkCategoryTab(items[0], 'links')).toBe(true);
+    expect(getLinkCategorySummary(items)).toBe('1 file · 1 link · 1 knowledge · 1 issue/PR');
+  });
+
+  it('keeps pinned rows first when applying alternate sort orders', () => {
+    const items: LinkDisplayItem[] = [
+      { ...item('old-z', 'Zebra', false), createdAt: '2026-01-01T00:00:00.000Z' },
+      { ...item('new-a', 'Alpha', false), createdAt: '2026-02-01T00:00:00.000Z' },
+      { ...item('pinned-m', 'Middle', true), createdAt: '2025-01-01T00:00:00.000Z' },
+    ];
+
+    expect(
+      [...items]
+        .sort((a, b) => compareLinkDisplayItemsBySort(a, b, 'recent'))
+        .map((entry) => entry.name)
+    ).toEqual(['Middle', 'Alpha', 'Zebra']);
+    expect(
+      [...items]
+        .sort((a, b) => compareLinkDisplayItemsBySort(a, b, 'za'))
+        .map((entry) => entry.name)
+    ).toEqual(['Middle', 'Zebra', 'Alpha']);
   });
 
   it('renders uploaded file rows with useful labels but no preview href', () => {

--- a/apps/agor-ui/src/components/Links/linkDisplay.test.ts
+++ b/apps/agor-ui/src/components/Links/linkDisplay.test.ts
@@ -1,0 +1,253 @@
+import type { Branch, Link } from '@agor-live/client';
+import { normalizeRefTargetKey, normalizeUrlTargetKey } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import {
+  buildLinkDisplayItems,
+  getCompactLinkDisplayName,
+  getLinkDisplayCategory,
+  getLinkDisplayGlyphLabel,
+  getLinkDisplayPillLabel,
+  getLinkDisplaySecondaryLabel,
+  type LinkDisplayItem,
+  linkToDisplayItem,
+  routeForKnowledgeRefUri,
+  sortLinkDisplayItems,
+  targetForLinkDisplay,
+} from './linkDisplay';
+
+const now = '2026-07-01T00:00:00.000Z';
+
+function makeLink(patch: Partial<Link> & Pick<Link, 'link_id' | 'kind' | 'source'>): Link {
+  return {
+    link_id: patch.link_id,
+    branch_id: null,
+    session_id: 'session-1' as Link['session_id'],
+    source_message_id: null,
+    kind: patch.kind,
+    source: patch.source,
+    url: null,
+    ref_uri: null,
+    file_path: null,
+    target_key: patch.url
+      ? normalizeUrlTargetKey(patch.url)
+      : patch.ref_uri
+        ? normalizeRefTargetKey(patch.ref_uri)
+        : patch.file_path
+          ? `file:${patch.file_path}`
+          : '',
+    is_pinned: false,
+    title: null,
+    mime_type: null,
+    metadata: null,
+    created_by: null,
+    created_at: now,
+    updated_at: now,
+    ...patch,
+  } as Link;
+}
+
+describe('link display KB routing', () => {
+  it('routes path-addressed KB refs and leaves opaque document/unit refs unrouted', () => {
+    expect(routeForKnowledgeRefUri('agor://kb/global/guides/architecture.md')).toBe(
+      '/kb/global/guides/architecture.md'
+    );
+    expect(routeForKnowledgeRefUri('agor://kb/team/runbooks/one%20two.md')).toBe(
+      '/kb/team/runbooks/one%20two.md'
+    );
+    expect(routeForKnowledgeRefUri('agor://kb/global')).toBe('/kb/global');
+    expect(
+      routeForKnowledgeRefUri('agor://kb/document/0190a000-0000-7000-8000-0000000000aa')
+    ).toBeNull();
+    expect(
+      routeForKnowledgeRefUri('agor://kb/unit/0190a000-0000-7000-8000-0000000000bb')
+    ).toBeNull();
+  });
+
+  it('maps routable KB refs to SPA targets without inventing routes for opaque refs', () => {
+    expect(targetForLinkDisplay({ refUri: 'agor://kb/global/readme.md' })).toEqual({
+      href: '/kb/global/readme.md',
+      navigation: 'spa',
+    });
+    expect(targetForLinkDisplay({ refUri: 'agor://kb/document/0190a000' })).toBeNull();
+  });
+
+  it('keeps KB document refs visible even when they are not directly routable', () => {
+    const refUri = 'agor://kb/document/0190a000-0000-7000-8000-0000000000aa';
+    const item = linkToDisplayItem(
+      makeLink({
+        link_id: 'link-kb-doc' as Link['link_id'],
+        kind: 'kb_ref',
+        source: 'parsed',
+        ref_uri: refUri,
+        target_key: normalizeRefTargetKey(refUri),
+      })
+    );
+
+    expect(item).toMatchObject({
+      name: 'KB document 0190a000',
+      category: 'knowledge',
+      refUri,
+      href: undefined,
+    });
+  });
+});
+
+describe('link display merge and sort', () => {
+  it('provides compact row names without duplicate type prefixes', () => {
+    expect(getCompactLinkDisplayName({ name: 'Issue: preset-io/agor#92', category: 'issue' })).toBe(
+      'preset-io/agor#92'
+    );
+    expect(getCompactLinkDisplayName({ name: 'PR: preset-io/agor#1692', category: 'pr' })).toBe(
+      'preset-io/agor#1692'
+    );
+    expect(getCompactLinkDisplayName({ name: 'URL: docs', category: 'url' })).toBe('docs');
+    expect(getCompactLinkDisplayName({ name: 'File: spec.pdf', category: 'pdf' })).toBe('spec.pdf');
+  });
+
+  it('sorts pinned items first, then alphabetically by display name', () => {
+    const items: LinkDisplayItem[] = [
+      item('z', 'Zebra', false),
+      item('beta', 'beta', true),
+      item('alpha', 'Alpha', true),
+      item('middle', 'Middle', false),
+    ];
+
+    expect(sortLinkDisplayItems(items).map((entry) => entry.name)).toEqual([
+      'Alpha',
+      'beta',
+      'Middle',
+      'Zebra',
+    ]);
+  });
+
+  it('merges branch issue/PR links with session links and dedupes by target key', () => {
+    const branch = {
+      issue_url: 'https://github.com/preset-io/agor/issues/92',
+      pull_request_url: 'https://github.com/preset-io/agor/pull/1692',
+    } as Branch;
+    const links = [
+      makeLink({
+        link_id: 'link-duplicate-pr' as Link['link_id'],
+        kind: 'pr',
+        source: 'parsed',
+        url: 'https://github.com/preset-io/agor/pull/1692#discussion',
+        target_key: normalizeUrlTargetKey('https://github.com/preset-io/agor/pull/1692'),
+        title: 'Pinned PR discussion',
+        is_pinned: true,
+      }),
+      makeLink({
+        link_id: 'link-docs' as Link['link_id'],
+        kind: 'url',
+        source: 'parsed',
+        url: 'https://example.com/docs',
+      }),
+    ];
+
+    const items = buildLinkDisplayItems({ branch, links });
+
+    expect(items.map((entry) => entry.name)).toEqual([
+      'Pinned PR discussion',
+      'Issue: preset-io/agor#92',
+      'URL: docs',
+    ]);
+    expect(items).toHaveLength(3);
+    expect(items[0]).toMatchObject({ isPinned: true, kind: 'pr' });
+  });
+
+  it('prefers persisted branch rows over synthetic branch refs when pin state is equal', () => {
+    const branch = {
+      issue_url: 'https://github.com/preset-io/agor/issues/92',
+    } as Branch;
+    const links = [
+      makeLink({
+        link_id: 'link-branch-issue' as Link['link_id'],
+        branch_id: 'branch-1' as Link['branch_id'],
+        session_id: null,
+        kind: 'issue',
+        source: 'manual',
+        url: 'https://github.com/preset-io/agor/issues/92',
+        title: 'Tracked issue',
+      }),
+    ];
+
+    const items = buildLinkDisplayItems({ branch, links });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      name: 'Tracked issue',
+      linkId: 'link-branch-issue',
+      ownerScope: 'branch',
+    });
+  });
+});
+
+describe('link display categories', () => {
+  it('infers neutral file categories and glyph labels from MIME type and extension', () => {
+    expect(getLinkDisplayCategory({ filePath: '/uploads/spec.pdf' })).toBe('pdf');
+    expect(getLinkDisplayCategory({ mimeType: 'text/markdown', filePath: '/uploads/readme' })).toBe(
+      'markdown'
+    );
+    expect(getLinkDisplayCategory({ filePath: '/uploads/data.csv' })).toBe('csv');
+    expect(getLinkDisplayGlyphLabel('pdf')).toBe('PDF');
+    expect(getLinkDisplayGlyphLabel('knowledge')).toBe('KB');
+  });
+
+  it('provides exploration-compatible pill labels without coupling to row markup', () => {
+    expect(getLinkDisplayPillLabel('issue')).toBe('Issue');
+    expect(getLinkDisplayPillLabel('pr')).toBe('PR');
+    expect(getLinkDisplayPillLabel('knowledge')).toBe('Knowledge');
+    expect(getLinkDisplayPillLabel('url')).toBe('Saved URL');
+    expect(getLinkDisplayPillLabel('image')).toBe('Image');
+    expect(getLinkDisplayPillLabel('document')).toBe('Doc');
+    expect(getLinkDisplayPillLabel('spreadsheet')).toBe('XLS');
+    expect(getLinkDisplayPillLabel('csv')).toBe('CSV');
+    expect(getLinkDisplayPillLabel('markdown')).toBe('MD');
+  });
+
+  it('renders uploaded file rows with useful labels but no preview href', () => {
+    const filePath = '/home/agor/.agor/uploads/tenant/session/spec.pdf';
+    const item = linkToDisplayItem(
+      makeLink({
+        link_id: 'link-file' as Link['link_id'],
+        kind: 'document',
+        source: 'upload',
+        file_path: filePath,
+        target_key: `file:${filePath}`,
+      })
+    );
+
+    expect(item).toMatchObject({
+      name: 'File: spec.pdf',
+      category: 'pdf',
+      filePath,
+      href: undefined,
+    });
+    expect(getLinkDisplaySecondaryLabel(item as LinkDisplayItem)).toBe('spec.pdf');
+    expect(getLinkDisplaySecondaryLabel(item as LinkDisplayItem)).not.toContain('/home/agor');
+  });
+
+  it('uses MIME type as a safe secondary label for uploaded files when present', () => {
+    const item = linkToDisplayItem(
+      makeLink({
+        link_id: 'link-markdown' as Link['link_id'],
+        kind: 'document',
+        source: 'upload',
+        file_path: '/home/agor/.agor/uploads/tenant/session/notes.md',
+        mime_type: 'text/markdown',
+      })
+    );
+
+    expect(getLinkDisplaySecondaryLabel(item as LinkDisplayItem)).toBe('text/markdown');
+  });
+});
+
+function item(key: string, name: string, isPinned: boolean): LinkDisplayItem {
+  return {
+    key,
+    name,
+    targetKey: `target:${key}`,
+    category: 'url',
+    ownerScope: 'session',
+    isPinned,
+  };
+}

--- a/apps/agor-ui/src/components/Links/linkDisplay.ts
+++ b/apps/agor-ui/src/components/Links/linkDisplay.ts
@@ -1,0 +1,496 @@
+import type { Branch, Link, LinkKind, LinkSource } from '@agor-live/client';
+import {
+  normalizeFileTargetKey,
+  normalizeRefTargetKey,
+  normalizeUrlTargetKey,
+} from '@agor-live/client';
+import { buildKnowledgeRoutePath } from '../../utils/knowledgeRoutes';
+import { getUrlDisplayLabel } from '../Pill/url-helpers';
+
+export type LinkDisplayCategory =
+  | 'knowledge'
+  | 'image'
+  | 'pdf'
+  | 'spreadsheet'
+  | 'csv'
+  | 'document'
+  | 'markdown'
+  | 'text'
+  | 'code'
+  | 'json'
+  | 'log'
+  | 'url'
+  | 'issue'
+  | 'pr'
+  | 'internal'
+  | 'unknown';
+
+export type LinkDisplayNavigation = 'external' | 'spa';
+export type LinkDisplaySource = LinkSource | 'branch';
+
+export interface LinkDisplayTarget {
+  href: string;
+  navigation: LinkDisplayNavigation;
+}
+
+export interface LinkDisplayItem {
+  key: string;
+  name: string;
+  targetKey: string;
+  category: LinkDisplayCategory;
+  kind?: LinkKind;
+  source?: LinkDisplaySource;
+  ownerScope: 'branch' | 'session';
+  isPinned: boolean;
+  url?: string;
+  refUri?: string;
+  filePath?: string;
+  mimeType?: string;
+  linkId?: string;
+  href?: string;
+  navigation?: LinkDisplayNavigation;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+const KB_URI_PREFIX = 'agor://kb/';
+const KB_DOCUMENT_URI_PREFIX = 'agor://kb/document/';
+const KB_UNIT_URI_PREFIX = 'agor://kb/unit/';
+
+function cleanSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function lastPathSegment(value: string): string {
+  const cleaned = value.split(/[?#]/)[0] ?? value;
+  const parts = cleaned.split('/').filter(Boolean);
+  return parts.at(-1) || value;
+}
+
+function urlWithoutProtocol(value: string): string {
+  try {
+    const parsed = new URL(value);
+    return `${parsed.hostname}${parsed.pathname}`;
+  } catch {
+    return value.replace(/^https?:\/\//i, '');
+  }
+}
+
+function extensionFromPath(value?: string | null): string {
+  const segment = lastPathSegment(value ?? '');
+  const dot = segment.lastIndexOf('.');
+  return dot >= 0 ? segment.slice(dot + 1).toLowerCase() : '';
+}
+
+function titleOrNull(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed || null;
+}
+
+function githubKindLabel(kind?: LinkKind): 'Issue' | 'PR' | null {
+  if (kind === 'issue') return 'Issue';
+  if (kind === 'pr') return 'PR';
+  return null;
+}
+
+export function routeForKnowledgeRefUri(refUri?: string | null, basePath = '/kb'): string | null {
+  if (!refUri?.startsWith(KB_URI_PREFIX)) return null;
+  if (refUri.startsWith(KB_DOCUMENT_URI_PREFIX) || refUri.startsWith(KB_UNIT_URI_PREFIX)) {
+    return null;
+  }
+
+  const rest = refUri.slice(KB_URI_PREFIX.length);
+  const [namespaceSlug, ...pathParts] = rest.split('/').filter(Boolean).map(cleanSegment);
+  if (!namespaceSlug || namespaceSlug === 'document' || namespaceSlug === 'unit') return null;
+
+  return buildKnowledgeRoutePath(basePath, namespaceSlug, pathParts.join('/') || null);
+}
+
+export function targetForLinkDisplay(args: {
+  url?: string | null;
+  refUri?: string | null;
+}): LinkDisplayTarget | null {
+  const route = routeForKnowledgeRefUri(args.refUri);
+  if (route) return { href: route, navigation: 'spa' };
+  if (args.url) return { href: args.url, navigation: 'external' };
+  return null;
+}
+
+export function getRefDisplayLabel(refUri: string): string {
+  if (refUri.startsWith(KB_DOCUMENT_URI_PREFIX)) {
+    return `KB document ${refUri.slice(KB_DOCUMENT_URI_PREFIX.length, KB_DOCUMENT_URI_PREFIX.length + 8)}`;
+  }
+  if (refUri.startsWith(KB_UNIT_URI_PREFIX)) {
+    return `KB unit ${refUri.slice(KB_UNIT_URI_PREFIX.length, KB_UNIT_URI_PREFIX.length + 8)}`;
+  }
+  if (refUri.startsWith(KB_URI_PREFIX)) return `KB: ${refUri.slice(KB_URI_PREFIX.length)}`;
+  return `Ref: ${refUri}`;
+}
+
+export function getLinkDisplayCategory(args: {
+  kind?: LinkKind | string | null;
+  mimeType?: string | null;
+  title?: string | null;
+  filePath?: string | null;
+  refUri?: string | null;
+}): LinkDisplayCategory {
+  if (args.kind === 'issue') return 'issue';
+  if (args.kind === 'pr') return 'pr';
+  if (args.kind === 'url') return 'url';
+  if (args.kind === 'internal') return 'internal';
+  if (args.kind === 'kb_ref' || args.refUri?.startsWith(KB_URI_PREFIX)) return 'knowledge';
+  if (args.kind === 'image' || args.mimeType?.startsWith('image/')) return 'image';
+
+  const mime = args.mimeType?.split(';')[0]?.trim().toLowerCase() ?? '';
+  const ext = extensionFromPath(args.filePath) || extensionFromPath(args.title);
+
+  if (mime === 'application/pdf' || ext === 'pdf') return 'pdf';
+  if (mime === 'text/csv' || ['csv', 'tsv'].includes(ext)) return 'csv';
+  if (
+    mime.includes('spreadsheet') ||
+    mime.includes('excel') ||
+    ['xls', 'xlsx', 'ods'].includes(ext)
+  ) {
+    return 'spreadsheet';
+  }
+  if (
+    mime.includes('wordprocessingml') ||
+    mime === 'application/msword' ||
+    ['doc', 'docx', 'rtf', 'odt'].includes(ext)
+  ) {
+    return 'document';
+  }
+  if (mime === 'application/json' || ext === 'json') return 'json';
+  if (ext === 'log') return 'log';
+  if (['md', 'markdown'].includes(ext) || mime === 'text/markdown') return 'markdown';
+  if (mime.startsWith('text/') || ['txt', 'adoc', 'rst'].includes(ext)) return 'text';
+  if (
+    [
+      'js',
+      'jsx',
+      'ts',
+      'tsx',
+      'py',
+      'rb',
+      'go',
+      'rs',
+      'java',
+      'c',
+      'cc',
+      'cpp',
+      'h',
+      'hpp',
+      'css',
+      'scss',
+      'html',
+      'xml',
+      'yaml',
+      'yml',
+      'toml',
+      'sql',
+      'sh',
+      'zsh',
+    ].includes(ext)
+  ) {
+    return 'code';
+  }
+
+  return args.filePath ? 'document' : 'unknown';
+}
+
+export function normalizeLinkFindResult(
+  result: Link[] | { data?: Link[] } | null | undefined
+): Link[] {
+  if (!result) return [];
+  return Array.isArray(result) ? result : (result.data ?? []);
+}
+
+export function isBranchOwnedLink(link: Link, branchId: string): boolean {
+  return link.branch_id === branchId && !link.session_id;
+}
+
+export function upsertLinkById(prev: Link[], link: Link): Link[] {
+  const existingIndex = prev.findIndex((entry) => entry.link_id === link.link_id);
+  if (existingIndex < 0) return [...prev, link];
+  const next = [...prev];
+  next[existingIndex] = link;
+  return next;
+}
+
+export function removeLinkById(prev: Link[], linkOrId: Link | string): Link[] {
+  const linkId = typeof linkOrId === 'string' ? linkOrId : linkOrId.link_id;
+  return prev.filter((entry) => entry.link_id !== linkId);
+}
+
+export function reconcilePinnedBranchLink(prev: Link[], link: Link, branchId: string): Link[] {
+  if (isBranchOwnedLink(link, branchId) && link.is_pinned) return upsertLinkById(prev, link);
+  return removeLinkById(prev, link);
+}
+
+export function getLinkDisplayGlyphLabel(category: LinkDisplayCategory): string {
+  switch (category) {
+    case 'knowledge':
+      return 'KB';
+    case 'image':
+      return 'IMG';
+    case 'pdf':
+      return 'PDF';
+    case 'spreadsheet':
+      return 'XLS';
+    case 'csv':
+      return 'CSV';
+    case 'document':
+      return 'DOC';
+    case 'markdown':
+      return 'MD';
+    case 'text':
+      return 'TXT';
+    case 'code':
+      return 'CODE';
+    case 'json':
+      return 'JSON';
+    case 'log':
+      return 'LOG';
+    case 'issue':
+      return 'ISSUE';
+    case 'pr':
+      return 'PR';
+    case 'url':
+      return 'URL';
+    case 'internal':
+      return 'REF';
+    default:
+      return 'LINK';
+  }
+}
+
+export function getLinkDisplayPillLabel(category: LinkDisplayCategory): string {
+  switch (category) {
+    case 'knowledge':
+      return 'Knowledge';
+    case 'image':
+      return 'Image';
+    case 'pdf':
+      return 'PDF';
+    case 'spreadsheet':
+      return 'XLS';
+    case 'csv':
+      return 'CSV';
+    case 'document':
+      return 'Doc';
+    case 'markdown':
+      return 'MD';
+    case 'text':
+      return 'Text';
+    case 'code':
+      return 'Code';
+    case 'json':
+      return 'JSON';
+    case 'log':
+      return 'Log';
+    case 'issue':
+      return 'Issue';
+    case 'pr':
+      return 'PR';
+    case 'url':
+      return 'Saved URL';
+    case 'internal':
+      return 'Ref';
+    default:
+      return 'Link';
+  }
+}
+
+export function getCompactLinkDisplayName(
+  item: Pick<LinkDisplayItem, 'name' | 'category'>
+): string {
+  const prefixesByCategory: Partial<Record<LinkDisplayCategory, string[]>> = {
+    issue: ['Issue: '],
+    pr: ['PR: '],
+    url: ['URL: '],
+    image: ['Image: ', 'File: '],
+    pdf: ['File: '],
+    spreadsheet: ['File: '],
+    csv: ['File: '],
+    document: ['File: '],
+    markdown: ['File: '],
+    text: ['File: '],
+    code: ['File: '],
+    json: ['File: '],
+    log: ['File: '],
+  };
+  for (const prefix of prefixesByCategory[item.category] ?? []) {
+    if (item.name.startsWith(prefix)) return item.name.slice(prefix.length);
+  }
+  return item.name;
+}
+
+export function getLinkDisplaySecondaryLabel(
+  item: Pick<LinkDisplayItem, 'url' | 'refUri' | 'filePath' | 'mimeType'>
+): string | null {
+  if (item.url) return urlWithoutProtocol(item.url);
+  if (item.refUri) return item.refUri;
+  if (!item.filePath) return null;
+
+  if (item.mimeType) return item.mimeType;
+
+  const filename = lastPathSegment(item.filePath);
+  return filename && filename !== item.filePath ? filename : 'Uploaded file';
+}
+
+export function targetKeyForLink(link: Link): string | null {
+  if (link.target_key) return link.target_key;
+  if (link.url) return normalizeUrlTargetKey(link.url);
+  if (link.ref_uri) return normalizeRefTargetKey(link.ref_uri);
+  if (link.file_path) return normalizeFileTargetKey(link.file_path);
+  return null;
+}
+
+export function linkToDisplayItem(link: Link): LinkDisplayItem | null {
+  const targetKey = targetKeyForLink(link);
+  if (!targetKey) return null;
+
+  const target = targetForLinkDisplay({ url: link.url, refUri: link.ref_uri });
+  const base = {
+    key: `link:${link.link_id}`,
+    targetKey,
+    kind: link.kind,
+    source: link.source,
+    ownerScope: link.session_id ? 'session' : 'branch',
+    isPinned: Boolean(link.is_pinned),
+    linkId: String(link.link_id),
+    mimeType: link.mime_type ?? undefined,
+    href: target?.href,
+    navigation: target?.navigation,
+    createdAt: link.created_at,
+    updatedAt: link.updated_at,
+  } satisfies Partial<LinkDisplayItem>;
+
+  if (link.url) {
+    const prefix = githubKindLabel(link.kind) ?? 'URL';
+    return {
+      ...base,
+      name: titleOrNull(link.title) ?? `${prefix}: ${getUrlDisplayLabel(link.url)}`,
+      category: getLinkDisplayCategory({ kind: link.kind, mimeType: link.mime_type }),
+      url: link.url,
+    } as LinkDisplayItem;
+  }
+
+  if (link.ref_uri) {
+    return {
+      ...base,
+      name: titleOrNull(link.title) ?? getRefDisplayLabel(link.ref_uri),
+      category: getLinkDisplayCategory({
+        kind: link.kind,
+        mimeType: link.mime_type,
+        refUri: link.ref_uri,
+      }),
+      refUri: link.ref_uri,
+    } as LinkDisplayItem;
+  }
+
+  if (link.file_path) {
+    const fallbackPrefix = link.kind === 'image' ? 'Image' : 'File';
+    return {
+      ...base,
+      name: titleOrNull(link.title) ?? `${fallbackPrefix}: ${lastPathSegment(link.file_path)}`,
+      category: getLinkDisplayCategory({
+        kind: link.kind,
+        mimeType: link.mime_type,
+        title: link.title,
+        filePath: link.file_path,
+      }),
+      filePath: link.file_path,
+    } as LinkDisplayItem;
+  }
+
+  return null;
+}
+
+function branchUrlToDisplayItem(args: {
+  key: string;
+  url: string;
+  kind: Extract<LinkKind, 'issue' | 'pr'>;
+}): LinkDisplayItem {
+  const label = args.kind === 'issue' ? 'Issue' : 'PR';
+  return {
+    key: args.key,
+    name: `${label}: ${getUrlDisplayLabel(args.url)}`,
+    targetKey: normalizeUrlTargetKey(args.url),
+    category: args.kind,
+    kind: args.kind,
+    source: 'branch',
+    ownerScope: 'branch',
+    isPinned: false,
+    url: args.url,
+    href: args.url,
+    navigation: 'external',
+  };
+}
+
+export function mergeLinkDisplayItems(items: LinkDisplayItem[]): LinkDisplayItem[] {
+  const byTarget = new Map<string, LinkDisplayItem>();
+  for (const item of items) {
+    const key = item.targetKey.toLowerCase();
+    const existing = byTarget.get(key);
+    if (
+      !existing ||
+      (item.isPinned && !existing.isPinned) ||
+      (item.isPinned === existing.isPinned && Boolean(item.linkId) && !existing.linkId)
+    ) {
+      byTarget.set(key, item);
+    }
+  }
+  return Array.from(byTarget.values());
+}
+
+export function compareLinkDisplayItems(a: LinkDisplayItem, b: LinkDisplayItem): number {
+  if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+  const nameOrder = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  if (nameOrder !== 0) return nameOrder;
+  return a.key.localeCompare(b.key);
+}
+
+export function sortLinkDisplayItems(items: LinkDisplayItem[]): LinkDisplayItem[] {
+  return [...items].sort(compareLinkDisplayItems);
+}
+
+export function buildLinkDisplayItems(args: {
+  branch?: Pick<Branch, 'issue_url' | 'pull_request_url'> | null;
+  links?: Link[];
+  includeBranchLinks?: boolean;
+}): LinkDisplayItem[] {
+  const items: LinkDisplayItem[] = [];
+  const includeBranchLinks = args.includeBranchLinks ?? true;
+
+  if (includeBranchLinks && args.branch?.issue_url) {
+    items.push(
+      branchUrlToDisplayItem({
+        key: 'branch:issue',
+        url: args.branch.issue_url,
+        kind: 'issue',
+      })
+    );
+  }
+
+  if (includeBranchLinks && args.branch?.pull_request_url) {
+    items.push(
+      branchUrlToDisplayItem({
+        key: 'branch:pr',
+        url: args.branch.pull_request_url,
+        kind: 'pr',
+      })
+    );
+  }
+
+  for (const link of args.links ?? []) {
+    const item = linkToDisplayItem(link);
+    if (item) items.push(item);
+  }
+
+  return sortLinkDisplayItems(mergeLinkDisplayItems(items));
+}

--- a/apps/agor-ui/src/components/Links/linkDisplay.ts
+++ b/apps/agor-ui/src/components/Links/linkDisplay.ts
@@ -28,6 +28,9 @@ export type LinkDisplayCategory =
 
 export type LinkDisplayNavigation = 'external' | 'spa';
 export type LinkDisplaySource = LinkSource | 'branch';
+export type LinkCategoryTabKey = 'all' | 'files' | 'links' | 'knowledge' | 'issues';
+export type LinkOwnerFilterKey = 'all' | 'branch' | 'session';
+export type LinkSortKey = 'az' | 'za' | 'recent' | 'oldest';
 
 export interface LinkDisplayTarget {
   href: string;
@@ -299,7 +302,7 @@ export function getLinkDisplayPillLabel(category: LinkDisplayCategory): string {
     case 'pr':
       return 'PR';
     case 'url':
-      return 'Saved URL';
+      return 'Link';
     case 'internal':
       return 'Ref';
     default:
@@ -460,6 +463,138 @@ export function compareLinkDisplayItems(a: LinkDisplayItem, b: LinkDisplayItem):
 
 export function sortLinkDisplayItems(items: LinkDisplayItem[]): LinkDisplayItem[] {
   return [...items].sort(compareLinkDisplayItems);
+}
+
+const ORGANIZER_DOCUMENT_CATEGORIES = new Set<LinkDisplayCategory>([
+  'image',
+  'pdf',
+  'spreadsheet',
+  'csv',
+  'document',
+  'markdown',
+  'text',
+  'code',
+  'json',
+  'log',
+]);
+
+export const LINK_CATEGORY_TAB_LABELS: Record<LinkCategoryTabKey, string> = {
+  all: 'All',
+  files: 'Files',
+  links: 'Links',
+  knowledge: 'Knowledge',
+  issues: 'Issues/PRs',
+};
+
+export const LINK_OWNER_FILTER_LABELS: Record<LinkOwnerFilterKey, string> = {
+  all: 'All locations',
+  branch: 'Branch',
+  session: 'This session',
+};
+
+export const LINK_SORT_LABELS: Record<LinkSortKey, string> = {
+  az: 'A-Z',
+  za: 'Z-A',
+  recent: 'Recent',
+  oldest: 'Old to new',
+};
+
+export function isFileLinkDisplayItem(item: LinkDisplayItem): boolean {
+  return Boolean(item.filePath) || ORGANIZER_DOCUMENT_CATEGORIES.has(item.category);
+}
+
+export function isKnowledgeLinkDisplayItem(item: LinkDisplayItem): boolean {
+  return item.category === 'knowledge' || Boolean(item.refUri?.startsWith(KB_URI_PREFIX));
+}
+
+export function isIssuePrLinkDisplayItem(item: LinkDisplayItem): boolean {
+  return item.category === 'issue' || item.category === 'pr';
+}
+
+export function isWebLinkDisplayItem(item: LinkDisplayItem): boolean {
+  return (
+    !isFileLinkDisplayItem(item) &&
+    !isKnowledgeLinkDisplayItem(item) &&
+    !isIssuePrLinkDisplayItem(item)
+  );
+}
+
+export function matchesLinkCategoryTab(
+  item: LinkDisplayItem,
+  category: LinkCategoryTabKey
+): boolean {
+  switch (category) {
+    case 'files':
+      return isFileLinkDisplayItem(item);
+    case 'links':
+      return isWebLinkDisplayItem(item);
+    case 'knowledge':
+      return isKnowledgeLinkDisplayItem(item);
+    case 'issues':
+      return isIssuePrLinkDisplayItem(item);
+    default:
+      return true;
+  }
+}
+
+export function matchesLinkOwnerFilter(
+  item: LinkDisplayItem,
+  ownerFilter: LinkOwnerFilterKey
+): boolean {
+  return ownerFilter === 'all' || item.ownerScope === ownerFilter;
+}
+
+function compareLinkNames(a: LinkDisplayItem, b: LinkDisplayItem): number {
+  const nameOrder = getCompactLinkDisplayName(a).localeCompare(
+    getCompactLinkDisplayName(b),
+    undefined,
+    { sensitivity: 'base' }
+  );
+  if (nameOrder !== 0) return nameOrder;
+  return a.key.localeCompare(b.key);
+}
+
+function getLinkTimestamp(item: LinkDisplayItem): string {
+  return item.updatedAt || item.createdAt || '';
+}
+
+export function compareLinkDisplayItemsBySort(
+  a: LinkDisplayItem,
+  b: LinkDisplayItem,
+  sort: LinkSortKey
+): number {
+  if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+
+  if (sort === 'za') return -compareLinkNames(a, b);
+
+  if (sort === 'recent' || sort === 'oldest') {
+    const timestampOrder = getLinkTimestamp(a).localeCompare(getLinkTimestamp(b));
+    if (timestampOrder !== 0) return sort === 'recent' ? -timestampOrder : timestampOrder;
+  }
+
+  return compareLinkNames(a, b);
+}
+
+export function getLinkCategoryCounts(
+  items: LinkDisplayItem[]
+): Record<LinkCategoryTabKey, number> {
+  return {
+    all: items.length,
+    files: items.filter(isFileLinkDisplayItem).length,
+    links: items.filter(isWebLinkDisplayItem).length,
+    knowledge: items.filter(isKnowledgeLinkDisplayItem).length,
+    issues: items.filter(isIssuePrLinkDisplayItem).length,
+  };
+}
+
+export function getLinkCategorySummary(items: LinkDisplayItem[]): string {
+  const counts = getLinkCategoryCounts(items);
+  return [
+    `${counts.files} ${counts.files === 1 ? 'file' : 'files'}`,
+    `${counts.links} ${counts.links === 1 ? 'link' : 'links'}`,
+    `${counts.knowledge} knowledge`,
+    `${counts.issues} ${counts.issues === 1 ? 'issue/PR' : 'issues/PRs'}`,
+  ].join(' · ');
 }
 
 export function buildLinkDisplayItems(args: {

--- a/apps/agor-ui/src/components/Links/linkDisplay.ts
+++ b/apps/agor-ui/src/components/Links/linkDisplay.ts
@@ -1,5 +1,6 @@
 import type { Branch, Link, LinkKind, LinkSource } from '@agor-live/client';
 import {
+  getSafeWebUrl,
   normalizeFileTargetKey,
   normalizeRefTargetKey,
   normalizeUrlTargetKey,
@@ -116,7 +117,8 @@ export function targetForLinkDisplay(args: {
 }): LinkDisplayTarget | null {
   const route = routeForKnowledgeRefUri(args.refUri);
   if (route) return { href: route, navigation: 'spa' };
-  if (args.url) return { href: args.url, navigation: 'external' };
+  const safeUrl = getSafeWebUrl(args.url);
+  if (safeUrl) return { href: safeUrl, navigation: 'external' };
   return null;
 }
 
@@ -417,6 +419,7 @@ function branchUrlToDisplayItem(args: {
   kind: Extract<LinkKind, 'issue' | 'pr'>;
 }): LinkDisplayItem {
   const label = args.kind === 'issue' ? 'Issue' : 'PR';
+  const safeUrl = getSafeWebUrl(args.url);
   return {
     key: args.key,
     name: `${label}: ${getUrlDisplayLabel(args.url)}`,
@@ -427,8 +430,8 @@ function branchUrlToDisplayItem(args: {
     ownerScope: 'branch',
     isPinned: false,
     url: args.url,
-    href: args.url,
-    navigation: 'external',
+    href: safeUrl ?? undefined,
+    navigation: safeUrl ? 'external' : undefined,
   };
 }
 

--- a/apps/agor-ui/src/components/Links/linkEvents.ts
+++ b/apps/agor-ui/src/components/Links/linkEvents.ts
@@ -1,0 +1,30 @@
+import type { Link } from '@agor-live/client';
+
+export const LINK_MUTATION_EVENT = 'agor:link-mutation';
+
+export type LinkMutationKind = 'created' | 'patched' | 'updated' | 'removed';
+
+export interface LinkMutationEventDetail {
+  link: Link;
+  mutation: LinkMutationKind;
+}
+
+export function dispatchLinkMutation(detail: LinkMutationEventDetail): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<LinkMutationEventDetail>(LINK_MUTATION_EVENT, { detail }));
+}
+
+export function listenForLinkMutations(
+  handler: (detail: LinkMutationEventDetail) => void
+): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const listener = (event: Event) => {
+    const detail = (event as CustomEvent<LinkMutationEventDetail>).detail;
+    if (!detail?.link?.link_id) return;
+    handler(detail);
+  };
+
+  window.addEventListener(LINK_MUTATION_EVENT, listener);
+  return () => window.removeEventListener(LINK_MUTATION_EVENT, listener);
+}

--- a/apps/agor-ui/src/components/Links/linkPromotion.test.ts
+++ b/apps/agor-ui/src/components/Links/linkPromotion.test.ts
@@ -1,0 +1,108 @@
+import type { Link } from '@agor-live/client';
+import { normalizeUrlTargetKey } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import { getAssistantPromotionState } from './linkPromotion';
+
+const now = '2026-07-06T00:00:00.000Z';
+
+function makeLink(patch: Partial<Link>): Link {
+  const url = patch.url ?? 'https://example.com/docs';
+  return {
+    link_id: 'assistant-link' as Link['link_id'],
+    branch_id: 'assistant-branch' as Link['branch_id'],
+    session_id: null,
+    source_message_id: null,
+    kind: 'url',
+    source: 'manual',
+    url,
+    ref_uri: null,
+    file_path: null,
+    target_key: normalizeUrlTargetKey(url),
+    is_pinned: true,
+    title: null,
+    mime_type: null,
+    metadata: null,
+    created_by: null,
+    created_at: now,
+    updated_at: now,
+    ...patch,
+  } as Link;
+}
+
+describe('assistant link promotion state', () => {
+  it('offers promotion when a saved source link is not on the assistant', () => {
+    const state = getAssistantPromotionState({
+      item: { linkId: 'source-link', targetKey: normalizeUrlTargetKey('https://example.com/a') },
+      assistantBranchId: 'assistant-branch',
+      assistantLinks: [],
+      sourceBranchId: 'branch-1',
+    });
+
+    expect(state).toMatchObject({
+      isPromoted: false,
+      canUseAssistantPromotion: true,
+      actionLabel: 'Promote to assistant',
+    });
+  });
+
+  it('offers removal when an assistant copy already has the same target key', () => {
+    const assistantLink = makeLink({ url: 'https://example.com/docs' });
+    const state = getAssistantPromotionState({
+      item: {
+        linkId: 'source-link',
+        targetKey: normalizeUrlTargetKey('https://example.com/docs#ignored'),
+      },
+      assistantBranchId: 'assistant-branch',
+      assistantLinks: [assistantLink],
+      sourceBranchId: 'branch-1',
+    });
+
+    expect(state).toMatchObject({
+      assistantLink,
+      isPromoted: true,
+      canUseAssistantPromotion: true,
+      actionLabel: 'Remove from assistant',
+    });
+  });
+
+  it('treats rows owned by the primary assistant branch as assistant-owned', () => {
+    const state = getAssistantPromotionState({
+      item: { linkId: 'assistant-link', targetKey: normalizeUrlTargetKey('https://example.com/a') },
+      assistantBranchId: 'assistant-branch',
+      assistantLinks: [],
+      sourceBranchId: 'assistant-branch',
+    });
+
+    expect(state).toMatchObject({
+      isAssistantOwned: true,
+      isPromoted: true,
+      actionLabel: 'Remove from assistant',
+    });
+  });
+
+  it('explains unavailable states for missing assistant or unsaved synthetic rows', () => {
+    expect(
+      getAssistantPromotionState({
+        item: { linkId: 'source-link', targetKey: 'url:https://example.com/a' },
+        assistantBranchId: null,
+        assistantLinks: [],
+        sourceBranchId: 'branch-1',
+      })
+    ).toMatchObject({
+      canUseAssistantPromotion: false,
+      unavailableReason: 'No primary assistant is assigned to this board.',
+    });
+
+    expect(
+      getAssistantPromotionState({
+        item: { targetKey: 'url:https://example.com/a' },
+        assistantBranchId: 'assistant-branch',
+        assistantLinks: [],
+        sourceBranchId: 'branch-1',
+      })
+    ).toMatchObject({
+      canUseAssistantPromotion: false,
+      unavailableReason: 'Only saved links can be promoted to the assistant.',
+    });
+  });
+});

--- a/apps/agor-ui/src/components/Links/linkPromotion.ts
+++ b/apps/agor-ui/src/components/Links/linkPromotion.ts
@@ -1,0 +1,82 @@
+import type { AgorClient, Link } from '@agor-live/client';
+import { type LinkDisplayItem, targetKeyForLink } from './linkDisplay';
+
+export interface AssistantPromotionState {
+  assistantLink: Link | null;
+  isPromoted: boolean;
+  isAssistantOwned: boolean;
+  canUseAssistantPromotion: boolean;
+  unavailableReason: string | null;
+  actionLabel: 'Promote to assistant' | 'Remove from assistant';
+}
+
+export function findAssistantLinkForTarget(
+  item: Pick<LinkDisplayItem, 'targetKey'>,
+  assistantLinks: Link[]
+): Link | null {
+  const targetKey = item.targetKey.toLowerCase();
+  return (
+    assistantLinks.find((link) => {
+      const linkTargetKey = targetKeyForLink(link);
+      return linkTargetKey?.toLowerCase() === targetKey;
+    }) ?? null
+  );
+}
+
+export function getAssistantPromotionState(args: {
+  item: Pick<LinkDisplayItem, 'targetKey' | 'linkId'>;
+  assistantBranchId?: string | null;
+  assistantLinks: Link[];
+  sourceBranchId?: string | null;
+}): AssistantPromotionState {
+  const assistantLink = args.assistantBranchId
+    ? findAssistantLinkForTarget(args.item, args.assistantLinks)
+    : null;
+  const isAssistantOwned = Boolean(
+    args.assistantBranchId && args.sourceBranchId && args.sourceBranchId === args.assistantBranchId
+  );
+  const isPromoted = Boolean(assistantLink || isAssistantOwned);
+  const actionLabel = isPromoted ? 'Remove from assistant' : 'Promote to assistant';
+
+  if (!args.assistantBranchId) {
+    return {
+      assistantLink,
+      isPromoted,
+      isAssistantOwned,
+      canUseAssistantPromotion: false,
+      unavailableReason: 'No primary assistant is assigned to this board.',
+      actionLabel,
+    };
+  }
+
+  if (!args.item.linkId && !assistantLink) {
+    return {
+      assistantLink,
+      isPromoted,
+      isAssistantOwned,
+      canUseAssistantPromotion: false,
+      unavailableReason: 'Only saved links can be promoted to the assistant.',
+      actionLabel,
+    };
+  }
+
+  return {
+    assistantLink,
+    isPromoted,
+    isAssistantOwned,
+    canUseAssistantPromotion: true,
+    unavailableReason: null,
+    actionLabel,
+  };
+}
+
+export async function promoteLinkToAssistant(args: {
+  client: AgorClient;
+  sourceLinkId: string;
+  assistantBranchId: string;
+}): Promise<Link> {
+  return (await args.client.service(`links/${args.sourceLinkId}/promote`).create({
+    target: 'assistant',
+    assistant_branch_id: args.assistantBranchId,
+  })) as Link;
+}

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.test.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.test.tsx
@@ -1,0 +1,68 @@
+import type { Link, Message } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { MessageBlock } from './MessageBlock';
+
+const now = '2026-07-06T00:00:00.000Z';
+
+function makeMessage(patch: Partial<Message> = {}): Message {
+  return {
+    message_id: 'message-1' as Message['message_id'],
+    session_id: 'session-1' as Message['session_id'],
+    task_id: 'task-1' as Message['task_id'],
+    type: 'user',
+    role: 'user',
+    index: 0,
+    timestamp: now,
+    content_preview: '',
+    content: '',
+    metadata: null,
+    ...patch,
+  } as Message;
+}
+
+function makeLink(patch: Partial<Link> = {}): Link {
+  return {
+    link_id: 'link-1' as Link['link_id'],
+    branch_id: null,
+    session_id: 'session-1' as Link['session_id'],
+    source_message_id: 'message-1' as Link['source_message_id'],
+    kind: 'document',
+    source: 'upload',
+    url: null,
+    ref_uri: null,
+    file_path: '/home/agor/.agor/uploads/session/spec.pdf',
+    target_key: 'file:/home/agor/.agor/uploads/session/spec.pdf',
+    is_pinned: false,
+    title: 'spec.pdf',
+    mime_type: 'application/pdf',
+    metadata: null,
+    created_by: null,
+    created_at: now,
+    updated_at: now,
+    ...patch,
+  } as Link;
+}
+
+describe('MessageBlock attachments', () => {
+  it('renders a user attachment-only message with blank content', () => {
+    render(
+      <MemoryRouter>
+        <MessageBlock message={makeMessage({ content: '   ' })} attachmentLinks={[makeLink()]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /open spec\.pdf/i })).toBeInTheDocument();
+  });
+
+  it('keeps blank messages without attachments hidden', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MessageBlock message={makeMessage({ content: '   ' })} />
+      </MemoryRouter>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -13,6 +13,7 @@ import {
   type AgorClient,
   type ContentBlock as CoreContentBlock,
   type DiffEnrichment,
+  type Link,
   type Message,
   type PermissionRequestContent,
   PermissionScope,
@@ -25,6 +26,7 @@ import { Bubble } from '@ant-design/x';
 import { Tooltip, theme } from 'antd';
 
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { BRAND, brandMarkHref } from '../../branding/brand';
 import { formatTimestampWithRelative } from '../../utils/time';
 import { getToolDisplayName } from '../../utils/toolDisplayName';
@@ -32,6 +34,16 @@ import { toolResultToDisplayText } from '../../utils/toolResultToDisplayText';
 import { AgorAvatar } from '../AgorAvatar';
 import { CollapsibleMarkdown } from '../CollapsibleText/CollapsibleMarkdown';
 import { CopyableContent } from '../CopyableContent';
+import {
+  LinkAttachmentCard,
+  type LinkAttachmentTarget,
+  routeForKnowledgeUri,
+} from '../Links/LinkAttachmentCard';
+import { LinkImagePreviewModal, type LinkImagePreviewTarget } from '../Links/LinkImagePreviewModal';
+import {
+  LinkMarkdownPreviewModal,
+  type LinkMarkdownPreviewTarget,
+} from '../Links/LinkMarkdownPreviewModal';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { PermissionRequestBlock } from '../PermissionRequestBlock';
 import { SystemMessage } from '../SystemMessage';
@@ -93,6 +105,7 @@ interface MessageBlockProps {
   assistantEmoji?: string; // Emoji override for assistant avatar (replaces tool icon)
   /** Authenticated Feathers client, forwarded to WidgetBlock for inline-form submission. */
   client?: AgorClient | null;
+  attachmentLinks?: Link[];
   onPermissionDecision?: (
     sessionId: string,
     requestId: string,
@@ -234,6 +247,37 @@ function getAgentAvatar({
   );
 }
 
+function getAttachmentTitle(link: Link): string {
+  const metadata = link.metadata && typeof link.metadata === 'object' ? link.metadata : null;
+  const originalName =
+    metadata && typeof metadata.originalName === 'string' ? metadata.originalName : null;
+  if (originalName) return originalName;
+  if (link.title) return link.title;
+  if (link.file_path) return link.file_path.split('/').pop() || link.file_path;
+  if (link.kind === 'kb_ref') return 'Knowledge link';
+  if (link.kind === 'document') return 'Uploaded document';
+  return 'Uploaded file';
+}
+
+function getAttachmentSubtitle(link: Link): string | null {
+  if (link.ref_uri) return link.ref_uri;
+  if (link.url) return link.url;
+  if (link.kind === 'image' && link.file_path) return link.file_path;
+  return null;
+}
+
+function getAttachmentUnavailableReason(link: Link): string | null {
+  if (link.kind === 'image' && link.source === 'upload' && link.file_path && link.link_id)
+    return null;
+  if (link.source === 'upload' && link.file_path && link.link_id) return null;
+  if (link.kind === 'document' || link.file_path || link.source === 'upload')
+    return 'Preview/download unavailable';
+  if (link.kind === 'kb_ref' && !routeForKnowledgeUri(link.ref_uri)) {
+    return 'No safe Knowledge route available';
+  }
+  return null;
+}
+
 // Memoized: every text block / tool block of every message in the conversation
 // re-rendered on every streaming chunk because TaskBlock's `messages` array
 // gets a fresh reference each tick. Default shallow compare is sufficient
@@ -259,8 +303,25 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   onPermissionDecision,
   assistantEmoji,
   client = null,
+  attachmentLinks = [],
 }) => {
   const { token } = theme.useToken();
+  const navigate = useNavigate();
+  const [previewTarget, setPreviewTarget] = React.useState<LinkImagePreviewTarget | null>(null);
+  const [markdownTarget, setMarkdownTarget] = React.useState<LinkMarkdownPreviewTarget | null>(
+    null
+  );
+
+  const openAttachmentTarget = React.useCallback(
+    (target: LinkAttachmentTarget) => {
+      if (target.navigation === 'spa') {
+        navigate(target.href);
+        return;
+      }
+      window.open(target.href, '_blank', 'noopener,noreferrer');
+    },
+    [navigate]
+  );
 
   // Handle permission request messages specially
   if (message.type === 'permission_request') {
@@ -648,6 +709,40 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
                           </div>
                         );
                       })}
+                      {isUser && attachmentLinks.length > 0 && (
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: token.sizeUnit,
+                            alignItems: 'flex-start',
+                          }}
+                        >
+                          {attachmentLinks.map((link) => (
+                            <LinkAttachmentCard
+                              key={link.link_id}
+                              kind={link.kind}
+                              source={link.source}
+                              linkId={link.link_id}
+                              title={getAttachmentTitle(link)}
+                              subtitle={getAttachmentSubtitle(link)}
+                              url={link.url}
+                              refUri={link.ref_uri}
+                              filePath={link.file_path}
+                              mimeType={link.mime_type}
+                              ownerLabel="This session"
+                              stateLabel={link.source === 'upload' ? 'Upload' : 'Collected'}
+                              disabledReason={getAttachmentUnavailableReason(link)}
+                              compact
+                              onDark={isUser}
+                              imageThumbnail
+                              onOpenImage={setPreviewTarget}
+                              onOpenMarkdown={setMarkdownTarget}
+                              onOpenTarget={openAttachmentTarget}
+                            />
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </CopyableContent>
                 }
@@ -794,6 +889,8 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
             </div>
           );
         })()}
+      <LinkImagePreviewModal target={previewTarget} onClose={() => setPreviewTarget(null)} />
+      <LinkMarkdownPreviewModal target={markdownTarget} onClose={() => setMarkdownTarget(null)} />
     </>
   );
 };

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -392,6 +392,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   // Determine if this should be displayed as user or agent message
   const isUser = message.role === 'user' && !isTaskPrompt && !isTaskResult;
   const isAgent = message.role === 'assistant' || isTaskPrompt || isTaskResult || isSystem;
+  const hasUserAttachments = isUser && attachmentLinks.length > 0;
 
   // Check if message is currently streaming
   const isStreaming = 'isStreaming' in message && message.isStreaming === true;
@@ -410,12 +411,15 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   const currentUser = currentUserId ? userById.get(currentUserId) : undefined;
 
   // Skip rendering if message has no content
-  if (!message.content || (typeof message.content === 'string' && message.content.trim() === '')) {
+  if (
+    (!message.content || (typeof message.content === 'string' && message.content.trim() === '')) &&
+    !hasUserAttachments
+  ) {
     return null;
   }
 
   // Skip rendering if message has empty content array (can happen during patch events)
-  if (Array.isArray(message.content) && message.content.length === 0) {
+  if (Array.isArray(message.content) && message.content.length === 0 && !hasUserAttachments) {
     return null;
   }
 
@@ -627,7 +631,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   const hasTextAfter = textAfterTools.some((text) => text.trim().length > 0);
   const hasTools = toolBlocks.length > 0;
 
-  if (!hasThinking && !hasTextBefore && !hasTextAfter && !hasTools) {
+  if (!hasThinking && !hasTextBefore && !hasTextAfter && !hasTools && !hasUserAttachments) {
     return null;
   }
 
@@ -649,7 +653,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
       )}
 
       {/* Text before tools (if any) - rare but possible */}
-      {hasTextBefore &&
+      {(hasTextBefore || hasUserAttachments) &&
         (() => {
           const avatar = isUser ? (
             <UserIdentityAvatar user={currentUser} />

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -1,61 +1,769 @@
-import { GithubOutlined, GlobalOutlined, LinkOutlined } from '@ant-design/icons';
+import {
+  BookOutlined,
+  DownloadOutlined,
+  EllipsisOutlined,
+  ExportOutlined,
+  FileImageOutlined,
+  FileTextOutlined,
+  GithubOutlined,
+  GlobalOutlined,
+  LinkOutlined,
+  PushpinFilled,
+  PushpinOutlined,
+  StopOutlined,
+} from '@ant-design/icons';
 import type { MenuProps } from 'antd';
-import { Badge, Button, Dropdown, Tooltip, theme } from 'antd';
-import type React from 'react';
+import {
+  Badge,
+  Button,
+  Divider,
+  Drawer,
+  Dropdown,
+  Empty,
+  Popover,
+  Segmented,
+  Space,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useThemedMessage } from '../../utils/message';
+import {
+  canDownloadLinkAttachment,
+  canPreviewMarkdownLinkAttachment,
+  LinkAttachmentGlyph,
+  type LinkAttachmentTarget,
+  targetForLinkAttachment,
+} from '../Links/LinkAttachmentCard';
+import { LinkImagePreviewModal, type LinkImagePreviewTarget } from '../Links/LinkImagePreviewModal';
+import {
+  LinkMarkdownPreviewModal,
+  type LinkMarkdownPreviewTarget,
+} from '../Links/LinkMarkdownPreviewModal';
+import { downloadLinkContent, getSafeLinkContentLabel } from '../Links/linkContent';
+import type { AssistantPromotionState } from '../Links/linkPromotion';
+
+export type SessionAttachmentKind =
+  | 'issue'
+  | 'pr'
+  | 'kb_ref'
+  | 'internal'
+  | 'image'
+  | 'document'
+  | 'url';
+export type SessionAttachmentSource = 'branch' | 'manual' | 'parsed' | 'upload';
+
+type LinksFilter = 'all' | 'branch' | 'session' | 'pinned' | 'files' | 'knowledge' | 'issues';
 
 export interface SessionAttachmentItem {
   key: string;
   name: string;
-  url: string;
+  url?: string | null;
+  refUri?: string | null;
+  filePath?: string | null;
+  mimeType?: string | null;
+  linkId?: string | null;
+  targetKey?: string | null;
+  kind?: SessionAttachmentKind;
+  source?: SessionAttachmentSource;
+  ownerScope?: 'branch' | 'session';
+  isPinned?: boolean;
+  disabled?: boolean;
+  subtitle?: string;
+  note?: string;
 }
 
 interface Props {
   items: SessionAttachmentItem[];
+  pinningLinkId?: string | null;
+  onTogglePinned?: (item: SessionAttachmentItem) => void | Promise<void>;
+  onRegisterOpenPinnedManager?: (openPinnedManager: (() => void) | null) => void;
+  getAssistantPromotionState?: (item: SessionAttachmentItem) => AssistantPromotionState;
+  onPromoteToAssistant?: (item: SessionAttachmentItem) => void | Promise<void>;
+  onRemoveFromAssistant?: (item: SessionAttachmentItem) => void | Promise<void>;
+  assistantPromotionBusyKey?: string | null;
 }
 
-function getIcon(url: string): React.ReactNode {
+function targetForItem(item: SessionAttachmentItem): LinkAttachmentTarget | null {
+  return targetForLinkAttachment({ url: item.url, refUri: item.refUri });
+}
+
+function canPreviewImage(item: SessionAttachmentItem): boolean {
+  return (
+    item.kind === 'image' && item.source === 'upload' && Boolean(item.linkId) && !item.disabled
+  );
+}
+
+function canPreviewMarkdown(item: SessionAttachmentItem): boolean {
+  return canPreviewMarkdownLinkAttachment({
+    source: item.source,
+    linkId: item.linkId,
+    kind: item.kind,
+    mimeType: item.mimeType,
+    title: item.name,
+    filePath: item.filePath,
+    refUri: item.refUri,
+  });
+}
+
+function canDownloadFile(item: SessionAttachmentItem): boolean {
+  return (
+    canDownloadLinkAttachment({
+      source: item.source,
+      linkId: item.linkId,
+      filePath: item.filePath,
+    }) &&
+    !canPreviewImage(item) &&
+    !canPreviewMarkdown(item)
+  );
+}
+
+function disabledReasonForItem(item: SessionAttachmentItem): string | null {
+  if (item.disabled) return item.note || 'Preview/download unavailable';
+  if (canPreviewImage(item)) return null;
+  if (canPreviewMarkdown(item) || canDownloadFile(item)) return null;
+  if (item.source === 'upload' || item.filePath || item.kind === 'image') {
+    return item.note || 'Preview/download unavailable';
+  }
+  if (!targetForItem(item)) return 'No safe route is available for this item yet.';
+  return null;
+}
+
+function getTargetDisplay(item: SessionAttachmentItem): string {
+  if (item.subtitle) return item.subtitle;
+  if (item.url) {
+    try {
+      const parsed = new URL(item.url);
+      return `${parsed.hostname}${parsed.pathname}`;
+    } catch {
+      return item.url;
+    }
+  }
+  if (item.refUri) return item.refUri;
+  if (item.filePath) return getSafeLinkContentLabel(item.filePath) || 'Uploaded file';
+  return 'No target';
+}
+
+function getOwnerScope(item: SessionAttachmentItem): 'branch' | 'session' {
+  if (item.ownerScope) return item.ownerScope;
+  return item.source === 'branch' ? 'branch' : 'session';
+}
+
+function isFileItem(item: SessionAttachmentItem): boolean {
+  return item.kind === 'image' || item.kind === 'document' || item.source === 'upload';
+}
+
+function isKnowledgeItem(item: SessionAttachmentItem): boolean {
+  return item.kind === 'kb_ref' || item.kind === 'internal';
+}
+
+function isIssuePrItem(item: SessionAttachmentItem): boolean {
+  return item.kind === 'issue' || item.kind === 'pr';
+}
+
+function getIcon(item: SessionAttachmentItem): React.ReactNode {
+  if (isKnowledgeItem(item)) return <BookOutlined />;
+  if (item.kind === 'image') return <FileImageOutlined />;
+  if (item.kind === 'document') return <FileTextOutlined />;
+
+  const target = item.url ?? item.refUri ?? '';
   try {
-    const { hostname } = new URL(url);
+    const { hostname } = new URL(target);
     if (hostname === 'github.com' || hostname.endsWith('.github.com')) return <GithubOutlined />;
   } catch {
     // ignore
   }
-  return <GlobalOutlined />;
+  return item.kind === 'url' ? <GlobalOutlined /> : <LinkOutlined />;
 }
 
-export const SessionAttachmentsDropdown: React.FC<Props> = ({ items }) => {
+function renderAttachmentGlyph(
+  item: SessionAttachmentItem,
+  disabled: boolean,
+  size: 'sm' | 'md' = 'sm'
+) {
+  if (isFileItem(item) || isKnowledgeItem(item)) {
+    return (
+      <LinkAttachmentGlyph
+        kind={item.kind}
+        mimeType={item.mimeType}
+        title={item.name}
+        filePath={item.filePath}
+        refUri={item.refUri}
+        disabled={disabled}
+        size={size}
+      />
+    );
+  }
+  return disabled ? <StopOutlined /> : getIcon(item);
+}
+
+function uniqueByTarget(items: SessionAttachmentItem[]): SessionAttachmentItem[] {
+  const seen = new Set<string>();
+  const result: SessionAttachmentItem[] = [];
+  for (const item of items) {
+    const target = item.url ?? item.refUri ?? item.filePath ?? item.key;
+    const key = `${item.kind ?? 'link'}:${target}`.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+}
+
+function plural(count: number, singular: string, pluralLabel = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralLabel}`;
+}
+
+function filterItems(items: SessionAttachmentItem[], filter: LinksFilter): SessionAttachmentItem[] {
+  switch (filter) {
+    case 'branch':
+      return items.filter((item) => getOwnerScope(item) === 'branch');
+    case 'session':
+      return items.filter((item) => getOwnerScope(item) === 'session');
+    case 'pinned':
+      return items.filter((item) => item.isPinned);
+    case 'files':
+      return items.filter(isFileItem);
+    case 'knowledge':
+      return items.filter(isKnowledgeItem);
+    case 'issues':
+      return items.filter(isIssuePrItem);
+    default:
+      return items;
+  }
+}
+
+export const SessionAttachmentsDropdown: React.FC<Props> = ({
+  items,
+  pinningLinkId = null,
+  onTogglePinned,
+  onRegisterOpenPinnedManager,
+  getAssistantPromotionState,
+  onPromoteToAssistant,
+  onRemoveFromAssistant,
+  assistantPromotionBusyKey = null,
+}) => {
   const { token } = theme.useToken();
+  const navigate = useNavigate();
+  const { showError } = useThemedMessage();
+  const [popoverOpen, setPopoverOpen] = React.useState(false);
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+  const [activeFilter, setActiveFilter] = React.useState<LinksFilter>('all');
+  const [previewTarget, setPreviewTarget] = React.useState<LinkImagePreviewTarget | null>(null);
+  const [markdownTarget, setMarkdownTarget] = React.useState<LinkMarkdownPreviewTarget | null>(
+    null
+  );
 
-  if (items.length === 0) return null;
+  const visibleItems = React.useMemo(() => uniqueByTarget(items), [items]);
+  const hasItems = visibleItems.length > 0;
+  const pinnedItems = visibleItems.filter((item) => item.isPinned);
+  const files = visibleItems.filter(isFileItem);
+  const knowledgeItems = visibleItems.filter(isKnowledgeItem);
+  const issuePrItems = visibleItems.filter(isIssuePrItem);
+  const nonPinnedNonFiles = visibleItems.filter((item) => !item.isPinned && !isFileItem(item));
 
-  const menuItems: MenuProps['items'] = items.map((item) => ({
-    key: item.key,
-    icon: getIcon(item.url),
-    label: (
-      <Tooltip title={item.name.length > 40 ? item.name : undefined} placement="left">
-        <span
+  const openPinnedManager = React.useCallback(() => {
+    setActiveFilter('pinned');
+    setDrawerOpen(true);
+  }, []);
+
+  React.useEffect(() => {
+    onRegisterOpenPinnedManager?.(openPinnedManager);
+    return () => onRegisterOpenPinnedManager?.(null);
+  }, [onRegisterOpenPinnedManager, openPinnedManager]);
+
+  if (!hasItems) return null;
+
+  const summary = `${plural(visibleItems.length, 'link')} · ${plural(
+    pinnedItems.length,
+    'pinned',
+    'pinned'
+  )} · ${plural(files.length, 'file')}`;
+
+  const fileReserve = files.length > 0 ? Math.min(2, files.length) : 0;
+  const quickPinned = pinnedItems.slice(0, Math.min(3, pinnedItems.length));
+  const quickPinnedKeys = new Set(quickPinned.map((item) => item.key));
+  const quickRecent = nonPinnedNonFiles.slice(0, Math.max(0, 7 - quickPinned.length - fileReserve));
+  const quickRecentKeys = new Set(quickRecent.map((item) => item.key));
+  const quickFiles = files
+    .filter((item) => !quickPinnedKeys.has(item.key) && !quickRecentKeys.has(item.key))
+    .slice(0, Math.max(0, 7 - quickPinned.length - quickRecent.length));
+  const quickItems = [...quickPinned, ...quickRecent, ...quickFiles];
+  const hiddenCount = Math.max(0, visibleItems.length - quickItems.length);
+
+  const openTarget = (item: SessionAttachmentItem) => {
+    if (canPreviewImage(item) && item.linkId) {
+      setPopoverOpen(false);
+      setPreviewTarget({ linkId: item.linkId, title: item.name, subtitle: getTargetDisplay(item) });
+      return;
+    }
+    if (canPreviewMarkdown(item) && item.linkId) {
+      setPopoverOpen(false);
+      setMarkdownTarget({
+        linkId: item.linkId,
+        title: item.name,
+        subtitle: getTargetDisplay(item),
+      });
+      return;
+    }
+    if (canDownloadFile(item) && item.linkId) {
+      setPopoverOpen(false);
+      downloadLinkContent(item.linkId, item.name).catch((err) => {
+        showError(err instanceof Error ? err.message : 'Download failed');
+      });
+      return;
+    }
+    const target = targetForItem(item);
+    if (!target || disabledReasonForItem(item)) return;
+    setPopoverOpen(false);
+    if (target.navigation === 'spa') {
+      navigate(target.href);
+      return;
+    }
+    window.open(target.href, '_blank', 'noopener,noreferrer');
+  };
+
+  const stopNavigation: React.MouseEventHandler<HTMLElement> = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleRowKeyDown =
+    (item: SessionAttachmentItem): React.KeyboardEventHandler<HTMLElement> =>
+    (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      event.preventDefault();
+      openTarget(item);
+    };
+
+  const canTogglePinned = (item: SessionAttachmentItem) => {
+    return getOwnerScope(item) === 'session' && Boolean(item.linkId) && Boolean(onTogglePinned);
+  };
+
+  const getPinActionLabel = (item: SessionAttachmentItem): string => {
+    const scope = getOwnerScope(item);
+    if (!canTogglePinned(item)) {
+      return scope === 'branch' ? 'Branch link pin is read-only here' : 'Pin unavailable';
+    }
+    if (scope === 'session') return item.isPinned ? 'Unpin from session header' : 'Pin in session';
+    return item.isPinned ? 'Unpin from branch card' : 'Pin to branch card';
+  };
+
+  const renderMiniPin = (item: SessionAttachmentItem) => {
+    const toggleable = canTogglePinned(item);
+    const isPinning = Boolean(item.linkId && pinningLinkId === item.linkId);
+    return (
+      <Tooltip title={getPinActionLabel(item)}>
+        <button
+          type="button"
+          aria-label={getPinActionLabel(item)}
+          aria-disabled={!toggleable || isPinning || undefined}
+          onClick={(event) => {
+            stopNavigation(event);
+            if (!toggleable || isPinning) return;
+            void onTogglePinned?.(item);
+          }}
           style={{
-            display: 'inline-block',
-            maxWidth: 200,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
+            border: 0,
+            background: 'transparent',
+            padding: 0,
+            color: item.isPinned ? token.colorPrimary : token.colorTextQuaternary,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 18,
+            flex: '0 0 auto',
+            cursor: toggleable && !isPinning ? 'pointer' : 'default',
+            opacity: isPinning ? 0.6 : 1,
           }}
         >
-          {item.name}
-        </span>
+          {item.isPinned ? <PushpinFilled /> : <PushpinOutlined />}
+        </button>
       </Tooltip>
-    ),
-    onClick: () => window.open(item.url, '_blank'),
-  }));
+    );
+  };
+
+  const renderQuietRow = (item: SessionAttachmentItem) => {
+    const disabledReason = disabledReasonForItem(item);
+    const disabled = Boolean(disabledReason);
+    return (
+      <Tooltip
+        key={item.key}
+        title={disabledReason ?? (canPreviewImage(item) ? 'Preview image' : 'Open link')}
+        placement="left"
+      >
+        <div
+          role={disabled ? undefined : 'link'}
+          tabIndex={disabled ? -1 : 0}
+          aria-disabled={disabled || undefined}
+          onClick={() => openTarget(item)}
+          onKeyDown={handleRowKeyDown(item)}
+          style={{
+            width: '100%',
+            border: 0,
+            borderRadius: token.borderRadius,
+            background: 'transparent',
+            cursor: disabled ? 'not-allowed' : 'pointer',
+            padding: `${token.sizeXXS}px ${token.sizeXS}px`,
+            textAlign: 'left',
+          }}
+        >
+          <span
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '34px minmax(0, 1fr) 20px 20px',
+              columnGap: token.sizeXS,
+              alignItems: 'center',
+              minWidth: 0,
+            }}
+          >
+            <span
+              style={{
+                width: 34,
+                color: disabled ? token.colorTextDisabled : token.colorTextTertiary,
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              {renderAttachmentGlyph(item, disabled)}
+            </span>
+            <span style={{ minWidth: 0, flex: 1 }}>
+              <Typography.Text
+                ellipsis
+                style={{
+                  display: 'block',
+                  color: disabled ? token.colorTextDisabled : token.colorText,
+                  fontSize: 13,
+                }}
+              >
+                {item.name}
+              </Typography.Text>
+            </span>
+            {canDownloadFile(item) && item.linkId ? (
+              <Tooltip title="Download file">
+                <Button
+                  type="text"
+                  size="small"
+                  aria-label={`Download ${item.name}`}
+                  icon={<DownloadOutlined />}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    downloadLinkContent(item.linkId!, item.name).catch((err) => {
+                      showError(err instanceof Error ? err.message : 'Download failed');
+                    });
+                  }}
+                  style={{
+                    width: 20,
+                    height: 20,
+                    minWidth: 20,
+                    padding: 0,
+                    color: token.colorTextTertiary,
+                  }}
+                />
+              </Tooltip>
+            ) : (
+              <span aria-hidden />
+            )}
+            {renderMiniPin(item)}
+          </span>
+        </div>
+      </Tooltip>
+    );
+  };
+
+  const renderAssistantPromotionMenu = (item: SessionAttachmentItem) => {
+    if (!getAssistantPromotionState) return <span aria-hidden />;
+
+    const state = getAssistantPromotionState(item);
+    const busyKey = state.assistantLink?.link_id ?? item.linkId ?? item.key;
+    const busy = assistantPromotionBusyKey === busyKey;
+    const menuItems: MenuProps['items'] = [
+      {
+        key: state.isPromoted ? 'remove-assistant' : 'promote-assistant',
+        label: state.actionLabel,
+        disabled: !state.canUseAssistantPromotion || busy,
+        title: state.unavailableReason ?? undefined,
+      },
+    ];
+
+    return (
+      <Tooltip title={state.unavailableReason ?? 'Assistant link actions'}>
+        <Dropdown
+          trigger={['click']}
+          menu={{
+            items: menuItems,
+            onClick: ({ domEvent }) => {
+              domEvent.preventDefault();
+              domEvent.stopPropagation();
+              if (!state.canUseAssistantPromotion || busy) return;
+              if (state.isPromoted) void onRemoveFromAssistant?.(item);
+              else void onPromoteToAssistant?.(item);
+            },
+          }}
+        >
+          <Button
+            type="text"
+            size="small"
+            aria-label={`Assistant actions for ${item.name}`}
+            loading={busy}
+            icon={<EllipsisOutlined />}
+            onClick={stopNavigation}
+            style={{
+              width: 24,
+              minWidth: 24,
+              height: 24,
+              padding: 0,
+              color: token.colorTextTertiary,
+            }}
+          />
+        </Dropdown>
+      </Tooltip>
+    );
+  };
+
+  const renderDrawerRow = (item: SessionAttachmentItem) => {
+    const disabledReason = disabledReasonForItem(item);
+    const disabled = Boolean(disabledReason);
+    return (
+      <div
+        key={item.key}
+        role={disabled ? undefined : 'link'}
+        tabIndex={disabled ? -1 : 0}
+        aria-disabled={disabled || undefined}
+        onClick={() => openTarget(item)}
+        onKeyDown={handleRowKeyDown(item)}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(0, 1fr) 40px 32px 32px',
+          gap: token.sizeSM,
+          alignItems: 'center',
+          padding: `${token.sizeSM}px 0`,
+          borderBottom: `1px solid ${token.colorBorderSecondary}`,
+          cursor: disabled ? 'not-allowed' : 'pointer',
+        }}
+      >
+        <div style={{ display: 'flex', gap: token.sizeSM, minWidth: 0, alignItems: 'flex-start' }}>
+          <span
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: token.borderRadius,
+              background: token.colorFillTertiary,
+              color: disabled ? token.colorTextDisabled : token.colorPrimary,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flex: '0 0 auto',
+            }}
+          >
+            {renderAttachmentGlyph(item, disabled)}
+          </span>
+          <span style={{ minWidth: 0 }}>
+            <Typography.Link
+              strong
+              ellipsis
+              disabled={disabled}
+              onClick={(event) => {
+                event.stopPropagation();
+                openTarget(item);
+              }}
+              style={{
+                display: 'block',
+                color: disabled ? token.colorTextDisabled : undefined,
+              }}
+            >
+              {item.name}
+            </Typography.Link>
+            <Typography.Text type="secondary" ellipsis style={{ display: 'block', fontSize: 12 }}>
+              {getTargetDisplay(item)}
+            </Typography.Text>
+            {disabled && (
+              <Typography.Text
+                type="warning"
+                style={{ display: 'block', fontSize: 12, marginTop: 2 }}
+              >
+                {disabledReason}
+              </Typography.Text>
+            )}
+          </span>
+        </div>
+        <Button
+          type="text"
+          size="small"
+          aria-label={
+            disabled
+              ? 'No route available'
+              : canPreviewImage(item)
+                ? `Preview ${item.name}`
+                : canDownloadFile(item)
+                  ? `Download ${item.name}`
+                  : `Open ${item.name}`
+          }
+          icon={
+            disabled ? (
+              <StopOutlined />
+            ) : canDownloadFile(item) ? (
+              <DownloadOutlined />
+            ) : (
+              <ExportOutlined />
+            )
+          }
+          disabled={disabled}
+          onClick={(event) => {
+            event.stopPropagation();
+            openTarget(item);
+          }}
+        />
+        {renderMiniPin(item)}
+        {renderAssistantPromotionMenu(item)}
+      </div>
+    );
+  };
+
+  const drawerItems = filterItems(visibleItems, activeFilter).sort((a, b) => {
+    const nameOrder = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    if (a.isPinned === b.isPinned) return nameOrder;
+    return a.isPinned ? -1 : 1;
+  });
+  const filterOptions = [
+    { label: `All ${visibleItems.length}`, value: 'all' },
+    {
+      label: `Branch ${visibleItems.filter((item) => getOwnerScope(item) === 'branch').length}`,
+      value: 'branch',
+    },
+    {
+      label: `This session ${visibleItems.filter((item) => getOwnerScope(item) === 'session').length}`,
+      value: 'session',
+    },
+    { label: `Files ${files.length}`, value: 'files' },
+    { label: `Knowledge ${knowledgeItems.length}`, value: 'knowledge' },
+    { label: `Issues/PRs ${issuePrItems.length}`, value: 'issues' },
+    { label: `Pinned ${pinnedItems.length}`, value: 'pinned' },
+  ];
+
+  const quickContent = (
+    <div style={{ width: 312 }} data-testid="links-organizer-popover">
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 8,
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <Typography.Text strong>Links</Typography.Text>
+          <Typography.Text type="secondary" style={{ display: 'block', fontSize: 12 }}>
+            {summary}
+          </Typography.Text>
+        </div>
+      </div>
+
+      {!hasItems ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description="No links collected yet."
+          style={{ margin: `${token.sizeSM}px 0` }}
+        />
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gap: 1,
+            marginTop: token.sizeSM,
+            maxHeight: 308,
+            overflowY: 'auto',
+            paddingRight: 2,
+          }}
+        >
+          {quickItems.map(renderQuietRow)}
+        </div>
+      )}
+
+      <Divider style={{ margin: `${token.sizeSM}px 0` }} />
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+        {hiddenCount > 0 ? `+${hiddenCount} more in ` : ''}
+        <Button
+          type="link"
+          size="small"
+          style={{ padding: 0, height: 'auto', fontSize: 12 }}
+          onClick={() => {
+            setPopoverOpen(false);
+            setDrawerOpen(true);
+          }}
+        >
+          Manage links
+        </Button>
+      </Typography.Text>
+    </div>
+  );
 
   return (
-    <Dropdown menu={{ items: menuItems }} trigger={['click']} placement="bottomRight">
-      <Tooltip title="Attachments">
-        <Badge count={items.length} color={token.colorPrimary} size="small" offset={[-4, 4]}>
-          <Button type="text" icon={<LinkOutlined style={{ color: token.colorPrimary }} />} />
-        </Badge>
-      </Tooltip>
-    </Dropdown>
+    <>
+      <Space size={4} align="center" style={{ minWidth: 0 }}>
+        <Popover
+          open={popoverOpen}
+          onOpenChange={setPopoverOpen}
+          content={quickContent}
+          trigger="click"
+          placement="bottomRight"
+          overlayInnerStyle={{
+            border: `1px solid ${token.colorBorderSecondary}`,
+          }}
+        >
+          <Tooltip title="Attachments">
+            <Badge
+              count={visibleItems.length}
+              color={token.colorPrimary}
+              size="small"
+              offset={[-4, 4]}
+            >
+              <Button
+                type="text"
+                aria-label="Open links organizer"
+                icon={<LinkOutlined style={{ color: token.colorPrimary }} />}
+              />
+            </Badge>
+          </Tooltip>
+        </Popover>
+      </Space>
+
+      <LinkImagePreviewModal target={previewTarget} onClose={() => setPreviewTarget(null)} />
+      <LinkMarkdownPreviewModal target={markdownTarget} onClose={() => setMarkdownTarget(null)} />
+
+      <Drawer
+        title="Manage links"
+        open={drawerOpen}
+        width={720}
+        onClose={() => setDrawerOpen(false)}
+        extra={<Typography.Text type="secondary">{summary}</Typography.Text>}
+      >
+        <div data-testid="links-organizer-manage">
+          <Space direction="vertical" size={token.sizeMD} style={{ width: '100%' }}>
+            <Segmented
+              value={activeFilter}
+              onChange={(value) => setActiveFilter(value as LinksFilter)}
+              options={filterOptions}
+            />
+            {drawerItems.length === 0 ? (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No links in this view." />
+            ) : (
+              <div
+                style={{
+                  maxHeight: 'min(58vh, 560px)',
+                  overflowY: 'auto',
+                  paddingRight: token.sizeXS,
+                }}
+              >
+                {drawerItems.map(renderDrawerRow)}
+              </div>
+            )}
+          </Space>
+        </div>
+      </Drawer>
+    </>
   );
 };

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -1,8 +1,6 @@
 import {
   BookOutlined,
-  DownloadOutlined,
   EllipsisOutlined,
-  ExportOutlined,
   FileImageOutlined,
   FileTextOutlined,
   GithubOutlined,
@@ -391,7 +389,14 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
     return (
       <Tooltip
         key={item.key}
-        title={disabledReason ?? (canPreviewImage(item) ? 'Preview image' : 'Open link')}
+        title={
+          disabledReason ??
+          (canPreviewImage(item)
+            ? 'Preview image'
+            : canDownloadFile(item)
+              ? 'Download file'
+              : 'Open link')
+        }
         placement="left"
       >
         <div
@@ -421,7 +426,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
           <span
             style={{
               display: 'grid',
-              gridTemplateColumns: '34px minmax(0, 1fr) 20px 20px',
+              gridTemplateColumns: '34px minmax(0, 1fr) 20px',
               columnGap: token.sizeXS,
               alignItems: 'center',
               minWidth: 0,
@@ -452,32 +457,6 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
                 {item.name}
               </Typography.Text>
             </span>
-            {canDownloadFile(item) && item.linkId ? (
-              <Tooltip title="Download file">
-                <Button
-                  className="agor-action-link-affordance"
-                  type="text"
-                  size="small"
-                  aria-label={`Download ${item.name}`}
-                  icon={<DownloadOutlined />}
-                  onClick={(event) => {
-                    stopNavigation(event);
-                    downloadLinkContent(item.linkId!, item.name).catch((err) => {
-                      showError(err instanceof Error ? err.message : 'Download failed');
-                    });
-                  }}
-                  style={{
-                    width: 20,
-                    height: 20,
-                    minWidth: 20,
-                    padding: 0,
-                    color: 'var(--agor-link-icon-color)',
-                  }}
-                />
-              </Tooltip>
-            ) : (
-              <span aria-hidden />
-            )}
             {renderMiniPin(item)}
           </span>
         </div>
@@ -548,7 +527,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
         onKeyDown={handleRowKeyDown(item)}
         style={{
           display: 'grid',
-          gridTemplateColumns: 'minmax(0, 1fr) 40px 32px 32px',
+          gridTemplateColumns: 'minmax(0, 1fr) 32px 32px',
           gap: token.sizeSM,
           alignItems: 'center',
           padding: `${token.sizeSM}px 0`,
@@ -601,33 +580,6 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             )}
           </span>
         </div>
-        <Button
-          type="text"
-          size="small"
-          aria-label={
-            disabled
-              ? 'No route available'
-              : canPreviewImage(item)
-                ? `Preview ${item.name}`
-                : canDownloadFile(item)
-                  ? `Download ${item.name}`
-                  : `Open ${item.name}`
-          }
-          icon={
-            disabled ? (
-              <StopOutlined />
-            ) : canDownloadFile(item) ? (
-              <DownloadOutlined />
-            ) : (
-              <ExportOutlined />
-            )
-          }
-          disabled={disabled}
-          onClick={(event) => {
-            event.stopPropagation();
-            openTarget(item);
-          }}
-        />
         {renderMiniPin(item)}
         {renderAssistantPromotionMenu(item)}
       </div>

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -371,6 +371,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
+            justifySelf: 'center',
             width: 18,
             flex: '0 0 auto',
             cursor: toggleable && !isPinning ? 'pointer' : 'default',
@@ -415,10 +416,11 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
               '--agor-link-row-hover-bg': 'transparent',
               '--agor-link-row-hover-color': token.colorPrimary,
               width: '100%',
+              boxSizing: 'border-box',
               border: 0,
               borderRadius: token.borderRadius,
               cursor: disabled ? 'not-allowed' : 'pointer',
-              padding: `${token.sizeXXS}px ${token.sizeXS}px`,
+              padding: `${token.sizeXXS}px ${token.sizeSM}px ${token.sizeXXS}px ${token.sizeXS}px`,
               textAlign: 'left',
             } as React.CSSProperties
           }
@@ -426,7 +428,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
           <span
             style={{
               display: 'grid',
-              gridTemplateColumns: '34px minmax(0, 1fr) 20px',
+              gridTemplateColumns: '34px minmax(0, 1fr) 24px',
               columnGap: token.sizeXS,
               alignItems: 'center',
               minWidth: 0,
@@ -639,7 +641,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             marginTop: token.sizeSM,
             maxHeight: 308,
             overflowY: 'auto',
-            paddingRight: 2,
+            paddingRight: token.sizeXS,
           }}
         >
           {quickItems.map(renderQuietRow)}

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -407,7 +407,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
               '--agor-link-icon-color': disabled
                 ? token.colorTextDisabled
                 : token.colorTextTertiary,
-              '--agor-link-row-hover-bg': token.colorFillQuaternary,
+              '--agor-link-row-hover-bg': 'transparent',
               '--agor-link-row-hover-color': token.colorPrimary,
               width: '100%',
               border: 0,

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -420,7 +420,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
               border: 0,
               borderRadius: token.borderRadius,
               cursor: disabled ? 'not-allowed' : 'pointer',
-              padding: `${token.sizeXXS}px ${token.sizeSM}px ${token.sizeXXS}px ${token.sizeXS}px`,
+              padding: `${token.sizeXXS}px ${token.sizeXS}px`,
               textAlign: 'left',
             } as React.CSSProperties
           }
@@ -641,7 +641,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             marginTop: token.sizeSM,
             maxHeight: 308,
             overflowY: 'auto',
-            paddingRight: token.sizeXS,
+            paddingRight: token.sizeXXS,
           }}
         >
           {quickItems.map(renderQuietRow)}

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -395,20 +395,28 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
         placement="left"
       >
         <div
+          className="agor-action-link-row"
           role={disabled ? undefined : 'link'}
           tabIndex={disabled ? -1 : 0}
           aria-disabled={disabled || undefined}
           onClick={() => openTarget(item)}
           onKeyDown={handleRowKeyDown(item)}
-          style={{
-            width: '100%',
-            border: 0,
-            borderRadius: token.borderRadius,
-            background: 'transparent',
-            cursor: disabled ? 'not-allowed' : 'pointer',
-            padding: `${token.sizeXXS}px ${token.sizeXS}px`,
-            textAlign: 'left',
-          }}
+          style={
+            {
+              '--agor-link-title-color': disabled ? token.colorTextDisabled : token.colorText,
+              '--agor-link-icon-color': disabled
+                ? token.colorTextDisabled
+                : token.colorTextTertiary,
+              '--agor-link-row-hover-bg': token.colorFillQuaternary,
+              '--agor-link-row-hover-color': token.colorPrimary,
+              width: '100%',
+              border: 0,
+              borderRadius: token.borderRadius,
+              cursor: disabled ? 'not-allowed' : 'pointer',
+              padding: `${token.sizeXXS}px ${token.sizeXS}px`,
+              textAlign: 'left',
+            } as React.CSSProperties
+          }
         >
           <span
             style={{
@@ -420,9 +428,10 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             }}
           >
             <span
+              className="agor-action-link-icon"
               style={{
                 width: 34,
-                color: disabled ? token.colorTextDisabled : token.colorTextTertiary,
+                color: 'var(--agor-link-icon-color)',
                 display: 'inline-flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -432,10 +441,11 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             </span>
             <span style={{ minWidth: 0, flex: 1 }}>
               <Typography.Text
+                className={disabled ? undefined : 'agor-action-link-title'}
                 ellipsis
                 style={{
                   display: 'block',
-                  color: disabled ? token.colorTextDisabled : token.colorText,
+                  color: disabled ? token.colorTextDisabled : 'var(--agor-link-title-color)',
                   fontSize: 13,
                 }}
               >
@@ -445,12 +455,13 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             {canDownloadFile(item) && item.linkId ? (
               <Tooltip title="Download file">
                 <Button
+                  className="agor-action-link-affordance"
                   type="text"
                   size="small"
                   aria-label={`Download ${item.name}`}
                   icon={<DownloadOutlined />}
                   onClick={(event) => {
-                    event.stopPropagation();
+                    stopNavigation(event);
                     downloadLinkContent(item.linkId!, item.name).catch((err) => {
                       showError(err instanceof Error ? err.message : 'Download failed');
                     });
@@ -460,7 +471,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
                     height: 20,
                     minWidth: 20,
                     padding: 0,
-                    color: token.colorTextTertiary,
+                    color: 'var(--agor-link-icon-color)',
                   }}
                 />
               </Tooltip>

--- a/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionAttachmentsDropdown.tsx
@@ -19,8 +19,9 @@ import {
   Dropdown,
   Empty,
   Popover,
-  Segmented,
+  Select,
   Space,
+  Tabs,
   Tooltip,
   Typography,
   theme,
@@ -41,6 +42,14 @@ import {
   type LinkMarkdownPreviewTarget,
 } from '../Links/LinkMarkdownPreviewModal';
 import { downloadLinkContent, getSafeLinkContentLabel } from '../Links/linkContent';
+import {
+  LINK_CATEGORY_TAB_LABELS,
+  LINK_OWNER_FILTER_LABELS,
+  LINK_SORT_LABELS,
+  type LinkCategoryTabKey,
+  type LinkOwnerFilterKey,
+  type LinkSortKey,
+} from '../Links/linkDisplay';
 import type { AssistantPromotionState } from '../Links/linkPromotion';
 
 export type SessionAttachmentKind =
@@ -53,7 +62,9 @@ export type SessionAttachmentKind =
   | 'url';
 export type SessionAttachmentSource = 'branch' | 'manual' | 'parsed' | 'upload';
 
-type LinksFilter = 'all' | 'branch' | 'session' | 'pinned' | 'files' | 'knowledge' | 'issues';
+type LinksCategoryTab = LinkCategoryTabKey;
+type LinksSourceFilter = LinkOwnerFilterKey;
+type LinksSort = LinkSortKey;
 
 export interface SessionAttachmentItem {
   key: string;
@@ -68,6 +79,8 @@ export interface SessionAttachmentItem {
   source?: SessionAttachmentSource;
   ownerScope?: 'branch' | 'session';
   isPinned?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
   disabled?: boolean;
   subtitle?: string;
   note?: string;
@@ -161,6 +174,10 @@ function isIssuePrItem(item: SessionAttachmentItem): boolean {
   return item.kind === 'issue' || item.kind === 'pr';
 }
 
+function isWebLinkItem(item: SessionAttachmentItem): boolean {
+  return !isFileItem(item) && !isKnowledgeItem(item) && !isIssuePrItem(item);
+}
+
 function getIcon(item: SessionAttachmentItem): React.ReactNode {
   if (isKnowledgeItem(item)) return <BookOutlined />;
   if (item.kind === 'image') return <FileImageOutlined />;
@@ -214,23 +231,64 @@ function plural(count: number, singular: string, pluralLabel = `${singular}s`): 
   return `${count} ${count === 1 ? singular : pluralLabel}`;
 }
 
-function filterItems(items: SessionAttachmentItem[], filter: LinksFilter): SessionAttachmentItem[] {
-  switch (filter) {
-    case 'branch':
-      return items.filter((item) => getOwnerScope(item) === 'branch');
-    case 'session':
-      return items.filter((item) => getOwnerScope(item) === 'session');
-    case 'pinned':
-      return items.filter((item) => item.isPinned);
+function getCategoryCounts(items: SessionAttachmentItem[]): Record<LinksCategoryTab, number> {
+  return {
+    all: items.length,
+    files: items.filter(isFileItem).length,
+    links: items.filter(isWebLinkItem).length,
+    knowledge: items.filter(isKnowledgeItem).length,
+    issues: items.filter(isIssuePrItem).length,
+  };
+}
+
+function getCategorySummary(items: SessionAttachmentItem[]): string {
+  const counts = getCategoryCounts(items);
+  return [
+    plural(counts.files, 'file'),
+    plural(counts.links, 'link'),
+    `${counts.knowledge} knowledge`,
+    `${counts.issues} ${counts.issues === 1 ? 'issue/PR' : 'issues/PRs'}`,
+  ].join(' · ');
+}
+
+function matchesCategory(item: SessionAttachmentItem, category: LinksCategoryTab): boolean {
+  switch (category) {
     case 'files':
-      return items.filter(isFileItem);
+      return isFileItem(item);
+    case 'links':
+      return isWebLinkItem(item);
     case 'knowledge':
-      return items.filter(isKnowledgeItem);
+      return isKnowledgeItem(item);
     case 'issues':
-      return items.filter(isIssuePrItem);
+      return isIssuePrItem(item);
     default:
-      return items;
+      return true;
   }
+}
+
+function matchesSourceFilter(
+  item: SessionAttachmentItem,
+  sourceFilter: LinksSourceFilter
+): boolean {
+  return sourceFilter === 'all' || getOwnerScope(item) === sourceFilter;
+}
+
+function getItemTimestamp(item: SessionAttachmentItem): string {
+  return item.updatedAt || item.createdAt || '';
+}
+
+function compareDrawerItems(a: SessionAttachmentItem, b: SessionAttachmentItem, sort: LinksSort) {
+  if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+
+  const nameOrder = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  if (sort === 'za') return nameOrder !== 0 ? -nameOrder : a.key.localeCompare(b.key);
+
+  if (sort === 'recent' || sort === 'oldest') {
+    const timestampOrder = getItemTimestamp(a).localeCompare(getItemTimestamp(b));
+    if (timestampOrder !== 0) return sort === 'recent' ? -timestampOrder : timestampOrder;
+  }
+
+  return nameOrder || a.key.localeCompare(b.key);
 }
 
 export const SessionAttachmentsDropdown: React.FC<Props> = ({
@@ -248,7 +306,9 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
   const { showError } = useThemedMessage();
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   const [drawerOpen, setDrawerOpen] = React.useState(false);
-  const [activeFilter, setActiveFilter] = React.useState<LinksFilter>('all');
+  const [activeCategory, setActiveCategory] = React.useState<LinksCategoryTab>('all');
+  const [sourceFilter, setSourceFilter] = React.useState<LinksSourceFilter>('all');
+  const [sortOrder, setSortOrder] = React.useState<LinksSort>('az');
   const [previewTarget, setPreviewTarget] = React.useState<LinkImagePreviewTarget | null>(null);
   const [markdownTarget, setMarkdownTarget] = React.useState<LinkMarkdownPreviewTarget | null>(
     null
@@ -258,12 +318,20 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
   const hasItems = visibleItems.length > 0;
   const pinnedItems = visibleItems.filter((item) => item.isPinned);
   const files = visibleItems.filter(isFileItem);
-  const knowledgeItems = visibleItems.filter(isKnowledgeItem);
-  const issuePrItems = visibleItems.filter(isIssuePrItem);
   const nonPinnedNonFiles = visibleItems.filter((item) => !item.isPinned && !isFileItem(item));
+  const categoryCounts = React.useMemo(() => getCategoryCounts(visibleItems), [visibleItems]);
+  const categoryTabs = React.useMemo(
+    () =>
+      (['all', 'files', 'links', 'knowledge', 'issues'] as const).map((key) => ({
+        key,
+        label: `${LINK_CATEGORY_TAB_LABELS[key]} ${categoryCounts[key]}`,
+      })),
+    [categoryCounts]
+  );
 
   const openPinnedManager = React.useCallback(() => {
-    setActiveFilter('pinned');
+    setActiveCategory('all');
+    setSourceFilter('all');
     setDrawerOpen(true);
   }, []);
 
@@ -274,11 +342,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
 
   if (!hasItems) return null;
 
-  const summary = `${plural(visibleItems.length, 'link')} · ${plural(
-    pinnedItems.length,
-    'pinned',
-    'pinned'
-  )} · ${plural(files.length, 'file')}`;
+  const summary = getCategorySummary(visibleItems);
 
   const fileReserve = files.length > 0 ? Math.min(2, files.length) : 0;
   const quickPinned = pinnedItems.slice(0, Math.min(3, pinnedItems.length));
@@ -367,7 +431,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
             border: 0,
             background: 'transparent',
             padding: 0,
-            color: item.isPinned ? token.colorPrimary : token.colorTextQuaternary,
+            color: item.isPinned ? token.colorWarning : token.colorTextQuaternary,
             display: 'inline-flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -544,7 +608,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
               height: 28,
               borderRadius: token.borderRadius,
               background: token.colorFillTertiary,
-              color: disabled ? token.colorTextDisabled : token.colorPrimary,
+              color: disabled ? token.colorTextDisabled : token.colorTextTertiary,
               display: 'inline-flex',
               alignItems: 'center',
               justifyContent: 'center',
@@ -588,26 +652,10 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
     );
   };
 
-  const drawerItems = filterItems(visibleItems, activeFilter).sort((a, b) => {
-    const nameOrder = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
-    if (a.isPinned === b.isPinned) return nameOrder;
-    return a.isPinned ? -1 : 1;
-  });
-  const filterOptions = [
-    { label: `All ${visibleItems.length}`, value: 'all' },
-    {
-      label: `Branch ${visibleItems.filter((item) => getOwnerScope(item) === 'branch').length}`,
-      value: 'branch',
-    },
-    {
-      label: `This session ${visibleItems.filter((item) => getOwnerScope(item) === 'session').length}`,
-      value: 'session',
-    },
-    { label: `Files ${files.length}`, value: 'files' },
-    { label: `Knowledge ${knowledgeItems.length}`, value: 'knowledge' },
-    { label: `Issues/PRs ${issuePrItems.length}`, value: 'issues' },
-    { label: `Pinned ${pinnedItems.length}`, value: 'pinned' },
-  ];
+  const drawerItems = visibleItems
+    .filter((item) => matchesCategory(item, activeCategory))
+    .filter((item) => matchesSourceFilter(item, sourceFilter))
+    .sort((a, b) => compareDrawerItems(a, b, sortOrder));
 
   const quickContent = (
     <div style={{ width: 312 }} data-testid="links-organizer-popover">
@@ -689,7 +737,7 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
               <Button
                 type="text"
                 aria-label="Open links organizer"
-                icon={<LinkOutlined style={{ color: token.colorPrimary }} />}
+                icon={<LinkOutlined style={{ color: token.colorTextSecondary }} />}
               />
             </Badge>
           </Tooltip>
@@ -708,11 +756,46 @@ export const SessionAttachmentsDropdown: React.FC<Props> = ({
       >
         <div data-testid="links-organizer-manage">
           <Space direction="vertical" size={token.sizeMD} style={{ width: '100%' }}>
-            <Segmented
-              value={activeFilter}
-              onChange={(value) => setActiveFilter(value as LinksFilter)}
-              options={filterOptions}
+            <Tabs
+              className="agor-link-category-tabs"
+              activeKey={activeCategory}
+              items={categoryTabs}
+              onChange={(key) => setActiveCategory(key as LinksCategoryTab)}
             />
+            <Space wrap size={token.sizeSM} style={{ width: '100%' }}>
+              <Space size={token.sizeXS}>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Sort
+                </Typography.Text>
+                <Select<LinksSort>
+                  size="small"
+                  value={sortOrder}
+                  options={(Object.keys(LINK_SORT_LABELS) as LinksSort[]).map((key) => ({
+                    value: key,
+                    label: LINK_SORT_LABELS[key],
+                  }))}
+                  onChange={setSortOrder}
+                  style={{ width: 128 }}
+                />
+              </Space>
+              <Space size={token.sizeXS}>
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  Location
+                </Typography.Text>
+                <Select<LinksSourceFilter>
+                  size="small"
+                  value={sourceFilter}
+                  options={(Object.keys(LINK_OWNER_FILTER_LABELS) as LinksSourceFilter[]).map(
+                    (key) => ({
+                      value: key,
+                      label: LINK_OWNER_FILTER_LABELS[key],
+                    })
+                  )}
+                  onChange={setSourceFilter}
+                  style={{ width: 142 }}
+                />
+              </Space>
+            </Space>
             {drawerItems.length === 0 ? (
               <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No links in this view." />
             ) : (

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -263,6 +263,8 @@ function displayItemToSessionAttachmentItem(item: LinkDisplayItem): SessionAttac
     source: item.source === 'branch' ? 'branch' : item.source,
     ownerScope: item.ownerScope,
     isPinned: item.isPinned,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
     disabled: isUnsupportedFileBacked,
     subtitle: getLinkDisplaySecondaryLabel(item) ?? undefined,
     note: isUnsupportedFileBacked ? 'Preview/download unavailable' : undefined,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -4,6 +4,7 @@ import type {
   CodexApprovalPolicy,
   CodexSandboxMode,
   EffortLevel,
+  Link,
   PermissionMode,
   Session,
   SessionID,
@@ -48,11 +49,25 @@ import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessi
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { FileUpload } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
+import {
+  buildLinkDisplayItems,
+  getLinkDisplaySecondaryLabel,
+  isBranchOwnedLink,
+  type LinkDisplayItem,
+  normalizeLinkFindResult,
+  removeLinkById,
+  upsertLinkById,
+} from '../Links/linkDisplay';
+import { dispatchLinkMutation, listenForLinkMutations } from '../Links/linkEvents';
+import {
+  findAssistantLinkForTarget,
+  getAssistantPromotionState as getLinkAssistantPromotionState,
+  promoteLinkToAssistant,
+} from '../Links/linkPromotion';
 import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
-import { getUrlDisplayLabel } from '../Pill/url-helpers';
 import { ToolIcon } from '../ToolIcon';
-import type { SessionAttachmentItem } from './SessionAttachmentsDropdown';
+import type { SessionAttachmentItem, SessionAttachmentKind } from './SessionAttachmentsDropdown';
 import { SessionAttachmentsDropdown } from './SessionAttachmentsDropdown';
 import { SessionFooter } from './SessionFooter';
 import { SessionPanelContent } from './SessionPanelContent';
@@ -214,6 +229,45 @@ PromptInput.displayName = 'PromptInput';
 
 // ---------------------------------------------------------------------------
 
+function sessionAttachmentKindForDisplayItem(
+  item: Pick<LinkDisplayItem, 'category' | 'filePath' | 'refUri' | 'url'>
+): SessionAttachmentKind {
+  switch (item.category) {
+    case 'issue':
+    case 'pr':
+    case 'image':
+    case 'internal':
+    case 'url':
+      return item.category;
+    case 'knowledge':
+      return 'kb_ref';
+    default:
+      if (item.filePath) return 'document';
+      if (item.refUri) return 'internal';
+      return 'url';
+  }
+}
+
+function displayItemToSessionAttachmentItem(item: LinkDisplayItem): SessionAttachmentItem {
+  const isUnsupportedFileBacked = Boolean(item.filePath) && item.source !== 'upload';
+  return {
+    key: item.key,
+    name: item.name,
+    url: item.url,
+    refUri: item.refUri,
+    filePath: item.filePath,
+    mimeType: item.mimeType,
+    linkId: item.linkId,
+    targetKey: item.targetKey,
+    kind: sessionAttachmentKindForDisplayItem(item),
+    source: item.source === 'branch' ? 'branch' : item.source,
+    ownerScope: item.ownerScope,
+    isPinned: item.isPinned,
+    disabled: isUnsupportedFileBacked,
+    subtitle: getLinkDisplaySecondaryLabel(item) ?? undefined,
+    note: isUnsupportedFileBacked ? 'Preview/download unavailable' : undefined,
+  };
+}
 // ---------------------------------------------------------------------------
 
 export interface SessionPanelProps {
@@ -221,6 +275,7 @@ export interface SessionPanelProps {
   session: Session | null;
   branch?: Branch | null;
   currentUserId?: string;
+  primaryAssistantId?: string | null;
   sessionMcpServerIds?: string[];
   open: boolean;
   onClose: () => void;
@@ -231,6 +286,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   session,
   branch = null,
   currentUserId,
+  primaryAssistantId = null,
   sessionMcpServerIds = [],
   open,
   onClose,
@@ -344,6 +400,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [spawnModalOpen, setSpawnModalOpen] = React.useState(false);
   const [uploadModalOpen, setUploadModalOpen] = React.useState(false);
   const [droppedFiles, setDroppedFiles] = React.useState<File[]>([]);
+  const [sessionLinks, setSessionLinks] = React.useState<Link[]>([]);
+  const [pinningLinkId, setPinningLinkId] = React.useState<string | null>(null);
+  const openPinnedLinksManagerRef = React.useRef<(() => void) | null>(null);
   const [stopRequestInFlight, setStopRequestInFlight] = React.useState(false);
   const reactiveSessionId = session?.session_id ?? null;
   const { state: reactiveSessionState } = useSharedReactiveSession(client, reactiveSessionId, {
@@ -352,6 +411,129 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   });
 
   const tasks = reactiveSessionState?.tasks || [];
+
+  // Load session-owned persisted links for the organizer; branch issue/PR rows
+  // are merged separately from the current branch through the display helpers.
+  React.useEffect(() => {
+    if (!client || !session || !open) {
+      setSessionLinks([]);
+      return;
+    }
+
+    let cancelled = false;
+    const linksService = client.service('links');
+
+    const fetchSessionLinks = async () => {
+      try {
+        const result = await linksService.find({
+          query: { session_id: session.session_id, $limit: 200 },
+        });
+        if (!cancelled) setSessionLinks(normalizeLinkFindResult(result));
+      } catch (error) {
+        // Links should not break the session panel if an older local daemon
+        // does not have the service yet.
+        console.warn('[SessionPanel] Failed to fetch session links:', error);
+        if (!cancelled) setSessionLinks([]);
+      }
+    };
+
+    const upsertIfCurrentSession = (link: Link) => {
+      if (link.session_id === session.session_id) {
+        setSessionLinks((prev) => upsertLinkById(prev, link));
+      } else {
+        setSessionLinks((prev) => removeLinkById(prev, link));
+      }
+    };
+
+    const removeIfCurrentSession = (link: Link) => {
+      setSessionLinks((prev) => removeLinkById(prev, link));
+    };
+
+    void fetchSessionLinks();
+    linksService.on('created', upsertIfCurrentSession);
+    linksService.on('patched', upsertIfCurrentSession);
+    linksService.on('updated', upsertIfCurrentSession);
+    linksService.on('removed', removeIfCurrentSession);
+    const stopListeningForLocalMutations = listenForLinkMutations(({ link, mutation }) => {
+      if (mutation === 'removed') {
+        removeIfCurrentSession(link);
+      } else {
+        upsertIfCurrentSession(link);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      linksService.removeListener('created', upsertIfCurrentSession);
+      linksService.removeListener('patched', upsertIfCurrentSession);
+      linksService.removeListener('updated', upsertIfCurrentSession);
+      linksService.removeListener('removed', removeIfCurrentSession);
+      stopListeningForLocalMutations();
+    };
+  }, [client, session, open]);
+
+  const [assistantLinks, setAssistantLinks] = React.useState<Link[]>([]);
+  const [assistantPromotionBusyKey, setAssistantPromotionBusyKey] = React.useState<string | null>(
+    null
+  );
+
+  React.useEffect(() => {
+    if (!client || !primaryAssistantId || !open) {
+      setAssistantLinks([]);
+      return;
+    }
+
+    let cancelled = false;
+    const linksService = client.service('links');
+
+    const upsertIfAssistantLink = (link: Link) => {
+      setAssistantLinks((prev) => {
+        if (isBranchOwnedLink(link, primaryAssistantId)) return upsertLinkById(prev, link);
+        return removeLinkById(prev, link);
+      });
+    };
+
+    const removeAssistantLink = (link: Link) => {
+      setAssistantLinks((prev) => removeLinkById(prev, link));
+    };
+
+    const fetchAssistantLinks = async () => {
+      try {
+        const result = await linksService.find({
+          query: { branch_id: primaryAssistantId, $limit: 200 },
+        });
+        if (!cancelled) {
+          setAssistantLinks(
+            normalizeLinkFindResult(result).filter((link) =>
+              isBranchOwnedLink(link, primaryAssistantId)
+            )
+          );
+        }
+      } catch (error) {
+        console.warn('[SessionPanel] Failed to fetch assistant links:', error);
+        if (!cancelled) setAssistantLinks([]);
+      }
+    };
+
+    void fetchAssistantLinks();
+    linksService.on('created', upsertIfAssistantLink);
+    linksService.on('patched', upsertIfAssistantLink);
+    linksService.on('updated', upsertIfAssistantLink);
+    linksService.on('removed', removeAssistantLink);
+    const stopListeningForLocalMutations = listenForLinkMutations(({ link, mutation }) => {
+      if (mutation === 'removed') removeAssistantLink(link);
+      else upsertIfAssistantLink(link);
+    });
+
+    return () => {
+      cancelled = true;
+      linksService.removeListener('created', upsertIfAssistantLink);
+      linksService.removeListener('patched', upsertIfAssistantLink);
+      linksService.removeListener('updated', upsertIfAssistantLink);
+      linksService.removeListener('removed', removeAssistantLink);
+      stopListeningForLocalMutations();
+    };
+  }, [client, open, primaryAssistantId]);
 
   // Fetch queued tasks (post never-lose-prompt: queueing lives on tasks, not messages).
   React.useEffect(() => {
@@ -465,24 +647,129 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     return null;
   }, [tasks, session?.agentic_tool]);
 
+  const linkDisplayItems = React.useMemo(
+    () => buildLinkDisplayItems({ branch, links: sessionLinks }),
+    [branch, sessionLinks]
+  );
   const attachmentItems = React.useMemo((): SessionAttachmentItem[] => {
-    const acc: SessionAttachmentItem[] = [];
-    if (branch?.issue_url) {
-      acc.push({
-        key: 'issue',
-        name: `Issue: ${getUrlDisplayLabel(branch.issue_url)}`,
-        url: branch.issue_url,
-      });
+    return linkDisplayItems.map(displayItemToSessionAttachmentItem);
+  }, [linkDisplayItems]);
+  const promotedPinnedSessionItems = React.useMemo(
+    () => attachmentItems.filter((item) => item.ownerScope === 'session' && item.isPinned),
+    [attachmentItems]
+  );
+
+  const attachmentLinksByMessageId = React.useMemo(() => {
+    const byMessageId = new Map<string, Link[]>();
+    for (const link of sessionLinks) {
+      if (link.source !== 'upload' || !link.source_message_id) continue;
+      const isUploadAttachment =
+        Boolean(link.file_path) && (link.kind === 'image' || link.kind === 'document');
+      if (!isUploadAttachment) continue;
+
+      const existing = byMessageId.get(link.source_message_id) ?? [];
+      existing.push(link);
+      byMessageId.set(link.source_message_id, existing);
     }
-    if (branch?.pull_request_url) {
-      acc.push({
-        key: 'pr',
-        name: `PR: ${getUrlDisplayLabel(branch.pull_request_url)}`,
-        url: branch.pull_request_url,
-      });
-    }
-    return acc;
-  }, [branch?.issue_url, branch?.pull_request_url]);
+    return byMessageId;
+  }, [sessionLinks]);
+
+  const handleToggleAttachmentPinned = React.useCallback(
+    async (item: SessionAttachmentItem) => {
+      if (!client || !item.linkId || item.ownerScope !== 'session' || pinningLinkId) return;
+
+      setPinningLinkId(item.linkId);
+      try {
+        const updated = await client.service('links').patch(item.linkId, {
+          is_pinned: !item.isPinned,
+        });
+        if (updated.session_id === session?.session_id) {
+          setSessionLinks((prev) => upsertLinkById(prev, updated));
+        } else {
+          setSessionLinks((prev) => removeLinkById(prev, updated));
+        }
+        dispatchLinkMutation({ link: updated, mutation: 'patched' });
+      } catch (error) {
+        showError(
+          `Failed to update pin: ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        setPinningLinkId(null);
+      }
+    },
+    [client, pinningLinkId, session?.session_id, showError]
+  );
+
+  const getAttachmentAssistantPromotionState = React.useCallback(
+    (item: SessionAttachmentItem) =>
+      getLinkAssistantPromotionState({
+        item: { linkId: item.linkId ?? undefined, targetKey: item.targetKey ?? item.key },
+        assistantBranchId: primaryAssistantId,
+        assistantLinks,
+        sourceBranchId: item.ownerScope === 'branch' ? branch?.branch_id : null,
+      }),
+    [assistantLinks, branch?.branch_id, primaryAssistantId]
+  );
+
+  const handlePromoteAttachmentToAssistant = React.useCallback(
+    async (item: SessionAttachmentItem) => {
+      if (!client || !primaryAssistantId || !item.linkId || assistantPromotionBusyKey) return;
+      setAssistantPromotionBusyKey(item.linkId);
+      try {
+        const promoted = await promoteLinkToAssistant({
+          client,
+          sourceLinkId: item.linkId,
+          assistantBranchId: primaryAssistantId,
+        });
+        setAssistantLinks((prev) => upsertLinkById(prev, promoted));
+        dispatchLinkMutation({ link: promoted, mutation: 'patched' });
+        showSuccess('Promoted to assistant');
+      } catch (error) {
+        showError(
+          `Failed to promote link: ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        setAssistantPromotionBusyKey(null);
+      }
+    },
+    [assistantPromotionBusyKey, client, primaryAssistantId, showError, showSuccess]
+  );
+
+  const handleRemoveAttachmentFromAssistant = React.useCallback(
+    async (item: SessionAttachmentItem) => {
+      if (!client || !primaryAssistantId || assistantPromotionBusyKey) return;
+      const assistantLink = findAssistantLinkForTarget(
+        { targetKey: item.targetKey ?? item.key },
+        assistantLinks
+      );
+      if (!assistantLink) return;
+      setAssistantPromotionBusyKey(assistantLink.link_id);
+      try {
+        const removed = (await client.service('links').remove(assistantLink.link_id)) as Link;
+        setAssistantLinks((prev) => removeLinkById(prev, assistantLink));
+        dispatchLinkMutation({ link: removed, mutation: 'removed' });
+        showSuccess('Removed from assistant');
+      } catch (error) {
+        showError(
+          `Failed to remove assistant link: ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        setAssistantPromotionBusyKey(null);
+      }
+    },
+    [assistantLinks, assistantPromotionBusyKey, client, primaryAssistantId, showError, showSuccess]
+  );
+
+  const handleRegisterOpenPinnedManager = React.useCallback(
+    (openPinnedManager: (() => void) | null) => {
+      openPinnedLinksManagerRef.current = openPinnedManager;
+    },
+    []
+  );
+
+  const handleOpenPinnedManager = React.useCallback(() => {
+    openPinnedLinksManagerRef.current?.();
+  }, []);
 
   const footerGradient = React.useMemo(() => {
     if (!latestContextWindow) return undefined;
@@ -944,7 +1231,16 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             </div>
           </Space>
           <Space size={4}>
-            <SessionAttachmentsDropdown items={attachmentItems} />
+            <SessionAttachmentsDropdown
+              items={attachmentItems}
+              pinningLinkId={pinningLinkId}
+              onTogglePinned={handleToggleAttachmentPinned}
+              onRegisterOpenPinnedManager={handleRegisterOpenPinnedManager}
+              getAssistantPromotionState={getAttachmentAssistantPromotionState}
+              onPromoteToAssistant={handlePromoteAttachmentToAssistant}
+              onRemoveFromAssistant={handleRemoveAttachmentFromAssistant}
+              assistantPromotionBusyKey={assistantPromotionBusyKey}
+            />
             <Dropdown menu={{ items: moreMenuItems }} trigger={['click']} placement="bottomRight">
               <Tooltip title="More actions">
                 <Button type="text" icon={<EllipsisOutlined />} />
@@ -991,6 +1287,9 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           isOpen={open}
           cliViewMode={cliViewMode}
           setCliViewMode={setCliViewMode}
+          attachmentLinksByMessageId={attachmentLinksByMessageId}
+          pinnedSessionLinks={promotedPinnedSessionItems}
+          onPinnedOverflow={handleOpenPinnedManager}
         />
 
         {/* Footer — rendered outside SessionPanelContent so that

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -1,4 +1,4 @@
-import type { AgorClient, Branch, Session, SpawnConfig, Task } from '@agor-live/client';
+import type { AgorClient, Branch, Link, Session, SpawnConfig, Task } from '@agor-live/client';
 import { getAssistantConfig, isAssistant, sessionPath, shortId } from '@agor-live/client';
 import {
   CodeOutlined,
@@ -20,6 +20,7 @@ import { BranchHeaderPill } from '../BranchHeaderPill';
 import { ConversationView } from '../ConversationView';
 import { EmbeddedTerminal } from '../EmbeddedTerminal/EmbeddedTerminalLazy';
 import { ForkSpawnModal } from '../ForkSpawnModal';
+import { type PromotedPinnedLinkItem, PromotedPinnedLinks } from '../Links/PromotedPinnedLinks';
 import { IssuePill, PullRequestPill } from '../Pill';
 
 export interface SessionPanelContentProps {
@@ -45,6 +46,9 @@ export interface SessionPanelContentProps {
    *  Tabs bar inline above the panel; when omitted, the parent is
    *  expected to render the bar itself (legacy header-level placement). */
   setCliViewMode?: (mode: 'terminal' | 'conversation') => void;
+  attachmentLinksByMessageId?: Map<string, Link[]>;
+  pinnedSessionLinks?: PromotedPinnedLinkItem[];
+  onPinnedOverflow?: () => void;
 }
 
 export const SessionPanelContent = React.memo<SessionPanelContentProps>(
@@ -66,6 +70,9 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
     isOpen,
     cliViewMode = 'terminal',
     setCliViewMode,
+    attachmentLinksByMessageId,
+    pinnedSessionLinks = [],
+    onPinnedOverflow,
   }) => {
     const { token } = theme.useToken();
     const { showSuccess, showError } = useThemedMessage();
@@ -180,6 +187,40 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
           </Space>
         </div>
 
+        {pinnedSessionLinks.length > 0 && (
+          <div
+            data-testid="session-pinned-preconversation"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: token.sizeSM,
+              minWidth: 0,
+              marginBottom: 0,
+              padding: `${token.paddingXXS + 2}px ${token.paddingXS}px`,
+            }}
+          >
+            <Typography.Text
+              type="secondary"
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: 0.2,
+                flex: '0 0 auto',
+              }}
+            >
+              Pinned
+            </Typography.Text>
+            <PromotedPinnedLinks
+              items={pinnedSessionLinks}
+              max={3}
+              variant="session-header"
+              overflowLabel="Manage pinned session links"
+              onOverflow={onPinnedOverflow}
+              data-testid="session-pinned-preconversation-links"
+            />
+          </div>
+        )}
+
         {/* CLI session: proper Tabs bar (CLI terminal / Agor conversation)
             sits directly above the panel it switches, with a Restart
             affordance pinned to the right when the terminal view is
@@ -245,7 +286,14 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             )}
           </div>
         ) : (
-          <Divider style={{ margin: `${token.sizeUnit * 2}px 0` }} />
+          <Divider
+            style={{
+              margin:
+                pinnedSessionLinks.length > 0
+                  ? `${token.sizeUnit}px 0`
+                  : `${token.sizeUnit * 2}px 0`,
+            }}
+          />
         )}
 
         {/* Claude Code CLI: embedded live `claude` REPL.
@@ -325,6 +373,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             assistantEmoji={
               branch && isAssistant(branch) ? getAssistantConfig(branch)?.emoji : undefined
             }
+            attachmentLinksByMessageId={attachmentLinksByMessageId}
           />
         </div>
 

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -9,7 +9,7 @@
  * - Groups 3+ sequential tool-only messages into ToolBlock
  */
 
-import type { AgorClient, StreamingMessageState } from '@agor-live/client';
+import type { AgorClient, Link, StreamingMessageState } from '@agor-live/client';
 import {
   type Message,
   MessageRole,
@@ -95,6 +95,7 @@ interface TaskBlockProps {
   assistantEmoji?: string;
   /** Authenticated Feathers client, forwarded to MessageBlock → WidgetBlock for inline submission. */
   client?: AgorClient | null;
+  attachmentLinksByMessageId?: Map<string, Link[]>;
   /** Whether this is the most recent task in the session */
   isLatestTask?: boolean;
 }
@@ -367,6 +368,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     assistantEmoji,
     isLatestTask = false,
     client = null,
+    attachmentLinksByMessageId,
   }) => {
     const { token } = theme.useToken();
 
@@ -651,6 +653,9 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           taskId={task.task_id}
                           assistantEmoji={assistantEmoji}
                           client={client}
+                          attachmentLinks={attachmentLinksByMessageId?.get(
+                            block.message.message_id
+                          )}
                         />
                       );
                     }

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -13,6 +13,77 @@
   align-items: center;
 }
 
+.agor-action-link-row {
+  --agor-link-row-bg: transparent;
+  --agor-link-title-color: inherit;
+  --agor-link-icon-color: inherit;
+  background-color: var(--agor-link-row-bg);
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease;
+}
+
+.agor-action-link-title {
+  transition:
+    color 0.16s ease,
+    text-decoration-color 0.16s ease;
+}
+
+.agor-action-link-icon,
+.agor-action-link-affordance {
+  transition: color 0.16s ease;
+}
+
+.agor-action-link-row:not([aria-disabled="true"]):hover {
+  --agor-link-row-bg: var(--agor-link-row-hover-bg, var(--ant-color-fill-quaternary));
+  --agor-link-title-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
+  --agor-link-icon-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
+}
+
+.agor-action-link-row:not([aria-disabled="true"]):hover .agor-action-link-title {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.agor-action-link-title:hover {
+  --agor-link-title-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.agor-action-link-chip {
+  --agor-link-chip-bg: transparent;
+  --agor-link-chip-border: transparent;
+  --agor-link-chip-color: inherit;
+  --agor-link-chip-accent-color: inherit;
+  border-color: var(--agor-link-chip-border);
+  background: var(--agor-link-chip-bg);
+  color: var(--agor-link-chip-color);
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease,
+    opacity 0.16s ease;
+}
+
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover {
+  --agor-link-chip-bg: var(--agor-link-chip-hover-bg, var(--ant-color-primary-bg));
+  --agor-link-chip-border: var(--agor-link-chip-hover-border, var(--ant-color-primary));
+  --agor-link-chip-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
+  --agor-link-chip-accent-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
+}
+
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-title {
+  --agor-link-title-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
+}
+
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-icon,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover
+  .agor-action-link-affordance {
+  --agor-link-icon-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
+}
+
 /* Prevent long text from causing horizontal scroll in collapse headers,
    but allow vertical overflow so flex-wrapped pill rows aren't clipped (#869). */
 .ant-collapse-header {

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -36,20 +36,22 @@
 }
 
 .agor-action-link-row:not([aria-disabled="true"]):hover {
-  --agor-link-row-bg: var(--agor-link-row-hover-bg, var(--ant-color-fill-quaternary));
+  --agor-link-row-bg: var(--agor-link-row-hover-bg, transparent);
   --agor-link-title-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
   --agor-link-icon-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
-}
-
-.agor-action-link-row:not([aria-disabled="true"]):hover .agor-action-link-title {
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 .agor-action-link-title:hover {
   --agor-link-title-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+.agor-action-link-row:not([aria-disabled="true"]):hover .agor-action-link-title,
+.agor-action-link-row:not([aria-disabled="true"]) .agor-action-link-title:hover,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-title,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]) .agor-action-link-title:hover {
+  text-decoration: none;
 }
 
 .agor-action-link-chip {

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -35,21 +35,31 @@
   transition: color 0.16s ease;
 }
 
-.agor-action-link-row:not([aria-disabled="true"]):hover {
+.agor-action-link-row:not([aria-disabled="true"]):hover,
+.agor-action-link-row:not([aria-disabled="true"]):focus-visible,
+.agor-action-link-row:not([aria-disabled="true"]):focus-within {
   --agor-link-row-bg: var(--agor-link-row-hover-bg, transparent);
   --agor-link-title-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
   --agor-link-icon-color: var(--agor-link-row-hover-icon-color, var(--ant-color-text-tertiary));
 }
 
-.agor-action-link-title:hover {
+.agor-action-link-title:hover,
+.agor-action-link-title:focus-visible {
   --agor-link-title-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
 .agor-action-link-row:not([aria-disabled="true"]):hover .agor-action-link-title,
+.agor-action-link-row:not([aria-disabled="true"]):focus-visible .agor-action-link-title,
+.agor-action-link-row:not([aria-disabled="true"]):focus-within .agor-action-link-title,
 .agor-action-link-row:not([aria-disabled="true"]) .agor-action-link-title:hover,
+.agor-action-link-row:not([aria-disabled="true"]) .agor-action-link-title:focus-visible,
 .agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-title,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-visible
+  .agor-action-link-title,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-within
+  .agor-action-link-title,
 .agor-action-link-chip:not(:disabled):not([aria-disabled="true"]) .agor-action-link-title:hover {
   text-decoration: none;
 }
@@ -69,7 +79,9 @@
     opacity 0.16s ease;
 }
 
-.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover {
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-visible,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-within {
   --agor-link-chip-bg: var(--agor-link-chip-hover-bg, var(--ant-color-primary-bg));
   --agor-link-chip-border: var(--agor-link-chip-hover-border, var(--ant-color-primary));
   --agor-link-chip-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
@@ -79,12 +91,24 @@
   );
 }
 
-.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-title {
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-title,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-visible
+  .agor-action-link-title,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-within
+  .agor-action-link-title {
   --agor-link-title-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
 }
 
 .agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-icon,
 .agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover
+  .agor-action-link-affordance,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-visible
+  .agor-action-link-icon,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-visible
+  .agor-action-link-affordance,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-within
+  .agor-action-link-icon,
+.agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):focus-within
   .agor-action-link-affordance {
   --agor-link-icon-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
 }

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -38,7 +38,7 @@
 .agor-action-link-row:not([aria-disabled="true"]):hover {
   --agor-link-row-bg: var(--agor-link-row-hover-bg, transparent);
   --agor-link-title-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
-  --agor-link-icon-color: var(--agor-link-row-hover-color, var(--ant-color-primary));
+  --agor-link-icon-color: var(--agor-link-row-hover-icon-color, var(--ant-color-text-tertiary));
 }
 
 .agor-action-link-title:hover {
@@ -73,7 +73,10 @@
   --agor-link-chip-bg: var(--agor-link-chip-hover-bg, var(--ant-color-primary-bg));
   --agor-link-chip-border: var(--agor-link-chip-hover-border, var(--ant-color-primary));
   --agor-link-chip-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
-  --agor-link-chip-accent-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
+  --agor-link-chip-accent-color: var(
+    --agor-link-chip-hover-accent-color,
+    var(--ant-color-text-tertiary)
+  );
 }
 
 .agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover .agor-action-link-title {
@@ -84,6 +87,21 @@
 .agor-action-link-chip:not(:disabled):not([aria-disabled="true"]):hover
   .agor-action-link-affordance {
   --agor-link-icon-color: var(--agor-link-chip-hover-color, var(--ant-color-primary));
+}
+
+.agor-link-category-tabs .ant-tabs-nav {
+  margin-bottom: 0;
+}
+
+.agor-link-category-tabs .ant-tabs-nav-list {
+  width: 100%;
+  display: flex;
+}
+
+.agor-link-category-tabs .ant-tabs-tab {
+  flex: 1 1 0;
+  justify-content: center;
+  margin: 0;
 }
 
 /* Prevent long text from causing horizontal scroll in collapse headers,

--- a/packages/core/src/types/link.test.ts
+++ b/packages/core/src/types/link.test.ts
@@ -4,6 +4,7 @@ import {
   extractLinksFromMessage,
   getLinkTargetCompatibilityError,
   getLinkTargetField,
+  getSafeWebUrl,
   LINK_KIND_TARGET_FIELD,
   LINK_SOURCE_TARGET_FIELDS,
   normalizeLinkTargetKey,
@@ -159,5 +160,38 @@ describe('link target semantics', () => {
         ref_uri: 'agor://session/01933e4a-7b89-7c35-a8f3-9d2e1c4b5a6f',
       })
     ).toBe('Internal links require target_object_type and target_object_id');
+  });
+
+  it('only allows absolute http(s) URL link targets', () => {
+    expect(getSafeWebUrl('https://example.com/docs?q=1#top')).toBe(
+      'https://example.com/docs?q=1#top'
+    );
+    expect(getSafeWebUrl('http://example.com/docs')).toBe('http://example.com/docs');
+
+    for (const url of [
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'blob:https://example.com/id',
+      'https://%',
+      '/relative/path',
+    ]) {
+      expect(getSafeWebUrl(url), url).toBeNull();
+      expect(
+        getLinkTargetCompatibilityError({
+          kind: 'url',
+          source: 'manual',
+          url,
+        }),
+        url
+      ).toBe('Link URL must be an absolute http(s) URL');
+    }
+
+    expect(
+      getLinkTargetCompatibilityError({
+        kind: 'url',
+        source: 'manual',
+        url: 'https://example.com/docs',
+      })
+    ).toBeNull();
   });
 });

--- a/packages/core/src/types/link.ts
+++ b/packages/core/src/types/link.ts
@@ -150,6 +150,7 @@ const HTTP_URL_RE = /https?:\/\/[^\s<>"')]+/gi;
 const TRAILING_PUNCTUATION_RE = /[.,;:!?\]}]+$/;
 const GITHUB_ISSUE_RE = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+(?:[/?#].*)?$/i;
 const GITHUB_PR_RE = /^https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+(?:[/?#].*)?$/i;
+const SAFE_WEB_URL_PROTOCOLS = new Set(['http:', 'https:']);
 
 export function isLinkKind(value: unknown): value is LinkKind {
   return typeof value === 'string' && (LINK_KINDS as readonly string[]).includes(value);
@@ -187,6 +188,24 @@ export function countLinkTargets(data: {
   }).length;
 }
 
+export function getSafeWebUrl(url?: string | null): string | null {
+  const trimmed = url?.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!SAFE_WEB_URL_PROTOCOLS.has(parsed.protocol.toLowerCase())) return null;
+    if (!parsed.hostname) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function isSafeWebUrl(url?: string | null): boolean {
+  return getSafeWebUrl(url) !== null;
+}
+
 export function getLinkTargetCompatibilityError(data: {
   kind: LinkKind;
   source: LinkSource;
@@ -208,6 +227,10 @@ export function getLinkTargetCompatibilityError(data: {
 
   if (!LINK_SOURCE_TARGET_FIELDS[data.source].some((field) => field === target)) {
     return `Link source ${data.source} cannot use target ${target}`;
+  }
+
+  if (target === 'url' && !isSafeWebUrl(data.url)) {
+    return 'Link URL must be an absolute http(s) URL';
   }
 
   const hasObjectType = Boolean(data.target_object_type);

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -1,5 +1,5 @@
 // src/types/task.ts
-import type { MessageID, SessionID, TaskID } from './id';
+import type { LinkID, MessageID, SessionID, TaskID } from './id';
 import type { MessageSource } from './message';
 import type { ReportPath, ReportTemplate } from './report';
 
@@ -65,6 +65,13 @@ export interface TaskMetadata {
    * this prompt. Links the task back to the originating widget for audit.
    */
   widget_id?: MessageID;
+  /**
+   * Uploaded link IDs that should be associated with the task's initial
+   * user-message row when the task starts. Used by the upload route so queued
+   * uploads attach to the eventual chat message instead of relying on a
+   * transient message row at upload time.
+   */
+  upload_link_ids?: LinkID[];
 }
 
 /**


### PR DESCRIPTION
## Linked issue

Refs #1716
Related #1766

## Summary

- Adds the production Links organizer UI for session links, Branch modal links, pinned session links, BranchCard pinned links, assistant pinned links, and chat upload attachment cards.
- Adds safe uploaded-link preview/download support via `/link-content/:linkId` for images, Markdown/text, and downloadable documents.
- Adds assistant link promotion/removal so session/branch links can be copied into the board's primary assistant links without moving the source link.
- Polishes link hover, pinned-chip, and row action behavior so rows remain clickable while pin/promote controls stay separate.

## Why / context

This takes the accepted `explore-links-organizer-ui` visual exploration and hardens it into real service-backed behavior on top of the links foundation branch.

The goal is to keep the visual UX that tested well while removing exploration-only fixtures, local paths, fake pin state, and query-mode demos. Links remain scoped as session-owned or branch-owned records; assistant links are represented as pinned branch-owned links on the board's primary assistant branch.

## Implementation notes

- This PR is stacked on `issue-90-links-foundation` / #1689.
- Session and branch link lists use persisted `links` service records plus existing branch issue/PR references.
- Pinned session links render below the session controls; branch-owned pinned links render on BranchCard; assistant pinned links render in the assistant side panel.
- Assistant promotion copies a source link target into the primary assistant branch and pins the assistant copy. It is idempotent by `target_key` and does not move/delete the source link.
- `/link-content/:linkId` is bearer-authenticated, loads through `links.get`, serves uploaded file-backed records only, rejects symlinks/out-of-upload-root paths, and enforces MIME/size constraints.
- Chat attachment cards are derived from uploaded session links with `source_message_id`; parsed URLs are not duplicated as cards.
- No schema migration is added in this PR.

## Validation / test plan

- [x] `pnpm exec biome check <focused changed files>`
- [x] `git diff --check`
- [x] Docker daemon tests: `link-promotion.test.ts` + `link-content.test.ts` — 10 tests passed
- [x] Docker UI tests: `linkPromotion.test.ts`, `linkDisplay.test.ts`, `SessionLinksControl.test.tsx`, `BoardAssistantPanel.test.tsx`, `SessionPanel.test.tsx` — 21 tests passed
- [x] Live env smoke on `http://localhost:5053` / `http://localhost:3053/health`
- [x] Live promotion validation: session link promote/remove, branch Links tab promote/remove, KB/ref promotion, uploaded image promotion/content route, assistant panel realtime update, source link retention after removal

Host Vitest could not run in this isolated worktree because local deps are incomplete (`vitest/config`, `vitest`, `@vitejs/plugin-react` unresolved); the same focused suites passed inside the branch Docker environment.

## Screenshots / demos

Screenshots captured from the live branch environment:

<details open>
<summary>Session quick links popover</summary>

![Session quick links popover](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/slice7-current-session-quick-popover.png)

</details>

<details>
<summary>Manage links drawer</summary>

![Manage links drawer](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/slice7-current-manage-links-drawer.png)

</details>

<details>
<summary>Branch Links tab</summary>

![Branch Links tab](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/slice7-current-branch-links-tab.png)

</details>

<details>
<summary>Session pinned links strip</summary>

![Session pinned links strip](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/slice7-current-session-pinned-strip.png)

</details>

<details>
<summary>Assistant pinned links</summary>

![Assistant pinned links](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/slice7-current-assistant-pinned-links.png)

</details>

<details>
<summary>BranchCard pinned links</summary>

![BranchCard pinned links](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/slice7-current-branchcard-pinned-links.png)

</details>

<details>
<summary>Chat attachment cards</summary>

![Chat attachment cards](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/slice7-current-chat-attachment-cards.png)

</details>

<details>
<summary>Assistant promotion state</summary>

![Assistant promotion state](https://raw.githubusercontent.com/preset-io/agor/pr-1823-screenshots/docs/pr-screenshots/1823/assistant-promotion-session-promoted-sidepanel.png)

</details>

## Risks / rollout / rollback

- The UI adds new link-management surfaces but uses existing service events and service-backed records.
- Uploaded content serving is intentionally narrow: uploaded file-backed links only, no arbitrary repo-file serving.
- BranchCard currently fetches pinned branch links per card; acceptable for this pass, but batching may be worth considering if large boards become slow.
- Rollback is reverting this PR; no migration or persistent schema change is introduced here.

## Out of scope / follow-ups

- Slack attachment ingestion into agent context (#1704 / #1718 / #1719).
- Agent-context/system-prompt injection for pinned links/KB (preset-io/agor-cloud#112).
- OCR/PDF/Office rich previews and extraction.
- Historical backfill for existing session links/uploads.
- Batched BranchCard pinned-link fetching if board-scale performance requires it.

