### PR TITLE
feat(gateway): Slack file metadata in history + on-demand file download tool

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -1161,6 +1161,7 @@ describe('gateway agent-tool capability gating (MCP)', () => {
         is_bot: false,
         is_trigger: false,
         is_mention: false,
+        files: [{ id: 'F123', name: 'error.log', mimetype: 'text/plain', size: 512 }],
       },
     ],
   };
@@ -1198,6 +1199,10 @@ describe('gateway agent-tool capability gating (MCP)', () => {
     });
     expect(payload.channel).toEqual({ slack_channel_id: 'C123' });
     expect(payload.messages[0]).toMatchObject({ actor_label: 'Alice', text: 'shipping update' });
+    expect(payload.messages[0].files).toEqual([
+      { id: 'F123', name: 'error.log', mimetype: 'text/plain', size: 512 },
+    ]);
+    expect(JSON.stringify(payload)).not.toContain('url_private_download');
     expect(JSON.stringify(payload)).not.toContain('xoxb-secret');
     expect(JSON.stringify(payload)).not.toContain('xapp-secret');
   });
@@ -1220,6 +1225,8 @@ describe('gateway agent-tool capability gating (MCP)', () => {
 
     expect(payload.markdown).toContain('# Slack channel C123 history');
     expect(payload.markdown).toContain('shipping update');
+    expect(payload.markdown).toContain('Attached file F123: error.log (text/plain, 512 bytes)');
+    expect(payload.markdown).not.toContain('url_private_download');
     expect(payload.messages).toBeUndefined();
   });
 
@@ -1892,6 +1899,210 @@ describe('gateway agent-tool capability gating (MCP)', () => {
       expect(getConnector).not.toHaveBeenCalled();
     });
   });
+
+  describe('agor_gateway_slack_file_download', () => {
+    const fileDownloadEnabled = {
+      ...slackChannel,
+      config: { ...slackChannel.config, agent_tools: { file_download: true } },
+    };
+
+    const slackFileInfo = {
+      id: 'F123',
+      name: 'error.log',
+      mimetype: 'text/plain',
+      size: 512,
+      url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/error.log',
+    };
+
+    let uploadDir: string;
+
+    function withUploadDir(): string {
+      uploadDir = fs.mkdtempSync(path.join(tmpdir(), 'agor-gateway-download-'));
+      vi.mocked(getUploadDirectory).mockReturnValue(uploadDir);
+      return uploadDir;
+    }
+
+    afterEach(() => {
+      if (uploadDir) fs.rmSync(uploadDir, { recursive: true, force: true });
+      vi.unstubAllGlobals();
+    });
+
+    it('downloads a file via files.info through the hardened ingestion path into the upload dir', async () => {
+      const dir = withUploadDir();
+      const fetchMock = vi.fn(
+        async () =>
+          new Response('log line one', {
+            status: 200,
+            headers: { 'content-type': 'text/plain' },
+          })
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const getFileInfo = vi.fn(async () => slackFileInfo);
+      vi.mocked(getConnector).mockReturnValue({ getFileInfo } as any);
+      spyCallerGatewaySession('branch-1', gatewaySource);
+      vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+        fileDownloadEnabled as any
+      );
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+
+      const tools = await captureTools('member');
+      const result = await tools.agor_gateway_slack_file_download.handler({ fileId: 'F123' });
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(getFileInfo).toHaveBeenCalledWith('F123');
+      // The download reuses the hardened inbound-ingestion path: bot-token
+      // Authorization against the allowlisted Slack host, manual redirects.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(slackFileInfo.url_private_download, {
+        headers: { Authorization: 'Bearer xoxb-secret' },
+        redirect: 'manual',
+      });
+      expect(payload).toMatchObject({
+        downloaded: true,
+        gateway_channel: { id: 'chan-1', target_branch_id: 'branch-1' },
+        file: { id: 'F123', name: 'error.log', mimetype: 'text/plain', size: 512 },
+      });
+      expect(payload.file.path.startsWith(dir)).toBe(true);
+      expect(payload.file.path).toContain('F123_error');
+      expect(fs.readFileSync(payload.file.path, 'utf8')).toBe('log line one');
+      expect(JSON.stringify(payload)).not.toContain('url_private_download');
+      expect(JSON.stringify(payload)).not.toContain('files.slack.com');
+      expect(JSON.stringify(payload)).not.toContain('xoxb-secret');
+    });
+
+    it('denies file download when the capability is disabled, with an actionable error', async () => {
+      spyCallerGatewaySession('branch-1', gatewaySource);
+      vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+        slackChannel as any
+      );
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+
+      const tools = await captureTools('admin');
+      const error = await tools.agor_gateway_slack_file_download
+        .handler({ fileId: 'F123' })
+        .then(() => null)
+        .catch((err: Error) => err);
+
+      expect(error).toBeTruthy();
+      expect(error!.message).toContain("capability 'file_download' is disabled");
+      expect(error!.message).toContain('agor_gateway_channels_update');
+      expect(error!.message).toContain('config.agent_tools.file_download');
+      expect(getConnector).not.toHaveBeenCalled();
+    });
+
+    it('denies file download across branches even for admins', async () => {
+      spyCallerSessionBranch('branch-2');
+      vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+        fileDownloadEnabled as any
+      );
+
+      const tools = await captureTools('admin');
+      await expect(
+        tools.agor_gateway_slack_file_download.handler({
+          gatewayChannelId: 'chan-1',
+          fileId: 'F123',
+        })
+      ).rejects.toThrow('targets a different branch');
+      expect(getConnector).not.toHaveBeenCalled();
+    });
+
+    it('rejects a disallowed mimetype without downloading', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      vi.mocked(getConnector).mockReturnValue({
+        getFileInfo: vi.fn(async () => ({ ...slackFileInfo, mimetype: 'application/pdf' })),
+      } as any);
+      spyCallerGatewaySession('branch-1', gatewaySource);
+      vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+        fileDownloadEnabled as any
+      );
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+
+      const tools = await captureTools('member');
+      await expect(
+        tools.agor_gateway_slack_file_download.handler({ fileId: 'F123' })
+      ).rejects.toThrow('which the gateway does not download');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('inherits the slack.com host allowlist from the hardened download path', async () => {
+      withUploadDir();
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+      vi.mocked(getConnector).mockReturnValue({
+        getFileInfo: vi.fn(async () => ({
+          ...slackFileInfo,
+          url_private_download: 'https://evil.example/files-pri/T1-F123/download/error.log',
+        })),
+      } as any);
+      spyCallerGatewaySession('branch-1', gatewaySource);
+      vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+        fileDownloadEnabled as any
+      );
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+
+      const tools = await captureTools('member');
+      await expect(
+        tools.agor_gateway_slack_file_download.handler({ fileId: 'F123' })
+      ).rejects.toThrow('Failed to download Slack file');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps the no-session path gated on admin or branch 'all' permission", async () => {
+      const dir = withUploadDir();
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response('log line one', {
+              status: 200,
+              headers: { 'content-type': 'text/plain' },
+            })
+        )
+      );
+      vi.mocked(getConnector).mockReturnValue({
+        getFileInfo: vi.fn(async () => slackFileInfo),
+      } as any);
+      vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+        fileDownloadEnabled as any
+      );
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+      vi.spyOn(BranchRepository.prototype, 'isOwner').mockResolvedValue(false);
+      const permission = vi
+        .spyOn(BranchRepository.prototype, 'resolveUserPermission')
+        .mockResolvedValue('view' as any);
+
+      const tools = await captureTools('member', makeFakeApp({}), null);
+      await expect(
+        tools.agor_gateway_slack_file_download.handler({
+          gatewayChannelId: 'chan-1',
+          fileId: 'F123',
+        })
+      ).rejects.toThrow("'all' branch permission");
+
+      permission.mockResolvedValue('all' as any);
+      const result = await tools.agor_gateway_slack_file_download.handler({
+        gatewayChannelId: 'chan-1',
+        fileId: 'F123',
+      });
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.downloaded).toBe(true);
+      expect(payload.file.path.startsWith(dir)).toBe(true);
+    });
+
+    it('rejects a malformed fileId at the schema layer', async () => {
+      const tools = await captureTools('member');
+      const schema = tools.agor_gateway_slack_file_download.cfg.inputSchema;
+
+      expect(schema.safeParse({ fileId: 'not-a-file-id' }).success).toBe(false);
+      expect(schema.safeParse({ fileId: 'f0123abc456' }).success).toBe(false);
+      expect(schema.safeParse({ fileId: 'C0123ABC456' }).success).toBe(false);
+      expect(schema.safeParse({}).success).toBe(false);
+      expect(schema.safeParse({ fileId: 'F0123ABC456' }).success).toBe(true);
+      expect(getConnector).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('getRequiredSecretFields — Slack app_token required unless explicitly outbound-only', () => {
@@ -1936,11 +2147,13 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
     channelHistory,
     reactions,
     fileUpload,
+    fileDownload,
     ...rest
   }: typeof dmOnly & {
     botDisplayName?: string;
     reactions?: boolean;
     fileUpload?: boolean;
+    fileDownload?: boolean;
   }) {
     return {
       ...rest,
@@ -1949,6 +2162,7 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
         channel_history: channelHistory,
         reactions,
         file_upload: fileUpload,
+        file_download: fileDownload,
       },
     };
   }
@@ -2101,6 +2315,32 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
     });
   });
 
