### PR TITLE
feat(executor): add execution attempt ownership

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -1,5 +1,6 @@
+import { EventEmitter } from 'node:events';
 import type { HookContext } from '@agor/core/types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { executorRuntimeScopeGuard, scopeExecutorRuntimeAuth } from './executor-runtime-scope';
 
 const payload = {
@@ -260,6 +261,88 @@ describe('executorRuntimeScopeGuard', () => {
     } as never);
 
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/no longer active/);
+  });
+
+  it('memoizes current attempt checks for hot executor request paths', async () => {
+    const tasks = Object.assign(new EventEmitter(), {
+      get: vi.fn(async () => ({
+        task_id: 'task-cache-1',
+        current_execution_attempt: {
+          attempt_id: 'attempt-cache-1',
+          executor_instance_id: 'executor-cache-1',
+        },
+      })),
+    });
+    const app = { service: (name: string) => (name === 'tasks' ? tasks : undefined) };
+    const scopedPayload = {
+      ...payload,
+      task_id: 'task-cache-1',
+      attempt_id: 'attempt-cache-1',
+      executor_instance_id: 'executor-cache-1',
+    };
+
+    await executorRuntimeScopeGuard()(
+      ctx({
+        path: 'messages/streaming',
+        method: 'create',
+        data: { data: { task_id: 'task-cache-1' } },
+        params: { authentication: { payload: scopedPayload }, query: {}, provider: 'socketio' },
+        app,
+      } as never)
+    );
+    await executorRuntimeScopeGuard()(
+      ctx({
+        path: 'messages/streaming',
+        method: 'create',
+        data: { data: { task_id: 'task-cache-1' } },
+        params: { authentication: { payload: scopedPayload }, query: {}, provider: 'socketio' },
+        app,
+      } as never)
+    );
+
+    expect(tasks.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates cached current attempt checks when the task is patched', async () => {
+    const tasks = Object.assign(new EventEmitter(), {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({
+          task_id: 'task-cache-2',
+          current_execution_attempt: {
+            attempt_id: 'attempt-cache-2',
+            executor_instance_id: 'executor-cache-2',
+          },
+        })
+        .mockResolvedValueOnce({
+          task_id: 'task-cache-2',
+          current_execution_attempt: {
+            attempt_id: 'attempt-cache-3',
+            executor_instance_id: 'executor-cache-2',
+          },
+        }),
+    });
+    const app = { service: (name: string) => (name === 'tasks' ? tasks : undefined) };
+    const scopedPayload = {
+      ...payload,
+      task_id: 'task-cache-2',
+      attempt_id: 'attempt-cache-2',
+      executor_instance_id: 'executor-cache-2',
+    };
+    const streamingContext = () =>
+      ctx({
+        path: 'messages/streaming',
+        method: 'create',
+        data: { data: { task_id: 'task-cache-2' } },
+        params: { authentication: { payload: scopedPayload }, query: {}, provider: 'socketio' },
+        app,
+      } as never);
+
+    await executorRuntimeScopeGuard()(streamingContext());
+    tasks.emit('patched', { task_id: 'task-cache-2' });
+
+    await expect(executorRuntimeScopeGuard()(streamingContext())).rejects.toThrow(/attempt scope/);
+    expect(tasks.get).toHaveBeenCalledTimes(2);
   });
 
   it('bypasses internal (provider-less) service composition', async () => {

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -7,6 +7,8 @@ const payload = {
   purpose: 'executor-task',
   session_id: 'session-1',
   task_id: 'task-1',
+  attempt_id: 'attempt-1',
+  executor_instance_id: 'executor-1',
   branch_id: 'branch-1',
 };
 
@@ -205,6 +207,59 @@ describe('executorRuntimeScopeGuard', () => {
     await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(
       /not valid for this endpoint/
     );
+  });
+
+  it('rejects executor tokens for stale task attempts before side effects', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'create',
+      data: { content: 'late message' },
+      app: {
+        service(name: string) {
+          if (name === 'tasks') {
+            return {
+              get: async () => ({
+                task_id: 'task-1',
+                current_execution_attempt: {
+                  attempt_id: 'attempt-2',
+                  executor_instance_id: 'executor-1',
+                },
+              }),
+            };
+          }
+          throw new Error(`unexpected service ${name}`);
+        },
+      },
+    } as never);
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/attempt scope/);
+  });
+
+  it('rejects executor tokens after their current attempt is terminal', async () => {
+    const context = ctx({
+      path: 'messages',
+      method: 'create',
+      data: { content: 'late message' },
+      app: {
+        service(name: string) {
+          if (name === 'tasks') {
+            return {
+              get: async () => ({
+                task_id: 'task-1',
+                current_execution_attempt: {
+                  attempt_id: 'attempt-1',
+                  executor_instance_id: 'executor-1',
+                  terminal_at: '2026-01-01T00:00:00.000Z',
+                },
+              }),
+            };
+          }
+          throw new Error(`unexpected service ${name}`);
+        },
+      },
+    } as never);
+
+    await expect(executorRuntimeScopeGuard()(context)).rejects.toThrow(/no longer active/);
   });
 
   it('bypasses internal (provider-less) service composition', async () => {

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -11,6 +11,7 @@ import {
 type Scope = {
   sessionId?: string;
   taskId?: string;
+  attemptId?: string;
   branchId?: string;
 };
 
@@ -56,6 +57,42 @@ function expectMatch(claim: string, value: unknown, label: string): void {
   if (value === undefined || value === null) return;
   if (String(value) !== claim) {
     throw new Forbidden(`Executor token ${label} scope does not match this request`);
+  }
+}
+
+async function requireCurrentAttemptScope(
+  context: HookContext,
+  payload: ExecutorSessionTokenPayload
+): Promise<void> {
+  if (!payload.task_id) return;
+  const app = (
+    context as HookContext & {
+      app?: { service(name: string): { get(id: string, params?: Params): Promise<unknown> } };
+    }
+  ).app;
+  if (!app) return;
+
+  const task = asRecord(await app.service('tasks').get(payload.task_id, { provider: undefined }));
+  const attempt = asRecord(task?.current_execution_attempt);
+  if (!attempt) return;
+
+  if (!payload.attempt_id) {
+    throw new Forbidden('Executor token is missing attempt scope');
+  }
+  if (attempt.attempt_id !== payload.attempt_id) {
+    throw new Forbidden('Executor token attempt scope does not match current task attempt');
+  }
+  if (
+    payload.executor_instance_id &&
+    attempt.executor_instance_id &&
+    attempt.executor_instance_id !== payload.executor_instance_id
+  ) {
+    throw new Forbidden(
+      'Executor token executor-instance scope does not match current task attempt'
+    );
+  }
+  if (attempt.terminal_at) {
+    throw new Forbidden('Executor token attempt is no longer active');
   }
 }
 
@@ -196,9 +233,12 @@ export function executorRuntimeScopeGuard() {
     const payload = scopedPayload(context);
     if (!payload) return context;
 
+    await requireCurrentAttemptScope(context, payload);
+
     const scope = {
       sessionId: getExecutorSessionTokenSessionId(payload),
       taskId: payload.task_id,
+      attemptId: payload.attempt_id,
       branchId: payload.branch_id,
     };
     const data = (context.data ?? {}) as Record<string, unknown>;

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -15,6 +15,19 @@ type Scope = {
   branchId?: string;
 };
 
+type CurrentAttemptScope = {
+  attemptId?: unknown;
+  executorInstanceId?: unknown;
+  terminalAt?: unknown;
+};
+
+const CURRENT_ATTEMPT_SCOPE_CACHE_TTL_MS = 1_000;
+const currentAttemptScopeCache = new Map<
+  string,
+  { expiresAtMs: number; attempt: CurrentAttemptScope | null }
+>();
+const currentAttemptInvalidators = new WeakSet<object>();
+
 function scopedPayload(context: HookContext): ExecutorSessionTokenPayload | null {
   const params = context.params as AuthenticatedParams & ExecutorSessionTokenPayload;
   const payload = params.authentication?.payload as ExecutorSessionTokenPayload | undefined;
@@ -46,6 +59,36 @@ function scopedPayload(context: HookContext): ExecutorSessionTokenPayload | null
   return null;
 }
 
+function currentAttemptCacheKey(payload: ExecutorSessionTokenPayload): string {
+  return `${payload.task_id ?? ''}\0${payload.attempt_id ?? ''}\0${payload.executor_instance_id ?? ''}`;
+}
+
+function invalidateCurrentAttemptScopeCache(taskId: unknown): void {
+  if (typeof taskId !== 'string') return;
+  const prefix = `${taskId}\0`;
+  for (const key of currentAttemptScopeCache.keys()) {
+    if (key.startsWith(prefix)) currentAttemptScopeCache.delete(key);
+  }
+}
+
+function ensureCurrentAttemptInvalidator(app: { service(name: string): unknown }): void {
+  const tasksService = app.service('tasks') as
+    | {
+        on?: (event: string, listener: (task: unknown) => void) => void;
+      }
+    | undefined;
+  if (!tasksService || currentAttemptInvalidators.has(tasksService)) return;
+  currentAttemptInvalidators.add(tasksService);
+
+  const invalidateFromTask = (task: unknown) => {
+    const record = asRecord(task);
+    invalidateCurrentAttemptScopeCache(record?.task_id);
+  };
+  tasksService.on?.('patched', invalidateFromTask);
+  tasksService.on?.('updated', invalidateFromTask);
+  tasksService.on?.('removed', invalidateFromTask);
+}
+
 function expectClaim(claim: string | undefined, label: string): string {
   if (!claim) {
     throw new Forbidden(`Executor token is missing ${label} scope`);
@@ -57,6 +100,30 @@ function expectMatch(claim: string, value: unknown, label: string): void {
   if (value === undefined || value === null) return;
   if (String(value) !== claim) {
     throw new Forbidden(`Executor token ${label} scope does not match this request`);
+  }
+}
+
+function validateCurrentAttemptScope(
+  payload: ExecutorSessionTokenPayload,
+  attempt: CurrentAttemptScope
+): void {
+  if (!payload.attempt_id) {
+    throw new Forbidden('Executor token is missing attempt scope');
+  }
+  if (attempt.attemptId !== payload.attempt_id) {
+    throw new Forbidden('Executor token attempt scope does not match current task attempt');
+  }
+  if (
+    payload.executor_instance_id &&
+    attempt.executorInstanceId &&
+    attempt.executorInstanceId !== payload.executor_instance_id
+  ) {
+    throw new Forbidden(
+      'Executor token executor-instance scope does not match current task attempt'
+    );
+  }
+  if (attempt.terminalAt) {
+    throw new Forbidden('Executor token attempt is no longer active');
   }
 }
 
@@ -72,28 +139,33 @@ async function requireCurrentAttemptScope(
   ).app;
   if (!app) return;
 
-  const task = asRecord(await app.service('tasks').get(payload.task_id, { provider: undefined }));
-  const attempt = asRecord(task?.current_execution_attempt);
-  if (!attempt) return;
+  ensureCurrentAttemptInvalidator(app);
+  const cacheKey = currentAttemptCacheKey(payload);
+  const nowMs = Date.now();
+  let cachedAttempt = currentAttemptScopeCache.get(cacheKey);
+  if (!cachedAttempt || cachedAttempt.expiresAtMs <= nowMs) {
+    const task = asRecord(await app.service('tasks').get(payload.task_id, { provider: undefined }));
+    const attempt = asRecord(task?.current_execution_attempt);
+    const attemptScope = attempt
+      ? {
+          attemptId: attempt.attempt_id,
+          executorInstanceId: attempt.executor_instance_id,
+          terminalAt: attempt.terminal_at,
+        }
+      : null;
+    if (attemptScope) {
+      validateCurrentAttemptScope(payload, attemptScope);
+    }
+    cachedAttempt = {
+      expiresAtMs: nowMs + CURRENT_ATTEMPT_SCOPE_CACHE_TTL_MS,
+      attempt: attemptScope,
+    };
+    currentAttemptScopeCache.set(cacheKey, cachedAttempt);
+  }
 
-  if (!payload.attempt_id) {
-    throw new Forbidden('Executor token is missing attempt scope');
-  }
-  if (attempt.attempt_id !== payload.attempt_id) {
-    throw new Forbidden('Executor token attempt scope does not match current task attempt');
-  }
-  if (
-    payload.executor_instance_id &&
-    attempt.executor_instance_id &&
-    attempt.executor_instance_id !== payload.executor_instance_id
-  ) {
-    throw new Forbidden(
-      'Executor token executor-instance scope does not match current task attempt'
-    );
-  }
-  if (attempt.terminal_at) {
-    throw new Forbidden('Executor token attempt is no longer active');
-  }
+  const attempt = cachedAttempt.attempt;
+  if (!attempt) return;
+  validateCurrentAttemptScope(payload, attempt);
 }
 
 function setIfAbsent(target: Record<string, unknown>, key: string, value: string): void {

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -33,6 +33,8 @@ function scopedPayload(context: HookContext): ExecutorSessionTokenPayload | null
       type: EXECUTOR_SESSION_TOKEN_TYPE,
       purpose: EXECUTOR_SESSION_TOKEN_PURPOSE,
       task_id: params.task_id,
+      attempt_id: params.attempt_id,
+      executor_instance_id: params.executor_instance_id,
       session_id: params.session_id,
       sessionId: params.sessionId,
       branch_id: params.branch_id,

--- a/apps/agor-daemon/src/auth/executor-session-token.ts
+++ b/apps/agor-daemon/src/auth/executor-session-token.ts
@@ -10,6 +10,8 @@ export type ExecutorSessionTokenPayload = JwtPayload & {
   /** @deprecated Legacy alias kept only for tokens minted before session_id became canonical. */
   sessionId?: string;
   task_id?: string;
+  attempt_id?: string;
+  executor_instance_id?: string;
   branch_id?: string;
 };
 

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -140,6 +140,8 @@ export class ServiceJWTStrategy extends JWTStrategy {
           session_id?: string;
           sessionId?: string;
           task_id?: string;
+          attempt_id?: string;
+          executor_instance_id?: string;
           branch_id?: string;
           purpose?: string;
         })
@@ -173,6 +175,7 @@ export class ServiceJWTStrategy extends JWTStrategy {
       const sessionInfo = await this.sessionTokenService.validateToken(token, {
         sessionId,
         taskId: payload.task_id,
+        attemptId: payload.attempt_id,
         branchId: payload.branch_id,
       });
       if (!sessionInfo) {
@@ -183,6 +186,8 @@ export class ServiceJWTStrategy extends JWTStrategy {
         ...result,
         session_id: sessionInfo.session_id,
         task_id: sessionInfo.task_id,
+        attempt_id: sessionInfo.attempt_id,
+        executor_instance_id: sessionInfo.executor_instance_id,
         branch_id: sessionInfo.branch_id,
       };
     }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -67,6 +67,7 @@ import {
   ROLES,
   SERVICE_GROUP_NAMES,
   SessionStatus,
+  TaskExecutionRuntimeBackend,
   TaskRuntimeEventKind,
   TaskRuntimePhase,
   TaskStatus,
@@ -1040,12 +1041,27 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     const gitStateAtStart = 'unknown';
     const refAtStart = 'unknown';
 
+    const runtimeBackend = config.execution?.executor_command_template
+      ? TaskExecutionRuntimeBackend.COMMAND_TEMPLATE
+      : TaskExecutionRuntimeBackend.LOCAL_SUBPROCESS;
+    const currentExecutionAttempt: NonNullable<Task['current_execution_attempt']> = {
+      schema_version: 1,
+      attempt_id: generateId(),
+      executor_instance_id: generateId(),
+      runtime_backend: runtimeBackend,
+      ...(runtimeBackend === TaskExecutionRuntimeBackend.COMMAND_TEMPLATE
+        ? { runtime_ref: task.task_id }
+        : {}),
+      started_at: startTimestamp,
+    };
+
     // Patch task: queued/created → running, with real ranges. queue_position
     // is cleared here so a draining task is no longer considered queued.
     const runningPatch: Partial<Task> = {
       status: TaskStatus.RUNNING,
       started_at: startTimestamp,
       queue_position: undefined,
+      current_execution_attempt: currentExecutionAttempt,
       message_range: {
         start_index: messageStartIndex,
         end_index: messageStartIndex + 1,
@@ -1059,7 +1075,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     };
     if (session.agentic_tool !== 'claude-code-cli') {
       runningPatch.runtime_vitals = buildDaemonTaskRuntimeVitals(
-        task.runtime_vitals,
+        undefined,
         TaskRuntimeEventKind.EXECUTOR_SPAWN_REQUESTED,
         {
           at: startTimestamp,
@@ -1257,6 +1273,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           sessionId,
           {
             taskId,
+            attemptId: currentExecutionAttempt.attempt_id,
+            executorInstanceId: currentExecutionAttempt.executor_instance_id,
             prompt: promptForExecutor,
             permissionMode: options.permissionMode,
             stream: useStreaming,
@@ -1274,30 +1292,61 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           `❌ [Daemon] Executor spawn failed for session=${shortId(sessionId)} task=${shortId(taskId)} agent=${session.agentic_tool} unix_username=${session.unix_username ?? 'null'}: ${errorMessage}`,
           error
         );
-        await safePatch(
-          'tasks',
-          taskId,
-          {
-            status: TaskStatus.FAILED,
-            completed_at: new Date().toISOString(),
-            error_message: errorMessage,
-            runtime_vitals: buildDaemonTaskRuntimeVitals(
-              (
-                await app
-                  .service('tasks')
-                  .get(taskId, params)
-                  .catch(() => updatedTask)
-              ).runtime_vitals,
-              TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
-              {
-                phase: TaskRuntimePhase.FAILED,
-                errorCode: 'spawn_exception',
-              }
-            ),
+        const runtimeAttemptParams = {
+          ...params,
+          runtimeAttempt: {
+            attemptId: currentExecutionAttempt.attempt_id,
+            executorInstanceId: currentExecutionAttempt.executor_instance_id,
           },
-          'Task',
-          params
-        );
+        } as RouteParams;
+        let spawnFailureApplied = false;
+        try {
+          const failedTask = (await app.service('tasks').patch(
+            taskId,
+            {
+              status: TaskStatus.FAILED,
+              completed_at: new Date().toISOString(),
+              error_message: errorMessage,
+              runtime_vitals: buildDaemonTaskRuntimeVitals(
+                (
+                  await app
+                    .service('tasks')
+                    .get(taskId, params)
+                    .catch(() => updatedTask)
+                ).runtime_vitals,
+                TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+                {
+                  phase: TaskRuntimePhase.FAILED,
+                  errorCode: 'spawn_exception',
+                }
+              ),
+            },
+            runtimeAttemptParams
+          )) as Task & { runtime_patch_ignored?: boolean };
+          spawnFailureApplied =
+            failedTask.runtime_patch_ignored !== true &&
+            failedTask.status === TaskStatus.FAILED &&
+            failedTask.error_message === errorMessage &&
+            failedTask.current_execution_attempt?.attempt_id === currentExecutionAttempt.attempt_id;
+        } catch (patchError) {
+          if (
+            patchError instanceof NotFoundError ||
+            (patchError instanceof Error && patchError.message.includes('No record found'))
+          ) {
+            console.log(
+              `⚠️  Task ${shortId(taskId)} was deleted mid-execution - skipping spawn failure update`
+            );
+          } else {
+            throw patchError;
+          }
+        }
+
+        if (!spawnFailureApplied) {
+          console.log(
+            `⏭️ [Daemon] Spawn failure for task ${shortId(taskId)} did not apply to the current attempt; skipping fallback transcript side effects`
+          );
+          return;
+        }
 
         // Synthesize a system message so the chat surfaces *why* the agent
         // didn't respond. Without this the transcript shows only the user

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -10,6 +10,7 @@ import {
   PublicBaseUrlNotConfiguredError,
   requirePublicBaseUrl,
   resolveExecutionSecurityMode,
+  resolveExecutorHeartbeatConfig,
 } from '@agor/core/config';
 import {
   and,
@@ -127,9 +128,11 @@ import { userRoomName } from './setup/socketio.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
 import {
+  hasExecutorConnectionEvidence,
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
   shouldFailCommandTemplateLauncherExit,
+  shouldScheduleCommandTemplateConnectTimeout,
 } from './utils/executor-spawn-classification.js';
 import { escapeHtml } from './utils/html.js';
 import {
@@ -786,6 +789,74 @@ function createExecuteHandler(
       if (!data.attemptId) return true;
       return task.current_execution_attempt?.attempt_id === data.attemptId;
     };
+    const taskHasExecutorConnectionEvidence = (task: Task): boolean =>
+      hasExecutorConnectionEvidence({
+        connected_at: task.current_execution_attempt?.connected_at,
+        last_heartbeat_at: task.current_execution_attempt?.last_heartbeat_at,
+        task_last_executor_heartbeat_at: task.last_executor_heartbeat_at,
+      });
+    const commandTemplateConnectTimeoutMs = resolveExecutorHeartbeatConfig(
+      config.execution
+    ).stale_after_ms;
+
+    const scheduleCommandTemplateConnectTimeoutCheck = (): void => {
+      const timer = setTimeout(() => {
+        void (async () => {
+          try {
+            const latestSession = await app.service('sessions').get(sessionId, params);
+            const latestTask = (await app.service('tasks').get(taskId, params)) as Task;
+            const latestConnected = taskHasExecutorConnectionEvidence(latestTask);
+            const latestTaskId = latestSession.tasks?.[latestSession.tasks.length - 1];
+            const stillLatestTask = !latestTaskId || latestTaskId === taskId;
+            const stillActiveTask =
+              isTaskExecuting(latestTask) || latestTask.status === TaskStatus.TIMED_OUT;
+            const stillSessionExecuting =
+              isSessionExecuting(latestSession) || latestSession.status === SessionStatus.TIMED_OUT;
+            const stillAttemptMatches = capturedAttemptMatches(latestTask);
+
+            if (
+              !stillAttemptMatches ||
+              latestConnected ||
+              !stillActiveTask ||
+              !stillLatestTask ||
+              !stillSessionExecuting
+            ) {
+              return;
+            }
+
+            await app.service('tasks').patch(
+              taskId,
+              {
+                status: TaskStatus.FAILED,
+                error_message:
+                  `Executor launcher exited successfully but executor did not connect ` +
+                  `within ${commandTemplateConnectTimeoutMs}ms.`,
+                runtime_vitals: buildDaemonTaskRuntimeVitals(
+                  latestTask.runtime_vitals,
+                  TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+                  {
+                    phase: TaskRuntimePhase.FAILED,
+                    errorCode: 'connect_timeout',
+                  }
+                ),
+              },
+              runtimeAttemptParams
+            );
+            appWithExecutor.sessionTokenService?.revokeToken(sessionToken);
+            console.log(
+              `✅ [Executor] Command-template executor connect timeout marked task ${shortId(taskId)} FAILED`
+            );
+          } catch (error) {
+            console.error(
+              `❌ [Executor] Failed command-template executor connect-timeout check:`,
+              error
+            );
+          }
+        })();
+      }, commandTemplateConnectTimeoutMs);
+
+      timer.unref?.();
+    };
 
     // Get branch path
     let cwd = process.cwd();
@@ -1008,7 +1079,7 @@ function createExecuteHandler(
           try {
             const currentSession = await app.service('sessions').get(sessionId, params);
             const currentTask = (await app.service('tasks').get(taskId, params)) as Task;
-            const connected = Boolean(currentTask.current_execution_attempt?.connected_at);
+            const connected = taskHasExecutorConnectionEvidence(currentTask);
             const activeTask =
               isTaskExecuting(currentTask) || currentTask.status === TaskStatus.TIMED_OUT;
             const latestTaskId = currentSession.tasks?.[currentSession.tasks.length - 1];
@@ -1051,6 +1122,18 @@ function createExecuteHandler(
                 `✅ [Executor] Command-template launcher failure marked task ${shortId(taskId)} FAILED (code: ${code})`
               );
             } else {
+              if (
+                shouldScheduleCommandTemplateConnectTimeout({
+                  code,
+                  connected,
+                  activeTask,
+                  isLatestTask,
+                  sessionExecuting,
+                  attemptMatches,
+                })
+              ) {
+                scheduleCommandTemplateConnectTimeoutCheck();
+              }
               console.log(
                 `ℹ️  [Executor] Command-template launcher exit is not authoritative (code: ${code}, connected: ${connected})`
               );
@@ -1214,7 +1297,13 @@ function createExecuteHandler(
           }
         }
 
-        appWithExecutor.sessionTokenService?.revokeToken(sessionToken);
+        if (!isCommandTemplateRuntime || wroteExitVitals) {
+          appWithExecutor.sessionTokenService?.revokeToken(sessionToken);
+        } else {
+          console.log(
+            `ℹ️  [Executor] Keeping command-template runtime token for task ${shortId(taskId)} after launcher exit; remote executor owns terminal revocation/expiry`
+          );
+        }
       },
     });
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -39,6 +39,7 @@ import type {
   MessageSource,
   Params,
   SessionID,
+  Task,
   UserID,
   UUID,
 } from '@agor/core/types';
@@ -128,6 +129,7 @@ import { requireMinimumRole } from './utils/authorization.js';
 import {
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
+  shouldFailCommandTemplateLauncherExit,
 } from './utils/executor-spawn-classification.js';
 import { escapeHtml } from './utils/html.js';
 import {
@@ -716,6 +718,8 @@ function createExecuteHandler(
     sessionId: string,
     data: {
       taskId: string;
+      attemptId?: string;
+      executorInstanceId?: string;
       prompt: string;
       permissionMode?: import('@agor/core/types').PermissionMode;
       stream?: boolean;
@@ -758,6 +762,8 @@ function createExecuteHandler(
       (params as AuthenticatedParams).user!.user_id,
       {
         taskId: data.taskId,
+        attemptId: data.attemptId,
+        executorInstanceId: data.executorInstanceId,
         branchId: session.branch_id,
         // Executor JWTs authenticate on every daemon API call over the runtime
         // connection, so low per-call max-use limits make normal execution
@@ -769,6 +775,17 @@ function createExecuteHandler(
     );
 
     const taskId = data.taskId;
+    const runtimeAttemptParams = {
+      ...params,
+      runtimeAttempt: {
+        attemptId: data.attemptId,
+        executorInstanceId: data.executorInstanceId,
+      },
+    };
+    const capturedAttemptMatches = (task: Task): boolean => {
+      if (!data.attemptId) return true;
+      return task.current_execution_attempt?.attempt_id === data.attemptId;
+    };
 
     // Get branch path
     let cwd = process.cwd();
@@ -900,6 +917,8 @@ function createExecuteHandler(
       params: {
         sessionId,
         taskId,
+        attemptId: data.attemptId,
+        executorInstanceId: data.executorInstanceId,
         prompt: data.prompt,
         tool: session.agentic_tool as
           | 'claude-code'
@@ -938,7 +957,8 @@ function createExecuteHandler(
     }
 
     const logPrefix = `[Executor ${shortId(sessionId)}]`;
-    const canRecordLocalPid = !config.execution?.executor_command_template;
+    const isCommandTemplateRuntime = !!config.execution?.executor_command_template;
+    const canRecordLocalPid = !isCommandTemplateRuntime;
     const tasksRuntimeVitalsService = app.service('tasks') as Parameters<
       typeof patchDaemonTaskRuntimeEvent
     >[0];
@@ -967,7 +987,7 @@ function createExecuteHandler(
           {
             processPid: canRecordLocalPid ? child.pid : undefined,
           },
-          params
+          runtimeAttemptParams
         );
         if (child.pid) {
           trackExecutorProcess(sessionId, child.pid);
@@ -979,77 +999,150 @@ function createExecuteHandler(
         untrackExecutorProcess(sessionId);
         let wroteExitVitals = false;
 
-        // Safety net: check if task is still running
-        try {
-          const currentSession = await app.service('sessions').get(sessionId, params);
-          const latestTaskId = currentSession.tasks?.[currentSession.tasks.length - 1];
+        if (isCommandTemplateRuntime) {
+          // In command-template mode this child is only a launcher (for example,
+          // kubectl/docker submit), not the authoritative executor lifecycle.
+          // A non-zero launcher exit before the executor connects is a spawn
+          // failure; successful exits, and any exit after executor_connected,
+          // are informational only.
+          try {
+            const currentSession = await app.service('sessions').get(sessionId, params);
+            const currentTask = (await app.service('tasks').get(taskId, params)) as Task;
+            const connected = Boolean(currentTask.current_execution_attempt?.connected_at);
+            const activeTask =
+              isTaskExecuting(currentTask) || currentTask.status === TaskStatus.TIMED_OUT;
+            const latestTaskId = currentSession.tasks?.[currentSession.tasks.length - 1];
+            const isLatestTask = !latestTaskId || latestTaskId === taskId;
+            const sessionExecuting =
+              isSessionExecuting(currentSession) ||
+              currentSession.status === SessionStatus.TIMED_OUT;
+            const attemptMatches = capturedAttemptMatches(currentTask);
 
-          if (latestTaskId && latestTaskId !== taskId) {
-            console.log(
-              `⏭️ [Executor] Task ${shortId(taskId)} is not the latest (latest: ${shortId(latestTaskId)}), skipping safety net`
-            );
-          } else if (
-            isSessionExecuting(currentSession) ||
-            currentSession.status === SessionStatus.TIMED_OUT
-          ) {
-            try {
-              const currentTask = await app.service('tasks').get(taskId, params);
-              if (isTaskExecuting(currentTask) || currentTask.status === TaskStatus.TIMED_OUT) {
-                const spawnFailureExit = isExecutorSpawnFailureExit(processSpawnObserved, code);
-                const eventKind = spawnFailureExit
-                  ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
-                  : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED;
-                const runtime_vitals = buildDaemonTaskRuntimeVitals(
-                  currentTask.runtime_vitals,
-                  eventKind,
-                  {
-                    phase: TaskRuntimePhase.FAILED,
-                    exitCode: code,
-                    errorCode: spawnFailureExit ? 'spawn_error' : 'unexpected_exit',
-                  }
-                );
-                await app.service('tasks').patch(
-                  taskId,
-                  {
-                    status: TaskStatus.FAILED,
-                    error_message: `Executor exited unexpectedly with code ${code ?? 'unknown'}.`,
-                    runtime_vitals,
-                  },
-                  params
-                );
-                wroteExitVitals = true;
-                console.log(
-                  `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
-                );
-              } else {
-                console.log(
-                  `⚠️  [Executor] Task ${shortId(taskId)} already ${currentTask.status}, but session still ${currentSession.status} — repairing session state`
+            if (
+              attemptMatches &&
+              shouldFailCommandTemplateLauncherExit({
+                code,
+                connected,
+                activeTask,
+                isLatestTask,
+                sessionExecuting,
+              })
+            ) {
+              const runtime_vitals = buildDaemonTaskRuntimeVitals(
+                currentTask.runtime_vitals,
+                TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED,
+                {
+                  phase: TaskRuntimePhase.FAILED,
+                  exitCode: code,
+                  errorCode: 'spawn_error',
+                }
+              );
+              await app.service('tasks').patch(
+                taskId,
+                {
+                  status: TaskStatus.FAILED,
+                  error_message: `Executor launcher exited before connect with code ${code ?? 'unknown'}.`,
+                  runtime_vitals,
+                },
+                runtimeAttemptParams
+              );
+              wroteExitVitals = true;
+              console.log(
+                `✅ [Executor] Command-template launcher failure marked task ${shortId(taskId)} FAILED (code: ${code})`
+              );
+            } else {
+              console.log(
+                `ℹ️  [Executor] Command-template launcher exit is not authoritative (code: ${code}, connected: ${connected})`
+              );
+            }
+          } catch (error) {
+            console.error(`❌ [Executor] Failed to handle command-template launcher exit:`, error);
+          }
+        } else {
+          // Safety net: check if task is still running
+          try {
+            const currentSession = await app.service('sessions').get(sessionId, params);
+            const latestTaskId = currentSession.tasks?.[currentSession.tasks.length - 1];
+
+            if (latestTaskId && latestTaskId !== taskId) {
+              console.log(
+                `⏭️ [Executor] Task ${shortId(taskId)} is not the latest (latest: ${shortId(latestTaskId)}), skipping safety net`
+              );
+            } else if (
+              isSessionExecuting(currentSession) ||
+              currentSession.status === SessionStatus.TIMED_OUT
+            ) {
+              try {
+                const currentTask = await app.service('tasks').get(taskId, params);
+                const attemptMatches = capturedAttemptMatches(currentTask);
+                if (!attemptMatches) {
+                  console.log(
+                    `⏭️ [Executor] Skipping stale executor exit for task ${shortId(taskId)}; captured attempt is no longer current`
+                  );
+                } else if (
+                  isTaskExecuting(currentTask) ||
+                  currentTask.status === TaskStatus.TIMED_OUT
+                ) {
+                  const spawnFailureExit = isExecutorSpawnFailureExit(processSpawnObserved, code);
+                  const eventKind = spawnFailureExit
+                    ? TaskRuntimeEventKind.EXECUTOR_SPAWN_FAILED
+                    : TaskRuntimeEventKind.EXECUTOR_PROCESS_EXITED;
+                  const runtime_vitals = buildDaemonTaskRuntimeVitals(
+                    currentTask.runtime_vitals,
+                    eventKind,
+                    {
+                      phase: TaskRuntimePhase.FAILED,
+                      exitCode: code,
+                      errorCode: spawnFailureExit ? 'spawn_error' : 'unexpected_exit',
+                    }
+                  );
+                  await app.service('tasks').patch(
+                    taskId,
+                    {
+                      status: TaskStatus.FAILED,
+                      error_message: `Executor exited unexpectedly with code ${code ?? 'unknown'}.`,
+                      runtime_vitals,
+                    },
+                    runtimeAttemptParams
+                  );
+                  wroteExitVitals = true;
+                  console.log(
+                    `✅ [Executor] Task ${shortId(taskId)} marked as FAILED after executor exit (code: ${code})`
+                  );
+                } else {
+                  console.log(
+                    `⚠️  [Executor] Task ${shortId(taskId)} already ${currentTask.status}, but session still ${currentSession.status} — repairing session state`
+                  );
+                  await app
+                    .service('sessions')
+                    .patch(
+                      sessionId,
+                      { status: SessionStatus.IDLE, ready_for_prompt: true },
+                      params
+                    );
+                }
+              } catch (taskError) {
+                console.error(
+                  `⚠️  [Executor] Failed to mark task ${shortId(taskId)} as FAILED, falling back to session IDLE update:`,
+                  taskError
                 );
                 await app
                   .service('sessions')
                   .patch(sessionId, { status: SessionStatus.IDLE, ready_for_prompt: true }, params);
+                console.log(
+                  `✅ [Executor] Session ${shortId(sessionId)} status updated to IDLE after executor exit (was: ${currentSession.status})`
+                );
               }
-            } catch (taskError) {
-              console.error(
-                `⚠️  [Executor] Failed to mark task ${shortId(taskId)} as FAILED, falling back to session IDLE update:`,
-                taskError
-              );
-              await app
-                .service('sessions')
-                .patch(sessionId, { status: SessionStatus.IDLE, ready_for_prompt: true }, params);
+            } else {
               console.log(
-                `✅ [Executor] Session ${shortId(sessionId)} status updated to IDLE after executor exit (was: ${currentSession.status})`
+                `ℹ️  [Executor] Session ${shortId(sessionId)} already in ${currentSession.status} state, skipping IDLE update`
               );
             }
-          } else {
-            console.log(
-              `ℹ️  [Executor] Session ${shortId(sessionId)} already in ${currentSession.status} state, skipping IDLE update`
-            );
+          } catch (error) {
+            console.error(`❌ [Executor] Failed to handle executor exit:`, error);
           }
-        } catch (error) {
-          console.error(`❌ [Executor] Failed to handle executor exit:`, error);
         }
-        if (!wroteExitVitals) {
+        if (!wroteExitVitals && !isCommandTemplateRuntime) {
           await patchDaemonTaskRuntimeEvent(
             tasksRuntimeVitalsService,
             taskId,
@@ -1062,7 +1155,7 @@ function createExecuteHandler(
                 ? { errorCode: 'spawn_error' }
                 : {}),
             },
-            params
+            runtimeAttemptParams
           );
         }
 
@@ -1101,7 +1194,9 @@ function createExecuteHandler(
                 if (filePath) {
                   const md5 = await computeFileHash(filePath);
                   if (md5) {
-                    await app.service('tasks').patch(taskId, { session_md5: md5 }, params);
+                    await app
+                      .service('tasks')
+                      .patch(taskId, { session_md5: md5 }, runtimeAttemptParams);
                   }
                 }
               } catch (md5Err) {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -791,6 +791,7 @@ function createExecuteHandler(
     };
     const taskHasExecutorConnectionEvidence = (task: Task): boolean =>
       hasExecutorConnectionEvidence({
+        has_current_attempt: !!task.current_execution_attempt,
         connected_at: task.current_execution_attempt?.connected_at,
         last_heartbeat_at: task.current_execution_attempt?.last_heartbeat_at,
         task_last_executor_heartbeat_at: task.last_executor_heartbeat_at,

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -172,6 +172,51 @@ describe('ConfigService.resolveApiKey', () => {
     });
   });
 
+  it('rejects executor runtime tokens for stale attempts', async () => {
+    const service = new ConfigService({} as never);
+    service.app = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return {
+            get: vi.fn(async () => ({
+              created_by: 'creator-1' as UserID,
+              session_id: 'session-1',
+              current_execution_attempt: {
+                attempt_id: 'attempt-current',
+                executor_instance_id: 'executor-current',
+                terminal_at: undefined,
+              },
+            })),
+          };
+        }
+        if (name === 'sessions') {
+          return { get: vi.fn(async () => ({ agentic_tool: 'codex' })) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await expect(
+      service.resolveApiKey(
+        { taskId: 'task-1' as TaskID, keyName: 'OPENAI_API_KEY', tool: 'codex' },
+        {
+          provider: 'socketio',
+          authentication: {
+            payload: {
+              type: 'executor-session',
+              purpose: 'executor-task',
+              task_id: 'task-1',
+              attempt_id: 'attempt-stale',
+              executor_instance_id: 'executor-current',
+            },
+          },
+        } as never
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+
+    expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
+  });
+
   it('recovers executor runtime scope from the verified access token when payload is absent', async () => {
     const service = new ConfigService({} as never);
     service.app = {

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -46,11 +46,18 @@ type ExecutorTokenPayload = {
   sessionId?: string;
   task_id?: string;
   branch_id?: string;
+  attempt_id?: string;
+  executor_instance_id?: string;
 };
 
 function getExecutorTokenPayload(params?: Params): ExecutorTokenPayload | undefined {
   const authParams = params as
-    | (AuthenticatedParams & { task_id?: string; authentication?: { strategy?: string } })
+    | (AuthenticatedParams & {
+        task_id?: string;
+        attempt_id?: string;
+        executor_instance_id?: string;
+        authentication?: { strategy?: string };
+      })
     | undefined;
   const payload = authParams?.authentication?.payload as ExecutorTokenPayload | undefined;
   if (payload?.type === 'executor-session' && payload.purpose === 'executor-task') {
@@ -76,12 +83,21 @@ function getExecutorTokenPayload(params?: Params): ExecutorTokenPayload | undefi
   // connections that have a task claim minted by ServiceJWTStrategy.
   if (authParams?.authentication?.strategy === 'jwt' && authParams.task_id) {
     const scopedParams = params as
-      | (Params & { session_id?: string; sessionId?: string; task_id?: string; branch_id?: string })
+      | (Params & {
+          session_id?: string;
+          sessionId?: string;
+          task_id?: string;
+          attempt_id?: string;
+          executor_instance_id?: string;
+          branch_id?: string;
+        })
       | undefined;
     return {
       type: 'executor-session',
       purpose: 'executor-task',
       task_id: authParams.task_id,
+      attempt_id: scopedParams?.attempt_id,
+      executor_instance_id: scopedParams?.executor_instance_id,
       session_id: scopedParams?.session_id,
       sessionId: scopedParams?.sessionId,
       branch_id: scopedParams?.branch_id,
@@ -91,9 +107,34 @@ function getExecutorTokenPayload(params?: Params): ExecutorTokenPayload | undefi
   return undefined;
 }
 
-/**
- * Mask API keys for secure display
- */
+function validateExecutorAttemptScope(executorPayload: ExecutorTokenPayload, task: unknown): void {
+  const record =
+    task && typeof task === 'object' && !Array.isArray(task)
+      ? (task as { current_execution_attempt?: Record<string, unknown> })
+      : undefined;
+  const attempt = record?.current_execution_attempt;
+  if (!attempt) return;
+
+  if (!executorPayload.attempt_id) {
+    throw new Forbidden('Executor token is missing attempt scope');
+  }
+  if (attempt.attempt_id !== executorPayload.attempt_id) {
+    throw new Forbidden('Executor token attempt scope does not match current task attempt');
+  }
+  if (
+    executorPayload.executor_instance_id &&
+    attempt.executor_instance_id &&
+    attempt.executor_instance_id !== executorPayload.executor_instance_id
+  ) {
+    throw new Forbidden(
+      'Executor token executor-instance scope does not match current task attempt'
+    );
+  }
+  if (attempt.terminal_at) {
+    throw new Forbidden('Executor token attempt is no longer active');
+  }
+}
+
 function maskApiKey(key: string | undefined): string | undefined {
   if (!key || typeof key !== 'string') return undefined;
   if (key.length <= 10) return '***';
@@ -219,6 +260,8 @@ export class ConfigService {
           type: 'executor-session',
           purpose: 'executor-task',
           task_id: sessionInfo.task_id,
+          attempt_id: sessionInfo.attempt_id,
+          executor_instance_id: sessionInfo.executor_instance_id,
         };
       }
     }
@@ -240,10 +283,12 @@ export class ConfigService {
     // executor-token calls and best-effort for internal/service-account calls.
     let userId: UserID | undefined;
     let sessionId: string | undefined;
+    let taskForScopeCheck: unknown;
     try {
       const tasksService = this.app?.service('tasks');
       if (tasksService) {
         const task = await tasksService.get(taskId, { provider: undefined });
+        taskForScopeCheck = task;
         userId = task?.created_by;
         sessionId = task?.session_id;
       }
@@ -256,6 +301,9 @@ export class ConfigService {
 
     if (executorPayload && (!userId || !sessionId)) {
       throw new Forbidden('Executor token task scope could not be verified');
+    }
+    if (executorPayload) {
+      validateExecutorAttemptScope(executorPayload, taskForScopeCheck);
     }
 
     // Executor runtime calls are narrowly scoped to the SDK for this session.

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
@@ -78,4 +78,48 @@ describe('ExecutorHeartbeatSupervisor', () => {
     await supervisor.checkOnce();
     expect(tasksPatch).not.toHaveBeenCalled();
   });
+
+  it('does not treat a previous task-level heartbeat as current-attempt heartbeat evidence', async () => {
+    const task = {
+      task_id: '018f0000-0000-7000-8000-000000000003',
+      session_id: '018f0000-0000-7000-8000-000000000004',
+      status: 'running',
+      last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: {
+        schema_version: 1,
+        attempt_id: '018f0000-0000-7000-8000-000000000005',
+        executor_instance_id: '018f0000-0000-7000-8000-000000000006',
+        runtime_backend: 'command_template',
+        started_at: '2026-01-01T00:00:04.000Z',
+      },
+    };
+    const failForLostHeartbeat = vi.fn();
+    const app = {
+      service: (name: string) => {
+        if (name === 'tasks') {
+          return {
+            getActiveWithExecutorHeartbeat: vi.fn().mockResolvedValue([task]),
+            get: vi.fn().mockResolvedValue(task),
+            failForLostHeartbeat,
+          };
+        }
+        throw new Error(`unknown service ${name}`);
+      },
+    } as any;
+
+    const supervisor = new ExecutorHeartbeatSupervisor({
+      app,
+      config: {
+        enabled: true,
+        interval_ms: 1000,
+        stale_after_ms: 3000,
+        callback: { command_template: null, timeout_ms: 3000 },
+      },
+      now: () => new Date('2026-01-01T00:00:05.000Z'),
+    });
+
+    await supervisor.checkOnce();
+
+    expect(failForLostHeartbeat).not.toHaveBeenCalled();
+  });
 });

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.ts
@@ -44,15 +44,21 @@ export class ExecutorHeartbeatSupervisor {
       const tasks = await tasksService.getActiveWithExecutorHeartbeat();
       const nowMs = this.now().getTime();
       for (const task of tasks) {
-        if (!task.last_executor_heartbeat_at) continue;
-        const heartbeatMs = new Date(task.last_executor_heartbeat_at).getTime();
+        const observedHeartbeatAt = task.current_execution_attempt
+          ? task.current_execution_attempt.last_heartbeat_at
+          : task.last_executor_heartbeat_at;
+        if (!observedHeartbeatAt) continue;
+        const heartbeatMs = new Date(observedHeartbeatAt).getTime();
         if (!Number.isFinite(heartbeatMs)) continue;
         if (nowMs - heartbeatMs <= this.options.config.stale_after_ms) continue;
 
         try {
           const current = await this.options.app.service('tasks').get(task.task_id);
-          if (current.status !== task.status || !current.last_executor_heartbeat_at) continue;
-          const currentHeartbeatMs = new Date(current.last_executor_heartbeat_at).getTime();
+          const currentHeartbeatAt = current.current_execution_attempt
+            ? current.current_execution_attempt.last_heartbeat_at
+            : current.last_executor_heartbeat_at;
+          if (current.status !== task.status || !currentHeartbeatAt) continue;
+          const currentHeartbeatMs = new Date(currentHeartbeatAt).getTime();
           if (!Number.isFinite(currentHeartbeatMs)) continue;
           if (nowMs - currentHeartbeatMs <= this.options.config.stale_after_ms) continue;
 

--- a/apps/agor-daemon/src/services/session-token-service.test.ts
+++ b/apps/agor-daemon/src/services/session-token-service.test.ts
@@ -13,6 +13,8 @@ describe('SessionTokenService runtime scoping', () => {
     const token = await service.generateToken('session-1', 'user-1', {
       taskId: 'task-1',
       branchId: 'branch-1',
+      attemptId: 'attempt-1',
+      executorInstanceId: 'executor-1',
     });
     const decoded = jwt.verify(token, 'session-token-test-secret', {
       issuer: 'agor',
@@ -24,13 +26,24 @@ describe('SessionTokenService runtime scoping', () => {
     expect(decoded.session_id).toBe('session-1');
     expect(decoded.task_id).toBe('task-1');
     expect(decoded.branch_id).toBe('branch-1');
+    expect(decoded.attempt_id).toBe('attempt-1');
+    expect(decoded.executor_instance_id).toBe('executor-1');
 
     await expect(
       service.validateToken(token, { sessionId: 'session-1', taskId: 'task-other' })
     ).resolves.toBeNull();
     await expect(
-      service.validateToken(token, { sessionId: 'session-1', taskId: 'task-1' })
-    ).resolves.toMatchObject({ session_id: 'session-1', task_id: 'task-1' });
+      service.validateToken(token, {
+        sessionId: 'session-1',
+        taskId: 'task-1',
+        attemptId: 'attempt-1',
+      })
+    ).resolves.toMatchObject({
+      session_id: 'session-1',
+      task_id: 'task-1',
+      attempt_id: 'attempt-1',
+      executor_instance_id: 'executor-1',
+    });
     await expect(
       service.validateToken(token, { sessionId: 'session-1', taskId: 'task-1' })
     ).resolves.toBeNull();

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -30,6 +30,8 @@ function sessionTokenDebug(...args: unknown[]): void {
 interface SessionTokenData {
   session_id: string;
   task_id?: string;
+  attempt_id?: string;
+  executor_instance_id?: string;
   branch_id?: string;
   user_id: string;
   created_at: Date;
@@ -41,6 +43,8 @@ interface SessionTokenData {
 export interface SessionInfo {
   session_id: string;
   task_id?: string;
+  attempt_id?: string;
+  executor_instance_id?: string;
   branch_id?: string;
   user_id: string;
 }
@@ -74,7 +78,13 @@ export class SessionTokenService {
   async generateToken(
     sessionId: string,
     userId: string,
-    scope: { taskId?: string; branchId?: string; maxUses?: number } = {}
+    scope: {
+      taskId?: string;
+      attemptId?: string;
+      executorInstanceId?: string;
+      branchId?: string;
+      maxUses?: number;
+    } = {}
   ): Promise<string> {
     if (!this.jwtSecret) {
       throw new Error('SessionTokenService: JWT secret not set. Call setJwtSecret() first.');
@@ -92,6 +102,8 @@ export class SessionTokenService {
       purpose: EXECUTOR_SESSION_TOKEN_PURPOSE,
       session_id: sessionId,
       task_id: scope.taskId,
+      attempt_id: scope.attemptId,
+      executor_instance_id: scope.executorInstanceId,
       branch_id: scope.branchId,
       ...(tenantId ? { tenant_id: tenantId } : {}),
       iat: Math.floor(now.getTime() / 1000), // Issued at
@@ -111,6 +123,8 @@ export class SessionTokenService {
     this.tokens.set(token, {
       session_id: sessionId,
       task_id: scope.taskId,
+      attempt_id: scope.attemptId,
+      executor_instance_id: scope.executorInstanceId,
       branch_id: scope.branchId,
       user_id: userId,
       created_at: now,
@@ -135,7 +149,7 @@ export class SessionTokenService {
    */
   async validateToken(
     token: string,
-    expected?: { sessionId?: string; taskId?: string; branchId?: string }
+    expected?: { sessionId?: string; taskId?: string; attemptId?: string; branchId?: string }
   ): Promise<SessionInfo | null> {
     // Get tracking data for this token
     const data = this.tokens.get(token);
@@ -156,6 +170,7 @@ export class SessionTokenService {
     if (
       (expected?.sessionId && data.session_id !== expected.sessionId) ||
       (expected?.taskId && data.task_id !== expected.taskId) ||
+      (expected?.attemptId && data.attempt_id !== expected.attemptId) ||
       (expected?.branchId && data.branch_id !== expected.branchId)
     ) {
       console.warn(`[SessionTokenService] Token scope mismatch`);
@@ -184,6 +199,8 @@ export class SessionTokenService {
     return {
       session_id: data.session_id,
       task_id: data.task_id,
+      attempt_id: data.attempt_id,
+      executor_instance_id: data.executor_instance_id,
       branch_id: data.branch_id,
       user_id: data.user_id,
     };

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -145,6 +145,8 @@ export function isRemoteRelationshipsEnrichedResult(result: unknown): boolean {
  */
 export type ExecuteTaskData = {
   taskId: string;
+  attemptId?: string;
+  executorInstanceId?: string;
   prompt: string;
   permissionMode?: import('@agor/core/types').PermissionMode;
   stream?: boolean;

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -1,4 +1,9 @@
-import { TaskStatus } from '@agor/core/types';
+import {
+  TaskExecutionRuntimeBackend,
+  TaskRuntimeEventKind,
+  TaskRuntimePhase,
+  TaskStatus,
+} from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { TasksService } from './tasks';
 
@@ -405,6 +410,321 @@ describe('TasksService executor heartbeat helpers', () => {
     });
 
     expect(result).toBe(stoppedTask);
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+  });
+
+  it('no-ops stale executor heartbeat patches and returns the current task', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000101';
+    const currentTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000102',
+      status: TaskStatus.RUNNING,
+      created_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: {
+        schema_version: 1 as const,
+        attempt_id: '018f0000-0000-7000-8000-000000000103',
+        executor_instance_id: '018f0000-0000-7000-8000-000000000104',
+        runtime_backend: TaskExecutionRuntimeBackend.LOCAL_SUBPROCESS,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(currentTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    const result = await service.patch(
+      taskId,
+      { last_executor_heartbeat_at: '2026-01-01T00:00:10.000Z' },
+      {
+        provider: 'socketio',
+        authentication: {
+          strategy: 'jwt',
+          payload: {
+            type: 'executor-session',
+            task_id: taskId,
+            attempt_id: '018f0000-0000-7000-8000-000000000999',
+            executor_instance_id: '018f0000-0000-7000-8000-000000000104',
+          },
+        },
+      } as any
+    );
+
+    expect(result).toMatchObject({
+      ...currentTask,
+      runtime_patch_ignored: true,
+    });
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+
+    const staleFinal = await service.patch(
+      taskId,
+      {
+        status: TaskStatus.FAILED,
+        completed_at: '2026-01-01T00:00:11.000Z',
+        error_message: 'stale executor failure',
+        raw_sdk_response: { stale: true },
+      },
+      {
+        provider: 'socketio',
+        authentication: {
+          strategy: 'jwt',
+          payload: {
+            type: 'executor-session',
+            task_id: taskId,
+            attempt_id: '018f0000-0000-7000-8000-000000000999',
+            executor_instance_id: '018f0000-0000-7000-8000-000000000104',
+          },
+        },
+      } as any
+    );
+
+    expect(staleFinal).toMatchObject({
+      ...currentTask,
+      runtime_patch_ignored: true,
+    });
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+  });
+
+  it('stamps connected, heartbeat, and terminal attempt fields for current executor patches', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000111';
+    const attempt = {
+      schema_version: 1 as const,
+      attempt_id: '018f0000-0000-7000-8000-000000000113',
+      executor_instance_id: '018f0000-0000-7000-8000-000000000114',
+      runtime_backend: TaskExecutionRuntimeBackend.COMMAND_TEMPLATE,
+      started_at: '2026-01-01T00:00:00.000Z',
+    };
+    let currentTask: any = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000112',
+      status: TaskStatus.RUNNING,
+      created_by: 'user-1',
+      created_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: attempt,
+    };
+    const session = { session_id: currentTask.session_id, status: 'running', tasks: [taskId] };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      app: any;
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+      heartbeatCallbackRunner: { run: ReturnType<typeof vi.fn> };
+    };
+    service.get = vi.fn().mockImplementation(async () => currentTask);
+    service.repository = {
+      update: vi.fn().mockImplementation(async (_id, data) => {
+        currentTask = { ...currentTask, ...data };
+        return currentTask;
+      }),
+    };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+    service.heartbeatCallbackRunner = { run: vi.fn() };
+    service.app = {
+      service: (name: string) => {
+        if (name === 'sessions') return { get: vi.fn().mockResolvedValue(session), patch: vi.fn() };
+        if (name === 'branches') return { get: vi.fn() };
+        throw new Error(`unexpected service ${name}`);
+      },
+    };
+    const params = {
+      provider: 'socketio',
+      authentication: {
+        strategy: 'jwt',
+        payload: {
+          type: 'executor-session',
+          task_id: taskId,
+          attempt_id: attempt.attempt_id,
+          executor_instance_id: attempt.executor_instance_id,
+        },
+      },
+    } as any;
+
+    await service.patch(
+      taskId,
+      {
+        runtime_vitals: {
+          schema_version: 1,
+          phase: TaskRuntimePhase.EXECUTOR_CONNECTED,
+          phase_started_at: '2026-01-01T00:00:01.000Z',
+          last_activity_at: '2026-01-01T00:00:01.000Z',
+          last_event: {
+            kind: TaskRuntimeEventKind.EXECUTOR_CONNECTED,
+            at: '2026-01-01T00:00:01.000Z',
+            source: 'executor',
+            phase: TaskRuntimePhase.EXECUTOR_CONNECTED,
+          },
+        },
+      },
+      params
+    );
+    expect(currentTask.current_execution_attempt.connected_at).toBe('2026-01-01T00:00:01.000Z');
+
+    await service.patch(taskId, { last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z' }, params);
+    expect(currentTask.current_execution_attempt.last_heartbeat_at).toBe(
+      '2026-01-01T00:00:02.000Z'
+    );
+
+    await service.patch(
+      taskId,
+      { status: TaskStatus.COMPLETED, completed_at: '2026-01-01T00:00:03.000Z' },
+      params
+    );
+    expect(currentTask.current_execution_attempt.terminal_at).toBe('2026-01-01T00:00:03.000Z');
+    expect(currentTask.current_execution_attempt.terminal_status).toBe(TaskStatus.COMPLETED);
+
+    const updateCount = service.repository.update.mock.calls.length;
+    const late = await service.patch(
+      taskId,
+      { last_executor_heartbeat_at: '2026-01-01T00:00:04.000Z' },
+      params
+    );
+    expect(late).toMatchObject({
+      ...currentTask,
+      runtime_patch_ignored: true,
+    });
+    expect(service.repository.update).toHaveBeenCalledTimes(updateCount);
+  });
+
+  it('no-ops stale daemon-owned terminal patches from an earlier attempt', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000121';
+    const currentTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000122',
+      status: TaskStatus.RUNNING,
+      created_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: {
+        schema_version: 1 as const,
+        attempt_id: '018f0000-0000-7000-8000-000000000123',
+        executor_instance_id: '018f0000-0000-7000-8000-000000000124',
+        runtime_backend: TaskExecutionRuntimeBackend.COMMAND_TEMPLATE,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(currentTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    const result = await service.patch(
+      taskId,
+      {
+        status: TaskStatus.FAILED,
+        completed_at: '2026-01-01T00:00:09.000Z',
+        error_message: 'stale launcher exit',
+      },
+      {
+        runtimeAttempt: {
+          attemptId: '018f0000-0000-7000-8000-000000000999',
+          executorInstanceId: '018f0000-0000-7000-8000-000000000124',
+        },
+      } as any
+    );
+
+    expect(result).toMatchObject({
+      ...currentTask,
+      runtime_patch_ignored: true,
+    });
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+  });
+
+  it('no-ops stale daemon-owned session_md5 sidecar writes', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000131';
+    const currentTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000132',
+      status: TaskStatus.RUNNING,
+      created_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: {
+        schema_version: 1 as const,
+        attempt_id: '018f0000-0000-7000-8000-000000000133',
+        executor_instance_id: '018f0000-0000-7000-8000-000000000134',
+        runtime_backend: TaskExecutionRuntimeBackend.LOCAL_SUBPROCESS,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(currentTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    const result = await service.patch(taskId, { session_md5: 'stale-hash' }, {
+      runtimeAttempt: {
+        attemptId: '018f0000-0000-7000-8000-000000000999',
+        executorInstanceId: '018f0000-0000-7000-8000-000000000134',
+      },
+    } as any);
+
+    expect(result).toMatchObject({
+      ...currentTask,
+      runtime_patch_ignored: true,
+    });
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+  });
+
+  it('no-ops late session_md5 writes after the current attempt is terminal', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000141';
+    const currentTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000142',
+      status: TaskStatus.COMPLETED,
+      created_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: {
+        schema_version: 1 as const,
+        attempt_id: '018f0000-0000-7000-8000-000000000143',
+        executor_instance_id: '018f0000-0000-7000-8000-000000000144',
+        runtime_backend: TaskExecutionRuntimeBackend.LOCAL_SUBPROCESS,
+        started_at: '2026-01-01T00:00:00.000Z',
+        terminal_at: '2026-01-01T00:00:05.000Z',
+        terminal_status: TaskStatus.COMPLETED,
+      },
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(currentTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    const result = await service.patch(taskId, { session_md5: 'late-hash' }, {
+      runtimeAttempt: {
+        attemptId: '018f0000-0000-7000-8000-000000000143',
+        executorInstanceId: '018f0000-0000-7000-8000-000000000144',
+      },
+    } as any);
+
+    expect(result).toMatchObject({
+      ...currentTask,
+      runtime_patch_ignored: true,
+    });
     expect(service.repository.update).not.toHaveBeenCalled();
     expect(service.emit).not.toHaveBeenCalled();
   });

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -708,6 +708,10 @@ describe('TasksService executor heartbeat helpers', () => {
       params
     );
     expect(currentTask.current_execution_attempt.connected_at).toBe('2026-01-01T00:00:01.000Z');
+    expect(currentTask.current_execution_attempt.last_heartbeat_at).toBe(
+      '2026-01-01T00:00:01.000Z'
+    );
+    expect(currentTask.last_executor_heartbeat_at).toBe('2026-01-01T00:00:01.000Z');
 
     await service.patch(taskId, { last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z' }, params);
     expect(currentTask.current_execution_attempt.last_heartbeat_at).toBe(

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -8,6 +8,24 @@ import { describe, expect, it, vi } from 'vitest';
 import { TasksService } from './tasks';
 
 describe('TasksService executor heartbeat helpers', () => {
+  const installLockedTaskRepo = (service: {
+    get: ReturnType<typeof vi.fn>;
+    repository: { update: ReturnType<typeof vi.fn> };
+    taskRepo?: { updateWithLockedCurrent: ReturnType<typeof vi.fn> };
+  }) => {
+    service.taskRepo = {
+      updateWithLockedCurrent: vi.fn(async (id: string, decide: (current: any) => any) => {
+        const before = await service.get(id);
+        const decision = decide(before);
+        if (decision.action === 'return') {
+          return { before, after: decision.task, updated: false };
+        }
+        const after = await service.repository.update(id, decision.updates);
+        return { before, after, updated: true };
+      }),
+    };
+  };
+
   it('fails lost heartbeat tasks and marks the session failed without draining its queue', async () => {
     const taskId = '018f0000-0000-7000-8000-000000000001';
     const sessionId = '018f0000-0000-7000-8000-000000000002';
@@ -34,6 +52,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(currentTask);
     service.repository = { update: vi.fn().mockResolvedValue(failedTask) };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.app = {
@@ -104,6 +123,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(completedTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.app = {
@@ -145,6 +165,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(failedTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.app = {
@@ -184,6 +205,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(failedTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
 
@@ -226,6 +248,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(currentTask);
     service.repository = { update: vi.fn().mockResolvedValue(stoppedTask) };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.dispatchCompletionCallbacks = dispatchCompletionCallbacks;
@@ -301,6 +324,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(currentTask);
     service.repository = { update: vi.fn().mockResolvedValue(stoppedTask) };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.dispatchCompletionCallbacks = vi.fn();
@@ -358,6 +382,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(stoppedTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.app = {
@@ -396,6 +421,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(stoppedTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.app = {
@@ -437,6 +463,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(currentTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
 
@@ -494,6 +521,70 @@ describe('TasksService executor heartbeat helpers', () => {
     expect(service.emit).not.toHaveBeenCalled();
   });
 
+  it('checks runtime attempt ownership against the locked task row', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000151';
+    const staleAttempt = {
+      schema_version: 1 as const,
+      attempt_id: '018f0000-0000-7000-8000-000000000153',
+      executor_instance_id: '018f0000-0000-7000-8000-000000000154',
+      runtime_backend: TaskExecutionRuntimeBackend.COMMAND_TEMPLATE,
+      started_at: '2026-01-01T00:00:00.000Z',
+    };
+    const preReadTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000152',
+      status: TaskStatus.RUNNING,
+      created_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: staleAttempt,
+    };
+    const lockedTask = {
+      ...preReadTask,
+      current_execution_attempt: {
+        ...staleAttempt,
+        attempt_id: '018f0000-0000-7000-8000-000000000155',
+      },
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      taskRepo: { updateWithLockedCurrent: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(preReadTask);
+    service.repository = { update: vi.fn() };
+    service.taskRepo = {
+      updateWithLockedCurrent: vi.fn(async (_id: string, decide: (current: any) => any) => {
+        const decision = decide(lockedTask);
+        if (decision.action === 'return') {
+          return { before: lockedTask, after: decision.task, updated: false };
+        }
+        const after = await service.repository.update(_id, decision.updates);
+        return { before: lockedTask, after, updated: true };
+      }),
+    };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    const result = await service.patch(
+      taskId,
+      { last_executor_heartbeat_at: '2026-01-01T00:00:10.000Z' },
+      {
+        runtimeAttempt: {
+          attemptId: staleAttempt.attempt_id,
+          executorInstanceId: staleAttempt.executor_instance_id,
+        },
+      } as any
+    );
+
+    expect(result).toMatchObject({
+      ...lockedTask,
+      runtime_patch_ignored: true,
+    });
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+  });
+
   it('stamps connected, heartbeat, and terminal attempt fields for current executor patches', async () => {
     const taskId = '018f0000-0000-7000-8000-000000000111';
     const attempt = {
@@ -527,6 +618,7 @@ describe('TasksService executor heartbeat helpers', () => {
         return currentTask;
       }),
     };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
     service.heartbeatCallbackRunner = { run: vi.fn() };
@@ -619,6 +711,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(currentTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
 
@@ -668,6 +761,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(currentTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
 
@@ -711,6 +805,7 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     service.get = vi.fn().mockResolvedValue(currentTask);
     service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
     service.id = 'task_id';
     service.emit = vi.fn();
 

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -521,6 +521,53 @@ describe('TasksService executor heartbeat helpers', () => {
     expect(service.emit).not.toHaveBeenCalled();
   });
 
+  it('uses preserved socket executor scope fields when JWT payload is absent', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000161';
+    const currentTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000162',
+      status: TaskStatus.RUNNING,
+      created_at: '2026-01-01T00:00:00.000Z',
+      current_execution_attempt: {
+        schema_version: 1 as const,
+        attempt_id: '018f0000-0000-7000-8000-000000000163',
+        executor_instance_id: '018f0000-0000-7000-8000-000000000164',
+        runtime_backend: TaskExecutionRuntimeBackend.COMMAND_TEMPLATE,
+        started_at: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(currentTask);
+    service.repository = { update: vi.fn() };
+    installLockedTaskRepo(service);
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    const result = await service.patch(
+      taskId,
+      { last_executor_heartbeat_at: '2026-01-01T00:00:10.000Z' },
+      {
+        provider: 'socketio',
+        authentication: { strategy: 'jwt' },
+        task_id: taskId,
+        attempt_id: '018f0000-0000-7000-8000-000000000999',
+        executor_instance_id: currentTask.current_execution_attempt.executor_instance_id,
+      } as any
+    );
+
+    expect(result).toMatchObject({
+      ...currentTask,
+      runtime_patch_ignored: true,
+    });
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+  });
+
   it('checks runtime attempt ownership against the locked task row', async () => {
     const taskId = '018f0000-0000-7000-8000-000000000151';
     const staleAttempt = {

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -207,9 +207,12 @@ function applyExecutionAttemptPatchState(
   if (!attempt) return;
 
   if (data.runtime_vitals?.last_event?.kind === TaskRuntimeEventKind.EXECUTOR_CONNECTED) {
+    const connectedAt = data.runtime_vitals.last_event.at ?? now;
+    data.last_executor_heartbeat_at ??= connectedAt;
     data.current_execution_attempt = {
       ...attempt,
-      connected_at: attempt.connected_at ?? data.runtime_vitals.last_event.at ?? now,
+      connected_at: attempt.connected_at ?? connectedAt,
+      last_heartbeat_at: attempt.last_heartbeat_at ?? connectedAt,
     };
     return;
   }

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -171,13 +171,30 @@ function executorAttemptClaims(params?: TaskParams): ExecutorAttemptClaims {
       }
     | undefined;
   const payload = auth?.payload;
+  const socketScope = params as
+    | (TaskParams & {
+        task_id?: unknown;
+        attempt_id?: unknown;
+        executor_instance_id?: unknown;
+      })
+    | undefined;
   const isExecutorRuntime =
-    payload?.type === 'executor-session' || (auth?.strategy === 'jwt' && !!payload?.task_id);
+    payload?.type === 'executor-session' ||
+    (auth?.strategy === 'jwt' && (!!payload?.task_id || !!socketScope?.task_id));
   return {
     isExecutorRuntime,
-    attemptId: typeof payload?.attempt_id === 'string' ? payload.attempt_id : undefined,
+    attemptId:
+      typeof payload?.attempt_id === 'string'
+        ? payload.attempt_id
+        : typeof socketScope?.attempt_id === 'string'
+          ? socketScope.attempt_id
+          : undefined,
     executorInstanceId:
-      typeof payload?.executor_instance_id === 'string' ? payload.executor_instance_id : undefined,
+      typeof payload?.executor_instance_id === 'string'
+        ? payload.executor_instance_id
+        : typeof socketScope?.executor_instance_id === 'string'
+          ? socketScope.executor_instance_id
+          : undefined,
   };
 }
 

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -32,6 +32,8 @@ import {
   isTerminalTaskStatus,
   SessionStatus,
   type TaskMetadata,
+  TaskRuntimeEventKind,
+  TaskRuntimePhase,
   TaskStatus,
 } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
@@ -86,12 +88,162 @@ export type TaskParams = QueryParams<{
    * terminal transition. Most callers should leave this unset.
    */
   suppressBtwCleanup?: boolean;
+  /** Internal runtime ownership scope for daemon-authored executor lifecycle patches. */
+  runtimeAttempt?: {
+    attemptId?: string;
+    executorInstanceId?: string;
+  };
   /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
   _agorSqlSessionAccessUserId?: UUID;
 };
 
 interface CompletionCallbackDispatchResult {
   callbackTask?: Task;
+}
+
+type ExecutorAttemptClaims = {
+  isExecutorRuntime: boolean;
+  attemptId?: string;
+  executorInstanceId?: string;
+};
+
+type RuntimeOwnedPatchNoopTask = Task & {
+  runtime_patch_ignored: true;
+  runtime_patch_ignored_reason: string;
+};
+
+const RUNTIME_OWNED_TASK_PATCH_KEYS = new Set<keyof Task>([
+  'last_executor_heartbeat_at',
+  'runtime_vitals',
+  'status',
+  'completed_at',
+  'duration_ms',
+  'agent_session_id',
+  'error_message',
+  'model',
+  'raw_sdk_response',
+  'normalized_sdk_response',
+  'computed_context_window',
+  'git_state',
+  'session_md5',
+]);
+
+function runtimeOwnedTaskPatch(data: Partial<Task>): boolean {
+  return Object.keys(data).some((key) => RUNTIME_OWNED_TASK_PATCH_KEYS.has(key as keyof Task));
+}
+
+function isTerminalRuntimeVitals(data: Partial<Task>): boolean {
+  const phase = data.runtime_vitals?.phase;
+  return (
+    phase === TaskRuntimePhase.COMPLETED ||
+    phase === TaskRuntimePhase.FAILED ||
+    phase === TaskRuntimePhase.STOPPED ||
+    phase === TaskRuntimePhase.TIMED_OUT ||
+    data.runtime_vitals?.last_event?.kind === TaskRuntimeEventKind.TURN_COMPLETED ||
+    data.runtime_vitals?.last_event?.kind === TaskRuntimeEventKind.TURN_FAILED ||
+    data.runtime_vitals?.last_event?.kind === TaskRuntimeEventKind.TURN_STOPPED ||
+    data.runtime_vitals?.last_event?.kind === TaskRuntimeEventKind.TURN_TIMED_OUT
+  );
+}
+
+function isTerminalRuntimePatch(data: Partial<Task>): boolean {
+  return isTerminalTaskStatus(data.status) || isTerminalRuntimeVitals(data);
+}
+
+function executorAttemptClaims(params?: TaskParams): ExecutorAttemptClaims {
+  if (params?.runtimeAttempt) {
+    return {
+      isExecutorRuntime: true,
+      attemptId: params.runtimeAttempt.attemptId,
+      executorInstanceId: params.runtimeAttempt.executorInstanceId,
+    };
+  }
+
+  const auth = params?.authentication as
+    | {
+        strategy?: string;
+        payload?: {
+          type?: unknown;
+          task_id?: unknown;
+          attempt_id?: unknown;
+          executor_instance_id?: unknown;
+        };
+      }
+    | undefined;
+  const payload = auth?.payload;
+  const isExecutorRuntime =
+    payload?.type === 'executor-session' || (auth?.strategy === 'jwt' && !!payload?.task_id);
+  return {
+    isExecutorRuntime,
+    attemptId: typeof payload?.attempt_id === 'string' ? payload.attempt_id : undefined,
+    executorInstanceId:
+      typeof payload?.executor_instance_id === 'string' ? payload.executor_instance_id : undefined,
+  };
+}
+
+function applyExecutionAttemptPatchState(
+  data: Partial<Task>,
+  currentTask: Task | undefined,
+  now = new Date().toISOString()
+): void {
+  const attempt = currentTask?.current_execution_attempt;
+  if (!attempt) return;
+
+  if (data.runtime_vitals?.last_event?.kind === TaskRuntimeEventKind.EXECUTOR_CONNECTED) {
+    data.current_execution_attempt = {
+      ...attempt,
+      connected_at: attempt.connected_at ?? data.runtime_vitals.last_event.at ?? now,
+    };
+    return;
+  }
+
+  if (data.last_executor_heartbeat_at) {
+    data.current_execution_attempt = {
+      ...attempt,
+      last_heartbeat_at: data.last_executor_heartbeat_at,
+    };
+  }
+
+  if (isTerminalRuntimePatch(data)) {
+    data.current_execution_attempt = {
+      ...(data.current_execution_attempt ?? attempt),
+      terminal_at:
+        data.completed_at ?? data.runtime_vitals?.last_event?.at ?? attempt.terminal_at ?? now,
+      terminal_status: data.status ?? attempt.terminal_status,
+    };
+  }
+}
+
+function shouldNoopRuntimeOwnedPatch(
+  data: Partial<Task>,
+  currentTask: Task,
+  claims: ExecutorAttemptClaims
+): string | null {
+  const attempt = currentTask.current_execution_attempt;
+  if (!attempt) return null;
+
+  if (claims.isExecutorRuntime) {
+    if (!claims.attemptId || claims.attemptId !== attempt.attempt_id) {
+      return `stale attempt ${claims.attemptId ?? 'missing'} (current ${attempt.attempt_id})`;
+    }
+    if (claims.executorInstanceId && claims.executorInstanceId !== attempt.executor_instance_id) {
+      return `stale executor instance ${claims.executorInstanceId} (current ${attempt.executor_instance_id})`;
+    }
+  }
+
+  if (attempt.terminal_at && !isTerminalRuntimePatch(data)) {
+    return `attempt already terminal (${attempt.terminal_status ?? 'unknown'})`;
+  }
+
+  return null;
+}
+
+function runtimeOwnedPatchNoopTask(task: Task, reason: string): RuntimeOwnedPatchNoopTask {
+  return {
+    ...task,
+    runtime_patch_ignored: true,
+    runtime_patch_ignored_reason: reason,
+  };
 }
 
 /**
@@ -454,7 +606,22 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
    */
   async patch(id: string, data: Partial<Task>, params?: TaskParams): Promise<Task | Task[]> {
     const nextStatus = data.status;
-    const currentTask = nextStatus !== undefined ? await this.get(id, params) : undefined;
+    const isRuntimeOwnedPatch = runtimeOwnedTaskPatch(data);
+    const currentTask =
+      nextStatus !== undefined || isRuntimeOwnedPatch ? await this.get(id, params) : undefined;
+
+    if (currentTask && isRuntimeOwnedPatch) {
+      const claims = executorAttemptClaims(params);
+      const noopReason = shouldNoopRuntimeOwnedPatch(data, currentTask, claims);
+      if (noopReason) {
+        console.warn(
+          `⏭️ [TasksService] Ignoring runtime-owned patch for task ${shortId(currentTask.task_id)}: ${noopReason}`
+        );
+        return runtimeOwnedPatchNoopTask(currentTask, noopReason);
+      }
+      applyExecutionAttemptPatchState(data, currentTask);
+    }
+
     if (currentTask && isTerminalTaskStatus(currentTask.status) && nextStatus !== undefined) {
       console.warn(
         `⏭️ [TasksService] Ignoring status rewrite for terminal task ${shortId(currentTask.task_id)} ` +

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -607,22 +607,15 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   async patch(id: string, data: Partial<Task>, params?: TaskParams): Promise<Task | Task[]> {
     const nextStatus = data.status;
     const isRuntimeOwnedPatch = runtimeOwnedTaskPatch(data);
-    const currentTask =
+    let currentTask =
       nextStatus !== undefined || isRuntimeOwnedPatch ? await this.get(id, params) : undefined;
 
-    if (currentTask && isRuntimeOwnedPatch) {
-      const claims = executorAttemptClaims(params);
-      const noopReason = shouldNoopRuntimeOwnedPatch(data, currentTask, claims);
-      if (noopReason) {
-        console.warn(
-          `⏭️ [TasksService] Ignoring runtime-owned patch for task ${shortId(currentTask.task_id)}: ${noopReason}`
-        );
-        return runtimeOwnedPatchNoopTask(currentTask, noopReason);
-      }
-      applyExecutionAttemptPatchState(data, currentTask);
-    }
-
-    if (currentTask && isTerminalTaskStatus(currentTask.status) && nextStatus !== undefined) {
+    if (
+      !isRuntimeOwnedPatch &&
+      currentTask &&
+      isTerminalTaskStatus(currentTask.status) &&
+      nextStatus !== undefined
+    ) {
       console.warn(
         `⏭️ [TasksService] Ignoring status rewrite for terminal task ${shortId(currentTask.task_id)} ` +
           `(${currentTask.status} → ${nextStatus})`
@@ -676,7 +669,49 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       }
     }
 
-    const result = await super.patch(id, data, params);
+    let result: Task | Task[];
+    if (isRuntimeOwnedPatch) {
+      const claims = executorAttemptClaims(params);
+      const guarded = await this.taskRepo.updateWithLockedCurrent(id, (lockedTask) => {
+        const noopReason = shouldNoopRuntimeOwnedPatch(data, lockedTask, claims);
+        if (noopReason) {
+          console.warn(
+            `⏭️ [TasksService] Ignoring runtime-owned patch for task ${shortId(lockedTask.task_id)}: ${noopReason}`
+          );
+          return {
+            action: 'return',
+            task: runtimeOwnedPatchNoopTask(lockedTask, noopReason),
+          };
+        }
+
+        if (isTerminalTaskStatus(lockedTask.status) && nextStatus !== undefined) {
+          console.warn(
+            `⏭️ [TasksService] Ignoring status rewrite for terminal task ${shortId(lockedTask.task_id)} ` +
+              `(${lockedTask.status} → ${nextStatus})`
+          );
+          return {
+            action: 'return',
+            task: lockedTask,
+          };
+        }
+
+        applyExecutionAttemptPatchState(data, lockedTask);
+        return {
+          action: 'update',
+          updates: data,
+        };
+      });
+
+      currentTask = guarded.before;
+      if (!guarded.updated) {
+        return guarded.after;
+      }
+
+      result = guarded.after;
+      this.emit?.('patched', result, params);
+    } else {
+      result = await super.patch(id, data, params);
+    }
 
     if (isRunningTransition && !Array.isArray(result)) {
       this.trackTaskStarted(result as Task);

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
+  shouldFailCommandTemplateLauncherExit,
 } from './executor-spawn-classification.js';
 
 describe('executor spawn classification', () => {
@@ -23,5 +24,41 @@ describe('executor spawn classification', () => {
 
   it('does not classify successful exits as spawn failures', () => {
     expect(isExecutorSpawnFailureExit(false, 0)).toBe(false);
+  });
+
+  it('does not fail command-template tasks for successful launcher exits', () => {
+    expect(
+      shouldFailCommandTemplateLauncherExit({
+        code: 0,
+        connected: false,
+        activeTask: true,
+        isLatestTask: true,
+        sessionExecuting: true,
+      })
+    ).toBe(false);
+  });
+
+  it('fails command-template tasks for non-zero launcher exits before executor_connected', () => {
+    expect(
+      shouldFailCommandTemplateLauncherExit({
+        code: 1,
+        connected: false,
+        activeTask: true,
+        isLatestTask: true,
+        sessionExecuting: true,
+      })
+    ).toBe(true);
+  });
+
+  it('does not fail command-template tasks for launcher exits after executor_connected', () => {
+    expect(
+      shouldFailCommandTemplateLauncherExit({
+        code: 1,
+        connected: true,
+        activeTask: true,
+        isLatestTask: true,
+        sessionExecuting: true,
+      })
+    ).toBe(false);
   });
 });

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
@@ -39,6 +39,12 @@ describe('executor spawn classification', () => {
         task_last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z',
       })
     ).toBe(true);
+    expect(
+      hasExecutorConnectionEvidence({
+        has_current_attempt: true,
+        task_last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z',
+      })
+    ).toBe(false);
   });
 
   it('does not fail command-template tasks for successful launcher exits', () => {

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  hasExecutorConnectionEvidence,
   hasObservedLaunchedExecutorProcess,
   isExecutorSpawnFailureExit,
   shouldFailCommandTemplateLauncherExit,
+  shouldScheduleCommandTemplateConnectTimeout,
 } from './executor-spawn-classification.js';
 
 describe('executor spawn classification', () => {
@@ -24,6 +26,19 @@ describe('executor spawn classification', () => {
 
   it('does not classify successful exits as spawn failures', () => {
     expect(isExecutorSpawnFailureExit(false, 0)).toBe(false);
+  });
+
+  it('treats attempt connection and heartbeat timestamps as executor connection evidence', () => {
+    expect(hasExecutorConnectionEvidence({})).toBe(false);
+    expect(hasExecutorConnectionEvidence({ connected_at: '2026-01-01T00:00:00.000Z' })).toBe(true);
+    expect(hasExecutorConnectionEvidence({ last_heartbeat_at: '2026-01-01T00:00:01.000Z' })).toBe(
+      true
+    );
+    expect(
+      hasExecutorConnectionEvidence({
+        task_last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z',
+      })
+    ).toBe(true);
   });
 
   it('does not fail command-template tasks for successful launcher exits', () => {
@@ -58,6 +73,42 @@ describe('executor spawn classification', () => {
         activeTask: true,
         isLatestTask: true,
         sessionExecuting: true,
+      })
+    ).toBe(false);
+  });
+
+  it('schedules a connect-timeout check for successful command-template launcher exits before connect', () => {
+    expect(
+      shouldScheduleCommandTemplateConnectTimeout({
+        code: 0,
+        connected: false,
+        activeTask: true,
+        isLatestTask: true,
+        sessionExecuting: true,
+        attemptMatches: true,
+      })
+    ).toBe(true);
+  });
+
+  it('does not schedule command-template connect timeout for stale attempts or connected executors', () => {
+    expect(
+      shouldScheduleCommandTemplateConnectTimeout({
+        code: 0,
+        connected: false,
+        activeTask: true,
+        isLatestTask: true,
+        sessionExecuting: true,
+        attemptMatches: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldScheduleCommandTemplateConnectTimeout({
+        code: 0,
+        connected: true,
+        activeTask: true,
+        isLatestTask: true,
+        sessionExecuting: true,
+        attemptMatches: true,
       })
     ).toBe(false);
   });

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.ts
@@ -12,3 +12,23 @@ export function hasObservedLaunchedExecutorProcess(child: Pick<ChildProcess, 'pi
 export function isExecutorSpawnFailureExit(processSpawnObserved: boolean, code: number | null) {
   return !processSpawnObserved && code !== 0;
 }
+
+export interface CommandTemplateLauncherExitState {
+  code: number | null;
+  connected: boolean;
+  activeTask: boolean;
+  isLatestTask: boolean;
+  sessionExecuting: boolean;
+}
+
+export function shouldFailCommandTemplateLauncherExit(
+  state: CommandTemplateLauncherExitState
+): boolean {
+  return (
+    state.code !== 0 &&
+    !state.connected &&
+    state.activeTask &&
+    state.isLatestTask &&
+    state.sessionExecuting
+  );
+}

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.ts
@@ -14,12 +14,16 @@ export function isExecutorSpawnFailureExit(processSpawnObserved: boolean, code: 
 }
 
 export interface ExecutorConnectionEvidenceState {
+  has_current_attempt?: boolean;
   connected_at?: unknown;
   last_heartbeat_at?: unknown;
   task_last_executor_heartbeat_at?: unknown;
 }
 
 export function hasExecutorConnectionEvidence(state: ExecutorConnectionEvidenceState): boolean {
+  if (state.has_current_attempt) {
+    return Boolean(state.connected_at || state.last_heartbeat_at);
+  }
   return Boolean(
     state.connected_at || state.last_heartbeat_at || state.task_last_executor_heartbeat_at
   );

--- a/apps/agor-daemon/src/utils/executor-spawn-classification.ts
+++ b/apps/agor-daemon/src/utils/executor-spawn-classification.ts
@@ -13,6 +13,18 @@ export function isExecutorSpawnFailureExit(processSpawnObserved: boolean, code: 
   return !processSpawnObserved && code !== 0;
 }
 
+export interface ExecutorConnectionEvidenceState {
+  connected_at?: unknown;
+  last_heartbeat_at?: unknown;
+  task_last_executor_heartbeat_at?: unknown;
+}
+
+export function hasExecutorConnectionEvidence(state: ExecutorConnectionEvidenceState): boolean {
+  return Boolean(
+    state.connected_at || state.last_heartbeat_at || state.task_last_executor_heartbeat_at
+  );
+}
+
 export interface CommandTemplateLauncherExitState {
   code: number | null;
   connected: boolean;
@@ -26,6 +38,23 @@ export function shouldFailCommandTemplateLauncherExit(
 ): boolean {
   return (
     state.code !== 0 &&
+    !state.connected &&
+    state.activeTask &&
+    state.isLatestTask &&
+    state.sessionExecuting
+  );
+}
+
+export interface CommandTemplateConnectTimeoutState extends CommandTemplateLauncherExitState {
+  attemptMatches: boolean;
+}
+
+export function shouldScheduleCommandTemplateConnectTimeout(
+  state: CommandTemplateConnectTimeoutState
+): boolean {
+  return (
+    state.attemptMatches &&
+    state.code === 0 &&
     !state.connected &&
     state.activeTask &&
     state.isLatestTask &&

--- a/apps/agor-daemon/src/utils/task-runtime-vitals.ts
+++ b/apps/agor-daemon/src/utils/task-runtime-vitals.ts
@@ -139,6 +139,9 @@ export async function patchDaemonTaskRuntimeEvent(
 ): Promise<TaskRuntimeVitals | undefined> {
   try {
     const task = await tasksService.get(taskId, params);
+    if (task.current_execution_attempt?.terminal_at) {
+      return undefined;
+    }
     const phase =
       options.phase ?? task.runtime_vitals?.phase ?? taskStatusToDaemonRuntimePhase(task.status);
     const runtime_vitals = buildDaemonTaskRuntimeVitals(task.runtime_vitals, kind, {

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -5,7 +5,12 @@
  */
 
 import type { Task, UUID } from '@agor/core/types';
-import { TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
+import {
+  TaskExecutionRuntimeBackend,
+  TaskRuntimeEventKind,
+  TaskRuntimePhase,
+  TaskStatus,
+} from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { generateId, toShortId } from '../../lib/ids';
 import type { Database } from '../client';
@@ -779,6 +784,38 @@ describe('TaskRepository.update', () => {
 
     expect(updated.last_executor_heartbeat_at).toBe(heartbeatAt);
     expect(found?.last_executor_heartbeat_at).toBe(heartbeatAt);
+  });
+
+  dbTest('should round-trip current_execution_attempt JSON on update', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const created = await taskRepo.create(
+      createTaskData({ session_id: sessionId, status: TaskStatus.RUNNING })
+    );
+    const startedAt = '2026-01-01T00:00:00.000Z';
+    const connectedAt = '2026-01-01T00:00:01.000Z';
+
+    const updated = await taskRepo.update(created.task_id, {
+      current_execution_attempt: {
+        schema_version: 1,
+        attempt_id: generateId(),
+        executor_instance_id: generateId(),
+        runtime_backend: TaskExecutionRuntimeBackend.COMMAND_TEMPLATE,
+        runtime_ref: 'pod/agor-task-1',
+        started_at: startedAt,
+        connected_at: connectedAt,
+      },
+    });
+    const found = await taskRepo.findById(created.task_id);
+
+    expect(updated.current_execution_attempt).toMatchObject({
+      schema_version: 1,
+      runtime_backend: TaskExecutionRuntimeBackend.COMMAND_TEMPLATE,
+      runtime_ref: 'pod/agor-task-1',
+      started_at: startedAt,
+      connected_at: connectedAt,
+    });
+    expect(found?.current_execution_attempt).toEqual(updated.current_execution_attempt);
   });
 
   dbTest(

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -101,6 +101,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         permission_request: task.permission_request, // Permission state for UI approval flow
         metadata: task.metadata, // Generic metadata bag (e.g., is_agor_callback, source)
         runtime_vitals: task.runtime_vitals, // Passive runtime-vitals observability
+        current_execution_attempt: task.current_execution_attempt, // Executor attempt ownership
       },
     };
   }

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -22,6 +22,16 @@ import {
 import { visibleSessionReferenceAccessExists } from './branch-access';
 import { deepMerge } from './merge-utils';
 
+export type TaskLockedUpdateDecision =
+  | { action: 'update'; updates: Partial<Task> }
+  | { action: 'return'; task: Task };
+
+export interface TaskLockedUpdateResult {
+  before: Task;
+  after: Task;
+  updated: boolean;
+}
+
 /**
  * Task repository implementation
  */
@@ -407,6 +417,81 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       if (error instanceof EntityNotFoundError) throw error;
       throw new RepositoryError(
         `Failed to update task: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Update a task while letting the caller decide against the row version that
+   * is locked inside the repository transaction.
+   *
+   * Use this for compare-and-swap style task updates where a pre-transaction
+   * read would be stale by the time the merge/write happens.
+   */
+  async updateWithLockedCurrent(
+    id: string,
+    decide: (current: Task) => TaskLockedUpdateDecision
+  ): Promise<TaskLockedUpdateResult> {
+    try {
+      const fullId = await this.resolveId(id);
+
+      const result = await this.db.transaction(async (tx) => {
+        await lockRowForUpdate(txAsDb(tx), this.db, tasks, eq(tasks.task_id, fullId));
+
+        const currentRow = await select(txAsDb(tx))
+          .from(tasks)
+          .where(eq(tasks.task_id, fullId))
+          .one();
+
+        if (!currentRow) {
+          throw new EntityNotFoundError('Task', id);
+        }
+
+        const current = this.rowToTask(currentRow);
+        const decision = decide(current);
+
+        if (decision.action === 'return') {
+          return {
+            before: current,
+            after: decision.task,
+            updated: false,
+          };
+        }
+
+        const merged = deepMerge(current, decision.updates);
+        if (decision.updates.runtime_vitals !== undefined) {
+          merged.runtime_vitals = decision.updates.runtime_vitals;
+        }
+        const insertData = this.taskToInsert(merged);
+
+        await update(txAsDb(tx), tasks)
+          .set({
+            status: insertData.status,
+            queue_position: insertData.queue_position,
+            completed_at: insertData.completed_at,
+            last_executor_heartbeat_at: insertData.last_executor_heartbeat_at,
+            session_md5: insertData.session_md5,
+            data: insertData.data,
+          })
+          .where(eq(tasks.task_id, fullId))
+          .run();
+
+        return {
+          before: current,
+          after: merged,
+          updated: true,
+        };
+      });
+
+      return result;
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      if (error instanceof EntityNotFoundError) throw error;
+      throw new RepositoryError(
+        `Failed to update task with locked current row: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
         error
       );
     }

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -372,6 +372,9 @@ export const tasks = pgTable(
 
         // Passive runtime-vitals observability
         runtime_vitals?: Task['runtime_vitals'];
+
+        // Current executor attempt ownership metadata
+        current_execution_attempt?: Task['current_execution_attempt'];
       }>()
       .notNull(),
   },

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -365,6 +365,9 @@ export const tasks = sqliteTable(
 
         // Passive runtime-vitals observability
         runtime_vitals?: Task['runtime_vitals'];
+
+        // Current executor attempt ownership metadata
+        current_execution_attempt?: Task['current_execution_attempt'];
       }>()
       .notNull(),
   },

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -115,6 +115,27 @@ export interface TaskRuntimeVitals {
   recent_events?: TaskRuntimeEvent[];
 }
 
+export const TaskExecutionRuntimeBackend = {
+  LOCAL_SUBPROCESS: 'local_subprocess',
+  COMMAND_TEMPLATE: 'command_template',
+} as const;
+
+export type TaskExecutionRuntimeBackend =
+  (typeof TaskExecutionRuntimeBackend)[keyof typeof TaskExecutionRuntimeBackend];
+
+export interface TaskExecutionAttempt {
+  schema_version: 1;
+  attempt_id: string;
+  executor_instance_id: string;
+  runtime_backend: TaskExecutionRuntimeBackend;
+  runtime_ref?: string;
+  started_at: string;
+  connected_at?: string;
+  last_heartbeat_at?: string;
+  terminal_at?: string;
+  terminal_status?: TaskStatus;
+}
+
 /**
  * Structured metadata attached to a task. All fields are optional, but the
  * ones that are present are load-bearing — typing them here prevents drift
@@ -255,6 +276,9 @@ export interface Task {
 
   /** Passive executor/agent runtime phase observability. No policy side effects. */
   runtime_vitals?: TaskRuntimeVitals;
+
+  /** Current executor attempt allowed to report runtime-owned task state. */
+  current_execution_attempt?: TaskExecutionAttempt;
 
   // Message range
   message_range: {

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -190,6 +190,8 @@ async function handlePromptPayload(
     sessionToken: payload.sessionToken,
     sessionId: payload.params.sessionId,
     taskId: payload.params.taskId,
+    attemptId: payload.params.attemptId,
+    executorInstanceId: payload.params.executorInstanceId,
     prompt: payload.params.prompt,
     tool: payload.params.tool,
     permissionMode: payload.params.permissionMode,

--- a/packages/executor/src/contract.test.ts
+++ b/packages/executor/src/contract.test.ts
@@ -90,4 +90,19 @@ describe('executor source contract', () => {
     // No loadConfig escape hatch.
     expect(configSrc).not.toMatch(/\bloadConfig\b/);
   });
+
+  it('emits executor_connected before heartbeat startup and SDK execution', () => {
+    const source = readFileSync(join(here, 'index.ts'), 'utf-8');
+    const authIndex = source.indexOf(
+      'createFeathersClient(this.config.daemonUrl, this.config.sessionToken)'
+    );
+    const connectedIndex = source.indexOf('await this.emitExecutorConnected();');
+    const executeIndex = source.indexOf('await this.executeTask();');
+    const heartbeatIndex = source.indexOf('this.heartbeat = startExecutorHeartbeat');
+
+    expect(authIndex).toBeGreaterThanOrEqual(0);
+    expect(connectedIndex).toBeGreaterThan(authIndex);
+    expect(executeIndex).toBeGreaterThan(connectedIndex);
+    expect(heartbeatIndex).toBeGreaterThan(executeIndex);
+  });
 });

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -209,4 +209,88 @@ describe('executeToolTask runtime vitals failure handling', () => {
       content: 'tool factory failed',
     });
   });
+
+  it('does not create fallback system-error messages when a stale failure patch is ignored', async () => {
+    const taskPatches: Array<{ id: string; data: Record<string, unknown> }> = [];
+    const messages: Array<Record<string, unknown>> = [];
+    const client = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return {
+            get: vi.fn(async (id: string) => ({ task_id: id })),
+            emit: vi.fn(),
+            patch: vi.fn(async (id: string, data: Record<string, unknown>) => {
+              taskPatches.push({ id, data });
+              if (data.status === TaskStatus.FAILED) {
+                return {
+                  task_id: id,
+                  status: TaskStatus.RUNNING,
+                  runtime_patch_ignored: true,
+                  runtime_patch_ignored_reason: 'stale attempt old (current new)',
+                };
+              }
+              return { task_id: id, ...data };
+            }),
+          };
+        }
+        if (name === 'sessions') {
+          return {
+            get: vi.fn(async () => ({ branch_id: 'branch-1', git_state: {} })),
+            patch: vi.fn(async () => ({})),
+          };
+        }
+        if (name === 'branches') {
+          return { get: vi.fn(async () => ({ path: '/tmp/agor-test-branch' })) };
+        }
+        if (name === 'config/resolve-api-key') {
+          return {
+            create: vi.fn(async () => ({
+              apiKey: undefined,
+              source: 'native',
+              useNativeAuth: true,
+            })),
+          };
+        }
+        if (name === 'messages') {
+          return {
+            find: vi.fn(async () => ({ total: 0 })),
+            create: vi.fn(async (data: Record<string, unknown>) => {
+              messages.push(data);
+              return data;
+            }),
+          };
+        }
+        if (name === '/tasks/streaming') {
+          return { create: vi.fn(async (data: Record<string, unknown>) => data) };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await expect(
+      executeToolTask({
+        client,
+        sessionId: 'session-1' as never,
+        taskId: 'task-1' as never,
+        prompt: 'hello',
+        abortController: new AbortController(),
+        apiKeyEnvVar: 'OPENAI_API_KEY',
+        toolName: 'codex' as never,
+        createTool: () => {
+          throw new Error('tool factory failed');
+        },
+      })
+    ).rejects.toThrow('tool factory failed');
+
+    expect(taskPatches).toContainEqual(
+      expect.objectContaining({
+        id: 'task-1',
+        data: expect.objectContaining({
+          status: TaskStatus.FAILED,
+          error_message: 'tool factory failed',
+        }),
+      })
+    );
+    expect(messages).toHaveLength(0);
+  });
 });

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -43,6 +43,14 @@ function sdkDebug(...args: unknown[]): void {
   }
 }
 
+function runtimePatchIgnored(result: unknown): boolean {
+  return (
+    result !== null &&
+    typeof result === 'object' &&
+    (result as { runtime_patch_ignored?: unknown }).runtime_patch_ignored === true
+  );
+}
+
 /**
  * Tool interface that all SDK wrappers must implement
  */
@@ -683,7 +691,10 @@ export async function executeToolTask(params: {
     // Update task status to completed/stopped with git SHA and SDK responses
     // Note: The stop endpoint may have already patched task to STOPPED via process kill.
     // The tasks.ts patch hook guards against double-updates (wasAlreadyTerminal check).
-    await client.service('tasks').patch(taskId, patchData);
+    const patchedTask = await client.service('tasks').patch(taskId, patchData);
+    if (runtimePatchIgnored(patchedTask)) {
+      throw new Error('Executor attempt is no longer current');
+    }
   } catch (error) {
     const err = error as Error;
     console.error(`[${toolName}] Execution failed:`, err);

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -19,7 +19,7 @@ import type {
   TaskID,
   TaskRuntimeVitals,
 } from '@agor/core/types';
-import { MessageRole, TaskRuntimeEventKind, TaskRuntimePhase } from '@agor/core/types';
+import { MessageRole, TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
 import { createFeathersBackedRepositories } from '../../db/feathers-repositories.js';
 import { getCurrentBranch, getGitState } from '../../git/index.js';
 import {
@@ -373,6 +373,22 @@ function shouldFallbackToLocalApiKeyResolution(err: unknown): boolean {
   return true;
 }
 
+function runtimeTaskPatchIgnored(task: unknown): boolean {
+  return (
+    typeof task === 'object' &&
+    task !== null &&
+    (task as { runtime_patch_ignored?: unknown }).runtime_patch_ignored === true
+  );
+}
+
+function terminalFailurePatchApplied(patchedTask: unknown, errorMessage: string): boolean {
+  if (runtimeTaskPatchIgnored(patchedTask)) return false;
+  if (typeof patchedTask !== 'object' || patchedTask === null) return false;
+
+  const task = patchedTask as Partial<Task>;
+  return task.status === TaskStatus.FAILED && task.error_message === errorMessage;
+}
+
 export async function resolveApiKeyForTask(
   keyName: ApiKeyName,
   client: AgorClient,
@@ -697,8 +713,17 @@ export async function executeToolTask(params: {
       };
     }
 
-    // Update task status to failed with git SHA
-    await client.service('tasks').patch(taskId, patchData);
+    // Update task status to failed with git SHA. If the daemon no-ops this as
+    // a stale attempt, do not append fallback transcript side effects for an
+    // executor that no longer owns the task.
+    const patchedTask = await client.service('tasks').patch(taskId, patchData);
+    const failureApplied = terminalFailurePatchApplied(patchedTask, patchData.error_message ?? '');
+    if (!failureApplied) {
+      console.warn(
+        `[${toolName}] Failure patch for task ${shortId(taskId)} did not apply to the current attempt; skipping fallback error message`
+      );
+      throw err;
+    }
 
     // Emit a system error message so the user sees what went wrong in the conversation
     try {

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AgorExecutor, type ExecutorConfig } from './index';
+
+type TestExecutor = AgorExecutor & {
+  client: {
+    service(name: 'tasks'): {
+      get: ReturnType<typeof vi.fn>;
+      patch: ReturnType<typeof vi.fn>;
+    };
+  };
+  emitExecutorConnected(): Promise<void>;
+};
+
+function executorWithTasksService(tasksService: {
+  get: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+}): TestExecutor {
+  const config: ExecutorConfig = {
+    sessionToken: 'token-1',
+    sessionId: 'session-1',
+    taskId: 'task-1',
+    prompt: 'hello',
+    tool: 'codex',
+    daemonUrl: 'http://daemon.test',
+  };
+  const executor = new AgorExecutor(config) as unknown as TestExecutor;
+  executor.client = {
+    service(name: 'tasks') {
+      if (name !== 'tasks') throw new Error(`unexpected service ${name}`);
+      return tasksService;
+    },
+  };
+  return executor;
+}
+
+describe('AgorExecutor emitExecutorConnected', () => {
+  it('fails fast when the daemon ignores the executor-connected patch', async () => {
+    const executor = executorWithTasksService({
+      get: vi.fn().mockResolvedValue({ runtime_vitals: undefined }),
+      patch: vi.fn().mockResolvedValue({ runtime_patch_ignored: true }),
+    });
+
+    await expect(executor.emitExecutorConnected()).rejects.toThrow(
+      /Failed to claim executor attempt: Executor attempt is no longer current/
+    );
+  });
+
+  it('fails fast when the executor-connected patch is not written', async () => {
+    const executor = executorWithTasksService({
+      get: vi.fn().mockResolvedValue({ runtime_vitals: undefined }),
+      patch: vi.fn().mockRejectedValue(new Error('socket disconnected')),
+    });
+
+    await expect(executor.emitExecutorConnected()).rejects.toThrow(
+      /Failed to claim executor attempt: Failed to write executor_connected runtime event/
+    );
+  });
+});

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -183,6 +183,9 @@ export class AgorExecutor {
         forceFlush: true,
       });
       reporter.stop();
+      if (!result) {
+        throw new Error('Failed to write executor_connected runtime event');
+      }
       if (isRuntimePatchIgnored(result)) {
         throw new Error('Executor attempt is no longer current');
       }

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -16,11 +16,12 @@ import type {
   SessionID,
   TaskID,
 } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { TaskRuntimeEventKind, TaskRuntimePhase, TaskStatus } from '@agor/core/types';
 import { patchConsole } from '@agor/core/utils/logger';
 import { type ExecutorHeartbeatHandle, startExecutorHeartbeat } from './executor-heartbeat.js';
 import type { ResolvedConfigSlice } from './payload-types.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
+import { TaskRuntimeVitalsReporter } from './runtime-vitals.js';
 import { type AgorClient, createFeathersClient } from './services/feathers-client.js';
 import { tryMarkTaskTerminal } from './terminal-task.js';
 
@@ -39,6 +40,8 @@ export interface ExecutorConfig {
   sessionToken: string;
   sessionId: string;
   taskId: string;
+  attemptId?: string;
+  executorInstanceId?: string;
   prompt: string;
   tool: 'claude-code' | 'gemini' | 'codex' | 'opencode' | 'copilot' | 'cursor';
   permissionMode?: PermissionMode;
@@ -86,6 +89,7 @@ export class AgorExecutor {
       executorDebug('[executor] Connecting to daemon via Feathers...');
       this.client = await createFeathersClient(this.config.daemonUrl, this.config.sessionToken);
       executorDebug('[executor] Connected to daemon');
+      await this.emitExecutorConnected();
 
       // Setup event listeners
       this.setupEventListeners();
@@ -147,6 +151,36 @@ export class AgorExecutor {
     });
 
     executorDebug('[executor] Event listeners registered');
+  }
+
+  /**
+   * Persist the executor_connected runtime event immediately after Feathers
+   * authentication succeeds. This deliberately runs before heartbeat startup
+   * and before any SDK_TURN_STARTED/runtime-vitals SDK events.
+   */
+  private async emitExecutorConnected(): Promise<void> {
+    if (!this.client) return;
+    try {
+      const task = await this.client.service('tasks').get(this.config.taskId);
+      const reporter = new TaskRuntimeVitalsReporter({
+        client: this.client,
+        taskId: this.config.taskId,
+        toolName: this.config.tool,
+        initialSnapshot: task.runtime_vitals,
+        minPatchIntervalMs: 0,
+      });
+      await reporter.record(TaskRuntimeEventKind.EXECUTOR_CONNECTED, {
+        source: 'executor',
+        phase: TaskRuntimePhase.EXECUTOR_CONNECTED,
+        forceFlush: true,
+      });
+      reporter.stop();
+    } catch (error) {
+      console.warn(
+        '[executor] Failed to emit executor_connected:',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
   }
 
   /**

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -36,6 +36,14 @@ function executorDebug(...args: unknown[]): void {
   }
 }
 
+function isRuntimePatchIgnored(result: unknown): result is { runtime_patch_ignored: true } {
+  return (
+    result !== null &&
+    typeof result === 'object' &&
+    (result as { runtime_patch_ignored?: unknown }).runtime_patch_ignored === true
+  );
+}
+
 export interface ExecutorConfig {
   sessionToken: string;
   sessionId: string;
@@ -169,16 +177,18 @@ export class AgorExecutor {
         initialSnapshot: task.runtime_vitals,
         minPatchIntervalMs: 0,
       });
-      await reporter.record(TaskRuntimeEventKind.EXECUTOR_CONNECTED, {
+      const result = await reporter.record(TaskRuntimeEventKind.EXECUTOR_CONNECTED, {
         source: 'executor',
         phase: TaskRuntimePhase.EXECUTOR_CONNECTED,
         forceFlush: true,
       });
       reporter.stop();
+      if (isRuntimePatchIgnored(result)) {
+        throw new Error('Executor attempt is no longer current');
+      }
     } catch (error) {
-      console.warn(
-        '[executor] Failed to emit executor_connected:',
-        error instanceof Error ? error.message : String(error)
+      throw new Error(
+        `Failed to claim executor attempt: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -29,6 +29,8 @@ describe('PromptPayloadSchema', () => {
       params: {
         sessionId: '550e8400-e29b-41d4-a716-446655440000',
         taskId: '550e8400-e29b-41d4-a716-446655440001',
+        attemptId: '550e8400-e29b-41d4-a716-446655440002',
+        executorInstanceId: '550e8400-e29b-41d4-a716-446655440003',
         prompt: 'Hello, world!',
         tool: 'claude-code',
         cwd: '/home/user/project',
@@ -39,6 +41,8 @@ describe('PromptPayloadSchema', () => {
     expect(result.command).toBe('prompt');
     expect(result.sessionToken).toBe('jwt-token-here');
     expect(result.params.tool).toBe('claude-code');
+    expect(result.params.attemptId).toBe('550e8400-e29b-41d4-a716-446655440002');
+    expect(result.params.executorInstanceId).toBe('550e8400-e29b-41d4-a716-446655440003');
   });
 
   it('should parse prompt payload with optional fields', () => {

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -157,6 +157,8 @@ export const PromptPayloadSchema = BasePayloadSchema.extend({
   params: z.object({
     sessionId: z.string().uuid(),
     taskId: z.string().uuid(),
+    attemptId: z.string().uuid().optional(),
+    executorInstanceId: z.string().uuid().optional(),
     prompt: z.string(),
     tool: ToolTypeSchema,
     permissionMode: PermissionModeSchema.optional(),

--- a/packages/executor/src/runtime-vitals.ts
+++ b/packages/executor/src/runtime-vitals.ts
@@ -1,5 +1,6 @@
 import type {
   Message,
+  Task,
   TaskRuntimeEvent,
   TaskRuntimeEventKind,
   TaskRuntimeEventSource,
@@ -44,6 +45,8 @@ export interface RuntimeVitalsRecordOptions {
   forceFlush?: boolean;
 }
 
+export type RuntimeVitalsPatchResult = Task & { runtime_patch_ignored?: boolean };
+
 export class TaskRuntimeVitalsReporter {
   private readonly now: () => Date;
   private readonly maxEvents: number;
@@ -51,7 +54,7 @@ export class TaskRuntimeVitalsReporter {
   private readonly warn: (...args: unknown[]) => void;
   private current: TaskRuntimeVitals | undefined;
   private lastFlushAtMs = 0;
-  private pendingFlush: Promise<void> = Promise.resolve();
+  private pendingFlush: Promise<RuntimeVitalsPatchResult | undefined> = Promise.resolve(undefined);
   private trailingFlushTimer: ReturnType<typeof setTimeout> | undefined;
   private stopped = false;
 
@@ -77,8 +80,8 @@ export class TaskRuntimeVitalsReporter {
   async record(
     kind: TaskRuntimeEventKind,
     options: RuntimeVitalsRecordOptions = {}
-  ): Promise<void> {
-    if (this.stopped) return;
+  ): Promise<RuntimeVitalsPatchResult | undefined> {
+    if (this.stopped) return undefined;
     const previous = this.current;
     const vitals = this.applyEvent(kind, options);
     const phaseChanged = !previous || previous.phase !== vitals.phase;
@@ -93,11 +96,11 @@ export class TaskRuntimeVitalsReporter {
 
     if (!shouldFlush) {
       this.scheduleTrailingFlush();
-      return;
+      return undefined;
     }
 
     this.cancelTrailingFlush();
-    await this.enqueueFlush(vitals);
+    return this.enqueueFlush(vitals);
   }
 
   /**
@@ -225,24 +228,27 @@ export class TaskRuntimeVitalsReporter {
     this.trailingFlushTimer = undefined;
   }
 
-  private async enqueueFlush(vitals: TaskRuntimeVitals): Promise<void> {
+  private async enqueueFlush(
+    vitals: TaskRuntimeVitals
+  ): Promise<RuntimeVitalsPatchResult | undefined> {
     this.lastFlushAtMs = this.now().getTime();
     const patch = async () => {
-      if (this.stopped) return;
+      if (this.stopped) return undefined;
       try {
-        await this.options.client.service('tasks').patch(this.options.taskId, {
+        return (await this.options.client.service('tasks').patch(this.options.taskId, {
           runtime_vitals: vitals,
-        });
+        })) as RuntimeVitalsPatchResult;
       } catch (error) {
         this.warn(
           '[runtime-vitals] Failed to write task runtime vitals:',
           error instanceof Error ? error.message : String(error)
         );
+        return undefined;
       }
     };
 
     this.pendingFlush = this.pendingFlush.then(patch, patch);
-    await this.pendingFlush;
+    return this.pendingFlush;
   }
 }
 

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
@@ -33,7 +33,10 @@ describe('createCanUseToolCallback', () => {
         cancelPendingRequests: vi.fn(),
       } as any,
       tasksService: {
-        patch: vi.fn().mockResolvedValue(undefined),
+        patch: vi.fn().mockImplementation(async (_id: string, data: Record<string, unknown>) => ({
+          task_id: taskId,
+          ...data,
+        })),
       } as any,
       messagesRepo: {
         findBySessionId: vi.fn().mockResolvedValue([]),
@@ -132,6 +135,26 @@ describe('createCanUseToolCallback', () => {
       expect(result.updatedPermissions).toBeUndefined();
       // Lock was acquired AND released.
       expect(deps.permissionLocks.size).toBe(0);
+    });
+
+    it('does not create permission side effects when awaiting-permission patch is stale', async () => {
+      const deps = createBaseDeps();
+      deps.tasksService.patch.mockResolvedValueOnce({
+        task_id: taskId,
+        status: 'running',
+        runtime_patch_ignored: true,
+        runtime_patch_ignored_reason: 'stale attempt old (current new)',
+      });
+
+      const callback = createCanUseToolCallback(sessionId, taskId, deps);
+      const result = await callback('Bash', { command: 'ls' }, noopOptions);
+
+      expect(result.behavior).toBe('deny');
+      expect(result.message).toMatch(/stale task attempt/i);
+      expect(deps.messagesService.create).not.toHaveBeenCalled();
+      expect(deps.sessionsService.patch).not.toHaveBeenCalled();
+      expect(deps.permissionService.emitRequest).not.toHaveBeenCalled();
+      expect(deps.permissionService.waitForDecision).not.toHaveBeenCalled();
     });
 
     it('emits an SDK persistence rule when the user picks "remember"', async () => {

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.ts
@@ -23,6 +23,23 @@ import type {
 import type { PermissionService } from '../../../permissions/permission-service.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../../base/index.js';
 
+function runtimeTaskPatchIgnored(task: unknown): boolean {
+  return (
+    typeof task === 'object' &&
+    task !== null &&
+    (task as { runtime_patch_ignored?: unknown }).runtime_patch_ignored === true
+  );
+}
+
+function taskStatusApplied(task: unknown, status: TaskStatus): boolean {
+  return (
+    !runtimeTaskPatchIgnored(task) &&
+    typeof task === 'object' &&
+    task !== null &&
+    (task as { status?: unknown }).status === status
+  );
+}
+
 /**
  * Create canUseTool callback for permission handling
  *
@@ -151,6 +168,24 @@ export function createCanUseToolCallback(
       const requestId = generateId();
       const timestamp = new Date().toISOString();
 
+      // Update task status to 'awaiting_permission' before creating sidecar
+      // permission state. A stale executor attempt gets a typed no-op response
+      // from the daemon; in that case it must not append permission messages,
+      // emit UI requests, or move the session.
+      const awaitingTask = await deps.tasksService.patch(taskId, {
+        status: TaskStatus.AWAITING_PERMISSION,
+      });
+      if (!taskStatusApplied(awaitingTask, TaskStatus.AWAITING_PERMISSION)) {
+        console.warn(
+          `⏭️ [canUseTool] Permission request for ${toolName} ignored because task ${taskId} is no longer owned by this executor attempt`
+        );
+        return {
+          behavior: 'deny' as const,
+          message: `Permission request ignored for stale task attempt: ${toolName}`,
+        };
+      }
+      console.log(`✅ [canUseTool] Task ${taskId} updated to awaiting_permission`);
+
       // Get current message index for this session
       const existingMessages = await deps.messagesRepo.findBySessionId(sessionId);
       const nextIndex = existingMessages.length;
@@ -185,12 +220,6 @@ export function createCanUseToolCallback(
         await deps.messagesService.create(permissionMessage);
         console.log(`✅ [canUseTool] Permission request message created`);
       }
-
-      // Update task status to 'awaiting_permission'
-      await deps.tasksService.patch(taskId, {
-        status: TaskStatus.AWAITING_PERMISSION,
-      });
-      console.log(`✅ [canUseTool] Task ${taskId} updated to awaiting_permission`);
 
       // Update session status to 'awaiting_permission'
       if (deps.sessionsService) {
@@ -251,10 +280,19 @@ export function createCanUseToolCallback(
           `⏰ [canUseTool] Permission timed out for ${toolName}, setting timed_out state...`
         );
 
-        await deps.tasksService.patch(taskId, {
+        const timedOutTask = await deps.tasksService.patch(taskId, {
           status: TaskStatus.TIMED_OUT,
           completed_at: new Date().toISOString(),
         });
+        if (!taskStatusApplied(timedOutTask, TaskStatus.TIMED_OUT)) {
+          console.warn(
+            `⏭️ [canUseTool] Permission timeout for ${toolName} ignored because task ${taskId} is no longer owned by this executor attempt`
+          );
+          return {
+            behavior: 'deny' as const,
+            message: `Permission request timed out for stale task attempt: ${toolName}`,
+          };
+        }
 
         if (deps.sessionsService) {
           await deps.sessionsService.patch(sessionId, {
@@ -273,9 +311,19 @@ export function createCanUseToolCallback(
       }
 
       // Update task status
-      await deps.tasksService.patch(taskId, {
+      const resolvedTask = await deps.tasksService.patch(taskId, {
         status: decision.allow ? TaskStatus.RUNNING : TaskStatus.FAILED,
       });
+      const resolvedStatus = decision.allow ? TaskStatus.RUNNING : TaskStatus.FAILED;
+      if (!taskStatusApplied(resolvedTask, resolvedStatus)) {
+        console.warn(
+          `⏭️ [canUseTool] Permission resolution for ${toolName} ignored because task ${taskId} is no longer owned by this executor attempt`
+        );
+        return {
+          behavior: 'deny' as const,
+          message: `Permission resolution ignored for stale task attempt: ${toolName}`,
+        };
+      }
 
       // If permission was denied, stop execution
       if (!decision.allow) {

--- a/packages/executor/src/sdk-handlers/copilot/permission-mapper.ts
+++ b/packages/executor/src/sdk-handlers/copilot/permission-mapper.ts
@@ -34,6 +34,23 @@ import type { PermissionService } from '../../permissions/permission-service.js'
 import type { PermissionMode } from '../../types.js';
 import type { MessagesService, SessionsPatchClient, TasksService } from '../base/index.js';
 
+function runtimeTaskPatchIgnored(task: unknown): boolean {
+  return (
+    typeof task === 'object' &&
+    task !== null &&
+    (task as { runtime_patch_ignored?: unknown }).runtime_patch_ignored === true
+  );
+}
+
+function taskStatusApplied(task: unknown, status: TaskStatus): boolean {
+  return (
+    !runtimeTaskPatchIgnored(task) &&
+    typeof task === 'object' &&
+    task !== null &&
+    (task as { status?: unknown }).status === status
+  );
+}
+
 /**
  * Re-export SDK types for convenience
  */
@@ -231,6 +248,23 @@ export function createPermissionHandler(
       const requestId = generateId();
       const timestamp = new Date().toISOString();
 
+      // Update task status to 'awaiting_permission' before creating sidecar
+      // permission state. A stale executor attempt gets a typed no-op response
+      // from the daemon; in that case it must not append permission messages,
+      // emit UI requests, or move the session.
+      const awaitingTask = await deps.tasksService.patch(taskId, {
+        status: TaskStatus.AWAITING_PERMISSION,
+      });
+      if (!taskStatusApplied(awaitingTask, TaskStatus.AWAITING_PERMISSION)) {
+        console.warn(
+          `⏭️ [Copilot Permission] Permission request ignored because task ${taskId} is no longer owned by this executor attempt`
+        );
+        return {
+          kind: 'denied-interactively-by-user',
+          feedback: `Permission request ignored for stale task attempt: ${getToolDisplayName(request)}`,
+        };
+      }
+
       // Get current message index
       const existingMessages = await deps.messagesRepo.findBySessionId(sessionId);
       const nextIndex = existingMessages.length;
@@ -260,11 +294,6 @@ export function createPermissionHandler(
         await deps.messagesService.create(permissionMessage);
         console.log(`✅ [Copilot Permission] Permission request message created`);
       }
-
-      // Update task status to 'awaiting_permission'
-      await deps.tasksService.patch(taskId, {
-        status: TaskStatus.AWAITING_PERMISSION,
-      });
 
       // Update session status to 'awaiting_permission'
       if (deps.sessionsService) {
@@ -324,10 +353,19 @@ export function createPermissionHandler(
           `⏰ [Copilot Permission] Permission timed out for ${toolName}, setting timed_out state...`
         );
 
-        await deps.tasksService.patch(taskId, {
+        const timedOutTask = await deps.tasksService.patch(taskId, {
           status: TaskStatus.TIMED_OUT,
           completed_at: new Date().toISOString(),
         });
+        if (!taskStatusApplied(timedOutTask, TaskStatus.TIMED_OUT)) {
+          console.warn(
+            `⏭️ [Copilot Permission] Permission timeout ignored because task ${taskId} is no longer owned by this executor attempt`
+          );
+          return {
+            kind: 'denied-interactively-by-user',
+            feedback: `Permission request timed out for stale task attempt: ${toolName}`,
+          };
+        }
 
         if (deps.sessionsService) {
           await deps.sessionsService.patch(sessionId, {
@@ -351,9 +389,18 @@ export function createPermissionHandler(
         // Cancel all pending permission requests for this session
         deps.permissionService.cancelPendingRequests(sessionId);
 
-        await deps.tasksService.patch(taskId, {
+        const failedTask = await deps.tasksService.patch(taskId, {
           status: TaskStatus.FAILED,
         });
+        if (!taskStatusApplied(failedTask, TaskStatus.FAILED)) {
+          console.warn(
+            `⏭️ [Copilot Permission] Permission denial ignored because task ${taskId} is no longer owned by this executor attempt`
+          );
+          return {
+            kind: 'denied-interactively-by-user',
+            feedback: `Permission denied for stale task attempt: ${toolName}`,
+          };
+        }
 
         if (deps.sessionsService) {
           await deps.sessionsService.patch(sessionId, {
@@ -368,9 +415,18 @@ export function createPermissionHandler(
       }
 
       // Approved — restore running status
-      await deps.tasksService.patch(taskId, {
+      const runningTask = await deps.tasksService.patch(taskId, {
         status: TaskStatus.RUNNING,
       });
+      if (!taskStatusApplied(runningTask, TaskStatus.RUNNING)) {
+        console.warn(
+          `⏭️ [Copilot Permission] Permission approval ignored because task ${taskId} is no longer owned by this executor attempt`
+        );
+        return {
+          kind: 'denied-interactively-by-user',
+          feedback: `Permission approval ignored for stale task attempt: ${toolName}`,
+        };
+      }
 
       if (deps.sessionsService) {
         await deps.sessionsService.patch(sessionId, {


### PR DESCRIPTION
## Linked issue

Refs preset-io/agor-cloud#161

## Summary

- Add `current_execution_attempt` task metadata to identify the active executor attempt.
- Propagate attempt identity through daemon execution, executor JWT claims, stdin payload, and executor config.
- Fence runtime-owned task writes so stale executor/launcher attempts cannot update heartbeat, vitals, terminal state, or runtime sidecar fields.
- Record `executor_connected` after executor auth and make command-template launcher exits non-authoritative after connection.

## Why / context

Runtime vitals need to work when execution is distributed. In command-template / future remote execution, the daemon may only launch a job while the real executor reports back later. This makes the task row plus the current execution attempt the ownership boundary: only the active attempt can report runtime facts or terminal state.

## Implementation notes

- Stores attempt metadata in existing task JSON data for backwards compatibility.
- Resets runtime vitals when a new attempt is created.
- Allows legacy tasks with no attempt metadata to continue accepting runtime patches.
- Runtime-owned stale writes return the current task with an ignored marker instead of throwing, so stale executors skip fallback transcript/session side effects.
- Keeps local subprocess safety-net behavior, while treating command-template launcher success/exit as non-authoritative once the executor has connected.

## Validation / test plan

- [x] `pnpm --filter @agor/daemon test -- src/services/session-token-service.test.ts src/services/tasks.executor-heartbeat.test.ts src/utils/executor-spawn-classification.test.ts src/utils/task-runtime-vitals.test.ts`
- [x] `pnpm --filter @agor/core test -- src/db/repositories/tasks.test.ts`
- [x] `pnpm --filter @agor/executor test -- src/payload-types.test.ts src/contract.test.ts src/runtime-vitals.test.ts src/executor-heartbeat.test.ts src/handlers/sdk/base-executor.test.ts src/sdk-handlers/claude/permissions/permission-hooks.test.ts`
- [x] `pnpm --filter @agor/daemon typecheck`
- [x] `pnpm --filter @agor/executor typecheck`
- [x] `pnpm --filter @agor/core typecheck`
- [x] `pnpm exec biome check --diagnostic-level=warn $(git diff --name-only | tr '\n' ' ')`
- [x] `git diff --check`

## Screenshots / demos

Not applicable; runtime/backend behavior only.

## Risks / rollout / rollback

- Existing in-flight/legacy tasks without attempt metadata remain compatible.
- The main behavior change is stricter rejection/no-op of stale runtime-owned task patches when an active attempt exists.
- Rollback is reverting this stack slice; no schema migration is introduced.

## Out of scope / follow-ups

- Kubernetes watcher/reconciler.
- Timeout policy, abort escalation, retry UX, and broad terminalization redesign.
- Attempt fencing for transcript/streaming writes beyond the stale side-effect guards included here.
