### PR TITLE
fix(ui): keep MCP header helpers browser-safe

### DIFF
--- a/packages/core/src/mcp/template-patterns.ts
+++ b/packages/core/src/mcp/template-patterns.ts
@@ -1,0 +1,29 @@
+/**
+ * Browser-safe MCP template pattern helpers.
+ *
+ * Keep this module free of Handlebars, env resolution, and DB imports; UI
+ * validation/redaction helpers import it through browser bundles.
+ */
+
+/**
+ * Check if a string contains Handlebars template syntax.
+ */
+export function containsTemplate(value: string): boolean {
+  return value.includes('{{') && value.includes('}}');
+}
+
+/**
+ * Matches a value that is EXACTLY one bare `{{ user.env.NAME }}` placeholder:
+ * optional surrounding/inner whitespace, a standard env-var name, nothing else.
+ *
+ * Deliberately rejects everything but a direct user-env reference: arbitrary
+ * expressions, helper/fallback forms, partial values, and multiple expressions.
+ */
+const USER_ENV_PLACEHOLDER_RE = /^\{\{\s*user\.env\.[A-Za-z_][A-Za-z0-9_]*\s*\}\}$/;
+
+/**
+ * Check if a string is a single bare `{{ user.env.NAME }}` placeholder.
+ */
+export function isUserEnvPlaceholder(value: string): boolean {
+  return USER_ENV_PLACEHOLDER_RE.test(value.trim());
+}

--- a/packages/core/src/mcp/template-resolver.ts
+++ b/packages/core/src/mcp/template-resolver.ts
@@ -52,6 +52,9 @@
 import { AGOR_USER_ENV_KEYS_VAR } from '../config/env-resolver';
 import { renderTemplate } from '../templates/handlebars-helpers';
 import type { MCPAuth, MCPServer } from '../types';
+import { containsTemplate, isUserEnvPlaceholder } from './template-patterns';
+
+export { containsTemplate, isUserEnvPlaceholder };
 
 /**
  * Template context available for MCP configuration resolution.
@@ -111,38 +114,6 @@ export function buildMCPTemplateContextFromEnv(
       env: userEnv,
     },
   };
-}
-
-/**
- * Check if a string contains Handlebars template syntax
- */
-export function containsTemplate(value: string): boolean {
-  return value.includes('{{') && value.includes('}}');
-}
-
-/**
- * Matches a value that is EXACTLY one bare `{{ user.env.NAME }}` placeholder:
- * optional surrounding/inner whitespace, a standard env-var name, nothing else.
- *
- * Deliberately rejects everything but a direct user-env reference — arbitrary
- * expressions (`{{secret}}`), helper/fallback forms
- * (`{{default user.env.X "sk-live-…"}}`), partial values (`sk-{{x}}`), and
- * multiple expressions (`{{a}}{{b}}`) — so a raw secret or a literal secret
- * fallback can never be mistaken for a placeholder.
- */
-const USER_ENV_PLACEHOLDER_RE = /^\{\{\s*user\.env\.[A-Za-z_][A-Za-z0-9_]*\s*\}\}$/;
-
-/**
- * Check if a string is a single bare `{{ user.env.NAME }}` placeholder.
- *
- * Redaction uses this to decide whether a secret-bearing auth field holds a
- * user-env placeholder — which references an env key and carries no secret
- * material itself, so it is safe to preserve for downstream resolution — versus
- * a raw secret (which must be redacted). Intentionally far narrower than
- * {@link containsTemplate}: only bare user-env references may bypass redaction.
- */
-export function isUserEnvPlaceholder(value: string): boolean {
-  return USER_ENV_PLACEHOLDER_RE.test(value.trim());
 }
 
 /**

--- a/packages/core/src/tools/mcp/http-headers.ts
+++ b/packages/core/src/tools/mcp/http-headers.ts
@@ -7,7 +7,7 @@
  * OAuth/JWT/bearer credentials.
  */
 
-import { isUserEnvPlaceholder } from '../../mcp/template-resolver';
+import { isUserEnvPlaceholder } from '../../mcp/template-patterns';
 
 export const MCP_HEADER_REDACTED_SENTINEL = '••••••••';
 


### PR DESCRIPTION
## Linked issue

Fixes #1832

## Summary

- Move pure MCP template pattern checks into a browser-safe module.
- Keep the full MCP template resolver as the server/runtime path.
- Point MCP HTTP header helpers at the browser-safe pattern helper.

## Why / context

The settings UI imports MCP header validation helpers for form handling. Those helpers depended on the full MCP template resolver, which also imports environment resolution and database code. In a browser bundle, that chain can reach `node:async_hooks` through tenant context and fail before React mounts, leaving the page blank with no daemon-side error.

## Implementation notes

The new `template-patterns` module intentionally contains only pure string checks. `template-resolver` re-exports those helpers to preserve the existing server-side import surface, while `http-headers` imports the browser-safe module directly.

## Validation / test plan

- [x] `pnpm exec biome check packages/core/src/mcp/template-patterns.ts packages/core/src/mcp/template-resolver.ts packages/core/src/tools/mcp/http-headers.ts`
- [x] `pnpm --filter @agor/core test -- src/tools/mcp/http-headers.test.ts src/mcp/template-resolver.test.ts`
- [x] Browser runtime check for `http://localhost:5173/`: root mounted and no server-only module exception.

## Screenshots / demos

Not applicable.

## Risks / rollout / rollback

Low risk. This is a pure helper extraction with the existing resolver export preserved. Roll back by reverting the helper split if needed.

## Out of scope / follow-ups

The unrelated local daemon package script edit is not part of this PR.
