### PR TITLE
fix(realtime): emit branch archive transitions

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -53,6 +53,12 @@ describe('tenant-owned service registration', () => {
     expect(TENANT_OWNED_SERVICE_PATHS).toContain('gateway');
   });
 
+  it('wraps custom board archive routes in tenant database scope', () => {
+    expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
+      expect.arrayContaining(['boards/:id/archive', 'boards/:id/unarchive'])
+    );
+  });
+
   it('wraps MCP OAuth/session helper services in tenant database scope', () => {
     expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
       expect.arrayContaining([

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -398,6 +398,8 @@ export const TENANT_OWNED_SERVICE_PATHS = [
   'tasks',
   'messages',
   'boards',
+  'boards/:id/archive',
+  'boards/:id/unarchive',
   'repos',
   'branches',
   'branches/:id/owners',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -303,15 +303,19 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   } as any);
   app.use(
     '/boards',
-    createBoardsService(db, (boardObject, params) => {
-      emitServiceEvent(app, {
-        path: 'board-objects',
-        event: 'patched',
-        data: boardObject,
-        params,
-        id: boardObject.object_id,
-      });
-    }),
+    createBoardsService(
+      db,
+      (boardObject, params) => {
+        emitServiceEvent(app, {
+          path: 'board-objects',
+          event: 'patched',
+          data: boardObject,
+          params,
+          id: boardObject.object_id,
+        });
+      },
+      (event) => emitServiceEvent(app, { path: 'boards', ...event })
+    ),
     {
       methods: [
         'find',

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -429,6 +429,30 @@ describe('BoardsService - Custom Methods', () => {
     expect(typeof service.clone).toBe('function');
     expect(typeof service.ensureTeammateWelcomeNote).toBe('function');
   });
+
+  dbTest('manually emits archive transitions from the custom method', async ({ db }) => {
+    const emitBoardEvent = vi.fn();
+    const service = new BoardsService(db, undefined, emitBoardEvent);
+    const board = (await service.create({
+      name: 'Archive realtime',
+      slug: 'archive-realtime',
+      created_by: TEST_USER,
+    })) as Board;
+    const params = {
+      user: { user_id: TEST_USER },
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+    } as never;
+
+    const archived = await service.archive(board.board_id, params);
+
+    expect(archived.archived).toBe(true);
+    expect(emitBoardEvent).toHaveBeenCalledWith({
+      event: 'patched',
+      data: archived,
+      params,
+      id: board.board_id,
+    });
+  });
 });
 
 describe('BoardsService.find SQL pushdown', () => {

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -27,6 +27,7 @@ import type {
 } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import { DrizzleService, type Query } from '../adapters/drizzle';
+import type { ManualServiceEvent } from '../utils/emit-service-event.js';
 import {
   type BoardObjectPatchedEventPayload,
   toBoardObjectPatchedEventPayload,
@@ -57,13 +58,15 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     boardObject: BoardObjectPatchedEventPayload,
     params?: BoardParams
   ) => void;
+  private emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void;
 
   constructor(
     db: TenantScopeAwareDatabase,
     emitBoardObjectPatched?: (
       boardObject: BoardObjectPatchedEventPayload,
       params?: BoardParams
-    ) => void
+    ) => void,
+    emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void
   ) {
     const boardRepo = new BoardRepository(db);
     super(boardRepo, {
@@ -78,6 +81,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     this.boardRepo = boardRepo;
     this.boardObjectRepo = new BoardObjectRepository(db);
     this.emitBoardObjectPatched = emitBoardObjectPatched;
+    this.emitBoardEvent = emitBoardEvent;
   }
 
   /**
@@ -435,7 +439,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
 
     // Hook chain enforces auth before we get here.
     const currentUserId = params!.user!.user_id;
-    const archivedBoard = await this.patch(
+    const archivedBoard = (await this.patch(
       id,
       {
         archived: true,
@@ -443,7 +447,15 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
         archived_by: currentUserId,
       } as Partial<Board>,
       params
-    );
+    )) as Board;
+    // Custom methods call the raw implementation, bypassing Feathers'
+    // standard patch event hook. Emit the transition for connected clients.
+    this.emitBoardEvent?.({
+      event: 'patched',
+      data: archivedBoard,
+      params,
+      id: archivedBoard.board_id,
+    });
 
     console.log(`✅ Archived board ${board.name}`);
     return archivedBoard as Board;
@@ -461,7 +473,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
 
     console.log(`📦 Unarchiving board: ${board.name}`);
 
-    const unarchivedBoard = await this.patch(
+    const unarchivedBoard = (await this.patch(
       id,
       {
         archived: false,
@@ -469,7 +481,13 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
         archived_by: undefined,
       } as Partial<Board>,
       params
-    );
+    )) as Board;
+    this.emitBoardEvent?.({
+      event: 'patched',
+      data: unarchivedBoard,
+      params,
+      id: unarchivedBoard.board_id,
+    });
 
     console.log(`✅ Unarchived board ${board.name}`);
     return unarchivedBoard as Board;
@@ -523,7 +541,8 @@ export function createBoardsService(
   emitBoardObjectPatched?: (
     boardObject: BoardObjectPatchedEventPayload,
     params?: BoardParams
-  ) => void
+  ) => void,
+  emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void
 ): BoardsService {
-  return new BoardsService(db, emitBoardObjectPatched);
+  return new BoardsService(db, emitBoardObjectPatched, emitBoardEvent);
 }

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -1091,8 +1091,9 @@ describe('BranchesService.unarchive', () => {
 });
 
 describe('BranchesService.archiveOrDelete', () => {
-  it('preserves a zoned board object when archiving through the archive operation', async () => {
-    const { service, boardObjectsService, sessionsService } = createServiceHarness();
+  it('preserves placement and manually emits the tenant-aware archive transition', async () => {
+    const { service, boardObjectsService, sessionsService, branchesService } =
+      createServiceHarness();
     const branchId = 'wt-archive-op' as BranchID;
     const userId = 'user-1' as UUID;
 
@@ -1120,7 +1121,10 @@ describe('BranchesService.archiveOrDelete', () => {
     await service.archiveOrDelete(
       branchId,
       { metadataAction: 'archive', filesystemAction: 'preserved' },
-      { user: { user_id: userId } } as never
+      {
+        user: { user_id: userId },
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+      } as never
     );
 
     expect(sessionsService.find).toHaveBeenCalledWith({
@@ -1129,6 +1133,20 @@ describe('BranchesService.archiveOrDelete', () => {
     });
     expect(boardObjectsService.findByBranchId).not.toHaveBeenCalled();
     expect(boardObjectsService.patch).not.toHaveBeenCalled();
+    expect(branchesService.emit).toHaveBeenCalledTimes(1);
+    expect(branchesService.emit).toHaveBeenCalledWith(
+      'patched',
+      expect.objectContaining({ branch_id: branchId, archived: true }),
+      expect.objectContaining({
+        path: 'branches',
+        method: 'patch',
+        event: 'patched',
+        id: branchId,
+        params: expect.objectContaining({
+          tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        }),
+      })
+    );
   });
 });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1509,6 +1509,17 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         )
       );
 
+      // archiveOrDelete is a custom service method. Its internal this.patch()
+      // call bypasses Feathers' standard-method event hook, so publish the
+      // branch transition explicitly (with the request tenant/RBAC context).
+      emitServiceEvent(this.app, {
+        path: 'branches',
+        event: 'patched',
+        data: archivedBranch,
+        params,
+        id: archivedBranch.branch_id,
+      });
+
       // Archive all sessions in this branch
       // Use internal call (no provider) to bypass RBAC hooks that would ignore branch_id filter
       const sessionsService = this.app.service('sessions');
@@ -1577,6 +1588,13 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const unarchivedBranch = await this.withTenantDatabase(params, () =>
       this.patch(id, patchData, params)
     );
+    emitServiceEvent(this.app, {
+      path: 'branches',
+      event: 'patched',
+      data: unarchivedBranch,
+      params,
+      id: unarchivedBranch.branch_id,
+    });
 
     // Recreate the git branch on filesystem if the directory is missing
     // (e.g., it was archived with filesystemAction: 'deleted')

--- a/apps/agor-daemon/src/utils/realtime-publish.test.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.test.ts
@@ -416,6 +416,49 @@ describe('configureRealtimePublish', () => {
     expect(channel.connections).toEqual([{ user: allowed }, { user: admin }]);
   });
 
+  it('delivers an archived branch tombstone only to tenant users who had view access', async () => {
+    const allowed = user('allowed');
+    const denied = user('denied');
+    const otherTenant = user('other-tenant');
+    const allowedConnection = { user: allowed };
+    const deniedConnection = { user: denied };
+    const app = makeApp(
+      [allowedConnection, deniedConnection, { user: otherTenant }],
+      {},
+      {
+        authenticated: [allowedConnection, deniedConnection, { user: otherTenant }],
+        'tenant:tenant-a': [allowedConnection, deniedConnection],
+      }
+    );
+    const archivedBranch = { ...branch('b1', 'none'), archived: true } as Branch;
+    const r = repos({
+      branch: archivedBranch,
+      permissions: { allowed: 'view', denied: 'none' },
+    });
+    configureRealtimePublish({
+      app,
+      db: scopeOnlyDb,
+      branchRbacEnabled: true,
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as any,
+        auth_claim: 'tenant_id',
+      },
+      ...r,
+    });
+
+    const channel = await app.runPublish(archivedBranch, {
+      path: 'branches',
+      method: 'patch',
+      event: 'patched',
+      id: 'b1',
+      params: { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
+    });
+
+    expect(channel.connections).toEqual([allowedConnection]);
+    expect(r.branchRepository.findRealtimeVisibilityBranch).toHaveBeenCalledWith('b1');
+  });
+
   it('scopes nested branch permission service events through the route branch id', async () => {
     const allowed = user('allowed');
     const denied = user('denied');

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -336,6 +336,23 @@ describe('useAgorData — socket-event bailouts', () => {
     expect(agorStore.getState().branchById.get('b-1')?.name).toBe('feature/x');
   });
 
+  it('evicts an archived branch and its sessions on branches.patched', async () => {
+    const branch = makeBranch();
+    const session = makeSession();
+    const { client, emit } = makeMockClient({ branches: [branch], sessions: [session] });
+    const { result } = renderHook(() => useAgorData(client));
+    await waitForInitialLoad(result);
+
+    expect(agorStore.getState().branchById.has('b-1')).toBe(true);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(true);
+
+    act(() => emit('branches', 'patched', { ...branch, archived: true }));
+
+    expect(agorStore.getState().branchById.has('b-1')).toBe(false);
+    expect(agorStore.getState().sessionById.has('s-1')).toBe(false);
+    expect(agorStore.getState().sessionsByBranch.has('b-1')).toBe(false);
+  });
+
   it('drops a duplicate `sessions.created` for an existing id', async () => {
     const session = makeSession();
     const { client, emit } = makeMockClient({ sessions: [session] });

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -556,6 +556,26 @@ describe('BranchRepository.findAll', () => {
     expect(archivedOnly.map((w) => w.branch_id)).toEqual([archived.branch_id]);
   });
 
+  dbTest('keeps archived rows resolvable for realtime tombstone authorization', async ({ db }) => {
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const repo = await repoRepo.create(createRepoData());
+    const archived = await branchRepo.create(
+      createBranchData({
+        repo_id: repo.repo_id,
+        name: 'archived-realtime',
+        branch_unique_id: 1,
+        others_can: 'view',
+      })
+    );
+    await branchRepo.update(archived.branch_id, { archived: true });
+
+    await expect(branchRepo.findRealtimeVisibilityBranch(archived.branch_id)).resolves.toEqual({
+      branch_id: archived.branch_id,
+      others_can: 'view',
+    });
+  });
+
   dbTest('should restrict to an explicit branchIds set', async ({ db }) => {
     const repoRepo = new RepoRepository(db);
     const wtRepo = new BranchRepository(db);


### PR DESCRIPTION
## Summary

- explicitly publish tenant-aware `branches.patched` events from custom branch archive/unarchive methods
- preserve branch RBAC delivery filtering and verify archived rows remain available to publish-time authorization
- fix the directly analogous board archive/unarchive event path and put both custom routes under the shared tenant DB scope
- pin UI store eviction for archived branches and their sessions

## Root cause

The board archive UI calls the custom `branches/:id/archive-or-delete` route. That route invokes `BranchesService.archiveOrDelete()`, which calls `this.patch()` on the raw service implementation. Raw internal method calls bypass Feathers' standard-method event hook.

Commit `21d5eb9d` / PR #1864 correctly removed adapter-level CRUD emits because they were malformed duplicates (`params` was passed where a HookContext was required). That exposed custom methods which had implicitly relied on the adapter emit. PR #1872 (`2287de38`) then established the intended contract: raw/custom mutations must use `emitServiceEvent()` so the event has a complete HookContext and snapshotted tenant params. Branch archive/unarchive was missed in that migration.

The suspected post-mutation visibility bug is **not** the archive cause. `BranchRepository.findRealtimeVisibilityBranch()` deliberately resolves archived rows. Tests prove the archived row is available and that publish-time filtering sends the transition to an authorized user in the event tenant while excluding an unauthorized user and another tenant.

## Changed

- branch archive/unarchive custom methods manually emit `branches.patched`
- board archive/unarchive custom methods manually emit `boards.patched` through the registered emitter callback
- custom board archive/unarchive routes are registered as tenant-owned services, ensuring mutation and deferred publication share the tenant DB transaction boundary
- backend tests cover HookContext tenant shape, authorized/unauthorized delivery, ordinary patch scoping, archived-row visibility, and tenant registration for board archive routes
- UI hook test covers branch/session eviction on the socket patch

## Intentionally unchanged / follow-ups

- normal Feathers CRUD patches remain automatic and are not manually re-emitted, avoiding duplicates
- branch board-object placement remains stored during archive so unarchive can restore in place; the card disappears because the archived branch is evicted
- cards already emit explicitly from their MCP custom archive path; sessions and artifacts already use `emitServiceEvent`; no speculative changes were made there
- hard-delete tombstones are a separate pre-mutation authorization-snapshot problem: after physical deletion, branch/owner rows are unavailable to an uncached RBAC lookup. This PR does not broaden publication or add an unsafe fallback

## Validation

- `pnpm i --frozen-lockfile`
- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/register-hooks.test.ts src/services/branches.test.ts src/services/boards.test.ts src/utils/realtime-publish.test.ts` (154 passed)
- `pnpm --filter @agor/core test -- src/db/repositories/branches.test.ts` (39 passed)
- `pnpm --filter agor-ui test -- src/hooks/useAgorData.test.tsx` (29 passed)
- Codex `gpt-5.5` review plus follow-up review: no substantive issues or merge blockers
