### PR TITLE
fix(ui): avoid premature stale tool status

### DIFF
--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
@@ -11,7 +11,7 @@
 import type { Message } from '@agor-live/client';
 import { describe, expect, it } from 'vitest';
 
-import { type Block, groupMessagesIntoBlocks } from './TaskBlock';
+import { type Block, blocksHaveSameMessages, groupMessagesIntoBlocks } from './TaskBlock';
 
 function userMessage(index: number, id: string): Message {
   return {
@@ -111,5 +111,53 @@ describe('groupMessagesIntoBlocks — widget_request ordering', () => {
 
     expect(messages.map((m) => m.message_id)).toEqual(originalOrder);
     expect(messages.map((m) => m.index)).toEqual(originalIndices);
+  });
+});
+
+describe('TaskBlock block reconciliation', () => {
+  it('detects in-place tool result patches on a previously grouped agent-chain block', () => {
+    const toolMessage = {
+      message_id: 'tool-msg-1',
+      session_id: 'sess-1',
+      type: 'message',
+      role: 'assistant',
+      index: 0,
+      timestamp: '2026-07-01T12:00:00.000Z',
+      content_preview: '',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'Bash',
+          input: { command: 'echo hi' },
+        },
+      ],
+      tool_uses: [{ id: 'tool-1', name: 'Bash', input: { command: 'echo hi' } }],
+    } as unknown as Message;
+
+    const previousBlock = groupMessagesIntoBlocks([toolMessage])[0];
+
+    // Feathers can patch the same message object in place when a running tool
+    // completes. Reconciliation must notice the content change even though the
+    // Message object identity is unchanged.
+    toolMessage.content = [
+      ...(toolMessage.content as Array<Record<string, unknown>>),
+      {
+        type: 'tool_result',
+        tool_use_id: 'tool-1',
+        content: 'hi\n',
+        is_error: false,
+      },
+    ] as unknown as Message['content'];
+    toolMessage.content_preview = 'hi\n';
+
+    const nextBlock = groupMessagesIntoBlocks([toolMessage])[0];
+
+    expect(previousBlock.type).toBe('agent-chain');
+    expect(nextBlock.type).toBe('agent-chain');
+    expect((previousBlock as Extract<Block, { type: 'agent-chain' }>).messages[0]).toBe(
+      (nextBlock as Extract<Block, { type: 'agent-chain' }>).messages[0]
+    );
+    expect(blocksHaveSameMessages(previousBlock, nextBlock)).toBe(false);
   });
 });

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -63,9 +63,9 @@ const EMPTY_USER_MAP = new Map<string, User>();
  * Block types for rendering
  */
 export type Block =
