### PR TITLE
chore: bump agor-live patch packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The reader's first pass is the headline only; sub-bullets are for the curious. K
 
 ### Chores
 
+- **Prepare agor-live patch release** — bumps `agor-live` and `@agor-live/client` to 0.23.2 and keeps the standalone agor-live package lock in sync. ([#1857](https://github.com/preset-io/agor/pull/1857))
 - **Refresh Claude tooling and agor-live patch versions** — bumps Claude Code CLI, Claude Agent SDK, and Anthropic SDK pins; adds Claude Sonnet 5 to the Claude model fallback catalog; and bumps `agor-live` / `@agor-live/client` to 0.23.1. ([#1727](https://github.com/preset-io/agor/pull/1727))
 
 ## 0.23.0 (TBD)

--- a/packages/agor-live/package-lock.json
+++ b/packages/agor-live/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agor-live",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agor-live",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "hasInstallScript": true,
       "license": "BUSL-1.1",
       "dependencies": {

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump `agor-live` from 0.23.1 to 0.23.2
- Bump `@agor-live/client` from 0.23.1 to 0.23.2
- Sync the standalone `packages/agor-live` package lock metadata
- Add the release-prep changelog entry

## Checks

- `pnpm check:agor-live-deps`
- `pnpm install --lockfile-only --ignore-scripts`
- `pnpm install --ignore-scripts`
- `pnpm --filter @agor-live/client typecheck`
