### PR TITLE
feat(executor): add OpenCode and Cursor runtime vitals

### DIFF
--- a/packages/executor/src/handlers/sdk/cursor.test.ts
+++ b/packages/executor/src/handlers/sdk/cursor.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  TaskRuntimeVitalsReporter,
+  wrapStreamingCallbacksWithRuntimeVitals,
+} from '../../runtime-vitals.js';
 import {
   buildCursorAssistantContent,
+  handleCursorEvent,
   normalizeCursorToolInput,
   normalizeCursorToolName,
 } from './cursor.js';
@@ -59,5 +65,137 @@ describe('Cursor SDK handler helpers', () => {
       cursor_tool_name: 'edit',
       status: 'completed',
     });
+  });
+
+  it('reports sanitized assistant and tool runtime vitals from parsed events', async () => {
+    const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const messages = new Map<string, Record<string, unknown>>();
+    const client = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return {
+            patch: vi.fn(async (id: string, data: Record<string, unknown>) => {
+              patches.push({ id, data });
+              return { task_id: id, ...data };
+            }),
+          };
+        }
+        if (name === 'messages') {
+          return {
+            create: vi.fn(async (data: Record<string, unknown>) => {
+              messages.set(String(data.message_id), data);
+              return data;
+            }),
+            patch: vi.fn(async (id: string, data: Record<string, unknown>) => {
+              messages.set(id, { ...(messages.get(id) ?? {}), ...data });
+              return messages.get(id);
+            }),
+          };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+    const reporter = new TaskRuntimeVitalsReporter({
+      client,
+      taskId: 'task-1',
+      toolName: 'cursor',
+      minPatchIntervalMs: 0,
+    });
+    let firstAgentEventRecorded = false;
+    const recordFirstAgentEvent = async () => {
+      if (firstAgentEventRecorded) return;
+      firstAgentEventRecorded = true;
+      await reporter.record(TaskRuntimeEventKind.FIRST_AGENT_EVENT, {
+        source: 'sdk',
+        phase: TaskRuntimePhase.RUNNING,
+        meaningful: true,
+        forceFlush: true,
+      });
+    };
+
+    const callbacks = wrapStreamingCallbacksWithRuntimeVitals(
+      {
+        onStreamStart: vi.fn(async () => undefined),
+        onStreamChunk: vi.fn(async () => undefined),
+        onStreamEnd: vi.fn(async () => undefined),
+        onStreamError: vi.fn(async () => undefined),
+        onThinkingStart: vi.fn(async () => undefined),
+        onThinkingChunk: vi.fn(async () => undefined),
+        onThinkingEnd: vi.fn(async () => undefined),
+      },
+      reporter
+    );
+
+    const baseArgs = {
+      client,
+      callbacks,
+      sessionId: 'session-1' as never,
+      taskId: 'task-1' as never,
+      assistantMessageId: 'assistant-1' as never,
+      model: 'cursor-model',
+      getNextIndex: () => 1,
+      toolCallMessageIds: [] as never[],
+      toolCallMessageIdsByCallId: new Map(),
+      completedToolCallIds: new Set<string>(),
+      getAssistantText: () => '',
+      setAssistantText: vi.fn(),
+      getThinkingText: () => '',
+      setThinkingText: vi.fn(),
+      isAssistantStreamStarted: () => false,
+      setAssistantStreamStarted: vi.fn(),
+      ensureAssistantMessageIndex: () => 1,
+      isThinkingStarted: () => false,
+      setThinkingStarted: vi.fn(),
+      vitalsReporter: reporter,
+      recordFirstAgentEvent,
+    };
+
+    await handleCursorEvent({
+      ...baseArgs,
+      event: {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hello' }] },
+      } as never,
+    });
+    await handleCursorEvent({
+      ...baseArgs,
+      event: {
+        type: 'tool_call',
+        call_id: 'call-1',
+        name: 'run_terminal_cmd',
+        status: 'running',
+        args: { cmd: 'echo secret-token' },
+      } as never,
+    });
+    await handleCursorEvent({
+      ...baseArgs,
+      event: {
+        type: 'tool_call',
+        call_id: 'call-1',
+        name: 'run_terminal_cmd',
+        status: 'completed',
+        args: { cmd: 'echo secret-token' },
+        result: 'secret-output',
+      } as never,
+    });
+
+    const terminalVitals = await reporter.terminalSnapshot(TaskRuntimeEventKind.TURN_COMPLETED, {
+      source: 'sdk',
+      phase: TaskRuntimePhase.COMPLETED,
+    });
+
+    expect(terminalVitals.recent_events?.map((event) => event.kind)).toEqual([
+      TaskRuntimeEventKind.FIRST_AGENT_EVENT,
+      TaskRuntimeEventKind.STREAM_START,
+      TaskRuntimeEventKind.TOOL_START,
+      TaskRuntimeEventKind.TOOL_COMPLETE,
+      TaskRuntimeEventKind.TURN_COMPLETED,
+    ]);
+    expect(terminalVitals.active_tool).toBeNull();
+    expect(terminalVitals.recent_events?.[2]).toMatchObject({
+      tool_name: 'Bash',
+      tool_use_id: 'call-1',
+    });
+    expect(JSON.stringify(terminalVitals)).not.toContain('secret');
   });
 });

