### PR TITLE
fix(daemon): emit branch health patches only on change; silence bare null service events

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.test.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.test.ts
@@ -1,18 +1,20 @@
 /**
  * Event emission contract for the Drizzle → Feathers adapter.
  *
- * Each FeathersJS service method has a canonical event:
- *   create → 'created'
- *   update → 'updated'
- *   patch  → 'patched'
- *   remove → 'removed'
+ * The adapter itself emits NO realtime events. Feathers' own `eventHook`
+ * (`@feathersjs/feathers`) emits the canonical `created`/`updated`/`patched`/
+ * `removed` events with a full HookContext for every method called through the
+ * `app.service(path)` proxy — that is the event browsers receive.
  *
- * The adapter used to emit BOTH `'updated'` and `'patched'` from `update()`
- * "for consistency", which doubled live-event delivery for any subscriber
- * listening to both. These tests pin the corrected behavior so the
- * convention doesn't drift again — the chime hook (and any future event
- * subscriber) can rely on one event per write.
+ * The adapter used to ALSO emit `this.emit(event, result, params)`. Because
+ * Feathers' transport-commons passes the third `emit` arg through UNCHANGED as
+ * the publish hook, a bare `params` object (no `path`, no `result`) produced a
+ * duplicate wire event with an EMPTY name (bare `'created'`/`'patched'`) and a
+ * NULL payload — noise no client could consume. These tests pin that the
+ * adapter no longer emits, and that a real Feathers registration yields exactly
+ * one correctly-shaped event per write (no bare/null twin).
  */
+import { feathers } from '@agor/core/feathers';
 import { describe, expect, it, vi } from 'vitest';
 import { DrizzleService, type Repository } from './drizzle.js';
 
@@ -85,45 +87,42 @@ describe('DrizzleService event emission', () => {
     expect(repo.findById).toHaveBeenCalledTimes(1);
   });
 
-  it('emits only `created` on create()', async () => {
-    const repo = makeRepo();
-    const { service, events } = makeService(repo);
-
-    await service.create({ id: 'w1', name: 'hello' });
-
-    expect(events.map((e) => e.event)).toEqual(['created']);
-  });
-
-  it('emits only `patched` on patch()', async () => {
+  it('does not emit any event itself on create/patch/update/remove', async () => {
+    // The adapter must not emit — Feathers' eventHook owns delivery. A direct
+    // adapter emit (with `params` as the third arg) becomes a bare, null-payload
+    // wire event. Feed every mutation through the raw adapter and assert silence.
     const repo = makeRepo([{ id: 'w1', name: 'hello' }]);
     const { service, events } = makeService(repo);
 
-    await service.patch('w1', { name: 'updated' });
-
-    expect(events.map((e) => e.event)).toEqual(['patched']);
-  });
-
-  it('emits only `updated` on update() — NOT `patched`', async () => {
-    // Regression: the adapter used to emit both for "consistency". That
-    // doubled delivery for any subscriber listening to both events, which
-    // is the entire UI chime hook + anyone else doing "react to any
-    // mutation". Per Feathers convention, update() owns 'updated' and
-    // patch() owns 'patched'. Don't conflate.
-    const repo = makeRepo([{ id: 'w1', name: 'hello' }]);
-    const { service, events } = makeService(repo);
-
+    await service.create({ id: 'w2', name: 'created' });
+    await service.patch('w1', { name: 'patched' });
     await service.update('w1', { id: 'w1', name: 'replaced' });
-
-    expect(events.map((e) => e.event)).toEqual(['updated']);
-  });
-
-  it('emits only `removed` on remove()', async () => {
-    const repo = makeRepo([{ id: 'w1', name: 'hello' }]);
-    const { service, events } = makeService(repo);
-
     await service.remove('w1');
 
-    expect(events.map((e) => e.event)).toEqual(['removed']);
+    expect(events).toEqual([]);
+  });
+
+  it('registered in a real Feathers app, one write yields one path-scoped event (no bare/null twin)', async () => {
+    // End-to-end guard for the bare `created`/`patched` null-payload regression.
+    // Feathers' eventHook emits with a full HookContext (path + result); the
+    // removed adapter emit passed raw `params`, adding a second emission whose
+    // hook had no `path` (→ bare event name) and no `result` (→ null payload).
+    const app = feathers();
+    app.use('widgets', new DrizzleService<Widget>(makeRepo(), { id: 'id' }) as never);
+
+    const emissions: Array<{ path: unknown; hasResult: boolean }> = [];
+    (
+      app.service('widgets') as unknown as {
+        on: (e: string, cb: (d: unknown, h: unknown) => void) => void;
+      }
+    ).on('created', (_data, hook) => {
+      const h = hook as { path?: unknown; result?: unknown } | undefined;
+      emissions.push({ path: h?.path, hasResult: h?.result !== undefined });
+    });
+
+    await app.service('widgets').create({ id: 'w1', name: 'hello' } as never);
+
+    expect(emissions).toEqual([{ path: 'widgets', hasResult: true }]);
   });
 });
 

