### PR TITLE
perf(agor-ui): stop idle paint/animation churn on home and board

### DIFF
--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -24,45 +24,76 @@
   min-width: 0;
 }
 
-/* Status dot pulse animations for homepage session indicators */
-@keyframes pulseGreen {
-  0% {
-    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.5);
-  }
-  70% {
-    box-shadow: 0 0 0 5px rgba(34, 197, 94, 0);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
-  }
-}
-@keyframes pulseOrange {
-  0% {
-    box-shadow: 0 0 0 0 rgba(249, 115, 22, 0.5);
-  }
-  70% {
-    box-shadow: 0 0 0 5px rgba(249, 115, 22, 0);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(249, 115, 22, 0);
-  }
-}
-.status-dot-run {
-  animation: pulseGreen 1.8s infinite;
-}
+/* Status dot pulse for homepage session indicators. The halo is a pseudo
+   element animated with transform/opacity only, so the loop runs entirely on
+   the compositor. Animating box-shadow instead (the previous approach) forces
+   a main-thread style recalc + paint every frame, which kept the idle home
+   page ~50% busy. `background: inherit` picks up the dot's inline status
+   color, so the halo always matches the dot. */
+.status-dot-run,
 .status-dot-wait {
-  animation: pulseOrange 1.8s infinite;
+  position: relative;
+}
+.status-dot-run::after,
+.status-dot-wait::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: inherit;
+  pointer-events: none;
+  will-change: transform, opacity;
+  animation: statusDotPulse 1.8s infinite;
+}
+@keyframes statusDotPulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+  70%,
+  100% {
+    transform: scale(2.43);
+    opacity: 0;
+  }
 }
 
