### PR TITLE
fix(env): avoid UID GID shell assignments

### DIFF
--- a/.agor.yml
+++ b/.agor.yml
@@ -22,7 +22,7 @@ environment:
       app: http://{{host.ip_address}}:{{add 7000 branch.unique_id}}
     full:
       start: >-
-        UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
+        env UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
         branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true AGOR_RBAC_ENABLED=true AGOR_UNIX_USER_MODE=strict docker compose -f
         docker-compose.yml -f docker-compose.postgres.yml -p agor-{{branch.name}}
         --profile postgres up -d --build postgres agor-dev
@@ -42,7 +42,7 @@ environment:
         agor-{{branch.name}} --profile postgres logs --tail=100
     sqlite:
       start: >-
-        UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
+        env UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
         branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true docker compose -p agor-{{branch.name}} up -d --build
       stop: docker compose -p agor-{{branch.name}} down
       description: Single-user dev with SQLite. No RBAC. Fastest to boot.
@@ -52,7 +52,7 @@ environment:
       app: http://{{host.ip_address}}:{{add 5000 branch.unique_id}}
     postgres:
       start: >-
-        UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
+        env UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
         branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true docker compose -f docker-compose.yml -f
         docker-compose.override.postgres.yml -p agor-{{branch.name}} --profile postgres up -d
         --build postgres agor-dev
@@ -69,7 +69,7 @@ environment:
         agor-{{branch.name}} --profile postgres logs --tail=100
     sqlite-demo:
       start: >-
-        UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
+        env UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
         branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true LOAD_FIXTURES=true docker compose -p agor-{{branch.name}} up -d --build
       description: >-
         SQLite dev + demo fixtures (SEED + LOAD_FIXTURES): boots a populated demo board with 4
@@ -78,7 +78,7 @@ environment:
       extends: sqlite
     postgres-demo:
       start: >-
-        UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
+        env UID=$(id -u) GID=$(stat -c %g . 2>/dev/null || id -g) INSTANCE_LABEL={{branch.name}} DAEMON_PORT={{add 3000 branch.unique_id}} UI_PORT={{add 5000
         branch.unique_id}} AGOR_BASE_URL=http://{{host.ip_address}}:{{add 5000 branch.unique_id}} VITE_DAEMON_URL=http://{{host.ip_address}}:{{add 3000 branch.unique_id}} SEED=true LOAD_FIXTURES=true docker compose -f docker-compose.yml -f
         docker-compose.override.postgres.yml -p agor-{{branch.name}} --profile postgres up -d
         --build postgres agor-dev

