### PR TITLE
fix(ui): remove duplicate unreadCommentsCount from stale merge resolution

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1120,12 +1120,6 @@ export const App: React.FC<AppProps> = ({
     useMemo(() => makeBranchesForBoardSelector(currentBoardId), [currentBoardId]),
     shallow
   );
-  // Shared between AppHeader's comments button and the collapsed rail's
-  // Comments item so both surfaces carry the same badge.
-  const unreadCommentsCount = activeComments.filter(
-    (c: BoardComment) => !c.parent_comment_id
-  ).length;
-
   // Comment-derived header scalars. Subscribing to the derived number/boolean
   // (instead of the comment map) keeps comment edits that don't change them —
   // and all comments on other boards — from waking the shell.


### PR DESCRIPTION
## What broke

`apps/agor-ui/src/components/App/App.tsx` on `main` declared `unreadCommentsCount` **twice**, breaking agor-ui typecheck and the `App.rerender` test-file import (main's CI was red).

## Why

The #1762 merge left a stale block that computed the count from an `activeComments` array — a leftover from a pre-refactor version of the file. `activeComments` is not defined anywhere, and the block also annotated with an unimported `BoardComment` type. The current version derives the count from the store selector (`makeUnreadCommentCountSelector`).

## Fix

Deleted the stale `activeComments`-based block (6 lines) and kept the `useAgorStore` store-selector version. The icon-rail render sites from #1762 already consume the store-derived value, so behavior is unchanged.

## Gates (all green)

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `npx vitest run src/components/App` ✅ (6 files, 34 tests)