### PR TITLE
fix(sessions): cascade archive descendants

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -24,7 +24,11 @@ import type {
   Session,
   Task,
 } from '@agor/core/types';
-import type { ExecuteTaskData } from './services/sessions.js';
+import type {
+  ExecuteTaskData,
+  SessionArchiveOptions,
+  SessionArchiveResult,
+} from './services/sessions.js';
 
 // Re-export core types for convenience
 export type AuthenticatedUser = CoreAuthenticatedUser;
@@ -60,6 +64,16 @@ export interface SessionsServiceImpl extends Service<Session, Partial<Session>, 
     ancestors: import('@agor/core/types').Session[];
     children: import('@agor/core/types').Session[];
   }>;
+  archive(
+    id: string,
+    options?: SessionArchiveOptions,
+    params?: FeathersParams
+  ): Promise<SessionArchiveResult>;
+  unarchive(
+    id: string,
+    options?: SessionArchiveOptions,
+    params?: FeathersParams
+  ): Promise<SessionArchiveResult>;
   enrichRemoteRelationships(
     sessionList: import('@agor/core/types').Session[]
   ): Promise<import('@agor/core/types').Session[]>;

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1453,3 +1453,45 @@ describe('attached_mcp_servers in session-info tools', () => {
     ]);
   });
 });
+
+describe('agor_sessions_archive tools', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('delegates archive and unarchive to the shared sessions service operations', async () => {
+    const archive = vi.fn(async () => ({ count: 3 }));
+    const unarchive = vi.fn(async () => ({ count: 2 }));
+    const app = makeFakeApp({
+      sessions: { archive, unarchive },
+    });
+
+    const tools = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-current', baseServiceParams: { provider: 'mcp' } },
+      ['agor_sessions_archive', 'agor_sessions_unarchive']
+    );
+
+    const archiveResult = await tools.agor_sessions_archive({
+      sessionId: 'sess-parent',
+      includeChildren: true,
+    });
+    const unarchiveResult = await tools.agor_sessions_unarchive({
+      sessionId: 'sess-parent',
+      includeChildren: false,
+    });
+
+    expect(archive).toHaveBeenCalledWith(
+      'sess-parent',
+      { includeChildren: true },
+      { provider: 'mcp' }
+    );
+    expect(unarchive).toHaveBeenCalledWith(
+      'sess-parent',
+      { includeChildren: false },
+      { provider: 'mcp' }
+    );
+    expect(JSON.parse(archiveResult.content[0].text)).toMatchObject({ archivedCount: 3 });
+    expect(JSON.parse(unarchiveResult.content[0].text)).toMatchObject({ unarchivedCount: 2 });
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1334,42 +1334,16 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const includeChildren = args.includeChildren !== false;
       const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
-      let archivedCount = 0;
-
-      await ctx.app
-        .service('sessions')
-        .patch(
-          args.sessionId,
-          { archived: true, archived_reason: 'manual' },
-          ctx.baseServiceParams
-        );
-      archivedCount++;
-
-      if (includeChildren) {
-        const collectDescendantIds = async (parentId: string): Promise<string[]> => {
-          const gen = await sessionsService.getGenealogy(parentId, ctx.baseServiceParams);
-          const ids: string[] = [];
-          for (const child of gen.children) {
-            ids.push(child.session_id);
-            const nested = await collectDescendantIds(child.session_id);
-            ids.push(...nested);
-          }
-          return ids;
-        };
-
-        const descendantIds = await collectDescendantIds(args.sessionId);
-        for (const childId of descendantIds) {
-          await ctx.app
-            .service('sessions')
-            .patch(childId, { archived: true, archived_reason: 'manual' }, ctx.baseServiceParams);
-          archivedCount++;
-        }
-      }
+      const result = await sessionsService.archive(
+        args.sessionId,
+        { includeChildren },
+        ctx.baseServiceParams
+      );
 
       return textResult({
         success: true,
-        archivedCount,
-        message: `Archived ${archivedCount} session(s).`,
+        archivedCount: result.count,
+        message: `Archived ${result.count} session(s).`,
       });
     }
   );
@@ -1395,42 +1369,16 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const includeChildren = args.includeChildren !== false;
       const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
-      let unarchivedCount = 0;
-
-      await ctx.app
-        .service('sessions')
-        .patch(
-          args.sessionId,
-          { archived: false, archived_reason: undefined },
-          ctx.baseServiceParams
-        );
-      unarchivedCount++;
-
-      if (includeChildren) {
-        const collectDescendantIds = async (parentId: string): Promise<string[]> => {
-          const gen = await sessionsService.getGenealogy(parentId, ctx.baseServiceParams);
-          const ids: string[] = [];
-          for (const child of gen.children) {
-            ids.push(child.session_id);
-            const nested = await collectDescendantIds(child.session_id);
-            ids.push(...nested);
-          }
-          return ids;
-        };
-
-        const descendantIds = await collectDescendantIds(args.sessionId);
-        for (const childId of descendantIds) {
-          await ctx.app
-            .service('sessions')
-            .patch(childId, { archived: false, archived_reason: undefined }, ctx.baseServiceParams);
-          unarchivedCount++;
-        }
-      }
+      const result = await sessionsService.unarchive(
+        args.sessionId,
+        { includeChildren },
+        ctx.baseServiceParams
+      );
 
       return textResult({
         success: true,
-        unarchivedCount,
-        message: `Unarchived ${unarchivedCount} session(s).`,
+        unarchivedCount: result.count,
+        message: `Unarchived ${result.count} session(s).`,
       });
     }
   );

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -805,7 +805,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     {
       async create(data: { includeChildren?: boolean } | undefined, params: RouteParams) {
         const id = params.route?.id;
-        if (!id) throw new Error('Session ID required');
+        if (!id) throw new BadRequest('Session ID required');
         return sessionsService.archive(id, data, params);
       },
     },
@@ -821,7 +821,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     {
       async create(data: { includeChildren?: boolean } | undefined, params: RouteParams) {
         const id = params.route?.id;
-        if (!id) throw new Error('Session ID required');
+        if (!id) throw new BadRequest('Session ID required');
         return sessionsService.unarchive(id, data, params);
       },
     },

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -799,6 +799,38 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     requireAuth
   );
 
