### PR TITLE
feat(onboarding): thread persona into the AI-teammate bootstrap prompt (fast-follow to #1609)

### DIFF
--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -920,6 +920,7 @@ export const App: React.FC<AppProps> = ({
         description: result.description,
         userName: user?.name,
         userEmail: user?.email,
+        persona: user?.preferences?.onboarding?.persona,
       }),
       modelConfig: result.modelConfig,
       effort: result.effort,

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -27,6 +27,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { useAgorStore } from '../../store/agorStore';
 import { selectBoardById } from '../../store/selectors';
 import type { CreateRepoOptions } from '../../types';
+import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 import type { NewSessionConfig } from '../NewSessionModal/NewSessionModal';
 
@@ -50,32 +51,7 @@ const STEP_META: Record<WizardStep, { number: number; label: string; skippable: 
   done: { number: 5, label: "You're ready", skippable: false },
 };
 
-const PERSONAS = [
-  {
-    id: 'developer',
-    emoji: '🔨',
-    title: 'I write code',
-    desc: 'AI does the repetitive parts - I focus on what is actually hard.',
-  },
-  {
-    id: 'pm',
-    emoji: '📋',
-    title: 'I manage projects',
-    desc: "AI drafts, summarizes, and chases status so I don't have to.",
-  },
-  {
-    id: 'lead',
-    emoji: '🎯',
-    title: 'I lead a team',
-    desc: 'AI multiplies what my team can do. I set direction, it handles the rest.',
-  },
-  {
-    id: 'solo',
-    emoji: '⚡',
-    title: 'Building solo',
-    desc: 'AI is the rest of the team - research, writing, execution, all of it.',
-  },
-];
+const PERSONAS = ONBOARDING_PERSONAS;
 
 interface LlmOption {
   id: string;

--- a/apps/agor-ui/src/utils/onboardingPersonas.ts
+++ b/apps/agor-ui/src/utils/onboardingPersonas.ts
@@ -1,0 +1,45 @@
+/**
+ * Canonical onboarding persona profiles.
+ *
+ * Single source of truth for the onboarding wizard's persona cards and for the
+ * AI-teammate bootstrap prompt, so the label/description a user picks in
+ * onboarding is the same text the teammate is told about. The `id` is the
+ * stable value persisted to `user.preferences.onboarding.persona`.
+ */
+export interface OnboardingPersona {
+  id: string;
+  emoji: string;
+  title: string;
+  desc: string;
+}
+
+export const ONBOARDING_PERSONAS: OnboardingPersona[] = [
+  {
+    id: 'developer',
+    emoji: '🔨',
+    title: 'I write code',
+    desc: 'AI does the repetitive parts - I focus on what is actually hard.',
+  },
+  {
+    id: 'pm',
+    emoji: '📋',
+    title: 'I manage projects',
+    desc: "AI drafts, summarizes, and chases status so I don't have to.",
+  },
+  {
+    id: 'lead',
+    emoji: '🎯',
+    title: 'I lead a team',
+    desc: 'AI multiplies what my team can do. I set direction, it handles the rest.',
+  },
+  {
+    id: 'solo',
+    emoji: '⚡',
+    title: 'Building solo',
+    desc: 'AI is the rest of the team - research, writing, execution, all of it.',
+  },
+];
+
+export function findOnboardingPersona(id?: string | null): OnboardingPersona | undefined {
+  return id ? ONBOARDING_PERSONAS.find((persona) => persona.id === id) : undefined;
+}

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -43,6 +43,20 @@ describe('buildTeammateBootstrapPrompt', () => {
     expect(prompt).not.toContain('AI teammate description:');
     expect(prompt).not.toContain('- User:');
     expect(prompt).not.toContain('- User email:');
+    expect(prompt).not.toContain('- User persona:');
     expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
+  });
+
+  it('adds a persona line with the id (plus title when known) and dumps unknown ids raw', () => {
+    const known = buildTeammateBootstrapPrompt({ displayName: 'Board Bot', persona: 'developer' });
+    expect(known).toContain('- User persona: developer (I write code)');
+
+    // an id not in ONBOARDING_PERSONAS still flows through, without a title suffix
+    const unknown = buildTeammateBootstrapPrompt({
+      displayName: 'Board Bot',
+      persona: 'architect',
+    });
+    expect(unknown).toContain('- User persona: architect');
+    expect(unknown).not.toContain('architect (');
   });
 });

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -1,9 +1,13 @@
+import { findOnboardingPersona } from './onboardingPersonas';
+
 export interface TeammateBootstrapPromptInput {
   displayName: string;
   emoji?: string | null;
   description?: string | null;
   userName?: string | null;
   userEmail?: string | null;
+  /** Onboarding persona id (see ONBOARDING_PERSONAS); shapes how the teammate introduces itself. */
+  persona?: string | null;
 }
 
 export interface TeammateBootstrapPromptContext {
@@ -16,6 +20,7 @@ export interface TeammateBootstrapPromptContext {
     name?: string;
     email?: string;
   };
+  persona?: { id: string; title?: string };
   firstSession: true;
 }
 
