### PR TITLE
fix(ui): stabilize session MCP popover updates

### DIFF
--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
@@ -1,0 +1,41 @@
+import type { MCPServer } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import { buildMcpServerOptions } from './MCPServerSelect';
+
+const server = (overrides: Partial<MCPServer>): MCPServer =>
+  ({
+    mcp_server_id: '11111111-2222-3333-4444-555555555555',
+    name: 'internal-name',
+    display_name: 'Friendly server',
+    transport: 'http',
+    enabled: true,
+    scope: 'global',
+    ...overrides,
+  }) as MCPServer;
+
+describe('buildMcpServerOptions', () => {
+  it('uses the friendly display name rather than the UUID', () => {
+    const options = buildMcpServerOptions([server({})]);
+    expect(options[0]?.label).toContain('Friendly server');
+    expect(options[0]?.label).not.toContain('11111111-2222');
+  });
+
+  it('keeps a selected disabled server labelled', () => {
+    const disabled = server({ enabled: false });
+    const options = buildMcpServerOptions([disabled], [disabled.mcp_server_id]);
+    expect(options).toEqual([
+      expect.objectContaining({
+        label: expect.stringContaining('Friendly server'),
+        value: disabled.mcp_server_id,
+        disabled: true,
+      }),
+    ]);
+  });
+
+  it('shows a clear short fallback for a selected server missing from hydration', () => {
+    const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    expect(buildMcpServerOptions([], [id])).toEqual([
+      { label: 'Unavailable MCP server (aaaaaaaa)', value: id, disabled: true },
+    ]);
+  });
+});

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
@@ -35,7 +35,7 @@ describe('buildMcpServerOptions', () => {
   it('shows a clear short fallback for a selected server missing from hydration', () => {
     const id = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     expect(buildMcpServerOptions([], [id])).toEqual([
-      { label: 'Unavailable MCP server (aaaaaaaa)', value: id, disabled: true },
+      { label: 'Unavailable MCP server (aaaaaaaabbbbccccddddeeee)', value: id, disabled: true },
     ]);
   });
 });

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
@@ -1,4 +1,4 @@
-import type { MCPServer } from '@agor-live/client';
+import { type MCPServer, shortId } from '@agor-live/client';
 import { Select, type SelectProps } from 'antd';
 
 export interface MCPServerSelectProps extends Omit<SelectProps, 'options'> {
@@ -11,15 +11,13 @@ export interface MCPServerSelectProps extends Omit<SelectProps, 'options'> {
 
 export function buildMcpServerOptions(mcpServers: MCPServer[], selectedIds: string[] = []) {
   const selected = new Set(selectedIds);
-  const compactId = (id: string) => id.slice(0, 8);
-
-  const options = mcpServers
+  const options: Array<{ label: string; value: string; disabled: boolean }> = mcpServers
     // Disabled servers cannot be newly attached, but must remain an option when
     // already selected. Otherwise Ant Select falls back to rendering the UUID.
     .filter((server) => server.enabled || selected.has(server.mcp_server_id))
     .map((server) => {
       const name =
-        server.display_name || server.name || `MCP server ${compactId(server.mcp_server_id)}`;
+        server.display_name || server.name || `MCP server ${shortId(server.mcp_server_id)}`;
       const authSuffix =
         server.auth?.type === 'oauth'
           ? ` · OAuth ${server.auth.oauth_mode === 'shared' ? '(shared)' : '(per-user)'}`
@@ -33,11 +31,11 @@ export function buildMcpServerOptions(mcpServers: MCPServer[], selectedIds: stri
       };
     });
 
-  const knownIds = new Set(mcpServers.map((server) => server.mcp_server_id));
+  const knownIds = new Set<string>(mcpServers.map((server) => server.mcp_server_id));
   for (const id of selectedIds) {
     if (!knownIds.has(id)) {
       options.push({
-        label: `Unavailable MCP server (${compactId(id)})`,
+        label: `Unavailable MCP server (${shortId(id)})`,
         value: id,
         disabled: true,
       });

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
@@ -9,6 +9,44 @@ export interface MCPServerSelectProps extends Omit<SelectProps, 'options'> {
   filterByScope?: 'global' | 'repo' | 'session';
 }
 
+export function buildMcpServerOptions(mcpServers: MCPServer[], selectedIds: string[] = []) {
+  const selected = new Set(selectedIds);
+  const compactId = (id: string) => id.slice(0, 8);
+
+  const options = mcpServers
+    // Disabled servers cannot be newly attached, but must remain an option when
+    // already selected. Otherwise Ant Select falls back to rendering the UUID.
+    .filter((server) => server.enabled || selected.has(server.mcp_server_id))
+    .map((server) => {
+      const name =
+        server.display_name || server.name || `MCP server ${compactId(server.mcp_server_id)}`;
+      const authSuffix =
+        server.auth?.type === 'oauth'
+          ? ` · OAuth ${server.auth.oauth_mode === 'shared' ? '(shared)' : '(per-user)'}`
+          : server.auth?.type === 'bearer' || server.auth?.token
+            ? ' · Token'
+            : '';
+      return {
+        label: `${name} (${server.transport})${authSuffix}`,
+        value: server.mcp_server_id,
+        disabled: !server.enabled,
+      };
+    });
+
+  const knownIds = new Set(mcpServers.map((server) => server.mcp_server_id));
+  for (const id of selectedIds) {
+    if (!knownIds.has(id)) {
+      options.push({
+        label: `Unavailable MCP server (${compactId(id)})`,
+        value: id,
+        disabled: true,
+      });
+    }
+  }
+
+  return options.sort((a, b) => a.label.localeCompare(b.label));
+}
+
 /**
  * Reusable MCP Server multi-select component
  *
@@ -31,25 +69,7 @@ export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
     ? mcpServers.filter((server) => server.scope === filterByScope)
     : mcpServers;
 
-  // Only show enabled servers
-  const enabledServers = filteredServers.filter((server) => server.enabled);
-
-  const options = enabledServers
-    .map((server) => {
-      const name = server.display_name || server.name;
-      const authSuffix =
-        server.auth?.type === 'oauth'
-          ? ` · OAuth ${server.auth.oauth_mode === 'shared' ? '(shared)' : '(per-user)'}`
-          : server.auth?.type === 'bearer' || server.auth?.token
-            ? ' · Token'
-            : '';
-      return {
-        label: `${name} (${server.transport})${authSuffix}`,
-        value: server.mcp_server_id,
-        disabled: !server.enabled,
-      };
-    })
-    .sort((a, b) => a.label.localeCompare(b.label));
+  const options = buildMcpServerOptions(filteredServers, value);
 
   return (
     <Select
@@ -58,6 +78,7 @@ export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
       allowClear
       showSearch
       optionFilterProp="label"
+      notFoundContent={mcpServers.length === 0 ? 'No MCP servers available' : 'No matching servers'}
       value={value}
       onChange={onChange}
       options={options}

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -90,7 +90,7 @@ export const SessionMcpFooterControl: React.FC<SessionMcpFooterControlProps> = (
           value={sessionMcpServerIds}
           onChange={handleChange}
           loading={saving}
-          disabled={!client}
+          disabled={!client || saving}
           style={{ width: '100%' }}
         />
 

--- a/apps/agor-ui/src/store/agorRealtimeActions.ts
+++ b/apps/agor-ui/src/store/agorRealtimeActions.ts
@@ -373,38 +373,9 @@ export function artifactRemoved(artifact: Artifact) {
   });
 }
 
-// ── Session ↔ MCP relationships ───────────────────────────────────────────--
-export function sessionMcpCreated(relationship: { session_id: string; mcp_server_id: string }) {
-  bumpRevision('sessionMcp');
-  setMap('sessionMcpServerIds', (prev) => {
-    const sessionMcpIds = prev.get(relationship.session_id) || [];
-    // Check if relationship already exists (duplicate event)
-    if (sessionMcpIds.includes(relationship.mcp_server_id)) return prev;
-
-    const next = new Map(prev);
-    next.set(relationship.session_id, [...sessionMcpIds, relationship.mcp_server_id]);
-    return next;
-  });
-}
-export function sessionMcpRemoved(relationship: { session_id: string; mcp_server_id: string }) {
-  bumpRevision('sessionMcp');
-  setMap('sessionMcpServerIds', (prev) => {
-    const sessionMcpIds = prev.get(relationship.session_id) || [];
-    const filtered = sessionMcpIds.filter((id) => id !== relationship.mcp_server_id);
-
-    // No change if MCP server wasn't in the list
-    if (filtered.length === sessionMcpIds.length) return prev;
-
-    const next = new Map(prev);
-    if (filtered.length > 0) {
-      next.set(relationship.session_id, filtered);
-    } else {
-      // Clean up empty arrays
-      next.delete(relationship.session_id);
-    }
-    return next;
-  });
-}
+// Re-export transport-neutral relationship actions so existing websocket
+// subscription wiring can keep using the realtime action namespace.
+export { sessionMcpCreated, sessionMcpRemoved } from './sessionMcpActions';
 
 // ── Board comments ────────────────────────────────────────────────────────--
 export function commentCreated(comment: BoardComment) {

--- a/apps/agor-ui/src/store/sessionMcpActions.ts
+++ b/apps/agor-ui/src/store/sessionMcpActions.ts
@@ -1,0 +1,37 @@
+/**
+ * Transport-neutral session ↔ MCP relationship store actions.
+ *
+ * REST mutation confirmations and websocket events both use these idempotent
+ * actions. Bumping the hydration revision ensures either transport racing an
+ * in-flight relationship snapshot causes that stale snapshot to be discarded.
+ */
+import { bumpRevision } from './agorHydration';
+import { type AgorState, agorStore } from './agorStore';
+
+const setMap: AgorState['setMap'] = (key, value) => agorStore.getState().setMap(key, value);
+
+export function sessionMcpCreated(relationship: { session_id: string; mcp_server_id: string }) {
+  bumpRevision('sessionMcp');
+  setMap('sessionMcpServerIds', (prev) => {
+    const sessionMcpIds = prev.get(relationship.session_id) || [];
+    if (sessionMcpIds.includes(relationship.mcp_server_id)) return prev;
+
+    const next = new Map(prev);
+    next.set(relationship.session_id, [...sessionMcpIds, relationship.mcp_server_id]);
+    return next;
+  });
+}
+
+export function sessionMcpRemoved(relationship: { session_id: string; mcp_server_id: string }) {
+  bumpRevision('sessionMcp');
+  setMap('sessionMcpServerIds', (prev) => {
+    const sessionMcpIds = prev.get(relationship.session_id) || [];
+    const filtered = sessionMcpIds.filter((id) => id !== relationship.mcp_server_id);
+    if (filtered.length === sessionMcpIds.length) return prev;
+
+    const next = new Map(prev);
+    if (filtered.length > 0) next.set(relationship.session_id, filtered);
+    else next.delete(relationship.session_id);
+    return next;
+  });
+}

--- a/apps/agor-ui/src/utils/sessionMcpServers.test.ts
+++ b/apps/agor-ui/src/utils/sessionMcpServers.test.ts
@@ -1,7 +1,7 @@
 import type { AgorClient } from '@agor-live/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { sessionMcpCreated } from '../store/agorRealtimeActions';
 import { agorStore } from '../store/agorStore';
+import { sessionMcpCreated } from '../store/sessionMcpActions';
 import { updateSessionMcpServers } from './sessionMcpServers';
 
 describe('updateSessionMcpServers', () => {

--- a/apps/agor-ui/src/utils/sessionMcpServers.test.ts
+++ b/apps/agor-ui/src/utils/sessionMcpServers.test.ts
@@ -1,0 +1,35 @@
+import type { AgorClient } from '@agor-live/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sessionMcpCreated } from '../store/agorRealtimeActions';
+import { agorStore } from '../store/agorStore';
+import { updateSessionMcpServers } from './sessionMcpServers';
+
+describe('updateSessionMcpServers', () => {
+  beforeEach(() => agorStore.getState().resetMaps());
+
+  it('updates the relationship store from successful REST responses without waiting for websocket events', async () => {
+    agorStore.getState().setMap('sessionMcpServerIds', new Map([['session-1', ['remove-me']]]));
+    const create = vi.fn().mockResolvedValue({});
+    const remove = vi.fn().mockResolvedValue({});
+    const client = { service: () => ({ create, remove }) } as unknown as AgorClient;
+
+    await updateSessionMcpServers(client, 'session-1', ['remove-me'], ['add-me']);
+
+    expect(create).toHaveBeenCalledWith({ mcpServerId: 'add-me' });
+    expect(remove).toHaveBeenCalledWith('remove-me');
+    expect(agorStore.getState().sessionMcpServerIds.get('session-1')).toEqual(['add-me']);
+  });
+
+  it('remains idempotent when the websocket event arrived before the REST response', async () => {
+    const create = vi.fn().mockImplementation(async () => {
+      sessionMcpCreated({ session_id: 'session-1', mcp_server_id: 'add-me' });
+    });
+    const client = {
+      service: () => ({ create, remove: vi.fn() }),
+    } as unknown as AgorClient;
+
+    await updateSessionMcpServers(client, 'session-1', [], ['add-me']);
+
+    expect(agorStore.getState().sessionMcpServerIds.get('session-1')).toEqual(['add-me']);
+  });
+});

--- a/apps/agor-ui/src/utils/sessionMcpServers.ts
+++ b/apps/agor-ui/src/utils/sessionMcpServers.ts
@@ -1,4 +1,5 @@
 import type { AgorClient } from '@agor-live/client';
+import { sessionMcpCreated, sessionMcpRemoved } from '../store/agorRealtimeActions';
 
 export async function updateSessionMcpServers(
   client: AgorClient,
@@ -12,9 +13,18 @@ export async function updateSessionMcpServers(
   await Promise.all([
     ...nextIds
       .filter((id) => !current.has(id))
-      .map((id) => client.service(`sessions/${sessionId}/mcp-servers`).create({ mcpServerId: id })),
+      .map(async (id) => {
+        await client.service(`sessions/${sessionId}/mcp-servers`).create({ mcpServerId: id });
+        // The REST response confirms persistence. Apply it immediately rather
+        // than making the UI depend on a subsequent websocket echo. The
+        // realtime action is idempotent, so the normal socket event is a no-op.
+        sessionMcpCreated({ session_id: sessionId, mcp_server_id: id });
+      }),
     ...currentIds
       .filter((id) => !next.has(id))
-      .map((id) => client.service(`sessions/${sessionId}/mcp-servers`).remove(id)),
+      .map(async (id) => {
+        await client.service(`sessions/${sessionId}/mcp-servers`).remove(id);
+        sessionMcpRemoved({ session_id: sessionId, mcp_server_id: id });
+      }),
   ]);
 }

--- a/apps/agor-ui/src/utils/sessionMcpServers.ts
+++ b/apps/agor-ui/src/utils/sessionMcpServers.ts
@@ -1,5 +1,5 @@
 import type { AgorClient } from '@agor-live/client';
-import { sessionMcpCreated, sessionMcpRemoved } from '../store/agorRealtimeActions';
+import { sessionMcpCreated, sessionMcpRemoved } from '../store/sessionMcpActions';
 
 export async function updateSessionMcpServers(
   client: AgorClient,


### PR DESCRIPTION
## Summary

- update the centralized session MCP relationship store immediately after successful REST mutations
- treat websocket relationship events as idempotent confirmation instead of the only UI update path
- prevent overlapping MCP selection mutations while an update is in flight
- preserve friendly labels for selected disabled servers and show a clear fallback for unavailable server metadata
- use canonical short IDs for fallback labels

## Root cause

The session MCP popover was controlled by `sessionMcpServerIds`, but successful add/remove requests relied exclusively on a later websocket event to update that store collection. If the event was delayed or missed during hydration or reconnect, the success toast appeared while the controlled selector retained stale values. Selected disabled or temporarily missing server metadata was also omitted from Select options, causing Ant Design to render raw IDs.

## Tests

- `pnpm i`
- `pnpm check`
- `pnpm --filter agor-ui test -- src/components/MCPServerSelect/MCPServerSelect.test.ts src/utils/sessionMcpServers.test.ts`

All checks pass.