### PR TITLE
feat(mcp): create assistant branches in one shot via agor_branches_create

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -254,6 +254,105 @@ describe('agor_branches_create', () => {
       baseServiceParams
     );
   });
+
+  it('creates a one-shot assistant branch by writing assistant metadata into custom_context', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-a', role: 'member' },
+    };
+    const createBranch = vi.fn(async (_repoId: string, data: unknown) => ({
+      branch_id: 'assistant-branch',
+      created_by: 'user-a',
+      ...(data as Record<string, unknown>),
+    }));
+    const reposGet = vi.fn(async () => ({
+      repo_id: 'repo-1',
+      slug: 'siebel-crm',
+      default_branch: 'main',
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch };
+        if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-a',
+      baseServiceParams,
+    });
+
+    const result = await create({
+      repoId: 'repo-1',
+      branchName: 'siebel-crm',
+      boardId: 'board-1',
+      autoSuffix: false,
+      assistant: { displayName: 'Siebel CRM', emoji: '🤖' },
+    });
+
+    // The assistant metadata must land on the initial branch row so
+    // BranchesService.create can wire the board primary assistant pointer and
+    // provision the Knowledge namespace atomically (mirrors the UI create flow).
+    expect(createBranch).toHaveBeenCalledWith(
+      'repo-1',
+      expect.objectContaining({
+        name: 'siebel-crm',
+        boardId: 'board-1',
+        custom_context: {
+          assistant: {
+            kind: 'assistant',
+            displayName: 'Siebel CRM',
+            emoji: '🤖',
+            frameworkRepo: 'siebel-crm',
+            createdViaOnboarding: false,
+          },
+        },
+      }),
+      baseServiceParams
+    );
+
+    const payload = JSON.parse(result.content[0].text) as { _assistant?: Record<string, unknown> };
+    expect(payload._assistant).toMatchObject({ created: true, display_name: 'Siebel CRM' });
+  });
+
+  it('does not set custom_context when no assistant metadata is provided', async () => {
+    const createBranch = vi.fn(async (_repoId: string, data: unknown) => ({
+      branch_id: 'plain-branch',
+      created_by: 'user-a',
+      ...(data as Record<string, unknown>),
+    }));
+    const reposGet = vi.fn(async () => ({
+      repo_id: 'repo-1',
+      slug: 'repo-slug',
+      default_branch: 'main',
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch };
+        if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-a',
+      baseServiceParams: {},
+    });
+
+    await create({
+      repoId: 'repo-1',
+      branchName: 'plain',
+      boardId: 'board-1',
+      autoSuffix: false,
+    });
+
+    const passed = createBranch.mock.calls[0][1] as Record<string, unknown>;
+    expect(passed).not.toHaveProperty('custom_context');
+  });
 });
 
 describe('branch MCP input schemas', () => {
@@ -296,6 +395,31 @@ describe('branch MCP input schemas', () => {
         ])
       );
     }