-  | { type: 'message'; message: Message }
-  | { type: 'agent-chain'; messages: Message[] }
-  | { type: 'compaction'; messages: Message[] }; // System messages (start + optional complete)
+  | { type: 'message'; message: Message; renderSignature?: string }
+  | { type: 'agent-chain'; messages: Message[]; renderSignature?: string }
+  | { type: 'compaction'; messages: Message[]; renderSignature?: string }; // System messages (start + optional complete)
 
 interface TaskBlockProps {
   task: Task;
@@ -357,10 +357,13 @@ export function groupMessagesIntoBlocks(messages: Message[]): Block[] {
   const isWidgetBlock = (b: Block): boolean =>
     b.type === 'message' && b.message.type === 'widget_request';
   if (blocks.some(isWidgetBlock)) {
-    return [...blocks.filter((b) => !isWidgetBlock(b)), ...blocks.filter(isWidgetBlock)];
+    return withBlockRenderSignatures([
+      ...blocks.filter((b) => !isWidgetBlock(b)),
+      ...blocks.filter(isWidgetBlock),
+    ]);
   }
 
-  return blocks;
+  return withBlockRenderSignatures(blocks);
 }
 
 /**
@@ -371,6 +374,43 @@ function getBlockKey(block: Block): string {
   return block.type === 'message'
     ? `m:${block.message.message_id}`
     : `${block.type}:${block.messages[0]?.message_id || 'unknown'}`;
+}
+
+/**
+ * Snapshot the render-relevant message shape for reconciliation.
+ *
+ * Feathers/live-query updates may patch a message object in place (e.g. Codex
+ * creates a tool_use-only message at tool:start, then patches the same message
+ * with the tool_result at tool:complete). React.memo only sees prop identity, so
+ * reconciling solely by message object reference can freeze an AgentChain on the
+ * old "no result" render and show the stale-tool tooltip. Store this signature
+ * on each freshly grouped block so the next render can detect in-place content
+ * changes by comparing against the previous snapshot.
+ */
+function getMessageRenderSignature(message: Message): string {
+  return JSON.stringify({
+    message_id: message.message_id,
+    role: message.role,
+    type: message.type,
+    index: message.index,
+    parent_tool_use_id: message.parent_tool_use_id ?? null,
+    content_preview: message.content_preview,
+    content: message.content,
+    tool_uses: message.tool_uses ?? null,
+    isStreaming: (message as { isStreaming?: boolean }).isStreaming === true,
+  });
+}
+
+function getBlockRenderSignature(block: Block): string {
+  const messages = block.type === 'message' ? [block.message] : block.messages;
+  return messages.map(getMessageRenderSignature).join('\n---message---\n');
+}
+
+function withBlockRenderSignatures(blocks: Block[]): Block[] {
+  return blocks.map((block) => ({
+    ...block,
+    renderSignature: getBlockRenderSignature(block),
+  }));
 }
 
 /**
@@ -388,8 +428,11 @@ function getBlockMarker(block: Block): 'streaming' | 'settled' {
 }
 
 /** Same composition: identical message references in identical order. */
-function blocksHaveSameMessages(a: Block, b: Block): boolean {
+export function blocksHaveSameMessages(a: Block, b: Block): boolean {
   if (a.type !== b.type) return false;
+  if (a.renderSignature && b.renderSignature) {
+    return a.renderSignature === b.renderSignature;
+  }
   if (a.type === 'message' && b.type === 'message') return a.message === b.message;
   const aMessages = (a as { messages: Message[] }).messages;
   const bMessages = (b as { messages: Message[] }).messages;

--- a/apps/agor-ui/src/components/ToolBlock/ToolBlock.test.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/ToolBlock.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 import { describe, expect, it } from 'vitest';
 import { ToolBlock } from './ToolBlock';
+import { deriveToolStatus } from './toolStatus';
 
 describe('ToolBlock', () => {
   it('renders failed tool-call status icons with the warning tone', () => {
@@ -27,5 +28,27 @@ describe('ToolBlock', () => {
 
     expect(statusIconWrapper).toHaveStyle({ color: 'rgb(255, 170, 0)' });
     expect(statusIconWrapper).not.toHaveStyle({ color: 'rgb(255, 0, 0)' });
+  });
+});
+
+describe('deriveToolStatus', () => {
+  it('keeps missing-result tools pending while the parent task is still running', () => {
+    expect(
+      deriveToolStatus({
+        hasResult: false,
+        isPotentiallyRunning: false,
+        isTaskRunning: true,
+      })
+    ).toBe('pending');
+  });
+
+  it('marks missing-result tools stale only after the parent task stops', () => {
+    expect(
+      deriveToolStatus({
+        hasResult: false,
+        isPotentiallyRunning: true,
+        isTaskRunning: false,
+      })
+    ).toBe('stale');
   });
 });

--- a/apps/agor-ui/src/components/ToolBlock/toolStatus.tsx
+++ b/apps/agor-ui/src/components/ToolBlock/toolStatus.tsx
@@ -41,17 +41,23 @@ interface ToolStatusInput {
  * Rules:
  * - Has result + error → 'error'
  * - Has result + no error → 'success'
- * - No result + potentially running + task running → 'pending' (spinner)
- * - No result + (not potentially running OR task done) → 'stale' (agent moved on)
+ * - No result + task running → 'pending' (spinner)
+ * - No result + task done → 'stale' (result not captured)
+ *
+ * Note: `isPotentiallyRunning` is kept as an input for call-site context, but
+ * is no longer used to mark a missing result stale while the task is still
+ * running. Some agents can emit user-visible assistant text before a long MCP
+ * tool result arrives; "subsequent message" is not a reliable abandonment
+ * signal until the parent task has actually stopped.
  */
 export function deriveToolStatus({
   hasResult,
   isError,
-  isPotentiallyRunning,
+  isPotentiallyRunning: _isPotentiallyRunning,
   isTaskRunning,
 }: ToolStatusInput): ToolStatus {
   if (hasResult) return isError ? 'error' : 'success';
-  return isPotentiallyRunning && isTaskRunning ? 'pending' : 'stale';
+  return isTaskRunning ? 'pending' : 'stale';
 }
 
 /** Render the icon for a given tool status. */


### PR DESCRIPTION
## Summary

- Keep missing tool results in `pending` while the parent task is still running; only show the stale/clock state once the task has stopped.
- Add render signatures to `TaskBlock` block reconciliation so in-place Feathers message patches (tool start → tool result on the same message object) still re-render memoized `AgentChain` children.
- Add regression coverage for both the status derivation and in-place tool-result patch case.

## Investigation notes

The tooltip comes from `ToolBlock/toolStatus.tsx` for the derived `stale` status. Before this PR, a tool with no matched `tool_result` became stale when either the task was done or the UI decided the tool was no longer “potentially running” based on subsequent messages/results.

That “agent moved on” inference is too aggressive for long MCP tools such as `agor_gateway_emit_message`: user-visible assistant messages can appear while the tool is still legitimately waiting on Slack/MCP, so a later message is not enough evidence that the result was abandoned.

A separate recent regression risk came from #1808’s memo optimization: if the data layer patches a message object in place, block reconciliation could reuse the previous block object and prevent a memoized `AgentChain` from seeing the newly attached `tool_result`.

## Tests

- `pnpm exec biome check apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx apps/agor-ui/src/components/ToolBlock/toolStatus.tsx apps/agor-ui/src/components/ToolBlock/ToolBlock.test.tsx`
- `pnpm --filter agor-ui test -- src/components/TaskBlock/TaskBlock.test.tsx src/components/ToolBlock/ToolBlock.test.tsx`
