### PR TITLE
feat(mcp): reflect soft 1:1 teammate↔board coupling in agor_branches_create

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -355,6 +355,213 @@ describe('agor_branches_create', () => {
     const passed = createBranch.mock.calls[0][1] as Record<string, unknown>;
     expect(passed).not.toHaveProperty('custom_context');
   });
+
+  it('auto-creates a dedicated board for a teammate when no boardId is given', async () => {
+    const createBranch = vi.fn(async (_repoId: string, data: unknown) => ({
+      branch_id: 'teammate-branch',
+      created_by: 'user-a',
+      ...(data as Record<string, unknown>),
+    }));
+    const reposGet = vi.fn(async () => ({
+      repo_id: 'repo-1',
+      slug: 'siebel-crm',
+      default_branch: 'main',
+    }));
+    const boardsCreate = vi.fn(async (data: Record<string, unknown>) => ({
+      board_id: 'board-auto',
+      name: data.name,
+      icon: data.icon,
+    }));
+    const boardsGet = vi.fn(async () => {
+      throw new Error('boards.get should not be called when auto-creating a board');
+    });
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch };
+        if (name === 'boards') return { get: boardsGet, create: boardsCreate };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-a',
+      baseServiceParams: {},
+    });
+
+    const result = await create({
+      repoId: 'repo-1',
+      branchName: 'siebel-crm',
+      autoSuffix: false,
+      teammate: { displayName: 'Siebel CRM', emoji: '🤖' },
+    });
+
+    // A board named after the teammate is created and used for placement.
+    expect(boardsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Siebel CRM', icon: '🤖', created_by: 'user-a' }),
+      {}
+    );
+    expect(createBranch).toHaveBeenCalledWith(
+      'repo-1',
+      expect.objectContaining({ boardId: 'board-auto' }),
+      {}
+    );
+
+    const payload = JSON.parse(result.content[0].text) as {
+      _teammate?: Record<string, unknown>;
+      _board?: Record<string, unknown>;
+      _warning?: string;
+    };
+    expect(payload._board).toMatchObject({ created: true, board_id: 'board-auto' });
+    expect(payload._teammate).toMatchObject({
+      created: true,
+      is_board_primary_teammate: true,
+      primary_board_id: 'board-auto',
+    });
+    expect(payload._warning).toBeUndefined();
+  });
+
+  it('auto-creates a board when createBoard=true is passed explicitly', async () => {
+    const createBranch = vi.fn(async (_repoId: string, data: unknown) => ({
+      branch_id: 'teammate-branch',
+      ...(data as Record<string, unknown>),
+    }));
+    const reposGet = vi.fn(async () => ({ repo_id: 'repo-1', slug: 's', default_branch: 'main' }));
+    const boardsCreate = vi.fn(async () => ({ board_id: 'board-auto', name: 'Helper' }));
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch };
+        if (name === 'boards') return { get: vi.fn(), create: boardsCreate };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-a',
+      baseServiceParams: {},
+    });
+
+    await create({
+      repoId: 'repo-1',
+      branchName: 'helper',
+      autoSuffix: false,
+      createBoard: true,
+      teammate: { displayName: 'Helper' },
+    });
+
+    expect(boardsCreate).toHaveBeenCalledTimes(1);
+    expect(createBranch).toHaveBeenCalledWith(
+      'repo-1',
+      expect.objectContaining({ boardId: 'board-auto' }),
+      {}
+    );
+  });
+
+  it('warns (does not block) when the target board already has a different primary teammate', async () => {
+    const createBranch = vi.fn(async (_repoId: string, data: unknown) => ({
+      branch_id: 'teammate-branch',
+      ...(data as Record<string, unknown>),
+    }));
+    const reposGet = vi.fn(async () => ({ repo_id: 'repo-1', slug: 's', default_branch: 'main' }));
+    const boardsCreate = vi.fn();
+    // resolveBoardId and the warning lookup both call boards.get; the board
+    // already has a *different* primary teammate.
+    const boardsGet = vi.fn(async () => ({
+      board_id: 'board-1',
+      primary_teammate_id: 'other-teammate',
+    }));
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch };
+        if (name === 'boards') return { get: boardsGet, create: boardsCreate };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-a',
+      baseServiceParams: {},
+    });
+
+    const result = await create({
+      repoId: 'repo-1',
+      branchName: 'second-teammate',
+      boardId: 'board-1',
+      autoSuffix: false,
+      teammate: { displayName: 'Second Teammate' },
+    });
+
+    // Still created on the passed board — the convention is soft, not enforced.
+    expect(boardsCreate).not.toHaveBeenCalled();
+    expect(createBranch).toHaveBeenCalledWith(
+      'repo-1',
+      expect.objectContaining({ boardId: 'board-1' }),
+      {}
+    );
+
+    const payload = JSON.parse(result.content[0].text) as {
+      _teammate?: Record<string, unknown>;
+      _board?: Record<string, unknown>;
+      _warning?: string;
+    };
+    expect(payload._warning).toContain('already has a primary teammate');
+    expect(payload._board).toBeUndefined();
+    expect(payload._teammate).toMatchObject({ is_board_primary_teammate: false });
+  });
+
+  it('rejects passing both boardId and createBoard=true', async () => {
+    const reposGet = vi.fn(async () => ({ repo_id: 'repo-1', slug: 's', default_branch: 'main' }));
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch: vi.fn() };
+        if (name === 'boards')
+          return { get: vi.fn(async () => ({ board_id: 'board-1' })), create: vi.fn() };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-a',
+      baseServiceParams: {},
+    });
+
+    await expect(
+      create({
+        repoId: 'repo-1',
+        branchName: 'teammate-x',
+        boardId: 'board-1',
+        createBoard: true,
+        autoSuffix: false,
+        teammate: { displayName: 'X' },
+      })
+    ).rejects.toThrow(/either boardId .* or createBoard/i);
+  });
+
+  it('still requires boardId for a normal (non-teammate) branch', async () => {
+    const reposGet = vi.fn(async () => ({ repo_id: 'repo-1', slug: 's', default_branch: 'main' }));
+    const boardsCreate = vi.fn();
+    const app = {
+      service(name: string) {
+        if (name === 'repos') return { get: reposGet, createBranch: vi.fn() };
+        if (name === 'boards') return { get: vi.fn(), create: boardsCreate };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-a',
+      baseServiceParams: {},
+    });
+
+    await expect(
+      create({ repoId: 'repo-1', branchName: 'plain', autoSuffix: false })
+    ).rejects.toThrow('boardId is required');
+    expect(boardsCreate).not.toHaveBeenCalled();
+  });
 });
 
 describe('branch MCP input schemas', () => {
@@ -420,6 +627,32 @@ describe('branch MCP input schemas', () => {
         branchName: 'siebel-crm',
         boardId: 'board-1',
         teammate: { displayName: '   ' },
+      }).success
+    ).toBe(false);
+  });
+
+  it('allows omitting boardId (teammate flow) and accepts a boolean createBoard', () => {
+    const config = registerAndCaptureConfig('agor_branches_create', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    // boardId is now optional at the schema level (required-ness for non-teammate
+    // branches is enforced in the handler).
+    expect(
+      config.inputSchema?.safeParse({
+        repoId: 'repo-1',
+        branchName: 'siebel-crm',
+        createBoard: true,
+        teammate: { displayName: 'Siebel CRM' },
+      }).success
+    ).toBe(true);
+
+    expect(
+      config.inputSchema?.safeParse({
+        repoId: 'repo-1',
+        branchName: 'siebel-crm',
+        createBoard: 'yes',
       }).success
     ).toBe(false);
   });

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { isBranchRbacEnabled, loadConfig } from '@agor/core/config';
 import { BranchRepository, shortId } from '@agor/core/db';
 import type {
+  Board,
   BoardID,
   Branch,
   BranchID,
@@ -16,7 +17,11 @@ import { computeZoneRelativePosition } from '@agor/core/utils/board-placement';
 import { normalizeOptionalHttpUrl } from '@agor/core/utils/url';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import type { BranchesServiceImpl, ReposServiceImpl } from '../../declarations.js';
+import type {
+  BoardsServiceImpl,
+  BranchesServiceImpl,
+  ReposServiceImpl,
+} from '../../declarations.js';
 import type { BranchParams } from '../../services/branches.js';
 import { isSuperAdmin } from '../../utils/branch-authorization.js';
 import {
@@ -419,7 +424,12 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation. ' +
         'To create a long-lived Agor teammate (a persistent AI teammate that manages other branches ' +
         'and maintains memory), pass the teammate object — this is the ONLY supported way to make a ' +
-        'teammate via MCP. Teammate status cannot be toggled later with agor_branches_update.',
+        'teammate via MCP. Teammate status cannot be toggled later with agor_branches_update. ' +
+        'Agor follows a soft 1:1 teammate↔board convention: when creating a teammate, boardId is ' +
+        'optional — omit it (or pass createBoard=true) to spin up a dedicated board for the teammate ' +
+        'and wire it as that board primary teammate. If you pass a boardId that already has a ' +
+        'different primary teammate, the branch is still created but a warning is returned (the ' +
+        'convention is not hard-enforced).',
       inputSchema: z.object({
         repoId: mcpRequiredId(
           'repoId',
@@ -432,11 +442,20 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
             'If the name conflicts with an existing branch, a numeric suffix is auto-appended (e.g., "my-feature-2"). ' +
             'Set autoSuffix=false to get an error on conflict instead.'
         ),
-        boardId: mcpRequiredId(
+        boardId: mcpOptionalId(
           'boardId',
           'Board',
-          'Board ID to place the branch on (positions to default coordinates). Required to ensure branches are visible in the UI.'
+          'Board ID to place the branch on (positions to default coordinates). Required for normal branches to ensure they are visible in the UI. ' +
+            'Optional when the teammate object is provided: omit it (or pass createBoard=true) to auto-create a dedicated board for the teammate.'
         ),
+        createBoard: z
+          .boolean()
+          .optional()
+          .describe(
+            'Teammate branches only. When true, create a fresh board for this teammate and wire it as ' +
+              'the board primary teammate (soft 1:1 teammate↔board convention). Mutually exclusive with boardId. ' +
+              'For a teammate, omitting both boardId and createBoard also auto-creates a board.'
+          ),
         ref: mcpOptionalString(
           'ref',
           'Git ref name to create or checkout. Defaults to branchName when creating a new git branch. ' +
@@ -551,8 +570,14 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       const repoId = await resolveRepoId(ctx, coerceString(args.repoId)!);
       let branchName = coerceString(args.branchName)!;
       const originalName = branchName;
-      const boardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
-      if (!boardId) throw new Error('boardId is required');
+      const boardIdArg = coerceString(args.boardId);
+      // Resolve the board up front only when one was passed. For teammate
+      // branches the board is optional (we may auto-create one below), so the
+      // required-board check is deferred to the board-strategy block.
+      let boardId: BoardID | undefined = boardIdArg
+        ? await resolveBoardId(ctx, boardIdArg)
+        : undefined;
+      const createBoardArg = typeof args.createBoard === 'boolean' ? args.createBoard : undefined;
       const zoneId = coerceString(args.zoneId);
       const autoSuffix = typeof args.autoSuffix === 'boolean' ? args.autoSuffix : true;
 
@@ -603,6 +628,79 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           createdViaOnboarding: teammateInput.createdViaOnboarding === true,
         };
       }
+
+      // Board strategy + soft 1:1 teammate<->board coupling.
+      //
+      // Convention (deliberately not hard-enforced): every teammate has a
+      // primary board and every board has a primary teammate. We reflect that
+      // on the tool surface without forcing it:
+      //   - teammate + no board  -> auto-create a dedicated board (becomes primary)
+      //   - teammate + createBoard=true -> same, explicit
+      //   - teammate + existing board that already has a *different* primary
+      //     teammate -> still create, but return a warning (do not block)
+      //   - normal branch -> boardId stays required (UI visibility invariant)
+      let createdBoard: Board | undefined;
+      let primaryTeammateWarning: string | undefined;
+
+      if (teammateConfig) {
+        if (boardId && createBoardArg === true) {
+          throw new Error(
+            'Pass either boardId (place the teammate on an existing board) or createBoard=true ' +
+              '(create a dedicated board), not both.'
+          );
+        }
+
+        if (!boardId) {
+          if (createBoardArg === false) {
+            throw new Error(
+              'boardId is required, or set createBoard=true (or omit createBoard) to auto-create ' +
+                'a dedicated board for this teammate.'
+            );
+          }
+
+          // No board given (or createBoard explicitly requested): spin up a
+          // dedicated board for this teammate. BranchesService.create then wires
+          // it as the board primary teammate via setPrimaryTeammateIfUnset.
+          const boardsService = ctx.app.service('boards') as unknown as BoardsServiceImpl;
+          createdBoard = (await boardsService.create(
+            {
+              name: teammateConfig.displayName,
+              created_by: ctx.userId,
+              ...(teammateConfig.emoji ? { icon: teammateConfig.emoji } : {}),
+            } as Partial<Board>,
+            ctx.baseServiceParams
+          )) as Board;
+          boardId = createdBoard.board_id;
+        } else {
+          // Existing board: honour the 1:1 convention softly. If the board
+          // already has a (different) primary teammate, warn — the new teammate
+          // will join the board but will NOT become its primary.
+          try {
+            const boardsService = ctx.app.service('boards') as unknown as BoardsServiceImpl;
+            const board = (await boardsService.get(boardId, ctx.baseServiceParams)) as Board;
+            if (board?.primary_teammate_id) {
+              primaryTeammateWarning =
+                `Board ${boardId} already has a primary teammate (${board.primary_teammate_id}). ` +
+                `Agor follows a soft 1:1 teammate↔board convention, so this teammate will be added ` +
+                `to the board but will NOT become its primary teammate. Omit boardId or pass ` +
+                `createBoard=true to give this teammate its own board.`;
+            }
+          } catch {
+            // resolveBoardId already validated the board exists; ignore any
+            // transient lookup failure here rather than block creation.
+          }
+        }
+      } else {
+        if (createBoardArg === true) {
+          throw new Error('createBoard is only supported when creating a teammate branch.');
+        }
+        if (!boardId) {
+          throw new Error('boardId is required');
+        }
+      }
+
+      // By here boardId is always resolved (passed, auto-created, or threw above).
+      if (!boardId) throw new Error('boardId is required');
 
       // Auto-suffix: resolve name conflicts by appending -2, -3, etc.
       // Uses direct DB query to bypass Feathers pagination limits
@@ -687,12 +785,32 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       }
 
       if (teammateConfig) {
-        const teammateResult = {
+        // No warning => this teammate is the sole/first primary on its board
+        // (freshly auto-created board, or an existing board with no prior
+        // primary). A warning means the board already had a different primary.
+        const becamePrimary = !primaryTeammateWarning;
+        response._teammate = {
           created: true,
           display_name: teammateConfig.displayName,
-          note: 'Created as a long-lived Agor teammate. The board primary teammate pointer and the teammate Knowledge namespace were provisioned automatically.',
+          primary_board_id: boardId,
+          is_board_primary_teammate: becamePrimary,
+          note: becamePrimary
+            ? 'Created as a long-lived Agor teammate and wired as the board primary teammate. The teammate Knowledge namespace was provisioned automatically.'
+            : 'Created as a long-lived Agor teammate. Its Knowledge namespace was provisioned, but the target board already had a primary teammate so this teammate is NOT the board primary.',
         };
-        response._teammate = teammateResult;
+
+        if (createdBoard) {
+          response._board = {
+            created: true,
+            board_id: createdBoard.board_id,
+            name: createdBoard.name,
+            note: 'A dedicated board was auto-created for this teammate (soft 1:1 teammate↔board convention).',
+          };
+        }
+
+        if (primaryTeammateWarning) {
+          response._warning = primaryTeammateWarning;
+        }
       }
 
       if (zoneId) {


### PR DESCRIPTION
## Motivation

Follow-up to #1861 (create teammate branches in one shot via `agor_branches_create`). On that PR, @mistercrunch left a review note:

> One side note is I've been trying to push for "general 1:1" coupling between assistants, boards, and knowledge namespaces. I like the idea that generally, all assistants have a primary board, and all boards have a primary assistant. I don't want to force it too much, but it's a nice assumption to have and can build-upon.
>
> [...] we might need for the interface to eventually reflect this, meaning we'd offer something like "also create a board" for this assistant, or if the board we're passing-in already has a primary assistant, we would warn or error, not sure.

This PR makes `agor_branches_create` reflect that convention — **softly, not enforced** — per the request. (Terminology note: since #1861, the codebase renamed *assistant* → *teammate*; this PR uses the current `teammate` naming. The branch name predates the rename.)

## What changed

Everything lives in the MCP tool surface (`apps/agor-daemon/src/mcp/tools/branches.ts`). **No service, schema, or DB changes** — the board↔teammate wiring reuses the existing `BranchesService.create` → `setPrimaryTeammateIfUnset` path, and `assertTeammateKindIsStable` / the `boards.primary_teammate_id` invariants are untouched.

1. **"Also create a board" for a teammate.** `boardId` is now optional for teammate branches. Omit it (or pass `createBoard=true`) and the tool auto-creates a dedicated board named after the teammate (with its emoji as icon); `BranchesService.create` then wires that board's `primary_teammate_id` to the new teammate. Normal (non-teammate) branches still require `boardId` — the UI-visibility invariant is unchanged.

2. **Warn, don't block, on a board that already has a different primary teammate.** If you pass a `boardId` whose board already has a `primary_teammate_id`, the branch is still created (the 1:1 assumption stays soft), but the response carries a `_warning` explaining the new teammate will **not** be the board primary, and points at the `createBoard=true` / omit-`boardId` escape hatch. Leaning warn-not-block as suggested.

3. **Soft, not forced.** `boardId` + `createBoard=true` together is rejected as ambiguous; `createBoard` on a non-teammate is rejected. Beyond that, nothing new is enforced — you *can* still put multiple teammates on one board, you just get told about it.

### Response additions (teammate branches)
- `_board` — present when a board was auto-created (`board_id`, `name`).
- `_teammate.is_board_primary_teammate` and `_teammate.primary_board_id` — so callers can see whether/where the teammate became the board primary.
- `_warning` — present when the target board already had a different primary teammate.

## Tests

Added to `branches.test.ts`:
- auto-creates a dedicated board when a teammate is created with no `boardId`
- `createBoard=true` explicitly creates a board
- warns (does not block) when the target board already has a different primary teammate
- rejects `boardId` + `createBoard=true`
- normal (non-teammate) branch still requires `boardId`
- schema accepts optional `boardId` + boolean `createBoard`

`vitest` (branches MCP suite, 37 tests), `tsc --noEmit`, and `biome` all pass. (The 9 unrelated `services/branches.test.ts` failures in this environment come from a local `~/.agor/config.yaml` `credentials`-key incompatibility and reproduce on `main` without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)