### PR TITLE
Default new boards to Gold Shimmer

### DIFF
--- a/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/CreateDialog.test.tsx
@@ -18,6 +18,7 @@
  * own slot, and the footer reads `validByTab[activeTab]`.
  */
 
+import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 import type { Repo } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -188,5 +189,25 @@ describe('CreateDialog — per-tab validity scoping', { timeout: 60_000 }, () =>
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Create Board/i })).toBeDisabled();
     }, ASYNC);
+  });
+
+  it('submits Gold Shimmer as the default board background', async () => {
+    const onCreateBoard = vi.fn();
+    renderDialog({ defaultTab: 'board', onCreateBoard });
+
+    fireEvent.change(await screen.findByPlaceholderText('My Board', undefined, ASYNC), {
+      target: { value: 'Launch Board' },
+    });
+    const button = screen.getByRole('button', { name: /Create Board/i });
+    await waitFor(() => expect(button).not.toBeDisabled(), ASYNC);
+    fireEvent.click(button);
+
+    await waitFor(
+      () =>
+        expect(onCreateBoard).toHaveBeenCalledWith(
+          expect.objectContaining({ background_color: GOLD_SHIMMER_BOARD_BACKGROUND })
+        ),
+      ASYNC
+    );
   });
 });

--- a/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
+++ b/apps/agor-ui/src/components/CreateDialog/tabs/BoardTab.tsx
@@ -1,3 +1,4 @@
+import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 import type { Board } from '@agor-live/client';
 import { Form } from 'antd';
 import { useCallback } from 'react';
@@ -31,8 +32,14 @@ export const BoardTab: React.FC<BoardTabProps> = ({ onValidityChange, formRef })
   };
 
   return (
-    <Form form={form} layout="vertical" preserve onValuesChange={handleValuesChange}>
-      <BoardFormFields form={form} autoFocus />
+    <Form
+      form={form}
+      layout="vertical"
+      preserve
+      initialValues={{ background_color: GOLD_SHIMMER_BOARD_BACKGROUND }}
+      onValuesChange={handleValuesChange}
+    >
+      <BoardFormFields form={form} autoFocus initialCustomCSS />
     </Form>
   );
 };

--- a/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/BoardsTable.tsx
@@ -1,3 +1,4 @@
+import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 import type {
   AgorClient,
   Board,
@@ -484,7 +485,15 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
           <Button icon={<UploadOutlined />} onClick={handleImportClick}>
             Import Board
           </Button>
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              form.resetFields();
+              form.setFieldsValue({ background_color: GOLD_SHIMMER_BOARD_BACKGROUND });
+              setCreateModalOpen(true);
+            }}
+          >
             New Board
           </Button>
         </Space>
