### PR TITLE
chore(config): retire obsolete configuration

### DIFF
--- a/apps/agor-cli/src/commands/config/get.ts
+++ b/apps/agor-cli/src/commands/config/get.ts
@@ -9,8 +9,7 @@ export default class ConfigGet extends Command {
   static description = 'Get a configuration value';
 
   static examples = [
-    '<%= config.bin %> <%= command.id %> defaults.board',
-    '<%= config.bin %> <%= command.id %> defaults.agent',
+    '<%= config.bin %> <%= command.id %> daemon.port',
     '<%= config.bin %> <%= command.id %> daemon.port',
   ];
 

--- a/apps/agor-cli/src/commands/config/index.ts
+++ b/apps/agor-cli/src/commands/config/index.ts
@@ -20,15 +20,6 @@ export default class ConfigIndex extends Command {
       this.log(chalk.bold('\nCurrent Configuration'));
       this.log(chalk.dim('─'.repeat(50)));
 
-      // Global Defaults
-      this.log(chalk.bold('\nGlobal Defaults:'));
-      if (config.defaults?.board) {
-        this.log(`  default board: ${chalk.gray(config.defaults.board)}`);
-      }
-      if (config.defaults?.agent) {
-        this.log(`  default agent: ${chalk.gray(config.defaults.agent)}`);
-      }
-
       // Database Settings
       // Use the same centralized database URL resolution as the daemon
       const databaseUrl = getDatabaseUrl();
@@ -76,9 +67,6 @@ export default class ConfigIndex extends Command {
       // Available Configuration Keys
       this.log(chalk.bold('\nAvailable Configuration Keys:'));
       this.log(chalk.dim('  Use `agor config set <key> <value>` to set any of these:'));
-      this.log('');
-      this.log(chalk.cyan('  Defaults:'));
-      this.log('    defaults.board, defaults.agent');
       this.log('');
       this.log(chalk.cyan('  Daemon:'));
       this.log('    daemon.port, daemon.host');

--- a/apps/agor-cli/src/commands/config/index.ts
+++ b/apps/agor-cli/src/commands/config/index.ts
@@ -29,16 +29,6 @@ export default class ConfigIndex extends Command {
         this.log(`  default agent: ${chalk.gray(config.defaults.agent)}`);
       }
 
-      // Display Settings
-      this.log(chalk.bold('\nDisplay Settings:'));
-      if (config.display?.tableStyle) {
-        this.log(`  table style:   ${chalk.gray(config.display.tableStyle)}`);
-      }
-      if (config.display?.colorOutput !== undefined) {
-        this.log(
-          `  color output:  ${chalk.gray(config.display.colorOutput ? 'enabled' : 'disabled')}`
-        );
-      }
       // Database Settings
       // Use the same centralized database URL resolution as the daemon
       const databaseUrl = getDatabaseUrl();
@@ -89,9 +79,6 @@ export default class ConfigIndex extends Command {
       this.log('');
       this.log(chalk.cyan('  Defaults:'));
       this.log('    defaults.board, defaults.agent');
-      this.log('');
-      this.log(chalk.cyan('  Display:'));
-      this.log('    display.tableStyle, display.colorOutput');
       this.log('');
       this.log(chalk.cyan('  Daemon:'));
       this.log('    daemon.port, daemon.host');

--- a/apps/agor-cli/src/commands/config/set.ts
+++ b/apps/agor-cli/src/commands/config/set.ts
@@ -10,8 +10,7 @@ export default class ConfigSet extends Command {
   static description = 'Set a configuration value';
 
   static examples = [
-    '<%= config.bin %> <%= command.id %> defaults.board experiments',
-    '<%= config.bin %> <%= command.id %> defaults.agent claude-code',
+    '<%= config.bin %> <%= command.id %> daemon.port 4000',
     '<%= config.bin %> <%= command.id %> daemon.port 4000',
   ];
 

--- a/apps/agor-cli/src/commands/config/unset.ts
+++ b/apps/agor-cli/src/commands/config/unset.ts
@@ -9,14 +9,11 @@ import chalk from 'chalk';
 export default class ConfigUnset extends Command {
   static description = 'Unset (clear) a configuration value';
 
-  static examples = [
-    '<%= config.bin %> <%= command.id %> defaults.board',
-    '<%= config.bin %> <%= command.id %> defaults.agent',
-  ];
+  static examples = ['<%= config.bin %> <%= command.id %> daemon.port'];
 
   static args = {
     key: Args.string({
-      description: 'Configuration key in format: section.key (e.g., defaults.board)',
+      description: 'Configuration key in format: section.key (e.g., daemon.port)',
       required: true,
     }),
   };

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -65,7 +65,7 @@ import { loadBuildInfo } from './setup/build-info.js';
 import { createDynamicCompressionMiddleware } from './setup/compression.js';
 import { buildCorsConfig, isSandpackOrigin } from './setup/cors.js';
 import { initializeDatabase } from './setup/database.js';
-import { warnDeprecatedAnonymousConfig } from './setup/first-run-admin.js';
+import { warnDeprecatedConfig } from './setup/first-run-admin.js';
 import { securityHeaders } from './setup/security-headers.js';
 import { configureChannels, createSocketIOConfig } from './setup/socketio.js';
 import { setBundledUiFallbackHeaders, setBundledUiStaticHeaders } from './setup/static-assets.js';
@@ -201,11 +201,8 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
     );
   }
 
-  // Surface a clear migration note if the config still carries leftover
-  // anonymous-mode keys. Operators upgrading from a release that had
-  // `daemon.allowAnonymous` / `daemon.requireAuth` see what to do; the keys
-  // are otherwise silently ignored.
-  warnDeprecatedAnonymousConfig(config);
+  // Surface a clear migration note for accepted-but-ignored upgrade keys.
+  warnDeprecatedConfig(config);
 
   // --------------------------------------------------------------------------
   // Auth configuration

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1818,14 +1818,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     },
   });
 
-  app.service('config').hooks({
-    before: {
-      all: [requireAuth],
-      find: [requireMinimumRole(ROLES.ADMIN, 'view configuration')],
-      get: [requireMinimumRole(ROLES.ADMIN, 'view configuration')],
-    },
-  });
-
   safeService('context')?.hooks({
     before: {
       all: [requireAuth],

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1823,7 +1823,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       all: [requireAuth],
       find: [requireMinimumRole(ROLES.ADMIN, 'view configuration')],
       get: [requireMinimumRole(ROLES.ADMIN, 'view configuration')],
-      patch: [requireMinimumRole(ROLES.ADMIN, 'update configuration')],
     },
   });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -11,6 +11,7 @@ import {
   isTenantAgenticToolEnabled,
   resolveBranchStorageConfig,
   resolveMultiTenancyConfig,
+  resolveTeammateFrameworkRepoUrl,
   resolveTenantContext,
 } from '@agor/core/config';
 import {
@@ -3759,6 +3760,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           description: config.daemon?.instanceDescription,
         },
         features: {
+          teammateFrameworkRepoUrl: resolveTeammateFrameworkRepoUrl(config),
           // Web terminal availability: UI should hide terminal buttons when false.
           // Server-side gate in register-hooks.ts is the source of truth; this
           // flag exists so the UI can skip rendering buttons that would fail.

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3758,14 +3758,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           label: config.daemon?.instanceLabel,
           description: config.daemon?.instanceDescription,
         },
-        onboarding: {
-          teammatePending:
-            config.onboarding?.teammatePending ??
-            config.onboarding?.assistantPending ??
-            config.onboarding?.persistedAgentPending ??
-            false,
-          frameworkRepoUrl: config.onboarding?.frameworkRepoUrl,
-        },
         features: {
           // Web terminal availability: UI should hide terminal buttons when false.
           // Server-side gate in register-hooks.ts is the source of truth; this

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -507,10 +507,6 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   configService.app = app;
   app.use('/admin/local-actions', createLocalActionsService());
 
-  // Operator configuration is file-owned. The browser API is deliberately
-  // read-only; tenant/user product state uses typed services instead.
-  app.use('/config', configService, { methods: ['find', 'get'] });
-
   app.use('/agentic-tool-settings', createTenantAgenticToolSettingsService(db));
   app.service('/agentic-tool-settings').hooks({ before: { all: [ctx.requireAuth] } });
   app.use('/agentic-tool-presets', createAgenticToolPresetsService(db));

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -507,7 +507,9 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   configService.app = app;
   app.use('/admin/local-actions', createLocalActionsService());
 
-  app.use('/config', configService);
+  // Operator configuration is file-owned. The browser API is deliberately
+  // read-only; tenant/user product state uses typed services instead.
+  app.use('/config', configService, { methods: ['find', 'get'] });
 
   app.use('/agentic-tool-settings', createTenantAgenticToolSettingsService(db));
   app.service('/agentic-tool-settings').hooks({ before: { all: [ctx.requireAuth] } });

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -12,39 +12,6 @@ import type { TaskID, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { ConfigService } from './config.js';
 
-describe('ConfigService retired config compatibility', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    configMocks.loadConfig.mockResolvedValue({
-      daemon: { port: 3030 },
-      defaults: { board: 'main', agent: 'claude-code' },
-      display: { tableStyle: 'ascii', colorOutput: false },
-      onboarding: { teammatePending: true, frameworkRepoUrl: 'https://example.test/repo.git' },
-    });
-  });
-
-  it('does not expose accepted legacy settings from /config', async () => {
-    const service = new ConfigService({} as never);
-    await expect(service.find()).resolves.toEqual({ daemon: { port: 3030 } });
-  });
-
-  it('does not expose accepted legacy display settings by dotted lookup', async () => {
-    const service = new ConfigService({} as never);
-    await expect(service.get('display.tableStyle')).resolves.toBeUndefined();
-  });
-
-  it('does not expose legacy defaults or onboarding state by dotted lookup', async () => {
-    const service = new ConfigService({} as never);
-    await expect(service.get('defaults.board')).resolves.toBeUndefined();
-    await expect(service.get('onboarding.teammatePending')).resolves.toBeUndefined();
-  });
-
-  it('has no mutation method because operator config is file-owned', () => {
-    const service = new ConfigService({} as never);
-    expect('patch' in service).toBe(false);
-  });
-});
-
 describe('ConfigService.resolveApiKey', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -13,6 +13,26 @@ import type { TaskID, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { ConfigService } from './config.js';
 
+describe('ConfigService retired display compatibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    configMocks.loadConfig.mockResolvedValue({
+      daemon: { port: 3030 },
+      display: { tableStyle: 'ascii', colorOutput: false },
+    });
+  });
+
+  it('does not expose accepted legacy display settings from /config', async () => {
+    const service = new ConfigService({} as never);
+    await expect(service.find()).resolves.toEqual({ daemon: { port: 3030 } });
+  });
+
+  it('does not expose accepted legacy display settings by dotted lookup', async () => {
+    const service = new ConfigService({} as never);
+    await expect(service.get('display.tableStyle')).resolves.toBeUndefined();
+  });
+});
+
 describe('ConfigService.resolveApiKey', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/agor-daemon/src/services/config.test.ts
+++ b/apps/agor-daemon/src/services/config.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const configMocks = vi.hoisted(() => ({
   loadConfig: vi.fn(async () => ({})),
-  saveConfig: vi.fn(async () => undefined),
   resolveApiKey: vi.fn(),
 }));
 
@@ -13,16 +12,18 @@ import type { TaskID, UserID } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { ConfigService } from './config.js';
 
-describe('ConfigService retired display compatibility', () => {
+describe('ConfigService retired config compatibility', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     configMocks.loadConfig.mockResolvedValue({
       daemon: { port: 3030 },
+      defaults: { board: 'main', agent: 'claude-code' },
       display: { tableStyle: 'ascii', colorOutput: false },
+      onboarding: { teammatePending: true, frameworkRepoUrl: 'https://example.test/repo.git' },
     });
   });
 
-  it('does not expose accepted legacy display settings from /config', async () => {
+  it('does not expose accepted legacy settings from /config', async () => {
     const service = new ConfigService({} as never);
     await expect(service.find()).resolves.toEqual({ daemon: { port: 3030 } });
   });
@@ -30,6 +31,17 @@ describe('ConfigService retired display compatibility', () => {
   it('does not expose accepted legacy display settings by dotted lookup', async () => {
     const service = new ConfigService({} as never);
     await expect(service.get('display.tableStyle')).resolves.toBeUndefined();
+  });
+
+  it('does not expose legacy defaults or onboarding state by dotted lookup', async () => {
+    const service = new ConfigService({} as never);
+    await expect(service.get('defaults.board')).resolves.toBeUndefined();
+    await expect(service.get('onboarding.teammatePending')).resolves.toBeUndefined();
+  });
+
+  it('has no mutation method because operator config is file-owned', () => {
+    const service = new ConfigService({} as never);
+    expect('patch' in service).toBe(false);
   });
 });
 
@@ -331,33 +343,5 @@ describe('ConfigService.resolveApiKey', () => {
     ).rejects.toBeInstanceOf(Forbidden);
 
     expect(configMocks.resolveApiKey).not.toHaveBeenCalled();
-  });
-});
-
-describe('ConfigService.patch onboarding compatibility', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    configMocks.loadConfig.mockResolvedValue({});
-  });
-
-  it('normalizes legacy assistantPending into teammatePending', async () => {
-    const service = new ConfigService({} as never);
-
-    const result = await service.patch(null, { onboarding: { assistantPending: true } } as never);
-
-    expect(configMocks.saveConfig).toHaveBeenCalledWith({
-      onboarding: { teammatePending: true },
-    });
-    expect(result.onboarding?.teammatePending).toBe(true);
-  });
-
-  it('normalizes legacy persistedAgentPending into teammatePending', async () => {
-    const service = new ConfigService({} as never);
-
-    await service.patch(null, { onboarding: { persistedAgentPending: true } } as never);
-
-    expect(configMocks.saveConfig).toHaveBeenCalledWith({
-      onboarding: { teammatePending: true },
-    });
   });
 });

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -5,13 +5,7 @@
  * Wraps @agor/core/config functions for UI access.
  */
 