@@ -39,6 +44,11 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
     lines.push(`- User email: ${context.user.email}`);
   }
 
+  if (context.persona) {
+    const suffix = context.persona.title ? ` (${context.persona.title})` : '';
+    lines.push(`- User persona: ${context.persona.id}${suffix}`);
+  }
+
   lines.push('');
   lines.push(
     'Read BOOTSTRAP.md, then say hello and ask only the next useful questions to shape this AI teammate.'
@@ -53,9 +63,12 @@ export function buildTeammateBootstrapPromptContext({
   description,
   userName,
   userEmail,
+  persona,
 }: TeammateBootstrapPromptInput): TeammateBootstrapPromptContext {
   const normalizedUserName = userName?.trim();
   const normalizedUserEmail = userEmail?.trim();
+  const personaId = persona?.trim();
+  const personaProfile = findOnboardingPersona(personaId);
 
   return {
     teammate: {
@@ -70,6 +83,9 @@ export function buildTeammateBootstrapPromptContext({
             ...(normalizedUserEmail ? { email: normalizedUserEmail } : {}),
           },
         }
+      : {}),
+    ...(personaId
+      ? { persona: { id: personaId, ...(personaProfile ? { title: personaProfile.title } : {}) } }
       : {}),
     firstSession: true,
   };

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -360,6 +360,8 @@ export interface EventStreamPreferences {
  * Per-user onboarding state (stored in user.preferences)
  */
 export interface OnboardingState {
+  /** Onboarding persona id the user selected (see ONBOARDING_PERSONAS in agor-ui). */
+  persona?: string;
   /** Which path the user took */
   path?: 'teammate' | 'own-repo';
   /** The repo ID associated with this onboarding (framework repo or user's repo) */


### PR DESCRIPTION
**Draft / fast-follow — stacked on #1609** (base is `onboarding-redesign`; retarget to `main` + rebase once #1609 lands).

## Why
Onboarding captures a **persona** (developer / pm / lead / solo). After the redesign it only drives the step-3 integration recommendations and is saved to `user.preferences.onboarding.persona` — but **nothing reads it back**, so the AI teammate that gets bootstrapped later (via `handleCreateTeammate`) has no idea what the user's role is. This closes that gap on the Agor side.

## What
- **`onboardingPersonas.ts` (new):** hoists the 4 persona profiles to a single source of truth. The wizard's cards and the bootstrap prompt now read the same `id / title / desc` (no drift).
- **`OnboardingState.persona`:** types the field onboarding already persists (it was being written through an untyped `Record<string, unknown>`).
- **`buildTeammateBootstrapPrompt`:** accepts `persona` and adds one context line that leads with the **stable id** so `agor-teammate` can key off it, enriched with the human title when the id is known:
  > `- User persona: developer (I write code)`

  An id not in the map still flows through (no title suffix); absent persona adds nothing. Covered by tests.
- **`handleCreateTeammate`:** passes `user.preferences.onboarding.persona`, so **every** teammate the user bootstraps carries it.

## Follow-up (not in this PR)
Per Max in the #1609 thread: dumping the persona name is enough on this side — the behavior lives in **[`preset-io/agor-teammate`](https://github.com/preset-io/agor-teammate)** (the framework, renamed from `agor-assistant`), which will branch on this line to do the right thing. Also open: whether finishing onboarding should auto-seed a persona-tailored teammate (the redesign decoupled onboarding from teammate creation).

## Checks
`tsc -b` clean, biome clean, `teammateBootstrapPrompt` + `OnboardingWizard` suites green. No behavior change when persona is absent.