### PR TITLE
perf(daemon): scope streaming events to session subscribers + coalesce streaming-time session patches

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -722,6 +722,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
+  // These routes re-emit onto the `messages` / `tasks` services (which carry
+  // the real streaming payloads); their OWN default `created` event is just the
+  // `{ success: true }` ack and must never broadcast — one per chunk otherwise
+  // reaches every service-account socket. Publish it to no one.
+  app.service('/messages/streaming').publish(() => []);
+  app.service('/tasks/streaming').publish(() => []);
+
   // ============================================================================
   // Sessions custom routes (fork, spawn, genealogy, prompt, stop, queue)
   // ============================================================================

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -114,6 +114,7 @@ import { createReposService } from './services/repos.js';
 import { createSchedulesService } from './services/schedules.js';
 import { createSessionEnvSelectionsService } from './services/session-env-selections.js';
 import { createSessionMCPServersService } from './services/session-mcp-servers.js';
+import { createSessionStreamsService } from './services/session-streams.js';
 import { createSessionsService } from './services/sessions.js';
 import { createTasksService } from './services/tasks.js';
 import { createTemplatesService } from './services/templates.js';
@@ -221,6 +222,19 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   sessionsService.setExecuteHandler(
     createExecuteHandler(ctx, sessionsService, sessionTokenService)
   );
