### PR TITLE
feat(executor): add daemon runtime vitals events

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -67,6 +67,8 @@ import {
   ROLES,
   SERVICE_GROUP_NAMES,
   SessionStatus,
+  TaskRuntimeEventKind,
+  TaskRuntimePhase,
   TaskStatus,
 } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
@@ -132,6 +134,7 @@ import {
 } from './utils/session-task-state.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
+import { buildDaemonTaskRuntimeVitals } from './utils/task-runtime-vitals.js';
 import {
   createTenantDatabaseScopeAroundHook,
   deferWithTenantDatabaseScope,
@@ -1039,25 +1042,35 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
     // Patch task: queued/created → running, with real ranges. queue_position
     // is cleared here so a draining task is no longer considered queued.
-    const updatedTask = (await app.service('tasks').patch(
-      task.task_id,
-      {
-        status: TaskStatus.RUNNING,
-        started_at: startTimestamp,
-        queue_position: undefined,
-        message_range: {
-          start_index: messageStartIndex,
-          end_index: messageStartIndex + 1,
-          start_timestamp: startTimestamp,
-          end_timestamp: startTimestamp,
-        },
-        git_state: {
-          ref_at_start: refAtStart,
-          sha_at_start: gitStateAtStart,
-        },
+    const runningPatch: Partial<Task> = {
+      status: TaskStatus.RUNNING,
+      started_at: startTimestamp,
+      queue_position: undefined,
+      message_range: {
+        start_index: messageStartIndex,
+        end_index: messageStartIndex + 1,
+        start_timestamp: startTimestamp,
+        end_timestamp: startTimestamp,
       },
-      params
-    )) as Task;
+      git_state: {
+        ref_at_start: refAtStart,
+        sha_at_start: gitStateAtStart,
+      },
+    };
+    if (session.agentic_tool !== 'claude-code-cli') {
+      runningPatch.runtime_vitals = buildDaemonTaskRuntimeVitals(
+        task.runtime_vitals,
+        TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+        {
+          at: startTimestamp,
+          phase: TaskRuntimePhase.EXECUTOR_STARTING,
+        }
+      );
+    }
+
+    const updatedTask = (await app
+      .service('tasks')
+      .patch(task.task_id, runningPatch, params)) as Task;
 
     // Alt D — write the user-message row before spawning. Gated by kill switch.
     // The executor's createUserMessage has a skip-if-exists guard so a duplicate
@@ -1268,6 +1281,19 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             status: TaskStatus.FAILED,
             completed_at: new Date().toISOString(),
             error_message: errorMessage,
+            runtime_vitals: buildDaemonTaskRuntimeVitals(
+              (
+                await app
+                  .service('tasks')
+                  .get(taskId, params)
+                  .catch(() => updatedTask)
+              ).runtime_vitals,
+              TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+              {
+                phase: TaskRuntimePhase.FAILED,
+                errorCode: 'spawn_exception',
+              }
+            ),
           },
           'Task',
           params

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -48,6 +48,8 @@ import {
   isTaskExecuting,
   ROLES,
   SessionStatus,
+  TaskRuntimeEventKind,
+  TaskRuntimePhase,
   TaskStatus,
 } from '@agor/core/types';
 import type { UnixUserMode } from '@agor/core/unix';
@@ -136,6 +138,10 @@ import {
 } from './utils/session-state.js';
 import { pullIfNeeded, pushAsync } from './utils/session-state-hooks.js';
 import { spawnExecutor } from './utils/spawn-executor.js';
+import {
+  buildDaemonTaskRuntimeVitals,
+  patchDaemonTaskRuntimeEvent,
+} from './utils/task-runtime-vitals.js';
 
 /**
  * Interface for dependencies needed by service registration.
@@ -928,6 +934,11 @@ function createExecuteHandler(
     }
 
     const logPrefix = `[Executor ${shortId(sessionId)}]`;
+    const canRecordLocalPid = !config.execution?.executor_command_template;
+    const tasksRuntimeVitalsService = app.service('tasks') as Parameters<
+      typeof patchDaemonTaskRuntimeEvent
+    >[0];
+    let processSpawnObserved = false;
 
     spawnExecutor(executorPayload, {
       cwd,
@@ -939,7 +950,17 @@ function createExecuteHandler(
         task_id: taskId,
         unix_user: executorUnixUser || undefined,
       },
-      onSpawn: (child) => {
+      onSpawn: async (child) => {
+        processSpawnObserved = true;
+        await patchDaemonTaskRuntimeEvent(
+          tasksRuntimeVitalsService,
+          taskId,
+          TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
+          {
+            processPid: canRecordLocalPid ? child.pid : undefined,
+          },
+          params
+        );
         if (child.pid) {
           trackExecutorProcess(sessionId, child.pid);
           console.log(`${logPrefix} PID: ${child.pid}`);
@@ -948,6 +969,7 @@ function createExecuteHandler(
       onExit: async (code) => {
         console.log(`${logPrefix} Exited with code ${code}`);
         untrackExecutorProcess(sessionId);
+        let wroteExitVitals = false;
 
         // Safety net: check if task is still running
         try {
@@ -965,14 +987,28 @@ function createExecuteHandler(
             try {
               const currentTask = await app.service('tasks').get(taskId, params);
               if (isTaskExecuting(currentTask) || currentTask.status === TaskStatus.TIMED_OUT) {
+                const eventKind = processSpawnObserved
+                  ? TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED
+                  : TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED;
+                const runtime_vitals = buildDaemonTaskRuntimeVitals(
+                  currentTask.runtime_vitals,
+                  eventKind,
+                  {
+                    phase: TaskRuntimePhase.FAILED,
+                    exitCode: code,
+                    errorCode: processSpawnObserved ? 'unexpected_exit' : 'spawn_error',
+                  }
+                );
                 await app.service('tasks').patch(
                   taskId,
                   {
                     status: TaskStatus.FAILED,
                     error_message: `Executor exited unexpectedly with code ${code ?? 'unknown'}.`,
+                    runtime_vitals,
                   },
                   params
                 );
+                wroteExitVitals = true;
                 console.log(
                   `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
                 );
@@ -1003,6 +1039,20 @@ function createExecuteHandler(
           }
         } catch (error) {
           console.error(`❌ [Executor] Failed to handle executor exit:`, error);
+        }
+        if (!wroteExitVitals) {
+          await patchDaemonTaskRuntimeEvent(
+            tasksRuntimeVitalsService,
+            taskId,
+            processSpawnObserved || code === 0
+              ? TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED
+              : TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+            {
+              exitCode: code,
+              ...(processSpawnObserved || code === 0 ? {} : { errorCode: 'spawn_error' }),
+            },
+            params
+          );
         }
 
         // Stateless FS mode: serialize session file to DB after executor exits

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -126,8 +126,10 @@ import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
 import {
+  hasExecutorRuntimeEvidence,
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
+  shouldFailTaskForChildExit,
 } from './utils/executor-spawn-classification.js';
 import { escapeHtml } from './utils/html.js';
 import {
@@ -938,11 +940,12 @@ function createExecuteHandler(
     }
 
     const logPrefix = `[Executor ${shortId(sessionId)}]`;
-    const canRecordLocalPid = !config.execution?.executor_command_template;
+    const usesCommandTemplate = !!config.execution?.executor_command_template;
+    const canRecordLocalPid = !usesCommandTemplate;
     const tasksRuntimeVitalsService = app.service('tasks') as Parameters<
       typeof patchDaemonTaskRuntimeEvent
     >[0];
-    let processSpawnObserved = false;
+    let localExecutorProcessObserved = false;
 
     spawnExecutor(executorPayload, {
       cwd,
@@ -954,31 +957,32 @@ function createExecuteHandler(
         task_id: taskId,
         unix_user: executorUnixUser || undefined,
       },
-      onSpawn: async (child) => {
-        processSpawnObserved = hasObservedLaunchedExecutorProcess(child);
-        if (!processSpawnObserved) {
+      onSpawn: (child) => {
+        const childProcessObserved = hasObservedLaunchedExecutorProcess(child);
+        localExecutorProcessObserved = canRecordLocalPid && childProcessObserved;
+        if (!childProcessObserved) {
           return;
         }
 
-        await patchDaemonTaskRuntimeEvent(
-          tasksRuntimeVitalsService,
-          taskId,
-          TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
-          {
-            processPid: canRecordLocalPid ? child.pid : undefined,
-          },
-          params
-        );
-        if (child.pid) {
+        if (canRecordLocalPid && child.pid) {
           trackExecutorProcess(sessionId, child.pid);
           console.log(`${logPrefix} PID: ${child.pid}`);
+          void patchDaemonTaskRuntimeEvent(
+            tasksRuntimeVitalsService,
+            taskId,
+            TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
+            { processPid: child.pid },
+            params
+          );
+        } else {
+          console.log(
+            `${logPrefix} Launcher PID: ${child.pid} (command-template submission process)`
+          );
         }
       },
       onExit: async (code) => {
         console.log(`${logPrefix} Exited with code ${code}`);
         untrackExecutorProcess(sessionId);
-        let wroteExitVitals = false;
-
         // Safety net: check if task is still running
         try {
           const currentSession = await app.service('sessions').get(sessionId, params);
@@ -995,32 +999,50 @@ function createExecuteHandler(
             try {
               const currentTask = await app.service('tasks').get(taskId, params);
               if (isTaskExecuting(currentTask) || currentTask.status === TaskStatus.TIMED_OUT) {
-                const spawnFailureExit = isExecutorSpawnFailureExit(processSpawnObserved, code);
-                const eventKind = spawnFailureExit
-                  ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
-                  : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED;
-                const runtime_vitals = buildDaemonTaskRuntimeVitals(
-                  currentTask.runtime_vitals,
-                  eventKind,
-                  {
-                    phase: TaskRuntimePhase.FAILED,
-                    exitCode: code,
-                    errorCode: spawnFailureExit ? 'spawn_error' : 'unexpected_exit',
-                  }
+                const executorRuntimeObserved = hasExecutorRuntimeEvidence(
+                  currentTask.runtime_vitals
                 );
-                await app.service('tasks').patch(
-                  taskId,
-                  {
-                    status: TaskStatus.FAILED,
-                    error_message: `Executor exited unexpectedly with code ${code ?? 'unknown'}.`,
-                    runtime_vitals,
-                  },
-                  params
-                );
-                wroteExitVitals = true;
-                console.log(
-                  `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
-                );
+                const shouldFailTask = shouldFailTaskForChildExit({
+                  usesCommandTemplate,
+                  code,
+                  localExecutorProcessObserved,
+                  executorRuntimeObserved,
+                });
+
+                if (shouldFailTask) {
+                  const spawnFailureExit = usesCommandTemplate
+                    ? !executorRuntimeObserved && code !== 0
+                    : isExecutorSpawnFailureExit(localExecutorProcessObserved, code);
+                  const eventKind = spawnFailureExit
+                    ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
+                    : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED;
+                  const runtime_vitals = buildDaemonTaskRuntimeVitals(
+                    currentTask.runtime_vitals,
+                    eventKind,
+                    {
+                      phase: TaskRuntimePhase.FAILED,
+                      exitCode: code,
+                      errorCode: spawnFailureExit ? 'spawn_error' : 'unexpected_exit',
+                    }
+                  );
+                  await app.service('tasks').patch(
+                    taskId,
+                    {
+                      status: TaskStatus.FAILED,
+                      error_message: `Executor exited unexpectedly with code ${code ?? 'unknown'}.`,
+                      runtime_vitals,
+                    },
+                    params
+                  );
+                  console.log(
+                    `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
+                  );
+                } else {
+                  console.log(
+                    `ℹ️  [Executor] Child exit was non-authoritative for task ${shortId(taskId)} ` +
+                      `(code: ${code ?? 'unknown'}, commandTemplate: ${usesCommandTemplate}, executorRuntimeObserved: ${executorRuntimeObserved})`
+                  );
+                }
               } else {
                 console.log(
                   `⚠️  [Executor] Task ${shortId(taskId)} already ${currentTask.status}, but session still ${currentSession.status} — repairing session state`
@@ -1049,23 +1071,6 @@ function createExecuteHandler(
         } catch (error) {
           console.error(`❌ [Executor] Failed to handle executor exit:`, error);
         }
-        if (!wroteExitVitals) {
-          await patchDaemonTaskRuntimeEvent(
-            tasksRuntimeVitalsService,
-            taskId,
-            isExecutorSpawnFailureExit(processSpawnObserved, code)
-              ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
-              : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED,
-            {
-              exitCode: code,
-              ...(isExecutorSpawnFailureExit(processSpawnObserved, code)
-                ? { errorCode: 'spawn_error' }
-                : {}),
-            },
-            params
-          );
-        }
-
         // Stateless FS mode: serialize session file to DB after executor exits
         if (config.execution?.stateless_fs_mode) {
           try {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -125,6 +125,10 @@ import { createUsersService } from './services/users.js';
 import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
+import {
+  hasObservedLaunchedExecutorProcess,
+  isExecutorSpawnFailureExit,
+} from './utils/executor-spawn-classification.js';
 import { escapeHtml } from './utils/html.js';
 import {
   shouldExposeMCPServerSecrets,
@@ -951,7 +955,11 @@ function createExecuteHandler(
         unix_user: executorUnixUser || undefined,
       },
       onSpawn: async (child) => {
-        processSpawnObserved = true;
+        processSpawnObserved = hasObservedLaunchedExecutorProcess(child);
+        if (!processSpawnObserved) {
+          return;
+        }
+
         await patchDaemonTaskRuntimeEvent(
           tasksRuntimeVitalsService,
           taskId,
@@ -987,16 +995,17 @@ function createExecuteHandler(
             try {
               const currentTask = await app.service('tasks').get(taskId, params);
               if (isTaskExecuting(currentTask) || currentTask.status === TaskStatus.TIMED_OUT) {
-                const eventKind = processSpawnObserved
-                  ? TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED
-                  : TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED;
+                const spawnFailureExit = isExecutorSpawnFailureExit(processSpawnObserved, code);
+                const eventKind = spawnFailureExit
+                  ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
+                  : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED;
                 const runtime_vitals = buildDaemonTaskRuntimeVitals(
                   currentTask.runtime_vitals,
                   eventKind,
                   {
                     phase: TaskRuntimePhase.FAILED,
                     exitCode: code,
-                    errorCode: processSpawnObserved ? 'unexpected_exit' : 'spawn_error',
+                    errorCode: spawnFailureExit ? 'spawn_error' : 'unexpected_exit',
                   }
                 );
                 await app.service('tasks').patch(
@@ -1044,12 +1053,14 @@ function createExecuteHandler(
           await patchDaemonTaskRuntimeEvent(
             tasksRuntimeVitalsService,
             taskId,
-            processSpawnObserved || code === 0
-              ? TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED
-              : TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+            isExecutorSpawnFailureExit(processSpawnObserved, code)
+              ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
+              : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED,
             {
               exitCode: code,
-              ...(processSpawnObserved || code === 0 ? {} : { errorCode: 'spawn_error' }),
+              ...(isExecutorSpawnFailureExit(processSpawnObserved, code)
+                ? { errorCode: 'spawn_error' }
+                : {}),
             },
             params
           );

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -126,7 +126,6 @@ import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
 import {
-  hasExecutorRuntimeEvidence,
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
   shouldFailTaskForChildExit,
@@ -999,20 +998,17 @@ function createExecuteHandler(
             try {
               const currentTask = await app.service('tasks').get(taskId, params);
               if (isTaskExecuting(currentTask) || currentTask.status === TaskStatus.TIMED_OUT) {
-                const executorRuntimeObserved = hasExecutorRuntimeEvidence(
-                  currentTask.runtime_vitals
-                );
                 const shouldFailTask = shouldFailTaskForChildExit({
                   usesCommandTemplate,
                   code,
                   localExecutorProcessObserved,
-                  executorRuntimeObserved,
                 });
 
                 if (shouldFailTask) {
-                  const spawnFailureExit = usesCommandTemplate
-                    ? !executorRuntimeObserved && code !== 0
-                    : isExecutorSpawnFailureExit(localExecutorProcessObserved, code);
+                  const spawnFailureExit = isExecutorSpawnFailureExit(
+                    localExecutorProcessObserved,
+                    code
+                  );
                   const eventKind = spawnFailureExit
                     ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
                     : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED;
@@ -1040,7 +1036,7 @@ function createExecuteHandler(
                 } else {
                   console.log(
                     `ℹ️  [Executor] Child exit was non-authoritative for task ${shortId(taskId)} ` +
-                      `(code: ${code ?? 'unknown'}, commandTemplate: ${usesCommandTemplate}, executorRuntimeObserved: ${executorRuntimeObserved})`
+                      `(code: ${code ?? 'unknown'}, commandTemplate: ${usesCommandTemplate})`
                   );
                 }
               } else {

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
@@ -1,7 +1,10 @@
+import { TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
 import {
+  hasExecutorRuntimeEvidence,
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
+  shouldFailTaskForChildExit,
 } from './executor-spawn-classification.js';
 
 describe('executor spawn classification', () => {
@@ -23,5 +26,81 @@ describe('executor spawn classification', () => {
 
   it('does not classify successful exits as spawn failures', () => {
     expect(isExecutorSpawnFailureExit(false, 0)).toBe(false);
+  });
+
+  it('detects executor runtime evidence from non-daemon vitals events', () => {
+    expect(hasExecutorRuntimeEvidence(undefined)).toBe(false);
+    expect(
+      hasExecutorRuntimeEvidence({
+        schema_version: 1,
+        phase: TaskRuntimePhase.EXECUTOR_STARTING,
+        phase_started_at: '2026-01-01T00:00:00.000Z',
+        last_activity_at: '2026-01-01T00:00:00.000Z',
+        last_event: {
+          kind: TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+          at: '2026-01-01T00:00:00.000Z',
+          source: 'daemon',
+        },
+      })
+    ).toBe(false);
+    expect(
+      hasExecutorRuntimeEvidence({
+        schema_version: 1,
+        phase: TaskRuntimePhase.SDK_STARTING,
+        phase_started_at: '2026-01-01T00:00:01.000Z',
+        last_activity_at: '2026-01-01T00:00:01.000Z',
+        last_event: {
+          kind: TaskRuntimeEventKind.SDK_TURN_STARTED,
+          at: '2026-01-01T00:00:01.000Z',
+          source: 'executor',
+        },
+      })
+    ).toBe(true);
+  });
+
+  it('keeps command-template launcher exits non-authoritative after successful submission or executor evidence', () => {
+    expect(
+      shouldFailTaskForChildExit({
+        usesCommandTemplate: true,
+        code: 0,
+        localExecutorProcessObserved: false,
+        executorRuntimeObserved: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldFailTaskForChildExit({
+        usesCommandTemplate: true,
+        code: 1,
+        localExecutorProcessObserved: false,
+        executorRuntimeObserved: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldFailTaskForChildExit({
+        usesCommandTemplate: true,
+        code: 1,
+        localExecutorProcessObserved: false,
+        executorRuntimeObserved: true,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps local subprocess exits authoritative before terminal state', () => {
+    expect(
+      shouldFailTaskForChildExit({
+        usesCommandTemplate: false,
+        code: 0,
+        localExecutorProcessObserved: true,
+        executorRuntimeObserved: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldFailTaskForChildExit({
+        usesCommandTemplate: false,
+        code: 127,
+        localExecutorProcessObserved: false,
+        executorRuntimeObserved: false,
+      })
+    ).toBe(true);
   });
 });

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
@@ -1,7 +1,5 @@
-import { TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
 import {
-  hasExecutorRuntimeEvidence,
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
   shouldFailTaskForChildExit,
@@ -28,43 +26,12 @@ describe('executor spawn classification', () => {
     expect(isExecutorSpawnFailureExit(false, 0)).toBe(false);
   });
 
-  it('detects executor runtime evidence from non-daemon vitals events', () => {
-    expect(hasExecutorRuntimeEvidence(undefined)).toBe(false);
-    expect(
-      hasExecutorRuntimeEvidence({
-        schema_version: 1,
-        phase: TaskRuntimePhase.EXECUTOR_STARTING,
-        phase_started_at: '2026-01-01T00:00:00.000Z',
-        last_activity_at: '2026-01-01T00:00:00.000Z',
-        last_event: {
-          kind: TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
-          at: '2026-01-01T00:00:00.000Z',
-          source: 'daemon',
-        },
-      })
-    ).toBe(false);
-    expect(
-      hasExecutorRuntimeEvidence({
-        schema_version: 1,
-        phase: TaskRuntimePhase.SDK_STARTING,
-        phase_started_at: '2026-01-01T00:00:01.000Z',
-        last_activity_at: '2026-01-01T00:00:01.000Z',
-        last_event: {
-          kind: TaskRuntimeEventKind.SDK_TURN_STARTED,
-          at: '2026-01-01T00:00:01.000Z',
-          source: 'executor',
-        },
-      })
-    ).toBe(true);
-  });
-
-  it('keeps command-template launcher exits non-authoritative after successful submission or executor evidence', () => {
+  it('keeps command-template launcher exits non-authoritative in this passive vitals path', () => {
     expect(
       shouldFailTaskForChildExit({
         usesCommandTemplate: true,
         code: 0,
         localExecutorProcessObserved: false,
-        executorRuntimeObserved: false,
       })
     ).toBe(false);
     expect(
@@ -72,15 +39,6 @@ describe('executor spawn classification', () => {
         usesCommandTemplate: true,
         code: 1,
         localExecutorProcessObserved: false,
-        executorRuntimeObserved: false,
-      })
-    ).toBe(true);
-    expect(
-      shouldFailTaskForChildExit({
-        usesCommandTemplate: true,
-        code: 1,
-        localExecutorProcessObserved: false,
-        executorRuntimeObserved: true,
       })
     ).toBe(false);
   });
@@ -91,7 +49,6 @@ describe('executor spawn classification', () => {
         usesCommandTemplate: false,
         code: 0,
         localExecutorProcessObserved: true,
-        executorRuntimeObserved: false,
       })
     ).toBe(true);
     expect(
@@ -99,7 +56,6 @@ describe('executor spawn classification', () => {
         usesCommandTemplate: false,
         code: 127,
         localExecutorProcessObserved: false,
-        executorRuntimeObserved: false,
       })
     ).toBe(true);
   });

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasObservedLaunchedExecutorProcess,
+  isExecutorSpawnFailureExit,
+} from './executor-spawn-classification.js';
+
+describe('executor spawn classification', () => {
+  it('does not treat a ChildProcess without a pid as an observed launch', () => {
+    expect(hasObservedLaunchedExecutorProcess({ pid: undefined })).toBe(false);
+  });
+
+  it('treats a positive ChildProcess pid as an observed launch', () => {
+    expect(hasObservedLaunchedExecutorProcess({ pid: 12345 })).toBe(true);
+  });
+
+  it('preserves spawn failure classification for spawn-error exits', () => {
+    expect(isExecutorSpawnFailureExit(false, 127)).toBe(true);
+  });
+
+  it('keeps real child exits classified as process exits', () => {
+    expect(isExecutorSpawnFailureExit(true, 127)).toBe(false);
+  });
+
+  it('does not classify successful exits as spawn failures', () => {
+    expect(isExecutorSpawnFailureExit(false, 0)).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.ts
@@ -1,9 +1,4 @@
 import type { ChildProcess } from 'node:child_process';
-import {
-  type TaskRuntimeEvent,
-  TaskRuntimeEventKind,
-  type TaskRuntimeVitals,
-} from '@agor/core/types';
 
 /**
  * `child_process.spawn()` returns a ChildProcess before the launch outcome is
@@ -18,49 +13,27 @@ export function isExecutorSpawnFailureExit(processSpawnObserved: boolean, code: 
   return !processSpawnObserved && code !== 0;
 }
 
-function runtimeEvents(vitals: TaskRuntimeVitals | undefined): TaskRuntimeEvent[] {
-  if (!vitals) return [];
-  return [vitals.last_event, ...(vitals.recent_events ?? [])].filter(
-    (event): event is TaskRuntimeEvent => event !== undefined
-  );
-}
-
-/**
- * Command-template launchers are only submission processes. The real executor
- * is proven by executor/sdk/tool/permission events that can only come from the
- * authenticated runtime after it connects back to the daemon.
- */
-export function hasExecutorRuntimeEvidence(vitals: TaskRuntimeVitals | undefined): boolean {
-  return runtimeEvents(vitals).some(
-    (event) =>
-      event.kind === TaskRuntimeEventKind.EXECUTOR_CONNECTED ||
-      event.source === 'executor' ||
-      event.source === 'sdk' ||
-      event.source === 'tool' ||
-      event.source === 'permission'
-  );
-}
-
 export interface ChildExitFailureClassification {
   usesCommandTemplate: boolean;
   code: number | null;
   localExecutorProcessObserved: boolean;
-  executorRuntimeObserved: boolean;
 }
 
 /**
  * Local child exit before terminal state means the executor was lost. In
- * command-template mode the child is just a launcher: only a non-zero launcher
- * exit before executor connection is authoritative as spawn failure.
+ * command-template mode the child is just a launcher/submission process, so
+ * this passive daemon vitals path must not treat launcher exit as authoritative
+ * task completion. Spawn/connect timeout policy should use authoritative
+ * lifecycle fields (for example executor connection/heartbeat fencing), not
+ * runtime_vitals observations.
  */
 export function shouldFailTaskForChildExit({
   usesCommandTemplate,
   code,
   localExecutorProcessObserved,
-  executorRuntimeObserved,
 }: ChildExitFailureClassification): boolean {
   if (usesCommandTemplate) {
-    return !executorRuntimeObserved && code !== 0;
+    return false;
   }
   return localExecutorProcessObserved || code !== 0;
 }

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.ts
@@ -1,0 +1,14 @@
+import type { ChildProcess } from 'node:child_process';
+
+/**
+ * `child_process.spawn()` returns a ChildProcess before the launch outcome is
+ * fully known. Spawn failures can still emit `error` after callers receive the
+ * object, and those failures commonly have no child PID.
+ */
+export function hasObservedLaunchedExecutorProcess(child: Pick<ChildProcess, 'pid'>): boolean {
+  return typeof child.pid === 'number' && Number.isSafeInteger(child.pid) && child.pid > 0;
+}
+
+export function isExecutorSpawnFailureExit(processSpawnObserved: boolean, code: number | null) {
+  return !processSpawnObserved && code !== 0;
+}

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.ts
@@ -1,4 +1,9 @@
 import type { ChildProcess } from 'node:child_process';
+import {
+  type TaskRuntimeEvent,
+  TaskRuntimeEventKind,
+  type TaskRuntimeVitals,
+} from '@agor/core/types';
 
 /**
  * `child_process.spawn()` returns a ChildProcess before the launch outcome is
@@ -11,4 +16,51 @@ export function hasObservedLaunchedExecutorProcess(child: Pick<ChildProcess, 'pi
 
 export function isExecutorSpawnFailureExit(processSpawnObserved: boolean, code: number | null) {
   return !processSpawnObserved && code !== 0;
+}
+
+function runtimeEvents(vitals: TaskRuntimeVitals | undefined): TaskRuntimeEvent[] {
+  if (!vitals) return [];
+  return [vitals.last_event, ...(vitals.recent_events ?? [])].filter(
+    (event): event is TaskRuntimeEvent => event !== undefined
+  );
+}
+
+/**
+ * Command-template launchers are only submission processes. The real executor
+ * is proven by executor/sdk/tool/permission events that can only come from the
+ * authenticated runtime after it connects back to the daemon.
+ */
+export function hasExecutorRuntimeEvidence(vitals: TaskRuntimeVitals | undefined): boolean {
+  return runtimeEvents(vitals).some(
+    (event) =>
+      event.kind === TaskRuntimeEventKind.EXECUTOR_CONNECTED ||
+      event.source === 'executor' ||
+      event.source === 'sdk' ||
+      event.source === 'tool' ||
+      event.source === 'permission'
+  );
+}
+
+export interface ChildExitFailureClassification {
+  usesCommandTemplate: boolean;
+  code: number | null;
+  localExecutorProcessObserved: boolean;
+  executorRuntimeObserved: boolean;
+}
+
+/**
+ * Local child exit before terminal state means the executor was lost. In
+ * command-template mode the child is just a launcher: only a non-zero launcher
+ * exit before executor connection is authoritative as spawn failure.
+ */
+export function shouldFailTaskForChildExit({
+  usesCommandTemplate,
+  code,
+  localExecutorProcessObserved,
+  executorRuntimeObserved,
+}: ChildExitFailureClassification): boolean {
+  if (usesCommandTemplate) {
+    return !executorRuntimeObserved && code !== 0;
+  }
+  return localExecutorProcessObserved || code !== 0;
 }

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -52,6 +52,7 @@ describe('configured executor spawning', () => {
     spawnMock.mockReset();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const unix = await import('@agor/core/unix');
     vi.mocked(unix.buildSpawnArgs).mockReturnValue({ cmd: 'node', args: ['executor', '--stdin'] });
@@ -223,6 +224,30 @@ describe('configured executor spawning', () => {
       command: 'prompt',
       resolvedConfig: expect.any(Object),
     });
+  });
+
+  it('writes the executor payload if async onSpawn never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      const proc = createMockProcess();
+      spawnMock.mockReturnValue(proc);
+      const onSpawn = vi.fn(() => new Promise<void>(() => {}));
+      const { spawnExecutor } = await import('./spawn-executor');
+
+      spawnExecutor({ command: 'prompt' }, { onSpawn, logPrefix: '[test]' });
+
+      expect(onSpawn).toHaveBeenCalledWith(proc);
+      expect(proc.written).toBe('');
+
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(JSON.parse(proc.written)).toMatchObject({
+        command: 'prompt',
+        resolvedConfig: expect.any(Object),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('derives LOG_LEVEL for executor processes when only NODE_ENV is set', async () => {

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -197,6 +197,34 @@ describe('configured executor spawning', () => {
     );
   });
 
+  it('waits for async onSpawn work before writing the executor payload', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    let resolveOnSpawn!: () => void;
+    const onSpawn = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveOnSpawn = resolve;
+        })
+    );
+    const { spawnExecutor } = await import('./spawn-executor');
+
+    spawnExecutor({ command: 'prompt' }, { onSpawn });
+
+    expect(onSpawn).toHaveBeenCalledWith(proc);
+    expect(proc.written).toBe('');
+
+    resolveOnSpawn();
+
+    await vi.waitFor(() => {
+      expect(proc.written).not.toBe('');
+    });
+    expect(JSON.parse(proc.written)).toMatchObject({
+      command: 'prompt',
+      resolvedConfig: expect.any(Object),
+    });
+  });
+
   it('derives LOG_LEVEL for executor processes when only NODE_ENV is set', async () => {
     const proc = createMockProcess();
     spawnMock.mockReturnValue(proc);

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -198,7 +198,7 @@ describe('configured executor spawning', () => {
     );
   });
 
-  it('waits for async onSpawn work before writing the executor payload', async () => {
+  it('does not wait for async onSpawn work before writing the executor payload', async () => {
     const proc = createMockProcess();
     spawnMock.mockReturnValue(proc);
     let resolveOnSpawn!: () => void;
@@ -213,41 +213,28 @@ describe('configured executor spawning', () => {
     spawnExecutor({ command: 'prompt' }, { onSpawn });
 
     expect(onSpawn).toHaveBeenCalledWith(proc);
-    expect(proc.written).toBe('');
+    expect(proc.written).not.toBe('');
 
     resolveOnSpawn();
-
-    await vi.waitFor(() => {
-      expect(proc.written).not.toBe('');
-    });
     expect(JSON.parse(proc.written)).toMatchObject({
       command: 'prompt',
       resolvedConfig: expect.any(Object),
     });
   });
 
-  it('writes the executor payload if async onSpawn never settles', async () => {
-    vi.useFakeTimers();
-    try {
-      const proc = createMockProcess();
-      spawnMock.mockReturnValue(proc);
-      const onSpawn = vi.fn(() => new Promise<void>(() => {}));
-      const { spawnExecutor } = await import('./spawn-executor');
+  it('still writes the executor payload if async onSpawn never settles', async () => {
+    const proc = createMockProcess();
+    spawnMock.mockReturnValue(proc);
+    const onSpawn = vi.fn(() => new Promise<void>(() => {}));
+    const { spawnExecutor } = await import('./spawn-executor');
 
-      spawnExecutor({ command: 'prompt' }, { onSpawn, logPrefix: '[test]' });
+    spawnExecutor({ command: 'prompt' }, { onSpawn, logPrefix: '[test]' });
 
-      expect(onSpawn).toHaveBeenCalledWith(proc);
-      expect(proc.written).toBe('');
-
-      await vi.advanceTimersByTimeAsync(5_000);
-
-      expect(JSON.parse(proc.written)).toMatchObject({
-        command: 'prompt',
-        resolvedConfig: expect.any(Object),
-      });
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(onSpawn).toHaveBeenCalledWith(proc);
+    expect(JSON.parse(proc.written)).toMatchObject({
+      command: 'prompt',
+      resolvedConfig: expect.any(Object),
+    });
   });
 
   it('derives LOG_LEVEL for executor processes when only NODE_ENV is set', async () => {

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -39,6 +39,7 @@ import { issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { withResolvedConfig } from './build-resolved-config-slice.js';
 
 let configuredDaemonUrl: string | null = null;
+const ON_SPAWN_PAYLOAD_TIMEOUT_MS = 5_000;
 
 function resolveExecutorLogLevel(env: Record<string, string>): string {
   return env.LOG_LEVEL || getCurrentLogLevel();
@@ -463,7 +464,13 @@ function writePayloadAfterSpawnHook(
   options: Pick<SpawnExecutorOptions, 'onSpawn'>,
   logPrefix: string
 ): void {
+  let wrotePayload = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
   const writePayload = () => {
+    if (wrotePayload) return;
+    wrotePayload = true;
+    if (timeout) clearTimeout(timeout);
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();
   };
@@ -477,6 +484,13 @@ function writePayloadAfterSpawnHook(
   try {
     const result = options.onSpawn?.(child);
     if (result && typeof result.then === 'function') {
+      timeout = setTimeout(() => {
+        console.warn(
+          `${logPrefix} onSpawn hook timed out after ${ON_SPAWN_PAYLOAD_TIMEOUT_MS}ms; writing executor payload anyway`
+        );
+        writePayload();
+      }, ON_SPAWN_PAYLOAD_TIMEOUT_MS);
+
       void result
         .catch((error) => {
           warn(error);

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -104,7 +104,7 @@ export interface SpawnExecutorOptions {
   templateVariables?: ExecutorTemplateVariables;
   onExit?: (code: number | null) => void;
   /** Fired after spawn, before stdin is written. Works for both local and templated paths. */
-  onSpawn?: (child: ChildProcess) => void;
+  onSpawn?: (child: ChildProcess) => void | Promise<void>;
   /** Caller-assembled env; bypasses internal curation. Ignored by templated path. */
   preparedEnv?: Record<string, string>;
   /** Pre-written 0600 env file; bypasses prepareImpersonationEnv(). Only with asUser. */
@@ -271,7 +271,6 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     env = process.env as Record<string, string>,
     logPrefix = '[Executor]',
     asUser: rawAsUser,
-    onSpawn,
     preparedEnv,
     preparedEnvFilePath,
   } = options;
@@ -379,8 +378,6 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
   // uses `sudo -u <asUser> rm -f` so it works under sticky /tmp.
   attachEnvFileCleanup(executorProcess, { envFilePath: prepared.envFilePath, asUser });
 
-  onSpawn?.(executorProcess);
-
   executorProcess.on('error', (error) => {
     console.error(`${logPrefix} Spawn error:`, error.message);
     // child_process may emit `error` without a following `exit` when the
@@ -399,8 +396,7 @@ function spawnExecutorLocal(payload: Record<string, unknown>, options: SpawnExec
     reportExit(code);
   });
 
-  executorProcess.stdin?.write(JSON.stringify(payload));
-  executorProcess.stdin?.end();
+  writePayloadAfterSpawnHook(executorProcess, payload, options, logPrefix);
 }
 
 function spawnExecutorWithTemplate(
@@ -432,8 +428,6 @@ function spawnExecutorWithTemplate(
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  options.onSpawn?.(executorProcess);
-
   executorProcess.stdout?.on('data', (data) => {
     console.log(`${logPrefix} ${data.toString().trim()}`);
   });
@@ -460,8 +454,41 @@ function spawnExecutorWithTemplate(
     reportExit(code);
   });
 
-  executorProcess.stdin?.write(JSON.stringify(payload));
-  executorProcess.stdin?.end();
+  writePayloadAfterSpawnHook(executorProcess, payload, options, logPrefix);
+}
+
+function writePayloadAfterSpawnHook(
+  child: ChildProcess,
+  payload: Record<string, unknown>,
+  options: Pick<SpawnExecutorOptions, 'onSpawn'>,
+  logPrefix: string
+): void {
+  const writePayload = () => {
+    child.stdin?.write(JSON.stringify(payload));
+    child.stdin?.end();
+  };
+  const warn = (error: unknown) => {
+    console.warn(
+      `${logPrefix} onSpawn hook failed before executor payload write:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  };
+
+  try {
+    const result = options.onSpawn?.(child);
+    if (result && typeof result.then === 'function') {
+      void result
+        .catch((error) => {
+          warn(error);
+        })
+        .finally(writePayload);
+      return;
+    }
+  } catch (error) {
+    warn(error);
+  }
+
+  writePayload();
 }
 
 const EXECUTOR_RESULT_PREFIX = 'AGOR_EXECUTOR_RESULT ';

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -39,7 +39,6 @@ import { issueRuntimeToken } from '../auth/runtime-tokens.js';
 import { withResolvedConfig } from './build-resolved-config-slice.js';
 
 let configuredDaemonUrl: string | null = null;
-const ON_SPAWN_PAYLOAD_TIMEOUT_MS = 5_000;
 
 function resolveExecutorLogLevel(env: Record<string, string>): string {
   return env.LOG_LEVEL || getCurrentLogLevel();
@@ -465,12 +464,10 @@ function writePayloadAfterSpawnHook(
   logPrefix: string
 ): void {
   let wrotePayload = false;
-  let timeout: ReturnType<typeof setTimeout> | undefined;
 
   const writePayload = () => {
     if (wrotePayload) return;
     wrotePayload = true;
-    if (timeout) clearTimeout(timeout);
     child.stdin?.write(JSON.stringify(payload));
     child.stdin?.end();
   };
@@ -484,19 +481,9 @@ function writePayloadAfterSpawnHook(
   try {
     const result = options.onSpawn?.(child);
     if (result && typeof result.then === 'function') {
-      timeout = setTimeout(() => {
-        console.warn(
-          `${logPrefix} onSpawn hook timed out after ${ON_SPAWN_PAYLOAD_TIMEOUT_MS}ms; writing executor payload anyway`
-        );
-        writePayload();
-      }, ON_SPAWN_PAYLOAD_TIMEOUT_MS);
-
-      void result
-        .catch((error) => {
-          warn(error);
-        })
-        .finally(writePayload);
-      return;
+      void result.catch((error) => {
+        warn(error);
+      });
     }
   } catch (error) {
     warn(error);

--- a/apps/agor-daemon/src/utils/task-runtime-vitals.test.ts
+++ b/apps/agor-daemon/src/utils/task-runtime-vitals.test.ts
@@ -133,6 +133,26 @@ describe('daemon task runtime vitals', () => {
     expect(patches[0]?.data).not.toHaveProperty('status');
   });
 
+  it('does not rewrite runtime vitals after the task is terminal', async () => {
+    const service = {
+      get: vi.fn(async () => ({ task_id: 'task-1', status: TaskStatus.COMPLETED }) as Task),
+      patch: vi.fn(),
+    };
+
+    const vitals = await patchDaemonTaskRuntimeEvent(
+      service,
+      'task-1',
+      TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
+      {
+        at: '2026-01-01T00:00:03.000Z',
+        processPid: 12345,
+      }
+    );
+
+    expect(vitals).toBeUndefined();
+    expect(service.patch).not.toHaveBeenCalled();
+  });
+
   it('preserves a newer runtime phase when appending a daemon event to a running task', async () => {
     const task: Partial<Task> = {
       task_id: 'task-1' as never,

--- a/apps/agor-daemon/src/utils/task-runtime-vitals.test.ts
+++ b/apps/agor-daemon/src/utils/task-runtime-vitals.test.ts
@@ -1,0 +1,169 @@
+import {
+  type Task,
+  TaskRuntimeEventKind,
+  TaskRuntimePhase,
+  type TaskRuntimeVitals,
+  TaskStatus,
+} from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildDaemonTaskRuntimeVitals,
+  patchDaemonTaskRuntimeEvent,
+} from './task-runtime-vitals.js';
+
+describe('daemon task runtime vitals', () => {
+  it('records compact spawn lifecycle events with sanitized process facts', () => {
+    const requested = buildDaemonTaskRuntimeVitals(
+      undefined,
+      TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+      {
+        at: '2026-01-01T00:00:00.000Z',
+        phase: TaskRuntimePhase.EXECUTOR_STARTING,
+      }
+    );
+
+    const spawned = buildDaemonTaskRuntimeVitals(
+      requested,
+      TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
+      {
+        at: '2026-01-01T00:00:01.000Z',
+        phase: TaskRuntimePhase.EXECUTOR_STARTING,
+        processPid: 12345,
+        errorCode: 'Raw message with spaces and SECRET=hidden',
+      }
+    );
+
+    expect(spawned.phase).toBe(TaskRuntimePhase.EXECUTOR_STARTING);
+    expect(spawned.counters?.events).toBe(2);
+    expect(spawned.recent_events?.map((event) => event.kind)).toEqual([
+      TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+      TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
+    ]);
+    expect(spawned.last_event).toMatchObject({
+      kind: TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
+      source: 'daemon',
+      process_pid: 12345,
+      error_code: 'unknown',
+    });
+    expect(JSON.stringify(spawned)).not.toContain('SECRET');
+  });
+
+  it('records spawn failure as a terminal failed snapshot and clears active_tool explicitly', () => {
+    const previous: TaskRuntimeVitals = {
+      schema_version: 1,
+      phase: TaskRuntimePhase.TOOL_RUNNING,
+      phase_started_at: '2026-01-01T00:00:00.000Z',
+      last_activity_at: '2026-01-01T00:00:00.000Z',
+      active_tool: {
+        tool_name: 'Bash',
+        tool_use_id: 'tool-1',
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+      counters: { events: 3, meaningful_progress_events: 1 },
+      recent_events: [],
+    };
+
+    const failed = buildDaemonTaskRuntimeVitals(
+      previous,
+      TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+      {
+        at: '2026-01-01T00:00:02.000Z',
+        phase: TaskRuntimePhase.FAILED,
+        errorCode: 'spawn_exception',
+      }
+    );
+
+    expect(failed.phase).toBe(TaskRuntimePhase.FAILED);
+    expect(failed.active_tool).toBeNull();
+    expect(failed.counters).toMatchObject({
+      events: 4,
+      meaningful_progress_events: 1,
+    });
+    expect(failed.last_event).toMatchObject({
+      kind: TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+      error_code: 'spawn_exception',
+    });
+  });
+
+  it('patches through the task update path using the current persisted snapshot', async () => {
+    const patches: Array<{ id: string; data: Partial<Task> }> = [];
+    const task: Partial<Task> = {
+      task_id: 'task-1' as never,
+      status: TaskStatus.RUNNING,
+      runtime_vitals: buildDaemonTaskRuntimeVitals(
+        undefined,
+        TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+        {
+          at: '2026-01-01T00:00:00.000Z',
+          phase: TaskRuntimePhase.EXECUTOR_STARTING,
+        }
+      ),
+    };
+    const service = {
+      get: vi.fn(async () => task as Task),
+      patch: vi.fn(async (id: string, data: Partial<Task>) => {
+        patches.push({ id, data });
+        task.runtime_vitals = data.runtime_vitals;
+        return { ...task, ...data } as Task;
+      }),
+    };
+
+    const vitals = await patchDaemonTaskRuntimeEvent(
+      service,
+      'task-1',
+      TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED,
+      {
+        at: '2026-01-01T00:00:03.000Z',
+        exitCode: 127,
+        errorCode: 'unexpected_exit',
+      }
+    );
+
+    expect(patches).toHaveLength(1);
+    expect(vitals?.last_event).toMatchObject({
+      kind: TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED,
+      exit_code: 127,
+      error_code: 'unexpected_exit',
+    });
+    expect(vitals?.recent_events?.map((event) => event.kind)).toEqual([
+      TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+      TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED,
+    ]);
+    expect(patches[0]?.data).toEqual({ runtime_vitals: vitals });
+    expect(patches[0]?.data).not.toHaveProperty('status');
+  });
+
+  it('preserves a newer runtime phase when appending a daemon event to a running task', async () => {
+    const task: Partial<Task> = {
+      task_id: 'task-1' as never,
+      status: TaskStatus.RUNNING,
+      runtime_vitals: buildDaemonTaskRuntimeVitals(
+        undefined,
+        TaskRuntimeEventKind.SDK_TURN_STARTED,
+        {
+          at: '2026-01-01T00:00:01.000Z',
+          phase: TaskRuntimePhase.SDK_STARTING,
+        }
+      ),
+    };
+    const service = {
+      get: vi.fn(async () => task as Task),
+      patch: vi.fn(async (_id: string, data: Partial<Task>) => {
+        task.runtime_vitals = data.runtime_vitals;
+        return { ...task, ...data } as Task;
+      }),
+    };
+
+    const vitals = await patchDaemonTaskRuntimeEvent(
+      service,
+      'task-1',
+      TaskRuntimeEventKind.EXECUTOR_PROCESS_SPAWNED,
+      {
+        at: '2026-01-01T00:00:02.000Z',
+      }
+    );
+
+    expect(vitals?.phase).toBe(TaskRuntimePhase.SDK_STARTING);
+    expect(vitals?.last_event?.phase).toBe(TaskRuntimePhase.SDK_STARTING);
+  });
+});

--- a/apps/agor-daemon/src/utils/task-runtime-vitals.ts
+++ b/apps/agor-daemon/src/utils/task-runtime-vitals.ts
@@ -1,0 +1,157 @@
+import type { Params, TaskRuntimeEvent, TaskRuntimeVitals } from '@agor/core/types';
+import { type Task, TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
+
+const DEFAULT_MAX_EVENTS = 20;
+const CLEARED_ACTIVE_TOOL = null as unknown as TaskRuntimeVitals['active_tool'];
+const ALLOWED_DAEMON_ERROR_CODES = new Set([
+  'cwd_missing',
+  'spawn_error',
+  'spawn_exception',
+  'unexpected_exit',
+  'unknown',
+]);
+
+type TasksRuntimeVitalsService = {
+  get(id: string, params?: Params): Promise<Task>;
+  patch(id: string, data: Partial<Task>, params?: Params): Promise<Task>;
+};
+
+export interface DaemonRuntimeVitalsEventOptions {
+  at?: Date | string;
+  phase?: TaskRuntimeVitals['phase'];
+  processPid?: number;
+  exitCode?: number | null;
+  errorCode?: string;
+  maxEvents?: number;
+}
+
+function toIsoTimestamp(input: Date | string | undefined): string {
+  if (!input) return new Date().toISOString();
+  return input instanceof Date ? input.toISOString() : input;
+}
+
+function sanitizePositiveInteger(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isSafeInteger(value) || value <= 0) return undefined;
+  return value;
+}
+
+function sanitizeExitCode(value: number | null | undefined): number | null | undefined {
+  if (value === null) return null;
+  if (value === undefined) return undefined;
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function sanitizeErrorCode(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return ALLOWED_DAEMON_ERROR_CODES.has(value) ? value : 'unknown';
+}
+
+function isTerminalPhase(phase: TaskRuntimeVitals['phase']): boolean {
+  return (
+    phase === TaskRuntimePhase.COMPLETED ||
+    phase === TaskRuntimePhase.FAILED ||
+    phase === TaskRuntimePhase.STOPPED ||
+    phase === TaskRuntimePhase.TIMED_OUT
+  );
+}
+
+export function taskStatusToDaemonRuntimePhase(
+  status: TaskStatus | undefined
+): TaskRuntimeVitals['phase'] | undefined {
+  switch (status) {
+    case TaskStatus.RUNNING:
+      return TaskRuntimePhase.RUNNING;
+    case TaskStatus.STOPPING:
+      return TaskRuntimePhase.STOPPING;
+    case TaskStatus.AWAITING_PERMISSION:
+      return TaskRuntimePhase.AWAITING_PERMISSION;
+    case TaskStatus.COMPLETED:
+      return TaskRuntimePhase.COMPLETED;
+    case TaskStatus.FAILED:
+      return TaskRuntimePhase.FAILED;
+    case TaskStatus.STOPPED:
+      return TaskRuntimePhase.STOPPED;
+    case TaskStatus.TIMED_OUT:
+      return TaskRuntimePhase.TIMED_OUT;
+    default:
+      return undefined;
+  }
+}
+
+export function buildDaemonTaskRuntimeVitals(
+  previous: TaskRuntimeVitals | undefined,
+  kind: TaskRuntimeEventKind,
+  options: DaemonRuntimeVitalsEventOptions = {}
+): TaskRuntimeVitals {
+  const at = toIsoTimestamp(options.at);
+  const phase = options.phase ?? previous?.phase ?? TaskRuntimePhase.RUNNING;
+  const phaseChanged = !previous || previous.phase !== phase;
+  const maxEvents = Math.max(1, Math.floor(options.maxEvents ?? DEFAULT_MAX_EVENTS));
+  const processPid = sanitizePositiveInteger(options.processPid);
+  const exitCode = sanitizeExitCode(options.exitCode);
+  const errorCode = sanitizeErrorCode(options.errorCode);
+
+  const event: TaskRuntimeEvent = {
+    kind,
+    at,
+    source: 'daemon',
+    phase,
+    ...(processPid !== undefined ? { process_pid: processPid } : {}),
+    ...(exitCode !== undefined ? { exit_code: exitCode } : {}),
+    ...(errorCode ? { error_code: errorCode } : {}),
+  };
+
+  const previousCounters = previous?.counters ?? {};
+  const counters: NonNullable<TaskRuntimeVitals['counters']> = {
+    ...previousCounters,
+    events: (previousCounters.events ?? 0) + 1,
+  };
+
+  const recent_events = [...(previous?.recent_events ?? []), event].slice(-maxEvents);
+  const shouldClearActiveTool =
+    isTerminalPhase(phase) || kind === TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED;
+  const active_tool = shouldClearActiveTool ? CLEARED_ACTIVE_TOOL : previous?.active_tool;
+
+  return {
+    schema_version: 1,
+    phase,
+    phase_started_at: phaseChanged ? at : (previous?.phase_started_at ?? at),
+    last_activity_at: at,
+    ...(previous?.last_meaningful_progress_at
+      ? { last_meaningful_progress_at: previous.last_meaningful_progress_at }
+      : {}),
+    ...(previous?.first_meaningful_progress_at
+      ? { first_meaningful_progress_at: previous.first_meaningful_progress_at }
+      : {}),
+    last_event: event,
+    ...(active_tool !== undefined ? { active_tool } : {}),
+    counters,
+    recent_events,
+  };
+}
+
+export async function patchDaemonTaskRuntimeEvent(
+  tasksService: TasksRuntimeVitalsService,
+  taskId: string,
+  kind: TaskRuntimeEventKind,
+  options: DaemonRuntimeVitalsEventOptions = {},
+  params?: Params
+): Promise<TaskRuntimeVitals | undefined> {
+  try {
+    const task = await tasksService.get(taskId, params);
+    const phase =
+      options.phase ?? task.runtime_vitals?.phase ?? taskStatusToDaemonRuntimePhase(task.status);
+    const runtime_vitals = buildDaemonTaskRuntimeVitals(task.runtime_vitals, kind, {
+      ...options,
+      phase,
+    });
+    await tasksService.patch(taskId, { runtime_vitals }, params);
+    return runtime_vitals;
+  } catch (error) {
+    console.warn(
+      '[runtime-vitals] Failed to write daemon task runtime vitals:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return undefined;
+  }
+}

--- a/apps/agor-daemon/src/utils/task-runtime-vitals.ts
+++ b/apps/agor-daemon/src/utils/task-runtime-vitals.ts
@@ -1,5 +1,11 @@
 import type { Params, TaskRuntimeEvent, TaskRuntimeVitals } from '@agor/core/types';
-import { type Task, TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
+import {
+  isTerminalTaskStatus,
+  type Task,
+  TaskRuntimeEventKind,
+  TaskRuntimePhase,
+  TaskStatus,
+} from '@agor/core/types';
 
 const DEFAULT_MAX_EVENTS = 20;
 const CLEARED_ACTIVE_TOOL = null as unknown as TaskRuntimeVitals['active_tool'];
@@ -139,6 +145,9 @@ export async function patchDaemonTaskRuntimeEvent(
 ): Promise<TaskRuntimeVitals | undefined> {
   try {
     const task = await tasksService.get(taskId, params);
+    if (isTerminalTaskStatus(task.status)) {
+      return undefined;
+    }
     const phase =
       options.phase ?? task.runtime_vitals?.phase ?? taskStatusToDaemonRuntimePhase(task.status);
     const runtime_vitals = buildDaemonTaskRuntimeVitals(task.runtime_vitals, kind, {

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -26,6 +26,7 @@ export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
  * supervisors that read these normalized phase/event fields.
  */
 export const TaskRuntimePhase = {
+  EXECUTOR_STARTING: 'executor_starting',
   EXECUTOR_CONNECTED: 'executor_connected',
   SDK_STARTING: 'sdk_starting',
   AWAITING_FIRST_AGENT_EVENT: 'awaiting_first_agent_event',
@@ -42,6 +43,10 @@ export const TaskRuntimePhase = {
 export type TaskRuntimePhase = (typeof TaskRuntimePhase)[keyof typeof TaskRuntimePhase];
 
 export const TaskRuntimeEventKind = {
+  EXECUTOR_SPAWN_REQUESTED: 'executor_spawn_requested',
+  EXECUTOR_PROCESS_SPAWNED: 'executor_process_spawned',
+  EXECUTOR_SPAWN_FAILED: 'executor_spawn_failed',
+  EXECUTOR_PROCESS_EXITED: 'executor_process_exited',
   EXECUTOR_CONNECTED: 'executor_connected',
   SDK_TURN_STARTED: 'sdk_turn_started',
   FIRST_AGENT_EVENT: 'first_agent_event',
@@ -73,6 +78,12 @@ export interface TaskRuntimeEvent {
   tool_name?: string;
   /** Native tool-call id when available; no arguments or payload. */
   tool_use_id?: string;
+  /** Local child process PID when the daemon knows it is the real local executor. */
+  process_pid?: number;
+  /** Child process exit code observed by the daemon; null means unknown/no code. */
+  exit_code?: number | null;
+  /** Small normalized failure code; never an exception message or raw stderr. */
+  error_code?: string;
 }
 
 export interface TaskRuntimeVitals {

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -17,6 +17,7 @@ import type {
   StreamingEventType,
   Task,
   TaskID,
+  TaskRuntimeVitals,
 } from '@agor/core/types';
 import { MessageRole, TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
@@ -430,10 +431,21 @@ export async function executeToolTask(params: {
 
   console.log(`[${toolName}] Executing task ${shortId(taskId)}...`);
 
+  let initialRuntimeVitals: TaskRuntimeVitals | undefined;
+  try {
+    initialRuntimeVitals = (await client.service('tasks').get(taskId)).runtime_vitals;
+  } catch (error) {
+    console.warn(
+      '[runtime-vitals] Failed to read initial task runtime vitals:',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
   const vitalsReporter = new TaskRuntimeVitalsReporter({
     client,
     taskId,
     toolName,
+    initialSnapshot: initialRuntimeVitals,
   });
   let abortHandler: (() => Promise<void>) | undefined;
 

--- a/packages/executor/src/runtime-vitals.test.ts
+++ b/packages/executor/src/runtime-vitals.test.ts
@@ -203,6 +203,51 @@ describe('TaskRuntimeVitalsReporter', () => {
     expect(terminalVitals.active_tool).toBeNull();
   });
 
+  it('continues from daemon-written initial snapshots instead of dropping lifecycle events', async () => {
+    const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const reporter = new TaskRuntimeVitalsReporter({
+      client: createClient(patches),
+      taskId: 'task-1',
+      toolName: 'codex',
+      minPatchIntervalMs: 0,
+      now: () => new Date('2026-01-01T00:00:01.000Z'),
+      initialSnapshot: {
+        schema_version: 1,
+        phase: TaskRuntimePhase.EXECUTOR_STARTING,
+        phase_started_at: '2026-01-01T00:00:00.000Z',
+        last_activity_at: '2026-01-01T00:00:00.000Z',
+        last_event: {
+          kind: TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+          at: '2026-01-01T00:00:00.000Z',
+          source: 'daemon',
+          phase: TaskRuntimePhase.EXECUTOR_STARTING,
+        },
+        counters: { events: 1 },
+        recent_events: [
+          {
+            kind: TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+            at: '2026-01-01T00:00:00.000Z',
+            source: 'daemon',
+            phase: TaskRuntimePhase.EXECUTOR_STARTING,
+          },
+        ],
+      },
+    });
+
+    await reporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+      phase: TaskRuntimePhase.SDK_STARTING,
+      source: 'executor',
+      forceFlush: true,
+    });
+
+    const vitals = patches[0]?.data.runtime_vitals as NonNullable<typeof reporter.snapshot>;
+    expect(vitals.counters?.events).toBe(2);
+    expect(vitals.recent_events?.map((event) => event.kind)).toEqual([
+      TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
+      TaskRuntimeEventKind.SDK_TURN_STARTED,
+    ]);
+  });
+
   it('builds terminal vitals without issuing terminal side-effect patches', async () => {
     const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
     const reporter = new TaskRuntimeVitalsReporter({

--- a/packages/executor/src/runtime-vitals.ts
+++ b/packages/executor/src/runtime-vitals.ts
@@ -28,6 +28,7 @@ export interface RuntimeVitalsReporterOptions {
   client: Pick<AgorClient, 'service'>;
   taskId: string;
   toolName: string;
+  initialSnapshot?: TaskRuntimeVitals;
   now?: () => Date;
   maxEvents?: number;
   minPatchIntervalMs?: number;
@@ -62,6 +63,7 @@ export class TaskRuntimeVitalsReporter {
       Math.floor(options.minPatchIntervalMs ?? DEFAULT_MIN_PATCH_INTERVAL_MS)
     );
     this.warn = options.warn ?? console.warn;
+    this.current = options.initialSnapshot;
   }
 
   get snapshot(): TaskRuntimeVitals | undefined {


### PR DESCRIPTION
## Linked issue

Refs preset-io/agor-cloud#148

## Summary

- Add passive daemon-side runtime-vitals events for executor spawn lifecycle.
- Preserve daemon lifecycle events when SDK runtime-vitals reporting starts.
- Add focused regression coverage for spawn ordering and snapshot continuation.

## Why / context

This continues the runtime-vitals foundation from #1837. The goal is to record daemon-observed executor lifecycle facts without introducing timeout, abort, queue, or terminalization policy changes.

## Implementation notes

- Adds normalized daemon event kinds for spawn requested, process spawned, spawn failed, and process exited.
- Adds an `executor_starting` phase and sanitized event metadata such as local PID, exit code, and allowlisted error code.
- Writes spawn-requested before executor launch and waits for async `onSpawn` handling before payload/stdin delivery, preventing early SDK vitals from racing ahead and replacing daemon spawn events.
- Seeds executor vitals from existing snapshots so daemon events remain in the recent-event chain.
- Keeps this PR passive/observational only.

## Validation / test plan

- [x] `pnpm --filter @agor/daemon test -- src/utils/task-runtime-vitals.test.ts`
- [x] `pnpm --filter @agor/executor test -- src/runtime-vitals.test.ts src/handlers/sdk/base-executor.test.ts`
- [x] `pnpm --filter @agor/core test -- src/db/repositories/tasks.test.ts src/types/task.test.ts`
- [x] `pnpm exec biome check $(git diff --name-only HEAD)`
- [x] `git diff --check`
- [x] Pre-commit staged-file Biome check

## Screenshots / demos

Not applicable; backend/executor lifecycle instrumentation only.

## Risks / rollout / rollback

Low runtime risk: this adds passive task metadata writes and does not enforce new policy. Rollback is reverting this PR.

## Out of scope / follow-ups

- Timeout supervision policy.
- Central terminalization semantics.
- Persisted abort requests and escalation.
- Non-shared-SDK runtime-vitals coverage.