--- a/packages/core/src/config/agor-yml.test.ts
+++ b/packages/core/src/config/agor-yml.test.ts
@@ -268,6 +268,30 @@ describe('parseAgorYml — misc', () => {
 });
 
 describe('parseAgorYml — repo .agor.yml demo variants', () => {
+  it('uses env(1) for UID/GID on Docker variants instead of shell assignments', () => {
+    const env = parseAgorYml(REPO_ROOT_AGOR_YML);
+    expect(env).not.toBeNull();
+
+    const uidGidVariants = Object.entries(env!.variants)
+      .filter(([, variant]) => {
+        const start = variant.start;
+        return start !== undefined && (start.includes('UID=') || start.includes('GID='));
+      })
+      .map(([name]) => name)
+      .sort();
+
+    expect(uidGidVariants).toEqual(['full', 'postgres', 'postgres-demo', 'sqlite', 'sqlite-demo']);
+
+    for (const name of uidGidVariants) {
+      const start = env!.variants[name].start;
+      if (start === undefined) {
+        throw new Error(`${name}.start is missing`);
+      }
+      expect(start, `${name}.start`).toMatch(/^env UID=\$\(id -u\) GID=/);
+      expect(start, `${name}.start`).not.toMatch(/^UID=/);
+    }
+  });
+
   it('resolves sqlite-demo / postgres-demo with LOAD_FIXTURES and required start/stop', () => {
     const env = parseAgorYml(REPO_ROOT_AGOR_YML);
     expect(env).not.toBeNull();

--- a/packages/core/src/unix/environment-command-deny-list.test.ts
+++ b/packages/core/src/unix/environment-command-deny-list.test.ts
@@ -113,7 +113,7 @@ describe('assertEnvCommandAllowed', () => {
   describe('realistic legitimate commands', () => {
     it.each([
       'docker compose up -d --build',
-      'SEED=true UID=$(id -u) docker compose -p agor up -d',
+      'env UID=$(id -u) SEED=true docker compose -p agor up -d',
       'docker compose down -v',
       'docker compose logs --tail=100',
       'pnpm --filter @agor/core test',

--- a/packages/core/src/unix/environment-command-spawn.ts
+++ b/packages/core/src/unix/environment-command-spawn.ts
@@ -197,7 +197,7 @@ export async function spawnEnvironmentCommand(
   // Build spawn args with impersonation.
   //
   // `shell: true` is critical here: env commands are user-authored shell
-  // strings (e.g. `SEED=true UID=$(id -u) docker compose up -d --build`)
+  // strings (e.g. `env UID=$(id -u) SEED=true docker compose up -d --build`)
   // that need shell parsing — env-var prefixes, `$(...)` subshells, argument
   // word-splitting, etc. Without this, the impersonated + secret-file path
   // emits `exec "$@"` which treats the whole string as a single program

--- a/packages/core/src/unix/run-as-user.test.ts
+++ b/packages/core/src/unix/run-as-user.test.ts
@@ -232,7 +232,7 @@ describe('run-as-user', () => {
       // shell string (e.g. `SEED=true docker compose up -d`) as a single
       // program name and failed with `exec: <whole string>: not found`.
       const ENV_COMMAND =
-        'SEED=true UID=$(id -u) GID=$(id -g) docker compose -p agor-x up -d --build';
+        'env UID=$(id -u) GID=$(id -g) SEED=true docker compose -p agor-x up -d --build';
 
       it('uses `exec bash -c "$2"` to shell-interpret the command (with envFilePath)', () => {
         const result = buildSpawnArgs(ENV_COMMAND, [], {


### PR DESCRIPTION
## Linked issue

Fixes #1839

## Summary

- Change Agor environment start command templates to pass `UID`/`GID` through `env` instead of shell assignments.
- Cover all affected Docker variants in `.agor.yml`: `full`, `sqlite`, `postgres`, `sqlite-demo`, and `postgres-demo`.
- Add focused regression coverage and update nearby unix command examples/comments to the safe shape.

## Why / context

Agor-managed branch env start commands could render as `UID=$(id -u) GID=... docker compose ...`. On shells where `UID` or `GID` are special/read-only variables, the command fails before Docker Compose starts, leaving the environment stuck in `starting` with no containers or compose logs.

Using `env UID=... GID=... docker compose ...` preserves the variables passed to Docker Compose without assigning shell special variables.

## Implementation notes

This is the narrow template fix only. It does not change Docker Compose services, ports, environment runner behavior, stop/nuke/logs commands, or command execution plumbing.

## Validation / test plan

- [x] Confirmed old shell assignment form fails in zsh/bash.
- [x] Confirmed new `env UID=... GID=...` no-op form succeeds in zsh/bash.
- [x] Rendered all five affected variants and replaced `docker compose` with `/usr/bin/true`; all parsed/exited successfully under zsh and bash.
- [x] `pnpm --filter @agor/core test -- agor-yml.test.ts run-as-user.test.ts environment-command-deny-list.test.ts`
- [x] `pnpm exec biome check <changed files>`
- [x] `git diff --check`

## Screenshots / demos

Not applicable; shell command/template fix.

## Risks / rollout / rollback

Risk is low and limited to environment start command templates. Rollback is reverting this PR, which restores the previous shell assignment form.

## Out of scope / follow-ups

This PR does not change environment state handling when a start command exits before containers are created. Surfacing that failure as `failed` with stderr can be handled separately if needed.