-import {
-  type AgorConfig,
-  type ApiKeyName,
-  loadConfig,
-  resolveApiKey,
-  saveConfig,
-} from '@agor/core/config';
+import { type AgorConfig, type ApiKeyName, loadConfig, resolveApiKey } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
@@ -41,8 +35,14 @@ function isResolvableApiKeyName(value: string): value is ApiKeyName {
 
 /** Keep retired upgrade-only keys out of the tenant-facing config API. */
 function publicConfig(config: AgorConfig): AgorConfig {
-  const result = structuredClone(config) as AgorConfig & { display?: Record<string, unknown> };
+  const result = structuredClone(config) as AgorConfig & {
+    defaults?: Record<string, unknown>;
+    display?: Record<string, unknown>;
+    onboarding?: Record<string, unknown>;
+  };
+  delete result.defaults;
   delete result.display;
+  delete result.onboarding;
   return result;
 }
 
@@ -285,46 +285,6 @@ export class ConfigService {
       useNativeAuth: result.useNativeAuth,
       ...(result.decryptionFailed && { decryptionFailed: true }),
     };
-  }
-
-  /**
-   * Update config values
-   *
-   * Temporary compatibility surface for onboarding state only. Product settings
-   * must use tenant-owned typed services.
-   */
-  async patch(_id: null, data: Partial<AgorConfig>, _params?: Params): Promise<AgorConfig> {
-    // Log patch keys without values to avoid leaking secrets
-    const patchSections = Object.keys(data);
-    console.log(`[Config Service] Patch received: sections=[${patchSections}]`);
-    if (patchSections.some((section) => section !== 'onboarding')) {
-      throw new BadRequest('Only onboarding may be patched through the legacy config service');
-    }
-    const config = await loadConfig();
-
-    // Allow updating onboarding configuration
-    if (data.onboarding) {
-      if (!config.onboarding) {
-        config.onboarding = {};
-      }
-      const teammatePending =
-        data.onboarding.teammatePending ??
-        data.onboarding.assistantPending ??
-        data.onboarding.persistedAgentPending;
-      if (teammatePending !== undefined) {
-        config.onboarding.teammatePending = teammatePending;
-        delete config.onboarding.assistantPending;
-        delete config.onboarding.persistedAgentPending;
-      }
-      if (data.onboarding.frameworkRepoUrl !== undefined) {
-        config.onboarding.frameworkRepoUrl = data.onboarding.frameworkRepoUrl;
-      }
-    }
-
-    await saveConfig(config);
-    console.log('[Config Service] Config saved successfully');
-
-    return publicConfig(config);
   }
 }
 

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -39,6 +39,13 @@ function isResolvableApiKeyName(value: string): value is ApiKeyName {
   return Object.hasOwn(RESOLVABLE_API_KEY_NAMES, value);
 }
 