+  });
+
+  it('accepts a valid assistant object and rejects an empty assistant displayName', () => {
+    const config = registerAndCaptureConfig('agor_branches_create', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    expect(
+      config.inputSchema?.safeParse({
+        repoId: 'repo-1',
+        branchName: 'siebel-crm',
+        boardId: 'board-1',
+        assistant: { displayName: 'Siebel CRM', emoji: '🤖' },
+      }).success
+    ).toBe(true);
+
+    expect(
+      config.inputSchema?.safeParse({
+        repoId: 'repo-1',
+        branchName: 'siebel-crm',
+        boardId: 'board-1',
+        assistant: { displayName: '   ' },
+      }).success
+    ).toBe(false);
   });
 
   it('rejects malformed pagination values before handler execution', () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { isBranchRbacEnabled, loadConfig } from '@agor/core/config';
 import { BranchRepository, shortId } from '@agor/core/db';
 import type {
+  AssistantConfig,
   BoardID,
   Branch,
   BranchID,
@@ -414,7 +415,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'To fork from an existing git branch under a unique name, set sourceBranch to the base git branch ' +
         'and branchName to your desired unique name (e.g., sourceBranch="issue-282", branchName="issue-282-review-1"). ' +
         'Use zoneId to place the branch in a specific zone (pin only, no trigger). ' +
-        'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation.',
+        'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation. ' +
+        'To create a long-lived Agor assistant (a persistent AI companion that manages other branches ' +
+        'and maintains memory), pass the assistant object — this is the ONLY supported way to make an ' +
+        'assistant via MCP. Assistant status cannot be toggled later with agor_branches_update.',
       inputSchema: z.object({
         repoId: mcpRequiredId(
           'repoId',
@@ -506,6 +510,40 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
             'Common shallow value: 100. Trade-off: smaller disk footprint, but ' +
             '`git log` past N commits is broken and some rebase operations fail.'
         ),
+        assistant: z
+          .object({
+            displayName: z
+              .string({ error: 'assistant.displayName must be a string.' })
+              .trim()
+              .min(1, 'assistant.displayName cannot be empty')
+              .describe('Human-friendly display name for the assistant (e.g., "Siebel CRM").'),
+            emoji: z.string().optional().describe('Emoji icon for this assistant (e.g., "🧑‍💻").'),
+            frameworkRepo: z
+              .string()
+              .optional()
+              .describe(
+                'Template/framework repo slug this assistant is based on. ' +
+                  "Defaults to the created branch's repo slug when omitted."
+              ),
+            frameworkVersion: z
+              .string()
+              .optional()
+              .describe('Framework version at creation time, for later upgrade detection.'),
+            createdViaOnboarding: z
+              .boolean()
+              .optional()
+              .describe(
+                'Whether this assistant was created via the onboarding wizard (defaults to false).'
+              ),
+          })
+          .optional()
+          .describe(
+            'When provided, create this branch as a long-lived Agor assistant. ' +
+              'The assistant metadata is written to custom_context.assistant on the initial branch row, ' +
+              'the board primary assistant pointer is wired automatically, and the assistant Knowledge ' +
+              'namespace is provisioned. Knowledge namespace/grant config (the "kb" field) is managed ' +
+              'separately and cannot be set here.'
+          ),
       }),
     },
     async (args) => {
@@ -532,6 +570,38 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       // Validate variant up front so the error lists the available variants.
       const variant = coerceString(args.variant);
       if (variant) assertValidVariant(repo, variant);
+
+      // Optional: mark the new branch as a long-lived assistant in one shot.
+      // Writing the assistant config onto the initial branch row (rather than a
+      // follow-up patch) is what the UI does too — it lets BranchesService.create
+      // wire the board primary_assistant_id pointer and provision the assistant
+      // Knowledge namespace atomically, and sidesteps the assertAssistantKindIsStable
+      // guard that (deliberately) blocks flipping assistant status via patch.
+      const assistantInput = args.assistant as
+        | {
+            displayName?: unknown;
+            emoji?: unknown;
+            frameworkRepo?: unknown;
+            frameworkVersion?: unknown;
+            createdViaOnboarding?: unknown;
+          }
+        | undefined;
+      let assistantConfig: AssistantConfig | undefined;
+      if (assistantInput) {
+        const displayName = coerceString(assistantInput.displayName)?.trim();
+        if (!displayName) throw new Error('assistant.displayName is required');
+        const emoji = coerceString(assistantInput.emoji);
+        const frameworkRepo = coerceString(assistantInput.frameworkRepo) ?? repo.slug;
+        const frameworkVersion = coerceString(assistantInput.frameworkVersion);
+        assistantConfig = {
+          kind: 'assistant',
+          displayName,
+          ...(emoji ? { emoji } : {}),
+          ...(frameworkRepo ? { frameworkRepo } : {}),
+          ...(frameworkVersion ? { frameworkVersion } : {}),
+          createdViaOnboarding: assistantInput.createdViaOnboarding === true,
+        };
+      }
 
       // Auto-suffix: resolve name conflicts by appending -2, -3, etc.
       // Uses direct DB query to bypass Feathers pagination limits
@@ -602,6 +672,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           ...(variant ? { environment_variant: variant } : {}),
           ...(storageMode ? { storage_mode: storageMode } : {}),
           ...(cloneDepth !== undefined ? { clone_depth: cloneDepth } : {}),
+          ...(assistantConfig ? { custom_context: { assistant: assistantConfig } } : {}),
         },
         ctx.baseServiceParams
       );
@@ -611,6 +682,14 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
 
       if (branchName !== originalName) {
         response._note = `Name '${originalName}' was already taken. Created as '${branchName}' instead (autoSuffix applied).`;
+      }
+
+      if (assistantConfig) {
+        response._assistant = {
+          created: true,
+          display_name: assistantConfig.displayName,
+          note: 'Created as a long-lived Agor assistant. The board primary assistant pointer and the assistant Knowledge namespace were provisioned automatically.',
+        };
       }
 
       if (zoneId) {
@@ -666,7 +745,9 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           .nullable()
           .optional()
           .describe(
-            'Custom context object for templates and automations. Pass null to clear existing context.'
+            'Custom context object for templates and automations. Pass null to clear existing context. ' +
+              'Note: this cannot toggle a branch between assistant and non-assistant status — that flip is ' +
+              'rejected. Create an assistant in one shot with the assistant param on agor_branches_create.'
           ),
         mcpServerIds: z
           .array(mcpRequiredId('mcpServerIds[]', 'MCP server', 'MCP server ID'))

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -814,6 +814,66 @@ describe('BranchesService.patch primary assistant invariants', () => {
   });
 });
 
