### PR TITLE
feat(gateway): ingest inbound Slack text/log attachments (#1718)

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -768,7 +768,7 @@ const slackManifestGenerateSchema = z.strictObject({
     .boolean()
     .default(false)
     .describe(
-      'Ingest images attached to inbound messages (adds the files:read scope). The gateway downloads them server-side and hands the stored paths to the session agent.'
+      'Ingest images and text files attached to inbound messages (adds the files:read scope). The gateway downloads them server-side and hands the stored paths to the session agent.'
     ),
   threadHistory: z
     .boolean()

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -9,7 +9,7 @@ import { getConnector } from '@agor/core/gateway';
 import type { GatewayChannel, SessionID, ThreadSessionMap, User, UserID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ingestInboundImageAttachments } from '../utils/gateway-attachments.js';
+import { ingestInboundAttachments } from '../utils/gateway-attachments.js';
 import { GatewayService, tenantIdFromGatewayChannel } from './gateway.js';
 
 vi.mock('@agor/core/gateway', async (importOriginal) => {
@@ -24,7 +24,7 @@ vi.mock('../utils/gateway-attachments.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/gateway-attachments.js')>();
   return {
     ...actual,
-    ingestInboundImageAttachments: vi.fn(),
+    ingestInboundAttachments: vi.fn(),
   };
 });
 
@@ -147,7 +147,7 @@ function makeGatewayHarness(args: {
 
 afterEach(() => {
   vi.mocked(getConnector).mockReset();
-  vi.mocked(ingestInboundImageAttachments).mockReset();
+  vi.mocked(ingestInboundAttachments).mockReset();
 });
 
 describe('gateway tenant metadata helpers', () => {
@@ -848,7 +848,7 @@ describe('GatewayService Slack attachment ingestion', () => {
   };
 
   it('downloads image attachments and folds the stored paths into the prompt', async () => {
-    vi.mocked(ingestInboundImageAttachments).mockResolvedValue({
+    vi.mocked(ingestInboundAttachments).mockResolvedValue({
       paths: ['/home/agor/.agor/uploads/screenshot_1.png'],
       failed: 0,
     });
@@ -867,7 +867,7 @@ describe('GatewayService Slack attachment ingestion', () => {
     });
 
     expect(result).toMatchObject({ success: true, sessionId: 'sess-1' });
-    expect(ingestInboundImageAttachments).toHaveBeenCalledWith({
+    expect(ingestInboundAttachments).toHaveBeenCalledWith({
       files: inboundFiles,
       botToken: 'xoxb-test',
     });
@@ -891,14 +891,14 @@ describe('GatewayService Slack attachment ingestion', () => {
       metadata: dmMetadata,
     });
 
-    expect(ingestInboundImageAttachments).not.toHaveBeenCalled();
+    expect(ingestInboundAttachments).not.toHaveBeenCalled();
     const prompt = promptCreate.mock.calls[0][0].prompt as string;
     expect(prompt).toContain('what does this screenshot show?');
     expect(prompt).not.toContain('Attached files:');
   });
 
   it('delivers the prompt with a degradation note when downloads fail', async () => {
-    vi.mocked(ingestInboundImageAttachments).mockResolvedValue({ paths: [], failed: 1 });
+    vi.mocked(ingestInboundAttachments).mockResolvedValue({ paths: [], failed: 1 });
     const { service, promptCreate } = makeGatewayHarness({
       channel: ingestChannel,
       existingMapping: makeMapping({ thread_id: 'D123-100.000000' }),
@@ -921,7 +921,7 @@ describe('GatewayService Slack attachment ingestion', () => {
   });
 
   it('folds successful paths and appends the note when only some downloads fail', async () => {
-    vi.mocked(ingestInboundImageAttachments).mockResolvedValue({
+    vi.mocked(ingestInboundAttachments).mockResolvedValue({
       paths: ['/home/agor/.agor/uploads/ok_1.png'],
       failed: 1,
     });

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -65,7 +65,7 @@ import { getSessionUrl } from '@agor/core/utils/url';
 import { hasBranchPermission } from '../utils/branch-authorization.js';
 import {
   buildPromptWithAttachments,
-  ingestInboundImageAttachments,
+  ingestInboundAttachments,
 } from '../utils/gateway-attachments.js';
 import { deferWithTenantDatabaseScope } from '../utils/tenant-db-scope.js';
 
@@ -2196,8 +2196,8 @@ export class GatewayService {
         promptText = buildGitHubInitialPrompt(data.thread_id, data.text, data.metadata);
       }
 
-      // Download Slack image attachments server-side and fold their stored
-      // paths into the prompt so the agent can Read them. Gated on the
+      // Download Slack image and text attachments server-side and fold their
+      // stored paths into the prompt so the agent can Read them. Gated on the
       // channel's ingest_files flag — channels without the files:read scope
       // never attempt downloads. Any failure degrades to a short note; the
       // prompt is always delivered.
@@ -2211,7 +2211,7 @@ export class GatewayService {
           typeof channelConfig.bot_token === 'string' ? channelConfig.bot_token : undefined;
         let failedAttachments = 0;
         if (botToken) {
-          const { paths, failed } = await ingestInboundImageAttachments({
+          const { paths, failed } = await ingestInboundAttachments({
             files: data.files,
             botToken,
           });

--- a/apps/agor-daemon/src/utils/gateway-attachments.test.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.test.ts
@@ -5,9 +5,9 @@ import type { InboundFile } from '@agor/core/gateway';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildPromptWithAttachments,
-  ingestInboundImageAttachments,
+  ingestInboundAttachments,
   isAllowedSlackFileUrl,
-  isIngestableImageFile,
+  isIngestableFile,
 } from './gateway-attachments.js';
 import { MAX_UPLOAD_FILE_SIZE } from './upload.js';
 
@@ -46,16 +46,30 @@ describe('isAllowedSlackFileUrl', () => {
   });
 });
 
-describe('isIngestableImageFile', () => {
+describe('isIngestableFile', () => {
   it('accepts allowlisted image types and normalizes mime parameters', () => {
-    expect(isIngestableImageFile(makeFile({ mimetype: 'image/png' }))).toBe(true);
-    expect(isIngestableImageFile(makeFile({ mimetype: 'IMAGE/JPEG; charset=binary' }))).toBe(true);
+    expect(isIngestableFile(makeFile({ mimetype: 'image/png' }))).toBe(true);
+    expect(isIngestableFile(makeFile({ mimetype: 'IMAGE/JPEG; charset=binary' }))).toBe(true);
   });
 
-  it('rejects non-image and non-allowlisted types', () => {
-    expect(isIngestableImageFile(makeFile({ mimetype: 'application/pdf' }))).toBe(false);
-    expect(isIngestableImageFile(makeFile({ mimetype: 'image/svg+xml' }))).toBe(false);
-    expect(isIngestableImageFile(makeFile({ mimetype: 'text/html' }))).toBe(false);
+  it('accepts allowlisted text-like types', () => {
+    expect(isIngestableFile(makeFile({ mimetype: 'text/plain' }))).toBe(true);
+    expect(isIngestableFile(makeFile({ mimetype: 'text/csv' }))).toBe(true);
+    expect(isIngestableFile(makeFile({ mimetype: 'text/markdown' }))).toBe(true);
+    expect(isIngestableFile(makeFile({ mimetype: 'application/json' }))).toBe(true);
+    expect(isIngestableFile(makeFile({ mimetype: 'Text/Plain; charset=utf-8' }))).toBe(true);
+  });
+
+  it('rejects non-allowlisted types', () => {
+    expect(isIngestableFile(makeFile({ mimetype: 'image/svg+xml' }))).toBe(false);
+    expect(isIngestableFile(makeFile({ mimetype: 'text/html' }))).toBe(false);
+    expect(isIngestableFile(makeFile({ mimetype: 'application/x-sh' }))).toBe(false);
+    expect(isIngestableFile(makeFile({ mimetype: 'application/xml' }))).toBe(false);
+  });
+
+  it('rejects allowlisted types outside the image/text ingest scope', () => {
+    expect(isIngestableFile(makeFile({ mimetype: 'application/pdf' }))).toBe(false);
+    expect(isIngestableFile(makeFile({ mimetype: 'application/zip' }))).toBe(false);
   });
 });
 
@@ -83,7 +97,7 @@ describe('buildPromptWithAttachments', () => {
   });
 });
 
-describe('ingestInboundImageAttachments', () => {
+describe('ingestInboundAttachments', () => {
   let uploadDir: string;
 
   beforeEach(async () => {
@@ -99,7 +113,7 @@ describe('ingestInboundImageAttachments', () => {
     const bytes = new Uint8Array([137, 80, 78, 71]);
     const fetchImpl = vi.fn(async () => makeImageResponse(bytes));
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile()],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -117,10 +131,39 @@ describe('ingestInboundImageAttachments', () => {
     expect(new Uint8Array(await fs.readFile(result.paths[0]))).toEqual(bytes);
   });
 
-  it('ignores non-image attachments without counting them as failures', async () => {
+  it('downloads a text attachment and stores it in the upload dir', async () => {
+    const body = 'ts,level,message\n1,error,boom\n';
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/csv; charset=utf-8' },
+        })
+    );
+
+    const result = await ingestInboundAttachments({
+      files: [
+        makeFile({
+          name: 'errors.csv',
+          mimetype: 'text/csv',
+          url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/errors.csv',
+        }),
+      ],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result.failed).toBe(0);
+    expect(result.paths).toHaveLength(1);
+    expect(path.basename(result.paths[0])).toMatch(/^F123_errors_\d+\.csv$/);
+    expect(await fs.readFile(result.paths[0], 'utf8')).toBe(body);
+  });
+
+  it('ignores non-ingestable attachments without counting them as failures', async () => {
     const fetchImpl = vi.fn();
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile({ mimetype: 'application/pdf', name: 'doc.pdf' })],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -135,7 +178,7 @@ describe('ingestInboundImageAttachments', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const fetchImpl = vi.fn();
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile({ url_private_download: 'https://evil.example.com/a.png' })],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -151,7 +194,7 @@ describe('ingestInboundImageAttachments', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const fetchImpl = vi.fn();
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile({ size: MAX_UPLOAD_FILE_SIZE + 1 })],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -172,7 +215,7 @@ describe('ingestInboundImageAttachments', () => {
         })
     );
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile()],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -200,7 +243,7 @@ describe('ingestInboundImageAttachments', () => {
       )
       .mockResolvedValueOnce(makeImageResponse(bytes));
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile()],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -220,7 +263,7 @@ describe('ingestInboundImageAttachments', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const chunkSize = 1024 * 1024;
     let chunksPulled = 0;
-    // Endless image stream with no Content-Length: if the implementation
+    // Endless text stream with no Content-Length: if the implementation
     // buffered before checking, this test would never terminate.
     const endlessBody = new ReadableStream<Uint8Array>({
       pull(controller) {
@@ -232,12 +275,12 @@ describe('ingestInboundImageAttachments', () => {
       async () =>
         new Response(endlessBody, {
           status: 200,
-          headers: { 'content-type': 'image/png' },
+          headers: { 'content-type': 'text/plain' },
         })
     );
 
-    const result = await ingestInboundImageAttachments({
-      files: [makeFile()],
+    const result = await ingestInboundAttachments({
+      files: [makeFile({ name: 'server.log', mimetype: 'text/plain' })],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
       uploadDir,
@@ -259,8 +302,29 @@ describe('ingestInboundImageAttachments', () => {
         })
     );
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile()],
+      botToken: 'xoxb-test',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      uploadDir,
+    });
+
+    expect(result).toEqual({ paths: [], failed: 1 });
+    expect(await fs.readdir(uploadDir)).toEqual([]);
+  });
+
+  it('rejects response bodies whose type is allowlisted but outside the ingest scope', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('%PDF-1.4', {
+          status: 200,
+          headers: { 'content-type': 'application/pdf' },
+        })
+    );
+
+    const result = await ingestInboundAttachments({
+      files: [makeFile({ name: 'report.txt', mimetype: 'text/plain' })],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
       uploadDir,
@@ -273,7 +337,7 @@ describe('ingestInboundImageAttachments', () => {
   it('stores same-named files with distinct Slack IDs at distinct paths', async () => {
     const fetchImpl = vi.fn(async () => makeImageResponse(new Uint8Array([1])));
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile({ id: 'F1', name: 'image.png' }), makeFile({ id: 'F2', name: 'image.png' })],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -296,7 +360,7 @@ describe('ingestInboundImageAttachments', () => {
         })
     );
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [makeFile()],
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,
@@ -314,7 +378,7 @@ describe('ingestInboundImageAttachments', () => {
       .mockRejectedValueOnce(new Error('network down'))
       .mockResolvedValueOnce(makeImageResponse(bytes));
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files: [
         makeFile({ id: 'F1', name: 'first.png' }),
         makeFile({ id: 'F2', name: 'second.png' }),
@@ -337,7 +401,7 @@ describe('ingestInboundImageAttachments', () => {
       makeFile({ id: `F${i}`, name: `img-${i}.png` })
     );
 
-    const result = await ingestInboundImageAttachments({
+    const result = await ingestInboundAttachments({
       files,
       botToken: 'xoxb-test',
       fetchImpl: fetchImpl as unknown as typeof fetch,

--- a/apps/agor-daemon/src/utils/gateway-attachments.ts
+++ b/apps/agor-daemon/src/utils/gateway-attachments.ts
@@ -1,14 +1,16 @@
 /**
  * Server-side ingestion of inbound gateway message attachments.
  *
- * Downloads image files attached to inbound Slack messages using the
- * channel's bot token and stores them in the daemon upload directory — the
- * same destination the session composer's `/sessions/:sessionId/upload`
- * route writes to — so the session's agent can Read them by absolute path.
+ * Downloads image and text-like files attached to inbound Slack messages
+ * using the channel's bot token and stores them in the daemon upload
+ * directory — the same destination the session composer's
+ * `/sessions/:sessionId/upload` route writes to — so the session's agent can
+ * Read them by absolute path.
  *
- * Non-image attachments are out of scope and never downloaded. Downloads are
- * restricted to Slack-owned hosts and to the same per-file size / per-message
- * count ceilings the upload route enforces.
+ * Other attachment types (PDFs, office documents, archives, media) are out of
+ * scope and never downloaded. Downloads are restricted to Slack-owned hosts
+ * and to the same per-file size / per-message count ceilings the upload route
+ * enforces.
  */
 
 import fs from 'node:fs/promises';
@@ -25,7 +27,7 @@ import {
 export interface AttachmentIngestResult {
   /** Absolute paths of stored files, in the order the attachments arrived. */
   paths: string[];
-  /** Image attachments that could not be fetched or stored. */
+  /** Ingestable attachments that could not be fetched or stored. */
   failed: number;
 }
 
@@ -49,18 +51,22 @@ export function isAllowedSlackFileUrl(rawUrl: string): boolean {
 }
 
 /**
- * Image MIME types the upload pipeline accepts — membership in the upload
- * route's allowlist, which deliberately excludes script-bearing image types
- * like image/svg+xml.
+ * MIME types the ingestion pipeline accepts: images and text-like files
+ * (logs, plain text, CSV, JSON, markdown) agents use as context. Constrained
+ * to the upload route's allowlist, which deliberately excludes script-bearing
+ * types like image/svg+xml; the image/text prefix check additionally keeps
+ * allowlisted-but-unsupported types (PDFs, office documents, archives) out of
+ * ingestion.
  */
-function isAllowedImageMime(rawMime: string): boolean {
+function isAllowedIngestMime(rawMime: string): boolean {
   const mime = rawMime.split(';')[0].trim().toLowerCase();
-  return mime.startsWith('image/') && ALLOWED_UPLOAD_MIME_TYPES.has(mime);
+  if (!ALLOWED_UPLOAD_MIME_TYPES.has(mime)) return false;
+  return mime.startsWith('image/') || mime.startsWith('text/') || mime === 'application/json';
 }
 
-/** Image attachments the upload pipeline accepts (same allowlist as the upload route). */
-export function isIngestableImageFile(file: InboundFile): boolean {
-  return isAllowedImageMime(file.mimetype);
+/** Image and text-like attachments the ingestion pipeline accepts. */
+export function isIngestableFile(file: InboundFile): boolean {
+  return isAllowedIngestMime(file.mimetype);
 }
 
 /**
@@ -141,12 +147,12 @@ async function readBodyWithLimit(response: Response, maxBytes: number): Promise<
 }
 
 /**
- * Download the image attachments of one inbound message and store them in the
- * upload directory. Never throws: every attachment that cannot be fetched,
- * validated, or written is counted in `failed` so the caller can still
- * deliver the prompt with a degradation note.
+ * Download the ingestable attachments of one inbound message and store them
+ * in the upload directory. Never throws: every attachment that cannot be
+ * fetched, validated, or written is counted in `failed` so the caller can
+ * still deliver the prompt with a degradation note.
  */
-export async function ingestInboundImageAttachments(args: {
+export async function ingestInboundAttachments(args: {
   files: InboundFile[];
   botToken: string;
   fetchImpl?: typeof fetch;
@@ -155,15 +161,15 @@ export async function ingestInboundImageAttachments(args: {
   const fetchImpl = args.fetchImpl ?? fetch;
   const uploadDir = args.uploadDir ?? getUploadDirectory();
 
-  const images = args.files.filter(isIngestableImageFile);
+  const ingestable = args.files.filter(isIngestableFile);
   const paths: string[] = [];
   let failed = 0;
 
-  for (const [index, file] of images.entries()) {
+  for (const [index, file] of ingestable.entries()) {
     if (index >= MAX_UPLOAD_FILES_PER_REQUEST) {
       failed++;
       console.warn(
-        `[gateway] Skipping attachment "${file.name}": message exceeds ${MAX_UPLOAD_FILES_PER_REQUEST}-image limit`
+        `[gateway] Skipping attachment "${file.name}": message exceeds ${MAX_UPLOAD_FILES_PER_REQUEST}-file limit`
       );
       continue;
     }
@@ -190,11 +196,11 @@ export async function ingestInboundImageAttachments(args: {
         throw new Error(`HTTP ${response.status}`);
       }
       // Slack answers with an HTML login/error page (status 200) when the
-      // token lacks files:read or cannot see the file — only accept images
-      // from the same allowlist the upload route enforces (which excludes
-      // script-bearing types like image/svg+xml).
+      // token lacks files:read or cannot see the file — only accept response
+      // bodies whose type the ingestion pipeline allows (which excludes
+      // text/html and script-bearing types like image/svg+xml).
       const contentType = response.headers.get('content-type') ?? '';
-      if (!isAllowedImageMime(contentType)) {
+      if (!isAllowedIngestMime(contentType)) {
         throw new Error(
           `unexpected content-type ${contentType.split(';')[0].trim().toLowerCase() || 'unknown'}`
         );

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -944,11 +944,11 @@ const SlackSetupWizard: React.FC<{
         )}
 
         <Form.Item
-          label="Ingest attached images"
+          label="Ingest attached files"
           name="ingest_files"
           valuePropName="checked"
           initialValue={false}
-          tooltip="Download images attached to inbound messages (screenshots) so session agents can view them. Adds the files:read scope."
+          tooltip="Download images and text files (screenshots, logs, CSV, JSON) attached to inbound messages so session agents can read them. Adds the files:read scope."
         >
           <Switch />
         </Form.Item>
@@ -2195,11 +2195,11 @@ const ChannelFormFields: React.FC<{
                     </Form.Item>
 
                     <Form.Item
-                      label="Ingest attached images"
+                      label="Ingest attached files"
                       name="ingest_files"
                       valuePropName="checked"
                       initialValue={false}
-                      tooltip="Download images attached to inbound messages (screenshots) so session agents can view them. Requires the files:read scope."
+                      tooltip="Download images and text files (screenshots, logs, CSV, JSON) attached to inbound messages so session agents can read them. Requires the files:read scope."
                     >
                       <Switch />
                     </Form.Item>


### PR DESCRIPTION
## Summary

Extends the inbound Slack attachment ingestion pipeline (#1847) from images-only to text-like files agents use as context: logs, plain text, CSV, JSON, and markdown.

- **Filter generalized**: `isIngestableImageFile` → `isIngestableFile` accepts `image/*` plus the text-like subset (`text/*`, `application/json`) of the existing `ALLOWED_UPLOAD_MIME_TYPES` upload-route allowlist — no new MIME list is introduced; the security boundary stays defined in one place.
- **Response content-type validation broadened** the same way: the download path now accepts allowlisted text types alongside images, and keeps rejecting everything else (`text/html` login pages, `image/svg+xml`, scripts, and allowlisted-but-out-of-scope types like `application/pdf`).
- **Rename**: `ingestInboundImageAttachments` → `ingestInboundAttachments`. All hardening is unchanged: slack.com host allowlist with per-hop redirect revalidation, streaming byte-cap on actual received bytes, per-file size and per-message count ceilings, `file.id`-prefixed filenames, graceful degradation (failures append a note, never throw).
- **Reuses the existing `ingest_files` flag and `files:read` scope** — no new flag or scope. UI labels/tooltips and the MCP tool description updated from "images" to "images and text files".
- Gateway service call site unchanged in logic — the filter inside the ingest function now decides image vs. text vs. skip.

Out of scope (deferred to #1719): PDFs, office documents, OCR, media.

## Tests

- Text attachment (text/csv) downloaded, stored, and path folded into the prompt
- `isIngestableFile` accepts text/plain, text/csv, text/markdown, application/json; rejects application/x-sh, application/xml, image/svg+xml, text/html, and allowlisted-but-out-of-scope application/pdf and application/zip
- Oversized text stream aborted by the streaming byte-cap
- Allowlisted-but-out-of-scope response content-type (application/pdf) rejected
- `ingest_files` off → no download (existing coverage, unchanged)

Full daemon suite: 1643 passed. `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)