+/** Keep retired upgrade-only keys out of the tenant-facing config API. */
+function publicConfig(config: AgorConfig): AgorConfig {
+  const result = structuredClone(config) as AgorConfig & { display?: Record<string, unknown> };
+  delete result.display;
+  return result;
+}
+
 type ExecutorTokenPayload = {
   type?: string;
   purpose?: string;
@@ -107,14 +114,14 @@ export class ConfigService {
    * Get full config (masked)
    */
   async find(_params?: Params): Promise<AgorConfig> {
-    return loadConfig();
+    return publicConfig(await loadConfig());
   }
 
   /**
    * Get specific config section or value
    */
   async get(id: string, _params?: Params): Promise<unknown> {
-    const config = await loadConfig();
+    const config = publicConfig(await loadConfig());
 
     // Support dot notation for the remaining bootstrap configuration.
     const parts = id.split('.');
@@ -317,7 +324,7 @@ export class ConfigService {
     await saveConfig(config);
     console.log('[Config Service] Config saved successfully');
 
-    return config;
+    return publicConfig(config);
   }
 }
 

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -5,7 +5,7 @@
  * Wraps @agor/core/config functions for UI access.
  */
 
-import { type AgorConfig, type ApiKeyName, loadConfig, resolveApiKey } from '@agor/core/config';
+import { type ApiKeyName, loadConfig, resolveApiKey } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { type Application, BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
@@ -31,19 +31,6 @@ const RESOLVABLE_API_KEY_NAMES: Record<ApiKeyName, true> = {
 
 function isResolvableApiKeyName(value: string): value is ApiKeyName {
   return Object.hasOwn(RESOLVABLE_API_KEY_NAMES, value);
-}
-
-/** Keep retired upgrade-only keys out of the tenant-facing config API. */
-function publicConfig(config: AgorConfig): AgorConfig {
-  const result = structuredClone(config) as AgorConfig & {
-    defaults?: Record<string, unknown>;
-    display?: Record<string, unknown>;
-    onboarding?: Record<string, unknown>;
-  };
-  delete result.defaults;
-  delete result.display;
-  delete result.onboarding;
-  return result;
 }
 
 type ExecutorTokenPayload = {
@@ -108,34 +95,6 @@ export class ConfigService {
 
   constructor(db: TenantScopeAwareDatabase) {
     this.db = db;
-  }
-
-  /**
-   * Get full config (masked)
-   */
-  async find(_params?: Params): Promise<AgorConfig> {
-    return publicConfig(await loadConfig());
-  }
-
-  /**
-   * Get specific config section or value
-   */
-  async get(id: string, _params?: Params): Promise<unknown> {
-    const config = publicConfig(await loadConfig());
-
-    // Support dot notation for the remaining bootstrap configuration.
-    const parts = id.split('.');
-    let value: unknown = config;
-
-    for (const part of parts) {
-      if (value && typeof value === 'object' && part in value) {
-        value = (value as Record<string, unknown>)[part];
-      } else {
-        return undefined;
-      }
-    }
-
-    return value;
   }
 
   /**

--- a/apps/agor-daemon/src/setup/first-run-admin.test.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.test.ts
@@ -97,6 +97,15 @@ describe('warnDeprecatedAnonymousConfig', () => {
     } as unknown as AgorConfig);
     expect(written).toContain('display.shortIdLength: 12');
   });
+
+  it('warns about retired CLI display settings while accepting old config files', () => {
+    warnDeprecatedAnonymousConfig({
+      display: { tableStyle: 'ascii', colorOutput: false },
+    } as unknown as AgorConfig);
+    expect(written).toContain('display.tableStyle: ascii');
+    expect(written).toContain('display.colorOutput: false');
+    expect(written).toContain('no longer have any effect');
+  });
 });
 
 describe('logFirstRunAdminBootstrap', () => {

--- a/apps/agor-daemon/src/setup/first-run-admin.test.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   logFirstRunAdminBootstrap,
   runFirstRunAdminBootstrap,
-  warnDeprecatedAnonymousConfig,
+  warnDeprecatedConfig,
 } from './first-run-admin.js';
 
 // Mock the pure-DB layer so we can exercise the daemon-side factory
@@ -31,7 +31,7 @@ vi.mock('@agor/core/db', async (importOriginal) => {
   };
 });
 
-describe('warnDeprecatedAnonymousConfig', () => {
+describe('warnDeprecatedConfig', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
   let written: string;
 
@@ -48,17 +48,17 @@ describe('warnDeprecatedAnonymousConfig', () => {
   });
 
   it('is silent when no daemon block exists', () => {
-    warnDeprecatedAnonymousConfig({} as AgorConfig);
+    warnDeprecatedConfig({} as AgorConfig);
     expect(written).toBe('');
   });
 
   it('is silent when daemon block has no deprecated keys', () => {
-    warnDeprecatedAnonymousConfig({ daemon: { port: 3030 } } as AgorConfig);
+    warnDeprecatedConfig({ daemon: { port: 3030 } } as AgorConfig);
     expect(written).toBe('');
   });
 
   it('warns when allowAnonymous is present', () => {
-    warnDeprecatedAnonymousConfig({
+    warnDeprecatedConfig({
       daemon: { allowAnonymous: true },
     } as unknown as AgorConfig);
     expect(written).toContain('DEPRECATED CONFIG KEYS DETECTED');
@@ -67,7 +67,7 @@ describe('warnDeprecatedAnonymousConfig', () => {
   });
 
   it('warns when requireAuth is present', () => {
-    warnDeprecatedAnonymousConfig({
+    warnDeprecatedConfig({
       daemon: { requireAuth: false },
     } as unknown as AgorConfig);
     expect(written).toContain('DEPRECATED CONFIG KEYS DETECTED');
@@ -75,7 +75,7 @@ describe('warnDeprecatedAnonymousConfig', () => {
   });
 
   it('lists both keys when both are present', () => {
-    warnDeprecatedAnonymousConfig({
+    warnDeprecatedConfig({
       daemon: { allowAnonymous: true, requireAuth: false },
     } as unknown as AgorConfig);
     expect(written).toContain('daemon.allowAnonymous: true');
@@ -85,26 +85,38 @@ describe('warnDeprecatedAnonymousConfig', () => {
   it('fires even when the deprecated value is falsy (key presence is what matters)', () => {
     // Operators who explicitly wrote `allowAnonymous: false` still get the
     // nudge — the key is dead, regardless of its value.
-    warnDeprecatedAnonymousConfig({
+    warnDeprecatedConfig({
       daemon: { allowAnonymous: false },
     } as unknown as AgorConfig);
     expect(written).toContain('daemon.allowAnonymous: false');
   });
 
   it('warns about the retired display.shortIdLength key', () => {
-    warnDeprecatedAnonymousConfig({
+    warnDeprecatedConfig({
       display: { shortIdLength: 12 },
     } as unknown as AgorConfig);
     expect(written).toContain('display.shortIdLength: 12');
   });
 
   it('warns about retired CLI display settings while accepting old config files', () => {
-    warnDeprecatedAnonymousConfig({
+    warnDeprecatedConfig({
       display: { tableStyle: 'ascii', colorOutput: false },
     } as unknown as AgorConfig);
     expect(written).toContain('display.tableStyle: ascii');
     expect(written).toContain('display.colorOutput: false');
     expect(written).toContain('no longer have any effect');
+  });
+
+  it('warns about retired global defaults and onboarding YAML state', () => {
+    warnDeprecatedConfig({
+      defaults: { board: 'main', agent: 'claude-code' },
+      onboarding: { teammatePending: true, frameworkRepoUrl: 'https://example.test/repo.git' },
+    } as unknown as AgorConfig);
+    expect(written).toContain('defaults.board: main');
+    expect(written).toContain('defaults.agent: claude-code');
+    expect(written).toContain('onboarding.teammatePending: true');
+    expect(written).toContain('onboarding.frameworkRepoUrl: https://example.test/repo.git');
+    expect(written).toContain('Onboarding progress is stored');
   });
 });
 

--- a/apps/agor-daemon/src/setup/first-run-admin.test.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.test.ts
@@ -116,6 +116,7 @@ describe('warnDeprecatedConfig', () => {
     expect(written).toContain('defaults.agent: claude-code');
     expect(written).toContain('onboarding.teammatePending: true');
     expect(written).toContain('onboarding.frameworkRepoUrl: https://example.test/repo.git');
+    expect(written).toContain('teammates.framework_repo_url');
     expect(written).toContain('Onboarding progress is stored');
   });
 });

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -268,17 +268,22 @@ export function logFirstRunAdminBootstrap(result: DaemonBootstrapResult): void {
 const DEPRECATED_ANONYMOUS_KEYS = ['allowAnonymous', 'requireAuth'] as const;
 
 /**
- * Print a clear stderr banner if the loaded config still carries leftover
- * keys from the anonymous-mode path. The keys themselves have no runtime
- * effect anymore — this is purely an operator-UX nudge.
+ * Print a clear stderr banner if the loaded config still carries retired
+ * upgrade-only keys. The keys have no runtime effect anymore — this is purely
+ * an operator-UX nudge.
  *
  * Detected separately from the `AgorConfig` type because we deliberately
  * removed these fields from the interface; we reach into the raw object via
  * a Record cast to see what the YAML file actually contained.
  */
-export function warnDeprecatedAnonymousConfig(config: AgorConfig): void {
+export function warnDeprecatedConfig(config: AgorConfig): void {
+  const legacy = config as AgorConfig & {
+    defaults?: Record<string, unknown>;
+    display?: Record<string, unknown>;
+    onboarding?: Record<string, unknown>;
+  };
   const daemon = (config as { daemon?: Record<string, unknown> }).daemon;
-  const display = (config as { display?: Record<string, unknown> }).display;
+  const display = legacy.display;
 
   const present = daemon
     ? DEPRECATED_ANONYMOUS_KEYS.filter((key) => Object.hasOwn(daemon, key))
@@ -288,7 +293,16 @@ export function warnDeprecatedAnonymousConfig(config: AgorConfig): void {
   const presentDisplay = display
     ? retiredDisplayKeys.filter((key) => Object.hasOwn(display, key))
     : [];
-  if (present.length === 0 && !hasShortIdLength && presentDisplay.length === 0) return;
+  const presentDefaults = legacy.defaults ? Object.keys(legacy.defaults) : [];
+  const presentOnboarding = legacy.onboarding ? Object.keys(legacy.onboarding) : [];
+  if (
+    present.length === 0 &&
+    !hasShortIdLength &&
+    presentDisplay.length === 0 &&
+    presentDefaults.length === 0 &&
+    presentOnboarding.length === 0
+  )
+    return;
 
   const lines: string[] = [
     '',
@@ -304,17 +318,27 @@ export function warnDeprecatedAnonymousConfig(config: AgorConfig): void {
   for (const key of presentDisplay) {
     lines.push(`    display.${key}: ${String(display?.[key])}`);
   }
+  for (const key of presentDefaults) {
+    lines.push(`    defaults.${key}: ${String(legacy.defaults?.[key])}`);
+  }
+  for (const key of presentOnboarding) {
+    lines.push(`    onboarding.${key}: ${String(legacy.onboarding?.[key])}`);
+  }
   lines.push(
     '',
-    '  These keys no longer have any effect. Authentication is always',
-    '  required, and terminal presentation is managed by each client.',
+    '  These keys no longer have any effect. Onboarding progress is stored',
+    '  per user, and product defaults and terminal presentation are managed',
+    '  by Agor and its clients.',
     '',
-    '  Action: remove these keys from your config.yaml at your',
-    '  convenience. If you previously ran anonymously, the daemon',
-    `  has auto-generated admin credentials at ${getAdminCredentialsPath()}`,
-    '  (printed below if just created on this start).',
-    '================================================================',
-    ''
+    '  Action: remove these keys from your config.yaml at your convenience.'
   );
+  if (present.length > 0) {
+    lines.push(
+      '  If you previously ran anonymously, the daemon has auto-generated',
+      `  admin credentials at ${getAdminCredentialsPath()}`,
+      '  (printed below if just created on this start).'
+    );
+  }
+  lines.push('================================================================', '');
   process.stderr.write(lines.join('\n'));
 }

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -284,7 +284,11 @@ export function warnDeprecatedAnonymousConfig(config: AgorConfig): void {
     ? DEPRECATED_ANONYMOUS_KEYS.filter((key) => Object.hasOwn(daemon, key))
     : [];
   const hasShortIdLength = !!display && Object.hasOwn(display, 'shortIdLength');
-  if (present.length === 0 && !hasShortIdLength) return;
+  const retiredDisplayKeys = ['tableStyle', 'colorOutput'] as const;
+  const presentDisplay = display
+    ? retiredDisplayKeys.filter((key) => Object.hasOwn(display, key))
+    : [];
+  if (present.length === 0 && !hasShortIdLength && presentDisplay.length === 0) return;
 
   const lines: string[] = [
     '',
@@ -297,10 +301,13 @@ export function warnDeprecatedAnonymousConfig(config: AgorConfig): void {
     lines.push(`    daemon.${key}: ${String(daemon?.[key])}`);
   }
   if (hasShortIdLength) lines.push(`    display.shortIdLength: ${String(display?.shortIdLength)}`);
+  for (const key of presentDisplay) {
+    lines.push(`    display.${key}: ${String(display?.[key])}`);
+  }
   lines.push(
     '',
     '  These keys no longer have any effect. Authentication is always',
-    '  required, and short-ID display length is managed by Agor.',
+    '  required, and terminal presentation is managed by each client.',
     '',
     '  Action: remove these keys from your config.yaml at your',
     '  convenience. If you previously ran anonymously, the daemon',

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -18,7 +18,7 @@ import { close, open, unlink, write } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import type { AgorConfig } from '@agor/core/config';
+import { type AgorConfig, RETIRED_CONFIG_KEYS } from '@agor/core/config';
 import {
   type AdminBootstrapResult,
   assertUsableBootstrapAdminPassword,
@@ -288,19 +288,23 @@ export function warnDeprecatedConfig(config: AgorConfig): void {
   const present = daemon
     ? DEPRECATED_ANONYMOUS_KEYS.filter((key) => Object.hasOwn(daemon, key))
     : [];
-  const hasShortIdLength = !!display && Object.hasOwn(display, 'shortIdLength');
-  const retiredDisplayKeys = ['tableStyle', 'colorOutput'] as const;
   const presentDisplay = display
-    ? retiredDisplayKeys.filter((key) => Object.hasOwn(display, key))
+    ? RETIRED_CONFIG_KEYS.display.filter((key) => Object.hasOwn(display, key))
     : [];
-  const presentDefaults = legacy.defaults ? Object.keys(legacy.defaults) : [];
-  const presentOnboarding = legacy.onboarding ? Object.keys(legacy.onboarding) : [];
+  const presentDefaults = legacy.defaults
+    ? RETIRED_CONFIG_KEYS.defaults.filter((key) => Object.hasOwn(legacy.defaults!, key))
+    : [];
+  const presentOnboarding = legacy.onboarding
+    ? RETIRED_CONFIG_KEYS.onboarding.filter((key) => Object.hasOwn(legacy.onboarding!, key))
+    : [];
+  const hasLegacyFrameworkRepoUrl =
+    !!legacy.onboarding && Object.hasOwn(legacy.onboarding, 'frameworkRepoUrl');
   if (
     present.length === 0 &&
-    !hasShortIdLength &&
     presentDisplay.length === 0 &&
     presentDefaults.length === 0 &&
-    presentOnboarding.length === 0
+    presentOnboarding.length === 0 &&
+    !hasLegacyFrameworkRepoUrl
   )
     return;
 
@@ -314,7 +318,6 @@ export function warnDeprecatedConfig(config: AgorConfig): void {
   for (const key of present) {
     lines.push(`    daemon.${key}: ${String(daemon?.[key])}`);
   }
-  if (hasShortIdLength) lines.push(`    display.shortIdLength: ${String(display?.shortIdLength)}`);
   for (const key of presentDisplay) {
     lines.push(`    display.${key}: ${String(display?.[key])}`);
   }
@@ -324,11 +327,17 @@ export function warnDeprecatedConfig(config: AgorConfig): void {
   for (const key of presentOnboarding) {
     lines.push(`    onboarding.${key}: ${String(legacy.onboarding?.[key])}`);
   }
+  if (hasLegacyFrameworkRepoUrl) {
+    lines.push(
+      `    onboarding.frameworkRepoUrl: ${String(legacy.onboarding?.frameworkRepoUrl)}`,
+      '      renamed to teammates.framework_repo_url (the legacy value still works)'
+    );
+  }
   lines.push(
     '',
-    '  These keys no longer have any effect. Onboarding progress is stored',
-    '  per user, and product defaults and terminal presentation are managed',
-    '  by Agor and its clients.',
+    '  Retired keys no longer have any effect. Onboarding progress is stored',
+    '  per user. The renamed framework repository key remains a compatibility',
+    '  fallback, but new configuration should use the replacement shown above.',
     '',
     '  Action: remove these keys from your config.yaml at your convenience.'
   );

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -564,7 +564,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
     `🚀 Agor daemon running at http://${displayHost}:${DAEMON_PORT} (bound to ${DAEMON_HOST})`
   );
   console.log(
-    `   health=/health auth=required services=/sessions,/tasks,/messages,/boards,/repos,/mcp-servers,/config,/context,/users`
+    `   health=/health auth=required services=/sessions,/tasks,/messages,/boards,/repos,/mcp-servers,/context,/users`
   );
 
   runPostStartJob('health-monitor-initialize', () => healthMonitor.initialize());

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -249,7 +249,6 @@ function AppContent() {
   const {
     config: authConfig,
     instanceConfig,
-    onboardingConfig,
     featuresConfig,
     loading: authConfigLoading,
     error: authConfigError,
@@ -511,15 +510,6 @@ function AppContent() {
       },
       { silent: true }
     ).catch(() => {});
-
-    // Clear the AI teammate pending flag if applicable
-    if (result.path === 'teammate' && client) {
-      try {
-        await client.service('config').patch(null, { onboarding: { teammatePending: false } });
-      } catch {
-        // Non-critical — ignore
-      }
-    }
 
     // Navigate to the user's board + session, or to the boards list if they
     // skipped. Use the centralized path builders — the old
@@ -1773,8 +1763,6 @@ function AppContent() {
           handleUpdateBranch(branchId, updates, { silent: true })
         }
         onCheckAuth={handleCheckAuth}
-        teammatePending={onboardingConfig?.teammatePending}
-        frameworkRepoUrl={onboardingConfig?.frameworkRepoUrl}
       />
 
       <DeviceRouter />

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1763,6 +1763,7 @@ function AppContent() {
           handleUpdateBranch(branchId, updates, { silent: true })
         }
         onCheckAuth={handleCheckAuth}
+        frameworkRepoUrl={featuresConfig?.teammateFrameworkRepoUrl}
       />
 
       <DeviceRouter />

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -116,9 +116,6 @@ export interface OnboardingWizardProps {
   onUpdateUser: (userId: string, updates: UpdateUserInput) => Promise<void>;
   onUpdateBranch?: (branchId: string, updates: Partial<Branch>) => Promise<void>;
   onCheckAuth?: (tool: AgenticToolName, apiKey?: string) => Promise<AuthCheckResult>;
-
-  teammatePending?: boolean;
-  frameworkRepoUrl?: string;
 }
 
 function sanitizeBranchName(input: string): string {
@@ -247,7 +244,6 @@ export function OnboardingWizard({
   onCreateSession,
   onUpdateUser,
   onCheckAuth,
-  frameworkRepoUrl,
 }: OnboardingWizardProps) {
   // Self-subscribe to the entity maps this wizard reads. The subscription used
   // to live in the outer App shell; relocating it here keeps the shell from
@@ -277,8 +273,6 @@ export function OnboardingWizard({
   const clonePollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const completingRepoRef = useRef<string | null>(null);
   const knownFailedRepoIdsRef = useRef<Set<string>>(new Set());
-  const effectiveFrameworkUrl = frameworkRepoUrl || FRAMEWORK_REPO_URL;
-
   const defaultBranchName = useMemo(
     () => defaultTeammateBranchName(teammateDisplayName),
     [teammateDisplayName]
@@ -696,7 +690,7 @@ export function OnboardingWizard({
     try {
       const cloneResult = await onCreateRepo(
         {
-          url: effectiveFrameworkUrl,
+          url: FRAMEWORK_REPO_URL,
           slug: FRAMEWORK_REPO_SLUG,
           default_branch: 'main',
         },
@@ -741,14 +735,7 @@ export function OnboardingWizard({
       setSetupStage('error');
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, [
-    effectiveFrameworkUrl,
-    fetchExistingFrameworkRepo,
-    finishSetupFromRepo,
-    onCreateRepo,
-    pollRepoUntilReady,
-    repoById,
-  ]);
+  }, [fetchExistingFrameworkRepo, finishSetupFromRepo, onCreateRepo, pollRepoUntilReady, repoById]);
 
   useEffect(() => {
     if (currentStep !== 'loading' || setupStage !== 'cloning') return;

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -116,6 +116,7 @@ export interface OnboardingWizardProps {
   onUpdateUser: (userId: string, updates: UpdateUserInput) => Promise<void>;
   onUpdateBranch?: (branchId: string, updates: Partial<Branch>) => Promise<void>;
   onCheckAuth?: (tool: AgenticToolName, apiKey?: string) => Promise<AuthCheckResult>;
+  frameworkRepoUrl?: string;
 }
 
 function sanitizeBranchName(input: string): string {
@@ -244,6 +245,7 @@ export function OnboardingWizard({
   onCreateSession,
   onUpdateUser,
   onCheckAuth,
+  frameworkRepoUrl,
 }: OnboardingWizardProps) {
   // Self-subscribe to the entity maps this wizard reads. The subscription used
   // to live in the outer App shell; relocating it here keeps the shell from
@@ -690,7 +692,7 @@ export function OnboardingWizard({
     try {
       const cloneResult = await onCreateRepo(
         {
-          url: FRAMEWORK_REPO_URL,
+          url: frameworkRepoUrl || FRAMEWORK_REPO_URL,
           slug: FRAMEWORK_REPO_SLUG,
           default_branch: 'main',
         },
@@ -735,7 +737,14 @@ export function OnboardingWizard({
       setSetupStage('error');
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, [fetchExistingFrameworkRepo, finishSetupFromRepo, onCreateRepo, pollRepoUntilReady, repoById]);
+  }, [
+    fetchExistingFrameworkRepo,
+    finishSetupFromRepo,
+    frameworkRepoUrl,
+    onCreateRepo,
+    pollRepoUntilReady,
+    repoById,
+  ]);
 
   useEffect(() => {
     if (currentStep !== 'loading' || setupStage !== 'cloning') return;

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -24,6 +24,8 @@ interface InstanceConfig {
 }
 
 export interface FeaturesConfig {
+  /** Operator-selected repository used to bootstrap the first teammate. */
+  teammateFrameworkRepoUrl?: string;
   /**
    * Whether the web terminal is enabled for members (execution.allow_web_terminal).
    * Defaults to true when the daemon config key is unset.

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -23,11 +23,6 @@ interface InstanceConfig {
   description?: string;
 }
 
-interface OnboardingConfig {
-  teammatePending?: boolean;
-  frameworkRepoUrl?: string;
-}
-
 export interface FeaturesConfig {
   /**
    * Whether the web terminal is enabled for members (execution.allow_web_terminal).
@@ -71,14 +66,12 @@ interface HealthResponse {
   database: string;
   auth: AuthConfig;
   instance?: InstanceConfig;
-  onboarding?: OnboardingConfig;
   features?: FeaturesConfig;
 }
 
 export function useAuthConfig() {
   const [config, setConfig] = useState<AuthConfig | null>(null);
   const [instanceConfig, setInstanceConfig] = useState<InstanceConfig | null>(null);
-  const [onboardingConfig, setOnboardingConfig] = useState<OnboardingConfig | null>(null);
   const [featuresConfig, setFeaturesConfig] = useState<FeaturesConfig | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -94,7 +87,6 @@ export function useAuthConfig() {
         const health: HealthResponse = await response.json();
         setConfig(health.auth);
         setInstanceConfig(health.instance ?? null);
-        setOnboardingConfig(health.onboarding ?? null);
         setFeaturesConfig(health.features);
         setError(null);
       } catch (err) {
@@ -102,7 +94,6 @@ export function useAuthConfig() {
         // Default to requiring auth on error (secure by default)
         setConfig({ requireAuth: true });
         setInstanceConfig(null);
-        setOnboardingConfig(null);
         setFeaturesConfig(undefined);
       } finally {
         setLoading(false);
@@ -115,7 +106,6 @@ export function useAuthConfig() {
   return {
     config,
     instanceConfig,
-    onboardingConfig,
     featuresConfig,
     loading,
     error,

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -9,10 +9,6 @@ const DEFAULT_DAEMON_HOST = 'localhost';
 
 export function getDefaultConfig(): AgorConfig {
   return {
-    defaults: {
-      board: 'main',
-      agent: 'claude-code',
-    },
     daemon: {
       port: DEFAULT_DAEMON_PORT,
       host: DEFAULT_DAEMON_HOST,

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -13,10 +13,6 @@ export function getDefaultConfig(): AgorConfig {
       board: 'main',
       agent: 'claude-code',
     },
-    display: {
-      tableStyle: 'unicode',
-      colorOutput: true,
-    },
     daemon: {
       port: DEFAULT_DAEMON_PORT,
       host: DEFAULT_DAEMON_HOST,

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -46,10 +46,6 @@ function createConfigData(overrides?: Partial<AgorConfig>): AgorConfig {
       board: 'test-board',
       agent: 'test-agent',
     },
-    display: {
-      tableStyle: 'ascii',
-      colorOutput: false,
-    },
     daemon: {
       port: 4000,
       host: '0.0.0.0',
@@ -92,8 +88,6 @@ describe('getDefaultConfig', () => {
     // Verify structure and key defaults
     expect(defaults.defaults?.board).toBe('main');
     expect(defaults.defaults?.agent).toBe('claude-code');
-    expect(defaults.display?.tableStyle).toBe('unicode');
-    expect(defaults.display?.colorOutput).toBe(true);
     expect(defaults.daemon?.port).toBe(3030);
     expect(defaults.daemon?.host).toBe('localhost');
     expect(defaults.ui?.port).toBe(5173);
@@ -255,13 +249,13 @@ describe('loadConfig', () => {
       configPath,
       yaml.dump({
         daemon: { allowAnonymous: false, requireAuth: true },
-        display: { shortIdLength: 12 },
+        display: { shortIdLength: 12, tableStyle: 'ascii', colorOutput: false },
       }),
       'utf-8'
     );
     await expect(loadConfig()).resolves.toMatchObject({
       daemon: { allowAnonymous: false, requireAuth: true },
-      display: { shortIdLength: 12 },
+      display: { shortIdLength: 12, tableStyle: 'ascii', colorOutput: false },
     });
   });
 
@@ -280,7 +274,6 @@ describe('loadConfig', () => {
     const loaded = await loadConfig();
     expect(loaded.daemon?.port).toBe(4040);
     expect(loaded.defaults).toBeUndefined();
-    expect(loaded.display).toBeUndefined();
   });
 
   it('does not configure an external launch login redirect by default', async () => {
@@ -776,10 +769,8 @@ describe('getConfigValue', () => {
     await saveConfig(partialConfig);
 
     const customValue = await getConfigValue('daemon.port');
-    const defaultValue = await getConfigValue('display.tableStyle');
-
     expect(customValue).toBe(9999);
-    expect(defaultValue).toBe('unicode'); // From defaults
+    expect(await getConfigValue('display.tableStyle')).toBeUndefined();
   });
 
   it('should return undefined for non-existent keys', async () => {
@@ -789,20 +780,13 @@ describe('getConfigValue', () => {
     expect(value).toBeUndefined();
   });
 
-  it('should handle boolean values', async () => {
-    const config = createConfigData();
-    await saveConfig(config);
+  it('ignores retired display settings from an existing config file', async () => {
+    await saveConfig({
+      display: { tableStyle: 'ascii', colorOutput: false },
+    } as unknown as AgorConfig);
 
-    const colorOutput = await getConfigValue('display.colorOutput');
-    expect(colorOutput).toBe(false);
-  });
-
-  it('should handle string values', async () => {
-    const config = createConfigData();
-    await saveConfig(config);
-
-    const tableStyle = await getConfigValue('display.tableStyle');
-    expect(tableStyle).toBe('ascii');
+    expect(await getConfigValue('display.tableStyle')).toBeUndefined();
+    expect(await getConfigValue('display.colorOutput')).toBeUndefined();
   });
 
   it('should handle number values', async () => {
@@ -822,6 +806,10 @@ describe('setConfigValue', () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agor-test-'));
     vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
+  });
+
+  it('rejects newly setting retired display keys', async () => {
+    await expect(setConfigValue('display.tableStyle', 'ascii')).rejects.toThrow(/has been retired/);
   });
 
   afterEach(async () => {
@@ -903,7 +891,6 @@ describe('setConfigValue', () => {
 
     const loaded = await loadConfig();
     expect(loaded.daemon?.port).toBe(5555);
-    expect(loaded.display).toMatchObject(config.display!);
     expect(loaded.defaults).toMatchObject(config.defaults!);
   });
 });
@@ -961,7 +948,6 @@ describe('unsetConfigValue', () => {
     await unsetConfigValue('daemon.port');
 
     const loaded = await loadConfig();
-    expect(loaded.display).toMatchObject(config.display!);
     expect(loaded.defaults).toMatchObject(config.defaults!);
   });
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -31,6 +31,7 @@ import {
   requirePublicBaseUrl,
   resolveBranchStorageConfig,
   resolveExecutionSecurityMode,
+  resolveTeammateFrameworkRepoUrl,
   saveConfig,
   setConfigValue,
   unsetConfigValue,
@@ -87,6 +88,33 @@ describe('getDefaultConfig', () => {
     expect(defaults.ui?.port).toBe(5173);
     expect(defaults.ui?.host).toBe('localhost');
     expect(defaults.analytics?.enabled).toBe(false);
+  });
+});
+
+describe('resolveTeammateFrameworkRepoUrl', () => {
+  it('uses the operator-owned teammate setting', () => {
+    expect(
+      resolveTeammateFrameworkRepoUrl({
+        teammates: { framework_repo_url: 'https://example.test/canonical.git' },
+      })
+    ).toBe('https://example.test/canonical.git');
+  });
+
+  it('keeps the legacy onboarding key as a compatibility fallback', () => {
+    expect(
+      resolveTeammateFrameworkRepoUrl({
+        onboarding: { frameworkRepoUrl: 'https://example.test/legacy.git' },
+      } as unknown as AgorConfig)
+    ).toBe('https://example.test/legacy.git');
+  });
+
+  it('prefers the canonical setting over the legacy fallback', () => {
+    expect(
+      resolveTeammateFrameworkRepoUrl({
+        teammates: { framework_repo_url: 'https://example.test/canonical.git' },
+        onboarding: { frameworkRepoUrl: 'https://example.test/legacy.git' },
+      } as unknown as AgorConfig)
+    ).toBe('https://example.test/canonical.git');
   });
 });
 
@@ -809,8 +837,12 @@ describe('setConfigValue', () => {
     vi.spyOn(os, 'homedir').mockReturnValue(tempDir);
   });
 
-  it('rejects newly setting retired display keys', async () => {
-    await expect(setConfigValue('display.tableStyle', 'ascii')).rejects.toThrow(/has been retired/);
+  it.each([
+    'display.tableStyle',
+    'display.colorOutput',
+    'display.shortIdLength',
+  ])('rejects newly setting retired key %s', async (key) => {
+    await expect(setConfigValue(key, 'legacy')).rejects.toThrow(/has been retired/);
   });
 
   afterEach(async () => {

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -867,6 +867,12 @@ describe('setConfigValue', () => {
     );
   });
 
+  it('directs new framework repository writes to the canonical operator key', async () => {
+    await expect(
+      setConfigValue('onboarding.frameworkRepoUrl', 'https://example.test/framework.git')
+    ).rejects.toThrow(/set teammates\.framework_repo_url instead/);
+  });
+
   it('should update existing value', async () => {
     const config = createConfigData();
     await saveConfig(config);

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -42,10 +42,6 @@ import type { AgorConfig } from './types';
  */
 function createConfigData(overrides?: Partial<AgorConfig>): AgorConfig {
   return {
-    defaults: {
-      board: 'test-board',
-      agent: 'test-agent',
-    },
     daemon: {
       port: 4000,
       host: '0.0.0.0',
@@ -86,8 +82,6 @@ describe('getDefaultConfig', () => {
     const defaults = getDefaultConfig();
 
     // Verify structure and key defaults
-    expect(defaults.defaults?.board).toBe('main');
-    expect(defaults.defaults?.agent).toBe('claude-code');
     expect(defaults.daemon?.port).toBe(3030);
     expect(defaults.daemon?.host).toBe('localhost');
     expect(defaults.ui?.port).toBe(5173);
@@ -249,13 +243,17 @@ describe('loadConfig', () => {
       configPath,
       yaml.dump({
         daemon: { allowAnonymous: false, requireAuth: true },
+        defaults: { board: 'main', agent: 'claude-code' },
         display: { shortIdLength: 12, tableStyle: 'ascii', colorOutput: false },
+        onboarding: { teammatePending: true, frameworkRepoUrl: 'https://example.test/repo.git' },
       }),
       'utf-8'
     );
     await expect(loadConfig()).resolves.toMatchObject({
       daemon: { allowAnonymous: false, requireAuth: true },
+      defaults: { board: 'main', agent: 'claude-code' },
       display: { shortIdLength: 12, tableStyle: 'ascii', colorOutput: false },
+      onboarding: { teammatePending: true, frameworkRepoUrl: 'https://example.test/repo.git' },
     });
   });
 
@@ -273,7 +271,6 @@ describe('loadConfig', () => {
 
     const loaded = await loadConfig();
     expect(loaded.daemon?.port).toBe(4040);
-    expect(loaded.defaults).toBeUndefined();
   });
 
   it('does not configure an external launch login redirect by default', async () => {
@@ -687,8 +684,8 @@ describe('saveConfig', () => {
     const content = await fs.readFile(configPath, 'utf-8');
 
     // Check that content is properly indented (2 spaces)
-    expect(content).toContain('defaults:');
-    expect(content).toContain('  board: ');
+    expect(content).toContain('daemon:');
+    expect(content).toContain('  port: ');
     expect(content).not.toContain('    '); // No 4-space indents (we use 2)
   });
 });
@@ -782,11 +779,15 @@ describe('getConfigValue', () => {
 
   it('ignores retired display settings from an existing config file', async () => {
     await saveConfig({
+      defaults: { board: 'legacy', agent: 'legacy-agent' },
       display: { tableStyle: 'ascii', colorOutput: false },
+      onboarding: { teammatePending: true },
     } as unknown as AgorConfig);
 
+    expect(await getConfigValue('defaults.board')).toBeUndefined();
     expect(await getConfigValue('display.tableStyle')).toBeUndefined();
     expect(await getConfigValue('display.colorOutput')).toBeUndefined();
+    expect(await getConfigValue('onboarding.teammatePending')).toBeUndefined();
   });
 
   it('should handle number values', async () => {
@@ -825,12 +826,13 @@ describe('setConfigValue', () => {
     expect(value).toBe(8888);
   });
 
-  it('should create section if it does not exist', async () => {
-    await saveConfig({});
-    await setConfigValue('onboarding.teammatePending', true);
-
-    const loaded = await loadConfig();
-    expect(loaded.onboarding?.teammatePending).toBe(true);
+  it('rejects retired defaults and onboarding keys', async () => {
+    await expect(setConfigValue('onboarding.teammatePending', true)).rejects.toThrow(
+      /has been retired/
+    );
+    await expect(setConfigValue('defaults.board', 'custom-board')).rejects.toThrow(
+      /has been retired/
+    );
   });
 
   it('should update existing value', async () => {
@@ -841,14 +843,6 @@ describe('setConfigValue', () => {
 
     const value = await getConfigValue('daemon.port');
     expect(value).toBe(7777);
-  });
-
-  it('should handle string values', async () => {
-    await saveConfig({});
-    await setConfigValue('defaults.board', 'custom-board');
-
-    const value = await getConfigValue('defaults.board');
-    expect(value).toBe('custom-board');
   });
 
   it('should handle boolean values', async () => {
@@ -891,7 +885,6 @@ describe('setConfigValue', () => {
 
     const loaded = await loadConfig();
     expect(loaded.daemon?.port).toBe(5555);
-    expect(loaded.defaults).toMatchObject(config.defaults!);
   });
 });
 
@@ -948,7 +941,7 @@ describe('unsetConfigValue', () => {
     await unsetConfigValue('daemon.port');
 
     const loaded = await loadConfig();
-    expect(loaded.defaults).toMatchObject(config.defaults!);
+    expect(loaded.ui).toEqual(config.ui);
   });
 
   it('should throw error for top-level keys', async () => {
@@ -1030,10 +1023,7 @@ describe('getDaemonUrl', () => {
   });
 
   it('should handle partial config with missing daemon section', async () => {
-    const config: AgorConfig = {
-      defaults: { board: 'main' },
-      // No daemon section
-    };
+    const config: AgorConfig = {};
     await saveConfig(config);
 
     const url = await getDaemonUrl();

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -248,8 +248,10 @@ function validateConfig(config: AgorConfig): void {
   };
   only(config.defaults, 'defaults', ['board', 'agent']);
   // Known upgrade-only keys remain loadable so the daemon can print its
-  // dedicated deprecation guidance before ignoring them.
-  only(config.display, 'display', ['tableStyle', 'colorOutput', 'shortIdLength']);
+  // dedicated deprecation guidance before ignoring them. `display` is not
+  // part of AgorConfig anymore: all three settings were retired.
+  const legacyDisplay = (config as { display?: unknown }).display;
+  only(legacyDisplay, 'display', ['tableStyle', 'colorOutput', 'shortIdLength']);
   only(config.daemon, 'daemon', [
     'port',
     'host',
@@ -612,10 +614,6 @@ export function getDefaultConfig(): AgorConfig {
       board: 'main',
       agent: 'claude-code',
     },
-    display: {
-      tableStyle: 'unicode',
-      colorOutput: true,
-    },
     daemon: {
       port: DAEMON.DEFAULT_PORT,
       host: DAEMON.DEFAULT_HOST,
@@ -680,13 +678,15 @@ export async function initConfig(): Promise<void> {
 export async function getConfigValue(key: string): Promise<string | boolean | number | undefined> {
   const config = await loadConfig();
   const defaults = getDefaultConfig();
+  const { display: _retiredDisplay, ...activeConfig } = config as AgorConfig & {
+    display?: unknown;
+  };
 
   // Merge config with defaults (deep merge for sections)
   const merged = {
     ...defaults,
-    ...config,
+    ...activeConfig,
     defaults: { ...defaults.defaults, ...config.defaults },
-    display: { ...defaults.display, ...config.display },
     daemon: { ...defaults.daemon, ...config.daemon },
     ui: { ...defaults.ui, ...config.ui },
     execution: { ...defaults.execution, ...config.execution },
@@ -716,6 +716,9 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
  * @param value - Value to set
  */
 export async function setConfigValue(key: string, value: string | boolean | number): Promise<void> {
+  if (key === 'display.tableStyle' || key === 'display.colorOutput') {
+    throw new Error(`Configuration key ${key} has been retired and no longer has any effect`);
+  }
   const config = await loadConfig();
   const parts = key.split('.');
 

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -744,6 +744,11 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
  * @param value - Value to set
  */
 export async function setConfigValue(key: string, value: string | boolean | number): Promise<void> {
+  if (key === 'onboarding.frameworkRepoUrl') {
+    throw new Error(
+      'Configuration key onboarding.frameworkRepoUrl is deprecated; set teammates.framework_repo_url instead'
+    );
+  }
   if (RETIRED_CONFIG_PATHS.has(key)) {
     throw new Error(`Configuration key ${key} has been retired and no longer has any effect`);
   }

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -246,12 +246,16 @@ function validateConfig(config: AgorConfig): void {
       if (!allowed.includes(key)) unknownPaths.push(`${path}.${key}`);
     }
   };
-  only(config.defaults, 'defaults', ['board', 'agent']);
+  const legacyConfig = config as AgorConfig & {
+    defaults?: unknown;
+    display?: unknown;
+    onboarding?: unknown;
+  };
+  only(legacyConfig.defaults, 'defaults', ['board', 'agent']);
   // Known upgrade-only keys remain loadable so the daemon can print its
   // dedicated deprecation guidance before ignoring them. `display` is not
   // part of AgorConfig anymore: all three settings were retired.
-  const legacyDisplay = (config as { display?: unknown }).display;
-  only(legacyDisplay, 'display', ['tableStyle', 'colorOutput', 'shortIdLength']);
+  only(legacyConfig.display, 'display', ['tableStyle', 'colorOutput', 'shortIdLength']);
   only(config.daemon, 'daemon', [
     'port',
     'host',
@@ -403,7 +407,7 @@ function validateConfig(config: AgorConfig): void {
     'last_usage_summary_day',
     'last_reported_version',
   ]);
-  only(config.onboarding, 'onboarding', [
+  only(legacyConfig.onboarding, 'onboarding', [
     'teammatePending',
     'assistantPending',
     'persistedAgentPending',
@@ -610,10 +614,6 @@ export async function saveConfig(config: AgorConfig): Promise<void> {
  */
 export function getDefaultConfig(): AgorConfig {
   return {
-    defaults: {
-      board: 'main',
-      agent: 'claude-code',
-    },
     daemon: {
       port: DAEMON.DEFAULT_PORT,
       host: DAEMON.DEFAULT_HOST,
@@ -678,15 +678,21 @@ export async function initConfig(): Promise<void> {
 export async function getConfigValue(key: string): Promise<string | boolean | number | undefined> {
   const config = await loadConfig();
   const defaults = getDefaultConfig();
-  const { display: _retiredDisplay, ...activeConfig } = config as AgorConfig & {
+  const {
+    defaults: _retiredDefaults,
+    display: _retiredDisplay,
+    onboarding: _retiredOnboarding,
+    ...activeConfig
+  } = config as AgorConfig & {
+    defaults?: unknown;
     display?: unknown;
+    onboarding?: unknown;
   };
 
   // Merge config with defaults (deep merge for sections)
   const merged = {
     ...defaults,
     ...activeConfig,
-    defaults: { ...defaults.defaults, ...config.defaults },
     daemon: { ...defaults.daemon, ...config.daemon },
     ui: { ...defaults.ui, ...config.ui },
     execution: { ...defaults.execution, ...config.execution },
@@ -716,7 +722,12 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
  * @param value - Value to set
  */
 export async function setConfigValue(key: string, value: string | boolean | number): Promise<void> {
-  if (key === 'display.tableStyle' || key === 'display.colorOutput') {
+  if (
+    key.startsWith('defaults.') ||
+    key.startsWith('onboarding.') ||
+    key === 'display.tableStyle' ||
+    key === 'display.colorOutput'
+  ) {
     throw new Error(`Configuration key ${key} has been retired and no longer has any effect`);
   }
   const config = await loadConfig();

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -22,6 +22,32 @@ import {
   type UnknownJson,
 } from './types';
 
+export const RETIRED_CONFIG_KEYS = {
+  defaults: ['board', 'agent'],
+  display: ['tableStyle', 'colorOutput', 'shortIdLength'],
+  onboarding: ['teammatePending', 'assistantPending', 'persistedAgentPending'],
+} as const;
+
+export const RETIRED_CONFIG_PATHS = new Set<string>(
+  Object.entries(RETIRED_CONFIG_KEYS).flatMap(([section, keys]) =>
+    keys.map((key) => `${section}.${key}`)
+  )
+);
+
+type LegacyConfig = AgorConfig & {
+  defaults?: Record<string, unknown>;
+  display?: Record<string, unknown>;
+  onboarding?: Record<string, unknown>;
+};
+
+/** Resolve the renamed operator setting while keeping old YAML loadable. */
+export function resolveTeammateFrameworkRepoUrl(config: AgorConfig): string | undefined {
+  const legacyUrl = (config as LegacyConfig).onboarding?.frameworkRepoUrl;
+  return (
+    config.teammates?.framework_repo_url ?? (typeof legacyUrl === 'string' ? legacyUrl : undefined)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // In-memory cache for the default-path config
 //
@@ -224,6 +250,7 @@ function validateConfig(config: AgorConfig): void {
     'execution',
     'security',
     'branches',
+    'teammates',
     'paths',
     'analytics',
     'telemetry',
@@ -246,16 +273,12 @@ function validateConfig(config: AgorConfig): void {
       if (!allowed.includes(key)) unknownPaths.push(`${path}.${key}`);
     }
   };
-  const legacyConfig = config as AgorConfig & {
-    defaults?: unknown;
-    display?: unknown;
-    onboarding?: unknown;
-  };
-  only(legacyConfig.defaults, 'defaults', ['board', 'agent']);
+  const legacyConfig = config as LegacyConfig;
+  only(legacyConfig.defaults, 'defaults', RETIRED_CONFIG_KEYS.defaults);
   // Known upgrade-only keys remain loadable so the daemon can print its
   // dedicated deprecation guidance before ignoring them. `display` is not
   // part of AgorConfig anymore: all three settings were retired.
-  only(legacyConfig.display, 'display', ['tableStyle', 'colorOutput', 'shortIdLength']);
+  only(legacyConfig.display, 'display', RETIRED_CONFIG_KEYS.display);
   only(config.daemon, 'daemon', [
     'port',
     'host',
@@ -379,6 +402,7 @@ function validateConfig(config: AgorConfig): void {
     'override',
   ]);
   only(config.branches, 'branches', ['others_can_default', 'others_fs_access_default']);
+  only(config.teammates, 'teammates', ['framework_repo_url']);
   only(config.paths, 'paths', ['data_home']);
   only(config.analytics, 'analytics', ['enabled', 'client', 'filters', 'plugins']);
   only(config.analytics?.client, 'analytics.client', ['app', 'version', 'debug']);
@@ -408,9 +432,7 @@ function validateConfig(config: AgorConfig): void {
     'last_reported_version',
   ]);
   only(legacyConfig.onboarding, 'onboarding', [
-    'teammatePending',
-    'assistantPending',
-    'persistedAgentPending',
+    ...RETIRED_CONFIG_KEYS.onboarding,
     'frameworkRepoUrl',
   ]);
   only(config.knowledge, 'knowledge', ['semantic_search']);
@@ -722,12 +744,7 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
  * @param value - Value to set
  */
 export async function setConfigValue(key: string, value: string | boolean | number): Promise<void> {
-  if (
-    key.startsWith('defaults.') ||
-    key.startsWith('onboarding.') ||
-    key === 'display.tableStyle' ||
-    key === 'display.colorOutput'
-  ) {
+  if (RETIRED_CONFIG_PATHS.has(key)) {
     throw new Error(`Configuration key ${key} has been retired and no longer has any effect`);
   }
   const config = await loadConfig();

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -942,6 +942,12 @@ export interface AgorBranchesSettings {
   others_fs_access_default?: 'none' | 'read' | 'write';
 }
 
+/** Operator-owned defaults for creating AI teammates. */
+export interface AgorTeammateSettings {
+  /** Repository cloned by the onboarding wizard when creating the first teammate. */
+  framework_repo_url?: string;
+}
+
 /**
  * Per-vendor HTTP proxy configuration.
  *
@@ -1050,6 +1056,9 @@ export interface AgorConfig {
   /** Branch-level defaults (others_can_default, others_fs_access_default) */
   branches?: AgorBranchesSettings;
 
+  /** Operator-owned teammate bootstrap settings. */
+  teammates?: AgorTeammateSettings;
+
   /** Path configuration (data_home for repos/branches separation) */
   paths?: AgorPathSettings;
 
@@ -1087,6 +1096,7 @@ export type ConfigKey =
   | `execution.${keyof AgorExecutionSettings}`
   | `security.${keyof AgorSecuritySettings}`
   | `branches.${keyof AgorBranchesSettings}`
+  | `teammates.${keyof AgorTeammateSettings}`
   | `paths.${keyof AgorPathSettings}`
   | `analytics.${keyof AgorAnalyticsSettings}`
   | `telemetry.${keyof AgorTelemetrySettings}`

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -35,17 +35,6 @@ export interface AgorDefaults {
 }
 
 /**
- * Display settings
- */
-export interface AgorDisplaySettings {
-  /** Table style: unicode, ascii, or minimal */
-  tableStyle?: 'unicode' | 'ascii' | 'minimal';
-
-  /** Enable color output */
-  colorOutput?: boolean;
-}
-
-/**
  * Daemon settings
  */
 export interface AgorDaemonSettings {
@@ -1068,9 +1057,6 @@ export interface AgorConfig {
   /** Global defaults */
   defaults?: AgorDefaults;
 
-  /** Display settings */
-  display?: AgorDisplaySettings;
-
   /** Daemon settings */
   daemon?: AgorDaemonSettings;
 
@@ -1126,7 +1112,6 @@ export interface AgorConfig {
  */
 export type ConfigKey =
   | `defaults.${keyof AgorDefaults}`
-  | `display.${keyof AgorDisplaySettings}`
   | `daemon.${keyof AgorDaemonSettings}`
   | `ui.${keyof AgorUISettings}`
   | `database.${keyof AgorDatabaseSettings}`

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -24,17 +24,6 @@ export type ManagedEnvsMinimumRole = 'none' | UserRole;
 export type UnknownJson = any;
 
 /**
- * Global default values
- */
-export interface AgorDefaults {
-  /** Default board for new sessions */
-  board?: string;
-
-  /** Default agent for new sessions */
-  agent?: string;
-}
-
-/**
  * Daemon settings
  */
 export interface AgorDaemonSettings {
@@ -920,20 +909,6 @@ export interface AgorAnalyticsModulePluginSettings {
 }
 
 /**
- * Onboarding settings (consumed by UI wizard; may be set by existing installs)
- */
-export interface AgorOnboardingSettings {
-  /** Whether AI teammate setup is pending (canonical key consumed by UI wizard) */
-  teammatePending?: boolean;
-  /** @deprecated Use teammatePending. Read for pre-rename config compatibility only. */
-  assistantPending?: boolean;
-  /** @deprecated Use teammatePending. Read for pre-rename config compatibility only. */
-  persistedAgentPending?: boolean;
-  /** Clone URL for the framework repo */
-  frameworkRepoUrl?: string;
-}
-
-/**
  * Branch-level defaults.
  *
  * Top-level `branches:` section (not under `execution:`) because these
@@ -1054,9 +1029,6 @@ export interface AgorMultiTenancySettings {
  * Complete Agor configuration
  */
 export interface AgorConfig {
-  /** Global defaults */
-  defaults?: AgorDefaults;
-
   /** Daemon settings */
   daemon?: AgorDaemonSettings;
 
@@ -1090,9 +1062,6 @@ export interface AgorConfig {
   /** Knowledge Base semantic search settings. */
   knowledge?: AgorKnowledgeSettings;
 
-  /** Onboarding settings (CLI init → UI wizard) */
-  onboarding?: AgorOnboardingSettings;
-
   /** App-level multi-tenancy settings. Defaults to static/default tenant. */
   multi_tenancy?: AgorMultiTenancySettings;
 
@@ -1111,7 +1080,6 @@ export interface AgorConfig {
  * Valid config keys (includes nested keys with dot notation)
  */
 export type ConfigKey =
-  | `defaults.${keyof AgorDefaults}`
   | `daemon.${keyof AgorDaemonSettings}`
   | `ui.${keyof AgorUISettings}`
   | `database.${keyof AgorDatabaseSettings}`
@@ -1122,5 +1090,4 @@ export type ConfigKey =
   | `paths.${keyof AgorPathSettings}`
   | `analytics.${keyof AgorAnalyticsSettings}`
   | `telemetry.${keyof AgorTelemetrySettings}`
-  | `knowledge.${keyof AgorKnowledgeSettings}`
-  | `onboarding.${keyof AgorOnboardingSettings}`;
+  | `knowledge.${keyof AgorKnowledgeSettings}`;


### PR DESCRIPTION
## Summary

- retire obsolete CLI-era display configuration (`display.tableStyle`, `display.colorOutput`, and `display.shortIdLength`)
- retire dead global default/onboarding-progress configuration while preserving legacy YAML as accepted-but-ignored with startup warnings
- move onboarding progress to user-owned state and preserve the configurable framework repository under operator-owned `teammates.framework_repo_url`, with the legacy onboarding key as a fallback
- remove the tenant-facing `/config` read surface, which exposed raw instance configuration, while retaining the scoped API-key resolution endpoint
- centralize retired configuration paths so validation, warnings, CLI mutation guards, and compatibility behavior cannot drift

## Compatibility

Existing config files containing retired keys continue to parse and start successfully. Retired keys are ignored with explicit warnings, and CLI writes to those paths are rejected. This avoids turning previously valid YAML into startup failures while preventing new usage.

`onboarding.frameworkRepoUrl` remains functional as a deprecated fallback. Operators can migrate to `teammates.framework_repo_url`; the canonical key takes precedence when both are present.

## Validation

- `pnpm i`
- `pnpm check`
- focused core configuration tests
- focused daemon configuration/onboarding tests
- focused UI onboarding tests
- Biome checks and core typecheck
- Codex follow-up review requested after addressing initial findings
