### PR TITLE
feat: Expose branch.base_ref and branch.ref_type to env variables

### DIFF
--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -2414,6 +2414,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         custom_context: branch.custom_context,
         unix_gid: unixGid,
         host_ip_address: hostIpAddress,
+        base_ref: branch.base_ref,
+        ref_type: branch.ref_type,
       },
       requestedVariant
     );

--- a/apps/agor-docs/content/guide/environment-configuration.mdx
+++ b/apps/agor-docs/content/guide/environment-configuration.mdx
@@ -81,6 +81,8 @@ Every field in a variant is a Handlebars template. The render context is built i
 | `{{branch.name}}` | Branch | `feat-new-filter` | Slugified branch name. Good for `docker compose -p`. |
 | `{{branch.path}}` | Branch | `/home/you/agor/feat-new-filter` | Absolute path on disk. |
 | `{{branch.gid}}` | Branch | `1042` | Unix GID of the branch's isolation group. |
+| `{{branch.base_ref}}` | Branch | `main` | Source branch/tag name the branch was created from (the "Base Branch"/"Base Tag" in the create dialog). The **name**, not a SHA. Empty string if unknown. |
+| `{{branch.ref_type}}` | Branch | `branch` | `branch` or `tag` — whether `base_ref` names a branch or a tag. Defaults to `branch`. |
 | `{{repo.slug}}` | Repo | `preset-io/superset` | Repository slug. |
 | `{{host.ip_address}}` | Auto-detected | `10.0.1.42` | Fallback order: `template_overrides.host.ip_address` → `daemon.host_ip_address` in `~/.agor/config.yaml` → autodetect. |
 | `{{custom.<key>}}` | Branch custom context | `{{custom.compose_profile}}` | Anything you store in `branch.custom_context`. |

--- a/packages/core/src/environment/render-snapshot.ts
+++ b/packages/core/src/environment/render-snapshot.ts
@@ -58,6 +58,8 @@ export interface RenderBranchInput {
   custom_context?: Record<string, unknown>;
   unix_gid?: number;
   host_ip_address?: string;
+  base_ref?: string;
+  ref_type?: 'branch' | 'tag';
 }
 
 /**
@@ -137,6 +139,8 @@ export function renderBranchSnapshot(
     custom_context: branch.custom_context,
     unix_gid: branch.unix_gid,
     host_ip_address: branch.host_ip_address,
+    base_ref: branch.base_ref,
+    ref_type: branch.ref_type,
   });
 
   // Per §5 of the design: defaults → template_overrides → custom.

--- a/packages/core/src/templates/handlebars-helpers.test.ts
+++ b/packages/core/src/templates/handlebars-helpers.test.ts
@@ -1056,6 +1056,8 @@ NAME={{replace (uppercase branch.name) "-" "_"}}
         name: 'my-branch',
         path: '/path/to/branch',
         gid: undefined,
+        base_ref: '',
+        ref_type: 'branch',
       };
       expect(context).toEqual({
         branch: expectedBranchEntity,
@@ -1069,6 +1071,33 @@ NAME={{replace (uppercase branch.name) "-" "_"}}
         },
         custom: { foo: 'bar' },
       });
+    });
+
+    it('should expose base_ref/ref_type under branch.* and the worktree.* alias', () => {
+      const context = buildBranchContext({
+        branch_unique_id: 1,
+        name: 'feat-x',
+        path: '/test',
+        base_ref: 'main',
+        ref_type: 'branch',
+      });
+
+      const rendered = renderTemplate(
+        'git fetch origin {{branch.base_ref}} ({{worktree.ref_type}})',
+        context
+      );
+      expect(rendered).toBe('git fetch origin main (branch)');
+    });
+
+    it('should default base_ref to empty string and ref_type to "branch" when unset', () => {
+      const context = buildBranchContext({
+        branch_unique_id: 1,
+        name: 'test',
+        path: '/test',
+      });
+
+      const rendered = renderTemplate('[{{branch.base_ref}}][{{branch.ref_type}}]', context);
+      expect(rendered).toBe('[][branch]');
     });
 
     it('should expose host.ip_address when provided', () => {

--- a/packages/core/src/templates/handlebars-helpers.ts
+++ b/packages/core/src/templates/handlebars-helpers.ts
@@ -292,6 +292,9 @@ export function renderTemplate(
  * - {{branch.name}} - Branch name (slug format)
  * - {{branch.path}} - Absolute path to branch directory
  * - {{branch.gid}} - Unix GID of branch's unix_group (resolved dynamically at execution time)
+ * - {{branch.base_ref}} - Source branch/tag name this branch was created from
+ *   (the "Base Branch"/"Base Tag" from the create dialog). Empty string if unknown.
+ * - {{branch.ref_type}} - 'branch' | 'tag': whether base_ref names a branch or a tag
  * - {{repo.slug}} - Repository slug
  * - {{host.ip_address}} - Primary non-loopback IPv4 of the daemon host
  *   (for health checks/URLs that must reach the host from inside a container).
@@ -312,12 +315,16 @@ export function buildBranchContext(branch: {
   custom_context?: Record<string, unknown>;
   unix_gid?: number;
   host_ip_address?: string;
+  base_ref?: string;
+  ref_type?: 'branch' | 'tag';
 }): Record<string, unknown> {
   const branchEntity = {
     unique_id: branch.branch_unique_id,
     name: branch.name,
     path: branch.path,
     gid: branch.unix_gid,
+    base_ref: branch.base_ref || '',
+    ref_type: branch.ref_type || 'branch',
   };
   return {
     // Scoped entities (accessible as {{entity.property}})

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -978,6 +978,8 @@ async function renderEnvironmentTemplates(
         custom_context: branch.custom_context,
         unix_gid: unixGid,
         host_ip_address: hostIpAddress,
+        base_ref: branch.base_ref,
+        ref_type: branch.ref_type,
       },
       branch.environment_variant
     );


### PR DESCRIPTION
## Summary
Exposing branch's `base_ref` and `ref_type` as environment variables that can be used in `.agor.yml` files.

## Why / context
This is pretty useful to orchestrate environment deployment through Codespaces with Agor. When you create a new branch in Agor, that branch doesn't yet exist upstream. That said, trying to spin up Codespaces would fail. This feature allows to configure the env to start pointing to the base branch (that exists upstream). For example:
``` bash
gh cs create -R "$REPO" -b "$BASE_BRANCH" -d "$DISPLAY" \
  --devcontainer-path "$DEVCONTAINER" \
  -l "$LOCATION" -m "$MACHINE" \
  --idle-timeout "$IDLE_TIMEOUT" --retention-period "$RETENTION" \
  --default-permissions
```

## Implementation notes
Might not be super widely adopted, but not a big change either. Just expanding the existing framework.

## Validation / test plan
- [x] pnpm test
- [x] pnpm typecheck
- [ ] Manual validation

## Screenshots / demos
No meaningful UI changes.

## Risks / rollout / rollback
No risks.

## Out of scope / follow-ups
Thought about using the `{{custom.*}}` branch properties. It doesn't have a native UI editor, so you must go through MCP change. Also feels like a natural feature.
