### PR TITLE
ci(audit): run pnpm audit on pnpm 11 for the bulk advisory endpoint

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -31,7 +31,12 @@ on:
   workflow_dispatch:
 
 env:
+  # Install runs on the repo's pinned pnpm (matches package.json `packageManager`
+  # and pnpm-lock.yaml's lockfileVersion). The audit runs on pnpm 11, the first
+  # line to query npm's bulk advisory endpoint — the legacy
+  # /-/npm/v1/security/audits endpoint that pnpm 9 uses was retired (HTTP 410).
   PNPM_VERSION: '9.15.1'
+  AUDIT_PNPM_VERSION: '11.13.0'
   NODE_VERSION: '22'
 
 jobs:
@@ -53,16 +58,18 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       # Blocking: any CRITICAL advisory in prod deps fails the build.
+      # `--pm-on-fail=ignore` stops pnpm 11 from self-switching down to the
+      # pinned `packageManager` (pnpm 9) declared in package.json.
       - name: pnpm audit (prod, critical — blocking)
-        run: pnpm audit --audit-level=critical --prod
+        run: npx --yes pnpm@${{ env.AUDIT_PNPM_VERSION }} audit --audit-level=critical --prod --pm-on-fail=ignore
 
       # Advisory: HIGH+ advisories are surfaced but non-blocking.
       # Promote to blocking once the prod tree is clean at the HIGH level.
       - name: pnpm audit (prod, high — advisory)
         if: always()
-        run: pnpm audit --audit-level=high --prod || true
+        run: npx --yes pnpm@${{ env.AUDIT_PNPM_VERSION }} audit --audit-level=high --prod --pm-on-fail=ignore || true
 
       # Full tree (incl. dev deps) — advisory only.
       - name: pnpm audit (all, high — advisory)
         if: always()
-        run: pnpm audit --audit-level=high || true
+        run: npx --yes pnpm@${{ env.AUDIT_PNPM_VERSION }} audit --audit-level=high --pm-on-fail=ignore || true


### PR DESCRIPTION
## Problem

Fixes #1922.

npm retired the legacy `/-/npm/v1/security/audits{,/quick}` endpoints (2026-07-15) in favor of `/-/npm/v1/security/advisories/bulk`. The `Security Audit` workflow pins pnpm `9.15.1`, whose audit client still calls the retired endpoint, so `pnpm audit` now fails on **every** PR that touches `pnpm-lock.yaml`/`**/package.json`/`pnpm-workspace.yaml`:

```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (at
https://registry.npmjs.org/-/npm/v1/security/audits) responded with 410:
{"error":"This endpoint is being retired. Use the bulk advisory endpoint instead..."}
```

pnpm 11 rewired the audit client to the bulk advisory endpoint ([pnpm/pnpm#11268](https://github.com/pnpm/pnpm/pull/11268)).

## Why not just bump `PNPM_VERSION`

A plain bump doesn't work, for two independent reasons verified locally:

1. **Frozen install breaks on the v9 lockfile.** pnpm 11 no longer reads `pnpm.overrides` from `package.json`, so `pnpm install --frozen-lockfile` against the existing (pnpm 9) lockfile fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on `overrides`.
2. **The `packageManager` pin self-downgrades pnpm.** With `packageManager: pnpm@9.15.1` in `package.json`, pnpm 11 silently self-switches back to 9.15.1 — so it would still hit the 410.

## Fix

Confined to the isolated `audit` job:

- **Install stays on the pinned pnpm 9** (`PNPM_VERSION` unchanged) so `--frozen-lockfile` still works against the existing lockfile.
- **Only the audit subcommands run on pnpm 11.13.0**, invoked via `npx`, reading the lockfile directly (audit needs no `node_modules`).
- `--pm-on-fail=ignore` stops the newer pnpm from self-switching back to the pinned `packageManager`.

The repo-wide `packageManager` field and the `PNPM_VERSION` in `ci.yml`/`agor-live-smoke.yml` are deliberately **untouched** — those drive the real install/build/test pipeline and stay on 9.15.1.

## Verification

Simulated the exact job locally against a clean `git archive` copy:

- `pnpm install --frozen-lockfile` on pnpm 9 → exit 0.
- `pnpm@11.13.0 audit` → hits the bulk endpoint successfully (no 410).
- Blocking `--audit-level=critical --prod` → exit 0 (0 critical in prod deps).
- Advisory HIGH steps surface findings but stay non-blocking via `|| true`.

Because this edit touches `audit.yml`, the path filter runs the audit job on this PR itself — see the checks below for the real end-to-end result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)