### PR TITLE
Fix Claude setup-token auth flow

### DIFF
--- a/apps/agor-daemon/src/services/check-auth.test.ts
+++ b/apps/agor-daemon/src/services/check-auth.test.ts
@@ -1,0 +1,117 @@
+import { resolveApiKey, resolveUserEnvironment } from '@agor/core/config';
+import { Claude } from '@agor/core/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCheckAuthService } from './check-auth';
+
+vi.mock('@agor/core/config', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/config')>('@agor/core/config');
+  return {
+    ...actual,
+    resolveApiKey: vi.fn(),
+    resolveUserEnvironment: vi.fn(),
+  };
+});
+
+vi.mock('@agor/core/sdk', () => ({
+  Claude: {
+    query: vi.fn(),
+  },
+}));
+
+const resolveApiKeyMock = vi.mocked(resolveApiKey);
+const resolveUserEnvironmentMock = vi.mocked(resolveUserEnvironment);
+const claudeQueryMock = vi.mocked(Claude.query);
+
+function mockClaudeAccount(account: Record<string, unknown> | null) {
+  claudeQueryMock.mockReturnValue({
+    accountInfo: vi.fn(async () => account),
+    close: vi.fn(),
+  } as never);
+}
+
+describe('check-auth Claude subscription tokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.ANTHROPIC_API_KEY;
+    resolveUserEnvironmentMock.mockResolvedValue({});
+  });
+
+  it('validates a raw claude setup-token as OAuth instead of an Anthropic API key', async () => {
+    mockClaudeAccount({ tokenSource: 'CLAUDE_CODE_OAUTH_TOKEN' });
+    const service = createCheckAuthService({} as never);
+
+    const result = await service.create({ tool: 'claude-code', apiKey: 'sk-ant-oat01-test' });
+
+    expect(result).toMatchObject({ authenticated: true, method: 'oauth' });
+    expect(claudeQueryMock).toHaveBeenCalledTimes(1);
+    expect(resolveApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  it('checks stored CLAUDE_CODE_OAUTH_TOKEN when no Anthropic API key is configured', async () => {
+    resolveApiKeyMock
+      .mockResolvedValueOnce({ apiKey: undefined, source: 'none', useNativeAuth: true })
+      .mockResolvedValueOnce({
+        apiKey: 'sk-ant-oat01-stored',
+        source: 'user',
+        useNativeAuth: false,
+      });
+    mockClaudeAccount({ tokenSource: 'CLAUDE_CODE_OAUTH_TOKEN' });
+    const service = createCheckAuthService({} as never);
+
+    const result = await service.create({ tool: 'claude-code' }, {
+      user: { user_id: 'user-1' },
+    } as never);
+
+    expect(result).toMatchObject({ authenticated: true, method: 'oauth' });
+    expect(resolveApiKeyMock).toHaveBeenNthCalledWith(1, 'ANTHROPIC_API_KEY', {
+      userId: 'user-1',
+      db: {},
+      tool: 'claude-code',
+    });
+    expect(resolveApiKeyMock).toHaveBeenNthCalledWith(2, 'CLAUDE_CODE_OAUTH_TOKEN', {
+      userId: 'user-1',
+      db: {},
+      tool: 'claude-code',
+    });
+  });
+
+  it('validates an Anthropic API key stored as a user env var', async () => {
+    resolveApiKeyMock.mockResolvedValue({ apiKey: undefined, source: 'none', useNativeAuth: true });
+    resolveUserEnvironmentMock.mockResolvedValue({ ANTHROPIC_API_KEY: 'sk-ant-api03-env' });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true } as Response);
+    const service = createCheckAuthService({} as never);
+
+    const result = await service.create({ tool: 'claude-code' }, {
+      user: { user_id: 'user-1' },
+    } as never);
+
+    expect(result).toMatchObject({ authenticated: true, method: 'api-key' });
+    expect(resolveUserEnvironmentMock).toHaveBeenCalledWith('user-1', {}, { tool: 'claude-code' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'x-api-key': 'sk-ant-api03-env' }),
+      })
+    );
+    fetchMock.mockRestore();
+  });
+
+  it('validates a Claude subscription token stored as a user env var', async () => {
+    resolveApiKeyMock
+      .mockResolvedValueOnce({ apiKey: undefined, source: 'none', useNativeAuth: true })
+      .mockResolvedValueOnce({ apiKey: undefined, source: 'none', useNativeAuth: true });
+    resolveUserEnvironmentMock.mockResolvedValue({
+      CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-env',
+    });
+    mockClaudeAccount({ tokenSource: 'CLAUDE_CODE_OAUTH_TOKEN' });
+    const service = createCheckAuthService({} as never);
+
+    const result = await service.create({ tool: 'claude-code' }, {
+      user: { user_id: 'user-1' },
+    } as never);
+
+    expect(result).toMatchObject({ authenticated: true, method: 'oauth' });
+    expect(resolveUserEnvironmentMock).toHaveBeenCalledWith('user-1', {}, { tool: 'claude-code' });
+  });
+});

