### PR TITLE
fix(executor): recover Codex stream disconnects

### DIFF
--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -1018,6 +1018,29 @@ describe('SessionRepository.update', () => {
     expect(updated.status).toBe(created.status);
     expect(updated.branch_id).toBe(created.branch_id);
   });
+
+  dbTest('should require null, not undefined, to clear sdk_session_id', async ({ db }) => {
+    const repo = new SessionRepository(db);
+    const branch = await createTestBranch(db);
+    const data = createSessionData({
+      branch_id: branch.branch_id,
+      sdk_session_id: 'dirty-thread-id',
+    });
+    const created = await repo.create(data);
+
+    const undefinedPatch = await repo.update(created.session_id, {
+      sdk_session_id: undefined,
+    });
+    expect(undefinedPatch.sdk_session_id).toBe('dirty-thread-id');
+
+    const nullPatch = await repo.update(created.session_id, {
+      sdk_session_id: null,
+    });
+    expect(nullPatch.sdk_session_id).toBeNull();
+
+    const reloaded = await repo.findById(created.session_id);
+    expect(reloaded?.sdk_session_id).toBeNull();
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -129,7 +129,7 @@ export const sessions = pgTable(
       .json<unknown>('data')
       .$type<{
         agentic_tool_version?: string;
-        sdk_session_id?: string; // SDK session ID for conversation continuity (Claude Agent SDK, Codex SDK, etc.)
+        sdk_session_id?: string | null; // SDK session ID for conversation continuity (Claude Agent SDK, Codex SDK, etc.)
         mcp_token?: string; // MCP authentication token for Agor self-access
         title?: string; // Session title (user-provided or auto-generated)
         description?: string; // Legacy field, may contain first prompt

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -116,7 +116,7 @@ export const sessions = sqliteTable(
       .json<unknown>('data')
       .$type<{
         agentic_tool_version?: string;
-        sdk_session_id?: string; // SDK session ID for conversation continuity (Claude Agent SDK, Codex SDK, etc.)
+        sdk_session_id?: string | null; // SDK session ID for conversation continuity (Claude Agent SDK, Codex SDK, etc.)
         mcp_token?: string; // MCP authentication token for Agor self-access
         title?: string; // Session title (user-provided or auto-generated)
         description?: string; // Legacy field, may contain first prompt

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -139,7 +139,7 @@ export interface Session {
   /** Agentic tool/CLI version */
   agentic_tool_version?: string;
   /** SDK session ID for maintaining conversation history (Claude Agent SDK, Codex SDK, etc.) */
-  sdk_session_id?: string;
+  sdk_session_id?: string | null;
   /** MCP authentication token for Agor self-access */
   mcp_token?: string;
   status: SessionStatus;

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -215,7 +215,7 @@ If you continue to see authentication errors, please contact your Agor administr
 
     // Get session for reference (needed to check existing sdk_session_id)
     const session = await this.sessionsRepo?.findById(sessionId);
-    const existingSdkSessionId = session?.sdk_session_id;
+    const existingSdkSessionId = session?.sdk_session_id ?? undefined;
 
     // Create message processor for this query
     const processor = new SDKMessageProcessor({
@@ -381,7 +381,7 @@ If you continue to see authentication errors, please contact your Agor administr
 
     // Get session for reference
     const session = await this.sessionsRepo?.findById(sessionId);
-    const existingSdkSessionId = session?.sdk_session_id;
+    const existingSdkSessionId = session?.sdk_session_id ?? undefined;
 
     // Create message processor
     const processor = new SDKMessageProcessor({

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -217,7 +217,12 @@ export async function setupQuery(
     console.warn(`⚠️  Session ${sessionId} has no branch_id, using process.cwd(): ${cwd}`);
   }
 
-  logPromptStart(sessionId, prompt, cwd, resume ? session.sdk_session_id : undefined);
+  logPromptStart(
+    sessionId,
+    prompt,
+    cwd,
+    resume ? (session.sdk_session_id ?? undefined) : undefined
+  );
 
   // Validate CWD exists before calling SDK
   try {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1359,6 +1359,43 @@ describe('CodexPromptService - tool payload mapping', () => {
     });
   });
 
+  it('clears a freshly captured Codex thread when a stream disconnects before terminal completion', async () => {
+    const { service, sessionRecord } = await makeStreamingService();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'item.started',
+        item: { id: 'cmd-1', type: 'command_execution', command: 'ls' },
+      },
+      {
+        type: 'error',
+        message:
+          'stream disconnected before completion: websocket closed by server before response.completed',
+      },
+    ];
+
+    await expect(
+      (async () => {
+        for await (const event of service.promptSessionStreaming('session-1' as any, 'review')) {
+          if ('threadId' in event && event.threadId) {
+            await mockSessionsRepo.update('session-1', { sdk_session_id: event.threadId });
+          }
+        }
+      })()
+    ).rejects.toThrow(
+      'Codex stream error: stream disconnected before completion: websocket closed by server before response.completed'
+    );
+
+    expect(mockSessionsRepo.update).toHaveBeenCalledWith('session-1', {
+      sdk_session_id: 'mock-thread-id',
+    });
+    expect(mockSessionsRepo.update).toHaveBeenCalledWith('session-1', {
+      sdk_session_id: null,
+    });
+    expect(sessionRecord.sdk_session_id).toBeNull();
+  });
+
   it('clears a stale Codex MCP resume thread with null before starting a fresh thread', async () => {
     const { service, sessionRecord } = await makeStreamingService({
       sdk_session_id: 'stale-mcp-thread-id',

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -49,10 +49,41 @@ let mockInstanceConfigs: Array<unknown> = [];
 let mockClosedInstanceIds: number[] = [];
 let mockStreamEvents: Array<Record<string, unknown>> = [];
 let mockStartThreadId: string | undefined = 'mock-thread-id';
+let mockStartedThreadOptions: Array<unknown> = [];
+let mockResumedThreadIds: Array<string> = [];
 
 async function* streamMockEvents() {
   for (const event of mockStreamEvents) {
     yield event;
+  }
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function applySessionRepositoryUpdateSemanticsForTest(
+  target: Record<string, unknown>,
+  patch: Record<string, unknown>
+) {
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) {
+      // Match SessionRepository.update() -> deepMerge(): undefined means "preserve".
+      continue;
+    }
+
+    const currentValue = target[key];
+    if (isPlainRecord(value) && isPlainRecord(currentValue)) {
+      applySessionRepositoryUpdateSemanticsForTest(currentValue, value);
+      continue;
+    }
+
+    target[key] = value;
   }
 }
 
@@ -80,7 +111,8 @@ vi.mock('@agor/core/sdk', () => {
       mockClosedInstanceIds.push(this.instanceId);
     }
 
-    startThread() {
+    startThread(options?: unknown) {
+      mockStartedThreadOptions.push(options);
       return {
         id: mockStartThreadId,
         run: vi.fn(),
@@ -89,6 +121,7 @@ vi.mock('@agor/core/sdk', () => {
     }
 
     resumeThread(threadId: string) {
+      mockResumedThreadIds.push(threadId);
       return {
         id: threadId,
         run: vi.fn(),
@@ -112,6 +145,7 @@ const mockSessionsRepo = {
 } as any;
 const mockSessionMCPServerRepo = {
   listServers: vi.fn().mockResolvedValue([]),
+  listServersWithMetadata: vi.fn().mockResolvedValue([]),
 } as any;
 const mockBranchesRepo = {
   findById: vi.fn(),
@@ -126,6 +160,8 @@ describe('CodexPromptService - SDK Instance Caching (issue #133)', () => {
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
     mockStartThreadId = 'mock-thread-id';
+    mockStartedThreadOptions = [];
+    mockResumedThreadIds = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
     appServerMocks.forkCodexThreadViaAppServer.mockReset();
@@ -248,6 +284,8 @@ describe('CodexPromptService - OPENAI_BASE_URL handling', () => {
     mockInstanceConfigs = [];
     mockClosedInstanceIds = [];
     delete process.env.OPENAI_BASE_URL;
+    mockStartedThreadOptions = [];
+    mockResumedThreadIds = [];
     vi.clearAllMocks();
   });
 
@@ -316,6 +354,8 @@ describe('CodexPromptService - prompt flow client initialization', () => {
     mockInstanceConfigs = [];
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
+    mockStartedThreadOptions = [];
+    mockResumedThreadIds = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
   });
@@ -466,6 +506,8 @@ describe('CodexPromptService - forked sessions', () => {
     mockInstanceConfigs = [];
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
+    mockStartedThreadOptions = [];
+    mockResumedThreadIds = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
     appServerMocks.forkCodexThreadViaAppServer.mockReset();
@@ -705,6 +747,84 @@ describe('CodexPromptService - Todo normalization', () => {
 });
 
 describe('CodexPromptService - tool payload mapping', () => {
+  async function makeStreamingService(
+    sessionOverrides: Partial<{
+      session_id: string;
+      sdk_session_id: string | null;
+      created_at: string;
+    }> = {}
+  ) {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    mockSessionsRepo.findById.mockReset();
+    mockSessionsRepo.update.mockReset();
+    mockSessionMCPServerRepo.listServersWithMetadata.mockReset();
+    mockSessionMCPServerRepo.listServersWithMetadata.mockResolvedValue([]);
+    mockBranchesRepo.findById.mockReset();
+    mockStartThreadId = 'mock-thread-id';
+    mockStartedThreadOptions = [];
+    mockResumedThreadIds = [];
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-mock.md');
+    serviceWithPrivates.buildMcpServersConfig = vi
+      .fn()
+      .mockResolvedValue({ servers: {}, total: 0 });
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    const sessionRecord = {
+      session_id: sessionOverrides.session_id ?? 'session-1',
+      branch_id: 'branch-1',
+      created_at: sessionOverrides.created_at ?? new Date().toISOString(),
+      sdk_session_id: sessionOverrides.sdk_session_id ?? null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    };
+
+    mockSessionsRepo.findById.mockResolvedValue(sessionRecord);
+    mockSessionsRepo.update.mockImplementation(
+      async (_id: string, patch: Record<string, unknown>) => {
+        applySessionRepositoryUpdateSemanticsForTest(sessionRecord, patch);
+        return sessionRecord;
+      }
+    );
+    mockBranchesRepo.findById.mockResolvedValue({
+      branch_id: 'branch-1',
+      path: process.cwd(),
+    });
+
+    return { service, sessionRecord };
+  }
+
+  it('models SessionRepository deepMerge clearing semantics in streaming tests', () => {
+    const sessionRecord: Record<string, unknown> = { sdk_session_id: 'dirty-thread-id' };
+
+    applySessionRepositoryUpdateSemanticsForTest(sessionRecord, {
+      sdk_session_id: undefined,
+    });
+    expect(sessionRecord.sdk_session_id).toBe('dirty-thread-id');
+
+    applySessionRepositoryUpdateSemanticsForTest(sessionRecord, {
+      sdk_session_id: null,
+    });
+    expect(sessionRecord.sdk_session_id).toBeNull();
+  });
+
   it('captures token_count context snapshot and forwards it on turn completion', async () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
@@ -1161,6 +1281,119 @@ describe('CodexPromptService - tool payload mapping', () => {
       })()
     ).rejects.toThrow('Codex stream error: stream exploded');
   });
+
+  it('treats recognized reconnect-progress stream errors as non-fatal when the turn later completes', async () => {
+    const { service } = await makeStreamingService();
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'error',
+        message:
+          'Reconnecting... 2/5 (stream disconnected before completion: websocket closed by server before response.completed)',
+      },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 3, cached_input_tokens: 0, output_tokens: 4 },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'review')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    expect(emitted.find((event) => event.type === 'complete')).toMatchObject({
+      threadId: 'mock-thread-id',
+    });
+    expect(mockSessionsRepo.update).not.toHaveBeenCalledWith('session-1', {
+      sdk_session_id: null,
+    });
+  });
+
+  it('clears a dirty Codex resume thread after a true pre-terminal stream disconnect before the next prompt', async () => {
+    const { service, sessionRecord } = await makeStreamingService({
+      sdk_session_id: 'dirty-thread-id',
+    });
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'error',
+        message:
+          'stream disconnected before completion: websocket closed by server before response.completed',
+      },
+    ];
+
+    await expect(
+      (async () => {
+        for await (const _event of service.promptSessionStreaming('session-1' as any, 'review')) {
+          // drain
+        }
+      })()
+    ).rejects.toThrow(
+      'Codex stream error: stream disconnected before completion: websocket closed by server before response.completed'
+    );
+
+    expect(mockSessionsRepo.update).toHaveBeenCalledWith('session-1', {
+      sdk_session_id: null,
+    });
+    expect(sessionRecord.sdk_session_id).toBeNull();
+
+    mockStreamEvents = [
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'continue')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    expect(mockResumedThreadIds).toEqual(['dirty-thread-id']);
+    expect(mockStartedThreadOptions).toHaveLength(1);
+    expect(emitted.find((event) => event.type === 'complete')).toMatchObject({
+      threadId: 'mock-thread-id',
+    });
+  });
+
+  it('clears a stale Codex MCP resume thread with null before starting a fresh thread', async () => {
+    const { service, sessionRecord } = await makeStreamingService({
+      sdk_session_id: 'stale-mcp-thread-id',
+      created_at: '2026-07-06T12:00:00.000Z',
+    });
+    mockSessionMCPServerRepo.listServersWithMetadata.mockResolvedValueOnce([
+      {
+        enabled: true,
+        added_at: new Date('2026-07-06T12:05:00.000Z').getTime(),
+        server: { name: 'new-server' },
+      },
+    ]);
+
+    mockStreamEvents = [
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ];
+
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'continue')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    expect(mockSessionsRepo.update).toHaveBeenCalledWith('session-1', {
+      sdk_session_id: null,
+    });
+    expect(sessionRecord.sdk_session_id).toBeNull();
+    expect(mockResumedThreadIds).toEqual([]);
+    expect(mockStartedThreadOptions).toHaveLength(1);
+    expect(emitted.find((event) => event.type === 'complete')).toMatchObject({
+      threadId: 'mock-thread-id',
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1215,6 +1448,8 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
     mockStartThreadId = 'mock-thread-id';
+    mockStartedThreadOptions = [];
+    mockResumedThreadIds = [];
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
     appServerMocks.forkCodexThreadViaAppServer.mockReset();

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -981,9 +981,10 @@ export class CodexPromptService {
   private async clearDirtyCodexResumeState(
     sessionId: SessionID,
     session: { sdk_session_id?: string | null },
-    reason: string
+    reason: string,
+    fallbackThreadId?: string
   ): Promise<void> {
-    const dirtyThreadId = session.sdk_session_id;
+    const dirtyThreadId = session.sdk_session_id ?? fallbackThreadId;
     if (!dirtyThreadId) return;
 
     console.warn(
@@ -1563,7 +1564,8 @@ export class CodexPromptService {
               await this.clearDirtyCodexResumeState(
                 sessionId,
                 session,
-                `pre-terminal stream disconnect: ${errorMessage}`
+                `pre-terminal stream disconnect: ${errorMessage}`,
+                thread.id || undefined
               );
             }
 
@@ -1589,7 +1591,8 @@ export class CodexPromptService {
             session,
             reconnectProgressMessage
               ? `stream ended before terminal completion after reconnect progress: ${reconnectProgressMessage}`
-              : 'stream ended before terminal completion'
+              : 'stream ended before terminal completion',
+            thread.id || undefined
           );
         }
         throw new Error(

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -106,6 +106,31 @@ function applyGatewayMcpStartupGuard(config: CodexConfigObject, requireMcpServer
   config.startup_timeout_ms = GATEWAY_MCP_STARTUP_TIMEOUT_MS;
 }
 
+function stringifyCodexStreamError(event: { message?: unknown; error?: unknown }): string {
+  const raw = event.message ?? event.error ?? 'unknown';
+  if (typeof raw === 'string') return raw;
+  if (raw instanceof Error) return raw.message;
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return String(raw);
+  }
+}
+
+function isCodexReconnectProgressMessage(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  return /^reconnecting\.\.\.\s*\d+\s*\/\s*\d+/.test(normalized);
+}
+
+function isCodexPreTerminalDisconnectMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('stream disconnected before completion') ||
+    normalized.includes('before response.completed') ||
+    normalized.includes('websocket closed by server before response.completed')
+  );
+}
+
 function getCodexHome(): string {
   return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
 }
@@ -953,6 +978,24 @@ export class CodexPromptService {
     );
   }
 
+  private async clearDirtyCodexResumeState(
+    sessionId: SessionID,
+    session: { sdk_session_id?: string | null },
+    reason: string
+  ): Promise<void> {
+    const dirtyThreadId = session.sdk_session_id;
+    if (!dirtyThreadId) return;
+
+    console.warn(
+      `⚠️  [Codex] Clearing dirty resume thread ${shortId(dirtyThreadId)} for session ${shortId(
+        sessionId
+      )}: ${reason}`
+    );
+
+    await this.sessionsRepo.update(sessionId, { sdk_session_id: null });
+    session.sdk_session_id = null;
+  }
+
   /**
    * Execute prompt with streaming support
    *
@@ -1127,9 +1170,9 @@ export class CodexPromptService {
       );
 
       // Clear SDK session ID to force fresh start with new MCP config
-      await this.sessionsRepo.update(sessionId, { sdk_session_id: undefined });
+      await this.sessionsRepo.update(sessionId, { sdk_session_id: null });
       // Update local session object to reflect the change
-      session.sdk_session_id = undefined;
+      session.sdk_session_id = null;
     }
 
     // Check if we need to update thread settings due to approval policy change
@@ -1198,6 +1241,7 @@ export class CodexPromptService {
       const turnOptions = abortController ? { signal: abortController.signal } : undefined;
       const { events } = await thread.runStreamed(prompt, turnOptions);
       codexDebug(`✅ [Codex] runStreamed() returned, starting event iteration`);
+      let submittedTurnIsUnsafeToResume = true;
 
       const currentMessage: Array<{
         type: string;
@@ -1217,6 +1261,7 @@ export class CodexPromptService {
 
       let eventCount = 0;
       let didStop = false;
+      let reconnectProgressMessage: string | undefined;
 
       for await (const event of events) {
         eventCount++;
@@ -1293,6 +1338,7 @@ export class CodexPromptService {
             codexDebug(
               `✅ [Codex] terminal event_msg (${payloadType}) received for session ${shortId(sessionId)}`
             );
+            submittedTurnIsUnsafeToResume = false;
 
             yield {
               type: 'complete',
@@ -1452,6 +1498,7 @@ export class CodexPromptService {
             const mappedUsage = extractCodexTokenUsage((event as { usage?: unknown }).usage);
             const contextUsage =
               latestContextUsage ?? (await extractLatestContextUsageFromRollout(thread.id || ''));
+            submittedTurnIsUnsafeToResume = false;
 
             // Yield complete message with all tool uses
             yield {
@@ -1497,16 +1544,33 @@ export class CodexPromptService {
             throw new Error(`Codex execution failed: ${errorMessage}`);
           }
 
-          case 'error':
+          case 'error': {
+            const errorMessage = stringifyCodexStreamError(
+              event as { message?: unknown; error?: unknown }
+            );
+
+            if (isCodexReconnectProgressMessage(errorMessage)) {
+              reconnectProgressMessage = errorMessage;
+              console.warn(
+                `⚠️  [Codex] Stream reconnect progress for session ${shortId(
+                  sessionId
+                )}: ${errorMessage}`
+              );
+              continue;
+            }
+
+            if (isCodexPreTerminalDisconnectMessage(errorMessage)) {
+              await this.clearDirtyCodexResumeState(
+                sessionId,
+                session,
+                `pre-terminal stream disconnect: ${errorMessage}`
+              );
+            }
+
             // Fatal stream-level error from Codex SDK.
             // Surface this as a task failure so users see it in the conversation.
-            throw new Error(
-              `Codex stream error: ${
-                (event as { message?: unknown; error?: unknown }).message ||
-                (event as { message?: unknown; error?: unknown }).error ||
-                'unknown'
-              }`
-            );
+            throw new Error(`Codex stream error: ${errorMessage}`);
+          }
 
           default:
             // Ignore other event types silently
@@ -1519,6 +1583,15 @@ export class CodexPromptService {
       // exited without emitting a terminal event (turn.completed / task_complete / turn_complete),
       // which is the bug described in issue #1749.
       if (!didStop) {
+        if (submittedTurnIsUnsafeToResume) {
+          await this.clearDirtyCodexResumeState(
+            sessionId,
+            session,
+            reconnectProgressMessage
+              ? `stream ended before terminal completion after reconnect progress: ${reconnectProgressMessage}`
+              : 'stream ended before terminal completion'
+          );
+        }
         throw new Error(
           'Codex stream ended without a terminal completion event (turn.completed, task_complete, or turn_complete). ' +
             'The Codex process may have exited unexpectedly (check the executor logs for exit code 0 clues). ' +


### PR DESCRIPTION
## Linked issue

Fixes #1821

## Summary

- Treat Codex reconnect-progress stream errors as non-fatal when the stream later reaches completion.
- Clear unsafe Codex resume state after true pre-terminal stream disconnects so the next prompt starts a fresh Codex thread.
- Update `sdk_session_id` typing and repository tests so explicit `null` clears are persisted correctly.

## Why / context

Codex can emit a stream error shaped like `Reconnecting... n/N (...)` before a later terminal completion event. Agor previously treated every top-level Codex stream `error` as fatal, so recoverable reconnect progress failed the task immediately.

When the stream really disconnected before terminal completion, Agor also kept the previous `sdk_session_id`. Follow-up prompts in the same Agor session could then resume a dirty/incomplete Codex thread and fail again.

## Implementation notes

- Added focused Codex stream-error helpers for message extraction, reconnect-progress detection, and pre-terminal disconnect detection.
- Preserved true fatal stream errors while allowing recognized reconnect-progress events to continue through the stream loop.
- Added dirty-resume cleanup for pre-terminal disconnects and streams that end without terminal completion after submission.
- Changed Codex resume clearing from `sdk_session_id: undefined` to `sdk_session_id: null`; the real session repository merge semantics preserve `undefined` but persist `null` as an explicit clear.
- Widened `Session.sdk_session_id` and sqlite/postgres session JSON typings to `string | null`.
- Left similar pre-existing Claude clear sites out of scope for a follow-up cleanup.

## Validation / test plan

- [x] `git diff --check`
- [x] `npx biome check packages/core/src/db/repositories/sessions.test.ts packages/core/src/db/schema.postgres.ts packages/core/src/db/schema.sqlite.ts packages/core/src/types/session.ts packages/executor/src/sdk-handlers/codex/prompt-service.test.ts packages/executor/src/sdk-handlers/codex/prompt-service.ts`
- [x] `pnpm --filter @agor/executor test -- src/sdk-handlers/codex/prompt-service.test.ts` — 45 tests
- [x] `pnpm --filter @agor/core test -- src/db/repositories/sessions.test.ts` — 72 tests
- [x] `pnpm --filter @agor/daemon test -- src/register-hooks.test.ts` — 43 tests

## Screenshots / demos

Not applicable; executor/backend behavior only.

## Risks / rollout / rollback

- On true pre-terminal Codex stream disconnects, the next prompt intentionally loses Codex-side resume continuity and starts a fresh thread to avoid reusing a dirty incomplete turn.
- No prompt auto-retry is added, avoiding duplicated side effects from partially executed turns.
- Rollback is a standard revert of this PR.

## Out of scope / follow-ups

- Similar pre-existing `sdk_session_id: undefined` clear sites in Claude query-builder remain unchanged and should be handled separately if desired.
- Live upstream websocket disconnects were not forced; deterministic stream fixtures cover the recovery behavior.
