### PR TITLE
feat(gateway): surface Slack app link + capability-change scope warning

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -490,6 +490,10 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
         create: [ctx.requireAuth, requireMinimumRole(ROLES.ADMIN, 'test gateway channels')],
       },
     });
+    // Request/response probe — its default `created` event would otherwise fall
+    // through the global publisher's `global` scope and broadcast the probe
+    // result to every authenticated socket. Publish to no one.
+    app.service('gateway-channels/test').publish(() => []);
 
     // Sub-path service resolving the Slack app id behind a channel's stored
     // bot token (auth.test → bots.info). Same gating rationale as /test above:
@@ -500,6 +504,8 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
         create: [ctx.requireAuth, requireMinimumRole(ROLES.ADMIN, 'read gateway app info')],
       },
     });
+    // Request/response read — same broadcast fall-through as /test above.
+    app.service('gateway-channels/app-info').publish(() => []);
 
     app.use('/thread-session-map', createThreadSessionMapService(db));
     app.use('/gateway', createGatewayService(db, app), {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -87,6 +87,7 @@ import { createFileService } from './services/file.js';
 import { createFilesService } from './services/files.js';
 import { createGatewayService } from './services/gateway.js';
 import { createGatewayChannelsService } from './services/gateway-channels.js';
+import { createGatewayChannelsAppInfoService } from './services/gateway-channels-app-info.js';
 import { createGatewayChannelsTestService } from './services/gateway-channels-test.js';
 import { registerGitHubAppSetupRoutes } from './services/github-app-setup.js';
 import {
@@ -487,6 +488,16 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     app.service('gateway-channels/test').hooks({
       before: {
         create: [ctx.requireAuth, requireMinimumRole(ROLES.ADMIN, 'test gateway channels')],
+      },
+    });
+
+    // Sub-path service resolving the Slack app id behind a channel's stored
+    // bot token (auth.test → bots.info). Same gating rationale as /test above:
+    // reads decrypted tokens via the repository, returns no token values.
+    app.use('/gateway-channels/app-info', createGatewayChannelsAppInfoService(db));
+    app.service('gateway-channels/app-info').hooks({
+      before: {
+        create: [ctx.requireAuth, requireMinimumRole(ROLES.ADMIN, 'read gateway app info')],
       },
     });
 

--- a/apps/agor-daemon/src/services/gateway-channels-app-info.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-app-info.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { GatewayChannel, HookContext } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STORED_BOT_TOKEN = 'xoxb-decrypted-secret';
+
+// Resolved token the service fed into the REAL connector, proving the
+// decrypted stored token reaches the app-info probe end-to-end.
+let capturedBotToken: string | undefined;
+let authTestImpl: () => Promise<unknown>;
+let botsInfoImpl: (params: { bot: string }) => Promise<unknown>;
+
+// Delegate to the real getConnector / SlackConnector so the real resolution
+// path runs, then stub only the web-client seam so no network is touched.
+vi.mock('@agor/core/gateway', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/gateway')>();
+  return {
+    ...actual,
+    getConnector: (channelType: string, config: Record<string, unknown>) => {
+      capturedBotToken = config.bot_token as string | undefined;
+      const connector = actual.getConnector(channelType as never, config) as unknown as {
+        web: unknown;
+      };
+      connector.web = {
+        auth: { test: () => authTestImpl() },
+        bots: { info: (params: { bot: string }) => botsInfoImpl(params) },
+      };
+      return connector;
+    },
+  };
+});
+
+const findById = vi.fn();
+
+vi.mock('@agor/core/db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@agor/core/db')>();
+  return {
+    ...actual,
+    GatewayChannelRepository: class {
+      findById = findById;
+    },
+  };
+});
+
+const { createGatewayChannelsAppInfoService } = await import('./gateway-channels-app-info.js');
+const { requireMinimumRole } = await import('../utils/authorization.js');
+
+const storedChannel: GatewayChannel = {
+  id: 'chan-1',
+  name: 'Slack',
+  channel_type: 'slack',
+  channel_key: 'key',
+  enabled: true,
+  target_branch_id: 'branch-1',
+  agor_user_id: 'user-1',
+  config: {
+    bot_token: STORED_BOT_TOKEN,
+  },
+  agentic_config: null,
+  created_by: 'user-1',
+  created_at: '2026-06-22T00:00:00.000Z',
+  updated_at: '2026-06-22T00:00:00.000Z',
+  last_message_at: null,
+} as unknown as GatewayChannel;
+
+beforeEach(() => {
+  capturedBotToken = undefined;
+  findById.mockReset();
+  findById.mockResolvedValue(storedChannel);
+  authTestImpl = async () => ({
+    ok: true,
+    team_id: 'T1',
+    user_id: 'U1',
+    bot_id: 'B1',
+  });
+  botsInfoImpl = async (params) => ({ ok: true, bot: { id: params.bot, app_id: 'A123' } });
+});
+
+describe('gateway-channels/app-info admin gate', () => {
+  const gate = requireMinimumRole(ROLES.ADMIN, 'read gateway app info');
+
+  it('rejects a non-admin caller', () => {
+    const context = {
+      params: { provider: 'rest', user: { user_id: 'u', role: ROLES.MEMBER } },
+    } as unknown as HookContext;
+    expect(() => gate(context)).toThrow();
+  });
+
+  it('allows an admin caller', () => {
+    const context = {
+      params: { provider: 'rest', user: { user_id: 'u', role: ROLES.ADMIN } },
+    } as unknown as HookContext;
+    expect(() => gate(context)).not.toThrow();
+  });
+});
+
+describe('gateway-channels/app-info hook wiring (register-services)', () => {
+  // A sub-path service does not inherit the parent gateway-channels hooks, so
+  // the registration MUST attach its own auth + admin gate on create. Mirrors
+  // the source-level wiring check used for `gateway-channels/test`.
+  const source = readFileSync(join(__dirname, '..', 'register-services.ts'), 'utf8');
+  const start = source.indexOf("app.service('gateway-channels/app-info').hooks(");
+  const block = start === -1 ? '' : source.slice(start, start + 300);
+
+  it('gates create with requireAuth then admin role', () => {
+    expect(start).toBeGreaterThan(-1);
+    expect(block).toMatch(/create:\s*\[\s*ctx\.requireAuth,\s*requireMinimumRole\(ROLES\.ADMIN/);
+  });
+});
+
+describe('gateway-channels/app-info service', () => {
+  it('resolves the app id through the real connector using the decrypted stored token', async () => {
+    const service = createGatewayChannelsAppInfoService({} as never);
+
+    const result = await service.create({ gatewayChannelId: 'chan-1' });
+
+    expect(findById).toHaveBeenCalledWith('chan-1');
+    expect(capturedBotToken).toBe(STORED_BOT_TOKEN);
+    expect(result).toEqual({ appId: 'A123', teamId: 'T1' });
+  });
+
+  it('requires a gatewayChannelId and 404s on an unknown channel', async () => {
+    const service = createGatewayChannelsAppInfoService({} as never);
+
+    await expect(service.create({})).rejects.toThrow(/gatewayChannelId/);
+
+    findById.mockResolvedValue(null);
+    await expect(service.create({ gatewayChannelId: 'missing' })).rejects.toThrow(/not found/i);
+  });
+
+  it('returns nulls instead of erroring when the connector cannot be built', async () => {
+    // No bot_token stored → SlackConnector constructor throws → unresolved.
+    findById.mockResolvedValue({ ...storedChannel, config: {} });
+    const service = createGatewayChannelsAppInfoService({} as never);
+
+    await expect(service.create({ gatewayChannelId: 'chan-1' })).resolves.toEqual({
+      appId: null,
+      teamId: null,
+    });
+  });
+
+  it('returns a result free of token values or prefixes, even on Slack errors', async () => {
+    botsInfoImpl = async () => {
+      throw { data: { ok: false, error: 'bot_not_found' } };
+    };
+    const service = createGatewayChannelsAppInfoService({} as never);
+
+    const result = await service.create({ gatewayChannelId: 'chan-1' });
+    const serialized = JSON.stringify(result);
+
+    expect(result).toEqual({ appId: null, teamId: 'T1' });
+    expect(serialized).not.toContain(STORED_BOT_TOKEN);
+    expect(serialized).not.toContain('xoxb');
+  });
+});

--- a/apps/agor-daemon/src/services/gateway-channels-app-info.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-app-info.test.ts
@@ -81,11 +81,16 @@ beforeEach(() => {
 describe('gateway-channels/app-info admin gate', () => {
   const gate = requireMinimumRole(ROLES.ADMIN, 'read gateway app info');
 
+  it('rejects an unauthenticated external caller', () => {
+    const context = { params: { provider: 'rest' } } as unknown as HookContext;
+    expect(() => gate(context)).toThrow(/authentication required/i);
+  });
+
   it('rejects a non-admin caller', () => {
     const context = {
       params: { provider: 'rest', user: { user_id: 'u', role: ROLES.MEMBER } },
     } as unknown as HookContext;
-    expect(() => gate(context)).toThrow();
+    expect(() => gate(context)).toThrow(/admin/i);
   });
 
   it('allows an admin caller', () => {
@@ -107,6 +112,13 @@ describe('gateway-channels/app-info hook wiring (register-services)', () => {
   it('gates create with requireAuth then admin role', () => {
     expect(start).toBeGreaterThan(-1);
     expect(block).toMatch(/create:\s*\[\s*ctx\.requireAuth,\s*requireMinimumRole\(ROLES\.ADMIN/);
+  });
+
+  it('suppresses realtime publication of the create result', () => {
+    // Without a per-service publisher the default `created` event falls
+    // through the global publisher's `global` scope and the app-info result
+    // would broadcast to every authenticated socket.
+    expect(source).toMatch(/app\.service\('gateway-channels\/app-info'\)\.publish\(\(\) => \[\]\)/);
   });
 });
 

--- a/apps/agor-daemon/src/services/gateway-channels-app-info.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-app-info.ts
@@ -1,0 +1,58 @@
+/**
+ * Gateway Channels App Info Service (`gateway-channels/app-info`)
+ *
+ * Admin-only sub-path service that resolves the platform app behind an
+ * existing gateway channel's stored credentials (Slack app id + team id via
+ * `auth.test` → `bots.info`), so the UI can deep-link to the app's manifest
+ * editor.
+ *
+ * Token resolution reads DECRYPTED credentials from the repository directly
+ * (never through the gateway-channels Feathers service, whose after-hook
+ * redacts secrets to the `••••••••` sentinel). The response carries only
+ * `{ appId, teamId }` — never token values. Resolution is best-effort: any
+ * failure (missing token, connector error, Slack API error) yields nulls
+ * rather than an error, so the UI degrades to a generic Slack link.
+ */
+
+import { GatewayChannelRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import { BadRequest, NotFound } from '@agor/core/feathers';
+import { getConnector } from '@agor/core/gateway';
+import type { AuthenticatedParams, SlackAppInfo } from '@agor/core/types';
+
+export interface GatewayChannelAppInfoInput {
+  gatewayChannelId?: string;
+}
+
+const UNRESOLVED: SlackAppInfo = { appId: null, teamId: null };
+
+/**
+ * Factory for the `gateway-channels/app-info` service.
+ */
+export function createGatewayChannelsAppInfoService(db: TenantScopeAwareDatabase) {
+  const channelRepo = new GatewayChannelRepository(db);
+
+  return {
+    async create(
+      data: GatewayChannelAppInfoInput,
+      _params?: AuthenticatedParams
+    ): Promise<SlackAppInfo> {
+      if (!data.gatewayChannelId) {
+        throw new BadRequest('gatewayChannelId is required');
+      }
+      const channel = await channelRepo.findById(data.gatewayChannelId);
+      if (!channel) {
+        throw new NotFound(`Gateway channel not found: ${data.gatewayChannelId}`);
+      }
+
+      try {
+        const connector = getConnector(channel.channel_type, channel.config);
+        if (!connector.getAppInfo) return UNRESOLVED;
+        return await connector.getAppInfo();
+      } catch {
+        // Connector construction fails when no bot token is stored yet; app
+        // identity is a nice-to-have, so report "unresolved" instead of erroring.
+        return UNRESOLVED;
+      }
+    },
+  };
+}

--- a/apps/agor-daemon/src/services/gateway-channels-test.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-test.test.ts
@@ -103,11 +103,16 @@ beforeEach(() => {
 describe('gateway-channels/test admin gate', () => {
   const gate = requireMinimumRole(ROLES.ADMIN, 'test gateway channels');
 
+  it('rejects an unauthenticated external caller', () => {
+    const context = { params: { provider: 'rest' } } as unknown as HookContext;
+    expect(() => gate(context)).toThrow(/authentication required/i);
+  });
+
   it('rejects a non-admin caller', () => {
     const context = {
       params: { provider: 'rest', user: { user_id: 'u', role: ROLES.MEMBER } },
     } as unknown as HookContext;
-    expect(() => gate(context)).toThrow();
+    expect(() => gate(context)).toThrow(/admin/i);
   });
 
   it('allows an admin caller', () => {
@@ -129,6 +134,13 @@ describe('gateway-channels/test hook wiring (register-services)', () => {
   it('gates create with requireAuth then admin role', () => {
     expect(start).toBeGreaterThan(-1);
     expect(block).toMatch(/create:\s*\[\s*ctx\.requireAuth,\s*requireMinimumRole\(ROLES\.ADMIN/);
+  });
+
+  it('suppresses realtime publication of the create result', () => {
+    // Without a per-service publisher the default `created` event falls
+    // through the global publisher's `global` scope and the full probe result
+    // would broadcast to every authenticated socket.
+    expect(source).toMatch(/app\.service\('gateway-channels\/test'\)\.publish\(\(\) => \[\]\)/);
   });
 });
 

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -493,6 +493,77 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     expect(link.closest('a')?.getAttribute('href')).toBe('https://api.slack.com/apps');
   });
 
+  it('keeps the generic link when the backend resolves a null app id', async () => {
+    const { client, appInfoCreate } = makeClient(undefined, { appId: null, teamId: null });
+    renderEditTable(client, makeSlackChannel());
+
+    await waitFor(() => expect(appInfoCreate).toHaveBeenCalledTimes(1));
+    const link = await screen.findByText(/Open Slack apps/);
+    expect(link.closest('a')?.getAttribute('href')).toBe('https://api.slack.com/apps');
+  });
+
+  it('drops a stale app-info response after switching to another channel', async () => {
+    // Per-channel deferred resolutions so channel A's response can land AFTER
+    // channel B's — the link must keep B's app id.
+    const resolvers = new Map<string, (info: unknown) => void>();
+    const appInfoCreate = vi.fn(
+      ({ gatewayChannelId }: { gatewayChannelId: string }) =>
+        new Promise((resolve) => resolvers.set(gatewayChannelId, resolve))
+    );
+    const client = {
+      service: (name: string) => {
+        if (name === 'gateway-channels/app-info') return { create: appInfoCreate };
+        return { create: vi.fn(), get: vi.fn() };
+      },
+    } as unknown as AgorClient;
+
+    const channelA = makeSlackChannel();
+    const channelB = {
+      ...makeSlackChannel(),
+      id: 'channel-2',
+      name: 'Zeta Slack', // sorts after "Team Slack" so row order is A, B
+    } as GatewayChannel;
+    const branch = makeBranch();
+    const user = makeUser();
+    renderWithProviders(
+      <GatewayChannelsTable
+        client={client}
+        gatewayChannelById={
+          new Map([
+            [channelA.id, channelA],
+            [channelB.id, channelB],
+          ])
+        }
+        branchById={new Map([[branch.branch_id, branch]])}
+        userById={new Map([[user.user_id, user]])}
+        mcpServerById={new Map<string, MCPServer>()}
+        currentUser={user}
+      />
+    );
+
+    // Open A's edit modal, close it, open B's while A's fetch is in flight.
+    fireEvent.click(screen.getAllByTitle('Edit')[0]);
+    clickButton(/^Cancel$/);
+    fireEvent.click(screen.getAllByTitle('Edit')[1]);
+    await waitFor(() => expect(appInfoCreate).toHaveBeenCalledTimes(2));
+
+    resolvers.get('channel-2')?.({ appId: 'ABBB222', teamId: 'T1' });
+    const link = await screen.findByText(/Open Slack app manifest/);
+    expect(link.closest('a')?.getAttribute('href')).toBe(
+      'https://api.slack.com/apps/ABBB222/app-manifest'
+    );
+
+    // A's stale response lands last and must be ignored.
+    resolvers.get('channel-1')?.({ appId: 'AAAA111', teamId: 'T1' });
+    await flush();
+    expect(
+      screen
+        .getByText(/Open Slack app manifest/)
+        .closest('a')
+        ?.getAttribute('href')
+    ).toBe('https://api.slack.com/apps/ABBB222/app-manifest');
+  });
+
   it('warns with the added scope when a capability toggle needs a scope the saved config lacks', async () => {
     const { client } = makeClient(undefined, { appId: 'A0123ABC', teamId: 'T1' });
     renderEditTable(client, makeSlackChannel());

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -96,21 +96,24 @@ function makeSlackChannel(): GatewayChannel {
 
 /**
  * Minimal AgorClient stub exposing only the services the table calls. Records
- * the `gateway-channels` create payload and the `gateway-channels/test` probe.
+ * the `gateway-channels` create payload, the `gateway-channels/test` probe,
+ * and the `gateway-channels/app-info` resolution fired on edit open.
  */
-function makeClient(testResult?: unknown) {
+function makeClient(testResult?: unknown, appInfo?: unknown) {
   const channelCreate = vi.fn().mockResolvedValue({});
   const testCreate = vi
     .fn()
     .mockResolvedValue(testResult ?? { ok: true, failures: [], notVerifiable: [] });
+  const appInfoCreate = vi.fn().mockResolvedValue(appInfo ?? { appId: null, teamId: null });
   const client = {
     service: (name: string) => {
       if (name === 'gateway-channels') return { create: channelCreate };
       if (name === 'gateway-channels/test') return { create: testCreate };
+      if (name === 'gateway-channels/app-info') return { create: appInfoCreate };
       return { create: vi.fn(), get: vi.fn() };
     },
   } as unknown as AgorClient;
-  return { client, channelCreate, testCreate };
+  return { client, channelCreate, testCreate, appInfoCreate };
 }
 
 function renderTable(client: AgorClient | null) {
@@ -466,6 +469,60 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     expect(
       screen.getByText('No token stored yet. Enter the app token (xapp-...).')
     ).toBeInTheDocument();
+  });
+
+  it('deep-links to the Slack app manifest editor with the server-resolved app id', async () => {
+    const { client, appInfoCreate } = makeClient(undefined, { appId: 'A0123ABC', teamId: 'T1' });
+    renderEditTable(client, makeSlackChannel());
+
+    await waitFor(() => expect(appInfoCreate).toHaveBeenCalledTimes(1));
+    // The app id resolves server-side from the STORED token — never form values.
+    expect(appInfoCreate.mock.calls[0][0]).toEqual({ gatewayChannelId: 'channel-1' });
+
+    const link = await screen.findByText(/Open Slack app manifest/);
+    expect(link.closest('a')?.getAttribute('href')).toBe(
+      'https://api.slack.com/apps/A0123ABC/app-manifest'
+    );
+  });
+
+  it('falls back to the generic Slack apps link when the app id cannot be resolved', async () => {
+    // client=null → no app-info fetch can run at all.
+    renderEditTable(null, makeSlackChannel());
+
+    const link = await screen.findByText(/Open Slack apps/);
+    expect(link.closest('a')?.getAttribute('href')).toBe('https://api.slack.com/apps');
+  });
+
+  it('warns with the added scope when a capability toggle needs a scope the saved config lacks', async () => {
+    const { client } = makeClient(undefined, { appId: 'A0123ABC', teamId: 'T1' });
+    renderEditTable(client, makeSlackChannel());
+    expandPanel('Message Sources');
+
+    // Nothing has changed yet — no scope-change warning.
+    expect(screen.queryByText(/This change adds the/)).toBeNull();
+
+    // "Agents can download files" adds files:read (via requiredBotScopes),
+    // which the saved config (enable_channels only) does not carry.
+    fireEvent.click(document.querySelector('#agent_file_download') as HTMLElement);
+
+    expect(await screen.findByText(/This change adds the/)).toBeInTheDocument();
+    expect(screen.queryAllByText('files:read').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Open Slack app manifest/).length).toBeGreaterThan(0);
+    expect(queryButton(/Copy manifest/)).toBeDefined();
+  });
+
+  it('does not warn on unrelated edits or on toggles that only remove scopes', async () => {
+    renderEditTable(null, makeSlackChannel());
+    expandPanel('Message Sources');
+
+    // Turning OFF thread history removes nothing scope-wise (it has no scopes)…
+    fireEvent.click(document.querySelector('#agent_thread_history') as HTMLElement);
+    // …and turning OFF the saved public-channels surface only REMOVES scopes.
+    fireEvent.click(document.querySelector('#enable_channels') as HTMLElement);
+
+    // The scope list re-derives (drop of channels:history) before we assert.
+    await waitFor(() => expect(screen.queryAllByText('channels:history').length).toBe(0));
+    expect(screen.queryByText(/This change adds the/)).toBeNull();
   });
 
   it("preserves a channel's stored mcpServerIds on save, even when the current user has their own agent defaults", async () => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.test.tsx
@@ -471,17 +471,20 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     ).toBeInTheDocument();
   });
 
-  it('deep-links to the Slack app manifest editor with the server-resolved app id', async () => {
-    const { client, appInfoCreate } = makeClient(undefined, { appId: 'A0123ABC', teamId: 'T1' });
+  it('deep-links to the Slack app manifest editor with the server-resolved app + team ids', async () => {
+    const { client, appInfoCreate } = makeClient(undefined, {
+      appId: 'A0BH0A7TUGJ',
+      teamId: 'T0BELR0LTNG',
+    });
     renderEditTable(client, makeSlackChannel());
 
     await waitFor(() => expect(appInfoCreate).toHaveBeenCalledTimes(1));
-    // The app id resolves server-side from the STORED token — never form values.
+    // The ids resolve server-side from the STORED token — never form values.
     expect(appInfoCreate.mock.calls[0][0]).toEqual({ gatewayChannelId: 'channel-1' });
 
     const link = await screen.findByText(/Open Slack app manifest/);
     expect(link.closest('a')?.getAttribute('href')).toBe(
-      'https://api.slack.com/apps/A0123ABC/app-manifest'
+      'https://app.slack.com/app-settings/T0BELR0LTNG/A0BH0A7TUGJ/app-manifest'
     );
   });
 
@@ -550,7 +553,7 @@ describe('GatewayChannelsTable Slack edit mode', () => {
     resolvers.get('channel-2')?.({ appId: 'ABBB222', teamId: 'T1' });
     const link = await screen.findByText(/Open Slack app manifest/);
     expect(link.closest('a')?.getAttribute('href')).toBe(
-      'https://api.slack.com/apps/ABBB222/app-manifest'
+      'https://app.slack.com/app-settings/T1/ABBB222/app-manifest'
     );
 
     // A's stale response lands last and must be ignored.
@@ -561,7 +564,7 @@ describe('GatewayChannelsTable Slack edit mode', () => {
         .getByText(/Open Slack app manifest/)
         .closest('a')
         ?.getAttribute('href')
-    ).toBe('https://api.slack.com/apps/ABBB222/app-manifest');
+    ).toBe('https://app.slack.com/app-settings/T1/ABBB222/app-manifest');
   });
 
   it('warns with the added scope when a capability toggle needs a scope the saved config lacks', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -2189,10 +2189,16 @@ const ChannelFormFields: React.FC<{
 
         {/* ── Collapsible sections (Slack edit) ── */}
         {channelType === 'slack' && mode === 'edit' && (
-          <div style={{ marginBottom: 8 }}>
-            <SlackOutlined style={{ marginInlineEnd: 6 }} />
-            <SlackAppManifestLink appInfo={slackAppInfo} />
-          </div>
+          <>
+            <div style={{ marginBottom: 8 }}>
+              <SlackOutlined style={{ marginInlineEnd: 6 }} />
+              <SlackAppManifestLink appInfo={slackAppInfo} />
+            </div>
+            {/* Single instance above the Collapse — the scope-affecting toggles
+                are spread across several panels, and an in-panel copy would
+                duplicate whenever more than one is expanded. */}
+            {scopeChangeWarning}
+          </>
         )}
         {channelType === 'slack' && mode === 'edit' && (
           <Collapse
@@ -2232,7 +2238,6 @@ const ChannelFormFields: React.FC<{
                         />
                       }
                     />
-                    {scopeChangeWarning}
                   </>
                 ),
               },
@@ -2428,8 +2433,6 @@ const ChannelFormFields: React.FC<{
                       <Switch />
                     </Form.Item>
 
-                    {scopeChangeWarning}
-
                     {sourcesEnabled && (
                       <CompactAlert
                         type="info"
@@ -2540,8 +2543,6 @@ const ChannelFormFields: React.FC<{
                         </span>
                       }
                     />
-
-                    {scopeChangeWarning}
                   </>
                 ),
               },
@@ -2694,6 +2695,10 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const [slackTestResult, setSlackTestResult] = useState<SlackTestResult | null>(null);
   // Slack app identity resolved server-side when the edit modal opens (edit mode).
   const [slackAppInfo, setSlackAppInfo] = useState<SlackAppInfo | null>(null);
+  // Channel id the in-flight app-info fetch belongs to; a response is dropped
+  // unless it still matches, so reopening the modal on another channel can't
+  // be overwritten by a slower earlier response.
+  const slackAppInfoChannelIdRef = useRef<string | null>(null);
 
   // Keep referenced target branches resolvable in CRUD even when archived branches
   // are excluded from the core store.
@@ -2773,6 +2778,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     setSlackTestLoading(false);
     setSlackTestResult(null);
     setSlackAppInfo(null);
+    slackAppInfoChannelIdRef.current = null;
   }, []);
 
   // Reset the whole create flow back to its universal first step.
@@ -3131,15 +3137,23 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     // Resolve the Slack app id behind the stored bot token (best-effort; the
     // backend returns nulls rather than erroring). Fire-and-forget so the modal
     // opens instantly; the app link degrades to a generic Slack link meanwhile.
+    // The ref pins the response to the channel still being edited — a slow
+    // response for a previously-opened channel must not deep-link this one to
+    // the wrong Slack app.
+    slackAppInfoChannelIdRef.current = channel.channel_type === 'slack' ? channel.id : null;
     if (channel.channel_type === 'slack' && client) {
       void (async () => {
+        let info: SlackAppInfo | null = null;
         try {
-          const info = (await client
-            .service('gateway-channels/app-info')
-            .create({ gatewayChannelId: channel.id })) as SlackAppInfo | undefined;
-          setSlackAppInfo(info ?? null);
+          info =
+            ((await client
+              .service('gateway-channels/app-info')
+              .create({ gatewayChannelId: channel.id })) as SlackAppInfo | undefined) ?? null;
         } catch {
-          setSlackAppInfo(null);
+          info = null;
+        }
+        if (slackAppInfoChannelIdRef.current === channel.id) {
+          setSlackAppInfo(info);
         }
       })();
     }

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -5,6 +5,7 @@ import {
   buildSlackManifest,
   requiredBotEvents,
   requiredBotScopes,
+  SLACK_APPS_URL,
   type SlackWizardOptions,
   slackAppManifestUrl,
 } from '@agor/core/gateway/slack-manifest';
@@ -598,19 +599,19 @@ const SlackTestResultView: React.FC<{ result: SlackTestResult }> = ({ result }) 
 };
 
 /**
- * External link to the channel's Slack app manifest editor. The app id is
- * resolved server-side from the stored bot token (`gateway-channels/app-info`);
- * when unresolved the link degrades to the generic Slack app list.
+ * External link to the channel's Slack app manifest editor. The app + team ids
+ * are resolved server-side from the stored bot token
+ * (`gateway-channels/app-info`); when unresolved the link degrades to the
+ * generic Slack app list.
  */
-const SlackAppManifestLink: React.FC<{ appInfo: SlackAppInfo | null }> = ({ appInfo }) => (
-  <Typography.Link
-    href={slackAppManifestUrl(appInfo?.appId)}
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    {appInfo?.appId ? 'Open Slack app manifest' : 'Open Slack apps'} ↗
-  </Typography.Link>
-);
+const SlackAppManifestLink: React.FC<{ appInfo: SlackAppInfo | null }> = ({ appInfo }) => {
+  const href = slackAppManifestUrl(appInfo?.appId, appInfo?.teamId);
+  return (
+    <Typography.Link href={href} target="_blank" rel="noopener noreferrer">
+      {href === SLACK_APPS_URL ? 'Open Slack apps' : 'Open Slack app manifest'} ↗
+    </Typography.Link>
+  );
+};
 
 /**
  * Inline warning shown while editing a channel whenever the pending capability
@@ -679,7 +680,6 @@ const SlackScopeChangeWarning: React.FC<{
           </Space>
         </>
       }
-      style={{ marginBottom: 16 }}
     />
   );
 };
@@ -1349,6 +1349,7 @@ const ChannelFormFields: React.FC<{
   slackAppInfo,
 }) => {
   const { showError } = useThemedMessage();
+  const { token } = theme.useToken();
 
   // Watch message source settings for showing warnings/scope requirements. A
   // watched value is `undefined` while its (lazily-rendered) Collapse panel is
@@ -2189,16 +2190,10 @@ const ChannelFormFields: React.FC<{
 
         {/* ── Collapsible sections (Slack edit) ── */}
         {channelType === 'slack' && mode === 'edit' && (
-          <>
-            <div style={{ marginBottom: 8 }}>
-              <SlackOutlined style={{ marginInlineEnd: 6 }} />
-              <SlackAppManifestLink appInfo={slackAppInfo} />
-            </div>
-            {/* Single instance above the Collapse — the scope-affecting toggles
-                are spread across several panels, and an in-panel copy would
-                duplicate whenever more than one is expanded. */}
-            {scopeChangeWarning}
-          </>
+          <div style={{ marginBottom: 8 }}>
+            <SlackOutlined style={{ marginInlineEnd: 6 }} />
+            <SlackAppManifestLink appInfo={slackAppInfo} />
+          </div>
         )}
         {channelType === 'slack' && mode === 'edit' && (
           <Collapse
@@ -2642,6 +2637,27 @@ const ChannelFormFields: React.FC<{
               },
             ]}
           />
+        )}
+
+        {/* Pinned to the bottom of the scrollable form body: the toggles that
+            add scopes live deep inside collapse panels, so an in-flow alert
+            above them is off-screen at the moment the user acts. Sticky keeps
+            it visible while toggling anywhere in the form and again at save
+            time. Solid background so form items don't show through the
+            (translucent) alert fill while it floats. */}
+        {channelType === 'slack' && mode === 'edit' && addedSlackScopes.length > 0 && (
+          <div
+            style={{
+              position: 'sticky',
+              bottom: 0,
+              zIndex: 2,
+              marginTop: 12,
+              padding: '8px 0',
+              background: token.colorBgElevated,
+            }}
+          >
+            {scopeChangeWarning}
+          </div>
         )}
       </div>
     </>

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -6,6 +6,7 @@ import {
   requiredBotEvents,
   requiredBotScopes,
   type SlackWizardOptions,
+  slackAppManifestUrl,
 } from '@agor/core/gateway/slack-manifest';
 import type {
   AgenticToolName,
@@ -17,6 +18,7 @@ import type {
   GatewayEnvVar,
   MCPServer,
   PermissionMode,
+  SlackAppInfo,
   SlackTestResult,
   User,
   UUID,
@@ -596,12 +598,102 @@ const SlackTestResultView: React.FC<{ result: SlackTestResult }> = ({ result }) 
 };
 
 /**
+ * External link to the channel's Slack app manifest editor. The app id is
+ * resolved server-side from the stored bot token (`gateway-channels/app-info`);
+ * when unresolved the link degrades to the generic Slack app list.
+ */
+const SlackAppManifestLink: React.FC<{ appInfo: SlackAppInfo | null }> = ({ appInfo }) => (
+  <Typography.Link
+    href={slackAppManifestUrl(appInfo?.appId)}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    {appInfo?.appId ? 'Open Slack app manifest' : 'Open Slack apps'} ↗
+  </Typography.Link>
+);
+
+/**
+ * Inline warning shown while editing a channel whenever the pending capability
+ * toggles require OAuth scopes the SAVED config does not — i.e. the installed
+ * Slack app is now missing scopes and must be updated + reinstalled before the
+ * capability works. The delta comes from {@link requiredBotScopes} on both
+ * configs (single source of truth), so unrelated edits never trigger it and
+ * removing a capability never warns.
+ */
+const SlackScopeChangeWarning: React.FC<{
+  addedScopes: string[];
+  appInfo: SlackAppInfo | null;
+  options: SlackWizardOptions;
+}> = ({ addedScopes, appInfo, options }) => {
+  const { showError } = useThemedMessage();
+  const [copied, setCopied] = useState(false);
+  const scopeKey = addedScopes.join(',');
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the scope set is the change trigger, not a value read in the body.
+  useEffect(() => {
+    setCopied(false);
+  }, [scopeKey]);
+
+  if (addedScopes.length === 0) return null;
+
+  const handleCopy = async () => {
+    const ok = await copyTextToClipboard(JSON.stringify(buildSlackManifest(options), null, 2));
+    if (ok) {
+      setCopied(true);
+    } else {
+      showError('Copy failed — copy the manifest from the App Manifest section.');
+    }
+  };
+
+  return (
+    <CompactAlert
+      type="warning"
+      icon={<ExclamationCircleOutlined />}
+      heading={
+        <>
+          This change adds the{' '}
+          {addedScopes.map((scope, i) => (
+            <span key={scope}>
+              {i > 0 ? ', ' : ''}
+              <code>{scope}</code>
+            </span>
+          ))}{' '}
+          scope{addedScopes.length > 1 ? 's' : ''}
+        </>
+      }
+      description={
+        <>
+          <div style={{ marginBottom: 6 }}>
+            Saving here does not change the Slack app — update its manifest and reinstall the app
+            for the new scope{addedScopes.length > 1 ? 's' : ''} to take effect.
+          </div>
+          <Space size="small" wrap>
+            <SlackAppManifestLink appInfo={appInfo} />
+            <Button
+              size="small"
+              icon={copied ? <CheckCircleOutlined /> : <CopyOutlined />}
+              onClick={handleCopy}
+            >
+              {copied ? 'Copied' : 'Copy manifest'}
+            </Button>
+          </Space>
+        </>
+      }
+      style={{ marginBottom: 16 }}
+    />
+  );
+};
+
+/**
  * Recommended Slack app manifest for an existing channel. Derived from the
  * channel's current capability toggles via {@link buildSlackManifest}, so it
  * always shows the manifest the app *should* have — not a readout of the app's
  * live Slack configuration. Paste it back into Slack to align scopes/events.
  */
-const SlackManifestPanel: React.FC<{ options: SlackWizardOptions }> = ({ options }) => {
+const SlackManifestPanel: React.FC<{
+  options: SlackWizardOptions;
+  appInfo: SlackAppInfo | null;
+}> = ({ options, appInfo }) => {
   const { token } = theme.useToken();
   const { showError } = useThemedMessage();
   const [copied, setCopied] = useState(false);
@@ -635,7 +727,15 @@ const SlackManifestPanel: React.FC<{ options: SlackWizardOptions }> = ({ options
         configuration, not a readout of your app&apos;s live settings. Paste it into{' '}
         <strong>App Manifest</strong> in your Slack app to align its scopes and events.
       </Typography.Text>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 8,
+        }}
+      >
+        <SlackAppManifestLink appInfo={appInfo} />
         <Button
           size="small"
           icon={copied ? <CheckCircleOutlined /> : <CopyOutlined />}
@@ -1226,6 +1326,8 @@ const ChannelFormFields: React.FC<{
   slackTestResult: SlackTestResult | null;
   slackTestLoading: boolean;
   onSlackTest: () => void;
+  /** Slack app identity resolved server-side on edit open (edit mode only). */
+  slackAppInfo: SlackAppInfo | null;
 }> = ({
   client,
   form,
@@ -1244,6 +1346,7 @@ const ChannelFormFields: React.FC<{
   slackTestResult,
   slackTestLoading,
   onSlackTest,
+  slackAppInfo,
 }) => {
   const { showError } = useThemedMessage();
 
@@ -1328,6 +1431,36 @@ const ChannelFormFields: React.FC<{
   );
   const slackScopes = useMemo(() => requiredBotScopes(slackOptions), [slackOptions]);
   const slackEvents = useMemo(() => requiredBotEvents(slackOptions), [slackOptions]);
+
+  // Scopes the channel's SAVED config requires — the baseline for detecting
+  // that a pending toggle ADDS a scope the installed Slack app may not hold.
+  const savedSlackScopes = useMemo(() => {
+    if (mode !== 'edit' || editingChannel?.channel_type !== 'slack') return null;
+    return requiredBotScopes({
+      appName: editingChannel.name || 'Agor',
+      publicChannels: Boolean(slackConfig?.enable_channels),
+      privateChannels: Boolean(slackConfig?.enable_groups),
+      groupDms: Boolean(slackConfig?.enable_mpim),
+      alignUsers: Boolean(slackConfig?.align_slack_users),
+      outbound: Boolean(slackConfig?.outbound_enabled),
+      ingestFiles: Boolean(slackConfig?.ingest_files),
+      agentTools: storedAgentTools,
+    });
+  }, [mode, editingChannel, slackConfig, storedAgentTools]);
+
+  const addedSlackScopes = useMemo(() => {
+    if (!savedSlackScopes) return [];
+    const saved = new Set(savedSlackScopes);
+    return slackScopes.filter((scope) => !saved.has(scope));
+  }, [savedSlackScopes, slackScopes]);
+
+  const scopeChangeWarning = (
+    <SlackScopeChangeWarning
+      addedScopes={addedSlackScopes}
+      appInfo={slackAppInfo}
+      options={slackOptions}
+    />
+  );
 
   const botTokenStored = isSecretStored(slackConfig, 'bot_token');
   const appTokenStored = isSecretStored(slackConfig, 'app_token');
@@ -2056,6 +2189,12 @@ const ChannelFormFields: React.FC<{
 
         {/* ── Collapsible sections (Slack edit) ── */}
         {channelType === 'slack' && mode === 'edit' && (
+          <div style={{ marginBottom: 8 }}>
+            <SlackOutlined style={{ marginInlineEnd: 6 }} />
+            <SlackAppManifestLink appInfo={slackAppInfo} />
+          </div>
+        )}
+        {channelType === 'slack' && mode === 'edit' && (
           <Collapse
             ghost
             destroyOnHidden={false}
@@ -2073,25 +2212,28 @@ const ChannelFormFields: React.FC<{
                   />
                 ),
                 children: (
-                  <PlatformIdentityFields
-                    alignFieldName="align_slack_users"
-                    alignLabel="Align Slack users"
-                    alignDescription="Match Slack profile email to an Agor user. Unmatched users are rejected."
-                    alignUsers={alignSlackUsers}
-                    userById={userById}
-                    alignedContent={
-                      <CompactAlert
-                        type="info"
-                        heading="Requires users:read.email scope"
-                        description={
-                          <span>
-                            Add <code>users:read.email</code> to your Slack app so Agor can match
-                            Slack profiles by email.
-                          </span>
-                        }
-                      />
-                    }
-                  />
+                  <>
+                    <PlatformIdentityFields
+                      alignFieldName="align_slack_users"
+                      alignLabel="Align Slack users"
+                      alignDescription="Match Slack profile email to an Agor user. Unmatched users are rejected."
+                      alignUsers={alignSlackUsers}
+                      userById={userById}
+                      alignedContent={
+                        <CompactAlert
+                          type="info"
+                          heading="Requires users:read.email scope"
+                          description={
+                            <span>
+                              Add <code>users:read.email</code> to your Slack app so Agor can match
+                              Slack profiles by email.
+                            </span>
+                          }
+                        />
+                      }
+                    />
+                    {scopeChangeWarning}
+                  </>
                 ),
               },
               // ── Credentials ──
@@ -2174,7 +2316,7 @@ const ChannelFormFields: React.FC<{
                     subtitle="recommended scopes & events"
                   />
                 ),
-                children: <SlackManifestPanel options={slackOptions} />,
+                children: <SlackManifestPanel options={slackOptions} appInfo={slackAppInfo} />,
               },
 
               // ── Message Sources ──
@@ -2286,6 +2428,8 @@ const ChannelFormFields: React.FC<{
                       <Switch />
                     </Form.Item>
 
+                    {scopeChangeWarning}
+
                     {sourcesEnabled && (
                       <CompactAlert
                         type="info"
@@ -2396,6 +2540,8 @@ const ChannelFormFields: React.FC<{
                         </span>
                       }
                     />
+
+                    {scopeChangeWarning}
                   </>
                 ),
               },
@@ -2546,6 +2692,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   // ── Slack guided-setup state (create mode) ──
   const [slackTestLoading, setSlackTestLoading] = useState(false);
   const [slackTestResult, setSlackTestResult] = useState<SlackTestResult | null>(null);
+  // Slack app identity resolved server-side when the edit modal opens (edit mode).
+  const [slackAppInfo, setSlackAppInfo] = useState<SlackAppInfo | null>(null);
 
   // Keep referenced target branches resolvable in CRUD even when archived branches
   // are excluded from the core store.
@@ -2624,6 +2772,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const resetSlackState = useCallback(() => {
     setSlackTestLoading(false);
     setSlackTestResult(null);
+    setSlackAppInfo(null);
   }, []);
 
   // Reset the whole create flow back to its universal first step.
@@ -2979,6 +3128,21 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     skipAgentDefaultsAfterEditHydrationRef.current = true;
     setSelectedAgent(agent);
     resetSlackState();
+    // Resolve the Slack app id behind the stored bot token (best-effort; the
+    // backend returns nulls rather than erroring). Fire-and-forget so the modal
+    // opens instantly; the app link degrades to a generic Slack link meanwhile.
+    if (channel.channel_type === 'slack' && client) {
+      void (async () => {
+        try {
+          const info = (await client
+            .service('gateway-channels/app-info')
+            .create({ gatewayChannelId: channel.id })) as SlackAppInfo | undefined;
+          setSlackAppInfo(info ?? null);
+        } catch {
+          setSlackAppInfo(null);
+        }
+      })();
+    }
     editForm.resetFields();
 
     const config = channel.config as Record<string, unknown>;
@@ -3330,6 +3494,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             slackTestResult={slackTestResult}
             slackTestLoading={slackTestLoading}
             onSlackTest={handleSlackTest}
+            slackAppInfo={null}
           />
         </Form>
       </Modal>
@@ -3369,6 +3534,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
             slackTestResult={slackTestResult}
             slackTestLoading={slackTestLoading}
             onSlackTest={handleSlackEditTest}
+            slackAppInfo={slackAppInfo}
           />
         </Form>
       </Modal>

--- a/packages/core/src/gateway/connector.ts
+++ b/packages/core/src/gateway/connector.ts
@@ -5,7 +5,7 @@
  * sending messages to and receiving messages from messaging platforms.
  */
 
-import type { ChannelType, SlackTestResult } from '../types/gateway';
+import type { ChannelType, SlackAppInfo, SlackTestResult } from '../types/gateway';
 
 /**
  * File attached to an inbound message (provider-neutral shape).
@@ -129,4 +129,12 @@ export interface GatewayConnector {
    * prove, so a green result is never mistaken for full verification.
    */
   testConnection?(): Promise<SlackTestResult>;
+
+  /**
+   * Best-effort resolution of the platform app behind the channel's stored
+   * credentials (e.g. Slack app id via `auth.test` → `bots.info`), so the UI
+   * can deep-link to the app's settings. Returns nulls on failure rather than
+   * throwing, and never includes token material.
+   */
+  getAppInfo?(): Promise<SlackAppInfo>;
 }

--- a/packages/core/src/gateway/connectors/slack-manifest.test.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.test.ts
@@ -476,23 +476,35 @@ describe('buildSlackManifest', () => {
 });
 
 describe('slackAppManifestUrl', () => {
-  it('deep-links to the app manifest editor when the app id is known', () => {
-    expect(slackAppManifestUrl('A0123ABC')).toBe(
-      'https://api.slack.com/apps/A0123ABC/app-manifest'
+  it('deep-links to the workspace-scoped manifest editor when both ids are known', () => {
+    // The per-app api.slack.com/apps/{id} path 404s; the manifest editor lives
+    // on the team-scoped app-settings surface.
+    expect(slackAppManifestUrl('A0BH0A7TUGJ', 'T0BELR0LTNG')).toBe(
+      'https://app.slack.com/app-settings/T0BELR0LTNG/A0BH0A7TUGJ/app-manifest'
+    );
+    expect(slackAppManifestUrl('A0BH0A7TUGJ', 'E0123ORG')).toBe(
+      'https://app.slack.com/app-settings/E0123ORG/A0BH0A7TUGJ/app-manifest'
     );
   });
 
-  it('falls back to the generic app list when the app id is unresolved', () => {
-    expect(slackAppManifestUrl(null)).toBe('https://api.slack.com/apps');
-    expect(slackAppManifestUrl(undefined)).toBe('https://api.slack.com/apps');
-    expect(slackAppManifestUrl('')).toBe('https://api.slack.com/apps');
+  it('falls back to the generic app list when either id is unresolved', () => {
+    expect(slackAppManifestUrl(null, null)).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl(undefined, undefined)).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('', '')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('A0BH0A7TUGJ', null)).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl(null, 'T0BELR0LTNG')).toBe('https://api.slack.com/apps');
   });
 
-  it('falls back when the app id does not match the Slack app-id shape', () => {
-    // The id is interpolated into a URL path, so anything that could alter
+  it('falls back when either id does not match its Slack id shape', () => {
+    // Both ids are interpolated into a URL path, so anything that could alter
     // the path/query/fragment must be refused, not encoded.
-    expect(slackAppManifestUrl('A123/../evil?x#y')).toBe('https://api.slack.com/apps');
-    expect(slackAppManifestUrl('a123abc')).toBe('https://api.slack.com/apps');
-    expect(slackAppManifestUrl('B0123ABC')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('A123/../evil?x#y', 'T0BELR0LTNG')).toBe(
+      'https://api.slack.com/apps'
+    );
+    expect(slackAppManifestUrl('a123abc', 'T0BELR0LTNG')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('B0123ABC', 'T0BELR0LTNG')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('A0BH0A7TUGJ', 'T1/../evil?x#y')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('A0BH0A7TUGJ', 't0belr0ltng')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('A0BH0A7TUGJ', 'X0123ABC')).toBe('https://api.slack.com/apps');
   });
 });

--- a/packages/core/src/gateway/connectors/slack-manifest.test.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.test.ts
@@ -5,6 +5,7 @@ import {
   requiredBotEvents,
   requiredBotScopes,
   type SlackWizardOptions,
+  slackAppManifestUrl,
 } from './slack-manifest';
 
 /**
@@ -471,5 +472,19 @@ describe('buildSlackManifest', () => {
         },
       }
     `);
+  });
+});
+
+describe('slackAppManifestUrl', () => {
+  it('deep-links to the app manifest editor when the app id is known', () => {
+    expect(slackAppManifestUrl('A0123ABC')).toBe(
+      'https://api.slack.com/apps/A0123ABC/app-manifest'
+    );
+  });
+
+  it('falls back to the generic app list when the app id is unresolved', () => {
+    expect(slackAppManifestUrl(null)).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl(undefined)).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('')).toBe('https://api.slack.com/apps');
   });
 });

--- a/packages/core/src/gateway/connectors/slack-manifest.test.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.test.ts
@@ -487,4 +487,12 @@ describe('slackAppManifestUrl', () => {
     expect(slackAppManifestUrl(undefined)).toBe('https://api.slack.com/apps');
     expect(slackAppManifestUrl('')).toBe('https://api.slack.com/apps');
   });
+
+  it('falls back when the app id does not match the Slack app-id shape', () => {
+    // The id is interpolated into a URL path, so anything that could alter
+    // the path/query/fragment must be refused, not encoded.
+    expect(slackAppManifestUrl('A123/../evil?x#y')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('a123abc')).toBe('https://api.slack.com/apps');
+    expect(slackAppManifestUrl('B0123ABC')).toBe('https://api.slack.com/apps');
+  });
 });

--- a/packages/core/src/gateway/connectors/slack-manifest.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.ts
@@ -61,21 +61,29 @@ export const SLACK_AGENT_TOOL_SCOPES: Record<SlackAgentToolCapability, string[]>
 
 /**
  * Slack app ids are an "A" followed by uppercase alphanumerics (e.g.
- * "A0123ABCD"). Anything else is treated as unresolved: the id lands in a URL
- * path, so this shape check is what keeps a malformed/hostile value (slashes,
- * query/fragment chars) from steering the link somewhere else.
+ * "A0BH0A7TUGJ"); team ids are the same shape behind a "T" (workspace) or "E"
+ * (enterprise org) prefix. Anything else is treated as unresolved: both ids
+ * land in a URL path, so these shape checks are what keep a malformed/hostile
+ * value (slashes, query/fragment chars) from steering the link somewhere else.
  */
 const SLACK_APP_ID_SHAPE = /^A[A-Z0-9]+$/;
+const SLACK_TEAM_ID_SHAPE = /^[TE][A-Z0-9]+$/;
+
+/** Generic Slack app list — the fallback when no manifest deep link can be built. */
+export const SLACK_APPS_URL = 'https://api.slack.com/apps';
 
 /**
- * URL of a Slack app's manifest editor when the app id is known, falling back
- * to the generic app list when it isn't (e.g. the id could not be resolved
- * from the stored bot token, or doesn't look like a Slack app id).
+ * URL of a Slack app's manifest editor when the app AND team ids are known,
+ * falling back to the generic app list otherwise. The manifest editor lives on
+ * the workspace-scoped app-settings surface — the per-app
+ * `api.slack.com/apps/{id}` path 404s — so the team id is required for the
+ * deep link. An app id without a team id doesn't occur in practice: the app id
+ * is only resolved after an `auth.test` that also supplies the team id.
  */
-export function slackAppManifestUrl(appId?: string | null): string {
-  return appId && SLACK_APP_ID_SHAPE.test(appId)
-    ? `https://api.slack.com/apps/${appId}/app-manifest`
-    : 'https://api.slack.com/apps';
+export function slackAppManifestUrl(appId?: string | null, teamId?: string | null): string {
+  return appId && SLACK_APP_ID_SHAPE.test(appId) && teamId && SLACK_TEAM_ID_SHAPE.test(teamId)
+    ? `https://app.slack.com/app-settings/${teamId}/${appId}/app-manifest`
+    : SLACK_APPS_URL;
 }
 
 export interface SlackBotEventSubscriptions {

--- a/packages/core/src/gateway/connectors/slack-manifest.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.ts
@@ -59,6 +59,15 @@ export const SLACK_AGENT_TOOL_SCOPES: Record<SlackAgentToolCapability, string[]>
   file_download: ['files:read'],
 };
 
+/**
+ * URL of a Slack app's manifest editor when the app id is known, falling back
+ * to the generic app list when it isn't (e.g. the id could not be resolved
+ * from the stored bot token).
+ */
+export function slackAppManifestUrl(appId?: string | null): string {
+  return appId ? `https://api.slack.com/apps/${appId}/app-manifest` : 'https://api.slack.com/apps';
+}
+
 export interface SlackBotEventSubscriptions {
   bot_events: string[];
 }

--- a/packages/core/src/gateway/connectors/slack-manifest.ts
+++ b/packages/core/src/gateway/connectors/slack-manifest.ts
@@ -60,12 +60,22 @@ export const SLACK_AGENT_TOOL_SCOPES: Record<SlackAgentToolCapability, string[]>
 };
 
 /**
+ * Slack app ids are an "A" followed by uppercase alphanumerics (e.g.
+ * "A0123ABCD"). Anything else is treated as unresolved: the id lands in a URL
+ * path, so this shape check is what keeps a malformed/hostile value (slashes,
+ * query/fragment chars) from steering the link somewhere else.
+ */
+const SLACK_APP_ID_SHAPE = /^A[A-Z0-9]+$/;
+
+/**
  * URL of a Slack app's manifest editor when the app id is known, falling back
  * to the generic app list when it isn't (e.g. the id could not be resolved
- * from the stored bot token).
+ * from the stored bot token, or doesn't look like a Slack app id).
  */
 export function slackAppManifestUrl(appId?: string | null): string {
-  return appId ? `https://api.slack.com/apps/${appId}/app-manifest` : 'https://api.slack.com/apps';
+  return appId && SLACK_APP_ID_SHAPE.test(appId)
+    ? `https://api.slack.com/apps/${appId}/app-manifest`
+    : 'https://api.slack.com/apps';
 }
 
 export interface SlackBotEventSubscriptions {

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -1515,6 +1515,14 @@ describe('SlackConnector.getAppInfo', () => {
     await expect(connector.getAppInfo()).resolves.toEqual({ appId: null, teamId: 'T1' });
   });
 
+  it('yields null appId when an OK bots.info response carries no app_id', async () => {
+    const connector = makeAppInfoConnector({
+      botsInfo: async (params) => ({ ok: true, bot: { id: params.bot } }),
+    });
+
+    await expect(connector.getAppInfo()).resolves.toEqual({ appId: null, teamId: 'T1' });
+  });
+
   it('yields null appId when auth.test carries no bot_id', async () => {
     const connector = makeAppInfoConnector({
       authTest: async () => ({ ok: true, team_id: 'T1', user_id: 'U1' }),

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -1451,6 +1451,87 @@ describe('SlackConnector.testConnection', () => {
   });
 });
 
+describe('SlackConnector.getAppInfo', () => {
+  /** Build a connector with a mocked bot web client so no network is touched. */
+  function makeAppInfoConnector(args: {
+    authTest?: () => Promise<unknown>;
+    botsInfo?: (params: { bot: string }) => Promise<unknown>;
+    capture?: { botsInfoParams?: { bot: string } };
+  }) {
+    const connector = new SlackConnector({ bot_token: 'xoxb-secret-token' });
+    (connector as unknown as { web: unknown }).web = {
+      auth: {
+        test:
+          args.authTest ?? (async () => ({ ok: true, team_id: 'T1', user_id: 'U1', bot_id: 'B1' })),
+      },
+      bots: {
+        info: async (params: { bot: string }) => {
+          if (args.capture) args.capture.botsInfoParams = params;
+          return args.botsInfo
+            ? args.botsInfo(params)
+            : { ok: true, bot: { id: params.bot, app_id: 'A123' } };
+        },
+      },
+    };
+    return connector;
+  }
+
+  it('resolves appId + teamId via auth.test → bots.info', async () => {
+    const capture: { botsInfoParams?: { bot: string } } = {};
+    const connector = makeAppInfoConnector({ capture });
+
+    const result = await connector.getAppInfo();
+
+    expect(result).toEqual({ appId: 'A123', teamId: 'T1' });
+    // bots.info must be queried with the bot id auth.test reported.
+    expect(capture.botsInfoParams).toEqual({ bot: 'B1' });
+  });
+
+  it('returns nulls without throwing when auth.test fails', async () => {
+    const connector = makeAppInfoConnector({
+      authTest: async () => {
+        throw { data: { ok: false, error: 'invalid_auth' } };
+      },
+    });
+
+    await expect(connector.getAppInfo()).resolves.toEqual({ appId: null, teamId: null });
+  });
+
+  it('keeps teamId but yields null appId when bots.info throws', async () => {
+    const connector = makeAppInfoConnector({
+      botsInfo: async () => {
+        throw { data: { ok: false, error: 'bot_not_found' } };
+      },
+    });
+
+    await expect(connector.getAppInfo()).resolves.toEqual({ appId: null, teamId: 'T1' });
+  });
+
+  it('yields null appId on a non-OK bots.info response', async () => {
+    const connector = makeAppInfoConnector({
+      botsInfo: async () => ({ ok: false, error: 'bot_not_found' }),
+    });
+
+    await expect(connector.getAppInfo()).resolves.toEqual({ appId: null, teamId: 'T1' });
+  });
+
+  it('yields null appId when auth.test carries no bot_id', async () => {
+    const connector = makeAppInfoConnector({
+      authTest: async () => ({ ok: true, team_id: 'T1', user_id: 'U1' }),
+    });
+
+    await expect(connector.getAppInfo()).resolves.toEqual({ appId: null, teamId: 'T1' });
+  });
+
+  it('never includes token material in the result', async () => {
+    const result = await makeAppInfoConnector({}).getAppInfo();
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain('xoxb');
+    expect(serialized).not.toContain('secret');
+  });
+});
+
 describe('extractSlackInboundFiles', () => {
   const slackFile = {
     id: 'F123',

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -31,6 +31,7 @@ import { slackifyMarkdown } from 'slackify-markdown';
 import type {
   ChannelType,
   SlackAgentToolsConfig,
+  SlackAppInfo,
   SlackTestFailure,
   SlackTestResult,
 } from '../../types/gateway';
@@ -957,6 +958,29 @@ export class SlackConnector implements GatewayConnector {
       failures,
       notVerifiable,
     };
+  }
+
+  /**
+   * Resolve the Slack app behind the configured bot token: `auth.test` yields
+   * the bot id + team id, then `bots.info` (baseline `users:read` scope — no
+   * scope beyond what every gateway channel already holds) yields the app id.
+   *
+   * Best-effort: any failure returns nulls rather than throwing, so the UI can
+   * fall back to a generic Slack link. The result never carries token values.
+   */
+  async getAppInfo(): Promise<SlackAppInfo> {
+    let teamId: string | null = null;
+    try {
+      const authTest = await this.web.auth.test();
+      if (!authTest.ok) return { appId: null, teamId: null };
+      teamId = authTest.team_id ?? null;
+      if (!authTest.bot_id) return { appId: null, teamId };
+      const botsInfo = await this.web.bots.info({ bot: authTest.bot_id });
+      if (!botsInfo.ok) return { appId: null, teamId };
+      return { appId: botsInfo.bot?.app_id ?? null, teamId };
+    } catch {
+      return { appId: null, teamId };
+    }
   }
 
   /**

--- a/packages/core/src/types/gateway.ts
+++ b/packages/core/src/types/gateway.ts
@@ -195,6 +195,17 @@ export interface SlackTestResult {
   notVerifiable: string[];
 }
 
+/**
+ * Identity of the Slack app behind a channel's bot token, resolved server-side
+ * via `auth.test` → `bots.info` (which only needs the baseline `users:read`
+ * scope). Fields are null when resolution fails — never an error — so callers
+ * can degrade to a generic Slack link. Never carries token material.
+ */
+export interface SlackAppInfo {
+  appId: string | null;
+  teamId: string | null;
+}
+
 // ============================================================================
 // Agentic Tool Configuration
 // ============================================================================


### PR DESCRIPTION
## Problem (Max's thread)

When a user enables a Slack capability on an **existing** gateway channel in the Agor UI (e.g. file download → needs `files:read`), nothing tells them the Slack app's manifest/permissions changed and must be updated + reinstalled in Slack. The capability silently doesn't work, and there was no direct path from Agor to their Slack app's settings.

## What this does

### Slack app id resolved server-side (`auth.test` → `bots.info`)

- `SlackConnector.getAppInfo()` resolves `{ appId, teamId }`: `auth.test` yields the bot id + team id, then `bots.info` yields the **`app_id`**. `bots.info` needs only `users:read`, which is already a baseline gateway scope — **no new scope required**.
- Exposed via a new admin-gated `gateway-channels/app-info` sub-path service that mirrors `gateway-channels/test`: decrypted bot token is read via the repository server-side; the response carries only `{ appId, teamId }` — **the token never reaches the client**.
- Best-effort everywhere: missing token / Slack error → `{ appId: null, teamId: null }`, never an error.

### UI: app link + capability-change warning

- The Slack edit form now shows **"Open Slack app manifest ↗"** (top of the form, App Manifest panel, and inside the warning), deep-linking to `https://api.slack.com/apps/{appId}/app-manifest`. When the app id can't be resolved it degrades to the generic `https://api.slack.com/apps` link.
- When an edit-form toggle **adds** OAuth scopes vs the channel's saved config, an inline warning appears next to the toggle ("This change adds the `files:read` scope… update the manifest and reinstall") with the app link and a copy-manifest button. The delta is computed with `requiredBotScopes(saved)` vs `requiredBotScopes(pending)` — the existing single source of truth, no hardcoded scope lists — so unrelated edits and scope-removing toggles never warn.

## Out of scope

Auto-syncing the manifest to Slack: `apps.manifest.update` requires a **config token**, a separate token type the user would have to generate and rotate — exactly the friction this avoids. Link + warning + copy-manifest only.

## Tests

- Connector: appId/teamId resolution via mocked web client, graceful nulls on `auth.test`/`bots.info` failure and missing `bot_id`, no token material in the result.
- Daemon: admin gate + hook wiring, decrypted stored token reaches the real connector, `NotFound`/`BadRequest`, token-free results on Slack errors, nulls when the connector can't be built.
- UI: deep link renders with the server-resolved app id (and generic fallback), warning renders on a scope-adding toggle and **not** on unrelated/scope-removing edits.

Full `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)