--- a/apps/agor-daemon/src/services/check-auth.test.ts
+++ b/apps/agor-daemon/src/services/check-auth.test.ts
@@ -45,6 +45,14 @@ describe('check-auth Claude subscription tokens', () => {
 
     expect(result).toMatchObject({ authenticated: true, method: 'oauth' });
     expect(claudeQueryMock).toHaveBeenCalledTimes(1);
+    expect(claudeQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          env: expect.objectContaining({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' }),
+        }),
+      })
+    );
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
     expect(resolveApiKeyMock).not.toHaveBeenCalled();
   });
 
@@ -64,6 +72,14 @@ describe('check-auth Claude subscription tokens', () => {
     } as never);
 
     expect(result).toMatchObject({ authenticated: true, method: 'oauth' });
+    expect(claudeQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          env: expect.objectContaining({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-stored' }),
+        }),
+      })
+    );
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
     expect(resolveApiKeyMock).toHaveBeenNthCalledWith(1, 'ANTHROPIC_API_KEY', {
       userId: 'user-1',
       db: {},
@@ -112,6 +128,14 @@ describe('check-auth Claude subscription tokens', () => {
     } as never);
 
     expect(result).toMatchObject({ authenticated: true, method: 'oauth' });
+    expect(claudeQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          env: expect.objectContaining({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-env' }),
+        }),
+      })
+    );
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
     expect(resolveUserEnvironmentMock).toHaveBeenCalledWith('user-1', {}, { tool: 'claude-code' });
   });
 });

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -16,7 +16,12 @@
  * - Cursor SDK: API-key presence check; the SDK validates the key at session start
  *
  * Resolution precedence (when no raw key is provided by the caller):
- *   user encrypted key → config.yaml → env var → native auth
+ *   primary per-tool credential / config / daemon env → user env vars for the
+ *   selected tool → secondary Claude subscription token → native auth.
+ *
+ * User Settings → Env Vars is not the recommended credential home, but
+ * executor environments receive those vars, so this service validates them via
+ * the same user/tool env resolver used for session spawn.
  */
 
 import { promises as fs } from 'node:fs';
@@ -69,7 +74,9 @@ async function withTimeout<T>(promise: Promise<T>, ms: number, message: string):
  *
  * Returns null on any failure (CLI missing, no auth, timeout, etc.).
  */
