### PR TITLE
feat(executor): add passive task runtime vitals

### DIFF
--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Task, UUID } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, toShortId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -780,6 +780,95 @@ describe('TaskRepository.update', () => {
     expect(updated.last_executor_heartbeat_at).toBe(heartbeatAt);
     expect(found?.last_executor_heartbeat_at).toBe(heartbeatAt);
   });
+
+  dbTest(
+    'should round-trip runtime_vitals and clear active_tool across deep-merge updates',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const startedAt = '2026-01-01T00:00:00.000Z';
+      const created = await taskRepo.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.RUNNING,
+          runtime_vitals: {
+            schema_version: 1,
+            phase: TaskRuntimePhase.SDK_STARTING,
+            phase_started_at: startedAt,
+            last_activity_at: startedAt,
+            last_event: {
+              kind: TaskRuntimeEventKind.SDK_TURN_STARTED,
+              at: startedAt,
+              source: 'executor',
+              phase: TaskRuntimePhase.SDK_STARTING,
+            },
+            active_tool: {
+              tool_name: 'Bash',
+              tool_use_id: 'tool-1',
+              started_at: startedAt,
+              last_activity_at: startedAt,
+            },
+            counters: { events: 1 },
+            recent_events: [
+              {
+                kind: TaskRuntimeEventKind.SDK_TURN_STARTED,
+                at: startedAt,
+                source: 'executor',
+                phase: TaskRuntimePhase.SDK_STARTING,
+              },
+            ],
+          },
+        })
+      );
+
+      const progressAt = '2026-01-01T00:00:01.000Z';
+      const updated = await taskRepo.update(created.task_id, {
+        runtime_vitals: {
+          schema_version: 1,
+          phase: TaskRuntimePhase.RUNNING,
+          phase_started_at: progressAt,
+          last_activity_at: progressAt,
+          last_meaningful_progress_at: progressAt,
+          first_meaningful_progress_at: progressAt,
+          last_event: {
+            kind: TaskRuntimeEventKind.TOOL_COMPLETE,
+            at: progressAt,
+            source: 'tool',
+            phase: TaskRuntimePhase.RUNNING,
+            tool_name: 'Bash',
+            tool_use_id: 'tool-1',
+          },
+          active_tool: null,
+          counters: { events: 2, meaningful_progress_events: 1 },
+          recent_events: [
+            {
+              kind: TaskRuntimeEventKind.SDK_TURN_STARTED,
+              at: startedAt,
+              source: 'executor',
+              phase: TaskRuntimePhase.SDK_STARTING,
+            },
+            {
+              kind: TaskRuntimeEventKind.TOOL_COMPLETE,
+              at: progressAt,
+              source: 'tool',
+              phase: TaskRuntimePhase.RUNNING,
+              tool_name: 'Bash',
+              tool_use_id: 'tool-1',
+            },
+          ],
+        },
+      });
+      await taskRepo.update(created.task_id, { tool_use_count: 2 });
+      const found = await taskRepo.findById(created.task_id);
+
+      expect(updated.runtime_vitals?.phase).toBe(TaskRuntimePhase.RUNNING);
+      expect(found?.runtime_vitals?.phase).toBe(TaskRuntimePhase.RUNNING);
+      expect(found?.runtime_vitals?.last_event?.kind).toBe(TaskRuntimeEventKind.TOOL_COMPLETE);
+      expect(found?.runtime_vitals?.active_tool).toBeNull();
+      expect(found?.runtime_vitals?.counters?.meaningful_progress_events).toBe(1);
+      expect(found?.tool_use_count).toBe(2);
+    }
+  );
 
   dbTest('should throw EntityNotFoundError for non-existent ID', async ({ db }) => {
     const taskRepo = new TaskRepository(db);

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -870,6 +870,80 @@ describe('TaskRepository.update', () => {
     }
   );
 
+  dbTest(
+    'should replace runtime_vitals snapshots instead of deep-merging stale nested fields',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const startedAt = '2026-01-01T00:00:00.000Z';
+      const progressAt = '2026-01-01T00:00:01.000Z';
+      const created = await taskRepo.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.RUNNING,
+          runtime_vitals: {
+            schema_version: 1,
+            phase: TaskRuntimePhase.TOOL_RUNNING,
+            phase_started_at: startedAt,
+            last_activity_at: startedAt,
+            last_event: {
+              kind: TaskRuntimeEventKind.TOOL_START,
+              at: startedAt,
+              source: 'tool',
+              phase: TaskRuntimePhase.TOOL_RUNNING,
+              tool_name: 'Bash',
+              tool_use_id: 'tool-1',
+            },
+            active_tool: {
+              tool_name: 'Bash',
+              tool_use_id: 'tool-1',
+              started_at: startedAt,
+              last_activity_at: startedAt,
+            },
+            counters: { events: 1 },
+            recent_events: [],
+          },
+        })
+      );
+
+      const updated = await taskRepo.update(created.task_id, {
+        runtime_vitals: {
+          schema_version: 1,
+          phase: TaskRuntimePhase.RUNNING,
+          phase_started_at: startedAt,
+          last_activity_at: progressAt,
+          last_event: {
+            kind: TaskRuntimeEventKind.THINKING,
+            at: progressAt,
+            source: 'sdk',
+            phase: TaskRuntimePhase.RUNNING,
+          },
+          counters: { events: 2, thinking_events: 1 },
+          recent_events: [
+            {
+              kind: TaskRuntimeEventKind.THINKING,
+              at: progressAt,
+              source: 'sdk',
+              phase: TaskRuntimePhase.RUNNING,
+            },
+          ],
+        },
+      });
+
+      const found = await taskRepo.findById(created.task_id);
+
+      expect(updated.runtime_vitals?.last_event).toEqual({
+        kind: TaskRuntimeEventKind.THINKING,
+        at: progressAt,
+        source: 'sdk',
+        phase: TaskRuntimePhase.RUNNING,
+      });
+      expect(updated.runtime_vitals?.active_tool).toBeUndefined();
+      expect(found?.runtime_vitals?.last_event).toEqual(updated.runtime_vitals?.last_event);
+      expect(found?.runtime_vitals?.active_tool).toBeUndefined();
+    }
+  );
+
   dbTest('should throw EntityNotFoundError for non-existent ID', async ({ db }) => {
     const taskRepo = new TaskRepository(db);
     await expect(taskRepo.update('99999999', { status: TaskStatus.COMPLETED })).rejects.toThrow(

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -100,6 +100,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         report: task.report,
         permission_request: task.permission_request, // Permission state for UI approval flow
         metadata: task.metadata, // Generic metadata bag (e.g., is_agor_callback, source)
+        runtime_vitals: task.runtime_vitals, // Passive runtime-vitals observability
       },
     };
   }

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -375,8 +375,13 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         const current = this.rowToTask(currentRow);
 
         // STEP 2: Deep merge updates into current task (in memory)
-        // Preserves nested objects like message_range when doing partial updates
+        // Preserves nested objects like message_range when doing partial updates.
+        // Runtime vitals are complete snapshots; replacing them avoids stale nested
+        // fields surviving across SDK progress events that intentionally omit them.
         const merged = deepMerge(current, updates);