-/* Blinking cursor animation for streaming messages */
-@keyframes blink {
-  0%,
-  49% {
-    opacity: 1;
+/* Ant Spin runs five infinite animations per spinner (a rotate plus four
+   per-dot opacity fades), all with implicit `from` keyframes, which Chrome
+   refuses to composite — every mounted <Spin> repaints on the main thread
+   every frame. Boards mount one per active session. Replace them with a
+   single explicit-keyframe rotate (compositor-friendly) and a static opacity
+   tail on the dots; at spinner sizes the rotating tail reads the same as the
+   original pulsing dots. */
+.ant-spin .ant-spin-dot-item {
+  animation-name: none;
+}
+.ant-spin .ant-spin-dot-item:nth-child(1) {
+  opacity: 1;
+}
+.ant-spin .ant-spin-dot-item:nth-child(2) {
+  opacity: 0.65;
+}
+.ant-spin .ant-spin-dot-item:nth-child(3) {
+  opacity: 0.45;
+}
+.ant-spin .ant-spin-dot-item:nth-child(4) {
+  opacity: 0.3;
+}
+.ant-spin .ant-spin-dot-spin {
+  animation: spinRotate 1.2s linear infinite;
+  will-change: transform;
+}
+/* Same implicit-keyframe problem for `<LoadingOutlined spin />` icons
+   (antd's loadingCircle keyframes) — retarget them at the composited rotate. */
+.anticon.anticon-spin {
+  animation: spinRotate 1s linear infinite;
+}
+@keyframes spinRotate {
+  from {
+    transform: rotate(0deg);
   }
-  50%,
-  100% {
-    opacity: 0;
+  to {
+    transform: rotate(360deg);
   }
 }
 

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -88,12 +88,27 @@
 .anticon.anticon-spin {
   animation: spinRotate 1s linear infinite;
 }
+/* 45deg start preserves antd's original spinner phase (its keyframes ran
+   45deg -> 405deg), so the first painted frame matches the stock Spin. */
 @keyframes spinRotate {
   from {
-    transform: rotate(0deg);
+    transform: rotate(45deg);
   }
   to {
-    transform: rotate(360deg);
+    transform: rotate(405deg);
+  }
+}
+
+/* At reduced-motion the pulse halo is purely decorative and a static spinner
+   still reads as "loading", so drop both loops. */
+@media (prefers-reduced-motion: reduce) {
+  .status-dot-run::after,
+  .status-dot-wait::after {
+    animation: none;
+  }
+  .ant-spin .ant-spin-dot-spin,
+  .anticon.anticon-spin {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## Problem

Chrome traces on prod (15s idle windows, real workspace) showed the HOME page ~50% main-thread busy at rest (Paint ×2620 ≈ 175/s, style recalc ×860) and the BOARD view ~24% busy (Paint ×463, animationiteration ×145).

## Phase 1 — inventory (what actually animates at idle)

A live `document.getAnimations()` census on prod found exactly two sources; nothing else loops at idle on either surface:

| Surface | Component | Animation | Property | Repaint class | Fix |
|---|---|---|---|---|---|
| Home | `StatusDot` (`.status-dot-run`/`.status-dot-wait`, one per running/awaiting session row in My Sessions + Jump Back In) | `pulseGreen`/`pulseOrange` 1.8s infinite | `box-shadow` | main-thread: style recalc + paint **every frame** | halo moved to a `::after` pseudo-element animating `transform: scale` + `opacity` only (compositor-driven); `background: inherit` keeps it the exact status color |
| Board | antd `<Spin size="small">` (one per active session row on branch cards; 6 mounted in the traced workspace) | `antRotate` (1 el) + `antSpinMove` (4 els) per spinner, infinite | `transform`, `opacity` — but with **implicit `from` keyframes**, which Chrome refuses to composite (verified: `will-change` does not help) | main-thread: recalc + paint every frame, 5 animations × N spinners, plus ~24 animationiteration dispatches/s | single explicit-keyframe `rotate` on the dot container + static opacity tail on the four dots (5 animations → 1, composited); same fix applied to `.anticon-spin` (`<LoadingOutlined spin>`), which uses the same implicit-keyframe rotate |

Findings that looked like suspects but weren't:

- **`animationiteration` ~25ms/handler**: no app or library code listens to it (react-dom root delegation only). Per-event cost is ~0.1–0.4ms; the 444ms total was ONE 441ms dispatch at trace start — a one-off antd cssinjs/render flush that happened to be batched into the first animation event, not a per-iteration cost. The minified `up` @ 440ms self-time in the trace is that same one-off.
- **The other `up` (same minified name, different fn)** is a tiny rAF tick in the antd chunk (~0.02ms/call) that only fires while frames are being produced; it goes quiescent once the paint loops stop.
- **Glass `backdrop-filter` surfaces**: the composited pulse inside `backdrop-filter: blur(20px)` cards does not force re-blurs (paints stay at the no-animation floor), so no isolation change was needed.
- **Board custom-CSS background presets** (`BoardFormFields` — `background-position`/`filter` loops) are paint-per-frame by construction, but the traced boards had none active. They're user data (stored per board); left unchanged, noted as a possible follow-up.
- `blink` keyframes in `index.css` had no remaining users — removed.

## Phase 2 — fix

One file: `apps/agor-ui/src/index.css`. All idle loops are now compositor-only (transform/opacity with explicit keyframes); no JS changes, no behavioral changes. Visual parity: dot halo identical geometry (3.5px→8.5px ring, same 1.8s cycle) and now exactly matches the dot color; spinner reads as the same 4-dot rotating chase (rotating fade tail instead of per-dot pulsing) — verified via computed styles on the prod DOM.

## Measurement (prod, not dev)

Instead of standing a dev env, the final CSS was injected into the live prod build (same rules, confirms the overrides win over antd cssinjs without `!important`) and traced with the same harness — 10s idle windows, same machine, back to back:

| | busy (main thread) | Paint | UpdateLayoutTree | animationiteration |
|---|---|---|---|---|
| Home before | 4455 ms | 1786 | 588 | 16 |
| **Home after** | **840 ms (−81%)** | **77** | **28** | ~0 |
| Board before | 2098 ms | 463 | 471 | 295 |
| **Board after** | **1282 ms (−39%)** | **46** | **59** | **48** |

Causal A/B check: disabling the animations entirely gives 819ms (home) / 899ms (board) — the fixes land at the no-animation floor. The board's remaining ~1.2s is websocket-driven React renders + GC (measured separately, out of scope per issue).

## Gates

- `pnpm typecheck` ✅ `pnpm lint` (biome, 626 files) ✅
- `pnpm test` — 125 files, 796 tests, all pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