+  registerAuthenticatedRoute(
+    app,
+    '/sessions/:id/archive',
+    {
+      async create(data: { includeChildren?: boolean } | undefined, params: RouteParams) {
+        const id = params.route?.id;
+        if (!id) throw new Error('Session ID required');
+        return sessionsService.archive(id, data, params);
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'archive sessions' },
+    },
+    requireAuth
+  );
+
+  registerAuthenticatedRoute(
+    app,
+    '/sessions/:id/unarchive',
+    {
+      async create(data: { includeChildren?: boolean } | undefined, params: RouteParams) {
+        const id = params.route?.id;
+        if (!id) throw new Error('Session ID required');
+        return sessionsService.unarchive(id, data, params);
+      },
+    },
+    {
+      create: { role: ROLES.MEMBER, action: 'unarchive sessions' },
+    },
+    requireAuth
+  );
+
   /**
    * Restart the Zellij pane for a Claude Code CLI session.
    *

--- a/apps/agor-daemon/src/services/sessions.archive.test.ts
+++ b/apps/agor-daemon/src/services/sessions.archive.test.ts
@@ -12,7 +12,11 @@ import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { type SessionParams, SessionsService } from './sessions';
 
-const STUB_APP = {} as unknown as Application;
+const STUB_APP = {
+  service: () => ({
+    emit: () => {},
+  }),
+} as unknown as Application;
 const TEST_USER_ID = 'test-user' as UUID;
 const OTHER_USER_ID = 'other-user' as UUID;
 
@@ -30,6 +34,7 @@ function makeAppWithConfig(config: {
         },
       };
     },
+    service: STUB_APP.service,
   } as unknown as Application;
 }
 
@@ -130,15 +135,15 @@ describe('SessionsService archive routes', () => {
       });
       await expect(getArchivedState(db, spawnedChild.session_id)).resolves.toEqual({
         archived: true,
-        archived_reason: 'manual',
+        archived_reason: 'parent_archived',
       });
       await expect(getArchivedState(db, nestedChild.session_id)).resolves.toEqual({
         archived: true,
-        archived_reason: 'manual',
+        archived_reason: 'parent_archived',
       });
       await expect(getArchivedState(db, forkedChild.session_id)).resolves.toEqual({
         archived: true,
-        archived_reason: 'manual',
+        archived_reason: 'parent_archived',
       });
 
       const unarchiveResult = await service.unarchive(parent.session_id);
@@ -162,6 +167,66 @@ describe('SessionsService archive routes', () => {
       });
     }
   );
+
+  dbTest('preserves descendants that were already archived for other reasons', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const parent = await createSession(db, branchId);
+    const activeChild = await createSession(db, branchId, {
+      genealogy: { parent_session_id: parent.session_id, children: [] },
+    });
+    const btwCompletedChild = await createSession(db, branchId, {
+      archived: true,
+      archived_reason: 'btw_completed',
+      fork_origin: 'btw',
+      genealogy: { forked_from_session_id: parent.session_id, children: [] },
+    });
+    const manualChild = await createSession(db, branchId, {
+      archived: true,
+      archived_reason: 'manual',
+      genealogy: { parent_session_id: parent.session_id, children: [] },
+    });
+
+    const archiveResult = await service.archive(parent.session_id);
+
+    expect(archiveResult.count).toBe(2);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
+      archived: true,
+      archived_reason: 'manual',
+    });
+    await expect(getArchivedState(db, activeChild.session_id)).resolves.toEqual({
+      archived: true,
+      archived_reason: 'parent_archived',
+    });
+    await expect(getArchivedState(db, btwCompletedChild.session_id)).resolves.toEqual({
+      archived: true,
+      archived_reason: 'btw_completed',
+    });
+    await expect(getArchivedState(db, manualChild.session_id)).resolves.toEqual({
+      archived: true,
+      archived_reason: 'manual',
+    });
+
+    const unarchiveResult = await service.unarchive(parent.session_id);
+
+    expect(unarchiveResult.count).toBe(2);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
+      archived: false,
+      archived_reason: undefined,
+    });
+    await expect(getArchivedState(db, activeChild.session_id)).resolves.toEqual({
+      archived: false,
+      archived_reason: undefined,
+    });
+    await expect(getArchivedState(db, btwCompletedChild.session_id)).resolves.toEqual({
+      archived: true,
+      archived_reason: 'btw_completed',
+    });
+    await expect(getArchivedState(db, manualChild.session_id)).resolves.toEqual({
+      archived: true,
+      archived_reason: 'manual',
+    });
+  });
 
   dbTest(
     'honors includeChildren false while generic patch remains single-session',
@@ -242,7 +307,7 @@ describe('SessionsService archive routes', () => {
       });
 
       await service.patch(parent.session_id, { archived: true, archived_reason: 'manual' });
-      await service.patch(child.session_id, { archived: true, archived_reason: 'manual' });
+      await service.patch(child.session_id, { archived: true, archived_reason: 'parent_archived' });
 
       await expect(
         service.unarchive(parent.session_id, undefined, externalParams(TEST_USER_ID))

--- a/apps/agor-daemon/src/services/sessions.archive.test.ts
+++ b/apps/agor-daemon/src/services/sessions.archive.test.ts
@@ -1,0 +1,283 @@
+import {
+  BranchRepository,
+  generateId,
+  RepoRepository,
+  SessionRelationshipRepository,
+  SessionRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { Branch, Session, SessionID, UUID } from '@agor/core/types';
+import { ROLES, SessionStatus } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { type SessionParams, SessionsService } from './sessions';
+
+const STUB_APP = {} as unknown as Application;
+const TEST_USER_ID = 'test-user' as UUID;
+const OTHER_USER_ID = 'other-user' as UUID;
+
+function makeAppWithConfig(config: {
+  branchRbac: boolean;
+  allowSuperadmin?: boolean;
+}): Application {
+  return {
+    get(key: string) {
+      if (key !== 'config') return undefined;
+      return {
+        execution: {
+          branch_rbac: config.branchRbac,
+          allow_superadmin: config.allowSuperadmin ?? false,
+        },
+      };
+    },
+  } as unknown as Application;
+}
+
+function externalParams(userId: UUID): SessionParams {
+  return {
+    provider: 'rest',
+    user: {
+      user_id: userId,
+      email: `${userId}@example.com`,
+      role: ROLES.MEMBER,
+    },
+  } as SessionParams;
+}
+
+async function createBranch(
+  db: any,
+  name = `feature-${generateId()}`,
+  overrides: Partial<Branch> = {}
+): Promise<UUID> {
+  const repoRepo = new RepoRepository(db);
+  const branchRepo = new BranchRepository(db);
+  const repo = await repoRepo.create({
+    repo_id: generateId(),
+    slug: `repo-${generateId()}`,
+    name: 'Test Repo',
+    repo_type: 'remote' as const,
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/tmp/test-repo-${generateId()}`,
+    default_branch: 'main',
+  });
+  const branch = await branchRepo.create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name,
+    ref: name,
+    branch_unique_id: Math.floor(Math.random() * 1_000_000),
+    path: `/tmp/test-repo-${generateId()}`,
+    base_ref: 'main',
+    new_branch: false,
+    created_by: TEST_USER_ID,
+    ...overrides,
+  });
+  return branch.branch_id as UUID;
+}
+
+async function createSession(
+  db: any,
+  branchId: UUID,
+  overrides: Partial<Session> = {}
+): Promise<Session> {
+  const sessionRepo = new SessionRepository(db);
+  return sessionRepo.create({
+    session_id: generateId(),
+    branch_id: branchId,
+    agentic_tool: 'claude-code',
+    status: SessionStatus.IDLE,
+    created_by: TEST_USER_ID,
+    git_state: { ref: 'main', base_sha: 'abc', current_sha: 'def' },
+    tasks: [],
+    contextFiles: [],
+    genealogy: { children: [] },
+    ...overrides,
+  });
+}
+
+async function getArchivedState(
+  db: any,
+  sessionId: SessionID
+): Promise<Pick<Session, 'archived' | 'archived_reason'>> {
+  const session = await new SessionRepository(db).findById(sessionId);
+  if (!session) throw new Error(`Session ${sessionId} not found`);
+  return { archived: session.archived, archived_reason: session.archived_reason };
+}
+
+describe('SessionsService archive routes', () => {
+  dbTest(
+    'archives and unarchives branch-local spawned, forked, and nested descendants',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const parent = await createSession(db, branchId);
+      const spawnedChild = await createSession(db, branchId, {
+        genealogy: { parent_session_id: parent.session_id, children: [] },
+      });
+      const nestedChild = await createSession(db, branchId, {
+        genealogy: { parent_session_id: spawnedChild.session_id, children: [] },
+      });
+      const forkedChild = await createSession(db, branchId, {
+        genealogy: { forked_from_session_id: parent.session_id, children: [] },
+      });
+
+      const archiveResult = await service.archive(parent.session_id);
+
+      expect(archiveResult.count).toBe(4);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
+        archived: true,
+        archived_reason: 'manual',
+      });
+      await expect(getArchivedState(db, spawnedChild.session_id)).resolves.toEqual({
+        archived: true,
+        archived_reason: 'manual',
+      });
+      await expect(getArchivedState(db, nestedChild.session_id)).resolves.toEqual({
+        archived: true,
+        archived_reason: 'manual',
+      });
+      await expect(getArchivedState(db, forkedChild.session_id)).resolves.toEqual({
+        archived: true,
+        archived_reason: 'manual',
+      });
+
+      const unarchiveResult = await service.unarchive(parent.session_id);
+
+      expect(unarchiveResult.count).toBe(4);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
+        archived: false,
+        archived_reason: undefined,
+      });
+      await expect(getArchivedState(db, spawnedChild.session_id)).resolves.toEqual({
+        archived: false,
+        archived_reason: undefined,
+      });
+      await expect(getArchivedState(db, nestedChild.session_id)).resolves.toEqual({
+        archived: false,
+        archived_reason: undefined,
+      });
+      await expect(getArchivedState(db, forkedChild.session_id)).resolves.toEqual({
+        archived: false,
+        archived_reason: undefined,
+      });
+    }
+  );
+
+  dbTest(
+    'honors includeChildren false while generic patch remains single-session',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const parent = await createSession(db, branchId);
+      const child = await createSession(db, branchId, {
+        genealogy: { parent_session_id: parent.session_id, children: [] },
+      });
+
+      await service.patch(parent.session_id, { archived: true, archived_reason: 'manual' });
+      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
+        archived: true,
+      });
+      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
+        archived: false,
+      });
+
+      await service.unarchive(parent.session_id, { includeChildren: false });
+      const archiveResult = await service.archive(parent.session_id, { includeChildren: false });
+
+      expect(archiveResult.count).toBe(1);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
+        archived: true,
+      });
+      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
+        archived: false,
+      });
+    }
+  );
+
+  dbTest('does not cascade through remote session relationships', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const sourceBranchId = await createBranch(db, 'source');
+    const targetBranchId = await createBranch(db, 'target');
+    const parent = await createSession(db, sourceBranchId);
+    const remoteChild = await createSession(db, targetBranchId);
+
+    await new SessionRelationshipRepository(db).create({
+      source_session_id: parent.session_id,
+      target_session_id: remoteChild.session_id,
+      relationship_type: 'remote_create',
+      created_by: TEST_USER_ID,
+    });
+
+    const archiveResult = await service.archive(parent.session_id);
+
+    expect(archiveResult.count).toBe(1);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
+      archived: true,
+    });
+    await expect(getArchivedState(db, remoteChild.session_id)).resolves.toMatchObject({
+      archived: false,
+    });
+  });
+
+  dbTest(
+    'rejects external archive and unarchive before mutating when RBAC prompt permission is missing',
+    async ({ db }) => {
+      const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+      const branchId = await createBranch(db, 'rbac-session-only', { others_can: 'session' });
+      const parent = await createSession(db, branchId, { created_by: TEST_USER_ID });
+      const child = await createSession(db, branchId, {
+        created_by: OTHER_USER_ID,
+        genealogy: { parent_session_id: parent.session_id, children: [] },
+      });
+
+      await expect(
+        service.archive(parent.session_id, undefined, externalParams(TEST_USER_ID))
+      ).rejects.toThrow(/prompt/);
+
+      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
+        archived: false,
+      });
+      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
+        archived: false,
+      });
+
+      await service.patch(parent.session_id, { archived: true, archived_reason: 'manual' });
+      await service.patch(child.session_id, { archived: true, archived_reason: 'manual' });
+
+      await expect(
+        service.unarchive(parent.session_id, undefined, externalParams(TEST_USER_ID))
+      ).rejects.toThrow(/prompt/);
+
+      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
+        archived: true,
+      });
+      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
+        archived: true,
+      });
+    }
+  );
+
+  dbTest('allows external archive when RBAC prompt permission is present', async ({ db }) => {
+    const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+    const branchId = await createBranch(db, 'rbac-prompt', { others_can: 'prompt' });
+    const parent = await createSession(db, branchId, { created_by: OTHER_USER_ID });
+    const child = await createSession(db, branchId, {
+      created_by: OTHER_USER_ID,
+      genealogy: { parent_session_id: parent.session_id, children: [] },
+    });
+
+    const result = await service.archive(
+      parent.session_id,
+      undefined,
+      externalParams(TEST_USER_ID)
+    );
+
+    expect(result.count).toBe(2);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
+      archived: true,
+    });
+    await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
+      archived: true,
+    });
+  });
+});

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -773,27 +773,9 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   }
 
   private async collectBranchLocalDescendants(root: Session): Promise<Session[]> {
-    const descendants: Session[] = [];
-    const visited = new Set<string>([root.session_id]);
-
-    const visit = async (parentId: string): Promise<void> => {
-      const children = await this.sessionRepo.findChildren(parentId);
-
-      for (const child of children) {
-        if (visited.has(child.session_id)) continue;
-        visited.add(child.session_id);
-
-        // Session archive cascades follow the branch-local genealogy tree only.
-        // Remote relationships are modeled separately and must not be affected.
-        if (child.branch_id !== root.branch_id) continue;
-
-        descendants.push(child);
-        await visit(child.session_id);
-      }
-    };
-
-    await visit(root.session_id);
-    return descendants;
+    // Session archive cascades follow the branch-local genealogy tree only.
+    // Remote relationships are modeled separately and must not be affected.
+    return this.sessionRepo.findBranchLocalDescendants(root.session_id, root.branch_id);
   }
 
   private getRuntimeExecutionConfig():
@@ -897,17 +879,16 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     const sessionsToPatch = includeChildren
       ? [root, ...(await this.collectBranchLocalDescendants(root))]
       : [root];
-    const affectedSessions: Session[] = [];
-
     await this.assertCanArchiveSessions(sessionsToPatch, archived, params);
 
-    for (const session of sessionsToPatch) {
-      const patch = {
-        archived,
-        archived_reason: archived ? 'manual' : null,
-      } as Partial<Session>;
-      const patched = (await this.patch(session.session_id, patch, params)) as Session;
-      affectedSessions.push(patched);
+    const affectedSessions = await this.sessionRepo.updateArchiveStateForIds(
+      sessionsToPatch.map((session) => session.session_id),
+      archived,
+      archived ? 'manual' : null
+    );
+
+    for (const affectedSession of affectedSessions) {
+      this.emit?.('patched', affectedSession, params);
     }
 
     const [session] = affectedSessions;

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -16,7 +16,7 @@ import {
   type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
-import { type Application, BadRequest, Forbidden } from '@agor/core/feathers';
+import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
   formatModelToolMismatchWarning,
   formatUnsupportedAgorCodexModelMessage,
@@ -27,6 +27,7 @@ import { resolveChildSessionConfig } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
   Branch,
+  BranchPermissionLevel,
   MCPServerID,
   Paginated,
   QueryParams,
@@ -41,6 +42,7 @@ import {
   determineSpawnIdentity,
   isSuperAdmin,
   loadUnixUsernameForUser,
+  PERMISSION_RANK,
   resolveChildUnixUsername,
 } from '../utils/branch-authorization.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
@@ -149,6 +151,16 @@ export type ExecuteTaskData = {
   permissionMode?: import('@agor/core/types').PermissionMode;
   stream?: boolean;
   messageSource?: import('@agor/core/types').MessageSource;
+};
+
+export type SessionArchiveOptions = {
+  includeChildren?: boolean;
+};
+
+export type SessionArchiveResult = {
+  session: Session;
+  affectedSessions: Session[];
+  count: number;
 };
 
 /**
@@ -758,6 +770,181 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
       ancestors,
       children,
     };
+  }
+
+  private async collectBranchLocalDescendants(root: Session): Promise<Session[]> {
+    const descendants: Session[] = [];
+    const visited = new Set<string>([root.session_id]);
+
+    const visit = async (parentId: string): Promise<void> => {
+      const children = await this.sessionRepo.findChildren(parentId);
+
+      for (const child of children) {
+        if (visited.has(child.session_id)) continue;
+        visited.add(child.session_id);
+
+        // Session archive cascades follow the branch-local genealogy tree only.
+        // Remote relationships are modeled separately and must not be affected.
+        if (child.branch_id !== root.branch_id) continue;
+
+        descendants.push(child);
+        await visit(child.session_id);
+      }
+    };
+
+    await visit(root.session_id);
+    return descendants;
+  }
+
+  private getRuntimeExecutionConfig():
+    | {
+        execution?: {
+          branch_rbac?: boolean;
+          allow_superadmin?: boolean;
+        };
+      }
+    | undefined {
+    try {
+      return (
+        this.app as {
+          get?: (key: string) => unknown;
+        }
+      ).get?.('config') as
+        | {
+            execution?: {
+              branch_rbac?: boolean;
+              allow_superadmin?: boolean;
+            };
+          }
+        | undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private shouldEnforceBranchRbac(): boolean {
+    return this.getRuntimeExecutionConfig()?.execution?.branch_rbac === true;
+  }
+
+  private shouldAllowSuperadminBypass(): boolean {
+    return this.getRuntimeExecutionConfig()?.execution?.allow_superadmin === true;
+  }
+
+  private async assertCanArchiveSessions(
+    sessions: Session[],
+    archived: boolean,
+    params?: SessionParams
+  ): Promise<void> {
+    if (!params?.provider || !this.shouldEnforceBranchRbac()) return;
+
+    const user = params.user;
+    if (!user) {
+      throw new NotAuthenticated('Authentication required');
+    }
+
+    if (user._isServiceAccount) {
+      return;
+    }
+
+    const userId = user.user_id as UUID | undefined;
+    if (!userId) {
+      throw new NotAuthenticated('Authentication required');
+    }
+
+    const allowSuperadmin = this.shouldAllowSuperadminBypass();
+    const userRole = user.role;
+    const action = archived ? 'archive sessions' : 'unarchive sessions';
+    const branchCache = new Map<string, Branch>();
+
+    for (const session of sessions) {
+      let branch = branchCache.get(session.branch_id);
+      if (!branch) {
+        branch = await this.branchRepo.findById(session.branch_id);
+        if (!branch) {
+          throw new Forbidden(`Branch not found for session: ${session.session_id}`);
+        }
+        branchCache.set(session.branch_id, branch);
+      }
+
+      const access = await this.branchRepo.resolveUserAccess(branch, userId);
+      const effectiveLevel: BranchPermissionLevel = isSuperAdmin(userRole, allowSuperadmin)
+        ? 'all'
+        : access.can;
+
+      if (PERMISSION_RANK[effectiveLevel] >= PERMISSION_RANK.prompt) {
+        continue;
+      }
+
+      if (effectiveLevel === 'session' && session.created_by === userId) {
+        continue;
+      }
+
+      throw new Forbidden(
+        `You need 'prompt' permission to ${action} in this branch. You have '${effectiveLevel}' permission.`
+      );
+    }
+  }
+
+  private async setArchiveStateForTree(
+    id: string,
+    archived: boolean,
+    options: SessionArchiveOptions | undefined,
+    params?: SessionParams
+  ): Promise<SessionArchiveResult> {
+    const root = await this.get(id, params);
+    const includeChildren = options?.includeChildren !== false;
+    const sessionsToPatch = includeChildren
+      ? [root, ...(await this.collectBranchLocalDescendants(root))]
+      : [root];
+    const affectedSessions: Session[] = [];
+
+    await this.assertCanArchiveSessions(sessionsToPatch, archived, params);
+
+    for (const session of sessionsToPatch) {
+      const patch = {
+        archived,
+        archived_reason: archived ? 'manual' : null,
+      } as Partial<Session>;
+      const patched = (await this.patch(session.session_id, patch, params)) as Session;
+      affectedSessions.push(patched);
+    }
+
+    const [session] = affectedSessions;
+    if (!session) {
+      throw new Error(`Session ${id} not found`);
+    }
+
+    return {
+      session,
+      affectedSessions,
+      count: affectedSessions.length,
+    };
+  }
+
+  /**
+   * Archive a session and, by default, its branch-local descendants.
+   *
+   * Generic `patch({ archived })` intentionally remains single-row so bulk
+   * archive, branch archive, and auto-cleanup paths keep their existing
+   * semantics.
+   */
+  async archive(
+    id: string,
+    options?: SessionArchiveOptions,
+    params?: SessionParams
+  ): Promise<SessionArchiveResult> {
+    return this.setArchiveStateForTree(id, true, options, params);
+  }
+
+  /**
+   * Restore a session and, by default, its branch-local descendants.
+   */
+  async unarchive(
+    id: string,
+    options?: SessionArchiveOptions,
+    params?: SessionParams
+  ): Promise<SessionArchiveResult> {
+    return this.setArchiveStateForTree(id, false, options, params);
   }
 
   /**

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -45,6 +45,7 @@ import {
   PERMISSION_RANK,
   resolveChildUnixUsername,
 } from '../utils/branch-authorization.js';
+import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
 
 /**
@@ -58,6 +59,16 @@ interface InheritableSessionConfig {
   permission_config?: Session['permission_config'];
   model_config?: Session['model_config'];
 }
+
+type SessionArchiveReason = NonNullable<Session['archived_reason']>;
+type SessionArchiveTarget = {
+  session: Session;
+  archived: boolean;
+  archivedReason: SessionArchiveReason | null;
+};
+
+const MANUAL_ARCHIVED_REASON = 'manual' satisfies SessionArchiveReason;
+const PARENT_ARCHIVED_REASON = 'parent_archived' satisfies SessionArchiveReason;
 
 /**
  * Extract the inheritable runtime configuration from a parent session.
@@ -876,19 +887,58 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
   ): Promise<SessionArchiveResult> {
     const root = await this.get(id, params);
     const includeChildren = options?.includeChildren !== false;
-    const sessionsToPatch = includeChildren
-      ? [root, ...(await this.collectBranchLocalDescendants(root))]
-      : [root];
-    await this.assertCanArchiveSessions(sessionsToPatch, archived, params);
+    const descendants = includeChildren ? await this.collectBranchLocalDescendants(root) : [];
+    const targets: SessionArchiveTarget[] = [
+      {
+        session: root,
+        archived,
+        archivedReason: archived ? MANUAL_ARCHIVED_REASON : null,
+      },
+    ];
 
-    const affectedSessions = await this.sessionRepo.updateArchiveStateForIds(
-      sessionsToPatch.map((session) => session.session_id),
+    for (const session of descendants) {
+      if (archived) {
+        if (!session.archived) {
+          targets.push({
+            session,
+            archived: true,
+            archivedReason: PARENT_ARCHIVED_REASON,
+          });
+        }
+        continue;
+      }
+
+      if (session.archived_reason === PARENT_ARCHIVED_REASON) {
+        targets.push({
+          session,
+          archived: false,
+          archivedReason: null,
+        });
+      }
+    }
+
+    await this.assertCanArchiveSessions(
+      targets.map((target) => target.session),
       archived,
-      archived ? 'manual' : null
+      params
+    );
+
+    const affectedSessions = await this.sessionRepo.updateArchiveStateForTargets(
+      targets.map((target) => ({
+        id: target.session.session_id,
+        archived: target.archived,
+        archivedReason: target.archivedReason,
+      }))
     );
 
     for (const affectedSession of affectedSessions) {
-      this.emit?.('patched', affectedSession, params);
+      emitServiceEvent(this.app, {
+        path: 'sessions',
+        event: 'patched',
+        data: affectedSession,
+        params,
+        id: affectedSession.session_id,
+      });
     }
 
     const [session] = affectedSessions;

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -859,10 +859,11 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     for (const session of sessions) {
       let branch = branchCache.get(session.branch_id);
       if (!branch) {
-        branch = await this.branchRepo.findById(session.branch_id);
-        if (!branch) {
+        const loadedBranch = await this.branchRepo.findById(session.branch_id);
+        if (!loadedBranch) {
           throw new Forbidden(`Branch not found for session: ${session.session_id}`);
         }
+        branch = loadedBranch;
         branchCache.set(session.branch_id, branch);
       }
 

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -442,8 +442,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       e.stopPropagation();
 
       modal.confirm({
-        title: 'Archive session?',
-        content: 'Are you sure you want to archive this session?',
+        title: 'Archive session and child sessions?',
+        content: 'Are you sure you want to archive this session and its child sessions?',
         okText: 'Archive',
         cancelText: 'Cancel',
         onOk: async () => {

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -451,7 +451,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           try {
             const result = await archiveSession(sessionId as SessionID);
             if (result) {
-              showSuccess('Session archived');
+              showSuccess('Session and child sessions archived');
             } else {
               showError('Failed to archive session');
             }

--- a/apps/agor-ui/src/components/BranchModal/tabs/SessionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/SessionsTab.tsx
@@ -1,12 +1,24 @@
 import type { AgorClient, Branch, Session, SessionID } from '@agor-live/client';
 import { EyeInvisibleOutlined, EyeOutlined, SearchOutlined } from '@ant-design/icons';
-import { Badge, Input, Space, Switch, Table, Tag, Tooltip, Typography, theme } from 'antd';
+import {
+  Badge,
+  Button,
+  Input,
+  Popconfirm,
+  Space,
+  Switch,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
 import { getSessionStatusTone } from '../../../utils/sessionStatus';
 import { getSessionDisplayTitle } from '../../../utils/sessionTitle';
-import { ArchiveToggleButton } from '../../ArchiveButton';
+import { ArchiveIcon } from '../../ArchiveButton';
 import { TaskStatusIcon } from '../../TaskStatusIcon';
 import { ToolIcon } from '../../ToolIcon/ToolIcon';
 
@@ -340,16 +352,41 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
       title: '',
       key: 'actions',
       width: 40,
-      render: (_, session) => (
-        <ArchiveToggleButton
-          archived={session.archived}
-          loading={archivingIds.has(session.session_id)}
-          tooltip={session.archived ? 'Archived • Click to unarchive' : 'Archive session'}
-          onToggle={(nextArchived) =>
-            handleArchiveToggle(session.session_id as SessionID, nextArchived)
-          }
-        />
-      ),
+      render: (_, session) => {
+        const nextArchived = !session.archived;
+        const actionLabel = nextArchived ? 'archive' : 'unarchive';
+        const title = nextArchived
+          ? 'Archive session and child sessions?'
+          : 'Unarchive session and child sessions?';
+        const description = nextArchived
+          ? 'This will archive this session and its branch-local child sessions.'
+          : 'This will unarchive this session and its branch-local child sessions.';
+        const tooltip = nextArchived
+          ? 'Archive session and child sessions'
+          : 'Archived • Click to unarchive session and child sessions';
+
+        return (
+          <Popconfirm
+            title={title}
+            description={description}
+            okText={nextArchived ? 'Archive' : 'Unarchive'}
+            cancelText="Cancel"
+            okButtonProps={{ danger: nextArchived }}
+            onConfirm={() => handleArchiveToggle(session.session_id as SessionID, nextArchived)}
+          >
+            <Tooltip title={tooltip}>
+              <Button
+                type="text"
+                size="small"
+                icon={<ArchiveIcon />}
+                loading={archivingIds.has(session.session_id)}
+                aria-label={`${actionLabel} session and child sessions`}
+                onClick={(event) => event.stopPropagation()}
+              />
+            </Tooltip>
+          </Popconfirm>
+        );
+      },
     },
   ];
 

--- a/apps/agor-ui/src/components/BranchModal/tabs/SessionsTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/SessionsTab.tsx
@@ -164,32 +164,47 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
 
       setArchivingIds((prev) => new Set(prev).add(sessionId));
       try {
-        await currentClient.service('sessions').patch(sessionId, {
-          archived: archive,
-          archived_reason: archive ? 'manual' : undefined,
-        } as Partial<Session>);
+        const result = (await currentClient
+          .service(`sessions/${sessionId}/${archive ? 'archive' : 'unarchive'}`)
+          .create({})) as {
+          session?: Session;
+          affectedSessions?: Session[];
+        };
+        const affectedSessions =
+          result.affectedSessions && result.affectedSessions.length > 0
+            ? result.affectedSessions
+            : result.session
+              ? [result.session]
+              : [];
 
-        // Keep local archived cache in sync for this modal view
-        if (archive) {
-          const source = activeSessions.find((s) => s.session_id === sessionId);
-          if (source) {
-            setActiveSessions((prev) => prev.filter((s) => s.session_id !== sessionId));
-            setArchivedSessions((prev) => {
-              if (prev.some((s) => s.session_id === sessionId)) return prev;
-              return [{ ...source, archived: true }, ...prev];
-            });
-          } else if (showArchived) {
-            void loadArchivedSessions();
+        // Keep local archived cache in sync for this modal view. Realtime
+        // events will converge other views; this prevents stale descendants in
+        // the currently open modal immediately after route completion.
+        if (affectedSessions.length > 0) {
+          const affectedIds = new Set(affectedSessions.map((session) => session.session_id));
+          setActiveSessions((prev) =>
+            prev.filter((session) => !affectedIds.has(session.session_id))
+          );
+          setArchivedSessions((prev) =>
+            prev.filter((session) => !affectedIds.has(session.session_id))
+          );
+
+          if (archive) {
+            setArchivedSessions((prev) => [...affectedSessions, ...prev]);
+          } else {
+            setActiveSessions((prev) =>
+              affectedSessions.reduce((next, session) => upsertSession(next, session), prev)
+            );
           }
+        } else if (showArchived) {
+          void loadArchivedSessions();
         } else {
-          const source = archivedSessions.find((s) => s.session_id === sessionId);
-          if (source) {
-            setActiveSessions((prev) => upsertSession(prev, { ...source, archived: false }));
-          }
-          setArchivedSessions((prev) => prev.filter((s) => s.session_id !== sessionId));
+          void loadActiveSessions();
         }
 
-        showSuccess(archive ? 'Session archived' : 'Session unarchived');
+        showSuccess(
+          archive ? 'Session and child sessions archived' : 'Session and child sessions unarchived'
+        );
       } catch (err) {
         showError(err instanceof Error ? err.message : 'Failed to update session');
       } finally {
@@ -200,15 +215,7 @@ const SessionsTabInner: React.FC<SessionsTabProps> = ({
         });
       }
     },
-    [
-      activeSessions,
-      archivedSessions,
-      loadArchivedSessions,
-      showArchived,
-      showSuccess,
-      showError,
-      upsertSession,
-    ]
+    [loadActiveSessions, loadArchivedSessions, showArchived, showSuccess, showError, upsertSession]
   );
 
   const combinedSessions = useMemo(() => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -857,7 +857,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       onOk: async () => {
         const archived = await archiveSession(session.session_id);
         if (archived) {
-          showSuccess('Session archived');
+          showSuccess('Session and child sessions archived');
           onClose();
         } else {
           showError('Failed to archive session');

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -850,8 +850,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
 
     modal.confirm({
-      title: 'Archive session?',
-      content: 'Are you sure you want to archive this session?',
+      title: 'Archive session and child sessions?',
+      content: 'Are you sure you want to archive this session and its child sessions?',
       okText: 'Archive',
       cancelText: 'Cancel',
       onOk: async () => {

--- a/apps/agor-ui/src/hooks/useSessionActions.test.tsx
+++ b/apps/agor-ui/src/hooks/useSessionActions.test.tsx
@@ -1,0 +1,56 @@
+import type { AgorClient, Session } from '@agor-live/client';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useSessionActions } from './useSessionActions';
+
+function makeClient(services: Record<string, unknown>): AgorClient {
+  return {
+    service: vi.fn((name: string) => {
+      const service = services[name];
+      if (!service) throw new Error(`Unexpected service: ${name}`);
+      return service;
+    }),
+  } as unknown as AgorClient;
+}
+
+describe('useSessionActions archive helpers', () => {
+  it('archives through the cascade archive route instead of generic sessions.patch', async () => {
+    const archivedSession = { session_id: 'session-1', archived: true } as Session;
+    const archiveCreate = vi.fn(async () => ({ session: archivedSession }));
+    const sessionsPatch = vi.fn();
+    const client = makeClient({
+      'sessions/session-1/archive': { create: archiveCreate },
+      sessions: { patch: sessionsPatch },
+    });
+
+    const { result } = renderHook(() => useSessionActions(client));
+    let returned: Session | null = null;
+    await act(async () => {
+      returned = await result.current.archiveSession('session-1' as Session['session_id']);
+    });
+
+    expect(returned).toBe(archivedSession);
+    expect(archiveCreate).toHaveBeenCalledWith({});
+    expect(sessionsPatch).not.toHaveBeenCalled();
+  });
+
+  it('unarchives through the cascade unarchive route instead of generic sessions.patch', async () => {
+    const unarchivedSession = { session_id: 'session-1', archived: false } as Session;
+    const unarchiveCreate = vi.fn(async () => ({ session: unarchivedSession }));
+    const sessionsPatch = vi.fn();
+    const client = makeClient({
+      'sessions/session-1/unarchive': { create: unarchiveCreate },
+      sessions: { patch: sessionsPatch },
+    });
+
+    const { result } = renderHook(() => useSessionActions(client));
+    let returned: Session | null = null;
+    await act(async () => {
+      returned = await result.current.unarchiveSession('session-1' as Session['session_id']);
+    });
+
+    expect(returned).toBe(unarchivedSession);
+    expect(unarchiveCreate).toHaveBeenCalledWith({});
+    expect(sessionsPatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -261,17 +261,43 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
   };
 
   const archiveSession = async (sessionId: SessionID): Promise<Session | null> => {
-    return updateSession(sessionId, {
-      archived: true,
-      archived_reason: 'manual',
-    } as Partial<Session>);
+    if (!client) {
+      setError('Client not connected');
+      return null;
+    }
+
+    try {
+      setError(null);
+      const result = (await client.service(`sessions/${sessionId}/archive`).create({})) as {
+        session: Session;
+      };
+      return result.session;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to archive session';
+      setError(message);
+      console.error('Failed to archive session:', err);
+      return null;
+    }
   };
 
   const unarchiveSession = async (sessionId: SessionID): Promise<Session | null> => {
-    return updateSession(sessionId, {
-      archived: false,
-      archived_reason: undefined,
-    } as Partial<Session>);
+    if (!client) {
+      setError('Client not connected');
+      return null;
+    }
+
+    try {
+      setError(null);
+      const result = (await client.service(`sessions/${sessionId}/unarchive`).create({})) as {
+        session: Session;
+      };
+      return result.session;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to unarchive session';
+      setError(message);
+      console.error('Failed to unarchive session:', err);
+      return null;
+    }
   };
 
   return {

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -697,6 +697,9 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         // object spread, so it intentionally does not carry non-enumerable
         // properties from rowToSession(currentRow).
         merged.last_updated = insertData.updated_at.toISOString();
+        if (insertData.archived_reason === null) {
+          merged.archived_reason = undefined;
+        }
         return attachHiddenTenant(merged, currentRow);
       });
 

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -538,18 +538,11 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       const fullId = await this.resolveId(sessionId);
       const baseUrl = await getBaseUrl();
 
-      // Query sessions where parent_session_id or forked_from_session_id matches
-      // Use database-agnostic JSON extraction helper
-      const { jsonExtract } = await import('../database-wrapper');
-
       const results = await select(this.db)
         .from(sessions)
         .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
         .where(
-          or(
-            sql`${jsonExtract(this.db, sessions.data, 'genealogy.parent_session_id')} = ${fullId}`,
-            sql`${jsonExtract(this.db, sessions.data, 'genealogy.forked_from_session_id')} = ${fullId}`
-          )
+          or(eq(sessions.parent_session_id, fullId), eq(sessions.forked_from_session_id, fullId))
         )
         .all();
 
@@ -567,6 +560,64 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
     } catch (error) {
       throw new RepositoryError(
         `Failed to find child sessions: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Find all branch-local descendants for a session with one branch-scoped read.
+   *
+   * Archive cascades can touch large trees; building the descendant set in
+   * memory avoids one child lookup per visited node and relies on the
+   * materialized genealogy columns rather than JSON extraction.
+   */
+  async findBranchLocalDescendants(sessionId: string, branchId: BranchID): Promise<Session[]> {
+    try {
+      const fullId = await this.resolveId(sessionId);
+      const baseUrl = await getBaseUrl();
+      const results = await select(this.db)
+        .from(sessions)
+        .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
+        .where(eq(sessions.branch_id, branchId))
+        .all();
+
+      const sessionById = new Map<string, Session>();
+      const childrenByParent = new Map<string, Session[]>();
+      for (const result of results as Array<{
+        sessions: SessionRow;
+        branches?: { board_id?: string } | null;
+      }>) {
+        const boardId = (result.branches?.board_id ?? null) as UUID | null;
+        const session = this.rowToSession(result.sessions, boardId, baseUrl);
+        sessionById.set(session.session_id, session);
+
+        const parentIds = [
+          session.genealogy?.parent_session_id,
+          session.genealogy?.forked_from_session_id,
+        ].filter((id): id is SessionID => typeof id === 'string' && id.length > 0);
+        for (const parentId of parentIds) {
+          const siblings = childrenByParent.get(parentId) ?? [];
+          siblings.push(session);
+          childrenByParent.set(parentId, siblings);
+        }
+      }
+
+      const descendants: Session[] = [];
+      const visited = new Set<string>([fullId]);
+      const queue = [...(childrenByParent.get(fullId) ?? [])];
+      while (queue.length > 0) {
+        const child = queue.shift();
+        if (!child || visited.has(child.session_id)) continue;
+        visited.add(child.session_id);
+        descendants.push(child);
+        queue.push(...(childrenByParent.get(child.session_id) ?? []));
+      }
+
+      return descendants.filter((session) => sessionById.has(session.session_id));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find branch-local descendants: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }
@@ -709,6 +760,70 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       if (error instanceof EntityNotFoundError) throw error;
       throw new RepositoryError(
         `Failed to update session: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Atomically update archive state for a known set of sessions.
+   *
+   * This is used by manual archive/unarchive cascades so either the whole
+   * branch-local tree flips state or none of it does.
+   */
+  async updateArchiveStateForIds(
+    ids: string[],
+    archived: boolean,
+    archivedReason: Session['archived_reason'] | null
+  ): Promise<Session[]> {
+    if (ids.length === 0) return [];
+
+    try {
+      const fullIds = await Promise.all(ids.map((id) => this.resolveId(id)));
+      const baseUrl = await getBaseUrl();
+      const now = new Date();
+      const result = await this.db.transaction(async (tx) => {
+        await update(txAsDb(tx), sessions)
+          .set({
+            archived,
+            archived_reason: archivedReason,
+            updated_at: now,
+          })
+          .where(inArray(sessions.session_id, fullIds))
+          .run();
+
+        const rows = await select(txAsDb(tx))
+          .from(sessions)
+          .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
+          .where(inArray(sessions.session_id, fullIds))
+          .all();
+
+        if (rows.length !== fullIds.length) {
+          throw new EntityNotFoundError('Session', ids[0]);
+        }
+
+        const byId = new Map<string, Session>();
+        for (const row of rows as Array<{
+          sessions: SessionRow;
+          branches?: { board_id?: string } | null;
+        }>) {
+          const boardId = (row.branches?.board_id ?? null) as UUID | null;
+          byId.set(row.sessions.session_id, this.rowToSession(row.sessions, boardId, baseUrl));
+        }
+
+        return fullIds.map((id) => {
+          const session = byId.get(id);
+          if (!session) throw new EntityNotFoundError('Session', id);
+          return session;
+        });
+      });
+
+      return result;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      if (error instanceof EntityNotFoundError) throw error;
+      throw new RepositoryError(
+        `Failed to update session archive state: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -39,6 +39,14 @@ export interface SessionWithLastMessage extends Session {
   last_message?: string;
 }
 
+type SessionArchiveReason = NonNullable<Session['archived_reason']>;
+
+export type SessionArchiveStateUpdate = {
+  id: string;
+  archived: boolean;
+  archivedReason: SessionArchiveReason | null;
+};
+
 /**
  * Patches that only acknowledge UI attention state should not make a session
  * look recently active. Keep this intentionally value-aware: setting
@@ -774,23 +782,59 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   async updateArchiveStateForIds(
     ids: string[],
     archived: boolean,
-    archivedReason: Session['archived_reason'] | null
+    archivedReason: SessionArchiveReason | null
   ): Promise<Session[]> {
-    if (ids.length === 0) return [];
+    return this.updateArchiveStateForTargets(
+      ids.map((id) => ({
+        id,
+        archived,
+        archivedReason,
+      }))
+    );
+  }
+
+  /**
+   * Atomically update archive state for known sessions that may need distinct
+   * archive reasons.
+   */
+  async updateArchiveStateForTargets(targets: SessionArchiveStateUpdate[]): Promise<Session[]> {
+    if (targets.length === 0) return [];
 
     try {
+      const ids = targets.map((target) => target.id);
       const fullIds = await Promise.all(ids.map((id) => this.resolveId(id)));
+      const updates = targets.map((target, index) => ({
+        ...target,
+        id: fullIds[index],
+      }));
       const baseUrl = await getBaseUrl();
       const now = new Date();
       const result = await this.db.transaction(async (tx) => {
-        await update(txAsDb(tx), sessions)
-          .set({
-            archived,
-            archived_reason: archivedReason,
-            updated_at: now,
-          })
-          .where(inArray(sessions.session_id, fullIds))
-          .run();
+        const groups = new Map<string, SessionArchiveStateUpdate[]>();
+        for (const updateTarget of updates) {
+          const key = `${updateTarget.archived}:${updateTarget.archivedReason ?? ''}`;
+          const group = groups.get(key) ?? [];
+          group.push(updateTarget);
+          groups.set(key, group);
+        }
+
+        for (const group of groups.values()) {
+          const [first] = group;
+          if (!first) continue;
+          await update(txAsDb(tx), sessions)
+            .set({
+              archived: first.archived,
+              archived_reason: first.archivedReason,
+              updated_at: now,
+            })
+            .where(
+              inArray(
+                sessions.session_id,
+                group.map((target) => target.id)
+              )
+            )
+            .run();
+        }
 
         const rows = await select(txAsDb(tx))
           .from(sessions)

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -121,7 +121,7 @@ export const sessions = pgTable(
     // Archive state (cascaded from branch archive)
     archived: t.bool('archived').notNull().default(false),
     archived_reason: text('archived_reason', {
-      enum: ['branch_archived', 'manual', 'btw_completed'],
+      enum: ['branch_archived', 'manual', 'parent_archived', 'btw_completed'],
     }),
 
     // JSON blob for everything else (cross-DB via json() type)

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -108,7 +108,7 @@ export const sessions = sqliteTable(
     // Archive state (cascaded from branch archive)
     archived: t.bool('archived').notNull().default(false),
     archived_reason: text('archived_reason', {
-      enum: ['branch_archived', 'manual', 'btw_completed'],
+      enum: ['branch_archived', 'manual', 'parent_archived', 'btw_completed'],
     }),
 
     // JSON blob for everything else (cross-DB via json() type)

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -478,9 +478,10 @@ export interface Session {
    *
    * - 'branch_archived': Cascaded from parent branch being archived
    * - 'manual': User manually archived this session
+   * - 'parent_archived': Cascaded from parent session being manually archived
    * - 'btw_completed': Ephemeral btw fork auto-archived after task completion
    */
-  archived_reason?: 'branch_archived' | 'manual' | 'btw_completed';
+  archived_reason?: 'branch_archived' | 'manual' | 'parent_archived' | 'btw_completed';
 
   /**
    * Durable non-genealogy relationships involving this session.


### PR DESCRIPTION
## Linked issue

Fixes #1747
Related: #1839

## Summary

- Add archive-specific session tree operations that cascade archive/unarchive to branch-local spawned/forked descendants.
- Add `POST /sessions/:id/archive` and `POST /sessions/:id/unarchive` route services and route UI archive actions through them.
- Reuse the shared operation from MCP archive/unarchive and add cascade/RBAC regression coverage.

## Why / context

Archiving a parent session from UI paths previously patched only the selected session. Child sessions stayed active because the UI used generic `sessions.patch({ archived })`, while genealogy-aware behavior existed only in some specialized paths. This left child sessions effectively orphaned in active views.

## Implementation notes

- Cascade follows existing branch-local genealogy (`parent_session_id` and `forked_from_session_id`) and does not include `remote_relationships`.
- Generic `sessions.patch`, bulk archive, branch archive, and cleanup semantics remain unchanged.
- External archive/unarchive calls preflight the full cascade target set against branch RBAC before mutating any session, preventing partial parent-only changes.
- UI confirmation copy now mentions child sessions.

## Validation / test plan

- [x] `pnpm --filter @agor/daemon test -- src/services/sessions.archive.test.ts`
- [x] `pnpm --filter @agor/daemon test -- src/mcp/tools/sessions.test.ts`
- [x] `pnpm --filter agor-ui test -- src/hooks/useSessionActions.test.tsx`
- [x] `pnpm exec biome check <touched files>`
- [x] `git diff --check`
- [x] Live REST smoke on branch daemon: create parent + child, archive parent through `POST /sessions/:id/archive`, verify both archived, unarchive parent through `POST /sessions/:id/unarchive`, verify both unarchived.

## Screenshots / demos

Not applicable; behavior is route/action wiring with existing UI surfaces.

## Risks / rollout / rollback

Risk is limited to archive-specific REST/UI/MCP paths. Rollback is reverting this PR, which restores direct parent-only archive behavior. No schema migration or data backfill is included.

## Out of scope / follow-ups

- Managed branch environment start command issue is tracked separately in #1839.
- No full browser-click UI smoke was performed; live REST route behavior and UI hook routing are covered.