+        if (updates.runtime_vitals !== undefined) {
+          merged.runtime_vitals = updates.runtime_vitals;
+        }
         const insertData = this.taskToInsert(merged);
 
         // STEP 3: Write merged task (within same transaction)

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -369,6 +369,9 @@ export const tasks = pgTable(
 
         // Generic metadata (e.g., is_agor_callback, source, child_session_id)
         metadata?: Task['metadata'];
+
+        // Passive runtime-vitals observability
+        runtime_vitals?: Task['runtime_vitals'];
       }>()
       .notNull(),
   },

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -362,6 +362,9 @@ export const tasks = sqliteTable(
 
         // Generic metadata (e.g., is_agor_callback, source, child_session_id)
         metadata?: Task['metadata'];
+
+        // Passive runtime-vitals observability
+        runtime_vitals?: Task['runtime_vitals'];
       }>()
       .notNull(),
   },

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -19,6 +19,92 @@ export const TaskStatus = {
 export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
 
 /**
+ * Passive, persisted runtime-vitals snapshot for a task.
+ *
+ * This is observability only: writers must not use it to terminalize, stop,
+ * abort, timeout, or drain queues. Policies can be layered later by daemon-side
+ * supervisors that read these normalized phase/event fields.
+ */
+export const TaskRuntimePhase = {
+  EXECUTOR_CONNECTED: 'executor_connected',
+  SDK_STARTING: 'sdk_starting',
+  AWAITING_FIRST_AGENT_EVENT: 'awaiting_first_agent_event',
+  RUNNING: 'running',
+  AWAITING_PERMISSION: 'awaiting_permission',
+  TOOL_RUNNING: 'tool_running',
+  STOPPING: 'stopping',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+  STOPPED: 'stopped',
+  TIMED_OUT: 'timed_out',
+} as const;
+
+export type TaskRuntimePhase = (typeof TaskRuntimePhase)[keyof typeof TaskRuntimePhase];
+
+export const TaskRuntimeEventKind = {
+  EXECUTOR_CONNECTED: 'executor_connected',
+  SDK_TURN_STARTED: 'sdk_turn_started',
+  FIRST_AGENT_EVENT: 'first_agent_event',
+  STREAM_START: 'stream_start',
+  THINKING: 'thinking',
+  ASSISTANT_MESSAGE: 'assistant_message',
+  TOOL_START: 'tool_start',
+  TOOL_PROGRESS: 'tool_progress',
+  TOOL_COMPLETE: 'tool_complete',
+  PERMISSION_WAIT_START: 'permission_wait_start',
+  PERMISSION_WAIT_END: 'permission_wait_end',
+  TASK_STATUS: 'task_status',
+  TURN_COMPLETED: 'turn_completed',
+  TURN_FAILED: 'turn_failed',
+  TURN_STOPPED: 'turn_stopped',
+  TURN_TIMED_OUT: 'turn_timed_out',
+} as const;
+
+export type TaskRuntimeEventKind = (typeof TaskRuntimeEventKind)[keyof typeof TaskRuntimeEventKind];
+
+export type TaskRuntimeEventSource = 'daemon' | 'executor' | 'sdk' | 'tool' | 'permission';
+
+export interface TaskRuntimeEvent {
+  kind: TaskRuntimeEventKind;
+  at: string;
+  source: TaskRuntimeEventSource;
+  phase?: TaskRuntimePhase;
+  /** Normalized tool name only; never raw tool input/output. */
+  tool_name?: string;
+  /** Native tool-call id when available; no arguments or payload. */
+  tool_use_id?: string;
+}
+
+export interface TaskRuntimeVitals {
+  schema_version: 1;
+  phase: TaskRuntimePhase;
+  phase_started_at: string;
+  last_activity_at: string;
+  /** Set only for agent/tool output signals, not executor heartbeat. */
+  last_meaningful_progress_at?: string;
+  first_meaningful_progress_at?: string;
+  last_event?: TaskRuntimeEvent;
+  active_tool?: {
+    tool_name?: string;
+    tool_use_id?: string;
+    started_at: string;
+    last_activity_at?: string;
+  } | null;
+  counters?: {
+    events?: number;
+    meaningful_progress_events?: number;
+    tool_starts?: number;
+    tool_completes?: number;
+    thinking_events?: number;
+    stream_starts?: number;
+    assistant_messages?: number;
+    permission_waits?: number;
+  };
+  /** Small recent-event ring buffer; capped by writers. */
+  recent_events?: TaskRuntimeEvent[];
+}
+
+/**
  * Structured metadata attached to a task. All fields are optional, but the
  * ones that are present are load-bearing — typing them here prevents drift
  * between the daemon (which writes them) and the UI/services that read them.
@@ -155,6 +241,9 @@ export interface Task {
    * so the UI styling for callbacks survives the queue → run hop.
    */
   metadata?: TaskMetadata;
+
+  /** Passive executor/agent runtime phase observability. No policy side effects. */
+  runtime_vitals?: TaskRuntimeVitals;
 
   // Message range
   message_range: {

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -1,6 +1,7 @@
 import { resolveApiKey } from '@agor/core/config';
+import { TaskRuntimePhase, TaskStatus } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { resolveApiKeyForTask } from './base-executor.js';
+import { executeToolTask, resolveApiKeyForTask } from './base-executor.js';
 
 vi.mock('@agor/core/config', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agor/core/config')>();
@@ -9,6 +10,15 @@ vi.mock('@agor/core/config', async (importOriginal) => {
     resolveApiKey: vi.fn(),
   };
 });
+
+vi.mock('../../git/index.js', () => ({
+  getCurrentBranch: vi.fn(async () => 'test-branch'),
+  getGitState: vi.fn(async () => 'abc123'),
+}));
+
+vi.mock('./git-safe-directory.js', () => ({
+  configureSessionGitSafeDirectories: vi.fn(async () => undefined),
+}));
 
 function makeClient(error: unknown) {
   return {
@@ -101,5 +111,102 @@ describe('resolveApiKeyForTask', () => {
     ).resolves.toMatchObject({ apiKey: 'local-key', source: 'env' });
 
     expect(resolveApiKey).toHaveBeenCalledWith('OPENAI_API_KEY', {});
+  });
+});
+
+describe('executeToolTask runtime vitals failure handling', () => {
+  it('writes terminal failed vitals when setup fails after sdk_starting', async () => {
+    const taskPatches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const messages: Array<Record<string, unknown>> = [];
+    const client = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return {
+            get: vi.fn(async (id: string) => ({ task_id: id })),
+            emit: vi.fn(),
+            patch: vi.fn(async (id: string, data: Record<string, unknown>) => {
+              taskPatches.push({ id, data });
+              return { task_id: id, ...data };
+            }),
+          };
+        }
+        if (name === 'sessions') {
+          return {
+            get: vi.fn(async () => ({ branch_id: 'branch-1', git_state: {} })),
+            patch: vi.fn(async () => ({})),
+          };
+        }
+        if (name === 'branches') {
+          return { get: vi.fn(async () => ({ path: '/tmp/agor-test-branch' })) };
+        }
+        if (name === 'config/resolve-api-key') {
+          return {
+            create: vi.fn(async () => ({
+              apiKey: undefined,
+              source: 'native',
+              useNativeAuth: true,
+            })),
+          };
+        }
+        if (name === 'messages') {
+          return {
+            find: vi.fn(async () => ({ total: 0 })),
+            create: vi.fn(async (data: Record<string, unknown>) => {
+              messages.push(data);
+              return data;
+            }),
+          };
+        }
+        if (name === '/tasks/streaming') {
+          return { create: vi.fn(async (data: Record<string, unknown>) => data) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await expect(
+      executeToolTask({
+        client,
+        sessionId: 'session-1' as never,
+        taskId: 'task-1' as never,
+        prompt: 'hello',
+        abortController: new AbortController(),
+        apiKeyEnvVar: 'OPENAI_API_KEY',
+        toolName: 'codex' as never,
+        createTool: () => {
+          throw new Error('tool factory failed');
+        },
+      })
+    ).rejects.toThrow('tool factory failed');
+
+    expect(taskPatches[0]).toMatchObject({
+      id: 'task-1',
+      data: {
+        runtime_vitals: expect.objectContaining({ phase: TaskRuntimePhase.SDK_STARTING }),
+      },
+    });
+    expect(taskPatches).toContainEqual(
+      expect.objectContaining({
+        id: 'task-1',
+        data: expect.objectContaining({
+          git_state: { ref_at_start: 'test-branch', sha_at_start: 'abc123' },
+        }),
+      })
+    );
+    expect(taskPatches).toContainEqual(
+      expect.objectContaining({
+        id: 'task-1',
+        data: expect.objectContaining({
+          status: TaskStatus.FAILED,
+          error_message: 'tool factory failed',
+          runtime_vitals: expect.objectContaining({ phase: TaskRuntimePhase.FAILED }),
+        }),
+      })
+    );
+    expect(messages[0]).toMatchObject({
+      task_id: 'task-1',
+      role: 'system',
+      content: 'tool factory failed',
+    });
   });
 });

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -435,84 +435,86 @@ export async function executeToolTask(params: {
     taskId,
     toolName,
   });
-  await vitalsReporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
-    source: 'executor',
-    phase: TaskRuntimePhase.SDK_STARTING,
-    forceFlush: true,
-  });
-
-  // Ensure plain git commands launched by the agent SDK inherit safe.directory
-  // trust for this managed checkout. Without this, Unix-isolated sessions can
-  // create and run successfully through executor-mediated git probes while
-  // `git status` inside the agent shell still fails with dubious ownership.
-  await configureSessionGitSafeDirectories(client, sessionId, `[${toolName} git.safe-directory]`);
-
-  // Capture and stamp task-start git state inside the executor as early as
-  // possible. The daemon transitions the task to RUNNING before spawn, but the
-  // authoritative branch git read belongs here with the rest of
-  // executor-mediated git work.
-  await stampGitStateAtTaskStart(client, sessionId, taskId);
-
-  // Resolve API key with proper precedence (user → config → env → native auth).
-  // Pass `toolName` so the daemon scopes the per-user lookup to this tool's
-  // credential bucket — prevents cross-SDK leak (e.g. Codex picking up an
-  // ANTHROPIC_API_KEY stored under claude-code).
-  const resolution = await resolveApiKeyForTask(apiKeyEnvVar, client, taskId, toolName);
-
-  // Fail fast if stored key can't be decrypted (e.g. master secret changed)
-  if (resolution.decryptionFailed) {
-    throw new Error(
-      `API key "${apiKeyEnvVar}" could not be decrypted. ` +
-        `The stored key may have been encrypted with a different master secret. ` +
-        `Please re-enter your API key in Settings > ${toolName} > Authentication.`
-    );
-  }
-
-  // Log resolution result
-  if (resolution.apiKey) {
-    sdkDebug(`[${toolName}] Using API key from ${resolution.source} level for ${apiKeyEnvVar}`);
-  } else {
-    sdkDebug(
-      `[${toolName}] No API key found - SDK will use native authentication (OAuth/CLI login)`
-    );
-  }
-
-  // Create execution context
-  const ctx = createExecutionContext(client, toolName, sessionId, vitalsReporter);
-
-  // Create tool instance using factory function
-  // Pass the resolved key (or empty string) and useNativeAuth flag
-  const tool = createTool(ctx.repos, resolution.apiKey || '', resolution.useNativeAuth);
-
-  // Wire up abort signal to tool's stopTask method.
-  // Triggered by SIGTERM handler calling abortController.abort().
-  const abortHandler = async () => {
-    console.log(`[${toolName}] Abort signal received, calling tool.stopTask()...`);
-    if (tool.stopTask) {
-      try {
-        const stopResult = await tool.stopTask(sessionId, taskId);
-        if (stopResult.success) {
-          console.log(`[${toolName}] Tool stopped successfully`);
-        } else {
-          console.warn(`[${toolName}] Tool stop failed: ${stopResult.reason}`);
-        }
-      } catch (error) {
-        console.error(`[${toolName}] Error calling stopTask:`, error);
-      }
-    } else {
-      console.warn(`[${toolName}] Tool does not implement stopTask method`);
-    }
-  };
-
-  // Handle race condition: if signal is already aborted, call handler immediately
-  if (params.abortController.signal.aborted) {
-    await abortHandler();
-  }
-
-  // Listen for abort signal
-  params.abortController.signal.addEventListener('abort', abortHandler);
+  let abortHandler: (() => Promise<void>) | undefined;
 
   try {
+    await vitalsReporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+      source: 'executor',
+      phase: TaskRuntimePhase.SDK_STARTING,
+      forceFlush: true,
+    });
+
+    // Ensure plain git commands launched by the agent SDK inherit safe.directory
+    // trust for this managed checkout. Without this, Unix-isolated sessions can
+    // create and run successfully through executor-mediated git probes while
+    // `git status` inside the agent shell still fails with dubious ownership.
+    await configureSessionGitSafeDirectories(client, sessionId, `[${toolName} git.safe-directory]`);
+
+    // Capture and stamp task-start git state inside the executor as early as
+    // possible. The daemon transitions the task to RUNNING before spawn, but the
+    // authoritative branch git read belongs here with the rest of
+    // executor-mediated git work.
+    await stampGitStateAtTaskStart(client, sessionId, taskId);
+
+    // Resolve API key with proper precedence (user → config → env → native auth).
+    // Pass `toolName` so the daemon scopes the per-user lookup to this tool's
+    // credential bucket — prevents cross-SDK leak (e.g. Codex picking up an
+    // ANTHROPIC_API_KEY stored under claude-code).
+    const resolution = await resolveApiKeyForTask(apiKeyEnvVar, client, taskId, toolName);
+
+    // Fail fast if stored key can't be decrypted (e.g. master secret changed)
+    if (resolution.decryptionFailed) {
+      throw new Error(
+        `API key "${apiKeyEnvVar}" could not be decrypted. ` +
+          `The stored key may have been encrypted with a different master secret. ` +
+          `Please re-enter your API key in Settings > ${toolName} > Authentication.`
+      );
+    }
+
+    // Log resolution result
+    if (resolution.apiKey) {
+      sdkDebug(`[${toolName}] Using API key from ${resolution.source} level for ${apiKeyEnvVar}`);
+    } else {
+      sdkDebug(
+        `[${toolName}] No API key found - SDK will use native authentication (OAuth/CLI login)`
+      );
+    }
+
+    // Create execution context
+    const ctx = createExecutionContext(client, toolName, sessionId, vitalsReporter);
+
+    // Create tool instance using factory function
+    // Pass the resolved key (or empty string) and useNativeAuth flag
+    const tool = createTool(ctx.repos, resolution.apiKey || '', resolution.useNativeAuth);
+
+    // Wire up abort signal to tool's stopTask method.
+    // Triggered by SIGTERM handler calling abortController.abort().
+    abortHandler = async () => {
+      console.log(`[${toolName}] Abort signal received, calling tool.stopTask()...`);
+      if (tool.stopTask) {
+        try {
+          const stopResult = await tool.stopTask(sessionId, taskId);
+          if (stopResult.success) {
+            console.log(`[${toolName}] Tool stopped successfully`);
+          } else {
+            console.warn(`[${toolName}] Tool stop failed: ${stopResult.reason}`);
+          }
+        } catch (error) {
+          console.error(`[${toolName}] Error calling stopTask:`, error);
+        }
+      } else {
+        console.warn(`[${toolName}] Tool does not implement stopTask method`);
+      }
+    };
+
+    // Handle race condition: if signal is already aborted, call handler immediately
+    if (params.abortController.signal.aborted) {
+      await abortHandler();
+    }
+
+    // Listen for abort signal
+    params.abortController.signal.addEventListener('abort', abortHandler);
+
     await vitalsReporter.record(TaskRuntimeEventKind.TASK_STATUS, {
       source: 'executor',
       phase: TaskRuntimePhase.AWAITING_FIRST_AGENT_EVENT,
@@ -718,6 +720,8 @@ export async function executeToolTask(params: {
     vitalsReporter.stop();
 
     // Clean up abort listener
-    params.abortController.signal.removeEventListener('abort', abortHandler);
+    if (abortHandler) {
+      params.abortController.signal.removeEventListener('abort', abortHandler);
+    }
   }
 }

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -18,9 +18,16 @@ import type {
   Task,
   TaskID,
 } from '@agor/core/types';
-import { MessageRole } from '@agor/core/types';
+import { MessageRole, TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import { getCurrentBranch, getGitState } from '../../git/index.js';
+import {
+  TaskRuntimeVitalsReporter,
+  wrapMessagesServiceWithRuntimeVitals,
+  wrapStreamingCallbacksWithRuntimeVitals,
+  wrapTasksServiceWithRuntimeVitals,
+  wrapTasksStreamingServiceWithRuntimeVitals,
+} from '../../runtime-vitals.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
 import type { AgorClient } from '../../services/feathers-client.js';
@@ -216,12 +223,34 @@ export function createStreamingCallbacks(
 export function createExecutionContext(
   client: AgorClient,
   toolName: string,
-  sessionId: SessionID
+  sessionId: SessionID,
+  vitalsReporter?: TaskRuntimeVitalsReporter
 ): ExecutionContext {
+  const repos = createFeathersBackedRepositories(client);
+  const callbacks = createStreamingCallbacks(client, toolName, sessionId);
+
+  if (!vitalsReporter) {
+    return { client, repos, callbacks };
+  }
+
   return {
     client,
-    repos: createFeathersBackedRepositories(client),
-    callbacks: createStreamingCallbacks(client, toolName, sessionId),
+    repos: {
+      ...repos,
+      messagesService: wrapMessagesServiceWithRuntimeVitals(
+        repos.messagesService,
+        vitalsReporter
+      ) as typeof repos.messagesService,
+      tasksService: wrapTasksServiceWithRuntimeVitals(
+        repos.tasksService,
+        vitalsReporter
+      ) as typeof repos.tasksService,
+      tasksStreamingService: wrapTasksStreamingServiceWithRuntimeVitals(
+        repos.tasksStreamingService,
+        vitalsReporter
+      ) as typeof repos.tasksStreamingService,
+    },
+    callbacks: wrapStreamingCallbacksWithRuntimeVitals(callbacks, vitalsReporter),
   };
 }
 
@@ -401,6 +430,17 @@ export async function executeToolTask(params: {
 
   console.log(`[${toolName}] Executing task ${shortId(taskId)}...`);
 
+  const vitalsReporter = new TaskRuntimeVitalsReporter({
+    client,
+    taskId,
+    toolName,
+  });
+  await vitalsReporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+    source: 'executor',
+    phase: TaskRuntimePhase.SDK_STARTING,
+    forceFlush: true,
+  });
+
   // Ensure plain git commands launched by the agent SDK inherit safe.directory
   // trust for this managed checkout. Without this, Unix-isolated sessions can
   // create and run successfully through executor-mediated git probes while
@@ -438,7 +478,7 @@ export async function executeToolTask(params: {
   }
 
   // Create execution context
-  const ctx = createExecutionContext(client, toolName, sessionId);
+  const ctx = createExecutionContext(client, toolName, sessionId, vitalsReporter);
 
   // Create tool instance using factory function
   // Pass the resolved key (or empty string) and useNativeAuth flag
@@ -473,6 +513,12 @@ export async function executeToolTask(params: {
   params.abortController.signal.addEventListener('abort', abortHandler);
 
   try {
+    await vitalsReporter.record(TaskRuntimeEventKind.TASK_STATUS, {
+      source: 'executor',
+      phase: TaskRuntimePhase.AWAITING_FIRST_AGENT_EVENT,
+      forceFlush: true,
+    });
+
     // Execute prompt with streaming
     // Pass abortController directly to SDK for proper cancellation support
     const result = await tool.executePromptWithStreaming(
@@ -503,10 +549,25 @@ export async function executeToolTask(params: {
       );
     }
 
+    const terminalVitalsKind = result.wasStopped
+      ? TaskRuntimeEventKind.TURN_STOPPED
+      : result.hadError
+        ? TaskRuntimeEventKind.TURN_FAILED
+        : TaskRuntimeEventKind.TURN_COMPLETED;
+    const terminalPhase = result.wasStopped
+      ? TaskRuntimePhase.STOPPED
+      : result.hadError
+        ? TaskRuntimePhase.FAILED
+        : TaskRuntimePhase.COMPLETED;
+
     // Build patch data
     const patchData: Partial<Task> = {
       status: taskStatus,
       completed_at: new Date().toISOString(),
+      runtime_vitals: await vitalsReporter.terminalSnapshot(terminalVitalsKind, {
+        source: 'sdk',
+        phase: terminalPhase,
+      }),
     };
 
     // Add git_state if we captured a SHA
@@ -604,6 +665,10 @@ export async function executeToolTask(params: {
     const patchData: Partial<Task> = {
       status: 'failed',
       completed_at: new Date().toISOString(),
+      runtime_vitals: await vitalsReporter.terminalSnapshot(TaskRuntimeEventKind.TURN_FAILED, {
+        source: 'sdk',
+        phase: TaskRuntimePhase.FAILED,
+      }),
       // Surface the actual failure reason so the UI / DB show what went wrong,
       // instead of the task silently flipping to FAILED with no context.
       error_message: err.message || String(err),
@@ -650,6 +715,8 @@ export async function executeToolTask(params: {
 
     throw err;
   } finally {
+    vitalsReporter.stop();
+
     // Clean up abort listener
     params.abortController.signal.removeEventListener('abort', abortHandler);
   }

--- a/packages/executor/src/runtime-vitals.test.ts
+++ b/packages/executor/src/runtime-vitals.test.ts
@@ -1,0 +1,272 @@
+import { TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TaskRuntimeVitalsReporter, wrapTasksServiceWithRuntimeVitals } from './runtime-vitals.js';
+
+function createClient(patches: Array<{ id: string; data: Record<string, unknown> }>) {
+  return {
+    service(name: string) {
+      if (name !== 'tasks') throw new Error(`unexpected service ${name}`);
+      return {
+        patch: vi.fn(async (id: string, data: Record<string, unknown>) => {
+          patches.push({ id, data });
+          return { task_id: id, ...data };
+        }),
+      };
+    },
+  } as never;
+}
+
+describe('TaskRuntimeVitalsReporter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stores compact capped events and throttles non-forced writes', async () => {
+    const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    let nowMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient(patches),
+      taskId: 'task-1',
+      toolName: 'codex',
+      maxEvents: 3,
+      minPatchIntervalMs: 5_000,
+      now: () => new Date(nowMs),
+    });
+
+    await reporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+      phase: TaskRuntimePhase.SDK_STARTING,
+      source: 'executor',
+      forceFlush: true,
+    });
+    nowMs += 1_000;
+    await reporter.record(TaskRuntimeEventKind.THINKING, {
+      phase: TaskRuntimePhase.RUNNING,
+      source: 'sdk',
+      meaningful: true,
+    });
+    await reporter.record(TaskRuntimeEventKind.TOOL_START, {
+      phase: TaskRuntimePhase.TOOL_RUNNING,
+      source: 'tool',
+      meaningful: true,
+      toolName: 'Bash',
+      toolUseId: 'tool-1',
+    });
+    await reporter.record(TaskRuntimeEventKind.TOOL_PROGRESS, {
+      phase: TaskRuntimePhase.TOOL_RUNNING,
+      source: 'tool',
+      meaningful: true,
+      toolName: 'Bash',
+      toolUseId: 'tool-1',
+    });
+
+    expect(patches).toHaveLength(3);
+    expect(patches[0]?.data).toEqual({ runtime_vitals: expect.any(Object) });
+    expect(patches[0]?.data).not.toHaveProperty('status');
+
+    nowMs += 5_000;
+    await reporter.record(TaskRuntimeEventKind.TOOL_COMPLETE, {
+      phase: TaskRuntimePhase.RUNNING,
+      source: 'tool',
+      meaningful: true,
+      toolName: 'Bash',
+      toolUseId: 'tool-1',
+    });
+
+    expect(patches).toHaveLength(4);
+    const vitals = patches[3]?.data.runtime_vitals as NonNullable<typeof reporter.snapshot>;
+    expect(vitals.recent_events).toHaveLength(3);
+    expect(vitals.recent_events?.map((event) => event.kind)).toEqual([
+      TaskRuntimeEventKind.TOOL_START,
+      TaskRuntimeEventKind.TOOL_PROGRESS,
+      TaskRuntimeEventKind.TOOL_COMPLETE,
+    ]);
+    expect(vitals.last_meaningful_progress_at).toBeDefined();
+    expect(vitals.counters?.meaningful_progress_events).toBe(4);
+    expect(vitals.active_tool).toBeNull();
+    expect(JSON.stringify(vitals)).not.toContain('secret');
+  });
+
+  it('flushes first meaningful progress immediately inside the throttle window', async () => {
+    const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    let nowMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient(patches),
+      taskId: 'task-1',
+      toolName: 'codex',
+      minPatchIntervalMs: 5_000,
+      now: () => new Date(nowMs),
+    });
+
+    await reporter.record(TaskRuntimeEventKind.TASK_STATUS, {
+      phase: TaskRuntimePhase.AWAITING_FIRST_AGENT_EVENT,
+      source: 'executor',
+      forceFlush: true,
+    });
+    nowMs += 1_000;
+
+    await reporter.record(TaskRuntimeEventKind.THINKING, {
+      phase: TaskRuntimePhase.RUNNING,
+      source: 'sdk',
+      meaningful: true,
+    });
+
+    expect(patches).toHaveLength(2);
+    const vitals = patches[1]?.data.runtime_vitals as NonNullable<typeof reporter.snapshot>;
+    expect(vitals.phase).toBe(TaskRuntimePhase.RUNNING);
+    expect(vitals.first_meaningful_progress_at).toBe('2026-01-01T00:00:01.000Z');
+    expect(vitals.last_event?.kind).toBe(TaskRuntimeEventKind.THINKING);
+  });
+
+  it('schedules a trailing flush for throttled updates', async () => {
+    vi.useFakeTimers();
+    const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    let nowMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient(patches),
+      taskId: 'task-1',
+      toolName: 'codex',
+      minPatchIntervalMs: 5_000,
+      now: () => new Date(nowMs),
+    });
+
+    await reporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+      phase: TaskRuntimePhase.SDK_STARTING,
+      source: 'executor',
+      forceFlush: true,
+    });
+    nowMs += 1_000;
+    await reporter.record(TaskRuntimeEventKind.THINKING, {
+      phase: TaskRuntimePhase.RUNNING,
+      source: 'sdk',
+      meaningful: true,
+    });
+
+    nowMs += 1_000;
+    await reporter.record(TaskRuntimeEventKind.THINKING, {
+      phase: TaskRuntimePhase.RUNNING,
+      source: 'sdk',
+      meaningful: true,
+    });
+
+    expect(patches).toHaveLength(2);
+
+    nowMs += 3_999;
+    await vi.advanceTimersByTimeAsync(3_999);
+    expect(patches).toHaveLength(2);
+
+    nowMs += 1;
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(patches).toHaveLength(3);
+    const vitals = patches[2]?.data.runtime_vitals as NonNullable<typeof reporter.snapshot>;
+    expect(vitals.last_activity_at).toBe('2026-01-01T00:00:02.000Z');
+    expect(vitals.last_event?.kind).toBe(TaskRuntimeEventKind.THINKING);
+    expect(vitals.counters?.meaningful_progress_events).toBe(2);
+  });
+
+  it('writes explicit active_tool null after tool completion and terminal snapshots', async () => {
+    const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    let nowMs = Date.parse('2026-01-01T00:00:00.000Z');
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient(patches),
+      taskId: 'task-1',
+      toolName: 'claude-code',
+      minPatchIntervalMs: 0,
+      now: () => new Date(nowMs),
+    });
+
+    await reporter.record(TaskRuntimeEventKind.TOOL_START, {
+      phase: TaskRuntimePhase.TOOL_RUNNING,
+      source: 'tool',
+      meaningful: true,
+      toolName: 'Bash',
+      toolUseId: 'tool-1',
+    });
+    nowMs += 1_000;
+    await reporter.record(TaskRuntimeEventKind.TOOL_COMPLETE, {
+      phase: TaskRuntimePhase.RUNNING,
+      source: 'tool',
+      meaningful: true,
+      toolName: 'Bash',
+      toolUseId: 'tool-1',
+    });
+
+    expect(
+      (patches[1]?.data.runtime_vitals as NonNullable<typeof reporter.snapshot>).active_tool
+    ).toBeNull();
+
+    const terminalVitals = await reporter.terminalSnapshot(TaskRuntimeEventKind.TURN_COMPLETED, {
+      phase: TaskRuntimePhase.COMPLETED,
+      source: 'sdk',
+    });
+
+    expect(terminalVitals.active_tool).toBeNull();
+  });
+
+  it('builds terminal vitals without issuing terminal side-effect patches', async () => {
+    const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient(patches),
+      taskId: 'task-1',
+      toolName: 'claude-code',
+      minPatchIntervalMs: 0,
+      now: () => new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await reporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+      phase: TaskRuntimePhase.SDK_STARTING,
+      forceFlush: true,
+    });
+
+    const terminalVitals = await reporter.terminalSnapshot(TaskRuntimeEventKind.TURN_COMPLETED, {
+      phase: TaskRuntimePhase.COMPLETED,
+      source: 'sdk',
+    });
+    await reporter.record(TaskRuntimeEventKind.THINKING, {
+      phase: TaskRuntimePhase.RUNNING,
+      source: 'sdk',
+      meaningful: true,
+      forceFlush: true,
+    });
+
+    expect(terminalVitals.phase).toBe(TaskRuntimePhase.COMPLETED);
+    expect(terminalVitals.last_event?.kind).toBe(TaskRuntimeEventKind.TURN_COMPLETED);
+    expect(patches).toHaveLength(1);
+    expect(patches[0]?.data).toEqual({ runtime_vitals: expect.any(Object) });
+    expect(patches[0]?.data).not.toHaveProperty('status');
+  });
+});
+
+describe('wrapTasksServiceWithRuntimeVitals', () => {
+  it('observes status patches but only adds runtime_vitals after caller-owned terminal patches', async () => {
+    const calls: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const rawTasksService = {
+      get: vi.fn(),
+      emit: vi.fn(),
+      patch: vi.fn(async (id: string, data: Record<string, unknown>) => {
+        calls.push({ id, data });
+        return { task_id: id, ...data };
+      }),
+    };
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient([]),
+      taskId: 'task-1',
+      toolName: 'claude-code',
+      minPatchIntervalMs: 0,
+      now: () => new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const wrapped = wrapTasksServiceWithRuntimeVitals(rawTasksService, reporter);
+
+    await wrapped.patch('task-1', { status: TaskStatus.AWAITING_PERMISSION });
+    await wrapped.patch('task-1', { status: TaskStatus.RUNNING });
+    await wrapped.patch('task-1', { status: TaskStatus.FAILED });
+
+    expect(calls).toEqual([
+      { id: 'task-1', data: { status: TaskStatus.AWAITING_PERMISSION } },
+      { id: 'task-1', data: { status: TaskStatus.RUNNING } },
+      { id: 'task-1', data: { status: TaskStatus.FAILED } },
+      { id: 'task-1', data: { runtime_vitals: expect.any(Object) } },
+    ]);
+    expect(calls[3]?.data).not.toHaveProperty('status');
+  });
+});

