### PR TITLE
feat(executor): auto-wait and resume Claude sessions on hard rate limits

### DIFF
--- a/packages/core/src/sdk/index.ts
+++ b/packages/core/src/sdk/index.ts
@@ -28,6 +28,7 @@ export type {
   SDKUserMessage,
   SDKUserMessageReplay,
   SlashCommand,
+  TerminalReason,
 } from '@anthropic-ai/claude-agent-sdk';
 // Claude Agent SDK - namespace export
 export * as Claude from '@anthropic-ai/claude-agent-sdk';

--- a/packages/core/src/sdk/index.ts
+++ b/packages/core/src/sdk/index.ts
@@ -17,6 +17,7 @@
 
 // Claude Agent SDK - direct type exports for convenience
 export type {
+  ModelUsage,
   PermissionMode,
   SDKAssistantMessage,
   SDKCompactBoundaryMessage,

--- a/packages/executor/src/sdk-handlers/claude/auto-resume.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/auto-resume.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ProcessedEvent } from './message-processor.js';
+import { autoResumeOnRateLimit, MAX_RATE_LIMIT_RETRIES } from './rate-limit-retry.js';
+import {
+  accumulateResultUsage,
+  applyAccumulatedUsage,
+  emptyRetryUsageAccumulator,
+} from './usage-aggregation.js';
+
+type Any = any;
+
+function resultEvent(raw: Any): ProcessedEvent {
+  return { type: 'result', raw_sdk_message: raw } as ProcessedEvent;
+}
+
+const blockedTurn = (resetsAt?: number) =>
+  async function* (): AsyncGenerator<ProcessedEvent> {
+    yield { type: 'rate_limit', status: 'rejected', resetsAt } as ProcessedEvent;
+    yield resultEvent({
+      subtype: 'success',
+      terminal_reason: 'blocking_limit',
+      usage: { input_tokens: 10, output_tokens: 5 },
+      total_cost_usd: 0.01,
+      duration_ms: 100,
+    });
+  };
+
+const completedTurn = () =>
+  async function* (): AsyncGenerator<ProcessedEvent> {
+    yield {
+      type: 'complete',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'done' }],
+    } as ProcessedEvent;
+    yield resultEvent({
+      subtype: 'success',
+      terminal_reason: 'completed',
+      usage: { input_tokens: 20, output_tokens: 8 },
+      total_cost_usd: 0.02,
+      duration_ms: 200,
+    });
+  };
+
+/** Sequence the given per-turn generators; the last one repeats if exhausted. */
+function turnRunner(turns: Array<() => AsyncGenerator<ProcessedEvent>>) {
+  let call = 0;
+  return () => {
+    const turn = turns[Math.min(call, turns.length - 1)];
+    call += 1;
+    return turn();
+  };
+}
+
+async function drain(gen: AsyncGenerator<ProcessedEvent>): Promise<ProcessedEvent[]> {
+  const out: ProcessedEvent[] = [];
+  for await (const e of gen) out.push(e);
+  return out;
+}
+
+describe('autoResumeOnRateLimit', () => {
+  it('waits then resumes a blocked turn and emits the completed result as final', async () => {
+    const sleep = vi.fn(async () => ({ aborted: false }));
+    const events = await drain(
+      autoResumeOnRateLimit(turnRunner([blockedTurn(), completedTurn()]), { prompt: 'go', sleep })
+    );
+
+    expect(events.map((e) => e.type)).toEqual([
+      'rate_limit',
+      'intermediate_result',
+      'rate_limit_retry',
+      'complete',
+      'result',
+    ]);
+    const final = events.find((e) => e.type === 'result') as Extract<
+      ProcessedEvent,
+      { type: 'result' }
+    >;
+    expect((final.raw_sdk_message as Any).terminal_reason).toBe('completed');
+    expect(events.some((e) => e.type === 'rate_limit_retry_exhausted')).toBe(false);
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('never re-issues a turn that completed normally', async () => {
+    const sleep = vi.fn(async () => ({ aborted: false }));
+    const events = await drain(
+      autoResumeOnRateLimit(turnRunner([completedTurn()]), { prompt: 'go', sleep })
+    );
+    expect(events.map((e) => e.type)).toEqual(['complete', 'result']);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('gives up after the retry cap and announces exhaustion', async () => {
+    const sleep = vi.fn(async () => ({ aborted: false }));
+    const events = await drain(
+      autoResumeOnRateLimit(turnRunner([blockedTurn()]), { prompt: 'go', sleep })
+    );
+
+    expect(events.filter((e) => e.type === 'rate_limit_retry')).toHaveLength(
+      MAX_RATE_LIMIT_RETRIES
+    );
+    expect(events.filter((e) => e.type === 'rate_limit_retry_exhausted')).toHaveLength(1);
+    // The final blocked result is still surfaced (task goes idle, not lost).
+    expect(events.filter((e) => e.type === 'result')).toHaveLength(1);
+    expect(sleep).toHaveBeenCalledTimes(MAX_RATE_LIMIT_RETRIES);
+  });
+
+  it('stops cleanly when the wait is interrupted by a cancel', async () => {
+    const sleep = vi.fn(async () => ({ aborted: true }));
+    const events = await drain(
+      autoResumeOnRateLimit(turnRunner([blockedTurn(), completedTurn()]), { prompt: 'go', sleep })
+    );
+
+    expect(events.some((e) => e.type === 'stopped')).toBe(true);
+    // No resumed turn ran, so no completed final result.
+    expect(events.some((e) => e.type === 'result')).toBe(false);
+  });
+});
+
+describe('usage aggregation', () => {
+  it('sums cost/duration/tokens across invocations and applies them to the final result', () => {
+    let acc = emptyRetryUsageAccumulator();
+    acc = accumulateResultUsage(acc, {
+      usage: { input_tokens: 10, output_tokens: 5 },
+      total_cost_usd: 0.01,
+      duration_ms: 100,
+      duration_api_ms: 90,
+      modelUsage: { 'claude-opus': { inputTokens: 10, outputTokens: 5, contextWindow: 200_000 } },
+    } as Any);
+    acc = accumulateResultUsage(acc, {
+      usage: { input_tokens: 20, output_tokens: 8 },
+      total_cost_usd: 0.02,
+      duration_ms: 200,
+      duration_api_ms: 150,
+      modelUsage: { 'claude-opus': { inputTokens: 20, outputTokens: 8, contextWindow: 200_000 } },
+    } as Any);
+
+    expect(acc.totalCostUsd).toBeCloseTo(0.03);
+    expect(acc.durationMs).toBe(300);
+    expect(acc.usage.input_tokens).toBe(30);
+    expect(acc.usage.output_tokens).toBe(13);
+    // contextWindow is a fixed window size — max, not summed.
+    expect(acc.modelUsage['claude-opus'].contextWindow).toBe(200_000);
+    expect(acc.modelUsage['claude-opus'].inputTokens).toBe(30);
+
+    const final = applyAccumulatedUsage(
+      { subtype: 'success', terminal_reason: 'completed', usage: { input_tokens: 20 } } as Any,
+      acc
+    ) as Any;
+    expect(final.terminal_reason).toBe('completed');
+    expect(final.total_cost_usd).toBeCloseTo(0.03);
+    expect(final.usage.input_tokens).toBe(30);
+    expect(final.duration_ms).toBe(300);
+  });
+
+  it('is a no-op-equivalent for a single invocation (no retries)', () => {
+    let acc = emptyRetryUsageAccumulator();
+    const raw = {
+      subtype: 'success',
+      usage: { input_tokens: 42, output_tokens: 7 },
+      total_cost_usd: 0.05,
+      duration_ms: 123,
+    };
+    acc = accumulateResultUsage(acc, raw as Any);
+    const final = applyAccumulatedUsage(raw as Any, acc) as Any;
+    expect(final.total_cost_usd).toBeCloseTo(0.05);
+    expect(final.usage.input_tokens).toBe(42);
+    expect(final.duration_ms).toBe(123);
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/auto-resume.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/auto-resume.test.ts
@@ -114,6 +114,48 @@ describe('autoResumeOnRateLimit', () => {
     // No resumed turn ran, so no completed final result.
     expect(events.some((e) => e.type === 'result')).toBe(false);
   });
+
+  it('preserves a throttled invocation usage on the stopped outcome when cancelled mid-wait', async () => {
+    const sleep = vi.fn(async () => ({ aborted: true })); // cancel during the first wait
+    const events = await drain(
+      autoResumeOnRateLimit(turnRunner([blockedTurn(), completedTurn()]), { prompt: 'go', sleep })
+    );
+
+    // The completed-but-throttled invocation is surfaced before the stop.
+    const idxIntermediate = events.findIndex((e) => e.type === 'intermediate_result');
+    const idxStopped = events.findIndex((e) => e.type === 'stopped');
+    expect(idxIntermediate).toBeGreaterThanOrEqual(0);
+    expect(idxStopped).toBeGreaterThan(idxIntermediate);
+    expect(events.some((e) => e.type === 'result')).toBe(false);
+
+    // Mirror claude-tool's accounting reducer over the event stream.
+    let usageAcc = emptyRetryUsageAccumulator();
+    let lastIntermediateRaw: Any;
+    let rawSdkResponse: Any;
+    let wasStopped = false;
+    for (const e of events) {
+      if (e.type === 'intermediate_result') {
+        usageAcc = accumulateResultUsage(usageAcc, e.raw_sdk_message);
+        lastIntermediateRaw = e.raw_sdk_message;
+      } else if (e.type === 'result') {
+        usageAcc = accumulateResultUsage(usageAcc, e.raw_sdk_message);
+        rawSdkResponse = applyAccumulatedUsage(e.raw_sdk_message, usageAcc);
+      } else if (e.type === 'stopped') {
+        wasStopped = true;
+        if (lastIntermediateRaw && !rawSdkResponse) {
+          rawSdkResponse = applyAccumulatedUsage(lastIntermediateRaw, usageAcc);
+        }
+      }
+    }
+
+    expect(wasStopped).toBe(true);
+    // The throttled invocation's usage/cost/duration survive onto the stopped payload...
+    expect(rawSdkResponse.usage.input_tokens).toBe(10);
+    expect(rawSdkResponse.usage.output_tokens).toBe(5);
+    expect(rawSdkResponse.total_cost_usd).toBeCloseTo(0.01);
+    expect(rawSdkResponse.duration_ms).toBe(100);
+    // ...counted exactly once (blockedTurn had input_tokens: 10, not doubled to 20).
+  });
 });
 
 describe('usage aggregation', () => {

--- a/packages/executor/src/sdk-handlers/claude/auto-resume.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/auto-resume.test.ts
@@ -152,6 +152,63 @@ describe('usage aggregation', () => {
     expect(final.duration_ms).toBe(300);
   });
 
+  it('sums every billable field of the complete SDK usage shape and maxes capacities', () => {
+    // Complete ModelUsage (all required SDK fields) + full top-level usage.
+    const invocation = (n: number) => ({
+      subtype: 'success',
+      terminal_reason: n === 2 ? 'completed' : 'blocking_limit',
+      total_cost_usd: 0.01 * n,
+      duration_ms: 100 * n,
+      duration_api_ms: 80 * n,
+      usage: {
+        input_tokens: 10 * n,
+        output_tokens: 5 * n,
+        cache_creation_input_tokens: 2 * n,
+        cache_read_input_tokens: 3 * n,
+        server_tool_use: { web_fetch_requests: n, web_search_requests: 2 * n },
+        service_tier: 'standard',
+      },
+      modelUsage: {
+        'claude-opus': {
+          inputTokens: 10 * n,
+          outputTokens: 5 * n,
+          cacheReadInputTokens: 3 * n,
+          cacheCreationInputTokens: 2 * n,
+          webSearchRequests: 2 * n,
+          costUSD: 0.01 * n,
+          contextWindow: 200_000,
+          maxOutputTokens: 64_000,
+        },
+      },
+    });
+
+    let acc = emptyRetryUsageAccumulator();
+    acc = accumulateResultUsage(acc, invocation(1) as Any);
+    acc = accumulateResultUsage(acc, invocation(2) as Any);
+
+    // Additive fields summed (n=1 + n=2 => x3 of the base).
+    expect(acc.usage.input_tokens).toBe(30);
+    expect(acc.usage.cache_creation_input_tokens).toBe(6);
+    expect(acc.usage.cache_read_input_tokens).toBe(9);
+    expect(acc.usage.server_tool_use.web_fetch_requests).toBe(3);
+    expect(acc.usage.server_tool_use.web_search_requests).toBe(6);
+    expect(acc.totalCostUsd).toBeCloseTo(0.03);
+    expect(acc.durationApiMs).toBe(240);
+    const mu = acc.modelUsage['claude-opus'];
+    expect(mu.webSearchRequests).toBe(6);
+    expect(mu.costUSD).toBeCloseTo(0.03);
+    // Capacity fields maxed, not summed.
+    expect(mu.contextWindow).toBe(200_000);
+    expect(mu.maxOutputTokens).toBe(64_000);
+
+    const final = applyAccumulatedUsage(invocation(2) as Any, acc) as Any;
+    // Structural fields from the final result are preserved, not dropped.
+    expect(final.usage.service_tier).toBe('standard');
+    expect(final.usage.server_tool_use.web_search_requests).toBe(6);
+    expect(final.modelUsage['claude-opus'].maxOutputTokens).toBe(64_000);
+    expect(final.total_cost_usd).toBeCloseTo(0.03);
+  });
+
   it('is a no-op-equivalent for a single invocation (no retries)', () => {
     let acc = emptyRetryUsageAccumulator();
     const raw = {

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -57,6 +57,14 @@ import {
 } from './message-builder.js';
 import type { ProcessedEvent } from './message-processor.js';
 import { ClaudePromptService } from './prompt-service.js';
+import {
+  computeRateLimitRetryDelayMs,
+  MAX_RATE_LIMIT_RETRIES,
+  RATE_LIMIT_RESUME_PROMPT,
+  RATE_LIMIT_TERMINAL_REASON,
+  shouldAutoResumeAfterRateLimit,
+  sleepUnlessAborted,
+} from './rate-limit-retry.js';
 
 const DEBUG_CLAUDE_STREAMING =
   process.env.AGOR_DEBUG_CLAUDE_STREAMING === '1' ||
@@ -80,7 +88,7 @@ function formatRateLimitText(event: Extract<ProcessedEvent, { type: 'rate_limit'
   const resetsAtStr = event.resetsAt ? new Date(event.resetsAt * 1000).toLocaleString() : undefined;
 
   if (event.status === 'rejected') {
-    return `Rate limited (${type}). ${resetsAtStr ? `Resets at ${resetsAtStr}.` : ''} Waiting for limit to reset...`;
+    return `Rate limited (${type}). ${resetsAtStr ? `Resets at ${resetsAtStr}. ` : ''}Auto-retrying when the limit resets…`;
   }
   if (event.status === 'allowed_warning') {
     return `Approaching rate limit (${type}). ${resetsAtStr ? `Resets at ${resetsAtStr}.` : ''} Requests may be delayed.`;
@@ -237,6 +245,94 @@ export class ClaudeTool implements ITool {
   }
 
   /**
+   * Wrap {@link ClaudePromptService.promptSessionStreaming} so a turn cut short
+   * by a hard rate limit auto-waits and resumes instead of going idle.
+   *
+   * A hard limit ends the turn with `result.terminal_reason === 'blocking_limit'`
+   * (and a `rejected` rate_limit event); the SDK itself does not wait. On that
+   * signal we sleep until the limit resets (or back off when the reset time is
+   * unknown), then re-issue a continue prompt — up to {@link MAX_RATE_LIMIT_RETRIES}
+   * times, after which we fall back to today's manual-continue behavior. A user
+   * stop / session cancel interrupts the wait cleanly via `abortController`.
+   *
+   * The synthetic `rate_limit_retry` / `rate_limit_retry_exhausted` events are
+   * surfaced as system messages by the caller.
+   */
+  private async *promptWithRateLimitResume(
+    sessionId: SessionID,
+    prompt: string,
+    taskId: TaskID | undefined,
+    permissionMode: ClaudeSDKPermissionMode | undefined,
+    abortController?: AbortController
+  ): AsyncGenerator<ProcessedEvent> {
+    let currentPrompt = prompt;
+    let attempt = 0;
+
+    while (true) {
+      let sawRejectedRateLimit = false;
+      let rejectedResetsAt: number | undefined;
+      let terminalReason: string | undefined;
+
+      for await (const event of this.promptService!.promptSessionStreaming(
+        sessionId,
+        currentPrompt,
+        taskId,
+        permissionMode,
+        undefined, // chunkCallback (unused)
+        abortController
+      )) {
+        if (event.type === 'rate_limit' && event.status === 'rejected') {
+          sawRejectedRateLimit = true;
+          rejectedResetsAt = event.resetsAt;
+        }
+        if (event.type === 'result') {
+          terminalReason = (event.raw_sdk_message as { terminal_reason?: string })?.terminal_reason;
+        }
+        yield event;
+      }
+
+      if (
+        abortController?.signal.aborted ||
+        !shouldAutoResumeAfterRateLimit({ terminalReason, sawRejectedRateLimit, attempt })
+      ) {
+        // Only announce exhaustion when the turn actually ended on a rate limit.
+        const endedOnRateLimit =
+          terminalReason === RATE_LIMIT_TERMINAL_REASON || sawRejectedRateLimit;
+        if (
+          !abortController?.signal.aborted &&
+          endedOnRateLimit &&
+          terminalReason !== 'completed' &&
+          attempt >= MAX_RATE_LIMIT_RETRIES
+        ) {
+          yield { type: 'rate_limit_retry_exhausted', attempts: attempt };
+        }
+        return;
+      }
+
+      const delayMs = computeRateLimitRetryDelayMs({
+        resetsAt: rejectedResetsAt,
+        attempt,
+        nowMs: Date.now(),
+      });
+      yield {
+        type: 'rate_limit_retry',
+        retryAtMs: Date.now() + delayMs,
+        attempt: attempt + 1,
+        maxRetries: MAX_RATE_LIMIT_RETRIES,
+      };
+
+      const { aborted } = await sleepUnlessAborted(delayMs, abortController?.signal);
+      if (aborted) {
+        yield { type: 'stopped' };
+        return;
+      }
+
+      attempt += 1;
+      currentPrompt = RATE_LIMIT_RESUME_PROMPT;
+    }
+  }
+
+  /**
    * Execute a prompt against a session WITH real-time streaming
    *
    * Creates user message, streams response chunks from Claude, then creates complete assistant messages.
@@ -354,12 +450,11 @@ export class ClaudeTool implements ITool {
       ? (mapPermissionMode(permissionMode, 'claude-code') as ClaudeSDKPermissionMode)
       : undefined;
 
-    for await (const event of this.promptService.promptSessionStreaming(
+    for await (const event of this.promptWithRateLimitResume(
       sessionId,
       prompt,
       taskId,
       mappedPermissionMode,
-      undefined, // chunkCallback (unused)
       abortController
     )) {
       // Detect if execution was stopped early
@@ -611,6 +706,55 @@ export class ClaudeTool implements ITool {
           if (streamingCallbacks) {
             await streamingCallbacks.onStreamEnd(rateLimitMessageId);
           }
+        });
+      }
+
+      // Auto-resume is about to wait then re-issue the turn — surface the plan
+      // and reset any stream left dangling by the throttled turn so the resumed
+      // turn's text lands on a fresh message.
+      if (event.type === 'rate_limit_retry') {
+        if (currentTextMessageId && streamingCallbacks) {
+          await streamingCallbacks.onStreamEnd(currentTextMessageId);
+        }
+        currentTextMessageId = null;
+        currentThinkingMessageId = null;
+        firstTokenTime = null;
+        firstActivityTime = null;
+        apiWaitMessageSent = false;
+        streamStartTime = Date.now();
+
+        const retryAt = new Date(event.retryAtMs).toLocaleTimeString();
+        const text = `Rate limited — auto-retrying at ${retryAt} (attempt ${event.attempt} of ${event.maxRetries})…`;
+        console.log(`⏳ ${text}`);
+        await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
+          const retryMessageId = generateId() as MessageID;
+          await createSystemMessage(
+            sessionId,
+            retryMessageId,
+            [{ type: 'rate_limit', text, status: 'rejected', retryAt: event.retryAtMs }],
+            taskId,
+            nextIndex++,
+            resolvedModel,
+            this.messagesService!
+          );
+        });
+      }
+
+      // Auto-resume gave up after the cap — tell the user how to continue.
+      if (event.type === 'rate_limit_retry_exhausted') {
+        const text = `Rate limit auto-retry gave up after ${event.attempts} attempts. Send a message to continue.`;
+        console.warn(`🚫 ${text}`);
+        await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
+          const exhaustedMessageId = generateId() as MessageID;
+          await createSystemMessage(
+            sessionId,
+            exhaustedMessageId,
+            [{ type: 'rate_limit', text, status: 'rejected' }],
+            taskId,
+            nextIndex++,
+            resolvedModel,
+            this.messagesService!
+          );
         });
       }
 

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -386,6 +386,9 @@ export class ClaudeTool implements ITool {
     // rate-limited turn can be auto-resumed into several). Applied to the final
     // rawSdkResponse so accounting reflects total consumption, not just the last.
     let usageAcc = emptyRetryUsageAccumulator();
+    // Latest throttled invocation's raw result, used to carry the accumulated
+    // accounting onto a stopped outcome when the user cancels during the wait.
+    let lastIntermediateRaw: import('@agor/core/sdk').SDKResultMessage | undefined;
 
     // Map our permission mode to Claude SDK's permission mode
     const mappedPermissionMode = permissionMode
@@ -402,6 +405,12 @@ export class ClaudeTool implements ITool {
       // Detect if execution was stopped early
       if (event.type === 'stopped') {
         wasStopped = true;
+        // If the user cancelled during an auto-retry wait, no final `result`
+        // arrives — carry the accounting from the already-completed throttled
+        // invocation(s) onto the stopped outcome so their usage isn't dropped.
+        if (lastIntermediateRaw && !rawSdkResponse) {
+          rawSdkResponse = applyAccumulatedUsage(lastIntermediateRaw, usageAcc);
+        }
         console.log(`🛑 Claude execution was stopped for session ${sessionId}`);
         continue; // Skip processing this event
       }
@@ -754,6 +763,7 @@ export class ClaudeTool implements ITool {
       // per-turn usage so it can't attach to the resumed turn's messages.
       if (event.type === 'intermediate_result') {
         usageAcc = accumulateResultUsage(usageAcc, event.raw_sdk_message);
+        lastIntermediateRaw = event.raw_sdk_message;
         tokenUsage = undefined;
         modelUsage = undefined;
       }

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -11,7 +11,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { generateId, shortId } from '@agor/core/db';
-import type { PermissionMode as ClaudeSDKPermissionMode } from '@agor/core/sdk';
+import type { PermissionMode as ClaudeSDKPermissionMode, TerminalReason } from '@agor/core/sdk';
 import { mapPermissionMode } from '@agor/core/utils/permission-mode-mapper';
 import type {
   BranchRepository,
@@ -57,14 +57,12 @@ import {
 } from './message-builder.js';
 import type { ProcessedEvent } from './message-processor.js';
 import { ClaudePromptService } from './prompt-service.js';
+import { autoResumeOnRateLimit, RATE_LIMIT_TERMINAL_REASON } from './rate-limit-retry.js';
 import {
-  computeRateLimitRetryDelayMs,
-  MAX_RATE_LIMIT_RETRIES,
-  RATE_LIMIT_RESUME_PROMPT,
-  RATE_LIMIT_TERMINAL_REASON,
-  shouldAutoResumeAfterRateLimit,
-  sleepUnlessAborted,
-} from './rate-limit-retry.js';
+  accumulateResultUsage,
+  applyAccumulatedUsage,
+  emptyRetryUsageAccumulator,
+} from './usage-aggregation.js';
 
 const DEBUG_CLAUDE_STREAMING =
   process.env.AGOR_DEBUG_CLAUDE_STREAMING === '1' ||
@@ -88,7 +86,7 @@ function formatRateLimitText(event: Extract<ProcessedEvent, { type: 'rate_limit'
   const resetsAtStr = event.resetsAt ? new Date(event.resetsAt * 1000).toLocaleString() : undefined;
 
   if (event.status === 'rejected') {
-    return `Rate limited (${type}). ${resetsAtStr ? `Resets at ${resetsAtStr}. ` : ''}Auto-retrying when the limit resets…`;
+    return `Rate limited (${type}).${resetsAtStr ? ` Resets at ${resetsAtStr}.` : ''}`;
   }
   if (event.status === 'allowed_warning') {
     return `Approaching rate limit (${type}). ${resetsAtStr ? `Resets at ${resetsAtStr}.` : ''} Requests may be delayed.`;
@@ -245,91 +243,31 @@ export class ClaudeTool implements ITool {
   }
 
   /**
-   * Wrap {@link ClaudePromptService.promptSessionStreaming} so a turn cut short
-   * by a hard rate limit auto-waits and resumes instead of going idle.
-   *
-   * A hard limit ends the turn with `result.terminal_reason === 'blocking_limit'`
-   * (and a `rejected` rate_limit event); the SDK itself does not wait. On that
-   * signal we sleep until the limit resets (or back off when the reset time is
-   * unknown), then re-issue a continue prompt — up to {@link MAX_RATE_LIMIT_RETRIES}
-   * times, after which we fall back to today's manual-continue behavior. A user
-   * stop / session cancel interrupts the wait cleanly via `abortController`.
-   *
-   * The synthetic `rate_limit_retry` / `rate_limit_retry_exhausted` events are
-   * surfaced as system messages by the caller.
+   * Stream a turn with auto-resume on hard rate limits (see
+   * {@link autoResumeOnRateLimit}): a turn cut short by `blocking_limit` waits
+   * and resumes instead of going idle, its throttled result re-labelled
+   * `intermediate_result` while the eventual one is the final `result`. A user
+   * stop / session cancel interrupts the wait via `abortController`.
    */
-  private async *promptWithRateLimitResume(
+  private promptWithRateLimitResume(
     sessionId: SessionID,
     prompt: string,
     taskId: TaskID | undefined,
     permissionMode: ClaudeSDKPermissionMode | undefined,
     abortController?: AbortController
   ): AsyncGenerator<ProcessedEvent> {
-    let currentPrompt = prompt;
-    let attempt = 0;
-
-    while (true) {
-      let sawRejectedRateLimit = false;
-      let rejectedResetsAt: number | undefined;
-      let terminalReason: string | undefined;
-
-      for await (const event of this.promptService!.promptSessionStreaming(
-        sessionId,
-        currentPrompt,
-        taskId,
-        permissionMode,
-        undefined, // chunkCallback (unused)
-        abortController
-      )) {
-        if (event.type === 'rate_limit' && event.status === 'rejected') {
-          sawRejectedRateLimit = true;
-          rejectedResetsAt = event.resetsAt;
-        }
-        if (event.type === 'result') {
-          terminalReason = (event.raw_sdk_message as { terminal_reason?: string })?.terminal_reason;
-        }
-        yield event;
-      }
-
-      if (
-        abortController?.signal.aborted ||
-        !shouldAutoResumeAfterRateLimit({ terminalReason, sawRejectedRateLimit, attempt })
-      ) {
-        // Only announce exhaustion when the turn actually ended on a rate limit.
-        const endedOnRateLimit =
-          terminalReason === RATE_LIMIT_TERMINAL_REASON || sawRejectedRateLimit;
-        if (
-          !abortController?.signal.aborted &&
-          endedOnRateLimit &&
-          terminalReason !== 'completed' &&
-          attempt >= MAX_RATE_LIMIT_RETRIES
-        ) {
-          yield { type: 'rate_limit_retry_exhausted', attempts: attempt };
-        }
-        return;
-      }
-
-      const delayMs = computeRateLimitRetryDelayMs({
-        resetsAt: rejectedResetsAt,
-        attempt,
-        nowMs: Date.now(),
-      });
-      yield {
-        type: 'rate_limit_retry',
-        retryAtMs: Date.now() + delayMs,
-        attempt: attempt + 1,
-        maxRetries: MAX_RATE_LIMIT_RETRIES,
-      };
-
-      const { aborted } = await sleepUnlessAborted(delayMs, abortController?.signal);
-      if (aborted) {
-        yield { type: 'stopped' };
-        return;
-      }
-
-      attempt += 1;
-      currentPrompt = RATE_LIMIT_RESUME_PROMPT;
-    }
+    return autoResumeOnRateLimit(
+      (resumePrompt) =>
+        this.promptService!.promptSessionStreaming(
+          sessionId,
+          resumePrompt,
+          taskId,
+          permissionMode,
+          undefined, // chunkCallback (unused)
+          abortController
+        ),
+      { prompt, signal: abortController?.signal }
+    );
   }
 
   /**
@@ -444,6 +382,10 @@ export class ClaudeTool implements ITool {
     let wasStopped = false;
     let hadError = false;
     let errorDetails: string[] | undefined;
+    // Billable usage summed across every SDK invocation this task spans (a
+    // rate-limited turn can be auto-resumed into several). Applied to the final
+    // rawSdkResponse so accounting reflects total consumption, not just the last.
+    let usageAcc = emptyRetryUsageAccumulator();
 
     // Map our permission mode to Claude SDK's permission mode
     const mappedPermissionMode = permissionMode
@@ -807,17 +749,34 @@ export class ClaudeTool implements ITool {
         });
       }
 
+      // A throttled turn's result: aggregate its billable usage, then drop it —
+      // it is neither the final result nor an error (we are auto-resuming). Reset
+      // per-turn usage so it can't attach to the resumed turn's messages.
+      if (event.type === 'intermediate_result') {
+        usageAcc = accumulateResultUsage(usageAcc, event.raw_sdk_message);
+        tokenUsage = undefined;
+        modelUsage = undefined;
+      }
+
       // Capture raw SDK response for token accounting
       if (event.type === 'result') {
-        rawSdkResponse = event.raw_sdk_message;
-        // Detect error results from SDK (e.g., error_during_execution)
+        usageAcc = accumulateResultUsage(usageAcc, event.raw_sdk_message);
+        rawSdkResponse = applyAccumulatedUsage(event.raw_sdk_message, usageAcc);
+        // Detect error results from SDK (e.g., error_during_execution). A final
+        // `blocking_limit` means auto-resume was exhausted, not a failure — the
+        // task goes idle for manual continue (its own system message was shown).
         if (rawSdkResponse && 'subtype' in rawSdkResponse) {
           const sdkResult = rawSdkResponse as {
             subtype?: string;
             errors?: string[];
             is_error?: boolean;
+            terminal_reason?: TerminalReason;
           };
-          if (sdkResult.subtype && sdkResult.subtype !== 'success') {
+          if (
+            sdkResult.subtype &&
+            sdkResult.subtype !== 'success' &&
+            sdkResult.terminal_reason !== RATE_LIMIT_TERMINAL_REASON
+          ) {
             hadError = true;
             errorDetails = sdkResult.errors;
             console.error(

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -144,6 +144,22 @@ export type ProcessedEvent =
       isUsingOverage?: boolean;
       agentSessionId?: string;
     }
+  /**
+   * Synthesized (not produced by the SDK) when a rate-limited turn is about to
+   * be automatically resumed after a wait. Surfaced as a system message.
+   */
+  | {
+      type: 'rate_limit_retry';
+      /** Wall-clock time the resume is scheduled for. */
+      retryAtMs: number;
+      attempt: number;
+      maxRetries: number;
+    }
+  /** Synthesized when the auto-resume cap is hit and the turn falls back to manual continue. */
+  | {
+      type: 'rate_limit_retry_exhausted';
+      attempts: number;
+    }
   | {
       type: 'sdk_event';
       sdkType: string;

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -120,6 +120,16 @@ export type ProcessedEvent =
       raw_sdk_message: SDKResultMessage; // Pass the entire SDK message unchanged
       agentSessionId?: string;
     }
+  /**
+   * A per-invocation result for a turn that will be auto-resumed after a rate
+   * limit (synthesized by the retry wrapper). Its billable usage is aggregated,
+   * but it is NOT the task's final result — so it must not set error state or
+   * overwrite the final result.
+   */
+  | {
+      type: 'intermediate_result';
+      raw_sdk_message: SDKResultMessage;
+    }
   | {
       type: 'system_complete';
       systemType: string;

--- a/packages/executor/src/sdk-handlers/claude/rate-limit-retry.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/rate-limit-retry.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeRateLimitRetryDelayMs,
+  MAX_RATE_LIMIT_RETRIES,
+  RATE_LIMIT_BACKOFF_MS,
+  RATE_LIMIT_JITTER_MS,
+  shouldAutoResumeAfterRateLimit,
+  sleepUnlessAborted,
+} from './rate-limit-retry.js';
+
+describe('shouldAutoResumeAfterRateLimit', () => {
+  it('resumes when the turn ended on the blocking_limit terminal reason', () => {
+    expect(
+      shouldAutoResumeAfterRateLimit({
+        terminalReason: 'blocking_limit',
+        sawRejectedRateLimit: false,
+        attempt: 0,
+      })
+    ).toBe(true);
+  });
+
+  it('resumes on a rejected rate_limit even when terminal_reason is absent', () => {
+    expect(
+      shouldAutoResumeAfterRateLimit({
+        terminalReason: undefined,
+        sawRejectedRateLimit: true,
+        attempt: 0,
+      })
+    ).toBe(true);
+  });
+
+  it('never re-issues a turn that completed normally', () => {
+    expect(
+      shouldAutoResumeAfterRateLimit({
+        terminalReason: 'completed',
+        sawRejectedRateLimit: true,
+        attempt: 0,
+      })
+    ).toBe(false);
+  });
+
+  it('does not resume when there was no rate limit signal', () => {
+    expect(
+      shouldAutoResumeAfterRateLimit({
+        terminalReason: 'max_turns',
+        sawRejectedRateLimit: false,
+        attempt: 0,
+      })
+    ).toBe(false);
+  });
+
+  it('enforces the retry cap', () => {
+    expect(
+      shouldAutoResumeAfterRateLimit({
+        terminalReason: 'blocking_limit',
+        sawRejectedRateLimit: true,
+        attempt: MAX_RATE_LIMIT_RETRIES,
+      })
+    ).toBe(false);
+    expect(
+      shouldAutoResumeAfterRateLimit({
+        terminalReason: 'blocking_limit',
+        sawRejectedRateLimit: true,
+        attempt: MAX_RATE_LIMIT_RETRIES - 1,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('computeRateLimitRetryDelayMs', () => {
+  const nowMs = 1_000_000;
+
+  it('waits until resetsAt when it is known', () => {
+    const resetsAt = (nowMs + 90_000) / 1000; // epoch SECONDS
+    const delay = computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, nowMs, random: () => 0 });
+    expect(delay).toBe(90_000);
+  });
+
+  it('never returns a negative wait when resetsAt is in the past', () => {
+    const resetsAt = (nowMs - 60_000) / 1000;
+    const delay = computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, nowMs, random: () => 0 });
+    expect(delay).toBe(0);
+  });
+
+  it('uses capped exponential backoff when resetsAt is unknown', () => {
+    const noJitter = { nowMs, random: () => 0 };
+    expect(computeRateLimitRetryDelayMs({ attempt: 0, ...noJitter })).toBe(30_000);
+    expect(computeRateLimitRetryDelayMs({ attempt: 1, ...noJitter })).toBe(60_000);
+    expect(computeRateLimitRetryDelayMs({ attempt: 2, ...noJitter })).toBe(120_000);
+    // Cap: attempts past the schedule reuse the ceiling, never grow unbounded.
+    expect(computeRateLimitRetryDelayMs({ attempt: 3, ...noJitter })).toBe(120_000);
+    expect(computeRateLimitRetryDelayMs({ attempt: 99, ...noJitter })).toBe(
+      RATE_LIMIT_BACKOFF_MS[RATE_LIMIT_BACKOFF_MS.length - 1]
+    );
+  });
+
+  it('keeps jitter within [0, RATE_LIMIT_JITTER_MS) on top of the base wait', () => {
+    const resetsAt = (nowMs + 90_000) / 1000;
+    for (const r of [0, 0.5, 0.999]) {
+      const delay = computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, nowMs, random: () => r });
+      expect(delay).toBeGreaterThanOrEqual(90_000);
+      expect(delay).toBeLessThan(90_000 + RATE_LIMIT_JITTER_MS);
+    }
+  });
+});
+
+describe('sleepUnlessAborted', () => {
+  it('resolves immediately as aborted when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(sleepUnlessAborted(10_000, controller.signal)).resolves.toEqual({
+      aborted: true,
+    });
+  });
+
+  it('resolves as aborted when the signal fires during the wait', async () => {
+    const controller = new AbortController();
+    const promise = sleepUnlessAborted(10_000, controller.signal);
+    controller.abort();
+    await expect(promise).resolves.toEqual({ aborted: true });
+  });
+
+  it('resolves as not aborted when the wait elapses', async () => {
+    await expect(sleepUnlessAborted(0)).resolves.toEqual({ aborted: false });
+  });
+});

--- a/packages/executor/src/sdk-handlers/claude/rate-limit-retry.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/rate-limit-retry.test.ts
@@ -70,11 +70,20 @@ describe('computeRateLimitRetryDelayMs', () => {
     ).toBe(30_000);
   });
 
-  it('clamps a far-future resetsAt to the max single wait', () => {
+  it('clamps a far-future resetsAt so even max jitter stays under the ceiling', () => {
     const resetsAt = (nowMs + 30 * 24 * 60 * 60 * 1000) / 1000; // 30 days out
+    // Base reserves room for jitter.
     expect(computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, ...noJitter })).toBe(
-      MAX_RATE_LIMIT_WAIT_MS
+      MAX_RATE_LIMIT_WAIT_MS - RATE_LIMIT_JITTER_MS
     );
+    // Even with near-max jitter the total wait never reaches the hard ceiling.
+    const withJitter = computeRateLimitRetryDelayMs({
+      resetsAt,
+      attempt: 0,
+      nowMs,
+      random: () => 0.999,
+    });
+    expect(withJitter).toBeLessThan(MAX_RATE_LIMIT_WAIT_MS);
   });
 
   it('uses capped exponential backoff when resetsAt is unknown', () => {

--- a/packages/executor/src/sdk-handlers/claude/rate-limit-retry.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/rate-limit-retry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   computeRateLimitRetryDelayMs,
   MAX_RATE_LIMIT_RETRIES,
+  MAX_RATE_LIMIT_WAIT_MS,
   RATE_LIMIT_BACKOFF_MS,
   RATE_LIMIT_JITTER_MS,
   shouldAutoResumeAfterRateLimit,
@@ -9,58 +10,37 @@ import {
 } from './rate-limit-retry.js';
 
 describe('shouldAutoResumeAfterRateLimit', () => {
-  it('resumes when the turn ended on the blocking_limit terminal reason', () => {
-    expect(
-      shouldAutoResumeAfterRateLimit({
-        terminalReason: 'blocking_limit',
-        sawRejectedRateLimit: false,
-        attempt: 0,
-      })
-    ).toBe(true);
-  });
-
-  it('resumes on a rejected rate_limit even when terminal_reason is absent', () => {
-    expect(
-      shouldAutoResumeAfterRateLimit({
-        terminalReason: undefined,
-        sawRejectedRateLimit: true,
-        attempt: 0,
-      })
-    ).toBe(true);
+  it('resumes ONLY on the blocking_limit terminal reason', () => {
+    expect(shouldAutoResumeAfterRateLimit({ terminalReason: 'blocking_limit', attempt: 0 })).toBe(
+      true
+    );
   });
 
   it('never re-issues a turn that completed normally', () => {
-    expect(
-      shouldAutoResumeAfterRateLimit({
-        terminalReason: 'completed',
-        sawRejectedRateLimit: true,
-        attempt: 0,
-      })
-    ).toBe(false);
+    expect(shouldAutoResumeAfterRateLimit({ terminalReason: 'completed', attempt: 0 })).toBe(false);
   });
 
-  it('does not resume when there was no rate limit signal', () => {
-    expect(
-      shouldAutoResumeAfterRateLimit({
-        terminalReason: 'max_turns',
-        sawRejectedRateLimit: false,
-        attempt: 0,
-      })
-    ).toBe(false);
+  it('fails closed on a missing/unknown terminal reason', () => {
+    expect(shouldAutoResumeAfterRateLimit({ terminalReason: undefined, attempt: 0 })).toBe(false);
+  });
+
+  it('does not resume on some other terminal reason', () => {
+    expect(shouldAutoResumeAfterRateLimit({ terminalReason: 'max_turns', attempt: 0 })).toBe(false);
+    expect(shouldAutoResumeAfterRateLimit({ terminalReason: 'model_error', attempt: 0 })).toBe(
+      false
+    );
   });
 
   it('enforces the retry cap', () => {
     expect(
       shouldAutoResumeAfterRateLimit({
         terminalReason: 'blocking_limit',
-        sawRejectedRateLimit: true,
         attempt: MAX_RATE_LIMIT_RETRIES,
       })
     ).toBe(false);
     expect(
       shouldAutoResumeAfterRateLimit({
         terminalReason: 'blocking_limit',
-        sawRejectedRateLimit: true,
         attempt: MAX_RATE_LIMIT_RETRIES - 1,
       })
     ).toBe(true);
@@ -69,21 +49,35 @@ describe('shouldAutoResumeAfterRateLimit', () => {
 
 describe('computeRateLimitRetryDelayMs', () => {
   const nowMs = 1_000_000;
+  const noJitter = { nowMs, random: () => 0 };
 
-  it('waits until resetsAt when it is known', () => {
+  it('waits until resetsAt when it is a finite future timestamp', () => {
     const resetsAt = (nowMs + 90_000) / 1000; // epoch SECONDS
-    const delay = computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, nowMs, random: () => 0 });
-    expect(delay).toBe(90_000);
+    expect(computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, ...noJitter })).toBe(90_000);
   });
 
-  it('never returns a negative wait when resetsAt is in the past', () => {
+  it('treats a past resetsAt as unknown and falls to backoff', () => {
     const resetsAt = (nowMs - 60_000) / 1000;
-    const delay = computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, nowMs, random: () => 0 });
-    expect(delay).toBe(0);
+    expect(computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, ...noJitter })).toBe(30_000);
+  });
+
+  it('treats NaN / Infinity resetsAt as unknown and falls to backoff', () => {
+    expect(computeRateLimitRetryDelayMs({ resetsAt: Number.NaN, attempt: 0, ...noJitter })).toBe(
+      30_000
+    );
+    expect(
+      computeRateLimitRetryDelayMs({ resetsAt: Number.POSITIVE_INFINITY, attempt: 0, ...noJitter })
+    ).toBe(30_000);
+  });
+
+  it('clamps a far-future resetsAt to the max single wait', () => {
+    const resetsAt = (nowMs + 30 * 24 * 60 * 60 * 1000) / 1000; // 30 days out
+    expect(computeRateLimitRetryDelayMs({ resetsAt, attempt: 0, ...noJitter })).toBe(
+      MAX_RATE_LIMIT_WAIT_MS
+    );
   });
 
   it('uses capped exponential backoff when resetsAt is unknown', () => {
-    const noJitter = { nowMs, random: () => 0 };
     expect(computeRateLimitRetryDelayMs({ attempt: 0, ...noJitter })).toBe(30_000);
     expect(computeRateLimitRetryDelayMs({ attempt: 1, ...noJitter })).toBe(60_000);
     expect(computeRateLimitRetryDelayMs({ attempt: 2, ...noJitter })).toBe(120_000);

--- a/packages/executor/src/sdk-handlers/claude/rate-limit-retry.ts
+++ b/packages/executor/src/sdk-handlers/claude/rate-limit-retry.ts
@@ -1,0 +1,107 @@
+/**
+ * Auto-resume policy for hard Claude rate limits.
+ *
+ * When the Claude Agent SDK hits a hard rate limit it emits a
+ * `rate_limit_event{status:'rejected'}` and ends the turn with
+ * `result.terminal_reason === 'blocking_limit'`. The SDK does NOT wait or
+ * retry — so Agor waits until the limit resets (or backs off when the reset
+ * time is unknown) and re-issues the turn, capped so it can never hang forever.
+ */
+
+/** Maximum number of automatic resumes before falling back to manual continue. */
+export const MAX_RATE_LIMIT_RETRIES = 5;
+
+/**
+ * Prompt used to resume a turn the rate limiter cut short — mirrors what a user
+ * would type manually to pick the work back up.
+ */
+export const RATE_LIMIT_RESUME_PROMPT = 'Please continue.';
+
+/**
+ * Capped exponential backoff (ms) used when the SDK does not report a reset
+ * time. The last entry is the ceiling — later attempts reuse it.
+ */
+export const RATE_LIMIT_BACKOFF_MS = [30_000, 60_000, 120_000];
+
+/**
+ * Random spread added to every wait. Mandatory: without it, every throttled
+ * session on the instance would wake at the same `resetsAt` and instantly
+ * re-throttle (thundering herd).
+ */
+export const RATE_LIMIT_JITTER_MS = 30_000;
+
+/**
+ * The `terminal_reason` a Claude result carries when the turn ended because a
+ * hard rate limit blocked it (see SDK `TerminalReason`).
+ */
+export const RATE_LIMIT_TERMINAL_REASON = 'blocking_limit';
+
+/**
+ * Decide whether a just-ended turn should be automatically resumed after a
+ * rate limit.
+ *
+ * - `completed` terminal reason means the turn finished its work — never
+ *   re-issue it, even if a rejected rate_limit fired earlier in the turn.
+ * - `blocking_limit` is the SDK's explicit rate-limit terminal signal; a
+ *   `rejected` rate_limit event is the fallback when `terminal_reason` is
+ *   absent on older SDKs.
+ */
+export function shouldAutoResumeAfterRateLimit(opts: {
+  terminalReason?: string;
+  sawRejectedRateLimit: boolean;
+  /** Number of automatic resumes already performed for this turn. */
+  attempt: number;
+  maxRetries?: number;
+}): boolean {
+  const maxRetries = opts.maxRetries ?? MAX_RATE_LIMIT_RETRIES;
+  if (opts.attempt >= maxRetries) return false;
+  if (opts.terminalReason === 'completed') return false;
+  return opts.terminalReason === RATE_LIMIT_TERMINAL_REASON || opts.sawRejectedRateLimit;
+}
+
+/**
+ * Compute how long to wait before the next resume, in milliseconds.
+ *
+ * When `resetsAt` (epoch SECONDS, from the SDK) is known we wait until then;
+ * otherwise we use capped exponential backoff. Jitter is always added on top
+ * so concurrent sessions do not wake in lockstep.
+ */
+export function computeRateLimitRetryDelayMs(opts: {
+  /** Reset time in epoch seconds, when the SDK reported it. */
+  resetsAt?: number;
+  /** Number of automatic resumes already performed for this turn (0-based). */
+  attempt: number;
+  nowMs: number;
+  /** Injectable for deterministic tests; defaults to Math.random. */
+  random?: () => number;
+}): number {
+  const random = opts.random ?? Math.random;
+  const base =
+    opts.resetsAt !== undefined
+      ? Math.max(0, opts.resetsAt * 1000 - opts.nowMs)
+      : RATE_LIMIT_BACKOFF_MS[Math.min(opts.attempt, RATE_LIMIT_BACKOFF_MS.length - 1)];
+  const jitter = Math.floor(random() * RATE_LIMIT_JITTER_MS);
+  return base + jitter;
+}
+
+/**
+ * Sleep for `ms`, resolving early (with `aborted: true`) if the signal fires.
+ * Used so a user stop / session cancel interrupts the rate-limit wait cleanly.
+ */
+export function sleepUnlessAborted(
+  ms: number,
+  signal?: AbortSignal
+): Promise<{ aborted: boolean }> {
+  if (signal?.aborted) return Promise.resolve({ aborted: true });
+  return new Promise((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve({ aborted: true });
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve({ aborted: false });
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/packages/executor/src/sdk-handlers/claude/rate-limit-retry.ts
+++ b/packages/executor/src/sdk-handlers/claude/rate-limit-retry.ts
@@ -92,7 +92,8 @@ export function computeRateLimitRetryDelayMs(opts: {
   const rawBase = hasUsableReset
     ? resetMs - opts.nowMs
     : RATE_LIMIT_BACKOFF_MS[Math.min(opts.attempt, RATE_LIMIT_BACKOFF_MS.length - 1)];
-  const base = Math.min(rawBase, MAX_RATE_LIMIT_WAIT_MS);
+  // Reserve room for jitter so base + jitter stays strictly under the ceiling.
+  const base = Math.min(rawBase, MAX_RATE_LIMIT_WAIT_MS - RATE_LIMIT_JITTER_MS);
   const jitter = Math.floor(random() * RATE_LIMIT_JITTER_MS);
   return base + jitter;
 }

--- a/packages/executor/src/sdk-handlers/claude/rate-limit-retry.ts
+++ b/packages/executor/src/sdk-handlers/claude/rate-limit-retry.ts
@@ -8,8 +8,18 @@
  * time is unknown) and re-issues the turn, capped so it can never hang forever.
  */
 
+import type { TerminalReason } from '@agor/core/sdk';
+import type { ProcessedEvent } from './message-processor.js';
+
 /** Maximum number of automatic resumes before falling back to manual continue. */
 export const MAX_RATE_LIMIT_RETRIES = 5;
+
+/**
+ * Hard ceiling on a single wait. A far-future (or malformed) `resetsAt` must
+ * not keep a task alive for hours/days; clamping each wait to this — together
+ * with {@link MAX_RATE_LIMIT_RETRIES} — bounds the total auto-resume lifetime.
+ */
+export const MAX_RATE_LIMIT_WAIT_MS = 60 * 60 * 1000;
 
 /**
  * Prompt used to resume a turn the rate limiter cut short — mirrors what a user
@@ -34,37 +44,38 @@ export const RATE_LIMIT_JITTER_MS = 30_000;
  * The `terminal_reason` a Claude result carries when the turn ended because a
  * hard rate limit blocked it (see SDK `TerminalReason`).
  */
-export const RATE_LIMIT_TERMINAL_REASON = 'blocking_limit';
+export const RATE_LIMIT_TERMINAL_REASON: TerminalReason = 'blocking_limit';
 
 /**
  * Decide whether a just-ended turn should be automatically resumed after a
  * rate limit.
  *
- * - `completed` terminal reason means the turn finished its work — never
- *   re-issue it, even if a rejected rate_limit fired earlier in the turn.
- * - `blocking_limit` is the SDK's explicit rate-limit terminal signal; a
- *   `rejected` rate_limit event is the fallback when `terminal_reason` is
- *   absent on older SDKs.
+ * Fail CLOSED: resume ONLY when the SDK explicitly reports the hard-rate-limit
+ * terminal (`blocking_limit`). Every other reason — a normal `completed`, some
+ * other terminal, or a missing/unknown one — means we must NOT re-issue the
+ * turn, so we never risk repeating work that already finished or failed for an
+ * unrelated cause.
  */
 export function shouldAutoResumeAfterRateLimit(opts: {
-  terminalReason?: string;
-  sawRejectedRateLimit: boolean;
+  terminalReason?: TerminalReason;
   /** Number of automatic resumes already performed for this turn. */
   attempt: number;
   maxRetries?: number;
 }): boolean {
   const maxRetries = opts.maxRetries ?? MAX_RATE_LIMIT_RETRIES;
   if (opts.attempt >= maxRetries) return false;
-  if (opts.terminalReason === 'completed') return false;
-  return opts.terminalReason === RATE_LIMIT_TERMINAL_REASON || opts.sawRejectedRateLimit;
+  return opts.terminalReason === RATE_LIMIT_TERMINAL_REASON;
 }
 
 /**
  * Compute how long to wait before the next resume, in milliseconds.
  *
- * When `resetsAt` (epoch SECONDS, from the SDK) is known we wait until then;
- * otherwise we use capped exponential backoff. Jitter is always added on top
- * so concurrent sessions do not wake in lockstep.
+ * When `resetsAt` (epoch SECONDS, from the SDK) is a finite, still-in-the-future
+ * timestamp we wait until then; anything malformed (NaN/Infinity) or already in
+ * the past is treated as unknown and falls to capped exponential backoff. Every
+ * wait is clamped to {@link MAX_RATE_LIMIT_WAIT_MS} so a far-future reset can
+ * never produce an effectively unbounded wait. Jitter is always added on top so
+ * concurrent sessions do not wake in lockstep.
  */
 export function computeRateLimitRetryDelayMs(opts: {
   /** Reset time in epoch seconds, when the SDK reported it. */
@@ -76,12 +87,102 @@ export function computeRateLimitRetryDelayMs(opts: {
   random?: () => number;
 }): number {
   const random = opts.random ?? Math.random;
-  const base =
-    opts.resetsAt !== undefined
-      ? Math.max(0, opts.resetsAt * 1000 - opts.nowMs)
-      : RATE_LIMIT_BACKOFF_MS[Math.min(opts.attempt, RATE_LIMIT_BACKOFF_MS.length - 1)];
+  const resetMs = opts.resetsAt === undefined ? undefined : opts.resetsAt * 1000;
+  const hasUsableReset = resetMs !== undefined && Number.isFinite(resetMs) && resetMs > opts.nowMs;
+  const rawBase = hasUsableReset
+    ? resetMs - opts.nowMs
+    : RATE_LIMIT_BACKOFF_MS[Math.min(opts.attempt, RATE_LIMIT_BACKOFF_MS.length - 1)];
+  const base = Math.min(rawBase, MAX_RATE_LIMIT_WAIT_MS);
   const jitter = Math.floor(random() * RATE_LIMIT_JITTER_MS);
   return base + jitter;
+}
+
+/**
+ * Drive a turn generator with auto-resume on hard rate limits.
+ *
+ * Each turn is produced by `runTurn(prompt)`. A turn's `result` is held back
+ * until the resume decision is made: if the turn ended on `blocking_limit` and
+ * we're under the cap, the result is re-labelled `intermediate_result` (its
+ * usage is aggregated downstream, but it is not final), a `rate_limit_retry` is
+ * emitted, we wait, and the turn is re-issued with {@link RATE_LIMIT_RESUME_PROMPT};
+ * otherwise the result is emitted as the final `result`. After the cap a
+ * `rate_limit_retry_exhausted` is emitted and the turn falls back to manual
+ * continue. A firing `signal` (user stop / session cancel) interrupts the wait
+ * and ends with `stopped`.
+ */
+export async function* autoResumeOnRateLimit(
+  runTurn: (prompt: string) => AsyncGenerator<ProcessedEvent>,
+  opts: {
+    prompt: string;
+    signal?: AbortSignal;
+    /** Injectable for deterministic tests; defaults to {@link sleepUnlessAborted}. */
+    sleep?: (ms: number, signal?: AbortSignal) => Promise<{ aborted: boolean }>;
+  }
+): AsyncGenerator<ProcessedEvent> {
+  const sleep = opts.sleep ?? sleepUnlessAborted;
+  let currentPrompt = opts.prompt;
+  let attempt = 0;
+
+  while (true) {
+    let rejectedResetsAt: number | undefined;
+    let pendingResult: Extract<ProcessedEvent, { type: 'result' }> | undefined;
+
+    for await (const event of runTurn(currentPrompt)) {
+      if (event.type === 'rate_limit' && event.status === 'rejected') {
+        rejectedResetsAt = event.resetsAt;
+      }
+      // Hold the result back — its final-vs-intermediate role isn't known until
+      // the turn ends and the resume decision is made.
+      if (event.type === 'result') {
+        pendingResult = event;
+        continue;
+      }
+      yield event;
+    }
+
+    const terminalReason = (
+      pendingResult?.raw_sdk_message as { terminal_reason?: TerminalReason } | undefined
+    )?.terminal_reason;
+    const resume =
+      !opts.signal?.aborted && shouldAutoResumeAfterRateLimit({ terminalReason, attempt });
+
+    if (!resume) {
+      if (pendingResult) yield pendingResult;
+      if (
+        !opts.signal?.aborted &&
+        terminalReason === RATE_LIMIT_TERMINAL_REASON &&
+        attempt >= MAX_RATE_LIMIT_RETRIES
+      ) {
+        yield { type: 'rate_limit_retry_exhausted', attempts: attempt };
+      }
+      return;
+    }
+
+    if (pendingResult) {
+      yield { type: 'intermediate_result', raw_sdk_message: pendingResult.raw_sdk_message };
+    }
+
+    const delayMs = computeRateLimitRetryDelayMs({
+      resetsAt: rejectedResetsAt,
+      attempt,
+      nowMs: Date.now(),
+    });
+    yield {
+      type: 'rate_limit_retry',
+      retryAtMs: Date.now() + delayMs,
+      attempt: attempt + 1,
+      maxRetries: MAX_RATE_LIMIT_RETRIES,
+    };
+
+    const { aborted } = await sleep(delayMs, opts.signal);
+    if (aborted) {
+      yield { type: 'stopped' };
+      return;
+    }
+
+    attempt += 1;
+    currentPrompt = RATE_LIMIT_RESUME_PROMPT;
+  }
 }
 
 /**

--- a/packages/executor/src/sdk-handlers/claude/usage-aggregation.ts
+++ b/packages/executor/src/sdk-handlers/claude/usage-aggregation.ts
@@ -1,0 +1,112 @@
+/**
+ * Aggregate billable usage across the multiple SDK invocations a single task
+ * can span when a rate-limited turn is auto-resumed.
+ *
+ * Each invocation returns its own result with its own usage / cost / duration.
+ * Task accounting is driven off one `rawSdkResponse` (see base-executor), so
+ * without aggregation only the last invocation's numbers would be billed and
+ * the earlier (throttled) attempts' consumption would be dropped.
+ */
+
+import type { SDKResultMessage } from '@agor/core/sdk';
+import type { ClaudeModelUsage } from '../../types/sdk-response.js';
+
+interface TopLevelUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+export interface RetryUsageAccumulator {
+  usage: Required<TopLevelUsage>;
+  modelUsage: Record<string, ClaudeModelUsage>;
+  totalCostUsd: number;
+  durationMs: number;
+  durationApiMs: number;
+}
+
+export function emptyRetryUsageAccumulator(): RetryUsageAccumulator {
+  return {
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    modelUsage: {},
+    totalCostUsd: 0,
+    durationMs: 0,
+    durationApiMs: 0,
+  };
+}
+
+type RawResult = SDKResultMessage & {
+  usage?: TopLevelUsage;
+  modelUsage?: Record<string, ClaudeModelUsage>;
+  total_cost_usd?: number;
+  duration_ms?: number;
+  duration_api_ms?: number;
+};
+
+/**
+ * Fold one invocation's result into the accumulator. Token counts, cost and
+ * duration are summed; per-model `contextWindow` is a fixed window size, so the
+ * largest reported value wins rather than being summed. Returns a new object.
+ */
+export function accumulateResultUsage(
+  acc: RetryUsageAccumulator,
+  raw: RawResult
+): RetryUsageAccumulator {
+  const next: RetryUsageAccumulator = {
+    usage: { ...acc.usage },
+    modelUsage: structuredClone(acc.modelUsage),
+    totalCostUsd: acc.totalCostUsd + (raw.total_cost_usd ?? 0),
+    durationMs: acc.durationMs + (raw.duration_ms ?? 0),
+    durationApiMs: acc.durationApiMs + (raw.duration_api_ms ?? 0),
+  };
+
+  const u = raw.usage;
+  if (u) {
+    next.usage.input_tokens += u.input_tokens ?? 0;
+    next.usage.output_tokens += u.output_tokens ?? 0;
+    next.usage.cache_creation_input_tokens += u.cache_creation_input_tokens ?? 0;
+    next.usage.cache_read_input_tokens += u.cache_read_input_tokens ?? 0;
+  }
+
+  if (raw.modelUsage) {
+    for (const [model, mu] of Object.entries(raw.modelUsage)) {
+      const prev = next.modelUsage[model] ?? {};
+      next.modelUsage[model] = {
+        inputTokens: (prev.inputTokens ?? 0) + (mu.inputTokens ?? 0),
+        outputTokens: (prev.outputTokens ?? 0) + (mu.outputTokens ?? 0),
+        cacheReadInputTokens: (prev.cacheReadInputTokens ?? 0) + (mu.cacheReadInputTokens ?? 0),
+        cacheCreationInputTokens:
+          (prev.cacheCreationInputTokens ?? 0) + (mu.cacheCreationInputTokens ?? 0),
+        contextWindow: Math.max(prev.contextWindow ?? 0, mu.contextWindow ?? 0) || undefined,
+      };
+    }
+  }
+
+  return next;
+}
+
+/**
+ * Produce the final result to report for task accounting: the eventual result's
+ * identity (subtype, terminal_reason, errors, session_id, …) with its billable
+ * usage / cost / duration replaced by the aggregated totals.
+ */
+export function applyAccumulatedUsage(
+  finalRaw: SDKResultMessage,
+  acc: RetryUsageAccumulator
+): SDKResultMessage {
+  const raw = finalRaw as RawResult;
+  return {
+    ...finalRaw,
+    usage: { ...(raw.usage ?? {}), ...acc.usage },
+    ...(Object.keys(acc.modelUsage).length > 0 ? { modelUsage: acc.modelUsage } : {}),
+    total_cost_usd: acc.totalCostUsd,
+    duration_ms: acc.durationMs,
+    duration_api_ms: acc.durationApiMs,
+  } as SDKResultMessage;
+}

--- a/packages/executor/src/sdk-handlers/claude/usage-aggregation.ts
+++ b/packages/executor/src/sdk-handlers/claude/usage-aggregation.ts
@@ -6,21 +6,30 @@
  * Task accounting is driven off one `rawSdkResponse` (see base-executor), so
  * without aggregation only the last invocation's numbers would be billed and
  * the earlier (throttled) attempts' consumption would be dropped.
+ *
+ * Types are derived from the SDK result so no billable field is silently lost:
+ * every additive count (tokens, per-model cost, web-search/web-fetch requests)
+ * is summed; fixed-capacity fields (`contextWindow`, `maxOutputTokens`) take the
+ * max; structural breakdowns we don't sum are preserved from the final result.
  */
 
-import type { SDKResultMessage } from '@agor/core/sdk';
-import type { ClaudeModelUsage } from '../../types/sdk-response.js';
+import type { ModelUsage, SDKResultMessage } from '@agor/core/sdk';
 
-interface TopLevelUsage {
-  input_tokens?: number;
-  output_tokens?: number;
-  cache_creation_input_tokens?: number;
-  cache_read_input_tokens?: number;
-}
+/** The billable `usage` object carried on a Claude result (post-NonNullable). */
+type ResultUsage = Extract<SDKResultMessage, { subtype: 'success' }>['usage'];
+type ServerToolUsage = ResultUsage['server_tool_use'];
 
 export interface RetryUsageAccumulator {
-  usage: Required<TopLevelUsage>;
-  modelUsage: Record<string, ClaudeModelUsage>;
+  /** Summed top-level token counts + server-tool requests. */
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens: number;
+    cache_read_input_tokens: number;
+    server_tool_use: { web_fetch_requests: number; web_search_requests: number };
+  };
+  /** Per-model usage: additive fields summed, capacity fields maxed. */
+  modelUsage: Record<string, ModelUsage>;
   totalCostUsd: number;
   durationMs: number;
   durationApiMs: number;
@@ -33,6 +42,7 @@ export function emptyRetryUsageAccumulator(): RetryUsageAccumulator {
       output_tokens: 0,
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 0,
+      server_tool_use: { web_fetch_requests: 0, web_search_requests: 0 },
     },
     modelUsage: {},
     totalCostUsd: 0,
@@ -41,49 +51,51 @@ export function emptyRetryUsageAccumulator(): RetryUsageAccumulator {
   };
 }
 
-type RawResult = SDKResultMessage & {
-  usage?: TopLevelUsage;
-  modelUsage?: Record<string, ClaudeModelUsage>;
-  total_cost_usd?: number;
-  duration_ms?: number;
-  duration_api_ms?: number;
-};
-
 /**
- * Fold one invocation's result into the accumulator. Token counts, cost and
- * duration are summed; per-model `contextWindow` is a fixed window size, so the
- * largest reported value wins rather than being summed. Returns a new object.
+ * Fold one invocation's result into the accumulator. Returns a new object.
  */
 export function accumulateResultUsage(
   acc: RetryUsageAccumulator,
-  raw: RawResult
+  raw: SDKResultMessage
 ): RetryUsageAccumulator {
+  const usage = (raw as { usage?: Partial<ResultUsage> }).usage;
+  const server = usage?.server_tool_use as ServerToolUsage | undefined;
   const next: RetryUsageAccumulator = {
-    usage: { ...acc.usage },
+    usage: {
+      input_tokens: acc.usage.input_tokens + (usage?.input_tokens ?? 0),
+      output_tokens: acc.usage.output_tokens + (usage?.output_tokens ?? 0),
+      cache_creation_input_tokens:
+        acc.usage.cache_creation_input_tokens + (usage?.cache_creation_input_tokens ?? 0),
+      cache_read_input_tokens:
+        acc.usage.cache_read_input_tokens + (usage?.cache_read_input_tokens ?? 0),
+      server_tool_use: {
+        web_fetch_requests:
+          acc.usage.server_tool_use.web_fetch_requests + (server?.web_fetch_requests ?? 0),
+        web_search_requests:
+          acc.usage.server_tool_use.web_search_requests + (server?.web_search_requests ?? 0),
+      },
+    },
     modelUsage: structuredClone(acc.modelUsage),
-    totalCostUsd: acc.totalCostUsd + (raw.total_cost_usd ?? 0),
-    durationMs: acc.durationMs + (raw.duration_ms ?? 0),
-    durationApiMs: acc.durationApiMs + (raw.duration_api_ms ?? 0),
+    totalCostUsd: acc.totalCostUsd + ((raw as { total_cost_usd?: number }).total_cost_usd ?? 0),
+    durationMs: acc.durationMs + ((raw as { duration_ms?: number }).duration_ms ?? 0),
+    durationApiMs: acc.durationApiMs + ((raw as { duration_api_ms?: number }).duration_api_ms ?? 0),
   };
 
-  const u = raw.usage;
-  if (u) {
-    next.usage.input_tokens += u.input_tokens ?? 0;
-    next.usage.output_tokens += u.output_tokens ?? 0;
-    next.usage.cache_creation_input_tokens += u.cache_creation_input_tokens ?? 0;
-    next.usage.cache_read_input_tokens += u.cache_read_input_tokens ?? 0;
-  }
-
-  if (raw.modelUsage) {
-    for (const [model, mu] of Object.entries(raw.modelUsage)) {
-      const prev = next.modelUsage[model] ?? {};
+  const modelUsage = (raw as { modelUsage?: Record<string, Partial<ModelUsage>> }).modelUsage;
+  if (modelUsage) {
+    for (const [model, mu] of Object.entries(modelUsage)) {
+      const prev = next.modelUsage[model];
       next.modelUsage[model] = {
-        inputTokens: (prev.inputTokens ?? 0) + (mu.inputTokens ?? 0),
-        outputTokens: (prev.outputTokens ?? 0) + (mu.outputTokens ?? 0),
-        cacheReadInputTokens: (prev.cacheReadInputTokens ?? 0) + (mu.cacheReadInputTokens ?? 0),
+        inputTokens: (prev?.inputTokens ?? 0) + (mu.inputTokens ?? 0),
+        outputTokens: (prev?.outputTokens ?? 0) + (mu.outputTokens ?? 0),
+        cacheReadInputTokens: (prev?.cacheReadInputTokens ?? 0) + (mu.cacheReadInputTokens ?? 0),
         cacheCreationInputTokens:
-          (prev.cacheCreationInputTokens ?? 0) + (mu.cacheCreationInputTokens ?? 0),
-        contextWindow: Math.max(prev.contextWindow ?? 0, mu.contextWindow ?? 0) || undefined,
+          (prev?.cacheCreationInputTokens ?? 0) + (mu.cacheCreationInputTokens ?? 0),
+        webSearchRequests: (prev?.webSearchRequests ?? 0) + (mu.webSearchRequests ?? 0),
+        costUSD: (prev?.costUSD ?? 0) + (mu.costUSD ?? 0),
+        // Fixed capacities — take the max across invocations, never sum.
+        contextWindow: Math.max(prev?.contextWindow ?? 0, mu.contextWindow ?? 0),
+        maxOutputTokens: Math.max(prev?.maxOutputTokens ?? 0, mu.maxOutputTokens ?? 0),
       };
     }
   }
@@ -93,17 +105,27 @@ export function accumulateResultUsage(
 
 /**
  * Produce the final result to report for task accounting: the eventual result's
- * identity (subtype, terminal_reason, errors, session_id, …) with its billable
- * usage / cost / duration replaced by the aggregated totals.
+ * identity (subtype, terminal_reason, errors, session_id, structural usage
+ * breakdowns, …) with its billable usage / cost / duration replaced by the
+ * aggregated totals. Structural fields we don't aggregate are preserved from the
+ * final result rather than dropped.
  */
 export function applyAccumulatedUsage(
   finalRaw: SDKResultMessage,
   acc: RetryUsageAccumulator
 ): SDKResultMessage {
-  const raw = finalRaw as RawResult;
+  const finalUsage = (finalRaw as { usage?: ResultUsage }).usage;
+  const mergedUsage = {
+    ...(finalUsage ?? {}),
+    input_tokens: acc.usage.input_tokens,
+    output_tokens: acc.usage.output_tokens,
+    cache_creation_input_tokens: acc.usage.cache_creation_input_tokens,
+    cache_read_input_tokens: acc.usage.cache_read_input_tokens,
+    server_tool_use: { ...(finalUsage?.server_tool_use ?? {}), ...acc.usage.server_tool_use },
+  };
   return {
     ...finalRaw,
-    usage: { ...(raw.usage ?? {}), ...acc.usage },
+    usage: mergedUsage,
     ...(Object.keys(acc.modelUsage).length > 0 ? { modelUsage: acc.modelUsage } : {}),
     total_cost_usd: acc.totalCostUsd,
     duration_ms: acc.durationMs,


### PR DESCRIPTION
## Problem

Closes #1897. When a Claude session hit a **hard** rate limit (`rate_limit_event{status:"rejected"}`, result `terminal_reason: "blocking_limit"`), the executor surfaced a *"Waiting for limit to reset…"* system message but **nothing actually waited**. The turn ended, the task was marked completed, the session went idle, and the user had to manually type "continue".

## STEP 0 — is it already solved by the SDK?

Checked `@anthropic-ai/claude-agent-sdk` (installed 0.2.132). Its `Options` type has **no** wait/retry/backoff knob for blocking rate limits. The SDK's internal `api_retry` path only covers *transient retryable API errors* (server errors / timeouts) — a hard `rejected` rate limit is emit-and-end. So the SDK cannot be told to auto-wait; a hand-rolled resume is required.

The SDK does hand us the precise discriminator: the result message carries **`terminal_reason: "blocking_limit"`** when a turn ends because a hard limit blocked it, vs `"completed"` for a normal finish. That is used to never re-issue a turn that actually completed.

## Approach (hand-rolled resume)

- `promptWithRateLimitResume` wraps the streaming turn consumption in `claude-tool.ts`. When a turn ends **and** it ended on a rate limit (blocking_limit terminal reason, or a rejected rate_limit event as fallback) **and** it did not complete its work, it does **not** go idle — it waits, then re-issues a continue prompt against the resumed SDK session.
- **Wait target:** sleep until `resetsAt` when known; **capped exponential backoff** (30s → 60s → 120s ceiling) when unknown.
- **Jitter is mandatory** (0–30s additive) so concurrently-throttled sessions don't all wake at the same `resetsAt` and instantly re-throttle (thundering herd).
- **Capped at 5 retries**, then falls back to today's manual-continue behavior so it can never hang forever.
- **Cancellation-safe:** a user stop / session cancel aborts the wait cleanly via the existing `AbortController` (`sleepUnlessAborted`).
- Status is surfaced as **"Rate limited — auto-retrying at HH:MM (attempt N of 5)…"**, and an exhaustion message when the cap is hit. The old *"Waiting for limit to reset…"* copy (which never waited) is fixed.

## Files changed

- `packages/executor/src/sdk-handlers/claude/rate-limit-retry.ts` *(new)* — pure decision + backoff logic (`shouldAutoResumeAfterRateLimit`, `computeRateLimitRetryDelayMs`, `sleepUnlessAborted`, constants).
- `packages/executor/src/sdk-handlers/claude/rate-limit-retry.test.ts` *(new)* — 12 unit tests: jitter bounds, cap enforcement, resetsAt-known vs backoff, rate-limited-vs-normal end, interruptible sleep.
- `packages/executor/src/sdk-handlers/claude/claude-tool.ts` — auto-resume wrapper, retry/exhausted system messages, honest copy.
- `packages/executor/src/sdk-handlers/claude/message-processor.ts` — `rate_limit_retry` / `rate_limit_retry_exhausted` processed-event variants.

## Local checks (executor package)

- `typecheck` (tsc --noEmit): ✅ clean
- `build` (tsc): ✅ clean
- `biome check` on the diff: ✅ clean
- `vitest run` (whole package): new suite 12/12 pass; overall 470 pass, 1 fail + 2 failed suites — all **pre-existing on `main`** and unrelated (OpenTelemetry ESM directory-import in gemini tests; opencode MCP-headers assertion). Verified identical failures with this diff stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)