### PR TITLE
fix(ui): keep branch header actions visible

### DIFF
--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.teammate.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.teammate.test.tsx
@@ -13,7 +13,9 @@ vi.mock('../BranchCard', () => ({
 }));
 
 vi.mock('../BranchHeaderPill', () => ({
-  BranchHeaderPill: () => <div data-testid="branch-header-pill" />,
+  BranchHeaderPill: ({ fluid }: { fluid?: boolean }) => (
+    <div data-testid="branch-header-pill" data-fluid={String(fluid)} />
+  ),
 }));
 
 const board = { board_id: 'board-1', name: 'Board', slug: 'board' } as Board;
@@ -49,5 +51,6 @@ describe('BoardTeammatePanel teammate tab', () => {
     expect(screen.getByTestId('teammate-session-sections')).toHaveTextContent(
       'defaultExpanded:true'
     );
+    expect(screen.getByTestId('branch-header-pill')).toHaveAttribute('data-fluid', 'true');
   });
 });

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -299,7 +299,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               </div>
             </div>
 
-            <Space size={4} wrap>
+            <div style={{ minWidth: 0 }}>
               <BranchHeaderPill
                 repo={primaryTeammateRepo}
                 branch={primaryTeammateBranch}
@@ -307,28 +307,35 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
                 onOpenBranch={onOpenSettings}
                 showEnvButtons={false}
                 compact
+                fluid
               />