+  it('adds files:read scope and agent_tools config when fileDownload is enabled', async () => {
+    const opts = { ...dmOnly, fileDownload: true };
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_slack_manifest_generate.handler(opts);
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.bot_scopes).toEqual(requiredBotScopes(wizardOptionsFor(opts)));
+    expect(payload.bot_scopes).toEqual(expect.arrayContaining(['files:read']));
+    expect(payload.create_channel_config_hint.config.agent_tools).toEqual({
+      thread_history: true,
+      channel_history: false,
+      file_download: true,
+    });
+  });
+
+  it('omits files:read when fileDownload is off and no other capability forces it', async () => {
+    const tools = await captureTools('admin');
+    const result = await tools.agor_gateway_slack_manifest_generate.handler({
+      ...dmOnly,
+      fileDownload: false,
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.bot_scopes).not.toContain('files:read');
+  });
+
   it('generates an all-on manifest and maps restrictToChannelIds to allowed_channel_ids', async () => {
     const opts = {
       appName: 'Agor',
@@ -2160,11 +2400,12 @@ describe('agor_gateway_slack_manifest_generate MCP tool', () => {
     });
     expect(parsed.alignUsers).toBe(true);
     // Schema defaults mirror the capability defaults: thread history stays on,
-    // channel history/reactions/fileUpload require explicit opt-in.
+    // channel history/reactions/fileUpload/fileDownload require explicit opt-in.
     expect(parsed.threadHistory).toBe(true);
     expect(parsed.channelHistory).toBe(false);
     expect(parsed.reactions).toBe(false);
     expect(parsed.fileUpload).toBe(false);
+    expect(parsed.fileDownload).toBe(false);
 
     const result = await tools.agor_gateway_slack_manifest_generate.handler(parsed);
     const payload = JSON.parse(result.content[0].text);

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -1914,6 +1914,8 @@ describe('gateway agent-tool capability gating (MCP)', () => {
       url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/error.log',
     };
 
+    const slackFileResult = { file: slackFileInfo, sourceConversationIds: ['C123'] };
+
     let uploadDir: string;
 
     function withUploadDir(): string {
@@ -1938,7 +1940,7 @@ describe('gateway agent-tool capability gating (MCP)', () => {
       );
       vi.stubGlobal('fetch', fetchMock);
 
-      const getFileInfo = vi.fn(async () => slackFileInfo);
+      const getFileInfo = vi.fn(async () => slackFileResult);
       vi.mocked(getConnector).mockReturnValue({ getFileInfo } as any);
       spyCallerGatewaySession('branch-1', gatewaySource);
       vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
@@ -2011,7 +2013,10 @@ describe('gateway agent-tool capability gating (MCP)', () => {
       const fetchMock = vi.fn();
       vi.stubGlobal('fetch', fetchMock);
       vi.mocked(getConnector).mockReturnValue({
-        getFileInfo: vi.fn(async () => ({ ...slackFileInfo, mimetype: 'application/pdf' })),
+        getFileInfo: vi.fn(async () => ({
+          ...slackFileResult,
+          file: { ...slackFileInfo, mimetype: 'application/pdf' },
+        })),
       } as any);
       spyCallerGatewaySession('branch-1', gatewaySource);
       vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
@@ -2032,8 +2037,11 @@ describe('gateway agent-tool capability gating (MCP)', () => {
       vi.stubGlobal('fetch', fetchMock);
       vi.mocked(getConnector).mockReturnValue({
         getFileInfo: vi.fn(async () => ({
-          ...slackFileInfo,
-          url_private_download: 'https://evil.example/files-pri/T1-F123/download/error.log',
+          ...slackFileResult,
+          file: {
+            ...slackFileInfo,
+            url_private_download: 'https://evil.example/files-pri/T1-F123/download/error.log',
+          },
         })),
       } as any);
       spyCallerGatewaySession('branch-1', gatewaySource);
@@ -2062,7 +2070,7 @@ describe('gateway agent-tool capability gating (MCP)', () => {
         )
       );
       vi.mocked(getConnector).mockReturnValue({
-        getFileInfo: vi.fn(async () => slackFileInfo),
+        getFileInfo: vi.fn(async () => slackFileResult),
       } as any);
       vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
         fileDownloadEnabled as any
@@ -2101,6 +2109,107 @@ describe('gateway agent-tool capability gating (MCP)', () => {
       expect(schema.safeParse({}).success).toBe(false);
       expect(schema.safeParse({ fileId: 'F0123ABC456' }).success).toBe(true);
       expect(getConnector).not.toHaveBeenCalled();
+    });
+
+    it('is not marked read-only — it writes into the daemon upload directory', async () => {
+      const tools = await captureTools('member');
+      expect(tools.agor_gateway_slack_file_download.cfg.annotations).toEqual({
+        destructiveHint: false,
+        idempotentHint: true,
+      });
+    });
+
+    describe('allowed_channel_ids whitelist on file provenance', () => {
+      const restrictedDownloadEnabled = {
+        ...slackChannel,
+        config: {
+          ...slackChannel.config,
+          agent_tools: { file_download: true },
+          allowed_channel_ids: ['C123'],
+        },
+      };
+
+      function setupRestrictedDownload(sourceConversationIds: string[]) {
+        vi.mocked(getConnector).mockReturnValue({
+          getFileInfo: vi.fn(async () => ({ file: slackFileInfo, sourceConversationIds })),
+        } as any);
+        spyCallerGatewaySession('branch-1', gatewaySource);
+        vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+          restrictedDownloadEnabled as any
+        );
+        vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+      }
+
+      it('denies a file whose only sources are non-whitelisted channels, without leaking them', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        setupRestrictedDownload(['C777', 'G888']);
+
+        const tools = await captureTools('member');
+        const error = await tools.agor_gateway_slack_file_download
+          .handler({ fileId: 'F123' })
+          .then(() => null)
+          .catch((err: Error) => err);
+
+        expect(error).toBeTruthy();
+        expect(error!.message).toContain('allowed_channel_ids');
+        expect(error!.message).not.toContain('C777');
+        expect(error!.message).not.toContain('G888');
+        expect(error!.message).not.toContain('error.log');
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it('denies a file with no visible source conversations when a whitelist is configured', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+        setupRestrictedDownload([]);
+
+        const tools = await captureTools('member');
+        await expect(
+          tools.agor_gateway_slack_file_download.handler({ fileId: 'F123' })
+        ).rejects.toThrow('allowed_channel_ids');
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it('allows a file shared into a whitelisted channel', async () => {
+        withUploadDir();
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(
+            async () =>
+              new Response('log line one', {
+                status: 200,
+                headers: { 'content-type': 'text/plain' },
+              })
+          )
+        );
+        setupRestrictedDownload(['C777', 'C123']);
+
+        const tools = await captureTools('member');
+        const result = await tools.agor_gateway_slack_file_download.handler({ fileId: 'F123' });
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.downloaded).toBe(true);
+      });
+
+      it('allows a file shared in a DM even with a whitelist configured', async () => {
+        withUploadDir();
+        vi.stubGlobal(
+          'fetch',
+          vi.fn(
+            async () =>
+              new Response('log line one', {
+                status: 200,
+                headers: { 'content-type': 'text/plain' },
+              })
+          )
+        );
+        setupRestrictedDownload(['D999']);
+
+        const tools = await captureTools('member');
+        const result = await tools.agor_gateway_slack_file_download.handler({ fileId: 'F123' });
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.downloaded).toBe(true);
+      });
     });
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -10,6 +10,7 @@ import {
 import {
   buildSlackManifest,
   getConnector,
+  type InboundFile,
   isSlackWriteTargetAllowed,
   requiredBotEvents,
   requiredBotScopes,
@@ -48,6 +49,7 @@ import {
   isPathInsideRoot,
   resolveBranchWorkspacePath,
 } from '../../utils/branch-workspace-path.js';
+import { ingestInboundAttachments, isIngestableFile } from '../../utils/gateway-attachments.js';
 import { getUploadDirectory, MAX_UPLOAD_FILE_SIZE } from '../../utils/upload.js';
 import {
   mcpLimit,
@@ -499,6 +501,12 @@ function slackHistoryMessageLines(messages: SlackThreadHistoryMessage[]): string
       message.text || '_No text_',
       ''
     );
+    for (const file of message.files ?? []) {
+      lines.push(
+        `_Attached file ${file.id}: ${file.name} (${file.mimetype}, ${file.size} bytes)_`,
+        ''
+      );
+    }
   }
   return lines;
 }
@@ -535,6 +543,16 @@ function normalizeSlackHistoryMessages(messages: SlackThreadHistoryMessage[]) {
     is_mention: message.is_mention === true,
     ...(message.user_id ? { user_id: message.user_id } : {}),
     ...(message.user_name ? { user_name: message.user_name } : {}),
+    ...(message.files?.length
+      ? {
+          files: message.files.map((file) => ({
+            id: file.id,
+            name: file.name,
+            mimetype: file.mimetype,
+            size: file.size,
+          })),
+        }
+      : {}),
   }));
 }
 
@@ -808,6 +826,12 @@ const slackManifestGenerateSchema = z.strictObject({
     .describe(
       'Let session agents upload files/images to a channel or thread via agor_gateway_slack_file_upload (adds the files:write scope). Maps to config.agent_tools.file_upload.'
     ),
+  fileDownload: z
+    .boolean()
+    .default(false)
+    .describe(
+      'Let session agents download files referenced in Slack history via agor_gateway_slack_file_download (adds the files:read scope). Maps to config.agent_tools.file_download.'
+    ),
   restrictToChannelIds: z
     .array(z.string().min(1))
     .optional()
@@ -833,6 +857,7 @@ function toSlackWizardOptions(
       channel_history: args.channelHistory,
       reactions: args.reactions,
       file_upload: args.fileUpload,
+      file_download: args.fileDownload,
     },
   };
 }
@@ -857,6 +882,7 @@ function toCreateChannelConfigHint(args: z.infer<typeof slackManifestGenerateSch
       channel_history: args.channelHistory,
       reactions: args.reactions,
       file_upload: args.fileUpload,
+      file_download: args.fileDownload,
     },
   };
   if (args.restrictToChannelIds && args.restrictToChannelIds.length > 0) {
@@ -922,6 +948,7 @@ function assertSlackFileUploadConnector(
  */
 const SLACK_CHANNEL_ID_PATTERN = /^[A-Z0-9]+$/;
 const SLACK_TIMESTAMP_PATTERN = /^\d+\.\d+$/;
+const SLACK_FILE_ID_PATTERN = /^F[A-Z0-9]+$/;
 
 function slackConversationIdSchema(fieldName: string, description: string) {
   return z
@@ -1002,18 +1029,54 @@ const slackFileUploadSchema = z.strictObject({
   comment: mcpOptionalNonEmptyString('comment', 'Optional message text introducing the file.'),
 });
 
+const slackFileDownloadSchema = z.strictObject({
+  gatewayChannelId: mcpOptionalId(
+    'gatewayChannelId',
+    'Gateway channel',
+    'Slack gateway channel ID (UUIDv7 or short ID). Optional when called from a gateway-created session, which defaults to its own gateway channel.'
+  ),
+  fileId: z
+    .string()
+    .regex(
+      SLACK_FILE_ID_PATTERN,
+      'fileId must look like a Slack file ID, e.g. F0123ABC456 (as returned in history file metadata).'
+    )
+    .describe(
+      'Slack file ID to download, e.g. F0123ABC456 — from the files metadata returned by the Slack history tools.'
+    ),
+});
+
+interface SlackFileInfoConnector {
+  getFileInfo(fileId: string): Promise<InboundFile>;
+}
+
+function assertSlackFileInfoConnector(
+  connector: unknown
+): asserts connector is SlackFileInfoConnector {
+  if (
+    !connector ||
+    typeof (connector as Partial<SlackFileInfoConnector>).getFileInfo !== 'function'
+  ) {
+    throw new Error('Slack file download is not available for this gateway connector.');
+  }
+}
+
 /**
  * Shared capability-gate + branch-binding resolver for agent-callable Slack
- * tools that target a Slack conversation (channel_history, reactions, file
- * upload) so every one of them enforces the same rules: capability toggle on
- * the TARGET gateway channel, branch-bound to the calling session, admin/'all'
- * branch permission required for callers without session context.
+ * gateway tools: capability toggle on the TARGET gateway channel, branch-bound
+ * to the calling session, admin/'all' branch permission required for callers
+ * without session context. Tools that additionally target a Slack conversation
+ * layer {@link resolveGatewaySlackToolTarget} on top.
  */
-async function resolveGatewaySlackToolTarget(
+async function resolveGatewaySlackChannelTarget(
   ctx: McpContext,
-  args: { gatewayChannelId?: string; slackChannelId?: string },
+  args: { gatewayChannelId?: string },
   capability: SlackAgentToolCapability
-): Promise<{ channel: GatewayChannel; branch: Branch | null; slackChannelId: string }> {
+): Promise<{
+  channel: GatewayChannel;
+  branch: Branch | null;
+  gatewaySource: GatewaySource | null;
+}> {
   const channelRepo = bindMcpRepositoryToTenantUnitOfWork(
     ctx,
     (db) => new GatewayChannelRepository(db)
@@ -1058,6 +1121,25 @@ async function resolveGatewaySlackToolTarget(
     throw new Error(`Gateway channel ${channel.id} is disabled.`);
   }
   requireGatewayCapability(channel, capability);
+
+  return { channel, branch, gatewaySource };
+}
+
+/**
+ * {@link resolveGatewaySlackChannelTarget} plus resolution of the Slack
+ * conversation the tool targets (channel_history, reactions, file upload),
+ * defaulting to the calling gateway session's own conversation.
+ */
+async function resolveGatewaySlackToolTarget(
+  ctx: McpContext,
+  args: { gatewayChannelId?: string; slackChannelId?: string },
+  capability: SlackAgentToolCapability
+): Promise<{ channel: GatewayChannel; branch: Branch | null; slackChannelId: string }> {
+  const { channel, branch, gatewaySource } = await resolveGatewaySlackChannelTarget(
+    ctx,
+    args,
+    capability
+  );
 
   const slackChannelId = args.slackChannelId ?? slackChannelIdFromGatewaySource(gatewaySource);
   if (!slackChannelId) {
@@ -1595,6 +1677,58 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
         slack_channel_id: target.slackChannelId,
         ...(args.threadTs ? { thread_ts: args.threadTs } : {}),
         file: uploaded,
+      });
+    }
+  );
+
+  server.registerTool(
+    'agor_gateway_slack_file_download',
+    {
+      description:
+        "Download a Slack file into the daemon upload directory through a gateway channel without exposing Slack tokens, returning the stored absolute path so the session agent can Read it. Pass a fileId from the files metadata returned by the Slack history tools. Gated by the channel's agent_tools.file_download capability (disabled by default — an admin enables it per channel, which also adds the files:read OAuth scope to the app manifest). Only image and text-like files (screenshots, logs, CSV, JSON, markdown) are downloaded — the same allowlist and size limits as inbound attachment ingestion. When called from a gateway-created session, gatewayChannelId defaults to that session's own channel; calls are restricted to gateway channels whose target branch matches the calling session's branch. Callers without session context need admin role or 'all' branch permission.",
+      annotations: { readOnlyHint: true },
+      inputSchema: slackFileDownloadSchema,
+    },
+    async (args) => {
+      const target = await resolveGatewaySlackChannelTarget(ctx, args, 'file_download');
+      const connector = getConnector('slack', target.channel.config);
+      assertSlackFileInfoConnector(connector);
+      const file = await connector.getFileInfo(args.fileId);
+      if (!isIngestableFile(file)) {
+        throw new Error(
+          `Slack file "${file.name}" has type ${file.mimetype}, which the gateway does not download. Only image and text-like files (png/jpeg/gif/webp, plain text, markdown, CSV, JSON) are supported.`
+        );
+      }
+      if (file.size > MAX_UPLOAD_FILE_SIZE) {
+        throw new Error(
+          `Slack file "${file.name}" is ${file.size} bytes, exceeding the ${MAX_UPLOAD_FILE_SIZE}-byte download limit.`
+        );
+      }
+      const botToken = target.channel.config?.bot_token;
+      if (typeof botToken !== 'string' || !botToken) {
+        throw new Error(`Gateway channel ${target.channel.id} has no bot token configured.`);
+      }
+      const { paths } = await ingestInboundAttachments({ files: [file], botToken });
+      const storedPath = paths[0];
+      if (!storedPath) {
+        throw new Error(
+          `Failed to download Slack file "${file.name}" (${args.fileId}); see daemon logs for details.`
+        );
+      }
+      return textResult({
+        downloaded: true,
+        gateway_channel: {
+          id: target.channel.id,
+          name: target.channel.name,
+          target_branch_id: target.channel.target_branch_id,
+        },
+        file: {
+          id: file.id,
+          name: file.name,
+          mimetype: file.mimetype,
+          size: file.size,
+          path: storedPath,
+        },
       });
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -10,12 +10,13 @@ import {
 import {
   buildSlackManifest,
   getConnector,
-  type InboundFile,
+  isSlackFileSourceAllowed,
   isSlackWriteTargetAllowed,
   requiredBotEvents,
   requiredBotScopes,
   type SlackChannelHistoryRequest,
   type SlackChannelHistoryResult,
+  type SlackFileInfo,
   type SlackThreadHistoryMessage,
   type SlackThreadHistoryRequest,
   type SlackThreadHistoryResult,
@@ -1047,7 +1048,7 @@ const slackFileDownloadSchema = z.strictObject({
 });
 
 interface SlackFileInfoConnector {
-  getFileInfo(fileId: string): Promise<InboundFile>;
+  getFileInfo(fileId: string): Promise<SlackFileInfo>;
 }
 
 function assertSlackFileInfoConnector(
@@ -1685,15 +1686,26 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     'agor_gateway_slack_file_download',
     {
       description:
-        "Download a Slack file into the daemon upload directory through a gateway channel without exposing Slack tokens, returning the stored absolute path so the session agent can Read it. Pass a fileId from the files metadata returned by the Slack history tools. Gated by the channel's agent_tools.file_download capability (disabled by default — an admin enables it per channel, which also adds the files:read OAuth scope to the app manifest). Only image and text-like files (screenshots, logs, CSV, JSON, markdown) are downloaded — the same allowlist and size limits as inbound attachment ingestion. When called from a gateway-created session, gatewayChannelId defaults to that session's own channel; calls are restricted to gateway channels whose target branch matches the calling session's branch. Callers without session context need admin role or 'all' branch permission.",
-      annotations: { readOnlyHint: true },
+        "Download a Slack file into the daemon upload directory through a gateway channel without exposing Slack tokens, returning the stored absolute path so the session agent can Read it. Pass a fileId from the files metadata returned by the Slack history tools. Gated by the channel's agent_tools.file_download capability (disabled by default — an admin enables it per channel, which also adds the files:read OAuth scope to the app manifest). Only image and text-like files (screenshots, logs, CSV, JSON, markdown) are downloaded — the same allowlist and size limits as inbound attachment ingestion — and when the channel restricts allowed_channel_ids, only files shared in a permitted conversation or DM. When called from a gateway-created session, gatewayChannelId defaults to that session's own channel; calls are restricted to gateway channels whose target branch matches the calling session's branch. Callers without session context need admin role or 'all' branch permission.",
+      annotations: { destructiveHint: false, idempotentHint: true },
       inputSchema: slackFileDownloadSchema,
     },
     async (args) => {
       const target = await resolveGatewaySlackChannelTarget(ctx, args, 'file_download');
       const connector = getConnector('slack', target.channel.config);
       assertSlackFileInfoConnector(connector);
-      const file = await connector.getFileInfo(args.fileId);
+      const { file, sourceConversationIds } = await connector.getFileInfo(args.fileId);
+      // files.info resolves any file the bot can see workspace-wide, so the
+      // channel's allowed_channel_ids whitelist must bind the file's SOURCE
+      // conversations, exactly like every other gateway tool binds its target.
+      // Checked before any metadata-bearing error so a denied caller learns
+      // nothing about the file. The error deliberately omits where the file
+      // lives.
+      if (!isSlackFileSourceAllowed(target.channel.config, sourceConversationIds)) {
+        throw new Error(
+          `Slack file ${args.fileId} is not shared in any conversation permitted by this gateway channel's allowed_channel_ids whitelist.`
+        );
+      }
       if (!isIngestableFile(file)) {
         throw new Error(
           `Slack file "${file.name}" has type ${file.mimetype}, which the gateway does not download. Only image and text-like files (png/jpeg/gif/webp, plain text, markdown, CSV, JSON) are supported.`

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -1686,7 +1686,7 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
     'agor_gateway_slack_file_download',
     {
       description:
-        "Download a Slack file into the daemon upload directory through a gateway channel without exposing Slack tokens, returning the stored absolute path so the session agent can Read it. Pass a fileId from the files metadata returned by the Slack history tools. Gated by the channel's agent_tools.file_download capability (disabled by default — an admin enables it per channel, which also adds the files:read OAuth scope to the app manifest). Only image and text-like files (screenshots, logs, CSV, JSON, markdown) are downloaded — the same allowlist and size limits as inbound attachment ingestion — and when the channel restricts allowed_channel_ids, only files shared in a permitted conversation or DM. When called from a gateway-created session, gatewayChannelId defaults to that session's own channel; calls are restricted to gateway channels whose target branch matches the calling session's branch. Callers without session context need admin role or 'all' branch permission.",
+        "Download a Slack file by fileId (from the files metadata in the Slack history tools) into the session upload directory, returning the stored path for the agent to Read. Gated by the channel's agent_tools.file_download capability; only files shared in a conversation permitted by the channel's allowed_channel_ids (DMs exempt), and only image/text-like types under the same limits as inbound attachment ingestion.",
       annotations: { destructiveHint: false, idempotentHint: true },
       inputSchema: slackFileDownloadSchema,
     },

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -407,6 +407,7 @@ const SLACK_PROBE_FIELDS = new Set<string>([
   'agent_channel_history',
   'agent_reactions',
   'agent_file_upload',
+  'agent_file_download',
   'slack_public_scope',
   'allowed_channel_ids',
 ]);
@@ -728,6 +729,8 @@ const SlackSetupWizard: React.FC<{
     Form.useWatch('agent_reactions', form) ?? SLACK_AGENT_TOOL_DEFAULTS.reactions;
   const agentFileUpload =
     Form.useWatch('agent_file_upload', form) ?? SLACK_AGENT_TOOL_DEFAULTS.file_upload;
+  const agentFileDownload =
+    Form.useWatch('agent_file_download', form) ?? SLACK_AGENT_TOOL_DEFAULTS.file_download;
   const publicScope = (Form.useWatch('slack_public_scope', form) as string) ?? 'all';
 
   const wizardOptions: SlackWizardOptions = useMemo(
@@ -744,6 +747,7 @@ const SlackSetupWizard: React.FC<{
         channel_history: agentChannelHistory,
         reactions: agentReactions,
         file_upload: agentFileUpload,
+        file_download: agentFileDownload,
       },
     }),
     [
@@ -758,6 +762,7 @@ const SlackSetupWizard: React.FC<{
       agentChannelHistory,
       agentReactions,
       agentFileUpload,
+      agentFileDownload,
     ]
   );
 
@@ -995,6 +1000,16 @@ const SlackSetupWizard: React.FC<{
           valuePropName="checked"
           initialValue={false}
           tooltip="Let session agents upload files/images to a channel or thread through the gateway MCP tool. Adds the files:write scope."
+        >
+          <Switch />
+        </Form.Item>
+
+        <Form.Item
+          label="Agents can download files"
+          name="agent_file_download"
+          valuePropName="checked"
+          initialValue={false}
+          tooltip="Let session agents download image/text files referenced in Slack history through the gateway MCP tool. Adds the files:read scope."
         >
           <Switch />
         </Form.Item>
@@ -1266,6 +1281,9 @@ const ChannelFormFields: React.FC<{
   const agentFileUpload = Boolean(
     Form.useWatch('agent_file_upload', form) ?? storedAgentTools.file_upload
   );
+  const agentFileDownload = Boolean(
+    Form.useWatch('agent_file_download', form) ?? storedAgentTools.file_download
+  );
   const alignGithubUsers = Form.useWatch('github_align_users', form) ?? false;
   // Track the live Name field so the manifest preview reflects in-progress edits,
   // falling back to the stored channel name.
@@ -1290,6 +1308,7 @@ const ChannelFormFields: React.FC<{
         channel_history: agentChannelHistory,
         reactions: agentReactions,
         file_upload: agentFileUpload,
+        file_download: agentFileDownload,
       },
     }),
     [
@@ -1304,6 +1323,7 @@ const ChannelFormFields: React.FC<{
       agentChannelHistory,
       agentReactions,
       agentFileUpload,
+      agentFileDownload,
     ]
   );
   const slackScopes = useMemo(() => requiredBotScopes(slackOptions), [slackOptions]);
@@ -2256,6 +2276,16 @@ const ChannelFormFields: React.FC<{
                       <Switch />
                     </Form.Item>
 
+                    <Form.Item
+                      label="Agents can download files"
+                      name="agent_file_download"
+                      valuePropName="checked"
+                      initialValue={false}
+                      tooltip="Let session agents download image/text files referenced in Slack history through the gateway MCP tool. Requires the files:read scope."
+                    >
+                      <Switch />
+                    </Form.Item>
+
                     {sourcesEnabled && (
                       <CompactAlert
                         type="info"
@@ -2653,6 +2683,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         channel_history: values.agent_channel_history ?? SLACK_AGENT_TOOL_DEFAULTS.channel_history,
         reactions: values.agent_reactions ?? SLACK_AGENT_TOOL_DEFAULTS.reactions,
         file_upload: values.agent_file_upload ?? SLACK_AGENT_TOOL_DEFAULTS.file_upload,
+        file_download: values.agent_file_download ?? SLACK_AGENT_TOOL_DEFAULTS.file_download,
       },
     };
     setSlackTestLoading(true);
@@ -2813,6 +2844,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         channel_history: values.agent_channel_history ?? SLACK_AGENT_TOOL_DEFAULTS.channel_history,
         reactions: values.agent_reactions ?? SLACK_AGENT_TOOL_DEFAULTS.reactions,
         file_upload: values.agent_file_upload ?? SLACK_AGENT_TOOL_DEFAULTS.file_upload,
+        file_download: values.agent_file_download ?? SLACK_AGENT_TOOL_DEFAULTS.file_download,
       };
     }
 
@@ -2986,6 +3018,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       formValues.agent_channel_history = agentTools.channel_history;
       formValues.agent_reactions = agentTools.reactions;
       formValues.agent_file_upload = agentTools.file_upload;
+      formValues.agent_file_download = agentTools.file_download;
     } else if (channel.channel_type === 'github') {
       formValues.github_app_id = config?.app_id;
       formValues.github_installation_id = config?.installation_id;

--- a/packages/core/src/gateway/connectors/slack-manifest.test.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.test.ts
@@ -138,6 +138,20 @@ describe('requiredBotScopes', () => {
     );
   });
 
+  it('adds files:read for the file_download capability and omits it otherwise', () => {
+    expect(requiredBotScopes(withOptions({ agentTools: { file_download: true } }))).toEqual([
+      'chat:write',
+      'files:read',
+      'im:history',
+      'im:read',
+      'users:read',
+    ]);
+    expect(requiredBotScopes(baseOptions)).not.toContain('files:read');
+    expect(requiredBotScopes(withOptions({ agentTools: { file_download: false } }))).not.toContain(
+      'files:read'
+    );
+  });
+
   it('all capabilities on — de-duplicated and sorted', () => {
     const allOn = withOptions({
       publicChannels: true,
@@ -151,6 +165,7 @@ describe('requiredBotScopes', () => {
         channel_history: true,
         reactions: true,
         file_upload: true,
+        file_download: true,
       },
     });
     expect(requiredBotScopes(allOn)).toEqual([
@@ -197,18 +212,20 @@ describe('requiredBotScopes', () => {
 });
 
 describe('resolveSlackAgentTools', () => {
-  it('defaults thread_history ON and channel_history/reactions/file_upload OFF for absent config', () => {
+  it('defaults thread_history ON and channel_history/reactions/file_upload/file_download OFF for absent config', () => {
     expect(resolveSlackAgentTools(undefined)).toEqual({
       thread_history: true,
       channel_history: false,
       reactions: false,
       file_upload: false,
+      file_download: false,
     });
     expect(resolveSlackAgentTools({})).toEqual({
       thread_history: true,
       channel_history: false,
       reactions: false,
       file_upload: false,
+      file_download: false,
     });
   });
 
@@ -219,12 +236,14 @@ describe('resolveSlackAgentTools', () => {
         channel_history: true,
         reactions: true,
         file_upload: true,
+        file_download: true,
       })
     ).toEqual({
       thread_history: false,
       channel_history: true,
       reactions: true,
       file_upload: true,
+      file_download: true,
     });
   });
 
@@ -234,6 +253,7 @@ describe('resolveSlackAgentTools', () => {
       channel_history: false,
       reactions: false,
       file_upload: false,
+      file_download: false,
     });
     expect(
       resolveSlackAgentTools({
@@ -241,18 +261,21 @@ describe('resolveSlackAgentTools', () => {
         channel_history: 1,
         reactions: 'true',
         file_upload: 0,
+        file_download: 'on',
       })
     ).toEqual({
       thread_history: true,
       channel_history: false,
       reactions: false,
       file_upload: false,
+      file_download: false,
     });
     expect(resolveSlackAgentTools([true])).toEqual({
       thread_history: true,
       channel_history: false,
       reactions: false,
       file_upload: false,
+      file_download: false,
     });
   });
 });

--- a/packages/core/src/gateway/connectors/slack-manifest.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.ts
@@ -56,6 +56,7 @@ export const SLACK_AGENT_TOOL_SCOPES: Record<SlackAgentToolCapability, string[]>
   channel_history: ['channels:history', 'groups:history', 'mpim:history'],
   reactions: ['reactions:write'],
   file_upload: ['files:write'],
+  file_download: ['files:read'],
 };
 
 export interface SlackBotEventSubscriptions {

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -3,6 +3,7 @@ import {
   extractSlackInboundFiles,
   isChannelAllowedByWhitelist,
   isSlackDirectMessageId,
+  isSlackFileSourceAllowed,
   isSlackWriteTargetAllowed,
   markdownToMrkdwn,
   markdownToSlackPayload,
@@ -693,20 +694,44 @@ describe('SlackConnector.getFileInfo', () => {
     url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/error.log',
   };
 
-  it('returns the normalized file from files.info', async () => {
+  it('returns the normalized file and its source conversations from files.info', async () => {
     const calls: unknown[] = [];
     const connector = new SlackConnector({ bot_token: 'xoxb-test' });
     (connector as unknown as { web: unknown }).web = {
       files: {
         info: async (args: unknown) => {
           calls.push(args);
-          return { ok: true, file: { ...slackFile, permalink: 'https://x.slack.com/p' } };
+          return {
+            ok: true,
+            file: {
+              ...slackFile,
+              permalink: 'https://x.slack.com/p',
+              channels: ['C123', 'C456'],
+              groups: ['G789'],
+              ims: ['D999'],
+            },
+          };
         },
       },
     };
 
-    await expect(connector.getFileInfo('F123')).resolves.toEqual(slackFile);
+    await expect(connector.getFileInfo('F123')).resolves.toEqual({
+      file: slackFile,
+      sourceConversationIds: ['C123', 'C456', 'G789', 'D999'],
+    });
     expect(calls).toEqual([{ file: 'F123' }]);
+  });
+
+  it('returns empty source conversations when files.info omits or malforms them', async () => {
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      files: { info: async () => ({ ok: true, file: { ...slackFile, channels: 'C123' } }) },
+    };
+
+    await expect(connector.getFileInfo('F123')).resolves.toEqual({
+      file: slackFile,
+      sourceConversationIds: [],
+    });
   });
 
   it('throws a Slack API error on a non-ok files.info response', async () => {
@@ -1256,6 +1281,32 @@ describe('isSlackWriteTargetAllowed', () => {
   it('allows everything when no whitelist is configured', () => {
     expect(isSlackWriteTargetAllowed({}, 'C999')).toBe(true);
     expect(isSlackWriteTargetAllowed({ allowed_channel_ids: [] }, 'C999')).toBe(true);
+  });
+});
+
+describe('isSlackFileSourceAllowed', () => {
+  const restricted = { allowed_channel_ids: ['C123'] };
+
+  it('allows a file shared in a whitelisted channel', () => {
+    expect(isSlackFileSourceAllowed(restricted, ['C999', 'C123'])).toBe(true);
+  });
+
+  it('denies a file whose only sources are non-whitelisted channels', () => {
+    expect(isSlackFileSourceAllowed(restricted, ['C999', 'G777'])).toBe(false);
+  });
+
+  it('allows a file shared in a DM even when a whitelist is configured', () => {
+    expect(isSlackFileSourceAllowed(restricted, ['D999'])).toBe(true);
+  });
+
+  it('denies a file with no visible source conversations when a whitelist is configured', () => {
+    expect(isSlackFileSourceAllowed(restricted, [])).toBe(false);
+  });
+
+  it('allows everything, including source-less files, when no whitelist is configured', () => {
+    expect(isSlackFileSourceAllowed({}, ['C999'])).toBe(true);
+    expect(isSlackFileSourceAllowed({}, [])).toBe(true);
+    expect(isSlackFileSourceAllowed({ allowed_channel_ids: [] }, [])).toBe(true);
   });
 });
 

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -631,6 +631,101 @@ describe('SlackConnector.fetchThreadHistory', () => {
     expect(history.messages.map((message) => message.text)).toEqual(['human one', 'human two']);
     expect(history.has_more).toBe(false);
   });
+
+  it('surfaces attached-file metadata without url_private_download', async () => {
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      conversations: {
+        replies: async () => ({
+          ok: true,
+          has_more: false,
+          messages: [
+            {
+              ts: '1700000000.000000',
+              user: 'U1',
+              text: 'here is the log',
+              files: [
+                {
+                  id: 'F123',
+                  name: 'error.log',
+                  mimetype: 'text/plain',
+                  size: 512,
+                  url_private_download:
+                    'https://files.slack.com/files-pri/T1-F123/download/error.log',
+                  permalink: 'https://x.slack.com/p',
+                },
+                // Malformed entry (no url) is dropped, matching inbound ingestion.
+                { id: 'F999', name: 'ghost.txt' },
+              ],
+            },
+            { ts: '1700000001.000000', user: 'U2', text: 'no attachments here' },
+          ],
+        }),
+      },
+      users: {
+        info: async ({ user }: { user: string }) => ({
+          ok: true,
+          user: { profile: { display_name: user } },
+        }),
+      },
+    };
+
+    const history = await connector.fetchThreadHistory({
+      threadId: 'C123-1700000000.000000',
+      limit: 10,
+    });
+
+    expect(history.messages[0].files).toEqual([
+      { id: 'F123', name: 'error.log', mimetype: 'text/plain', size: 512 },
+    ]);
+    expect(history.messages[1].files).toBeUndefined();
+    expect(JSON.stringify(history)).not.toContain('url_private_download');
+    expect(JSON.stringify(history)).not.toContain('files.slack.com');
+  });
+});
+
+describe('SlackConnector.getFileInfo', () => {
+  const slackFile = {
+    id: 'F123',
+    name: 'error.log',
+    mimetype: 'text/plain',
+    size: 512,
+    url_private_download: 'https://files.slack.com/files-pri/T1-F123/download/error.log',
+  };
+
+  it('returns the normalized file from files.info', async () => {
+    const calls: unknown[] = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      files: {
+        info: async (args: unknown) => {
+          calls.push(args);
+          return { ok: true, file: { ...slackFile, permalink: 'https://x.slack.com/p' } };
+        },
+      },
+    };
+
+    await expect(connector.getFileInfo('F123')).resolves.toEqual(slackFile);
+    expect(calls).toEqual([{ file: 'F123' }]);
+  });
+
+  it('throws a Slack API error on a non-ok files.info response', async () => {
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      files: { info: async () => ({ ok: false, error: 'file_not_found' }) },
+    };
+
+    await expect(connector.getFileInfo('F123')).rejects.toThrow('Slack API error: file_not_found');
+  });
+
+  it('throws when files.info returns a malformed file object', async () => {
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      files: { info: async () => ({ ok: true, file: { id: 'F123', name: 'error.log' } }) },
+    };
+
+    await expect(connector.getFileInfo('F123')).rejects.toThrow('no downloadable file for F123');
+  });
 });
 
 describe('SlackConnector.fetchChannelHistory', () => {

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -104,6 +104,20 @@ export interface SlackUserAvatarProfile {
   avatarUrl: string | null;
 }
 
+/**
+ * Agent-facing metadata for a file attached to a Slack history message.
+ * Deliberately excludes `url_private_download` (and every other Slack file
+ * URL): agents reference a file by `id` and fetch it on demand through the
+ * capability-gated download tool, so bot-token-authenticated URLs never
+ * appear in agent-visible output.
+ */
+export interface SlackHistoryFile {
+  id: string;
+  name: string;
+  mimetype: string;
+  size: number;
+}
+
 export interface SlackThreadHistoryMessage {
   ts: string;
   iso_time: string;
@@ -114,6 +128,7 @@ export interface SlackThreadHistoryMessage {
   is_bot: boolean;
   is_trigger: boolean;
   is_mention: boolean;
+  files?: SlackHistoryFile[];
 }
 
 export interface SlackThreadHistoryRequest {
@@ -1455,6 +1470,24 @@ export class SlackConnector implements GatewayConnector {
     };
   }
 
+  /**
+   * Fetch a Slack file's metadata (including its bot-token-authenticated
+   * `url_private_download`) via `files.info`. The returned {@link InboundFile}
+   * is for server-side download plumbing only — callers exposing file data to
+   * agents must strip the URL (see {@link SlackHistoryFile}).
+   */
+  async getFileInfo(fileId: string): Promise<InboundFile> {
+    const result = await this.web.files.info({ file: fileId });
+    if (!result.ok) {
+      throw new Error(`Slack API error: ${result.error ?? 'unknown error'}`);
+    }
+    const [file] = extractSlackInboundFiles([result.file]);
+    if (!file) {
+      throw new Error(`Slack files.info returned no downloadable file for ${fileId}`);
+    }
+    return file;
+  }
+
   /** Resolve a Slack channel by its human name (with or without #). */
   async resolveChannelByName(name: string): Promise<{ channel: string; name: string }> {
     const normalized = name.replace(/^#/, '').trim().toLowerCase();
@@ -1569,6 +1602,12 @@ export class SlackConnector implements GatewayConnector {
               : undefined;
         const actorLabel = userName ?? botName ?? userId ?? botId ?? 'unknown';
         const text = typeof raw.text === 'string' ? raw.text : '';
+        const files = extractSlackInboundFiles(raw.files).map(({ id, name, mimetype, size }) => ({
+          id,
+          name,
+          mimetype,
+          size,
+        }));
         messages.push({
           ts,
           iso_time: slackTsToIso(ts),
@@ -1579,6 +1618,7 @@ export class SlackConnector implements GatewayConnector {
           is_bot: isBot,
           is_trigger: req.triggerTs === ts,
           is_mention: this.botUserId ? text.includes(`<@${this.botUserId}>`) : false,
+          ...(files.length > 0 ? { files } : {}),
         });
         if (messages.length >= requestedLimit) {
           stoppedAtRequestedLimitWithMoreRaw = i < rawMessages.length - 1;

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -118,6 +118,17 @@ export interface SlackHistoryFile {
   size: number;
 }
 
+/**
+ * Result of {@link SlackConnector.getFileInfo}. Server-side only: `file`
+ * carries the bot-token-authenticated download URL, and
+ * `sourceConversationIds` (the conversations the file is shared into) exists
+ * solely for the gateway's whitelist check — neither may reach agent output.
+ */
+export interface SlackFileInfo {
+  file: InboundFile;
+  sourceConversationIds: string[];
+}
+
 export interface SlackThreadHistoryMessage {
   ts: string;
   iso_time: string;
@@ -751,6 +762,29 @@ export function isSlackWriteTargetAllowed(
   const allowedChannelIds = normalizeAllowedChannelIds(config.allowed_channel_ids);
   const channelType = isSlackDirectMessageId(channelId) ? 'im' : 'channel';
   return isChannelAllowedByWhitelist(channelType, channelId, allowedChannelIds);
+}
+
+/**
+ * Whether a Slack file may be downloaded through this gateway channel, given
+ * the conversations the file is shared into and the channel's
+ * `allowed_channel_ids` config.
+ *
+ * `files.info` resolves ANY file the bot can see workspace-wide, so without
+ * this check a file id (from a permalink or prompt injection) would bypass the
+ * whitelist that bounds every other gateway tool. Policy mirrors
+ * {@link isSlackWriteTargetAllowed} per source conversation — DMs are always
+ * exempt, an empty/absent whitelist allows everything — and requires at least
+ * one source conversation to pass. A file with no visible source conversations
+ * is only allowed when no whitelist is configured, so the whitelist fails
+ * closed rather than open.
+ */
+export function isSlackFileSourceAllowed(
+  config: Record<string, unknown>,
+  sourceConversationIds: string[]
+): boolean {
+  const allowedChannelIds = normalizeAllowedChannelIds(config.allowed_channel_ids);
+  if (allowedChannelIds.length === 0) return true;
+  return sourceConversationIds.some((id) => isSlackWriteTargetAllowed(config, id));
 }
 
 export class SlackConnector implements GatewayConnector {
@@ -1475,8 +1509,12 @@ export class SlackConnector implements GatewayConnector {
    * `url_private_download`) via `files.info`. The returned {@link InboundFile}
    * is for server-side download plumbing only — callers exposing file data to
    * agents must strip the URL (see {@link SlackHistoryFile}).
+   * `sourceConversationIds` preserves where the file is shared
+   * (channels + groups + ims) so the gateway can enforce its
+   * `allowed_channel_ids` whitelist ({@link isSlackFileSourceAllowed});
+   * it must not be exposed to agents either.
    */
-  async getFileInfo(fileId: string): Promise<InboundFile> {
+  async getFileInfo(fileId: string): Promise<SlackFileInfo> {
     const result = await this.web.files.info({ file: fileId });
     if (!result.ok) {
       throw new Error(`Slack API error: ${result.error ?? 'unknown error'}`);
@@ -1485,7 +1523,11 @@ export class SlackConnector implements GatewayConnector {
     if (!file) {
       throw new Error(`Slack files.info returned no downloadable file for ${fileId}`);
     }
-    return file;
+    const raw = result.file as { channels?: unknown; groups?: unknown; ims?: unknown };
+    const sourceConversationIds = [raw.channels, raw.groups, raw.ims].flatMap((ids) =>
+      Array.isArray(ids) ? ids.filter((id): id is string => typeof id === 'string') : []
+    );
+    return { file, sourceConversationIds };
   }
 
   /** Resolve a Slack channel by its human name (with or without #). */

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -12,6 +12,7 @@ export { GitHubConnector, parseThreadId as parseGitHubThreadId } from './connect
 export type {
   SlackChannelHistoryRequest,
   SlackChannelHistoryResult,
+  SlackHistoryFile,
   SlackThreadHistoryMessage,
   SlackThreadHistoryRequest,
   SlackThreadHistoryResult,

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -12,6 +12,7 @@ export { GitHubConnector, parseThreadId as parseGitHubThreadId } from './connect
 export type {
   SlackChannelHistoryRequest,
   SlackChannelHistoryResult,
+  SlackFileInfo,
   SlackHistoryFile,
   SlackThreadHistoryMessage,
   SlackThreadHistoryRequest,
@@ -21,6 +22,7 @@ export {
   extractSlackInboundFiles,
   isChannelAllowedByWhitelist,
   isSlackDirectMessageId,
+  isSlackFileSourceAllowed,
   isSlackWriteTargetAllowed,
   markdownToMrkdwn,
   SlackConnector,

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -111,6 +111,8 @@ export interface SlackAgentToolsConfig {
   reactions?: boolean;
   /** Upload a file/image to a channel or thread (agor_gateway_slack_file_upload). */
   file_upload?: boolean;
+  /** Download a Slack file into the upload area by id (agor_gateway_slack_file_download). */
+  file_download?: boolean;
 }
 
 export type SlackAgentToolCapability = keyof SlackAgentToolsConfig;
@@ -127,12 +129,16 @@ export type SlackAgentToolCapability = keyof SlackAgentToolsConfig;
  * - `reactions` and `file_upload` default OFF — both add write scopes
  *   (`reactions:write`, `files:write`) the installed app may not hold, so
  *   they require explicit opt-in.
+ * - `file_download` defaults OFF — it lets agents pull workspace file content
+ *   on demand and adds the `files:read` scope the installed app may not hold,
+ *   so it requires explicit opt-in.
  */
 export const SLACK_AGENT_TOOL_DEFAULTS: Record<SlackAgentToolCapability, boolean> = {
   thread_history: true,
   channel_history: false,
   reactions: false,
   file_upload: false,
+  file_download: false,
 };
 
 /**


### PR DESCRIPTION
Implements Max's "metadata + on-demand download" idea for Slack gateway files, in two parts.

## Part 1 — file metadata in history reads

`agor_gateway_slack_thread_history_get` / `agor_gateway_slack_channel_history_get` previously returned text only, so an agent couldn't see that a message carried a file. History messages now include a `files` array with per-file **metadata only** — `id`, `name`, `mimetype`, `size` — populated in the connector's shared history normalization (reusing `extractSlackInboundFiles`). `url_private_download` is deliberately stripped from all agent-facing output (JSON and markdown formats): agents reference a file by its `id`, so bot-token-authenticated URLs never enter a transcript.

## Part 2 — on-demand download tool `agor_gateway_slack_file_download`

- **Input:** `fileId` (from the history metadata) + optional `gatewayChannelId` (defaults to the calling gateway session's own channel via `gateway_source`).
- **Gate + bind:** mirrors the existing resolver/gating pattern exactly — capability-gated on the **target** channel's `agent_tools.file_download` (new capability, default **disabled**), hard-bound to the calling session's branch (cross-branch denied even for admins), and callers without session context need admin or `'all'` branch permission. The shared resolver was split into a channel-level half (`resolveGatewaySlackChannelTarget`) reused by conversation-targeting tools.
- **Fetch:** `files.info(fileId)` with the channel's bot token to obtain `url_private_download`, then downloads through **#1847's hardened ingestion path** (`ingestInboundAttachments`): slack.com host allowlist with per-hop redirect revalidation, streaming byte-cap, size limits, `file.id`-prefixed filename in the daemon upload directory. Respects the same `isIngestableFile` type boundary (images + text-like only; svg/scripts/PDF/etc. rejected before any fetch). Returns the stored absolute path so the agent can Read it.

## Capability + scope (single source of truth)

`file_download` added to `SlackAgentToolsConfig` (default off) and `SLACK_AGENT_TOOL_SCOPES` → `files:read`, so enabling the toggle drives both the call-time gate and the manifest scopes. Surfaced in the UI wizard/edit forms and `agor_gateway_slack_manifest_generate` like the other capabilities.

## Out of scope

Eager auto-download of history files (this is on-demand only); PDFs/OCR (#1719).

## Tests

- History results include file metadata and never leak `url_private_download` (connector + MCP layer, JSON + markdown).
- `files.info` normalization (`getFileInfo`) happy/error/malformed paths.
- Download tool: hardened-path reuse proven end-to-end (stubbed fetch — asserts bot-token auth against the allowlisted Slack URL with manual redirects), capability-disabled → actionable error, cross-branch denied even as admin, disallowed mimetype rejected without fetching, host allowlist inherited (no fetch to non-slack.com), no-session admin/`'all'` path, `fileId` schema validation.
- Manifest: `files:read` present iff `file_download` on (unless forced by another capability such as `ingest_files`).

## Stacking

⚠️ **Stacked on #1883** (`gateway-slack-text-ingestion`) — this PR's base is E's branch, NOT main. Rebase to main after #1883 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)