+describe('BranchesService one-shot assistant creation wiring', () => {
+  // A branch created with assistant metadata on the initial row (the MCP create
+  // path and the UI path) must designate the board's primary assistant. This is
+  // the promotion that IS supported — as opposed to flipping an existing branch
+  // via patch, which the assertAssistantKindIsStable guard (deliberately) blocks.
+  function createAssistantWiringHarness() {
+    const boardsEmit = vi.fn();
+    const app = {
+      service(path: string) {
+        if (path === 'boards') return { emit: boardsEmit };
+        throw new Error(`Unknown service: ${path}`);
+      },
+    } as unknown as Application;
+    const boardRepo = {
+      setPrimaryAssistantIfUnset: vi.fn(async (boardId: string) => ({
+        board_id: boardId,
+        primary_assistant_id: 'assistant-new',
+      })),
+    };
+    const service = new BranchesService(createTenantScopeTestDb() as never, app);
+    (service as unknown as { boardRepo: typeof boardRepo }).boardRepo = boardRepo;
+    const invoke = (branch: Record<string, unknown>) =>
+      (
+        service as unknown as {
+          maybeSetBoardPrimaryAssistant: (b: unknown) => Promise<void>;
+        }
+      ).maybeSetBoardPrimaryAssistant(branch);
+    return { boardRepo, boardsEmit, invoke };
+  }
+
+  it('sets the board primary assistant pointer for a newly created assistant branch', async () => {
+    const { boardRepo, boardsEmit, invoke } = createAssistantWiringHarness();
+
+    await invoke({
+      branch_id: 'assistant-new' as BranchID,
+      board_id: 'board-a' as BoardID,
+      custom_context: assistantContext,
+    });
+
+    expect(boardRepo.setPrimaryAssistantIfUnset).toHaveBeenCalledWith('board-a', 'assistant-new');
+    expect(boardsEmit).toHaveBeenCalledWith(
+      'patched',
+      expect.objectContaining({ board_id: 'board-a' })
+    );
+  });
+
+  it('leaves the board primary pointer untouched for a non-assistant branch', async () => {
+    const { boardRepo, boardsEmit, invoke } = createAssistantWiringHarness();
+
+    await invoke({
+      branch_id: 'plain-new' as BranchID,
+      board_id: 'board-a' as BoardID,
+      custom_context: {},
+    });
+
+    expect(boardRepo.setPrimaryAssistantIfUnset).not.toHaveBeenCalled();
+    expect(boardsEmit).not.toHaveBeenCalled();
+  });
+});
+
 describe('BranchesService.unarchive', () => {
   it('preserves existing board_id when options.boardId is not provided', async () => {
     const { service, boardObjectsService, sessionsService } = createServiceHarness();


### PR DESCRIPTION
## The contradiction

There is currently **no MCP path that can produce a real Agor assistant branch**:

- `agor_branches_create` (`apps/agor-daemon/src/mcp/tools/branches.ts`) never forwarded a `custom_context`, so a branch created via MCP can never come out marked as an assistant. `BranchesService.create()` already supports assistant metadata on the initial row (it's exactly what the UI's `createAssistantBranch` does), but the tool didn't expose it.
- `agor_branches_update` *does* accept `customContext`, but it routes through `BranchesService.patch()` → `assertAssistantKindIsStable()`, which deliberately rejects any patch that would flip a branch between assistant and non-assistant:

  > `Branches cannot be converted between assistant and non-assistant types. Create a new branch or assistant instead.`

So the documented "create then update `customContext.assistant`" recipe fails every time: create can't set assistant status, and update refuses to.

## Root cause (confirmed by trace)

- `isAssistant()` — `packages/core/src/types/branch.ts:791` — treats a branch as an assistant when `custom_context.assistant.kind === 'assistant'` (plus legacy `agent`/`persisted-agent`).
- `BranchesService.create()` — `apps/agor-daemon/src/services/branches.ts:695` — accepts `custom_context` and, when the branch `isAssistant`, fires `maybeEnsureAssistantKnowledgeNamespace()` (:754) and `maybeSetBoardPrimaryAssistant()` (:735). This is the fully-wired path.
- `BranchesService.patch()` — `:1002` — calls `assertAssistantKindIsStable()` (`:923`), which throws the error above whenever a patch would flip `isAssistant()` in **either** direction.
- MCP `agor_branches_create` (`:408`) passed no `custom_context` to `reposService.createBranch`; `agor_branches_update` (`:627`) is blocked by the guard.

## Intent of the guard (why it stays)

The guard was added in **#1300 "Make boards assistant-centric"** ("Tighten primary assistant invariants", "Close primary assistant edge cases"). Demoting a live assistant (assistant→non-assistant) would orphan the board `primary_assistant_id` pointer and the assistant Knowledge namespace wiring. That's the dangerous direction and it stays blocked.

Crucially, **promotion via `patch` is only half-wired**: `patch()` never calls `maybeEnsureAssistantKnowledgeNamespace`, and `maintainPrimaryAssistantAfterPatch` does not set the board pointer for an in-place promotion (no board change, not previously archived). So relaxing the guard to allow promotion would produce a half-configured assistant.

## The fix

Add an optional `assistant` object to `agor_branches_create`. When provided, the tool builds an `AssistantConfig` and writes it to `custom_context.assistant` on the initial branch row — mirroring the UI's `createAssistantBranch` flow — so `BranchesService.create()` wires the board `primary_assistant_id` and provisions the Knowledge namespace atomically. `frameworkRepo` defaults to the branch's repo slug; the Knowledge `kb` config is intentionally not settable here.

The `assertAssistantKindIsStable` guard is **left fully intact in both directions**. Assistant status is expressed at creation (the only place the board pointer and Knowledge namespace get wired); the risky assistant→non-assistant demotion stays guarded. `agor_branches_update`'s `customContext` description now points callers at the create-time flow.

This unblocks raising new assistants (e.g. the **Siebel CRM** assistant) via MCP.

## Test coverage

- `agor_branches_create` with `assistant` forwards `custom_context.assistant` (with `frameworkRepo` defaulting to the repo slug) and returns an `_assistant` note.
- No `assistant` param → `custom_context` is left unset.
- Input schema accepts a valid `assistant` and rejects an empty `displayName`.
- `BranchesService` create-path wiring sets the board primary assistant pointer for an assistant branch and leaves it untouched for a plain branch.
- Existing patch guards (both demotion and promotion blocked via `patch`) remain green.

`vitest` (branches MCP + service suites, 75 tests), `tsc --noEmit`, and `biome` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)