### PR TITLE
refactor(ui): redesign Connect-AI panel per live-review feedback

### DIFF
--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -12,6 +12,7 @@
 import { resolveApiKey } from '@agor/core/config';
 import type { SessionRepository, TaskRepository } from '@agor/core/db';
 import type { HookContext, Message, Session, Task } from '@agor/core/types';
+import { MessageRole } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { classifyMissingCredentialFailure } from './classify-missing-credential';
 
@@ -72,6 +73,104 @@ describe('classifyMissingCredentialFailure', () => {
     expect((ctx.data as Message).metadata?.tool).toBe('claude-code');
     // Raw stderr text must not survive into the persisted content.
     expect((ctx.data as Message).content).not.toContain('/login');
+  });
+
+  describe('zero-token "success" pathway (claude CLI reports success but never called the model)', () => {
+    // Reproduces the live repro from a fresh no-credential container: the SDK's
+    // result event has subtype 'success' with zero real assistant turns, so
+    // message-processor.ts synthesizes the result text into a plain assistant
+    // message instead of throwing — no `is_task_failure` marker exists for
+    // this pathway, so classification falls back to the zero-token signal.
+    const zeroTokenAssistantMessage: Partial<Message> = {
+      task_id: 'task-1' as Message['task_id'],
+      session_id: 'session-1' as Message['session_id'],
+      type: 'assistant',
+      role: MessageRole.ASSISTANT,
+      content: [{ type: 'text', text: 'Not logged in · Please run /login' }],
+      metadata: { tokens: { input: 0, output: 0 } },
+    };
+
+    it('classifies a zero-token assistant message when no credential resolves anywhere', async () => {
+      vi.mocked(resolveApiKey).mockResolvedValue({
+        apiKey: undefined,
+        source: 'none',
+        useNativeAuth: true,
+      });
+
+      const ctx = await runHook()(makeContext({ ...zeroTokenAssistantMessage }));
+      const result = ctx.data as Message;
+
+      expect(result.metadata?.error_kind).toBe('missing_credential');
+      expect(result.metadata?.tool).toBe('claude-code');
+      // Normalized onto system/SYSTEM so the UI has one render branch
+      // regardless of which SDK pathway produced the classification.
+      expect(result.type).toBe('system');
+      expect(result.role).toBe(MessageRole.SYSTEM);
+      expect(JSON.stringify(result.content)).not.toContain('/login');
+    });
+
+    it('does not classify (and does not touch) a real assistant reply with nonzero tokens', async () => {
+      const realReply: Partial<Message> = {
+        task_id: 'task-1' as Message['task_id'],
+        session_id: 'session-1' as Message['session_id'],
+        type: 'assistant',
+        role: MessageRole.ASSISTANT,
+        content: [{ type: 'text', text: 'Here is the answer.' }],
+        metadata: { tokens: { input: 512, output: 24 } },
+      };
+
+      const ctx = await runHook()(makeContext({ ...realReply }));
+
+      expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+      expect((ctx.data as Message).type).toBe('assistant');
+      expect(resolveApiKey).not.toHaveBeenCalled();
+    });
+
+    it('does not reclassify legitimate zero-token output (e.g. /cost) when the user IS authenticated', async () => {
+      // Same structural shape as a genuine auth failure (zero tokens, no
+      // is_task_failure marker) — this is the local-slash-command case the
+      // heuristic can't structurally distinguish from an auth failure.
+      // resolveApiKey is the actual arbiter: a real credential means this
+      // output is left completely untouched.
+      vi.mocked(resolveApiKey).mockResolvedValue({
+        apiKey: 'sk-ant-user-key',
+        source: 'user',
+        useNativeAuth: false,
+      });
+
+      const localCommandOutput: Partial<Message> = {
+        task_id: 'task-1' as Message['task_id'],
+        session_id: 'session-1' as Message['session_id'],
+        type: 'assistant',
+        role: MessageRole.ASSISTANT,
+        content: [{ type: 'text', text: 'Total cost: $0.42' }],
+        metadata: { tokens: { input: 0, output: 0 } },
+      };
+
+      const ctx = await runHook()(makeContext({ ...localCommandOutput }));
+      const result = ctx.data as Message;
+
+      expect(result.metadata?.error_kind).toBeUndefined();
+      expect(result.type).toBe('assistant');
+      expect(result.role).toBe(MessageRole.ASSISTANT);
+      expect(JSON.stringify(result.content)).toContain('Total cost');
+    });
+
+    it('does not trigger for user- or system-role messages even with zero tokens', async () => {
+      const userMessage: Partial<Message> = {
+        task_id: 'task-1' as Message['task_id'],
+        session_id: 'session-1' as Message['session_id'],
+        type: 'user',
+        role: MessageRole.USER,
+        content: 'hello',
+        metadata: { tokens: { input: 0, output: 0 } },
+      };
+
+      const ctx = await runHook()(makeContext({ ...userMessage }));
+
+      expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+      expect(resolveApiKey).not.toHaveBeenCalled();
+    });
   });
 
   it('does not classify when a workspace/env-level credential resolves', async () => {

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for `classifyMissingCredentialFailure` — the before-create hook on
+ * the `messages` service that swaps the raw provider CLI/SDK error text for
+ * a structured "missing credential" classification.
+ *
+ * The behavior under test: classification must be driven entirely by
+ * `resolveApiKey`'s resolution result (user > config.yaml > env > native
+ * auth) — never by inspecting the error text itself — and must never touch
+ * messages the executor didn't mark as a task-failure notice.
+ */
+
+import { resolveApiKey } from '@agor/core/config';
+import type { SessionRepository, TaskRepository } from '@agor/core/db';
+import type { HookContext, Message, Session, Task } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { classifyMissingCredentialFailure } from './classify-missing-credential';
+
+vi.mock('@agor/core/config', () => ({
+  resolveApiKey: vi.fn(),
+}));
+
+const TOOL_DISPLAY_NAMES = { 'claude-code': 'Claude Code', opencode: 'OpenCode' };
+
+function makeContext(data: Partial<Message> | undefined): HookContext {
+  return { data } as unknown as HookContext;
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return { task_id: 'task-1', session_id: 'session-1', created_by: 'user-1', ...overrides } as Task;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return { session_id: 'session-1', agentic_tool: 'claude-code', ...overrides } as Session;
+}
+
+describe('classifyMissingCredentialFailure', () => {
+  let taskRepository: Pick<TaskRepository, 'findById'>;
+  let sessionsRepository: Pick<SessionRepository, 'findById'>;
+
+  beforeEach(() => {
+    vi.mocked(resolveApiKey).mockReset();
+    taskRepository = { findById: vi.fn().mockResolvedValue(makeTask()) };
+    sessionsRepository = { findById: vi.fn().mockResolvedValue(makeSession()) };
+  });
+
+  function runHook() {
+    return classifyMissingCredentialFailure(
+      {} as never,
+      taskRepository,
+      sessionsRepository,
+      TOOL_DISPLAY_NAMES
+    );
+  }
+
+  const failureMessage: Partial<Message> = {
+    task_id: 'task-1' as Message['task_id'],
+    session_id: 'session-1' as Message['session_id'],
+    content: 'Claude SDK error after 3 messages: Not logged in · Please run /login',
+    metadata: { is_task_failure: true },
+  };
+
+  it('classifies as missing_credential when no credential resolves anywhere', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: undefined,
+      source: 'none',
+      useNativeAuth: true,
+    });
+
+    const ctx = await runHook()(makeContext({ ...failureMessage }));
+
+    expect((ctx.data as Message).metadata?.error_kind).toBe('missing_credential');
+    expect((ctx.data as Message).metadata?.tool).toBe('claude-code');
+    // Raw stderr text must not survive into the persisted content.
+    expect((ctx.data as Message).content).not.toContain('/login');
+  });
+
+  it('does not classify when a workspace/env-level credential resolves', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-env-key',
+      source: 'env',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(makeContext({ ...failureMessage }));
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect((ctx.data as Message).content).toBe(failureMessage.content);
+  });
+
+  it('does not classify when a per-user credential resolves', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: 'sk-ant-user-key',
+      source: 'user',
+      useNativeAuth: false,
+    });
+
+    const ctx = await runHook()(makeContext({ ...failureMessage }));
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+  });
+
+  it('does not classify unrelated messages (no is_task_failure marker)', async () => {
+    vi.mocked(resolveApiKey).mockResolvedValue({
+      apiKey: undefined,
+      source: 'none',
+      useNativeAuth: true,
+    });
+
+    const rateLimitMessage: Partial<Message> = {
+      task_id: 'task-1' as Message['task_id'],
+      session_id: 'session-1' as Message['session_id'],
+      content: 'Rate limited, retrying...',
+      metadata: {},
+    };
+
+    const ctx = await runHook()(makeContext({ ...rateLimitMessage }));
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect(resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when context.data is undefined', async () => {
+    const ctx = await runHook()(makeContext(undefined));
+    expect(ctx.data).toBeUndefined();
+    expect(resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('falls through untouched for tools with no mapped API key (e.g. opencode)', async () => {
+    sessionsRepository.findById = vi
+      .fn()
+      .mockResolvedValue(makeSession({ agentic_tool: 'opencode' }));
+
+    const ctx = await runHook()(makeContext({ ...failureMessage }));
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect(resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('falls through untouched when the task or session cannot be found', async () => {
+    taskRepository.findById = vi.fn().mockResolvedValue(null);
+
+    const ctx = await runHook()(makeContext({ ...failureMessage }));
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect(resolveApiKey).not.toHaveBeenCalled();
+  });
+
+  it('swallows classification errors and leaves the message untouched', async () => {
+    vi.mocked(resolveApiKey).mockRejectedValue(new Error('boom'));
+
+    const ctx = await runHook()(makeContext({ ...failureMessage }));
+
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect((ctx.data as Message).content).toBe(failureMessage.content);
+  });
+});

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -1,0 +1,86 @@
+/**
+ * Before-create hook on the `messages` service that classifies a task's
+ * failure notice as a "missing credential" failure — without ever matching
+ * the underlying error text (which is a raw passthrough of the provider
+ * CLI/SDK's stderr and is fragile to upstream wording changes).
+ *
+ * Detection reuses `resolveApiKey` — the exact same resolution chain
+ * (per-user encrypted key -> config.yaml -> env var -> native CLI/OAuth)
+ * that `apps/agor-daemon/src/services/check-auth.ts` uses for the
+ * onboarding wizard's "Test Connection" button. If the task already failed
+ * while attempting the native-auth fallback, that failed attempt IS the
+ * proof native auth doesn't work — so no second SDK probe is needed here.
+ *
+ * Only acts on messages the executor marks with `metadata.is_task_failure`
+ * (see `packages/executor/src/handlers/sdk/base-executor.ts`), so unrelated
+ * system messages (daemon restart, rate limit, etc.) are never touched.
+ */
+
+import { resolveApiKey } from '@agor/core/config';
+import {
+  type SessionRepository,
+  TaskRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
+import type { HookContext, Message, TaskID, UserID } from '@agor/core/types';
+import { TOOL_API_KEY_NAMES } from '@agor/core/types';
+
+/** Friendly, jargon-free fallback for any consumer that renders `content`
+ * raw without checking `metadata.error_kind` (mobile app, gateway relays,
+ * CLI `agor session get`, etc). The web UI renders its own copy from the
+ * MissingCredentialPanel component instead of this string. */
+function fallbackContent(toolDisplayName: string): string {
+  return `This session needs to be connected to ${toolDisplayName} before it can run.`;
+}
+
+export function classifyMissingCredentialFailure(
+  db: TenantScopeAwareDatabase,
+  sessionsRepository: Pick<SessionRepository, 'findById'>,
+  toolDisplayNames: Record<string, string>
+) {
+  const taskRepo = new TaskRepository(db);
+
+  return async (context: HookContext): Promise<HookContext> => {
+    const data = context.data as Partial<Message> | undefined;
+    if (!data?.metadata?.is_task_failure || !data.task_id || !data.session_id) {
+      return context;
+    }
+
+    try {
+      const [task, session] = await Promise.all([
+        taskRepo.findById(data.task_id as TaskID),
+        sessionsRepository.findById(data.session_id),
+      ]);
+      if (!task || !session) return context;
+
+      const tool = session.agentic_tool;
+      const keyName = TOOL_API_KEY_NAMES[tool];
+      // Tools with no mapped key (opencode: always ready; anything
+      // unmapped/future: a structurally different problem) fall through
+      // untouched to the existing generic failure handling.
+      if (!keyName) return context;
+
+      const { apiKey } = await resolveApiKey(keyName, {
+        userId: task.created_by as UserID,
+        db,
+        tool,
+      });
+      if (apiKey) return context; // A credential DID resolve — some other failure.
+
+      context.data = {
+        ...data,
+        content: fallbackContent(toolDisplayNames[tool] ?? tool),
+        content_preview: fallbackContent(toolDisplayNames[tool] ?? tool).substring(0, 200),
+        metadata: {
+          ...data.metadata,
+          error_kind: 'missing_credential',
+          tool,
+        },
+      };
+    } catch (err) {
+      console.error('[classifyMissingCredentialFailure] classification failed:', err);
+    }
+
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -1,7 +1,7 @@
 /**
  * Before-create hook on the `messages` service that classifies a task's
- * failure notice as a "missing credential" failure — without ever matching
- * the underlying error text (which is a raw passthrough of the provider
+ * failure as a "missing credential" failure — without ever matching the
+ * underlying error text (which is a raw passthrough of the provider
  * CLI/SDK's stderr and is fragile to upstream wording changes).
  *
  * Detection reuses `resolveApiKey` — the exact same resolution chain
@@ -11,15 +11,39 @@
  * while attempting the native-auth fallback, that failed attempt IS the
  * proof native auth doesn't work — so no second SDK probe is needed here.
  *
- * Only acts on messages the executor marks with `metadata.is_task_failure`
- * (see `packages/executor/src/handlers/sdk/base-executor.ts`), so unrelated
- * system messages (daemon restart, rate limit, etc.) are never touched.
+ * There are two structurally distinct ways a provider CLI/SDK reports "no
+ * credential" back to the executor, and this hook has to catch both:
+ *
+ * 1. **Thrown error** — the SDK call throws, `base-executor.ts`'s catch
+ *    block patches the task to `failed` and creates a `system`-role message
+ *    marked `metadata.is_task_failure` with the raw error text as content.
+ * 2. **Zero-token "success"** — the claude CLI can return a normal
+ *    `subtype: 'success'` result whose `result` text IS the auth-failure
+ *    message, with zero real assistant turns and zero tokens consumed (see
+ *    `message-processor.ts`'s `handleResult()`: when a result event carries
+ *    text but produced no streamed assistant messages, that text gets
+ *    synthesized into a plain `assistant`-role message — the same code path
+ *    used for local slash-command output like `/cost`). The task completes
+ *    normally; nothing throws.
+ *
+ * Case 2 has no explicit "this failed" marker to key off of, so detection
+ * falls back to a structural proxy: a real successful Claude turn always
+ * consumes tokens (the system prompt alone costs hundreds), so an
+ * `assistant` message with `metadata.tokens.input === 0 &&
+ * metadata.tokens.output === 0` is a reliable signal that no real model
+ * call happened. That signal is NOT unique to auth failures — local
+ * slash-command output is zero-token too — so it is only ever used to
+ * decide whether to *run* the resolveApiKey check, never to decide the
+ * outcome. An authenticated user's `/cost` output still has a credential
+ * resolve, so the hook leaves it untouched; only a genuine no-credential
+ * session gets reclassified. This keeps detection fully structural (SDK
+ * facts + the same resolution chain used elsewhere), never text-matching.
  */
 
 import { resolveApiKey } from '@agor/core/config';
 import type { SessionRepository, TaskRepository, TenantScopeAwareDatabase } from '@agor/core/db';
 import type { HookContext, Message, TaskID, UserID } from '@agor/core/types';
-import { TOOL_API_KEY_NAMES } from '@agor/core/types';
+import { MessageRole, TOOL_API_KEY_NAMES } from '@agor/core/types';
 
 /** Friendly, jargon-free fallback for any consumer that renders `content`
  * raw without checking `metadata.error_kind` (mobile app, gateway relays,
@@ -37,9 +61,16 @@ export function classifyMissingCredentialFailure(
 ) {
   return async (context: HookContext): Promise<HookContext> => {
     const data = context.data as Partial<Message> | undefined;
-    if (!data?.metadata?.is_task_failure || !data.task_id || !data.session_id) {
-      return context;
-    }
+    if (!data?.task_id || !data.session_id) return context;
+
+    const isThrownFailureNotice = data.metadata?.is_task_failure === true;
+    const isUnverifiedZeroTokenSuccess =
+      data.type === 'assistant' &&
+      data.role === MessageRole.ASSISTANT &&
+      data.metadata?.tokens?.input === 0 &&
+      data.metadata?.tokens?.output === 0;
+
+    if (!isThrownFailureNotice && !isUnverifiedZeroTokenSuccess) return context;
 
     try {
       const [task, session] = await Promise.all([
@@ -64,6 +95,16 @@ export function classifyMissingCredentialFailure(
 
       context.data = {
         ...data,
+        // Normalize both pathways onto `system`/SYSTEM: the zero-token
+        // pathway's message is currently typed `assistant` (it was
+        // synthesized from the SDK result text as if it were a real reply),
+        // but it was never actually the assistant talking — same as the
+        // thrown-error pathway, this is a system-level notice. Unifying
+        // both here means the UI only needs one render branch
+        // (`MessageBlock`'s `isSystem && error_kind === 'missing_credential'`
+        // check) regardless of which SDK pathway produced it.
+        type: 'system',
+        role: MessageRole.SYSTEM,
         content: fallbackContent(toolDisplayNames[tool] ?? tool),
         content_preview: fallbackContent(toolDisplayNames[tool] ?? tool).substring(0, 200),
         metadata: {

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -38,6 +38,47 @@
  * resolve, so the hook leaves it untouched; only a genuine no-credential
  * session gets reclassified. This keeps detection fully structural (SDK
  * facts + the same resolution chain used elsewhere), never text-matching.
+ *
+ * Per-provider coverage (audited, not just assumed — see
+ * TOOL_API_KEY_NAMES for which tools this hook even applies to):
+ *
+ * - **claude-code / claude-code-cli**: both pathways confirmed live against
+ *   a genuinely credential-less container — case 1 covers the SDK throwing,
+ *   case 2 covers the zero-token "success" repro this hook was extended for.
+ * - **codex**: throws on missing credential (`codex/prompt-service.ts`
+ *   explicitly detects 401/Unauthorized and throws before any assistant
+ *   message is created) — case 1 covers it; case 2 never triggers since no
+ *   message is ever created on that path. Uses the shared
+ *   `buildAssistantMessageMetadata()` helper for real replies.
+ * - **gemini**: throws during auth setup, before any message is created —
+ *   same shape as codex. Case 1 covers it.
+ * - **copilot**: uses the shared `buildAssistantMessageMetadata()` helper
+ *   (so case 2 WOULD fire if the Copilot SDK ever produced a zero-token
+ *   "success" auth failure), and has no explicit auth-error throw path
+ *   analogous to codex/gemini's — whether Copilot's SDK actually produces a
+ *   throw or a zero-token success on missing credential is UNVERIFIED (no
+ *   live Copilot credential available to test against). Structurally
+ *   covered if it manifests as either shape; flagging as unverified rather
+ *   than claiming confirmed coverage.
+ * - **cursor**: `resolveCursorApiKey()` throws when no `CURSOR_API_KEY` is
+ *   configured at all — case 1 covers that. However `cursor.ts`'s own
+ *   `createAssistantMessage()` does NOT call the shared
+ *   `buildAssistantMessageMetadata()` helper and never sets
+ *   `metadata.tokens` (the Cursor SDK integration doesn't plumb token usage
+ *   at all yet) — so case 2 can never fire for cursor, even in principle.
+ *   Deliberately NOT fixed by forcing `tokens: {input:0, output:0}` onto
+ *   every cursor message: with no real usage data, EVERY cursor reply would
+ *   look zero-token, turning the heuristic into an unconditional (if
+ *   harmless, since resolveApiKey remains the arbiter) trigger rather than a
+ *   meaningful proxy. A real fix needs actual token-usage plumbing from
+ *   `@cursor/sdk` (marked experimental in this codebase) — out of scope
+ *   here. Practical impact today is narrow: an already-configured-but-
+ *   invalid Cursor key that fails without throwing would show raw
+ *   error text instead of this panel.
+ * - **opencode**: NOT a gap — `TOOL_API_KEY_NAMES` has no entry for it by
+ *   design (server-based, no credential concept; `check-auth.ts` always
+ *   reports it authenticated), so `!keyName` below intentionally skips it
+ *   before either case is evaluated.
  */
 
 import { resolveApiKey } from '@agor/core/config';

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -17,11 +17,7 @@
  */
 
 import { resolveApiKey } from '@agor/core/config';
-import {
-  type SessionRepository,
-  TaskRepository,
-  type TenantScopeAwareDatabase,
-} from '@agor/core/db';
+import type { SessionRepository, TaskRepository, TenantScopeAwareDatabase } from '@agor/core/db';
 import type { HookContext, Message, TaskID, UserID } from '@agor/core/types';
 import { TOOL_API_KEY_NAMES } from '@agor/core/types';
 
@@ -35,11 +31,10 @@ function fallbackContent(toolDisplayName: string): string {
 
 export function classifyMissingCredentialFailure(
   db: TenantScopeAwareDatabase,
+  taskRepository: Pick<TaskRepository, 'findById'>,
   sessionsRepository: Pick<SessionRepository, 'findById'>,
   toolDisplayNames: Record<string, string>
 ) {
-  const taskRepo = new TaskRepository(db);
-
   return async (context: HookContext): Promise<HookContext> => {
     const data = context.data as Partial<Message> | undefined;
     if (!data?.metadata?.is_task_failure || !data.task_id || !data.session_id) {
@@ -48,7 +43,7 @@ export function classifyMissingCredentialFailure(
 
     try {
       const [task, session] = await Promise.all([
-        taskRepo.findById(data.task_id as TaskID),
+        taskRepository.findById(data.task_id as TaskID),
         sessionsRepository.findById(data.session_id),
       ]);
       if (!task || !session) return context;

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -66,6 +66,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import {
+  AGENTIC_TOOL_DISPLAY_NAMES,
   GATEWAY_REDACTED_SENTINEL,
   GATEWAY_SENSITIVE_CONFIG_FIELDS,
   hasMinimumRole,
@@ -77,6 +78,7 @@ import type {
   MessagesServiceImpl,
   SessionsServiceImpl,
 } from './declarations.js';
+import { classifyMissingCredentialFailure } from './hooks/classify-missing-credential.js';
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import type { ArtifactsService } from './services/artifacts.js';
 import type { GatewayService } from './services/gateway.js';
@@ -720,6 +722,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
               ensureCanPromptInSession(superadminOpts), // Require 'prompt' (or 'session' for own sessions)
             ]
           : []),
+        // Detect "no credential resolved for this session's provider" task
+        // failures structurally (reusing resolveApiKey's resolution order),
+        // never by matching the raw stderr-passthrough error text. Drives
+        // the Connect-AI empty state instead of a raw "/login" message.
+        classifyMissingCredentialFailure(db, sessionsRepository, AGENTIC_TOOL_DISPLAY_NAMES),
       ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update messages'),

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -27,6 +27,7 @@ import {
   ScheduleRepository,
   type SessionRepository,
   shortId,
+  TaskRepository,
   type TenantScopeAwareDatabase,
   UserMCPOAuthTokenRepository,
   type UsersRepository,
@@ -453,6 +454,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     sessionsRepository,
   } = ctx;
 
+  // Used by classifyMissingCredentialFailure to look up the acting user for
+  // a failed task (no service-layer equivalent already in ctx).
+  const taskRepository = new TaskRepository(db);
+
   // Helper: safely get a service (returns undefined if not registered due to tier=off)
   const safeService = (path: string) => {
     try {
@@ -726,7 +731,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         // failures structurally (reusing resolveApiKey's resolution order),
         // never by matching the raw stderr-passthrough error text. Drives
         // the Connect-AI empty state instead of a raw "/login" message.
-        classifyMissingCredentialFailure(db, sessionsRepository, AGENTIC_TOOL_DISPLAY_NAMES),
+        classifyMissingCredentialFailure(
+          db,
+          taskRepository,
+          sessionsRepository,
+          AGENTIC_TOOL_DISPLAY_NAMES
+        ),
       ],
       patch: [
         requireMinimumRole(ROLES.MEMBER, 'update messages'),

--- a/apps/agor-daemon/src/services/check-auth-helpers.test.ts
+++ b/apps/agor-daemon/src/services/check-auth-helpers.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for `isRealAuthSource` — the helper `check-auth.ts`'s
+ * `hasAuthSignal` check uses to decide whether an `AccountInfo` source field
+ * indicates a real credential.
+ *
+ * Regression coverage for a live-repro bug: against a genuinely
+ * credential-less container, the Claude Agent SDK's `accountInfo()`
+ * resolved with `tokenSource: 'none'` (a literal string sentinel, not
+ * `undefined`) — a plain truthy check on that field reported "authenticated"
+ * for a session with zero real credentials, which made the Connect-AI empty
+ * state's per-viewer live check (`MissingCredentialPanel`, which calls this
+ * same `check-auth` service) show "you're already connected" instead of the
+ * actionable CTA for a user with no credential at all.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isRealAuthSource } from './check-auth-helpers';
+
+describe('isRealAuthSource', () => {
+  it('treats the literal "none" sentinel as no signal', () => {
+    expect(isRealAuthSource('none')).toBe(false);
+  });
+
+  it('is case-insensitive for the sentinel', () => {
+    expect(isRealAuthSource('None')).toBe(false);
+    expect(isRealAuthSource('NONE')).toBe(false);
+  });
+
+  it('treats undefined and empty string as no signal', () => {
+    expect(isRealAuthSource(undefined)).toBe(false);
+    expect(isRealAuthSource('')).toBe(false);
+  });
+
+  it('treats a real source value as a signal', () => {
+    expect(isRealAuthSource('oauth')).toBe(true);
+    expect(isRealAuthSource('api-key')).toBe(true);
+    expect(isRealAuthSource('anthropic-console')).toBe(true);
+  });
+});

--- a/apps/agor-daemon/src/services/check-auth-helpers.ts
+++ b/apps/agor-daemon/src/services/check-auth-helpers.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure, dependency-free helpers for `check-auth.ts`. Kept in a separate
+ * module (rather than inline) so they're unit-testable without pulling in
+ * `check-auth.ts`'s full import graph (Claude Agent SDK -> OpenTelemetry),
+ * which breaks under vitest's ESM resolution when imported directly.
+ */
+
+/**
+ * Whether an `AccountInfo` source field (`apiKeySource` / `tokenSource`)
+ * indicates a real credential. The Claude Agent SDK signals "no source"
+ * with the literal string `'none'` rather than omitting the field
+ * (confirmed live against a genuinely credential-less container:
+ * `accountInfo()` resolved with `tokenSource: 'none'`), so a plain truthy
+ * check on the raw string false-positives as authenticated.
+ */
+export function isRealAuthSource(value: string | undefined): boolean {
+  return !!value && value.toLowerCase() !== 'none';
+}

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -33,6 +33,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { TOOL_API_KEY_NAMES } from '@agor/core/types';
+import { isRealAuthSource } from './check-auth-helpers.js';
 
 /** Tools where no API key is required — native CLI/OAuth auth is a real, usable path. */
 const NATIVE_AUTH_TOOLS = new Set<string>(['claude-code', 'codex']);
@@ -304,7 +305,9 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
           // Need at least one auth-indicating field to call it real.
           const hasAuthSignal = !!(
             account &&
-            (account.apiKeySource || account.tokenSource || account.email)
+            (isRealAuthSource(account.apiKeySource) ||
+              isRealAuthSource(account.tokenSource) ||
+              account.email)
           );
           // Surface what the probe actually saw — invaluable when the wizard
           // says "authenticated" but the session can't find creds.
@@ -316,9 +319,9 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
             }`
           );
           if (hasAuthSignal && account) {
-            const method: AuthCheckResult['method'] = account.apiKeySource
+            const method: AuthCheckResult['method'] = isRealAuthSource(account.apiKeySource)
               ? 'api-key'
-              : account.tokenSource
+              : isRealAuthSource(account.tokenSource)
                 ? 'oauth'
                 : 'native';
             const hintParts: string[] = [];

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1,4 +1,5 @@
 import type {
+  AgenticToolName,
   AgorClient,
   Artifact,
   Board,
@@ -373,6 +374,13 @@ export const App: React.FC<AppProps> = ({
 
   const [leftPanelTab, setLeftPanelTab] = useState<BoardAssistantPanelTab>('assistant');
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);
+  // Deep-links UserSettingsModal to a specific Agentic Tools tab (e.g. the
+  // Connect-AI empty state's "Connect Claude" CTA) instead of always landing
+  // on "General". Cleared on close so a later plain settings-menu click
+  // doesn't re-land on a stale tool tab.
+  const [userSettingsInitialTool, setUserSettingsInitialTool] = useState<
+    AgenticToolName | undefined
+  >(undefined);
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window === 'undefined' ? 1440 : window.innerWidth
   );
@@ -997,6 +1005,10 @@ export const App: React.FC<AppProps> = ({
         setBranchModalTab(tab);
       },
       onOpenTerminal: canOpenTerminal ? handleOpenTerminal : undefined,
+      onOpenAgenticToolSettings: (tool: AgenticToolName) => {
+        setUserSettingsInitialTool(tool);
+        setUserSettingsOpen(true);
+      },
     }),
     [
       onSendPrompt,
@@ -1568,11 +1580,13 @@ export const App: React.FC<AppProps> = ({
           open={effectiveUserSettingsOpen}
           onClose={() => {
             setUserSettingsOpen(false);
+            setUserSettingsInitialTool(undefined);
             onUserSettingsClose?.();
           }}
           user={user || null}
           currentUser={user || null}
           client={client}
+          initialTab={userSettingsInitialTool}
           onUpdate={onUpdateUser}
           onRestartOnboarding={async () => {
             setUserSettingsOpen(false);

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -1009,6 +1009,7 @@ export const App: React.FC<AppProps> = ({
         setUserSettingsInitialTool(tool);
         setUserSettingsOpen(true);
       },
+      onUpdateUser,
     }),
     [
       onSendPrompt,
@@ -1024,6 +1025,7 @@ export const App: React.FC<AppProps> = ({
       handleSessionClick,
       handleOpenTerminal,
       canOpenTerminal,
+      onUpdateUser,
     ]
   );
 

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -16,6 +16,7 @@ import type {
   Message,
   PermissionScope,
   SessionID,
+  UpdateUserInput,
   User,
 } from '@agor-live/client';
 import { shortId, TaskStatus } from '@agor-live/client';
@@ -131,6 +132,12 @@ export interface ConversationViewProps {
    * empty state's primary CTA.
    */
   onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+  /**
+   * Saves a per-user credential field. Forwarded to TaskBlock → MessageBlock
+   * → MissingCredentialPanel for the Connect-AI empty state's inline
+   * "paste an API key" quick-connect.
+   */
+  onUpdateUser?: (userId: string, updates: UpdateUserInput) => void | Promise<void>;
 }
 
 export const ConversationView = React.memo<ConversationViewProps>(
@@ -151,6 +158,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     genealogy,
     assistantEmoji,
     onOpenAgenticToolSettings,
+    onUpdateUser,
   }) => {
     const { token } = theme.useToken();
     const [copied, copy] = useCopyToClipboard();
@@ -512,6 +520,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
               isLatestTask={taskIndex === tasks.length - 1}
               client={client}
               onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+              onUpdateUser={onUpdateUser}
             />
           ))}
         </div>

--- a/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
+++ b/apps/agor-ui/src/components/ConversationView/ConversationView.tsx
@@ -10,7 +10,14 @@
  * - Auto-scrolling to latest content
  */
 
-import type { AgorClient, Message, PermissionScope, SessionID, User } from '@agor-live/client';
+import type {
+  AgenticToolName,
+  AgorClient,
+  Message,
+  PermissionScope,
+  SessionID,
+  User,
+} from '@agor-live/client';
 import { shortId, TaskStatus } from '@agor-live/client';
 import { BranchesOutlined, CopyOutlined, ForkOutlined } from '@ant-design/icons';
 import { Alert, Button, Spin, Typography, theme } from 'antd';
@@ -117,6 +124,13 @@ export interface ConversationViewProps {
    * Emoji override for assistant avatar in message bubbles
    */
   assistantEmoji?: string;
+
+  /**
+   * Opens Settings deep-linked to a provider's Agentic Tools tab. Forwarded
+   * to TaskBlock → MessageBlock → MissingCredentialPanel for the Connect-AI
+   * empty state's primary CTA.
+   */
+  onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
 }
 
 export const ConversationView = React.memo<ConversationViewProps>(
@@ -136,6 +150,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
     isActive = true,
     genealogy,
     assistantEmoji,
+    onOpenAgenticToolSettings,
   }) => {
     const { token } = theme.useToken();
     const [copied, copy] = useCopyToClipboard();
@@ -496,6 +511,7 @@ export const ConversationView = React.memo<ConversationViewProps>(
               assistantEmoji={assistantEmoji}
               isLatestTask={taskIndex === tasks.length - 1}
               client={client}
+              onOpenAgenticToolSettings={onOpenAgenticToolSettings}
             />
           ))}
         </div>

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -10,6 +10,7 @@
  */
 
 import {
+  type AgenticToolName,
   type AgorClient,
   type ContentBlock as CoreContentBlock,
   type DiffEnrichment,
@@ -33,6 +34,7 @@ import { AgorAvatar } from '../AgorAvatar';
 import { CollapsibleMarkdown } from '../CollapsibleText/CollapsibleMarkdown';
 import { CopyableContent } from '../CopyableContent';
 import { MarkdownRenderer } from '../MarkdownRenderer';
+import { MissingCredentialPanel } from '../MissingCredentialPanel';
 import { PermissionRequestBlock } from '../PermissionRequestBlock';
 import { SystemMessage } from '../SystemMessage';
 import { ThinkingBlock } from '../ThinkingBlock';
@@ -100,6 +102,9 @@ interface MessageBlockProps {
     allow: boolean,
     scope: PermissionScope
   ) => void;
+  /** Opens Settings deep-linked to a provider's Agentic Tools tab. Forwarded
+   * to MissingCredentialPanel for the Connect-AI empty state's primary CTA. */
+  onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
 }
 
 /** Get short description for a tool call (file path, pattern, command, etc.) */
@@ -330,6 +335,7 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   onPermissionDecision,
   assistantEmoji,
   client = null,
+  onOpenAgenticToolSettings,
 }) => {
   const { token } = theme.useToken();
 
@@ -489,6 +495,20 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
         </div>
         <MarkdownRenderer content={markdownContent} />
       </div>
+    );
+  }
+
+  // Task failed because no credential resolved for the session's configured
+  // provider (see apps/agor-daemon/src/hooks/classify-missing-credential.ts).
+  // Replaces the raw provider CLI/SDK error text with a friendly, actionable
+  // panel instead of rendering `message.content` directly.
+  if (isSystem && message.metadata?.error_kind === 'missing_credential' && message.metadata?.tool) {
+    return (
+      <MissingCredentialPanel
+        tool={message.metadata.tool}
+        client={client}
+        onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+      />
     );
   }
 

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -19,6 +19,7 @@ import {
   PermissionScope,
   PermissionStatus,
   shortId,
+  type UpdateUserInput,
   type User,
 } from '@agor-live/client';
 import { RobotOutlined, SyncOutlined, WarningOutlined } from '@ant-design/icons';
@@ -105,6 +106,14 @@ interface MessageBlockProps {
   /** Opens Settings deep-linked to a provider's Agentic Tools tab. Forwarded
    * to MissingCredentialPanel for the Connect-AI empty state's primary CTA. */
   onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+  /** Saves a per-user credential field. Forwarded to MissingCredentialPanel
+   * for the Connect-AI empty state's inline "paste an API key" quick-connect. */
+  onUpdateUser?: (userId: string, updates: UpdateUserInput) => void | Promise<void>;
+  /** The actual logged-in viewer's id — deliberately distinct from
+   * `currentUserId` above, which callers (e.g. TaskBlock) may set to a
+   * message's author for avatar/identity display rather than the viewer.
+   * Used as the save target for MissingCredentialPanel's inline quick-connect. */
+  viewerUserId?: string;
 }
 
 /** Get short description for a tool call (file path, pattern, command, etc.) */
@@ -336,6 +345,8 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
   assistantEmoji,
   client = null,
   onOpenAgenticToolSettings,
+  onUpdateUser,
+  viewerUserId,
 }) => {
   const { token } = theme.useToken();
 
@@ -507,7 +518,9 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
       <MissingCredentialPanel
         tool={message.metadata.tool}
         client={client}
+        currentUserId={viewerUserId}
         onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+        onUpdateUser={onUpdateUser}
       />
     );
   }

--- a/apps/agor-ui/src/components/MissingCredentialPanel/MissingCredentialPanel.tsx
+++ b/apps/agor-ui/src/components/MissingCredentialPanel/MissingCredentialPanel.tsx
@@ -1,0 +1,176 @@
+/**
+ * MissingCredentialPanel - Connect-AI empty state
+ *
+ * Replaces the raw provider CLI/SDK error text ("Not logged in · Please run
+ * /login") with a friendly, actionable panel when a task failed because no
+ * credential resolved for the session's configured provider.
+ *
+ * Scoped per-viewing-user, live: the daemon only records that *some* user's
+ * attempt had no credential (see `metadata.error_kind` /
+ * `apps/agor-daemon/src/hooks/classify-missing-credential.ts`). Two people
+ * can be looking at the same session with different credential state (one
+ * connected, one not), so this component re-checks auth for whoever is
+ * currently viewing it via the same `check-auth` service the onboarding
+ * wizard uses, rather than trusting a stored, task-run-time snapshot.
+ */
+
+import type { AgenticToolName, AgorClient, AuthCheckResult } from '@agor-live/client';
+import { AGENTIC_TOOL_DISPLAY_NAMES, AGENTIC_TOOL_KEY_CREATION_URL } from '@agor-live/client';
+import { CheckCircleOutlined } from '@ant-design/icons';
+import { Button, Space, Spin, Typography, theme } from 'antd';
+import { useEffect, useState } from 'react';
+import { SystemMessage } from '../SystemMessage';
+
+const { Text, Link } = Typography;
+
+/**
+ * Tools where an existing subscription/CLI login is a real alternative to
+ * pasting an API key. Mirrors the helper copy already shown in
+ * `ApiKeyFields.tsx` for these tools — kept short here since the full
+ * instructions live on the Settings screen this panel deep-links to.
+ */
+const NATIVE_AUTH_HINT: Partial<Record<AgenticToolName, string>> = {
+  'claude-code': 'Already on a Claude Pro or Max plan? You can connect that instead of an API key.',
+  'claude-code-cli':
+    'Already on a Claude Pro or Max plan? You can connect that instead of an API key.',
+  codex:
+    'Already signed in with ChatGPT on this machine? Codex can use that instead of an API key.',
+};
+
+export interface MissingCredentialPanelProps {
+  /** The provider this session is configured to use and needs a credential for. */
+  tool: AgenticToolName;
+  client?: AgorClient | null;
+  /** Opens Settings deep-linked to this tool's Agentic Tools tab. Sourced from
+   * `AppActionsContext` by the nearest ancestor that already consumes it
+   * (`SessionPanelContent`), then threaded down as an explicit prop —
+   * matching how `MessageBlock` receives `client`/`onPermissionDecision`
+   * rather than reaching into context itself. */
+  onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+}
+
+export const MissingCredentialPanel: React.FC<MissingCredentialPanelProps> = ({
+  tool,
+  client,
+  onOpenAgenticToolSettings,
+}) => {
+  const { token } = theme.useToken();
+  const [checking, setChecking] = useState(true);
+  const [authResult, setAuthResult] = useState<AuthCheckResult | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!client) {
+      setChecking(false);
+      return;
+    }
+    setChecking(true);
+    client
+      .service('check-auth')
+      .create({ tool })
+      .then((result) => {
+        if (!cancelled) setAuthResult(result as AuthCheckResult);
+      })
+      .catch(() => {
+        if (!cancelled) setAuthResult(null);
+      })
+      .finally(() => {
+        if (!cancelled) setChecking(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Re-check whenever the viewer or the tool changes; `client` identity is
+    // stable per authenticated session so this effectively runs once per
+    // (tool, logged-in user) pair.
+  }, [client, tool]);
+
+  const displayName = AGENTIC_TOOL_DISPLAY_NAMES[tool] ?? tool;
+  const keyCreationUrl = AGENTIC_TOOL_KEY_CREATION_URL[tool];
+  const nativeAuthHint = NATIVE_AUTH_HINT[tool];
+
+  if (dismissed) return null;
+
+  if (checking) {
+    return (
+      <SystemMessage
+        content={
+          <Space size="small">
+            <Spin size="small" />
+            <Text type="secondary" style={{ fontSize: 13 }}>
+              Checking your {displayName} connection…
+            </Text>
+          </Space>
+        }
+      />
+    );
+  }
+
+  // The current viewer already has a working credential — the CTA doesn't
+  // apply to them. This happens when a *different* user ran the prompt that
+  // failed. No primary action needed; sending a new message runs under this
+  // viewer's own (working) credential.
+  if (authResult?.authenticated) {
+    return (
+      <SystemMessage
+        content={
+          <Space size="small" align="start">
+            <CheckCircleOutlined style={{ color: token.colorSuccess, marginTop: 2 }} />
+            <Text type="secondary" style={{ fontSize: 13 }}>
+              This run needed a connected {displayName} account. Your account is already connected —
+              sending a new message should work.
+            </Text>
+          </Space>
+        }
+      />
+    );
+  }
+
+  return (
+    <SystemMessage
+      content={
+        <div style={{ maxWidth: 480 }}>
+          <Text style={{ fontSize: 13 }}>
+            Agor doesn't have its own AI model — it drives {displayName} on your behalf, so it needs
+            a way to reach your account before this session can respond.
+          </Text>
+
+          <div style={{ marginTop: token.marginSM }}>
+            <Button
+              type="primary"
+              onClick={() => onOpenAgenticToolSettings?.(tool)}
+              disabled={!onOpenAgenticToolSettings}
+            >
+              Connect {displayName}
+            </Button>
+          </div>
+
+          <Space orientation="vertical" size={4} style={{ marginTop: token.marginSM }}>
+            {keyCreationUrl && (
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                Don't have a key yet?{' '}
+                <Link href={keyCreationUrl} target="_blank" rel="noopener noreferrer">
+                  Get one from {displayName}'s console →
+                </Link>
+              </Text>
+            )}
+            {nativeAuthHint && (
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                {nativeAuthHint}
+              </Text>
+            )}
+            <Button
+              type="text"
+              size="small"
+              onClick={() => setDismissed(true)}
+              style={{ paddingLeft: 0, color: token.colorTextTertiary }}
+            >
+              Not right now
+            </Button>
+          </Space>
+        </div>
+      }
+    />
+  );
+};

--- a/apps/agor-ui/src/components/MissingCredentialPanel/MissingCredentialPanel.tsx
+++ b/apps/agor-ui/src/components/MissingCredentialPanel/MissingCredentialPanel.tsx
@@ -12,13 +12,28 @@
  * connected, one not), so this component re-checks auth for whoever is
  * currently viewing it via the same `check-auth` service the onboarding
  * wizard uses, rather than trusting a stored, task-run-time snapshot.
+ *
+ * This panel is treated as the answer to "why didn't this respond" rather
+ * than a transient notice — there is deliberately no dismiss affordance.
+ *
+ * Two co-equal ways to resolve it: paste a key right here (same save path
+ * as Settings' own field — `onUpdateUser` with an `agentic_tools` patch,
+ * see `ApiKeyFields.tsx` / `UserSettingsModal.handleToolFieldSave`), or
+ * open Settings for anything needing more than a single field (native /
+ * subscription auth, multiple fields, etc).
  */
 
-import type { AgenticToolName, AgorClient, AuthCheckResult } from '@agor-live/client';
-import { AGENTIC_TOOL_DISPLAY_NAMES, AGENTIC_TOOL_KEY_CREATION_URL } from '@agor-live/client';
-import { CheckCircleOutlined } from '@ant-design/icons';
-import { Button, Space, Spin, Typography, theme } from 'antd';
+import type {
+  AgenticToolName,
+  AgorClient,
+  AuthCheckResult,
+  UpdateUserInput,
+} from '@agor-live/client';
+import { AGENTIC_TOOL_DISPLAY_NAMES } from '@agor-live/client';
+import { CheckCircleOutlined, KeyOutlined, SettingOutlined } from '@ant-design/icons';
+import { Alert, Button, Divider, Input, Result, Space, Spin, Typography } from 'antd';
 import { useEffect, useState } from 'react';
+import { TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
 import { SystemMessage } from '../SystemMessage';
 
 const { Text, Link } = Typography;
@@ -27,38 +42,50 @@ const { Text, Link } = Typography;
  * Tools where an existing subscription/CLI login is a real alternative to
  * pasting an API key. Mirrors the helper copy already shown in
  * `ApiKeyFields.tsx` for these tools — kept short here since the full
- * instructions live on the Settings screen this panel deep-links to.
+ * instructions live on the Settings screen.
  */
 const NATIVE_AUTH_HINT: Partial<Record<AgenticToolName, string>> = {
-  'claude-code': 'Already on a Claude Pro or Max plan? You can connect that instead of an API key.',
-  'claude-code-cli':
-    'Already on a Claude Pro or Max plan? You can connect that instead of an API key.',
-  codex:
-    'Already signed in with ChatGPT on this machine? Codex can use that instead of an API key.',
+  'claude-code': 'Already on a Claude Pro or Max plan? Connect that instead, in Settings.',
+  'claude-code-cli': 'Already on a Claude Pro or Max plan? Connect that instead, in Settings.',
+  codex: 'Already signed in with ChatGPT on this machine? Codex can use that — see Settings.',
 };
 
 export interface MissingCredentialPanelProps {
   /** The provider this session is configured to use and needs a credential for. */
   tool: AgenticToolName;
   client?: AgorClient | null;
+  /** Current viewer's user id — the account the inline "paste a key" save targets. */
+  currentUserId?: string;
   /** Opens Settings deep-linked to this tool's Agentic Tools tab. Sourced from
    * `AppActionsContext` by the nearest ancestor that already consumes it
    * (`SessionPanelContent`), then threaded down as an explicit prop —
    * matching how `MessageBlock` receives `client`/`onPermissionDecision`
    * rather than reaching into context itself. */
   onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+  /** Saves a per-user credential field — the same `onUpdateUser` callback
+   * Settings' own API-key fields already save through. Sourced and threaded
+   * the same way as `onOpenAgenticToolSettings`. */
+  onUpdateUser?: (userId: string, updates: UpdateUserInput) => void | Promise<void>;
 }
 
 export const MissingCredentialPanel: React.FC<MissingCredentialPanelProps> = ({
   tool,
   client,
+  currentUserId,
   onOpenAgenticToolSettings,
+  onUpdateUser,
 }) => {
-  const { token } = theme.useToken();
   const [checking, setChecking] = useState(true);
   const [authResult, setAuthResult] = useState<AuthCheckResult | null>(null);
-  const [dismissed, setDismissed] = useState(false);
+  const [apiKeyValue, setApiKeyValue] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
+  // `checkAuthNonce` re-triggers the effect below on demand (e.g. right
+  // after a successful inline save) without duplicating the fetch logic.
+  const [checkAuthNonce, setCheckAuthNonce] = useState(0);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: checkAuthNonce is a sentinel dep — bumping it (e.g. after a successful inline save) intentionally re-triggers this effect without duplicating the fetch logic.
   useEffect(() => {
     let cancelled = false;
     if (!client) {
@@ -81,16 +108,33 @@ export const MissingCredentialPanel: React.FC<MissingCredentialPanelProps> = ({
     return () => {
       cancelled = true;
     };
-    // Re-check whenever the viewer or the tool changes; `client` identity is
-    // stable per authenticated session so this effectively runs once per
-    // (tool, logged-in user) pair.
-  }, [client, tool]);
+    // Re-check whenever the viewer or the tool changes (`client` identity is
+    // stable per authenticated session, so this effectively runs once per
+    // (tool, logged-in user) pair) or `checkAuthNonce` is bumped manually.
+  }, [client, tool, checkAuthNonce]);
 
   const displayName = AGENTIC_TOOL_DISPLAY_NAMES[tool] ?? tool;
-  const keyCreationUrl = AGENTIC_TOOL_KEY_CREATION_URL[tool];
+  const primaryField = TOOL_FIELD_CONFIGS[tool]?.[0];
   const nativeAuthHint = NATIVE_AUTH_HINT[tool];
 
-  if (dismissed) return null;
+  const handleSaveKey = async () => {
+    if (!currentUserId || !primaryField || !apiKeyValue.trim() || !onUpdateUser) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onUpdateUser(currentUserId, {
+        agentic_tools: {
+          [tool]: { [primaryField.field]: apiKeyValue.trim() },
+        } as UpdateUserInput['agentic_tools'],
+      });
+      setApiKeyValue('');
+      setCheckAuthNonce((n) => n + 1); // Live-refresh so a successful save flips the panel immediately.
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Could not save that key. Try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (checking) {
     return (
@@ -115,13 +159,12 @@ export const MissingCredentialPanel: React.FC<MissingCredentialPanelProps> = ({
     return (
       <SystemMessage
         content={
-          <Space size="small" align="start">
-            <CheckCircleOutlined style={{ color: token.colorSuccess, marginTop: 2 }} />
-            <Text type="secondary" style={{ fontSize: 13 }}>
-              This run needed a connected {displayName} account. Your account is already connected —
-              sending a new message should work.
-            </Text>
-          </Space>
+          <Result
+            icon={<CheckCircleOutlined />}
+            title={`${displayName} is connected`}
+            subTitle="This run needed a connected account. Send a new message to try again."
+            style={{ padding: '8px 0' }}
+          />
         }
       />
     );
@@ -130,45 +173,66 @@ export const MissingCredentialPanel: React.FC<MissingCredentialPanelProps> = ({
   return (
     <SystemMessage
       content={
-        <div style={{ maxWidth: 480 }}>
-          <Text style={{ fontSize: 13 }}>
-            Agor doesn't have its own AI model — it drives {displayName} on your behalf, so it needs
-            a way to reach your account before this session can respond.
-          </Text>
+        <div style={{ maxWidth: 460 }}>
+          <Result
+            icon={<KeyOutlined />}
+            title={`${displayName} isn't connected`}
+            subTitle={`Agor drives ${displayName} using your own account instead of running its own model — connect it to continue.`}
+            style={{ padding: '8px 0 0' }}
+          />
 
-          <div style={{ marginTop: token.marginSM }}>
-            <Button
-              type="primary"
-              onClick={() => onOpenAgenticToolSettings?.(tool)}
-              disabled={!onOpenAgenticToolSettings}
-            >
-              Connect {displayName}
-            </Button>
-          </div>
+          {primaryField && (
+            <>
+              <Text strong style={{ fontSize: 13 }}>
+                {primaryField.label}
+              </Text>
+              <Space.Compact style={{ width: '100%', marginTop: 6 }}>
+                <Input.Password
+                  placeholder={primaryField.placeholder}
+                  value={apiKeyValue}
+                  onChange={(e) => setApiKeyValue(e.target.value)}
+                  onPressEnter={handleSaveKey}
+                  disabled={saving}
+                />
+                <Button
+                  type="primary"
+                  icon={<KeyOutlined />}
+                  onClick={handleSaveKey}
+                  loading={saving}
+                  disabled={!apiKeyValue.trim() || !onUpdateUser || !currentUserId}
+                >
+                  Save
+                </Button>
+              </Space.Compact>
+              {primaryField.docUrl && (
+                <Text type="secondary" style={{ fontSize: 12, display: 'block', marginTop: 4 }}>
+                  Get one from{' '}
+                  <Link href={primaryField.docUrl} target="_blank" rel="noopener noreferrer">
+                    {displayName}'s console →
+                  </Link>
+                </Text>
+              )}
+              {nativeAuthHint && (
+                <Text type="secondary" style={{ fontSize: 12, display: 'block', marginTop: 4 }}>
+                  {nativeAuthHint}
+                </Text>
+              )}
+              {saveError && (
+                <Alert type="error" message={saveError} showIcon style={{ marginTop: 8 }} />
+              )}
 
-          <Space orientation="vertical" size={4} style={{ marginTop: token.marginSM }}>
-            {keyCreationUrl && (
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                Don't have a key yet?{' '}
-                <Link href={keyCreationUrl} target="_blank" rel="noopener noreferrer">
-                  Get one from {displayName}'s console →
-                </Link>
-              </Text>
-            )}
-            {nativeAuthHint && (
-              <Text type="secondary" style={{ fontSize: 12 }}>
-                {nativeAuthHint}
-              </Text>
-            )}
-            <Button
-              type="text"
-              size="small"
-              onClick={() => setDismissed(true)}
-              style={{ paddingLeft: 0, color: token.colorTextTertiary }}
-            >
-              Not right now
-            </Button>
-          </Space>
+              <Divider style={{ margin: '16px 0', fontSize: 12 }}>or</Divider>
+            </>
+          )}
+
+          <Button
+            block
+            icon={<SettingOutlined />}
+            onClick={() => onOpenAgenticToolSettings?.(tool)}
+            disabled={!onOpenAgenticToolSettings}
+          >
+            Open Settings
+          </Button>
         </div>
       }
     />

--- a/apps/agor-ui/src/components/MissingCredentialPanel/index.ts
+++ b/apps/agor-ui/src/components/MissingCredentialPanel/index.ts
@@ -1,0 +1,2 @@
+export type { MissingCredentialPanelProps } from './MissingCredentialPanel';
+export { MissingCredentialPanel } from './MissingCredentialPanel';

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -105,6 +105,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
       onViewLogs,
       onPermissionDecision,
       onOpenAgenticToolSettings,
+      onUpdateUser,
     } = useAppActions();
 
     // Get repo from branch
@@ -327,6 +328,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
               branch && isAssistant(branch) ? getAssistantConfig(branch)?.emoji : undefined
             }
             onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+            onUpdateUser={onUpdateUser}
           />
         </div>
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -104,6 +104,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
       onNukeEnvironment,
       onViewLogs,
       onPermissionDecision,
+      onOpenAgenticToolSettings,
     } = useAppActions();
 
     // Get repo from branch
@@ -325,6 +326,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             assistantEmoji={
               branch && isAssistant(branch) ? getAssistantConfig(branch)?.emoji : undefined
             }
+            onOpenAgenticToolSettings={onOpenAgenticToolSettings}
           />
         </div>
 

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -8,7 +8,7 @@ import type {
   UpdateUserInput,
   User,
 } from '@agor-live/client';
-import { hasMinimumRole, ROLE_OPTIONS, ROLES } from '@agor-live/client';
+import { AGENTIC_TOOL_DISPLAY_NAMES, hasMinimumRole, ROLE_OPTIONS, ROLES } from '@agor-live/client';
 import {
   ApiOutlined,
   CloseOutlined,
@@ -81,6 +81,13 @@ export interface UserSettingsModalProps {
   currentUser?: User | null;
   onUpdate?: (userId: string, updates: UpdateUserInput) => void;
   onRestartOnboarding?: () => void | Promise<void>;
+  /**
+   * Deep-link to a specific Agentic Tools tab on open (e.g. from the
+   * Connect-AI empty state's "Connect Claude" CTA), instead of always
+   * landing on "General". Only applied on the open transition — switching
+   * tabs afterward is unaffected.
+   */
+  initialTab?: AgenticToolName;
 }
 
 export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
@@ -91,6 +98,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   currentUser,
   onUpdate,
   onRestartOnboarding,
+  initialTab,
 }) => {
   // Entity maps are read from the store rather than drilled through props so
   // the App shell doesn't have to forward them into every modal.
@@ -178,8 +186,8 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
   // Initialize forms when user changes or modal opens
   const initializeForms = useCallback(
-    (userData: User) => {
-      setActiveTab('general');
+    (userData: User, openToTab?: AgenticToolName) => {
+      setActiveTab(openToTab ?? 'general');
       setDirtyAgenticConfigTools(new Set());
       setAgenticConfigDraftByTool({});
 
@@ -240,9 +248,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     if (!user || !userId || initializedUserIdRef.current === userId) return;
 
     initializedUserIdRef.current = userId;
-    initializeForms(user);
+    initializeForms(user, initialTab);
     void loadUserGroups();
-  }, [open, user, initializeForms, loadUserGroups]);
+  }, [open, user, initialTab, initializeForms, loadUserGroups]);
 
   // Hydrate tab-specific forms only after that tab has rendered its
   // corresponding <Form>. Calling setFieldsValue on never-mounted form
@@ -923,15 +931,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       case 'cursor': {
         const toolName = activeTab as AgenticToolName;
         const currentForm = agenticFormByTool[toolName];
-        const displayNames: Record<AgenticToolName, string> = {
-          'claude-code': 'Claude Code',
-          'claude-code-cli': 'Claude Code CLI',
-          codex: 'Codex',
-          gemini: 'Gemini',
-          opencode: 'OpenCode',
-          copilot: 'Copilot',
-          cursor: 'Cursor SDK',
-        };
+        const displayNames = AGENTIC_TOOL_DISPLAY_NAMES;
         // Field set is owned by ApiKeyFields' `TOOL_FIELD_CONFIGS`. Per-field
         // saving spinners are tracked in `savingToolField` keyed by `${tool}.${field}`.
         const toolFields = TOOL_FIELD_CONFIGS[toolName] ?? [];

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -9,7 +9,7 @@
  * - Groups 3+ sequential tool-only messages into ToolBlock
  */
 
-import type { AgorClient, StreamingMessageState } from '@agor-live/client';
+import type { AgenticToolName, AgorClient, StreamingMessageState } from '@agor-live/client';
 import {
   type Message,
   MessageRole,
@@ -97,6 +97,9 @@ interface TaskBlockProps {
   client?: AgorClient | null;
   /** Whether this is the most recent task in the session */
   isLatestTask?: boolean;
+  /** Opens Settings deep-linked to a provider's Agentic Tools tab. Forwarded
+   * to MessageBlock → MissingCredentialPanel for the Connect-AI empty state. */
+  onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
 }
 
 /**
@@ -367,6 +370,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     assistantEmoji,
     isLatestTask = false,
     client = null,
+    onOpenAgenticToolSettings,
   }) => {
     const { token } = theme.useToken();
 
@@ -651,6 +655,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           taskId={task.task_id}
                           assistantEmoji={assistantEmoji}
                           client={client}
+                          onOpenAgenticToolSettings={onOpenAgenticToolSettings}
                         />
                       );
                     }

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -9,7 +9,12 @@
  * - Groups 3+ sequential tool-only messages into ToolBlock
  */
 
-import type { AgenticToolName, AgorClient, StreamingMessageState } from '@agor-live/client';
+import type {
+  AgenticToolName,
+  AgorClient,
+  StreamingMessageState,
+  UpdateUserInput,
+} from '@agor-live/client';
 import {
   type Message,
   MessageRole,
@@ -100,6 +105,10 @@ interface TaskBlockProps {
   /** Opens Settings deep-linked to a provider's Agentic Tools tab. Forwarded
    * to MessageBlock → MissingCredentialPanel for the Connect-AI empty state. */
   onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+  /** Saves a per-user credential field. Forwarded to MessageBlock →
+   * MissingCredentialPanel for the Connect-AI empty state's inline
+   * "paste an API key" quick-connect. */
+  onUpdateUser?: (userId: string, updates: UpdateUserInput) => void | Promise<void>;
 }
 
 /**
@@ -371,6 +380,7 @@ export const TaskBlock = React.memo<TaskBlockProps>(
     isLatestTask = false,
     client = null,
     onOpenAgenticToolSettings,
+    onUpdateUser,
   }) => {
     const { token } = theme.useToken();
 
@@ -656,6 +666,13 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                           assistantEmoji={assistantEmoji}
                           client={client}
                           onOpenAgenticToolSettings={onOpenAgenticToolSettings}
+                          onUpdateUser={onUpdateUser}
+                          // NOTE: intentionally distinct from `currentUserId`
+                          // above, which is set to `task.created_by` here for
+                          // message-authorship display — this is the actual
+                          // logged-in viewer, needed for MissingCredentialPanel's
+                          // inline "paste an API key" save target.
+                          viewerUserId={currentUserId}
                         />
                       );
                     }

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -1,4 +1,10 @@
-import type { PermissionMode, PermissionScope, Session, SpawnConfig } from '@agor-live/client';
+import type {
+  AgenticToolName,
+  PermissionMode,
+  PermissionScope,
+  Session,
+  SpawnConfig,
+} from '@agor-live/client';
 import type React from 'react';
 import { createContext, useContext } from 'react';
 import type { BranchModalTab } from '../components/BranchModal/BranchModal';
@@ -41,6 +47,12 @@ export interface AppActionsContextValue {
   onSessionClick?: (sessionId: string) => void;
   onOpenBranch?: (branchId: string, tab?: BranchModalTab) => void;
   onOpenTerminal?: (commands: string[], branchId?: string) => void;
+  /**
+   * Open the current user's Settings modal, deep-linked to a specific
+   * Agentic Tools provider tab (e.g. the Connect-AI empty state's
+   * "Connect Claude" CTA).
+   */
+  onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
 }
 
 const AppActionsContext = createContext<AppActionsContextValue | undefined>(undefined);

--- a/apps/agor-ui/src/contexts/AppActionsContext.tsx
+++ b/apps/agor-ui/src/contexts/AppActionsContext.tsx
@@ -4,6 +4,7 @@ import type {
   PermissionScope,
   Session,
   SpawnConfig,
+  UpdateUserInput,
 } from '@agor-live/client';
 import type React from 'react';
 import { createContext, useContext } from 'react';
@@ -53,6 +54,12 @@ export interface AppActionsContextValue {
    * "Connect Claude" CTA).
    */
   onOpenAgenticToolSettings?: (tool: AgenticToolName) => void;
+  /**
+   * Saves a per-user profile/credential field (e.g. the Connect-AI empty
+   * state's inline "paste an API key" quick-connect — the same save path
+   * Settings' own API-key fields use).
+   */
+  onUpdateUser?: (userId: string, updates: UpdateUserInput) => void | Promise<void>;
 }
 
 const AppActionsContext = createContext<AppActionsContextValue | undefined>(undefined);

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -232,22 +232,6 @@ export const AGENTIC_TOOL_DISPLAY_NAMES: Record<AgenticToolName, string> = {
   cursor: 'Cursor SDK',
 };
 
-/**
- * Where a user can create a fresh API key for each tool. Mirrors the `docUrl`
- * values already used per-field in `ApiKeyFields.tsx` — kept here too so
- * non-Settings surfaces (e.g. the Connect-AI empty state) can link out
- * without importing UI-layer field config. Tools with no key concept
- * (opencode) are intentionally absent.
- */
-export const AGENTIC_TOOL_KEY_CREATION_URL: Partial<Record<AgenticToolName, string>> = {
-  'claude-code': 'https://platform.claude.com/settings/keys',
-  'claude-code-cli': 'https://platform.claude.com/settings/keys',
-  codex: 'https://platform.openai.com/api-keys',
-  gemini: 'https://aistudio.google.com/app/apikey',
-  copilot: 'https://github.com/settings/tokens',
-  cursor: 'https://cursor.com/dashboard/integrations',
-};
-
 export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapabilities> = {
   'claude-code': {
     supportsSessionFork: true,

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -217,6 +217,37 @@ export const TOOL_API_KEY_NAMES: Partial<Record<AgenticToolName, ApiKeyName>> = 
   cursor: 'CURSOR_API_KEY',
 };
 
+/**
+ * Human-readable display name for each agentic tool.
+ * Single source of truth for user-facing copy (Settings tabs, onboarding,
+ * the Connect-AI empty state) — avoids drift between duplicated inline maps.
+ */
+export const AGENTIC_TOOL_DISPLAY_NAMES: Record<AgenticToolName, string> = {
+  'claude-code': 'Claude Code',
+  'claude-code-cli': 'Claude Code CLI',
+  codex: 'Codex',
+  gemini: 'Gemini',
+  opencode: 'OpenCode',
+  copilot: 'Copilot',
+  cursor: 'Cursor SDK',
+};
+
+/**
+ * Where a user can create a fresh API key for each tool. Mirrors the `docUrl`
+ * values already used per-field in `ApiKeyFields.tsx` — kept here too so
+ * non-Settings surfaces (e.g. the Connect-AI empty state) can link out
+ * without importing UI-layer field config. Tools with no key concept
+ * (opencode) are intentionally absent.
+ */
+export const AGENTIC_TOOL_KEY_CREATION_URL: Partial<Record<AgenticToolName, string>> = {
+  'claude-code': 'https://platform.claude.com/settings/keys',
+  'claude-code-cli': 'https://platform.claude.com/settings/keys',
+  codex: 'https://platform.openai.com/api-keys',
+  gemini: 'https://aistudio.google.com/app/apikey',
+  copilot: 'https://github.com/settings/tokens',
+  cursor: 'https://cursor.com/dashboard/integrations',
+};
+
 export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapabilities> = {
   'claude-code': {
     supportsSessionFork: true,

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -5,6 +5,7 @@
  * Messages are stored in a normalized table and referenced by tasks via message_range.
  */
 
+import type { AgenticToolName } from './agentic-tool';
 import type { MessageID, SessionID, TaskID } from './id';
 import type { WidgetMessageMetadata } from './widget';
 
@@ -277,6 +278,26 @@ export interface Message {
      * prompt back to the originating widget for audit / debugging.
      */
     widget_id?: MessageID;
+
+    /**
+     * Marks the system message the executor creates when a task fails (see
+     * `base-executor.ts`). Lets the daemon's `classifyMissingCredentialFailure`
+     * hook (apps/agor-daemon/src/hooks/classify-missing-credential.ts) find
+     * exactly this message without relying on type/role heuristics that other
+     * system messages (daemon restart, rate limit, etc.) also use.
+     */
+    is_task_failure?: boolean;
+
+    /**
+     * Set server-side when a task failure is classified as "no credential
+     * resolved for this session's configured provider" — using the same
+     * resolution order as `resolveApiKey` (user > config.yaml > env > native
+     * auth), never by matching the error text. Drives the Connect-AI empty
+     * state in place of the raw error message. `tool` names the provider
+     * that needs a credential.
+     */
+    error_kind?: 'missing_credential';
+    tool?: AgenticToolName;
 
     /** Additional agent-specific fields */
     [key: string]: unknown;

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -643,6 +643,11 @@ export async function executeToolTask(params: {
         timestamp: new Date().toISOString(),
         content: err.message,
         content_preview: err.message.substring(0, 200),
+        // Marks this as *the* task-failure notice so the daemon's
+        // classifyMissingCredentialFailure hook can find it reliably,
+        // instead of guessing from type/role (which other system messages
+        // like daemon-restart/rate-limit notices also use).
+        metadata: { is_task_failure: true },
       });
     } catch (msgErr) {
       console.error(`[${toolName}] Failed to create error message:`, msgErr);


### PR DESCRIPTION
## Linked issue

Split out of #1754 at Kasia's request, this is UI-only follow-up work, kept separate from that PR's detection-logic fix and from the in-flight session-creation work (#1801).

## Summary

Structural rework of `MissingCredentialPanel`, based on seeing the original version live:

- Result-based layout (icon/title/subTitle/actions), matching the one existing precedent in this codebase (`OnboardingWizard`'s auth step), instead of an ad-hoc stack of differently-sized text fragments.
- Two co-equal ways to resolve it, not one CTA plus buried links: an inline "paste an API key" field (saves through the same `onUpdateUser` -> `agentic_tools` path Settings' own field already uses, sourced from `TOOL_FIELD_CONFIGS` so it stays per-provider correct) alongside an equally-weighted "Open Settings" button for anything needing more than a single field.
- Removed the dismiss affordance and its state entirely, this panel is the answer to why a task didn't produce output, not a transient notice to brush past.
- Copy no longer presumes first-time setup ("needs a way to reach your account"); "{provider} isn't connected" reads naturally whether a credential was never set up or used to work and broke.

## Why / context

After #1754's detection logic shipped, seeing the resulting panel live surfaced UX gaps the original design didn't anticipate: the layout felt ad-hoc next to existing empty-state precedent, users had to hunt for a secondary path if the primary CTA didn't fit their situation, and the copy read oddly for the "used to work, now broken" case (as distinct from never-connected).

## Implementation notes

- Added `onUpdateUser` to `AppActionsContext` (same pattern as `onOpenAgenticToolSettings`).
- Introduced a distinct `viewerUserId` prop through `TaskBlock` -> `MessageBlock` rather than reusing the existing `currentUserId`, which `TaskBlock` already overloads to mean the task's author (for avatar display), not the logged-in viewer.
- Removed `AGENTIC_TOOL_KEY_CREATION_URL` (now redundant with `TOOL_FIELD_CONFIGS.docUrl`, which the panel reads directly).

## Validation / test plan

- [x] Builds on top of #1754's detection logic unchanged; no daemon-side behavior touched.
- [ ] Manual click-through pending (dev environment access).

## Out of scope / follow-ups

- Depends on #1754's detection logic being merged first; this PR's diff will shrink to just the UI changes once that lands and this rebases.