### PR TITLE
fix(env): compare health state semantically

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -645,6 +645,30 @@ describe('BranchesService environment start async behavior', () => {
       expect(emit).not.toHaveBeenCalled();
     });
 
+    it('does not treat JSONB object key reordering as a health transition', async () => {
+      const initialEnv = healthyEnv();
+      initialEnv.last_health_check = {
+        message: 'HTTP 200',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        status: 'healthy',
+      };
+      const { service, branch, patchSpy, observationUpdateSpy, emit } =
+        createGateHarness(initialEnv);
+
+      await service.updateEnvironment(branch.branch_id, {
+        status: 'running',
+        last_health_check: {
+          timestamp: '2026-01-01T00:00:05.000Z',
+          status: 'healthy',
+          message: 'HTTP 200',
+        },
+      });
+
+      expect(patchSpy).not.toHaveBeenCalled();
+      expect(observationUpdateSpy).toHaveBeenCalledTimes(1);
+      expect(emit).not.toHaveBeenCalled();
+    });
+
     it('does not write or emit an exactly identical observation', async () => {
       const { service, branch, patchSpy, observationUpdateSpy, emit } = createGateHarness(
         healthyEnv()

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -7,6 +7,7 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { isDeepStrictEqual } from 'node:util';
 import { analyticsLogger } from '@agor/core/analytics';
 import {
   createUserProcessEnvironment,
@@ -1891,8 +1892,10 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     // successful re-probe advances last_health_check.timestamp in storage, but
     // that bookkeeping alone must not emit a full `branches.patched` payload to
     // every authorized browser every five seconds.
-    const hasPersistedChange =
-      JSON.stringify(existing.environment_instance) !== JSON.stringify(updatedEnvironment);
+    const hasPersistedChange = !isDeepStrictEqual(
+      existing.environment_instance,
+      updatedEnvironment
+    );
     if (!hasPersistedChange) {
       return existing;
     }
@@ -1912,7 +1915,12 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       newState.last_health_check = healthCheck as typeof newState.last_health_check;
     }
 
-    const hasChanged = JSON.stringify(oldState) !== JSON.stringify(newState);
+    // PostgreSQL JSONB does not preserve object-key insertion order. Comparing
+    // serialized objects can therefore report a change when the JSON values are
+    // identical, sending every observation down the realtime patch path. Deep
+    // equality preserves array ordering while treating object key order as
+    // irrelevant, which matches the JSON semantics stored in the database.
+    const hasChanged = !isDeepStrictEqual(oldState, newState);
 
     // Observation-only persistence deliberately bypasses Feathers publication.
     // It also preserves branch.updated_at so health bookkeeping does not affect


### PR DESCRIPTION
## Summary

- compare persisted and user-visible environment health state semantically instead of with `JSON.stringify`
- avoid treating PostgreSQL JSONB object-key reordering as a meaningful health transition
- add regression coverage for identical health values with different object key order

## Production follow-up

After #1893 was merged and deployed, the Live Event Stream still showed five-second `branches patched` bursts. The running daemon reported a build SHA containing #1893, so this was not a stale deployment.

Read-only production sampling showed `branches.updated_at` still advancing within milliseconds of `environment_instance.last_health_check.timestamp`, confirming identical health observations were still entering the meaningful-change/realtime path.

The remaining gate compared objects with `JSON.stringify`. PostgreSQL stores environment data as JSONB, whose object key order is not semantically meaningful or guaranteed to match JavaScript insertion order. Equivalent health objects could therefore compare unequal.

`isDeepStrictEqual` keeps array ordering significant but ignores object key order, matching the stored JSON semantics.

## Validation

- `pnpm check`
- `pnpm --filter @agor/daemon test -- src/services/branches.test.ts src/services/health-monitor.test.ts` — 59 passed
- `pnpm --filter @agor/core test -- src/db/repositories/branches.test.ts` — 39 passed
