### PR TITLE
perf(ui): mount heavy modals on demand

### DIFF
--- a/apps/agor-ui/src/components/ArchiveDeleteBranchModal/ArchiveDeleteBranchModal.tsx
+++ b/apps/agor-ui/src/components/ArchiveDeleteBranchModal/ArchiveDeleteBranchModal.tsx
@@ -15,6 +15,7 @@ interface ArchiveDeleteBranchModalProps {
     filesystemAction: 'preserved' | 'cleaned' | 'deleted';
   }) => void;
   onCancel: () => void;
+  afterClose?: () => void;
 }
 
 export const ArchiveDeleteBranchModal: React.FC<ArchiveDeleteBranchModalProps> = ({
@@ -25,6 +26,7 @@ export const ArchiveDeleteBranchModal: React.FC<ArchiveDeleteBranchModalProps> =
   initialMetadataAction = 'archive',
   onConfirm,
   onCancel,
+  afterClose,
 }) => {
   const [filesystemAction, setFilesystemAction] = useState<'preserved' | 'cleaned' | 'deleted'>(
     'cleaned'
@@ -51,6 +53,7 @@ export const ArchiveDeleteBranchModal: React.FC<ArchiveDeleteBranchModalProps> =
       open={open}
       onOk={handleOk}
       onCancel={onCancel}
+      afterClose={afterClose}
       okText={okText}
       okButtonProps={okButtonProps}
       cancelText="Cancel"

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -62,6 +62,30 @@ describe('BranchCard drag handle', () => {
     expect(onOpenTerminal).toHaveBeenCalledWith([], 'branch-1');
   });
 
+  it('mounts the archive modal on demand and removes it after close', async () => {
+    render(
+      <ConnectionProvider value={connected}>
+        <BranchCard
+          branch={branch}
+          repo={repo}
+          sessions={[]}
+          userById={new Map()}
+          client={null}
+          onArchiveOrDelete={vi.fn()}
+        />
+      </ConnectionProvider>
+    );
+
+    expect(screen.queryByText('Archive or Delete Branch')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTitle('Archive or delete branch'));
+    expect(await screen.findByText('Archive or Delete Branch')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() =>
+      expect(screen.queryByText('Archive or Delete Branch')).not.toBeInTheDocument()
+    );
+  });
+
   it('uses a darker primary background surface while a branch session is executing', async () => {
     const runningSession = {
       session_id: 'session-running',

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -127,6 +127,7 @@ const BranchCardComponent = ({
 
   // Archive/Delete modal state
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
+  const [archiveDeleteModalMounted, setArchiveDeleteModalMounted] = useState(false);
 
   // Notes expansion state
   const [notesExpanded, setNotesExpanded] = useState(false);
@@ -504,7 +505,10 @@ const BranchCardComponent = ({
               <ArchiveActionButton
                 tooltip="Archive or delete branch"
                 disabled={connectionDisabled}
-                onClick={() => setArchiveDeleteModalOpen(true)}
+                onClick={() => {
+                  setArchiveDeleteModalMounted(true);
+                  setArchiveDeleteModalOpen(true);
+                }}
               />
             )}
           </div>
@@ -626,9 +630,9 @@ const BranchCardComponent = ({
       )}
 
       {/* Branch cards are repeated across the canvas, so mount this only on demand. */}
-      {archiveDeleteModalOpen && (
+      {archiveDeleteModalMounted && (
         <ArchiveDeleteBranchModal
-          open
+          open={archiveDeleteModalOpen}
           branch={branch}
           sessionCount={sessions.length}
           environmentRunning={branch.environment_instance?.status === 'running'}
@@ -637,6 +641,7 @@ const BranchCardComponent = ({
             setArchiveDeleteModalOpen(false);
           }}
           onCancel={() => setArchiveDeleteModalOpen(false)}
+          afterClose={() => setArchiveDeleteModalMounted(false)}
         />
       )}
     </Card>

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -625,18 +625,20 @@ const BranchCardComponent = ({
         />
       )}
 
-      {/* Archive/Delete Modal */}
-      <ArchiveDeleteBranchModal
-        open={archiveDeleteModalOpen}
-        branch={branch}
-        sessionCount={sessions.length}
-        environmentRunning={branch.environment_instance?.status === 'running'}
-        onConfirm={(options) => {
-          onArchiveOrDelete?.(branch.branch_id, options);
-          setArchiveDeleteModalOpen(false);
-        }}
-        onCancel={() => setArchiveDeleteModalOpen(false)}
-      />
+      {/* Branch cards are repeated across the canvas, so mount this only on demand. */}
+      {archiveDeleteModalOpen && (
+        <ArchiveDeleteBranchModal
+          open
+          branch={branch}
+          sessionCount={sessions.length}
+          environmentRunning={branch.environment_instance?.status === 'running'}
+          onConfirm={(options) => {
+            onArchiveOrDelete?.(branch.branch_id, options);
+            setArchiveDeleteModalOpen(false);
+          }}
+          onCancel={() => setArchiveDeleteModalOpen(false)}
+        />
+      )}
     </Card>
   );
 };

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -1137,16 +1137,18 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           </div>
         )}
 
-        <ForkSpawnModal
-          open={forkSpawnModal.open}
-          action={forkSpawnModal.action}
-          session={forkSpawnModal.session}
-          currentUser={currentUserId ? userById.get(currentUserId) : undefined}
-          onConfirm={handleForkSpawnConfirm}
-          onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
-          client={client}
-          userById={userById}
-        />
+        {forkSpawnModal.open && (
+          <ForkSpawnModal
+            open
+            action={forkSpawnModal.action}
+            session={forkSpawnModal.session}
+            currentUser={currentUserId ? userById.get(currentUserId) : undefined}
+            onConfirm={handleForkSpawnConfirm}
+            onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
+            client={client}
+            userById={userById}
+          />
+        )}
       </>
     );
   }
@@ -1272,16 +1274,18 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         </>
       )}
 
-      <ForkSpawnModal
-        open={forkSpawnModal.open}
-        action={forkSpawnModal.action}
-        session={forkSpawnModal.session}
-        currentUser={currentUserId ? userById.get(currentUserId) : undefined}
-        onConfirm={handleForkSpawnConfirm}
-        onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
-        client={client}
-        userById={userById}
-      />
+      {forkSpawnModal.open && (
+        <ForkSpawnModal
+          open
+          action={forkSpawnModal.action}
+          session={forkSpawnModal.session}
+          currentUser={currentUserId ? userById.get(currentUserId) : undefined}
+          onConfirm={handleForkSpawnConfirm}
+          onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
+          client={client}
+          userById={userById}
+        />
+      )}
     </ConfigProvider>
   );
 };

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -437,6 +437,10 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     }
   };
 
