### PR TITLE
fix(daemon): scope task-start governance reads

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -446,6 +446,17 @@ export const TENANT_OWNED_SERVICE_PATHS = [
   'leaderboard',
 ];
 
+// These endpoints perform network/process work after their tenant DB reads,
+// so they carry tenant identity for the full request and open short database
+// units of work at the call site instead of holding an HTTP-long transaction.
+const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
+  'check-auth',
+  'claude-models',
+  'copilot-models',
+  'cursor-models',
+  'terminals',
+] as const;
+
 export function registerHooks(ctx: RegisterHooksContext): void {
   const {
     db,
@@ -561,6 +572,12 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         before: { all: [scopeTenantBefore] },
         after: { all: [assertTenantAfter] },
       });
+    }
+  };
+
+  const registerTenantIdentityHooks = (): void => {
+    for (const path of TENANT_IDENTITY_ONLY_SERVICE_PATHS) {
+      safeService(path)?.hooks({ around: { all: [tenantIdentityAround] } });
     }
   };
 
@@ -3344,4 +3361,5 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   if (tenantColumnsEnabled) {
     registerTenantHooks();
   }
+  registerTenantIdentityHooks();
 }

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -2603,24 +2603,31 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         async (context) => {
           const session = context.result as Session;
           if (session.agentic_tool !== 'claude-code-cli') return context;
-          try {
-            const branch = await context.app
-              .service('branches')
-              .get(session.branch_id, { provider: undefined });
-            const cwd = (branch as { path?: string } | undefined)?.path;
-            if (cwd) {
+          // Session creation is tenant-transactional. Defer filesystem,
+          // watcher, and terminal integration until after commit while retaining
+          // tenant identity; each DB helper then opens its own short unit.
+          deferWithTenantContext(
+            context.params,
+            async () => {
+              const branch = await context.app
+                .service('branches')
+                .get(session.branch_id, { provider: undefined });
+              const cwd = (branch as { path?: string } | undefined)?.path;
+              if (!cwd) {
+                console.warn(
+                  `[claude-cli-integration] no branch.path for session ${session.session_id}; skipping spawn`
+                );
+                return;
+              }
               const { onCliSessionCreated } = await import('./services/claude-cli-integration.js');
               await onCliSessionCreated(context.app, session, cwd);
-            } else {
-              console.warn(
-                `[claude-cli-integration] no branch.path for session ${session.session_id}; skipping spawn`
-              );
+            },
+            (err) => {
+              // Never fail the committed session on integration errors — the
+              // session row is still useful even if the watcher misfires.
+              console.error('[claude-cli-integration] onCliSessionCreated failed:', err);
             }
-          } catch (err) {
-            // Never fail the session create on integration errors — the
-            // session row is still useful even if the watcher misfires.
-            console.error('[claude-cli-integration] onCliSessionCreated failed:', err);
-          }
+          );
           return context;
         },
         async (context) => {

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -1098,16 +1098,22 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     },
     params: RouteParams
   ): Promise<Task> {
-    const { messageStartIndex, session: loadedSession } = await runWithTenantDatabaseScope(
-      db,
-      getCurrentTenantId(),
-      async () => ({
-        session: await sessionsService.get(task.session_id, params),
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for task executor startup');
+    const {
+      agenticToolEnabled,
+      messageStartIndex,
+      session: loadedSession,
+    } = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+      const session = await sessionsService.get(task.session_id, params);
+      return {
+        session,
+        agenticToolEnabled: await isTenantAgenticToolEnabled(session.agentic_tool, tenantDb),
         // Recompute message_range.start_index against the live message count.
         messageStartIndex: await sessionsRepository.countMessages(task.session_id),
-      })
-    );
-    if (!(await isTenantAgenticToolEnabled(loadedSession.agentic_tool, db))) {
+      };
+    });
+    if (!agenticToolEnabled) {
       throw new Forbidden(`${loadedSession.agentic_tool} is disabled for this workspace`);
     }
     const session = await sessionsService.materializeAgenticToolPreset(loadedSession, params);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -21,6 +21,7 @@ import {
   inArray,
   isPostgresDatabase,
   MCPServerRepository,
+  runWithTenantDatabaseScope,
   SessionMCPServerRepository,
   type SessionMCPServerRow,
   select,
@@ -721,7 +722,12 @@ function createExecuteHandler(
     if (!session) {
       throw new Error(`Session ${sessionId} not found`);
     }
-    if (!(await isTenantAgenticToolEnabled(session.agentic_tool, db))) {
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for executor startup');
+    const agenticToolEnabled = await runWithTenantDatabaseScope(db, tenantId, (tenantDb) =>
+      isTenantAgenticToolEnabled(session.agentic_tool, tenantDb)
+    );
+    if (!agenticToolEnabled) {
       throw new Error(`${session.agentic_tool} is disabled for this workspace`);
     }
     session = await sessionsService.materializeAgenticToolPreset(session, params);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -7,7 +7,6 @@
 
 import {
   type AgorConfig,
-  isTenantAgenticToolEnabled,
   PublicBaseUrlNotConfiguredError,
   requirePublicBaseUrl,
   resolveExecutionSecurityMode,
@@ -17,6 +16,7 @@ import {
   BoardRepository,
   BranchRepository,
   eq,
+  GatewayChannelRepository,
   getCurrentTenantId,
   inArray,
   isPostgresDatabase,
@@ -84,6 +84,7 @@ import { createConfigService } from './services/config.js';
 import { createContextService } from './services/context.js';
 import { createCopilotModelsService } from './services/copilot-models.js';
 import { createCursorModelsService } from './services/cursor-models.js';
+import { prepareSessionForExecutorStart } from './services/executor-startup.js';
 import { createFileService } from './services/file.js';
 import { createFilesService } from './services/files.js';
 import { createGatewayService } from './services/gateway.js';
@@ -718,19 +719,8 @@ function createExecuteHandler(
     // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type varies by context
     params: any
   ) => {
-    let session = await sessionsService.get(sessionId, params);
-    if (!session) {
-      throw new Error(`Session ${sessionId} not found`);
-    }
     const tenantId = getCurrentTenantId();
-    if (!tenantId) throw new Error('Missing active tenant context for executor startup');
-    const agenticToolEnabled = await runWithTenantDatabaseScope(db, tenantId, (tenantDb) =>
-      isTenantAgenticToolEnabled(session.agentic_tool, tenantDb)
-    );
-    if (!agenticToolEnabled) {
-      throw new Error(`${session.agentic_tool} is disabled for this workspace`);
-    }
-    session = await sessionsService.materializeAgenticToolPreset(session, params);
+    const session = await prepareSessionForExecutorStart(db, sessionsService, sessionId, params);
     if (
       session.agentic_tool_preset_id &&
       data.permissionMode !== undefined &&
@@ -783,12 +773,13 @@ function createExecuteHandler(
     // Get branch path
     let cwd = process.cwd();
     if (session.branch_id) {
-      try {
-        const branch = await app.service('branches').get(session.branch_id, params);
-        cwd = branch.path;
-      } catch (error) {
-        console.warn(`Could not get branch path for ${session.branch_id}:`, error);
-      }
+      const branchPath = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+        const branch = await new BranchRepository(tenantDb).findById(session.branch_id);
+        return branch?.path;
+      });
+      if (!branchPath)
+        throw new Error(`Branch ${session.branch_id} not found for executor startup`);
+      cwd = branchPath;
     }
 
     // Determine Unix user for executor
@@ -832,16 +823,15 @@ function createExecuteHandler(
     const userId = (params as AuthenticatedParams).user?.user_id as UserID | undefined;
 
     // Resolve gateway-level env vars
-    let gatewayEnv: import('@agor/core/types').GatewayEnvVar[] | undefined;
     const gatewaySource = (session.custom_context as Record<string, unknown> | undefined)
       ?.gateway_source as { channel_id?: string } | undefined;
-    if (gatewaySource?.channel_id) {
-      try {
-        const { GatewayChannelRepository, decryptApiKey, isEncrypted } = await import(
-          '@agor/core/db'
+    const executorEnv = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+      let gatewayEnv: import('@agor/core/types').GatewayEnvVar[] | undefined;
+      if (gatewaySource?.channel_id) {
+        const { decryptApiKey, isEncrypted } = await import('@agor/core/db');
+        const channel = await new GatewayChannelRepository(tenantDb).findById(
+          gatewaySource.channel_id
         );
-        const channelRepo = new GatewayChannelRepository(db);
-        const channel = await channelRepo.findById(gatewaySource.channel_id);
         if (channel?.agentic_config?.envVars) {
           gatewayEnv = channel.agentic_config.envVars.map((v) => ({
             ...v,
@@ -855,21 +845,19 @@ function createExecuteHandler(
             })(),
           }));
         }
-      } catch {
-        // Non-fatal
       }
-    }
 
-    // Provider connections are resolved once by the executor through the
-    // task-scoped daemon API. Generic process environment never carries them.
-    const executorEnv = await createUserProcessEnvironment(
-      userId,
-      db,
-      undefined,
-      !!executorUnixUser,
-      gatewayEnv,
-      sessionId as SessionID
-    );
+      // Provider connections are resolved once by the executor through the
+      // task-scoped daemon API. Generic process environment never carries them.
+      return createUserProcessEnvironment(
+        userId,
+        tenantDb,
+        undefined,
+        !!executorUnixUser,
+        gatewayEnv,
+        sessionId as SessionID
+      );
+    });
 
     // Validate required user environment variables
     const requiredUserEnvVars = config.execution?.required_user_env_vars;
@@ -886,14 +874,16 @@ function createExecuteHandler(
           '',
           'This is a one-time setup — once configured, this message will not appear again.',
         ].join('\n');
-        await appendSystemMessage({
-          app,
-          db,
-          sessionId,
-          taskId: data.taskId,
-          content: errorContent,
-          contentPreview: `Missing required env vars: ${missingVars.join(', ')}`,
-        });
+        await runWithTenantDatabaseScope(db, tenantId, (tenantDb) =>
+          appendSystemMessage({
+            app,
+            db,
+            sessionId,
+            taskId: data.taskId,
+            content: errorContent,
+            contentPreview: `Missing required env vars: ${missingVars.join(', ')}`,
+          })
+        );
         throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`);
       }
     }

--- a/apps/agor-daemon/src/services/check-auth.test.ts
+++ b/apps/agor-daemon/src/services/check-auth.test.ts
@@ -1,4 +1,5 @@
 import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
+import { runWithTenantContext } from '@agor/core/db';
 import { Claude } from '@agor/core/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCheckAuthService } from './check-auth';
@@ -21,6 +22,7 @@ vi.mock('@agor/core/sdk', () => ({
 const resolveApiKeyMock = vi.mocked(resolveApiKey);
 const isTenantAgenticToolEnabledMock = vi.mocked(isTenantAgenticToolEnabled);
 const claudeQueryMock = vi.mocked(Claude.query);
+const TEST_DB = { run: vi.fn() } as never;
 
 function mockClaudeAccount(account: Record<string, unknown> | null) {
   claudeQueryMock.mockReturnValue({
@@ -29,7 +31,13 @@ function mockClaudeAccount(account: Record<string, unknown> | null) {
   } as never);
 }
 
-const service = () => createCheckAuthService({} as never);
+const service = () => {
+  const delegate = createCheckAuthService(TEST_DB);
+  return {
+    create: (...args: Parameters<typeof delegate.create>) =>
+      runWithTenantContext('tenant-test', () => delegate.create(...args)),
+  };
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -85,12 +93,12 @@ describe('check-auth Claude subscription tokens', () => {
     expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
     expect(resolveApiKeyMock).toHaveBeenNthCalledWith(1, 'ANTHROPIC_API_KEY', {
       userId: 'user-1',
-      db: {},
+      db: TEST_DB,
       tool: 'claude-code',
     });
     expect(resolveApiKeyMock).toHaveBeenNthCalledWith(2, 'CLAUDE_CODE_OAUTH_TOKEN', {
       userId: 'user-1',
-      db: {},
+      db: TEST_DB,
       tool: 'claude-code',
     });
   });

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -17,7 +17,12 @@
  */
 
 import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
-import type { TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
 import type { SDKUserMessage } from '@agor/core/sdk';
 import { Claude } from '@agor/core/sdk';
 import type {
@@ -231,8 +236,16 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
     ): Promise<AuthCheckResult> {
       const { tool, apiKey: rawKey } = data;
       const userId = params?.user?.user_id as UserID | undefined;
+      const tenantId = getCurrentTenantId();
+      if (!tenantId) throw new Error('Missing active tenant context for agent authentication');
+      const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) =>
+        runWithTenantDatabaseScope(db, tenantId, work);
 
-      if (!(await isTenantAgenticToolEnabled(tool as AgenticToolName, db))) {
+      if (
+        !(await withTenantDatabase((tenantDb) =>
+          isTenantAgenticToolEnabled(tool as AgenticToolName, tenantDb)
+        ))
+      ) {
         return unauthenticated('none', `${tool} is disabled for this workspace.`);
       }
 
@@ -272,11 +285,14 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
 
       // Otherwise resolve from the tenant's explicit user/workspace policy.
       const toolName = tool as AgenticToolName;
-      const { apiKey, decryptionFailed, connection, useNativeAuth } = await resolveApiKey(keyName, {
-        userId,
-        db,
-        tool: toolName,
-      });
+      const { apiKey, decryptionFailed, connection, useNativeAuth } = await withTenantDatabase(
+        (tenantDb) =>
+          resolveApiKey(keyName, {
+            userId,
+            db: tenantDb,
+            tool: toolName,
+          })
+      );
 
       if (decryptionFailed) {
         return unauthenticated(
@@ -299,11 +315,13 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
       }
 
       if (tool === 'claude-code') {
-        const subscriptionResolution = await resolveApiKey('CLAUDE_CODE_OAUTH_TOKEN', {
-          userId,
-          db,
-          tool: 'claude-code',
-        });
+        const subscriptionResolution = await withTenantDatabase((tenantDb) =>
+          resolveApiKey('CLAUDE_CODE_OAUTH_TOKEN', {
+            userId,
+            db: tenantDb,
+            tool: 'claude-code',
+          })
+        );
 
         if (subscriptionResolution.decryptionFailed) {
           return unauthenticated(

--- a/apps/agor-daemon/src/services/claude-cli-integration.test.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.test.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { buildClaudeCliSpawn } from '@agor/core/claude-cli';
+import {
+  getCurrentTenantDatabaseScope,
+  runWithTenantContext,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Session } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -18,6 +23,7 @@ vi.mock('../mcp/tokens.js', () => ({
 }));
 
 const generatedPaths: string[] = [];
+const testDb = { run: vi.fn() } as unknown as TenantScopeAwareDatabase;
 
 function makeApp(
   config: {
@@ -26,7 +32,11 @@ function makeApp(
   } = {}
 ): Application {
   return {
-    get: (key: string) => (key === 'config' ? config : undefined),
+    get: (key: string) => {
+      if (key === 'config') return config;
+      if (key === 'database') return testDb;
+      return undefined;
+    },
   } as unknown as Application;
 }
 
@@ -101,9 +111,18 @@ describe('Claude CLI Agor MCP config', () => {
   });
 
   it('writes a private temp config for the session creator', async () => {
-    const filePath = await writeClaudeCliMcpConfigForSession(makeApp(), makeSession(), {
-      actor: { user_id: 'user-1', role: 'member' },
+    vi.mocked(generateSessionToken).mockImplementationOnce(async () => {
+      expect(getCurrentTenantDatabaseScope()).toMatchObject({
+        kind: 'tenant',
+        tenantId: 'tenant-x',
+      });
+      return 'tok_test';
     });
+    const filePath = await runWithTenantContext('tenant-x', () =>
+      writeClaudeCliMcpConfigForSession(makeApp(), makeSession(), {
+        actor: { user_id: 'user-1', role: 'member' },
+      })
+    );
     expect(filePath).toBeTruthy();
     generatedPaths.push(filePath as string);
 

--- a/apps/agor-daemon/src/services/claude-cli-integration.test.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.test.ts
@@ -141,6 +141,33 @@ describe('Claude CLI Agor MCP config', () => {
     );
   });
 
+  it('keeps token issuance best-effort after tenant scope entry succeeds', async () => {
+    vi.mocked(generateSessionToken).mockRejectedValueOnce(new Error('temporary token store error'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      runWithTenantContext('tenant-x', () =>
+        writeClaudeCliMcpConfigForSession(makeApp(), makeSession(), {
+          actor: { user_id: 'user-1', role: 'member' },
+        })
+      )
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to issue MCP token'),
+      'temporary token store error'
+    );
+  });
+
+  it('fails fast before token issuance without tenant identity', async () => {
+    await expect(
+      writeClaudeCliMcpConfigForSession(makeApp(), makeSession(), {
+        actor: { user_id: 'user-1', role: 'member' },
+      })
+    ).rejects.toThrow('Missing active tenant context for Claude CLI MCP config generation');
+    expect(generateSessionToken).not.toHaveBeenCalled();
+  });
+
   it('resolves the MCP config file owner from Unix isolation mode', () => {
     expect(resolveClaudeCliMcpConfigTargetUnixUser(undefined, makeSession())).toBeUndefined();
 

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -1424,13 +1424,22 @@ export async function writeClaudeCliMcpConfigForSession(
     return undefined;
   }
 
-  try {
-    const { generateSessionToken } = await import('../mcp/tokens.js');
-    const mcpToken = await generateSessionToken(
+  const db = getDb(app);
+  if (!db) throw new Error('Missing tenant database for Claude CLI MCP config generation');
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) {
+    throw new Error('Missing active tenant context for Claude CLI MCP config generation');
+  }
+  const { generateSessionToken } = await import('../mcp/tokens.js');
+  const mcpToken = await runWithTenantDatabaseScope(db, tenantId, () =>
+    generateSessionToken(
       app,
       session.session_id,
       session.created_by as import('@agor/core/types').UserID
-    );
+    )
+  );
+
+  try {
     const mcpConfig = buildClaudeCliAgorMcpConfig({
       daemonUrl: getDaemonUrl(),
       mcpToken,

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -117,11 +117,19 @@ export async function resolveClaudeCliProviderSpawn(
   built: { bin: string; args: string[] }
 ): Promise<{ bin: string; args: string[] } | null> {
   const db = getDb(app) ?? undefined;
-  if (!db || !(await isTenantAgenticToolEnabled('claude-code', db))) return null;
-  const resolved = await resolveProviderConnection('claude-code', {
-    userId: (session.created_by as import('@agor/core/types').UserID | null) ?? undefined,
-    db,
+  if (!db) return null;
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) {
+    throw new Error('Missing active tenant context for Claude CLI provider resolution');
+  }
+  const resolved = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+    if (!(await isTenantAgenticToolEnabled('claude-code', tenantDb))) return null;
+    return resolveProviderConnection('claude-code', {
+      userId: (session.created_by as import('@agor/core/types').UserID | null) ?? undefined,
+      db: tenantDb,
+    });
   });
+  if (!resolved) return null;
   const connection = resolved.connection as Record<string, string | undefined>;
   const hasCredential = [
     'ANTHROPIC_API_KEY',

--- a/apps/agor-daemon/src/services/claude-cli-integration.ts
+++ b/apps/agor-daemon/src/services/claude-cli-integration.ts
@@ -1431,13 +1431,22 @@ export async function writeClaudeCliMcpConfigForSession(
     throw new Error('Missing active tenant context for Claude CLI MCP config generation');
   }
   const { generateSessionToken } = await import('../mcp/tokens.js');
-  const mcpToken = await runWithTenantDatabaseScope(db, tenantId, () =>
-    generateSessionToken(
-      app,
-      session.session_id,
-      session.created_by as import('@agor/core/types').UserID
-    )
-  );
+  const mcpToken = await runWithTenantDatabaseScope(db, tenantId, async () => {
+    try {
+      return await generateSessionToken(
+        app,
+        session.session_id,
+        session.created_by as import('@agor/core/types').UserID
+      );
+    } catch (err) {
+      console.warn(
+        `[claude-cli-integration] failed to issue MCP token for session ${shortId(session.session_id)}; Agor MCP tools will be unavailable in Claude CLI/RemoteTrigger:`,
+        err instanceof Error ? err.message : String(err)
+      );
+      return undefined;
+    }
+  });
+  if (!mcpToken) return undefined;
 
   try {
     const mcpConfig = buildClaudeCliAgorMcpConfig({
@@ -1514,6 +1523,8 @@ export async function onCliSessionCreated(
   branchCwd: string
 ): Promise<void> {
   if (session.agentic_tool !== 'claude-code-cli') return;
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) throw new Error('Missing active tenant context for Claude CLI session startup');
   const homeDir = resolveHomeDirForCliSession(session);
   const slug = slugForCwd(branchCwd);
   const jsonlPath = claudeSessionJsonlPath(homeDir, branchCwd, session.session_id);
@@ -1540,20 +1551,22 @@ export async function onCliSessionCreated(
   try {
     const db = getDb(app);
     if (db) {
-      const repo = new SessionRepository(db);
-      const row = await repo.findById(session.session_id).catch(() => null);
-      if (row) {
-        const patch = {
-          sdk_session_id: session.session_id,
-          cli_state: {
-            ...(row.cli_state ?? {}),
-            slug,
-            jsonl_path: jsonlPath,
-            zellij_tab_name: tabName,
-          },
-        } satisfies Partial<Session>;
-        await repo.update(session.session_id, patch);
-      }
+      await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+        const repo = new SessionRepository(tenantDb);
+        const row = await repo.findById(session.session_id).catch(() => null);
+        if (row) {
+          const patch = {
+            sdk_session_id: session.session_id,
+            cli_state: {
+              ...(row.cli_state ?? {}),
+              slug,
+              jsonl_path: jsonlPath,
+              zellij_tab_name: tabName,
+            },
+          } satisfies Partial<Session>;
+          await repo.update(session.session_id, patch);
+        }
+      });
     }
   } catch (err) {
     console.warn('[claude-cli-integration] failed to persist initial cli_state', err);

--- a/apps/agor-daemon/src/services/claude-models.ts
+++ b/apps/agor-daemon/src/services/claude-models.ts
@@ -7,7 +7,12 @@
  */
 
 import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
-import { shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { AVAILABLE_CLAUDE_MODEL_ALIASES, DEFAULT_CLAUDE_MODEL } from '@agor/core/models';
 import type { Params, UserID } from '@agor/core/types';
 import Anthropic from '@anthropic-ai/sdk';
@@ -113,14 +118,18 @@ export class ClaudeModelsService {
   constructor(private db: TenantScopeAwareDatabase) {}
 
   async find(params?: AuthenticatedParams): Promise<ClaudeModelsResult> {
-    if (!(await isTenantAgenticToolEnabled('claude-code', this.db))) {
-      throw new Error('Claude Code is disabled for this workspace');
-    }
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for Claude model discovery');
     const userId = params?.user?.user_id;
-    const resolution = await resolveApiKey('ANTHROPIC_API_KEY', {
-      userId,
-      db: this.db,
-      tool: 'claude-code',
+    const resolution = await runWithTenantDatabaseScope(this.db, tenantId, async (tenantDb) => {
+      if (!(await isTenantAgenticToolEnabled('claude-code', tenantDb))) {
+        throw new Error('Claude Code is disabled for this workspace');
+      }
+      return resolveApiKey('ANTHROPIC_API_KEY', {
+        userId,
+        db: tenantDb,
+        tool: 'claude-code',
+      });
     });
 
     if (!resolution.apiKey) {

--- a/apps/agor-daemon/src/services/copilot-models.ts
+++ b/apps/agor-daemon/src/services/copilot-models.ts
@@ -25,7 +25,12 @@
  */
 
 import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
-import { shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { COPILOT_MODEL_METADATA, DEFAULT_COPILOT_MODEL } from '@agor/core/models';
 import type { Params, UserID } from '@agor/core/types';
 import { CopilotClient, type ModelInfo } from '@github/copilot-sdk';
@@ -73,17 +78,21 @@ export class CopilotModelsService {
   constructor(private db: TenantScopeAwareDatabase) {}
 
   async find(params?: AuthenticatedParams): Promise<CopilotModelsResult> {
-    if (!(await isTenantAgenticToolEnabled('copilot', this.db))) {
-      throw new Error('GitHub Copilot is disabled for this workspace');
-    }
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for Copilot model discovery');
     const userId = params?.user?.user_id;
 
     // Resolve the GitHub token through the tenant's explicit scope policy.
     // Falls through to static if nothing is configured anywhere.
-    const resolution = await resolveApiKey('COPILOT_GITHUB_TOKEN', {
-      userId,
-      db: this.db,
-      tool: 'copilot',
+    const resolution = await runWithTenantDatabaseScope(this.db, tenantId, async (tenantDb) => {
+      if (!(await isTenantAgenticToolEnabled('copilot', tenantDb))) {
+        throw new Error('GitHub Copilot is disabled for this workspace');
+      }
+      return resolveApiKey('COPILOT_GITHUB_TOKEN', {
+        userId,
+        db: tenantDb,
+        tool: 'copilot',
+      });
     });
 
     if (!resolution.apiKey) {

--- a/apps/agor-daemon/src/services/cursor-models.test.ts
+++ b/apps/agor-daemon/src/services/cursor-models.test.ts
@@ -1,3 +1,4 @@
+import { runWithTenantContext } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const configMocks = vi.hoisted(() => ({
@@ -32,8 +33,10 @@ describe('CursorModelsService', () => {
       { id: 'composer-latest', displayName: 'Composer Latest' },
     ]);
 
-    const service = new CursorModelsService({} as never);
-    const result = await service.find({ user: { user_id: 'user-id' } } as never);
+    const service = new CursorModelsService({ run: vi.fn() } as never);
+    const result = await runWithTenantContext('tenant-test', () =>
+      service.find({ user: { user_id: 'user-id' } } as never)
+    );
 
     expect(result.default).toBe('composer-latest');
     expect(result.source).toBe('dynamic');
@@ -44,8 +47,10 @@ describe('CursorModelsService', () => {
     configMocks.resolveApiKey.mockResolvedValue({ apiKey: 'cursor-key', source: 'user' });
     cursorMocks.modelsList.mockRejectedValue(new Error('boom'));
 
-    const service = new CursorModelsService({} as never);
-    const result = await service.find({ user: { user_id: 'user-id' } } as never);
+    const service = new CursorModelsService({ run: vi.fn() } as never);
+    const result = await runWithTenantContext('tenant-test', () =>
+      service.find({ user: { user_id: 'user-id' } } as never)
+    );
 
     expect(result).toMatchObject({
       default: 'composer-latest',

--- a/apps/agor-daemon/src/services/cursor-models.ts
+++ b/apps/agor-daemon/src/services/cursor-models.ts
@@ -8,7 +8,12 @@
  */
 
 import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
-import { shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { CURSOR_MODEL_METADATA, DEFAULT_CURSOR_MODEL } from '@agor/core/models';
 import type { Params, UserID } from '@agor/core/types';
 import { Cursor, type SDKModel } from '@cursor/sdk';
@@ -72,14 +77,18 @@ export class CursorModelsService {
   constructor(private db: TenantScopeAwareDatabase) {}
 
   async find(params?: AuthenticatedParams): Promise<CursorModelsResult> {
-    if (!(await isTenantAgenticToolEnabled('cursor', this.db))) {
-      throw new Error('Cursor is disabled for this workspace');
-    }
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for Cursor model discovery');
     const userId = params?.user?.user_id;
-    const resolution = await resolveApiKey('CURSOR_API_KEY', {
-      userId,
-      db: this.db,
-      tool: 'cursor',
+    const resolution = await runWithTenantDatabaseScope(this.db, tenantId, async (tenantDb) => {
+      if (!(await isTenantAgenticToolEnabled('cursor', tenantDb))) {
+        throw new Error('Cursor is disabled for this workspace');
+      }
+      return resolveApiKey('CURSOR_API_KEY', {
+        userId,
+        db: tenantDb,
+        tool: 'cursor',
+      });
     });
 
     if (!resolution.apiKey) {

--- a/apps/agor-daemon/src/services/executor-startup.test.ts
+++ b/apps/agor-daemon/src/services/executor-startup.test.ts
@@ -1,0 +1,129 @@
+import {
+  getCurrentTenantDatabaseScope,
+  runWithSystemDatabaseScope,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+} from '@agor/core/db';
+import type { Session } from '@agor/core/types';
+import { SessionStatus } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  isTenantAgenticToolEnabled: vi.fn(async () => true),
+}));
+
+vi.mock('@agor/core/config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agor/core/config')>()),
+  isTenantAgenticToolEnabled: mocks.isTenantAgenticToolEnabled,
+}));
+
+import { prepareSessionForExecutorStart } from './executor-startup';
+
+const session = {
+  session_id: 'session-1',
+  branch_id: 'branch-1',
+  agentic_tool: 'codex',
+  status: SessionStatus.IDLE,
+} as Session;
+
+function createSessionsService() {
+  return {
+    get: vi.fn(async () => {
+      expect(getCurrentTenantDatabaseScope()).toMatchObject({
+        kind: 'tenant',
+        tenantId: 'tenant-x',
+      });
+      return session;
+    }),
+    materializeAgenticToolPreset: vi.fn(async (loaded: Session) => {
+      expect(getCurrentTenantDatabaseScope()).toMatchObject({
+        kind: 'tenant',
+        tenantId: 'tenant-x',
+      });
+      return loaded;
+    }),
+  };
+}
+
+describe('prepareSessionForExecutorStart tenant scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isTenantAgenticToolEnabled.mockImplementation(async (_tool, db) => {
+      expect(db).toBe(getCurrentTenantDatabaseScope()?.db);
+      return true;
+    });
+  });
+
+  it('opens one short tenant unit of work from identity-only context', async () => {
+    const db = { run: vi.fn() } as never;
+    const sessionsService = createSessionsService();
+
+    await expect(
+      runWithTenantContext('tenant-x', () =>
+        prepareSessionForExecutorStart(
+          db,
+          sessionsService as never,
+          session.session_id,
+          {} as never
+        )
+      )
+    ).resolves.toBe(session);
+
+    expect(sessionsService.get).toHaveBeenCalledOnce();
+    expect(sessionsService.materializeAgenticToolPreset).toHaveBeenCalledOnce();
+    expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+  });
+
+  it('joins an existing tenant database scope', async () => {
+    const db = { run: vi.fn() } as never;
+    const sessionsService = createSessionsService();
+
+    await runWithTenantContext('tenant-x', () =>
+      runWithTenantDatabaseScope(db, 'tenant-x', async () => {
+        const outerScope = getCurrentTenantDatabaseScope();
+        await prepareSessionForExecutorStart(
+          db,
+          sessionsService as never,
+          session.session_id,
+          {} as never
+        );
+        expect(getCurrentTenantDatabaseScope()).toBe(outerScope);
+      })
+    );
+  });
+
+  it('fails fast for missing, mismatched, and system tenant identity', async () => {
+    const db = { run: vi.fn() } as never;
+    const sessionsService = createSessionsService();
+
+    await expect(
+      prepareSessionForExecutorStart(db, sessionsService as never, session.session_id, {} as never)
+    ).rejects.toThrow('Missing active tenant context for executor startup');
+
+    await runWithTenantDatabaseScope(db, 'tenant-b', async () => {
+      await expect(
+        runWithTenantContext('tenant-x', () =>
+          prepareSessionForExecutorStart(
+            db,
+            sessionsService as never,
+            session.session_id,
+            {} as never
+          )
+        )
+      ).rejects.toThrow('Cannot enter tenant scope tenant-x from active tenant scope tenant-b');
+    });
+
+    await runWithSystemDatabaseScope(db, 'executor startup test', async () => {
+      await expect(
+        runWithTenantContext('tenant-x', () =>
+          prepareSessionForExecutorStart(
+            db,
+            sessionsService as never,
+            session.session_id,
+            {} as never
+          )
+        )
+      ).rejects.toThrow('Cannot enter tenant scope tenant-x from active system database scope');
+    });
+  });
+});

--- a/apps/agor-daemon/src/services/executor-startup.ts
+++ b/apps/agor-daemon/src/services/executor-startup.ts
@@ -1,0 +1,33 @@
+import { isTenantAgenticToolEnabled } from '@agor/core/config';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
+import type { AuthenticatedParams, Session } from '@agor/core/types';
+import type { SessionsServiceImpl } from '../declarations.js';
+
+type ExecutorStartupSessionsService = Pick<
+  SessionsServiceImpl,
+  'get' | 'materializeAgenticToolPreset'
+>;
+
+/** Load and validate the session state needed before any executor/process work begins. */
+export async function prepareSessionForExecutorStart(
+  db: TenantScopeAwareDatabase,
+  sessionsService: ExecutorStartupSessionsService,
+  sessionId: string,
+  params: AuthenticatedParams
+): Promise<Session> {
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) throw new Error('Missing active tenant context for executor startup');
+
+  return runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+    const session = await sessionsService.get(sessionId, params);
+    if (!session) throw new Error(`Session ${sessionId} not found`);
+    if (!(await isTenantAgenticToolEnabled(session.agentic_tool, tenantDb))) {
+      throw new Error(`${session.agentic_tool} is disabled for this workspace`);
+    }
+    return sessionsService.materializeAgenticToolPreset(session, params);
+  });
+}

--- a/apps/agor-daemon/src/services/sessions.materialize-agentic-tool-preset.test.ts
+++ b/apps/agor-daemon/src/services/sessions.materialize-agentic-tool-preset.test.ts
@@ -1,0 +1,150 @@
+import {
+  AgenticToolPresetRepository,
+  BranchRepository,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  generateId,
+  getCurrentTenantDatabaseScope,
+  RepoRepository,
+  runWithSystemDatabaseScope,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+  SessionRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import type { Session, UserID } from '@agor/core/types';
+import { SessionStatus } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { SessionsService } from './sessions';
+
+const STUB_APP = {} as Application;
+const ACTOR_ID = '00000000-0000-7000-8000-000000000001' as UserID;
+
+async function seedPresetSession(db: Database) {
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `repo-${generateId()}`,
+    name: 'Tenant scope test repo',
+    repo_type: 'remote',
+    remote_url: 'https://github.com/test/repo.git',
+    local_path: `/tmp/${generateId()}`,
+    default_branch: 'main',
+  });
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name: 'tenant-scope-test',
+    ref: 'tenant-scope-test',
+    branch_unique_id: Math.floor(Math.random() * 1_000_000),
+    path: `/tmp/${generateId()}`,
+    base_ref: 'main',
+    new_branch: false,
+    created_by: ACTOR_ID,
+  });
+  const preset = await new AgenticToolPresetRepository(db).create(
+    {
+      tool: 'codex',
+      name: 'Task start preset',
+      configuration: { modelConfig: { mode: 'exact', model: 'gpt-5.4' } },
+    },
+    ACTOR_ID
+  );
+  const session = await new SessionRepository(db).create({
+    session_id: generateId(),
+    branch_id: branch.branch_id,
+    agentic_tool: 'codex',
+    agentic_tool_preset_id: preset.preset_id,
+    status: SessionStatus.IDLE,
+    created_by: ACTOR_ID,
+    git_state: { ref: 'main', base_sha: 'abc', current_sha: 'abc' },
+    tasks: [],
+    contextFiles: [],
+    genealogy: { children: [] },
+  });
+  return session;
+}
+
+describe('SessionsService.materializeAgenticToolPreset tenant scope', () => {
+  dbTest('opens a tenant unit of work from identity-only context', async ({ db }) => {
+    const session = await seedPresetSession(db);
+    const guardedDb = createTenantScopedDatabaseProxy(db, {
+      requireScope: true,
+      label: 'materialize preset test',
+    });
+    const service = new SessionsService(guardedDb, STUB_APP);
+    const sessionRepo = (service as unknown as { sessionRepo: SessionRepository }).sessionRepo;
+    const originalUpdate = sessionRepo.update.bind(sessionRepo);
+    const seenScopes: unknown[] = [];
+    vi.spyOn(sessionRepo, 'update').mockImplementation(async (...args) => {
+      seenScopes.push(getCurrentTenantDatabaseScope());
+      return originalUpdate(...args);
+    });
+
+    const materialized = await runWithTenantContext('tenant-x', () =>
+      service.materializeAgenticToolPreset(session)
+    );
+
+    expect(materialized.model_config?.model).toBe('gpt-5.4');
+    expect(seenScopes).toHaveLength(1);
+    expect(seenScopes[0]).toMatchObject({ kind: 'tenant', tenantId: 'tenant-x' });
+    expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+  });
+
+  dbTest('joins an existing tenant database scope', async ({ db }) => {
+    const session = await seedPresetSession(db);
+    const guardedDb = createTenantScopedDatabaseProxy(db, { requireScope: true });
+    const service = new SessionsService(guardedDb, STUB_APP);
+    const sessionRepo = (service as unknown as { sessionRepo: SessionRepository }).sessionRepo;
+    const originalUpdate = sessionRepo.update.bind(sessionRepo);
+    let updateScope: unknown;
+    vi.spyOn(sessionRepo, 'update').mockImplementation(async (...args) => {
+      updateScope = getCurrentTenantDatabaseScope();
+      return originalUpdate(...args);
+    });
+
+    await runWithTenantContext('tenant-x', () =>
+      runWithTenantDatabaseScope(guardedDb, 'tenant-x', async () => {
+        const outerScope = getCurrentTenantDatabaseScope();
+        await service.materializeAgenticToolPreset(session);
+        expect(updateScope).toBe(outerScope);
+      })
+    );
+  });
+
+  dbTest('scopes inline-policy validation when no preset is selected', async ({ db }) => {
+    const presetSession = await seedPresetSession(db);
+    const inlineSession = {
+      ...presetSession,
+      agentic_tool_preset_id: null,
+    } as Session;
+    const guardedDb = createTenantScopedDatabaseProxy(db, { requireScope: true });
+    const service = new SessionsService(guardedDb, STUB_APP);
+
+    await expect(
+      runWithTenantContext('tenant-x', () => service.materializeAgenticToolPreset(inlineSession))
+    ).resolves.toBe(inlineSession);
+  });
+
+  dbTest('fails fast for missing or mismatched tenant identity', async ({ db }) => {
+    const session = await seedPresetSession(db);
+    const guardedDb = createTenantScopedDatabaseProxy(db, { requireScope: true });
+    const service = new SessionsService(guardedDb, STUB_APP);
+
+    await expect(service.materializeAgenticToolPreset(session)).rejects.toThrow(
+      'Missing active tenant context for agentic tool preset materialization'
+    );
+
+    await runWithTenantDatabaseScope(guardedDb, 'tenant-b', async () => {
+      await expect(
+        runWithTenantContext('tenant-a', () => service.materializeAgenticToolPreset(session))
+      ).rejects.toThrow('Cannot enter tenant scope tenant-a from active tenant scope tenant-b');
+    });
+
+    await runWithSystemDatabaseScope(guardedDb, 'materialization system test', async () => {
+      await expect(
+        runWithTenantContext('tenant-a', () => service.materializeAgenticToolPreset(session))
+      ).rejects.toThrow('Cannot enter tenant scope tenant-a from active system database scope');
+    });
+  });
+});

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -15,6 +15,8 @@ import {
 } from '@agor/core/config';
 import {
   BranchRepository,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
   SessionEnvSelectionRepository,
   SessionMCPServerRepository,
   SessionRelationshipRepository,
@@ -261,21 +263,27 @@ export class SessionsService extends DrizzleService<Session, Partial<Session>, S
 
   /** Re-resolve a live preset immediately before a task starts. */
   async materializeAgenticToolPreset(session: Session, _params?: SessionParams): Promise<Session> {
-    if (!session.agentic_tool_preset_id) {
-      await assertInlineAgenticConfigurationAllowed(this.db, session.agentic_tool);
-      return session;
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) {
+      throw new Error('Missing active tenant context for agentic tool preset materialization');
     }
-    const preset = await resolveAgenticToolPreset(
-      this.db,
-      session.agentic_tool,
-      session.agentic_tool_preset_id
-    );
-    const updated = await this.sessionRepo.update(
-      session.session_id,
-      presetConfigurationToSessionPatch(session.agentic_tool, preset.configuration),
-      { replaceAgenticConfig: true }
-    );
-    return updated;
+
+    return runWithTenantDatabaseScope(this.db, tenantId, async (tenantDb) => {
+      if (!session.agentic_tool_preset_id) {
+        await assertInlineAgenticConfigurationAllowed(tenantDb, session.agentic_tool);
+        return session;
+      }
+      const preset = await resolveAgenticToolPreset(
+        tenantDb,
+        session.agentic_tool,
+        session.agentic_tool_preset_id
+      );
+      return this.sessionRepo.update(
+        session.session_id,
+        presetConfigurationToSessionPatch(session.agentic_tool, preset.configuration),
+        { replaceAgenticConfig: true }
+      );
+    });
   }
 
   protected async fetchData(_query: Query, params?: SessionParams): Promise<Session[]> {

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -12,6 +12,10 @@ const mocks = vi.hoisted(() => {
   };
   return {
     branch,
+    tenantId: 'tenant-x' as string | undefined,
+    tenantDb: { scope: 'tenant-x' },
+    databaseScopeDepth: 0,
+    repositoryDbs: [] as unknown[],
     branchesById: new Map<string, typeof branch>([[branch.branch_id, branch]]),
     execSync: vi.fn((cmd: string) => {
       if (cmd === 'which zellij') return Buffer.from('/usr/bin/zellij\n');
@@ -37,6 +41,9 @@ vi.mock('@agor/core/config', () => ({
 
 vi.mock('@agor/core/db', () => ({
   BranchRepository: class {
+    constructor(db: unknown) {
+      mocks.repositoryDbs.push(db);
+    }
     async findById(branchId: string) {
       return mocks.branchesById.get(branchId) ?? null;
     }
@@ -44,8 +51,29 @@ vi.mock('@agor/core/db', () => ({
       return true;
     }
   },
-  SessionRepository: class {},
+  getCurrentTenantId: () => mocks.tenantId,
+  runWithTenantDatabaseScope: async (
+    _db: unknown,
+    tenantId: string | undefined,
+    work: (db: unknown) => Promise<unknown>
+  ) => {
+    if (!tenantId) throw new Error('Missing tenant identity');
+    mocks.databaseScopeDepth += 1;
+    try {
+      return await work(mocks.tenantDb);
+    } finally {
+      mocks.databaseScopeDepth -= 1;
+    }
+  },
+  SessionRepository: class {
+    constructor(db: unknown) {
+      mocks.repositoryDbs.push(db);
+    }
+  },
   UsersRepository: class {
+    constructor(db: unknown) {
+      mocks.repositoryDbs.push(db);
+    }
     async findById() {
       return { unix_username: 'alice' };
     }
@@ -101,6 +129,51 @@ const params = {
   provider: 'rest',
   user: { user_id: 'user-1', role: 'admin' },
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.tenantId = 'tenant-x';
+  mocks.databaseScopeDepth = 0;
+  mocks.repositoryDbs.length = 0;
+});
+
+describe('TerminalsService tenant database units of work', () => {
+  it('keeps repository and environment reads scoped while process spawn stays outside', async () => {
+    mocks.branchesById.clear();
+    mocks.branchesById.set(mocks.branch.branch_id, mocks.branch);
+    mocks.resolveUserEnvironment.mockImplementation(async () => {
+      expect(mocks.databaseScopeDepth).toBeGreaterThan(0);
+      return {};
+    });
+    mocks.createUserProcessEnvironment.mockImplementation(async () => {
+      expect(mocks.databaseScopeDepth).toBeGreaterThan(0);
+      return {};
+    });
+    mocks.spawnExecutorFireAndForget.mockImplementation(() => {
+      expect(mocks.databaseScopeDepth).toBe(0);
+    });
+
+    const service = new TerminalsService(makeApp() as never, {} as never);
+    await service.create({ branchId: mocks.branch.branch_id }, params as never);
+
+    expect(mocks.repositoryDbs.length).toBeGreaterThan(0);
+    expect(mocks.repositoryDbs).toEqual(
+      expect.arrayContaining([mocks.tenantDb, mocks.tenantDb, mocks.tenantDb])
+    );
+    expect(mocks.spawnExecutorFireAndForget).toHaveBeenCalledOnce();
+    expect(mocks.databaseScopeDepth).toBe(0);
+  });
+
+  it('fails fast without ambient tenant identity', async () => {
+    mocks.tenantId = undefined;
+    const service = new TerminalsService(makeApp() as never, {} as never);
+
+    await expect(service.create({}, params as never)).rejects.toThrow(
+      'Missing active tenant context for terminal creation'
+    );
+    expect(mocks.spawnExecutorFireAndForget).not.toHaveBeenCalled();
+  });
+});
 
 describe('TerminalsService cold-start concurrency', () => {
   beforeEach(() => {

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -30,9 +30,12 @@ import {
 } from '@agor/core/config';
 import {
   BranchRepository,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
   SessionRepository,
   shortId,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
@@ -250,6 +253,14 @@ export class TerminalsService {
     }
   }
 
+  private withTenantDatabase<T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>): Promise<T> {
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) {
+      throw new Error('Missing active tenant context for terminal database access');
+    }
+    return runWithTenantDatabaseScope(this.db, tenantId, work);
+  }
+
   /**
    * Create a new terminal session
    *
@@ -266,6 +277,10 @@ export class TerminalsService {
     isNew: boolean;
     branchName?: string;
   }> {
+    if (!getCurrentTenantId()) {
+      throw new Error('Missing active tenant context for terminal creation');
+    }
+
     // Check if Zellij is available
     if (!this.zellijAvailable) {
       throw new Error(
@@ -286,30 +301,32 @@ export class TerminalsService {
         if (!userId) {
           throw new Forbidden('Authentication required to open terminals');
         }
-        const branchRepo = new BranchRepository(this.db);
-        const branch = await branchRepo.findById(data.branchId);
-        if (!branch) {
-          throw new Forbidden(`Branch not found: ${data.branchId}`);
-        }
-        const isOwner = await branchRepo.isOwner(branch.branch_id, userId);
-        const effectivePermission = await branchRepo.resolveUserPermission(branch, userId);
-        const allowSuperadmin = config.execution?.allow_superadmin === true;
-        const userRole = params?.user?.role as string | undefined;
-        if (
-          !hasBranchPermission(
-            branch,
-            userId,
-            isOwner,
-            'session',
-            userRole,
-            allowSuperadmin,
-            effectivePermission
-          )
-        ) {
-          throw new Forbidden(
-            `You need 'session' permission on branch ${branch.name} to open a terminal there.`
-          );
-        }
+        await this.withTenantDatabase(async (tenantDb) => {
+          const branchRepo = new BranchRepository(tenantDb);
+          const branch = await branchRepo.findById(data.branchId!);
+          if (!branch) {
+            throw new Forbidden(`Branch not found: ${data.branchId}`);
+          }
+          const isOwner = await branchRepo.isOwner(branch.branch_id, userId);
+          const effectivePermission = await branchRepo.resolveUserPermission(branch, userId);
+          const allowSuperadmin = config.execution?.allow_superadmin === true;
+          const userRole = params?.user?.role as string | undefined;
+          if (
+            !hasBranchPermission(
+              branch,
+              userId,
+              isOwner,
+              'session',
+              userRole,
+              allowSuperadmin,
+              effectivePermission
+            )
+          ) {
+            throw new Forbidden(
+              `You need 'session' permission on branch ${branch.name} to open a terminal there.`
+            );
+          }
+        });
       }
     }
 
@@ -442,9 +459,9 @@ export class TerminalsService {
     sessionId: string;
   } | null> {
     if (!sessionId) return null;
-    try {
-      const sessionRepo = new SessionRepository(this.db);
-      const session = await sessionRepo.findById(sessionId).catch(() => null);
+    const config = params?.provider ? await loadConfig() : undefined;
+    const resolved = await this.withTenantDatabase(async (tenantDb) => {
+      const session = await new SessionRepository(tenantDb).findById(sessionId);
       if (session?.agentic_tool !== 'claude-code-cli') return null;
       // Branch-spoofing guard: when the caller supplied a branchId,
       // it MUST match the session's. Otherwise the upstream RBAC
@@ -459,26 +476,24 @@ export class TerminalsService {
       // did, but against the *session's* branch id. This catches the
       // case where the caller omitted `branchId` entirely (so the
       // upstream check was skipped) and only passed `ensureCliSessionId`.
+      const branchRepo = new BranchRepository(tenantDb);
+      const branch = await branchRepo.findById(session.branch_id);
+      if (!branch?.path) return null;
+
       if (params?.provider) {
-        const config = await loadConfig();
-        const rbacEnabled = config.execution?.branch_rbac === true;
+        const rbacEnabled = config?.execution?.branch_rbac === true;
         if (rbacEnabled) {
           const callerUserId = params?.user?.user_id as UserID | undefined;
           if (!callerUserId) {
             throw new Forbidden('Authentication required to ensure a CLI tab');
           }
-          const branchRepo = new BranchRepository(this.db);
-          const wt = await branchRepo.findById(session.branch_id);
-          if (!wt) {
-            throw new Forbidden(`Session's branch not found: ${session.branch_id}`);
-          }
-          const isOwner = await branchRepo.isOwner(wt.branch_id, callerUserId);
-          const effectivePermission = await branchRepo.resolveUserPermission(wt, callerUserId);
-          const allowSuperadmin = config.execution?.allow_superadmin === true;
+          const isOwner = await branchRepo.isOwner(branch.branch_id, callerUserId);
+          const effectivePermission = await branchRepo.resolveUserPermission(branch, callerUserId);
+          const allowSuperadmin = config?.execution?.allow_superadmin === true;
           const userRole = params?.user?.role as string | undefined;
           if (
             !hasBranchPermission(
-              wt,
+              branch,
               callerUserId,
               isOwner,
               'session',
@@ -493,48 +508,42 @@ export class TerminalsService {
           }
         }
       }
-      if (
-        params?.provider &&
-        !canControlCliSession({
-          callerUserId: params.user?.user_id,
-          callerRole: params.user?.role,
-          sessionCreatedBy: session.created_by,
-        })
-      ) {
-        throw new Forbidden('You can only ensure CLI tabs for Claude CLI sessions you created.');
-      }
-      const branchRepo = new BranchRepository(this.db);
-      const branch = await branchRepo.findById(session.branch_id);
-      if (!branch?.path) return null;
-      const mcpConfigPath = await writeClaudeCliMcpConfigForSession(this.app, session, {
-        actor: params?.user ?? null,
-      });
-      const spawnCfg = buildSpawnConfigForSession(session, branch.path, { mcpConfigPath });
-      const built = await resolveClaudeCliProviderSpawn(
-        this.app,
-        session,
-        buildClaudeCliSpawn(spawnCfg)
-      );
-      if (!built) return null;
-      const tabName =
-        session.cli_state?.zellij_tab_name ??
-        spawnCfg.displayName ??
-        `cli-${shortId(session.session_id)}`;
-      return {
-        tabName,
-        cwd: branch.path,
-        command: built.bin,
-        commandArgs: built.args,
-        sessionId: session.session_id,
-      };
-    } catch (err) {
-      // Re-throw Forbidden so the caller sees the auth failure — only
-      // swallow unexpected errors (DB hiccup etc.) into a graceful
-      // "no ensure-create" fallback.
-      if (err instanceof Forbidden) throw err;
-      console.warn('[TerminalsService] resolveEnsureCliTab failed', err);
-      return null;
+      return { session, branch };
+    });
+    if (!resolved) return null;
+    const { session, branch } = resolved;
+
+    if (
+      params?.provider &&
+      !canControlCliSession({
+        callerUserId: params.user?.user_id,
+        callerRole: params.user?.role,
+        sessionCreatedBy: session.created_by,
+      })
+    ) {
+      throw new Forbidden('You can only ensure CLI tabs for Claude CLI sessions you created.');
     }
+    const mcpConfigPath = await writeClaudeCliMcpConfigForSession(this.app, session, {
+      actor: params?.user ?? null,
+    });
+    const spawnCfg = buildSpawnConfigForSession(session, branch.path, { mcpConfigPath });
+    const built = await resolveClaudeCliProviderSpawn(
+      this.app,
+      session,
+      buildClaudeCliSpawn(spawnCfg)
+    );
+    if (!built) return null;
+    const tabName =
+      session.cli_state?.zellij_tab_name ??
+      spawnCfg.displayName ??
+      `cli-${shortId(session.session_id)}`;
+    return {
+      tabName,
+      cwd: branch.path,
+      command: built.bin,
+      commandArgs: built.args,
+      sessionId: session.session_id,
+    };
   }
 
   private async createExecutorTerminal(
@@ -639,8 +648,9 @@ export class TerminalsService {
 
       // If branch specified, tell executor to create/focus tab
       if (data.branchId) {
-        const branchRepo = new BranchRepository(this.db);
-        const branch = await branchRepo.findById(data.branchId);
+        const branch = await this.withTenantDatabase((tenantDb) =>
+          new BranchRepository(tenantDb).findById(data.branchId!)
+        );
         if (branch) {
           const branchTabName = buildBranchShellTabName(branch);
           // Emit tab command via channel - executor will handle it
@@ -751,16 +761,10 @@ export class TerminalsService {
       const unixUserMode = config.execution?.unix_user_mode ?? 'simple';
       const executorUser = config.execution?.executor_unix_user;
 
-      let impersonatedUser: string | null = null;
-      const usersRepo = new UsersRepository(this.db);
-      try {
-        const user = await usersRepo.findById(userId);
-        if (user?.unix_username) {
-          impersonatedUser = user.unix_username;
-        }
-      } catch (error) {
-        console.warn(`⚠️ Failed to load user ${userId}:`, error);
-      }
+      const user = await this.withTenantDatabase((tenantDb) =>
+        new UsersRepository(tenantDb).findById(userId)
+      );
+      const impersonatedUser = user?.unix_username ?? null;
 
       const impersonationResult = resolveUnixUserForImpersonation({
         mode: unixUserMode as UnixUserMode,
@@ -785,14 +789,22 @@ export class TerminalsService {
       let branchName: string | undefined;
       let branchTabName: string | undefined;
 
-      if (data.branchId) {
-        const branchRepo = new BranchRepository(this.db);
-        const branch = await branchRepo.findById(data.branchId);
-        if (branch) {
-          branchName = branch.name;
-          branchTabName = buildBranchShellTabName(branch);
-          cwd = resolveBranchShellCwd(branch, finalUnixUser);
-        }
+      const { branch, userEnv, executorEnv } = await this.withTenantDatabase(async (tenantDb) => ({
+        branch: data.branchId ? await new BranchRepository(tenantDb).findById(data.branchId) : null,
+        userEnv: await resolveUserEnvironment(userId, tenantDb),
+        // Get executor process environment (includes system vars). When
+        // impersonating, strip HOME/USER/LOGNAME/SHELL so sudo -u can set them.
+        executorEnv: await createUserProcessEnvironment(
+          userId,
+          tenantDb,
+          undefined,
+          !!finalUnixUser
+        ),
+      }));
+      if (branch) {
+        branchName = branch.name;
+        branchTabName = buildBranchShellTabName(branch);
+        cwd = resolveBranchShellCwd(branch, finalUnixUser);
       }
 
       // Build Zellij session name
@@ -803,18 +815,8 @@ export class TerminalsService {
       const daemonUrl = `http://localhost:${config.daemon?.port || 3030}`;
       const sessionToken = generateScopedServiceToken(this.app, params);
 
-      // Get user environment and write env file for shell sourcing
-      const userEnv = await resolveUserEnvironment(userId, this.db);
+      // File/process work stays outside the tenant database unit of work.
       const envFile = writeEnvFile(userId, userEnv, finalUnixUser);
-
-      // Get executor process environment (includes system vars)
-      // When impersonating, strip HOME/USER/LOGNAME/SHELL so sudo -u can set them
-      const executorEnv = await createUserProcessEnvironment(
-        userId,
-        this.db,
-        undefined,
-        !!finalUnixUser
-      );
 
       // Spawn executor with zellij.attach command
       spawnExecutorFireAndForget(

--- a/apps/agor-daemon/src/utils/session-state-hooks.test.ts
+++ b/apps/agor-daemon/src/utils/session-state-hooks.test.ts
@@ -1,0 +1,77 @@
+import {
+  getCurrentTenantDatabaseScope,
+  runWithTenantContext,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  findLatest: vi.fn(async () => null),
+  repositoryDbs: [] as unknown[],
+}));
+
+vi.mock('@agor/core/db', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@agor/core/db')>()),
+  SerializedSessionRepository: class {
+    constructor(db: unknown) {
+      mocks.repositoryDbs.push(db);
+    }
+    findLatest = mocks.findLatest;
+  },
+}));
+
+vi.mock('./session-state', () => ({
+  computeFileHash: vi.fn(async () => ''),
+  findCodexSessionFile: vi.fn(async () => null),
+  getCodexHome: vi.fn(() => '/tmp/codex'),
+  getSessionFilePath: vi.fn(() => '/tmp/session.jsonl'),
+  restoreFile: vi.fn(),
+  serializeFile: vi.fn(),
+}));
+
+import { pullIfNeeded, pushAsync } from './session-state-hooks';
+
+const db = { run: vi.fn() } as unknown as TenantScopeAwareDatabase;
+const context = {
+  db,
+  sessionId: 'session-1',
+  sdkSessionId: 'sdk-session-1',
+  branchPath: '/tmp/branch',
+  tool: 'claude-code' as const,
+};
+
+describe('session state hook tenant scopes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.repositoryDbs.length = 0;
+    mocks.findLatest.mockImplementation(async () => {
+      expect(getCurrentTenantDatabaseScope()).toMatchObject({
+        kind: 'tenant',
+        tenantId: 'tenant-x',
+      });
+      return null;
+    });
+  });
+
+  it('opens a short tenant unit for restore metadata reads', async () => {
+    await runWithTenantContext('tenant-x', () => pullIfNeeded(context));
+
+    expect(mocks.findLatest).toHaveBeenCalledOnce();
+    expect(mocks.repositoryDbs).toEqual([expect.anything()]);
+    expect(mocks.repositoryDbs[0]).toBeDefined();
+    expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+  });
+
+  it('fails fast without tenant identity', async () => {
+    await expect(pullIfNeeded(context)).rejects.toThrow(
+      'Missing active tenant context for session state restore'
+    );
+    expect(() =>
+      pushAsync({
+        ...context,
+        branchId: 'branch-1',
+        taskId: 'task-1',
+      })
+    ).toThrow('Missing active tenant context for session state persistence');
+  });
+});

--- a/apps/agor-daemon/src/utils/session-state-hooks.ts
+++ b/apps/agor-daemon/src/utils/session-state-hooks.ts
@@ -9,7 +9,13 @@
  * register-services.ts and operate on the daemon's DB + filesystem directly.
  */
 
-import { SerializedSessionRepository, shortId, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  SerializedSessionRepository,
+  shortId,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import type { AgenticToolName } from '@agor/core/types';
 import {
   computeFileHash,
@@ -58,7 +64,8 @@ interface PushContext {
  * 5. No 'done' row, no local file → fresh session, proceed
  */
 export async function pullIfNeeded(ctx: PullContext): Promise<void> {
-  const repo = new SerializedSessionRepository(ctx.db);
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) throw new Error('Missing active tenant context for session state restore');
 
   // Both claude-code and codex now resolve transcripts under the executor
   // user's HOME (~/.claude or ~/.codex). For simple mode executorHomeDir is
@@ -71,7 +78,9 @@ export async function pullIfNeeded(ctx: PullContext): Promise<void> {
   );
 
   // Check latest row (any status)
-  let latest = await repo.findLatest(ctx.sessionId);
+  let latest = await runWithTenantDatabaseScope(ctx.db, tenantId, (tenantDb) =>
+    new SerializedSessionRepository(tenantDb).findLatest(ctx.sessionId)
+  );
 
   if (!latest) {
     // Case 1: No rows at all → fresh session
@@ -85,9 +94,12 @@ export async function pullIfNeeded(ctx: PullContext): Promise<void> {
       console.log(
         `[session-state] Cleaning stale 'processing' row ${shortId(latest.id)} (age: ${Math.round(age / 1000)}s)`
       );
-      await repo.deleteById(latest.id);
-      // Fall through: check if there's a 'done' row behind it
-      latest = await repo.findLatestDone(ctx.sessionId);
+      latest = await runWithTenantDatabaseScope(ctx.db, tenantId, async (tenantDb) => {
+        const repo = new SerializedSessionRepository(tenantDb);
+        await repo.deleteById(latest!.id);
+        // Fall through: check if there's a 'done' row behind it
+        return repo.findLatestDone(ctx.sessionId);
+      });
       if (!latest) {
         // Case 5: No done row after cleanup
         return;
@@ -98,7 +110,9 @@ export async function pullIfNeeded(ctx: PullContext): Promise<void> {
       console.warn(
         `[session-state] Latest row is 'processing' (age: ${Math.round(age / 1000)}s), falling back to latest done row`
       );
-      latest = await repo.findLatestDone(ctx.sessionId);
+      latest = await runWithTenantDatabaseScope(ctx.db, tenantId, (tenantDb) =>
+        new SerializedSessionRepository(tenantDb).findLatestDone(ctx.sessionId)
+      );
       if (!latest) {
         // No done row available — proceed without restore
         return;
@@ -133,15 +147,15 @@ export async function pullIfNeeded(ctx: PullContext): Promise<void> {
  * Skips if file hash unchanged. Otherwise: insertProcessing → gzip → markDone → deletePreviousTurns.
  */
 export function pushAsync(ctx: PushContext): void {
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) throw new Error('Missing active tenant context for session state persistence');
   // Fire and forget — errors are logged but never propagated
-  void doPush(ctx).catch((err) => {
+  void doPush(ctx, tenantId).catch((err) => {
     console.error('[session-state] pushAsync failed:', err instanceof Error ? err.message : err);
   });
 }
 
-async function doPush(ctx: PushContext): Promise<void> {
-  const repo = new SerializedSessionRepository(ctx.db);
-
+async function doPush(ctx: PushContext, tenantId: string): Promise<void> {
   // For Codex, find the actual session file (may be in a date-based subdirectory)
   let filePath: string;
   if (ctx.tool === 'codex') {
@@ -170,26 +184,34 @@ async function doPush(ctx: PushContext): Promise<void> {
   }
 
   // Determine turn_index
-  const latestRow = await repo.findLatest(ctx.sessionId);
-  const turnIndex = latestRow ? latestRow.turn_index + 1 : 0;
-
-  // Insert processing row (fast — no payload yet)
-  const row = await repo.insertProcessing({
-    sessionId: ctx.sessionId,
-    branchId: ctx.branchId,
-    taskId: ctx.taskId,
-    turnIndex,
-    md5: currentMd5,
-  });
+  const { row, turnIndex } = await runWithTenantDatabaseScope(
+    ctx.db,
+    tenantId,
+    async (tenantDb) => {
+      const repo = new SerializedSessionRepository(tenantDb);
+      const latestRow = await repo.findLatest(ctx.sessionId);
+      const turnIndex = latestRow ? latestRow.turn_index + 1 : 0;
+      const row = await repo.insertProcessing({
+        sessionId: ctx.sessionId,
+        branchId: ctx.branchId,
+        taskId: ctx.taskId,
+        turnIndex,
+        md5: currentMd5,
+      });
+      return { row, turnIndex };
+    }
+  );
 
   // Gzip the file
   const payload = await serializeFile(filePath);
 
-  // Mark done with payload
-  await repo.markDone(row.id, payload);
-
-  // Clean up old rows (only delete turns older than this one — safe against concurrent pushes)
-  await repo.deletePreviousTurns(ctx.sessionId, turnIndex);
+  await runWithTenantDatabaseScope(ctx.db, tenantId, async (tenantDb) => {
+    const repo = new SerializedSessionRepository(tenantDb);
+    // Mark done with payload
+    await repo.markDone(row.id, payload);
+    // Only delete turns older than this one — safe against concurrent pushes.
+    await repo.deletePreviousTurns(ctx.sessionId, turnIndex);
+  });
 
   console.log(
     `[session-state] Pushed session state (turn ${turnIndex}, ${payload.length} bytes gzipped)`

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -1,5 +1,6 @@
 import {
   enqueueTenantDatabasePostCommitCallback,
+  getCurrentTenantDatabaseScope,
   getCurrentTenantId,
   runWithoutTenantDatabaseScope,
   runWithTenantDatabaseScope,
@@ -10,6 +11,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 import {
   createTenantDatabaseScopeAroundHook,
+  deferWithTenantContext,
   deferWithTenantDatabaseScope,
 } from './tenant-db-scope.js';
 
@@ -404,5 +406,38 @@ describe('createTenantDatabaseScopeAroundHook', () => {
       tenant_id: 'tenant-from-socket',
       source: 'auth_claim',
     });
+  });
+});
+
+describe('deferWithTenantContext', () => {
+  it('runs orchestration after commit with identity but no inherited database scope', async () => {
+    const events: string[] = [];
+    const completed = Promise.withResolvers<void>();
+    const db = {
+      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
+        events.push('transaction:start');
+        const result = await callback({ execute: vi.fn(async () => []) });
+        events.push('transaction:committed');
+        return result;
+      }),
+    };
+
+    await runWithTenantDatabaseScope(db as never, 'tenant-deferred', async () => {
+      deferWithTenantContext({}, async () => {
+        expect(getCurrentTenantId()).toBe('tenant-deferred');
+        expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+        events.push('deferred:work');
+        completed.resolve();
+      });
+      events.push('hook:return');
+    });
+    await completed.promise;
+
+    expect(events).toEqual([
+      'transaction:start',
+      'hook:return',
+      'transaction:committed',
+      'deferred:work',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- open short tenant database units of work for task-start governance checks and live preset materialization
- scope deferred executor session, branch, gateway environment, user environment, CLI bootstrap, terminal, and stateless session-state reads without holding transactions across process or filesystem work
- make identity-only model/auth/terminal endpoints scope their governance and credential reads
- fail fast when task-start or terminal work has no tenant identity, while preserving nested-scope mismatch/system-scope guards
- add regression coverage for identity-only entry, ambient scope joining, process/DB boundary separation, inline policy validation, and tenant/system mismatches

## Governance helper audit

| Call site | Helpers | Classification / action |
|---|---|---|
| `register-routes.ts` `spawnTaskExecutor` | `isTenantAgenticToolEnabled` | **Fixed** — moved into the existing short session/message-count tenant unit of work; preset materialization opens its own short unit. |
| `register-services.ts` `createExecuteHandler` | `isTenantAgenticToolEnabled` | **Fixed** — `prepareSessionForExecutorStart` scopes raw session load, governance, and preset materialization together; later branch/gateway/user-environment reads use separate short units before process work. |
| `register-routes.ts` `/sessions/:id/prompt` | `isTenantAgenticToolEnabled` | **Already scoped** — `registerAuthenticatedRoute` installs `tenantDatabaseScopeAround`; materialization now joins it idempotently. |
| `SessionsService.materializeAgenticToolPreset` | `assertInlineAgenticConfigurationAllowed`, `resolveAgenticToolPreset` | **Fixed** — requires ambient tenant identity and scopes policy lookup, preset lookup, and session update together. |
| `SessionsService.create` | `isTenantAgenticToolEnabled`, `resolveAgenticConfigurationReference`, `assertInlineAgenticConfigurationAllowed` | **Already scoped** — `sessions` is a tenant-owned Feathers service with the tenant DB around hook. |
| `SessionsService.patch` | `isTenantAgenticToolEnabled`, `resolveAgenticConfigurationReference`, `assertInlineAgenticConfigurationAllowed` | **Already scoped** — same tenant-owned service hook. |
| `SchedulesService.validateConfig` / `normalizeConfig` | `resolveAgenticToolPreset`, `assertInlineAgenticConfigurationAllowed`, `resolveAgenticConfigurationReference` | **Already scoped** — `schedules` is a tenant-owned Feathers service. |
| `GatewayChannelsService.validateConfig` / `normalizeConfig` | `resolveAgenticToolPreset`, `assertInlineAgenticConfigurationAllowed`, `resolveAgenticConfigurationReference` | **Already scoped** — `gateway-channels` is a tenant-owned Feathers service. |
| `UsersService.patch` | `resolveAgenticToolPreset`, `assertInlineAgenticConfigurationAllowed` | **Already scoped** — `users` is a tenant-owned Feathers service. |
| `GatewayService.resolveAgenticConfig` | `resolveAgenticToolPreset`, `assertInlineAgenticConfigurationAllowed` | **Already explicitly scoped** — fixed in `289b6fd7`; Socket Mode carries identity and opens a short unit. |
| `SchedulerService.processSchedule` | `resolveAgenticToolPreset`, `assertInlineAgenticConfigurationAllowed` | **Already explicitly scoped** — fixed in `289b6fd7` through `withTenantDatabase`. |
| `CheckAuthService.create` | `isTenantAgenticToolEnabled` | **Fixed** — identity-only request hook plus short governance/credential units; provider probes stay outside transactions. |
| `ClaudeModelsService.find` | `isTenantAgenticToolEnabled` | **Fixed** — identity-only request hook plus one short governance/credential unit; Anthropic request stays outside. |
| `CopilotModelsService.find` | `isTenantAgenticToolEnabled` | **Fixed** — identity-only request hook plus one short governance/credential unit; Copilot subprocess stays outside. |
| `CursorModelsService.find` | `isTenantAgenticToolEnabled` | **Fixed** — identity-only request hook plus one short governance/credential unit; Cursor request stays outside. |
| `resolveClaudeCliProviderSpawn` | `isTenantAgenticToolEnabled` | **Fixed** — short governance/provider-resolution unit; terminal/CLI work stays outside. `terminals` carries tenant identity only and now scopes every repository/environment section independently. |
| `writeClaudeCliMcpConfigForSession` | token session existence read | **Fixed during review** — token issuance joins a short tenant unit; config file generation remains outside the transaction. |
| `session-state-hooks.ts` | serialized session state repositories | **Fixed during review** — restore/persist metadata uses short tenant units separated from hash, compression, and filesystem work. |
| `agentic-tool-preset-resolver.ts` internal composition | all three preset helpers | **Intentionally unchanged** — recursive/composed calls reuse the caller-supplied scoped database and do not own a unit of work. |

## Review follow-up

The first Codex review identified deferred executor startup and terminal database reads as merge blockers. Both were addressed, including previously caught reads that could silently skip branch, CLI bootstrap, Unix identity, or environment resolution. Regression tests now assert that DB work observes a tenant unit while executor process work runs after the unit closes.

## Verification

- `pnpm check` — passed (typecheck, Biome, design-system fixtures, short-ID check, multitenancy boundaries, workspace builds); 8 pre-existing undeclared-env warnings only
- `pnpm vitest run` in `apps/agor-daemon` — 132 files passed, 1 skipped; 1660 tests passed, 31 skipped
- targeted core tests: `tenant-scope.test.ts` and `agentic-tool-preset-resolver.test.ts` — 22 passed


### Second review follow-up

The follow-up review found that CLI session-create integration still ran inside the service transaction and that token issuance had accidentally escaped its documented best-effort contract. CLI watcher/config/terminal startup is now deferred after commit with tenant identity only, each subsequent DB helper opens a short unit, and token issuance failures degrade to a logged no-MCP configuration only after tenant scope entry succeeds. Missing identity/database and tenant-scope nesting errors still fail fast.
