### PR TITLE
feat(gateway): ingest inbound Slack image attachments

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -1063,6 +1063,7 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
     groupDms: false,
     alignUsers: false,
     outbound: false,
+    ingestFiles: false,
   };
 
   it('marks the manifest generator read-only', async () => {
@@ -1091,6 +1092,7 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
         enable_mpim: false,
         align_slack_users: false,
         outbound_enabled: false,
+        ingest_files: false,
       },
     });
     expect(Array.isArray(payload.setup_steps)).toBe(true);
@@ -1173,6 +1175,7 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
       groupDms: true,
       alignUsers: true,
       outbound: true,
+      ingestFiles: true,
     };
     const tools = await captureTools('admin');
     const result = await tools.agor_gateway_slack_manifest_generate.handler({
@@ -1192,8 +1195,10 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
       enable_mpim: true,
       align_slack_users: true,
       outbound_enabled: true,
+      ingest_files: true,
       allowed_channel_ids: ['C123', 'C456'],
     });
+    expect(payload.bot_scopes).toEqual(expect.arrayContaining(['files:read']));
     expect(payload.caveats).toEqual(
       expect.arrayContaining([
         expect.stringContaining('restrictToChannelIds maps to config.allowed_channel_ids'),

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -625,6 +625,12 @@ const slackManifestGenerateSchema = z.strictObject({
     .boolean()
     .default(false)
     .describe('Proactive outbound: post to channels by name and DM users by email.'),
+  ingestFiles: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Ingest images attached to inbound messages (adds the files:read scope). The gateway downloads them server-side and hands the stored paths to the session agent.'
+    ),
   restrictToChannelIds: z
     .array(z.string().min(1))
     .optional()
@@ -644,6 +650,7 @@ function toSlackWizardOptions(
     groupDms: args.groupDms,
     alignUsers: args.alignUsers,
     outbound: args.outbound,
+    ingestFiles: args.ingestFiles,
   };
 }
 
@@ -661,6 +668,7 @@ function toCreateChannelConfigHint(args: z.infer<typeof slackManifestGenerateSch
     enable_mpim: args.groupDms,
     align_slack_users: args.alignUsers,
     outbound_enabled: args.outbound,
+    ingest_files: args.ingestFiles,
   };
   if (args.restrictToChannelIds && args.restrictToChannelIds.length > 0) {
     config.allowed_channel_ids = args.restrictToChannelIds;

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -9,6 +9,7 @@ import { getConnector } from '@agor/core/gateway';
 import type { GatewayChannel, SessionID, ThreadSessionMap, User, UserID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ingestInboundImageAttachments } from '../utils/gateway-attachments.js';
 import { GatewayService, tenantIdFromGatewayChannel } from './gateway.js';
 
 vi.mock('@agor/core/gateway', async (importOriginal) => {
@@ -16,6 +17,14 @@ vi.mock('@agor/core/gateway', async (importOriginal) => {
   return {
     ...actual,
     getConnector: vi.fn(),
+  };
+});
+
+vi.mock('../utils/gateway-attachments.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/gateway-attachments.js')>();
+  return {
+    ...actual,
+    ingestInboundImageAttachments: vi.fn(),
   };
 });
 
@@ -138,6 +147,7 @@ function makeGatewayHarness(args: {
 
 afterEach(() => {
   vi.mocked(getConnector).mockReset();
+  vi.mocked(ingestInboundImageAttachments).mockReset();
 });
 
 describe('gateway tenant metadata helpers', () => {
@@ -792,5 +802,125 @@ describe('GatewayService outbound emit session branch binding', () => {
     );
     expect(branchRepo.resolveUserPermission).toHaveBeenCalled();
     expect(sendSlackMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('GatewayService Slack attachment ingestion', () => {
+  const ingestChannel = {
+    ...slackChannel,
+    config: { bot_token: 'xoxb-test', ingest_files: true },
+  } as GatewayChannel;
+
+  const inboundFiles = [
+    {
+      id: 'F123',
+      name: 'screenshot.png',
+      mimetype: 'image/png',
+      size: 2048,
+      url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/screenshot.png',
+    },
+  ];
+
+  const dmMetadata = {
+    channel: 'D123',
+    channel_type: 'im',
+    slack_message_ts: '103.000000',
+  };
+
+  it('downloads image attachments and folds the stored paths into the prompt', async () => {
+    vi.mocked(ingestInboundImageAttachments).mockResolvedValue({
+      paths: ['/home/agor/.agor/uploads/screenshot_1.png'],
+      failed: 0,
+    });
+    const { service, promptCreate } = makeGatewayHarness({
+      channel: ingestChannel,
+      existingMapping: makeMapping({ thread_id: 'D123-100.000000' }),
+      connector: {},
+    });
+
+    const result = await service.create({
+      channel_key: 'slack-key',
+      thread_id: 'D123-100.000000',
+      text: 'what does this screenshot show?',
+      files: inboundFiles,
+      metadata: dmMetadata,
+    });
+
+    expect(result).toMatchObject({ success: true, sessionId: 'sess-1' });
+    expect(ingestInboundImageAttachments).toHaveBeenCalledWith({
+      files: inboundFiles,
+      botToken: 'xoxb-test',
+    });
+    const prompt = promptCreate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain('Attached files:\n- /home/agor/.agor/uploads/screenshot_1.png');
+    expect(prompt).toContain('what does this screenshot show?');
+    expect(prompt).not.toContain('an attachment could not be fetched');
+  });
+
+  it('never attempts downloads when the channel does not enable ingest_files', async () => {
+    const { service, promptCreate } = makeGatewayHarness({
+      existingMapping: makeMapping({ thread_id: 'D123-100.000000' }),
+      connector: {},
+    });
+
+    await service.create({
+      channel_key: 'slack-key',
+      thread_id: 'D123-100.000000',
+      text: 'what does this screenshot show?',
+      files: inboundFiles,
+      metadata: dmMetadata,
+    });
+
+    expect(ingestInboundImageAttachments).not.toHaveBeenCalled();
+    const prompt = promptCreate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain('what does this screenshot show?');
+    expect(prompt).not.toContain('Attached files:');
+  });
+
+  it('delivers the prompt with a degradation note when downloads fail', async () => {
+    vi.mocked(ingestInboundImageAttachments).mockResolvedValue({ paths: [], failed: 1 });
+    const { service, promptCreate } = makeGatewayHarness({
+      channel: ingestChannel,
+      existingMapping: makeMapping({ thread_id: 'D123-100.000000' }),
+      connector: {},
+    });
+
+    const result = await service.create({
+      channel_key: 'slack-key',
+      thread_id: 'D123-100.000000',
+      text: 'what does this screenshot show?',
+      files: inboundFiles,
+      metadata: dmMetadata,
+    });
+
+    expect(result).toMatchObject({ success: true, sessionId: 'sess-1' });
+    const prompt = promptCreate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain('what does this screenshot show?');
+    expect(prompt).toContain('(an attachment could not be fetched)');
+    expect(prompt).not.toContain('Attached files:');
+  });
+
+  it('folds successful paths and appends the note when only some downloads fail', async () => {
+    vi.mocked(ingestInboundImageAttachments).mockResolvedValue({
+      paths: ['/home/agor/.agor/uploads/ok_1.png'],
+      failed: 1,
+    });
+    const { service, promptCreate } = makeGatewayHarness({
+      channel: ingestChannel,
+      existingMapping: makeMapping({ thread_id: 'D123-100.000000' }),
+      connector: {},
+    });
+
+    await service.create({
+      channel_key: 'slack-key',
+      thread_id: 'D123-100.000000',
+      text: 'compare these',
+      files: inboundFiles,
+      metadata: dmMetadata,
+    });
+
+    const prompt = promptCreate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain('Attached files:\n- /home/agor/.agor/uploads/ok_1.png');
+    expect(prompt).toContain('(an attachment could not be fetched)');
   });
 });

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -27,6 +27,7 @@ import type { Application } from '@agor/core/feathers';
 import type {
   GatewayConnector,
   GatewayContext,
+  InboundFile,
   InboundMessage,
   SlackThreadHistoryRequest,
   SlackThreadHistoryResult,
@@ -62,6 +63,10 @@ import type {
 import { hasMinimumRole, ROLES, SessionStatus } from '@agor/core/types';
 import { getSessionUrl } from '@agor/core/utils/url';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
+import {
+  buildPromptWithAttachments,
+  ingestInboundImageAttachments,
+} from '../utils/gateway-attachments.js';
 import { deferWithTenantDatabaseScope } from '../utils/tenant-db-scope.js';
 
 /**
@@ -72,6 +77,7 @@ interface PostMessageData {
   thread_id: string;
   text: string;
   user_name?: string;
+  files?: InboundFile[];
   metadata?: Record<string, unknown>;
 }
 
@@ -2187,6 +2193,43 @@ export class GatewayService {
         promptText = buildGitHubInitialPrompt(data.thread_id, data.text, data.metadata);
       }
 
+      // Download Slack image attachments server-side and fold their stored
+      // paths into the prompt so the agent can Read them. Gated on the
+      // channel's ingest_files flag — channels without the files:read scope
+      // never attempt downloads. Any failure degrades to a short note; the
+      // prompt is always delivered.
+      if (
+        channel.channel_type === 'slack' &&
+        channelConfig.ingest_files === true &&
+        data.files &&
+        data.files.length > 0
+      ) {
+        const botToken =
+          typeof channelConfig.bot_token === 'string' ? channelConfig.bot_token : undefined;
+        let failedAttachments = 0;
+        if (botToken) {
+          const { paths, failed } = await ingestInboundImageAttachments({
+            files: data.files,
+            botToken,
+          });
+          failedAttachments = failed;
+          if (paths.length > 0) {
+            promptText = buildPromptWithAttachments(promptText, paths);
+            console.log(
+              `[gateway] Ingested ${paths.length} Slack attachment(s) for session ${shortId(sessionId)}`
+            );
+          }
+        } else {
+          failedAttachments = data.files.length;
+          console.warn(
+            `[gateway] Cannot ingest Slack attachments for channel ${shortId(channel.id)}: no bot_token in config`
+          );
+        }
+        if (failedAttachments > 0) {
+          promptText = `${promptText}\n\n(an attachment could not be fetched)`;
+        }
+      }
+
       // Prepend gateway context block so the agent knows the message source.
       // Applied to ALL messages (initial + follow-up) since each message may
       // come from a different user in a shared channel.
@@ -2616,6 +2659,7 @@ export class GatewayService {
         thread_id: msg.threadId,
         text: msg.text,
         user_name: msg.userId,
+        ...(msg.files ? { files: msg.files } : {}),
         metadata: msg.metadata,
       });
     });

--- a/apps/agor-daemon/src/utils/gateway-attachments.test.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.test.ts
@@ -108,7 +108,7 @@ describe('ingestInboundImageAttachments', () => {
 
     expect(fetchImpl).toHaveBeenCalledWith(
       'https://files.slack.com/files-pri/T1-F123/download/screenshot.png',
-      { headers: { Authorization: 'Bearer xoxb-test' } }
+      { headers: { Authorization: 'Bearer xoxb-test' }, redirect: 'manual' }
     );
     expect(result.failed).toBe(0);
     expect(result.paths).toHaveLength(1);
@@ -160,6 +160,93 @@ describe('ingestInboundImageAttachments', () => {
 
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(result).toEqual({ paths: [], failed: 1 });
+  });
+
+  it('rejects redirects to non-allowlisted hosts and never sends the token there', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://attacker.example/exfil.png' },
+        })
+    );
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile()],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result).toEqual({ paths: [], failed: 1 });
+    // The Authorization header must only ever reach allowlisted slack.com
+    // hosts: the redirect target is validated BEFORE any fetch to it.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    for (const [calledUrl] of fetchImpl.mock.calls) {
+      expect(isAllowedSlackFileUrl(calledUrl as string)).toBe(true);
+    }
+  });
+
+  it('follows redirects between allowlisted Slack hosts with the token', async () => {
+    const bytes = new Uint8Array([137, 80, 78, 71]);
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://files.slack.com/files-pri/T1-F123/other/screenshot.png' },
+        })
+      )
+      .mockResolvedValueOnce(makeImageResponse(bytes));
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile()],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result.failed).toBe(0);
+    expect(result.paths).toHaveLength(1);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://files.slack.com/files-pri/T1-F123/other/screenshot.png',
+      { headers: { Authorization: 'Bearer xoxb-test' }, redirect: 'manual' }
+    );
+  });
+
+  it('aborts oversized streaming bodies without a trustworthy Content-Length', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const chunkSize = 1024 * 1024;
+    let chunksPulled = 0;
+    // Endless image stream with no Content-Length: if the implementation
+    // buffered before checking, this test would never terminate.
+    const endlessBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        chunksPulled++;
+        controller.enqueue(new Uint8Array(chunkSize));
+      },
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(endlessBody, {
+          status: 200,
+          headers: { 'content-type': 'image/png' },
+        })
+    );
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile()],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result).toEqual({ paths: [], failed: 1 });
+    // Reading stopped as soon as the running total crossed the 50MB ceiling.
+    expect(chunksPulled).toBeLessThanOrEqual(MAX_UPLOAD_FILE_SIZE / chunkSize + 2);
+    expect(await fs.readdir(uploadDir)).toEqual([]);
   });
 
   it('rejects non-image response bodies (Slack HTML error pages)', async () => {

--- a/apps/agor-daemon/src/utils/gateway-attachments.test.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.test.ts
@@ -113,7 +113,7 @@ describe('ingestInboundImageAttachments', () => {
     expect(result.failed).toBe(0);
     expect(result.paths).toHaveLength(1);
     expect(result.paths[0].startsWith(uploadDir)).toBe(true);
-    expect(path.basename(result.paths[0])).toMatch(/^screenshot_\d+\.png$/);
+    expect(path.basename(result.paths[0])).toMatch(/^F123_screenshot_\d+\.png$/);
     expect(new Uint8Array(await fs.readFile(result.paths[0]))).toEqual(bytes);
   });
 
@@ -249,6 +249,43 @@ describe('ingestInboundImageAttachments', () => {
     expect(await fs.readdir(uploadDir)).toEqual([]);
   });
 
+  it('rejects image/svg+xml response bodies (excluded from the upload allowlist)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<svg onload="alert(1)"/>', {
+          status: 200,
+          headers: { 'content-type': 'image/svg+xml' },
+        })
+    );
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile()],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result).toEqual({ paths: [], failed: 1 });
+    expect(await fs.readdir(uploadDir)).toEqual([]);
+  });
+
+  it('stores same-named files with distinct Slack IDs at distinct paths', async () => {
+    const fetchImpl = vi.fn(async () => makeImageResponse(new Uint8Array([1])));
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile({ id: 'F1', name: 'image.png' }), makeFile({ id: 'F2', name: 'image.png' })],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result.failed).toBe(0);
+    expect(result.paths).toHaveLength(2);
+    expect(result.paths[0]).not.toBe(result.paths[1]);
+    expect(await fs.readdir(uploadDir)).toHaveLength(2);
+  });
+
   it('rejects non-image response bodies (Slack HTML error pages)', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const fetchImpl = vi.fn(
@@ -289,7 +326,7 @@ describe('ingestInboundImageAttachments', () => {
 
     expect(result.failed).toBe(1);
     expect(result.paths).toHaveLength(1);
-    expect(path.basename(result.paths[0])).toMatch(/^second_\d+\.png$/);
+    expect(path.basename(result.paths[0])).toMatch(/^F2_second_\d+\.png$/);
   });
 
   it('counts images beyond the per-message cap as failed without fetching them', async () => {

--- a/apps/agor-daemon/src/utils/gateway-attachments.test.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.test.ts
@@ -1,0 +1,227 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { InboundFile } from '@agor/core/gateway';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildPromptWithAttachments,
+  ingestInboundImageAttachments,
+  isAllowedSlackFileUrl,
+  isIngestableImageFile,
+} from './gateway-attachments.js';
+import { MAX_UPLOAD_FILE_SIZE } from './upload.js';
+
+function makeFile(overrides: Partial<InboundFile> = {}): InboundFile {
+  return {
+    id: 'F123',
+    name: 'screenshot.png',
+    mimetype: 'image/png',
+    size: 1024,
+    url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/screenshot.png',
+    ...overrides,
+  };
+}
+
+function makeImageResponse(body: Uint8Array, headers: Record<string, string> = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'image/png', ...headers },
+  });
+}
+
+describe('isAllowedSlackFileUrl', () => {
+  it('allows https URLs on slack.com and its subdomains', () => {
+    expect(isAllowedSlackFileUrl('https://files.slack.com/files-pri/T1-F1/download/a.png')).toBe(
+      true
+    );
+    expect(isAllowedSlackFileUrl('https://slack.com/some/file')).toBe(true);
+  });
+
+  it('rejects other hosts, lookalike domains, plain http, and malformed URLs', () => {
+    expect(isAllowedSlackFileUrl('https://evil.example.com/a.png')).toBe(false);
+    expect(isAllowedSlackFileUrl('https://notslack.com/a.png')).toBe(false);
+    expect(isAllowedSlackFileUrl('https://files.slack.com.evil.com/a.png')).toBe(false);
+    expect(isAllowedSlackFileUrl('http://files.slack.com/a.png')).toBe(false);
+    expect(isAllowedSlackFileUrl('not a url')).toBe(false);
+  });
+});
+
+describe('isIngestableImageFile', () => {
+  it('accepts allowlisted image types and normalizes mime parameters', () => {
+    expect(isIngestableImageFile(makeFile({ mimetype: 'image/png' }))).toBe(true);
+    expect(isIngestableImageFile(makeFile({ mimetype: 'IMAGE/JPEG; charset=binary' }))).toBe(true);
+  });
+
+  it('rejects non-image and non-allowlisted types', () => {
+    expect(isIngestableImageFile(makeFile({ mimetype: 'application/pdf' }))).toBe(false);
+    expect(isIngestableImageFile(makeFile({ mimetype: 'image/svg+xml' }))).toBe(false);
+    expect(isIngestableImageFile(makeFile({ mimetype: 'text/html' }))).toBe(false);
+  });
+});
+
+describe('buildPromptWithAttachments', () => {
+  it('returns the trimmed text when there are no attachments', () => {
+    expect(buildPromptWithAttachments('  hello  ', [])).toBe('hello');
+  });
+
+  it('prepends the attachment block to regular prompts', () => {
+    expect(buildPromptWithAttachments('look at this', ['/tmp/a.png'])).toBe(
+      'Attached files:\n- /tmp/a.png\n\nlook at this'
+    );
+  });
+
+  it('keeps slash commands first', () => {
+    expect(buildPromptWithAttachments('/review', ['/tmp/a.png'])).toBe(
+      '/review\n\nAttached files:\n- /tmp/a.png'
+    );
+  });
+
+  it('returns only the attachment block when the text is empty', () => {
+    expect(buildPromptWithAttachments('', ['/tmp/a.png', '/tmp/b.png'])).toBe(
+      'Attached files:\n- /tmp/a.png\n- /tmp/b.png'
+    );
+  });
+});
+
+describe('ingestInboundImageAttachments', () => {
+  let uploadDir: string;
+
+  beforeEach(async () => {
+    uploadDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-attachments-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(uploadDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('downloads an image with the bot token and stores it in the upload dir', async () => {
+    const bytes = new Uint8Array([137, 80, 78, 71]);
+    const fetchImpl = vi.fn(async () => makeImageResponse(bytes));
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile()],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://files.slack.com/files-pri/T1-F123/download/screenshot.png',
+      { headers: { Authorization: 'Bearer xoxb-test' } }
+    );
+    expect(result.failed).toBe(0);
+    expect(result.paths).toHaveLength(1);
+    expect(result.paths[0].startsWith(uploadDir)).toBe(true);
+    expect(path.basename(result.paths[0])).toMatch(/^screenshot_\d+\.png$/);
+    expect(new Uint8Array(await fs.readFile(result.paths[0]))).toEqual(bytes);
+  });
+
+  it('ignores non-image attachments without counting them as failures', async () => {
+    const fetchImpl = vi.fn();
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile({ mimetype: 'application/pdf', name: 'doc.pdf' })],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toEqual({ paths: [], failed: 0 });
+  });
+
+  it('never fetches disallowed hosts and counts them as failed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchImpl = vi.fn();
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile({ url_private_download: 'https://evil.example.com/a.png' })],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toEqual({ paths: [], failed: 1 });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('skips files whose declared size exceeds the per-file limit', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchImpl = vi.fn();
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile({ size: MAX_UPLOAD_FILE_SIZE + 1 })],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result).toEqual({ paths: [], failed: 1 });
+  });
+
+  it('rejects non-image response bodies (Slack HTML error pages)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('<html>login</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        })
+    );
+
+    const result = await ingestInboundImageAttachments({
+      files: [makeFile()],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result).toEqual({ paths: [], failed: 1 });
+  });
+
+  it('continues past failures and still stores the remaining images', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const bytes = new Uint8Array([1, 2, 3]);
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(makeImageResponse(bytes));
+
+    const result = await ingestInboundImageAttachments({
+      files: [
+        makeFile({ id: 'F1', name: 'first.png' }),
+        makeFile({ id: 'F2', name: 'second.png' }),
+      ],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.paths).toHaveLength(1);
+    expect(path.basename(result.paths[0])).toMatch(/^second_\d+\.png$/);
+  });
+
+  it('counts images beyond the per-message cap as failed without fetching them', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const bytes = new Uint8Array([1]);
+    const fetchImpl = vi.fn(async () => makeImageResponse(bytes));
+    const files = Array.from({ length: 12 }, (_, i) =>
+      makeFile({ id: `F${i}`, name: `img-${i}.png` })
+    );
+
+    const result = await ingestInboundImageAttachments({
+      files,
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(10);
+    expect(result.paths).toHaveLength(10);
+    expect(result.failed).toBe(2);
+  });
+});

--- a/apps/agor-daemon/src/utils/gateway-attachments.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.ts
@@ -29,6 +29,8 @@ export interface AttachmentIngestResult {
   failed: number;
 }
 
+const MAX_REDIRECT_HOPS = 3;
+
 /**
  * Whether a platform file URL may be downloaded with the channel's bot token.
  * Slack serves `url_private_download` from files.slack.com; anything outside
@@ -74,6 +76,62 @@ export function buildPromptWithAttachments(text: string, attachmentPaths: string
 }
 
 /**
+ * Fetch an allowlisted URL, following redirects manually so that EVERY hop's
+ * host is validated against the Slack allowlist before it is fetched. This
+ * makes "the bot-token Authorization header is only ever sent to allowlisted
+ * slack.com hosts" an invariant of this function, rather than a property of
+ * the runtime's cross-origin redirect header stripping.
+ */
+async function fetchFromAllowedHosts(
+  initialUrl: string,
+  headers: Record<string, string>,
+  fetchImpl: typeof fetch
+): Promise<Response> {
+  let url = initialUrl;
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    if (!isAllowedSlackFileUrl(url)) {
+      throw new Error('download URL host not allowed');
+    }
+    const response = await fetchImpl(url, { headers, redirect: 'manual' });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        throw new Error(`redirect (HTTP ${response.status}) without Location header`);
+      }
+      url = new URL(location, url).toString();
+      continue;
+    }
+    return response;
+  }
+  throw new Error(`too many redirects (limit ${MAX_REDIRECT_HOPS})`);
+}
+
+/**
+ * Buffer a response body while enforcing the byte ceiling on the ACTUAL bytes
+ * received, aborting mid-stream the moment the running total exceeds it —
+ * Content-Length can be absent or false, so the declared-size prechecks are
+ * only cheap early-outs, never the bound.
+ */
+async function readBodyWithLimit(response: Response, maxBytes: number): Promise<Buffer> {
+  if (!response.body) {
+    return Buffer.alloc(0);
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  // Throwing inside for-await invokes the iterator's return(), which cancels
+  // the underlying stream — no bytes past the ceiling are buffered.
+  for await (const chunk of response.body) {
+    const buf = Buffer.from(chunk as Uint8Array);
+    total += buf.byteLength;
+    if (total > maxBytes) {
+      throw new Error(`downloaded size exceeds per-file limit ${maxBytes}`);
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
  * Download the image attachments of one inbound message and store them in the
  * upload directory. Never throws: every attachment that cannot be fetched,
  * validated, or written is counted in `failed` so the caller can still
@@ -114,9 +172,11 @@ export async function ingestInboundImageAttachments(args: {
     }
 
     try {
-      const response = await fetchImpl(file.url_private_download, {
-        headers: { Authorization: `Bearer ${args.botToken}` },
-      });
+      const response = await fetchFromAllowedHosts(
+        file.url_private_download,
+        { Authorization: `Bearer ${args.botToken}` },
+        fetchImpl
+      );
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
@@ -133,10 +193,7 @@ export async function ingestInboundImageAttachments(args: {
       if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_FILE_SIZE) {
         throw new Error(`declared size ${declaredLength} exceeds per-file limit`);
       }
-      const body = Buffer.from(await response.arrayBuffer());
-      if (body.byteLength > MAX_UPLOAD_FILE_SIZE) {
-        throw new Error(`downloaded size ${body.byteLength} exceeds per-file limit`);
-      }
+      const body = await readBodyWithLimit(response, MAX_UPLOAD_FILE_SIZE);
 
       await fs.mkdir(uploadDir, { recursive: true });
       const filePath = path.join(uploadDir, buildUploadFilename(file.name));

--- a/apps/agor-daemon/src/utils/gateway-attachments.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.ts
@@ -1,0 +1,152 @@
+/**
+ * Server-side ingestion of inbound gateway message attachments.
+ *
+ * Downloads image files attached to inbound Slack messages using the
+ * channel's bot token and stores them in the daemon upload directory — the
+ * same destination the session composer's `/sessions/:sessionId/upload`
+ * route writes to — so the session's agent can Read them by absolute path.
+ *
+ * Non-image attachments are out of scope and never downloaded. Downloads are
+ * restricted to Slack-owned hosts and to the same per-file size / per-message
+ * count ceilings the upload route enforces.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { InboundFile } from '@agor/core/gateway';
+import {
+  ALLOWED_UPLOAD_MIME_TYPES,
+  buildUploadFilename,
+  getUploadDirectory,
+  MAX_UPLOAD_FILE_SIZE,
+  MAX_UPLOAD_FILES_PER_REQUEST,
+} from './upload.js';
+
+export interface AttachmentIngestResult {
+  /** Absolute paths of stored files, in the order the attachments arrived. */
+  paths: string[];
+  /** Image attachments that could not be fetched or stored. */
+  failed: number;
+}
+
+/**
+ * Whether a platform file URL may be downloaded with the channel's bot token.
+ * Slack serves `url_private_download` from files.slack.com; anything outside
+ * slack.com would leak the bot token to an attacker-controlled host.
+ */
+export function isAllowedSlackFileUrl(rawUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:') return false;
+  const host = url.hostname.toLowerCase();
+  return host === 'slack.com' || host.endsWith('.slack.com');
+}
+
+/** Image attachments the upload pipeline accepts (same allowlist as the upload route). */
+export function isIngestableImageFile(file: InboundFile): boolean {
+  const mime = file.mimetype.split(';')[0].trim().toLowerCase();
+  return mime.startsWith('image/') && ALLOWED_UPLOAD_MIME_TYPES.has(mime);
+}
+
+/**
+ * Fold stored attachment paths into a prompt.
+ *
+ * Server-side copy of the session composer's `buildPromptWithAttachments`
+ * (`apps/agor-ui/src/components/SessionPanel/composerAttachments.ts`) — the
+ * daemon must not import agor-ui. Keep the two in sync.
+ */
+export function buildPromptWithAttachments(text: string, attachmentPaths: string[]): string {
+  const trimmedText = text.trim();
+  if (attachmentPaths.length === 0) return trimmedText;
+
+  const attachmentBlock = [
+    'Attached files:',
+    ...attachmentPaths.map((attachmentPath) => `- ${attachmentPath}`),
+  ].join('\n');
+  if (trimmedText.startsWith('/')) {
+    return `${trimmedText}\n\n${attachmentBlock}`;
+  }
+  return trimmedText ? `${attachmentBlock}\n\n${trimmedText}` : attachmentBlock;
+}
+
+/**
+ * Download the image attachments of one inbound message and store them in the
+ * upload directory. Never throws: every attachment that cannot be fetched,
+ * validated, or written is counted in `failed` so the caller can still
+ * deliver the prompt with a degradation note.
+ */
+export async function ingestInboundImageAttachments(args: {
+  files: InboundFile[];
+  botToken: string;
+  fetchImpl?: typeof fetch;
+  uploadDir?: string;
+}): Promise<AttachmentIngestResult> {
+  const fetchImpl = args.fetchImpl ?? fetch;
+  const uploadDir = args.uploadDir ?? getUploadDirectory();
+
+  const images = args.files.filter(isIngestableImageFile);
+  const paths: string[] = [];
+  let failed = 0;
+
+  for (const [index, file] of images.entries()) {
+    if (index >= MAX_UPLOAD_FILES_PER_REQUEST) {
+      failed++;
+      console.warn(
+        `[gateway] Skipping attachment "${file.name}": message exceeds ${MAX_UPLOAD_FILES_PER_REQUEST}-image limit`
+      );
+      continue;
+    }
+    if (file.size > MAX_UPLOAD_FILE_SIZE) {
+      failed++;
+      console.warn(
+        `[gateway] Skipping attachment "${file.name}": ${file.size} bytes exceeds per-file limit ${MAX_UPLOAD_FILE_SIZE}`
+      );
+      continue;
+    }
+    if (!isAllowedSlackFileUrl(file.url_private_download)) {
+      failed++;
+      console.warn(`[gateway] Skipping attachment "${file.name}": download URL host not allowed`);
+      continue;
+    }
+
+    try {
+      const response = await fetchImpl(file.url_private_download, {
+        headers: { Authorization: `Bearer ${args.botToken}` },
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      // Slack answers with an HTML login/error page (status 200) when the
+      // token lacks files:read or cannot see the file — only accept images.
+      const contentType = (response.headers.get('content-type') ?? '')
+        .split(';')[0]
+        .trim()
+        .toLowerCase();
+      if (!contentType.startsWith('image/')) {
+        throw new Error(`unexpected content-type ${contentType || 'unknown'}`);
+      }
+      const declaredLength = Number.parseInt(response.headers.get('content-length') ?? '', 10);
+      if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_FILE_SIZE) {
+        throw new Error(`declared size ${declaredLength} exceeds per-file limit`);
+      }
+      const body = Buffer.from(await response.arrayBuffer());
+      if (body.byteLength > MAX_UPLOAD_FILE_SIZE) {
+        throw new Error(`downloaded size ${body.byteLength} exceeds per-file limit`);
+      }
+
+      await fs.mkdir(uploadDir, { recursive: true });
+      const filePath = path.join(uploadDir, buildUploadFilename(file.name));
+      await fs.writeFile(filePath, body);
+      paths.push(filePath);
+    } catch (error) {
+      failed++;
+      console.warn(`[gateway] Failed to ingest attachment "${file.name}":`, error);
+    }
+  }
+
+  return { paths, failed };
+}

--- a/apps/agor-daemon/src/utils/gateway-attachments.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.ts
@@ -48,10 +48,19 @@ export function isAllowedSlackFileUrl(rawUrl: string): boolean {
   return host === 'slack.com' || host.endsWith('.slack.com');
 }
 
+/**
+ * Image MIME types the upload pipeline accepts — membership in the upload
+ * route's allowlist, which deliberately excludes script-bearing image types
+ * like image/svg+xml.
+ */
+function isAllowedImageMime(rawMime: string): boolean {
+  const mime = rawMime.split(';')[0].trim().toLowerCase();
+  return mime.startsWith('image/') && ALLOWED_UPLOAD_MIME_TYPES.has(mime);
+}
+
 /** Image attachments the upload pipeline accepts (same allowlist as the upload route). */
 export function isIngestableImageFile(file: InboundFile): boolean {
-  const mime = file.mimetype.split(';')[0].trim().toLowerCase();
-  return mime.startsWith('image/') && ALLOWED_UPLOAD_MIME_TYPES.has(mime);
+  return isAllowedImageMime(file.mimetype);
 }
 
 /**
@@ -181,13 +190,14 @@ export async function ingestInboundImageAttachments(args: {
         throw new Error(`HTTP ${response.status}`);
       }
       // Slack answers with an HTML login/error page (status 200) when the
-      // token lacks files:read or cannot see the file — only accept images.
-      const contentType = (response.headers.get('content-type') ?? '')
-        .split(';')[0]
-        .trim()
-        .toLowerCase();
-      if (!contentType.startsWith('image/')) {
-        throw new Error(`unexpected content-type ${contentType || 'unknown'}`);
+      // token lacks files:read or cannot see the file — only accept images
+      // from the same allowlist the upload route enforces (which excludes
+      // script-bearing types like image/svg+xml).
+      const contentType = response.headers.get('content-type') ?? '';
+      if (!isAllowedImageMime(contentType)) {
+        throw new Error(
+          `unexpected content-type ${contentType.split(';')[0].trim().toLowerCase() || 'unknown'}`
+        );
       }
       const declaredLength = Number.parseInt(response.headers.get('content-length') ?? '', 10);
       if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_FILE_SIZE) {
@@ -196,7 +206,10 @@ export async function ingestInboundImageAttachments(args: {
       const body = await readBodyWithLimit(response, MAX_UPLOAD_FILE_SIZE);
 
       await fs.mkdir(uploadDir, { recursive: true });
-      const filePath = path.join(uploadDir, buildUploadFilename(file.name));
+      // Slack names every pasted screenshot "image.png"; prefix the unique
+      // Slack file ID so same-millisecond downloads can never overwrite each
+      // other (the timestamp in buildUploadFilename is not unique enough).
+      const filePath = path.join(uploadDir, buildUploadFilename(`${file.id}_${file.name}`));
       await fs.writeFile(filePath, body);
       paths.push(filePath);
     } catch (error) {

--- a/apps/agor-daemon/src/utils/upload.ts
+++ b/apps/agor-daemon/src/utils/upload.ts
@@ -80,6 +80,25 @@ export function validateUploadDestinationQuery(destination: unknown): void {
 }
 
 /**
+ * Sanitize an original filename (path traversal, unsafe chars) and suffix it
+ * with a timestamp so concurrent uploads of the same name never overwrite.
+ */
+export function buildUploadFilename(originalname: string): string {
+  const basename = path.basename(originalname);
+
+  const sanitized = basename
+    .replace(/\.\./g, '_') // Remove path traversal attempts
+    .replace(/[/\\:*?"<>|]/g, '_') // Remove filesystem-unsafe chars (Windows + Unix)
+    .replace(/\.+$/g, '') // Remove trailing dots (Windows issue)
+    .substring(0, 200); // Limit length (leave room for timestamp)
+
+  const timestamp = Date.now();
+  const ext = path.extname(sanitized);
+  const nameWithoutExt = sanitized.slice(0, -ext.length || undefined);
+  return `${nameWithoutExt}_${timestamp}${ext}`;
+}
+
+/**
  * Create multer storage configuration
  */
 export function createUploadStorage() {
@@ -115,22 +134,7 @@ export function createUploadStorage() {
     },
 
     filename: (_req, file, cb) => {
-      // Sanitize filename to prevent path traversal attacks while preserving readability
-      // 1. Extract basename to remove any path components
-      const basename = path.basename(file.originalname);
-
-      // 2. Remove only truly dangerous characters (preserve spaces, unicode, etc.)
-      const sanitized = basename
-        .replace(/\.\./g, '_') // Remove path traversal attempts
-        .replace(/[/\\:*?"<>|]/g, '_') // Remove filesystem-unsafe chars (Windows + Unix)
-        .replace(/\.+$/g, '') // Remove trailing dots (Windows issue)
-        .substring(0, 200); // Limit length (leave room for timestamp)
-
-      // 3. Add timestamp suffix to prevent overwrites (but keep it human-readable)
-      const timestamp = Date.now();
-      const ext = path.extname(sanitized);
-      const nameWithoutExt = sanitized.slice(0, -ext.length || undefined);
-      const uniqueFilename = `${nameWithoutExt}_${timestamp}${ext}`;
+      const uniqueFilename = buildUploadFilename(file.originalname);
 
       if (DEBUG_UPLOAD) {
         console.log(

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -394,6 +394,7 @@ const SLACK_PROBE_FIELDS = new Set<string>([
   'enable_mpim',
   'align_slack_users',
   'outbound_enabled',
+  'ingest_files',
   'slack_public_scope',
   'allowed_channel_ids',
 ]);
@@ -704,6 +705,7 @@ const SlackSetupWizard: React.FC<{
   const enableMpim = Form.useWatch('enable_mpim', form) ?? false;
   const alignUsers = Form.useWatch('align_slack_users', form) ?? true;
   const outbound = Form.useWatch('outbound_enabled', form) ?? false;
+  const ingestFiles = Form.useWatch('ingest_files', form) ?? false;
   const publicScope = (Form.useWatch('slack_public_scope', form) as string) ?? 'all';
 
   const wizardOptions: SlackWizardOptions = useMemo(
@@ -714,8 +716,9 @@ const SlackSetupWizard: React.FC<{
       groupDms: enableMpim,
       alignUsers,
       outbound,
+      ingestFiles,
     }),
-    [appName, enableChannels, enableGroups, enableMpim, alignUsers, outbound]
+    [appName, enableChannels, enableGroups, enableMpim, alignUsers, outbound, ingestFiles]
   );
 
   const manifestJson = useMemo(
@@ -905,6 +908,16 @@ const SlackSetupWizard: React.FC<{
             <UserSelect userById={userById} />
           </Form.Item>
         )}
+
+        <Form.Item
+          label="Ingest attached images"
+          name="ingest_files"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Download images attached to inbound messages (screenshots) so session agents can view them. Adds the files:read scope."
+        >
+          <Switch />
+        </Form.Item>
 
         <Form.Item
           label="Enable outbound sends"
@@ -1153,6 +1166,7 @@ const ChannelFormFields: React.FC<{
   const outboundEnabled = Boolean(
     Form.useWatch('outbound_enabled', form) ?? slackConfig?.outbound_enabled
   );
+  const ingestFiles = Boolean(Form.useWatch('ingest_files', form) ?? slackConfig?.ingest_files);
   const alignGithubUsers = Form.useWatch('github_align_users', form) ?? false;
   // Track the live Name field so the manifest preview reflects in-progress edits,
   // falling back to the stored channel name.
@@ -1171,8 +1185,17 @@ const ChannelFormFields: React.FC<{
       groupDms: enableMpim,
       alignUsers: alignSlackUsers,
       outbound: outboundEnabled,
+      ingestFiles,
     }),
-    [channelName, enableChannels, enableGroups, enableMpim, alignSlackUsers, outboundEnabled]
+    [
+      channelName,
+      enableChannels,
+      enableGroups,
+      enableMpim,
+      alignSlackUsers,
+      outboundEnabled,
+      ingestFiles,
+    ]
   );
   const slackScopes = useMemo(() => requiredBotScopes(slackOptions), [slackOptions]);
   const slackEvents = useMemo(() => requiredBotEvents(slackOptions), [slackOptions]);
@@ -2071,6 +2094,16 @@ const ChannelFormFields: React.FC<{
                       <Switch />
                     </Form.Item>
 
+                    <Form.Item
+                      label="Ingest attached images"
+                      name="ingest_files"
+                      valuePropName="checked"
+                      initialValue={false}
+                      tooltip="Download images attached to inbound messages (screenshots) so session agents can view them. Requires the files:read scope."
+                    >
+                      <Switch />
+                    </Form.Item>
+
                     {sourcesEnabled && (
                       <CompactAlert
                         type="info"
@@ -2454,6 +2487,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       align_slack_users: values.align_slack_users ?? false,
       allowed_channel_ids: values.allowed_channel_ids ?? [],
       outbound_enabled: values.outbound_enabled ?? false,
+      ingest_files: values.ingest_files ?? false,
     };
     setSlackTestLoading(true);
     setSlackTestResult(null);
@@ -2597,6 +2631,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       config.allowed_channel_ids = values.allowed_channel_ids ?? [];
       config.outbound_enabled = values.outbound_enabled ?? false;
       config.default_outbound_target = values.default_outbound_target || null;
+      config.ingest_files = values.ingest_files ?? false;
     }
 
     // Build agentic config from form values
@@ -2754,6 +2789,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       formValues.allowed_channel_ids = (config?.allowed_channel_ids as string[]) ?? [];
       formValues.outbound_enabled = config?.outbound_enabled ?? false;
       formValues.default_outbound_target = config?.default_outbound_target;
+      formValues.ingest_files = config?.ingest_files ?? false;
     } else if (channel.channel_type === 'github') {
       formValues.github_app_id = config?.app_id;
       formValues.github_installation_id = config?.installation_id;

--- a/packages/core/src/gateway/connector.ts
+++ b/packages/core/src/gateway/connector.ts
@@ -8,6 +8,21 @@
 import type { ChannelType, SlackTestResult } from '../types/gateway';
 
 /**
+ * File attached to an inbound message (provider-neutral shape).
+ *
+ * `url_private_download` is a platform URL that requires the channel's
+ * credentials to fetch; connectors pass it through verbatim and the gateway
+ * decides whether/how to download it.
+ */
+export interface InboundFile {
+  id: string;
+  name: string;
+  mimetype: string;
+  size: number;
+  url_private_download: string;
+}
+
+/**
  * Inbound message from a messaging platform
  */
 export interface InboundMessage {
@@ -15,6 +30,7 @@ export interface InboundMessage {
   text: string;
   userId: string;
   timestamp: string;
+  files?: InboundFile[];
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/core/src/gateway/connectors/slack-manifest.test.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.test.ts
@@ -19,6 +19,7 @@ const baseOptions: SlackWizardOptions = {
   groupDms: false,
   alignUsers: false,
   outbound: false,
+  ingestFiles: false,
 };
 
 function withOptions(overrides: Partial<SlackWizardOptions>): SlackWizardOptions {
@@ -71,6 +72,17 @@ describe('requiredBotScopes', () => {
     ]);
   });
 
+  it('adds files:read for file ingestion and omits it otherwise', () => {
+    expect(requiredBotScopes(withOptions({ ingestFiles: true }))).toEqual([
+      'chat:write',
+      'files:read',
+      'im:history',
+      'im:read',
+      'users:read',
+    ]);
+    expect(requiredBotScopes(baseOptions)).not.toContain('files:read');
+  });
+
   it('all capabilities on — de-duplicated and sorted', () => {
     const allOn = withOptions({
       publicChannels: true,
@@ -78,6 +90,7 @@ describe('requiredBotScopes', () => {
       groupDms: true,
       alignUsers: true,
       outbound: true,
+      ingestFiles: true,
     });
     expect(requiredBotScopes(allOn)).toEqual([
       'app_mentions:read',
@@ -85,6 +98,7 @@ describe('requiredBotScopes', () => {
       'channels:read',
       'chat:write',
       'chat:write.public',
+      'files:read',
       'groups:history',
       'groups:read',
       'im:history',

--- a/packages/core/src/gateway/connectors/slack-manifest.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.ts
@@ -29,6 +29,8 @@ export interface SlackWizardOptions {
   alignUsers: boolean;
   /** Proactive outbound: post to channels by name and DM users by email. */
   outbound: boolean;
+  /** Ingest files attached to inbound messages (screenshots/images). */
+  ingestFiles: boolean;
 }
 
 export interface SlackBotEventSubscriptions {
@@ -97,6 +99,9 @@ export function requiredBotScopes(opts: SlackWizardOptions): string[] {
   }
   if (opts.alignUsers) {
     scopes.push('users:read.email');
+  }
+  if (opts.ingestFiles) {
+    scopes.push('files:read');
   }
   if (opts.outbound) {
     // Outbound name resolution lists public+private channels and opens DMs by

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  extractSlackInboundFiles,
   isChannelAllowedByWhitelist,
   markdownToMrkdwn,
   markdownToSlackPayload,
@@ -1019,5 +1020,38 @@ describe('SlackConnector.testConnection', () => {
     const failure = result.failures.find((f) => f.capability === 'channel_access');
     expect(failure?.slackError).toBe('not_in_channel');
     expect(failure?.reason).toMatch(/not a member/i);
+  });
+});
+
+describe('extractSlackInboundFiles', () => {
+  const slackFile = {
+    id: 'F123',
+    name: 'screenshot.png',
+    mimetype: 'image/png',
+    size: 2048,
+    url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/screenshot.png',
+  };
+
+  it('maps well-formed Slack file objects and drops extra fields', () => {
+    const raw = [{ ...slackFile, permalink: 'https://x.slack.com/p', user: 'U1' }];
+    expect(extractSlackInboundFiles(raw)).toEqual([slackFile]);
+  });
+
+  it('drops malformed entries but keeps valid ones', () => {
+    const raw = [
+      null,
+      'not-an-object',
+      { ...slackFile, id: undefined },
+      { ...slackFile, size: '2048' },
+      { ...slackFile, url_private_download: undefined },
+      slackFile,
+    ];
+    expect(extractSlackInboundFiles(raw)).toEqual([slackFile]);
+  });
+
+  it('returns an empty array for non-array input', () => {
+    expect(extractSlackInboundFiles(undefined)).toEqual([]);
+    expect(extractSlackInboundFiles({})).toEqual([]);
+    expect(extractSlackInboundFiles('files')).toEqual([]);
   });
 });

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -14,7 +14,8 @@
  *     enable_mpim?: boolean,                        // Listen in group DMs
  *     require_mention?: boolean,                    // Legacy; Slack channel-like prompts now always require @mention
  *     allow_thread_replies_without_mention?: boolean, // Legacy; ignored for Slack channel-like prompts
- *     allowed_channel_ids?: string[]                // Channel ID whitelist
+ *     allowed_channel_ids?: string[],               // Channel ID whitelist
+ *     ingest_files?: boolean                        // Forward message attachments (requires files:read)
  *   }
  *
  * Thread ID format: "{channel_id}-{thread_ts}"
@@ -27,7 +28,7 @@ import { WebClient } from '@slack/web-api';
 import { slackifyMarkdown } from 'slackify-markdown';
 
 import type { ChannelType, SlackTestFailure, SlackTestResult } from '../../types/gateway';
-import type { GatewayConnector, InboundMessage, OutboundPayload } from '../connector';
+import type { GatewayConnector, InboundFile, InboundMessage, OutboundPayload } from '../connector';
 
 // Block Kit table block limits (Slack docs, native block introduced Aug 2025).
 const TABLE_MAX_ROWS = 100;
@@ -82,6 +83,9 @@ interface SlackConfig {
 
   // User alignment: resolve Slack user email → Agor user
   align_slack_users?: boolean;
+
+  // Ingest files attached to inbound messages (requires files:read scope)
+  ingest_files?: boolean;
 }
 
 export interface SlackUserAvatarProfile {
@@ -635,6 +639,37 @@ const SLACK_NOT_VERIFIABLE = [
  * direct messages the moment any whitelist is configured. The whitelist only
  * governs channel-like surfaces (`channel`/`group`/`mpim`).
  */
+/**
+ * Normalize a Slack event's `files` array into provider-neutral
+ * {@link InboundFile} entries, dropping malformed items. Slack file objects
+ * carry many more fields; only the ones the gateway needs survive — notably
+ * `url_private_download`, which requires the bot token to fetch.
+ */
+export function extractSlackInboundFiles(raw: unknown): InboundFile[] {
+  if (!Array.isArray(raw)) return [];
+  const files: InboundFile[] = [];
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) continue;
+    const candidate = item as Record<string, unknown>;
+    if (
+      typeof candidate.id === 'string' &&
+      typeof candidate.name === 'string' &&
+      typeof candidate.mimetype === 'string' &&
+      typeof candidate.size === 'number' &&
+      typeof candidate.url_private_download === 'string'
+    ) {
+      files.push({
+        id: candidate.id,
+        name: candidate.name,
+        mimetype: candidate.mimetype,
+        size: candidate.size,
+        url_private_download: candidate.url_private_download,
+      });
+    }
+  }
+  return files;
+}
+
 export function isChannelAllowedByWhitelist(
   channelType: string,
   channelId: string | undefined,
@@ -1650,6 +1685,11 @@ export class SlackConnector implements GatewayConnector {
           console.log(
             `[slack] Resolved message_replied event to latest reply thread_ts=${event.thread_ts ?? '(none)'} ts=${event.ts ?? '(none)'}`
           );
+        } else if (event.subtype === 'file_share' && this.config.ingest_files === true) {
+          // Messages with uploaded files arrive as subtype `file_share` rather
+          // than a plain message. When file ingestion is enabled, treat them
+          // as normal new messages so the attachments (and any accompanying
+          // text) reach the gateway.
         } else {
           console.debug(
             `[slack] Skipping message subtype=${event.subtype} user=${event.user ?? '(none)'} thread_ts=${event.thread_ts ?? '(none)'} ts=${event.ts ?? '(none)'}`
@@ -1810,11 +1850,15 @@ export class SlackConnector implements GatewayConnector {
         slackChannelName = await this.lookupChannelName(event.channel);
       }
 
+      const inboundFiles =
+        this.config.ingest_files === true ? extractSlackInboundFiles(event.files) : [];
+
       callback({
         threadId,
         text: messageText,
         userId: event.user ?? 'unknown',
         timestamp: event.ts ?? new Date().toISOString(),
+        ...(inboundFiles.length > 0 ? { files: inboundFiles } : {}),
         metadata: {
           channel: event.channel,
           channel_type: channelType,

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -5,7 +5,7 @@
  * through messaging platforms (Slack, Discord, etc.)
  */
 
-export type { GatewayConnector, InboundMessage, OutboundPayload } from './connector';
+export type { GatewayConnector, InboundFile, InboundMessage, OutboundPayload } from './connector';
 export { normalizeOutbound } from './connector';
 export { getConnector, hasConnector, registerConnector } from './connector-registry';
 export { GitHubConnector, parseThreadId as parseGitHubThreadId } from './connectors/github';
@@ -15,6 +15,7 @@ export type {
   SlackThreadHistoryResult,
 } from './connectors/slack';
 export {
+  extractSlackInboundFiles,
   isChannelAllowedByWhitelist,
   markdownToMrkdwn,
   SlackConnector,


### PR DESCRIPTION
Closes #1704.

## Problem

Inbound Slack messages carry a `files[]` array (pasted screenshots), but Agor dropped it in two places:

- the Slack connector extracted only `event.text`, and
- messages that carry uploads arrive as `message` events with `subtype: file_share`, which the inbound handler skipped entirely — so a DM containing a screenshot never even reached the gateway.

Agents spawned from Slack could never see a pasted screenshot.

## What this does

When a Slack channel opts in via a new `ingest_files` config flag:

1. **Connector** (`packages/core/src/gateway/connectors/slack.ts`) accepts `file_share` messages and maps `event.files` onto a new provider-neutral `InboundMessage.files` (`InboundFile { id, name, mimetype, size, url_private_download }`).
2. **Gateway** (`apps/agor-daemon/src/services/gateway.ts` + new `utils/gateway-attachments.ts`) downloads each **image** attachment server-side with the channel's bot token and stores it in `~/.agor/uploads/` — the same destination and filename convention as the #1744 composer upload route — then folds the stored paths into the session prompt via a server-side copy of `buildPromptWithAttachments`. The agent can then `Read` the image.
3. **Manifest** (`slack-manifest.ts`): a new required `ingestFiles` wizard option derives the `files:read` bot scope through the existing single-source `SlackWizardOptions → requiredBotScopes` path. The UI wizard (create + edit) and the `agor_gateway_slack_manifest_generate` MCP tool both expose the toggle and thread it into `config.ingest_files`, so manifest and runtime gating cannot drift.

### Guardrails

- Downloads are restricted to `https://` URLs on `slack.com` / `*.slack.com` (the bot token is never sent elsewhere).
- Same ceilings as the upload route: 50 MB/file, 10 files/message (reused constants from `utils/upload.ts`).
- Slack answers HTML (not an error status) when the token lacks `files:read`; non-`image/*` response bodies are rejected.
- **Graceful degradation**: any download failure appends `(an attachment could not be fetched)` to the prompt — the prompt is always delivered, never crashed.
- Non-image files are out of scope (follow-up handles text/docs) and are ignored without a failure note.
- Channels without the flag keep exactly the current behavior (including the `file_share` skip).

## Tests

- `slack.test.ts`: `event.files` → `InboundFile[]` mapping, malformed-entry filtering.
- `gateway-attachments.test.ts` (new): download + store with bot token, host allowlist (incl. lookalike-domain rejection), oversize/cap/HTML-response rejection, continue-past-failure, prompt folding semantics.
- `gateway.test.ts`: end-to-end service tests — paths folded into the delivered prompt, no download attempted when `ingest_files` is off, degradation note on total and partial failure.
- `slack-manifest.test.ts` / `gateway-channels.test.ts`: `files:read` present when the toggle is on, absent when off, `ingest_files` in the MCP create-config hint.

## Verification

A live DM-a-screenshot walkthrough was **not** performed: all Slack channels on this instance point at the production daemon (running main), their tokens are redacted from MCP, adding `files:read` requires reinstalling each Slack app, and sending a DM needs a human Slack user — none of which this session can do without disrupting production listeners. In its place:

- full unit/service coverage above (178 tests green across core + daemon), and
- a real-network probe of the riskiest path: `ingestInboundImageAttachments` against live `files.slack.com` with an invalid token fails closed (`{paths: [], failed: 1}`, nothing written to disk, no throw), and the allowlist accepts real Slack download URLs while rejecting `files.slack.com.attacker.io`.

`pnpm typecheck`, `lint`, `check:shortid`, `build`, and tests for core/daemon/UI are green. `check:multitenancy-boundaries` fails only on its 5 pre-existing baseline violations (register-hooks.ts, health-monitor.test, branches.test, tenant-db-scope.test, widgets/env-vars) — none touched here; the gate is local-only and not run in CI. `@agor/git#test` fails on main too (`vitest run` with zero test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)