+  const closeForkSpawnModal = () => setForkSpawnModal((current) => ({ ...current, open: false }));
+  const unmountForkSpawnModal = () =>
+    setForkSpawnModal({ open: false, action: 'fork', session: null });
+
   const handleArchiveSession = useCallback(
     (sessionId: string, e: React.MouseEvent) => {
       e.stopPropagation();
@@ -1137,14 +1141,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           </div>
         )}
 
-        {forkSpawnModal.open && (
+        {forkSpawnModal.session && (
           <ForkSpawnModal
-            open
+            open={forkSpawnModal.open}
             action={forkSpawnModal.action}
             session={forkSpawnModal.session}
             currentUser={currentUserId ? userById.get(currentUserId) : undefined}
             onConfirm={handleForkSpawnConfirm}
-            onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
+            onCancel={closeForkSpawnModal}
+            afterClose={unmountForkSpawnModal}
             client={client}
             userById={userById}
           />
@@ -1274,14 +1279,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         </>
       )}
 
-      {forkSpawnModal.open && (
+      {forkSpawnModal.session && (
         <ForkSpawnModal
-          open
+          open={forkSpawnModal.open}
           action={forkSpawnModal.action}
           session={forkSpawnModal.session}
           currentUser={currentUserId ? userById.get(currentUserId) : undefined}
           onConfirm={handleForkSpawnConfirm}
-          onCancel={() => setForkSpawnModal({ open: false, action: 'fork', session: null })}
+          onCancel={closeForkSpawnModal}
+          afterClose={unmountForkSpawnModal}
           client={client}
           userById={userById}
         />

--- a/apps/agor-ui/src/components/CardModal/CardModal.tsx
+++ b/apps/agor-ui/src/components/CardModal/CardModal.tsx
@@ -43,6 +43,7 @@ interface CardModalProps {
   zoneColor?: string;
   client: AgorClient | null;
   onClose: () => void;
+  afterClose?: () => void;
   onCardUpdated?: (card: CardWithType) => void;
   onCardDeleted?: (cardId: string) => void;
 }
@@ -55,6 +56,7 @@ const CardModalComponent = ({
   zoneColor,
   client,
   onClose,
+  afterClose,
   onCardUpdated,
   onCardDeleted,
 }: CardModalProps) => {
@@ -153,6 +155,7 @@ const CardModalComponent = ({
     <Modal
       open={open}
       onCancel={onClose}
+      afterClose={afterClose}
       width={560}
       footer={
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>

--- a/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
+++ b/apps/agor-ui/src/components/ForkSpawnModal/ForkSpawnModal.tsx
@@ -33,6 +33,7 @@ export interface ForkSpawnModalProps {
   mcpServerById?: Map<string, MCPServer>;
   initialPrompt?: string;
   onConfirm: (config: string | Partial<SpawnConfig>) => Promise<void>;
+  afterClose?: () => void;
   onCancel: () => void;
   client: AgorClient | null;
   userById: Map<string, User>;
@@ -46,6 +47,7 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
   mcpServerById = new Map(),
   initialPrompt = '',
   onConfirm,
+  afterClose,
   onCancel,
   client,
   userById,
@@ -203,6 +205,7 @@ export const ForkSpawnModal: React.FC<ForkSpawnModalProps> = ({
       open={open}
       onOk={handleOk}
       onCancel={handleCancel}
+      afterClose={afterClose}
       okText={`${actionLabel} Session`}
       confirmLoading={loading}
       width={700}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2990,9 +2990,9 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         )}
 
         {/* Card Detail Modal */}
-        {cardModalOpen && (
+        {selectedCard && (
           <CardModal
-            open
+            open={cardModalOpen}
             card={selectedCard}
             board={board}
             zoneName={
@@ -3018,14 +3018,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             client={client}
             onClose={() => {
               setCardModalOpen(false);
-              setSelectedCard(null);
             }}
+            afterClose={() => setSelectedCard(null)}
             onCardUpdated={(updatedCard) => {
               setSelectedCard(updatedCard);
             }}
             onCardDeleted={() => {
               setCardModalOpen(false);
-              setSelectedCard(null);
             }}
           />
         )}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -2990,43 +2990,45 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         )}
 
         {/* Card Detail Modal */}
-        <CardModal
-          open={cardModalOpen}
-          card={selectedCard}
-          board={board}
-          zoneName={
-            selectedCard
-              ? (() => {
-                  const bo = boardObjectByCard.get(selectedCard.card_id);
-                  return bo?.zone_id ? zoneLabels[bo.zone_id] || undefined : undefined;
-                })()
-              : undefined
-          }
-          zoneColor={
-            selectedCard
-              ? (() => {
-                  const bo = boardObjectByCard.get(selectedCard.card_id);
-                  if (!bo?.zone_id) return undefined;
-                  const zoneObj = board?.objects?.[bo.zone_id];
-                  return zoneObj && zoneObj.type === 'zone'
-                    ? zoneObj.borderColor || zoneObj.color
-                    : undefined;
-                })()
-              : undefined
-          }
-          client={client}
-          onClose={() => {
-            setCardModalOpen(false);
-            setSelectedCard(null);
-          }}
-          onCardUpdated={(updatedCard) => {
-            setSelectedCard(updatedCard);
-          }}
-          onCardDeleted={() => {
-            setCardModalOpen(false);
-            setSelectedCard(null);
-          }}
-        />
+        {cardModalOpen && (
+          <CardModal
+            open
+            card={selectedCard}
+            board={board}
+            zoneName={
+              selectedCard
+                ? (() => {
+                    const bo = boardObjectByCard.get(selectedCard.card_id);
+                    return bo?.zone_id ? zoneLabels[bo.zone_id] || undefined : undefined;
+                  })()
+                : undefined
+            }
+            zoneColor={
+              selectedCard
+                ? (() => {
+                    const bo = boardObjectByCard.get(selectedCard.card_id);
+                    if (!bo?.zone_id) return undefined;
+                    const zoneObj = board?.objects?.[bo.zone_id];
+                    return zoneObj && zoneObj.type === 'zone'
+                      ? zoneObj.borderColor || zoneObj.color
+                      : undefined;
+                  })()
+                : undefined
+            }
+            client={client}
+            onClose={() => {
+              setCardModalOpen(false);
+              setSelectedCard(null);
+            }}
+            onCardUpdated={(updatedCard) => {
+              setSelectedCard(updatedCard);
+            }}
+            onCardDeleted={() => {
+              setCardModalOpen(false);
+              setSelectedCard(null);
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
@@ -106,9 +106,7 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
       if (Object.keys(updates).length > 0) {
         onUpdate?.(editingArtifact.artifact_id, updates);
       }
-      form.resetFields();
       setEditModalOpen(false);
-      setEditingArtifact(null);
     });
   };
 
@@ -334,14 +332,16 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
         />
       )}
 
-      {editModalOpen && (
+      {editingArtifact && (
         <Modal
           title="Edit Artifact"
-          open
+          open={editModalOpen}
           onOk={handleUpdate}
           onCancel={() => {
-            form.resetFields();
             setEditModalOpen(false);
+          }}
+          afterClose={() => {
+            form.resetFields();
             setEditingArtifact(null);
           }}
           okText="Save"

--- a/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/ArtifactsTable.tsx
@@ -334,45 +334,47 @@ export const ArtifactsTable: React.FC<ArtifactsTableProps> = ({
         />
       )}
 
-      <Modal
-        title="Edit Artifact"
-        open={editModalOpen}
-        onOk={handleUpdate}
-        onCancel={() => {
-          form.resetFields();
-          setEditModalOpen(false);
-          setEditingArtifact(null);
-        }}
-        okText="Save"
-      >
-        <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
-          <Form.Item
-            label="Name"
-            name="name"
-            rules={[{ required: true, message: 'Please enter a name' }]}
-          >
-            <Input placeholder="My Artifact" />
-          </Form.Item>
-          <Form.Item label="Description" name="description">
-            <Input.TextArea rows={3} placeholder="Optional description" />
-          </Form.Item>
-          <Form.Item
-            label="Board"
-            name="board_id"
-            tooltip="Move this artifact to a different board. Its position on the board is preserved."
-            rules={[{ required: true, message: 'Please select a board' }]}
-          >
-            <Select
-              showSearch
-              placeholder="Select board..."
-              options={boardOptions}
-              filterOption={(input, option) =>
-                (option?.label?.toString() ?? '').toLowerCase().includes(input.toLowerCase())
-              }
-            />
-          </Form.Item>
-        </Form>
-      </Modal>
+      {editModalOpen && (
+        <Modal
+          title="Edit Artifact"
+          open
+          onOk={handleUpdate}
+          onCancel={() => {
+            form.resetFields();
+            setEditModalOpen(false);
+            setEditingArtifact(null);
+          }}
+          okText="Save"
+        >
+          <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+            <Form.Item
+              label="Name"
+              name="name"
+              rules={[{ required: true, message: 'Please enter a name' }]}
+            >
+              <Input placeholder="My Artifact" />
+            </Form.Item>
+            <Form.Item label="Description" name="description">
+              <Input.TextArea rows={3} placeholder="Optional description" />
+            </Form.Item>
+            <Form.Item
+              label="Board"
+              name="board_id"
+              tooltip="Move this artifact to a different board. Its position on the board is preserved."
+              rules={[{ required: true, message: 'Please select a board' }]}
+            >
+              <Select
+                showSearch
+                placeholder="Select board..."
+                options={boardOptions}
+                filterOption={(input, option) =>
+                  (option?.label?.toString() ?? '').toLowerCase().includes(input.toLowerCase())
+                }
+              />
+            </Form.Item>
+          </Form>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
@@ -504,44 +504,50 @@ export const CardsTable: React.FC<CardsTableProps> = ({
       </Layout>
 
       {/* Create CardType Modal */}
-      <Modal
-        title="Create Card Type"
-        open={createTypeModalOpen}
-        onOk={handleCreateType}
-        onCancel={() => {
-          form.resetFields();
-          setCreateTypeModalOpen(false);
-        }}
-        okText="Create"
-      >
-        {typeFormContent}
-      </Modal>
+      {createTypeModalOpen && (
+        <Modal
+          title="Create Card Type"
+          open
+          onOk={handleCreateType}
+          onCancel={() => {
+            form.resetFields();
+            setCreateTypeModalOpen(false);
+          }}
+          okText="Create"
+        >
+          {typeFormContent}
+        </Modal>
+      )}
 
       {/* Edit CardType Modal */}
-      <Modal
-        title="Edit Card Type"
-        open={editTypeModalOpen}
-        onOk={handleUpdateType}
-        onCancel={() => {
-          form.resetFields();
-          setEditTypeModalOpen(false);
-          setEditingType(null);
-        }}
-        okText="Save"
-      >
-        {typeFormContent}
-      </Modal>
+      {editTypeModalOpen && (
+        <Modal
+          title="Edit Card Type"
+          open
+          onOk={handleUpdateType}
+          onCancel={() => {
+            form.resetFields();
+            setEditTypeModalOpen(false);
+            setEditingType(null);
+          }}
+          okText="Save"
+        >
+          {typeFormContent}
+        </Modal>
+      )}
 
       {/* Card Detail Modal (reuse Phase 2 component) */}
-      <CardModal
-        open={!!cardModalCard}
-        card={cardModalCard}
-        board={cardModalBoard}
-        client={client}
-        onClose={() => setCardModalCard(null)}
-        onCardUpdated={handleCardUpdated}
-        onCardDeleted={handleCardDeleted}
-      />
+      {cardModalCard && (
+        <CardModal
+          open
+          card={cardModalCard}
+          board={cardModalBoard}
+          client={client}
+          onClose={() => setCardModalCard(null)}
+          onCardUpdated={handleCardUpdated}
+          onCardDeleted={handleCardDeleted}
+        />
+      )}
     </div>
   );
 };

--- a/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/CardsTable.tsx
@@ -55,9 +55,11 @@ export const CardsTable: React.FC<CardsTableProps> = ({
   // State
   const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null);
   const [createTypeModalOpen, setCreateTypeModalOpen] = useState(false);
+  const [createTypeModalMounted, setCreateTypeModalMounted] = useState(false);
   const [editTypeModalOpen, setEditTypeModalOpen] = useState(false);
   const [editingType, setEditingType] = useState<CardType | null>(null);
   const [cardModalCard, setCardModalCard] = useState<CardWithType | null>(null);
+  const [cardModalOpen, setCardModalOpen] = useState(false);
   const [typeSearchTerm, setTypeSearchTerm] = useState('');
   const [cardSearchTerm, setCardSearchTerm] = useState('');
   const [form] = Form.useForm();
@@ -132,7 +134,6 @@ export const CardsTable: React.FC<CardsTableProps> = ({
         color: colorValue || undefined,
         json_schema: values.json_schema ? JSON.parse(values.json_schema) : undefined,
       });
-      form.resetFields();
       setCreateTypeModalOpen(false);
       showSuccess('Card type created');
     } catch (err: unknown) {
@@ -156,9 +157,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
         color: colorValue || undefined,
         json_schema: values.json_schema ? JSON.parse(values.json_schema) : undefined,
       });
-      form.resetFields();
       setEditTypeModalOpen(false);
-      setEditingType(null);
       showSuccess('Card type updated');
     } catch (err: unknown) {
       if (err && typeof err === 'object' && 'errorFields' in err) return;
@@ -253,7 +252,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
   };
 
   const handleCardDeleted = (_cardId: string) => {
-    setCardModalCard(null);
+    setCardModalOpen(false);
   };
 
   // Type form content (shared between create and edit modals)
@@ -350,6 +349,7 @@ export const CardsTable: React.FC<CardsTableProps> = ({
               icon={<PlusOutlined />}
               onClick={() => {
                 form.resetFields();
+                setCreateTypeModalMounted(true);
                 setCreateTypeModalOpen(true);
               }}
             >
@@ -467,7 +467,10 @@ export const CardsTable: React.FC<CardsTableProps> = ({
                 size="small"
                 pagination={{ pageSize: 20, hideOnSinglePage: true }}
                 onRow={(record) => ({
-                  onClick: () => setCardModalCard(record),
+                  onClick: () => {
+                    setCardModalCard(record);
+                    setCardModalOpen(true);
+                  },
                   style: { cursor: 'pointer' },
                 })}
                 locale={{
@@ -504,14 +507,17 @@ export const CardsTable: React.FC<CardsTableProps> = ({
       </Layout>
 
       {/* Create CardType Modal */}
-      {createTypeModalOpen && (
+      {createTypeModalMounted && (
         <Modal
           title="Create Card Type"
-          open
+          open={createTypeModalOpen}
           onOk={handleCreateType}
           onCancel={() => {
-            form.resetFields();
             setCreateTypeModalOpen(false);
+          }}
+          afterClose={() => {
+            form.resetFields();
+            setCreateTypeModalMounted(false);
           }}
           okText="Create"
         >
@@ -520,14 +526,16 @@ export const CardsTable: React.FC<CardsTableProps> = ({
       )}
 
       {/* Edit CardType Modal */}
-      {editTypeModalOpen && (
+      {editingType && (
         <Modal
           title="Edit Card Type"
-          open
+          open={editTypeModalOpen}
           onOk={handleUpdateType}
           onCancel={() => {
-            form.resetFields();
             setEditTypeModalOpen(false);
+          }}
+          afterClose={() => {
+            form.resetFields();
             setEditingType(null);
           }}
           okText="Save"
@@ -539,11 +547,12 @@ export const CardsTable: React.FC<CardsTableProps> = ({
       {/* Card Detail Modal (reuse Phase 2 component) */}
       {cardModalCard && (
         <CardModal
-          open
+          open={cardModalOpen}
           card={cardModalCard}
           board={cardModalBoard}
           client={client}
-          onClose={() => setCardModalCard(null)}
+          onClose={() => setCardModalOpen(false)}
+          afterClose={() => setCardModalCard(null)}
           onCardUpdated={handleCardUpdated}
           onCardDeleted={handleCardDeleted}
         />

--- a/docs/internal/modal-rendering-audit-2026-07-10.md
+++ b/docs/internal/modal-rendering-audit-2026-07-10.md
@@ -1,0 +1,40 @@
+# UI modal rendering audit
+
+## Findings
+
+- The UI uses a mix of conditional rendering and always-mounted custom modal components with a
+  controlled `open` prop. Ant Design does not create a modal's portal contents before its first
+  open by default, but an eagerly rendered custom wrapper still runs its hooks, and modal contents
+  normally remain mounted after the first close unless destroyed.
+- Canvas zone configuration/deletion, artifact consent, environment logs, new-session, and several
+  session-canvas dialogs were already rendered only while their backing state exists.
+- Branch cards and their repeated session sections eagerly mounted archive and fork/spawn modal
+  wrappers for every card. Settings card/artifact tables and the canvas card-detail modal also kept
+  inactive modal trees mounted.
+- Some forms explicitly use `destroyOnHidden={false}`. Those retain inactive panel/form state on
+  purpose and were not changed.
+
+## Changes
+
+- Branch-card archive/delete and per-card fork/spawn modals now mount only when opened.
+- Canvas card details now mount only when a card is selected.
+- Card-type create/edit, settings card details, and artifact edit forms now mount on demand and
+  unmount on close. Their close handlers already reset the relevant form/selection state.
+- Added a focused branch-card regression test covering mount-on-open and removal-on-close.
+
+## Deliberately unchanged
+
+- App-level settings, user settings, onboarding, and other singleton controlled modals remain
+  declarative. They occur once rather than per canvas item, and changing their lifecycle could reset
+  intentionally retained navigation or draft state.
+- Confirmation APIs and lightweight singleton dialogs were left alone; they do not create repeated
+  hidden component trees.
+- Components with explicit state-retention comments or `destroyOnHidden={false}` were preserved.
+
+## Recommended convention
+
+For rare or heavy dialogs, especially within lists/canvas nodes, render the custom modal component
+only when open (`open && <FeatureModal open ... />`). This naturally removes wrapper hooks and form
+state on close. If the wrapper must remain mounted, use Ant Design's `destroyOnHidden` when state
+retention is not desired. Keep a modal mounted only when preserving a draft or expensive live
+resource is an intentional, documented behavior.

--- a/docs/internal/modal-rendering-audit-2026-07-10.md
+++ b/docs/internal/modal-rendering-audit-2026-07-10.md
@@ -35,8 +35,9 @@
 
 ## Recommended convention
 
-For rare or heavy dialogs, especially within lists/canvas nodes, render the custom modal component
-only when open (`open && <FeatureModal open ... />`). This naturally removes wrapper hooks and form
-state on close. If the wrapper must remain mounted, use Ant Design's `destroyOnHidden` when state
-retention is not desired. Keep a modal mounted only when preserving a draft or expensive live
-resource is an intentional, documented behavior.
+For rare or heavy dialogs, especially within lists/canvas nodes, keep separate mounted-entity and
+visibility state. Mount the custom modal on demand, pass its controlled `open` prop, set `open=false`
+to begin closing, and clear the mounted entity from `afterClose`. This avoids eager wrapper hooks and
+form state without bypassing Ant Design's exit motion or close lifecycle. If the wrapper must remain
+mounted, use Ant Design's `destroyOnHidden` when state retention is not desired. Keep a closed modal
+mounted only when preserving a draft or expensive live resource is intentional and documented.

--- a/docs/internal/modal-rendering-audit-2026-07-10.md
+++ b/docs/internal/modal-rendering-audit-2026-07-10.md
@@ -21,6 +21,8 @@
 - Card-type create/edit, settings card details, and artifact edit forms now mount on demand and
   unmount on close. Their close handlers already reset the relevant form/selection state.
 - Added a focused branch-card regression test covering mount-on-open and removal-on-close.
+- Modal wrappers stay mounted through Ant Design's exit motion and unmount from `afterClose`, so
+  render-on-open does not bypass the component's close lifecycle.
 
 ## Deliberately unchanged
 


### PR DESCRIPTION
# UI modal rendering audit

## Findings

- The UI uses a mix of conditional rendering and always-mounted custom modal components with a
  controlled `open` prop. Ant Design does not create a modal's portal contents before its first
  open by default, but an eagerly rendered custom wrapper still runs its hooks, and modal contents
  normally remain mounted after the first close unless destroyed.
- Canvas zone configuration/deletion, artifact consent, environment logs, new-session, and several
  session-canvas dialogs were already rendered only while their backing state exists.
- Branch cards and their repeated session sections eagerly mounted archive and fork/spawn modal
  wrappers for every card. Settings card/artifact tables and the canvas card-detail modal also kept
  inactive modal trees mounted.
- Some forms explicitly use `destroyOnHidden={false}`. Those retain inactive panel/form state on
  purpose and were not changed.

## Changes

- Branch-card archive/delete and per-card fork/spawn modals now mount only when opened.
- Canvas card details now mount only when a card is selected.
- Card-type create/edit, settings card details, and artifact edit forms now mount on demand and
  unmount on close. Their close handlers already reset the relevant form/selection state.
- Added a focused branch-card regression test covering mount-on-open and removal-on-close.

## Deliberately unchanged

- App-level settings, user settings, onboarding, and other singleton controlled modals remain
  declarative. They occur once rather than per canvas item, and changing their lifecycle could reset
  intentionally retained navigation or draft state.
- Confirmation APIs and lightweight singleton dialogs were left alone; they do not create repeated
  hidden component trees.
- Components with explicit state-retention comments or `destroyOnHidden={false}` were preserved.

## Recommended convention

For rare or heavy dialogs, especially within lists/canvas nodes, render the custom modal component
only when open (`open && <FeatureModal open ... />`). This naturally removes wrapper hooks and form
state on close. If the wrapper must remain mounted, use Ant Design's `destroyOnHidden` when state
retention is not desired. Keep a modal mounted only when preserving a draft or expensive live
resource is an intentional, documented behavior.