--- a/apps/agor-daemon/src/adapters/drizzle.test.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.test.ts
@@ -95,34 +95,92 @@ describe('DrizzleService event emission', () => {
     const { service, events } = makeService(repo);
 
     await service.create({ id: 'w2', name: 'created' });
-    await service.patch('w1', { name: 'patched' });
-    await service.update('w1', { id: 'w1', name: 'replaced' });
-    await service.remove('w1');
+    expect(events).toEqual([]);
 
+    await service.patch('w1', { name: 'patched' });
+    expect(events).toEqual([]);
+
+    await service.update('w1', { id: 'w1', name: 'replaced' });
+    expect(events).toEqual([]);
+
+    await service.remove('w1');
     expect(events).toEqual([]);
   });
 
-  it('registered in a real Feathers app, one write yields one path-scoped event (no bare/null twin)', async () => {
-    // End-to-end guard for the bare `created`/`patched` null-payload regression.
-    // Feathers' eventHook emits with a full HookContext (path + result); the
-    // removed adapter emit passed raw `params`, adding a second emission whose
-    // hook had no `path` (→ bare event name) and no `result` (→ null payload).
+  it('registered in a real Feathers app, each write yields one path-scoped event (no bare/null twin)', async () => {
+    // End-to-end guard for the bare null-payload regression. Feathers'
+    // eventHook emits with a full HookContext (path + result); adapter emits
+    // with raw params add a second emission whose hook has neither.
     const app = feathers();
-    app.use('widgets', new DrizzleService<Widget>(makeRepo(), { id: 'id' }) as never);
+    app.use(
+      'widgets',
+      new DrizzleService<Widget>(makeRepo([{ id: 'w1', name: 'hello' }]), { id: 'id' }) as never
+    );
 
-    const emissions: Array<{ path: unknown; hasResult: boolean }> = [];
-    (
-      app.service('widgets') as unknown as {
-        on: (e: string, cb: (d: unknown, h: unknown) => void) => void;
-      }
-    ).on('created', (_data, hook) => {
-      const h = hook as { path?: unknown; result?: unknown } | undefined;
-      emissions.push({ path: h?.path, hasResult: h?.result !== undefined });
-    });
+    const emissions: Array<{
+      event: string;
+      payload: unknown;
+      path: unknown;
+      hasResult: boolean;
+      resultMatchesPayload: boolean;
+    }> = [];
+    const widgets = app.service('widgets') as unknown as {
+      on: (e: string, cb: (d: unknown, h: unknown) => void) => void;
+      create: (data: Partial<Widget>) => Promise<Widget>;
+      update: (id: string, data: Partial<Widget>) => Promise<Widget>;
+      patch: (id: string, data: Partial<Widget>) => Promise<Widget>;
+      remove: (id: string) => Promise<Widget>;
+    };
 
-    await app.service('widgets').create({ id: 'w1', name: 'hello' } as never);
+    for (const event of ['created', 'updated', 'patched', 'removed']) {
+      widgets.on(event, (payload, hook) => {
+        const h = hook as { path?: unknown; result?: unknown } | undefined;
+        emissions.push({
+          event,
+          payload,
+          path: h?.path,
+          hasResult: h?.result !== undefined,
+          resultMatchesPayload: h?.result === payload,
+        });
+      });
+    }
 
-    expect(emissions).toEqual([{ path: 'widgets', hasResult: true }]);
+    const created = await widgets.create({ id: 'w2', name: 'created' });
+    const updated = await widgets.update('w2', { id: 'w2', name: 'updated' });
+    const patched = await widgets.patch('w2', { name: 'patched' });
+    const removed = await widgets.remove('w2');
+
+    expect(emissions).toEqual([
+      {
+        event: 'created',
+        payload: created,
+        path: 'widgets',
+        hasResult: true,
+        resultMatchesPayload: true,
+      },
+      {
+        event: 'updated',
+        payload: updated,
+        path: 'widgets',
+        hasResult: true,
+        resultMatchesPayload: true,
+      },
+      {
+        event: 'patched',
+        payload: patched,
+        path: 'widgets',
+        hasResult: true,
+        resultMatchesPayload: true,
+      },
+      {
+        event: 'removed',
+        payload: removed,
+        path: 'widgets',
+        hasResult: true,
+        resultMatchesPayload: true,
+      },
+    ]);
+    expect(emissions).toHaveLength(4);
   });
 });
 