+
+  // Realtime control-plane: browsers subscribe (create) / unsubscribe (remove)
+  // to a session's per-connection streaming channel so per-chunk streaming
+  // events reach only the tabs actively viewing that session. Access is gated
+  // by the session read inside the service. The create/remove events are
+  // control-plane only and must never broadcast, so publish to no connections.
+  app.use('/session-streams', createSessionStreamsService(app), {
+    methods: ['create', 'remove'],
+  });
+  app.service('/session-streams').hooks({
+    before: { all: [ctx.requireAuth] },
+  });
+  app.service('/session-streams').publish(() => []);
 
   app.use('/tasks', createTasksService(db, app), {
     // Custom events not in this list are dropped at the FeathersJS transport

--- a/apps/agor-daemon/src/services/session-streams.test.ts
+++ b/apps/agor-daemon/src/services/session-streams.test.ts
@@ -35,6 +35,29 @@ describe('session-streams service', () => {
     expect(result).toEqual({ session_id: 's1', subscribed: true });
   });
 
+  it('joins the canonical room id when the caller passes a short id', async () => {
+    // The resolved row carries the full UUID; publishers emit to that room, so
+    // a short-id subscriber must be joined under the canonical id, not the
+    // short id it supplied.
+    const { app, join, channel, get } = makeApp(async () => ({
+      session_id: 'ffffffff-1111-2222-3333-444444444444',
+    }));
+    const service = createSessionStreamsService(app);
+
+    const result = await service.create({ session_id: 'ffffffff' }, {
+      connection,
+      provider: 'socketio',
+    } as never);
+
+    expect(get).toHaveBeenCalledWith('ffffffff', expect.objectContaining({ query: {} }));
+    expect(channel).toHaveBeenCalledWith('session-stream:ffffffff-1111-2222-3333-444444444444');
+    expect(join).toHaveBeenCalledWith(connection);
+    expect(result).toEqual({
+      session_id: 'ffffffff-1111-2222-3333-444444444444',
+      subscribed: true,
+    });
+  });
+
   it('rejects a subscription to an inaccessible session and does not join', async () => {
     const { app, join, get } = makeApp(async () => {
       throw new Error('Forbidden');

--- a/apps/agor-daemon/src/services/session-streams.test.ts
+++ b/apps/agor-daemon/src/services/session-streams.test.ts
@@ -100,4 +100,18 @@ describe('session-streams service', () => {
     expect(leave).toHaveBeenCalledWith(connection);
     expect(result).toEqual({ session_id: 's1', subscribed: false });
   });
+
+  it('unsubscribe skips the resolve round-trip when given a full UUID', async () => {
+    const { app, leave, channel, get } = makeApp(async () => ({ session_id: 's1' }));
+    const service = createSessionStreamsService(app);
+    const fullId = 'ffffffff-1111-2222-3333-444444444444';
+
+    const result = await service.remove(fullId, { connection, provider: 'socketio' } as never);
+
+    // The client already sends the canonical id, so no sessions.get lookup.
+    expect(get).not.toHaveBeenCalled();
+    expect(channel).toHaveBeenCalledWith(`session-stream:${fullId}`);
+    expect(leave).toHaveBeenCalledWith(connection);
+    expect(result).toEqual({ session_id: fullId, subscribed: false });
+  });
 });

--- a/apps/agor-daemon/src/services/session-streams.test.ts
+++ b/apps/agor-daemon/src/services/session-streams.test.ts
@@ -2,12 +2,24 @@ import type { Application } from '@agor/core/feathers';
 import { describe, expect, it, vi } from 'vitest';
 import { createSessionStreamsService } from './session-streams.js';
 
-function makeApp(sessionsGet: (id: string, params: unknown) => Promise<unknown>) {
+function makeApp(
+  sessionsGet: (id: string, params: unknown) => Promise<unknown>,
+  existingChannels: string[] = []
+) {
   const join = vi.fn();
   const leave = vi.fn();
-  const channel = vi.fn(() => ({ join, leave }));
+  // Names that already exist plus any materialized by a channel lookup; the
+  // leave path is existence-gated, so an absent room must not be created.
+  const created = new Set<string>(existingChannels);
+  const channel = vi.fn((name: string) => {
+    created.add(name);
+    return { join, leave };
+  });
   const get = vi.fn(sessionsGet);
   const app = {
+    get channels() {
+      return [...created];
+    },
     channel,
     service: vi.fn((path: string) => {
       if (path === 'sessions') return { get };
@@ -91,7 +103,10 @@ describe('session-streams service', () => {
   });
 
   it('leaves the per-session channel on unsubscribe', async () => {
-    const { app, leave, channel } = makeApp(async () => ({ session_id: 's1' }));
+    const { app, leave, channel } = makeApp(
+      async () => ({ session_id: 's1' }),
+      ['session-stream:s1']
+    );
     const service = createSessionStreamsService(app);
 
     const result = await service.remove('s1', { connection, provider: 'socketio' } as never);
@@ -102,9 +117,12 @@ describe('session-streams service', () => {
   });
 
   it('unsubscribe skips the resolve round-trip when given a full UUID', async () => {
-    const { app, leave, channel, get } = makeApp(async () => ({ session_id: 's1' }));
-    const service = createSessionStreamsService(app);
     const fullId = 'ffffffff-1111-2222-3333-444444444444';
+    const { app, leave, channel, get } = makeApp(
+      async () => ({ session_id: 's1' }),
+      [`session-stream:${fullId}`]
+    );
+    const service = createSessionStreamsService(app);
 
     const result = await service.remove(fullId, { connection, provider: 'socketio' } as never);
 
@@ -112,6 +130,20 @@ describe('session-streams service', () => {
     expect(get).not.toHaveBeenCalled();
     expect(channel).toHaveBeenCalledWith(`session-stream:${fullId}`);
     expect(leave).toHaveBeenCalledWith(connection);
+    expect(result).toEqual({ session_id: fullId, subscribed: false });
+  });
+
+  it('unsubscribe from an absent room does not materialize it', async () => {
+    // No existing channels — the room was never joined (or already pruned).
+    const fullId = 'ffffffff-1111-2222-3333-444444444444';
+    const { app, leave } = makeApp(async () => ({ session_id: fullId }));
+    const service = createSessionStreamsService(app);
+
+    const result = await service.remove(fullId, { connection, provider: 'socketio' } as never);
+
+    // The leave path is existence-gated: no channel created, no leave issued.
+    expect(leave).not.toHaveBeenCalled();
+    expect(app.channels).not.toContain(`session-stream:${fullId}`);
     expect(result).toEqual({ session_id: fullId, subscribed: false });
   });
 });

--- a/apps/agor-daemon/src/services/session-streams.test.ts
+++ b/apps/agor-daemon/src/services/session-streams.test.ts
@@ -1,0 +1,80 @@
+import type { Application } from '@agor/core/feathers';
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionStreamsService } from './session-streams.js';
+
+function makeApp(sessionsGet: (id: string, params: unknown) => Promise<unknown>) {
+  const join = vi.fn();
+  const leave = vi.fn();
+  const channel = vi.fn(() => ({ join, leave }));
+  const get = vi.fn(sessionsGet);
+  const app = {
+    channel,
+    service: vi.fn((path: string) => {
+      if (path === 'sessions') return { get };
+      throw new Error(`Unexpected service: ${path}`);
+    }),
+  } as unknown as Application;
+  return { app, join, leave, channel, get };
+}
+
+const connection = { id: 'socket-1' };
+
+describe('session-streams service', () => {
+  it('joins the per-session channel after an access check passes', async () => {
+    const { app, join, channel, get } = makeApp(async () => ({ session_id: 's1' }));
+    const service = createSessionStreamsService(app);
+
+    const result = await service.create({ session_id: 's1' }, {
+      connection,
+      provider: 'socketio',
+    } as never);
+
+    expect(get).toHaveBeenCalledWith('s1', expect.objectContaining({ query: {} }));
+    expect(channel).toHaveBeenCalledWith('session-stream:s1');
+    expect(join).toHaveBeenCalledWith(connection);
+    expect(result).toEqual({ session_id: 's1', subscribed: true });
+  });
+
+  it('rejects a subscription to an inaccessible session and does not join', async () => {
+    const { app, join, get } = makeApp(async () => {
+      throw new Error('Forbidden');
+    });
+    const service = createSessionStreamsService(app);
+
+    await expect(
+      service.create({ session_id: 's1' }, { connection, provider: 'socketio' } as never)
+    ).rejects.toThrow('Forbidden');
+    expect(get).toHaveBeenCalled();
+    expect(join).not.toHaveBeenCalled();
+  });
+
+  it('requires a realtime connection', async () => {
+    const { app, get } = makeApp(async () => ({ session_id: 's1' }));
+    const service = createSessionStreamsService(app);
+
+    await expect(
+      service.create({ session_id: 's1' }, { provider: 'rest' } as never)
+    ).rejects.toThrow(/realtime connection/);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('requires a session_id', async () => {
+    const { app } = makeApp(async () => ({ session_id: 's1' }));
+    const service = createSessionStreamsService(app);
+
+    await expect(service.create({}, { connection, provider: 'socketio' } as never)).rejects.toThrow(
+      /session_id/
+    );
+  });
+
+  it('leaves the per-session channel on unsubscribe', async () => {
+    const { app, leave, channel } = makeApp(async () => ({ session_id: 's1' }));
+    const service = createSessionStreamsService(app);
+
+    const result = await service.remove('s1', { connection, provider: 'socketio' } as never);
+
+    expect(channel).toHaveBeenCalledWith('session-stream:s1');
+    expect(leave).toHaveBeenCalledWith(connection);
+    expect(result).toEqual({ session_id: 's1', subscribed: false });
+  });
+});

--- a/apps/agor-daemon/src/services/session-streams.ts
+++ b/apps/agor-daemon/src/services/session-streams.ts
@@ -1,0 +1,64 @@
+import type { Application } from '@agor/core/feathers';
+import { BadRequest } from '@agor/core/feathers';
+import type { Params } from '@agor/core/types';
+import { joinSessionStreamChannel, leaveSessionStreamChannel } from '../utils/realtime-publish.js';
+
+/**
+ * `session-streams` — a realtime control-plane service that lets a browser
+ * declare interest in a session's streaming events. Subscribing joins the
+ * calling CONNECTION to the per-session stream channel so the daemon can route
+ * high-frequency streaming chunks to only the tabs viewing that session,
+ * instead of broadcasting them to the whole tenant.
+ *
+ * Access is gated by a tenant-scoped `sessions.get`, which runs the same auth /
+ * tenant / branch-view checks a normal session read does — no weaker path to a
+ * session's live text than to its stored messages. Feathers drops connections
+ * from channels automatically on disconnect, so unsubscribe on refresh /
+ * navigation is best-effort; the socket teardown is the real cleanup.
+ */
+export interface SessionStreamSubscription {
+  session_id: string;
+  subscribed: boolean;
+}
+
+interface SubscribeData {
+  session_id?: string;
+  sessionId?: string;
+}
+
+export function createSessionStreamsService(app: Application) {
+  const assertAccessible = async (sessionId: string, params: Params): Promise<void> => {
+    // Reuse the canonical session read as the access gate. Neutralize the
+    // query so the sessions query validator doesn't reject control-plane
+    // params, but preserve provider/connection/user/tenant so tenant scoping
+    // and branch-view RBAC still apply.
+    await app
+      .service('sessions')
+      .get(sessionId as never, { ...(params ?? {}), query: {} } as never);
+  };
+
+  return {
+    async create(data: SubscribeData, params: Params): Promise<SessionStreamSubscription> {
+      const connection = (params as { connection?: unknown } | undefined)?.connection;
+      if (!connection) {
+        throw new BadRequest('session stream subscription requires a realtime connection');
+      }
+      const sessionId = data?.session_id ?? data?.sessionId;
+      if (!sessionId || typeof sessionId !== 'string') {
+        throw new BadRequest('session_id is required');
+      }
+      await assertAccessible(sessionId, params);
+      joinSessionStreamChannel(app, sessionId, connection);
+      return { session_id: sessionId, subscribed: true };
+    },
+
+    async remove(id: string, params: Params): Promise<SessionStreamSubscription> {
+      const connection = (params as { connection?: unknown } | undefined)?.connection;
+      const sessionId = typeof id === 'string' ? id : '';
+      if (connection && sessionId) {
+        leaveSessionStreamChannel(app, sessionId, connection);
+      }
+      return { session_id: sessionId, subscribed: false };
+    },
+  };
+}

--- a/apps/agor-daemon/src/services/session-streams.ts
+++ b/apps/agor-daemon/src/services/session-streams.ts
@@ -26,6 +26,13 @@ interface SubscribeData {
   sessionId?: string;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** A full session UUID needs no short-id/alias resolution before leaving. */
+function isCanonicalSessionId(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
 export function createSessionStreamsService(app: Application) {
   // Reuse the canonical session read as the access gate AND to resolve the
   // caller-supplied id (which may be a short id / alias) to the row's full
@@ -69,15 +76,19 @@ export function createSessionStreamsService(app: Application) {
       if (!connection || !sessionId) {
         return { session_id: sessionId, subscribed: false };
       }
-      // Resolve to the canonical room id when possible so we leave the room we
-      // actually joined. Unsubscribing must not require access (a revoked user
-      // still needs to leave), so fall back to the raw id if the read fails.
+      // The client sends the canonical (full UUID) id it stored from subscribe,
+      // so skip the resolving round-trip when the id is already canonical. Only
+      // a short-id / alias caller needs a lookup. Unsubscribing must not require
+      // access (a revoked user still needs to leave), so fall back to the raw id
+      // if the read fails.
       let canonicalId = sessionId;
-      try {
-        canonicalId = (await resolveAccessibleSessionId(sessionId, params)) ?? sessionId;
-      } catch {
-        // Best-effort: leave under the supplied id; socket teardown is the
-        // ultimate cleanup regardless.
+      if (!isCanonicalSessionId(sessionId)) {
+        try {
+          canonicalId = (await resolveAccessibleSessionId(sessionId, params)) ?? sessionId;
+        } catch {
+          // Best-effort: leave under the supplied id; socket teardown is the
+          // ultimate cleanup regardless.
+        }
       }
       leaveSessionStreamChannel(app, canonicalId, connection);
       return { session_id: canonicalId, subscribed: false };

--- a/apps/agor-daemon/src/services/session-streams.ts
+++ b/apps/agor-daemon/src/services/session-streams.ts
@@ -27,14 +27,23 @@ interface SubscribeData {
 }
 
 export function createSessionStreamsService(app: Application) {
-  const assertAccessible = async (sessionId: string, params: Params): Promise<void> => {
-    // Reuse the canonical session read as the access gate. Neutralize the
-    // query so the sessions query validator doesn't reject control-plane
-    // params, but preserve provider/connection/user/tenant so tenant scoping
-    // and branch-view RBAC still apply.
-    await app
+  // Reuse the canonical session read as the access gate AND to resolve the
+  // caller-supplied id (which may be a short id / alias) to the row's full
+  // session_id. Neutralize the query so the sessions query validator doesn't
+  // reject control-plane params, but preserve provider/connection/user/tenant
+  // so tenant scoping and branch-view RBAC still apply. Returns the canonical
+  // session_id, or null when the row carries none.
+  const resolveAccessibleSessionId = async (
+    sessionId: string,
+    params: Params
+  ): Promise<string | null> => {
+    const session = (await app
       .service('sessions')
-      .get(sessionId as never, { ...(params ?? {}), query: {} } as never);
+      .get(sessionId as never, { ...(params ?? {}), query: {} } as never)) as
+      | { session_id?: string }
+      | null
+      | undefined;
+    return session?.session_id ?? null;
   };
 
   return {
@@ -47,18 +56,31 @@ export function createSessionStreamsService(app: Application) {
       if (!sessionId || typeof sessionId !== 'string') {
         throw new BadRequest('session_id is required');
       }
-      await assertAccessible(sessionId, params);
-      joinSessionStreamChannel(app, sessionId, connection);
-      return { session_id: sessionId, subscribed: true };
+      // Join the CANONICAL room id so short-id / alias callers land in the same
+      // room publishers emit to (they carry the full UUID).
+      const canonicalId = (await resolveAccessibleSessionId(sessionId, params)) ?? sessionId;
+      joinSessionStreamChannel(app, canonicalId, connection);
+      return { session_id: canonicalId, subscribed: true };
     },
 
     async remove(id: string, params: Params): Promise<SessionStreamSubscription> {
       const connection = (params as { connection?: unknown } | undefined)?.connection;
       const sessionId = typeof id === 'string' ? id : '';
-      if (connection && sessionId) {
-        leaveSessionStreamChannel(app, sessionId, connection);
+      if (!connection || !sessionId) {
+        return { session_id: sessionId, subscribed: false };
       }
-      return { session_id: sessionId, subscribed: false };
+      // Resolve to the canonical room id when possible so we leave the room we
+      // actually joined. Unsubscribing must not require access (a revoked user
+      // still needs to leave), so fall back to the raw id if the read fails.
+      let canonicalId = sessionId;
+      try {
+        canonicalId = (await resolveAccessibleSessionId(sessionId, params)) ?? sessionId;
+      } catch {
+        // Best-effort: leave under the supplied id; socket teardown is the
+        // ultimate cleanup regardless.
+      }
+      leaveSessionStreamChannel(app, canonicalId, connection);
+      return { session_id: canonicalId, subscribed: false };
     },
   };
 }

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -28,6 +28,7 @@ import type {
 import jwt from 'jsonwebtoken';
 import type { Server, Socket } from 'socket.io';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
+import { leaveAllSessionStreamChannels } from '../utils/realtime-publish.js';
 import type { BuildInfo } from './build-info.js';
 import type { CorsOrigin } from './cors.js';
 
@@ -905,6 +906,10 @@ export function configureChannels(
             .leave(context.connection as never);
         }
       }
+      // Streaming rooms are separate per-session channels; drop the logged-out
+      // connection from all of them so it stops receiving live session text
+      // while it remains socket-connected.
+      leaveAllSessionStreamChannels(app, context.connection);
     }
   });
 }

--- a/apps/agor-daemon/src/utils/realtime-access-cache.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-access-cache.test.ts
@@ -37,6 +37,38 @@ describe('RealtimeAccessCache', () => {
     expect(sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledTimes(2);
   });
 
+  it('caches the session owner id and invalidates it with the session', async () => {
+    let now = 1_000;
+    const branchRepository = {
+      findRealtimeVisibilityBranch: vi.fn(),
+      findExplicitViewUserIds: vi.fn(),
+    } as unknown as RealtimeAccessBranchRepository;
+    const sessionsRepository = {
+      findBranchIdBySessionId: vi.fn(async () => 'b1'),
+      findCreatedByBySessionId: vi.fn(async () => 'owner-1'),
+    } as unknown as RealtimeAccessSessionRepository;
+    const cache = new RealtimeAccessCache({
+      branchRepository,
+      sessionsRepository,
+      sessionBranchTtlMs: 60_000,
+      now: () => now,
+    });
+
+    await expect(cache.getSessionOwnerId('s1')).resolves.toBe('owner-1');
+    await expect(cache.getSessionOwnerId('s1')).resolves.toBe('owner-1');
+    expect(sessionsRepository.findCreatedByBySessionId).toHaveBeenCalledTimes(1);
+
+    // Invalidation forces a fresh lookup on the next read.
+    cache.invalidateSession('s1');
+    await expect(cache.getSessionOwnerId('s1')).resolves.toBe('owner-1');
+    expect(sessionsRepository.findCreatedByBySessionId).toHaveBeenCalledTimes(2);
+
+    // And the ttl still applies.
+    now += 60_001;
+    await cache.getSessionOwnerId('s1');
+    expect(sessionsRepository.findCreatedByBySessionId).toHaveBeenCalledTimes(3);
+  });
+
   it('uses separate ttl values for session and branch caches', async () => {
     let now = 1_000;
     const branchRepository = {

--- a/apps/agor-daemon/src/utils/realtime-access-cache.ts
+++ b/apps/agor-daemon/src/utils/realtime-access-cache.ts
@@ -14,6 +14,7 @@ export type RealtimeAccessBranchRepository = {
 
 export type RealtimeAccessSessionRepository = {
   findBranchIdBySessionId(sessionId: string): Promise<BranchID | null>;
+  findCreatedByBySessionId(sessionId: string): Promise<UUID | null>;
 };
 
 type BranchVisibilityCacheEntry = BranchRealtimeVisibility & {
@@ -22,6 +23,11 @@ type BranchVisibilityCacheEntry = BranchRealtimeVisibility & {
 
 type SessionBranchCacheEntry = {
   branchId: BranchID | null;
+  expiresAt: number;
+};
+
+type SessionOwnerCacheEntry = {
+  ownerId: UserID | null;
   expiresAt: number;
 };
 
@@ -50,6 +56,7 @@ function branchAllowsAllAuthenticated(branch: Pick<Branch, 'others_can'>): boole
 export class RealtimeAccessCache {
   private readonly branchVisibility = new Map<BranchID, BranchVisibilityCacheEntry>();
   private readonly sessionBranches = new Map<string, SessionBranchCacheEntry>();
+  private readonly sessionOwners = new Map<string, SessionOwnerCacheEntry>();
   private readonly branchVisibilityTtlMs: number;
   private readonly sessionBranchTtlMs: number;
   private readonly now: () => number;
@@ -75,6 +82,30 @@ export class RealtimeAccessCache {
       expiresAt: now + this.sessionBranchTtlMs,
     });
     return branchId;
+  }
+
+  /**
+   * Owning user id for a session, cached on the same cadence as the
+   * session→branch map. Used only to offer streaming events to the session
+   * creator's own connections as a fallback when they haven't subscribed to
+   * the per-session stream channel yet.
+   */
+  async getSessionOwnerId(sessionId: string): Promise<UserID | null> {
+    const cached = this.sessionOwners.get(sessionId);
+    const now = this.now();
+    if (cached && cached.expiresAt > now) {
+      return cached.ownerId;
+    }
+
+    const ownerId =
+      ((await this.options.sessionsRepository.findCreatedByBySessionId(
+        sessionId
+      )) as UserID | null) ?? null;
+    this.sessionOwners.set(sessionId, {
+      ownerId,
+      expiresAt: now + this.sessionBranchTtlMs,
+    });
+    return ownerId;
   }
 
   async getBranchVisibility(branchId: BranchID): Promise<BranchRealtimeVisibility | null> {
@@ -119,6 +150,7 @@ export class RealtimeAccessCache {
 
   invalidateSession(sessionId: string): void {
     this.sessionBranches.delete(sessionId);
+    this.sessionOwners.delete(sessionId);
   }
 
   clearVisibility(): void {
@@ -128,6 +160,7 @@ export class RealtimeAccessCache {
   clearAll(): void {
     this.branchVisibility.clear();
     this.sessionBranches.clear();
+    this.sessionOwners.clear();
   }
 
   private visibilityFromEntry(entry: BranchVisibilityCacheEntry): BranchRealtimeVisibility {

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -24,8 +24,19 @@ function makeApp(
   channels: Record<string, unknown[]> = {}
 ) {
   let publishFn: ((data: unknown, context: any) => unknown) | undefined;
+  // Names accessed via the channel factory — mirrors Feathers materializing a
+  // channel on lookup, so tests can assert the publish path did NOT create a
+  // room.
+  const created = new Set<string>();
   const app = {
-    channel: vi.fn((name: string) => new FakeChannel(channels[name] ?? connections)),
+    // Provided channels plus any materialized by a channel lookup.
+    get channels() {
+      return [...new Set([...Object.keys(channels), ...created])];
+    },
+    channel: vi.fn((name: string) => {
+      created.add(name);
+      return new FakeChannel(channels[name] ?? connections);
+    }),
     publish: vi.fn((fn) => {
       publishFn = fn;
     }),
@@ -941,6 +952,66 @@ describe('configureRealtimePublish streaming scope', () => {
     );
 
     expect(unionConnections(result)).toEqual([owner]);
+  });
+
+  it('does not materialize a room for a session with no subscribers', async () => {
+    // No `session-stream:s1` channel provided → the session has no subscribers.
+    const viewer = { user: user('viewer') };
+    const app = makeApp([viewer], {}, { authenticated: [viewer] });
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    await app.runPublish({ session_id: 's1', message_id: 'm1', chunk: 'hello' }, streamingContext);
+
+    // The publish path must not have created the empty room.
+    expect(app.channels).not.toContain('session-stream:s1');
+  });
+
+  it('delivers to a subscribed session whose room already exists', async () => {
+    const subscribed = { user: user('subscribed') };
+    const app = makeApp(
+      [subscribed],
+      {},
+      {
+        authenticated: [subscribed],
+        'session-stream:s1': [subscribed],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hello' },
+      streamingContext
+    );
+
+    expect(app.channels).toContain('session-stream:s1');
+    expect(unionConnections(result)).toEqual([subscribed]);
+  });
+
+  it('does not resurrect the room after the last subscriber has left', async () => {
+    // The room was pruned when its last subscriber left, so it is absent again.
+    const viewer = { user: user('viewer') };
+    const app = makeApp([viewer], {}, { authenticated: [viewer] });
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    await app.runPublish({ session_id: 's1', message_id: 'm1', chunk: 'a' }, streamingContext);
+    await app.runPublish({ session_id: 's1', message_id: 'm1', chunk: 'b' }, streamingContext);
+
+    expect(app.channels).not.toContain('session-stream:s1');
   });
 
   it('excludes a room member no longer in the tenant/auth channel (logout fail-open guard, RBAC off)', async () => {

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -857,4 +857,89 @@ describe('configureRealtimePublish streaming scope', () => {
 
     expect(unionConnections(result)).toEqual([subscribed]);
   });
+
+  it('drops a subscribed connection whose branch access was revoked (RBAC on)', async () => {
+    // Both are in the room, but only `allowed` currently holds view on the
+    // explicit-users branch. Publish-time filtering must exclude `revoked`
+    // rather than trust its stale room membership.
+    const allowed = { user: user('allowed') };
+    const revoked = { user: user('revoked') };
+    const app = makeApp(
+      [allowed, revoked],
+      {},
+      {
+        authenticated: [allowed, revoked],
+        'session-stream:s1': [allowed, revoked],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      permissions: { allowed: 'view' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hello' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([allowed]);
+  });
+
+  it('drops the owner fallback when the owner lost branch access (RBAC on)', async () => {
+    // Nobody is subscribed; the owner is the only candidate, but their view was
+    // revoked, so the owner-fallback must NOT deliver.
+    const owner = { user: user('owner-user') };
+    const viewer = { user: user('viewer') };
+    const app = makeApp(
+      [owner, viewer],
+      {},
+      {
+        authenticated: [owner, viewer],
+        'session-stream:s1': [],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      permissions: { viewer: 'view' },
+      owner: 'owner-user',
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hello' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([]);
+  });
+
+  it('delivers to the owner fallback while they retain branch access (RBAC on)', async () => {
+    const owner = { user: user('owner-user') };
+    const other = { user: user('other') };
+    const app = makeApp(
+      [owner, other],
+      {},
+      {
+        authenticated: [owner, other],
+        'session-stream:s1': [],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'none'),
+      session: session('s1', 'b1'),
+      permissions: { 'owner-user': 'view' },
+      owner: 'owner-user',
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hello' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([owner]);
+  });
 });

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -60,6 +60,8 @@ function repos(options: {
   branch: Branch;
   session?: Session | null;
   permissions: Record<string, Branch['others_can']>;
+  /** Owning user id returned by findCreatedByBySessionId (owner-fallback tests). */
+  owner?: string | null;
 }) {
   const viewableUserIds = Object.entries(options.permissions)
     .filter(([, permission]) =>
@@ -75,6 +77,9 @@ function repos(options: {
   const sessionsRepository = {
     findBranchIdBySessionId: vi.fn(async (id: string) =>
       options.session?.session_id === id ? options.session.branch_id : null
+    ),
+    findCreatedByBySessionId: vi.fn(async (id: string) =>
+      options.session?.session_id === id ? (options.owner ?? null) : null
     ),
   } as unknown as RealtimeAccessSessionRepository;
   return { branchRepository, sessionsRepository };
@@ -463,31 +468,40 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }, service]);
   });
 
-  it('caches session branch and branch visibility across streaming events', async () => {
-    const allowed = user('allowed');
-    const denied = user('denied');
-    const app = makeApp([{ user: allowed }, { user: denied }]);
+  it('caches the session owner lookup across repeated streaming chunks', async () => {
+    // Streaming chunks are no longer branch-scoped — they route to the session
+    // room plus the owner fallback — so the per-chunk work is the owner lookup,
+    // which must be cached rather than hitting the DB on every chunk.
+    const owner = { user: user('owner-user') };
+    const other = { user: user('other') };
+    const app = makeApp(
+      [owner, other],
+      {},
+      {
+        authenticated: [owner, other],
+        'session-stream:s1': [],
+      }
+    );
     const r = repos({
-      branch: branch('b1', 'none'),
+      branch: branch('b1', 'view'),
       session: session('s1', 'b1'),
-      permissions: { allowed: 'view', denied: 'none' },
+      permissions: {},
+      owner: 'owner-user',
     });
     configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
 
     const first = await app.runPublish(
       { message_id: 'm1', session_id: 's1', chunk: 'a' },
-      { path: 'messages', method: 'emit', event: 'streaming:chunk' }
+      { path: 'messages', method: 'emit', event: 'streaming:chunk', params: {} }
     );
     const second = await app.runPublish(
       { message_id: 'm1', session_id: 's1', chunk: 'b' },
-      { path: 'messages', method: 'emit', event: 'streaming:chunk' }
+      { path: 'messages', method: 'emit', event: 'streaming:chunk', params: {} }
     );
 
-    expect(first.connections).toEqual([{ user: allowed }]);
-    expect(second.connections).toEqual([{ user: allowed }]);
-    expect(r.sessionsRepository.findBranchIdBySessionId).toHaveBeenCalledTimes(1);
-    expect(r.branchRepository.findRealtimeVisibilityBranch).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(r.branchRepository.findExplicitViewUserIds)).toHaveBeenCalledTimes(1);
+    expect(unionConnections(first)).toEqual([owner]);
+    expect(unionConnections(second)).toEqual([owner]);
+    expect(r.sessionsRepository.findCreatedByBySessionId).toHaveBeenCalledTimes(1);
   });
 
   it('resolves custom sessions events through camelCase sessionId', async () => {
@@ -662,5 +676,185 @@ describe('configureRealtimePublish', () => {
 
     expect(channel.connections).toEqual([service]);
     expect(tasksGet).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Streaming events (per-chunk message/thinking deltas and task tool events) are
+ * routed to the per-session stream room, service connections, and the session
+ * owner's connections — never the whole tenant. The publish handler returns an
+ * array of channels for these; Feathers unions them, so tests collapse the
+ * array to a unique connection set.
+ */
+function unionConnections(result: unknown): unknown[] {
+  const channels = Array.isArray(result) ? result : [result];
+  const seen = new Set<unknown>();
+  const out: unknown[] = [];
+  for (const channel of channels) {
+    for (const connection of (channel as FakeChannel).connections) {
+      if (!seen.has(connection)) {
+        seen.add(connection);
+        out.push(connection);
+      }
+    }
+  }
+  return out;
+}
+
+describe('configureRealtimePublish streaming scope', () => {
+  const streamingContext = {
+    path: 'messages',
+    method: 'create',
+    event: 'streaming:chunk',
+    params: {},
+  };
+
+  it('delivers a streaming chunk to subscribed connections, not other authenticated tabs', async () => {
+    const viewer = { user: user('viewer') };
+    const subscribed = { user: user('subscribed') };
+    const app = makeApp(
+      [viewer, subscribed],
+      {},
+      {
+        authenticated: [viewer, subscribed],
+        'session-stream:s1': [subscribed],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hello' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([subscribed]);
+  });
+
+  it('still delivers streaming chunks to service-account connections (gateway/Slack)', async () => {
+    const viewer = { user: user('viewer') };
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp(
+      [viewer, service],
+      {},
+      {
+        authenticated: [viewer, service],
+        'session-stream:s1': [],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hi' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([service]);
+  });
+
+  it('delivers to the session owner as a fallback even when they have not subscribed', async () => {
+    const owner = { user: user('owner-user') };
+    const other = { user: user('other-user') };
+    const app = makeApp(
+      [owner, other],
+      {},
+      {
+        authenticated: [owner, other],
+        'session-stream:s1': [],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+      owner: 'owner-user',
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hi' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([owner]);
+  });
+
+  it('routes tasks tool:start events through the same session scoping', async () => {
+    const subscribed = { user: user('subscribed') };
+    const other = { user: user('other') };
+    const app = makeApp(
+      [subscribed, other],
+      {},
+      {
+        authenticated: [subscribed, other],
+        'session-stream:s1': [subscribed],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', task_id: 't1', tool_use_id: 'x', tool_name: 'Bash' },
+      { path: 'tasks', method: 'create', event: 'tool:start', params: {} }
+    );
+
+    expect(unionConnections(result)).toEqual([subscribed]);
+  });
+
+  it('fails closed to service connections when a streaming event carries no session id', async () => {
+    const viewer = { user: user('viewer') };
+    const service = { user: { _isServiceAccount: true, role: 'service' } };
+    const app = makeApp(
+      [viewer, service],
+      {},
+      {
+        authenticated: [viewer, service],
+      }
+    );
+    const r = repos({ branch: branch('b1', 'view'), permissions: {} });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const result = await app.runPublish({ message_id: 'm1', chunk: 'orphan' }, streamingContext);
+
+    expect(unionConnections(result)).toEqual([service]);
+  });
+
+  it('scopes streaming even when branch RBAC is enabled', async () => {
+    const subscribed = { user: user('subscribed') };
+    const other = { user: user('other') };
+    const app = makeApp(
+      [subscribed, other],
+      {},
+      {
+        authenticated: [subscribed, other],
+        'session-stream:s1': [subscribed],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: { subscribed: 'view', other: 'view' },
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: true, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hello' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([subscribed]);
   });
 });

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -6,7 +6,7 @@ import type {
   RealtimeAccessBranchRepository,
   RealtimeAccessSessionRepository,
 } from './realtime-access-cache';
-import { configureRealtimePublish } from './realtime-publish';
+import { configureRealtimePublish, leaveAllSessionStreamChannels } from './realtime-publish';
 
 class FakeChannel {
   constructor(public connections: unknown[]) {}
@@ -941,5 +941,58 @@ describe('configureRealtimePublish streaming scope', () => {
     );
 
     expect(unionConnections(result)).toEqual([owner]);
+  });
+
+  it('excludes a room member no longer in the tenant/auth channel (logout fail-open guard, RBAC off)', async () => {
+    // `loggedOut` still sits in the session-stream room (Feathers only drops
+    // room membership on socket disconnect) but has been removed from the
+    // authenticated channel. Intersecting the room with tenantScoped must keep
+    // streaming from reaching it — this is the RBAC-off path that would
+    // otherwise return the room unfiltered.
+    const active = { user: user('active') };
+    const loggedOut = { user: user('gone') };
+    const app = makeApp(
+      [active],
+      {},
+      {
+        authenticated: [active],
+        'session-stream:s1': [active, loggedOut],
+      }
+    );
+    const r = repos({
+      branch: branch('b1', 'view'),
+      session: session('s1', 'b1'),
+      permissions: {},
+    });
+    configureRealtimePublish({ app, branchRbacEnabled: false, ...r });
+
+    const result = await app.runPublish(
+      { session_id: 's1', message_id: 'm1', chunk: 'hello' },
+      streamingContext
+    );
+
+    expect(unionConnections(result)).toEqual([active]);
+  });
+});
+
+describe('leaveAllSessionStreamChannels', () => {
+  it('leaves only session-stream rooms for the connection', () => {
+    const leaves: Array<[string, unknown]> = [];
+    const app = {
+      channels: ['authenticated', 'tenant:default', 'session-stream:s1', 'session-stream:s2'],
+      channel: (name: string) => ({
+        leave: (connection: unknown) => {
+          leaves.push([name, connection]);
+        },
+      }),
+    } as unknown as Parameters<typeof leaveAllSessionStreamChannels>[0];
+    const connection = { id: 'c1' };
+
+    leaveAllSessionStreamChannels(app, connection);
+
+    expect(leaves).toEqual([
+      ['session-stream:s1', connection],
+      ['session-stream:s2', connection],
+    ]);
   });
 });

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -52,6 +52,18 @@ export function leaveAllSessionStreamChannels(app: Application, connection: unkn
 }
 
 /**
+ * Return an existing channel by name, or null if it has never been created.
+ * Feathers' channel lookup MATERIALIZES the channel when absent — and a channel
+ * with no joined connection is never auto-cleaned (Feathers only prunes on the
+ * last leave) — so the publish path must not touch a room that has no
+ * subscribers. Only `session-streams.create` (a real join) should create the
+ * room; joined channels get Feathers' empty-cleanup on leave/disconnect.
+ */
+function existingChannel(app: Application, name: string): PublishChannel | null {
+  return (app.channels ?? []).includes(name) ? app.channel(name) : null;
+}
+
+/**
  * Join a connection to a session's streaming room. Centralized here (the
  * tenant-aware realtime facade) so subscribe/publish share one channel name
  * and the raw `app.channel` surface stays in a single audited file.
@@ -396,8 +408,13 @@ async function resolveStreamingDelivery(
   const tenantConnections = new Set<unknown>(
     (tenantScoped as unknown as { connections: unknown[] }).connections
   );
-  const roomChannel = app.channel(sessionStreamChannelName(sessionId));
-  const room = roomChannel.filter((connection: unknown) => tenantConnections.has(connection));
+  // Never materialize the room on the publish path — a session streaming with
+  // zero subscribers would otherwise accumulate an empty, never-cleaned channel
+  // per session. Only an actual subscribe (join) creates it.
+  const existingRoom = existingChannel(app, sessionStreamChannelName(sessionId));
+  const room = existingRoom
+    ? existingRoom.filter((connection: unknown) => tenantConnections.has(connection))
+    : null;
 
   let ownerId: string | null = null;
   try {
@@ -413,7 +430,8 @@ async function resolveStreamingDelivery(
 
   // RBAC off: no visibility model — deliver to subscribers + owner + service.
   if (!branchRbacEnabled) {
-    const channels: PublishChannel[] = [room, serviceConnections];
+    const channels: PublishChannel[] = [serviceConnections];
+    if (room) channels.push(room);
     if (ownerId) channels.push(ownerChannel());
     return channels;
   }
@@ -425,17 +443,18 @@ async function resolveStreamingDelivery(
   if (!visibility) return serviceConnections;
 
   if (visibility.mode === 'allAuthenticated') {
-    const channels: PublishChannel[] = [room, serviceConnections];
+    const channels: PublishChannel[] = [serviceConnections];
+    if (room) channels.push(room);
     if (ownerId) channels.push(ownerChannel());
     return channels;
   }
 
   // Explicit-users branch: room members and the owner fallback must currently
   // hold view access (service accounts and superadmins always pass).
-  const channels: PublishChannel[] = [
-    filterToUserIdsOrSuperadmins(room, visibility.userIds, allowSuperadmin),
-    serviceConnections,
-  ];
+  const channels: PublishChannel[] = [serviceConnections];
+  if (room) {
+    channels.push(filterToUserIdsOrSuperadmins(room, visibility.userIds, allowSuperadmin));
+  }
   if (ownerId && visibility.userIds.has(ownerId as UserID)) {
     channels.push(ownerChannel());
   }

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -346,6 +346,14 @@ function filterToServiceConnections(authenticated: PublishChannel): PublishChann
  *      already-open tabs keep updating during deploy skew, before a
  *      stale-cached client has re-subscribed after refresh.
  *
+ * Authorization is enforced at PUBLISH time, not just at subscribe time: when
+ * branch RBAC is on, room members AND the owner fallback are filtered through
+ * the current cached branch visibility, so a viewer whose access is revoked
+ * mid-stream stops receiving chunks on the very next event (rather than waiting
+ * for unsubscribe / disconnect). The cache keeps this per-chunk cost cheap, and
+ * room membership is small. With RBAC off there is no visibility model, so
+ * subscription + owner + service delivery stands.
+ *
  * Everything else (created/patched/removed, status transitions) keeps its
  * existing tenant/branch scoping. Malformed events without a resolvable
  * session id fail closed to service connections only.
@@ -354,16 +362,15 @@ async function resolveStreamingDelivery(
   app: Application,
   data: unknown,
   tenantScoped: PublishChannel,
-  accessCache: RealtimeAccessCache
+  accessCache: RealtimeAccessCache,
+  branchRbacEnabled: boolean,
+  allowSuperadmin: boolean
 ): Promise<PublishChannel | PublishChannel[]> {
   const serviceConnections = filterToServiceConnections(tenantScoped);
   const sessionId = extractSessionId(data);
   if (!sessionId) return serviceConnections;
 
-  const channels: PublishChannel[] = [
-    app.channel(sessionStreamChannelName(sessionId)),
-    serviceConnections,
-  ];
+  const room = app.channel(sessionStreamChannelName(sessionId));
 
   let ownerId: string | null = null;
   try {
@@ -372,14 +379,39 @@ async function resolveStreamingDelivery(
     // Best-effort owner fallback; the session room + service connections still
     // deliver even if the owner lookup fails.
   }
-  if (ownerId) {
-    channels.push(
-      tenantScoped.filter(
-        (connection: unknown) => userFromConnection(connection)?.user_id === ownerId
-      )
+  const ownerChannel = (): PublishChannel =>
+    tenantScoped.filter(
+      (connection: unknown) => userFromConnection(connection)?.user_id === ownerId
     );
+
+  // RBAC off: no visibility model — deliver to subscribers + owner + service.
+  if (!branchRbacEnabled) {
+    const channels: PublishChannel[] = [room, serviceConnections];
+    if (ownerId) channels.push(ownerChannel());
+    return channels;
   }
 
+  // RBAC on: enforce CURRENT branch visibility at publish time. Resolving the
+  // branch/visibility fails closed to service connections if unknown.
+  const branchId = await accessCache.getBranchIdForSession(sessionId);
+  const visibility = branchId ? await accessCache.getBranchVisibility(branchId) : null;
+  if (!visibility) return serviceConnections;
+
+  if (visibility.mode === 'allAuthenticated') {
+    const channels: PublishChannel[] = [room, serviceConnections];
+    if (ownerId) channels.push(ownerChannel());
+    return channels;
+  }
+
+  // Explicit-users branch: room members and the owner fallback must currently
+  // hold view access (service accounts and superadmins always pass).
+  const channels: PublishChannel[] = [
+    filterToUserIdsOrSuperadmins(room, visibility.userIds, allowSuperadmin),
+    serviceConnections,
+  ];
+  if (ownerId && visibility.userIds.has(ownerId as UserID)) {
+    channels.push(ownerChannel());
+  }
   return channels;
 }
 
@@ -497,7 +529,14 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     // owner connections) regardless of branch RBAC — this is the always-on
     // firehose the tenant broadcast must not carry.
     if (isStreamingEvent(context)) {
-      return resolveStreamingDelivery(app, data, tenantScoped, accessCache);
+      return resolveStreamingDelivery(
+        app,
+        data,
+        tenantScoped,
+        accessCache,
+        branchRbacEnabled,
+        allowSuperadmin
+      );
     }
 
     if (!branchRbacEnabled) return tenantScoped;

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -44,7 +44,7 @@ export function sessionStreamChannelName(sessionId: string): string {
  * still sit in a session-stream room).
  */
 export function leaveAllSessionStreamChannels(app: Application, connection: unknown): void {
-  for (const name of app.channels) {
+  for (const name of app.channels ?? []) {
     if (name.startsWith(SESSION_STREAM_CHANNEL_PREFIX)) {
       app.channel(name).leave(connection as never);
     }

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -76,13 +76,19 @@ export function joinSessionStreamChannel(
   app.channel(sessionStreamChannelName(sessionId)).join(connection as never);
 }
 
-/** Remove a connection from a session's streaming room. */
+/**
+ * Remove a connection from a session's streaming room, but only if the room
+ * already exists. A `remove` for a never-joined room (any authenticated caller
+ * can send one) or a dispose after logout/disconnect already pruned the room
+ * would otherwise re-materialize an empty, never-cleaned channel — the same
+ * leak class as the publish path. `.leave` on an absent room is a no-op anyway.
+ */
 export function leaveSessionStreamChannel(
   app: Application,
   sessionId: string,
   connection: unknown
 ): void {
-  app.channel(sessionStreamChannelName(sessionId)).leave(connection as never);
+  existingChannel(app, sessionStreamChannelName(sessionId))?.leave(connection as never);
 }
 
 const DEBUG_REALTIME_PUBLISH =

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -29,8 +29,26 @@ function tenantChannelName(tenantId: string): string {
  * additionally impossible because the subscribe path gates on a tenant-scoped
  * `sessions.get`.
  */
+const SESSION_STREAM_CHANNEL_PREFIX = 'session-stream:';
+
 export function sessionStreamChannelName(sessionId: string): string {
-  return `session-stream:${sessionId}`;
+  return `${SESSION_STREAM_CHANNEL_PREFIX}${sessionId}`;
+}
+
+/**
+ * Remove a connection from every session-stream room it has joined. Called on
+ * logout so a still-connected-but-deauthenticated socket stops receiving live
+ * session text — Feathers only auto-drops channel membership on socket
+ * disconnect, and streaming delivery would otherwise keep reaching a logged-out
+ * connection (which is no longer in the authenticated/tenant channels but may
+ * still sit in a session-stream room).
+ */
+export function leaveAllSessionStreamChannels(app: Application, connection: unknown): void {
+  for (const name of app.channels) {
+    if (name.startsWith(SESSION_STREAM_CHANNEL_PREFIX)) {
+      app.channel(name).leave(connection as never);
+    }
+  }
 }
 
 /**
@@ -370,7 +388,17 @@ async function resolveStreamingDelivery(
   const sessionId = extractSessionId(data);
   if (!sessionId) return serviceConnections;
 
-  const room = app.channel(sessionStreamChannelName(sessionId));
+  // Intersect the room with the tenant/auth channel: a connection that logged
+  // out (removed from authenticated + tenant channels) or was tenant-evicted
+  // but is still socket-connected may linger in a session-stream room, so this
+  // structurally guarantees nothing outside the current tenant/auth set can
+  // receive — independent of the per-connection room cleanup on logout.
+  const tenantConnections = new Set<unknown>(
+    (tenantScoped as unknown as { connections: unknown[] }).connections
+  );
+  const room = app
+    .channel(sessionStreamChannelName(sessionId))
+    .filter((connection: unknown) => tenantConnections.has(connection));
 
   let ownerId: string | null = null;
   try {

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -396,9 +396,8 @@ async function resolveStreamingDelivery(
   const tenantConnections = new Set<unknown>(
     (tenantScoped as unknown as { connections: unknown[] }).connections
   );
-  const room = app
-    .channel(sessionStreamChannelName(sessionId))
-    .filter((connection: unknown) => tenantConnections.has(connection));
+  const roomChannel = app.channel(sessionStreamChannelName(sessionId));
+  const room = roomChannel.filter((connection: unknown) => tenantConnections.has(connection));
 
   let ownerId: string | null = null;
   try {

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -19,6 +19,42 @@ function tenantChannelName(tenantId: string): string {
   return `tenant:${tenantId}`;
 }
 
+/**
+ * Per-session channel that carries only the high-frequency streaming events
+ * (message text/thinking chunks, tool start/complete). Connections join this
+ * room via the `session-streams` service after passing a session-access check,
+ * so streaming traffic reaches only the tabs actively viewing a session
+ * instead of the whole tenant. Session ids are globally-unique UUIDv7, so the
+ * unprefixed name cannot collide across tenants; cross-tenant membership is
+ * additionally impossible because the subscribe path gates on a tenant-scoped
+ * `sessions.get`.
+ */
+export function sessionStreamChannelName(sessionId: string): string {
+  return `session-stream:${sessionId}`;
+}
+
+/**
+ * Join a connection to a session's streaming room. Centralized here (the
+ * tenant-aware realtime facade) so subscribe/publish share one channel name
+ * and the raw `app.channel` surface stays in a single audited file.
+ */
+export function joinSessionStreamChannel(
+  app: Application,
+  sessionId: string,
+  connection: unknown
+): void {
+  app.channel(sessionStreamChannelName(sessionId)).join(connection as never);
+}
+
+/** Remove a connection from a session's streaming room. */
+export function leaveSessionStreamChannel(
+  app: Application,
+  sessionId: string,
+  connection: unknown
+): void {
+  app.channel(sessionStreamChannelName(sessionId)).leave(connection as never);
+}
+
 const DEBUG_REALTIME_PUBLISH =
   process.env.AGOR_DEBUG_REALTIME_PUBLISH === '1' ||
   process.env.DEBUG?.includes('realtime-publish');
@@ -64,11 +100,33 @@ const SESSION_ID_SCOPED_PATHS = new Set([
 ]);
 const OPTIONAL_BRANCH_OR_SESSION_SCOPED_PATHS = new Set(['board-objects', 'board-comments']);
 
+// High-frequency per-chunk events emitted on the `messages` service during a
+// streaming turn (text + thinking deltas). These fan out once per token-batch,
+// so they must be scoped to session subscribers rather than the whole tenant.
+const MESSAGE_STREAMING_EVENTS = new Set([
+  'streaming:start',
+  'streaming:chunk',
+  'streaming:end',
+  'streaming:error',
+  'thinking:start',
+  'thinking:chunk',
+  'thinking:end',
+]);
+
+// Per-chunk / per-tool events emitted on the `tasks` service during a turn.
+const TASK_STREAMING_EVENTS = new Set(['thinking:chunk', 'tool:start', 'tool:complete']);
+
 function isStreamingEvent(context: PublishContext): boolean {
-  return (
-    context.path === 'messages/streaming' ||
-    (context.path === 'messages' && context.event?.startsWith('streaming:') === true)
-  );
+  if (context.path === 'messages/streaming') return true;
+  const event = context.event;
+  if (!event) return false;
+  if (context.path === 'messages') {
+    return event.startsWith('streaming:') || MESSAGE_STREAMING_EVENTS.has(event);
+  }
+  if (context.path === 'tasks') {
+    return TASK_STREAMING_EVENTS.has(event);
+  }
+  return false;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -276,6 +334,55 @@ function filterToServiceConnections(authenticated: PublishChannel): PublishChann
   return authenticated.filter((connection: unknown) => isServiceConnection(connection));
 }
 
+/**
+ * Delivery set for a streaming event. Streaming chunks are the dominant
+ * always-on realtime cost, so they bypass the tenant-wide broadcast and go to:
+ *
+ *   1. the per-session stream room — connections that explicitly subscribed
+ *      (session panels / transcripts that passed a session-access check),
+ *   2. service connections — gateway / Slack streaming and other service
+ *      consumers keep working exactly as before,
+ *   3. the session owner's own connections — a cheap fallback so a creator's
+ *      already-open tabs keep updating during deploy skew, before a
+ *      stale-cached client has re-subscribed after refresh.
+ *
+ * Everything else (created/patched/removed, status transitions) keeps its
+ * existing tenant/branch scoping. Malformed events without a resolvable
+ * session id fail closed to service connections only.
+ */
+async function resolveStreamingDelivery(
+  app: Application,
+  data: unknown,
+  tenantScoped: PublishChannel,
+  accessCache: RealtimeAccessCache
+): Promise<PublishChannel | PublishChannel[]> {
+  const serviceConnections = filterToServiceConnections(tenantScoped);
+  const sessionId = extractSessionId(data);
+  if (!sessionId) return serviceConnections;
+
+  const channels: PublishChannel[] = [
+    app.channel(sessionStreamChannelName(sessionId)),
+    serviceConnections,
+  ];
+
+  let ownerId: string | null = null;
+  try {
+    ownerId = await accessCache.getSessionOwnerId(sessionId);
+  } catch {
+    // Best-effort owner fallback; the session room + service connections still
+    // deliver even if the owner lookup fails.
+  }
+  if (ownerId) {
+    channels.push(
+      tenantScoped.filter(
+        (connection: unknown) => userFromConnection(connection)?.user_id === ownerId
+      )
+    );
+  }
+
+  return channels;
+}
+
 function filterToUserIdsOrAdmins(
   authenticated: PublishChannel,
   userIds: Set<string> | Set<UserID>,
@@ -386,6 +493,13 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
         throw error;
       }
     }
+    // Streaming events are routed to session subscribers (plus service and
+    // owner connections) regardless of branch RBAC — this is the always-on
+    // firehose the tenant broadcast must not carry.
+    if (isStreamingEvent(context)) {
+      return resolveStreamingDelivery(app, data, tenantScoped, accessCache);
+    }
+
     if (!branchRbacEnabled) return tenantScoped;
 
     const scope = await resolvePublishScope(data, context, accessCache);

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -26,9 +26,15 @@ interface MockClientOptions {
   tasks: Task[];
   messagesByTask: Record<string, Message[]>;
   failTaskMessageFetch?: boolean;
+  /** When true, `session-streams.create` blocks until releaseCreate() is called. */
+  deferCreate?: boolean;
 }
 
 function createMockClient(opts: MockClientOptions) {
+  // Records the relative order of subscribe vs. hydrate vs. unsubscribe so
+  // tests can assert the subscribe-before-hydrate ordering and dispose races.
+  const order: string[] = [];
+
   const messageFindAll = vi.fn(async ({ query }: { query: Record<string, unknown> }) => {
     if (typeof query.task_id === 'string') {
       if (opts.failTaskMessageFetch) {
@@ -42,13 +48,31 @@ function createMockClient(opts: MockClientOptions) {
 
   const listener = () => ({ on: vi.fn(), removeListener: vi.fn() });
 
+  let releaseCreate: (() => void) | null = null;
   const sessionStreams = {
-    create: vi.fn(async () => ({ session_id: SESSION_ID, subscribed: true })),
-    remove: vi.fn(async () => ({ session_id: SESSION_ID, subscribed: false })),
+    create: vi.fn(async () => {
+      order.push('subscribe');
+      if (opts.deferCreate) {
+        await new Promise<void>((resolve) => {
+          releaseCreate = resolve;
+        });
+      }
+      return { session_id: SESSION_ID, subscribed: true };
+    }),
+    remove: vi.fn(async () => {
+      order.push('unsubscribe');
+      return { session_id: SESSION_ID, subscribed: false };
+    }),
   };
 
   const services: Record<string, unknown> = {
-    sessions: { get: vi.fn(async () => ({ session_id: SESSION_ID }) as Session), ...listener() },
+    sessions: {
+      get: vi.fn(async () => {
+        order.push('hydrate');
+        return { session_id: SESSION_ID } as Session;
+      }),
+      ...listener(),
+    },
     tasks: { findAll: vi.fn(async () => opts.tasks), ...listener() },
     messages: { findAll: messageFindAll, ...listener() },
     'session-streams': sessionStreams,
@@ -75,7 +99,9 @@ function createMockClient(opts: MockClientOptions) {
     for (const handler of ioHandlers[event] ?? []) handler();
   };
 
-  return { client, messageFindAll, sessionStreams, fireIo };
+  const releaseCreateFn = () => releaseCreate?.();
+
+  return { client, messageFindAll, sessionStreams, fireIo, order, releaseCreate: releaseCreateFn };
 }
 
 async function bootstrapHandle(opts: MockClientOptions, taskHydration: TaskHydrationMode) {
@@ -226,7 +252,49 @@ describe('ReactiveSessionHandle stream subscription', () => {
     await handle.ready();
 
     handle.dispose();
-    expect(sessionStreams.remove).toHaveBeenCalledWith(SESSION_ID);
+    // Unsubscribe is serialized onto the stream-op chain, so it runs on a
+    // microtask after dispose returns.
+    await vi.waitFor(() => {
+      expect(sessionStreams.remove).toHaveBeenCalledWith(SESSION_ID);
+    });
+  });
+
+  it('subscribes before hydrating so mid-stream chunks land after state exists', async () => {
+    const mock = createMockClient(opts);
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+    await handle.ready();
+
+    // The subscribe ack is awaited before any session-state fetch, so a chunk
+    // arriving right after subscribe cannot precede hydration.
+    expect(mock.order[0]).toBe('subscribe');
+    expect(mock.order).toContain('hydrate');
+    expect(mock.order.indexOf('subscribe')).toBeLessThan(mock.order.indexOf('hydrate'));
+    handle.dispose();
+  });
+
+  it('dispose during an in-flight subscribe leaves no room membership', async () => {
+    const mock = createMockClient({ tasks: [], messagesByTask: {}, deferCreate: true });
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+
+    // Let the subscribe op actually start and block inside create() so we
+    // exercise the genuine in-flight race (not the trivial "disposed before the
+    // op ran" case).
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+    });
+
+    // Dispose enqueues the compensating unsubscribe onto the same serialized
+    // chain, behind the in-flight create.
+    handle.dispose();
+    mock.releaseCreate();
+
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.remove).toHaveBeenCalledTimes(1);
+    });
+    // The create ran once and the unsubscribe ran strictly after it, so the
+    // net membership is empty rather than a stale re-join.
+    expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+    expect(mock.order).toEqual(['subscribe', 'unsubscribe']);
   });
 
   it('re-subscribes after a socket reconnect (new connection has no room membership)', async () => {

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -342,17 +342,59 @@ describe('ReactiveSessionHandle stream subscription', () => {
     expect(mock.order).toEqual(['subscribe', 'unsubscribe']);
   });
 
-  it('re-subscribes after a socket reconnect (new connection has no room membership)', async () => {
-    const { client, sessionStreams, fireIo } = createMockClient(opts);
-    const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration: 'none' });
-    await handle.ready();
-    expect(sessionStreams.create).toHaveBeenCalledTimes(1);
+  it('re-subscribes on reconnect and awaits the ack before resyncing', async () => {
+    // Deferred create lets us prove the resync ordering: hydration must not run
+    // while the re-subscribe ack is pending, only after it resolves.
+    const mock = createMockClient({
+      tasks: [makeTask('task-1', TaskStatus.RUNNING)],
+      messagesByTask: {},
+      deferCreate: true,
+    });
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
 
-    fireIo('connect');
+    // Complete the initial attach subscription first.
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+    });
+    mock.releaseCreate();
     await handle.ready();
+    mock.order.length = 0; // observe only the reconnect ordering below
 
-    expect(sessionStreams.create).toHaveBeenCalledTimes(2);
+    // Reconnect: disconnect resets the re-subscribe token, connect re-subscribes.
+    mock.fireIo('disconnect');
+    mock.fireIo('connect');
+
+    // The re-subscribe create is in flight; resync/hydration must NOT have run.
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.create).toHaveBeenCalledTimes(2);
+    });
+    await Promise.resolve();
+    expect(mock.order).toEqual(['subscribe']);
+
+    // Resolving the re-subscribe ack lets the resync proceed — strictly after.
+    mock.releaseCreate();
+    await handle.ready();
+    expect(mock.order).toEqual(['subscribe', 'hydrate']);
     handle.dispose();
+  });
+
+  it('re-subscribes exactly once across multiple handles on reconnect', async () => {
+    const mock = createMockClient({ tasks: [], messagesByTask: {} });
+    const a = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+    const b = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+    await a.ready();
+    await b.ready();
+    expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+
+    mock.fireIo('disconnect');
+    mock.fireIo('connect');
+    await a.ready();
+    await b.ready();
+
+    // Two handles, one shared re-subscribe (not one per handle).
+    expect(mock.sessionStreams.create).toHaveBeenCalledTimes(2);
+    a.dispose();
+    b.dispose();
   });
 
   it('tolerates a client without the session-streams service (deploy skew)', async () => {

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -42,21 +42,40 @@ function createMockClient(opts: MockClientOptions) {
 
   const listener = () => ({ on: vi.fn(), removeListener: vi.fn() });
 
+  const sessionStreams = {
+    create: vi.fn(async () => ({ session_id: SESSION_ID, subscribed: true })),
+    remove: vi.fn(async () => ({ session_id: SESSION_ID, subscribed: false })),
+  };
+
   const services: Record<string, unknown> = {
     sessions: { get: vi.fn(async () => ({ session_id: SESSION_ID }) as Session), ...listener() },
     tasks: { findAll: vi.fn(async () => opts.tasks), ...listener() },
     messages: { findAll: messageFindAll, ...listener() },
+    'session-streams': sessionStreams,
   };
   const queueService = { find: vi.fn(async () => ({ data: [] })) };
 
+  const ioHandlers: Record<string, Array<(...args: unknown[]) => void>> = {};
   const client = {
-    io: { connected: true, on: vi.fn(), off: vi.fn() },
+    io: {
+      connected: true,
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        const handlers = ioHandlers[event] ?? [];
+        handlers.push(handler);
+        ioHandlers[event] = handlers;
+      }),
+      off: vi.fn(),
+    },
     service: vi.fn((name: string) =>
       name.includes('/tasks/queue') ? queueService : services[name]
     ),
   } as unknown as AgorClient;
 
-  return { client, messageFindAll };
+  const fireIo = (event: string) => {
+    for (const handler of ioHandlers[event] ?? []) handler();
+  };
+
+  return { client, messageFindAll, sessionStreams, fireIo };
 }
 
 async function bootstrapHandle(opts: MockClientOptions, taskHydration: TaskHydrationMode) {
@@ -186,5 +205,63 @@ describe('ReactiveSessionHandle resync hydration parity', () => {
     expect(messageFindAll).toHaveBeenCalledWith({
       query: { task_id: 'task-4', $sort: { index: 1 } },
     });
+  });
+});
+
+describe('ReactiveSessionHandle stream subscription', () => {
+  const opts = { tasks: [], messagesByTask: {} };
+
+  it('subscribes to the session stream on attach', async () => {
+    const { client, sessionStreams } = createMockClient(opts);
+    const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration: 'none' });
+    await handle.ready();
+
+    expect(sessionStreams.create).toHaveBeenCalledWith({ session_id: SESSION_ID });
+    handle.dispose();
+  });
+
+  it('unsubscribes on dispose', async () => {
+    const { client, sessionStreams } = createMockClient(opts);
+    const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration: 'none' });
+    await handle.ready();
+
+    handle.dispose();
+    expect(sessionStreams.remove).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('re-subscribes after a socket reconnect (new connection has no room membership)', async () => {
+    const { client, sessionStreams, fireIo } = createMockClient(opts);
+    const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration: 'none' });
+    await handle.ready();
+    expect(sessionStreams.create).toHaveBeenCalledTimes(1);
+
+    fireIo('connect');
+    await handle.ready();
+
+    expect(sessionStreams.create).toHaveBeenCalledTimes(2);
+    handle.dispose();
+  });
+
+  it('tolerates a client without the session-streams service (deploy skew)', async () => {
+    const { client } = createMockClient(opts);
+    (
+      client.service as unknown as { mockImplementation: (fn: (n: string) => unknown) => void }
+    ).mockImplementation((name: string) =>
+      name === 'session-streams'
+        ? undefined
+        : {
+            get: vi.fn(async () => ({})),
+            findAll: vi.fn(async () => []),
+            find: vi.fn(async () => ({ data: [] })),
+            on: vi.fn(),
+            removeListener: vi.fn(),
+          }
+    );
+
+    // Construction + dispose must not throw even though subscribe/unsubscribe
+    // hit an undefined service.
+    const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration: 'none' });
+    await handle.ready();
+    expect(() => handle.dispose()).not.toThrow();
   });
 });

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -57,19 +57,25 @@ function createMockClient(opts: MockClientOptions) {
       byEvent[event] = handlers;
       serviceHandlers[svc] = byEvent;
     }),
-    removeListener: vi.fn(),
+    removeListener: vi.fn((event: string, handler: (...a: unknown[]) => void) => {
+      const handlers = serviceHandlers[svc]?.[event];
+      if (!handlers) return;
+      const idx = handlers.indexOf(handler);
+      if (idx !== -1) handlers.splice(idx, 1);
+    }),
   });
   const emitServiceEvent = (svc: string, event: string, payload: unknown) => {
-    for (const handler of serviceHandlers[svc]?.[event] ?? []) handler(payload);
+    for (const handler of [...(serviceHandlers[svc]?.[event] ?? [])]) handler(payload);
   };
 
-  let releaseCreate: (() => void) | null = null;
+  // Deferred create() resolvers (queue supports multiple in-flight creates).
+  const createResolvers: Array<() => void> = [];
   const sessionStreams = {
     create: vi.fn(async () => {
       order.push('subscribe');
       if (opts.deferCreate) {
         await new Promise<void>((resolve) => {
-          releaseCreate = resolve;
+          createResolvers.push(resolve);
         });
       }
       return { session_id: SESSION_ID, subscribed: true };
@@ -103,7 +109,12 @@ function createMockClient(opts: MockClientOptions) {
         handlers.push(handler);
         ioHandlers[event] = handlers;
       }),
-      off: vi.fn(),
+      off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        const handlers = ioHandlers[event];
+        if (!handlers) return;
+        const idx = handlers.indexOf(handler);
+        if (idx !== -1) handlers.splice(idx, 1);
+      }),
     },
     service: vi.fn((name: string) =>
       name.includes('/tasks/queue') ? queueService : services[name]
@@ -111,10 +122,14 @@ function createMockClient(opts: MockClientOptions) {
   } as unknown as AgorClient;
 
   const fireIo = (event: string) => {
-    for (const handler of ioHandlers[event] ?? []) handler();
+    for (const handler of [...(ioHandlers[event] ?? [])]) handler();
   };
 
-  const releaseCreateFn = () => releaseCreate?.();
+  // Release all currently-blocked create() calls (FIFO drain).
+  const releaseCreateFn = () => {
+    const pending = createResolvers.splice(0);
+    for (const resolve of pending) resolve();
+  };
 
   return {
     client,
@@ -426,5 +441,123 @@ describe('ReactiveSessionHandle stream subscription', () => {
       expect(remove).toHaveBeenCalledWith(canonical);
     });
     expect(remove).not.toHaveBeenCalledWith(shortId);
+  });
+
+  it('shares one subscription across handles and only unsubscribes on the last detach', async () => {
+    // Two handles for the same session (different taskHydration) share one
+    // socket connection and thus one room membership.
+    const mock = createMockClient({
+      tasks: [makeTask('task-1', TaskStatus.RUNNING)],
+      messagesByTask: {},
+    });
+    const a = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+    const b = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+    await a.ready();
+    await b.ready();
+
+    // Single shared subscription — not one per handle.
+    expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+
+    // Disposing one handle must NOT evict the shared connection from the room.
+    a.dispose();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mock.sessionStreams.remove).not.toHaveBeenCalled();
+
+    // The surviving handle still receives chunks.
+    mock.emitServiceEvent('messages', 'streaming:chunk', {
+      message_id: 'm1',
+      session_id: SESSION_ID,
+      chunk: 'still here',
+    });
+    expect(b.getStreamingMessage('m1')?.content).toBe('still here');
+
+    // Last detach actually removes the membership.
+    b.dispose();
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('a late create from a disposing handle cannot evict a newer handle (ordered chain)', async () => {
+    const mock = createMockClient({ tasks: [], messagesByTask: {}, deferCreate: true });
+    const a = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+
+    // a's create is in flight (deferred).
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+    });
+
+    // a disposes (refcount 0 → remove enqueued behind the in-flight create),
+    // then a NEW handle b attaches (refcount 0→1 → create enqueued behind the
+    // remove on the same shared chain).
+    a.dispose();
+    const b = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+
+    // Drain a's create; the remove then runs, then b's create is issued.
+    mock.releaseCreate();
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.remove).toHaveBeenCalledTimes(1);
+      expect(mock.sessionStreams.create).toHaveBeenCalledTimes(2);
+    });
+    // Drain b's create so the join completes last.
+    mock.releaseCreate();
+    await b.ready();
+
+    // Order proves b's join lands strictly after a's remove — membership is b's.
+    expect(mock.order.filter((o) => o !== 'hydrate')).toEqual([
+      'subscribe',
+      'unsubscribe',
+      'subscribe',
+    ]);
+    b.dispose();
+  });
+
+  it('renders thinking chunks that arrive mid-thinking (attach during a thinking block)', async () => {
+    const mock = createMockClient({
+      tasks: [makeTask('task-1', TaskStatus.RUNNING)],
+      messagesByTask: {},
+    });
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+    await handle.ready();
+
+    mock.emitServiceEvent('messages', 'thinking:chunk', {
+      message_id: 'm1',
+      session_id: SESSION_ID,
+      chunk: 'pondering',
+    });
+
+    const streamed = handle.getStreamingMessage('m1');
+    expect(streamed?.thinkingContent).toBe('pondering');
+    expect(streamed?.isThinking).toBe(true);
+    expect(streamed?.task_id).toBe('task-1');
+    handle.dispose();
+  });
+
+  it('re-stamps task_id on streams that arrived before tasks were hydrated', async () => {
+    const mock = createMockClient({
+      tasks: [makeTask('task-1', TaskStatus.RUNNING)],
+      messagesByTask: {},
+      deferCreate: true,
+    });
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+
+    // Subscribe is in flight; tasks are not hydrated yet, so a chunk landing now
+    // initializes the stream with an undefined task_id.
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+    });
+    mock.emitServiceEvent('messages', 'streaming:chunk', {
+      message_id: 'm1',
+      session_id: SESSION_ID,
+      chunk: 'hi',
+    });
+    expect(handle.getStreamingMessage('m1')?.task_id).toBeUndefined();
+
+    // Completing the ack lets bootstrap hydrate tasks and re-stamp the stream.
+    mock.releaseCreate();
+    await handle.ready();
+    expect(handle.getStreamingMessage('m1')?.task_id).toBe('task-1');
+    handle.dispose();
   });
 });

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -602,4 +602,81 @@ describe('ReactiveSessionHandle stream subscription', () => {
     expect(handle.getStreamingMessage('m1')?.task_id).toBe('task-1');
     handle.dispose();
   });
+
+  // A minimal client whose session-streams.create always echoes `canonical`
+  // (the full UUID) regardless of the id form the caller supplied.
+  function makeCanonicalClient(canonical: string) {
+    const create = vi.fn(async () => ({ session_id: canonical, subscribed: true }));
+    const remove = vi.fn(async () => ({ session_id: canonical, subscribed: false }));
+    const listener = () => ({ on: vi.fn(), removeListener: vi.fn() });
+    const services: Record<string, unknown> = {
+      sessions: { get: vi.fn(async () => ({ session_id: canonical }) as Session), ...listener() },
+      tasks: { findAll: vi.fn(async () => []), ...listener() },
+      messages: { findAll: vi.fn(async () => []), ...listener() },
+      'session-streams': { create, remove },
+    };
+    const queueService = { find: vi.fn(async () => ({ data: [] })) };
+    const client = {
+      io: { connected: true, on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) =>
+        name.includes('/tasks/queue') ? queueService : services[name]
+      ),
+    } as unknown as AgorClient;
+    return { client, create, remove };
+  }
+
+  it('shares one canonical room across short-id and full-id retains (short first)', async () => {
+    const shortId = 'ffffffff';
+    const canonical = 'ffffffff-1111-2222-3333-444444444444';
+    const { client, create, remove } = makeCanonicalClient(canonical);
+
+    const short = new ReactiveSessionHandle(client, shortId, { taskHydration: 'none' });
+    await short.ready();
+    const full = new ReactiveSessionHandle(client, canonical, { taskHydration: 'lazy' });
+    await full.ready();
+
+    // The full-id retain resolves to the canonical entry the short-id retain
+    // established — reuse, no second create.
+    expect(create).toHaveBeenCalledTimes(1);
+
+    // Disposing one id form must NOT evict the shared room membership.
+    short.dispose();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(remove).not.toHaveBeenCalled();
+
+    // Only the last detach across all id forms removes it — once, canonically.
+    full.dispose();
+    await vi.waitFor(() => {
+      expect(remove).toHaveBeenCalledTimes(1);
+    });
+    expect(remove).toHaveBeenCalledWith(canonical);
+  });
+
+  it('folds a redundant subscription into the canonical room (full first, then short)', async () => {
+    const shortId = 'ffffffff';
+    const canonical = 'ffffffff-1111-2222-3333-444444444444';
+    const { client, create, remove } = makeCanonicalClient(canonical);
+
+    const full = new ReactiveSessionHandle(client, canonical, { taskHydration: 'none' });
+    await full.ready();
+    const short = new ReactiveSessionHandle(client, shortId, { taskHydration: 'lazy' });
+    await short.ready();
+
+    // The client can't know the short id maps to the canonical room without
+    // asking, so a second create is sent — but both join ONE canonical room and
+    // the entries fold together.
+    expect(create).toHaveBeenCalledTimes(2);
+
+    full.dispose();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(remove).not.toHaveBeenCalled();
+
+    short.dispose();
+    await vi.waitFor(() => {
+      expect(remove).toHaveBeenCalledTimes(1);
+    });
+    expect(remove).toHaveBeenCalledWith(canonical);
+  });
 });

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -46,7 +46,22 @@ function createMockClient(opts: MockClientOptions) {
     return Object.values(opts.messagesByTask).flat();
   });
 
-  const listener = () => ({ on: vi.fn(), removeListener: vi.fn() });
+  // Capture service event handlers so tests can fire realtime events (e.g. a
+  // streaming:chunk that arrives with no preceding streaming:start).
+  const serviceHandlers: Record<string, Record<string, Array<(...a: unknown[]) => void>>> = {};
+  const listener = (svc: string) => ({
+    on: vi.fn((event: string, handler: (...a: unknown[]) => void) => {
+      const byEvent = serviceHandlers[svc] ?? {};
+      const handlers = byEvent[event] ?? [];
+      handlers.push(handler);
+      byEvent[event] = handlers;
+      serviceHandlers[svc] = byEvent;
+    }),
+    removeListener: vi.fn(),
+  });
+  const emitServiceEvent = (svc: string, event: string, payload: unknown) => {
+    for (const handler of serviceHandlers[svc]?.[event] ?? []) handler(payload);
+  };
 
   let releaseCreate: (() => void) | null = null;
   const sessionStreams = {
@@ -71,10 +86,10 @@ function createMockClient(opts: MockClientOptions) {
         order.push('hydrate');
         return { session_id: SESSION_ID } as Session;
       }),
-      ...listener(),
+      ...listener('sessions'),
     },
-    tasks: { findAll: vi.fn(async () => opts.tasks), ...listener() },
-    messages: { findAll: messageFindAll, ...listener() },
+    tasks: { findAll: vi.fn(async () => opts.tasks), ...listener('tasks') },
+    messages: { findAll: messageFindAll, ...listener('messages') },
     'session-streams': sessionStreams,
   };
   const queueService = { find: vi.fn(async () => ({ data: [] })) };
@@ -101,7 +116,15 @@ function createMockClient(opts: MockClientOptions) {
 
   const releaseCreateFn = () => releaseCreate?.();
 
-  return { client, messageFindAll, sessionStreams, fireIo, order, releaseCreate: releaseCreateFn };
+  return {
+    client,
+    messageFindAll,
+    sessionStreams,
+    fireIo,
+    emitServiceEvent,
+    order,
+    releaseCreate: releaseCreateFn,
+  };
 }
 
 async function bootstrapHandle(opts: MockClientOptions, taskHydration: TaskHydrationMode) {
@@ -259,16 +282,23 @@ describe('ReactiveSessionHandle stream subscription', () => {
     });
   });
 
-  it('subscribes before hydrating so mid-stream chunks land after state exists', async () => {
-    const mock = createMockClient(opts);
+  it('does not hydrate until the subscribe ack resolves', async () => {
+    // Hold create() unresolved: hydration must NOT have started yet. This fails
+    // if subscribe were fire-and-forget (hydration would race ahead).
+    const mock = createMockClient({ tasks: [], messagesByTask: {}, deferCreate: true });
     const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
-    await handle.ready();
 
-    // The subscribe ack is awaited before any session-state fetch, so a chunk
-    // arriving right after subscribe cannot precede hydration.
-    expect(mock.order[0]).toBe('subscribe');
-    expect(mock.order).toContain('hydrate');
-    expect(mock.order.indexOf('subscribe')).toBeLessThan(mock.order.indexOf('hydrate'));
+    await vi.waitFor(() => {
+      expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+    });
+    // Give any (incorrectly) un-awaited hydration a chance to run.
+    await Promise.resolve();
+    expect(mock.order).toEqual(['subscribe']);
+
+    // Resolving the subscribe ack lets hydration proceed — strictly after.
+    mock.releaseCreate();
+    await handle.ready();
+    expect(mock.order).toEqual(['subscribe', 'hydrate']);
     handle.dispose();
   });
 
@@ -331,5 +361,70 @@ describe('ReactiveSessionHandle stream subscription', () => {
     const handle = new ReactiveSessionHandle(client, SESSION_ID, { taskHydration: 'none' });
     await handle.ready();
     expect(() => handle.dispose()).not.toThrow();
+  });
+
+  it('renders chunks that arrive after start already fired (attach mid-stream)', async () => {
+    // A viewer opening a running session subscribes after streaming:start; the
+    // chunk handler must initialize the stream from the chunk instead of
+    // dropping it, grouping it under the active task so it renders.
+    const mock = createMockClient({
+      tasks: [makeTask('task-1', TaskStatus.RUNNING)],
+      messagesByTask: {},
+    });
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'none' });
+    await handle.ready();
+
+    // No streaming:start — the stream is already in progress upstream.
+    mock.emitServiceEvent('messages', 'streaming:chunk', {
+      message_id: 'm1',
+      session_id: SESSION_ID,
+      chunk: 'hello',
+    });
+    mock.emitServiceEvent('messages', 'streaming:chunk', {
+      message_id: 'm1',
+      session_id: SESSION_ID,
+      chunk: ' world',
+    });
+
+    const streamed = handle.getStreamingMessage('m1');
+    expect(streamed?.content).toBe('hello world');
+    expect(streamed?.isStreaming).toBe(true);
+    // Grouped under the active task so useStreamingMessagesByTask renders it.
+    expect(streamed?.task_id).toBe('task-1');
+    handle.dispose();
+  });
+
+  it('unsubscribes using the canonical room id returned by subscribe', async () => {
+    // A short-id caller joins the canonical room (create echoes the full id);
+    // remove must target that canonical room, so a later-revoked user still
+    // leaves the room they actually joined.
+    const shortId = 'ffffffff';
+    const canonical = 'ffffffff-1111-2222-3333-444444444444';
+    const create = vi.fn(async () => ({ session_id: canonical, subscribed: true }));
+    const remove = vi.fn(async () => ({ session_id: canonical, subscribed: false }));
+    const listener = () => ({ on: vi.fn(), removeListener: vi.fn() });
+    const services: Record<string, unknown> = {
+      sessions: { get: vi.fn(async () => ({ session_id: canonical }) as Session), ...listener() },
+      tasks: { findAll: vi.fn(async () => []), ...listener() },
+      messages: { findAll: vi.fn(async () => []), ...listener() },
+      'session-streams': { create, remove },
+    };
+    const queueService = { find: vi.fn(async () => ({ data: [] })) };
+    const client = {
+      io: { connected: true, on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) =>
+        name.includes('/tasks/queue') ? queueService : services[name]
+      ),
+    } as unknown as AgorClient;
+
+    const handle = new ReactiveSessionHandle(client, shortId, { taskHydration: 'none' });
+    await handle.ready();
+    expect(create).toHaveBeenCalledWith({ session_id: shortId });
+
+    handle.dispose();
+    await vi.waitFor(() => {
+      expect(remove).toHaveBeenCalledWith(canonical);
+    });
+    expect(remove).not.toHaveBeenCalledWith(shortId);
   });
 });

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -1,7 +1,11 @@
 import type { AgorClient, Message, Session, Task } from '@agor/core/client';
 import { TaskStatus } from '@agor/core/client';
 import { describe, expect, it, vi } from 'vitest';
-import { ReactiveSessionHandle, type TaskHydrationMode } from './reactive-session';
+import {
+  __streamSubscriptionCountForTest,
+  ReactiveSessionHandle,
+  type TaskHydrationMode,
+} from './reactive-session';
 
 const SESSION_ID = 'session-1';
 
@@ -758,5 +762,52 @@ describe('ReactiveSessionHandle stream subscription', () => {
     expect(handle.getStreamingMessage('m2')).toBeUndefined();
 
     handle.dispose();
+  });
+
+  it('a short-id handle disposed before its ack leaves the registry empty', async () => {
+    const shortId = 'ffffffff';
+    const canonical = 'ffffffff-1111-2222-3333-444444444444';
+    const createResolvers: Array<() => void> = [];
+    const create = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        createResolvers.push(resolve);
+      });
+      return { session_id: canonical, subscribed: true };
+    });
+    const remove = vi.fn(async () => ({ session_id: canonical, subscribed: false }));
+    const listener = () => ({ on: vi.fn(), removeListener: vi.fn() });
+    const services: Record<string, unknown> = {
+      sessions: { get: vi.fn(async () => ({ session_id: canonical }) as Session), ...listener() },
+      tasks: { findAll: vi.fn(async () => []), ...listener() },
+      messages: { findAll: vi.fn(async () => []), ...listener() },
+      'session-streams': { create, remove },
+    };
+    const queueService = { find: vi.fn(async () => ({ data: [] })) };
+    const client = {
+      io: { connected: true, on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) =>
+        name.includes('/tasks/queue') ? queueService : services[name]
+      ),
+    } as unknown as AgorClient;
+
+    const handle = new ReactiveSessionHandle(client, shortId, { taskHydration: 'none' });
+    // The create ack is held; dispose BEFORE it lands (release captured the
+    // short-id key, but the ack re-keys the entry to the canonical id).
+    await vi.waitFor(() => {
+      expect(create).toHaveBeenCalledTimes(1);
+    });
+    handle.dispose();
+    for (const resolve of createResolvers.splice(0)) resolve();
+
+    await vi.waitFor(() => {
+      expect(remove).toHaveBeenCalledTimes(1);
+    });
+    // The compensating remove targeted the canonical room...
+    expect(remove).toHaveBeenCalledWith(canonical);
+    // ...and the registry ends empty (entry dropped under its re-keyed id,
+    // connect handler detached) rather than leaking a stale entry.
+    await vi.waitFor(() => {
+      expect(__streamSubscriptionCountForTest(client)).toBe(0);
+    });
   });
 });

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -679,4 +679,84 @@ describe('ReactiveSessionHandle stream subscription', () => {
     });
     expect(remove).toHaveBeenCalledWith(canonical);
   });
+
+  // Client for a handle constructed with a SHORT id: hydration + create ack echo
+  // the canonical id, and events (which always carry the full UUID) can be fired.
+  function makeShortIdEventClient(canonical: string) {
+    const serviceHandlers: Record<string, Record<string, Array<(...a: unknown[]) => void>>> = {};
+    const listener = (svc: string) => ({
+      on: vi.fn((event: string, handler: (...a: unknown[]) => void) => {
+        const byEvent = serviceHandlers[svc] ?? {};
+        const handlers = byEvent[event] ?? [];
+        handlers.push(handler);
+        byEvent[event] = handlers;
+        serviceHandlers[svc] = byEvent;
+      }),
+      removeListener: vi.fn(),
+    });
+    const emit = (svc: string, event: string, payload: unknown) => {
+      for (const handler of [...(serviceHandlers[svc]?.[event] ?? [])]) handler(payload);
+    };
+    const runningTask = {
+      task_id: 'task-1',
+      session_id: canonical,
+      status: TaskStatus.RUNNING,
+    } as unknown as Task;
+    const services: Record<string, unknown> = {
+      // Hydration returns the canonical row even though we asked by short id.
+      sessions: {
+        get: vi.fn(async () => ({ session_id: canonical }) as Session),
+        ...listener('sessions'),
+      },
+      tasks: { findAll: vi.fn(async () => [runningTask]), ...listener('tasks') },
+      messages: { findAll: vi.fn(async () => []), ...listener('messages') },
+      'session-streams': {
+        create: vi.fn(async () => ({ session_id: canonical, subscribed: true })),
+        remove: vi.fn(async () => ({ session_id: canonical, subscribed: false })),
+      },
+    };
+    const queueService = { find: vi.fn(async () => ({ data: [] })) };
+    const client = {
+      io: { connected: true, on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) =>
+        name.includes('/tasks/queue') ? queueService : services[name]
+      ),
+    } as unknown as AgorClient;
+    return { client, emit };
+  }
+
+  it('a short-id handle matches events that carry the canonical id', async () => {
+    const shortId = 'ffffffff';
+    const canonical = 'ffffffff-1111-2222-3333-444444444444';
+    const { client, emit } = makeShortIdEventClient(canonical);
+    const handle = new ReactiveSessionHandle(client, shortId, { taskHydration: 'none' });
+    await handle.ready();
+
+    // (a) a canonical-id streaming chunk renders into streaming state.
+    emit('messages', 'streaming:chunk', {
+      message_id: 'm1',
+      session_id: canonical,
+      chunk: 'hello',
+    });
+    expect(handle.getStreamingMessage('m1')?.content).toBe('hello');
+
+    // (b) a canonical-id tool event applies.
+    emit('tasks', 'tool:start', {
+      task_id: 'task-1',
+      session_id: canonical,
+      tool_use_id: 'tool-1',
+      tool_name: 'Bash',
+    });
+    expect(handle.getTaskTools('task-1').map((t) => t.toolName)).toContain('Bash');
+
+    // (c) sanity — an event for a DIFFERENT session id is still ignored.
+    emit('messages', 'streaming:chunk', {
+      message_id: 'm2',
+      session_id: 'aaaaaaaa-0000-0000-0000-000000000000',
+      chunk: 'nope',
+    });
+    expect(handle.getStreamingMessage('m2')).toBeUndefined();
+
+    handle.dispose();
+  });
 });

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -1097,11 +1097,21 @@ export function attachReactiveSessionApi(client: AgorClient): ReactiveAgorClient
 // each with its own taskHydration) share ONE connection for the same session.
 // If every handle sent its own `remove` on dispose, disposing any one would
 // evict the shared connection from the room and silently kill the others'
-// streams. So subscription is refcounted per (client, session id): the first
-// attach subscribes, the last detach unsubscribes, and a single shared op chain
-// orders create/remove across handles (a late create from a disposing handle
-// can't land after a newer handle's create). On reconnect every still-wanted
+// streams. So subscription is refcounted; a single shared op chain orders
+// create/remove across handles (a late create from a disposing handle can't
+// land after a newer handle's create), and on reconnect every still-wanted
 // session re-subscribes exactly once.
+//
+// The room is keyed by the CANONICAL session id the daemon echoes from
+// `create` — not the caller-supplied id — because deep-link URLs carry short
+// ids while other surfaces use the full UUID, and both resolve to one room.
+// Two mechanisms keep exactly ONE refcounted membership per (client, canonical
+// room): (1) `keyToCanonical` re-keys/aliases an entry to the canonical id once
+// its ack returns, so a later retain of either id form reuses it without a
+// second `create`; (2) `roomWanters` counts the entries currently joined to a
+// canonical room, so `remove` fires only when the LAST retainer across all id
+// forms releases — even in the race where both forms subscribe before either
+// ack lands (their entries merge, and the count still gates the single remove).
 
 interface StreamSubscription {
   refCount: number;
@@ -1109,6 +1119,10 @@ interface StreamSubscription {
   /** Canonical room id echoed by create; used so `remove` leaves the right room. */
   roomId: string | null;
   wantSubscribed: boolean;
+  /** True once this entry has contributed +1 to `roomWanters[roomId]`. */
+  joined: boolean;
+  /** Set when this entry was folded into the canonical entry; its ops no-op. */
+  superseded: boolean;
   /**
    * The re-subscribe op for the CURRENT connection, shared by every handle so a
    * reconnect re-subscribes each session exactly once. Reset to null on socket
@@ -1119,6 +1133,10 @@ interface StreamSubscription {
 
 interface ClientStreamState {
   subs: Map<string, StreamSubscription>;
+  /** Caller-supplied id (short or full) → canonical room id, learned from acks. */
+  keyToCanonical: Map<string, string>;
+  /** Canonical room id → count of entries currently joined to it. */
+  roomWanters: Map<string, number>;
   disconnectHandler: (() => void) | null;
 }
 
@@ -1127,10 +1145,19 @@ const CLIENT_STREAM_STATE = new WeakMap<AgorClient, ClientStreamState>();
 function getClientStreamState(client: AgorClient): ClientStreamState {
   let state = CLIENT_STREAM_STATE.get(client);
   if (!state) {
-    state = { subs: new Map(), disconnectHandler: null };
+    state = {
+      subs: new Map(),
+      keyToCanonical: new Map(),
+      roomWanters: new Map(),
+      disconnectHandler: null,
+    };
     CLIENT_STREAM_STATE.set(client, state);
   }
   return state;
+}
+
+function resolveStreamKey(state: ClientStreamState, sessionId: string): string {
+  return state.keyToCanonical.get(sessionId) ?? sessionId;
 }
 
 /** Serialize a create/remove op onto the subscription's shared chain. */
@@ -1146,30 +1173,77 @@ function runSubscriptionOp(sub: StreamSubscription, op: () => Promise<void>): Pr
 async function createSubscription(
   client: AgorClient,
   sessionId: string,
-  sub: StreamSubscription
+  sub: StreamSubscription,
+  key: string
 ): Promise<void> {
-  // Released before this op ran — nothing to join.
-  if (!sub.wantSubscribed) return;
+  // Released or folded before this op ran — nothing to join.
+  if (!sub.wantSubscribed || sub.superseded) return;
+  let canonical: string | undefined;
   try {
     const result = (await client.service('session-streams').create({ session_id: sessionId })) as
       | { session_id?: string }
       | undefined;
-    if (typeof result?.session_id === 'string' && result.session_id) {
-      sub.roomId = result.session_id;
-    }
+    canonical = typeof result?.session_id === 'string' ? result.session_id : undefined;
   } catch {
     // Deploy skew / access error: the daemon's owner fallback covers the
     // creator's own tabs, and access errors also surface via bootstrap/resync.
   }
+  if (!canonical) return;
+
+  const state = CLIENT_STREAM_STATE.get(client);
+  if (!state) return;
+
+  // Learn the mapping so future retains of either id form resolve to the room.
+  state.keyToCanonical.set(sessionId, canonical);
+  state.keyToCanonical.set(canonical, canonical);
+  if (key !== canonical) state.keyToCanonical.set(key, canonical);
+
+  // Normalize this entry onto the canonical id.
+  let target = sub;
+  if (key !== canonical && state.subs.get(canonical) !== sub) {
+    const existing = state.subs.get(canonical);
+    if (existing) {
+      // Race: another id form already established the canonical entry. Fold
+      // this entry's refcount into it and retire this one (its pending ops
+      // no-op via `superseded`); both joined the same room, so the count is
+      // taken from the canonical entry only.
+      existing.refCount += sub.refCount;
+      existing.wantSubscribed = existing.wantSubscribed || sub.wantSubscribed;
+      sub.superseded = true;
+      if (state.subs.get(key) === sub) state.subs.delete(key);
+      target = existing;
+    } else {
+      if (state.subs.get(key) === sub) state.subs.delete(key);
+      state.subs.set(canonical, sub);
+    }
+  }
+
+  target.roomId = canonical;
+  // The server-side join actually happened, so account for it even if the
+  // entry was released mid-flight — the pending remove (enqueued after this
+  // create) will then leave the room. Skipping this would leak the membership.
+  if (!target.joined) {
+    target.joined = true;
+    state.roomWanters.set(canonical, (state.roomWanters.get(canonical) ?? 0) + 1);
+  }
 }
 
-async function removeSubscription(
-  client: AgorClient,
-  sessionId: string,
-  sub: StreamSubscription
-): Promise<void> {
+async function removeSubscription(client: AgorClient, sub: StreamSubscription): Promise<void> {
+  if (sub.superseded) return;
+  const state = CLIENT_STREAM_STATE.get(client);
+  const roomId = sub.roomId;
+  // Never joined (create failed / not yet acked): nothing to leave.
+  if (!sub.joined || !roomId || !state) return;
+  sub.joined = false;
+  const remaining = (state.roomWanters.get(roomId) ?? 1) - 1;
+  if (remaining > 0) {
+    // Another id-form entry still wants the room — keep the membership.
+    state.roomWanters.set(roomId, remaining);
+    return;
+  }
+  state.roomWanters.delete(roomId);
   try {
-    await client.service('session-streams').remove(sub.roomId ?? sessionId);
+    await client.service('session-streams').remove(roomId);
   } catch {
     // Ignore — socket teardown removes room membership regardless.
   }
@@ -1191,16 +1265,19 @@ function ensureStreamDisconnectHandler(client: AgorClient, state: ClientStreamSt
 
 function retainSessionStream(client: AgorClient, sessionId: string): Promise<void> {
   const state = getClientStreamState(client);
-  let sub = state.subs.get(sessionId);
+  const key = resolveStreamKey(state, sessionId);
+  let sub = state.subs.get(key);
   if (!sub) {
     sub = {
       refCount: 0,
       chain: Promise.resolve(),
       roomId: null,
       wantSubscribed: false,
+      joined: false,
+      superseded: false,
       reconnect: null,
     };
-    state.subs.set(sessionId, sub);
+    state.subs.set(key, sub);
   }
   const was = sub.refCount;
   sub.refCount += 1;
@@ -1210,7 +1287,7 @@ function retainSessionStream(client: AgorClient, sessionId: string): Promise<voi
   // the shared chain) enqueues the create; it lands after any pending remove.
   if (was === 0) {
     const target = sub;
-    return runSubscriptionOp(target, () => createSubscription(client, sessionId, target));
+    return runSubscriptionOp(target, () => createSubscription(client, sessionId, target, key));
   }
   return sub.chain;
 }
@@ -1223,10 +1300,12 @@ function retainSessionStream(client: AgorClient, sessionId: string): Promise<voi
  */
 function resubscribeSessionStream(client: AgorClient, sessionId: string): Promise<void> {
   const state = CLIENT_STREAM_STATE.get(client);
-  const sub = state?.subs.get(sessionId);
+  if (!state) return Promise.resolve();
+  const key = resolveStreamKey(state, sessionId);
+  const sub = state.subs.get(key);
   if (!sub?.wantSubscribed) return Promise.resolve();
   if (!sub.reconnect) {
-    sub.reconnect = runSubscriptionOp(sub, () => createSubscription(client, sessionId, sub));
+    sub.reconnect = runSubscriptionOp(sub, () => createSubscription(client, sessionId, sub, key));
   }
   return sub.reconnect;
 }
@@ -1234,16 +1313,17 @@ function resubscribeSessionStream(client: AgorClient, sessionId: string): Promis
 function releaseSessionStream(client: AgorClient, sessionId: string): void {
   const state = CLIENT_STREAM_STATE.get(client);
   if (!state) return;
-  const sub = state.subs.get(sessionId);
+  const key = resolveStreamKey(state, sessionId);
+  const sub = state.subs.get(key);
   if (!sub || sub.refCount === 0) return;
   sub.refCount -= 1;
   if (sub.refCount > 0) return;
   sub.wantSubscribed = false;
-  void runSubscriptionOp(sub, () => removeSubscription(client, sessionId, sub)).then(() => {
+  void runSubscriptionOp(sub, () => removeSubscription(client, sub)).then(() => {
     // Drop the entry only if nothing re-attached while the remove drained; a
     // re-attach reuses this same sub and its ordered chain.
-    if (sub.refCount === 0 && !sub.wantSubscribed && state.subs.get(sessionId) === sub) {
-      state.subs.delete(sessionId);
+    if (sub.refCount === 0 && !sub.wantSubscribed && state.subs.get(key) === sub) {
+      state.subs.delete(key);
       if (state.subs.size === 0 && state.disconnectHandler) {
         client.io.off('disconnect', state.disconnectHandler);
         state.disconnectHandler = null;

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -156,21 +156,6 @@ export class ReactiveSessionHandle {
   private readyPromise: Promise<void>;
   private disposed = false;
 
-  /**
-   * Serializes stream subscribe/unsubscribe so a delayed `create` can't land
-   * after a `remove` and re-join a disposed handle. Every op chains onto this,
-   * and dispose enqueues a compensating `remove` after any in-flight `create`.
-   */
-  private streamOpChain: Promise<void> = Promise.resolve();
-
-  /**
-   * Canonical room id echoed back by `session-streams.create` (the resolved
-   * row's full session_id). Used for `remove` so a short-id / alias caller —
-   * including one whose access was later revoked — leaves the room it actually
-   * joined rather than a raw-id room it never entered.
-   */
-  private streamRoomId: string | null = null;
-
   private stateSnapshot: ReactiveSessionState;
 
   constructor(client: AgorClient, sessionId: string, options?: ReactiveSessionOptions) {
@@ -195,21 +180,22 @@ export class ReactiveSessionHandle {
     };
 
     this.attachListeners();
-    // Subscribe to the streaming channel BEFORE hydrating: the subscribe ack is
-    // awaited so any chunk arriving after it lands on top of hydrated state,
-    // and anything earlier is captured by the hydration itself — a viewer
-    // opening mid-stream can't fall into the gap where early chunks arrive with
-    // no streaming state and get dropped. Reconnects re-subscribe the same way
-    // via onSocketConnect (rooms are per-connection; a reconnect is a new one).
+    // Retain the shared per-connection stream subscription for this session and
+    // AWAIT its ack BEFORE hydrating: a chunk arriving after the ack lands on
+    // top of hydrated state, and anything earlier is captured by the hydration
+    // itself — a viewer opening mid-stream can't fall into the gap where early
+    // chunks arrive with no streaming state and get dropped. Reconnects
+    // re-subscribe once via the registry's connect handler (rooms are
+    // per-connection; a reconnect is a new one).
     this.readyPromise = this.subscribeThenHydrate(() => this.bootstrap());
   }
 
   /**
-   * Await the streaming subscription, then run the hydration/resync step, so
-   * chunk delivery and state hydration can't interleave into a lost-update gap.
+   * Await the streaming subscription, then run the hydration step, so chunk
+   * delivery and state hydration can't interleave into a lost-update gap.
    */
   private async subscribeThenHydrate(hydrate: () => Promise<void>): Promise<void> {
-    await this.subscribeToStream();
+    await retainSessionStream(this.client, this.sessionId);
     if (this.disposed) return;
     await hydrate();
   }
@@ -325,66 +311,16 @@ export class ReactiveSessionHandle {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    // Best-effort: leave the streaming room. Enqueued after any in-flight
-    // subscribe so a late-landing create is always followed by this remove.
-    // The daemon also drops the connection from the channel on socket
-    // disconnect, so this only matters while the socket stays open (e.g.
-    // navigating between sessions in one tab).
-    void this.unsubscribeFromStream();
+    // Release this handle's refcount on the shared per-connection subscription.
+    // The last handle for the session sends the actual `remove`; disposing one
+    // of several handles must NOT evict the shared connection from the room and
+    // kill the others' streams.
+    releaseSessionStream(this.client, this.sessionId);
     for (const cleanup of this.disposeCallbacks) {
       cleanup();
     }
     this.disposeCallbacks.length = 0;
     this.listeners.clear();
-  }
-
-  /** Run a stream subscribe/unsubscribe op serialized after any in-flight op. */
-  private runStreamOp(op: () => Promise<void>): Promise<void> {
-    const next = this.streamOpChain.then(op, op);
-    // Keep the chain alive regardless of any single op's outcome.
-    this.streamOpChain = next.then(
-      () => undefined,
-      () => undefined
-    );
-    return next;
-  }
-
-  /**
-   * Join this session's per-connection streaming channel on the daemon.
-   * Best-effort: a daemon that predates the `session-streams` service (deploy
-   * skew) rejects the call, in which case the daemon's owner-fallback delivery
-   * keeps this session's own tabs updating until the daemon is upgraded.
-   * Serialized so it cannot re-join after a dispose-issued unsubscribe.
-   */
-  private subscribeToStream(): Promise<void> {
-    return this.runStreamOp(async () => {
-      // Skip if disposed: dispose enqueues a compensating unsubscribe after
-      // this op, so ordering alone already prevents stale membership; this just
-      // avoids a pointless round-trip.
-      if (this.disposed) return;
-      try {
-        const result = (await this.client
-          .service('session-streams')
-          .create({ session_id: this.sessionId })) as { session_id?: string } | undefined;
-        // Remember the canonical room id so unsubscribe leaves the right room
-        // even for short-id callers or after access is revoked.
-        if (typeof result?.session_id === 'string' && result.session_id) {
-          this.streamRoomId = result.session_id;
-        }
-      } catch {
-        // Ignore — see method doc. Access errors also surface via bootstrap/resync.
-      }
-    });
-  }
-
-  private unsubscribeFromStream(): Promise<void> {
-    return this.runStreamOp(async () => {
-      try {
-        await this.client.service('session-streams').remove(this.streamRoomId ?? this.sessionId);
-      } catch {
-        // Ignore — the socket teardown removes room membership regardless.
-      }
-    });
   }
 
   private assertNotDisposed(): void {
@@ -467,6 +403,9 @@ export class ReactiveSessionHandle {
         tasks,
         messagesByTask,
         loadedTaskIds,
+        // Repair task_id on any stream initialized from a chunk that arrived
+        // before tasks were hydrated (task_id was undefined then).
+        streamingMessages: restampStreamingTaskIds(prev.streamingMessages, tasks),
         queuedTasks: sortTasksByQueuePosition((queueResult as QueueFindResult).data || []),
         loading: false,
         error: null,
@@ -497,10 +436,11 @@ export class ReactiveSessionHandle {
     const onSocketConnect = () => {
       if (this.disposed) return;
       this.updateState((prev) => ({ ...prev, connected: true }));
-      // A reconnect is a new socket connection with no room membership, so
-      // re-declare interest and await the ack before resyncing — same ordering
-      // as the initial attach so post-subscribe chunks land after hydration.
-      this.readyPromise = this.subscribeThenHydrate(() => this.resync());
+      // Re-subscription on reconnect is owned by the shared registry's connect
+      // handler (once per still-wanted session); the handle just resyncs its
+      // state, and the chunk handler initializes any stream that starts before
+      // this resync completes.
+      this.readyPromise = this.resync();
     };
     const onSocketDisconnect = () => {
       if (this.disposed) return;
@@ -878,13 +818,29 @@ export class ReactiveSessionHandle {
       if (event.session_id !== this.sessionId) return;
       this.updateState((prev) => {
         const current = prev.streamingMessages.get(event.message_id);
-        if (!current) return prev;
         const nextStreaming = new Map(prev.streamingMessages);
-        nextStreaming.set(event.message_id, {
-          ...current,
-          isThinking: true,
-          thinkingContent: (current.thinkingContent || '') + event.chunk,
-        });
+        if (current) {
+          nextStreaming.set(event.message_id, {
+            ...current,
+            isThinking: true,
+            thinkingContent: (current.thinkingContent || '') + event.chunk,
+          });
+        } else {
+          // Attached mid-thinking (a long thinking block, no start replay):
+          // initialize from this chunk so live thinking renders under the
+          // active task instead of being dropped.
+          nextStreaming.set(event.message_id, {
+            message_id: event.message_id,
+            session_id: event.session_id,
+            task_id: findLatestHydratableTask(prev.tasks)?.task_id,
+            role: 'assistant',
+            content: '',
+            thinkingContent: event.chunk,
+            timestamp: new Date().toISOString(),
+            isStreaming: true,
+            isThinking: true,
+          });
+        }
         return {
           ...prev,
           streamingMessages: nextStreaming,
@@ -1065,6 +1021,7 @@ export class ReactiveSessionHandle {
         queuedTasks: sortTasksByQueuePosition((queueResult as QueueFindResult).data || []),
         messagesByTask,
         loadedTaskIds,
+        streamingMessages: restampStreamingTaskIds(prev.streamingMessages, tasks),
         error: null,
         terminal: false,
         lastSyncedAt: new Date().toISOString(),
@@ -1121,6 +1078,140 @@ export function attachReactiveSessionApi(client: AgorClient): ReactiveAgorClient
   };
 
   return reactiveClient;
+}
+
+// --- Per-connection stream subscription registry ---------------------------
+//
+// A session-stream room membership is per socket CONNECTION, but several
+// ReactiveSessionHandles (e.g. a board peek, an open panel, and a transcript,
+// each with its own taskHydration) share ONE connection for the same session.
+// If every handle sent its own `remove` on dispose, disposing any one would
+// evict the shared connection from the room and silently kill the others'
+// streams. So subscription is refcounted per (client, session id): the first
+// attach subscribes, the last detach unsubscribes, and a single shared op chain
+// orders create/remove across handles (a late create from a disposing handle
+// can't land after a newer handle's create). On reconnect every still-wanted
+// session re-subscribes exactly once.
+
+interface StreamSubscription {
+  refCount: number;
+  chain: Promise<void>;
+  /** Canonical room id echoed by create; used so `remove` leaves the right room. */
+  roomId: string | null;
+  wantSubscribed: boolean;
+}
+
+interface ClientStreamState {
+  subs: Map<string, StreamSubscription>;
+  connectHandler: (() => void) | null;
+}
+
+const CLIENT_STREAM_STATE = new WeakMap<AgorClient, ClientStreamState>();
+
+function getClientStreamState(client: AgorClient): ClientStreamState {
+  let state = CLIENT_STREAM_STATE.get(client);
+  if (!state) {
+    state = { subs: new Map(), connectHandler: null };
+    CLIENT_STREAM_STATE.set(client, state);
+  }
+  return state;
+}
+
+/** Serialize a create/remove op onto the subscription's shared chain. */
+function runSubscriptionOp(sub: StreamSubscription, op: () => Promise<void>): Promise<void> {
+  const next = sub.chain.then(op, op);
+  sub.chain = next.then(
+    () => undefined,
+    () => undefined
+  );
+  return next;
+}
+
+async function createSubscription(
+  client: AgorClient,
+  sessionId: string,
+  sub: StreamSubscription
+): Promise<void> {
+  // Released before this op ran — nothing to join.
+  if (!sub.wantSubscribed) return;
+  try {
+    const result = (await client.service('session-streams').create({ session_id: sessionId })) as
+      | { session_id?: string }
+      | undefined;
+    if (typeof result?.session_id === 'string' && result.session_id) {
+      sub.roomId = result.session_id;
+    }
+  } catch {
+    // Deploy skew / access error: the daemon's owner fallback covers the
+    // creator's own tabs, and access errors also surface via bootstrap/resync.
+  }
+}
+
+async function removeSubscription(
+  client: AgorClient,
+  sessionId: string,
+  sub: StreamSubscription
+): Promise<void> {
+  try {
+    await client.service('session-streams').remove(sub.roomId ?? sessionId);
+  } catch {
+    // Ignore — socket teardown removes room membership regardless.
+  }
+}
+
+function ensureStreamConnectHandler(client: AgorClient, state: ClientStreamState): void {
+  if (state.connectHandler) return;
+  const handler = () => {
+    for (const [sessionId, sub] of state.subs) {
+      if (sub.wantSubscribed) {
+        void runSubscriptionOp(sub, () => createSubscription(client, sessionId, sub));
+      }
+    }
+  };
+  state.connectHandler = handler;
+  client.io.on('connect', handler);
+}
+
+function retainSessionStream(client: AgorClient, sessionId: string): Promise<void> {
+  const state = getClientStreamState(client);
+  let sub = state.subs.get(sessionId);
+  if (!sub) {
+    sub = { refCount: 0, chain: Promise.resolve(), roomId: null, wantSubscribed: false };
+    state.subs.set(sessionId, sub);
+  }
+  const was = sub.refCount;
+  sub.refCount += 1;
+  sub.wantSubscribed = true;
+  ensureStreamConnectHandler(client, state);
+  // First attach (including re-attach while a prior remove is still draining on
+  // the shared chain) enqueues the create; it lands after any pending remove.
+  if (was === 0) {
+    const target = sub;
+    return runSubscriptionOp(target, () => createSubscription(client, sessionId, target));
+  }
+  return sub.chain;
+}
+
+function releaseSessionStream(client: AgorClient, sessionId: string): void {
+  const state = CLIENT_STREAM_STATE.get(client);
+  if (!state) return;
+  const sub = state.subs.get(sessionId);
+  if (!sub || sub.refCount === 0) return;
+  sub.refCount -= 1;
+  if (sub.refCount > 0) return;
+  sub.wantSubscribed = false;
+  void runSubscriptionOp(sub, () => removeSubscription(client, sessionId, sub)).then(() => {
+    // Drop the entry only if nothing re-attached while the remove drained; a
+    // re-attach reuses this same sub and its ordered chain.
+    if (sub.refCount === 0 && !sub.wantSubscribed && state.subs.get(sessionId) === sub) {
+      state.subs.delete(sessionId);
+      if (state.subs.size === 0 && state.connectHandler) {
+        client.io.off('connect', state.connectHandler);
+        state.connectHandler = null;
+        CLIENT_STREAM_STATE.delete(client);
+      }
+    }
+  });
 }
 
 interface SharedReactiveSessionEntry {
@@ -1213,6 +1304,29 @@ function findLatestHydratableTask(tasks: Task[]): Task | undefined {
     if (tasks[i].status !== TaskStatus.QUEUED) return tasks[i];
   }
   return undefined;
+}
+
+/**
+ * Fill in task_id for streaming messages initialized from a chunk that arrived
+ * before task state was hydrated (task_id left undefined). Once tasks are known
+ * the latest hydratable task is the active one, so grouping repairs and the
+ * live text renders under the right TaskBlock. Returns the same map reference
+ * when nothing changed, to preserve downstream memoization.
+ */
+function restampStreamingTaskIds(
+  streamingMessages: ReactiveStreamingMessagesById,
+  tasks: Task[]
+): ReactiveStreamingMessagesById {
+  const activeTaskId = findLatestHydratableTask(tasks)?.task_id;
+  if (!activeTaskId) return streamingMessages;
+  let next = streamingMessages;
+  for (const [id, message] of streamingMessages) {
+    if (!message.task_id) {
+      if (next === streamingMessages) next = new Map(streamingMessages);
+      next.set(id, { ...message, task_id: activeTaskId });
+    }
+  }
+  return next;
 }
 
 function sortMessagesByIndex(messages: Message[]): Message[] {

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -1362,10 +1362,14 @@ function releaseSessionStream(client: AgorClient, sessionId: string): void {
   if (sub.refCount > 0) return;
   sub.wantSubscribed = false;
   void runSubscriptionOp(sub, () => removeSubscription(client, sub)).then(() => {
-    // Drop the entry only if nothing re-attached while the remove drained; a
-    // re-attach reuses this same sub and its ordered chain.
-    if (sub.refCount === 0 && !sub.wantSubscribed && state.subs.get(key) === sub) {
-      state.subs.delete(key);
+    // Re-resolve the key: the create ack (which ran before this remove on the
+    // shared chain) may have re-keyed the entry from the id we captured to its
+    // canonical id — e.g. a short-id handle disposed before its ack. Consulting
+    // the stale key would leave the entry (and the connect-handler lifecycle)
+    // orphaned. Drop it only if nothing re-attached while the remove drained.
+    const currentKey = resolveStreamKey(state, sessionId);
+    if (sub.refCount === 0 && !sub.wantSubscribed && state.subs.get(currentKey) === sub) {
+      state.subs.delete(currentKey);
       if (state.subs.size === 0 && state.disconnectHandler) {
         client.io.off('disconnect', state.disconnectHandler);
         state.disconnectHandler = null;
@@ -1373,6 +1377,15 @@ function releaseSessionStream(client: AgorClient, sessionId: string): void {
       }
     }
   });
+}
+
+/**
+ * @internal Test-only: number of live stream-subscription registry entries for
+ * a client (0 once the last release has torn the client's state down). Lets
+ * tests assert the registry doesn't leak entries across re-key / dispose races.
+ */
+export function __streamSubscriptionCountForTest(client: AgorClient): number {
+  return CLIENT_STREAM_STATE.get(client)?.subs.size ?? 0;
 }
 
 interface SharedReactiveSessionEntry {

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -163,6 +163,14 @@ export class ReactiveSessionHandle {
    */
   private streamOpChain: Promise<void> = Promise.resolve();
 
+  /**
+   * Canonical room id echoed back by `session-streams.create` (the resolved
+   * row's full session_id). Used for `remove` so a short-id / alias caller —
+   * including one whose access was later revoked — leaves the room it actually
+   * joined rather than a raw-id room it never entered.
+   */
+  private streamRoomId: string | null = null;
+
   private stateSnapshot: ReactiveSessionState;
 
   constructor(client: AgorClient, sessionId: string, options?: ReactiveSessionOptions) {
@@ -355,7 +363,14 @@ export class ReactiveSessionHandle {
       // avoids a pointless round-trip.
       if (this.disposed) return;
       try {
-        await this.client.service('session-streams').create({ session_id: this.sessionId });
+        const result = (await this.client
+          .service('session-streams')
+          .create({ session_id: this.sessionId })) as { session_id?: string } | undefined;
+        // Remember the canonical room id so unsubscribe leaves the right room
+        // even for short-id callers or after access is revoked.
+        if (typeof result?.session_id === 'string' && result.session_id) {
+          this.streamRoomId = result.session_id;
+        }
       } catch {
         // Ignore — see method doc. Access errors also surface via bootstrap/resync.
       }
@@ -365,7 +380,7 @@ export class ReactiveSessionHandle {
   private unsubscribeFromStream(): Promise<void> {
     return this.runStreamOp(async () => {
       try {
-        await this.client.service('session-streams').remove(this.sessionId);
+        await this.client.service('session-streams').remove(this.streamRoomId ?? this.sessionId);
       } catch {
         // Ignore — the socket teardown removes room membership regardless.
       }
@@ -770,12 +785,30 @@ export class ReactiveSessionHandle {
       if (event.session_id !== this.sessionId) return;
       this.updateState((prev) => {
         const current = prev.streamingMessages.get(event.message_id);
-        if (!current) return prev;
         const nextStreaming = new Map(prev.streamingMessages);
-        nextStreaming.set(event.message_id, {
-          ...current,
-          content: current.content + event.chunk,
-        });
+        if (current) {
+          nextStreaming.set(event.message_id, {
+            ...current,
+            content: current.content + event.chunk,
+          });
+        } else {
+          // Attached or reconnected after streaming:start already fired: the
+          // start event won't repeat, so initialize the stream from this chunk
+          // instead of dropping it. Content begins here; earlier text arrives
+          // when the message row lands at the next boundary (onMessageCreated
+          // then clears this entry). task_id is inferred from the active task
+          // so the live text groups under the right TaskBlock.
+          nextStreaming.set(event.message_id, {
+            message_id: event.message_id,
+            session_id: event.session_id,
+            task_id: findLatestHydratableTask(prev.tasks)?.task_id,
+            role: 'assistant',
+            content: event.chunk,
+            thinkingContent: '',
+            timestamp: new Date().toISOString(),
+            isStreaming: true,
+          });
+        }
         return {
           ...prev,
           streamingMessages: nextStreaming,

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -156,6 +156,16 @@ export class ReactiveSessionHandle {
   private readyPromise: Promise<void>;
   private disposed = false;
 
+  /**
+   * The canonical (full-UUID) session id. When this handle was constructed with
+   * a short id / alias, incoming realtime events still carry the full UUID, so
+   * event matching must accept it too. Learned from the subscribe ack and from
+   * hydration (the fetched session row's `session_id` is always canonical); we
+   * deliberately do NOT overwrite `sessionId`, which echoes back what the
+   * caller passed (API calls resolve short ids server-side anyway).
+   */
+  private canonicalSessionId: string | null = null;
+
   private stateSnapshot: ReactiveSessionState;
 
   constructor(client: AgorClient, sessionId: string, options?: ReactiveSessionOptions) {
@@ -203,12 +213,26 @@ export class ReactiveSessionHandle {
     hydrate: () => Promise<void>
   ): Promise<void> {
     await subscribed;
+    // Learn the canonical id from the ack so events (full-UUID) arriving before
+    // hydration completes already match — the mid-stream chunk case.
+    const canonical = getCanonicalSessionId(this.client, this.sessionId);
+    if (canonical) this.canonicalSessionId = canonical;
     if (this.disposed) return;
     await hydrate();
   }
 
   get sessionId(): string {
     return this.stateSnapshot.sessionId;
+  }
+
+  /**
+   * True when a realtime event's session id belongs to this handle — matching
+   * either the id the caller requested or the canonical id learned from the
+   * subscribe ack / hydration. Events always carry the canonical (full-UUID)
+   * id, so a short-id handle relies on the canonical match.
+   */
+  private matchesSession(id: string): boolean {
+    return id === this.sessionId || id === this.canonicalSessionId;
   }
 
   get state(): ReactiveSessionState {
@@ -367,6 +391,10 @@ export class ReactiveSessionHandle {
           .catch(() => ({ data: [] }) as QueueFindResult),
       ]);
 
+      // The fetched row's id is canonical even when we asked by short id — the
+      // authoritative source for event matching.
+      if (session?.session_id) this.canonicalSessionId = session.session_id;
+
       let messagesByTask = new Map<string, Message[]>();
       let loadedTaskIds = new Set<string>();
 
@@ -462,7 +490,7 @@ export class ReactiveSessionHandle {
     this.disposeCallbacks.push(() => this.client.io.off('disconnect', onSocketDisconnect));
 
     const onSessionPatched = (session: Session) => {
-      if (session.session_id !== this.sessionId) return;
+      if (!this.matchesSession(session.session_id)) return;
       this.updateState((prev) => ({
         ...prev,
         session,
@@ -470,7 +498,7 @@ export class ReactiveSessionHandle {
       }));
     };
     const onSessionRemoved = (session: Session) => {
-      if (session.session_id !== this.sessionId) return;
+      if (!this.matchesSession(session.session_id)) return;
       this.updateState((prev) => ({
         ...prev,
         session: null,
@@ -487,7 +515,7 @@ export class ReactiveSessionHandle {
     this.disposeCallbacks.push(() => sessionsService.removeListener('removed', onSessionRemoved));
 
     const onTaskCreated = (task: Task) => {
-      if (task.session_id !== this.sessionId) return;
+      if (!this.matchesSession(task.session_id)) return;
       this.updateState((prev) => {
         const tasks = prev.tasks.some((t) => t.task_id === task.task_id)
           ? prev.tasks
@@ -507,7 +535,7 @@ export class ReactiveSessionHandle {
       });
     };
     const onTaskPatched = (task: Task) => {
-      if (task.session_id !== this.sessionId) return;
+      if (!this.matchesSession(task.session_id)) return;
       this.updateState((prev) => {
         const index = prev.tasks.findIndex((t) => t.task_id === task.task_id);
         const nextTasks = index === -1 ? [...prev.tasks, task] : [...prev.tasks];
@@ -538,7 +566,7 @@ export class ReactiveSessionHandle {
       });
     };
     const onTaskRemoved = (task: Task) => {
-      if (task.session_id !== this.sessionId) return;
+      if (!this.matchesSession(task.session_id)) return;
       this.updateState((prev) => {
         const nextByTask = new Map(prev.messagesByTask);
         nextByTask.delete(task.task_id);
@@ -577,7 +605,7 @@ export class ReactiveSessionHandle {
     );
 
     const onToolStart = (event: ToolStartEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const existing = prev.toolsByTask.get(event.task_id) || [];
         if (existing.some((t) => t.toolUseId === event.tool_use_id)) return prev;
@@ -597,7 +625,7 @@ export class ReactiveSessionHandle {
       });
     };
     const onToolComplete = (event: ToolCompleteEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const existing = prev.toolsByTask.get(event.task_id) || [];
         if (existing.length === 0) return prev;
@@ -624,7 +652,7 @@ export class ReactiveSessionHandle {
     );
 
     const onMessageCreated = (message: Message) => {
-      if (message.session_id !== this.sessionId) return;
+      if (!this.matchesSession(message.session_id)) return;
       this.updateState((prev) => {
         const nextStreaming = new Map(prev.streamingMessages);
         nextStreaming.delete(message.message_id);
@@ -664,7 +692,7 @@ export class ReactiveSessionHandle {
 
     const onMessagePatched = (message: Message) => {
       const taskId = message.task_id;
-      if (message.session_id !== this.sessionId || !taskId) return;
+      if (!this.matchesSession(message.session_id) || !taskId) return;
       this.updateState((prev) => {
         const current = prev.messagesByTask.get(taskId);
         if (!current) return prev;
@@ -683,7 +711,7 @@ export class ReactiveSessionHandle {
     };
 
     const onMessageRemoved = (message: Message) => {
-      if (message.session_id !== this.sessionId) return;
+      if (!this.matchesSession(message.session_id)) return;
       const taskId = message.task_id;
       this.updateState((prev) => {
         const nextStreaming = new Map(prev.streamingMessages);
@@ -711,7 +739,7 @@ export class ReactiveSessionHandle {
     };
 
     const onStreamingStart = (event: StreamingStartEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const nextStreaming = new Map(prev.streamingMessages);
         nextStreaming.set(event.message_id, {
@@ -732,7 +760,7 @@ export class ReactiveSessionHandle {
     };
 
     const onStreamingChunk = (event: StreamingChunkEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const current = prev.streamingMessages.get(event.message_id);
         const nextStreaming = new Map(prev.streamingMessages);
@@ -767,7 +795,7 @@ export class ReactiveSessionHandle {
     };
 
     const onStreamingEnd = (event: StreamingEndEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const current = prev.streamingMessages.get(event.message_id);
         if (!current) return prev;
@@ -784,7 +812,7 @@ export class ReactiveSessionHandle {
     };
 
     const onStreamingError = (event: StreamingErrorEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const current = prev.streamingMessages.get(event.message_id);
         if (!current) return prev;
@@ -802,7 +830,7 @@ export class ReactiveSessionHandle {
     };
 
     const onThinkingStart = (event: ThinkingStartEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const nextStreaming = new Map(prev.streamingMessages);
         const existing = nextStreaming.get(event.message_id);
@@ -825,7 +853,7 @@ export class ReactiveSessionHandle {
     };
 
     const onThinkingChunk = (event: ThinkingChunkEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const current = prev.streamingMessages.get(event.message_id);
         const nextStreaming = new Map(prev.streamingMessages);
@@ -859,7 +887,7 @@ export class ReactiveSessionHandle {
     };
 
     const onThinkingEnd = (event: ThinkingEndEvent) => {
-      if (event.session_id !== this.sessionId) return;
+      if (!this.matchesSession(event.session_id)) return;
       this.updateState((prev) => {
         const current = prev.streamingMessages.get(event.message_id);
         if (!current) return prev;
@@ -986,6 +1014,9 @@ export class ReactiveSessionHandle {
           .find()
           .catch(() => ({ data: [] }) as QueueFindResult),
       ]);
+
+      // The fetched row's id is canonical even when we asked by short id.
+      if (session?.session_id) this.canonicalSessionId = session.session_id;
 
       let messagesByTask = this.stateSnapshot.messagesByTask;
       let loadedTaskIds = this.stateSnapshot.loadedTaskIds;
@@ -1158,6 +1189,17 @@ function getClientStreamState(client: AgorClient): ClientStreamState {
 
 function resolveStreamKey(state: ClientStreamState, sessionId: string): string {
   return state.keyToCanonical.get(sessionId) ?? sessionId;
+}
+
+/**
+ * The canonical session id the daemon echoed for a caller-supplied id, learned
+ * from a `create` ack, or null if not yet known. Lets a short-id handle match
+ * incoming events (which carry the full UUID) once its subscription is acked.
+ */
+function getCanonicalSessionId(client: AgorClient, sessionId: string): string | null {
+  const state = CLIENT_STREAM_STATE.get(client);
+  const canonical = state?.keyToCanonical.get(sessionId);
+  return canonical && canonical !== sessionId ? canonical : null;
 }
 
 /** Serialize a create/remove op onto the subscription's shared chain. */

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -180,6 +180,11 @@ export class ReactiveSessionHandle {
     };
 
     this.attachListeners();
+    // Declare interest in this session's streaming channel so the daemon routes
+    // per-chunk streaming events to this connection. The socket is usually
+    // already connected here; reconnects re-subscribe via onSocketConnect
+    // because rooms are per-connection and a reconnect is a new connection.
+    this.subscribeToStream();
     this.readyPromise = this.bootstrap();
   }
 
@@ -294,11 +299,38 @@ export class ReactiveSessionHandle {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    // Best-effort: leave the streaming room. The daemon also drops the
+    // connection from the channel automatically on socket disconnect, so this
+    // only matters while the socket stays open (e.g. navigating between
+    // sessions in one tab).
+    this.unsubscribeFromStream();
     for (const cleanup of this.disposeCallbacks) {
       cleanup();
     }
     this.disposeCallbacks.length = 0;
     this.listeners.clear();
+  }
+
+  /**
+   * Join this session's per-connection streaming channel on the daemon.
+   * Best-effort: a daemon that predates the `session-streams` service (deploy
+   * skew) rejects the call, in which case the daemon's owner-fallback delivery
+   * keeps this session's own tabs updating until the daemon is upgraded.
+   */
+  private subscribeToStream(): void {
+    void Promise.resolve(
+      this.client.service('session-streams').create({ session_id: this.sessionId })
+    ).catch(() => {
+      // Ignore — see method doc. Access errors also surface via bootstrap/resync.
+    });
+  }
+
+  private unsubscribeFromStream(): void {
+    void Promise.resolve(this.client.service('session-streams').remove(this.sessionId)).catch(
+      () => {
+        // Ignore — the socket teardown removes room membership regardless.
+      }
+    );
   }
 
   private assertNotDisposed(): void {
@@ -411,6 +443,9 @@ export class ReactiveSessionHandle {
     const onSocketConnect = () => {
       if (this.disposed) return;
       this.updateState((prev) => ({ ...prev, connected: true }));
+      // A reconnect is a new socket connection with no room membership, so
+      // re-declare interest before resyncing state.
+      this.subscribeToStream();
       this.readyPromise = this.resync();
     };
     const onSocketDisconnect = () => {

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -156,6 +156,13 @@ export class ReactiveSessionHandle {
   private readyPromise: Promise<void>;
   private disposed = false;
 
+  /**
+   * Serializes stream subscribe/unsubscribe so a delayed `create` can't land
+   * after a `remove` and re-join a disposed handle. Every op chains onto this,
+   * and dispose enqueues a compensating `remove` after any in-flight `create`.
+   */
+  private streamOpChain: Promise<void> = Promise.resolve();
+
   private stateSnapshot: ReactiveSessionState;
 
   constructor(client: AgorClient, sessionId: string, options?: ReactiveSessionOptions) {
@@ -180,12 +187,23 @@ export class ReactiveSessionHandle {
     };
 
     this.attachListeners();
-    // Declare interest in this session's streaming channel so the daemon routes
-    // per-chunk streaming events to this connection. The socket is usually
-    // already connected here; reconnects re-subscribe via onSocketConnect
-    // because rooms are per-connection and a reconnect is a new connection.
-    this.subscribeToStream();
-    this.readyPromise = this.bootstrap();
+    // Subscribe to the streaming channel BEFORE hydrating: the subscribe ack is
+    // awaited so any chunk arriving after it lands on top of hydrated state,
+    // and anything earlier is captured by the hydration itself — a viewer
+    // opening mid-stream can't fall into the gap where early chunks arrive with
+    // no streaming state and get dropped. Reconnects re-subscribe the same way
+    // via onSocketConnect (rooms are per-connection; a reconnect is a new one).
+    this.readyPromise = this.subscribeThenHydrate(() => this.bootstrap());
+  }
+
+  /**
+   * Await the streaming subscription, then run the hydration/resync step, so
+   * chunk delivery and state hydration can't interleave into a lost-update gap.
+   */
+  private async subscribeThenHydrate(hydrate: () => Promise<void>): Promise<void> {
+    await this.subscribeToStream();
+    if (this.disposed) return;
+    await hydrate();
   }
 
   get sessionId(): string {
@@ -299,11 +317,12 @@ export class ReactiveSessionHandle {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    // Best-effort: leave the streaming room. The daemon also drops the
-    // connection from the channel automatically on socket disconnect, so this
-    // only matters while the socket stays open (e.g. navigating between
-    // sessions in one tab).
-    this.unsubscribeFromStream();
+    // Best-effort: leave the streaming room. Enqueued after any in-flight
+    // subscribe so a late-landing create is always followed by this remove.
+    // The daemon also drops the connection from the channel on socket
+    // disconnect, so this only matters while the socket stays open (e.g.
+    // navigating between sessions in one tab).
+    void this.unsubscribeFromStream();
     for (const cleanup of this.disposeCallbacks) {
       cleanup();
     }
@@ -311,34 +330,46 @@ export class ReactiveSessionHandle {
     this.listeners.clear();
   }
 
+  /** Run a stream subscribe/unsubscribe op serialized after any in-flight op. */
+  private runStreamOp(op: () => Promise<void>): Promise<void> {
+    const next = this.streamOpChain.then(op, op);
+    // Keep the chain alive regardless of any single op's outcome.
+    this.streamOpChain = next.then(
+      () => undefined,
+      () => undefined
+    );
+    return next;
+  }
+
   /**
    * Join this session's per-connection streaming channel on the daemon.
    * Best-effort: a daemon that predates the `session-streams` service (deploy
    * skew) rejects the call, in which case the daemon's owner-fallback delivery
    * keeps this session's own tabs updating until the daemon is upgraded.
+   * Serialized so it cannot re-join after a dispose-issued unsubscribe.
    */
-  private subscribeToStream(): void {
-    try {
-      void Promise.resolve(
-        this.client.service('session-streams').create({ session_id: this.sessionId })
-      ).catch(() => {
+  private subscribeToStream(): Promise<void> {
+    return this.runStreamOp(async () => {
+      // Skip if disposed: dispose enqueues a compensating unsubscribe after
+      // this op, so ordering alone already prevents stale membership; this just
+      // avoids a pointless round-trip.
+      if (this.disposed) return;
+      try {
+        await this.client.service('session-streams').create({ session_id: this.sessionId });
+      } catch {
         // Ignore — see method doc. Access errors also surface via bootstrap/resync.
-      });
-    } catch {
-      // Service unavailable on this client build — nothing to subscribe to.
-    }
+      }
+    });
   }
 
-  private unsubscribeFromStream(): void {
-    try {
-      void Promise.resolve(this.client.service('session-streams').remove(this.sessionId)).catch(
-        () => {
-          // Ignore — the socket teardown removes room membership regardless.
-        }
-      );
-    } catch {
-      // Service unavailable on this client build — nothing to unsubscribe from.
-    }
+  private unsubscribeFromStream(): Promise<void> {
+    return this.runStreamOp(async () => {
+      try {
+        await this.client.service('session-streams').remove(this.sessionId);
+      } catch {
+        // Ignore — the socket teardown removes room membership regardless.
+      }
+    });
   }
 
   private assertNotDisposed(): void {
@@ -452,9 +483,9 @@ export class ReactiveSessionHandle {
       if (this.disposed) return;
       this.updateState((prev) => ({ ...prev, connected: true }));
       // A reconnect is a new socket connection with no room membership, so
-      // re-declare interest before resyncing state.
-      this.subscribeToStream();
-      this.readyPromise = this.resync();
+      // re-declare interest and await the ack before resyncing — same ordering
+      // as the initial attach so post-subscribe chunks land after hydration.
+      this.readyPromise = this.subscribeThenHydrate(() => this.resync());
     };
     const onSocketDisconnect = () => {
       if (this.disposed) return;

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -184,18 +184,25 @@ export class ReactiveSessionHandle {
     // AWAIT its ack BEFORE hydrating: a chunk arriving after the ack lands on
     // top of hydrated state, and anything earlier is captured by the hydration
     // itself — a viewer opening mid-stream can't fall into the gap where early
-    // chunks arrive with no streaming state and get dropped. Reconnects
-    // re-subscribe once via the registry's connect handler (rooms are
-    // per-connection; a reconnect is a new one).
-    this.readyPromise = this.subscribeThenHydrate(() => this.bootstrap());
+    // chunks arrive with no streaming state and get dropped. Reconnects apply
+    // the same ordering via onSocketConnect (rooms are per-connection; a
+    // reconnect is a new one).
+    this.readyPromise = this.subscribeThenHydrate(
+      retainSessionStream(this.client, this.sessionId),
+      () => this.bootstrap()
+    );
   }
 
   /**
-   * Await the streaming subscription, then run the hydration step, so chunk
-   * delivery and state hydration can't interleave into a lost-update gap.
+   * Await the streaming subscription ack, then run the hydration step, so chunk
+   * delivery and state hydration can't interleave into a lost-update gap. Used
+   * on both attach (retain) and reconnect (re-subscribe) with the same ordering.
    */
-  private async subscribeThenHydrate(hydrate: () => Promise<void>): Promise<void> {
-    await retainSessionStream(this.client, this.sessionId);
+  private async subscribeThenHydrate(
+    subscribed: Promise<void>,
+    hydrate: () => Promise<void>
+  ): Promise<void> {
+    await subscribed;
     if (this.disposed) return;
     await hydrate();
   }
@@ -436,11 +443,14 @@ export class ReactiveSessionHandle {
     const onSocketConnect = () => {
       if (this.disposed) return;
       this.updateState((prev) => ({ ...prev, connected: true }));
-      // Re-subscription on reconnect is owned by the shared registry's connect
-      // handler (once per still-wanted session); the handle just resyncs its
-      // state, and the chunk handler initializes any stream that starts before
-      // this resync completes.
-      this.readyPromise = this.resync();
+      // A reconnect is a new connection with no room membership. Await the
+      // shared re-subscribe (deduped to one join per session across handles)
+      // BEFORE resyncing — the same subscribe-then-hydrate ordering as attach,
+      // so a chunk arriving after the join lands on top of the resynced state.
+      this.readyPromise = this.subscribeThenHydrate(
+        resubscribeSessionStream(this.client, this.sessionId),
+        () => this.resync()
+      );
     };
     const onSocketDisconnect = () => {
       if (this.disposed) return;
@@ -1099,11 +1109,17 @@ interface StreamSubscription {
   /** Canonical room id echoed by create; used so `remove` leaves the right room. */
   roomId: string | null;
   wantSubscribed: boolean;
+  /**
+   * The re-subscribe op for the CURRENT connection, shared by every handle so a
+   * reconnect re-subscribes each session exactly once. Reset to null on socket
+   * disconnect so the next reconnect issues a fresh join.
+   */
+  reconnect: Promise<void> | null;
 }
 
 interface ClientStreamState {
   subs: Map<string, StreamSubscription>;
-  connectHandler: (() => void) | null;
+  disconnectHandler: (() => void) | null;
 }
 
 const CLIENT_STREAM_STATE = new WeakMap<AgorClient, ClientStreamState>();
@@ -1111,7 +1127,7 @@ const CLIENT_STREAM_STATE = new WeakMap<AgorClient, ClientStreamState>();
 function getClientStreamState(client: AgorClient): ClientStreamState {
   let state = CLIENT_STREAM_STATE.get(client);
   if (!state) {
-    state = { subs: new Map(), connectHandler: null };
+    state = { subs: new Map(), disconnectHandler: null };
     CLIENT_STREAM_STATE.set(client, state);
   }
   return state;
@@ -1159,30 +1175,37 @@ async function removeSubscription(
   }
 }
 
-function ensureStreamConnectHandler(client: AgorClient, state: ClientStreamState): void {
-  if (state.connectHandler) return;
+// A reconnect is a new connection with no room membership. Reset each sub's
+// re-subscribe token on disconnect so the next `resubscribeSessionStream` (one
+// per session, driven by the handles' connect listeners) issues a fresh join.
+function ensureStreamDisconnectHandler(client: AgorClient, state: ClientStreamState): void {
+  if (state.disconnectHandler) return;
   const handler = () => {
-    for (const [sessionId, sub] of state.subs) {
-      if (sub.wantSubscribed) {
-        void runSubscriptionOp(sub, () => createSubscription(client, sessionId, sub));
-      }
+    for (const sub of state.subs.values()) {
+      sub.reconnect = null;
     }
   };
-  state.connectHandler = handler;
-  client.io.on('connect', handler);
+  state.disconnectHandler = handler;
+  client.io.on('disconnect', handler);
 }
 
 function retainSessionStream(client: AgorClient, sessionId: string): Promise<void> {
   const state = getClientStreamState(client);
   let sub = state.subs.get(sessionId);
   if (!sub) {
-    sub = { refCount: 0, chain: Promise.resolve(), roomId: null, wantSubscribed: false };
+    sub = {
+      refCount: 0,
+      chain: Promise.resolve(),
+      roomId: null,
+      wantSubscribed: false,
+      reconnect: null,
+    };
     state.subs.set(sessionId, sub);
   }
   const was = sub.refCount;
   sub.refCount += 1;
   sub.wantSubscribed = true;
-  ensureStreamConnectHandler(client, state);
+  ensureStreamDisconnectHandler(client, state);
   // First attach (including re-attach while a prior remove is still draining on
   // the shared chain) enqueues the create; it lands after any pending remove.
   if (was === 0) {
@@ -1190,6 +1213,22 @@ function retainSessionStream(client: AgorClient, sessionId: string): Promise<voi
     return runSubscriptionOp(target, () => createSubscription(client, sessionId, target));
   }
   return sub.chain;
+}
+
+/**
+ * Re-subscribe a still-wanted session on reconnect and return the shared op
+ * promise so the caller can await the join BEFORE resyncing. Deduped per
+ * connection: the first handle to call it enqueues the create; every other
+ * handle for the same session awaits the same promise (exactly one join).
+ */
+function resubscribeSessionStream(client: AgorClient, sessionId: string): Promise<void> {
+  const state = CLIENT_STREAM_STATE.get(client);
+  const sub = state?.subs.get(sessionId);
+  if (!sub?.wantSubscribed) return Promise.resolve();
+  if (!sub.reconnect) {
+    sub.reconnect = runSubscriptionOp(sub, () => createSubscription(client, sessionId, sub));
+  }
+  return sub.reconnect;
 }
 
 function releaseSessionStream(client: AgorClient, sessionId: string): void {
@@ -1205,9 +1244,9 @@ function releaseSessionStream(client: AgorClient, sessionId: string): void {
     // re-attach reuses this same sub and its ordered chain.
     if (sub.refCount === 0 && !sub.wantSubscribed && state.subs.get(sessionId) === sub) {
       state.subs.delete(sessionId);
-      if (state.subs.size === 0 && state.connectHandler) {
-        client.io.off('connect', state.connectHandler);
-        state.connectHandler = null;
+      if (state.subs.size === 0 && state.disconnectHandler) {
+        client.io.off('disconnect', state.disconnectHandler);
+        state.disconnectHandler = null;
         CLIENT_STREAM_STATE.delete(client);
       }
     }

--- a/packages/client/src/reactive-session.ts
+++ b/packages/client/src/reactive-session.ts
@@ -318,19 +318,27 @@ export class ReactiveSessionHandle {
    * keeps this session's own tabs updating until the daemon is upgraded.
    */
   private subscribeToStream(): void {
-    void Promise.resolve(
-      this.client.service('session-streams').create({ session_id: this.sessionId })
-    ).catch(() => {
-      // Ignore — see method doc. Access errors also surface via bootstrap/resync.
-    });
+    try {
+      void Promise.resolve(
+        this.client.service('session-streams').create({ session_id: this.sessionId })
+      ).catch(() => {
+        // Ignore — see method doc. Access errors also surface via bootstrap/resync.
+      });
+    } catch {
+      // Service unavailable on this client build — nothing to subscribe to.
+    }
   }
 
   private unsubscribeFromStream(): void {
-    void Promise.resolve(this.client.service('session-streams').remove(this.sessionId)).catch(
-      () => {
-        // Ignore — the socket teardown removes room membership regardless.
-      }
-    );
+    try {
+      void Promise.resolve(this.client.service('session-streams').remove(this.sessionId)).catch(
+        () => {
+          // Ignore — the socket teardown removes room membership regardless.
+        }
+      );
+    } catch {
+      // Service unavailable on this client build — nothing to unsubscribe from.
+    }
   }
 
   private assertNotDisposed(): void {

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -289,6 +289,30 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   }
 
   /**
+   * Resolve the owning user id for a session without hydrating the full row.
+   * Used by realtime delivery to offer streaming events to the session
+   * creator's own connections as a fallback, so their open tabs keep updating
+   * even before they subscribe to the per-session stream channel.
+   */
+  async findCreatedByBySessionId(id: string): Promise<UUID | null> {
+    try {
+      const fullId = await this.resolveId(id);
+      const row = await select(this.db, { created_by: sessions.created_by })
+        .from(sessions)
+        .where(eq(sessions.session_id, fullId))
+        .one();
+      return (row?.created_by as UUID | undefined) ?? null;
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) return null;
+      if (error instanceof AmbiguousIdError) throw error;
+      throw new RepositoryError(
+        `Failed to find session owner: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Find all sessions
    *
    * LEFT JOINs with branches to populate board_id and url in a single query.

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -50,7 +50,7 @@ const checks = [
       'apps/agor-daemon/src/mcp/tools/artifacts.ts': 1,
       'apps/agor-daemon/src/mcp/tools/boards.ts': 2,
       'apps/agor-daemon/src/mcp/tools/cards.ts': 8,
-      'apps/agor-daemon/src/utils/realtime-publish.ts': 4,
+      'apps/agor-daemon/src/utils/realtime-publish.ts': 7,
       'apps/agor-daemon/src/setup/socketio.ts': 18,
     },
   },

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -50,10 +50,11 @@ const checks = [
       'apps/agor-daemon/src/mcp/tools/artifacts.ts': 1,
       'apps/agor-daemon/src/mcp/tools/boards.ts': 2,
       'apps/agor-daemon/src/mcp/tools/cards.ts': 8,
-      // The tenant-aware realtime facade: tenant/session channel join/leave,
-      // the publish handler, and session-stream room routing (join, leave,
-      // leave-all, and the publish-time room lookup) all live here on purpose.
-      'apps/agor-daemon/src/utils/realtime-publish.ts': 8,
+      // The tenant-aware realtime facade: tenant/session channel join, the
+      // publish handler, session-stream join, the existence-gated room lookup
+      // (existingChannel — used by publish + leave paths so they never
+      // materialize a room), and leave-all all live here on purpose.
+      'apps/agor-daemon/src/utils/realtime-publish.ts': 7,
       'apps/agor-daemon/src/setup/socketio.ts': 18,
     },
   },

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -50,7 +50,10 @@ const checks = [
       'apps/agor-daemon/src/mcp/tools/artifacts.ts': 1,
       'apps/agor-daemon/src/mcp/tools/boards.ts': 2,
       'apps/agor-daemon/src/mcp/tools/cards.ts': 8,
-      'apps/agor-daemon/src/utils/realtime-publish.ts': 7,
+      // The tenant-aware realtime facade: tenant/session channel join/leave,
+      // the publish handler, and session-stream room routing (join, leave,
+      // leave-all, and the publish-time room lookup) all live here on purpose.
+      'apps/agor-daemon/src/utils/realtime-publish.ts': 8,
       'apps/agor-daemon/src/setup/socketio.ts': 18,
     },
   },


### PR DESCRIPTION
## Problem

Production browsers are saturated by the org's realtime firehose. Client rendering is already frame-batched, so the remaining always-on cost is **receiving** events: with branch RBAC off (the production default), `app.publish` short-circuits every service event to the whole tenant. Every browser therefore pays socket parse + Feathers dispatch for **every streaming chunk of every session org-wide** — a continuous wall of short tasks and saturated network for the duration of any active turn, anywhere in the org.

This scopes the per-chunk streaming firehose to the tabs actually viewing a session, while leaving board/home-facing events (created/patched/removed, status transitions) exactly as tenant-scoped as before.

## Phase 1 — event census (one streaming Claude turn)

Emitters, with frequency and `file:line`:

| Freq | Service · event | Emitter |
| --- | --- | --- |
| **per-chunk** | `messages` · `streaming:start\|chunk\|end\|error`, `thinking:start\|chunk\|end` | executor `broadcastEvent` → `POST /messages/streaming` — `packages/executor/src/handlers/sdk/base-executor.ts:136-208`; re-emitted on the `messages` service in `apps/agor-daemon/src/register-routes.ts:661` |
| **per-chunk** | `tasks` · `thinking:chunk` | executor `emitTaskEvent` → `POST /tasks/streaming` — `packages/executor/src/sdk-handlers/claude/claude-tool.ts:491`; re-emitted on `tasks` in `apps/agor-daemon/src/register-routes.ts:699` |
| **per-tool** | `tasks` · `tool:start` / `tool:complete` | `packages/executor/src/sdk-handlers/claude/claude-tool.ts:406,418` → `POST /tasks/streaming` → `register-routes.ts:699` |
| **per-message** | `messages` · `created` / `patched` | executor message-builder → `POST /messages` (Feathers auto-events) |
| **per-turn** | `tasks` · `patched` (terminal) | `apps/agor-daemon/src/services/tasks.ts` terminal patch |
| **per-turn** | `sessions` · `patched` (status IDLE/FAILED + `ready_for_prompt`) | `apps/agor-daemon/src/services/tasks.ts:612` |
| **per-turn** | `sessions` · `patched` (`git_state.current_sha`) | `packages/executor/src/handlers/sdk/base-executor.ts:276` |
| **per-10s** | `tasks` · `patched` (`last_executor_heartbeat_at`) | `packages/executor/src/executor-heartbeat.ts:42` (task row only) |

### Phase 1.2 — the high-frequency `session:patched` emitter

**There is no per-token / per-chunk `session:patched` emitter in this branch.** All session-row patches are turn-boundary or status transitions:

- SDK context-window / usage mirroring lands on the **task** row at turn end — `normalized_sdk_response.contextUsageSnapshot` at `packages/executor/src/handlers/sdk/base-executor.ts:565` — not the session. A prior "roughly per-token `session:patched`" is not reproducible here; it was most likely this context mirroring before it moved onto the task row.
- The session `git_state` patch (`base-executor.ts:276`) and the terminal-status patch (`tasks.ts:612`) each fire once per turn.
- The 10s cadence patches the **task** row (`executor-heartbeat.ts:42`), never the session.

Sole UI consumer of streaming/thinking/tool events: `ReactiveSessionHandle` in `packages/client/src/reactive-session.ts` (`attachListeners`). `apps/agor-ui/src/hooks/useTaskEvents.ts` is defined but unused.

## Phase 2 — design

### A. Session-interest rooms for streaming events

- **New `session-streams` service** (`apps/agor-daemon/src/services/session-streams.ts`): `create({session_id})` joins the calling connection to `session-stream:<id>`; `remove(id)` leaves it. Access is gated by a tenant-scoped `sessions.get` — the same auth / tenant / branch-view checks a normal session read runs, so there is no weaker path to a session's live text than to its stored messages. Join/leave use the **canonical** `session_id` from the resolved row, so short-id / alias callers land in the same room publishers emit to (the full UUID). The create/remove events are control-plane and publish to nobody (`service.publish(() => [])`). Feathers drops connections from channels automatically on socket disconnect, so cleanup is handled by the transport.
- **Publish routing** (`apps/agor-daemon/src/utils/realtime-publish.ts`): an extended `isStreamingEvent` predicate matches messages `streaming:*`/`thinking:*` and tasks `thinking:chunk`/`tool:start`/`tool:complete`. These route — regardless of branch RBAC — to **(1)** the per-session channel, **(2)** service-account connections (`filterToServiceConnections`, so gateway/Slack streaming and other service consumers keep working), and **(3)** the session **owner's** connections as a cheap fallback (cached owner lookup) that keeps a creator's already-open tabs live during deploy skew before a stale client re-subscribes.
- **Authorization is enforced at publish time, not just subscribe time.** Subscription join checks access once, but access can be revoked afterwards — so when branch RBAC is on, the publish path runs the room members **and** the owner-fallback candidates through the current cached branch visibility (`RealtimeAccessCache.getBranchVisibility` + the same `filterToUserIdsOrSuperadmins` filtering the non-streaming path uses) before returning the channel. A viewer or creator whose access is revoked mid-stream stops receiving chunks on the very next event, rather than lingering until unsubscribe/disconnect. The cache keeps this per-chunk and room membership is small, so the scoping win is preserved. With RBAC off there is no visibility model, so subscriber + owner + service delivery stands. Malformed streaming events without a resolvable session id fail closed to service connections only; everything else keeps today's tenant/branch scoping.
- **Logout / tenant-eviction can't leak a live stream.** Feathers only drops channel membership on socket *disconnect*, so a logged-out-but-still-connected socket (removed from the authenticated/tenant channels but lingering in a session-stream room) would otherwise keep receiving live text — with RBAC off or `allAuthenticated` visibility the room is returned unfiltered. Two cheap, independent cuts close this: (1) publish-time, the session room is **intersected with `tenantScoped`**, so nothing outside the current tenant/auth channel set can receive regardless of RBAC (this also hardens tenant-removal staleness); (2) on logout the connection is removed from **all** `session-stream:*` rooms (`leaveAllSessionStreamChannels`).
- **Client** (`packages/client/src/reactive-session.ts`): room membership is per socket **connection**, but several `ReactiveSessionHandle`s (a board peek, an open panel, a transcript — each with its own `taskHydration`) share one connection for the same session. So subscription is **refcounted per (client, canonical room)** in a module-level registry with a single shared op chain: the first attach subscribes, the last detach unsubscribes, and disposing one handle no longer evicts the shared room membership and kills the others' streams. The room is keyed by the **canonical** session id the daemon echoes from `create` (not the caller-supplied id), so mixed short-id (deep-link URLs) and full-UUID retains of the same session resolve to one membership: a learned alias re-keys the entry so a later retain of either form reuses it, and a room-level want-count gates the single `remove` so it fires only when the last retainer across all id forms releases (even when both forms subscribe before either ack lands — their entries fold together). The shared chain also orders create/remove across handle churn (a late create from a disposing handle can't land after a newer handle's create), and **reconnect re-subscribes every still-wanted session exactly once** (deduped through the registry, reset per connection on `disconnect`). Two further guarantees: (a) a handle **awaits the subscribe ack before hydrating** its state — on **both attach and reconnect** — so a viewer opening (or reconnecting) mid-stream can't fall into the gap where early chunks arrive before any streaming state exists; (b) the chunk/thinking-chunk handlers **initialize stream state from the chunk** when no `streaming:start` was seen (attach mid-stream), and task hydration **re-stamps** any stream whose `task_id` was still unknown. Subscription is best-effort: a daemon without the service (deploy skew) is tolerated, and the owner-fallback covers the creator's own tabs meanwhile.

Two browsers on the same session both stream — rooms are additive. Gateway/Slack streaming is unaffected: it is handled server-side inside the `/messages/streaming` route (`handleMessageStreamingEvent`) and additionally reaches any service-account socket via `filterToServiceConnections`.

### B. Coalescing the streaming-time session patch

No change — because the census found **no per-token session patch to coalesce**. The former per-token cost now lands on the task row at turn end (`base-executor.ts:565`), and the recurring session patches are turn-boundary status/git-state (once each). Adding a throttle would be dead code guarding an emitter that does not fire per-chunk. Status-transition patches (running/awaiting/idle/ready_for_prompt) are deliberately untouched — boards, home, and favicons need those immediate and tenant-visible.

### C. 10s heartbeat

Left alone (task row, per instruction).

## Changes by file

- `apps/agor-daemon/src/services/session-streams.ts` — **new** subscribe/unsubscribe service (access-gated join/leave).
- `apps/agor-daemon/src/utils/realtime-publish.ts` — `sessionStreamChannelName`, `join/leaveSessionStreamChannel` facade, extended `isStreamingEvent`, `resolveStreamingDelivery` (room + service + owner), routed before the RBAC branch.
- `apps/agor-daemon/src/utils/realtime-access-cache.ts` — cached `getSessionOwnerId` (same TTL as session→branch). `created_by` is immutable, so a cache entry is never stale for owner purposes; the TTL handles eviction (and `invalidateSession` clears it if ever wired to session removal).
- `apps/agor-daemon/src/setup/socketio.ts` — logout leaves all `session-stream:*` rooms for the connection.
- `apps/agor-daemon/src/register-routes.ts` — `/messages/streaming` + `/tasks/streaming` route services publish their own default `created` ack to no one.
- `apps/agor-daemon/src/services/session-streams.ts` — `remove` skips the resolve round-trip for a full-UUID id.
- `apps/agor-daemon/src/register-services.ts` — register `session-streams` (`requireAuth`, publish-to-nobody).
- `packages/core/src/db/repositories/sessions.ts` — lean `findCreatedByBySessionId`.
- `packages/client/src/reactive-session.ts` — subscribe on attach / dispose / reconnect; deploy-skew tolerant.
- `scripts/check-multitenancy-boundaries.mjs` — `realtime-publish.ts` baseline is **7** (the session-stream channel plumbing — join, existence-gated room lookup used by both publish and leave, and leave-all — all live in the audited realtime facade; the count reflects reality and the checker is unchanged).
- Tests: `realtime-publish.test.ts`, `realtime-access-cache.test.ts`, `session-streams.test.ts`, `reactive-session.test.ts`.

## Channel-materialization sweep

`app.channel(name)` **creates** the channel when absent, and a never-joined channel is never auto-pruned — so any read/leave path that hits an absent room leaks an empty channel. Every `app.channel(` site in `apps/agor-daemon` was audited:

| Site | Purpose | Class | Action |
| --- | --- | --- | --- |
| `realtime-publish.ts` `joinSessionStreamChannel` | session-stream **join** | (a) intentional — join creates the room, self-cleaning on last leave | none |
| `realtime-publish.ts` `existingChannel` | existence-gated lookup (used by publish + leave) | (b) guarded by an `app.channels` membership check | the fix |
| `realtime-publish.ts` `leaveSessionStreamChannel` | session-stream **leave** | (b) unbounded session ids — **materialized on leave** | **fixed** → routes through `existingChannel` |
| `realtime-publish.ts` `leaveAllSessionStreamChannels` | logout leave-all | (b) but iterates `app.channels` (existing names only) → never materializes | safe, none |
| `realtime-publish.ts` publish handler `app.channel('authenticated')` ×2 + `app.channel(tenant…)` | tenant/auth delivery base | (a) long-lived singletons, bounded by tenant count, read every event | none |
| `setup/socketio.ts` login `join` (authenticated + tenant) | connection join | (a) intentional join | none |
| `setup/socketio.ts` logout `leave` (authenticated + tenant) | connection leave | (a) long-lived, bounded — the connection joined these at login | none |

Client registry: every place a captured key string is consulted after a re-key could have happened was audited. `retainSessionStream` / `resubscribeSessionStream` re-resolve the key on each call (safe); `createSubscription` uses the captured key intentionally as the *from* side of the re-key; only `releaseSessionStream`'s deferred cleanup used a stale captured key — **fixed** by re-resolving at cleanup time.

## Gate results

- `@agor/core`, `@agor-live/client`, `@agor/daemon` typecheck: **pass**.
- Daemon suite: **1443 passed / 31 skipped / 0 failed**. Coverage includes: streaming reaches only subscribed connections; unsubscribed tabs get nothing; service accounts still receive; owner fallback delivers; revoked subscriber/owner stop receiving with RBAC on, an owner retaining access still receives; a room member removed from the tenant/auth channel (logout) receives nothing; `leaveAllSessionStreamChannels` leaves only session-stream rooms; publish never materializes a room for an unsubscribed session and doesn't resurrect a pruned one; short-id subscribe joins the canonical room; `remove` skips resolution for a full UUID; **`remove` on an absent room does not materialize it**.
- Client suite: **24 passed** — attach/dispose/deploy-skew; subscribe-before-hydrate ordering; reconnect awaits the re-subscribe ack before resyncing and re-subscribes exactly once across handles; dispose during in-flight subscribe leaves no membership; two handles share one subscription (disposing one keeps the other streaming); a late create can't evict a newer handle; mixed short-id/full-id retains share one canonical room (both id orderings); short-id handle matches canonical-id events; **a short-id handle disposed before its ack leaves the registry empty with a canonical-targeted remove**; mid-stream chunk / mid-thinking upsert render; task_id re-stamp after hydrate.
- agor-ui suite: **778 passed** (only the pre-existing `App.tsx` file fails to transform — see below).
- `check:multitenancy-boundaries`: passes; new channel plumbing lives in the audited realtime facade; `session-streams`/`register-services`/`socketio` add no raw realtime primitives beyond the facade.
- biome: clean on all touched files.

### Pre-existing, unrelated to this change

- `apps/agor-ui/src/components/App/App.tsx` has a duplicate `unreadCommentsCount` declaration (referencing undefined `activeComments` / `BoardComment`) that fails agor-ui typecheck and the `App.rerender` test import. This is present on `main` (introduced by `71d08168`, this branch's base), is being fixed separately, and is untouched here — the client-side change lives in `packages/client` and typechecks clean; the agor-ui suite is otherwise green (778 passing).
- `check:multitenancy-boundaries` also reports pre-existing baseline drift in `register-hooks.ts` and a few test files, likewise present with these changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