-async function probeClaudeCodeAuth(): Promise<Claude.AccountInfo | null> {
+async function probeClaudeCodeAuth(
+  env?: Record<string, string>
+): Promise<Claude.AccountInfo | null> {
   let releaseHeldInput!: () => void;
   const heldInputPromise = new Promise<void>((resolve) => {
     releaseHeldInput = resolve;
@@ -82,7 +89,7 @@ async function probeClaudeCodeAuth(): Promise<Claude.AccountInfo | null> {
 
   const q = Claude.query({
     prompt: neverYields(),
-    options: {},
+    options: env ? { env } : {},
   });
 
   try {
@@ -183,43 +190,33 @@ function isClaudeSubscriptionToken(token: string): boolean {
   return token.trim().startsWith('sk-ant-oat');
 }
 
-async function withTemporaryEnv<T>(
-  env: Record<string, string | undefined>,
-  fn: () => Promise<T>
-): Promise<T> {
-  const previous = new Map<string, string | undefined>();
-  for (const key of Object.keys(env)) {
-    previous.set(key, process.env[key]);
-    const value = env[key];
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
+function buildClaudeProbeEnv(token: string): Record<string, string> {
+  const env: Record<string, string> = {
+    CLAUDE_CODE_OAUTH_TOKEN: token.trim(),
+  };
+
+  // The SDK uses an explicit bundled Claude binary path, but preserving PATH
+  // keeps child-process basics working without exposing all daemon env vars.
+  if (process.env.PATH) env.PATH = process.env.PATH;
+
+  // Preserve common proxy settings so validation works in proxied installs.
+  for (const key of [
+    'HTTPS_PROXY',
+    'HTTP_PROXY',
+    'NO_PROXY',
+    'https_proxy',
+    'http_proxy',
+    'no_proxy',
+  ]) {
+    const value = process.env[key];
+    if (value) env[key] = value;
   }
 
-  try {
-    return await fn();
-  } finally {
-    for (const [key, value] of previous) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
+  return env;
 }
 
 async function validateClaudeSubscriptionToken(token: string): Promise<boolean> {
-  const account = await withTemporaryEnv(
-    {
-      CLAUDE_CODE_OAUTH_TOKEN: token.trim(),
-      // Avoid an unrelated daemon-level API key making this probe green.
-      ANTHROPIC_API_KEY: undefined,
-    },
-    () => probeClaudeCodeAuth()
-  );
+  const account = await probeClaudeCodeAuth(buildClaudeProbeEnv(token));
   return !!account?.tokenSource;
 }
 

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -22,7 +22,7 @@
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { resolveApiKey } from '@agor/core/config';
+import { resolveApiKey, resolveUserEnvironment } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import type { SDKUserMessage } from '@agor/core/sdk';
 import { Claude } from '@agor/core/sdk';
@@ -179,6 +179,50 @@ async function probeCodexAuth(): Promise<CodexAuthProbeResult | null> {
   return null;
 }
 
+function isClaudeSubscriptionToken(token: string): boolean {
+  return token.trim().startsWith('sk-ant-oat');
+}
+
+async function withTemporaryEnv<T>(
+  env: Record<string, string | undefined>,
+  fn: () => Promise<T>
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(env)) {
+    previous.set(key, process.env[key]);
+    const value = env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function validateClaudeSubscriptionToken(token: string): Promise<boolean> {
+  const account = await withTemporaryEnv(
+    {
+      CLAUDE_CODE_OAUTH_TOKEN: token.trim(),
+      // Avoid an unrelated daemon-level API key making this probe green.
+      ANTHROPIC_API_KEY: undefined,
+    },
+    () => probeClaudeCodeAuth()
+  );
+  return !!account?.tokenSource;
+}
+
 async function validateApiKey(tool: string, key: string): Promise<boolean> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -253,7 +297,20 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
       }
 
       // If caller provided a raw key (user typed it in the wizard), validate directly.
+      // Claude subscription tokens from `claude setup-token` are not Anthropic
+      // Console API keys; the Claude SDK/CLI reads them from CLAUDE_CODE_OAUTH_TOKEN.
       if (rawKey?.trim()) {
+        if (tool === 'claude-code' && isClaudeSubscriptionToken(rawKey)) {
+          const ok = await validateClaudeSubscriptionToken(rawKey);
+          return {
+            authenticated: ok,
+            method: ok ? 'oauth' : 'none',
+            hint: ok
+              ? undefined
+              : 'Claude subscription token rejected — run `claude setup-token` again and paste the fresh token.',
+          };
+        }
+
         const ok = await validateApiKey(tool, rawKey.trim());
         return {
           authenticated: ok,
@@ -281,6 +338,15 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
         };
       }
 
+      let effectiveUserEnv: Record<string, string> | undefined;
+      const getEffectiveUserEnv = async () => {
+        if (!userId) return {};
+        effectiveUserEnv ??= await resolveUserEnvironment(userId, db, {
+          tool: tool as AgenticToolName,
+        });
+        return effectiveUserEnv;
+      };
+
       if (apiKey) {
         const ok = await validateApiKey(tool, apiKey);
         return {
@@ -290,6 +356,52 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
             ? undefined
             : 'Stored key was rejected by provider — update it in Settings → Agent Setup.',
         };
+      }
+
+      // User Settings → Env Vars is not the recommended credential home, but
+      // executors do receive those values. Validate that wild setup through the
+      // same user/tool env resolver used to spawn sessions.
+      const userEnv = await getEffectiveUserEnv();
+      const userEnvApiKey = userEnv[keyName];
+      if (userEnvApiKey) {
+        const ok = await validateApiKey(tool, userEnvApiKey);
+        return {
+          authenticated: ok,
+          method: 'api-key',
+          hint: ok
+            ? undefined
+            : 'Stored env var key was rejected by provider — update it in Settings → Env Vars.',
+        };
+      }
+
+      if (tool === 'claude-code') {
+        const subscriptionResolution = await resolveApiKey('CLAUDE_CODE_OAUTH_TOKEN', {
+          userId,
+          db,
+          tool: 'claude-code',
+        });
+
+        if (subscriptionResolution.decryptionFailed) {
+          return {
+            authenticated: false,
+            method: 'none',
+            hint: 'Stored Claude subscription token could not be decrypted (master-secret mismatch). Re-enter it in Settings → Agent Setup.',
+          };
+        }
+
+        const subscriptionToken = subscriptionResolution.apiKey || userEnv.CLAUDE_CODE_OAUTH_TOKEN;
+        if (subscriptionToken) {
+          const ok = await validateClaudeSubscriptionToken(subscriptionToken);
+          return {
+            authenticated: ok,
+            method: ok ? 'oauth' : 'none',
+            hint: ok
+              ? undefined
+              : subscriptionResolution.apiKey
+                ? 'Stored Claude subscription token was rejected — update it in Settings → Agent Setup.'
+                : 'Claude subscription token env var was rejected — update CLAUDE_CODE_OAUTH_TOKEN in Settings → Env Vars.',
+          };
+        }
       }
 
       if (useNativeAuth && NATIVE_AUTH_TOOLS.has(tool)) {

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -309,12 +309,15 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
           {/* Built-in per-field helpers retained from the legacy component. */}
           {field === 'CLAUDE_CODE_OAUTH_TOKEN' && !isSet && (
             <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-              On the machine Agor runs sessions on, run{' '}
+              In any terminal with Claude Code installed, run{' '}
               <Text code style={{ fontSize: token.fontSizeSM }}>
                 claude setup-token
               </Text>{' '}
-              and paste the printed token here. This uses Claude subscription auth instead of a raw
-              API key.
+              and paste the printed token here. Need Claude Code?{' '}
+              <Link href="https://docs.claude.com/en/docs/claude-code/setup" target="_blank">
+                Install docs
+              </Link>
+              .
             </Text>
           )}
           {field === 'ANTHROPIC_AUTH_TOKEN' && (

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -1,4 +1,4 @@
-import type { AgenticToolName } from '@agor-live/client';
+import type { AgenticToolConfigField, AgenticToolName } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -17,7 +17,7 @@ const { Text, Link } = Typography;
  */
 export interface AgenticToolFieldConfig {
   /** Env var name. Matches the key under `agentic_tools[tool][field]` on disk. */
-  field: string;
+  field: AgenticToolConfigField;
   /** Human-readable label shown above the input. */
   label: string;
   /** Short qualifier shown next to the label (e.g. "Pro / Max plan"). */
@@ -159,7 +159,7 @@ export const TOOL_FIELD_CONFIGS: Record<AgenticToolName, AgenticToolFieldConfig[
 };
 
 /** Map field name → presence flag (true if the user has a value stored). */
-export type FieldStatus = Record<string, boolean>;
+export type FieldStatus = Partial<Record<AgenticToolConfigField, boolean>>;
 
 export interface ApiKeyFieldsProps {
   /**
@@ -170,11 +170,11 @@ export interface ApiKeyFieldsProps {
   /** Per-field set/unset flags from `user.agentic_tools[tool]`. */
   fieldStatus: FieldStatus;
   /** Persist a new value for one field (encrypts at rest). */
-  onSave: (field: string, value: string) => Promise<void>;
+  onSave: (field: AgenticToolConfigField, value: string) => Promise<void>;
   /** Clear the stored value for one field. */
-  onClear: (field: string) => Promise<void>;
+  onClear: (field: AgenticToolConfigField) => Promise<void>;
   /** Per-field saving spinner state. */
-  saving?: Record<string, boolean>;
+  saving?: Partial<Record<AgenticToolConfigField, boolean>>;
   /** Disable all inputs (e.g. while RBAC is loading). */
   disabled?: boolean;
   /**
@@ -192,7 +192,7 @@ export interface ApiKeyFieldsProps {
    * back to the user instead of just a "Set" tag — useful for base URLs
    * where the exact path matters.
    */
-  publicValues?: Record<string, string>;
+  publicValues?: Partial<Record<AgenticToolConfigField, string>>;
 }
 
 export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
@@ -206,11 +206,13 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
   publicValues,
 }) => {
   const { token } = theme.useToken();
-  const [inputValues, setInputValues] = useState<Record<string, string>>({});
+  const [inputValues, setInputValues] = useState<Partial<Record<AgenticToolConfigField, string>>>(
+    {}
+  );
 
   const configs = fields ?? TOOL_FIELD_CONFIGS[tool] ?? [];
 
-  const handleSave = async (field: string) => {
+  const handleSave = async (field: AgenticToolConfigField) => {
     const value = inputValues[field]?.trim();
     if (!value) return;
 

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
@@ -1,0 +1,39 @@
+import type { User } from '@agor-live/client';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OnboardingBanners } from './OnboardingBanners';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    user_id: 'user-1',
+    email: 'user@example.com',
+    name: 'User',
+    role: 'member',
+    onboarding_completed: true,
+    ...overrides,
+  } as User;
+}
+
+describe('OnboardingBanners', () => {
+  it('treats CLAUDE_CODE_OAUTH_TOKEN in user env vars as Claude auth', async () => {
+    const onCheckAuth = vi.fn(async () => ({ authenticated: true, method: 'oauth' as const }));
+
+    render(
+      <OnboardingBanners
+        user={makeUser({
+          env_vars: {
+            CLAUDE_CODE_OAUTH_TOKEN: { set: true, scope: 'global', resource_id: null },
+          },
+        })}
+        mcpServerCount={1}
+        canManageMcp={false}
+        onOpenUserSettings={vi.fn()}
+        onOpenWorkspaceSettings={vi.fn()}
+        onCheckAuth={onCheckAuth}
+      />
+    );
+
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledWith('claude-code'));
+    expect(screen.queryByText(/connect an ai provider/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -38,6 +38,7 @@ function hasAnyLlmKey(user: User | null | undefined): boolean {
     codex?.OPENAI_API_KEY ||
     gemini?.GEMINI_API_KEY ||
     user.env_vars?.ANTHROPIC_API_KEY ||
+    user.env_vars?.CLAUDE_CODE_OAUTH_TOKEN ||
     user.env_vars?.OPENAI_API_KEY ||
     user.env_vars?.GEMINI_API_KEY
   );
@@ -51,7 +52,8 @@ function primaryAgentForUser(user: User | null | undefined): AgenticToolName | n
   if (
     claude?.ANTHROPIC_API_KEY ||
     claude?.CLAUDE_CODE_OAUTH_TOKEN ||
-    user.env_vars?.ANTHROPIC_API_KEY
+    user.env_vars?.ANTHROPIC_API_KEY ||
+    user.env_vars?.CLAUDE_CODE_OAUTH_TOKEN
   )
     return 'claude-code';
   if (codex?.OPENAI_API_KEY || user.env_vars?.OPENAI_API_KEY) return 'codex';

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -190,10 +190,17 @@ describe('OnboardingWizard', () => {
     const claudeOption = providerOptions.find((option) => option.value === 'claude-code');
     const codexOption = providerOptions.find((option) => option.value === 'codex');
     expect(claudeOption).toBeChecked();
-    expect(screen.getAllByText(/ANTHROPIC_API_KEY/).length).toBeGreaterThan(0);
-
-    fireEvent.click(screen.getByText('Subscription'));
+    expect(baseElement.querySelector('input[value="claude-subscription-token"]')).toBeChecked();
     expect(screen.getByText(/claude setup-token/)).toBeInTheDocument();
+    expect(screen.getByText(/terminal with Claude Code installed/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /install docs/i })).toHaveAttribute(
+      'href',
+      'https://docs.claude.com/en/docs/claude-code/setup'
+    );
+
+    fireEvent.click(screen.getByText('API key'));
+    expect(baseElement.querySelector('input[value="api-key"]')).toBeChecked();
+    expect(screen.getAllByText(/ANTHROPIC_API_KEY/).length).toBeGreaterThan(0);
 
     fireEvent.click(codexOption as HTMLInputElement);
     expect(codexOption).toBeChecked();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -8,6 +8,7 @@
  */
 
 import type {
+  AgenticToolConfigField,
   AgenticToolName,
   AssistantConfig,
   AuthCheckResult,
@@ -140,7 +141,10 @@ function entriesByRepoId(repos: Repo[]): Map<string, Repo> {
   return new Map(repos.map((repo) => [repo.repo_id, repo]));
 }
 
-function apiKeyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-key'): string {
+function apiKeyNameForAgent(
+  agent: AgenticToolName,
+  authMethod: AuthMethod = 'api-key'
+): AgenticToolConfigField {
   if (agent === 'claude-code' && authMethod === 'claude-subscription-token') {
     return 'CLAUDE_CODE_OAUTH_TOKEN';
   }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -58,6 +58,7 @@ import {
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById, selectBranchById, selectRepoById } from '../../store/selectors';
 import type { CreateRepoOptions } from '../../types';
+import { buildAgenticToolCredentialPatch } from '../../utils/agenticToolCredentials';
 import { buildAssistantBootstrapPrompt } from '../../utils/assistantBootstrapPrompt';
 import { ensureAssistantWelcomeNote } from '../../utils/assistantWelcomeNote';
 import { slugify } from '../../utils/repoSlug';
@@ -200,6 +201,7 @@ const AGENT_KEY_CONSOLES: Record<AgenticToolName, { label: string; url: string }
 };
 
 function defaultAuthMethodForAgent(agent: AgenticToolName): AuthMethod {
+  if (agent === 'claude-code') return 'claude-subscription-token';
   return agent === 'codex' ? 'codex-cli-auth' : 'api-key';
 }
 
@@ -255,7 +257,9 @@ export function OnboardingWizard({
   const [selectedAgent, setSelectedAgent] = useState<AgenticToolName>('claude-code');
   const [lastRecommendedAgent, setLastRecommendedAgent] = useState<AgenticToolName>('claude-code');
   const [useDifferentProvider, setUseDifferentProvider] = useState(false);
-  const [authMethod, setAuthMethod] = useState<AuthMethod>('api-key');
+  const [authMethod, setAuthMethod] = useState<AuthMethod>(() =>
+    defaultAuthMethodForAgent('claude-code')
+  );
   const [apiKey, setApiKey] = useState('');
   const [overrideDetectedAuth, setOverrideDetectedAuth] = useState(false);
   const [manualTestResult, setManualTestResult] = useState<AuthCheckResult | null>(null);
@@ -324,7 +328,8 @@ export function OnboardingWizard({
       const hasAnthropicKey = !!(
         claudeFields?.ANTHROPIC_API_KEY ||
         claudeFields?.CLAUDE_CODE_OAUTH_TOKEN ||
-        user?.env_vars?.ANTHROPIC_API_KEY
+        user?.env_vars?.ANTHROPIC_API_KEY ||
+        user?.env_vars?.CLAUDE_CODE_OAUTH_TOKEN
       );
       const hasOpenAIKey = !!(codexFields?.OPENAI_API_KEY || user?.env_vars?.OPENAI_API_KEY);
       const hasGeminiKey = !!(geminiFields?.GEMINI_API_KEY || user?.env_vars?.GEMINI_API_KEY);
@@ -800,11 +805,10 @@ export function OnboardingWizard({
     const targetTool: AgenticToolName =
       selectedAgent === 'opencode' ? 'claude-code' : selectedAgent;
     try {
-      await onUpdateUser(user.user_id, {
-        agentic_tools: {
-          [targetTool]: { [keyName]: apiKey.trim() },
-        } as UpdateUserInput['agentic_tools'],
-      });
+      await onUpdateUser(
+        user.user_id,
+        buildAgenticToolCredentialPatch(targetTool, keyName, apiKey.trim())
+      );
       await startSetup();
     } catch (err) {
       setError(`Failed to save API key: ${err instanceof Error ? err.message : String(err)}`);
@@ -903,7 +907,15 @@ export function OnboardingWizard({
             style={{ marginBottom: 16, textAlign: 'left' }}
             description={
               <span>
-                Run <Text code>claude setup-token</Text>, then paste the token below.
+                In any terminal with Claude Code installed, run <Text code>claude setup-token</Text>
+                , then paste the printed token below. Need Claude Code?{' '}
+                <Typography.Link
+                  href="https://docs.claude.com/en/docs/claude-code/setup"
+                  target="_blank"
+                >
+                  Install docs
+                </Typography.Link>
+                .
               </span>
             }
           />

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -5,7 +5,12 @@
  * Each tool tab displays its API key configuration and tool-specific settings.
  */
 
-import type { AgenticToolName, AgorClient, AgorConfig } from '@agor-live/client';
+import type {
+  AgenticToolConfigField,
+  AgenticToolName,
+  AgorClient,
+  AgorConfig,
+} from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -57,9 +62,9 @@ const ApiKeyTabContent: React.FC<{
   tool: AgenticToolName;
   fieldStatus: FieldStatus;
   keysError: string | null;
-  savingKeys: Record<string, boolean>;
-  onSave: (field: string, value: string) => Promise<void>;
-  onClear: (field: string) => Promise<void>;
+  savingKeys: Partial<Record<AgenticToolConfigField, boolean>>;
+  onSave: (field: AgenticToolConfigField, value: string) => Promise<void>;
+  onClear: (field: AgenticToolConfigField) => Promise<void>;
   onClearError: () => void;
 }> = ({ tool, fieldStatus, keysError, savingKeys, onSave, onClear, onClearError }) => {
   const { token } = theme.useToken();
@@ -117,7 +122,9 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
   // each per-tool tab projects out only the fields it owns via
   // `GLOBAL_TOOL_FIELDS[tool]`.
   const [loadingKeys, setLoadingKeys] = useState(true);
-  const [savingKeys, setSavingKeys] = useState<Record<string, boolean>>({});
+  const [savingKeys, setSavingKeys] = useState<Partial<Record<AgenticToolConfigField, boolean>>>(
+    {}
+  );
   const [keysError, setKeysError] = useState<string | null>(null);
   const [fieldStatus, setFieldStatus] = useState<FieldStatus>({});
 
@@ -192,7 +199,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
   }, [client]);
 
   // Save API key
-  const handleSaveKey = async (field: string, value: string) => {
+  const handleSaveKey = async (field: AgenticToolConfigField, value: string) => {
     if (!client) return;
 
     try {
@@ -216,7 +223,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
   };
 
   // Clear API key
-  const handleClearKey = async (field: string) => {
+  const handleClearKey = async (field: AgenticToolConfigField) => {
     if (!client) return;
 
     try {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -41,6 +41,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { selectMcpServerById } from '../../store/selectors';
+import { buildAgenticToolCredentialPatch } from '../../utils/agenticToolCredentials';
 import { DEFAULT_AUDIO_PREFERENCES } from '../../utils/audio';
 import { searchableSelectProps, toGroupSelectOption } from '../../utils/selectSearch';
 import {
@@ -441,11 +442,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
     try {
       setSavingToolField((prev) => ({ ...prev, [spinnerKey]: true }));
-      await onUpdate?.(user.user_id, {
-        agentic_tools: {
-          [tool]: { [field]: value },
-        } as UpdateUserInput['agentic_tools'],
-      });
+      await onUpdate?.(user.user_id, buildAgenticToolCredentialPatch(tool, field, value));
       setAgenticToolStatus((prev) => ({
         ...prev,
         [tool]: { ...(prev[tool] ?? {}), [field]: true },
@@ -465,11 +462,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
     try {
       setSavingToolField((prev) => ({ ...prev, [spinnerKey]: true }));
-      await onUpdate?.(user.user_id, {
-        agentic_tools: {
-          [tool]: { [field]: null },
-        } as UpdateUserInput['agentic_tools'],
-      });
+      await onUpdate?.(user.user_id, buildAgenticToolCredentialPatch(tool, field, null));
       setAgenticToolStatus((prev) => {
         const nextToolFields = { ...(prev[tool] ?? {}) };
         delete nextToolFields[field];

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -1,4 +1,5 @@
 import type {
+  AgenticToolConfigField,
   AgenticToolName,
   AgorClient,
   EnvVarMetadata,
@@ -434,7 +435,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   // service merges only the touched fields and encrypts at rest.
   const handleToolFieldSave = async (
     tool: AgenticToolName,
-    field: string,
+    field: AgenticToolConfigField,
     value: string
   ): Promise<void> => {
     if (!user) return;
@@ -456,7 +457,10 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   };
 
   // Clear a per-tool credential field by sending `null` in the patch.
-  const handleToolFieldClear = async (tool: AgenticToolName, field: string): Promise<void> => {
+  const handleToolFieldClear = async (
+    tool: AgenticToolName,
+    field: AgenticToolConfigField
+  ): Promise<void> => {
     if (!user) return;
     const spinnerKey = `${tool}.${field}`;
 
@@ -950,7 +954,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         // saving spinners are tracked in `savingToolField` keyed by `${tool}.${field}`.
         const toolFields = TOOL_FIELD_CONFIGS[toolName] ?? [];
         const fieldStatus: FieldStatus = agenticToolStatus[toolName] ?? {};
-        const savingForTool: Record<string, boolean> = Object.fromEntries(
+        const savingForTool: Partial<Record<AgenticToolConfigField, boolean>> = Object.fromEntries(
           toolFields.map((c) => [c.field, !!savingToolField[`${toolName}.${c.field}`]])
         );
         const defaultsPane = (
@@ -999,7 +1003,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
               onClear={(field) => handleToolFieldClear(toolName, field)}
               saving={savingForTool}
               publicValues={
-                user?.agentic_tools_public_values?.[toolName] as Record<string, string> | undefined
+                user?.agentic_tools_public_values?.[toolName] as
+                  | Partial<Record<AgenticToolConfigField, string>>
+                  | undefined
               }
             />
           </>

--- a/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
+++ b/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildAgenticToolCredentialPatch } from './agenticToolCredentials';
+
+describe('buildAgenticToolCredentialPatch', () => {
+  it('uses the same canonical storage path for onboarding and User Settings Claude subscription tokens', () => {
+    const onboardingPatch = buildAgenticToolCredentialPatch(
+      'claude-code',
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'sk-ant-oat01-test'
+    );
+    const settingsPatch = buildAgenticToolCredentialPatch(
+      'claude-code',
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'sk-ant-oat01-test'
+    );
+
+    expect(onboardingPatch).toEqual(settingsPatch);
+    expect(onboardingPatch).toEqual({
+      agentic_tools: {
+        'claude-code': { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' },
+      },
+    });
+  });
+
+  it('clears a token by sending null at the same canonical field path', () => {
+    expect(buildAgenticToolCredentialPatch('claude-code', 'CLAUDE_CODE_OAUTH_TOKEN', null)).toEqual(
+      {
+        agentic_tools: {
+          'claude-code': { CLAUDE_CODE_OAUTH_TOKEN: null },
+        },
+      }
+    );
+  });
+});

--- a/apps/agor-ui/src/utils/agenticToolCredentials.ts
+++ b/apps/agor-ui/src/utils/agenticToolCredentials.ts
@@ -1,0 +1,20 @@
+import type { AgenticToolName, UpdateUserInput } from '@agor-live/client';
+
+export type CredentialPatchValue = string | null;
+
+/**
+ * Build the canonical per-user agentic-tool credential patch consumed by the
+ * users service. Both onboarding and User Settings should go through this
+ * shape so credentials land under the same encrypted `data.agentic_tools` blob.
+ */
+export function buildAgenticToolCredentialPatch(
+  tool: AgenticToolName,
+  field: string,
+  value: CredentialPatchValue
+): Pick<UpdateUserInput, 'agentic_tools'> {
+  return {
+    agentic_tools: {
+      [tool]: { [field]: value },
+    } as UpdateUserInput['agentic_tools'],
+  };
+}

--- a/apps/agor-ui/src/utils/agenticToolCredentials.ts
+++ b/apps/agor-ui/src/utils/agenticToolCredentials.ts
@@ -1,4 +1,4 @@
-import type { AgenticToolName, UpdateUserInput } from '@agor-live/client';
+import type { AgenticToolConfigField, AgenticToolName, UpdateUserInput } from '@agor-live/client';
 
 export type CredentialPatchValue = string | null;
 
@@ -9,7 +9,7 @@ export type CredentialPatchValue = string | null;
  */
 export function buildAgenticToolCredentialPatch(
   tool: AgenticToolName,
-  field: string,
+  field: AgenticToolConfigField,
   value: CredentialPatchValue
 ): Pick<UpdateUserInput, 'agentic_tools'> {
   return {


### PR DESCRIPTION
## Summary

- Route onboarding and User Settings credential saves through one canonical `agentic_tools[tool][field]` patch helper.
- Teach `check-auth` that Claude `setup-token` values are `CLAUDE_CODE_OAUTH_TOKEN` OAuth credentials, not Anthropic Console API keys.
- Validate credentials stored in User Settings → Env Vars by reusing the same user/tool env resolver used for executor session environments.
- Validate Claude subscription tokens through the Claude SDK with an explicit per-probe env, avoiding daemon-global `process.env` mutation.
- Include `CLAUDE_CODE_OAUTH_TOKEN` env-var setups in onboarding/banner key detection.
- Clarify the short `claude setup-token` instructions with terminal/Claude Code install context and a Claude Code install-docs link.
- Add regression tests for shared storage shape, Claude subscription-token auth checks, user env-var auth checks, and banner detection.

## Root cause

The onboarding wizard already saved Claude subscription tokens to the same canonical per-user storage path as User Settings: `agentic_tools['claude-code'].CLAUDE_CODE_OAUTH_TOKEN`. The broken part was auth verification: `check-auth` only resolved/validated `ANTHROPIC_API_KEY` for Claude Code, so a `claude setup-token` value could be tested as the wrong credential type or ignored when stored.

There was also a gap for non-recommended-but-working setups where users put `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in User Settings → Env Vars. Executors can receive those env vars, but auth verification and banners were not fully aligned with that effective runtime env.

## Canonical path after this change

Onboarding and User Settings now save Claude subscription tokens through the same helper and storage shape: `agentic_tools['claude-code'].CLAUDE_CODE_OAUTH_TOKEN`. `check-auth` resolves credentials in the same order sessions effectively use them: canonical per-tool credentials first, then user env vars for the tool, then native Claude auth fallback.

## Verification

- `pnpm i`
- `pnpm --filter @agor/daemon test -- src/services/check-auth.test.ts`
- `pnpm --filter agor-ui test -- src/components/OnboardingBanners/OnboardingBanners.test.tsx src/utils/agenticToolCredentials.test.ts src/components/OnboardingWizard/OnboardingWizard.test.tsx src/components/SettingsModal/UserSettingsModal.test.tsx`
- `pnpm --filter agor-ui typecheck`
- `pnpm check` — typecheck/lint/shortid phases passed; stopped at existing `check:multitenancy-boundaries` baseline violations unrelated to this PR.