--- a/packages/executor/src/runtime-vitals.test.ts
+++ b/packages/executor/src/runtime-vitals.test.ts
@@ -1,6 +1,10 @@
 import { TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { TaskRuntimeVitalsReporter, wrapTasksServiceWithRuntimeVitals } from './runtime-vitals.js';
+import {
+  TaskRuntimeVitalsReporter,
+  wrapMessagesServiceWithRuntimeVitals,
+  wrapTasksServiceWithRuntimeVitals,
+} from './runtime-vitals.js';
 
 function createClient(patches: Array<{ id: string; data: Record<string, unknown> }>) {
   return {
@@ -234,6 +238,39 @@ describe('TaskRuntimeVitalsReporter', () => {
     expect(patches).toHaveLength(1);
     expect(patches[0]?.data).toEqual({ runtime_vitals: expect.any(Object) });
     expect(patches[0]?.data).not.toHaveProperty('status');
+  });
+});
+
+describe('wrapMessagesServiceWithRuntimeVitals', () => {
+  it('preserves Feathers service context when forwarding patch', async () => {
+    const rawMessagesService = {
+      marker: 'messages-service-context',
+      create: vi.fn(async (data: Record<string, unknown>) => ({
+        message_id: 'message-1',
+        role: 'user',
+        ...data,
+      })),
+      patch: vi.fn(async function (
+        this: { marker: string },
+        id: string,
+        data: Record<string, unknown>
+      ) {
+        return { message_id: id, marker: this.marker, ...data };
+      }),
+    };
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient([]),
+      taskId: 'task-1',
+      toolName: 'claude-code',
+      minPatchIntervalMs: 0,
+      now: () => new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const wrapped = wrapMessagesServiceWithRuntimeVitals(rawMessagesService, reporter);
+
+    await expect(wrapped.patch('message-1', { text: 'ok' })).resolves.toMatchObject({
+      marker: 'messages-service-context',
+      text: 'ok',
+    });
   });
 });
 

--- a/packages/executor/src/runtime-vitals.ts
+++ b/packages/executor/src/runtime-vitals.ts
@@ -1,0 +1,465 @@
+import type {
+  Message,
+  TaskRuntimeEvent,
+  TaskRuntimeEventKind,
+  TaskRuntimeEventSource,
+  TaskRuntimePhase,
+  TaskRuntimeVitals,
+} from '@agor/core/types';
+import {
+  TaskRuntimeEventKind as EventKind,
+  MessageRole,
+  TaskRuntimePhase as Phase,
+  TaskStatus,
+} from '@agor/core/types';
+import type {
+  MessagesService,
+  TasksService,
+  TasksStreamingService,
+} from './sdk-handlers/base/service-clients.js';
+import type { StreamingCallbacks } from './sdk-handlers/base/types.js';
+import type { AgorClient } from './services/feathers-client.js';
+
+const DEFAULT_MAX_EVENTS = 20;
+const DEFAULT_MIN_PATCH_INTERVAL_MS = 5_000;
+const CLEARED_ACTIVE_TOOL = null as unknown as TaskRuntimeVitals['active_tool'];
+
+export interface RuntimeVitalsReporterOptions {
+  client: Pick<AgorClient, 'service'>;
+  taskId: string;
+  toolName: string;
+  now?: () => Date;
+  maxEvents?: number;
+  minPatchIntervalMs?: number;
+  warn?: (...args: unknown[]) => void;
+}
+
+export interface RuntimeVitalsRecordOptions {
+  phase?: TaskRuntimePhase;
+  source?: TaskRuntimeEventSource;
+  meaningful?: boolean;
+  toolName?: string;
+  toolUseId?: string;
+  forceFlush?: boolean;
+}
+
+export class TaskRuntimeVitalsReporter {
+  private readonly now: () => Date;
+  private readonly maxEvents: number;
+  private readonly minPatchIntervalMs: number;
+  private readonly warn: (...args: unknown[]) => void;
+  private current: TaskRuntimeVitals | undefined;
+  private lastFlushAtMs = 0;
+  private pendingFlush: Promise<void> = Promise.resolve();
+  private trailingFlushTimer: ReturnType<typeof setTimeout> | undefined;
+  private stopped = false;
+
+  constructor(private readonly options: RuntimeVitalsReporterOptions) {
+    this.now = options.now ?? (() => new Date());
+    this.maxEvents = Math.max(1, Math.floor(options.maxEvents ?? DEFAULT_MAX_EVENTS));
+    this.minPatchIntervalMs = Math.max(
+      0,
+      Math.floor(options.minPatchIntervalMs ?? DEFAULT_MIN_PATCH_INTERVAL_MS)
+    );
+    this.warn = options.warn ?? console.warn;
+  }
+
+  get snapshot(): TaskRuntimeVitals | undefined {
+    return this.current;
+  }
+
+  get taskId(): string {
+    return this.options.taskId;
+  }
+
+  async record(
+    kind: TaskRuntimeEventKind,
+    options: RuntimeVitalsRecordOptions = {}
+  ): Promise<void> {
+    if (this.stopped) return;
+    const previous = this.current;
+    const vitals = this.applyEvent(kind, options);
+    const phaseChanged = !previous || previous.phase !== vitals.phase;
+    const firstMeaningfulProgress =
+      options.meaningful === true && previous?.first_meaningful_progress_at === undefined;
+    const shouldFlush =
+      options.forceFlush === true ||
+      phaseChanged ||
+      firstMeaningfulProgress ||
+      this.minPatchIntervalMs === 0 ||
+      this.now().getTime() - this.lastFlushAtMs >= this.minPatchIntervalMs;
+
+    if (!shouldFlush) {
+      this.scheduleTrailingFlush();
+      return;
+    }
+
+    this.cancelTrailingFlush();
+    await this.enqueueFlush(vitals);
+  }
+
+  /**
+   * Build the final vitals snapshot to include in the terminal task patch.
+   * This stops later passive writes and waits for older queued writes so the
+   * terminal patch lands last when the caller includes this snapshot.
+   */
+  async terminalSnapshot(
+    kind: TaskRuntimeEventKind,
+    options: RuntimeVitalsRecordOptions = {}
+  ): Promise<TaskRuntimeVitals> {
+    this.stopped = true;
+    this.cancelTrailingFlush();
+    await this.pendingFlush.catch(() => undefined);
+    return this.applyEvent(kind, { ...options, forceFlush: false });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.cancelTrailingFlush();
+  }
+
+  private applyEvent(
+    kind: TaskRuntimeEventKind,
+    options: RuntimeVitalsRecordOptions
+  ): TaskRuntimeVitals {
+    const at = this.now().toISOString();
+    const source = options.source ?? 'executor';
+    const phase = options.phase ?? this.current?.phase ?? Phase.RUNNING;
+    const event: TaskRuntimeEvent = {
+      kind,
+      at,
+      source,
+      phase,
+      ...(options.toolName ? { tool_name: options.toolName } : {}),
+      ...(options.toolUseId ? { tool_use_id: options.toolUseId } : {}),
+    };
+
+    const previous = this.current;
+    const previousCounters = previous?.counters ?? {};
+    const phaseChanged = !previous || previous.phase !== phase;
+    const meaningful = options.meaningful === true;
+    const counters: NonNullable<TaskRuntimeVitals['counters']> = {
+      ...previousCounters,
+      events: (previousCounters.events ?? 0) + 1,
+    };
+
+    if (meaningful) {
+      counters.meaningful_progress_events = (previousCounters.meaningful_progress_events ?? 0) + 1;
+    }
+    if (kind === EventKind.TOOL_START)
+      counters.tool_starts = (previousCounters.tool_starts ?? 0) + 1;
+    if (kind === EventKind.TOOL_COMPLETE) {
+      counters.tool_completes = (previousCounters.tool_completes ?? 0) + 1;
+    }
+    if (kind === EventKind.THINKING)
+      counters.thinking_events = (previousCounters.thinking_events ?? 0) + 1;
+    if (kind === EventKind.STREAM_START)
+      counters.stream_starts = (previousCounters.stream_starts ?? 0) + 1;
+    if (kind === EventKind.ASSISTANT_MESSAGE) {
+      counters.assistant_messages = (previousCounters.assistant_messages ?? 0) + 1;
+    }
+    if (kind === EventKind.PERMISSION_WAIT_START) {
+      counters.permission_waits = (previousCounters.permission_waits ?? 0) + 1;
+    }
+
+    const recentEvents = [...(previous?.recent_events ?? []), event].slice(-this.maxEvents);
+    const lastMeaningful = meaningful ? at : previous?.last_meaningful_progress_at;
+    const firstMeaningful = meaningful
+      ? (previous?.first_meaningful_progress_at ?? at)
+      : previous?.first_meaningful_progress_at;
+
+    let activeTool = previous?.active_tool;
+    if (kind === EventKind.TOOL_START) {
+      activeTool = {
+        ...(options.toolName ? { tool_name: options.toolName } : {}),
+        ...(options.toolUseId ? { tool_use_id: options.toolUseId } : {}),
+        started_at: at,
+        last_activity_at: at,
+      };
+    } else if (kind === EventKind.TOOL_PROGRESS && activeTool) {
+      activeTool = { ...activeTool, last_activity_at: at };
+    } else if (kind === EventKind.TOOL_COMPLETE) {
+      const sameTool =
+        !activeTool ||
+        !options.toolUseId ||
+        !activeTool.tool_use_id ||
+        activeTool.tool_use_id === options.toolUseId;
+      activeTool = sameTool ? CLEARED_ACTIVE_TOOL : activeTool;
+    } else if (isTerminalTaskRuntimeEvent(kind)) {
+      activeTool = CLEARED_ACTIVE_TOOL;
+    }
+
+    this.current = {
+      schema_version: 1,
+      phase,
+      phase_started_at: phaseChanged ? at : (previous?.phase_started_at ?? at),
+      last_activity_at: at,
+      ...(lastMeaningful ? { last_meaningful_progress_at: lastMeaningful } : {}),
+      ...(firstMeaningful ? { first_meaningful_progress_at: firstMeaningful } : {}),
+      last_event: event,
+      ...(activeTool !== undefined ? { active_tool: activeTool } : {}),
+      counters,
+      recent_events: recentEvents,
+    };
+
+    return this.current;
+  }
+
+  private scheduleTrailingFlush(): void {
+    if (this.trailingFlushTimer || this.stopped) return;
+
+    const elapsedMs = this.now().getTime() - this.lastFlushAtMs;
+    const delayMs = Math.max(0, this.minPatchIntervalMs - elapsedMs);
+    this.trailingFlushTimer = setTimeout(() => {
+      this.trailingFlushTimer = undefined;
+      if (this.stopped || !this.current) return;
+      void this.enqueueFlush(this.current);
+    }, delayMs);
+  }
+
+  private cancelTrailingFlush(): void {
+    if (!this.trailingFlushTimer) return;
+    clearTimeout(this.trailingFlushTimer);
+    this.trailingFlushTimer = undefined;
+  }
+
+  private async enqueueFlush(vitals: TaskRuntimeVitals): Promise<void> {
+    this.lastFlushAtMs = this.now().getTime();
+    const patch = async () => {
+      if (this.stopped) return;
+      try {
+        await this.options.client.service('tasks').patch(this.options.taskId, {
+          runtime_vitals: vitals,
+        });
+      } catch (error) {
+        this.warn(
+          '[runtime-vitals] Failed to write task runtime vitals:',
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    };
+
+    this.pendingFlush = this.pendingFlush.then(patch, patch);
+    await this.pendingFlush;
+  }
+}
+
+function isTerminalTaskRuntimeEvent(kind: TaskRuntimeEventKind): boolean {
+  return (
+    kind === EventKind.TURN_COMPLETED ||
+    kind === EventKind.TURN_FAILED ||
+    kind === EventKind.TURN_STOPPED ||
+    kind === EventKind.TURN_TIMED_OUT
+  );
+}
+
+export function taskStatusToRuntimePhase(status: string | undefined): TaskRuntimePhase | undefined {
+  switch (status) {
+    case TaskStatus.RUNNING:
+      return Phase.RUNNING;
+    case TaskStatus.STOPPING:
+      return Phase.STOPPING;
+    case TaskStatus.AWAITING_PERMISSION:
+      return Phase.AWAITING_PERMISSION;
+    case TaskStatus.COMPLETED:
+      return Phase.COMPLETED;
+    case TaskStatus.FAILED:
+      return Phase.FAILED;
+    case TaskStatus.STOPPED:
+      return Phase.STOPPED;
+    case TaskStatus.TIMED_OUT:
+      return Phase.TIMED_OUT;
+    default:
+      return undefined;
+  }
+}
+
+export function terminalEventForStatus(
+  status: string | undefined
+): TaskRuntimeEventKind | undefined {
+  switch (status) {
+    case TaskStatus.COMPLETED:
+      return EventKind.TURN_COMPLETED;
+    case TaskStatus.FAILED:
+      return EventKind.TURN_FAILED;
+    case TaskStatus.STOPPED:
+      return EventKind.TURN_STOPPED;
+    case TaskStatus.TIMED_OUT:
+      return EventKind.TURN_TIMED_OUT;
+    default:
+      return undefined;
+  }
+}
+
+export function isMeaningfulTaskRuntimeEvent(kind: TaskRuntimeEventKind): boolean {
+  return (
+    kind === EventKind.FIRST_AGENT_EVENT ||
+    kind === EventKind.STREAM_START ||
+    kind === EventKind.THINKING ||
+    kind === EventKind.ASSISTANT_MESSAGE ||
+    kind === EventKind.TOOL_START ||
+    kind === EventKind.TOOL_PROGRESS ||
+    kind === EventKind.TOOL_COMPLETE
+  );
+}
+
+function extractToolField(
+  data: Record<string, unknown>,
+  key: 'tool_name' | 'tool_use_id'
+): string | undefined {
+  const value = data[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function wrapStreamingCallbacksWithRuntimeVitals(
+  callbacks: StreamingCallbacks,
+  reporter: TaskRuntimeVitalsReporter
+): StreamingCallbacks {
+  return {
+    ...callbacks,
+    onStreamStart: async (...args) => {
+      await callbacks.onStreamStart(...args);
+      void reporter.record(EventKind.STREAM_START, {
+        source: 'sdk',
+        phase: Phase.RUNNING,
+        meaningful: true,
+      });
+    },
+    onThinkingStart: async (...args) => {
+      await callbacks.onThinkingStart?.(...args);
+      void reporter.record(EventKind.THINKING, {
+        source: 'sdk',
+        phase: Phase.RUNNING,
+        meaningful: true,
+      });
+    },
+    onThinkingChunk: async (...args) => {
+      await callbacks.onThinkingChunk?.(...args);
+      void reporter.record(EventKind.THINKING, {
+        source: 'sdk',
+        phase: Phase.RUNNING,
+        meaningful: true,
+      });
+    },
+  };
+}
+
+export function wrapTasksStreamingServiceWithRuntimeVitals(
+  service: TasksStreamingService,
+  reporter: TaskRuntimeVitalsReporter
+): TasksStreamingService {
+  return {
+    ...service,
+    create: async (data) => {
+      const result = await service.create(data);
+      if (data.event === 'tool:start') {
+        void reporter.record(EventKind.TOOL_START, {
+          source: 'tool',
+          phase: Phase.TOOL_RUNNING,
+          meaningful: true,
+          toolName: extractToolField(data.data, 'tool_name'),
+          toolUseId: extractToolField(data.data, 'tool_use_id'),
+        });
+      } else if (data.event === 'tool:complete') {
+        void reporter.record(EventKind.TOOL_COMPLETE, {
+          source: 'tool',
+          phase: Phase.RUNNING,
+          meaningful: true,
+          toolName: extractToolField(data.data, 'tool_name'),
+          toolUseId: extractToolField(data.data, 'tool_use_id'),
+        });
+      } else if (data.event === 'thinking:chunk') {
+        void reporter.record(EventKind.THINKING, {
+          source: 'sdk',
+          phase: Phase.RUNNING,
+          meaningful: true,
+        });
+      }
+      return result;
+    },
+  };
+}
+
+export function wrapMessagesServiceWithRuntimeVitals(
+  service: MessagesService,
+  reporter: TaskRuntimeVitalsReporter
+): MessagesService {
+  return {
+    ...service,
+    create: async (data) => {
+      const result = await service.create(data);
+      if (isAssistantMessage(result)) {
+        void reporter.record(EventKind.ASSISTANT_MESSAGE, {
+          source: 'sdk',
+          phase: Phase.RUNNING,
+          meaningful: true,
+        });
+      }
+      return result;
+    },
+  };
+}
+
+export function wrapTasksServiceWithRuntimeVitals(
+  service: TasksService,
+  reporter: TaskRuntimeVitalsReporter
+): TasksService {
+  return {
+    ...service,
+    get: service.get.bind(service),
+    emit: service.emit.bind(service),
+    patch: async (id, data) => {
+      const result = await service.patch(id, data);
+      if (id !== reporter.taskId) return result;
+
+      const status = typeof data.status === 'string' ? data.status : undefined;
+      const phase = taskStatusToRuntimePhase(status);
+      if (!phase) return result;
+
+      const terminalKind = terminalEventForStatus(status);
+      if (terminalKind) {
+        const vitals = await reporter.terminalSnapshot(terminalKind, {
+          source: 'executor',
+          phase,
+          meaningful: false,
+        });
+        try {
+          await service.patch(id, { runtime_vitals: vitals });
+        } catch (error) {
+          console.warn(
+            '[runtime-vitals] Failed to write terminal task runtime vitals:',
+            error instanceof Error ? error.message : String(error)
+          );
+        }
+        return result;
+      }
+
+      if (status === TaskStatus.AWAITING_PERMISSION) {
+        void reporter.record(EventKind.PERMISSION_WAIT_START, {
+          source: 'permission',
+          phase,
+          forceFlush: true,
+        });
+      } else if (status === TaskStatus.RUNNING) {
+        const previousPhase = reporter.snapshot?.phase;
+        if (previousPhase === Phase.AWAITING_PERMISSION) {
+          void reporter.record(EventKind.PERMISSION_WAIT_END, {
+            source: 'permission',
+            phase,
+            forceFlush: true,
+          });
+        } else {
+          void reporter.record(EventKind.TASK_STATUS, { source: 'executor', phase });
+        }
+      } else {
+        void reporter.record(EventKind.TASK_STATUS, { source: 'executor', phase });
+      }
+
+      return result;
+    },
+  };
+}
+
+function isAssistantMessage(message: Message): boolean {
+  return message.role === MessageRole.ASSISTANT || message.type === 'assistant';
+}

--- a/packages/executor/src/runtime-vitals.ts
+++ b/packages/executor/src/runtime-vitals.ts
@@ -386,6 +386,7 @@ export function wrapMessagesServiceWithRuntimeVitals(
 ): MessagesService {
   return {
     ...service,
+    patch: service.patch.bind(service),
     create: async (data) => {
       const result = await service.create(data);
       if (isAssistantMessage(result)) {


### PR DESCRIPTION
## Linked issue

Related: preset-io/agor-cloud#145
Related: #1542

## Summary

- Add a typed `TaskRuntimeVitals` snapshot model on tasks.
- Persist passive runtime vitals in existing task JSON data.
- Add shared SDK executor instrumentation for phase/progress/tool/permission/terminal events.
- Add throttled/capped runtime-vitals writes with terminal safety and stale `active_tool` clearing.

## Why / context

The previous SDK startup watchdog direction was too narrow: it could detect one startup stall symptom, but it did not establish a common model for where an executor task is stuck. This PR adds the passive observability foundation first so future daemon-side policies can reason from normalized task runtime facts instead of one-off executor-local watchdogs.

## Implementation notes

- Vitals are observability only: no timeout enforcement, abort redesign, queue-drain changes, or terminalization refactor.
- Heartbeat remains separate from meaningful runtime progress.
- `runtime_vitals` is stored in task JSON data; no database migration/column is added.
- Event history is capped and payloads are normalized/sanitized; no prompts, raw SDK payloads, tool inputs, or message content are stored.
- Phase changes and first meaningful progress flush promptly; same-phase updates are throttled with a trailing flush.
- Terminal snapshots clear `active_tool` and cancel pending trailing writes.

## Validation / test plan

- [x] `pnpm --filter @agor/executor test -- src/runtime-vitals.test.ts src/handlers/sdk/base-executor.test.ts`
- [x] `pnpm --filter @agor/core test -- src/db/repositories/tasks.test.ts`
- [x] `pnpm --filter @agor/core typecheck`
- [x] `pnpm --filter @agor/executor typecheck`
- [x] `pnpm exec biome check <changed files>`
- [x] `git diff --check`
- [x] Commit hook ran Biome on staged files

## Screenshots / demos

Not applicable; this is runtime/task observability plumbing with no UI surface.

## Risks / rollout / rollback

- Main risk is extra task patch traffic from vitals updates; writes are throttled/capped to limit noise.
- Historical tasks without `runtime_vitals` remain valid and should be treated as unknown by future consumers.
- Rollback is safe by reverting the PR; no migration is involved.

## Out of scope / follow-ups

- Daemon first-progress supervision policy: preset-io/agor-cloud#148
- Central terminalization/timeout semantics: preset-io/agor-cloud#149
- Persisted abort requests/escalation: preset-io/agor-cloud#150
- CLI/OpenCode/Cursor vitals coverage: preset-io/agor-cloud#151
- Tool-call idle / whole-turn timeout policy: preset-io/agor-cloud#152
