### PR TITLE
fix(env): reduce branch patch churn from health probes

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -543,9 +543,9 @@ describe('BranchesService environment start async behavior', () => {
   });
 
   // The health monitor probes every running env every 5s. updateEnvironment
-  // must persist + broadcast ONLY when a health-relevant field actually changes,
-  // never on a bare re-probe or a timestamp-only refresh, or every client
-  // rebuilds its branch map and re-runs branch-derived subscriptions per probe.
+  // persists each observation timestamp, but broadcasts ONLY when a
+  // health-relevant field actually changes. Otherwise every client rebuilds
+  // its branch map and re-runs branch-derived subscriptions per probe.
   describe('health-probe change gate', () => {
     function createGateHarness(initialEnv: Record<string, unknown>) {
       const { service, branchesService } = createServiceHarness();
@@ -581,7 +581,7 @@ describe('BranchesService environment start async behavior', () => {
       access_urls: [{ name: 'App', url: 'http://localhost:5173' }],
     });
 
-    it('does not patch or emit when the re-probe reports no change', async () => {
+    it('persists but does not emit when the re-probe only advances the timestamp', async () => {
       const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
 
       await service.updateEnvironment(branch.branch_id, {
@@ -593,11 +593,22 @@ describe('BranchesService environment start async behavior', () => {
         },
       });
 
-      expect(patchSpy).not.toHaveBeenCalled();
+      expect(patchSpy).toHaveBeenCalledTimes(1);
+      expect(patchSpy).toHaveBeenCalledWith(
+        branch.branch_id,
+        {
+          environment_instance: expect.objectContaining({
+            last_health_check: expect.objectContaining({
+              timestamp: '2026-01-01T00:00:05.000Z',
+            }),
+          }),
+        },
+        undefined
+      );
       expect(emit).not.toHaveBeenCalled();
     });
 
-    it('does not broadcast when only the health-check timestamp changes', async () => {
+    it('does not broadcast timestamp bookkeeping', async () => {
       const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
 
       // Same status + health status + message; only the bookkeeping timestamp
@@ -605,6 +616,22 @@ describe('BranchesService environment start async behavior', () => {
       await service.updateEnvironment(branch.branch_id, {
         last_health_check: {
           timestamp: '2026-06-30T12:00:00.000Z',
+          status: 'healthy',
+          message: 'HTTP 200',
+        },
+      });
+
+      expect(patchSpy).toHaveBeenCalledTimes(1);
+      expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('does not write or emit an exactly identical observation', async () => {
+      const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
+
+      await service.updateEnvironment(branch.branch_id, {
+        status: 'running',
+        last_health_check: {
+          timestamp: '2026-01-01T00:00:00.000Z',
           status: 'healthy',
           message: 'HTTP 200',
         },

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -561,13 +561,28 @@ describe('BranchesService environment start async behavior', () => {
       vi.spyOn(service, 'get').mockImplementation(
         async () => ({ ...branch, environment_instance: currentEnv }) as never
       );
+      const observationUpdateSpy = vi
+        .spyOn(
+          (
+            service as unknown as {
+              branchRepo: {
+                update: BranchRepository['update'];
+              };
+            }
+          ).branchRepo,
+          'update'
+        )
+        .mockImplementation(async (_id, data) => {
+          currentEnv = data.environment_instance as Record<string, unknown>;
+          return { ...branch, environment_instance: currentEnv } as never;
+        });
       const patchSpy = vi.spyOn(service, 'patch').mockImplementation(async (_id, data) => {
         const next = { ...branch, ...(data as object) };
         currentEnv = (next as { environment_instance: Record<string, unknown> })
           .environment_instance;
         return next as never;
       });
-      return { service, branch, patchSpy, emit: branchesService.emit };
+      return { service, branch, patchSpy, observationUpdateSpy, emit: branchesService.emit };
     }
 
     const healthyEnv = () => ({
@@ -582,7 +597,9 @@ describe('BranchesService environment start async behavior', () => {
     });
 
     it('persists but does not emit when the re-probe only advances the timestamp', async () => {
-      const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
+      const { service, branch, patchSpy, observationUpdateSpy, emit } = createGateHarness(
+        healthyEnv()
+      );
 
       await service.updateEnvironment(branch.branch_id, {
         status: 'running',
@@ -593,8 +610,8 @@ describe('BranchesService environment start async behavior', () => {
         },
       });
 
-      expect(patchSpy).toHaveBeenCalledTimes(1);
-      expect(patchSpy).toHaveBeenCalledWith(
+      expect(patchSpy).not.toHaveBeenCalled();
+      expect(observationUpdateSpy).toHaveBeenCalledWith(
         branch.branch_id,
         {
           environment_instance: expect.objectContaining({
@@ -603,13 +620,15 @@ describe('BranchesService environment start async behavior', () => {
             }),
           }),
         },
-        undefined
+        { preserveUpdatedAt: true }
       );
       expect(emit).not.toHaveBeenCalled();
     });
 
     it('does not broadcast timestamp bookkeeping', async () => {
-      const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
+      const { service, branch, patchSpy, observationUpdateSpy, emit } = createGateHarness(
+        healthyEnv()
+      );
 
       // Same status + health status + message; only the bookkeeping timestamp
       // moved. A timestamp must never defeat the change gate.
@@ -621,12 +640,15 @@ describe('BranchesService environment start async behavior', () => {
         },
       });
 
-      expect(patchSpy).toHaveBeenCalledTimes(1);
+      expect(patchSpy).not.toHaveBeenCalled();
+      expect(observationUpdateSpy).toHaveBeenCalledTimes(1);
       expect(emit).not.toHaveBeenCalled();
     });
 
     it('does not write or emit an exactly identical observation', async () => {
-      const { service, branch, patchSpy, emit } = createGateHarness(healthyEnv());
+      const { service, branch, patchSpy, observationUpdateSpy, emit } = createGateHarness(
+        healthyEnv()
+      );
 
       await service.updateEnvironment(branch.branch_id, {
         status: 'running',
@@ -638,6 +660,7 @@ describe('BranchesService environment start async behavior', () => {
       });
 
       expect(patchSpy).not.toHaveBeenCalled();
+      expect(observationUpdateSpy).not.toHaveBeenCalled();
       expect(emit).not.toHaveBeenCalled();
     });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1896,24 +1896,29 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     const hasChanged = JSON.stringify(oldState) !== JSON.stringify(newState);
 
+    // Observation-only persistence deliberately bypasses Feathers publication.
+    // It also preserves branch.updated_at so health bookkeeping does not affect
+    // branch ordering or modification semantics every five seconds.
+    if (!hasChanged) {
+      return this.withTenantDatabase(resolvedParams, () =>
+        this.branchRepo.update(
+          id,
+          { environment_instance: updatedEnvironment },
+          { preserveUpdatedAt: true }
+        )
+      );
+    }
+
     const branch = await this.withTenantDatabase(resolvedParams, () =>
       this.patch(
         id,
         {
           environment_instance: updatedEnvironment,
-          ...(hasChanged ? { updated_at: new Date().toISOString() } : {}),
+          updated_at: new Date().toISOString(),
         },
         resolvedParams
       )
     );
-
-    // Observation-only persistence deliberately bypasses Feathers publication.
-    // The custom method calls the raw service implementation, so simply
-    // returning here keeps the database timestamp accurate without generating
-    // a realtime branch patch.
-    if (!hasChanged) {
-      return branch;
-    }
 
     // this.patch() calls the raw implementation and bypasses Feathers event
     // dispatch, so the patched event is not automatically emitted. Emit it

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1869,8 +1869,18 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       }
     }
 
-    // Check if environment state actually changed (ignoring timestamp-only updates)
-    // For health checks, we only care about status and message changes, not timestamp
+    // Distinguish persisted observations from user-visible state changes. A
+    // successful re-probe advances last_health_check.timestamp in storage, but
+    // that bookkeeping alone must not emit a full `branches.patched` payload to
+    // every authorized browser every five seconds.
+    const hasPersistedChange =
+      JSON.stringify(existing.environment_instance) !== JSON.stringify(updatedEnvironment);
+    if (!hasPersistedChange) {
+      return existing;
+    }
+
+    // For realtime publication, health status and message matter; the
+    // observation timestamp does not.
     const oldState = { ...existing.environment_instance };
     const newState = { ...updatedEnvironment };
 
@@ -1886,21 +1896,24 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     const hasChanged = JSON.stringify(oldState) !== JSON.stringify(newState);
 
-    // Only emit WebSocket event if state changed
-    if (!hasChanged) {
-      return existing;
-    }
-
     const branch = await this.withTenantDatabase(resolvedParams, () =>
       this.patch(
         id,
         {
           environment_instance: updatedEnvironment,
-          updated_at: new Date().toISOString(),
+          ...(hasChanged ? { updated_at: new Date().toISOString() } : {}),
         },
         resolvedParams
       )
     );
+
+    // Observation-only persistence deliberately bypasses Feathers publication.
+    // The custom method calls the raw service implementation, so simply
+    // returning here keeps the database timestamp accurate without generating
+    // a realtime branch patch.
+    if (!hasChanged) {
+      return branch;
+    }
 
     // this.patch() calls the raw implementation and bypasses Feathers event
     // dispatch, so the patched event is not automatically emitted. Emit it

--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -201,4 +201,85 @@ describe('HealthMonitor tenant context', () => {
     expect(ambientTenantIds).toEqual(['tenant-a', 'tenant-a']);
     monitor.cleanup();
   });
+
+  it('deduplicates repeated lifecycle patches during the startup grace period', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+    const branch = makeBranch({ environment_instance: { status: 'running' } });
+
+    branches.emit('patched', branch);
+    branches.emit('patched', branch);
+    branches.emit('patched', branch);
+
+    expect(monitor.getStatus()).toMatchObject({
+      monitoringCount: 1,
+      monitoredBranches: [branch.branch_id],
+    });
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS * 2);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(3));
+    monitor.cleanup();
+  });
+
+  it('cancels a pending grace check when the environment stops', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+    const branch = makeBranch({ environment_instance: { status: 'starting' } });
+
+    branches.emit('patched', branch);
+    branches.emit(
+      'patched',
+      makeBranch({
+        branch_id: branch.branch_id,
+        environment_instance: { status: 'stopped' },
+      })
+    );
+
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+    await vi.advanceTimersByTimeAsync(
+      ENVIRONMENT.STARTUP_GRACE_PERIOD_MS + ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS
+    );
+    expect(branches.checkHealth).not.toHaveBeenCalled();
+    monitor.cleanup();
+  });
+
+  it('does not overlap slow health checks for the same branch', async () => {
+    const branches = new BranchServiceMock();
+    let releaseCheck: (() => void) | undefined;
+    branches.checkHealth.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseCheck = resolve;
+        })
+    );
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+
+    branches.emit('patched', makeBranch({ environment_instance: { status: 'running' } }));
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS * 3);
+    expect(branches.checkHealth).toHaveBeenCalledTimes(1);
+
+    releaseCheck?.();
+    await vi.runAllTicks();
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(2));
+    monitor.cleanup();
+  });
+
+  it('cleanup cancels pending grace timers', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+
+    branches.emit('patched', makeBranch({ environment_instance: { status: 'running' } }));
+    monitor.cleanup();
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    expect(branches.checkHealth).not.toHaveBeenCalled();
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+  });
 });

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -61,6 +61,11 @@ export interface HealthMonitorOptions {
   discoverActiveEnvironmentRefs?: () => Promise<HealthMonitorActiveEnvironmentRef[]>;
 }
 
+interface HealthMonitorTimer {
+  handle: NodeJS.Timeout;
+  phase: 'grace' | 'interval';
+}
+
 function tenantParamsFromBranch(branch: Branch): HealthMonitorParams | undefined {
   const tenantId = getHiddenTenantId(branch);
   if (!tenantId) return undefined;
@@ -69,7 +74,16 @@ function tenantParamsFromBranch(branch: Branch): HealthMonitorParams | undefined
 
 export class HealthMonitor {
   private app: Application;
-  private intervals = new Map<BranchID, NodeJS.Timeout>();
+  /**
+   * One timer per branch, including the startup grace period.
+   *
+   * The grace timeout must be registered immediately. Previously a branch had
+   * no entry until the grace period elapsed, so every lifecycle patch received
+   * during those three seconds scheduled another permanent interval. Only the
+   * last interval was retained in the map; the others could never be stopped.
+   */
+  private timers = new Map<BranchID, HealthMonitorTimer>();
+  private checksInFlight = new Set<BranchID>();
   private branchParams = new Map<BranchID, HealthMonitorParams>();
   private isShuttingDown = false;
   private defaultParams?: HealthMonitorParams;
@@ -141,13 +155,13 @@ export class HealthMonitor {
         return;
       }
       if (params) this.branchParams.set(branch.branch_id, params);
-      if (!this.intervals.has(branch.branch_id)) {
+      if (!this.timers.has(branch.branch_id)) {
         healthMonitorDebug(`🏥 Starting health monitoring for branch: ${branch.name}`);
         this.startMonitoring(branch.branch_id, params);
       }
     } else {
       // Stop monitoring if status is not running or starting.
-      if (this.intervals.has(branch.branch_id)) {
+      if (this.timers.has(branch.branch_id)) {
         healthMonitorDebug(`🏥 Stopping health monitoring for branch: ${branch.name}`);
         this.stopMonitoring(branch.branch_id);
       }
@@ -159,7 +173,7 @@ export class HealthMonitor {
    * Start monitoring a branch's health
    */
   private startMonitoring(branchId: BranchID, params = this.branchParams.get(branchId)) {
-    // Clear existing interval if any
+    // Clear an existing grace timeout or interval before replacing it.
     this.stopMonitoring(branchId);
     if (params) this.branchParams.set(branchId, params);
 
@@ -172,20 +186,31 @@ export class HealthMonitor {
     // DB scope so every check enters a fresh scope through the branches service
     // hooks using the stored tenant params.
     runWithoutTenantDatabaseScope(() => {
-      setTimeout(() => {
-        if (this.isShuttingDown) return;
+      const graceHandle = setTimeout(() => {
+        const currentTimer = this.timers.get(branchId);
+        if (
+          this.isShuttingDown ||
+          currentTimer?.phase !== 'grace' ||
+          currentTimer.handle !== graceHandle
+        ) {
+          return;
+        }
 
         // Perform first health check
-        this.checkHealth(branchId);
+        void this.checkHealth(branchId);
 
         // Set up periodic health checks
         const interval = setInterval(() => {
           if (this.isShuttingDown) return;
-          this.checkHealth(branchId);
+          void this.checkHealth(branchId);
         }, ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS);
 
-        this.intervals.set(branchId, interval);
+        this.timers.set(branchId, { handle: interval, phase: 'interval' });
       }, ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+
+      // Register the grace period synchronously so repeated `patched` events
+      // cannot schedule duplicate intervals before this timeout fires.
+      this.timers.set(branchId, { handle: graceHandle, phase: 'grace' });
     });
   }
 
@@ -193,10 +218,11 @@ export class HealthMonitor {
    * Stop monitoring a branch's health
    */
   private stopMonitoring(branchId: BranchID) {
-    const interval = this.intervals.get(branchId);
-    if (interval) {
-      clearInterval(interval);
-      this.intervals.delete(branchId);
+    const timer = this.timers.get(branchId);
+    if (timer) {
+      if (timer.phase === 'grace') clearTimeout(timer.handle);
+      else clearInterval(timer.handle);
+      this.timers.delete(branchId);
     }
   }
 
@@ -204,6 +230,13 @@ export class HealthMonitor {
    * Perform health check for a specific branch
    */
   private async checkHealth(branchId: BranchID) {
+    // `setInterval` does not await async callbacks. The normal HTTP timeout is
+    // shorter than the poll interval, but DB stalls or executor/service delays
+    // can exceed it. Never let two observations for one branch race and write a
+    // stale healthy/unhealthy result over the newer one.
+    if (this.checksInFlight.has(branchId)) return;
+    this.checksInFlight.add(branchId);
+
     try {
       const branchesService = this.app.service('branches') as unknown as BranchesServiceImpl;
 
@@ -267,6 +300,8 @@ export class HealthMonitor {
         `❌ Health check failed for branch ${shortId(branchId)}:`,
         error instanceof Error ? error.message : error
       );
+    } finally {
+      this.checksInFlight.delete(branchId);
     }
   }
 
@@ -413,13 +448,14 @@ export class HealthMonitor {
   cleanup() {
     this.isShuttingDown = true;
 
-    // Clear all intervals
-    const stoppedCount = this.intervals.size;
-    for (const interval of this.intervals.values()) {
-      clearInterval(interval);
+    // Clear pending grace periods and active intervals.
+    const stoppedCount = this.timers.size;
+    for (const timer of this.timers.values()) {
+      if (timer.phase === 'grace') clearTimeout(timer.handle);
+      else clearInterval(timer.handle);
     }
 
-    this.intervals.clear();
+    this.timers.clear();
     this.branchParams.clear();
     console.log(`🏥 Health Monitor cleaned up (${stoppedCount} monitor(s) stopped)`);
   }
@@ -430,8 +466,8 @@ export class HealthMonitor {
   getStatus() {
     return {
       isShuttingDown: this.isShuttingDown,
-      monitoredBranches: Array.from(this.intervals.keys()),
-      monitoringCount: this.intervals.size,
+      monitoredBranches: Array.from(this.timers.keys()),
+      monitoringCount: this.timers.size,
     };
   }
 }

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -750,6 +750,45 @@ describe('BranchRepository.findByRepoAndName', () => {
 // ============================================================================
 
 describe('BranchRepository.update', () => {
+  dbTest('can preserve updated_at for observation-only bookkeeping', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const repo = await repoRepo.create(createRepoData());
+    const created = await branchRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        environment_instance: {
+          status: 'running',
+          last_health_check: {
+            timestamp: '2026-01-01T00:00:00.000Z',
+            status: 'healthy',
+            message: 'HTTP 200',
+          },
+        },
+      })
+    );
+
+    const updated = await branchRepo.update(
+      created.branch_id,
+      {
+        environment_instance: {
+          status: created.environment_instance?.status ?? 'running',
+          last_health_check: {
+            timestamp: '2026-01-01T00:00:05.000Z',
+            status: 'healthy',
+            message: 'HTTP 200',
+          },
+        },
+      },
+      { preserveUpdatedAt: true }
+    );
+
+    expect(updated.environment_instance?.last_health_check?.timestamp).toBe(
+      '2026-01-01T00:00:05.000Z'
+    );
+    expect(updated.updated_at).toBe(created.updated_at);
+  });
+
   dbTest('should update by full UUID and short ID', async ({ db }) => {
     const repoRepo = new RepoRepository(db);
     const wtRepo = new BranchRepository(db);

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -518,7 +518,11 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
    * Uses a transaction to ensure read-merge-write is atomic, preventing race conditions
    * when multiple updates happen concurrently (e.g., schedule config + environment updates).
    */
-  async update(id: string, updates: Partial<Branch>): Promise<Branch> {
+  async update(
+    id: string,
+    updates: Partial<Branch>,
+    options?: { preserveUpdatedAt?: boolean }
+  ): Promise<Branch> {
     // STEP 1: Read current branch (outside transaction for short ID resolution)
     const existing = await this.findById(id);
     if (!existing) {
@@ -556,10 +560,13 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
         branch_id: current.branch_id, // Never change ID
         repo_id: current.repo_id, // Never change repo
         created_at: current.created_at, // Never change created timestamp
-        updated_at: new Date().toISOString(), // Always update timestamp
+        updated_at: options?.preserveUpdatedAt ? current.updated_at : new Date().toISOString(),
       });
 
       const insertData = this.branchToInsert(merged);
+      if (options?.preserveUpdatedAt) {
+        insertData.updated_at = new Date(current.updated_at);
+      }
 
       // STEP 4: Write merged branch (within same transaction)
       const row = await update(txAsDb(tx), branches)


### PR DESCRIPTION
## Summary

- keep managed-environment health probes on their existing five-second cadence while suppressing timestamp-only `branches.patched` broadcasts
- persist every health observation without changing branch-level `updated_at` bookkeeping
- track startup-grace timers immediately so repeated branch events cannot create leaked polling intervals
- prevent overlapping health checks for the same branch

## Root cause

The health monitor waited through a three-second startup grace period before registering a branch timer. Multiple branch events during that window could each schedule a permanent interval, while only the final interval was retained in the timer map. Earlier intervals leaked and continued polling.

Separately, each successful probe persisted a new `last_health_check.timestamp`. That observation-only write surfaced as a full branch patch, sending unchanged health state to authorized browser clients every five seconds.

Production correlation showed:

- five-second bursts where only `updated_at` and `environment_instance.last_health_check.timestamp` changed
- repeated identical transition logs from duplicate health-monitor loops
- events were tenant/RBAC scoped; superadmin visibility explained why the observing browser received private branches owned by other users

## Behavior after this change

- one startup-grace or polling timer per active branch
- no overlapping health request for a branch
- health checks continue every five seconds
- persisted `last_health_check.timestamp` remains current
- observation-only persistence preserves `branches.updated_at`
- `branches.patched` still fires for meaningful environment and health transitions
- existing tenant/RBAC realtime publication is unchanged
- no new custom realtime event

## Validation

- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/health-monitor.test.ts src/services/branches.test.ts src/utils/realtime-publish.test.ts src/utils/emit-service-event.test.ts`
- `pnpm --filter agor-ui test -- src/hooks/useAgorData.test.tsx`
- `pnpm --filter @agor/core test -- src/db/repositories/branches.test.ts`
- Codex GPT-5.5 review; its timestamp-metadata finding was addressed in commit `35d84bdf`