--- a/packages/executor/src/handlers/sdk/cursor.ts
+++ b/packages/executor/src/handlers/sdk/cursor.ts
@@ -21,12 +21,17 @@ import type {
   SessionID,
   Task,
   TaskID,
+  TaskRuntimeVitals,
 } from '@agor/core/types';
-import { MessageRole } from '@agor/core/types';
+import { MessageRole, TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import { Agent, type McpServerConfig, type Run, type SDKMessage } from '@cursor/sdk';
 import { getDaemonUrl } from '../../config.js';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import type { ResolvedConfigSlice } from '../../payload-types.js';
+import {
+  TaskRuntimeVitalsReporter,
+  wrapStreamingCallbacksWithRuntimeVitals,
+} from '../../runtime-vitals.js';
 import { getMcpServersForSession } from '../../sdk-handlers/base/mcp-scoping.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import type { AgorClient } from '../../services/feathers-client.js';
@@ -444,6 +449,23 @@ export async function executeCursorTask(params: {
     );
   }
 
+  let initialRuntimeVitals: TaskRuntimeVitals | undefined;
+  try {
+    initialRuntimeVitals = (await client.service('tasks').get(taskId)).runtime_vitals;
+  } catch (error) {
+    console.warn(
+      '[runtime-vitals] Failed to read initial task runtime vitals:',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  const vitalsReporter = new TaskRuntimeVitalsReporter({
+    client,
+    taskId,
+    toolName: 'cursor',
+    initialSnapshot: initialRuntimeVitals,
+  });
+
   let currentRun: Run | undefined;
   const abortHandler = () => {
     if (!currentRun) return;
@@ -455,13 +477,22 @@ export async function executeCursorTask(params: {
   params.abortController.signal.addEventListener('abort', abortHandler);
 
   try {
+    await vitalsReporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+      source: 'executor',
+      phase: TaskRuntimePhase.SDK_STARTING,
+      forceFlush: true,
+    });
+
     await configureSessionGitSafeDirectories(client, sessionId, '[cursor git.safe-directory]');
     await stampGitStateAtTaskStart(client, sessionId, taskId);
 
     const apiKey = await resolveCursorApiKey(client, taskId);
     const session = await client.service('sessions').get(sessionId);
     const repos = createFeathersBackedRepositories(client);
-    const callbacks = createStreamingCallbacks(client, 'cursor', sessionId);
+    const callbacks = wrapStreamingCallbacksWithRuntimeVitals(
+      createStreamingCallbacks(client, 'cursor', sessionId),
+      vitalsReporter
+    );
 
     if (!session.branch_id) {
       throw new Error('Cursor sessions require a branch_id so the local runtime has a cwd.');
@@ -525,8 +556,25 @@ export async function executeCursorTask(params: {
       let thinkingText = '';
       const toolCallMessageIds: MessageID[] = [];
       const toolCallMessageIdsByCallId = new Map<string, MessageID>();
+      const completedToolCallIds = new Set<string>();
       const rawMessages: SDKMessage[] = [];
+      let firstAgentEventRecorded = false;
+      const recordFirstAgentEvent = async () => {
+        if (firstAgentEventRecorded) return;
+        firstAgentEventRecorded = true;
+        await vitalsReporter.record(TaskRuntimeEventKind.FIRST_AGENT_EVENT, {
+          source: 'sdk',
+          phase: TaskRuntimePhase.RUNNING,
+          meaningful: true,
+          forceFlush: true,
+        });
+      };
 
+      await vitalsReporter.record(TaskRuntimeEventKind.TASK_STATUS, {
+        source: 'executor',
+        phase: TaskRuntimePhase.AWAITING_FIRST_AGENT_EVENT,
+        forceFlush: true,
+      });
       currentRun = await agent.send(prompt, {
         model,
         mcpServers,
@@ -554,6 +602,7 @@ export async function executeCursorTask(params: {
           getNextIndex: () => nextIndex++,
           toolCallMessageIds,
           toolCallMessageIdsByCallId,
+          completedToolCallIds,
           getAssistantText: () => assistantText,
           setAssistantText: (value) => {
             assistantText = value;
@@ -571,6 +620,8 @@ export async function executeCursorTask(params: {
           setThinkingStarted: (value) => {
             thinkingStarted = value;
           },
+          vitalsReporter,
+          recordFirstAgentEvent,
         });
       }
 
@@ -598,6 +649,11 @@ export async function executeCursorTask(params: {
           preview: finalText,
           model: recordedModel,
         });
+        await vitalsReporter.record(TaskRuntimeEventKind.ASSISTANT_MESSAGE, {
+          source: 'sdk',
+          phase: TaskRuntimePhase.RUNNING,
+          meaningful: true,
+        });
       }
 
       const failed = runResult.status === 'error';
@@ -606,6 +662,21 @@ export async function executeCursorTask(params: {
       const taskPatch: Partial<Task> = {
         status: stopped ? 'stopped' : failed ? 'failed' : 'completed',
         completed_at: new Date().toISOString(),
+        runtime_vitals: await vitalsReporter.terminalSnapshot(
+          stopped
+            ? TaskRuntimeEventKind.TURN_STOPPED
+            : failed
+              ? TaskRuntimeEventKind.TURN_FAILED
+              : TaskRuntimeEventKind.TURN_COMPLETED,
+          {
+            source: 'sdk',
+            phase: stopped
+              ? TaskRuntimePhase.STOPPED
+              : failed
+                ? TaskRuntimePhase.FAILED
+                : TaskRuntimePhase.COMPLETED,
+          }
+        ),
         ...(recordedModel ? { model: recordedModel } : {}),
         raw_sdk_response: {
           run: runResult,
@@ -629,6 +700,10 @@ export async function executeCursorTask(params: {
     const taskPatch: Partial<Task> = {
       status: 'failed',
       completed_at: new Date().toISOString(),
+      runtime_vitals: await vitalsReporter.terminalSnapshot(TaskRuntimeEventKind.TURN_FAILED, {
+        source: 'sdk',
+        phase: TaskRuntimePhase.FAILED,
+      }),
       error_message: err.message,
     };
     if (shaAtEnd) {
@@ -639,11 +714,12 @@ export async function executeCursorTask(params: {
     await createSystemErrorMessage({ client, sessionId, taskId, message: err.message });
     throw err;
   } finally {
+    vitalsReporter.stop();
     params.abortController.signal.removeEventListener('abort', abortHandler);
   }
 }
 
-async function handleCursorEvent(args: {
+export async function handleCursorEvent(args: {
   event: SDKMessage;
   client: AgorClient;
   callbacks: StreamingCallbacks;
@@ -658,6 +734,7 @@ async function handleCursorEvent(args: {
   getNextIndex: () => number;
   toolCallMessageIds: MessageID[];
   toolCallMessageIdsByCallId: Map<string, MessageID>;
+  completedToolCallIds: Set<string>;
   getAssistantText: () => string;
   setAssistantText: (value: string) => void;
   getThinkingText: () => string;
@@ -667,6 +744,8 @@ async function handleCursorEvent(args: {
   ensureAssistantMessageIndex: () => number;
   isThinkingStarted: () => boolean;
   setThinkingStarted: (value: boolean) => void;
+  vitalsReporter?: TaskRuntimeVitalsReporter;
+  recordFirstAgentEvent?: () => Promise<void>;
 }): Promise<void> {
   switch (args.event.type) {
     case 'assistant': {
@@ -680,6 +759,7 @@ async function handleCursorEvent(args: {
       if (!delta) return;
       const updatedText = isCumulative ? nextText : previousText + nextText;
 
+      await args.recordFirstAgentEvent?.();
       if (!args.isAssistantStreamStarted()) {
         args.ensureAssistantMessageIndex();
         await args.callbacks.onStreamStart(args.assistantMessageId, {
@@ -703,6 +783,7 @@ async function handleCursorEvent(args: {
       if (!delta) return;
       const updatedText = isCumulative ? args.event.text : previousText + args.event.text;
 
+      await args.recordFirstAgentEvent?.();
       if (!args.isThinkingStarted() && args.callbacks.onThinkingStart) {
         args.ensureAssistantMessageIndex();
         await args.callbacks.onThinkingStart(args.assistantMessageId, {});
@@ -714,6 +795,7 @@ async function handleCursorEvent(args: {
     }
 
     case 'tool_call': {
+      const toolName = normalizeCursorToolName(args.event.name);
       const existingMessageId = args.toolCallMessageIdsByCallId.get(args.event.call_id);
       if (existingMessageId) {
         await updateToolMessage({
@@ -721,6 +803,17 @@ async function handleCursorEvent(args: {
           messageId: existingMessageId,
           event: args.event,
         });
+        if (args.event.status !== 'running' && !args.completedToolCallIds.has(args.event.call_id)) {
+          args.completedToolCallIds.add(args.event.call_id);
+          await args.recordFirstAgentEvent?.();
+          await args.vitalsReporter?.record(TaskRuntimeEventKind.TOOL_COMPLETE, {
+            source: 'tool',
+            phase: TaskRuntimePhase.RUNNING,
+            meaningful: true,
+            toolName,
+            toolUseId: args.event.call_id,
+          });
+        }
         return;
       }
 
@@ -734,6 +827,25 @@ async function handleCursorEvent(args: {
       });
       args.toolCallMessageIdsByCallId.set(args.event.call_id, messageId);
       args.toolCallMessageIds.push(messageId);
+      await args.recordFirstAgentEvent?.();
+      if (args.event.status === 'running') {
+        await args.vitalsReporter?.record(TaskRuntimeEventKind.TOOL_START, {
+          source: 'tool',
+          phase: TaskRuntimePhase.TOOL_RUNNING,
+          meaningful: true,
+          toolName,
+          toolUseId: args.event.call_id,
+        });
+      } else {
+        args.completedToolCallIds.add(args.event.call_id);
+        await args.vitalsReporter?.record(TaskRuntimeEventKind.TOOL_COMPLETE, {
+          source: 'tool',
+          phase: TaskRuntimePhase.RUNNING,
+          meaningful: true,
+          toolName,
+          toolUseId: args.event.call_id,
+        });
+      }
       return;
     }
 

--- a/packages/executor/src/handlers/sdk/opencode.ts
+++ b/packages/executor/src/handlers/sdk/opencode.ts
@@ -10,10 +10,20 @@
  */
 
 import { generateId, shortId } from '@agor/core';
-import type { MessageID, PermissionMode, SessionID, TaskID } from '@agor/core/types';
-import { MessageRole } from '@agor/core/types';
+import type {
+  MessageID,
+  PermissionMode,
+  SessionID,
+  TaskID,
+  TaskRuntimeVitals,
+} from '@agor/core/types';
+import { MessageRole, TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import type { ResolvedConfigSlice } from '../../payload-types.js';
+import {
+  TaskRuntimeVitalsReporter,
+  wrapMessagesServiceWithRuntimeVitals,
+} from '../../runtime-vitals.js';
 import { OpenCodeTool } from '../../sdk-handlers/opencode/index.js';
 import type { AgorClient } from '../../services/feathers-client.js';
 import { createStreamingCallbacks } from './base-executor.js';
@@ -36,7 +46,30 @@ export async function executeOpenCodeTask(params: {
 
   console.log(`[opencode] Executing task ${shortId(taskId)}...`);
 
+  let initialRuntimeVitals: TaskRuntimeVitals | undefined;
   try {
+    initialRuntimeVitals = (await client.service('tasks').get(taskId)).runtime_vitals;
+  } catch (error) {
+    console.warn(
+      '[runtime-vitals] Failed to read initial task runtime vitals:',
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  const vitalsReporter = new TaskRuntimeVitalsReporter({
+    client,
+    taskId,
+    toolName: 'opencode',
+    initialSnapshot: initialRuntimeVitals,
+  });
+
+  try {
+    await vitalsReporter.record(TaskRuntimeEventKind.SDK_TURN_STARTED, {
+      source: 'executor',
+      phase: TaskRuntimePhase.SDK_STARTING,
+      forceFlush: true,
+    });
+
     // Get session to extract model config
     const session = await client.service('sessions').get(sessionId);
     console.log('[opencode] Session loaded:', {
@@ -77,10 +110,11 @@ export async function executeOpenCodeTask(params: {
         enabled: true,
         serverUrl,
       },
-      repos.messagesService,
+      wrapMessagesServiceWithRuntimeVitals(repos.messagesService, vitalsReporter),
       repos.sessionMCP,
       repos.mcpServers,
-      repos.mcpOAuthAuthHeaders
+      repos.mcpOAuthAuthHeaders,
+      vitalsReporter
     );
 
     let opencodeSessionId: string;
@@ -153,6 +187,11 @@ export async function executeOpenCodeTask(params: {
     // Execute task using OpenCode's executeTask interface
     // This will create the assistant message with streaming
     // Pass nextIndex + 1 for assistant message index
+    await vitalsReporter.record(TaskRuntimeEventKind.TASK_STATUS, {
+      source: 'executor',
+      phase: TaskRuntimePhase.AWAITING_FIRST_AGENT_EVENT,
+      forceFlush: true,
+    });
     const result = await tool.executeTask?.(sessionId, prompt, taskId, callbacks, nextIndex + 1);
 
     console.log(`[opencode] Execution completed: status=${result?.status}`);
@@ -165,11 +204,20 @@ export async function executeOpenCodeTask(params: {
 
     console.log('[opencode] Setting task model:', modelIdentifier);
 
+    const failed = result?.status !== 'completed';
+
     // Update task status to completed and set model
     await client.service('tasks').patch(taskId, {
-      status: result?.status === 'completed' ? 'completed' : 'failed',
+      status: failed ? 'failed' : 'completed',
       completed_at: new Date().toISOString(),
       model: modelIdentifier, // Set the model identifier used for this task (provider/model format)
+      runtime_vitals: await vitalsReporter.terminalSnapshot(
+        failed ? TaskRuntimeEventKind.TURN_FAILED : TaskRuntimeEventKind.TURN_COMPLETED,
+        {
+          source: 'sdk',
+          phase: failed ? TaskRuntimePhase.FAILED : TaskRuntimePhase.COMPLETED,
+        }
+      ),
     });
   } catch (error) {
     const err = error as Error;
@@ -179,8 +227,14 @@ export async function executeOpenCodeTask(params: {
     await client.service('tasks').patch(taskId, {
       status: 'failed',
       completed_at: new Date().toISOString(),
+      runtime_vitals: await vitalsReporter.terminalSnapshot(TaskRuntimeEventKind.TURN_FAILED, {
+        source: 'sdk',
+        phase: TaskRuntimePhase.FAILED,
+      }),
     });
 
     throw err;
+  } finally {
+    vitalsReporter.stop();
   }
 }

--- a/packages/executor/src/sdk-handlers/opencode/opencode-tool.test.ts
+++ b/packages/executor/src/sdk-handlers/opencode/opencode-tool.test.ts
@@ -8,7 +8,9 @@
  * - Capabilities reflecting MCP support
  */
 
+import { TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskRuntimeVitalsReporter } from '../../runtime-vitals.js';
 import { OpenCodeTool } from './opencode-tool.js';
 
 // Track client creation calls
@@ -17,6 +19,10 @@ const createdClients: Array<{ baseUrl: string; directory?: string }> = [];
 
 // Mock MCP add calls per client
 const mockMcpAddCalls: Array<{ name: string; config: unknown }> = [];
+let mockEventStream: unknown[] = [];
+let mockPromptResponse: { data: { parts: unknown[]; info: Record<string, unknown> } } = {
+  data: { parts: [], info: {} },
+};
 
 // Create a mock client factory
 function createMockClient(opts: { baseUrl: string; directory?: string }) {
@@ -28,11 +34,11 @@ function createMockClient(opts: { baseUrl: string; directory?: string }) {
       list: vi.fn().mockResolvedValue({ data: [] }),
       create: vi.fn().mockResolvedValue({ data: { id: 'mock-session-id' } }),
       get: vi.fn().mockResolvedValue({ data: {} }),
-      prompt: vi.fn().mockResolvedValue({ data: { parts: [], info: {} } }),
+      prompt: vi.fn().mockResolvedValue(mockPromptResponse),
       messages: vi.fn().mockResolvedValue({ data: [] }),
     },
     event: {
-      subscribe: vi.fn().mockResolvedValue({ stream: [] }),
+      subscribe: vi.fn().mockResolvedValue({ stream: mockEventStream }),
     },
     mcp: {
       add: vi
@@ -79,6 +85,8 @@ describe('OpenCodeTool', () => {
     clientCreateCount = 0;
     createdClients.length = 0;
     mockMcpAddCalls.length = 0;
+    mockEventStream = [];
+    mockPromptResponse = { data: { parts: [], info: {} } };
     vi.clearAllMocks();
   });
 
@@ -524,6 +532,164 @@ describe('OpenCodeTool', () => {
   });
 
   describe('executeTask Integration', () => {
+    it('reports sanitized stream and tool runtime vitals from OpenCode events', async () => {
+      mockEventStream = [
+        {
+          type: 'message.updated',
+          properties: {
+            info: {
+              sessionID: 'oc-session-vitals',
+              role: 'assistant',
+              id: 'assistant-vitals',
+            },
+          },
+        },
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'text-part',
+              messageID: 'assistant-vitals',
+              type: 'text',
+              text: 'hello',
+            },
+          },
+        },
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'tool-part',
+              callID: 'tool-call-1',
+              messageID: 'assistant-vitals',
+              type: 'tool',
+              tool: 'bash',
+              state: {
+                status: 'pending',
+                input: { command: 'echo secret-token' },
+              },
+            },
+          },
+        },
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'tool-part',
+              callID: 'tool-call-1',
+              messageID: 'assistant-vitals',
+              type: 'tool',
+              tool: 'bash',
+              state: {
+                status: 'running',
+                input: { command: 'echo secret-token' },
+              },
+            },
+          },
+        },
+        {
+          type: 'message.part.updated',
+          properties: {
+            part: {
+              id: 'tool-part',
+              callID: 'tool-call-1',
+              messageID: 'assistant-vitals',
+              type: 'tool',
+              tool: 'bash',
+              state: {
+                status: 'completed',
+                output: 'secret-output',
+              },
+            },
+          },
+        },
+        { type: 'session.status', properties: { status: { type: 'idle' } } },
+      ];
+      mockPromptResponse = {
+        data: {
+          info: { id: 'assistant-vitals' },
+          parts: [
+            { type: 'text', text: 'hello' },
+            {
+              type: 'tool',
+              id: 'tool-part',
+              callID: 'tool-call-1',
+              tool: 'bash',
+              state: {
+                input: { command: 'echo secret-token' },
+                status: 'completed',
+                output: 'secret-output',
+              },
+            },
+          ],
+        },
+      };
+      const patches: Array<{ id: string; data: Record<string, unknown> }> = [];
+      const reporter = new TaskRuntimeVitalsReporter({
+        client: {
+          service(name: string) {
+            if (name !== 'tasks') throw new Error(`unexpected service ${name}`);
+            return {
+              patch: vi.fn(async (id: string, data: Record<string, unknown>) => {
+                patches.push({ id, data });
+                return { task_id: id, ...data };
+              }),
+            };
+          },
+        } as never,
+        taskId: 'task-vitals',
+        toolName: 'opencode',
+        minPatchIntervalMs: 0,
+      });
+      const tool = new OpenCodeTool(
+        { enabled: true, serverUrl: 'http://localhost:4096' },
+        mockMessagesService,
+        mockSessionMCPRepo,
+        mockMCPServerRepo,
+        undefined,
+        reporter
+      );
+      tool.setSessionContext('session-vitals', 'oc-session-vitals');
+
+      const result = await tool.executeTask?.(
+        'session-vitals',
+        'prompt secret should not enter vitals',
+        'task-vitals',
+        {
+          onStreamStart: vi.fn(async () => undefined),
+          onStreamChunk: vi.fn(async () => undefined),
+          onStreamEnd: vi.fn(async () => undefined),
+          onStreamError: vi.fn(async () => undefined),
+          onThinkingStart: vi.fn(async () => undefined),
+          onThinkingChunk: vi.fn(async () => undefined),
+          onThinkingEnd: vi.fn(async () => undefined),
+        },
+        1
+      );
+      const terminalVitals = await reporter.terminalSnapshot(TaskRuntimeEventKind.TURN_COMPLETED, {
+        source: 'sdk',
+        phase: TaskRuntimePhase.COMPLETED,
+      });
+
+      expect(result?.status).toBe('completed');
+      expect(terminalVitals.recent_events?.map((event) => event.kind)).toEqual([
+        TaskRuntimeEventKind.FIRST_AGENT_EVENT,
+        TaskRuntimeEventKind.STREAM_START,
+        TaskRuntimeEventKind.TOOL_START,
+        TaskRuntimeEventKind.TOOL_COMPLETE,
+        TaskRuntimeEventKind.TURN_COMPLETED,
+      ]);
+      expect(terminalVitals.active_tool).toBeNull();
+      expect(terminalVitals.counters?.tool_starts).toBe(1);
+      expect(terminalVitals.counters?.tool_completes).toBe(1);
+      expect(terminalVitals.recent_events?.[2]).toMatchObject({
+        tool_name: 'bash',
+        tool_use_id: 'tool-call-1',
+      });
+      expect(JSON.stringify(terminalVitals)).not.toContain('secret');
+      expect(patches.length).toBeGreaterThan(0);
+    });
+
     it('should use directory-scoped client based on session branch path', async () => {
       const tool = new OpenCodeTool(
         { enabled: true, serverUrl: 'http://localhost:4096' },

--- a/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
+++ b/packages/executor/src/sdk-handlers/opencode/opencode-tool.ts
@@ -18,7 +18,7 @@ import { generateId, shortId } from '@agor/core';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
-import { MessageRole } from '@agor/core/types';
+import { MessageRole, TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
 import type { Part as OpenCodePart } from '@opencode-ai/sdk';
 import { createOpencodeClient } from '@opencode-ai/sdk';
 import { getDaemonUrl } from '../../config.js';
@@ -27,6 +27,7 @@ import type {
   MCPServerRepository,
   SessionMCPServerRepository,
 } from '../../db/feathers-repositories.js';
+import type { TaskRuntimeVitalsReporter } from '../../runtime-vitals.js';
 import type { NormalizedSdkResponse, RawSdkResponse } from '../../types/sdk-response.js';
 import { enrichContentBlocks } from '../base/diff-enrichment.js';
 import type {
@@ -103,7 +104,8 @@ export class OpenCodeTool implements ITool {
     messagesService?: MessagesService,
     sessionMCPRepo?: SessionMCPServerRepository,
     mcpServerRepo?: MCPServerRepository,
-    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository
+    private mcpOAuthAuthHeadersRepo?: MCPOAuthAuthHeadersRepository,
+    private vitalsReporter?: TaskRuntimeVitalsReporter
   ) {
     this.config = config;
     this.messagesService = messagesService;
@@ -534,6 +536,68 @@ export class OpenCodeTool implements ITool {
       const allParts: Array<{ id: string; type: string; data: unknown }> = []; // Store all parts for later processing
       let currentTextMessageId: string | null = null;
       let currentReasoningMessageId: string | null = null;
+      let firstAgentEventRecorded = false;
+      const toolRuntimeStatuses = new Map<string, string | undefined>();
+      const toolRuntimeStartedIds = new Set<string>();
+      const recordFirstAgentEvent = async () => {
+        if (firstAgentEventRecorded) return;
+        firstAgentEventRecorded = true;
+        await this.vitalsReporter?.record(TaskRuntimeEventKind.FIRST_AGENT_EVENT, {
+          source: 'sdk',
+          phase: TaskRuntimePhase.RUNNING,
+          meaningful: true,
+          forceFlush: true,
+        });
+      };
+      const recordToolRuntimeFact = async (part: {
+        id?: string;
+        callID?: string;
+        tool?: string;
+        state?: { status?: string };
+      }) => {
+        const rawToolUseId = part.callID || part.id;
+        const toolUseId =
+          typeof rawToolUseId === 'string' && rawToolUseId.length > 0 ? rawToolUseId : undefined;
+        const toolName =
+          typeof part.tool === 'string' && part.tool.length > 0 ? part.tool : undefined;
+        const hasPreviousStatus = toolUseId ? toolRuntimeStatuses.has(toolUseId) : false;
+        const previousStatus = toolUseId ? toolRuntimeStatuses.get(toolUseId) : undefined;
+        const status =
+          typeof part.state?.status === 'string' && part.state.status.length > 0
+            ? part.state.status
+            : undefined;
+        if (toolUseId) {
+          toolRuntimeStatuses.set(toolUseId, status);
+        }
+        if (hasPreviousStatus && status === previousStatus) return;
+
+        const terminalStatus = status === 'completed' || status === 'error';
+        if (!terminalStatus) {
+          if (toolUseId && toolRuntimeStartedIds.has(toolUseId)) return;
+          if (toolUseId) {
+            toolRuntimeStartedIds.add(toolUseId);
+          }
+
+          await recordFirstAgentEvent();
+          await this.vitalsReporter?.record(TaskRuntimeEventKind.TOOL_START, {
+            source: 'tool',
+            phase: TaskRuntimePhase.TOOL_RUNNING,
+            meaningful: true,
+            toolName,
+            toolUseId,
+          });
+          return;
+        }
+
+        await recordFirstAgentEvent();
+        await this.vitalsReporter?.record(TaskRuntimeEventKind.TOOL_COMPLETE, {
+          source: 'tool',
+          phase: TaskRuntimePhase.RUNNING,
+          meaningful: true,
+          toolName,
+          toolUseId,
+        });
+      };
 
       // IMPORTANT: Subscribe to event stream BEFORE sending prompt
       // Events are emitted in real-time as prompt executes
@@ -679,6 +743,12 @@ export class OpenCodeTool implements ITool {
                 // Stream delta to UI based on part type
                 if (delta.length > 0) {
                   if (part.type === 'reasoning') {
+                    await recordFirstAgentEvent();
+                    await this.vitalsReporter?.record(TaskRuntimeEventKind.THINKING, {
+                      source: 'sdk',
+                      phase: TaskRuntimePhase.RUNNING,
+                      meaningful: true,
+                    });
                     // Stream reasoning chunks
                     if (!currentReasoningMessageId) {
                       currentReasoningMessageId = generateId();
@@ -692,8 +762,14 @@ export class OpenCodeTool implements ITool {
                       delta
                     );
                   } else if (part.type === 'text') {
+                    await recordFirstAgentEvent();
                     // Stream text chunks
                     if (!currentTextMessageId) {
+                      await this.vitalsReporter?.record(TaskRuntimeEventKind.STREAM_START, {
+                        source: 'sdk',
+                        phase: TaskRuntimePhase.RUNNING,
+                        meaningful: true,
+                      });
                       currentTextMessageId = generateId();
                       streamingCallbacks.onStreamStart(currentTextMessageId as MessageID, {
                         session_id: sessionId as SessionID,
@@ -704,6 +780,14 @@ export class OpenCodeTool implements ITool {
                     }
                     streamingCallbacks.onStreamChunk(currentTextMessageId as MessageID, delta);
                   } else if (part.type === 'tool') {
+                    await recordToolRuntimeFact(
+                      part as {
+                        id?: string;
+                        callID?: string;
+                        tool?: string;
+                        state?: { status?: string };
+                      }
+                    );
                     // Tool execution - log full details
                     console.log('[OpenCodeTool] ========== TOOL PART ==========');
                     console.log('[OpenCodeTool] Tool part ID:', part.id);
@@ -712,6 +796,14 @@ export class OpenCodeTool implements ITool {
                   }
                 }
               } else if (part.type === 'tool') {
+                await recordToolRuntimeFact(
+                  part as {
+                    id?: string;
+                    callID?: string;
+                    tool?: string;
+                    state?: { status?: string };
+                  }
+                );
                 // Tool parts without text field - log full structure
                 console.log('[OpenCodeTool] ========== TOOL PART (no text) ==========');
                 console.log('[OpenCodeTool] Tool part ID:', part.id);


### PR DESCRIPTION
## Linked issue

Refs preset-io/agor-cloud#151

## Summary

- Add passive runtime-vitals reporting for OpenCode executor handling.
- Add passive runtime-vitals reporting for Cursor executor handling.
- Cover sanitized stream/tool/terminal events with targeted tests.

## Why / context

#1837 added the shared runtime-vitals foundation and #1840 added daemon spawn/process lifecycle events. OpenCode and Cursor still only had daemon-level vitals, so tasks could remain in an executor-starting-looking phase without handler-level progress or terminal vitals. This PR adds the first non-shared-SDK coverage slice without changing timeout or terminalization policy.

## Implementation notes

- Reporters seed from existing task runtime-vitals so daemon spawn/process events are preserved.
- OpenCode and Cursor record normalized SDK/turn start, first-progress, assistant/thinking/stream progress, parsed tool start/complete, and terminal snapshots.
- OpenCode dedupes non-terminal tool starts per tool id so pending-to-running transitions do not inflate tool-start counters.
- Runtime-vitals payloads remain sanitized: event metadata and tool name/id only; no prompts, raw SDK payloads, tool inputs/outputs, stdout/stderr, or credentials.
- This PR is passive only; it does not change timeout, abort, queue drain, terminalization, Claude CLI, Gemini, or Copilot behavior.

## Validation / test plan

- [x] `pnpm --filter @agor/executor test -- src/handlers/sdk/cursor.test.ts src/runtime-vitals.test.ts`
- [x] `pnpm --filter @agor/executor test -- src/sdk-handlers/opencode/opencode-tool.test.ts -t "reports sanitized stream and tool runtime vitals"`
- [x] `pnpm --filter @agor/executor typecheck`
- [x] `pnpm exec biome check $(git diff --name-only HEAD)`
- [x] `git diff --check`

## Screenshots / demos

Not applicable; executor instrumentation only.

## Risks / rollout / rollback

Low runtime risk: this only adds passive task metadata patches and tests. Rollback is reverting this PR.

## Out of scope / follow-ups

- Claude Code CLI watcher vitals.
- Gemini/Copilot tool-event gaps.
- Timeout policy.
- Abort redesign or terminalization changes.