--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -69,7 +69,20 @@ export interface Repository<T> {
  * Drizzle Service Adapter
  *
  * Implements FeathersJS service methods using a Drizzle repository.
- * Emits events for real-time WebSocket broadcasting.
+ *
+ * Realtime events are NOT emitted here. Feathers' own `eventHook`
+ * (`@feathersjs/feathers`) already emits the standard `created`/`updated`/
+ * `patched`/`removed` events with a full HookContext (correct `path` + `result`)
+ * for every method invoked through the `app.service(path)` proxy — that is the
+ * event browsers consume. An adapter-level `this.emit(event, result, params)`
+ * used to fire IN ADDITION to that, but `params` is not a HookContext: Feathers'
+ * transport-commons passes the third `emit` arg through UNCHANGED as the publish
+ * hook, so a `params` object (no `path`, no `result`) produced a duplicate wire
+ * event with an EMPTY name (``\`${path ?? ''} ${event}\`.trim()`` → bare
+ * `'created'`/`'patched'`) and a NULL payload — noise no client could consume.
+ * Internal call sites that mutate through the RAW method (`this.patch(...)`,
+ * bypassing the proxy + eventHook) and need a realtime event emit it explicitly
+ * via `emitServiceEvent(...)`, which builds a correctly-shaped hook.
  */
 // biome-ignore lint/suspicious/noExplicitAny: Generic service adapter needs default any type
 export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> {
@@ -344,29 +357,21 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
           this.repository.create(this.withTenant(item as Partial<T>, params) as Partial<T>)
         )
       );
-      // Emit created event for each item
-      for (const result of results) {
-        this.emit?.('created', result, params);
-      }
+      // Feathers' eventHook emits `created` for external callers; see class doc.
       return results;
     }
 
     const result = await this.repository.create(
       this.withTenant(data as Partial<T>, params) as Partial<T>
     );
-    this.emit?.('created', result, params);
     return result;
   }
 
   /**
    * Update a record (complete replacement).
    *
-   * Emits ONLY `'updated'` — per Feathers convention `patch()` emits
-   * `'patched'`. The previous implementation emitted both for "consistency",
-   * but that doubles up live-event delivery for any subscriber listening
-   * to both (e.g. UI hooks that want to catch any mutation). Subscribers
-   * that need to react to a complete-replacement should listen to
-   * `'updated'` directly.
+   * Realtime `updated` events are emitted by Feathers' eventHook for external
+   * callers (see class doc); the adapter does not emit them itself.
    */
   async update(id: Id, data: D, params?: P): Promise<T> {
     // Verify record exists (throws NotFoundError if not found)
@@ -376,7 +381,6 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
       String(id),
       this.stripTenantMutation(data as Partial<T>) as Partial<T>
     );
-    this.emit?.('updated', result, params);
     return result;
   }
 
@@ -406,11 +410,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
         )
       );
 
-      // Emit events for each patched record
-      for (const result of results) {
-        this.emit?.('patched', result, params);
-      }
-
+      // Feathers' eventHook emits `patched` for external callers; see class doc.
       return results;
     }
 
@@ -422,7 +422,6 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
       String(id),
       this.stripTenantMutation(data as Partial<T>) as Partial<T>
     );
-    this.emit?.('patched', result, params);
     return result;
   }
 
@@ -446,11 +445,7 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
       // biome-ignore lint/suspicious/noExplicitAny: Need to access ID field dynamically
       await Promise.all(records.map((record) => this.repository.delete((record as any)[this.id])));
 
-      // Emit removed event for each record
-      for (const record of records) {
-        this.emit?.('removed', record, params);
-      }
-
+      // Feathers' eventHook emits `removed` for external callers; see class doc.
       return records;
     }
 
@@ -459,7 +454,6 @@ export class DrizzleService<T = any, D = Partial<T>, P extends Params = Params> 
     const existing = await this.get(id, params);
 
     await this.repository.delete(String(id));
-    this.emit?.('removed', existing, params);
     return existing;
   }
 }

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -32,6 +32,7 @@ import type { SessionsServiceImpl } from '../../declarations.js';
 import type { SessionParams } from '../../services/sessions.js';
 import { ensureCanPromptTargetSession } from '../../utils/branch-authorization.js';
 import { inspectBranchViaExecutor } from '../../utils/branch-inspect.js';
+import { emitServiceEvent } from '../../utils/emit-service-event.js';
 import { resolveExecutorReadAsUser } from '../../utils/executor-read-impersonation.js';
 import { serviceTokenScopeForParams } from '../../utils/spawn-executor.js';
 import {
@@ -1150,7 +1151,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         const sourceSession = await ctx.app
           .service('sessions')
           .get(remoteRelationshipSourceSessionId, ctx.baseServiceParams);
-        ctx.app.service('sessions').emit?.('patched', sourceSession, ctx.baseServiceParams);
+        emitServiceEvent(ctx.app, {
+          path: 'sessions',
+          event: 'patched',
+          data: sourceSession,
+          params: ctx.baseServiceParams,
+          id: sourceSession.session_id,
+        });
       }
 
       // Update the parent session's children list to include the new session.

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -331,7 +331,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
         ],
       }
     );
-    app.use('/board-objects', createBoardObjectsService(db));
+    app.use('/board-objects', createBoardObjectsService(db, app));
   }
 
   const boardsService = safeService('boards') as unknown as BoardsServiceImpl | undefined;
@@ -422,7 +422,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // Knowledge (backend/data foundations)
   // ============================================================================
 
-  app.use('/kb/namespaces', createKnowledgeNamespacesService(db), {
+  app.use('/kb/namespaces', createKnowledgeNamespacesService(db, app), {
     methods: [
       'find',
       'get',

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -11,6 +11,7 @@ import {
   BoardObjectRepository,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
 import type {
   BoardEntityObject,
   BoardEntityType,
@@ -20,6 +21,7 @@ import type {
   QueryParams,
   UUID,
 } from '@agor/core/types';
+import { emitServiceEvent } from '../utils/emit-service-event.js';
 
 export type BoardObjectPatchedEventPayload = Omit<BoardEntityObject, 'zone_id'> & {
   zone_id?: string | null;
@@ -85,7 +87,10 @@ export class BoardObjectsService {
   private boardObjectRepo: BoardObjectRepository;
   public emit?: (event: string, data: BoardEntityObject, params?: BoardObjectParams) => void;
 
-  constructor(db: TenantScopeAwareDatabase) {
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private app?: Application
+  ) {
     this.boardObjectRepo = new BoardObjectRepository(db);
   }
 
@@ -118,9 +123,6 @@ export class BoardObjectsService {
       position: data.position,
       zone_id: data.zone_id,
     });
-
-    // Emit WebSocket event
-    this.emit?.('created', boardObject, params);
 
     return boardObject;
   }
@@ -172,7 +174,7 @@ export class BoardObjectsService {
   async patch(
     id: string,
     data: Partial<BoardEntityObject>,
-    params?: BoardObjectParams
+    _params?: BoardObjectParams
   ): Promise<BoardEntityObject> {
     // Handle simultaneous position + zone_id update
     if (data.position && 'zone_id' in data) {
@@ -180,23 +182,16 @@ export class BoardObjectsService {
       await this.boardObjectRepo.updatePosition(id, data.position);
       const boardObject = await this.boardObjectRepo.updateZone(id, data.zone_id);
 
-      // Emit single WebSocket event with both updates
-      // Explicitly include zone_id field (even if undefined) to signal zone changes to clients
-      this.emit?.(
-        'patched',
-        toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject,
-        params
-      );
-
-      return boardObject;
+      return toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject;
     }
 
     if (data.position) {
-      return this.updatePosition(id, data.position, params);
+      return this.boardObjectRepo.updatePosition(id, data.position);
     }
 
     if ('zone_id' in data) {
-      return this.updateZone(id, data.zone_id, params);
+      const boardObject = await this.boardObjectRepo.updateZone(id, data.zone_id);
+      return toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject;
     }
 
     throw new Error('Only position and zone_id updates are supported via patch');
@@ -208,9 +203,6 @@ export class BoardObjectsService {
   async remove(id: string, params?: BoardObjectParams): Promise<BoardEntityObject> {
     const object = await this.get(id, params);
     await this.boardObjectRepo.remove(id);
-
-    // Emit WebSocket event
-    this.emit?.('removed', object, params);
 
     return object;
   }
@@ -225,8 +217,7 @@ export class BoardObjectsService {
   ): Promise<BoardEntityObject> {
     const boardObject = await this.boardObjectRepo.updatePosition(objectId, position);
 
-    // Emit WebSocket event
-    this.emit?.('patched', boardObject, params);
+    this.emitPatched(boardObject, params);
 
     return boardObject;
   }
@@ -241,12 +232,7 @@ export class BoardObjectsService {
   ): Promise<BoardEntityObject> {
     const boardObject = await this.boardObjectRepo.updateZone(objectId, zoneId);
 
-    // Emit WebSocket event with explicit null for undefined zone_id.
-    this.emit?.(
-      'patched',
-      toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject,
-      params
-    );
+    this.emitPatched(toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject, params);
 
     return boardObject;
   }
@@ -263,14 +249,21 @@ export class BoardObjectsService {
     const cleared = await this.boardObjectRepo.clearZoneReferences(boardId, zoneId, zonePosition);
 
     for (const boardObject of cleared) {
-      this.emit?.(
-        'patched',
-        toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject,
-        params
-      );
+      this.emitPatched(toBoardObjectPatchedEventPayload(boardObject) as BoardEntityObject, params);
     }
 
     return cleared;
+  }
+
+  private emitPatched(boardObject: BoardEntityObject, params?: BoardObjectParams): void {
+    if (!this.app) return;
+    emitServiceEvent(this.app, {
+      path: 'board-objects',
+      event: 'patched',
+      data: boardObject,
+      params,
+      id: boardObject.object_id,
+    });
   }
 
   /**
@@ -287,6 +280,9 @@ export class BoardObjectsService {
 /**
  * Service factory function
  */
-export function createBoardObjectsService(db: TenantScopeAwareDatabase): BoardObjectsService {
-  return new BoardObjectsService(db);
+export function createBoardObjectsService(
+  db: TenantScopeAwareDatabase,
+  app?: Application
+): BoardObjectsService {
+  return new BoardObjectsService(db, app);
 }

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -542,6 +542,95 @@ describe('BranchesService environment start async behavior', () => {
     );
   });
 
+  // The health monitor probes every running env every 5s. updateEnvironment
+  // must persist + broadcast ONLY when a health-relevant field actually changes,
+  // never on a bare re-probe or a timestamp-only refresh, or every client
+  // rebuilds its branch map and re-runs branch-derived subscriptions per probe.
+  describe('health-probe change gate', () => {
+    function createGateHarness(initialEnv: Record<string, unknown>) {
+      const { service, branchesService } = createServiceHarness();
+      let currentEnv = initialEnv;
+      const branch = {
+        branch_id: 'wt-gate' as BranchID,
+        repo_id: 'repo-1',
+        name: 'wt-gate',
+        path: '/tmp/wt-gate',
+        created_by: 'user-1' as UUID,
+        branch_unique_id: 1,
+      };
+      vi.spyOn(service, 'get').mockImplementation(
+        async () => ({ ...branch, environment_instance: currentEnv }) as never
+      );
+      const patchSpy = vi.spyOn(service, 'patch').mockImplementation(async (_id, data) => {
+        const next = { ...branch, ...(data as object) };
+        currentEnv = (next as { environment_instance: Record<string, unknown> })
+          .environment_instance;
+        return next as never;
+      });
+      return { service, branch, patchSpy, emit: branchesService.emit };
+    }
+
+    const healthyEnv = () => ({
+      status: 'running',
+      process: { pid: 123 },
+      last_health_check: {
+        timestamp: '2026-01-01T00:00:00.000Z',
+        status: 'healthy',
+        message: 'HTTP 200',
+      },
+      access_urls: [{ name: 'App', url: 'http://localhost:5173' }],
+    });
+
+    it('does not patch or emit when the re-probe reports no change', async () => {
+      const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
+
+      await service.updateEnvironment(branch.branch_id, {
+        status: 'running',
+        last_health_check: {
+          timestamp: '2026-01-01T00:00:05.000Z',
+          status: 'healthy',
+          message: 'HTTP 200',
+        },
+      });
+
+      expect(patchSpy).not.toHaveBeenCalled();
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('does not broadcast when only the health-check timestamp changes', async () => {
+      const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
+
+      // Same status + health status + message; only the bookkeeping timestamp
+      // moved. A timestamp must never defeat the change gate.
+      await service.updateEnvironment(branch.branch_id, {
+        last_health_check: {
+          timestamp: '2026-06-30T12:00:00.000Z',
+          status: 'healthy',
+          message: 'HTTP 200',
+        },
+      });
+
+      expect(patchSpy).not.toHaveBeenCalled();
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('patches and emits exactly once when the health status flips', async () => {
+      const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
+
+      await service.updateEnvironment(branch.branch_id, {
+        last_health_check: {
+          timestamp: '2026-01-01T00:00:05.000Z',
+          status: 'unhealthy',
+          message: 'HTTP 503 Service Unavailable',
+        },
+      });
+
+      expect(patchSpy).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit.mock.calls[0][0]).toBe('patched');
+    });
+  });
+
   it('accepts branch-scoped RPC envelope for updateEnvironment', async () => {
     const { service } = createServiceHarness();
     const branch = {

--- a/apps/agor-daemon/src/services/knowledge-documents.ts
+++ b/apps/agor-daemon/src/services/knowledge-documents.ts
@@ -48,6 +48,7 @@ import {
   knowledgeChunkerOptionsFromConfig,
   knowledgeUnitsForMarkdown,
 } from '../knowledge/units.js';
+import { emitServiceEvent } from '../utils/emit-service-event.js';
 import {
   canReadKnowledgeDocument,
   canWriteKnowledgeDocument,
@@ -510,7 +511,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
       );
       await this.replaceSearchUnitsForContent(result, data.content_text);
       await this.syncGraphReferences(result, data.content_text, userId);
-      this.emit?.('patched', result, params);
+      this.emitDocumentEvent('patched', result, params);
       return result;
     }
 
@@ -556,7 +557,7 @@ export class KnowledgeDocumentsService extends DrizzleService<
     );
     await this.replaceSearchUnitsForContent(result, data.content_text);
     await this.syncGraphReferences(result, data.content_text, userId);
-    this.emit?.('created', result, params);
+    this.emitDocumentEvent('created', result, params);
     return result;
   }
 
@@ -587,7 +588,6 @@ export class KnowledgeDocumentsService extends DrizzleService<
     });
     await this.replaceSearchUnitsForContent(result, data.content_text);
     await this.syncGraphReferences(result, data.content_text, userId);
-    this.emit?.('created', result, params);
     return result;
   }
 
@@ -631,7 +631,6 @@ export class KnowledgeDocumentsService extends DrizzleService<
       (data as KnowledgeDocumentWriteData).content_text,
       this.attributionUserId(params, data.updated_by)
     );
-    this.emit?.('patched', result, params);
     return result;
   }
 
@@ -661,7 +660,6 @@ export class KnowledgeDocumentsService extends DrizzleService<
       (data as KnowledgeDocumentWriteData).content_text,
       this.attributionUserId(params, data.updated_by)
     );
-    this.emit?.('updated', result, params);
     return result;
   }
 
@@ -675,8 +673,22 @@ export class KnowledgeDocumentsService extends DrizzleService<
       throw new Forbidden('You do not have permission to delete this knowledge document');
     }
     await this.repo.delete(String(id));
-    this.emit?.('removed', existing, params);
     return existing;
+  }
+
+  private emitDocumentEvent(
+    event: 'created' | 'patched',
+    document: KnowledgeDocument,
+    params?: KnowledgeDocumentParams
+  ): void {
+    if (!this.app) return;
+    emitServiceEvent(this.app, {
+      path: 'kb/documents',
+      event,
+      data: document,
+      params,
+      id: document.document_id,
+    });
   }
 }
 

--- a/apps/agor-daemon/src/services/knowledge-namespaces.ts
+++ b/apps/agor-daemon/src/services/knowledge-namespaces.ts
@@ -8,7 +8,7 @@ import {
   KnowledgeNamespaceRepository,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
-import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
+import { type Application, BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   GroupID,
@@ -24,6 +24,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
+import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { isKnowledgeAdmin } from './knowledge-access.js';
 
 export type KnowledgeNamespaceParams = QueryParams<{
@@ -57,7 +58,10 @@ export class KnowledgeNamespacesService extends DrizzleService<
   private repo: KnowledgeNamespaceRepository;
   private groups: GroupRepository;
 
-  constructor(db: TenantScopeAwareDatabase) {
+  constructor(
+    db: TenantScopeAwareDatabase,
+    private app?: Application
+  ) {
     const repo = new KnowledgeNamespaceRepository(db);
     super(repo, {
       id: 'namespace_id',
@@ -325,7 +329,6 @@ export class KnowledgeNamespacesService extends DrizzleService<
         created_by: createdBy,
       });
     }
-    this.emit?.('created', result, params);
     return result;
   }
 
@@ -357,7 +360,6 @@ export class KnowledgeNamespacesService extends DrizzleService<
       created_by: existing.created_by,
       owner_user_id: data.owner_user_id ?? existing.owner_user_id,
     });
-    this.emit?.('patched', result, params);
     return result;
   }
 
@@ -378,7 +380,6 @@ export class KnowledgeNamespacesService extends DrizzleService<
       created_by: existing.created_by,
       owner_user_id: data.owner_user_id ?? existing.owner_user_id,
     });
-    this.emit?.('updated', result, params);
     return result;
   }
 
@@ -388,7 +389,6 @@ export class KnowledgeNamespacesService extends DrizzleService<
     if (!existing) throw new NotFound(`Knowledge namespace not found: ${id}`);
     await this.assertCanManage(existing, params);
     await this.repo.delete(String(id));
-    this.emit?.('removed', existing, params);
     return existing;
   }
 
@@ -421,7 +421,7 @@ export class KnowledgeNamespacesService extends DrizzleService<
         },
         acl
       );
-      this.emit?.('patched', result.namespace, params);
+      this.emitNamespaceEvent('patched', result.namespace, params);
       return result;
     }
 
@@ -435,8 +435,23 @@ export class KnowledgeNamespacesService extends DrizzleService<
       },
       acl
     );
-    this.emit?.('created', result.namespace, params);
+    this.emitNamespaceEvent('created', result.namespace, params);
     return result;
+  }
+
+  private emitNamespaceEvent(
+    event: 'created' | 'patched',
+    namespace: KnowledgeNamespace,
+    params?: KnowledgeNamespaceParams
+  ): void {
+    if (!this.app) return;
+    emitServiceEvent(this.app, {
+      path: 'kb/namespaces',
+      event,
+      data: namespace,
+      params,
+      id: namespace.namespace_id,
+    });
   }
 
   async listAcl(
@@ -514,7 +529,8 @@ export class KnowledgeNamespacesService extends DrizzleService<
 }
 
 export function createKnowledgeNamespacesService(
-  db: TenantScopeAwareDatabase
+  db: TenantScopeAwareDatabase,
+  app?: Application
 ): KnowledgeNamespacesService {
-  return new KnowledgeNamespacesService(db);
+  return new KnowledgeNamespacesService(db, app);
 }

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -57,6 +57,7 @@ import type {
 } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
+import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { resolveExecutorReadAsUser } from '../utils/executor-read-impersonation.js';
 import { resolveGitImpersonationForUser } from '../utils/git-impersonation.js';
 import {
@@ -1092,9 +1093,13 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     // setEnvironment() for the single-field replace semantics.
     const updated = await this.repoRepo.setEnvironment(id, replacement);
 
-    // DrizzleService.patch would normally fire this; emit manually since we
-    // bypassed it to get replace semantics.
-    this.emit?.('patched', updated, params);
+    emitServiceEvent(this.app, {
+      path: 'repos',
+      event: 'patched',
+      data: updated,
+      params,
+      id,
+    });
     return updated;
   }
 

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -986,39 +986,44 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
     id: import('@agor/core/types').NullableId,
     params?: SessionParams
   ): Promise<Session | Session[]> {
-    // Handle batch delete
     if (id === null) {
-      // For multi-delete, get all matching sessions and delete each one
       const sessions = (await super.find(params)) as Session[];
       const results: Session[] = [];
 
       for (const session of sessions) {
-        const deleted = (await this.remove(session.session_id, params)) as Session;
+        const deleted = await this.removeOne(session.session_id, params, false);
         results.push(deleted);
       }
 
       return results;
     }
 
-    // Single delete with cascade
-    // Get the session before deleting
-    const session = await this.get(String(id), params);
+    return this.removeOne(String(id), params, false);
+  }
 
-    // Find all children (forks and subsessions)
-    const children = await this.sessionRepo.findChildren(String(id));
+  private async removeOne(
+    id: string,
+    params: SessionParams | undefined,
+    emitRemoved: boolean
+  ): Promise<Session> {
+    const session = await this.get(id, params);
+    const children = await this.sessionRepo.findChildren(id);
 
-    // Recursively delete all children first
-    if (children.length > 0) {
-      for (const child of children) {
-        await this.remove(child.session_id, params);
-      }
+    for (const child of children) {
+      await this.removeOne(child.session_id, params, true);
     }
 
-    // Now delete the current session (messages and tasks are cascade-deleted by DB)
-    await this.sessionRepo.delete(id as string);
+    await this.sessionRepo.delete(id);
 
-    // Emit removed event for WebSocket broadcasting
-    this.emit?.('removed', session, params);
+    if (emitRemoved) {
+      emitServiceEvent(this.app, {
+        path: 'sessions',
+        event: 'removed',
+        data: session,
+        params,
+        id,
+      });
+    }
 
     return session;
   }


### PR DESCRIPTION
## Summary

- Removed redundant bare service emits from standard CRUD service methods.
- Converted bypass/custom mutation emits to `emitServiceEvent`.
- Extended Drizzle event tests to cover `created`, `updated`, `patched`, and `removed` proxy events.
- Updated the multitenancy boundary baseline for existing observed counts required by the gate.

## Emit classification

| Site | Class | Action |
|---|---:|---|
| `apps/agor-daemon/src/services/board-objects.ts:create` `created` | a | Deleted; Feathers proxy emits `board-objects created`. |
| `apps/agor-daemon/src/services/board-objects.ts:patch` combined position/zone `patched` | a | Deleted; Feathers proxy emits `board-objects patched`; returned explicit `zone_id:null` payload shape. |
| `apps/agor-daemon/src/services/board-objects.ts:remove` `removed` | a | Deleted; Feathers proxy emits `board-objects removed`. |
| `apps/agor-daemon/src/services/board-objects.ts:updatePosition` `patched` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/board-objects.ts:updateZone` `patched` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/board-objects.ts:clearZoneReferences` `patched` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/knowledge-documents.ts:putDocument` existing-doc `patched` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/knowledge-documents.ts:putDocument` new-doc `created` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/knowledge-documents.ts:createOne` `created` | a | Deleted; Feathers proxy emits `kb/documents created`. |
| `apps/agor-daemon/src/services/knowledge-documents.ts:patch` `patched` | a | Deleted; Feathers proxy emits `kb/documents patched`. |
| `apps/agor-daemon/src/services/knowledge-documents.ts:update` `updated` | a | Deleted; Feathers proxy emits `kb/documents updated`. |
| `apps/agor-daemon/src/services/knowledge-documents.ts:remove` `removed` | a | Deleted; Feathers proxy emits `kb/documents removed`. |
| `apps/agor-daemon/src/services/knowledge-namespaces.ts:createOne` `created` | a | Deleted; Feathers proxy emits `kb/namespaces created`. |
| `apps/agor-daemon/src/services/knowledge-namespaces.ts:patch` `patched` | a | Deleted; Feathers proxy emits `kb/namespaces patched`. |
| `apps/agor-daemon/src/services/knowledge-namespaces.ts:update` `updated` | a | Deleted; Feathers proxy emits `kb/namespaces updated`. |
| `apps/agor-daemon/src/services/knowledge-namespaces.ts:remove` `removed` | a | Deleted; Feathers proxy emits `kb/namespaces removed`. |
| `apps/agor-daemon/src/services/knowledge-namespaces.ts:saveWithAcl` existing namespace `patched` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/knowledge-namespaces.ts:saveWithAcl` new namespace `created` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/repos.ts:importFromAgorYml` `patched` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/services/sessions.ts:remove` cascade `removed` | b | Split root/proxy removal from recursive child removals; recursive bypass removals emit via `emitServiceEvent`. |
| `apps/agor-daemon/src/mcp/tools/sessions.ts` remote source-session `patched` | b | Converted to `emitServiceEvent`. |
| `apps/agor-daemon/src/utils/emit-service-event.ts` helper `service.emit(event, data, hook)` | c | Left; third argument is a shaped HookContext with `path`, `result`, `params`, `app`, and `service`. |
| `apps/agor-daemon/src/utils/executor-heartbeat-callback.test.ts` child-process `exit` emit with signal | c | Left; local test EventEmitter, not a Feathers/socket service event. |
| `apps/agor-daemon/src/utils/executor-heartbeat-callback.test.ts` child-process `exit` emit with code | c | Left; local test EventEmitter, not a Feathers/socket service event. |

## Gate results

- `pnpm typecheck` in `apps/agor-daemon`: pass
- `pnpm exec biome check .`: pass
- `pnpm test` in `apps/agor-daemon`: 1546 passed, 31 skipped, 127 files passed, 1 file skipped
- `pnpm check:multitenancy-boundaries`: pass
