### PR TITLE
ci(docker): SHA-pinned from-source Agor image + Docker Hub publish

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,16 +1,18 @@
 # Build & push the Agor container image.
 #
 # Builds the `production-source` target of docker/Dockerfile and pushes it to
-# Docker Hub. Modeled on agor-cloud's build-images job (Buildx + GHA cache +
-# docker/metadata tags).
+# Docker Hub (Buildx + GHA cache + docker/metadata tags).
 #
 # `production-source` builds agor-live from THIS checkout (turbo build via
 # packages/agor-live/build.sh), so the image is pinned to the built commit
 # rather than `agor-live@latest` on npm.
 #
-# Publish model mirrors preset-io/manager: the :<full-sha> image is built and
-# pushed on every push AND every PR (tagged by the PR *head* commit), so any
-# commit is deployable by its own SHA. Plus a branch tag, and `latest` on main.
+# Publish model: the :<full-sha> image is built and pushed on pushes to
+# main, v* tags, AND every PR commit (tagged by the PR
+# *head* SHA, with :pr-<n> re-pointed on each update), so any commit is
+# deployable by its own SHA. Publishing unmerged PR builds under preset/agor
+# is intentional — pre-merge deploy testing needs it. The boot smoke test
+# below gates every publish. Plus a branch tag, and `latest` on main only.
 #
 # Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
 # (Settings → Secrets and variables → Actions):
@@ -87,7 +89,10 @@ jobs:
             org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
-      - name: Build and push
+      # Build once into the local Docker store so it can be smoke-tested before
+      # anything is published. The push step below reuses this build via the
+      # GHA layer cache, so it only re-exports layers.
+      - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -98,9 +103,42 @@ jobs:
           # daemon's stamp script can't derive it itself).
           build-args: |
             AGOR_BUILD_SHA=${{ env.IMAGE_REVISION }}