@@ -514,7 +523,7 @@ export const BoardsTable: React.FC<BoardsTableProps> = ({
         okText="Create"
       >
         <Form form={form} layout="vertical" preserve style={{ marginTop: 16 }}>
-          <BoardFormFields form={form} extra={customContextField} />
+          <BoardFormFields form={form} extra={customContextField} initialCustomCSS />
         </Form>
       </Modal>
 

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -147,6 +147,7 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
   allGroups = [],
 }) => {
   const [useCustomCSS, setUseCustomCSS] = useState(initialCustomCSS);
+  const backgroundColor = Form.useWatch('background_color', { form, preserve: true });
 
   const generalFields = (
     <>
@@ -266,6 +267,11 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
               allowClear
               showSearch
               options={BACKGROUND_PRESETS}
+              value={
+                BACKGROUND_PRESETS.some((preset) => preset.value === backgroundColor)
+                  ? backgroundColor
+                  : undefined
+              }
               onChange={(value) => {
                 if (value) form.setFieldsValue({ background_color: value });
               }}

--- a/apps/agor-ui/src/components/forms/boardBackgroundPresets.ts
+++ b/apps/agor-ui/src/components/forms/boardBackgroundPresets.ts
@@ -1,5 +1,7 @@
 // biome-ignore-all lint/plugin/noHardcodedColorLiteral: centralized user-selectable board background palette stores exact persisted gradients
 
+import { GOLD_SHIMMER_BOARD_BACKGROUND_PRESET } from '@agor/core/design/board-backgrounds';
+
 export const BACKGROUND_PRESETS = [
   {
     label: 'Rainbow (7 colors)',
@@ -16,10 +18,7 @@ export const BACKGROUND_PRESETS = [
     value:
       'linear-gradient(180deg, #f093fb 0%, #f5576c 25%, #4facfe 50%, #00f2fe 75%, #43e97b 100%)',
   },
-  {
-    label: 'Gold shimmer',
-    value: 'linear-gradient(135deg, #f5af19 0%, #f12711 30%, #f5af19 60%, #f12711 100%)',
-  },
+  GOLD_SHIMMER_BOARD_BACKGROUND_PRESET,
   {
     label: 'Cyan/magenta grid',
     value:

--- a/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
+++ b/apps/agor-ui/src/pages/MarketingScreenshotPage.tsx
@@ -1,4 +1,6 @@
 // biome-ignore-all lint/plugin/noHardcodedColorLiteral: demo-only marketing screenshot palette
+
+import { GOLD_SHIMMER_BOARD_BACKGROUND } from '@agor/core/design/board-backgrounds';
 import type {
   ActiveUser,
   Board,
@@ -55,7 +57,7 @@ const board: Board = {
   created_by: users[0].user_id,
   archived: false,
   url: '/demo/marketing-screenshots',
-  background_color: 'linear-gradient(135deg, #f5af19 0%, #f12711 30%, #f5af19 60%, #f12711 100%)',
+  background_color: GOLD_SHIMMER_BOARD_BACKGROUND,
   objects: {
     'zone-ship': {
       type: 'zone',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,12 @@
       "import": "./dist/types/index.js",
       "require": "./dist/types/index.cjs"
     },
+    "./design/board-backgrounds": {
+      "source": "./src/design/board-backgrounds.ts",
+      "types": "./dist/design/board-backgrounds.d.ts",
+      "import": "./dist/design/board-backgrounds.js",
+      "require": "./dist/design/board-backgrounds.cjs"
+    },
     "./db": {
       "source": "./src/db/index.ts",
       "types": "./dist/db/index.d.ts",

--- a/packages/core/src/db/repositories/boards.test.ts
+++ b/packages/core/src/db/repositories/boards.test.ts
@@ -8,6 +8,7 @@
 import type { Board, BoardID, BoardObject, UUID } from '@agor/core/types';
 import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
+import { DEFAULT_BOARD_BACKGROUND } from '../../design/board-backgrounds';
 import { generateId, shortId, toShortId } from '../../lib/ids';
 import type { Database } from '../client';
 import { select, update } from '../database-wrapper';
@@ -43,6 +44,9 @@ function createBoardData(overrides?: Partial<Board>): Partial<Board> {
   };
   if (overrides && Object.hasOwn(overrides, 'primary_teammate_id')) {
     data.primary_teammate_id = overrides.primary_teammate_id;
+  }
+  if (overrides && Object.hasOwn(overrides, 'background_color')) {
+    data.background_color = overrides.background_color;
   }
   return data;
 }
@@ -110,6 +114,23 @@ async function getStoredBoardIcon(db: Database, boardId: UUID): Promise<string |
 // ============================================================================
 
 describe('BoardRepository.create', () => {
+  dbTest('defaults an omitted background to Gold Shimmer', async ({ db }) => {
+    const repo = new BoardRepository(db);
+
+    const created = await repo.create(createBoardData());
+
+    expect(created.background_color).toBe(DEFAULT_BOARD_BACKGROUND);
+  });
+
+  dbTest('preserves an explicitly supplied background', async ({ db }) => {
+    const repo = new BoardRepository(db);
+    const background = 'linear-gradient(90deg, red, blue)';
+
+    const created = await repo.create(createBoardData({ background_color: background }));
+
+    expect(created.background_color).toBe(background);
+  });
+
   dbTest('should create board with all required fields', async ({ db }) => {
     const repo = new BoardRepository(db);
     const data = createBoardData({

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -18,6 +18,7 @@ import { isTeammate } from '@agor/core/types';
 import { and, eq, inArray, isNull, like, ne, type SQL } from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
+import { DEFAULT_BOARD_BACKGROUND } from '../../design/board-backgrounds';
 import { generateId } from '../../lib/ids';
 import { generateSlug } from '../../lib/slugs';
 import { normalizeExactEmojiShortcode } from '../../utils/emoji-shortcodes';
@@ -165,7 +166,9 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
           board.default_dangerously_allow_session_sharing ?? false,
         color: board.color,
         icon: normalizeExactEmojiShortcode(board.icon),
-        background_color: board.background_color,
+        background_color: Object.hasOwn(board, 'background_color')
+          ? board.background_color
+          : DEFAULT_BOARD_BACKGROUND,
         custom_css: board.custom_css,
         objects: board.objects,
         custom_context: board.custom_context,

--- a/packages/core/src/design/board-backgrounds.ts
+++ b/packages/core/src/design/board-backgrounds.ts
@@ -1,0 +1,9 @@
+export const GOLD_SHIMMER_BOARD_BACKGROUND =
+  'linear-gradient(135deg, #f5af19 0%, #f12711 30%, #f5af19 60%, #f12711 100%)';
+
+export const GOLD_SHIMMER_BOARD_BACKGROUND_PRESET = {
+  label: 'Gold Shimmer',
+  value: GOLD_SHIMMER_BOARD_BACKGROUND,
+} as const;
+
+export const DEFAULT_BOARD_BACKGROUND = GOLD_SHIMMER_BOARD_BACKGROUND;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from './api/index.js';
 export * from './config/index.js';
 export { getBranchesDir, getBranchPath, getReposDir } from './config/index.js';
 export * from './db/index.js';
+export * from './design/board-backgrounds.js';
 export * from './environment/render-snapshot.js';
 export * from './git/index.js';
 export * from './knowledge/index.js';


### PR DESCRIPTION
## Summary

- define Gold Shimmer as the canonical shared board-background preset and default
- apply the default in the board repository so UI, API, MCP, onboarding, teammate, and seed creation paths stay consistent
- initialize UI board forms with Gold Shimmer selected while preserving explicit backgrounds and existing boards
- remove the duplicate marketing screenshot gradient literal

## Testing

- `pnpm --filter @agor/core test -- src/db/repositories/boards.test.ts`
- `pnpm --filter agor-ui test -- src/components/CreateDialog/CreateDialog.test.tsx`
- `pnpm exec biome check ...` (changed files)

## Validation notes

- Core and UI typechecks were attempted but are currently blocked by unresolved pre-existing workspace package exports (`@agor/git`, `@agor-live/client`) in this clean worktree.
