### PR TITLE
feat(daemon): DB connectivity probe + liveness/readiness endpoints (#1726)

### DIFF
--- a/apps/agor-daemon/src/health/db-probe.test.ts
+++ b/apps/agor-daemon/src/health/db-probe.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for the daemon self-health probes.
+ *
+ * Covers the three outcomes that matter for the readiness contract:
+ *   - success  -> { ok: true, latencyMs }
+ *   - failure  -> { ok: false, error }
+ *   - timeout  -> { ok: false, error: '…timeout' } (never hangs)
+ * plus dialect branching (SQLite `.run` vs Postgres `.execute`).
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  initializeDatabase,
+  MissingTenantDatabaseScopeError,
+  sql,
+} from '@agor/core/db';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DB_PROBE_TIMEOUT_MS, probeDatabase, probePendingMigrations } from './db-probe';
+
+/** A SQLite-shaped fake: has `.run`, so `isSQLiteDatabase` returns true. */
+function sqliteFake(run: () => Promise<unknown>): Database {
+  return { run } as unknown as Database;
+}
+
+/** A Postgres-shaped fake: no `.run`, only `.execute`. */
+function postgresFake(execute: () => Promise<unknown>): Database {
+  return { execute } as unknown as Database;
+}
+
+describe('probeDatabase', () => {
+  it('returns ok with a latency reading when the SQLite query succeeds', async () => {
+    const db = sqliteFake(() => Promise.resolve({ rows: [{ 1: 1 }] }));
+    const result = await probeDatabase(db);
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('uses .execute() for the Postgres dialect', async () => {
+    let called = false;
+    const db = postgresFake(() => {
+      called = true;
+      return Promise.resolve([{ 1: 1 }]);
+    });
+    const result = await probeDatabase(db);
+    expect(called).toBe(true);
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok:false with the error message when the query rejects', async () => {
+    const db = sqliteFake(() => Promise.reject(new Error('connection refused')));
+    const result = await probeDatabase(db);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('connection refused');
+  });
+
+  it('never hangs: a stalled query times out and reports failure', async () => {
+    // A query that never resolves — the probe must still return via timeout.
+    const db = sqliteFake(() => new Promise<never>(() => {}));
+    const start = Date.now();
+    const result = await probeDatabase(db, 50);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timeout/i);
+    // Comfortably below the default; proves we didn't wait on the query.
+    expect(Date.now() - start).toBeLessThan(DB_PROBE_TIMEOUT_MS);
+  });
+});
+
+describe('probePendingMigrations', () => {
+  it('reports failure (never throws) when the underlying check rejects', async () => {
+    const db = sqliteFake(() => Promise.reject(new Error('no such table')));
+    const result = await probePendingMigrations(db, 200);
+    expect(result.ok).toBe(false);
+    expect(result.pending).toBe(0);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('times out instead of hanging on a stalled check', async () => {
+    const db = sqliteFake(() => new Promise<never>(() => {}));
+    const result = await probePendingMigrations(db, 50);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timeout/i);
+  });
+});
+
+// Regression: in `required_from_auth` multi-tenancy mode the daemon's DB handle
+// is a scope-guarded proxy (requireScope:true) that throws unless a tenant OR
+// system scope is active. The probes must enter a system scope themselves —
+// otherwise they'd throw, get swallowed as a DB failure, and report a healthy
+// DB as down (false 503 / degraded). These tests use a real guarded proxy so a
+// regression here fails loudly.
+describe('probes against a scope-guarded proxy (required_from_auth mode)', () => {
+  let dir: string;
+  let scoped: Database;
+
+  const setup = async () => {
+    dir = mkdtempSync(join(tmpdir(), 'agor-health-probe-'));
+    const base = createDatabase({ url: `file:${join(dir, 'test.db')}` });
+    await initializeDatabase(base);
+    scoped = createTenantScopedDatabaseProxy(base, { requireScope: true, label: 'agor.db' });
+  };
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('guard is active: touching the raw proxy without a scope throws (sanity)', async () => {
+    await setup();
+    // Proves the proxy really is guarded — otherwise the tests below would pass
+    // even if the probes forgot to enter a scope.
+    expect(() => scoped.run(sql`SELECT 1`)).toThrow(MissingTenantDatabaseScopeError);
+  });
+
+  it('probeDatabase reports ok through the guarded proxy', async () => {
+    await setup();
+    const result = await probeDatabase(scoped);
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('probePendingMigrations reports ok (0 pending) through the guarded proxy', async () => {
+    await setup();
+    const result = await probePendingMigrations(scoped);
+    expect(result.ok).toBe(true);
+    expect(result.pending).toBe(0);
+  });
+});

--- a/apps/agor-daemon/src/health/db-probe.ts
+++ b/apps/agor-daemon/src/health/db-probe.ts
@@ -1,0 +1,116 @@
+/**
+ * Cheap, hard-time-bounded probes of the daemon's own database, backing the
+ * health endpoints in `routes.ts`. Time-bounding matters because these run on
+ * every k8s poll — a hung DB must never stall the endpoint. The 1.5s ceiling
+ * only bounds how long the *endpoint* waits; the underlying query is itself
+ * capped server-side (Postgres `statement_timeout` 60s, SQLite `busy_timeout`
+ * 5s), so a stalled connection is reclaimed rather than leaked indefinitely.
+ *
+ * All DB work runs inside an explicit system scope: the daemon's DB handle is
+ * a tenant-scope-aware proxy, and in `required_from_auth` multi-tenancy mode it
+ * throws unless a tenant *or* system scope is active. A connectivity check is
+ * tenant-agnostic global work, so `runWithSystemDatabaseScope` is the correct
+ * (and only supported) no-tenant entry — without it these probes would throw
+ * and report the DB as down when it is perfectly healthy.
+ *
+ * Unrelated to the `HealthMonitor` service, which polls branch environments.
+ */
+
+import {
+  checkMigrationStatus,
+  type Database,
+  isSQLiteDatabase,
+  runWithSystemDatabaseScope,
+  sql,
+} from '@agor/core/db';
+
+/** ~1.5s: above a healthy round-trip, short enough that a hung DB fails fast. */
+export const DB_PROBE_TIMEOUT_MS = 1500;
+
+export interface DbProbeResult {
+  ok: boolean;
+  latencyMs: number;
+  /** Present only when `ok` is false. */
+  error?: string;
+}
+
+/**
+ * Race a promise against a timeout. The work isn't cancellable (a hung query
+ * keeps running), but the caller stops waiting on it — enough to stay responsive.
+ */
+function withTimeout<T>(work: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} exceeded ${timeoutMs}ms timeout`)),
+      timeoutMs
+    );
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
+ * Probe database connectivity with a cheap, dialect-aware `SELECT 1` and a
+ * hard timeout. Never throws — a failure or timeout is returned as
+ * `{ ok: false, error }` so callers can map it onto a status code without a
+ * try/catch of their own. Safe to call with the daemon's tenant-scope-aware
+ * `Database`: it enters a system scope internally (see file header).
+ */
+export async function probeDatabase(
+  db: Database,
+  timeoutMs: number = DB_PROBE_TIMEOUT_MS
+): Promise<DbProbeResult> {
+  const start = Date.now();
+  try {
+    await runWithSystemDatabaseScope(db, 'health db probe', (systemDb) => {
+      // SQLite (libSQL) exposes `.run()`; Postgres exposes `.execute()`. Both
+      // return a thenable, so racing them against the timeout is uniform.
+      const query = isSQLiteDatabase(systemDb)
+        ? systemDb.run(sql`SELECT 1`)
+        : systemDb.execute(sql`SELECT 1`);
+      return withTimeout(Promise.resolve(query), timeoutMs, 'database probe');
+    });
+    return { ok: true, latencyMs: Date.now() - start };
+  } catch (error) {
+    return {
+      ok: false,
+      latencyMs: Date.now() - start,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export interface MigrationsProbeResult {
+  /** True when the check completed (regardless of pending count). */
+  ok: boolean;
+  /** Migrations on disk not yet applied (0 when up to date). */
+  pending: number;
+  error?: string;
+}
+
+/**
+ * Count un-applied migrations. Diagnostic only — surfaced on authenticated
+ * `/health`, never gates readiness (a migration shouldn't flap pods out of
+ * rotation; that's a startupProbe concern). Never throws; time-bounded. Like
+ * `probeDatabase`, safe to call with the tenant-scope-aware `Database` — it
+ * enters a system scope internally.
+ */
+export async function probePendingMigrations(
+  db: Database,
+  timeoutMs: number = DB_PROBE_TIMEOUT_MS
+): Promise<MigrationsProbeResult> {
+  try {
+    const status = await runWithSystemDatabaseScope(db, 'health migrations probe', (systemDb) =>
+      withTimeout(checkMigrationStatus(systemDb), timeoutMs, 'pending-migrations probe')
+    );
+    return { ok: true, pending: status.pending.length };
+  } catch (error) {
+    return {
+      ok: false,
+      pending: 0,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/apps/agor-daemon/src/health/payload.test.ts
+++ b/apps/agor-daemon/src/health/payload.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Contract tests for the `/health` payload shaping. These lock the guarantees
+ * the route handler relies on: `status` reflects DB health, the public DB
+ * section never leaks the raw error, and the authenticated section does.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { DbProbeResult, MigrationsProbeResult } from './db-probe';
+import { authenticatedHealthDb, healthMigrations, healthStatus, publicHealthDb } from './payload';
+
+const okProbe: DbProbeResult = { ok: true, latencyMs: 3 };
+const failedProbe: DbProbeResult = { ok: false, latencyMs: 1500, error: 'ECONNREFUSED host:5432' };
+
+describe('healthStatus', () => {
+  it('is ok when the DB probe succeeds', () => {
+    expect(healthStatus(okProbe)).toBe('ok');
+  });
+  it('is degraded when the DB probe fails', () => {
+    expect(healthStatus(failedProbe)).toBe('degraded');
+  });
+});
+
+describe('publicHealthDb', () => {
+  it('exposes only ok + latencyMs, never the raw error', () => {
+    expect(publicHealthDb(okProbe)).toEqual({ ok: true, latencyMs: 3 });
+    const shaped = publicHealthDb(failedProbe);
+    expect(shaped).toEqual({ ok: false, latencyMs: 1500 });
+    expect('error' in shaped).toBe(false);
+    expect(JSON.stringify(shaped)).not.toContain('ECONNREFUSED');
+  });
+});
+
+describe('authenticatedHealthDb', () => {
+  it('includes the raw error when the probe failed', () => {
+    expect(authenticatedHealthDb(failedProbe)).toEqual({
+      ok: false,
+      latencyMs: 1500,
+      error: 'ECONNREFUSED host:5432',
+    });
+  });
+  it('omits error when the probe succeeded', () => {
+    const shaped = authenticatedHealthDb(okProbe);
+    expect(shaped).toEqual({ ok: true, latencyMs: 3 });
+    expect('error' in shaped).toBe(false);
+  });
+});
+
+describe('healthMigrations', () => {
+  it('reports the pending count and omits error on success', () => {
+    const shaped = healthMigrations({ ok: true, pending: 0 } satisfies MigrationsProbeResult);
+    expect(shaped).toEqual({ pending: 0 });
+    expect('error' in shaped).toBe(false);
+  });
+  it('includes error when the check failed', () => {
+    expect(healthMigrations({ ok: false, pending: 0, error: 'no such table' })).toEqual({
+      pending: 0,
+      error: 'no such table',
+    });
+  });
+});

--- a/apps/agor-daemon/src/health/payload.ts
+++ b/apps/agor-daemon/src/health/payload.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure shaping of the `/health` payload's DB-derived fields. Extracted from the
+ * `/health` route handler so the contract can be unit-tested without standing
+ * up the full daemon: public payloads must never leak the raw DB error, and the
+ * top-level `status` must flip to `degraded` when connectivity fails.
+ */
+
+import type { DbProbeResult, MigrationsProbeResult } from './db-probe.js';
+
+export type HealthStatus = 'ok' | 'degraded';
+
+/** Top-level `/health` status: `degraded` iff the DB probe failed. */
+export function healthStatus(dbProbe: DbProbeResult): HealthStatus {
+  return dbProbe.ok ? 'ok' : 'degraded';
+}
+
+/**
+ * Public DB section — connectivity + latency only. Deliberately omits the raw
+ * probe error, which can carry connection details, from unauthenticated callers.
+ */
+export function publicHealthDb(dbProbe: DbProbeResult): { ok: boolean; latencyMs: number } {
+  return { ok: dbProbe.ok, latencyMs: dbProbe.latencyMs };
+}
+
+/** Authenticated DB section — adds the raw error when the probe failed. */
+export function authenticatedHealthDb(dbProbe: DbProbeResult): {
+  ok: boolean;
+  latencyMs: number;
+  error?: string;
+} {
+  return { ...publicHealthDb(dbProbe), ...(dbProbe.error ? { error: dbProbe.error } : {}) };
+}
+
+/** Authenticated migrations diagnostic — pending count, plus error if the check failed. */
+export function healthMigrations(migrations: MigrationsProbeResult): {
+  pending: number;
+  error?: string;
+} {
+  return { pending: migrations.pending, ...(migrations.error ? { error: migrations.error } : {}) };
+}

--- a/apps/agor-daemon/src/health/routes.test.ts
+++ b/apps/agor-daemon/src/health/routes.test.ts
@@ -1,0 +1,77 @@
+/**
+ * HTTP-level tests for the liveness/readiness probe routes.
+ *
+ * These stand up a bare Express app, register the *production* route handlers
+ * via `registerHealthProbeRoutes`, and hit them over a real socket — so we're
+ * verifying the actual status-code contract (200 vs 503), not a reimplementation.
+ */
+
+import type { Server } from 'node:http';
+import type { Database } from '@agor/core/db';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerHealthProbeRoutes } from './routes';
+
+/** SQLite-shaped fake whose probe query resolves (DB reachable). */
+const healthyDb = { run: () => Promise.resolve({ rows: [] }) } as unknown as Database;
+/** SQLite-shaped fake whose probe query rejects (DB unreachable). */
+const brokenDb = {
+  run: () => Promise.reject(new Error('ECONNREFUSED')),
+} as unknown as Database;
+
+let server: Server | undefined;
+
+async function startWith(db: Database): Promise<string> {
+  const app = express();
+  registerHealthProbeRoutes(app, db);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, resolve);
+  });
+  const addr = server?.address();
+  if (!addr || typeof addr === 'string') throw new Error('failed to bind test server');
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+    server = undefined;
+  }
+});
+
+describe('GET /livez', () => {
+  it('returns 200 without touching the DB (even when the DB is down)', async () => {
+    // Pass the broken DB to prove liveness never consults it.
+    const base = await startWith(brokenDb);
+    const res = await fetch(`${base}/livez`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+});
+
+describe('GET /readyz', () => {
+  it('returns 200 with db latency when the DB is reachable', async () => {
+    const base = await startWith(healthyDb);
+    const res = await fetch(`${base}/readyz`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; db: { ok: boolean; latencyMs: number } };
+    expect(body.status).toBe('ok');
+    expect(body.db.ok).toBe(true);
+    expect(body.db.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns 503 with a degraded body when the DB is unreachable', async () => {
+    const base = await startWith(brokenDb);
+    const res = await fetch(`${base}/readyz`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { status: string; db: { ok: boolean } };
+    expect(body.status).toBe('error');
+    expect(body.db.ok).toBe(false);
+  });
+
+  it('does not leak the raw DB error to unauthenticated callers', async () => {
+    const base = await startWith(brokenDb);
+    const res = await fetch(`${base}/readyz`);
+    expect(JSON.stringify(await res.json())).not.toContain('ECONNREFUSED');
+  });
+});

--- a/apps/agor-daemon/src/health/routes.ts
+++ b/apps/agor-daemon/src/health/routes.ts
@@ -1,0 +1,50 @@
+/**
+ * Kubernetes-style liveness (/livez) and readiness (/readyz) probes (#1726).
+ *
+ * Raw Express routes, not Feathers services, so we control the status code
+ * (Feathers `find` is always 200; readiness needs 503). Both are unauthenticated
+ * like `/health` and expose only { ok, latencyMs } — safe for public k8s probes
+ * and the #1735 watchdog.
+ *
+ * The split is load-bearing: point a `livenessProbe` at a DB check and a DB
+ * outage restarts every pod (fleet-wide crash loop). Liveness MUST stay
+ * dependency-free; readiness is where the DB probe belongs, and a 503 there just
+ * pulls the pod from rotation without killing it.
+ */
+
+import type { Database } from '@agor/core/db';
+import type { Application } from 'express';
+import { probeDatabase } from './db-probe.js';
+
+/**
+ * The slice of Express we use. Structural (just `get`) so this registers
+ * against both the Feathers app (production) and a bare Express app (tests),
+ * while keeping Express' typed `Request`/`Response` in the handlers.
+ */
+export type ProbeRouteApp = Pick<Application, 'get'>;
+
+export function registerHealthProbeRoutes(app: ProbeRouteApp, db: Database): void {
+  // Liveness: trivial in-process 200, no DB. If this can't answer, the event
+  // loop is wedged and a restart is the right remedy.
+  app.get('/livez', (_req, res) => {
+    res.status(200).json({ status: 'ok' });
+  });
+
+  // Readiness: run the DB probe; 503 on failure. The raw error is logged, not
+  // returned, so nothing leaks to unauthenticated callers.
+  app.get('/readyz', async (_req, res) => {
+    const dbProbe = await probeDatabase(db);
+    if (!dbProbe.ok) {
+      console.warn(`[health] /readyz DB probe failed after ${dbProbe.latencyMs}ms:`, dbProbe.error);
+      res.status(503).json({
+        status: 'error',
+        db: { ok: false, latencyMs: dbProbe.latencyMs },
+      });
+      return;
+    }
+    res.status(200).json({
+      status: 'ok',
+      db: { ok: true, latencyMs: dbProbe.latencyMs },
+    });
+  });
+}

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -90,6 +90,14 @@ import type {
   TasksServiceImpl,
 } from './declarations.js';
 import { killExecutorProcess } from './executor-tracking.js';
+import { probeDatabase, probePendingMigrations } from './health/db-probe.js';
+import {
+  authenticatedHealthDb,
+  healthMigrations,
+  healthStatus,
+  publicHealthDb,
+} from './health/payload.js';
+import { registerHealthProbeRoutes } from './health/routes.js';
 import { resolveForUserIdWithGate } from './oauth-auth-helpers.js';
 import type { GatewayService } from './services/gateway.js';
 import {
@@ -3546,8 +3554,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   app.use('/health', {
     async find(params?: AuthenticatedParams) {
       const publicLaunchAuth = resolvePublicLaunchAuthSettings(config);
+      // `/health` stays 200 always (pre-login UI fetches must not throw), so the
+      // DB signal rides on `status`: ok | degraded. /readyz is the one that 503s.
+      // Only { ok, latencyMs } is public; the raw error is authenticated-only below.
+      const dbProbe = await probeDatabase(db);
       const publicResponse = {
-        status: 'ok',
+        status: healthStatus(dbProbe),
+        db: publicHealthDb(dbProbe),
         timestamp: Date.now(),
         version: DAEMON_VERSION,
         // Build identity for the version-sync banner (apps/agor-ui ConnectionStatus).
@@ -3633,8 +3646,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           databaseInfo = { dialect, path: DB_PATH };
         }
 
+        // Diagnostic only; not in the public payload, doesn't gate readiness.
+        // Gated behind auth like the rest of this block (any authenticated
+        // user, matching the existing `database`/`execution` fields below —
+        // not admin-only).
+        const migrations = await probePendingMigrations(db);
+
         return {
           ...publicResponse,
+          // Full DB probe detail, including the raw error, is authenticated-only
+          // (never in the public payload).
+          db: authenticatedHealthDb(dbProbe),
+          migrations: healthMigrations(migrations),
           database: databaseInfo,
           auth: {
             ...publicResponse.auth,
@@ -3690,6 +3713,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     description: 'Health check endpoint (always public)',
     security: [],
   };
+
+  // Liveness (/livez) and readiness (/readyz) probes — see health/routes.ts.
+  registerHealthProbeRoutes(app, db);
 
   // ============================================================================
   // OpenCode models + health endpoints

--- a/apps/agor-docs/content/guide/architecture.mdx
+++ b/apps/agor-docs/content/guide/architecture.mdx
@@ -511,6 +511,32 @@ On a fresh install with zero users, the daemon auto-creates an admin user on fir
 
 All strategies use FeathersJS authentication with configurable storage.
 
+## Health & Readiness Probes
+
+The daemon exposes three **unauthenticated** monitoring endpoints:
+
+| Endpoint  | Purpose                    | Touches DB? | Status codes                     |
+| --------- | -------------------------- | ----------- | -------------------------------- |
+| `/livez`  | Liveness — process alive   | **No**      | `200` (when responsive)          |
+| `/readyz` | Readiness — can serve      | **Yes**     | `200` healthy · `503` DB down    |
+| `/health` | Rich status for UI / admin | **Yes**     | `200` always (`status` reflects) |
+
+`/readyz` runs a time-bounded `SELECT 1` and returns `{ status, db: { ok, latencyMs } }`.
+`/health` stays `200` always (pre-login UI fetches must not throw) and carries the
+signal on `status` (`ok`/`degraded`); authenticated callers also get the DB error,
+masked DB URL, and a non-gating pending-migrations count.
+
+Wire k8s probes liveness→`/livez`, readiness→`/readyz` — **never** point liveness
+at a DB-checking endpoint, or a DB outage restarts every pod (fleet-wide crash
+loop) instead of just pulling them from rotation:
+
+```yaml
+livenessProbe:
+  httpGet: { path: /livez, port: 3030 }
+readinessProbe:
+  httpGet: { path: /readyz, port: 3030 }
+```
+
 ## Next Steps
 
 - **[Getting Started](/guide/getting-started)** — Install and run Agor

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -85,7 +85,15 @@ const checks = [
       /import\s+(?:type\s+)?{[^}]*(?:\bDatabase\b|\bRawDatabase\b)[^}]*}\s*from\s*['"]@agor\/core\/db(?:\/client)?['"]/gs,
       /import\s+(?:type\s+)?\*\s+as\s+\w+\s+from\s*['"]@agor\/core\/db(?:\/client)?['"]/gs,
     ],
-    baseline: {},
+    baseline: {
+      // Health probes take a Database handle to run a tenant-agnostic
+      // connectivity check (SELECT 1) / migration count. This is explicit
+      // global work: the probe enters an explicit system scope via
+      // runWithSystemDatabaseScope (not a raw tenant-scope bypass), which is
+      // the supported no-tenant path for guarded proxies.
+      'apps/agor-daemon/src/health/db-probe.ts': 1,
+      'apps/agor-daemon/src/health/routes.ts': 1,
+    },
   },
   {
     name: 'raw Drizzle transactions',


### PR DESCRIPTION
## What & why

`/health` returned a static `status: 'ok'` without ever touching the DB, so it could report healthy while Postgres was down — useless as a liveness/readiness signal. Closes **#1726**, unblocks **#1735**.

Core idea: **separate liveness from readiness**.

| Endpoint | Touches DB? | Codes | For |
|---|---|---|---|
| `GET /livez` | No | `200` | k8s `livenessProbe` |
| `GET /readyz` | Yes (`SELECT 1`, ~1.5s cap) | `200` / `503` | k8s `readinessProbe` + #1735 watchdog |
| `GET /health` | Yes | `200` (`status: ok\|degraded`) | UI / admin |

- `/livez` never touches the DB — pointing a liveness probe at a DB check would make a DB outage restart *every* pod (crash loop). `/readyz`'s 503 just pulls the pod from rotation.
- `/health` stays 200 so pre-login UI fetches don't throw; DB signal rides on `status`. Authenticated callers also get the raw DB error, masked DB URL, and a non-gating pending-migrations count.
- Probes are public (like `/health` already is — fetched unauthenticated pre-login) and leak nothing: only `{ ok, latencyMs }`, raw error logged server-side.

**On the #1726 open questions:** endpoint shape → `/livez` + `/readyz` (k8s `z`-convention) plus enriched `/health`; status → 503 on `/readyz`, `/health` stays 200; auth → `/health` was already public, so no split needed.

## Implementation
- `health/db-probe.ts` — `probeDatabase` (dialect-aware, time-bounded, never throws) + `probePendingMigrations`.
- `health/routes.ts` — `registerHealthProbeRoutes` (raw Express for 503 control).
- `register-routes.ts` — wired in; `/health` enriched.

## Tests & docs
- `db-probe.test.ts` (success/failure/timeout/dialect) + `routes.test.ts` (real Express: `/livez` 200 with DB down, `/readyz` 200/503, no error leak). `pnpm typecheck` + biome green.
- Architecture guide: short Health & Readiness Probes subsection with the recommended k8s wiring. Deploy manifests live in `agor-cloud`.

Closes #1726. Unblocks #1735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)