### PR TITLE
Fix tenant-scoped env status updates

### DIFF
--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -517,6 +517,57 @@ describe('POST /mcp with personal API keys', () => {
     );
   });
 
+  it('carries authenticated user tenant into service params for MCP tool calls and session validation', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+      tenant_id: 'tenant-a',
+    }));
+    const getSession = vi.fn(async () => ({ session_id: 'session-full-id' }));
+
+    await withMcpServer(
+      { users: { get: getUser }, sessions: { get: getSession } },
+      async (baseUrl) => {
+        const resp = await fetch(`${baseUrl}/mcp`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'X-API-Key': 'agor_sk_valid',
+            'X-Agor-Session-Id': 'session-short',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 22,
+            method: 'tools/call',
+            params: { name: 'agor_users_get_current', arguments: {} },
+          }),
+        });
+
+        expect(resp.status).toBe(200);
+        expect(parseMcpResponse(await resp.text()).error).toBeUndefined();
+        expect(getSession).toHaveBeenCalledWith(
+          'session-short',
+          expect.objectContaining({
+            authenticated: true,
+            provider: 'mcp',
+            tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+          })
+        );
+        expect(getUser).toHaveBeenCalledWith(
+          'user-1',
+          expect.objectContaining({
+            authenticated: true,
+            provider: 'mcp',
+            tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+          })
+        );
+      }
+    );
+  });
+
   it('accepts a valid personal API key session context from ?sessionId=', async () => {
     await mockPersonalApiKeyUser();
     const getUser = vi.fn(async () => ({

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -17,7 +17,13 @@ import { randomUUID } from 'node:crypto';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { shortId, UserApiKeysRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { DaemonServicesConfig, ServiceGroupName, SessionID, UserID } from '@agor/core/types';
+import type {
+  DaemonServicesConfig,
+  ServiceGroupName,
+  SessionID,
+  TenantContext,
+  UserID,
+} from '@agor/core/types';
 import { getServiceTier, SERVICE_GROUP_TO_MCP_DOMAINS, SERVICE_TIER_RANK } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -58,6 +64,13 @@ function mcpRequestDebug(...args: unknown[]): void {
   }
 }
 
+function tenantFromAuthenticatedUser(user: AuthenticatedUser): TenantContext | undefined {
+  const tenantId = typeof user.tenant_id === 'string' ? user.tenant_id.trim() : '';
+  return tenantId
+    ? { tenant_id: tenantId as TenantContext['tenant_id'], source: 'auth_claim' }
+    : undefined;
+}
+
 /**
  * Shared context passed to every tool handler.
  */
@@ -68,7 +81,7 @@ export interface McpContext {
   /** Current Agor session context, when the caller supplied or authenticated with one. */
   sessionId?: SessionID;
   authenticatedUser: AuthenticatedUser;
-  baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider'>;
+  baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider' | 'tenant'>;
 }
 
 /**
@@ -594,7 +607,11 @@ export function setupMCPRoutes(
         }
       }
 
-      const baseServiceParams: Pick<AuthenticatedParams, 'user' | 'authenticated' | 'provider'> = {
+      const tenant = tenantFromAuthenticatedUser(authenticatedUser);
+      const baseServiceParams: Pick<
+        AuthenticatedParams,
+        'user' | 'authenticated' | 'provider' | 'tenant'
+      > = {
         user: {
           user_id: authenticatedUser.user_id,
           email: authenticatedUser.email,
@@ -602,6 +619,7 @@ export function setupMCPRoutes(
         },
         authenticated: true,
         provider: 'mcp',
+        ...(tenant ? { tenant } : {}),
       };
 
       // Personal API key callers may optionally bind a current-session context

--- a/apps/agor-daemon/src/mcp/tools/environment.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.test.ts
@@ -35,6 +35,9 @@ vi.mock('@agor/core/db', () => ({
       return [];
     }
   },
+  runWithTenantDatabaseScope: vi.fn(
+    async (_db: unknown, _tenantId: unknown, work: () => Promise<unknown>) => work()
+  ),
 }));
 
 type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
@@ -132,6 +135,41 @@ describe('environment tool authorization plumbing', () => {
 
     expect(parsed.success).toBe(false);
     expect(parsed.error).toMatch(/'all' branch permission/);
+    expect(startCalls).toEqual([['wt-1', params]]);
+  });
+
+  it('runs MCP environment actions inside the tenant database scope when tenant params are present', async () => {
+    const { runWithTenantDatabaseScope } = await import('@agor/core/db');
+    vi.mocked(runWithTenantDatabaseScope).mockClear();
+
+    const params = {
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' as const },
+    };
+    const startCalls: unknown[][] = [];
+    const ctx = {
+      ...makeCtx({
+        branches: {
+          startEnvironment: async (...args: unknown[]) => {
+            startCalls.push(args);
+            return { branch_id: 'wt-1', environment_instance: { status: 'starting' } };
+          },
+        },
+      }),
+      baseServiceParams: params,
+    };
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_start');
+    const result = await handler({ branchId: 'wt-1' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(runWithTenantDatabaseScope).toHaveBeenCalledWith(
+      ctx.db,
+      'tenant-a',
+      expect.any(Function)
+    );
     expect(startCalls).toEqual([['wt-1', params]]);
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/environment.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.test.ts
@@ -172,6 +172,55 @@ describe('environment tool authorization plumbing', () => {
     );
     expect(startCalls).toEqual([['wt-1', params]]);
   });
+
+  it('validates environment variants through tenant-scoped repo reads', async () => {
+    const { runWithTenantDatabaseScope } = await import('@agor/core/db');
+    vi.mocked(runWithTenantDatabaseScope).mockClear();
+
+    const params = {
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' as const },
+    };
+    const repoGetCalls: unknown[][] = [];
+    const renderCalls: unknown[][] = [];
+    const ctx = {
+      ...makeCtx({
+        repos: {
+          get: async (...args: unknown[]) => {
+            repoGetCalls.push(args);
+            return fakeRepo;
+          },
+        },
+        branches: {
+          get: async () => ({
+            branch_id: 'wt-1',
+            repo_id: 'repo-1',
+            environment_variant: 'dev',
+            environment_instance: { status: 'stopped' },
+          }),
+          renderEnvironment: async (...args: unknown[]) => {
+            renderCalls.push(args);
+            return { branch_id: 'wt-1', environment_variant: 'e2e' };
+          },
+        },
+      }),
+      baseServiceParams: params,
+    };
+
+    const handler = await captureEnvironmentTool(ctx, 'agor_environment_set');
+    const result = await handler({ branchId: 'wt-1', variant: 'e2e' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(runWithTenantDatabaseScope).toHaveBeenCalledWith(
+      ctx.db,
+      'tenant-a',
+      expect.any(Function)
+    );
+    expect(repoGetCalls).toEqual([['repo-1', params]]);
+    expect(renderCalls).toEqual([['wt-1', { variant: 'e2e' }, params]]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -230,7 +230,9 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
 
         if (variant) {
           const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
-          const repo = await reposService.get(branch.repo_id);
+          const repo = await runWithMcpEnvironmentTenant(ctx, () =>
+            reposService.get(branch.repo_id, ctx.baseServiceParams)
+          );
           assertValidVariant(repo, variant);
         }
 

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -1,3 +1,4 @@
+import { runWithTenantDatabaseScope } from '@agor/core/db';
 import type { BranchID } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -6,6 +7,12 @@ import { mcpOptionalString, mcpRequiredId } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
 import { assertValidVariant } from './_environment-helpers.js';
+
+async function runWithMcpEnvironmentTenant<T>(ctx: McpContext, work: () => Promise<T>): Promise<T> {
+  const tenantId = ctx.baseServiceParams.tenant?.tenant_id;
+  if (!tenantId) return work();
+  return runWithTenantDatabaseScope(ctx.db, tenantId, work);
+}
 
 export function registerEnvironmentTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_environment_start
@@ -23,9 +30,8 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
       const branchId = coerceString(args.branchId)!;
       const branchesService = ctx.app.service('branches') as unknown as BranchesServiceImpl;
       try {
-        const branch = await branchesService.startEnvironment(
-          branchId as BranchID,
-          ctx.baseServiceParams
+        const branch = await runWithMcpEnvironmentTenant(ctx, () =>
+          branchesService.startEnvironment(branchId as BranchID, ctx.baseServiceParams)
         );
         return textResult({
           success: true,
@@ -63,9 +69,8 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
       const branchId = coerceString(args.branchId)!;
       const branchesService = ctx.app.service('branches') as unknown as BranchesServiceImpl;
       try {
-        const branch = await branchesService.stopEnvironment(
-          branchId as BranchID,
-          ctx.baseServiceParams
+        const branch = await runWithMcpEnvironmentTenant(ctx, () =>
+          branchesService.stopEnvironment(branchId as BranchID, ctx.baseServiceParams)
         );
         return textResult({
           success: true,
@@ -96,7 +101,9 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
     async (args) => {
       const branchId = coerceString(args.branchId)!;
       const branchesService = ctx.app.service('branches') as unknown as BranchesServiceImpl;
-      const branch = await branchesService.checkHealth(branchId as BranchID, ctx.baseServiceParams);
+      const branch = await runWithMcpEnvironmentTenant(ctx, () =>
+        branchesService.checkHealth(branchId as BranchID, ctx.baseServiceParams)
+      );
       const envStatus = branch.environment_instance?.status;
       const isActive = envStatus === 'running' || envStatus === 'starting';
       const startedAt = isActive
@@ -131,7 +138,9 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
     async (args) => {
       const branchId = coerceString(args.branchId)!;
       const branchesService = ctx.app.service('branches') as unknown as BranchesServiceImpl;
-      const logsResult = await branchesService.getLogs(branchId as BranchID, ctx.baseServiceParams);
+      const logsResult = await runWithMcpEnvironmentTenant(ctx, () =>
+        branchesService.getLogs(branchId as BranchID, ctx.baseServiceParams)
+      );
       return textResult(logsResult);
     }
   );
@@ -230,10 +239,12 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         // uniformly. The error it throws is propagated by the outer catch
         // below.
 
-        const updated = await branchesService.renderEnvironment(
-          branchId as BranchID,
-          targetVariant ? { variant: targetVariant } : undefined,
-          ctx.baseServiceParams
+        const updated = await runWithMcpEnvironmentTenant(ctx, () =>
+          branchesService.renderEnvironment(
+            branchId as BranchID,
+            targetVariant ? { variant: targetVariant } : undefined,
+            ctx.baseServiceParams
+          )
         );
 
         if (!andStart) {
@@ -247,9 +258,8 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
         // The variant has now been persisted. If start fails, surface that
         // distinctly so callers know the configuration change DID land.
         try {
-          const started = await branchesService.startEnvironment(
-            branchId as BranchID,
-            ctx.baseServiceParams
+          const started = await runWithMcpEnvironmentTenant(ctx, () =>
+            branchesService.startEnvironment(branchId as BranchID, ctx.baseServiceParams)
           );
           return textResult({
             success: true,
@@ -302,9 +312,8 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
       const branchId = coerceString(args.branchId)!;
       const branchesService = ctx.app.service('branches') as unknown as BranchesServiceImpl;
       try {
-        const branch = await branchesService.nukeEnvironment(
-          branchId as BranchID,
-          ctx.baseServiceParams
+        const branch = await runWithMcpEnvironmentTenant(ctx, () =>
+          branchesService.nukeEnvironment(branchId as BranchID, ctx.baseServiceParams)
         );
         return textResult({
           success: true,

--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { ENVIRONMENT } from '@agor/core/config';
-import { getCurrentTenantId, tenantDatabaseScope } from '@agor/core/db';
+import { getCurrentTenantId, runWithTenantDatabaseScope } from '@agor/core/db';
 import type { Branch } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HealthMonitor } from './health-monitor';
@@ -140,6 +140,7 @@ describe('HealthMonitor tenant context', () => {
     const branches = new BranchServiceMock();
     const monitor = new HealthMonitor(makeApp(branches) as never, {
       defaultParams: { tenant: { tenant_id: 'default', source: 'static' } },
+      db: { run: vi.fn() } as never,
     });
 
     branches.emit(
@@ -163,7 +164,7 @@ describe('HealthMonitor tenant context', () => {
     monitor.cleanup();
   });
 
-  it('does not let health-check timers inherit the caller tenant DB scope', async () => {
+  it('enters the branch tenant DB scope instead of inheriting stale timer scope', async () => {
     const branches = new BranchServiceMock();
     const ambientTenantIds: Array<string | undefined> = [];
     branches.get.mockImplementation(async (branchId: string) => {
@@ -180,26 +181,24 @@ describe('HealthMonitor tenant context', () => {
 
     const monitor = new HealthMonitor(makeApp(branches) as never, {
       defaultParams: { tenant: { tenant_id: 'default', source: 'static' } },
+      db: { run: vi.fn() } as never,
     });
 
-    tenantDatabaseScope.run(
-      { kind: 'tenant', tenantId: 'stale-transaction', db: {} as never },
-      () => {
-        branches.emit(
-          'patched',
-          makeBranch({
-            branch_id: 'branch-tenant-a',
-            tenant_id: 'tenant-a',
-            environment_instance: { status: 'running' },
-          })
-        );
-      }
-    );
+    await runWithTenantDatabaseScope({ run: vi.fn() } as never, 'stale-transaction', async () => {
+      branches.emit(
+        'patched',
+        makeBranch({
+          branch_id: 'branch-tenant-a',
+          tenant_id: 'tenant-a',
+          environment_instance: { status: 'running' },
+        })
+      );
+    });
 
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(1));
 
-    expect(ambientTenantIds).toEqual([undefined, undefined]);
+    expect(ambientTenantIds).toEqual(['tenant-a', 'tenant-a']);
     monitor.cleanup();
   });
 });

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -217,22 +217,33 @@ export class HealthMonitor {
         return;
       }
 
-      // Get current branch state
-      const branch = await branchesService.get(branchId, params as never);
+      const runCheck = async () => {
+        // Get current branch state
+        const branch = await branchesService.get(branchId, params as never);
 
-      // Only check if still running or starting
-      const status = branch.environment_instance?.status;
-      if (status !== 'running' && status !== 'starting') {
-        // Silently stop monitoring (not an error - expected when env stops)
-        // Start/stop logs are already handled in handleBranchUpdate()
-        this.stopMonitoring(branchId);
-        return;
+        // Only check if still running or starting
+        const status = branch.environment_instance?.status;
+        if (status !== 'running' && status !== 'starting') {
+          // Silently stop monitoring (not an error - expected when env stops)
+          // Start/stop logs are already handled in handleBranchUpdate()
+          this.stopMonitoring(branchId);
+          return;
+        }
+
+        // Perform health check via the service method. This direct custom
+        // service call bypasses Feathers around hooks, so when the monitor has
+        // a db handle and tenant params, enter the same tenant DB/ALS scope the
+        // scheduler uses before mutating branch environment state and emitting
+        // realtime patches.
+        await branchesService.checkHealth(branchId, params as never);
+      };
+
+      const tenantId = params?.tenant?.tenant_id;
+      if (this.db && tenantId) {
+        await runWithTenantDatabaseScope(this.db, tenantId, runCheck);
+      } else {
+        await runCheck();
       }
-
-      // Perform health check via the service method
-      // This will update environment_instance and broadcast via WebSocket
-      // Logging is handled in checkHealth() method - only logs on state changes
-      await branchesService.checkHealth(branchId, params as never);
     } catch (error) {
       // If branch was deleted or not found, stop monitoring silently
       // This is expected when branches are deleted while health checks are in progress

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -711,6 +711,38 @@ describe('configureChannels tenant isolation', () => {
     expect(joins.has(tenantChannelName('tenant-b'))).toBe(false);
   });
 
+  it('joins tenant channel from login params when auth result has no tenant claim yet', () => {
+    const { app, handlers, joins } = makeChannelHarness();
+    configureChannels(app, {
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as never,
+        auth_claim: 'tenant_id',
+      },
+    });
+    const connection = { data: {} } as any;
+
+    handlers.get('login')?.(
+      {
+        user: { user_id: ALICE, email: 'alice@example.test' },
+        authentication: { payload: {} },
+      },
+      {
+        connection,
+        params: { tenant: { tenant_id: 'tenant-from-params', source: 'auth_claim' } },
+      }
+    );
+
+    expect(connection.tenant).toEqual({ tenant_id: 'tenant-from-params', source: 'auth_claim' });
+    expect(connection.data.tenant).toEqual({
+      tenant_id: 'tenant-from-params',
+      source: 'auth_claim',
+    });
+    expect(joins.get('authenticated')).toEqual([connection]);
+    expect(joins.get(tenantChannelName('tenant-from-params'))).toEqual([connection]);
+    expect(joins.get(tenantUserChannelName('tenant-from-params', ALICE))).toEqual([connection]);
+  });
+
   it('leaves tenant-scoped channels on logout', () => {
     const { app, handlers, leaves } = makeChannelHarness();
     configureChannels(app, {

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -786,7 +786,7 @@ export function createSocketIOConfig(
     // The io.on('connection') handler above only catches pre-authenticated sockets
     // (those with a handshake token). Most browser sockets authenticate AFTER connecting,
     // so we need to join the user room here when the login event fires.
-    app.on('login', (authResult: unknown, context: { connection?: unknown }) => {
+    app.on('login', (authResult: unknown, context: { connection?: unknown; params?: unknown }) => {
       if (!context.connection) return;
       const result = authResult as { user?: { user_id?: string } };
       const userId = result.user?.user_id;
@@ -852,7 +852,7 @@ export function configureChannels(
 
   // Join authenticated connections to the 'authenticated' channel
   // This is the only way to receive broadcast events
-  app.on('login', (authResult: unknown, context: { connection?: unknown }) => {
+  app.on('login', (authResult: unknown, context: { connection?: unknown; params?: unknown }) => {
     if (context.connection) {
       const result = authResult as {
         user?: { user_id?: string; email?: string; tenant_id?: string };
@@ -861,9 +861,20 @@ export function configureChannels(
       console.debug('✅ Login event fired:', result.user?.user_id, result.user?.email);
 
       const connection = context.connection as FeathersSocket & { tenant?: TenantContext };
+      const loginParams =
+        context.params && typeof context.params === 'object'
+          ? (context.params as {
+              tenant?: TenantContext;
+              tenant_id?: string;
+              headers?: Record<string, unknown>;
+            })
+          : undefined;
       const tenant = options.multiTenancy
         ? resolveTenantContext(options.multiTenancy, {
             params: {
+              tenant: loginParams?.tenant,
+              tenant_id: loginParams?.tenant_id,
+              headers: loginParams?.headers,
               user: result.user,
               authentication: { payload: result.authentication?.payload },
             },

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -37,7 +37,8 @@ const checks = [
     // Baseline of existing call sites. New occurrences should go through the
     // tenant-aware realtime facade instead of adding more raw emits/rooms.
     baseline: {
-      'apps/agor-daemon/src/register-hooks.ts': 11,
+      // Board custom-method hooks manually emit board events here; tracked as legacy raw emits.
+      'apps/agor-daemon/src/register-hooks.ts': 12,
       'apps/agor-daemon/src/register-services.ts': 12,
       'apps/agor-daemon/src/register-routes.ts': 19,
       'apps/agor-daemon/src/startup.ts': 1,
@@ -79,6 +80,9 @@ const checks = [
     patterns: [/\bsetImmediate\s*\(/g],
     baseline: {
       'apps/agor-daemon/src/utils/tenant-db-scope.ts': 1,
+      // Test-only event loop flushes.
+      'apps/agor-daemon/src/services/branches.test.ts': 1,
+      'apps/agor-daemon/src/utils/tenant-db-scope.test.ts': 1,
     },
   },
   {
@@ -97,6 +101,8 @@ const checks = [
       // the supported no-tenant path for guarded proxies.
       'apps/agor-daemon/src/health/db-probe.ts': 1,
       'apps/agor-daemon/src/health/routes.ts': 1,
+      // Widget action accepts the app db handle to instantiate tenant-scoped repositories.
+      'apps/agor-daemon/src/widgets/env-vars/index.ts': 1,
     },
   },
   {
@@ -112,7 +118,7 @@ const checks = [
       'packages/core/src/db/repositories/branches.ts': 1,
       'packages/core/src/db/repositories/knowledge.ts': 7,
       'packages/core/src/db/repositories/repos.ts': 3,
-      'packages/core/src/db/repositories/sessions.ts': 1,
+      'packages/core/src/db/repositories/sessions.ts': 2,
       'packages/core/src/db/repositories/schedules.ts': 1,
       'packages/core/src/seed/demo-fixtures.ts': 1,
       'apps/agor-daemon/src/services/scheduler.ts': 1,


### PR DESCRIPTION
## Summary
- run MCP environment tools inside the resolved tenant database/ALS scope before calling branch env custom methods
- run health-monitor checks inside the branch tenant database/ALS scope, matching scheduler-style background processing
- carry tenant context into MCP `baseServiceParams` and preserve login params during socket tenant-channel joins
- refresh multitenancy-boundary baselines with inline justifications for existing raw call sites so `pnpm check` passes

## Investigation
The persisted branch environment state updates, but env-related realtime patches are produced by custom/internal code paths (`branchesService.startEnvironment/checkHealth/updateEnvironment`) rather than ordinary Feathers REST/socket service methods. Those direct calls can bypass the tenant database around-hook that normally sets both DB tenant scope and the ambient tenant context used by realtime publish fallback.

Scheduler already handles this by doing discovery globally/static, then entering `runWithTenantDatabaseScope` per tenant before creating work. This PR applies the same pattern to health-monitor checks and MCP environment tool calls.

In static/single-tenant mode, the tenant id is still `default` and realtime is still published through `tenant:default`, so preserving tenant/ALS scope is still the correct invariant even though required-from-auth resolution is not involved.

## Tests
- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon exec vitest run src/services/health-monitor.test.ts src/mcp/tools/environment.test.ts src/mcp/server.test.ts src/setup/socketio.test.ts src/utils/realtime-publish.test.ts`
