### PR TITLE
fix(terminal): reconnect handling + readiness acks for embedded terminal (#1919)

### DIFF
--- a/apps/agor-daemon/src/auth/require-auth.test.ts
+++ b/apps/agor-daemon/src/auth/require-auth.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Verifies the terminal-executor rejection guard is actually COMPOSED into the
+ * shared `requireAuth` hook — not just that the guard throws in isolation. A
+ * future refactor that drops the composition would fail here.
+ */
+
+import { Forbidden } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { createRequireAuthHook } from './require-auth';
+
+const multiTenancy = { mode: 'static' as const, static_tenant_id: 'tenant-default' as never };
+
+function ctxWithUser(user: unknown): HookContext {
+  return { params: { provider: 'rest', user } } as unknown as HookContext;
+}
+
+describe('createRequireAuthHook composition', () => {
+  it('rejects a terminal-executor identity that passed the auth strategy', async () => {
+    // The strategy authenticated the token (that part must work for socket
+    // reconnect); requireAuth must still reject it for REST/Feathers.
+    const authenticatedHook = vi.fn(async (ctx: HookContext) => ctx);
+    const requireAuth = createRequireAuthHook(authenticatedHook, multiTenancy);
+
+    await expect(
+      requireAuth(
+        ctxWithUser({
+          user_id: 'executor-service',
+          role: 'terminal-executor',
+          _isTerminalExecutor: true,
+        })
+      )
+    ).rejects.toBeInstanceOf(Forbidden);
+    expect(authenticatedHook).toHaveBeenCalled();
+  });
+
+  it('passes a normal authenticated user through and resolves the tenant', async () => {
+    const authenticatedHook = vi.fn(async (ctx: HookContext) => ctx);
+    const requireAuth = createRequireAuthHook(authenticatedHook, multiTenancy);
+
+    const result = await requireAuth(ctxWithUser({ user_id: 'u1', role: 'member' }));
+    expect((result.params as { tenant?: { tenant_id: string } }).tenant?.tenant_id).toBe(
+      'tenant-default'
+    );
+  });
+
+  it('passes a full service account through (not a terminal-executor)', async () => {
+    const authenticatedHook = vi.fn(async (ctx: HookContext) => ctx);
+    const requireAuth = createRequireAuthHook(authenticatedHook, multiTenancy);
+
+    await expect(
+      requireAuth(
+        ctxWithUser({ user_id: 'executor-service', role: 'service', _isServiceAccount: true })
+      )
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/agor-daemon/src/auth/require-auth.ts
+++ b/apps/agor-daemon/src/auth/require-auth.ts
@@ -1,0 +1,41 @@
+/**
+ * The shared `requireAuth` hook factory — the single REST/Feathers auth
+ * chokepoint. Composes the authentication strategy hook, the terminal-executor
+ * rejection guard, and tenant resolution. Extracted from index.ts so the
+ * composition (specifically that the terminal-executor guard is wired in) is
+ * unit-testable and can't be silently dropped by a refactor.
+ */
+
+import {
+  type ResolvedMultiTenancyConfig,
+  resolveTenantContext,
+  TenantResolutionError,
+} from '@agor/core/config';
+import { NotAuthenticated } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { rejectTerminalExecutorIdentity } from './terminal-executor-guard.js';
+
+export type AuthHook = (context: HookContext) => Promise<HookContext>;
+
+export function createRequireAuthHook(
+  authenticatedHook: AuthHook,
+  multiTenancy: ResolvedMultiTenancyConfig
+): AuthHook {
+  return async (context: HookContext): Promise<HookContext> => {
+    const authed = await authenticatedHook(context);
+    // A terminal-executor identity is valid ONLY for the Socket.IO terminal
+    // channel (handled outside Feathers); reject it from every REST/Feathers
+    // service call here so it can't ride the RBAC rank table's viewer-rank
+    // fallthrough into API access.
+    await rejectTerminalExecutorIdentity(authed);
+    try {
+      authed.params.tenant = resolveTenantContext(multiTenancy, { params: authed.params });
+      return authed;
+    } catch (error) {
+      if (error instanceof TenantResolutionError) {
+        throw new NotAuthenticated(error.message);
+      }
+      throw error;
+    }
+  };
+}

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.terminal-scope.test.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.terminal-scope.test.ts
@@ -1,0 +1,65 @@
+/**
+ * ServiceJWTStrategy: a token carrying `terminal_user_id` must resolve to a
+ * RESTRICTED terminal-executor identity, NOT a full service account. This is
+ * the security boundary that keeps the long-lived terminal token from being a
+ * daemon-wide RBAC bypass — every `_isServiceAccount` consumer (register-hooks,
+ * board-owners, branch-owners, sessions, users, groups, …) skips its checks, so
+ * the terminal token must never carry that flag or `role: 'service'`.
+ */
+
+import { JWTStrategy } from '@agor/core/feathers';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ServiceJWTStrategy } from './service-jwt-strategy';
+
+const ALICE = '11111111-aaaa-aaaa-aaaa-111111111111';
+
+function stubSuperAuthenticate(payload: Record<string, unknown>) {
+  // super.authenticate() (base JWTStrategy) verifies the JWT and loads the
+  // entity; stub it to return the verified payload + the getEntity intermediate
+  // (a full service account) so we can assert the override's post-processing.
+  return vi.spyOn(JWTStrategy.prototype, 'authenticate').mockResolvedValue({
+    authentication: { payload },
+    user: { user_id: 'executor-service', role: 'service', _isServiceAccount: true },
+  } as never);
+}
+
+describe('ServiceJWTStrategy terminal-scoped identity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('mints a restricted terminal-executor identity for a terminal_user_id token', async () => {
+    stubSuperAuthenticate({
+      sub: 'executor-service',
+      type: 'service',
+      purpose: 'executor-service',
+      terminal_user_id: ALICE,
+    });
+    const strategy = new ServiceJWTStrategy();
+    const result = (await strategy.authenticate({ accessToken: 'header.payload.sig' }, {})) as {
+      user: Record<string, unknown>;
+    };
+
+    expect(result.user.terminal_user_id).toBe(ALICE);
+    expect(result.user._isTerminalExecutor).toBe(true);
+    // The critical assertions: NOT a full service account, NOT role 'service'.
+    expect(result.user._isServiceAccount).toBeUndefined();
+    expect(result.user.role).not.toBe('service');
+  });
+
+  it('still mints a full service account for a plain (unscoped) service token', async () => {
+    stubSuperAuthenticate({
+      sub: 'executor-service',
+      type: 'service',
+      purpose: 'executor-service',
+    });
+    const strategy = new ServiceJWTStrategy();
+    const result = (await strategy.authenticate({ accessToken: 'header.payload.sig' }, {})) as {
+      user: Record<string, unknown>;
+    };
+
+    expect(result.user._isServiceAccount).toBe(true);
+    expect(result.user._isTerminalExecutor).toBeUndefined();
+    expect(result.user.terminal_user_id).toBeUndefined();
+  });
+});

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -142,6 +142,7 @@ export class ServiceJWTStrategy extends JWTStrategy {
           task_id?: string;
           branch_id?: string;
           purpose?: string;
+          terminal_user_id?: string;
         })
       | undefined;
 
@@ -149,7 +150,9 @@ export class ServiceJWTStrategy extends JWTStrategy {
       if (payload.purpose !== undefined && payload.purpose !== 'executor-service') {
         throw new Error('Invalid service token purpose');
       }
-      // Override user in result with service account
+      // Override user in result with service account. Carry the optional
+      // `terminal_user_id` scope so the socket layer can restrict this
+      // executor's terminal:* emits to its own user (see socketio.ts).
       return {
         ...result,
         user: {
@@ -157,6 +160,9 @@ export class ServiceJWTStrategy extends JWTStrategy {
           email: 'executor@agor.internal',
           role: 'service',
           _isServiceAccount: true,
+          ...(typeof payload.terminal_user_id === 'string'
+            ? { terminal_user_id: payload.terminal_user_id }
+            : {}),
         },
       };
     }

--- a/apps/agor-daemon/src/auth/service-jwt-strategy.ts
+++ b/apps/agor-daemon/src/auth/service-jwt-strategy.ts
@@ -150,9 +150,29 @@ export class ServiceJWTStrategy extends JWTStrategy {
       if (payload.purpose !== undefined && payload.purpose !== 'executor-service') {
         throw new Error('Invalid service token purpose');
       }
-      // Override user in result with service account. Carry the optional
-      // `terminal_user_id` scope so the socket layer can restrict this
-      // executor's terminal:* emits to its own user (see socketio.ts).
+      const terminalUserId =
+        typeof payload.terminal_user_id === 'string' ? payload.terminal_user_id : undefined;
+      // A terminal-scoped token is a RESTRICTED identity: it authenticates the
+      // web-terminal executor's socket for its OWN user's terminal channel
+      // only. It must NOT be a full service account — `_isServiceAccount` and
+      // `role: 'service'` bypass RBAC across REST/Feathers paths (see
+      // register-hooks / board-owners / branch-owners / sessions /
+      // mcp-token-authorization), and the terminal executor makes no such
+      // calls. So we mint a low-privilege identity that carries no bypass
+      // anywhere; the socket terminal handlers enforce it via terminal_user_id.
+      if (terminalUserId) {
+        return {
+          ...result,
+          user: {
+            user_id: 'executor-service',
+            email: 'executor@agor.internal',
+            role: 'terminal-executor',
+            _isTerminalExecutor: true,
+            terminal_user_id: terminalUserId,
+          },
+        };
+      }
+      // Full service account (git/prompt/etc. executor paths).
       return {
         ...result,
         user: {
@@ -160,9 +180,6 @@ export class ServiceJWTStrategy extends JWTStrategy {
           email: 'executor@agor.internal',
           role: 'service',
           _isServiceAccount: true,
-          ...(typeof payload.terminal_user_id === 'string'
-            ? { terminal_user_id: payload.terminal_user_id }
-            : {}),
         },
       };
     }

--- a/apps/agor-daemon/src/auth/terminal-executor-guard.test.ts
+++ b/apps/agor-daemon/src/auth/terminal-executor-guard.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Proves the terminal-executor identity is REJECTED from REST/Feathers — not
+ * merely under-privileged. These exercise the real production authz predicates
+ * (`requireMinimumRole` / `hasMinimumRole`), not token shape, which is exactly
+ * the gap a shape-only test missed: `role: 'terminal-executor'` falls through
+ * the RBAC rank table to viewer rank and would otherwise pass viewer gating.
+ */
+
+import { Forbidden } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+import { hasMinimumRole, ROLES } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { requireMinimumRole } from '../utils/authorization';
+import {
+  isTerminalExecutorIdentity,
+  rejectTerminalExecutorIdentity,
+} from './terminal-executor-guard';
+
+const terminalUser = {
+  user_id: 'executor-service',
+  email: 'executor@agor.internal',
+  role: 'terminal-executor',
+  _isTerminalExecutor: true,
+  terminal_user_id: '11111111-aaaa-aaaa-aaaa-111111111111',
+};
+
+function ctx(user: unknown): HookContext {
+  return { params: { provider: 'rest', user } } as unknown as HookContext;
+}
+
+describe('terminal-executor identity is rejected from REST/Feathers', () => {
+  it('THE GAP: the RBAC rank system alone does not reject the terminal role', () => {
+    // Real production predicate: 'terminal-executor' isn't a rank key, so it
+    // falls through to 0 (== viewer). This is why an explicit reject is needed.
+    expect(hasMinimumRole('terminal-executor', ROLES.VIEWER)).toBe(true);
+  });
+
+  it('THE GAP: a real viewer-gated hook lets the terminal identity through', () => {
+    const viewerGate = requireMinimumRole(ROLES.VIEWER, 'read data');
+    // Without the guard, this does NOT throw — the terminal token would reach
+    // the service handler with viewer-level access.
+    expect(() => viewerGate(ctx(terminalUser))).not.toThrow();
+    expect(viewerGate(ctx(terminalUser))).toBeDefined();
+  });
+
+  it('THE FIX: the guard rejects the terminal identity outright', async () => {
+    await expect(rejectTerminalExecutorIdentity(ctx(terminalUser))).rejects.toBeInstanceOf(
+      Forbidden
+    );
+    await expect(rejectTerminalExecutorIdentity(ctx(terminalUser))).rejects.toThrow(
+      /not valid for API access/
+    );
+  });
+
+  it('lets normal users and full service accounts through the guard', async () => {
+    await expect(
+      rejectTerminalExecutorIdentity(ctx({ user_id: 'u', role: 'member' }))
+    ).resolves.toBeDefined();
+    await expect(
+      rejectTerminalExecutorIdentity(
+        ctx({ user_id: 'executor-service', role: 'service', _isServiceAccount: true })
+      )
+    ).resolves.toBeDefined();
+    // Internal calls (no provider / no user) are untouched.
+    await expect(
+      rejectTerminalExecutorIdentity({ params: {} } as unknown as HookContext)
+    ).resolves.toBeDefined();
+  });
+
+  it('isTerminalExecutorIdentity discriminates the identity', () => {
+    expect(isTerminalExecutorIdentity({ _isTerminalExecutor: true })).toBe(true);
+    expect(isTerminalExecutorIdentity({ _isServiceAccount: true })).toBe(false);
+    expect(isTerminalExecutorIdentity({ role: 'member' })).toBe(false);
+    expect(isTerminalExecutorIdentity(undefined)).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/auth/terminal-executor-guard.ts
+++ b/apps/agor-daemon/src/auth/terminal-executor-guard.ts
@@ -1,0 +1,35 @@
+/**
+ * Terminal-executor identity guard.
+ *
+ * A terminal-scoped executor token (see terminals.ts / ServiceJWTStrategy)
+ * authenticates ONLY the Socket.IO terminal channel — those events are handled
+ * in socketio.ts, outside Feathers, and are gated on `terminal_user_id`.
+ *
+ * As a REST/Feathers identity it must be REJECTED, not merely under-privileged:
+ * its `role: 'terminal-executor'` is not a key in the RBAC rank table, so
+ * `hasMinimumRole()` falls through to rank 0 (== viewer) and it would otherwise
+ * pass `requireAuth` and any viewer-gated check. "Low" is not "none"; we make it
+ * "none" here by rejecting the request outright at the shared auth chokepoint.
+ */
+
+import { Forbidden } from '@agor/core/feathers';
+import type { HookContext } from '@agor/core/types';
+
+/** Whether an authenticated identity is a terminal-scoped executor token. */
+export function isTerminalExecutorIdentity(user: unknown): boolean {
+  return (user as { _isTerminalExecutor?: boolean } | undefined)?._isTerminalExecutor === true;
+}
+
+/**
+ * Reject any REST/Feathers service call made by a terminal-executor identity.
+ * Composed into `requireAuth` so it runs for every authenticated endpoint. The
+ * authentication service itself is NOT gated by `requireAuth`, so the executor
+ * can still (re)authenticate its socket.
+ */
+export async function rejectTerminalExecutorIdentity(context: HookContext): Promise<HookContext> {
+  const user = (context.params as { user?: unknown } | undefined)?.user;
+  if (isTerminalExecutorIdentity(user)) {
+    throw new Forbidden('Terminal-executor tokens are not valid for API access.');
+  }
+  return context;
+}

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -37,9 +37,7 @@ import {
   resolveGitConfigParameters,
   resolveMultiTenancyConfig,
   resolveSecurity,
-  resolveTenantContext,
   saveConfig,
-  TenantResolutionError,
 } from '@agor/core/config';
 import { getDatabaseUrl, runWithTenantDatabaseScope } from '@agor/core/db';
 import {
@@ -47,7 +45,6 @@ import {
   Forbidden,
   feathers,
   feathersExpress,
-  NotAuthenticated,
   rest,
   socketio,
 } from '@agor/core/feathers';
@@ -58,7 +55,7 @@ import cors from 'cors';
 import express from 'express';
 import expressStaticGzip from 'express-static-gzip';
 import { scopeExecutorRuntimeAuth } from './auth/executor-runtime-scope.js';
-import { rejectTerminalExecutorIdentity } from './auth/terminal-executor-guard.js';
+import { createRequireAuthHook } from './auth/require-auth.js';
 import { registerHooks } from './register-hooks.js';
 import { registerRoutes } from './register-routes.js';
 import { registerServices } from './register-services.js';
@@ -211,23 +208,7 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   const authenticatedHook = scopeExecutorRuntimeAuth(
     authenticate({ strategies: ['api-key', 'jwt'] })
   );
-  const requireAuth = async (context: HookContext): Promise<HookContext> => {
-    const authed = await authenticatedHook(context);
-    // A terminal-executor identity is valid ONLY for the Socket.IO terminal
-    // channel (handled outside Feathers); reject it from every REST/Feathers
-    // service call here, the shared auth chokepoint, so it can't ride the
-    // RBAC rank table's viewer-rank fallthrough into API access.
-    await rejectTerminalExecutorIdentity(authed);
-    try {
-      authed.params.tenant = resolveTenantContext(multiTenancy, { params: authed.params });
-      return authed;
-    } catch (error) {
-      if (error instanceof TenantResolutionError) {
-        throw new NotAuthenticated(error.message);
-      }
-      throw error;
-    }
-  };
+  const requireAuth = createRequireAuthHook(authenticatedHook, multiTenancy);
 
   const enforcePasswordChange = async (context: HookContext) => {
     const user = context.params?.user as User | undefined;

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -58,6 +58,7 @@ import cors from 'cors';
 import express from 'express';
 import expressStaticGzip from 'express-static-gzip';
 import { scopeExecutorRuntimeAuth } from './auth/executor-runtime-scope.js';
+import { rejectTerminalExecutorIdentity } from './auth/terminal-executor-guard.js';
 import { registerHooks } from './register-hooks.js';
 import { registerRoutes } from './register-routes.js';
 import { registerServices } from './register-services.js';
@@ -212,6 +213,11 @@ export async function startDaemon(options?: DaemonStartOptions): Promise<void> {
   );
   const requireAuth = async (context: HookContext): Promise<HookContext> => {
     const authed = await authenticatedHook(context);
+    // A terminal-executor identity is valid ONLY for the Socket.IO terminal
+    // channel (handled outside Feathers); reject it from every REST/Feathers
+    // service call here, the shared auth chokepoint, so it can't ride the
+    // RBAC rank table's viewer-rank fallthrough into API access.
+    await rejectTerminalExecutorIdentity(authed);
     try {
       authed.params.tenant = resolveTenantContext(multiTenancy, { params: authed.params });
       return authed;

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -119,6 +119,9 @@ function makeApp() {
   const emit = vi.fn();
   return {
     emit,
+    // The service subscribes to executor ready/error app events in its
+    // constructor; a no-op recorder keeps that wiring from throwing under test.
+    on: vi.fn(),
     io: {
       to: vi.fn(() => ({ emit })),
     },
@@ -218,6 +221,104 @@ describe('TerminalsService cold-start concurrency', () => {
     expect(firstResult.isNew).toBe(true);
     expect(secondResult.isNew).toBe(false);
     expect(firstResult.sessionName).toBe(secondResult.sessionName);
+  });
+});
+
+describe('TerminalsService readiness ack gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.execSync.mockImplementation((cmd: string) => {
+      if (cmd === 'which zellij') return Buffer.from('/usr/bin/zellij\n');
+      if (cmd.startsWith('sudo -n chown ')) return Buffer.from('');
+      throw new Error('not found');
+    });
+    mocks.resolveUnixUserForImpersonation.mockReturnValue({ unixUser: null });
+    mocks.resolveUserEnvironment.mockResolvedValue({});
+    mocks.createUserProcessEnvironment.mockResolvedValue({});
+    mocks.branchesById.clear();
+    mocks.branchesById.set(mocks.branch.branch_id, mocks.branch);
+    mocks.loadConfig.mockResolvedValue({
+      daemon: { port: 3030 },
+      execution: { branch_rbac: false },
+    });
+  });
+
+  it('reports ready=false on cold start and ready=true once the executor acks', async () => {
+    const service = new TerminalsService(makeApp() as never, {} as never);
+
+    const cold = await service.create(
+      { branchId: 'branch-1', rows: 24, cols: 80 },
+      params as never
+    );
+    expect(cold.isNew).toBe(true);
+    expect(cold.ready).toBe(false);
+
+    // Executor announces its PTY is attached.
+    service.handleExecutorReady(params.user.user_id as never);
+
+    const warm = await service.create(
+      { branchId: 'branch-1', rows: 24, cols: 80 },
+      params as never
+    );
+    expect(warm.isNew).toBe(false);
+    expect(warm.ready).toBe(true);
+  });
+
+  it('notifies the browser channel on ready and error acks', () => {
+    const app = makeApp();
+    const service = new TerminalsService(app as never, {} as never);
+
+    service.handleExecutorReady(params.user.user_id as never);
+    expect(app.io.to).toHaveBeenCalledWith(`user/${params.user.user_id}/terminal`);
+    expect(app.emit).toHaveBeenCalledWith('terminal:ready', { userId: params.user.user_id });
+
+    service.handleExecutorError(params.user.user_id as never, 'spawn failed');
+    expect(app.emit).toHaveBeenCalledWith('terminal:error', {
+      userId: params.user.user_id,
+      message: 'spawn failed',
+    });
+  });
+
+  it('defers cold-start tab focus until the readiness ack arrives', async () => {
+    const app = makeApp();
+    const service = new TerminalsService(app as never, {} as never);
+
+    await service.create(
+      { branchId: 'branch-1', focusTabName: 'cli-abc', rows: 24, cols: 80 },
+      params as never
+    );
+
+    // Cold start: the executor isn't up yet, so no focus is emitted.
+    expect(app.emit).not.toHaveBeenCalledWith(
+      'terminal:tab',
+      expect.objectContaining({ action: 'focus', tabName: 'cli-abc' })
+    );
+
+    // Ack arrives → the gated focus fires.
+    service.handleExecutorReady(params.user.user_id as never);
+    await vi.waitFor(() => {
+      expect(app.emit).toHaveBeenCalledWith('terminal:tab', {
+        userId: params.user.user_id,
+        action: 'focus',
+        tabName: 'cli-abc',
+      });
+    });
+  });
+
+  it('drops readiness when the executor exits so the next start waits again', async () => {
+    const service = new TerminalsService(makeApp() as never, {} as never);
+
+    await service.create({ branchId: 'branch-1', rows: 24, cols: 80 }, params as never);
+    service.handleExecutorReady(params.user.user_id as never);
+    service.handleExecutorExit(params.user.user_id as never);
+
+    const afterExit = await service.create(
+      { branchId: 'branch-1', rows: 24, cols: 80 },
+      params as never
+    );
+    // Executor map was cleared on exit → this is a fresh cold start, not ready.
+    expect(afterExit.isNew).toBe(true);
+    expect(afterExit.ready).toBe(false);
   });
 });
 

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => {
       throw new Error('not found');
     }),
     spawnExecutorFireAndForget: vi.fn(),
+    generateScopedServiceToken: vi.fn(() => 'session-token'),
     resolveUnixUserForImpersonation: vi.fn(() => ({ unixUser: null })),
     resolveUserEnvironment: vi.fn(async () => ({})),
     createUserProcessEnvironment: vi.fn(async () => ({})),
@@ -102,7 +103,7 @@ vi.mock('../utils/mcp-token-authorization.js', () => ({
 
 vi.mock('../utils/spawn-executor.js', () => ({
   generateSessionToken: () => 'session-token',
-  generateScopedServiceToken: () => 'session-token',
+  generateScopedServiceToken: mocks.generateScopedServiceToken,
   serviceTokenScopeForParams: () => ({}),
   spawnExecutorFireAndForget: mocks.spawnExecutorFireAndForget,
 }));
@@ -241,6 +242,21 @@ describe('TerminalsService readiness ack gating', () => {
       daemon: { port: 3030 },
       execution: { branch_rbac: false },
     });
+  });
+
+  it('binds terminal_user_id and a long TTL into the executor service token', async () => {
+    // Reconnection reuses this same token; the default 5m service-token TTL
+    // would expire mid-session and break reconnect (the whole point of the
+    // feature). The token must be user-scoped AND long-lived.
+    const service = new TerminalsService(makeApp() as never, {} as never);
+    await service.create({ branchId: 'branch-1', rows: 24, cols: 80 }, params as never);
+
+    expect(mocks.generateScopedServiceToken).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { terminal_user_id: params.user.user_id },
+      '30d'
+    );
   });
 
   it('reports ready=false on cold start and ready=true once the executor acks', async () => {
@@ -455,6 +471,38 @@ describe('TerminalsService branch shell tabs', () => {
         expect.objectContaining({ action: 'create', tabName: 'adopt-me · 33333333' })
       );
     });
+  });
+
+  it('skips warm choreography entirely when the readiness ack never arrives (no best-effort)', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.execSync.mockImplementation((cmd: string) => {
+        if (cmd === 'which zellij') return Buffer.from('/usr/bin/zellij\n');
+        if (cmd.startsWith('pgrep ')) return Buffer.from('4242\n'); // adopted
+        if (cmd.startsWith('sudo -n chown ')) return Buffer.from('');
+        throw new Error('not found');
+      });
+      const branch = {
+        ...mocks.branch,
+        branch_id: '44444444-4444-7444-8444-444444444444' as BranchID,
+        name: 'never-ready',
+        path: '/tmp/repo/never-ready',
+      };
+      mocks.branchesById.set(branch.branch_id, branch);
+
+      const app = makeApp();
+      const service = new TerminalsService(app as never, {} as never);
+      await service.create({ branchId: branch.branch_id, rows: 24, cols: 80 }, params as never);
+
+      // Advance well past the readiness timeout without any ack.
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      // Best-effort firing is gone: nothing is emitted into the dead room.
+      expect(app.emit).not.toHaveBeenCalledWith('terminal:tab', expect.anything());
+      expect(app.emit).not.toHaveBeenCalledWith('terminal:redraw', expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('falls back to branch.path when an impersonated same-name symlink resolves elsewhere', async () => {

--- a/apps/agor-daemon/src/services/terminals.test.ts
+++ b/apps/agor-daemon/src/services/terminals.test.ts
@@ -392,6 +392,11 @@ describe('TerminalsService branch shell tabs', () => {
       },
     });
 
+    // Warm reuse only drives the executor once it has acked readiness — an
+    // adopted-but-not-yet-reconnected executor must not get commands fired into
+    // an empty room. Mark ready to model a live, acked executor.
+    service.handleExecutorReady(params.user.user_id as never);
+
     const second = await service.create(
       { branchId: secondBranch.branch_id, rows: 24, cols: 80 },
       params as never
@@ -400,12 +405,55 @@ describe('TerminalsService branch shell tabs', () => {
     expect(second).toMatchObject({
       isNew: false,
       branchName: 'same-name',
+      ready: true,
     });
-    expect(app.emit).toHaveBeenCalledWith('terminal:tab', {
-      userId: params.user.user_id,
-      action: 'create',
-      tabName: 'same-name · 22222222',
-      cwd: secondBranch.path,
+    await vi.waitFor(() => {
+      expect(app.emit).toHaveBeenCalledWith('terminal:tab', {
+        userId: params.user.user_id,
+        action: 'create',
+        tabName: 'same-name · 22222222',
+        cwd: secondBranch.path,
+      });
+    });
+  });
+
+  it('does not fire warm choreography until an adopted executor re-announces readiness', async () => {
+    // Model a post-restart adoption: pgrep finds the surviving process, so the
+    // executor is in the map (warm path) but has NOT re-acked readiness yet.
+    mocks.execSync.mockImplementation((cmd: string) => {
+      if (cmd === 'which zellij') return Buffer.from('/usr/bin/zellij\n');
+      if (cmd.startsWith('pgrep ')) return Buffer.from('4242\n'); // adoption hit
+      if (cmd.startsWith('sudo -n chown ')) return Buffer.from('');
+      throw new Error('not found');
+    });
+    const branch = {
+      ...mocks.branch,
+      branch_id: '33333333-3333-7333-8333-333333333333' as BranchID,
+      name: 'adopt-me',
+      path: '/tmp/repo/adopt-me',
+    };
+    mocks.branchesById.set(branch.branch_id, branch);
+
+    const app = makeApp();
+    const service = new TerminalsService(app as never, {} as never);
+
+    const result = await service.create(
+      { branchId: branch.branch_id, rows: 24, cols: 80 },
+      params as never
+    );
+
+    // Adopted, not spawned, and not yet ready.
+    expect(mocks.spawnExecutorFireAndForget).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ isNew: false, ready: false });
+    expect(app.emit).not.toHaveBeenCalledWith('terminal:tab', expect.anything());
+
+    // The surviving executor reconnects and re-announces — now choreography fires.
+    service.handleExecutorReady(params.user.user_id as never);
+    await vi.waitFor(() => {
+      expect(app.emit).toHaveBeenCalledWith(
+        'terminal:tab',
+        expect.objectContaining({ action: 'create', tabName: 'adopt-me · 33333333' })
+      );
     });
   });
 

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -233,6 +233,23 @@ export class TerminalsService {
     this.app = app;
     this.db = db;
 
+    // The socketio relay converts the executor's readiness/failure acks into
+    // app events (it can't reach this service instance directly). Readiness
+    // gates the tab choreography and tells the browser channel it may leave
+    // its "connecting" state.
+    (this.app as unknown as import('node:events').EventEmitter).on(
+      'terminal:ready',
+      (data: { userId?: string }) => {
+        if (data?.userId) this.handleExecutorReady(data.userId as UserID);
+      }
+    );
+    (this.app as unknown as import('node:events').EventEmitter).on(
+      'terminal:error',
+      (data: { userId?: string; message?: string }) => {
+        if (data?.userId) this.handleExecutorError(data.userId as UserID, data.message);
+      }
+    );
+
     // Check if Zellij is available - warn but don't fail
     this.zellijAvailable = isZellijAvailable();
 
@@ -276,6 +293,13 @@ export class TerminalsService {
     sessionName: string;
     isNew: boolean;
     branchName?: string;
+    /**
+     * Whether the executor's PTY bridge is confirmed up right now (ready ack
+     * received, or a live executor adopted). The browser flips to connected
+     * immediately when true; when false it waits for the async `terminal:ready`
+     * channel event rather than trusting this call's resolution.
+     */
+    ready: boolean;
   }> {
     if (!getCurrentTenantId()) {
       throw new Error('Missing active tenant context for terminal creation');
@@ -419,6 +443,136 @@ export class TerminalsService {
    * panic in its screen/plugin state update path.
    */
   private executorStarting: Map<UserID, Promise<void>> = new Map();
+
+  /**
+   * Users whose executor has confirmed (via `terminal:ready`) that its PTY is
+   * spawned and zellij is attached, or whose live executor we adopted after a
+   * restart. Membership means "the bridge is up right now" — the create()
+   * response reports it so the browser can flip to connected without waiting
+   * on a channel event that may have raced its own join.
+   */
+  private readyExecutors: Set<UserID> = new Set();
+
+  /**
+   * One-shot settlers waiting for a user's executor to resolve its readiness.
+   * Settled with `true` on a ready ack and `false` on executor exit/error or
+   * timeout. Used to gate cold-start tab choreography on the real ack instead
+   * of a blind boot timer.
+   */
+  private readyWaiters: Map<UserID, Set<(ready: boolean) => void>> = new Map();
+
+  /**
+   * How long the cold-start choreography waits for the readiness ack before
+   * giving up and firing best-effort. Generous relative to a typical zellij
+   * boot (~1-3s); a genuinely dead executor surfaces to the browser via its
+   * own `terminal:error` ack rather than this timeout.
+   */
+  private static readonly READY_TIMEOUT_MS = 10_000;
+
+  /**
+   * Record executor readiness: unblock any waiters and let a browser already
+   * sitting on the channel (cold boot, or a post-reconnect re-announce) leave
+   * its "connecting" state.
+   */
+  handleExecutorReady(userId: UserID): void {
+    this.readyExecutors.add(userId);
+    this.settleReadyWaiters(userId, true);
+    this.app.io?.to(`user/${userId}/terminal`).emit('terminal:ready', { userId });
+  }
+
+  /**
+   * Relay an executor attach failure to the browser channel so it shows an
+   * error instead of hanging on "connecting".
+   */
+  handleExecutorError(userId: UserID, message?: string): void {
+    this.readyExecutors.delete(userId);
+    this.settleReadyWaiters(userId, false);
+    this.app.io?.to(`user/${userId}/terminal`).emit('terminal:error', { userId, message });
+  }
+
+  /** Settle and clear every pending readiness waiter for a user. */
+  private settleReadyWaiters(userId: UserID, ready: boolean): void {
+    const waiters = this.readyWaiters.get(userId);
+    if (!waiters) return;
+    this.readyWaiters.delete(userId);
+    for (const settle of [...waiters]) settle(ready);
+  }
+
+  /**
+   * Resolve `true` once the user's executor is ready, or `false` if it exits /
+   * errors or hasn't become ready within {@link READY_TIMEOUT_MS}. Resolves
+   * immediately when the executor is already known-ready.
+   */
+  private awaitExecutorReady(userId: UserID): Promise<boolean> {
+    if (this.readyExecutors.has(userId)) return Promise.resolve(true);
+    return new Promise<boolean>((resolve) => {
+      const waiters = this.readyWaiters.get(userId) ?? new Set();
+      const settle = (ready: boolean) => {
+        clearTimeout(timer);
+        waiters.delete(settle);
+        resolve(ready);
+      };
+      const timer = setTimeout(() => settle(false), TerminalsService.READY_TIMEOUT_MS);
+      // Don't keep the process (or a test worker) alive on this fallback timer.
+      timer.unref?.();
+      waiters.add(settle);
+      this.readyWaiters.set(userId, waiters);
+    });
+  }
+
+  /**
+   * Emit the CLI ensure-or-focus tab command for a user. Extracted so the warm
+   * and cold create paths share one implementation of the
+   * "claude alive ⇒ focus, dead ⇒ forceRecreate" branching.
+   *
+   * `skipTabName` suppresses a redundant focus when the requested tab is the
+   * same branch-shell tab we just created (warm path only).
+   */
+  private async dispatchTabFocus(
+    userId: UserID,
+    opts: {
+      cliEnsure?: {
+        tabName: string;
+        cwd: string;
+        command: string;
+        commandArgs: string[];
+        sessionId: string;
+      } | null;
+      focusTabName?: string;
+      skipTabName?: string;
+    }
+  ): Promise<void> {
+    const { cliEnsure, focusTabName, skipTabName } = opts;
+    const channel = `user/${userId}/terminal`;
+    if (cliEnsure && cliEnsure.tabName !== skipTabName) {
+      const alive = await isClaudeRunningFor(
+        cliEnsure.sessionId as unknown as import('@agor/core/types').SessionID
+      );
+      if (alive) {
+        this.app.io?.to(channel).emit('terminal:tab', {
+          userId,
+          action: 'focus',
+          tabName: cliEnsure.tabName,
+        });
+      } else {
+        this.app.io?.to(channel).emit('terminal:tab', {
+          userId,
+          action: 'create',
+          tabName: cliEnsure.tabName,
+          cwd: cliEnsure.cwd,
+          command: cliEnsure.command,
+          commandArgs: cliEnsure.commandArgs,
+          forceRecreate: true,
+        });
+      }
+    } else if (focusTabName && focusTabName !== skipTabName) {
+      this.app.io?.to(channel).emit('terminal:tab', {
+        userId,
+        action: 'focus',
+        tabName: focusTabName,
+      });
+    }
+  }
 
   /**
    * Create or join an executor-based terminal session
@@ -592,6 +746,7 @@ export class TerminalsService {
     sessionName: string;
     isNew: boolean;
     branchName?: string;
+    ready: boolean;
   }> {
     const userId = params?.user?.user_id as UserID;
     if (!userId) {
@@ -636,6 +791,11 @@ export class TerminalsService {
           activeBranches: new Set(),
           startedAt: new Date(),
         });
+        // A live `zellij attach` process is by definition already bridging —
+        // treat it as ready so the warm path can flip the browser to connected
+        // without waiting on a ready ack the surviving executor won't re-send
+        // until its own socket reconnects.
+        this.readyExecutors.add(userId);
       }
     }
 
@@ -664,7 +824,7 @@ export class TerminalsService {
           // Ensure-create the CLI tab when an `ensureCliSessionId` was
           // supplied.
           //
-          // Server-side claude liveness check decides the action:
+          // Server-side claude liveness check (in dispatchTabFocus) decides:
           //   - `claude` alive ⇒ `focus` (preserves scrollback)
           //   - `claude` dead  ⇒ `create` + `forceRecreate: true`
           //     (closes every stale duplicate of the tab name, then
@@ -677,45 +837,16 @@ export class TerminalsService {
           // auto-converse focused the stale tab instead of respawning.
           //
           // Falls back to the old plain-focus behavior when the caller
-          // provided a `focusTabName` without an `ensureCliSessionId`.
-          if (data.cliEnsure && data.cliEnsure.tabName !== branchTabName) {
-            const ensure = data.cliEnsure;
-            const alive = await isClaudeRunningFor(
-              ensure.sessionId as unknown as import('@agor/core/types').SessionID
-            );
-            setTimeout(() => {
-              if (alive) {
-                this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
-                  userId,
-                  action: 'focus',
-                  tabName: ensure.tabName,
-                });
-              } else {
-                this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
-                  userId,
-                  action: 'create',
-                  tabName: ensure.tabName,
-                  cwd: ensure.cwd,
-                  command: ensure.command,
-                  commandArgs: ensure.commandArgs,
-                  forceRecreate: true,
-                });
-              }
-            }, 300);
-          } else if (data.focusTabName && data.focusTabName !== branchTabName) {
-            setTimeout(() => {
-              this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
-                userId,
-                action: 'focus',
-                tabName: data.focusTabName,
-              });
-            }, 300);
-          }
+          // provided a `focusTabName` without an `ensureCliSessionId`. The
+          // executor here is already attached (it was in the map), so this
+          // fires immediately rather than guessing a boot delay.
+          await this.dispatchTabFocus(userId, {
+            cliEnsure: data.cliEnsure,
+            focusTabName: data.focusTabName,
+            skipTabName: branchTabName,
+          });
 
-          // Request screen redraw after a short delay to let client join channel first
-          setTimeout(() => {
-            this.app.io?.to(`user/${userId}/terminal`).emit('terminal:redraw', { userId });
-          }, 200);
+          this.app.io?.to(`user/${userId}/terminal`).emit('terminal:redraw', { userId });
 
           return {
             userId,
@@ -723,20 +854,19 @@ export class TerminalsService {
             sessionName: existing.sessionName,
             isNew: false,
             branchName: branch.name,
+            ready: this.readyExecutors.has(userId),
           };
         }
       }
 
-      // Request screen redraw after a short delay to let client join channel first
-      setTimeout(() => {
-        this.app.io?.to(`user/${userId}/terminal`).emit('terminal:redraw', { userId });
-      }, 200);
+      this.app.io?.to(`user/${userId}/terminal`).emit('terminal:redraw', { userId });
 
       return {
         userId,
         channel: `user/${userId}/terminal`,
         sessionName: existing.sessionName,
         isNew: false,
+        ready: this.readyExecutors.has(userId),
       };
     }
 
@@ -843,6 +973,11 @@ export class TerminalsService {
         }
       );
 
+      // Fresh spawn: this executor hasn't acked readiness yet. Drop any stale
+      // flag from a prior (now-dead) executor so the gate below waits for the
+      // new one's real ack rather than a leftover.
+      this.readyExecutors.delete(userId);
+
       // Track the executor
       this.executorTerminals.set(userId, {
         sessionName,
@@ -851,43 +986,22 @@ export class TerminalsService {
       });
 
       // Cold-start path: the executor hasn't yet attached to its Feathers
-      // channel, so the `onCliSessionCreated` dispatch (if any) landed in
-      // an empty room and was dropped. Re-emit after the executor boots
-      // (~1.5s). Same liveness branching as the warm path — `claude`
-      // alive ⇒ focus, dead ⇒ forceRecreate (close any stale tab from
-      // an earlier daemon instance, then spawn fresh).
-      if (data.cliEnsure) {
-        const ensure = data.cliEnsure;
-        const alive = await isClaudeRunningFor(
-          ensure.sessionId as unknown as import('@agor/core/types').SessionID
-        );
-        setTimeout(() => {
-          if (alive) {
-            this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
-              userId,
-              action: 'focus',
-              tabName: ensure.tabName,
-            });
-          } else {
-            this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
-              userId,
-              action: 'create',
-              tabName: ensure.tabName,
-              cwd: ensure.cwd,
-              command: ensure.command,
-              commandArgs: ensure.commandArgs,
-              forceRecreate: true,
-            });
+      // channel, so a `terminal:tab` emitted now would land in an empty room
+      // and be dropped. Gate the CLI ensure/focus dispatch on the executor's
+      // `terminal:ready` ack instead of guessing a boot delay. Same liveness
+      // branching as the warm path (handled in dispatchTabFocus). Fire
+      // best-effort if the ack never arrives so a missed ack doesn't strand
+      // the tab, and log it.
+      if (data.cliEnsure || data.focusTabName) {
+        const { cliEnsure, focusTabName } = data;
+        void this.awaitExecutorReady(userId).then((ready) => {
+          if (!ready) {
+            console.warn(
+              `[TerminalsService] readiness ack not received for user ${shortId(userId)} — dispatching tab focus best-effort`
+            );
           }
-        }, 1500);
-      } else if (data.focusTabName) {
-        setTimeout(() => {
-          this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
-            userId,
-            action: 'focus',
-            tabName: data.focusTabName,
-          });
-        }, 1500);
+          return this.dispatchTabFocus(userId, { cliEnsure, focusTabName });
+        });
       }
 
       return {
@@ -896,6 +1010,7 @@ export class TerminalsService {
         sessionName,
         isNew: true,
         branchName,
+        ready: false,
       };
     } finally {
       if (this.executorStarting.get(userId) === startReservation) {
@@ -951,6 +1066,10 @@ export class TerminalsService {
    */
   handleExecutorExit(userId: UserID): void {
     this.executorTerminals.delete(userId);
+    this.readyExecutors.delete(userId);
+    // Release any pending readiness waiters as not-ready so they settle
+    // immediately instead of hanging until their timeout.
+    this.settleReadyWaiters(userId, false);
     console.log(`[TerminalsService] Executor terminal exited for user ${shortId(userId)}`);
   }
 }

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -65,13 +65,14 @@ import {
  * service-token default would break reconnection). 30 days covers realistic
  * usage.
  *
- * SECURITY: the `terminal_user_id` claim makes this a RESTRICTED, low-privilege
- * identity — ServiceJWTStrategy resolves it to `_isTerminalExecutor` (not a
- * full `_isServiceAccount`), so it does NOT bypass RBAC on any REST/Feathers
- * path; it only authorizes its own user's terminal socket channel. That
- * confinement is what makes a long TTL acceptable (there's no revocation story
- * for a stateless JWT). A leaked token grants terminal-channel I/O for that one
- * user for its lifetime — no broader daemon access.
+ * SECURITY: the `terminal_user_id` claim makes this a RESTRICTED identity —
+ * ServiceJWTStrategy resolves it to `_isTerminalExecutor` (NOT a full
+ * `_isServiceAccount`), and `rejectTerminalExecutorIdentity` (composed into
+ * `requireAuth`) REJECTS it from every REST/Feathers service call. It is valid
+ * ONLY for its own user's Socket.IO terminal channel. That confinement is what
+ * makes a long TTL acceptable (there's no revocation story for a stateless
+ * JWT): a leaked token grants terminal-channel I/O for that one user for its
+ * lifetime — no broader daemon access.
  */
 const TERMINAL_EXECUTOR_TOKEN_TTL = '30d';
 

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -791,11 +791,13 @@ export class TerminalsService {
           activeBranches: new Set(),
           startedAt: new Date(),
         });
-        // A live `zellij attach` process is by definition already bridging —
-        // treat it as ready so the warm path can flip the browser to connected
-        // without waiting on a ready ack the surviving executor won't re-send
-        // until its own socket reconnects.
-        this.readyExecutors.add(userId);
+        // Deliberately NOT marked ready here. A `pgrep` match means the process
+        // exists, not that it has re-established its socket + re-authenticated
+        // after the daemon restart — it may be reconnecting or failing auth.
+        // Readiness is granted only when the adopted executor actually
+        // re-announces `terminal:ready` (handleExecutorReady). Until then the
+        // warm path gates its choreography and reports ready:false so the
+        // browser waits for the real ack instead of us firing into a dead room.
       }
     }
 
@@ -813,44 +815,41 @@ export class TerminalsService {
         );
         if (branch) {
           const branchTabName = buildBranchShellTabName(branch);
-          // Emit tab command via channel - executor will handle it
-          this.app.io?.to(`user/${userId}/terminal`).emit('terminal:tab', {
-            userId,
-            action: 'create',
-            tabName: branchTabName,
-            cwd: branch.path,
-          });
+          const channel = `user/${userId}/terminal`;
 
-          // Ensure-create the CLI tab when an `ensureCliSessionId` was
-          // supplied.
+          // Gate ALL executor-directed choreography on readiness. For a normal
+          // warm reuse (the executor acked ready this daemon session) this
+          // resolves immediately; for an adopted post-restart executor it
+          // waits until the process actually re-announces `terminal:ready`,
+          // so we don't emit tab/redraw commands into an empty/dead room.
           //
-          // Server-side claude liveness check (in dispatchTabFocus) decides:
-          //   - `claude` alive ⇒ `focus` (preserves scrollback)
-          //   - `claude` dead  ⇒ `create` + `forceRecreate: true`
-          //     (closes every stale duplicate of the tab name, then
-          //     spawns fresh with the layout-file claude argv)
-          //
-          // Without this branching, reopening a session whose
-          // foreground claude exited (Ctrl-D, kill -9, post-restart-
-          // before-watchdog-fires) left the user staring at a bash
-          // prompt — the executor's default "tab exists ⇒ focus"
-          // auto-converse focused the stale tab instead of respawning.
-          //
-          // Falls back to the old plain-focus behavior when the caller
-          // provided a `focusTabName` without an `ensureCliSessionId`. The
-          // executor here is already attached (it was in the map), so this
-          // fires immediately rather than guessing a boot delay.
-          await this.dispatchTabFocus(userId, {
-            cliEnsure: data.cliEnsure,
-            focusTabName: data.focusTabName,
-            skipTabName: branchTabName,
+          // dispatchTabFocus does the claude liveness branching (alive ⇒
+          // focus preserves scrollback; dead ⇒ create+forceRecreate spawns a
+          // fresh claude), falling back to a plain focus when only a
+          // `focusTabName` was supplied.
+          void this.awaitExecutorReady(userId).then(async (isReady) => {
+            if (!isReady) {
+              console.warn(
+                `[TerminalsService] readiness ack not received for user ${shortId(userId)} — warm choreography best-effort`
+              );
+            }
+            this.app.io?.to(channel).emit('terminal:tab', {
+              userId,
+              action: 'create',
+              tabName: branchTabName,
+              cwd: branch.path,
+            });
+            await this.dispatchTabFocus(userId, {
+              cliEnsure: data.cliEnsure,
+              focusTabName: data.focusTabName,
+              skipTabName: branchTabName,
+            });
+            this.app.io?.to(channel).emit('terminal:redraw', { userId });
           });
-
-          this.app.io?.to(`user/${userId}/terminal`).emit('terminal:redraw', { userId });
 
           return {
             userId,
-            channel: `user/${userId}/terminal`,
+            channel,
             sessionName: existing.sessionName,
             isNew: false,
             branchName: branch.name,
@@ -859,7 +858,11 @@ export class TerminalsService {
         }
       }
 
-      this.app.io?.to(`user/${userId}/terminal`).emit('terminal:redraw', { userId });
+      void this.awaitExecutorReady(userId).then((isReady) => {
+        if (isReady) {
+          this.app.io?.to(`user/${userId}/terminal`).emit('terminal:redraw', { userId });
+        }
+      });
 
       return {
         userId,
@@ -941,9 +944,14 @@ export class TerminalsService {
       const userSessionSuffix = shortId(userId);
       const sessionName = `agor-${userSessionSuffix}`;
 
-      // Generate session token for executor
+      // Generate session token for executor. Bind the userId into the token
+      // (`terminal_user_id`) so the socket layer can scope this executor's
+      // terminal:* emits to its own user — a tenant-scoped service token alone
+      // can't act for the right user only. See socketio.ts terminal handlers.
       const daemonUrl = `http://localhost:${config.daemon?.port || 3030}`;
-      const sessionToken = generateScopedServiceToken(this.app, params);
+      const sessionToken = generateScopedServiceToken(this.app, params, {
+        terminal_user_id: userId,
+      });
 
       // File/process work stays outside the tenant database unit of work.
       const envFile = writeEnvFile(userId, userEnv, finalUnixUser);

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -58,6 +58,15 @@ import {
   writeClaudeCliMcpConfigForSession,
 } from './claude-cli-integration.js';
 
+/**
+ * TTL for the terminal executor's scoped service token. Terminals are
+ * long-lived and the executor re-authenticates with the same token across
+ * reconnects, so this must comfortably exceed a session's lifetime (the 5m
+ * service-token default would break reconnection). 30 days covers realistic
+ * usage; a token grants only terminal-channel access for one user.
+ */
+const TERMINAL_EXECUTOR_TOKEN_TTL = '30d';
+
 interface CreateTerminalData {
   rows?: number;
   cols?: number;
@@ -828,10 +837,15 @@ export class TerminalsService {
           // fresh claude), falling back to a plain focus when only a
           // `focusTabName` was supplied.
           void this.awaitExecutorReady(userId).then(async (isReady) => {
+            // Strictly gated: if the ack never arrives (executor errored, or an
+            // adopted process never re-announced) we do NOT fire into a dead
+            // room. The executor's own terminal:error / the ready:false in the
+            // response already keep the browser out of a false "connected".
             if (!isReady) {
               console.warn(
-                `[TerminalsService] readiness ack not received for user ${shortId(userId)} — warm choreography best-effort`
+                `[TerminalsService] readiness ack not received for user ${shortId(userId)} — skipping warm choreography`
               );
+              return;
             }
             this.app.io?.to(channel).emit('terminal:tab', {
               userId,
@@ -948,10 +962,21 @@ export class TerminalsService {
       // (`terminal_user_id`) so the socket layer can scope this executor's
       // terminal:* emits to its own user — a tenant-scoped service token alone
       // can't act for the right user only. See socketio.ts terminal handlers.
+      //
+      // Terminal executors are long-lived and re-authenticate with THIS SAME
+      // token on every reconnect (network blip / daemon restart — the whole
+      // point of this feature). The default 5m service-token TTL would expire
+      // mid-session and make reconnection fail, so we issue it with a long TTL
+      // covering realistic session lifetimes. (A refresh-on-reconnect scheme
+      // would be more robust but there's no authenticated channel to fetch a
+      // new token on an expired socket; a long TTL fits the current auth model.)
       const daemonUrl = `http://localhost:${config.daemon?.port || 3030}`;
-      const sessionToken = generateScopedServiceToken(this.app, params, {
-        terminal_user_id: userId,
-      });
+      const sessionToken = generateScopedServiceToken(
+        this.app,
+        params,
+        { terminal_user_id: userId },
+        TERMINAL_EXECUTOR_TOKEN_TTL
+      );
 
       // File/process work stays outside the tenant database unit of work.
       const envFile = writeEnvFile(userId, userEnv, finalUnixUser);
@@ -1003,10 +1028,12 @@ export class TerminalsService {
       if (data.cliEnsure || data.focusTabName) {
         const { cliEnsure, focusTabName } = data;
         void this.awaitExecutorReady(userId).then((ready) => {
+          // Strictly gated on the readiness ack — no blind best-effort fire.
           if (!ready) {
             console.warn(
-              `[TerminalsService] readiness ack not received for user ${shortId(userId)} — dispatching tab focus best-effort`
+              `[TerminalsService] readiness ack not received for user ${shortId(userId)} — skipping cold-start tab focus`
             );
+            return;
           }
           return this.dispatchTabFocus(userId, { cliEnsure, focusTabName });
         });

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -63,7 +63,15 @@ import {
  * long-lived and the executor re-authenticates with the same token across
  * reconnects, so this must comfortably exceed a session's lifetime (the 5m
  * service-token default would break reconnection). 30 days covers realistic
- * usage; a token grants only terminal-channel access for one user.
+ * usage.
+ *
+ * SECURITY: the `terminal_user_id` claim makes this a RESTRICTED, low-privilege
+ * identity — ServiceJWTStrategy resolves it to `_isTerminalExecutor` (not a
+ * full `_isServiceAccount`), so it does NOT bypass RBAC on any REST/Feathers
+ * path; it only authorizes its own user's terminal socket channel. That
+ * confinement is what makes a long TTL acceptable (there's no revocation story
+ * for a stateless JWT). A leaked token grants terminal-channel I/O for that one
+ * user for its lifetime — no broader daemon access.
  */
 const TERMINAL_EXECUTOR_TOKEN_TTL = '30d';
 
@@ -471,10 +479,10 @@ export class TerminalsService {
   private readyWaiters: Map<UserID, Set<(ready: boolean) => void>> = new Map();
 
   /**
-   * How long the cold-start choreography waits for the readiness ack before
-   * giving up and firing best-effort. Generous relative to a typical zellij
-   * boot (~1-3s); a genuinely dead executor surfaces to the browser via its
-   * own `terminal:error` ack rather than this timeout.
+   * How long the choreography waits for the readiness ack before giving up and
+   * SKIPPING it entirely (no blind best-effort fire). Generous relative to a
+   * typical zellij boot (~1-3s); a genuinely dead executor surfaces to the
+   * browser via its own `terminal:error` ack rather than this timeout.
    */
   private static readonly READY_TIMEOUT_MS = 10_000;
 
@@ -1022,9 +1030,9 @@ export class TerminalsService {
       // channel, so a `terminal:tab` emitted now would land in an empty room
       // and be dropped. Gate the CLI ensure/focus dispatch on the executor's
       // `terminal:ready` ack instead of guessing a boot delay. Same liveness
-      // branching as the warm path (handled in dispatchTabFocus). Fire
-      // best-effort if the ack never arrives so a missed ack doesn't strand
-      // the tab, and log it.
+      // branching as the warm path (handled in dispatchTabFocus). If the ack
+      // never arrives we SKIP the dispatch entirely — no blind best-effort
+      // fire into a dead room — and log it.
       if (data.cliEnsure || data.focusTabName) {
         const { cliEnsure, focusTabName } = data;
         void this.awaitExecutorReady(userId).then((ready) => {

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -226,21 +226,31 @@ function asServicePostConnect(socket: FakeSocket) {
   };
 }
 /**
- * A terminal executor service socket, user-scoped via the `terminal_user_id`
- * claim bound into its token at spawn time (see terminals.ts / socketio.ts
- * handshake middleware). This is what real terminal executors carry.
+ * A terminal executor socket: a RESTRICTED identity user-scoped via
+ * `terminal_user_id`. Deliberately NOT a full service account (no
+ * `_isServiceAccount`) — that's the whole point of the terminal-scoped token.
+ * Mirrors what ServiceJWTStrategy mints for a token carrying terminal_user_id.
  */
 function asServiceForUser(socket: FakeSocket, userId: string) {
   socket.feathers = {
-    user: { user_id: 'executor-service', _isServiceAccount: true, terminal_user_id: userId },
+    user: {
+      user_id: 'executor-service',
+      role: 'terminal-executor',
+      _isTerminalExecutor: true,
+      terminal_user_id: userId,
+    },
   };
 }
 /** Handshake-token variant of a user-scoped terminal executor socket. */
 function asServiceHandshakeForUser(socket: FakeSocket, userId: string) {
   socket.feathers = {
-    user: { user_id: 'executor-service', _isServiceAccount: true, terminal_user_id: userId },
+    user: {
+      user_id: 'executor-service',
+      role: 'terminal-executor',
+      _isTerminalExecutor: true,
+      terminal_user_id: userId,
+    },
   };
-  socket.data.isService = true;
   socket.data.terminalUserId = userId;
 }
 
@@ -284,6 +294,25 @@ describe('getSocketAuthState', () => {
     const s = makeSocket();
     asServicePostConnect(s);
     expect(getSocketAuthState(s as any)).toEqual({ userId: null, isService: true });
+  });
+  it('reports a terminal-scoped identity as service-for-terminal WITH its terminalUserId', () => {
+    const s = makeSocket();
+    asServiceForUser(s, ALICE);
+    expect(getSocketAuthState(s as any)).toEqual({
+      userId: null,
+      isService: true,
+      terminalUserId: ALICE,
+    });
+  });
+  it('a terminal-scoped identity carries no _isServiceAccount (no REST RBAC bypass)', () => {
+    // The whole point of the terminal token: it authenticates the socket for
+    // its own channel but is NOT a full service account, so the RBAC-bypass
+    // hooks (which read user._isServiceAccount) never fire for it.
+    const s = makeSocket();
+    asServiceForUser(s, ALICE);
+    const user = (s.feathers as { user: { _isServiceAccount?: boolean; role?: string } }).user;
+    expect(user._isServiceAccount).toBeUndefined();
+    expect(user.role).not.toBe('service');
   });
   it('service account wins over user_id: synthetic executor user is not treated as a real user', () => {
     // The synthetic service user carries user_id='executor-service'. If we

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -225,6 +225,16 @@ function asServicePostConnect(socket: FakeSocket) {
     user: { user_id: 'executor-service', _isServiceAccount: true },
   };
 }
+/**
+ * A terminal executor service socket, user-scoped via the `terminal_user_id`
+ * claim bound into its token at spawn time (see terminals.ts / socketio.ts
+ * handshake middleware). This is what real terminal executors carry.
+ */
+function asServiceForUser(socket: FakeSocket, userId: string) {
+  socket.feathers = {
+    user: { user_id: 'executor-service', _isServiceAccount: true, terminal_user_id: userId },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Pure helpers
@@ -582,6 +592,16 @@ describe('terminal:* handler authorization', () => {
       ]);
     });
 
+    it("a user-scoped executor may not emit output/tab for a different user's channel", () => {
+      const { io } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServiceForUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:output')?.({ userId: BOB, data: 'x' });
+      s.handlers.get('terminal:tab')?.({ userId: BOB, action: 'create', tabName: 't' });
+      expect(io.emitted).toEqual([]);
+    });
+
     it('all three reject when allow_web_terminal is false even for service sockets', () => {
       const { io } = buildHarness({ webTerminalEnabled: false });
       const s = makeSocket('exec-sock');
@@ -595,10 +615,10 @@ describe('terminal:* handler authorization', () => {
   });
 
   describe('terminal:ready / terminal:error (executor readiness acks)', () => {
-    it('relays a service socket ready ack to the app for the terminals service', () => {
+    it('relays a user-scoped service socket ready ack to the app', () => {
       const { io, app } = buildHarness();
       const s = makeSocket('exec-sock');
-      asServicePostConnect(s);
+      asServiceForUser(s, ALICE);
       connect(io, s);
       s.handlers.get('terminal:ready')?.({ userId: ALICE, sessionName: 'agor-x', tabName: 't' });
       expect(app.emit).toHaveBeenCalledWith('terminal:ready', {
@@ -608,13 +628,36 @@ describe('terminal:* handler authorization', () => {
       });
     });
 
-    it('relays a service socket error ack to the app', () => {
+    it('relays a user-scoped service socket error ack to the app', () => {
+      const { io, app } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServiceForUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:error')?.({ userId: ALICE, message: 'boom' });
+      expect(app.emit).toHaveBeenCalledWith('terminal:error', { userId: ALICE, message: 'boom' });
+    });
+
+    it("rejects an executor scoped to ALICE flipping BOB's readiness (cross-user forgery)", () => {
+      const { io, app } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServiceForUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:ready')?.({ userId: BOB });
+      s.handlers.get('terminal:error')?.({ userId: BOB, message: 'spoof' });
+      expect(app.emit).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('may not act for'));
+    });
+
+    it('rejects ready/error from an unscoped service token (requireScope)', () => {
+      // A generic (non-terminal) service token carries no terminal_user_id and
+      // therefore may not drive per-user readiness state.
       const { io, app } = buildHarness();
       const s = makeSocket('exec-sock');
       asServicePostConnect(s);
       connect(io, s);
-      s.handlers.get('terminal:error')?.({ userId: ALICE, message: 'boom' });
-      expect(app.emit).toHaveBeenCalledWith('terminal:error', { userId: ALICE, message: 'boom' });
+      s.handlers.get('terminal:ready')?.({ userId: ALICE });
+      s.handlers.get('terminal:error')?.({ userId: ALICE });
+      expect(app.emit).not.toHaveBeenCalled();
     });
 
     it('rejects ready/error acks from user-token sockets (only service may emit)', () => {
@@ -630,7 +673,7 @@ describe('terminal:* handler authorization', () => {
     it('rejects ready/error acks when allow_web_terminal is false', () => {
       const { io, app } = buildHarness({ webTerminalEnabled: false });
       const s = makeSocket('exec-sock');
-      asServicePostConnect(s);
+      asServiceForUser(s, ALICE);
       connect(io, s);
       s.handlers.get('terminal:ready')?.({ userId: ALICE });
       s.handlers.get('terminal:error')?.({ userId: ALICE });

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -987,6 +987,46 @@ describe('configureChannels tenant isolation', () => {
     expect(joins.get(tenantUserChannelName('tenant-from-params', ALICE))).toEqual([connection]);
   });
 
+  it('does NOT join a terminal-executor identity to any broadcast channel', () => {
+    // The long-lived terminal token must not get a realtime firehose
+    // subscription — it consumes only raw terminal:* room events, never
+    // Feathers channel broadcasts.
+    const { app, handlers, joins } = makeChannelHarness();
+    configureChannels(app, {
+      multiTenancy: {
+        mode: 'required_from_auth',
+        static_tenant_id: 'default' as never,
+        auth_claim: 'tenant_id',
+      },
+    });
+    const connection = { data: {} } as any;
+
+    handlers.get('login')?.(
+      {
+        user: { user_id: 'executor-service', _isTerminalExecutor: true },
+        authentication: { payload: { tenant_id: 'tenant-a' } },
+      },
+      { connection }
+    );
+
+    expect(joins.size).toBe(0);
+  });
+
+  it('still joins a full service account to broadcast channels (service delivery)', () => {
+    const { app, handlers, joins } = makeChannelHarness();
+    configureChannels(app, {
+      multiTenancy: { mode: 'static', static_tenant_id: 'tenant-a' as never },
+    });
+    const connection = { data: {} } as any;
+
+    handlers.get('login')?.(
+      { user: { user_id: 'executor-service', _isServiceAccount: true }, authentication: {} },
+      { connection }
+    );
+
+    expect(joins.get('authenticated')).toEqual([connection]);
+  });
+
   it('leaves tenant-scoped channels on logout', () => {
     const { app, handlers, leaves } = makeChannelHarness();
     configureChannels(app, {

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -166,11 +166,13 @@ function makeIO(): FakeIO {
 }
 
 function makeApp(): Application {
-  // Minimal Application surface used by createSocketIOConfig: app.service('users').get
-  // and app.on('login'). Tests don't exercise the login event path.
+  // Minimal Application surface used by createSocketIOConfig: app.service('users').get,
+  // app.on('login'), and app.emit for the terminal:ready/error relay. Tests
+  // don't exercise the login event path.
   return {
     service: () => ({ get: async () => ({ user_id: 'u' }) }),
     on: () => {},
+    emit: vi.fn(),
   } as any;
 }
 
@@ -185,7 +187,7 @@ function buildHarness(opts: Partial<SocketIOOptions> = {}) {
     ...opts,
   } as SocketIOOptions);
   config.callback(io as any);
-  return { io, config };
+  return { io, config, app };
 }
 
 function connect(io: FakeIO, socket: FakeSocket) {
@@ -589,6 +591,50 @@ describe('terminal:* handler authorization', () => {
       s.handlers.get('terminal:exit')?.({ userId: ALICE, exitCode: 0 });
       s.handlers.get('terminal:tab')?.({ userId: ALICE, action: 'create', tabName: 't' });
       expect(io.emitted).toEqual([]);
+    });
+  });
+
+  describe('terminal:ready / terminal:error (executor readiness acks)', () => {
+    it('relays a service socket ready ack to the app for the terminals service', () => {
+      const { io, app } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServicePostConnect(s);
+      connect(io, s);
+      s.handlers.get('terminal:ready')?.({ userId: ALICE, sessionName: 'agor-x', tabName: 't' });
+      expect(app.emit).toHaveBeenCalledWith('terminal:ready', {
+        userId: ALICE,
+        sessionName: 'agor-x',
+        tabName: 't',
+      });
+    });
+
+    it('relays a service socket error ack to the app', () => {
+      const { io, app } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServicePostConnect(s);
+      connect(io, s);
+      s.handlers.get('terminal:error')?.({ userId: ALICE, message: 'boom' });
+      expect(app.emit).toHaveBeenCalledWith('terminal:error', { userId: ALICE, message: 'boom' });
+    });
+
+    it('rejects ready/error acks from user-token sockets (only service may emit)', () => {
+      const { io, app } = buildHarness();
+      const s = makeSocket('alice-sock');
+      asUser(s, ALICE);
+      connect(io, s);
+      s.handlers.get('terminal:ready')?.({ userId: ALICE });
+      s.handlers.get('terminal:error')?.({ userId: ALICE, message: 'spoof' });
+      expect(app.emit).not.toHaveBeenCalled();
+    });
+
+    it('rejects ready/error acks when allow_web_terminal is false', () => {
+      const { io, app } = buildHarness({ webTerminalEnabled: false });
+      const s = makeSocket('exec-sock');
+      asServicePostConnect(s);
+      connect(io, s);
+      s.handlers.get('terminal:ready')?.({ userId: ALICE });
+      s.handlers.get('terminal:error')?.({ userId: ALICE });
+      expect(app.emit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -235,6 +235,14 @@ function asServiceForUser(socket: FakeSocket, userId: string) {
     user: { user_id: 'executor-service', _isServiceAccount: true, terminal_user_id: userId },
   };
 }
+/** Handshake-token variant of a user-scoped terminal executor socket. */
+function asServiceHandshakeForUser(socket: FakeSocket, userId: string) {
+  socket.feathers = {
+    user: { user_id: 'executor-service', _isServiceAccount: true, terminal_user_id: userId },
+  };
+  socket.data.isService = true;
+  socket.data.terminalUserId = userId;
+}
 
 // ---------------------------------------------------------------------------
 // Pure helpers
@@ -508,13 +516,13 @@ describe('terminal:* handler authorization', () => {
       expect(io.emitted).toEqual([]);
     });
 
-    it('terminal:output accepts post-connect authed service sockets and relays to channel', () => {
+    it('terminal:output accepts post-connect authed, user-scoped service sockets and relays', () => {
       // Regression for executor flow: connect anonymously, then
-      // client.authenticate() attaches `_isServiceAccount: true` to feathers.user
-      // without ever setting socket.data.isService. Previous impl rejected this.
+      // client.authenticate() attaches `_isServiceAccount: true` +
+      // `terminal_user_id` to feathers.user without setting socket.data.isService.
       const { io } = buildHarness();
       const s = makeSocket('exec-sock', io);
-      asServicePostConnect(s);
+      asServiceForUser(s, ALICE);
       connect(io, s);
       s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'hello' });
       expect(io.emitted).toEqual([
@@ -532,7 +540,7 @@ describe('terminal:* handler authorization', () => {
       // `socket.to` so the sender is excluded.
       const { io } = buildHarness();
       const s = makeSocket('exec-sock', io);
-      asServicePostConnect(s);
+      asServiceForUser(s, ALICE);
       connect(io, s);
       s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'hello' });
       expect(io.emitted).toEqual([
@@ -553,7 +561,7 @@ describe('terminal:* handler authorization', () => {
       const channel = `user/${ALICE}/terminal`;
 
       const exec = makeSocket('exec-sock', io);
-      asServicePostConnect(exec);
+      asServiceForUser(exec, ALICE);
       connect(io, exec);
       exec.join(channel);
 
@@ -576,11 +584,11 @@ describe('terminal:* handler authorization', () => {
       expect(exec.received).toEqual([]);
     });
 
-    it('terminal:output also accepts handshake-token service sockets (socket.data.isService path)', () => {
+    it('terminal:output also accepts user-scoped handshake-token service sockets', () => {
       // Separately covers the fast-path: service token presented at handshake.
       const { io } = buildHarness();
       const s = makeSocket('exec-sock', io);
-      asServiceHandshake(s);
+      asServiceHandshakeForUser(s, ALICE);
       connect(io, s);
       s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'hi' });
       expect(io.emitted).toEqual([
@@ -600,6 +608,22 @@ describe('terminal:* handler authorization', () => {
       s.handlers.get('terminal:output')?.({ userId: BOB, data: 'x' });
       s.handlers.get('terminal:tab')?.({ userId: BOB, action: 'create', tabName: 't' });
       expect(io.emitted).toEqual([]);
+    });
+
+    it('an UNSCOPED service token may not forge output/exit/tab for any user', () => {
+      // Closes the "enforce-if-present" bypass: a generic service token with no
+      // terminal_user_id can no longer supply a victim userId on these events.
+      const { io } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServicePostConnect(s); // service, but no terminal scope
+      connect(io, s);
+      s.handlers.get('terminal:output')?.({ userId: ALICE, data: 'x' });
+      s.handlers.get('terminal:exit')?.({ userId: ALICE, exitCode: 0 });
+      s.handlers.get('terminal:tab')?.({ userId: ALICE, action: 'create', tabName: 't' });
+      expect(io.emitted).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('not scoped to a terminal user')
+      );
     });
 
     it('all three reject when allow_web_terminal is false even for service sockets', () => {
@@ -712,15 +736,27 @@ describe('terminal:* handler authorization', () => {
       expect(s.joined.has(`user/${ALICE}/terminal`)).toBe(true);
     });
 
-    it('allows a service socket to join any user terminal channel', () => {
+    it('allows a user-scoped executor to join ONLY its own user terminal channel', () => {
       const { io } = buildHarness();
       const s = makeSocket('exec-sock');
-      asServicePostConnect(s);
+      asServiceForUser(s, ALICE);
       connect(io, s);
       s.handlers.get('join')?.(`user/${ALICE}/terminal`);
       s.handlers.get('join')?.(`user/${BOB}/terminal`);
       expect(s.joined.has(`user/${ALICE}/terminal`)).toBe(true);
-      expect(s.joined.has(`user/${BOB}/terminal`)).toBe(true);
+      // Scoped to ALICE — must NOT be able to join BOB's channel and harvest
+      // his terminal traffic.
+      expect(s.joined.has(`user/${BOB}/terminal`)).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('may not join'));
+    });
+
+    it('rejects a join from an unscoped service token entirely', () => {
+      const { io } = buildHarness();
+      const s = makeSocket('exec-sock');
+      asServicePostConnect(s); // service, no terminal scope
+      connect(io, s);
+      s.handlers.get('join')?.(`user/${ALICE}/terminal`);
+      expect(s.joined.has(`user/${ALICE}/terminal`)).toBe(false);
     });
 
     it('rejects join when allow_web_terminal is false', () => {

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -901,6 +901,45 @@ describe('terminal:* handler authorization', () => {
   });
 });
 
+describe('presence/cursor exclude the terminal-executor identity', () => {
+  it('does NOT join a terminal-executor socket to a board presence room', () => {
+    const { io } = buildHarness();
+    const s = makeSocket('exec-sock');
+    asServiceForUser(s, ALICE);
+    connect(io, s);
+    s.handlers.get('presence:watch-board')?.('board-1');
+    expect(s.joined.has(boardPresenceRoomName('board-1'))).toBe(false);
+  });
+
+  it('DOES join a normal authenticated user to a board presence room', () => {
+    const { io } = buildHarness();
+    const s = makeSocket('alice-sock');
+    asUser(s, ALICE);
+    connect(io, s);
+    s.handlers.get('presence:watch-board')?.('board-1');
+    expect(s.joined.has(boardPresenceRoomName('board-1'))).toBe(true);
+  });
+
+  it('drops cursor-move / cursor-leave from a terminal-executor socket (no broadcast)', () => {
+    const { io } = buildHarness();
+    const s = makeSocket('exec-sock', io);
+    asServiceForUser(s, ALICE);
+    connect(io, s);
+    s.handlers.get('cursor-move')?.({ boardId: 'board-1', x: 1, y: 2, timestamp: 1 });
+    s.handlers.get('cursor-leave')?.({ boardId: 'board-1', timestamp: 1 });
+    expect(io.emitted).toEqual([]);
+  });
+
+  it('still broadcasts cursor-move from a normal user', () => {
+    const { io } = buildHarness();
+    const s = makeSocket('alice-sock', io);
+    asUser(s, ALICE);
+    connect(io, s);
+    s.handlers.get('cursor-move')?.({ boardId: 'board-1', x: 1, y: 2, timestamp: 1 });
+    expect(io.emitted.some((e) => e.event === 'cursor-moved')).toBe(true);
+  });
+});
+
 describe('configureChannels tenant isolation', () => {
   function makeChannelHarness() {
     const handlers = new Map<string, (...args: any[]) => void>();

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -635,20 +635,14 @@ export function createSocketIOConfig(
       };
 
       // Common preflight for executor-emitted terminal events
-      // (output/exit/tab/ready/error). Requires a service socket and a
-      // non-empty payload userId. Additionally, when the service token is
-      // terminal-scoped (`terminalUserId`, bound at spawn time), the payload
-      // userId MUST match it — otherwise one user's executor could emit for
-      // another user. `requireScope` forces the scope to be present at all
-      // (used for the new ready/error acks, which every terminal executor
-      // carries); output/exit/tab enforce-if-present to stay compatible with
-      // any generic service emitter while still scoping real terminal
-      // executors. Returns true when the event may proceed.
-      const requireServiceForOwnUserId = (
-        event: string,
-        payloadUserId: unknown,
-        opts: { requireScope: boolean } = { requireScope: false }
-      ): boolean => {
+      // (output/exit/tab/ready/error). Requires a service socket whose token is
+      // terminal-scoped (`terminalUserId`, bound at spawn time) AND whose scope
+      // matches the payload userId. The scope is required unconditionally: the
+      // only legitimate emitter of these events is the terminal executor, which
+      // always carries it, so a generic/unscoped service token has no business
+      // driving another user's terminal. Returns true when the event may
+      // proceed.
+      const requireServiceForOwnUserId = (event: string, payloadUserId: unknown): boolean => {
         if (!webTerminalEnabled) {
           rejectTerminal(event, 'web terminal disabled (allow_web_terminal=false)');
           return false;
@@ -662,11 +656,11 @@ export function createSocketIOConfig(
           rejectTerminal(event, 'missing userId');
           return false;
         }
-        if (opts.requireScope && !auth.terminalUserId) {
+        if (!auth.terminalUserId) {
           rejectTerminal(event, 'service token is not scoped to a terminal user');
           return false;
         }
-        if (auth.terminalUserId && auth.terminalUserId !== payloadUserId) {
+        if (auth.terminalUserId !== payloadUserId) {
           rejectTerminal(
             event,
             `service token scoped to ${shortId(auth.terminalUserId)}… may not act for ` +
@@ -693,10 +687,21 @@ export function createSocketIOConfig(
           rejectTerminal('join', `unauthenticated socket cannot join ${channel}`);
           return;
         }
-        // Service sockets (executor) are allowed to join any user's terminal
-        // channel — that's how they relay PTY I/O for the user they're
-        // proxying. User sockets may only join their OWN channel.
-        if (!auth.isService && auth.userId !== target) {
+        // Channel membership determines who RECEIVES a user's terminal traffic
+        // (output/input/resize), so it must be scoped to that user. A terminal
+        // executor's service token is bound to a single user (`terminalUserId`)
+        // and may only join THAT user's channel — not any user's. A service
+        // token with no terminal scope has no business on a terminal channel at
+        // all. User sockets may only join their own channel.
+        if (auth.isService) {
+          if (!auth.terminalUserId || auth.terminalUserId !== target) {
+            rejectTerminal(
+              'join',
+              `service token scoped to ${auth.terminalUserId ? shortId(auth.terminalUserId) : 'nothing'}… may not join ${shortId(target)}…'s channel`
+            );
+            return;
+          }
+        } else if (auth.userId !== target) {
           rejectTerminal(
             'join',
             `user ${auth.userId ? shortId(auth.userId) : 'unknown'}… tried to join ${shortId(target)}…'s channel`
@@ -707,9 +712,9 @@ export function createSocketIOConfig(
         socket.join(channel);
       });
 
-      // Handle explicit channel leaves. Same auth model as join: service
-      // sockets can leave any channel, users can only leave their own. We
-      // also reject for unauthenticated sockets to prevent noise / probing.
+      // Handle explicit channel leaves. Same scoping as join: a terminal
+      // executor may only leave its own user's channel, users only their own.
+      // We also reject for unauthenticated sockets to prevent noise / probing.
       socket.on('leave', (channel: string) => {
         const target = parseTerminalChannel(channel);
         if (target) {
@@ -718,7 +723,15 @@ export function createSocketIOConfig(
             rejectTerminal('leave', `unauthenticated socket cannot leave ${channel}`);
             return;
           }
-          if (!auth.isService && auth.userId !== target) {
+          if (auth.isService) {
+            if (!auth.terminalUserId || auth.terminalUserId !== target) {
+              rejectTerminal(
+                'leave',
+                `service token scoped to ${auth.terminalUserId ? shortId(auth.terminalUserId) : 'nothing'}… may not leave ${shortId(target)}…'s channel`
+              );
+              return;
+            }
+          } else if (auth.userId !== target) {
             rejectTerminal(
               'leave',
               `user ${auth.userId ? shortId(auth.userId) : 'unknown'}… tried to leave ${shortId(target)}…'s channel`
@@ -809,21 +822,14 @@ export function createSocketIOConfig(
       socket.on(
         'terminal:ready',
         (data: { userId: string; sessionName?: string; tabName?: string }) => {
-          // requireScope: the ready ack flips global per-user readiness state
-          // and triggers browser broadcasts, so we insist the emitting token is
-          // actually scoped to this user (not just any service token).
-          if (!requireServiceForOwnUserId('terminal:ready', data?.userId, { requireScope: true })) {
-            return;
-          }
+          if (!requireServiceForOwnUserId('terminal:ready', data?.userId)) return;
           app.emit('terminal:ready', data);
         }
       );
 
       // Executor attach-failure ack. Same user-scoped service trust as ready.
       socket.on('terminal:error', (data: { userId: string; message?: string }) => {
-        if (!requireServiceForOwnUserId('terminal:error', data?.userId, { requireScope: true })) {
-          return;
-        }
+        if (!requireServiceForOwnUserId('terminal:error', data?.userId)) return;
         app.emit('terminal:error', data);
       });
 

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -28,6 +28,7 @@ import type {
 import jwt from 'jsonwebtoken';
 import type { Server, Socket } from 'socket.io';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
+import { isTerminalExecutorIdentity } from '../auth/terminal-executor-guard.js';
 import { leaveAllSessionStreamChannels } from '../utils/realtime-publish.js';
 import type { BuildInfo } from './build-info.js';
 import type { CorsOrigin } from './cors.js';
@@ -471,8 +472,12 @@ export function createSocketIOConfig(
       }
 
       // Auto-join per-user room for user-scoped events (OAuth prompts, notifications)
-      // Try at connection time (for sockets that authenticate via handshake token)
-      if (user?.user_id) {
+      // Try at connection time (for sockets that authenticate via handshake token).
+      // Terminal-executor identities are excluded from ALL room/channel joins —
+      // they only ever consume raw `terminal:*` events on their own
+      // `user/<id>/terminal` room, never Feathers channel broadcasts, so channel
+      // membership would just hand them a firehose subscription they must not have.
+      if (user?.user_id && !isTerminalExecutorIdentity(user)) {
         socket.join(userRoomName(user.user_id));
         console.log(
           `🏠 Socket ${socket.id} joined user room at connection: user:${shortId(user.user_id)}`
@@ -869,6 +874,8 @@ export function createSocketIOConfig(
       const result = authResult as { user?: { user_id?: string } };
       const userId = result.user?.user_id;
       if (!userId) return;
+      // Terminal-executor identities get no user room (see connection handler).
+      if (isTerminalExecutorIdentity(result.user)) return;
 
       // Find the socket whose feathers connection matches this login
       for (const [, socket] of io.sockets.sockets) {
@@ -937,6 +944,14 @@ export function configureChannels(
         authentication?: { payload?: unknown };
       };
       console.debug('✅ Login event fired:', result.user?.user_id, result.user?.email);
+
+      // A terminal-executor identity must NOT receive broadcast events. It only
+      // consumes raw `terminal:*` events on its own `user/<id>/terminal` room,
+      // never Feathers channel broadcasts — joining `authenticated`/tenant
+      // channels would give the long-lived terminal token a read-everything
+      // subscription to the realtime firehose. Keyed on `_isTerminalExecutor`
+      // specifically so full service accounts KEEP their channel membership.
+      if (isTerminalExecutorIdentity(result.user)) return;
 
       const connection = context.connection as FeathersSocket & { tenant?: TenantContext };
       const loginParams =

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -500,9 +500,18 @@ export function createSocketIOConfig(
         return user?.user_id || 'unknown';
       };
 
+      // A terminal-executor identity has zero non-terminal daemon visibility:
+      // it must not watch board presence rooms or emit/receive cursor+presence
+      // activity (it would otherwise spoof presence and observe collaborators).
+      // Presence/cursor events run outside Feathers hooks, so they're guarded
+      // here directly, consistent with the channel-join exclusions.
+      const isTerminalExecutorSocket = () =>
+        isTerminalExecutorIdentity((socket as FeathersSocket).feathers?.user);
+
       socket.on('presence:watch-board', (boardId: string) => {
         const auth = getSocketAuthState(socket);
-        if (!isAuthenticated(auth) || typeof boardId !== 'string' || !boardId.trim()) return;
+        if (!isAuthenticated(auth) || isTerminalExecutorSocket()) return;
+        if (typeof boardId !== 'string' || !boardId.trim()) return;
         socket.join(boardPresenceRoomName(boardId));
       });
 
@@ -513,6 +522,7 @@ export function createSocketIOConfig(
 
       // Handle cursor movement events
       socket.on('cursor-move', (data: CursorMoveEvent) => {
+        if (isTerminalExecutorSocket()) return;
         const userId = getUserId();
         const fs = socket as FeathersSocket;
         const previousBoardId = fs.data.currentBoardId;
@@ -558,6 +568,7 @@ export function createSocketIOConfig(
 
       // Handle cursor leave events (user navigates away from board)
       socket.on('cursor-leave', (data: CursorLeaveEvent) => {
+        if (isTerminalExecutorSocket()) return;
         const userId = getUserId();
         const fs = socket as FeathersSocket;
 

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -771,6 +771,51 @@ export function createSocketIOConfig(
         console.log(`🖥️  Terminal exited for user ${data.userId}: code=${data.exitCode}`);
       });
 
+      // Executor readiness ack: the PTY exists and zellij is attached.
+      // Executor-only — a forged ready could trick the daemon into driving
+      // tab choreography (and the browser into showing "connected") against a
+      // terminal that isn't actually up. Relayed to the TerminalsService via
+      // an app event so it can gate its choreography on this instead of a
+      // blind timer; the service is the sole authority that then notifies the
+      // browser channel.
+      socket.on(
+        'terminal:ready',
+        (data: { userId: string; sessionName?: string; tabName?: string }) => {
+          if (!webTerminalEnabled) {
+            rejectTerminal('terminal:ready', 'web terminal disabled');
+            return;
+          }
+          const auth = getSocketAuthState(socket);
+          if (!auth.isService) {
+            rejectTerminal('terminal:ready', 'only service tokens may emit terminal:ready');
+            return;
+          }
+          if (typeof data?.userId !== 'string' || !data.userId) {
+            rejectTerminal('terminal:ready', 'missing userId');
+            return;
+          }
+          app.emit('terminal:ready', data);
+        }
+      );
+
+      // Executor attach-failure ack. Same service-only trust model as ready.
+      socket.on('terminal:error', (data: { userId: string; message?: string }) => {
+        if (!webTerminalEnabled) {
+          rejectTerminal('terminal:error', 'web terminal disabled');
+          return;
+        }
+        const auth = getSocketAuthState(socket);
+        if (!auth.isService) {
+          rejectTerminal('terminal:error', 'only service tokens may emit terminal:error');
+          return;
+        }
+        if (typeof data?.userId !== 'string' || !data.userId) {
+          rejectTerminal('terminal:error', 'missing userId');
+          return;
+        }
+        app.emit('terminal:error', data);
+      });
+
       // Track disconnections
       socket.on('disconnect', (reason) => {
         activeConnections--;

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -61,6 +61,8 @@ interface FeathersSocket extends Socket {
   };
   data: {
     isService?: boolean;
+    /** Terminal user scope for handshake-token service sockets (see SocketAuthState). */
+    terminalUserId?: string;
     currentBoardId?: string;
     lastPresenceEmitAt?: number;
     tenant?: TenantContext;
@@ -117,14 +119,25 @@ export interface SocketAuthState {
   userId: string | null;
   isService: boolean;
   tenant?: TenantContext;
+  /**
+   * For terminal executor service sockets: the single user this executor is
+   * allowed to act for (bound into its token as `terminal_user_id` at spawn
+   * time). Undefined for generic (non-terminal) service tokens and for user
+   * sockets. Terminal handlers require the payload's userId to match this.
+   */
+  terminalUserId?: string;
 }
 
 function socketAuthState(
   userId: string | null,
   isService: boolean,
-  tenant?: TenantContext
+  tenant?: TenantContext,
+  terminalUserId?: string
 ): SocketAuthState {
-  return tenant ? { userId, isService, tenant } : { userId, isService };
+  const state: SocketAuthState = { userId, isService };
+  if (tenant) state.tenant = tenant;
+  if (terminalUserId) state.terminalUserId = terminalUserId;
+  return state;
 }
 
 /**
@@ -152,10 +165,15 @@ export function getSocketAuthState(socket: Socket): SocketAuthState {
   const s = socket as FeathersSocket;
   const user = s.feathers?.user;
   if (user?._isServiceAccount === true) {
-    return socketAuthState(null, true, s.data?.tenant);
+    return socketAuthState(
+      null,
+      true,
+      s.data?.tenant,
+      (user as { terminal_user_id?: string }).terminal_user_id
+    );
   }
   if (s.data?.isService === true) {
-    return socketAuthState(null, true, s.data?.tenant);
+    return socketAuthState(null, true, s.data?.tenant, s.data?.terminalUserId);
   }
   if (user?.user_id) {
     return socketAuthState(user.user_id, false, s.data?.tenant);
@@ -339,7 +357,7 @@ export function createSocketIOConfig(
         const decoded = jwt.verify(token, jwtSecret, {
           issuer: RUNTIME_JWT_ISSUER,
           audience: RUNTIME_JWT_AUDIENCE,
-        }) as { sub: string; type?: string; role?: string };
+        }) as { sub: string; type?: string; role?: string; terminal_user_id?: string };
 
         // Allow user tokens and service tokens (used by executor)
         // - undefined/access: User tokens (SessionTokenService doesn't set type claim)
@@ -374,11 +392,17 @@ export function createSocketIOConfig(
               email: 'executor@agor.internal',
               role: 'service',
               _isServiceAccount: true,
+              ...(typeof decoded.terminal_user_id === 'string'
+                ? { terminal_user_id: decoded.terminal_user_id }
+                : {}),
             },
           };
           // Keep the handshake fast-path marker too — older code and any
           // future callers that only look at socket.data still see it.
           fs.data.isService = true;
+          if (typeof decoded.terminal_user_id === 'string') {
+            fs.data.terminalUserId = decoded.terminal_user_id;
+          }
           if (tenant) {
             (fs as FeathersSocket & { tenant?: TenantContext }).tenant = tenant;
             if (fs.data) fs.data.tenant = tenant;
@@ -610,6 +634,49 @@ export function createSocketIOConfig(
         return auth.userId;
       };
 
+      // Common preflight for executor-emitted terminal events
+      // (output/exit/tab/ready/error). Requires a service socket and a
+      // non-empty payload userId. Additionally, when the service token is
+      // terminal-scoped (`terminalUserId`, bound at spawn time), the payload
+      // userId MUST match it — otherwise one user's executor could emit for
+      // another user. `requireScope` forces the scope to be present at all
+      // (used for the new ready/error acks, which every terminal executor
+      // carries); output/exit/tab enforce-if-present to stay compatible with
+      // any generic service emitter while still scoping real terminal
+      // executors. Returns true when the event may proceed.
+      const requireServiceForOwnUserId = (
+        event: string,
+        payloadUserId: unknown,
+        opts: { requireScope: boolean } = { requireScope: false }
+      ): boolean => {
+        if (!webTerminalEnabled) {
+          rejectTerminal(event, 'web terminal disabled (allow_web_terminal=false)');
+          return false;
+        }
+        const auth = getSocketAuthState(socket);
+        if (!auth.isService) {
+          rejectTerminal(event, `only service tokens may emit ${event}`);
+          return false;
+        }
+        if (typeof payloadUserId !== 'string' || !payloadUserId) {
+          rejectTerminal(event, 'missing userId');
+          return false;
+        }
+        if (opts.requireScope && !auth.terminalUserId) {
+          rejectTerminal(event, 'service token is not scoped to a terminal user');
+          return false;
+        }
+        if (auth.terminalUserId && auth.terminalUserId !== payloadUserId) {
+          rejectTerminal(
+            event,
+            `service token scoped to ${shortId(auth.terminalUserId)}… may not act for ` +
+              `${shortId(payloadUserId)}…`
+          );
+          return false;
+        }
+        return true;
+      };
+
       // Handle explicit channel joins (for terminal channels)
       socket.on('join', (channel: string) => {
         if (!webTerminalEnabled) {
@@ -669,19 +736,7 @@ export function createSocketIOConfig(
       // arbitrary output (e.g. fake "permission granted" prompts) into
       // another user's terminal.
       socket.on('terminal:output', (data: { userId: string; data: string }) => {
-        if (!webTerminalEnabled) {
-          rejectTerminal('terminal:output', 'web terminal disabled');
-          return;
-        }
-        const auth = getSocketAuthState(socket);
-        if (!auth.isService) {
-          rejectTerminal('terminal:output', 'only service tokens may emit terminal:output');
-          return;
-        }
-        if (typeof data?.userId !== 'string' || !data.userId) {
-          rejectTerminal('terminal:output', 'missing userId');
-          return;
-        }
+        if (!requireServiceForOwnUserId('terminal:output', data?.userId)) return;
         const channel = `user/${data.userId}/terminal`;
         // `socket.to` (not `io.to`) excludes the sender. The executor joins
         // its own `user/<id>/terminal` channel to relay I/O, so `io.to` would
@@ -728,22 +783,7 @@ export function createSocketIOConfig(
       socket.on(
         'terminal:tab',
         (data: { userId: string; action: string; tabName: string; cwd?: string }) => {
-          if (!webTerminalEnabled) {
-            rejectTerminal('terminal:tab', 'web terminal disabled');
-            return;
-          }
-          const auth = getSocketAuthState(socket);
-          if (!auth.isService) {
-            rejectTerminal(
-              'terminal:tab',
-              'only service tokens may emit terminal:tab (browsers must use HTTP terminals.create)'
-            );
-            return;
-          }
-          if (typeof data?.userId !== 'string' || !data.userId) {
-            rejectTerminal('terminal:tab', 'missing userId');
-            return;
-          }
+          if (!requireServiceForOwnUserId('terminal:tab', data?.userId)) return;
           const channel = `user/${data.userId}/terminal`;
           io.to(channel).emit('terminal:tab', data);
         }
@@ -753,19 +793,7 @@ export function createSocketIOConfig(
       // Executor-only — a forged exit would let a member terminate or
       // confuse another user's terminal session.
       socket.on('terminal:exit', (data: { userId: string; exitCode: number; signal?: number }) => {
-        if (!webTerminalEnabled) {
-          rejectTerminal('terminal:exit', 'web terminal disabled');
-          return;
-        }
-        const auth = getSocketAuthState(socket);
-        if (!auth.isService) {
-          rejectTerminal('terminal:exit', 'only service tokens may emit terminal:exit');
-          return;
-        }
-        if (typeof data?.userId !== 'string' || !data.userId) {
-          rejectTerminal('terminal:exit', 'missing userId');
-          return;
-        }
+        if (!requireServiceForOwnUserId('terminal:exit', data?.userId)) return;
         const channel = `user/${data.userId}/terminal`;
         io.to(channel).emit('terminal:exit', data);
         console.log(`🖥️  Terminal exited for user ${data.userId}: code=${data.exitCode}`);
@@ -781,36 +809,19 @@ export function createSocketIOConfig(
       socket.on(
         'terminal:ready',
         (data: { userId: string; sessionName?: string; tabName?: string }) => {
-          if (!webTerminalEnabled) {
-            rejectTerminal('terminal:ready', 'web terminal disabled');
-            return;
-          }
-          const auth = getSocketAuthState(socket);
-          if (!auth.isService) {
-            rejectTerminal('terminal:ready', 'only service tokens may emit terminal:ready');
-            return;
-          }
-          if (typeof data?.userId !== 'string' || !data.userId) {
-            rejectTerminal('terminal:ready', 'missing userId');
+          // requireScope: the ready ack flips global per-user readiness state
+          // and triggers browser broadcasts, so we insist the emitting token is
+          // actually scoped to this user (not just any service token).
+          if (!requireServiceForOwnUserId('terminal:ready', data?.userId, { requireScope: true })) {
             return;
           }
           app.emit('terminal:ready', data);
         }
       );
 
-      // Executor attach-failure ack. Same service-only trust model as ready.
+      // Executor attach-failure ack. Same user-scoped service trust as ready.
       socket.on('terminal:error', (data: { userId: string; message?: string }) => {
-        if (!webTerminalEnabled) {
-          rejectTerminal('terminal:error', 'web terminal disabled');
-          return;
-        }
-        const auth = getSocketAuthState(socket);
-        if (!auth.isService) {
-          rejectTerminal('terminal:error', 'only service tokens may emit terminal:error');
-          return;
-        }
-        if (typeof data?.userId !== 'string' || !data.userId) {
-          rejectTerminal('terminal:error', 'missing userId');
+        if (!requireServiceForOwnUserId('terminal:error', data?.userId, { requireScope: true })) {
           return;
         }
         app.emit('terminal:error', data);

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -164,16 +164,19 @@ function socketAuthState(
 export function getSocketAuthState(socket: Socket): SocketAuthState {
   const s = socket as FeathersSocket;
   const user = s.feathers?.user;
+  // Terminal-scoped executor identity: a service identity for TERMINAL socket
+  // auth only (join/output/etc.), NOT a full RBAC-bypassing service account.
+  // Checked first and never carries `isService` privilege onto REST paths —
+  // those read `user._isServiceAccount`, which this identity lacks by design.
+  const terminalUserId = user?.terminal_user_id ?? s.data?.terminalUserId;
+  if (typeof terminalUserId === 'string' && terminalUserId) {
+    return socketAuthState(null, true, s.data?.tenant, terminalUserId);
+  }
   if (user?._isServiceAccount === true) {
-    return socketAuthState(
-      null,
-      true,
-      s.data?.tenant,
-      (user as { terminal_user_id?: string }).terminal_user_id
-    );
+    return socketAuthState(null, true, s.data?.tenant);
   }
   if (s.data?.isService === true) {
-    return socketAuthState(null, true, s.data?.tenant, s.data?.terminalUserId);
+    return socketAuthState(null, true, s.data?.tenant);
   }
   if (user?.user_id) {
     return socketAuthState(user.user_id, false, s.data?.tenant);
@@ -382,26 +385,35 @@ export function createSocketIOConfig(
           // a service socket (trusted, no user) from an anonymous socket that
           // simply hasn't authenticated yet (untrusted, no user).
           const fs = socket as FeathersSocket;
-          // Attach synthetic service user so getSocketAuthState returns
-          // isService=true via the canonical `_isServiceAccount` path. This
-          // mirrors what ServiceJWTStrategy.getEntity does on the Feathers
-          // side for sockets that authenticate post-connect.
+          const terminalUserId =
+            typeof decoded.terminal_user_id === 'string' ? decoded.terminal_user_id : undefined;
+          // Mirror ServiceJWTStrategy: a terminal-scoped token is a RESTRICTED
+          // identity (no `_isServiceAccount`, no `role: 'service'`, so no RBAC
+          // bypass on REST paths); a plain service token is a full service
+          // account. See getSocketAuthState + service-jwt-strategy.ts.
           fs.feathers = {
-            user: {
-              user_id: 'executor-service',
-              email: 'executor@agor.internal',
-              role: 'service',
-              _isServiceAccount: true,
-              ...(typeof decoded.terminal_user_id === 'string'
-                ? { terminal_user_id: decoded.terminal_user_id }
-                : {}),
-            },
+            user: terminalUserId
+              ? {
+                  user_id: 'executor-service',
+                  email: 'executor@agor.internal',
+                  role: 'terminal-executor',
+                  _isTerminalExecutor: true,
+                  terminal_user_id: terminalUserId,
+                }
+              : {
+                  user_id: 'executor-service',
+                  email: 'executor@agor.internal',
+                  role: 'service',
+                  _isServiceAccount: true,
+                },
           };
-          // Keep the handshake fast-path marker too — older code and any
-          // future callers that only look at socket.data still see it.
-          fs.data.isService = true;
-          if (typeof decoded.terminal_user_id === 'string') {
-            fs.data.terminalUserId = decoded.terminal_user_id;
+          if (terminalUserId) {
+            fs.data.terminalUserId = terminalUserId;
+          } else {
+            // Handshake fast-path marker ONLY for full service accounts — older
+            // code that looks at socket.data.isService must not see a terminal
+            // token as a full service account.
+            fs.data.isService = true;
           }
           if (tenant) {
             (fs as FeathersSocket & { tenant?: TenantContext }).tenant = tenant;

--- a/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.service-token.test.ts
@@ -37,6 +37,22 @@ describe('executor service token scoping', () => {
     expect(serviceTokenScopeForParams({})).toEqual({});
   });
 
+  it('stamps role: service for a plain (unscoped) service token', () => {
+    const decoded = jwt.decode(createServiceToken('test-secret', '5m', {})) as { role?: string };
+    expect(decoded.role).toBe('service');
+  });
+
+  it('stamps role: terminal-executor for a terminal-scoped token (no full service role)', () => {
+    // Both resolvers override role before use, but a token that leaks its raw
+    // role must not read as a full service account to any future consumer.
+    const decoded = jwt.decode(
+      createServiceToken('test-secret', '30d', { terminal_user_id: 'u1' })
+    ) as { role?: string; terminal_user_id?: string };
+    expect(decoded.role).toBe('terminal-executor');
+    expect(decoded.role).not.toBe('service');
+    expect(decoded.terminal_user_id).toBe('u1');
+  });
+
   it('generates tenant-scoped service tokens directly from params', () => {
     const token = generateScopedServiceToken(
       { settings: { authentication: { secret: 'test-secret' } } },

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -861,13 +861,14 @@ export function generateSessionToken(
   app: {
     settings: { authentication?: { secret?: string } };
   },
-  scope: Record<string, unknown> = {}
+  scope: Record<string, unknown> = {},
+  expiresIn?: SignOptions['expiresIn']
 ): string {
   const jwtSecret = app.settings.authentication?.secret;
   if (!jwtSecret) {
     throw new Error('JWT secret not configured in app settings');
   }
-  return createServiceToken(jwtSecret, undefined, scope);
+  return createServiceToken(jwtSecret, expiresIn, scope);
 }
 
 /**
@@ -882,9 +883,14 @@ export function generateScopedServiceToken(
     settings: { authentication?: { secret?: string } };
   },
   params?: Partial<AuthenticatedParams>,
-  extraScope: Record<string, unknown> = {}
+  extraScope: Record<string, unknown> = {},
+  expiresIn?: SignOptions['expiresIn']
 ): string {
-  return generateSessionToken(app, { ...serviceTokenScopeForParams(params), ...extraScope });
+  return generateSessionToken(
+    app,
+    { ...serviceTokenScopeForParams(params), ...extraScope },
+    expiresIn
+  );
 }
 
 // ============================================================================

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -881,9 +881,10 @@ export function generateScopedServiceToken(
   app: {
     settings: { authentication?: { secret?: string } };
   },
-  params?: Partial<AuthenticatedParams>
+  params?: Partial<AuthenticatedParams>,
+  extraScope: Record<string, unknown> = {}
 ): string {
-  return generateSessionToken(app, serviceTokenScopeForParams(params));
+  return generateSessionToken(app, { ...serviceTokenScopeForParams(params), ...extraScope });
 }
 
 // ============================================================================

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -821,14 +821,22 @@ export function createServiceToken(
   expiresIn?: SignOptions['expiresIn'],
   scope: Record<string, unknown> = {}
 ): string {
+  // A terminal-scoped token (carries `terminal_user_id`) is a restricted
+  // identity, not a full service account. Stamp its role accordingly at MINT
+  // time too — both resolvers already override `role` before use, but this
+  // closes the trap where future code reads `payload.role` directly and would
+  // otherwise see a full 'service' role on a terminal token.
+  const isTerminalScoped =
+    typeof (scope as { terminal_user_id?: unknown }).terminal_user_id === 'string';
   return issueRuntimeToken(
     {
       sub: 'executor-service',
       type: 'service',
       purpose: 'executor-service',
-      // Service tokens can perform privileged operations
-      role: 'service',
       ...scope,
+      // Placed AFTER ...scope so it wins; service tokens can perform privileged
+      // operations, terminal-scoped tokens deliberately cannot.
+      role: isTerminalScoped ? 'terminal-executor' : 'service',
     },
     jwtSecret,
     expiresIn || '5m'

--- a/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminal.test.tsx
+++ b/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminal.test.tsx
@@ -1,0 +1,143 @@
+import type { AgorClient } from '@agor-live/client';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// xterm touches canvas/DOM internals that jsdom can't render; the component's
+// reconnect/ready plumbing doesn't depend on real terminal output, so stub it.
+// The class lives inside the factory because vi.mock is hoisted above imports.
+vi.mock('@xterm/xterm', () => ({
+  Terminal: class MockTerminal {
+    rows = 24;
+    cols = 80;
+    _core = { _renderService: { dimensions: { css: { cell: { width: 0, height: 0 } } } } };
+    open() {}
+    loadAddon() {}
+    onRender() {
+      return { dispose() {} };
+    }
+    onData() {}
+    onResize() {}
+    resize() {}
+    write() {}
+    writeln() {}
+    clear() {}
+    dispose() {}
+  },
+}));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: class {} }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }));
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+
+import { EmbeddedTerminal } from './EmbeddedTerminal';
+
+const ALICE = '11111111-aaaa-aaaa-aaaa-111111111111';
+
+interface FakeSocket {
+  connected: boolean;
+  emitted: Array<{ event: string; data: unknown }>;
+  on(event: string, fn: (...args: unknown[]) => void): void;
+  off(event: string, fn: (...args: unknown[]) => void): void;
+  emit(event: string, data?: unknown): void;
+  trigger(event: string, data?: unknown): void;
+}
+
+function makeFakeSocket(): FakeSocket {
+  const handlers = new Map<string, Set<(...args: unknown[]) => void>>();
+  return {
+    connected: true,
+    emitted: [],
+    on(event, fn) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)?.add(fn);
+    },
+    off(event, fn) {
+      handlers.get(event)?.delete(fn);
+    },
+    emit(event, data) {
+      this.emitted.push({ event, data });
+    },
+    trigger(event, data) {
+      for (const fn of handlers.get(event) ?? []) fn(data);
+    },
+  };
+}
+
+function makeClient(socket: FakeSocket, create: ReturnType<typeof vi.fn>) {
+  return {
+    io: socket,
+    service: vi.fn(() => ({ create })),
+  } as unknown as AgorClient;
+}
+
+describe('EmbeddedTerminal reconnect + readiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stays "connecting" until the ready ack, then connects', async () => {
+    const socket = makeFakeSocket();
+    const create = vi.fn().mockResolvedValue({
+      userId: ALICE,
+      channel: `user/${ALICE}/terminal`,
+      sessionName: 'agor-x',
+      isNew: true,
+      ready: false,
+    });
+    render(<EmbeddedTerminal client={makeClient(socket, create)} userId={ALICE} />);
+
+    // Cold start: create resolved but no ready ack yet → still connecting.
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/Connecting to terminal/)).toBeInTheDocument();
+    // It joined the channel to receive output.
+    expect(socket.emitted.some((e) => e.event === 'join')).toBe(true);
+
+    // Executor acks readiness → connected, indicator clears.
+    socket.trigger('terminal:ready', { userId: ALICE });
+    await waitFor(() =>
+      expect(screen.queryByText(/Connecting to terminal/)).not.toBeInTheDocument()
+    );
+  });
+
+  it('shows reconnecting and re-issues create + join when the socket reconnects', async () => {
+    const socket = makeFakeSocket();
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({
+        userId: ALICE,
+        channel: `user/${ALICE}/terminal`,
+        sessionName: 'agor-x',
+        isNew: true,
+        ready: false,
+      })
+      // Warm path on reconnect: executor still alive.
+      .mockResolvedValue({
+        userId: ALICE,
+        channel: `user/${ALICE}/terminal`,
+        sessionName: 'agor-x',
+        isNew: false,
+        ready: true,
+      });
+    render(<EmbeddedTerminal client={makeClient(socket, create)} userId={ALICE} />);
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    socket.trigger('terminal:ready', { userId: ALICE });
+
+    // A blip drops the socket.
+    socket.connected = false;
+    socket.trigger('disconnect', 'transport close');
+    expect(await screen.findByText(/Reconnecting/)).toBeInTheDocument();
+
+    // Transport restored → re-attach (re-create + re-join) and connect via the
+    // warm ready flag.
+    const joinsBefore = socket.emitted.filter((e) => e.event === 'join').length;
+    socket.connected = true;
+    socket.trigger('connect');
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(socket.emitted.filter((e) => e.event === 'join').length).toBeGreaterThan(joinsBefore)
+    );
+    await waitFor(() => expect(screen.queryByText(/Reconnecting/)).not.toBeInTheDocument());
+  });
+});

--- a/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminal.tsx
+++ b/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminal.tsx
@@ -202,7 +202,15 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
       socket.emit('terminal:resize', { userId, cols, rows });
     });
 
+    // Monotonic attach generation. Each (re)attach bumps it; a disconnect
+    // bumps it too. An attach only applies its result if it's still the
+    // current generation and the socket is still connected — otherwise a stale
+    // pre-disconnect attach could resolve late and wrongly flip the UI back to
+    // "connected", or out-of-order responses across flaps could clobber state.
+    let attachGeneration = 0;
+
     const attach = async () => {
+      const generation = ++attachGeneration;
       try {
         // The daemon-side terminals.create handles the tab-focus emit when
         // `focusTabName` is supplied — browser sockets are NOT allowed to
@@ -221,7 +229,9 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
           isNew: boolean;
           ready?: boolean;
         };
-        if (!mounted) return;
+        // Drop a stale/superseded attach: another (re)connect started after
+        // this call, or the socket dropped while it was in flight.
+        if (!mounted || generation !== attachGeneration || !socket.connected) return;
 
         currentChannel = result.channel;
         socket.emit('join', result.channel);
@@ -241,7 +251,7 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
           setError(null);
         }
       } catch (err) {
-        if (!mounted) return;
+        if (!mounted || generation !== attachGeneration) return;
         const msg = err instanceof Error ? err.message : String(err);
         setError(msg);
         setReconnecting(false);
@@ -262,6 +272,9 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
       void attach();
     };
     const handleDisconnect = () => {
+      // Invalidate any in-flight attach so a late resolve can't flip us back
+      // to connected while we're actually down.
+      attachGeneration++;
       setConnected(false);
       setReconnecting(true);
     };

--- a/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminal.tsx
+++ b/apps/agor-ui/src/components/EmbeddedTerminal/EmbeddedTerminal.tsx
@@ -33,6 +33,7 @@ import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Terminal } from '@xterm/xterm';
+import { Badge } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { loadWebglRenderer } from '../../utils/xtermWebgl';
 import '@xterm/xterm/css/xterm.css';
@@ -93,6 +94,7 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
   const terminalRef = useRef<Terminal | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
 
   useEffect(() => {
     if (!client || !userId || !containerRef.current) return;
@@ -111,6 +113,22 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
         terminalRef.current.writeln(`\r\n\r\n[Terminal exited with code ${payload.exitCode}]`);
         setConnected(false);
       }
+    };
+    // Readiness is the authoritative connected signal: the executor confirmed
+    // its PTY is spawned and attached. Flipping on this (not on the
+    // terminals.create resolution) avoids the "connected but silently dead"
+    // state after a reconnect or a post-spawn executor crash.
+    const handleReady = (payload: { userId: string }) => {
+      if (payload.userId !== userId) return;
+      setConnected(true);
+      setReconnecting(false);
+      setError(null);
+    };
+    const handleReadyError = (payload: { userId: string; message?: string }) => {
+      if (payload.userId !== userId) return;
+      setError(payload.message || 'Terminal failed to start');
+      setConnected(false);
+      setReconnecting(false);
     };
 
     const terminal = new Terminal({
@@ -170,12 +188,26 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
     const ro = new ResizeObserver(() => fitToContainer());
     ro.observe(containerRef.current);
 
-    (async () => {
+    // Register channel + input listeners once. They persist across socket
+    // reconnects (only the server-side room join is lost — see handleReconnect).
+    socket.on('terminal:output', handleOutput);
+    socket.on('terminal:exit', handleExit);
+    socket.on('terminal:ready', handleReady);
+    socket.on('terminal:error', handleReadyError);
+
+    terminal.onData((data) => {
+      socket.emit('terminal:input', { userId, input: data });
+    });
+    terminal.onResize(({ cols, rows }) => {
+      socket.emit('terminal:resize', { userId, cols, rows });
+    });
+
+    const attach = async () => {
       try {
         // The daemon-side terminals.create handles the tab-focus emit when
         // `focusTabName` is supplied — browser sockets are NOT allowed to
         // emit `terminal:tab` directly (rejected by the daemon's gateway
-        // guard).
+        // guard). It is idempotent, so re-issuing it on reconnect is safe.
         const result = (await client.service('terminals').create({
           rows: terminal.rows,
           cols: terminal.cols,
@@ -187,37 +219,56 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
           channel: string;
           sessionName: string;
           isNew: boolean;
+          ready?: boolean;
         };
         if (!mounted) return;
 
         currentChannel = result.channel;
         socket.emit('join', result.channel);
-        socket.on('terminal:output', handleOutput);
-        socket.on('terminal:exit', handleExit);
-
-        terminal.onData((data) => {
-          socket.emit('terminal:input', { userId, input: data });
-        });
-        terminal.onResize(({ cols, rows }) => {
-          socket.emit('terminal:resize', { userId, cols, rows });
-        });
-        // Kick a resize to trigger a Zellij full redraw.
+        // Kick a resize to trigger a Zellij full redraw once (re)joined.
         socket.emit('terminal:resize', {
           userId,
           cols: terminal.cols,
           rows: terminal.rows,
         });
 
-        setConnected(true);
+        // Warm path: the executor is already attached, so the response says
+        // it's ready and we connect right away. Cold path: stay in the
+        // connecting state until the executor's `terminal:ready` ack arrives.
+        if (result.ready) {
+          setConnected(true);
+          setReconnecting(false);
+          setError(null);
+        }
       } catch (err) {
+        if (!mounted) return;
         const msg = err instanceof Error ? err.message : String(err);
         setError(msg);
+        setReconnecting(false);
         if (terminalRef.current) {
           terminalRef.current.writeln('\r\n[Failed to attach to terminal]');
           terminalRef.current.writeln(`[Error: ${msg}]`);
         }
       }
-    })();
+    };
+
+    // The socket auto-reconnects after a network blip or daemon restart, but
+    // the server-side room membership and (possibly) the executor are gone.
+    // Re-join + re-issue create on every (re)connect; surface a visible
+    // "reconnecting" state rather than silently doing nothing.
+    const handleReconnect = () => {
+      setReconnecting(true);
+      setConnected(false);
+      void attach();
+    };
+    const handleDisconnect = () => {
+      setConnected(false);
+      setReconnecting(true);
+    };
+    socket.on('connect', handleReconnect);
+    socket.on('disconnect', handleDisconnect);
+
+    void attach();
 
     return () => {
       mounted = false;
@@ -230,11 +281,16 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
       if (socket) {
         socket.off('terminal:output', handleOutput);
         socket.off('terminal:exit', handleExit);
+        socket.off('terminal:ready', handleReady);
+        socket.off('terminal:error', handleReadyError);
+        socket.off('connect', handleReconnect);
+        socket.off('disconnect', handleDisconnect);
         if (currentChannel) {
           socket.emit('leave', currentChannel);
         }
       }
       setConnected(false);
+      setReconnecting(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, userId, branchId, focusTabName, ensureCliSessionId]);
@@ -292,12 +348,13 @@ export const EmbeddedTerminal: React.FC<EmbeddedTerminalProps> = ({
         ref={containerRef}
         style={fill ? { flex: 1, minHeight: 0 } : { flex: 1, minHeight: height - 24 }}
       />
-      {error && (
-        <div style={{ color: '#ff7875', fontSize: 12, padding: 4 }}>Terminal error: {error}</div>
-      )}
-      {!connected && !error && (
-        <div style={{ color: '#bfbfbf', fontSize: 12, padding: 4 }}>Connecting to terminal…</div>
-      )}
+      {error ? (
+        <Badge status="error" text={`Terminal error: ${error}`} style={{ padding: 4 }} />
+      ) : reconnecting ? (
+        <Badge status="warning" text="Reconnecting…" style={{ padding: 4 }} />
+      ) : !connected ? (
+        <Badge status="processing" text="Connecting to terminal…" style={{ padding: 4 }} />
+      ) : null}
     </div>
   );
 };

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.test.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.test.tsx
@@ -1,23 +1,17 @@
-import type { AgorClient } from '@agor-live/client';
+import type { AgorClient, User } from '@agor-live/client';
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// xterm touches canvas/DOM internals that jsdom can't render; the component's
-// reconnect/ready plumbing doesn't depend on real terminal output, so stub it.
-// The class lives inside the factory because vi.mock is hoisted above imports.
+// xterm touches canvas/DOM internals jsdom can't render; the modal's
+// reconnect/ready plumbing doesn't depend on real terminal output.
 vi.mock('@xterm/xterm', () => ({
   Terminal: class MockTerminal {
-    rows = 24;
-    cols = 80;
-    _core = { _renderService: { dimensions: { css: { cell: { width: 0, height: 0 } } } } };
+    rows = 40;
+    cols = 160;
     open() {}
     loadAddon() {}
-    onRender() {
-      return { dispose() {} };
-    }
     onData() {}
     onResize() {}
-    resize() {}
     write() {}
     writeln() {}
     clear() {}
@@ -28,7 +22,7 @@ vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: class {} }));
 vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }));
 vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
 
-import { EmbeddedTerminal } from './EmbeddedTerminal';
+import { TerminalModal } from './TerminalModal';
 
 const ALICE = '11111111-aaaa-aaaa-aaaa-111111111111';
 
@@ -69,7 +63,13 @@ function makeClient(socket: FakeSocket, create: ReturnType<typeof vi.fn>) {
   } as unknown as AgorClient;
 }
 
-describe('EmbeddedTerminal reconnect + readiness', () => {
+const memberUser = { user_id: ALICE, role: 'member' } as unknown as User;
+// Stable reference: the modal effect depends on `initialCommands`, so a fresh
+// array each render would thrash the effect (tear down + re-attach) and reset
+// transient state under test.
+const NO_COMMANDS: string[] = [];
+
+describe('TerminalModal reconnect + readiness', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -77,7 +77,7 @@ describe('EmbeddedTerminal reconnect + readiness', () => {
     vi.restoreAllMocks();
   });
 
-  it('stays "connecting" until the ready ack, then connects', async () => {
+  it('connects on the ready ack and re-attaches on reconnect', async () => {
     const socket = makeFakeSocket();
     const create = vi.fn().mockResolvedValue({
       userId: ALICE,
@@ -86,65 +86,34 @@ describe('EmbeddedTerminal reconnect + readiness', () => {
       isNew: true,
       ready: false,
     });
-    render(<EmbeddedTerminal client={makeClient(socket, create)} userId={ALICE} />);
-
-    // Cold start: create resolved but no ready ack yet → still connecting.
-    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
-    expect(await screen.findByText(/Connecting to terminal/)).toBeInTheDocument();
-    // It joined the channel to receive output.
-    expect(socket.emitted.some((e) => e.event === 'join')).toBe(true);
-
-    // Executor acks readiness → connected, indicator clears.
-    socket.trigger('terminal:ready', { userId: ALICE });
-    await waitFor(() =>
-      expect(screen.queryByText(/Connecting to terminal/)).not.toBeInTheDocument()
+    render(
+      <TerminalModal
+        open
+        onClose={() => {}}
+        client={makeClient(socket, create)}
+        user={memberUser}
+        initialCommands={NO_COMMANDS}
+      />
     );
-  });
 
-  it('shows reconnecting and re-issues create + join when the socket reconnects', async () => {
-    const socket = makeFakeSocket();
-    const create = vi
-      .fn()
-      .mockResolvedValueOnce({
-        userId: ALICE,
-        channel: `user/${ALICE}/terminal`,
-        sessionName: 'agor-x',
-        isNew: true,
-        ready: false,
-      })
-      // Warm path on reconnect: executor still alive.
-      .mockResolvedValue({
-        userId: ALICE,
-        channel: `user/${ALICE}/terminal`,
-        sessionName: 'agor-x',
-        isNew: false,
-        ready: true,
-      });
-    render(<EmbeddedTerminal client={makeClient(socket, create)} userId={ALICE} />);
+    // Effect is gated on the modal's afterOpenChange; wait for the first attach.
     await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+
+    // Cold path: not connected until the executor acks readiness.
     socket.trigger('terminal:ready', { userId: ALICE });
 
-    // A blip drops the socket.
+    // A blip drops the socket → reconnecting; reconnect re-issues create.
     socket.connected = false;
     socket.trigger('disconnect', 'transport close');
     expect(await screen.findByText(/Reconnecting/)).toBeInTheDocument();
 
-    // Transport restored → re-attach (re-create + re-join) and connect via the
-    // warm ready flag.
-    const joinsBefore = socket.emitted.filter((e) => e.event === 'join').length;
     socket.connected = true;
     socket.trigger('connect');
     await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
-    await waitFor(() =>
-      expect(socket.emitted.filter((e) => e.event === 'join').length).toBeGreaterThan(joinsBefore)
-    );
-    await waitFor(() => expect(screen.queryByText(/Reconnecting/)).not.toBeInTheDocument());
   });
 
   it('ignores a stale attach that resolves after a disconnect/reconnect', async () => {
     const socket = makeFakeSocket();
-    // Hand back a controllable promise per attach so we can resolve the first
-    // (stale) one AFTER a reconnect has superseded it.
     const deferreds: Array<(v: unknown) => void> = [];
     const create = vi.fn(
       () =>
@@ -152,11 +121,17 @@ describe('EmbeddedTerminal reconnect + readiness', () => {
           deferreds.push(resolve);
         })
     );
-    render(<EmbeddedTerminal client={makeClient(socket, create)} userId={ALICE} />);
+    render(
+      <TerminalModal
+        open
+        onClose={() => {}}
+        client={makeClient(socket, create)}
+        user={memberUser}
+        initialCommands={NO_COMMANDS}
+      />
+    );
     await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
 
-    // Socket drops (invalidating the in-flight attach) then comes back and
-    // starts a fresh attach.
     socket.connected = false;
     socket.trigger('disconnect', 'transport close');
     socket.connected = true;
@@ -164,8 +139,7 @@ describe('EmbeddedTerminal reconnect + readiness', () => {
     await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
     expect(await screen.findByText(/Reconnecting/)).toBeInTheDocument();
 
-    // The STALE first attach resolves late with ready:true. It must be dropped
-    // (superseded generation) and must NOT flip the UI to connected.
+    // Stale first attach resolves late → must be dropped (superseded generation).
     deferreds[0]?.({
       userId: ALICE,
       channel: `user/${ALICE}/terminal`,
@@ -175,15 +149,5 @@ describe('EmbeddedTerminal reconnect + readiness', () => {
     });
     await Promise.resolve();
     expect(screen.getByText(/Reconnecting/)).toBeInTheDocument();
-
-    // The current attach resolving DOES connect.
-    deferreds[1]?.({
-      userId: ALICE,
-      channel: `user/${ALICE}/terminal`,
-      sessionName: 'agor-x',
-      isNew: false,
-      ready: true,
-    });
-    await waitFor(() => expect(screen.queryByText(/Reconnecting/)).not.toBeInTheDocument());
   });
 });

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -122,6 +122,10 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
     let mounted = true;
     let currentChannel: string | null = null;
     let initialCommandsSent = false;
+    // Monotonic attach generation: each (re)attach bumps it and a disconnect
+    // bumps it, so a stale/out-of-order attach resolve can't flip the modal
+    // back to connected after the socket has moved on.
+    let attachGeneration = 0;
     let transformData: (value: string) => string = (value) => value;
     const socket = client.io;
 
@@ -287,6 +291,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
     });
 
     const attach = async () => {
+      const generation = ++attachGeneration;
       try {
         // Request terminal from daemon
         // This spawns an executor with zellij.attach if not already running.
@@ -304,7 +309,10 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
           ready?: boolean;
         };
 
-        if (!mounted) {
+        // Drop a stale/superseded attach (a later reconnect started, or the
+        // socket dropped while this call was in flight) so a late resolve
+        // can't wrongly flip the modal back to connected.
+        if (!mounted || generation !== attachGeneration || !socket.connected) {
           return;
         }
 
@@ -349,7 +357,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
           setReconnecting(false);
         }
       } catch (error) {
-        if (!mounted) return;
+        if (!mounted || generation !== attachGeneration) return;
         console.error('[Terminal] Failed to create terminal:', error);
         const message = error instanceof Error ? error.message : String(error);
         setReconnecting(false);
@@ -380,6 +388,9 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
       void attach();
     };
     const handleDisconnect = () => {
+      // Invalidate any in-flight attach so a late resolve can't flip us back
+      // to connected while we're actually down.
+      attachGeneration++;
       setIsConnected(false);
       setReconnecting(true);
     };

--- a/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
+++ b/apps/agor-ui/src/components/TerminalModal/TerminalModal.tsx
@@ -6,7 +6,7 @@ import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Terminal } from '@xterm/xterm';
-import { App, Modal } from 'antd';
+import { App, Badge, Modal } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { loadWebglRenderer } from '../../utils/xtermWebgl';
 import '@xterm/xterm/css/xterm.css';
@@ -92,6 +92,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
   const [modalReady, setModalReady] = useState(false);
   const [zellijMissing, setZellijMissing] = useState(false);
   const [sessionInfo, setSessionInfo] = useState<{
@@ -120,6 +121,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
 
     let mounted = true;
     let currentChannel: string | null = null;
+    let initialCommandsSent = false;
     let transformData: (value: string) => string = (value) => value;
     const socket = client.io;
 
@@ -128,6 +130,10 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
       if (socket) {
         socket.off('terminal:output', handleChannelOutput);
         socket.off('terminal:exit', handleChannelExit);
+        socket.off('terminal:ready', handleChannelReady);
+        socket.off('terminal:error', handleChannelError);
+        socket.off('connect', handleReconnect);
+        socket.off('disconnect', handleDisconnect);
         if (currentChannel) {
           socket.emit('leave', currentChannel);
         }
@@ -149,6 +155,25 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
         terminalRef.current.writeln('[Close and reopen terminal to start a new session]');
         setIsConnected(false);
       }
+    };
+
+    // Readiness is the authoritative connected signal — the executor confirmed
+    // its PTY is spawned and attached. We flip on this rather than on the
+    // terminals.create resolution so a post-spawn executor crash surfaces
+    // instead of leaving the modal wedged on a blank screen.
+    const handleChannelReady = (payload: { userId: string }) => {
+      if (payload.userId !== user?.user_id) return;
+      setIsConnected(true);
+      setReconnecting(false);
+    };
+
+    const handleChannelError = (payload: { userId: string; message?: string }) => {
+      if (payload.userId !== user?.user_id) return;
+      if (terminalRef.current) {
+        terminalRef.current.writeln(`\r\n[Terminal error: ${payload.message ?? 'attach failed'}]`);
+      }
+      setIsConnected(false);
+      setReconnecting(false);
     };
 
     // Create xterm instance with common configuration
@@ -233,17 +258,39 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
       }
     };
 
-    // Setup terminal (channel I/O via Zellij executor)
-    const setupTerminal = async () => {
-      const terminal = createTerminalInstance();
+    // Create the xterm instance and wire persistent listeners once. Only the
+    // server-side room join is lost on a socket reconnect, so these survive it;
+    // `attach` re-joins and re-issues the (idempotent) create.
+    const terminal = createTerminalInstance();
+    transformData = expandOscHyperlinks;
+    // Size the terminal to the modal body before announcing dims to the daemon,
+    // then keep it fitted as the viewport (and thus the modal) resizes — see the
+    // ResizeObserver below.
+    fitToContainer();
+    socket.on('terminal:output', handleChannelOutput);
+    socket.on('terminal:exit', handleChannelExit);
+    socket.on('terminal:ready', handleChannelReady);
+    socket.on('terminal:error', handleChannelError);
 
-      // Size the terminal to the modal body before announcing dims to the
-      // daemon, then keep it fitted as the viewport (and thus the modal) resizes.
-      fitToContainer();
+    terminal.onData((data) => {
+      socket.emit('terminal:input', {
+        userId: user?.user_id,
+        input: data,
+      });
+    });
+    terminal.onResize(({ cols, rows }) => {
+      socket.emit('terminal:resize', {
+        userId: user?.user_id,
+        cols,
+        rows,
+      });
+    });
 
+    const attach = async () => {
       try {
         // Request terminal from daemon
-        // This spawns an executor with zellij.attach if not already running
+        // This spawns an executor with zellij.attach if not already running.
+        // Idempotent, so re-issuing it on reconnect is safe.
         const result = (await client.service('terminals').create({
           rows: terminal.rows,
           cols: terminal.cols,
@@ -254,6 +301,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
           sessionName: string;
           isNew: boolean;
           branchName?: string;
+          ready?: boolean;
         };
 
         if (!mounted) {
@@ -261,8 +309,6 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
         }
 
         currentChannel = result.channel;
-        setIsConnected(true);
-        transformData = expandOscHyperlinks;
         setSessionInfo({
           zellijSession: result.sessionName,
           zellijReused: !result.isNew,
@@ -276,27 +322,6 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
         // Join the user's terminal channel
         socket.emit('join', result.channel);
 
-        // Listen for terminal output via channel
-        socket.on('terminal:output', handleChannelOutput);
-        socket.on('terminal:exit', handleChannelExit);
-
-        // Handle user input - send via channel
-        terminal.onData((data) => {
-          socket.emit('terminal:input', {
-            userId: user?.user_id,
-            input: data,
-          });
-        });
-
-        // Handle terminal resize
-        terminal.onResize(({ cols, rows }) => {
-          socket.emit('terminal:resize', {
-            userId: user?.user_id,
-            cols,
-            rows,
-          });
-        });
-
         // Send initial resize to trigger Zellij full redraw (important for reconnections)
         // This ensures the tab bar and status bar are properly rendered
         socket.emit('terminal:resize', {
@@ -305,8 +330,10 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
           rows: terminal.rows,
         });
 
-        // Execute initial commands if provided
-        if (initialCommands.length > 0) {
+        // Execute initial commands once, on the first successful attach — not
+        // on every reconnect, which would re-run them against the live session.
+        if (initialCommands.length > 0 && !initialCommandsSent) {
+          initialCommandsSent = true;
           for (const cmd of initialCommands) {
             socket.emit('terminal:input', {
               userId: user?.user_id,
@@ -314,9 +341,18 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
             });
           }
         }
+
+        // Warm path: the executor is already attached, so connect right away.
+        // Cold path: wait for the executor's `terminal:ready` ack.
+        if (result.ready) {
+          setIsConnected(true);
+          setReconnecting(false);
+        }
       } catch (error) {
+        if (!mounted) return;
         console.error('[Terminal] Failed to create terminal:', error);
         const message = error instanceof Error ? error.message : String(error);
+        setReconnecting(false);
         // Surface the "Zellij not installed" case as a friendly inline panel
         // with a link to the install docs, rather than a raw xterm error.
         if (/zellij is not installed/i.test(message)) {
@@ -334,8 +370,24 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
       }
     };
 
+    // The socket auto-reconnects after a network blip or daemon restart, but
+    // the server-side room membership and (possibly) the executor are gone.
+    // Re-join + re-issue create on every (re)connect and surface a visible
+    // "reconnecting" state rather than silently freezing.
+    const handleReconnect = () => {
+      setReconnecting(true);
+      setIsConnected(false);
+      void attach();
+    };
+    const handleDisconnect = () => {
+      setIsConnected(false);
+      setReconnecting(true);
+    };
+    socket.on('connect', handleReconnect);
+    socket.on('disconnect', handleDisconnect);
+
     // Setup terminal
-    setupTerminal();
+    void attach();
 
     // Re-fit when the modal body resizes (viewport changes, browser zoom).
     const ro = new ResizeObserver(() => fitToContainer());
@@ -353,6 +405,7 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
       // Zellij session persists - just clean up listeners
       removeChannelListeners();
       setIsConnected(false);
+      setReconnecting(false);
       setSessionInfo({});
       setZellijMissing(false);
     };
@@ -432,6 +485,11 @@ export const TerminalModal: React.FC<TerminalModalProps> = ({
         </div>
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12, color: '#fff' }}>
+          {reconnecting ? (
+            <Badge status="warning" text="Reconnecting…" />
+          ) : !isConnected ? (
+            <Badge status="processing" text="Connecting to terminal…" />
+          ) : null}
           {/* Concrete size gives @xterm/addon-fit a box to measure; the
               width="auto" Modal then sizes itself to the terminal. */}
           <div ref={terminalDivRef} style={{ width: '80vw', maxWidth: 1100, height: '70vh' }} />

--- a/packages/core/src/types/feathers.ts
+++ b/packages/core/src/types/feathers.ts
@@ -53,6 +53,17 @@ export interface AuthenticatedUser {
   role: string;
   /** True for service accounts (executor) — bypasses RBAC checks */
   _isServiceAccount?: boolean;
+  /**
+   * True for terminal-executor tokens: a RESTRICTED identity that authenticates
+   * a web-terminal executor's socket for its own user's terminal channel only.
+   * Deliberately distinct from `_isServiceAccount` — a terminal token must NOT
+   * bypass RBAC on REST/Feathers paths (the terminal executor only streams PTY
+   * I/O over the socket). Enforced by the socket terminal handlers via
+   * `terminal_user_id`; carries no privilege anywhere else.
+   */
+  _isTerminalExecutor?: boolean;
+  /** The single user a terminal-executor identity may act for on its channel. */
+  terminal_user_id?: string;
 }
 
 /**

--- a/packages/executor/src/commands/zellij.test.ts
+++ b/packages/executor/src/commands/zellij.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createReconnectGrace } from './zellij.js';
+import { createReconnectGrace, waitForZellijReady } from './zellij.js';
 
 describe('createReconnectGrace', () => {
   beforeEach(() => {
@@ -80,5 +80,53 @@ describe('createReconnectGrace', () => {
     grace.onDisconnect(); // must NOT restart the countdown
     vi.advanceTimersByTime(10_000);
     expect(onGraceElapsed).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down when the bridge never becomes healthy again (reconnect without re-auth)', () => {
+    // Models a socket that flaps back to transport-connected but never
+    // re-authenticates: onReconnect (which zellij.ts only calls after a
+    // successful re-auth) is never invoked, so the window still fires.
+    let bridgeHealthy = false;
+    const onGraceElapsed = vi.fn();
+    const grace = createReconnectGrace({
+      graceMs: 30_000,
+      isConnected: () => bridgeHealthy,
+      onGraceElapsed,
+    });
+
+    grace.onDisconnect();
+    // Transport blips but re-auth keeps failing; bridgeHealthy stays false and
+    // onReconnect is never called.
+    bridgeHealthy = false;
+    vi.advanceTimersByTime(30_000);
+    expect(onGraceElapsed).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('waitForZellijReady', () => {
+  it('resolves true as soon as the probe succeeds, without exhausting attempts', async () => {
+    let calls = 0;
+    const probe = vi.fn(async () => {
+      calls += 1;
+      return calls >= 3; // fail twice, then succeed
+    });
+    const ready = await waitForZellijReady('agor-x', {
+      attempts: 10,
+      probe,
+      sleep: async () => {},
+    });
+    expect(ready).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it('resolves false after exhausting attempts when zellij never comes up', async () => {
+    const probe = vi.fn(async () => false);
+    const ready = await waitForZellijReady('agor-x', {
+      attempts: 4,
+      probe,
+      sleep: async () => {},
+    });
+    expect(ready).toBe(false);
+    expect(probe).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/executor/src/commands/zellij.test.ts
+++ b/packages/executor/src/commands/zellij.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createReconnectGrace } from './zellij.js';
+
+describe('createReconnectGrace', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not tear down immediately on disconnect — it waits out the grace window', () => {
+    const connected = false;
+    const onGraceElapsed = vi.fn();
+    const grace = createReconnectGrace({
+      graceMs: 30_000,
+      isConnected: () => connected,
+      onGraceElapsed,
+    });
+
+    grace.onDisconnect();
+    expect(grace.isPending()).toBe(true);
+
+    // Still within the window: nothing happens.
+    vi.advanceTimersByTime(29_999);
+    expect(onGraceElapsed).not.toHaveBeenCalled();
+
+    // Window elapses while still disconnected → tear down.
+    vi.advanceTimersByTime(1);
+    expect(onGraceElapsed).toHaveBeenCalledTimes(1);
+    expect(grace.isPending()).toBe(false);
+  });
+
+  it('cancels the teardown when the socket reconnects within the window', () => {
+    let connected = false;
+    const onGraceElapsed = vi.fn();
+    const grace = createReconnectGrace({
+      graceMs: 30_000,
+      isConnected: () => connected,
+      onGraceElapsed,
+    });
+
+    grace.onDisconnect();
+    // Transport comes back before the window elapses.
+    connected = true;
+    grace.onReconnect();
+    expect(grace.isPending()).toBe(false);
+
+    vi.advanceTimersByTime(60_000);
+    expect(onGraceElapsed).not.toHaveBeenCalled();
+  });
+
+  it('does not tear down if the socket is connected again when the window fires', () => {
+    let connected = false;
+    const onGraceElapsed = vi.fn();
+    const grace = createReconnectGrace({
+      graceMs: 30_000,
+      isConnected: () => connected,
+      onGraceElapsed,
+    });
+
+    grace.onDisconnect();
+    // Reconnect happens but (hypothetically) the cancel was missed; the
+    // window still re-checks liveness before exiting, so no teardown.
+    connected = true;
+    vi.advanceTimersByTime(30_000);
+    expect(onGraceElapsed).not.toHaveBeenCalled();
+  });
+
+  it('coalesces repeated disconnects into a single pending window', () => {
+    const onGraceElapsed = vi.fn();
+    const grace = createReconnectGrace({
+      graceMs: 30_000,
+      isConnected: () => false,
+      onGraceElapsed,
+    });
+
+    grace.onDisconnect();
+    vi.advanceTimersByTime(20_000);
+    grace.onDisconnect(); // must NOT restart the countdown
+    vi.advanceTimersByTime(10_000);
+    expect(onGraceElapsed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -36,6 +36,75 @@ let feathersClient: AgorClient | null = null;
 let _currentUserId: string | null = null;
 let currentPtyCols = 160;
 let currentPtyRows = 40;
+let currentTabName: string | undefined;
+
+/**
+ * Grace window after a socket disconnect before the executor tears down.
+ *
+ * A transient network blip or a daemon restart drops the socket, but the
+ * zellij session is long-lived and survives detach, so the PTY bridge is
+ * recoverable: the feathers client auto-reconnects (and re-authenticates)
+ * on its own. We keep the PTY + zellij session alive for this long and only
+ * exit if the socket has not come back by the time it elapses. Exiting
+ * immediately (the old behavior) turned every blip into a dead terminal that
+ * the browser still believed was connected.
+ */
+const DISCONNECT_GRACE_MS = 30_000;
+
+/** Active grace controller for the running attach, so cleanup can cancel it. */
+let graceController: ReturnType<typeof createReconnectGrace> | null = null;
+
+/**
+ * A single-shot grace window that holds an executor alive across a socket
+ * disconnect and tears it down only if the socket has not reconnected when the
+ * window elapses. Extracted (and injectable) so the reconnect-before-exit
+ * behavior can be unit-tested without a live PTY or socket.
+ */
+export function createReconnectGrace(opts: {
+  graceMs: number;
+  isConnected: () => boolean;
+  onGraceElapsed: () => void;
+}): {
+  onDisconnect: () => void;
+  onReconnect: () => void;
+  cancel: () => void;
+  isPending: () => boolean;
+} {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const clear = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  return {
+    onDisconnect() {
+      if (timer) return; // already counting down
+      timer = setTimeout(() => {
+        timer = null;
+        if (!opts.isConnected()) opts.onGraceElapsed();
+      }, opts.graceMs);
+    },
+    onReconnect: clear,
+    cancel: clear,
+    isPending: () => timer !== null,
+  };
+}
+
+/**
+ * Announce that the PTY exists and is attached so the daemon can gate its
+ * tab focus/redraw choreography on a real signal instead of a blind timer,
+ * and the browser can flip from "connecting" to connected. Safe to call
+ * repeatedly (initial spawn + every reconnect) — the daemon treats it as
+ * idempotent readiness.
+ */
+function emitTerminalReady(socket: AgorClient['io'], userId: string): void {
+  socket.emit('terminal:ready', {
+    userId,
+    sessionName: currentSessionName ?? undefined,
+    tabName: currentTabName,
+  });
+}
 
 /** Longest a buffered chunk may wait before it is emitted. */
 const OUTPUT_FLUSH_INTERVAL_MS = 16;
@@ -156,9 +225,19 @@ export async function handleZellijAttach(
   }
 
   try {
-    // Connect to daemon
+    // Connect to daemon. On reconnect, the socket is fresh: it has left the
+    // terminal channel room and a restarted daemon has forgotten this
+    // executor. Re-join and re-announce readiness once re-authenticated so
+    // input keeps flowing and the daemon rediscovers the live bridge.
     const daemonUrl = payload.daemonUrl || 'http://localhost:3030';
-    feathersClient = await createExecutorClient(daemonUrl, payload.sessionToken);
+    feathersClient = await createExecutorClient(daemonUrl, payload.sessionToken, {
+      onReauthenticated: () => {
+        const s = feathersClient?.io;
+        if (!s) return;
+        s.emit('join', `user/${userId}/terminal`);
+        if (ptyProcess) emitTerminalReady(s, userId);
+      },
+    });
     _currentUserId = userId;
 
     console.log(`[zellij.attach] Connected to daemon, joining channel user/${userId}/terminal`);
@@ -168,17 +247,32 @@ export async function handleZellijAttach(
     const socket = feathersClient.io;
     socket.emit('join', `user/${userId}/terminal`);
 
-    // Handle socket disconnect gracefully
-    // This happens when daemon restarts (watch mode) - just exit cleanly
-    // A new executor will be spawned when user reopens terminal
+    graceController = createReconnectGrace({
+      graceMs: DISCONNECT_GRACE_MS,
+      isConnected: () => socket.connected,
+      onGraceElapsed: () => {
+        console.log('[zellij.attach] Reconnect grace elapsed — exiting');
+        if (ptyProcess) {
+          ptyProcess.kill();
+          ptyProcess = null;
+        }
+        process.exit(0);
+      },
+    });
+
+    // Cancel any pending teardown the moment the transport is restored. The
+    // re-join + readiness re-announce happen in onReauthenticated above (the
+    // fresh socket must re-authenticate before the daemon accepts them).
+    socket.on('connect', () => graceController?.onReconnect());
+
+    // A disconnect is recoverable — hold the PTY through a grace window and
+    // let the client's auto-reconnect restore the bridge. Only tear down if
+    // the socket is still gone when the window elapses.
     socket.on('disconnect', (reason: string) => {
-      console.log(`[zellij.attach] Socket disconnected: ${reason}`);
-      // Clean up and exit gracefully instead of crashing
-      if (ptyProcess) {
-        ptyProcess.kill();
-        ptyProcess = null;
-      }
-      process.exit(0);
+      console.log(
+        `[zellij.attach] Socket disconnected: ${reason} — holding PTY for ${DISCONNECT_GRACE_MS}ms pending reconnect`
+      );
+      graceController?.onDisconnect();
     });
 
     // Import node-pty dynamically (native module)
@@ -251,10 +345,16 @@ export async function handleZellijAttach(
 
     ptyProcess = pty;
     currentSessionName = sessionName; // Store for tab management
+    currentTabName = tabName;
     currentPtyCols = cols || 80;
     currentPtyRows = rows || 24;
 
     console.log(`[zellij.attach] PTY spawned, PID: ${pty.pid}`);
+
+    // The PTY exists and zellij attach is running — announce readiness so the
+    // daemon can drive its tab choreography off a real signal and the browser
+    // can leave its "connecting" state.
+    emitTerminalReady(socket, userId);
 
     // Stream PTY output to channel, coalesced into fewer/larger frames so
     // heavy output doesn't drown the browser terminal in tiny writes.
@@ -407,6 +507,13 @@ export async function handleZellijAttach(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error('[zellij.attach] Failed:', errorMessage);
+
+    // Surface the attach failure to the browser so it shows an error instead
+    // of hanging on "connecting" forever — the readiness ack never arrives on
+    // this path.
+    if (feathersClient?.io.connected) {
+      feathersClient.io.emit('terminal:error', { userId, message: errorMessage });
+    }
 
     // Cleanup on error
     if (ptyProcess) {
@@ -806,6 +913,10 @@ ${argsLine}    }
  * Cleanup function - called when executor is shutting down
  */
 export function cleanupZellij(): void {
+  if (graceController) {
+    graceController.cancel();
+    graceController = null;
+  }
   if (ptyProcess) {
     console.log('[zellij] Killing PTY process');
     ptyProcess.kill();
@@ -816,4 +927,5 @@ export function cleanupZellij(): void {
     feathersClient = null;
   }
   currentSessionName = null;
+  currentTabName = undefined;
 }

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -491,6 +491,11 @@ export async function handleZellijAttach(
             message: 'Terminal failed to start: zellij session did not become ready',
           });
         }
+        // Tear down instead of lingering as a dead PTY the daemon would adopt
+        // (leaving the browser stuck on "Connecting…" with no recovery). Killing
+        // the PTY fires pty.onExit → terminal:exit → process.exit, so the daemon
+        // evicts its executor map entry and the next open does a clean cold spawn.
+        ptyProcess?.kill();
         return;
       }
       zellijAttached = true;

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -55,6 +55,24 @@ const DISCONNECT_GRACE_MS = 30_000;
 let graceController: ReturnType<typeof createReconnectGrace> | null = null;
 
 /**
+ * Whether the socket is not just transport-connected but actually
+ * re-authenticated as the executor service — i.e. the daemon will accept our
+ * emits again. Set true only after (re)authentication succeeds, false on
+ * disconnect. The grace window keys teardown off THIS, not raw
+ * `socket.connected`, so a socket that reconnects transport-only but never
+ * re-authenticates doesn't keep a dead PTY alive forever.
+ */
+let bridgeHealthy = false;
+
+/**
+ * Whether zellij's attach has been confirmed operational (a `zellij action`
+ * against the session succeeded), as opposed to node-pty merely having
+ * returned a PID. Gates the readiness ack so the daemon's tab choreography
+ * can't race an un-booted zellij, and gates the reconnect re-announce.
+ */
+let zellijAttached = false;
+
+/**
  * A single-shot grace window that holds an executor alive across a socket
  * disconnect and tears it down only if the socket has not reconnected when the
  * window elapses. Extracted (and injectable) so the reconnect-before-exit
@@ -231,14 +249,22 @@ export async function handleZellijAttach(
     // input keeps flowing and the daemon rediscovers the live bridge.
     const daemonUrl = payload.daemonUrl || 'http://localhost:3030';
     feathersClient = await createExecutorClient(daemonUrl, payload.sessionToken, {
+      // Fires only after a reconnect RE-AUTHENTICATES (not on raw transport
+      // connect). This is when the daemon will accept our emits again, so it's
+      // the only safe point to mark the bridge healthy, cancel the pending
+      // teardown, re-join the channel, and re-announce readiness.
       onReauthenticated: () => {
+        bridgeHealthy = true;
+        graceController?.onReconnect();
         const s = feathersClient?.io;
         if (!s) return;
         s.emit('join', `user/${userId}/terminal`);
-        if (ptyProcess) emitTerminalReady(s, userId);
+        if (ptyProcess && zellijAttached) emitTerminalReady(s, userId);
       },
     });
     _currentUserId = userId;
+    // Initial connect + authenticate already succeeded inside createExecutorClient.
+    bridgeHealthy = true;
 
     console.log(`[zellij.attach] Connected to daemon, joining channel user/${userId}/terminal`);
 
@@ -249,9 +275,12 @@ export async function handleZellijAttach(
 
     graceController = createReconnectGrace({
       graceMs: DISCONNECT_GRACE_MS,
-      isConnected: () => socket.connected,
+      // Key teardown off re-authentication, NOT raw transport connectivity: a
+      // socket can be transport-connected yet unauthenticated (reauth failing),
+      // in which case the bridge is dead and we should still exit.
+      isConnected: () => bridgeHealthy,
       onGraceElapsed: () => {
-        console.log('[zellij.attach] Reconnect grace elapsed — exiting');
+        console.log('[zellij.attach] Reconnect grace elapsed without a healthy bridge — exiting');
         if (ptyProcess) {
           ptyProcess.kill();
           ptyProcess = null;
@@ -260,17 +289,14 @@ export async function handleZellijAttach(
       },
     });
 
-    // Cancel any pending teardown the moment the transport is restored. The
-    // re-join + readiness re-announce happen in onReauthenticated above (the
-    // fresh socket must re-authenticate before the daemon accepts them).
-    socket.on('connect', () => graceController?.onReconnect());
-
-    // A disconnect is recoverable — hold the PTY through a grace window and
-    // let the client's auto-reconnect restore the bridge. Only tear down if
-    // the socket is still gone when the window elapses.
+    // A disconnect is recoverable — hold the PTY through a grace window and let
+    // the client's auto-reconnect + re-auth restore the bridge. The teardown is
+    // cancelled in onReauthenticated (above), not on raw `connect`, so a
+    // transport-only reconnect that never re-authenticates still tears down.
     socket.on('disconnect', (reason: string) => {
+      bridgeHealthy = false;
       console.log(
-        `[zellij.attach] Socket disconnected: ${reason} — holding PTY for ${DISCONNECT_GRACE_MS}ms pending reconnect`
+        `[zellij.attach] Socket disconnected: ${reason} — holding PTY for ${DISCONNECT_GRACE_MS}ms pending re-auth`
       );
       graceController?.onDisconnect();
     });
@@ -351,13 +377,10 @@ export async function handleZellijAttach(
 
     console.log(`[zellij.attach] PTY spawned, PID: ${pty.pid}`);
 
-    // The PTY exists and zellij attach is running — announce readiness so the
-    // daemon can drive its tab choreography off a real signal and the browser
-    // can leave its "connecting" state.
-    emitTerminalReady(socket, userId);
-
     // Stream PTY output to channel, coalesced into fewer/larger frames so
-    // heavy output doesn't drown the browser terminal in tiny writes.
+    // heavy output doesn't drown the browser terminal in tiny writes. Readiness
+    // is NOT announced here — it's emitted only after waitForZellijReady
+    // confirms zellij's attach actually booted (see below).
     const outputCoalescer = createOutputCoalescer((data) => {
       socket.emit('terminal:output', { userId, data });
     });
@@ -451,20 +474,36 @@ export async function handleZellijAttach(
       }
     });
 
-    // Create initial tab if specified. Retried because `zellij attach
-    // --create` boots the session asynchronously — the first
-    // `action new-tab` after a fast attach can race with the server
-    // setup and get back "There is no active session!" before the
-    // session is registered. Without retry + catch, that error
-    // propagates as an unhandled promise rejection and crashes the
-    // executor (Node 22+ behavior).
-    if (tabName) {
-      void (async () => {
-        await new Promise((r) => setTimeout(r, 500));
+    // Confirm zellij's attach is actually operational before announcing
+    // readiness and creating the initial tab. `zellij attach --create` boots
+    // the session asynchronously — node-pty returning a PID does NOT mean the
+    // session server is up. We probe with a lightweight `zellij action` until
+    // it succeeds, THEN ack ready, so the daemon's tab choreography never
+    // races an un-booted zellij. If it never comes up, surface terminal:error
+    // instead of a false ready that would leave the browser hanging.
+    void (async () => {
+      const attached = await waitForZellijReady(sessionName);
+      if (!attached) {
+        console.error('[zellij.attach] zellij session did not become ready');
+        if (feathersClient?.io.connected) {
+          feathersClient.io.emit('terminal:error', {
+            userId,
+            message: 'Terminal failed to start: zellij session did not become ready',
+          });
+        }
+        return;
+      }
+      zellijAttached = true;
+      emitTerminalReady(socket, userId);
+
+      // Create the initial tab now that the session is confirmed up. Keep a
+      // bounded retry as belt-and-suspenders against a residual boot race:
+      // without the catch, a rejection here crashes the executor (Node 22+).
+      if (tabName) {
         for (let attempt = 0; attempt < 5; attempt++) {
           try {
             await handleTabAction('create', tabName, cwd);
-            return;
+            break;
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             if (/no active session/i.test(msg) && attempt < 4) {
@@ -475,11 +514,11 @@ export async function handleZellijAttach(
               continue;
             }
             console.warn('[zellij.attach] Initial new-tab failed (giving up):', msg);
-            return;
+            break;
           }
         }
-      })();
-    }
+      }
+    })();
 
     // Source env file after Zellij initializes (user env vars like API keys)
     if (envFile && ptyProcess) {
@@ -514,6 +553,15 @@ export async function handleZellijAttach(
     if (feathersClient?.io.connected) {
       feathersClient.io.emit('terminal:error', { userId, message: errorMessage });
     }
+
+    // Cancel any pending teardown timer so a failed attach doesn't keep the
+    // process pinned alive until the full grace window expires.
+    if (graceController) {
+      graceController.cancel();
+      graceController = null;
+    }
+    bridgeHealthy = false;
+    zellijAttached = false;
 
     // Cleanup on error
     if (ptyProcess) {
@@ -601,6 +649,62 @@ export async function handleZellijTab(
  * Current Zellij session name (set when attach starts)
  */
 let currentSessionName: string | null = null;
+
+/**
+ * Probe whether a zellij session is up and accepting `action` commands.
+ * Runs a quiet `query-tab-names` (stdout/stderr ignored) and reports whether
+ * it exited 0. Used as the readiness signal that zellij attach actually
+ * booted, as opposed to node-pty merely returning a PID.
+ */
+function isZellijSessionUp(sessionName: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proc = spawn('zellij', ['--session', sessionName, 'action', 'query-tab-names'], {
+      stdio: 'ignore',
+    });
+    const timeout = setTimeout(() => {
+      try {
+        proc.kill();
+      } catch {
+        /* already exited */
+      }
+      resolve(false);
+    }, 3000);
+    proc.on('exit', (code) => {
+      clearTimeout(timeout);
+      resolve(code === 0);
+    });
+    proc.on('error', () => {
+      clearTimeout(timeout);
+      resolve(false);
+    });
+  });
+}
+
+/**
+ * Poll {@link isZellijSessionUp} until it succeeds or the attempt budget is
+ * exhausted. ~20 * 300ms ≈ 6s ceiling, comfortably longer than a normal
+ * zellij boot; on exhaustion the caller surfaces terminal:error rather than a
+ * false readiness ack. Exported for unit testing with an injected probe.
+ */
+export async function waitForZellijReady(
+  sessionName: string,
+  opts: {
+    attempts?: number;
+    delayMs?: number;
+    probe?: (sessionName: string) => Promise<boolean>;
+    sleep?: (ms: number) => Promise<void>;
+  } = {}
+): Promise<boolean> {
+  const attempts = opts.attempts ?? 20;
+  const delayMs = opts.delayMs ?? 300;
+  const probe = opts.probe ?? isZellijSessionUp;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (await probe(sessionName)) return true;
+    if (attempt < attempts - 1) await sleep(delayMs);
+  }
+  return false;
+}
 
 /**
  * Query existing tab names from Zellij session
@@ -928,4 +1032,6 @@ export function cleanupZellij(): void {
   }
   currentSessionName = null;
   currentTabName = undefined;
+  bridgeHealthy = false;
+  zellijAttached = false;
 }

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -51,9 +51,22 @@ class MemoryStorage {
  * @param sessionToken - Session token for authentication
  * @returns Authenticated Feathers client
  */
+export interface ExecutorClientHooks {
+  /**
+   * Fired after the socket reconnects AND successfully re-authenticates as the
+   * executor service account. Long-running commands (e.g. the zellij terminal
+   * bridge) use this to re-establish socket-scoped state that a fresh socket
+   * loses — channel room membership and readiness announcements — which the
+   * auto-reconnect transport cannot restore on its own. Never fired for the
+   * initial connect; only for reconnects.
+   */
+  onReauthenticated?: () => void | Promise<void>;
+}
+
 export async function createExecutorClient(
   daemonUrl: string,
-  sessionToken: string
+  sessionToken: string,
+  hooks?: ExecutorClientHooks
 ): Promise<AgorClient> {
   const startedAt = Date.now();
   const logSocketEvent = (event: string, detail?: unknown) => {
@@ -108,6 +121,7 @@ export async function createExecutorClient(
       await client.reAuthenticate(true);
       console.log(`[executor] Re-authenticated successfully after ${label}`);
       resetServerDisconnectRecovery();
+      await hooks?.onReauthenticated?.();
       return true;
     } catch {
       // Fallback: authenticate with raw JWT if storage-based re-auth fails
@@ -118,6 +132,7 @@ export async function createExecutorClient(
         });
         console.log(`[executor] Re-authenticated with JWT fallback after ${label}`);
         resetServerDisconnectRecovery();
+        await hooks?.onReauthenticated?.();
         return true;
       } catch (error) {
         console.error(`[executor] Re-authentication failed after ${label}:`, error);


### PR DESCRIPTION
Fixes the reconnect/reliability half of #1919 (items **1** and **3** of the issue plan). The rendering-perf half (items 2, 4, 5) is out of scope here and handled separately.

## Problem

The embedded terminal (xterm.js ↔ Socket.IO ↔ daemon ↔ executor → node-pty → zellij) froze whenever a connection blipped or the daemon restarted:

1. **No reconnect handling.** The executor called `process.exit(0)` on *any* socket disconnect, killing the PTY bridge; neither `EmbeddedTerminal` nor `TerminalModal` re-joined its channel or re-issued `terminals.create` after the socket reconnected. The browser still showed `connected: true` and silently stopped receiving output — indistinguishable from a hang.
2. **No readiness ack.** `connected` flipped when the `terminals.create` call *resolved*, not when the executor confirmed the PTY existed. A post-spawn executor crash left the UI stuck on "Connecting…" forever, and the daemon guessed executor boot timing with blind `setTimeout(200/300/1500ms)` waits.

## Changes

**Executor (`packages/executor`)**
- Replace `process.exit(0)`-on-disconnect with a 30s grace window (`createReconnectGrace`, extracted + unit-tested). The zellij session survives detach, so the PTY is held while the feathers client auto-reconnects; the executor exits only if the socket hasn't returned when the window elapses.
- New `onReauthenticated` hook on the executor feathers client: after a reconnect re-authenticates, re-join the terminal channel and re-emit readiness so a restarted daemon rediscovers the live bridge and input keeps flowing.
- Emit `terminal:ready` once the PTY is spawned/attached, and `terminal:error` when attach fails.

**Daemon (`apps/agor-daemon`)**
- socketio relay: service-only `terminal:ready` / `terminal:error` handlers forwarded to the terminals service via app events.
- terminals service: track executor readiness, **gate cold-start tab focus/ensure/redraw on the `terminal:ready` ack** instead of the blind timers, adopt live post-restart executors as ready, and return a `ready` flag from `create()` so warm reconnects connect without racing a channel event.

**Frontend (`apps/agor-ui`)**
- `EmbeddedTerminal` + `TerminalModal`: on socket (re)connect, re-join the channel and re-issue the idempotent `terminals.create`; flip `connected` on the `terminal:ready` ack (or the warm `ready` flag), not on create resolving; show a small AntD `Badge` "reconnecting…" / "connecting…" / error affordance instead of silently freezing.

## Tests
- Executor: grace-before-exit / reconnect-cancels-teardown (`zellij.test.ts`).
- Daemon: ready-ack gating + `ready` flag + relay authorization (`terminals.test.ts`, `socketio.test.ts`).
- UI: `EmbeddedTerminal` stays "connecting" until the ack, then reconnects + re-joins on socket connect (`EmbeddedTerminal.test.tsx`).

`pnpm check` (biome + tsc + build) passes; full daemon (1679) and UI (885) suites green. The 3 failing executor suites (gemini/opencode) are pre-existing and unrelated (verified by stashing this branch's changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)