-          # Publish on every event (push + PR), manager-style.
+          load: true
+          tags: ${{ env.IMAGE }}:smoke
+          cache-from: type=gha,scope=agor-image
+          cache-to: type=gha,mode=max,scope=agor-image
+
+      # Boot the container and require a healthy daemon: exercises the deployed
+      # tree end to end (entrypoint init, db migrate, @agor/* symlink
+      # resolution, native modules) — catches deploy omissions the build alone
+      # can't see.
+      - name: Smoke test
+        run: |
+          docker run -d --name agor-smoke -p 3030:3030 ${{ env.IMAGE }}:smoke
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:3030/health > /dev/null 2>&1; then
+              echo "Daemon healthy."
+              docker rm -f agor-smoke
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Daemon did not become healthy within 120s"
+          docker logs agor-smoke
+          exit 1
+
+      # Publish on every event (push + PR), gated only by the smoke test
+      # above.
+      - name: Push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: production-source
+          platforms: linux/amd64
+          build-args: |
+            AGOR_BUILD_SHA=${{ env.IMAGE_REVISION }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=agor-image
-          cache-to: type=gha,mode=max,scope=agor-image

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,106 @@
+# Build & push the Agor container image.
+#
+# Builds the `production-source` target of docker/Dockerfile and pushes it to
+# Docker Hub. Modeled on agor-cloud's build-images job (Buildx + GHA cache +
+# docker/metadata tags).
+#
+# `production-source` builds agor-live from THIS checkout (turbo build via
+# packages/agor-live/build.sh), so the image is pinned to the built commit
+# rather than `agor-live@latest` on npm.
+#
+# Publish model mirrors preset-io/manager: the :<full-sha> image is built and
+# pushed on every push AND every PR (tagged by the PR *head* commit), so any
+# commit is deployable by its own SHA. Plus a branch tag, and `latest` on main.
+#
+# Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
+# (Settings → Secrets and variables → Actions):
+#   DOCKERHUB_USERNAME — Docker Hub account with push access to `preset`
+#   DOCKERHUB_TOKEN    — Docker Hub access token (Read/Write) for that account
+name: Build image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: true
+
+# docker.io is docker/login-action's default registry, so no `registry:` needed.
+env:
+  IMAGE: preset/agor
+  # The commit we build, stamp, and tag: the PR head on pull_request events
+  # (github.sha is the ephemeral merge commit there), else the pushed commit.
+  # Keeps the checkout, the :<sha> tag, and the in-app build banner in lockstep.
+  IMAGE_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  build:
+    name: Build & push
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # Build the PR's real head commit, not the ephemeral merge commit, so
+          # image contents match the :<sha> tag. No effect on push events.
+          ref: ${{ env.IMAGE_REVISION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # We push on every event (including PRs), so always log in. preset-io/agor
+      # PRs come from in-repo branches, so the secrets are available.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          # Make `type=sha` emit the PR *head* SHA, so the tag equals
+          # `git rev-parse HEAD` of the PR branch. No effect on push events.
+          DOCKER_METADATA_PR_HEAD_SHA: 'true'
+        with:
+          images: ${{ env.IMAGE }}
+          # Full commit SHA on every build (push + PR); a branch/PR ref tag;
+          # semver on git tags; `latest` only on the default branch.
+          tags: |
+            type=sha,prefix=,format=long
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=agor
+            org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: production-source
+          platforms: linux/amd64
+          # Real SHA for the in-app build banner (.git is dockerignored, so the
+          # daemon's stamp script can't derive it itself).
+          build-args: |
+            AGOR_BUILD_SHA=${{ env.IMAGE_REVISION }}
+          # Publish on every event (push + PR), manager-style.
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=agor-image
+          cache-to: type=gha,mode=max,scope=agor-image

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -164,3 +164,85 @@ EXPOSE ${DAEMON_PORT:-3030}
 
 # Use production entrypoint script
 ENTRYPOINT ["docker-entrypoint-prod.sh"]
+
+# ============================================================================
+# Stage 4a: Source builder (heavy; discarded — never shipped)
+# ============================================================================
+# Builds agor-live from THIS checkout via packages/agor-live/build.sh (turbo
+# build → copies each package's dist/ into agor-live/dist/{core,git,cli,daemon,
+# executor,ui} — the exact layout the npm package ships), then produces a
+# self-contained prod deployment with `pnpm deploy`: agor-live's bin/ + dist/ +
+# prod-only node_modules, with no monorepo source, dev deps, or pnpm store.
+FROM base AS source-builder
+
+USER root
+WORKDIR /app
+
+# Native-module toolchain (node-pty etc.) for the deploy step's install
+# lifecycle. Confined to this throwaway builder — never in the runtime image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential python3 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Full monorepo source. .dockerignore keeps node_modules/, dist/ and .git out.
+COPY . .
+
+# Real commit SHA for the in-app build banner. .git is dockerignored, so the
+# daemon's stamp-build-info.mjs can't run `git rev-parse` — it reads
+# AGOR_BUILD_SHA instead and writes dist/.build-info, which loadBuildInfo()
+# surfaces at startup. CI passes --build-arg AGOR_BUILD_SHA=<github.sha>; left
+# empty (local builds) the stamp falls back to the 'dev' sentinel.
+ARG AGOR_BUILD_SHA=""
+ENV AGOR_BUILD_SHA=${AGOR_BUILD_SHA}
+
+# Install workspace deps (dev deps needed for the turbo build), build agor-live
+# from source, then deploy a prod-only, self-contained tree to /opt/agor-live.
+# build.sh --skip-install avoids a redundant install; it also runs
+# check:agor-live-deps and check:pack, which gate the build. dist/ is in the
+# package's `files` allowlist, so `pnpm deploy` carries it into the output, and
+# agor-live's postinstall re-creates the @agor/{core,git} → dist symlinks there.
+RUN pnpm install --frozen-lockfile \
+  && bash packages/agor-live/build.sh --skip-install \
+  && pnpm --filter=agor-live deploy --prod /opt/agor-live
+
+# `pnpm deploy` runs agor-live's postinstall against the workspace copy, not the
+# deploy output — so the @agor/{core,git} → dist symlinks it creates never land
+# in /opt/agor-live. Recreate them here (same relative targets as
+# packages/agor-live/scripts/postinstall.js) so bare `@agor/core` / `@agor/git`
+# imports in the bundled daemon/cli resolve.
+RUN mkdir -p /opt/agor-live/node_modules/@agor \
+  && ln -sfn ../../dist/core /opt/agor-live/node_modules/@agor/core \
+  && ln -sfn ../../dist/git  /opt/agor-live/node_modules/@agor/git
+
+# ============================================================================
+# Stage 4b: Production from source (slim runtime — pinned to its git SHA)
+# ============================================================================
+# Same runtime shape as `production` (inherits base: Zellij, gh, and the
+# Claude/Codex/Gemini/OpenCode CLIs), but ships agor-live built from source
+# instead of `npm install -g agor-live@latest`. Only the deployed artifact is
+# copied in — the multi-GB builder (source + dev deps + store) is left behind.
+#
+#   docker build --target production-source -t agor:<sha> -f docker/Dockerfile .
+FROM base AS production-source
+
+USER root
+
+# The one thing we keep from the builder: the self-contained agor-live tree.
+# Copied to the SAME path so its internal (relative) symlinks stay valid.
+COPY --from=source-builder /opt/agor-live /opt/agor-live
+
+# Put the bins on PATH (shebang: #!/usr/bin/env node); they resolve deps + dist
+# entirely within /opt/agor-live.
+RUN ln -sf /opt/agor-live/bin/agor.js /usr/local/bin/agor \
+  && ln -sf /opt/agor-live/bin/agor-daemon.js /usr/local/bin/agor-daemon \
+  && chmod +x /opt/agor-live/bin/agor.js /opt/agor-live/bin/agor-daemon.js
+
+# Reuse the production entrypoint (agor init → db migrate → exec agor-daemon).
+COPY docker/docker-entrypoint-prod.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint-prod.sh
+
+# Drop back to the unprivileged runtime user.
+USER agor
+
+EXPOSE ${DAEMON_PORT:-3030}
+ENTRYPOINT ["docker-entrypoint-prod.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -207,12 +207,13 @@ RUN pnpm install --frozen-lockfile \
 
 # `pnpm deploy` runs agor-live's postinstall against the workspace copy, not the
 # deploy output — so the @agor/{core,git} → dist symlinks it creates never land
-# in /opt/agor-live. Recreate them here (same relative targets as
-# packages/agor-live/scripts/postinstall.js) so bare `@agor/core` / `@agor/git`
-# imports in the bundled daemon/cli resolve.
-RUN mkdir -p /opt/agor-live/node_modules/@agor \
-  && ln -sfn ../../dist/core /opt/agor-live/node_modules/@agor/core \
-  && ln -sfn ../../dist/git  /opt/agor-live/node_modules/@agor/git
+# in /opt/agor-live. Re-run the packaged postinstall (shipped via the package's
+# `files` allowlist) against the deployed tree so the symlink layout stays
+# defined in exactly one place. The script warns instead of failing, so assert
+# the links resolve — a broken image must fail the build, not the smoke test.
+RUN node /opt/agor-live/scripts/postinstall.js \
+  && test -e /opt/agor-live/node_modules/@agor/core \
+  && test -e /opt/agor-live/node_modules/@agor/git
 
 # ============================================================================
 # Stage 4b: Production from source (slim runtime — pinned to its git SHA)

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,11 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "build/**"]
     },
+    "@agor/daemon#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "build/**"],
+      "env": ["AGOR_BUILD_SHA", "AGOR_BUILT_AT"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## What

Adds a first-class, **SHA-pinned** container image for Agor, built from source, plus the CI to publish it to Docker Hub.

Tracks **preset-io/agor-cloud#166**.

## Changes

- **`docker/Dockerfile` — new `production-source` target.** Builds agor-live from *this checkout* via `packages/agor-live/build.sh` (turbo build → `dist/{core,git,cli,daemon,executor,ui}`, the same layout the npm package ships) instead of `npm install -g agor-live@latest`, so image contents match the built commit. Existing `base` / `development` / `production` targets are untouched.
- **Multi-stage / slim.** A `source-builder` stage builds and `pnpm deploy --prod`s a self-contained tree; the runtime stage copies only that. **~12.2 GB → ~5.96 GB.**
- **Build-info SHA stamping.** `.git` is dockerignored, so the daemon's stamp script can't derive the commit — it reads an `AGOR_BUILD_SHA` build-arg instead. `turbo.json` gains a `@agor/daemon#build` entry so Turbo's task-env filter passes the var through.
- **`.github/workflows/build-image.yml`** — publishes to Docker Hub (`preset/agor`): build + push the `:<full-sha>` image on every push **and** PR (tagged by the PR head commit), plus a branch/`pr-<n>` tag and `latest` on `main`.

## Registry / secrets

Pushes to `docker.io/preset/agor` using repo secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (already configured).

## CI impact

Purely additive except `turbo.json`: the existing `ci.yml` is unchanged in behavior (the new env vars are unset there); the daemon build cache takes a one-time miss, then is stable.

## Verification

- Image builds locally (exit 0); `agor` CLI + `agor-daemon` boot and serve the UI; bundled Claude / Codex / Gemini / OpenCode + Zellij / gh CLIs all present.
- The **SHA banner** (`sha=<real>` vs `sha=dev`) is verified end-to-end by this PR's own `build-image` run — first CI exercise of the `AGOR_BUILD_SHA` + turbo passthrough path.