-              {primaryTeammateBranch.created_by && (
-                <CreatedByTag
-                  createdBy={primaryTeammateBranch.created_by}
-                  currentUserId={currentUserId}
-                  userById={userById}
-                  prefix="Created by"
-                />
+              {(primaryTeammateBranch.created_by ||
+                primaryTeammateBranch.issue_url ||
+                primaryTeammateBranch.pull_request_url) && (
+                <Space size={4} wrap style={{ marginTop: 4 }}>
+                  {primaryTeammateBranch.created_by && (
+                    <CreatedByTag
+                      createdBy={primaryTeammateBranch.created_by}
+                      currentUserId={currentUserId}
+                      userById={userById}
+                      prefix="Created by"
+                    />
+                  )}
+                  {primaryTeammateBranch.issue_url && (
+                    <IssuePill
+                      issueUrl={primaryTeammateBranch.issue_url}
+                      currentRepo={primaryTeammateRepo}
+                    />
+                  )}
+                  {primaryTeammateBranch.pull_request_url && (
+                    <PullRequestPill
+                      prUrl={primaryTeammateBranch.pull_request_url}
+                      currentRepo={primaryTeammateRepo}
+                    />
+                  )}
+                </Space>
               )}
-              {primaryTeammateBranch.issue_url && (
-                <IssuePill
-                  issueUrl={primaryTeammateBranch.issue_url}
-                  currentRepo={primaryTeammateRepo}
-                />
-              )}
-              {primaryTeammateBranch.pull_request_url && (
-                <PullRequestPill
-                  prUrl={primaryTeammateBranch.pull_request_url}
-                  currentRepo={primaryTeammateRepo}
-                />
-              )}
-            </Space>
+            </div>
             {teammateDescription && (
               <div className="markdown-compact" style={{ color: token.colorTextSecondary }}>
                 <MarkdownRenderer content={teammateDescription} compact showControls={false} />

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -6,6 +6,7 @@ import {
   App as AntApp,
   Button,
   Empty,
+  Flex,
   Select,
   Skeleton,
   Space,
@@ -299,7 +300,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               </div>
             </div>
 
-            <div style={{ minWidth: 0 }}>
+            <Flex vertical style={{ minWidth: 0 }}>
               <BranchHeaderPill
                 repo={primaryTeammateRepo}
                 branch={primaryTeammateBranch}
@@ -312,7 +313,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               {(primaryTeammateBranch.created_by ||
                 primaryTeammateBranch.issue_url ||
                 primaryTeammateBranch.pull_request_url) && (
-                <Space size={4} wrap style={{ marginTop: 4 }}>
+                <Flex gap={token.sizeUnit} wrap style={{ marginTop: token.sizeUnit }}>
                   {primaryTeammateBranch.created_by && (
                     <CreatedByTag
                       createdBy={primaryTeammateBranch.created_by}
@@ -333,9 +334,9 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
                       currentRepo={primaryTeammateRepo}
                     />
                   )}
-                </Space>
+                </Flex>
               )}
-            </div>
+            </Flex>
             {teammateDescription && (
               <div className="markdown-compact" style={{ color: token.colorTextSecondary }}>
                 <MarkdownRenderer content={teammateDescription} compact showControls={false} />

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
@@ -100,8 +100,8 @@ const defaultProps = {
 };
 
 describe('BranchHeaderPill', () => {
-  it('hides the destructive nuke action in compact mode', () => {
-    render(<BranchHeaderPill {...defaultProps} compact />);
+  it('keeps compact fluid actions at the default width and hides the destructive action', () => {
+    render(<BranchHeaderPill {...defaultProps} compact fluid />);
 
     expect(
       screen.getByRole('button', {
@@ -160,7 +160,7 @@ describe('BranchHeaderPill', () => {
     expect(link).toHaveAttribute('href', '/ui/s/abc123/');
   });
 
-  it('lets a fluid identity shrink without compressing its action sections', () => {
+  it('keeps a fluid identity accessible and selects the narrow action-button variant', () => {
     render(
       <BranchHeaderPill {...defaultProps} identityLink="https://agor.example/ui/s/abc123/" fluid />
     );
@@ -168,35 +168,15 @@ describe('BranchHeaderPill', () => {
     const identity = screen.getByRole('link', {
       name: 'preset-io/agor / feature/remove-nuke · Open session',
     });
-    expect(identity).toHaveStyle({
-      display: 'flex',
-      flex: '1 1 auto',
-      minWidth: '0',
-      overflow: 'hidden',
-    });
-    expect(identity.parentElement).toHaveStyle({
-      display: 'flex',
-      width: '100%',
-      minWidth: '0',
-      maxWidth: '100%',
-    });
+    expect(identity).toHaveAttribute('data-tooltip-trigger', 'hover,focus');
 
     expect(screen.getByText(repo.slug)).toHaveStyle({
-      flex: '0 1 auto',
-      minWidth: '0',
+      overflow: 'hidden',
       textOverflow: 'ellipsis',
     });
     expect(screen.getByText(branch.name)).toHaveStyle({
-      flex: '1 1 auto',
-      minWidth: '0',
+      overflow: 'hidden',
       textOverflow: 'ellipsis',
-    });
-
-    expect(screen.getByRole('button', { name: 'Start environment' }).parentElement).toHaveStyle({
-      flexShrink: '0',
-    });
-    expect(screen.getByRole('button', { name: 'Sessions' }).parentElement).toHaveStyle({
-      flexShrink: '0',
     });
 
     for (const name of [

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
@@ -169,6 +169,14 @@ describe('BranchHeaderPill', () => {
       name: 'preset-io/agor / feature/remove-nuke · Open session',
     });
     expect(identity).toHaveAttribute('data-tooltip-trigger', 'hover,focus');
+    expect(identity).toHaveStyle({
+      flex: '1 1 auto',
+      minWidth: '0',
+    });
+    expect(identity.parentElement).toHaveStyle({
+      width: '100%',
+      minWidth: '0',
+    });
 
     expect(screen.getByText(repo.slug)).toHaveStyle({
       overflow: 'hidden',
@@ -177,6 +185,13 @@ describe('BranchHeaderPill', () => {
     expect(screen.getByText(branch.name)).toHaveStyle({
       overflow: 'hidden',
       textOverflow: 'ellipsis',
+    });
+
+    expect(screen.getByRole('button', { name: 'Start environment' }).parentElement).toHaveStyle({
+      flexShrink: '0',
+    });
+    expect(screen.getByRole('button', { name: 'Sessions' }).parentElement).toHaveStyle({
+      flexShrink: '0',
     });
 
     for (const name of [

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
@@ -14,8 +14,21 @@ vi.mock('antd', async () => {
     }: React.ButtonHTMLAttributes<HTMLButtonElement> & { icon?: React.ReactNode }) =>
       React.createElement('button', props, icon, children),
     Spin: () => React.createElement('span', null, 'loading'),
-    Tooltip: ({ children }: { children: React.ReactNode }) =>
-      React.createElement(React.Fragment, null, children),
+    Tooltip: ({
+      children,
+      trigger,
+    }: {
+      children: React.ReactNode;
+      trigger?: string | string[];
+    }) => {
+      if (!React.isValidElement(children)) {
+        return React.createElement(React.Fragment, null, children);
+      }
+
+      return React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+        'data-tooltip-trigger': Array.isArray(trigger) ? trigger.join(',') : trigger,
+      });
+    },
     Tag: Object.assign(
       ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) =>
         React.createElement('span', props, children),
@@ -90,16 +103,29 @@ describe('BranchHeaderPill', () => {
   it('hides the destructive nuke action in compact mode', () => {
     render(<BranchHeaderPill {...defaultProps} compact />);
 
+    expect(
+      screen.getByRole('button', {
+        name: 'preset-io/agor / feature/remove-nuke · Open branch settings',
+      })
+    ).toHaveAttribute('data-tooltip-trigger', 'hover,focus');
     expect(screen.getByRole('button', { name: 'Start environment' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Stop environment' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'View environment logs' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Nuke environment' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sessions' })).toHaveStyle({
+      width: '22px',
+      minWidth: '22px',
+    });
   });
 
   it('keeps the destructive nuke action in non-compact mode', () => {
     render(<BranchHeaderPill {...defaultProps} />);
 
     expect(screen.getByRole('button', { name: 'Nuke environment' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Start environment' })).toHaveStyle({
+      width: '22px',
+      minWidth: '22px',
+    });
   });
 
   it('can explicitly hide only the destructive nuke action', () => {
@@ -114,8 +140,11 @@ describe('BranchHeaderPill', () => {
   it('uses the supplied identity link for the branch identity area', () => {
     render(<BranchHeaderPill {...defaultProps} identityLink="https://agor.example/ui/s/abc123/" />);
 
-    const link = screen.getByRole('link', { name: /preset-io\/agor.*feature\/remove-nuke/ });
+    const link = screen.getByRole('link', {
+      name: 'preset-io/agor / feature/remove-nuke · Open session',
+    });
     expect(link).toHaveAttribute('href', 'https://agor.example/ui/s/abc123/');
+    expect(link).toHaveAttribute('data-tooltip-trigger', 'hover,focus');
   });
 
   it('renders basename-aware internal identity links', () => {
@@ -125,7 +154,66 @@ describe('BranchHeaderPill', () => {
       </MemoryRouter>
     );
 
-    const link = screen.getByRole('link', { name: /preset-io\/agor.*feature\/remove-nuke/ });
+    const link = screen.getByRole('link', {
+      name: 'preset-io/agor / feature/remove-nuke · Open session',
+    });
     expect(link).toHaveAttribute('href', '/ui/s/abc123/');
+  });
+
+  it('lets a fluid identity shrink without compressing its action sections', () => {
+    render(
+      <BranchHeaderPill {...defaultProps} identityLink="https://agor.example/ui/s/abc123/" fluid />
+    );
+
+    const identity = screen.getByRole('link', {
+      name: 'preset-io/agor / feature/remove-nuke · Open session',
+    });
+    expect(identity).toHaveStyle({
+      display: 'flex',
+      flex: '1 1 auto',
+      minWidth: '0',
+      overflow: 'hidden',
+    });
+    expect(identity.parentElement).toHaveStyle({
+      display: 'flex',
+      width: '100%',
+      minWidth: '0',
+      maxWidth: '100%',
+    });
+
+    expect(screen.getByText(repo.slug)).toHaveStyle({
+      flex: '0 1 auto',
+      minWidth: '0',
+      textOverflow: 'ellipsis',
+    });
+    expect(screen.getByText(branch.name)).toHaveStyle({
+      flex: '1 1 auto',
+      minWidth: '0',
+      textOverflow: 'ellipsis',
+    });
+
+    expect(screen.getByRole('button', { name: 'Start environment' }).parentElement).toHaveStyle({
+      flexShrink: '0',
+    });
+    expect(screen.getByRole('button', { name: 'Sessions' }).parentElement).toHaveStyle({
+      flexShrink: '0',
+    });
+
+    for (const name of [
+      'Start environment',
+      'Stop environment',
+      'View environment logs',
+      'Nuke environment',
+      'Sessions',
+      'Files',
+      'Schedule',
+      'Edit branch',
+    ]) {
+      expect(screen.getByRole('button', { name })).toHaveStyle({
+        height: '22px',
+        width: '20px',
+        minWidth: '20px',
+      });
+    }
   });
 });

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -51,7 +51,26 @@ interface BranchHeaderPillProps {
 }
 
 const PILL_HEIGHT = 22;
-const FLUID_ACTION_WIDTH = 20;
+const ACTION_BUTTON_HEIGHT = 22;
+const DEFAULT_ACTION_BUTTON_WIDTH = 22;
+
+const DEFAULT_ACTION_BUTTON_STYLE: React.CSSProperties = {
+  height: ACTION_BUTTON_HEIGHT,
+  width: DEFAULT_ACTION_BUTTON_WIDTH,
+  minWidth: DEFAULT_ACTION_BUTTON_WIDTH,
+  padding: 0,
+};
+
+// The configured environment and shortcut sections cannot shrink. Reclaim two
+// pixels per action only in the constrained, non-compact fluid layout so the
+// complete action row fits before identity text collapses to its ellipsis.
+const FLUID_ACTION_BUTTON_WIDTH = 20;
+const FLUID_ACTION_BUTTON_STYLE: React.CSSProperties = {
+  height: ACTION_BUTTON_HEIGHT,
+  width: FLUID_ACTION_BUTTON_WIDTH,
+  minWidth: FLUID_ACTION_BUTTON_WIDTH,
+  padding: 0,
+};
 
 export function BranchHeaderPill({
   repo,
@@ -85,17 +104,8 @@ export function BranchHeaderPill({
   const controlDisabledTooltip = resolvedCanControlEnvironment
     ? undefined
     : "Requires branch 'all' permission or admin access";
-  // The configured environment and shortcut sections have an intrinsic width
-  // that cannot shrink. Reclaim two pixels per action only in the constrained,
-  // non-compact fluid layout so the complete action row fits before identity
-  // text is allowed to collapse to its ellipsis.
-  const actionWidth = fluid && !compact ? FLUID_ACTION_WIDTH : PILL_HEIGHT;
-  const iconButtonStyle: React.CSSProperties = {
-    height: PILL_HEIGHT,
-    width: actionWidth,
-    minWidth: actionWidth,
-    padding: 0,
-  };
+  const actionButtonStyle =
+    fluid && !compact ? FLUID_ACTION_BUTTON_STYLE : DEFAULT_ACTION_BUTTON_STYLE;
 
   const status = env?.status || 'stopped';
   const isRunning = status === 'running';
@@ -367,7 +377,7 @@ export function BranchHeaderPill({
                       if (!startDisabled) onStartEnvironment(branch.branch_id);
                     }}
                     disabled={startDisabled}
-                    style={iconButtonStyle}
+                    style={actionButtonStyle}
                   />
                 </Tooltip>
               )}
@@ -396,7 +406,7 @@ export function BranchHeaderPill({
                       if (!stopDisabled) onStopEnvironment(branch.branch_id);
                     }}
                     disabled={stopDisabled}
-                    style={iconButtonStyle}
+                    style={actionButtonStyle}
                   />
                 </Tooltip>
               )}
@@ -414,7 +424,7 @@ export function BranchHeaderPill({
                       if (resolvedCanControlEnvironment) onViewLogs(branch.branch_id);
                     }}
                     disabled={!resolvedCanControlEnvironment}
-                    style={iconButtonStyle}
+                    style={actionButtonStyle}
                   />
                 </Tooltip>
               )}
@@ -435,7 +445,7 @@ export function BranchHeaderPill({
                       }
                     }}
                     disabled={connectionDisabled || !resolvedCanControlEnvironment}
-                    style={iconButtonStyle}
+                    style={actionButtonStyle}
                   />
                 </Tooltip>
               )}
@@ -486,7 +496,7 @@ export function BranchHeaderPill({
             aria-label="Sessions"
             icon={<TeamOutlined />}
             onClick={openTab('sessions')}
-            style={iconButtonStyle}
+            style={actionButtonStyle}
           />
         </Tooltip>
         <Tooltip title="Files">
@@ -496,7 +506,7 @@ export function BranchHeaderPill({
             aria-label="Files"
             icon={<FolderOutlined />}
             onClick={openTab('files')}
-            style={iconButtonStyle}
+            style={actionButtonStyle}
           />
         </Tooltip>
         <Tooltip title="Schedule">
@@ -506,7 +516,7 @@ export function BranchHeaderPill({
             aria-label="Schedule"
             icon={<CalendarOutlined />}
             onClick={openTab('schedule')}
-            style={iconButtonStyle}
+            style={actionButtonStyle}
           />
         </Tooltip>
         <Tooltip title="Edit branch">
@@ -519,7 +529,7 @@ export function BranchHeaderPill({
               e.stopPropagation();
               openModal();
             }}
-            style={iconButtonStyle}
+            style={actionButtonStyle}
           />
         </Tooltip>
       </div>

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -41,6 +41,8 @@ interface BranchHeaderPillProps {
   showNukeEnvironment?: boolean;
   /** Optional link for the branch identity area. Used by session surfaces for deep links. */
   identityLink?: string | null;
+  /** Fill the available row width and let the identity shrink before action sections. */
+  fluid?: boolean;
   /**
    * Compact rendering for constrained side panels.
    * Hides the repo slug in the identity section and omits destructive environment actions.
@@ -49,13 +51,7 @@ interface BranchHeaderPillProps {
 }
 
 const PILL_HEIGHT = 22;
-
-const iconButtonStyle: React.CSSProperties = {
-  height: PILL_HEIGHT,
-  width: PILL_HEIGHT,
-  minWidth: PILL_HEIGHT,
-  padding: 0,
-};
+const FLUID_ACTION_WIDTH = 20;
 
 export function BranchHeaderPill({
   repo,
@@ -71,6 +67,7 @@ export function BranchHeaderPill({
   showEnvButtons = true,
   showNukeEnvironment = true,
   identityLink,
+  fluid = false,
   compact = false,
 }: BranchHeaderPillProps) {
   const { token } = theme.useToken();
@@ -88,6 +85,17 @@ export function BranchHeaderPill({
   const controlDisabledTooltip = resolvedCanControlEnvironment
     ? undefined
     : "Requires branch 'all' permission or admin access";
+  // The configured environment and shortcut sections have an intrinsic width
+  // that cannot shrink. Reclaim two pixels per action only in the constrained,
+  // non-compact fluid layout so the complete action row fits before identity
+  // text is allowed to collapse to its ellipsis.
+  const actionWidth = fluid && !compact ? FLUID_ACTION_WIDTH : PILL_HEIGHT;
+  const iconButtonStyle: React.CSSProperties = {
+    height: PILL_HEIGHT,
+    width: actionWidth,
+    minWidth: actionWidth,
+    padding: 0,
+  };
 
   const status = env?.status || 'stopped';
   const isRunning = status === 'running';
@@ -121,20 +129,34 @@ export function BranchHeaderPill({
 
   const identityContent = (
     <>
-      <BranchesOutlined style={{ fontSize: 12 }} />
+      <BranchesOutlined style={{ fontSize: 12, flexShrink: 0 }} />
       {!compact && (
         <>
-          <span style={{ fontFamily: token.fontFamilyCode, fontSize: token.fontSizeSM }}>
+          <span
+            style={{
+              fontFamily: token.fontFamilyCode,
+              fontSize: token.fontSizeSM,
+              ...(fluid
+                ? {
+                    flex: '0 1 auto',
+                    minWidth: 0,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }
+                : {}),
+            }}
+          >
             {repo.slug}
           </span>
-          <ApartmentOutlined style={{ fontSize: 10, opacity: 0.6 }} />
+          <ApartmentOutlined style={{ fontSize: 10, opacity: 0.6, flexShrink: 0 }} />
         </>
       )}
       <span
         style={{
           fontFamily: token.fontFamilyCode,
           fontSize: token.fontSizeSM,
-          maxWidth: compact ? 220 : 180,
+          ...(fluid ? { flex: '1 1 auto', minWidth: 0 } : { maxWidth: compact ? 220 : 180 }),
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
@@ -194,13 +216,9 @@ export function BranchHeaderPill({
     }
   };
 
-  const identityTooltip = identityLink
-    ? `${repo.slug} / ${branch.name} · Open session`
-    : compact
-      ? `${repo.slug} / ${branch.name} · Open branch settings`
-      : 'Open branch settings';
+  const identityTooltip = `${repo.slug} / ${branch.name} · ${identityLink ? 'Open session' : 'Open branch settings'}`;
   const identityLinkStyle: React.CSSProperties = {
-    display: 'inline-flex',
+    display: fluid ? 'flex' : 'inline-flex',
     alignItems: 'center',
     gap: 4,
     padding: compact ? '0 6px' : '0 8px',
@@ -208,6 +226,7 @@ export function BranchHeaderPill({
     height: PILL_HEIGHT,
     color: 'inherit',
     textDecoration: 'none',
+    ...(fluid ? { flex: '1 1 auto', minWidth: 0, overflow: 'hidden' } : {}),
   };
   const isInternalIdentityLink = identityLink?.startsWith('/');
 
@@ -221,24 +240,36 @@ export function BranchHeaderPill({
         padding: 0,
         overflow: 'hidden',
         lineHeight: `${PILL_HEIGHT}px`,
-        display: 'inline-flex',
+        display: fluid ? 'flex' : 'inline-flex',
         alignItems: 'stretch',
         cursor: 'default',
+        ...(fluid ? { width: '100%', minWidth: 0, maxWidth: '100%' } : {}),
       }}
     >
       {/* Section 1: Repo + Branch — click opens either the supplied identity URL or the branch modal. */}
-      <Tooltip title={identityTooltip}>
+      <Tooltip title={identityTooltip} trigger={['hover', 'focus']}>
         {identityLink && isInternalIdentityLink ? (
-          <Link to={identityLink} onClick={(e) => e.stopPropagation()} style={identityLinkStyle}>
+          <Link
+            to={identityLink}
+            aria-label={identityTooltip}
+            onClick={(e) => e.stopPropagation()}
+            style={identityLinkStyle}
+          >
             {identityContent}
           </Link>
         ) : identityLink ? (
-          <a href={identityLink} onClick={(e) => e.stopPropagation()} style={identityLinkStyle}>
+          <a
+            href={identityLink}
+            aria-label={identityTooltip}
+            onClick={(e) => e.stopPropagation()}
+            style={identityLinkStyle}
+          >
             {identityContent}
           </a>
         ) : (
           <button
             type="button"
+            aria-label={identityTooltip}
             onClick={openModal}
             style={{
               display: 'inline-flex',
@@ -251,6 +282,7 @@ export function BranchHeaderPill({
               border: 'none',
               color: 'inherit',
               font: 'inherit',
+              ...(fluid ? { flex: '1 1 auto', minWidth: 0, overflow: 'hidden' } : {}),
             }}
           >
             {identityContent}
@@ -268,6 +300,7 @@ export function BranchHeaderPill({
             padding: '0 4px',
             height: PILL_HEIGHT,
             borderLeft: `1px solid ${token.colorBorderSecondary}`,
+            flexShrink: 0,
           }}
         >
           {hasConfig ? (
@@ -443,6 +476,7 @@ export function BranchHeaderPill({
           padding: '0 3px',
           height: PILL_HEIGHT,
           borderLeft: `1px solid ${token.colorBorderSecondary}`,
+          flexShrink: 0,
         }}
       >
         <Tooltip title={`Sessions${sessionCount != null ? ` (${sessionCount})` : ''}`}>

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -9,7 +9,7 @@ import {
   VerticalAlignBottomOutlined,
   VerticalAlignTopOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Divider, Space, Tabs, Tooltip, Typography, theme } from 'antd';
+import { Alert, Button, Divider, Flex, Space, Tabs, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAgorStore } from '../../store/agorStore';
@@ -136,7 +136,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
         >
           {/* Pills section (only shown if there's content) */}
           {branch && (
-            <div style={{ flex: '1 1 0', minWidth: 0 }}>
+            <Flex vertical style={{ flex: '1 1 0', minWidth: 0 }}>
               {/* Unified Branch Pill — owns the first row so its actions keep priority. */}
               {repo && (
                 <BranchHeaderPill
@@ -152,7 +152,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                 />
               )}
               {(branch.issue_url || branch.pull_request_url) && (
-                <Space size={8} wrap style={{ marginTop: token.sizeUnit }}>
+                <Space size={token.sizeUnit * 2} wrap style={{ marginTop: token.sizeUnit }}>
                   {branch.issue_url && (
                     <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
                   )}
@@ -164,7 +164,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                   )}
                 </Space>
               )}
-            </div>
+            </Flex>
           )}
           {/* Spacer if no pills */}
           {!branch && <div style={{ flex: 1 }} />}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -128,16 +128,17 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
           style={{
             marginBottom: token.sizeUnit,
             display: 'flex',
-            alignItems: 'center',
+            // Keep navigation aligned with the branch pill's first row when metadata wraps below it.
+            alignItems: 'flex-start',
             justifyContent: 'space-between',
             gap: token.sizeUnit * 2,
           }}
         >
           {/* Pills section (only shown if there's content) */}
           {branch && (
-            <Space size={8} wrap style={{ flex: 1 }}>
-              {/* Unified Branch Pill */}
-              {branch && repo && (
+            <div style={{ flex: '1 1 0', minWidth: 0 }}>
+              {/* Unified Branch Pill — owns the first row so its actions keep priority. */}
+              {repo && (
                 <BranchHeaderPill
                   repo={repo}
                   branch={branch}
@@ -147,21 +148,28 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                   onNukeEnvironment={onNukeEnvironment}
                   onViewLogs={onViewLogs}
                   identityLink={sessionPath(session.session_id)}
+                  fluid
                 />
               )}
-              {/* Issue and PR Pills */}
-              {branch?.issue_url && (
-                <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
+              {(branch.issue_url || branch.pull_request_url) && (
+                <Space size={8} wrap style={{ marginTop: token.sizeUnit }}>
+                  {branch.issue_url && (
+                    <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
+                  )}
+                  {branch.pull_request_url && (
+                    <PullRequestPill
+                      prUrl={branch.pull_request_url}
+                      currentRepo={repo ?? undefined}
+                    />
+                  )}
+                </Space>
               )}
-              {branch?.pull_request_url && (
-                <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo ?? undefined} />
-              )}
-            </Space>
+            </div>
           )}
           {/* Spacer if no pills */}
           {!branch && <div style={{ flex: 1 }} />}
           {/* Scroll Navigation Buttons - always visible */}
-          <Space size={4}>
+          <Space size={4} style={{ flexShrink: 0 }}>
             <Tooltip title="Scroll to top of conversation">
               <Button
                 type="text"


### PR DESCRIPTION
## Linked issue

N/A — no public issue is linked.

## Summary

- Keep environment, branch shortcut, and conversation scroll actions visible in constrained session and teammate drawers.
- Truncate long repository and branch identities while preserving the full identity on hover and keyboard focus with accessible labels.
- Align the responsive layout with AntD Flex and theme-token spacing conventions.

## Why / context

Long identities and wrapped metadata could displace or clip important controls at narrow drawer widths. The configured environment action group exposed the remaining intrinsic-width edge case.

## Implementation notes

- Opt affected surfaces into fluid `BranchHeaderPill` sizing and let the identity yield space before fixed actions.
- Use AntD Flex for the affected layout wrappers and theme tokens for routine metadata spacing.
- Keep stable module-level action styles: configured non-compact fluid buttons use 20px widths, while compact and non-fluid actions retain 22px widths.
- Wrap metadata on its own row and top-align session scroll controls with the pill row.

## Validation / test plan

- [x] `pnpm --filter agor-ui test -- BranchHeaderPill BoardTeammatePanel` (5 files / 16 tests)
- [x] `pnpm --filter agor-ui test -- SessionPanel` (9 files / 61 tests)
- [x] Biome checks on touched files
- [x] Refreshed rendered wide, medium, and narrow checks for session and teammate drawers
- [x] Configured minimum-width check at 357.55px: all 11 controls visible, zero overlaps, pill 247/247, Edit unclipped with 4px margin, and scroll alignment delta 0px
- [x] Independent browser layout measurement confirmed

## Screenshots / demos

Rendered screenshots were refreshed during local validation; no private or local paths are included here.

## Risks / rollout / rollback

UI-only sizing and layout change. Opt-in fluid behavior limits shared-component impact. Rollback is reverting the commits.

## Out of scope / follow-ups

No action-priority redesign or overflow menu.
