### PR TITLE
feat(executor): centralize runtime lifecycle

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -1,6 +1,10 @@
 import type { HookContext } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import { executorRuntimeScopeGuard, scopeExecutorRuntimeAuth } from './executor-runtime-scope';
+import {
+  executorRuntimeScopeGuard,
+  requireExecutorRuntimeToken,
+  scopeExecutorRuntimeAuth,
+} from './executor-runtime-scope';
 
 const payload = {
   type: 'executor-session',
@@ -20,6 +24,39 @@ function ctx(overrides: Partial<HookContext>): HookContext {
 }
 
 describe('executorRuntimeScopeGuard', () => {
+  it('accepts the scoped executor connection method and rejects a different task', async () => {
+    const context = ctx({
+      path: 'tasks',
+      method: 'connectExecutor',
+      data: { task_id: 'task-1' },
+    });
+
+    await expect(executorRuntimeScopeGuard()(context)).resolves.toBe(context);
+    await expect(
+      executorRuntimeScopeGuard()(
+        ctx({ path: 'tasks', method: 'connectExecutor', data: { task_id: 'task-2' } })
+      )
+    ).rejects.toThrow(/task scope/);
+  });
+
+  it('requires an executor token for the executor connection method', async () => {
+    const context = ctx({
+      method: 'connectExecutor',
+      data: { task_id: 'task-1' },
+      params: { provider: 'socketio', query: {}, user: { user_id: 'user-1' } },
+    });
+
+    await expect(requireExecutorRuntimeToken()(context)).rejects.toThrow(/executor token/);
+  });
+
+  it('allows a patch only for the executor token task', async () => {
+    const matching = ctx({ method: 'patch', id: 'task-1', data: { status: 'running' } });
+    const otherTask = ctx({ method: 'patch', id: 'task-2', data: { status: 'running' } });
+
+    await expect(executorRuntimeScopeGuard()(matching)).resolves.toBe(matching);
+    await expect(executorRuntimeScopeGuard()(otherTask)).rejects.toThrow(/task scope/);
+  });
+
   it('narrows find queries to executor token scope', async () => {
     const context = ctx({ path: 'messages', method: 'find' });
 

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -43,6 +43,11 @@ function scopedPayload(context: HookContext): ExecutorSessionTokenPayload | null
   return null;
 }
 
+/** Whether this authenticated transport request carries executor scope for one task. */
+export function isTaskScopedExecutorRequest(context: HookContext, taskId: string): boolean {
+  return scopedPayload(context)?.task_id === taskId;
+}
+
 function expectClaim(claim: string | undefined, label: string): string {
   if (!claim) {
     throw new Forbidden(`Executor token is missing ${label} scope`);
@@ -170,6 +175,16 @@ export function scopeExecutorRuntimeAuth(requireAuth: AuthHook): AuthHook {
   return async (context: HookContext): Promise<HookContext> => {
     const authenticated = await requireAuth(context);
     return executorRuntimeScopeGuard()(authenticated);
+  };
+}
+
+/** Require this transport call to carry a task-scoped executor session token. */
+export function requireExecutorRuntimeToken() {
+  return async (context: HookContext): Promise<HookContext> => {
+    if (!scopedPayload(context)) {
+      throw new Forbidden('A task-scoped executor token is required for this request');
+    }
+    return context;
   };
 }
 

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -120,6 +120,7 @@ export interface SessionsServiceImpl extends Service<Session, Partial<Session>, 
  * Tasks service with custom methods (server-side implementation)
  */
 export interface TasksServiceImpl extends Service<Task, Partial<Task>, FeathersParams> {
+  connectExecutor(data: { task_id: string }, params?: FeathersParams): Promise<Task>;
   createMany(data: Array<Partial<Task>>): Promise<Task[]>;
   complete(
     id: string,

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -18,12 +18,14 @@
  * branch-authorization.test.ts), so here we only verify the classifier.
  */
 
+import { TaskStatus } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
 import {
   enrichSessionFindResultWithRemoteRelationships,
   getTrustedSessionTenantId,
   isPromptFlowPatchOnly,
   PROMPT_FLOW_PATCH_FIELDS,
+  protectServerManagedTaskWrites,
   shouldDrainQueueAfterSessionPostTurnPatch,
   shouldRunSessionPostTurnHooks,
   shouldValidateRepoEnvironmentPayload,
@@ -47,6 +49,247 @@ const makeSession = (sessionId: string): import('@agor/core/types').Session =>
     ready_for_prompt: false,
     archived: false,
   }) as import('@agor/core/types').Session;
+
+describe('protectServerManagedTaskWrites', () => {
+  const executorPayload = {
+    type: 'executor-session',
+    purpose: 'executor-task',
+    session_id: 'session-1',
+    task_id: 'task-1',
+    branch_id: 'branch-1',
+  };
+  const externalContext = (
+    method: 'create' | 'update' | 'patch',
+    data: unknown,
+    options: {
+      taskId?: string;
+      executorTaskId?: string;
+      persistedTask?: Record<string, unknown>;
+    } = {}
+  ): import('@agor/core/types').HookContext =>
+    ({
+      path: 'tasks',
+      method,
+      id: options.taskId,
+      data,
+      params: {
+        provider: 'rest',
+        ...(options.executorTaskId
+          ? {
+              authentication: {
+                payload: { ...executorPayload, task_id: options.executorTaskId },
+              },
+            }
+          : {}),
+      },
+      service: options.persistedTask
+        ? { findByIdForScopeCheck: async () => options.persistedTask }
+        : undefined,
+    }) as import('@agor/core/types').HookContext;
+
+  it.each([
+    'create',
+    'update',
+    'patch',
+  ] as const)('rejects executor_connected_at on external %s', async (method) => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext(method, { executor_connected_at: '2026-07-10T20:00:00.000Z' })
+      )
+    ).rejects.toThrow('executor_connected_at is server-managed');
+  });
+
+  it('rejects executor_connected_at in bulk create data', async () => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext('create', [
+          { full_prompt: 'safe' },
+          { executor_connected_at: '2026-07-10T20:00:00.000Z' },
+        ])
+      )
+    ).rejects.toThrow('executor_connected_at is server-managed');
+  });
+
+  it.each([
+    'create',
+    'update',
+    'patch',
+  ] as const)('rejects server-owned dispatching status on external %s', async (method) => {
+    await expect(
+      protectServerManagedTaskWrites(externalContext(method, { status: TaskStatus.DISPATCHING }))
+    ).rejects.toThrow('dispatching task status is server-managed');
+  });
+
+  it.each([
+    'create',
+    'update',
+    'patch',
+  ] as const)('rejects server-owned dispatching status in external %s array data', async (method) => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext(method, [
+          { status: TaskStatus.CREATED },
+          { status: TaskStatus.DISPATCHING },
+        ])
+      )
+    ).rejects.toThrow('dispatching task status is server-managed');
+  });
+
+  it.each([
+    'create',
+    'update',
+    'patch',
+  ] as const)('rejects server-owned running status on external %s', async (method) => {
+    await expect(
+      protectServerManagedTaskWrites(externalContext(method, { status: TaskStatus.RUNNING }))
+    ).rejects.toThrow('running task status is server-managed');
+  });
+
+  it.each([
+    'create',
+    'update',
+    'patch',
+  ] as const)('rejects server-owned running status in external %s array data', async (method) => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext(method, [{ status: TaskStatus.CREATED }, { status: TaskStatus.RUNNING }])
+      )
+    ).rejects.toThrow('running task status is server-managed');
+  });
+
+  it('blocks the external dispatching-to-created-to-running bypass', async () => {
+    await expect(
+      protectServerManagedTaskWrites(externalContext('patch', { status: TaskStatus.CREATED }))
+    ).resolves.toBeDefined();
+    await expect(
+      protectServerManagedTaskWrites(externalContext('patch', { status: TaskStatus.RUNNING }))
+    ).rejects.toThrow('running task status is server-managed');
+  });
+
+  it('rejects a pre-claim executor running patch', async () => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext(
+          'patch',
+          { status: TaskStatus.RUNNING },
+          {
+            taskId: 'task-1',
+            executorTaskId: 'task-1',
+            persistedTask: {
+              task_id: 'task-1',
+              status: TaskStatus.DISPATCHING,
+              executor_connected_at: null,
+            },
+          }
+        )
+      )
+    ).rejects.toThrow('running task status is server-managed');
+  });
+
+  it('rejects a connected task-scoped executor forging dispatching', async () => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext(
+          'patch',
+          { status: TaskStatus.DISPATCHING },
+          {
+            taskId: 'task-1',
+            executorTaskId: 'task-1',
+            persistedTask: {
+              task_id: 'task-1',
+              status: TaskStatus.AWAITING_INPUT,
+              executor_connected_at: '2026-07-10T20:00:00.000Z',
+            },
+          }
+        )
+      )
+    ).rejects.toThrow('dispatching task status is server-managed');
+  });
+
+  it('rejects a normal user resuming an already-connected task', async () => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext(
+          'patch',
+          { status: TaskStatus.RUNNING },
+          {
+            taskId: 'task-1',
+            persistedTask: {
+              task_id: 'task-1',
+              status: TaskStatus.AWAITING_PERMISSION,
+              executor_connected_at: '2026-07-10T20:00:00.000Z',
+            },
+          }
+        )
+      )
+    ).rejects.toThrow('running task status is server-managed');
+  });
+
+  it.each([
+    TaskStatus.AWAITING_PERMISSION,
+    TaskStatus.AWAITING_INPUT,
+  ])('allows a connected scoped executor to resume from %s', async (status) => {
+    const context = externalContext(
+      'patch',
+      { status: TaskStatus.RUNNING },
+      {
+        taskId: 'task-1',
+        executorTaskId: 'task-1',
+        persistedTask: {
+          task_id: 'task-1',
+          status,
+          executor_connected_at: '2026-07-10T20:00:00.000Z',
+        },
+      }
+    );
+
+    await expect(protectServerManagedTaskWrites(context)).resolves.toBe(context);
+  });
+
+  it('rejects a connected executor token scoped to another task', async () => {
+    await expect(
+      protectServerManagedTaskWrites(
+        externalContext(
+          'patch',
+          { status: TaskStatus.RUNNING },
+          {
+            taskId: 'task-1',
+            executorTaskId: 'task-2',
+            persistedTask: {
+              task_id: 'task-1',
+              status: TaskStatus.AWAITING_PERMISSION,
+              executor_connected_at: '2026-07-10T20:00:00.000Z',
+            },
+          }
+        )
+      )
+    ).rejects.toThrow('running task status is server-managed');
+  });
+
+  it('allows external executors to finish running tasks', async () => {
+    await expect(
+      protectServerManagedTaskWrites(externalContext('patch', { status: TaskStatus.COMPLETED }))
+    ).resolves.toBeDefined();
+  });
+
+  it('preserves trusted internal direct-to-running task writes', async () => {
+    const context = externalContext('patch', {
+      status: TaskStatus.RUNNING,
+    });
+    context.params.provider = undefined;
+
+    await expect(protectServerManagedTaskWrites(context)).resolves.toBe(context);
+  });
+
+  it('preserves trusted internal dispatching task writes', async () => {
+    const context = externalContext('patch', {
+      status: TaskStatus.DISPATCHING,
+    });
+    context.params.provider = undefined;
+
+    await expect(protectServerManagedTaskWrites(context)).resolves.toBe(context);
+  });
+});
 
 describe('tenant-owned service registration', () => {
   it('wraps gateway inbound routing in tenant database scope', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -37,7 +37,7 @@ import {
   validateRenderedManagedEnvUrlFields,
   validateRepoEnvironmentLifecyclePolicy,
 } from '@agor/core/environment/webhook';
-import type { Application } from '@agor/core/feathers';
+import type { Application, FeathersService } from '@agor/core/feathers';
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import {
   boardCommentQueryValidator,
@@ -71,12 +71,18 @@ import {
   GATEWAY_SENSITIVE_CONFIG_FIELDS,
   hasMinimumRole,
   ROLES,
+  TaskStatus,
 } from '@agor/core/types';
-import { executorRuntimeScopeGuard } from './auth/executor-runtime-scope.js';
+import {
+  executorRuntimeScopeGuard,
+  isTaskScopedExecutorRequest,
+  requireExecutorRuntimeToken,
+} from './auth/executor-runtime-scope.js';
 import type {
   BoardsServiceImpl,
   MessagesServiceImpl,
   SessionsServiceImpl,
+  TasksServiceImpl,
 } from './declarations.js';
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import { resolveForUserIdWithGate } from './oauth-auth-helpers.js';
@@ -456,6 +462,56 @@ const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'cursor-models',
   'terminals',
 ] as const;
+
+const EXECUTOR_RESUMABLE_TASK_STATUSES = new Set<TaskStatus>([
+  TaskStatus.AWAITING_PERMISSION,
+  TaskStatus.AWAITING_INPUT,
+]);
+
+async function isConnectedExecutorResume(context: HookContext): Promise<boolean> {
+  if (context.method !== 'patch' || typeof context.id !== 'string') return false;
+  if (!isTaskScopedExecutorRequest(context, context.id)) return false;
+
+  const service = context.service as unknown as {
+    findByIdForScopeCheck?: (id: string) => Promise<unknown>;
+  };
+  const existing = await service.findByIdForScopeCheck?.(context.id);
+  if (!existing || typeof existing !== 'object') return false;
+
+  const task = existing as { status?: unknown; executor_connected_at?: unknown };
+  return (
+    EXECUTOR_RESUMABLE_TASK_STATUSES.has(task.status as TaskStatus) &&
+    typeof task.executor_connected_at === 'string' &&
+    task.executor_connected_at.length > 0
+  );
+}
+
+/** Prevent callers on a Feathers transport from forging executor-owned task state. */
+export async function protectServerManagedTaskWrites(context: HookContext): Promise<HookContext> {
+  if (!context.params.provider) return context;
+
+  const writes = Array.isArray(context.data) ? context.data : [context.data];
+  const records = writes.filter(
+    (write): write is Record<string, unknown> => write !== null && typeof write === 'object'
+  );
+  if (records.some((write) => Object.hasOwn(write, 'executor_connected_at'))) {
+    throw new Forbidden('executor_connected_at is server-managed');
+  }
+  if (records.some((write) => write.status === TaskStatus.DISPATCHING)) {
+    throw new Forbidden('dispatching task status is server-managed');
+  }
+  if (records.some((write) => write.status === TaskStatus.RUNNING)) {
+    const isSingleRunningPatch =
+      records.length === 1 &&
+      records[0].status === TaskStatus.RUNNING &&
+      !Array.isArray(context.data);
+    if (!isSingleRunningPatch || !(await isConnectedExecutorResume(context))) {
+      throw new Forbidden('running task status is server-managed');
+    }
+  }
+
+  return context;
+}
 
 export function registerHooks(ctx: RegisterHooksContext): void {
   const {
@@ -2882,7 +2938,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // Tasks hooks
   // ============================================================================
 
-  app.service('tasks').hooks({
+  const tasksService = app.service('tasks') as FeathersService<Application, TasksServiceImpl>;
+  tasksService.hooks({
     before: {
       all: [typedValidateQuery(taskQueryValidator), requireAuth, executorRuntimeScopeGuard()],
       find: [
@@ -2900,6 +2957,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
       ],
       create: [
+        protectServerManagedTaskWrites,
         requireMinimumRole(ROLES.MEMBER, 'create tasks'),
         ...(branchRbacEnabled
           ? [
@@ -2912,7 +2970,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           : []),
         injectCreatedBy(),
       ],
+      update: [protectServerManagedTaskWrites],
       patch: [
+        protectServerManagedTaskWrites,
         ...(branchRbacEnabled
           ? [
               resolveSessionContext(),
@@ -2922,6 +2982,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             ]
           : []),
       ],
+      connectExecutor: [requireExecutorRuntimeToken()],
       remove: [
         requireMinimumRole(ROLES.MEMBER, 'delete tasks'),
         // RBAC: deleting a task requires 'all' permission on the branch

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -144,6 +144,7 @@ import {
   shouldReconcileSessionPromptState,
 } from './utils/session-task-state.js';
 import { type SessionTurnLocks, withSessionTurnLock } from './utils/session-turn-lock.js';
+import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import {
   createTenantDatabaseScopeAroundHook,
@@ -1064,7 +1065,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
   /**
    * spawnTaskExecutor — sole transition point for `tasks.status` going from
-   * `created` / `queued` → `running`.
+   * `created` / `queued` → `dispatching` (or directly to `running` for CLI).
    *
    * Both the IDLE branch of POST /sessions/:id/prompt and the queued-task
    * drainer call this helper. Centralising the transition guarantees that:
@@ -1119,19 +1120,20 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     const session = await sessionsService.materializeAgenticToolPreset(loadedSession, params);
     const startTimestamp = new Date().toISOString();
 
-    // The daemon transitions the task to RUNNING and writes required sentinel
-    // git fields before executor spawn. The executor overwrites these with the
-    // authoritative task-start git state from inside the managed checkout.
+    // The daemon persists launch intent and writes required sentinel git fields
+    // before executor spawn. Non-CLI executors claim DISPATCHING → RUNNING after
+    // authenticating; claude-code-cli has no executor connection and stays direct.
     const gitStateAtStart = 'unknown';
     const refAtStart = 'unknown';
 
-    // Patch task: queued/created → running, with real ranges. queue_position
+    const launchState = buildTaskLaunchState(session.agentic_tool, startTimestamp);
+
+    // Patch task: queued/created → launch status, with real ranges. queue_position
     // is cleared here so a draining task is no longer considered queued.
     const updatedTask = (await app.service('tasks').patch(
       task.task_id,
       {
-        status: TaskStatus.RUNNING,
-        started_at: startTimestamp,
+        ...launchState,
         queue_position: undefined,
         message_range: {
           start_index: messageStartIndex,
@@ -1192,7 +1194,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     //
     // The session-status flip used to fall out of `TasksService.create` when
     // the IDLE path created a task with `status: RUNNING` directly. Now the
-    // IDLE path creates `status: CREATED` and we patch to RUNNING here, which
+    // IDLE path creates `status: CREATED` and we patch the task here, which
     // `TasksService.patch` does NOT mirror onto the session. Without this
     // explicit patch, `session.status` stays IDLE while a task is RUNNING,
     // causing the queue gate in the prompt route to wave subsequent prompts

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -242,6 +242,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   app.service('/session-streams').publish(() => []);
 
   app.use('/tasks', createTasksService(db, app), {
+    methods: ['find', 'get', 'create', 'update', 'patch', 'remove', 'connectExecutor'],
     // Custom events not in this list are dropped at the FeathersJS transport
     // boundary — they fire on the local EventEmitter but never reach socket
     // clients. Keep this in sync with every `app.service('tasks').emit(...)`

--- a/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
@@ -1,0 +1,45 @@
+import type { Task } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TasksService } from './tasks';
+
+describe('TasksService executor connection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs successful executor connection latency', async () => {
+    const task = {
+      task_id: '018f0000-0000-7000-8000-000000000001',
+      session_id: '018f0000-0000-7000-8000-000000000002',
+      created_by: '018f0000-0000-7000-8000-000000000003',
+      full_prompt: 'test',
+      status: TaskStatus.RUNNING,
+      message_range: {
+        start_index: 0,
+        end_index: 0,
+        start_timestamp: '2026-01-01T00:00:00.000Z',
+      },
+      git_state: { ref_at_start: 'main', sha_at_start: 'abc123' },
+      tool_use_count: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+      started_at: '2026-01-01T00:00:01.000Z',
+      executor_connected_at: '2026-01-01T00:00:01.125Z',
+    } as Task;
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      emit: ReturnType<typeof vi.fn>;
+    };
+    Reflect.set(service, 'taskRepo', {
+      connectExecutor: vi.fn().mockResolvedValue({ task, transitioned: true }),
+    });
+    service.emit = vi.fn();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await service.connectExecutor({ task_id: task.task_id });
+
+    expect(log).toHaveBeenCalledWith(
+      '🔌 [TasksService] Executor connected for task 018f00000000700080000000 in 125ms'
+    );
+    expect(service.emit).toHaveBeenCalledWith('patched', task);
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -192,6 +192,38 @@ describe('TasksService executor heartbeat helpers', () => {
     expect(service.emit).not.toHaveBeenCalled();
   });
 
+  it.each([
+    TaskStatus.COMPLETED,
+    TaskStatus.STOPPED,
+  ])('does not let a terminal %s task enter an executor awaiting state', async (terminalStatus) => {
+    const taskId = '018f0000-0000-7000-8000-000000000009';
+    const terminalTask = {
+      task_id: taskId,
+      session_id: '018f0000-0000-7000-8000-000000000010',
+      status: terminalStatus,
+      created_at: '2026-01-01T00:00:00.000Z',
+      completed_at: '2026-01-01T00:00:05.000Z',
+      executor_connected_at: '2026-01-01T00:00:01.000Z',
+    };
+    const service = Object.create(TasksService.prototype) as TasksService & {
+      get: ReturnType<typeof vi.fn>;
+      repository: { update: ReturnType<typeof vi.fn> };
+      id: string;
+      emit: ReturnType<typeof vi.fn>;
+    };
+    service.get = vi.fn().mockResolvedValue(terminalTask);
+    service.repository = { update: vi.fn() };
+    service.id = 'task_id';
+    service.emit = vi.fn();
+
+    for (const status of [TaskStatus.AWAITING_PERMISSION, TaskStatus.AWAITING_INPUT]) {
+      await expect(service.patch(taskId, { status })).resolves.toBe(terminalTask);
+    }
+
+    expect(service.repository.update).not.toHaveBeenCalled();
+    expect(service.emit).not.toHaveBeenCalled();
+  });
+
   it('supports administrative stopped patches without callbacks or queue draining', async () => {
     const taskId = '018f0000-0000-7000-8000-000000000010';
     const sessionId = '018f0000-0000-7000-8000-000000000011';

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -17,7 +17,7 @@ import {
   TaskRepository,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
-import type { Application } from '@agor/core/feathers';
+import { type Application, Conflict } from '@agor/core/feathers';
 import type {
   ContentBlock,
   Paginated,
@@ -1164,10 +1164,41 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   }
 
   /**
-   * Custom method: Get orphaned tasks (running, stopping, awaiting permission)
+   * Custom method: Get orphaned tasks (dispatching, running, stopping, awaiting permission)
    */
   async getOrphaned(_params?: TaskParams): Promise<Task[]> {
     return this.taskRepo.findOrphaned();
+  }
+
+  /** Internal helper for hooks that must validate persisted executor connection state. */
+  async findByIdForScopeCheck(taskId: TaskID): Promise<Task | null> {
+    return this.taskRepo.findById(taskId);
+  }
+
+  /** Claim a DISPATCHING task after executor transport authentication. */
+  async connectExecutor(data: { task_id: string }, _params?: TaskParams): Promise<Task> {
+    const connection = await this.taskRepo.connectExecutor(data.task_id);
+    if (!connection) {
+      const current = await this.taskRepo.findById(data.task_id);
+      throw new Conflict(
+        `Task ${shortId(data.task_id)} cannot connect an executor from status ${current?.status ?? 'unknown'}`
+      );
+    }
+    if (connection.transitioned) {
+      const startedAt = Date.parse(connection.task.started_at ?? '');
+      const connectedAt = Date.parse(connection.task.executor_connected_at ?? '');
+      if (Number.isFinite(startedAt) && Number.isFinite(connectedAt)) {
+        console.log(
+          `🔌 [TasksService] Executor connected for task ${shortId(connection.task.task_id)} ` +
+            `in ${Math.max(0, connectedAt - startedAt)}ms`
+        );
+      }
+      this.trackTaskStarted(connection.task);
+      // The guarded repository transition bypasses the standard patch method,
+      // so publish the canonical patched event explicitly for reactive clients.
+      this.emit?.('patched', connection.task);
+    }
+    return connection.task;
   }
 
   /**

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -164,7 +164,7 @@ async function cleanupOrphanStatusesInTenantScope(
   // Determine restart type before touching anything — sentinel is consumed here
   const wasGraceful = await readAndClearSentinel();
 
-  // Find all orphaned executor-owned tasks (running, stopping, awaiting_permission, awaiting_input)
+  // Find all orphaned executor-owned tasks (dispatching, running, stopping, awaiting_permission, awaiting_input)
   const orphanedTasks = await tasksService.getOrphaned(startupParams as never);
 
   if (orphanedTasks.length > 0) {

--- a/apps/agor-daemon/src/utils/session-tasks.ts
+++ b/apps/agor-daemon/src/utils/session-tasks.ts
@@ -1,6 +1,6 @@
 /**
- * Helpers for finding "active" tasks for a session — RUNNING / STOPPING / AWAITING_PERMISSION /
- * AWAITING_INPUT — sorted by recency.
+ * Helpers for finding "active" tasks for a session — DISPATCHING / RUNNING / STOPPING /
+ * AWAITING_PERMISSION / AWAITING_INPUT — sorted by recency.
  *
  * Background: `TasksService.find()` short-circuits on `session_id: string`
  * (see `services/tasks.ts:65-110`) and returns ALL session tasks in

--- a/apps/agor-daemon/src/utils/task-launch-state.test.ts
+++ b/apps/agor-daemon/src/utils/task-launch-state.test.ts
@@ -1,0 +1,29 @@
+import { TaskStatus } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { buildTaskLaunchState } from './task-launch-state.js';
+
+describe('buildTaskLaunchState', () => {
+  it('launches claude-code-cli directly into running without a connection timestamp', () => {
+    const launchState = buildTaskLaunchState('claude-code-cli', '2026-07-10T20:00:00.000Z');
+
+    expect(launchState).toEqual({
+      status: TaskStatus.RUNNING,
+      started_at: '2026-07-10T20:00:00.000Z',
+    });
+    expect(launchState).not.toHaveProperty('executor_connected_at');
+  });
+
+  it.each([
+    'claude-code',
+    'codex',
+    'gemini',
+    'opencode',
+    'copilot',
+    'cursor',
+  ] as const)('launches %s through the executor dispatch state', (tool) => {
+    expect(buildTaskLaunchState(tool, '2026-07-10T20:00:00.000Z')).toEqual({
+      status: TaskStatus.DISPATCHING,
+      started_at: '2026-07-10T20:00:00.000Z',
+    });
+  });
+});

--- a/apps/agor-daemon/src/utils/task-launch-state.ts
+++ b/apps/agor-daemon/src/utils/task-launch-state.ts
@@ -1,0 +1,17 @@
+import type { AgenticToolName, Task } from '@agor/core/types';
+import { TaskStatus, usesExecutorRuntime } from '@agor/core/types';
+
+/**
+ * Build the task fields persisted immediately before launch. CLI sessions have
+ * no executor connection, so they skip DISPATCHING and remain without an
+ * executor connection timestamp.
+ */
+export function buildTaskLaunchState(
+  agenticTool: AgenticToolName,
+  startedAt: string
+): Pick<Task, 'status' | 'started_at'> {
+  return {
+    status: usesExecutorRuntime(agenticTool) ? TaskStatus.DISPATCHING : TaskStatus.RUNNING,
+    started_at: startedAt,
+  };
+}

--- a/apps/agor-docs/content/api-reference/index.mdx
+++ b/apps/agor-docs/content/api-reference/index.mdx
@@ -155,10 +155,12 @@ Possible response shapes:
 {
   "success": true,
   "taskId": "0195d3c0-82df-7a75-b9b3-83f58de12345",
-  "status": "running",
+  "status": "dispatching",
   "streaming": true
 }
 ```
+
+For non-CLI sessions, the immediate response is `dispatching`; the authenticated executor changes the task to `running` after it connects. `claude-code-cli` sessions have no separate executor connection and return `running` directly.
 
 ```json
 {
@@ -194,7 +196,7 @@ curl -X POST http://localhost:3030/tasks/<task-id>/run \
   -d '{ "stream": true }'
 ```
 
-The response is the patched `Task` row with `status: 'running'`. The endpoint only accepts tasks in `created` state on an `idle` session — `queued` tasks drain automatically in queue-position order, and busy sessions should be prompted via `POST /sessions/:id/prompt` (which creates and queues the task atomically).
+The response is the patched `Task` row with `status: 'dispatching'` for non-CLI sessions; the authenticated executor changes it to `running` after connecting. `claude-code-cli` sessions return `running` directly because they have no separate executor connection. The endpoint only accepts tasks in `created` state on an `idle` session — `queued` tasks drain automatically in queue-position order, and busy sessions should be prompted via `POST /sessions/:id/prompt` (which creates and queues the task atomically).
 
 ## Message Content Shape
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -1012,6 +1012,13 @@ execution:
       -- agor-executor --stdin
 ```
 
+### Upgrade Remote Executors with the Daemon
+
+Remote executors may be deployed independently, but they are part of the same
+runtime contract as the daemon. Upgrade remote executor images to the same Agor
+release when upgrading the daemon; mixed-version daemon/executor deployments are
+not a supported rollout mode.
+
 ### Step 5: Test Single Executor
 
 Spawn one executor pod manually:

--- a/apps/agor-ui/src/components/Pill/TimerPill.tsx
+++ b/apps/agor-ui/src/components/Pill/TimerPill.tsx
@@ -32,6 +32,7 @@ interface TimerPillProps {
 }
 
 const ACTIVE_STATUSES: TimerStatus[] = [
+  TaskStatus.DISPATCHING,
   TaskStatus.RUNNING,
   TaskStatus.STOPPING,
   TaskStatus.AWAITING_PERMISSION,
@@ -46,6 +47,11 @@ const statusConfig: Record<
     label?: string;
   }
 > = {
+  [TaskStatus.DISPATCHING]: {
+    icon: <HourglassOutlined />,
+    color: PILL_COLORS.processing,
+    label: 'Starting executor…',
+  },
   [TaskStatus.RUNNING]: {
     icon: <HourglassOutlined />,
     color: PILL_COLORS.processing,

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -619,6 +619,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     for (let index = tasks.length - 1; index >= 0; index -= 1) {
       const candidate = tasks[index];
       if (
+        candidate.status === TaskStatus.DISPATCHING ||
         candidate.status === TaskStatus.RUNNING ||
         candidate.status === TaskStatus.STOPPING ||
         candidate.status === TaskStatus.AWAITING_PERMISSION ||

--- a/apps/agor-ui/src/components/TaskStatusIcon.tsx
+++ b/apps/agor-ui/src/components/TaskStatusIcon.tsx
@@ -37,6 +37,8 @@ export const TaskStatusIcon: React.FC<TaskStatusIconProps> = ({ status, size = 1
     case TaskStatus.RUNNING:
     case 'running': // SessionStatus.RUNNING
       return <Spin size={spinSize} />;
+    case TaskStatus.DISPATCHING:
+      return <LoadingOutlined style={{ ...iconStyle, color: token.colorPrimary }} />;
     case TaskStatus.STOPPING:
     case 'stopping': // SessionStatus.STOPPING - animated spinner with warning color
       return <LoadingOutlined style={{ ...iconStyle, color: token.colorWarning }} />;

--- a/context/concepts/task-queueing.md
+++ b/context/concepts/task-queueing.md
@@ -9,7 +9,8 @@ encodes whether the prompt ran or got queued.**
 
 - `task.status === 'queued'` → session was busy; the task is waiting and will
   drain automatically when the session goes idle.
-- `task.status === 'running'` → ran immediately.
+- `task.status === 'dispatching'` → daemon persisted launch intent and is starting a non-CLI executor.
+- `task.status === 'running'` → the executor connected (or the session uses `claude-code-cli`).
 - `task.queue_position` → ordering within the session's queue (lowest drains
   first), populated only while QUEUED.
 
@@ -22,12 +23,14 @@ There is no separate "queued vs ran" envelope. The route does not take a
    `TaskRepository.createPending({ status })`. CREATED if the session is idle
    with no queue, QUEUED otherwise. Sentinel values (`message_range.start_index = -1`,
    `git_state.sha_at_start = ''`) are stamped here and stay until the
-   QUEUED → RUNNING transition.
+   QUEUED → DISPATCHING/RUNNING launch transition.
 2. **Drain** — when a session reaches a terminal task state, the queue
    processor picks the lowest `queue_position` and hands it to
-   `spawnTaskExecutor`, which is the *sole* place that pins
-   `message_range`/`git_state`, writes the initial user-message row, and
-   spawns the executor.
+   `spawnTaskExecutor`, which is the _sole_ place that pins
+   `message_range`/`git_state`, writes the initial user-message row, persists
+   DISPATCHING, and spawns the executor. After authentication, non-CLI
+   executors atomically claim DISPATCHING → RUNNING; `claude-code-cli` goes
+   directly to RUNNING because it has no executor connection.
 3. **Race safety** — `createPending` wraps the `max(queue_position) + 1`
    read-then-insert in a transaction so concurrent writers can't collide on
    identical positions.

--- a/packages/core/drizzle/postgres/0064_task_dispatching.sql
+++ b/packages/core/drizzle/postgres/0064_task_dispatching.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tasks" ADD COLUMN "executor_connected_at" timestamp with time zone;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1784000200000,
       "tag": "0063_drop_links",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1784300000000,
+      "tag": "0064_task_dispatching",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0071_task_dispatching.sql
+++ b/packages/core/drizzle/sqlite/0071_task_dispatching.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `executor_connected_at` integer;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1784000200000,
       "tag": "0070_drop_links",
       "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "6",
+      "when": 1784300000000,
+      "tag": "0071_task_dispatching",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/api/index.test.ts
+++ b/packages/core/src/api/index.test.ts
@@ -616,6 +616,14 @@ describe('createClient', () => {
       );
     });
 
+    it('registers tasks.connectExecutor custom method on client', () => {
+      const client = createClient();
+      const tasksService = client.service('tasks') as unknown as {
+        methods: MockedFunction<(...names: string[]) => unknown>;
+      };
+      expect(tasksService.methods).toHaveBeenCalledWith('connectExecutor');
+    });
+
     it('does not register custom methods on services without any', () => {
       const client = createClient();
       const sessionsService = client.service('sessions') as unknown as {

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -69,6 +69,7 @@ const BOARDS_SERVICE_EXTENDED = Symbol('agor.boardsServiceExtended');
 const USERS_SERVICE_EXTENDED = Symbol('agor.usersServiceExtended');
 const REPOS_SERVICE_EXTENDED = Symbol('agor.reposServiceExtended');
 const BRANCHES_SERVICE_EXTENDED = Symbol('agor.branchesServiceExtended');
+const TASKS_SERVICE_EXTENDED = Symbol('agor.tasksServiceExtended');
 const SERVICE_FIND_ALL_EXTENDED = Symbol('agor.serviceFindAllExtended');
 const CLIENT_SERVICE_FACTORY_EXTENDED = Symbol('agor.clientServiceFactoryExtended');
 const CLIENT_SESSIONS_HELPERS_EXTENDED = Symbol('agor.clientSessionsHelpersExtended');
@@ -151,7 +152,8 @@ export interface TasksClientHelpers {
   /**
    * Trigger executor pickup for an already-created task. Pure-REST harnesses
    * use this after `POST /tasks` to avoid needing an MCP client. Returns the
-   * Task with `status: 'running'`. Only `'created'` tasks on idle sessions
+   * Task with `status: 'dispatching'` for non-CLI executors (or `'running'`
+   * for `claude-code-cli`). Only `'created'` tasks on idle sessions
    * are accepted — `'queued'` tasks drain automatically in queue-position
    * order via the queue processor, and busy sessions should be prompted via
    * `client.sessions.prompt()` (which creates and queues the task atomically).
@@ -293,6 +295,8 @@ export interface SessionsService extends AgorService<Session> {
  * Tasks service with bulk creation support
  */
 export interface TasksService extends AgorService<Task> {
+  /** Claim a daemon-dispatched task after executor authentication. */
+  connectExecutor(data: { task_id: string }, params?: Params): Promise<Task>;
   /**
    * Create multiple tasks in a single request
    * Returns array of created tasks with IDs
@@ -869,6 +873,18 @@ function extendBranchesService(client: AgorClient): void {
   branchesService[BRANCHES_SERVICE_EXTENDED] = true;
 }
 
+function extendTasksService(client: AgorClient): void {
+  const tasksService = client.service('tasks') as AgorService<Task> & {
+    [TASKS_SERVICE_EXTENDED]?: boolean;
+    methods?: (...names: string[]) => unknown;
+  };
+  if (tasksService[TASKS_SERVICE_EXTENDED]) return;
+  if (typeof tasksService.methods === 'function') {
+    tasksService.methods('connectExecutor');
+  }
+  tasksService[TASKS_SERVICE_EXTENDED] = true;
+}
+
 function extendServiceFactory(client: AgorClient): void {
   const augmentedClient = client as AgorClient & {
     [CLIENT_SERVICE_FACTORY_EXTENDED]?: boolean;
@@ -999,6 +1015,7 @@ export async function createRestClient(
   extendUsersService(client);
   extendReposService(client);
   extendBranchesService(client);
+  extendTasksService(client);
   extendSessionsHelpers(client);
   extendTasksHelpers(client);
 
@@ -1090,6 +1107,7 @@ export function createClient(
   extendUsersService(client);
   extendReposService(client);
   extendBranchesService(client);
+  extendTasksService(client);
   extendSessionsHelpers(client);
   extendTasksHelpers(client);
 

--- a/packages/core/src/db/migrations.test.ts
+++ b/packages/core/src/db/migrations.test.ts
@@ -13,4 +13,13 @@ describe('Postgres migrations', () => {
     expect(migration).not.toMatch(/\bembedding\s+vector\b/i);
     expect(migration).toContain('kb_embedding_spaces');
   });
+
+  it('stores executor connection timestamps as UTC-safe instants', async () => {
+    const migration = await readFile(
+      new URL('../../drizzle/postgres/0064_task_dispatching.sql', import.meta.url),
+      'utf8'
+    );
+
+    expect(migration).toMatch(/ADD COLUMN "executor_connected_at" timestamp with time zone/i);
+  });
 });

--- a/packages/core/src/db/repositories/tasks.postgres.test.ts
+++ b/packages/core/src/db/repositories/tasks.postgres.test.ts
@@ -1,0 +1,99 @@
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { UUID } from '../../types/id';
+import { TaskStatus } from '../../types/task';
+import { createDatabase, type Database } from '../client';
+import { isPostgresDatabase } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+import { SessionRepository } from './sessions';
+import { TaskRepository } from './tasks';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)('TaskRepository PostgreSQL', () => {
+  let db: Database;
+  const originalTimezone = process.env.TZ;
+
+  beforeAll(async () => {
+    process.env.TZ = 'America/Sao_Paulo';
+    db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+    await initializeDatabase(db);
+    if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+    await db.execute(sql`SET TIME ZONE 'America/Sao_Paulo'`);
+  });
+
+  afterAll(async () => {
+    if (originalTimezone === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTimezone;
+    await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+  });
+
+  it('preserves the claimed UTC instant across an idempotent reread in a non-UTC timezone', async () => {
+    expect(new Date('2026-07-11T00:00:00').getTimezoneOffset()).toBe(180);
+
+    const repo = await new RepoRepository(db).create({
+      repo_id: generateId(),
+      slug: `postgres-task-claim-${Date.now()}`,
+      name: 'Postgres task claim',
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/postgres-task-claim.git',
+      local_path: '/tmp/postgres-task-claim',
+      default_branch: 'main',
+    });
+    const branch = await new BranchRepository(db).create({
+      branch_id: generateId(),
+      repo_id: repo.repo_id,
+      name: 'postgres-task-claim',
+      ref: 'main',
+      branch_unique_id: 1888,
+      path: '/tmp/postgres-task-claim/branch',
+      created_by: 'postgres-test-user' as UUID,
+    });
+    const session = await new SessionRepository(db).create({
+      session_id: generateId(),
+      branch_id: branch.branch_id,
+      agentic_tool: 'claude-code',
+      created_by: 'postgres-test-user',
+    });
+    const tasks = new TaskRepository(db);
+    const task = await tasks.create({
+      task_id: generateId(),
+      session_id: session.session_id,
+      created_by: 'postgres-test-user',
+      full_prompt: 'postgres timestamp regression',
+      status: TaskStatus.DISPATCHING,
+      message_range: {
+        start_index: 0,
+        end_index: 0,
+        start_timestamp: new Date().toISOString(),
+      },
+      git_state: { ref_at_start: 'main', sha_at_start: 'postgres-test' },
+      tool_use_count: 0,
+    });
+
+    const beforeClaim = Date.now();
+    const first = await tasks.connectExecutor(task.task_id);
+    const second = await tasks.connectExecutor(task.task_id);
+    const afterClaim = Date.now();
+
+    expect(first?.transitioned).toBe(true);
+    expect(second).toEqual({ task: first?.task, transitioned: false });
+    const connectedAt = Date.parse(first!.task.executor_connected_at!);
+    expect(connectedAt).toBeGreaterThanOrEqual(beforeClaim);
+    expect(connectedAt).toBeLessThanOrEqual(afterClaim);
+
+    if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+    const [column] = await db.execute(sql`
+      SELECT data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'tasks'
+        AND column_name = 'executor_connected_at'
+    `);
+    expect(column?.data_type).toBe('timestamp with time zone');
+  });
+});

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -246,6 +246,7 @@ describe('TaskRepository.create', () => {
 
     const statuses = [
       TaskStatus.CREATED,
+      TaskStatus.DISPATCHING,
       TaskStatus.RUNNING,
       TaskStatus.STOPPING,
       TaskStatus.AWAITING_PERMISSION,
@@ -680,6 +681,7 @@ describe('TaskRepository.findByStatus', () => {
 
     const statuses = [
       TaskStatus.CREATED,
+      TaskStatus.DISPATCHING,
       TaskStatus.RUNNING,
       TaskStatus.STOPPING,
       TaskStatus.AWAITING_PERMISSION,
@@ -701,10 +703,141 @@ describe('TaskRepository.findByStatus', () => {
 });
 
 // ============================================================================
+// Executor connection
+// ============================================================================
+
+describe('TaskRepository.connectExecutor', () => {
+  dbTest(
+    'atomically transitions dispatching to running with a server timestamp',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const startedAt = '2026-01-01T00:00:00.000Z';
+      const created = await taskRepo.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.DISPATCHING,
+          started_at: startedAt,
+        })
+      );
+
+      const connection = await taskRepo.connectExecutor(created.task_id);
+      const found = await taskRepo.findById(created.task_id);
+
+      expect(connection?.transitioned).toBe(true);
+      expect(connection?.task.status).toBe(TaskStatus.RUNNING);
+      expect(connection?.task.started_at).toBe(startedAt);
+      expect(connection?.task.executor_connected_at).toBeDefined();
+      expect(found).toMatchObject({
+        status: TaskStatus.RUNNING,
+        started_at: startedAt,
+        executor_connected_at: connection?.task.executor_connected_at,
+      });
+    }
+  );
+
+  dbTest(
+    'is idempotent once running and does not rewrite the connection timestamp',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const created = await taskRepo.create(
+        createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
+      );
+
+      const first = await taskRepo.connectExecutor(created.task_id);
+      const second = await taskRepo.connectExecutor(created.task_id);
+
+      expect(second).toEqual({ task: first?.task, transitioned: false });
+    }
+  );
+
+  dbTest('serializes concurrent executor claims without SQLite lock errors', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const created = await taskRepo.create(
+      createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
+    );
+
+    const claims = await Promise.all([
+      taskRepo.connectExecutor(created.task_id),
+      taskRepo.connectExecutor(created.task_id),
+    ]);
+
+    expect(claims.map((claim) => claim?.transitioned).sort()).toEqual([false, true]);
+    expect(new Set(claims.map((claim) => claim?.task.executor_connected_at)).size).toBe(1);
+    expect((await taskRepo.findById(created.task_id))?.status).toBe(TaskStatus.RUNNING);
+  });
+
+  dbTest('does not accept a timestamp-less running row as a prior claim', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const corrupted = await taskRepo.create(
+      createTaskData({ session_id: sessionId, status: TaskStatus.RUNNING })
+    );
+
+    expect(await taskRepo.connectExecutor(corrupted.task_id)).toBeNull();
+    expect(await taskRepo.findById(corrupted.task_id)).toMatchObject({
+      status: TaskStatus.RUNNING,
+      executor_connected_at: undefined,
+    });
+  });
+
+  dbTest('does not revive stopping, stopped, or terminal tasks', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    for (const status of [
+      TaskStatus.STOPPING,
+      TaskStatus.STOPPED,
+      TaskStatus.COMPLETED,
+      TaskStatus.FAILED,
+      TaskStatus.TIMED_OUT,
+    ]) {
+      const task = await taskRepo.create(createTaskData({ session_id: sessionId, status }));
+      expect(await taskRepo.connectExecutor(task.task_id)).toBeNull();
+      expect((await taskRepo.findById(task.task_id))?.status).toBe(status);
+    }
+  });
+
+  dbTest(
+    'includes dispatching in orphan cleanup but not connected-heartbeat supervision',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const task = await taskRepo.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.DISPATCHING,
+          last_executor_heartbeat_at: '2026-01-01T00:00:00.000Z',
+        })
+      );
+
+      expect((await taskRepo.findOrphaned()).map((item) => item.task_id)).toContain(task.task_id);
+      expect(
+        (await taskRepo.findActiveWithExecutorHeartbeat()).map((item) => item.task_id)
+      ).not.toContain(task.task_id);
+    }
+  );
+});
+
+// ============================================================================
 // Update
 // ============================================================================
 
 describe('TaskRepository.update', () => {
+  dbTest('does not let generic updates claim a dispatching task', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const created = await taskRepo.create(
+      createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
+    );
+
+    await expect(taskRepo.update(created.task_id, { status: TaskStatus.RUNNING })).rejects.toThrow(
+      'dispatching tasks must be claimed through connectExecutor'
+    );
+    expect((await taskRepo.findById(created.task_id))?.status).toBe(TaskStatus.DISPATCHING);
+  });
+
   dbTest('should update task by full UUID and short ID', async ({ db }) => {
     const taskRepo = new TaskRepository(db);
     const sessionId = await createSessionWithDeps(db);
@@ -720,6 +853,124 @@ describe('TaskRepository.update', () => {
     const updated2 = await taskRepo.update(idPrefix, { status: TaskStatus.COMPLETED });
     expect(updated2.status).toBe(TaskStatus.COMPLETED);
   });
+
+  dbTest('allows a running executor task to complete normally', async ({ db }) => {
+    const taskRepo = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const created = await taskRepo.create(
+      createTaskData({ session_id: sessionId, status: TaskStatus.RUNNING })
+    );
+
+    const updated = await taskRepo.update(created.task_id, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-07-10T20:00:00.000Z',
+    });
+
+    expect(updated).toMatchObject({
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-07-10T20:00:00.000Z',
+    });
+  });
+
+  for (const terminalStatus of [TaskStatus.COMPLETED, TaskStatus.STOPPED]) {
+    dbTest(
+      `does not revive a ${terminalStatus} task through awaiting_permission then running`,
+      async ({ db }) => {
+        const taskRepo = new TaskRepository(db);
+        const sessionId = await createSessionWithDeps(db);
+        const created = await taskRepo.create(
+          createTaskData({
+            session_id: sessionId,
+            status: terminalStatus,
+            executor_connected_at: '2026-07-10T20:00:00.000Z',
+          })
+        );
+
+        await expect(
+          taskRepo.update(created.task_id, { status: TaskStatus.AWAITING_PERMISSION })
+        ).rejects.toThrow(`terminal task status cannot be changed from ${terminalStatus}`);
+        await expect(
+          taskRepo.update(created.task_id, { status: TaskStatus.RUNNING })
+        ).rejects.toThrow(`terminal task status cannot be changed from ${terminalStatus}`);
+        expect((await taskRepo.findById(created.task_id))?.status).toBe(terminalStatus);
+      }
+    );
+  }
+
+  for (const terminalStatus of [TaskStatus.COMPLETED, TaskStatus.STOPPED]) {
+    dbTest(
+      `does not revive a ${terminalStatus} task through awaiting_input then running`,
+      async ({ db }) => {
+        const taskRepo = new TaskRepository(db);
+        const sessionId = await createSessionWithDeps(db);
+        const created = await taskRepo.create(
+          createTaskData({
+            session_id: sessionId,
+            status: terminalStatus,
+            executor_connected_at: '2026-07-10T20:00:00.000Z',
+          })
+        );
+
+        await expect(
+          taskRepo.update(created.task_id, { status: TaskStatus.AWAITING_INPUT })
+        ).rejects.toThrow(`terminal task status cannot be changed from ${terminalStatus}`);
+        await expect(
+          taskRepo.update(created.task_id, { status: TaskStatus.RUNNING })
+        ).rejects.toThrow(`terminal task status cannot be changed from ${terminalStatus}`);
+        expect((await taskRepo.findById(created.task_id))?.status).toBe(terminalStatus);
+      }
+    );
+  }
+
+  dbTest(
+    'allows metadata-only updates after completion without changing status',
+    async ({ db }) => {
+      const taskRepo = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const created = await taskRepo.create(
+        createTaskData({ session_id: sessionId, status: TaskStatus.COMPLETED })
+      );
+
+      const updated = await taskRepo.update(created.task_id, { tool_use_count: 7 });
+
+      expect(updated).toMatchObject({ status: TaskStatus.COMPLETED, tool_use_count: 7 });
+    }
+  );
+
+  for (const resumableStatus of [TaskStatus.AWAITING_PERMISSION, TaskStatus.AWAITING_INPUT]) {
+    dbTest(
+      `keeps terminal status across a concurrent resume from ${resumableStatus}`,
+      async ({ db }) => {
+        const taskRepo = new TaskRepository(db);
+        const sessionId = await createSessionWithDeps(db);
+        const created = await taskRepo.create(
+          createTaskData({
+            session_id: sessionId,
+            status: resumableStatus,
+            executor_connected_at: '2026-07-10T20:00:00.000Z',
+          })
+        );
+
+        // Do not assume which transaction acquires the row lock first. If the
+        // resume wins it may complete before the terminal write; if completion
+        // wins, the resume must reject. The lifecycle invariant is identical.
+        const [completionResult, resumeResult] = await Promise.allSettled([
+          taskRepo.update(created.task_id, { status: TaskStatus.COMPLETED }),
+          taskRepo.update(created.task_id, { status: TaskStatus.RUNNING }),
+        ]);
+
+        expect(completionResult.status).toBe('fulfilled');
+        if (resumeResult.status === 'fulfilled') {
+          expect(resumeResult.value.status).toBe(TaskStatus.RUNNING);
+        } else {
+          expect(String(resumeResult.reason)).toContain(
+            'terminal task status cannot be changed from completed'
+          );
+        }
+        expect((await taskRepo.findById(created.task_id))?.status).toBe(TaskStatus.COMPLETED);
+      }
+    );
+  }
 
   dbTest('should update multiple fields and preserve unchanged ones', async ({ db }) => {
     const taskRepo = new TaskRepository(db);

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -5,11 +5,19 @@
  */
 
 import type { SessionID, Task, TaskMetadata, UUID } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { isTerminalTaskStatus, TaskStatus } from '@agor/core/types';
 import { and, eq, inArray, like, sql } from 'drizzle-orm';
 import { generateId, shortId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, lockRowForUpdate, select, txAsDb, update } from '../database-wrapper';
+import {
+  deleteFrom,
+  insert,
+  isSQLiteDatabase,
+  lockRowForUpdate,
+  select,
+  txAsDb,
+  update,
+} from '../database-wrapper';
 import { type TaskInsert, type TaskRow, tasks } from '../schema';
 import {
   AmbiguousIdError,
@@ -22,11 +30,48 @@ import {
 import { visibleSessionReferenceAccessExists } from './branch-access';
 import { deepMerge } from './merge-utils';
 
+function isSQLiteBusyError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.message.includes('SQLITE_BUSY') || error.message.includes('database is locked')) {
+    return true;
+  }
+  return 'cause' in error && isSQLiteBusyError(error.cause);
+}
+
 /**
  * Task repository implementation
  */
 export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
   constructor(private db: Database) {}
+
+  /** Acquire the task write lock consistently across database dialects. */
+  private async lockTaskForMutation(txDb: Database, taskId: string): Promise<void> {
+    // PostgreSQL provides a real row lock. SQLite transactions begin deferred,
+    // so acquire the write lock with a no-op row update before reading.
+    if (isSQLiteDatabase(this.db)) {
+      await update(txDb, tasks)
+        .set({ status: sql`${tasks.status}` })
+        .where(eq(tasks.task_id, taskId))
+        .run();
+      return;
+    }
+
+    await lockRowForUpdate(txDb, this.db, tasks, eq(tasks.task_id, taskId));
+  }
+
+  /** Retry an entire SQLite mutation so a contending writer re-reads fresh state. */
+  private async runTaskMutation<T>(mutation: () => Promise<T>, attempt = 0): Promise<T> {
+    try {
+      return await mutation();
+    } catch (error) {
+      // libSQL reports write contention immediately even with busy_timeout.
+      if (isSQLiteDatabase(this.db) && attempt < 4 && isSQLiteBusyError(error)) {
+        await new Promise((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
+        return this.runTaskMutation(mutation, attempt + 1);
+      }
+      throw error;
+    }
+  }
 
   /**
    * Convert database row to Task type
@@ -38,6 +83,10 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       status: row.status,
       queue_position: row.queue_position ?? undefined,
       created_at: new Date(row.created_at).toISOString(),
+      started_at: row.started_at ? new Date(row.started_at).toISOString() : undefined,
+      executor_connected_at: row.executor_connected_at
+        ? new Date(row.executor_connected_at).toISOString()
+        : undefined,
       completed_at: row.completed_at ? new Date(row.completed_at).toISOString() : undefined,
       last_executor_heartbeat_at: row.last_executor_heartbeat_at
         ? new Date(row.last_executor_heartbeat_at).toISOString()
@@ -72,6 +121,10 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       task_id: taskId,
       session_id: task.session_id,
       created_at: new Date(now), // Always use server timestamp, ignore client-provided value
+      started_at: task.started_at ? new Date(task.started_at) : undefined,
+      executor_connected_at: task.executor_connected_at
+        ? new Date(task.executor_connected_at)
+        : undefined,
       completed_at: task.completed_at ? new Date(task.completed_at) : undefined,
       last_executor_heartbeat_at: task.last_executor_heartbeat_at
         ? new Date(task.last_executor_heartbeat_at)
@@ -274,7 +327,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
   }
 
   /**
-   * Find orphaned tasks (running, stopping, awaiting permission, or awaiting input)
+   * Find orphaned tasks (dispatching, running, stopping, awaiting permission, or awaiting input)
    * These are tasks that were interrupted when daemon stopped.
    *
    * NOTE: QUEUED tasks are intentionally NOT considered orphans — they were
@@ -287,7 +340,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       const rows = await select(this.db)
         .from(tasks)
         .where(
-          sql`${tasks.status} IN ('running', 'stopping', 'awaiting_permission', 'awaiting_input')`
+          sql`${tasks.status} IN ('dispatching', 'running', 'stopping', 'awaiting_permission', 'awaiting_input')`
         )
         .all();
 
@@ -342,6 +395,51 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
   }
 
   /**
+   * Atomically claim a daemon-dispatched task for its authenticated executor.
+   * Repeated claims after the first successful transition are idempotent.
+   */
+  async connectExecutor(id: string): Promise<{ task: Task; transitioned: boolean } | null> {
+    try {
+      const fullId = await this.resolveId(id);
+      return await this.runTaskMutation(() =>
+        this.db.transaction(async (tx) => {
+          const txDb = txAsDb(tx);
+          await this.lockTaskForMutation(txDb, fullId);
+
+          const row = await select(txDb).from(tasks).where(eq(tasks.task_id, fullId)).one();
+          if (!row) throw new EntityNotFoundError('Task', id);
+
+          if (row.status === TaskStatus.RUNNING && row.executor_connected_at) {
+            return { task: this.rowToTask(row), transitioned: false };
+          }
+          if (row.status !== TaskStatus.DISPATCHING) return null;
+
+          const connectedAt = new Date();
+          await update(txDb, tasks)
+            .set({ status: TaskStatus.RUNNING, executor_connected_at: connectedAt })
+            .where(eq(tasks.task_id, fullId))
+            .run();
+
+          return {
+            task: this.rowToTask({
+              ...row,
+              status: TaskStatus.RUNNING,
+              executor_connected_at: connectedAt,
+            }),
+            transitioned: true,
+          };
+        })
+      );
+    } catch (error) {
+      if (error instanceof RepositoryError || error instanceof EntityNotFoundError) throw error;
+      throw new RepositoryError(
+        `Failed to connect executor: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Update task by ID (atomic with database-level transaction)
    *
    * Uses a transaction to ensure read-merge-write is atomic, preventing race conditions
@@ -356,44 +454,72 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       );
 
       // Use transaction to make read-merge-write atomic
-      const result = await this.db.transaction(async (tx) => {
-        // Acquire row-level lock on PostgreSQL to prevent lost updates
+      const mutate = () =>
+        this.db.transaction(async (tx) => {
+          const txDb = txAsDb(tx);
 
-        await lockRowForUpdate(txAsDb(tx), this.db, tasks, eq(tasks.task_id, fullId));
+          await this.lockTaskForMutation(txDb, fullId);
 
-        // STEP 1: Read current task (within transaction)
-        const currentRow = await select(txAsDb(tx))
-          .from(tasks)
-          .where(eq(tasks.task_id, fullId))
-          .one();
+          // STEP 1: Read current task (within transaction)
+          const currentRow = await select(txDb).from(tasks).where(eq(tasks.task_id, fullId)).one();
 
-        if (!currentRow) {
-          throw new EntityNotFoundError('Task', id);
-        }
+          if (!currentRow) {
+            throw new EntityNotFoundError('Task', id);
+          }
 
-        const current = this.rowToTask(currentRow);
+          const current = this.rowToTask(currentRow);
 
-        // STEP 2: Deep merge updates into current task (in memory)
-        // Preserves nested objects like message_range when doing partial updates
-        const merged = deepMerge(current, updates);
-        const insertData = this.taskToInsert(merged);
+          // Terminal task status is immutable at the row-locked mutation boundary.
+          // Service-level checks are useful for friendly idempotence, but cannot
+          // make a terminal-vs-resume race safe because their read happens before
+          // this transaction acquires the lock. Metadata-only updates remain
+          // allowed for existing callers.
+          if (
+            isTerminalTaskStatus(current.status) &&
+            updates.status !== undefined &&
+            updates.status !== current.status
+          ) {
+            throw new RepositoryError(
+              `terminal task status cannot be changed from ${current.status}`
+            );
+          }
 
-        // STEP 3: Write merged task (within same transaction)
-        await update(txAsDb(tx), tasks)
-          .set({
-            status: insertData.status,
-            queue_position: insertData.queue_position,
-            completed_at: insertData.completed_at,
-            last_executor_heartbeat_at: insertData.last_executor_heartbeat_at,
-            session_md5: insertData.session_md5,
-            data: insertData.data,
-          })
-          .where(eq(tasks.task_id, fullId))
-          .run();
+          // The authenticated executor claim is the only path allowed to cross
+          // this boundary. connectExecutor performs its own guarded SQL update
+          // above; generic service update/patch calls flow through this method.
+          if (current.status === TaskStatus.DISPATCHING && updates.status === TaskStatus.RUNNING) {
+            throw new RepositoryError('dispatching tasks must be claimed through connectExecutor');
+          }
 
-        // Return merged task (no need to re-fetch, we have it in memory)
-        return merged;
-      });
+          // STEP 2: Deep merge updates into current task (in memory)
+          // Preserves nested objects like message_range when doing partial updates.
+          // The latest pulse is a complete snapshot; replacing it avoids stale
+          // id/label fields surviving when a newer pulse omits them.
+          const merged = deepMerge(current, updates);
+          if (updates.latest_executor_pulse !== undefined) {
+            merged.latest_executor_pulse = updates.latest_executor_pulse;
+          }
+          const insertData = this.taskToInsert(merged);
+
+          // STEP 3: Write merged task (within same transaction)
+          await update(txDb, tasks)
+            .set({
+              status: insertData.status,
+              queue_position: insertData.queue_position,
+              started_at: insertData.started_at,
+              executor_connected_at: insertData.executor_connected_at,
+              completed_at: insertData.completed_at,
+              last_executor_heartbeat_at: insertData.last_executor_heartbeat_at,
+              session_md5: insertData.session_md5,
+              data: insertData.data,
+            })
+            .where(eq(tasks.task_id, fullId))
+            .run();
+
+          // Return merged task (no need to re-fetch, we have it in memory)
+          return merged;
+        });
+      const result = await this.runTaskMutation(mutate);
       return result;
     } catch (error) {
       if (error instanceof RepositoryError) throw error;

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -316,12 +316,14 @@ export const tasks = pgTable(
       .references(() => sessions.session_id, { onDelete: 'cascade' }),
     created_at: t.timestamp('created_at').notNull(),
     started_at: t.timestamp('started_at'),
+    executor_connected_at: t.timestamp('executor_connected_at'),
     completed_at: t.timestamp('completed_at'),
     last_executor_heartbeat_at: t.timestamp('last_executor_heartbeat_at'),
     status: text('status', {
       enum: [
         'queued',
         'created',
+        'dispatching',
         'running',
         'stopping',
         'awaiting_permission',

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -309,12 +309,14 @@ export const tasks = sqliteTable(
       .references(() => sessions.session_id, { onDelete: 'cascade' }),
     created_at: t.timestamp('created_at').notNull(),
     started_at: t.timestamp('started_at'),
+    executor_connected_at: t.timestamp('executor_connected_at'),
     completed_at: t.timestamp('completed_at'),
     last_executor_heartbeat_at: t.timestamp('last_executor_heartbeat_at'),
     status: text('status', {
       enum: [
         'queued',
         'created',
+        'dispatching',
         'running',
         'stopping',
         'awaiting_permission',

--- a/packages/core/src/feathers/index.ts
+++ b/packages/core/src/feathers/index.ts
@@ -31,7 +31,7 @@ export {
 export type { Application as ExpressApplication } from '@feathersjs/express';
 // Express Integration
 export { default as feathersExpress, errorHandler, rest } from '@feathersjs/express';
-export type { Application, Service, ServiceMethods } from '@feathersjs/feathers';
+export type { Application, FeathersService, Service, ServiceMethods } from '@feathersjs/feathers';
 // Core Feathers
 export { feathers } from '@feathersjs/feathers';
 // Schema validation

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -127,6 +127,7 @@ export const taskQuerySchema = createQuerySchema(
       Type.Union([
         Type.Literal('queued'),
         Type.Literal('created'),
+        Type.Literal('dispatching'),
         Type.Literal('running'),
         Type.Literal('stopping'),
         Type.Literal('awaiting_permission'),

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -47,6 +47,19 @@ export type AgenticToolName =
   | 'cursor';
 
 /**
+ * Agentic tools launched and observed directly by the daemon instead of the
+ * independently running executor process. Add future non-executor adapters
+ * here so task launch state does not accumulate tool-specific conditionals.
+ */
+export const NON_EXECUTOR_AGENTIC_TOOLS: ReadonlySet<AgenticToolName> = new Set([
+  'claude-code-cli',
+]);
+
+export function usesExecutorRuntime(tool: AgenticToolName): boolean {
+  return !NON_EXECUTOR_AGENTIC_TOOLS.has(tool);
+}
+
+/**
  * Agentic tool metadata for UI display
  *
  * Represents a configured agentic coding tool with installation status,

--- a/packages/core/src/types/task.test.ts
+++ b/packages/core/src/types/task.test.ts
@@ -3,13 +3,14 @@ import { isTaskExecuting, TaskStatus } from './task';
 
 describe('task execution helpers', () => {
   it('identifies executor-owned task states', () => {
+    expect(isTaskExecuting({ status: TaskStatus.DISPATCHING })).toBe(true);
     expect(isTaskExecuting({ status: TaskStatus.RUNNING })).toBe(true);
     expect(isTaskExecuting({ status: TaskStatus.STOPPING })).toBe(true);
     expect(isTaskExecuting({ status: TaskStatus.AWAITING_PERMISSION })).toBe(true);
     expect(isTaskExecuting({ status: TaskStatus.AWAITING_INPUT })).toBe(true);
   });
 
-  it('excludes queued, pre-executor, and terminal task states', () => {
+  it('excludes queued, pre-dispatch, and terminal task states', () => {
     expect(isTaskExecuting({ status: TaskStatus.QUEUED })).toBe(false);
     expect(isTaskExecuting({ status: TaskStatus.CREATED })).toBe(false);
     expect(isTaskExecuting({ status: TaskStatus.COMPLETED })).toBe(false);

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -6,6 +6,7 @@ import type { ReportPath, ReportTemplate } from './report';
 export const TaskStatus = {
   QUEUED: 'queued', // Task created but not yet running (waiting for executor to drain queue)
   CREATED: 'created',
+  DISPATCHING: 'dispatching', // Daemon persisted launch intent; executor has not connected yet
   RUNNING: 'running',
   STOPPING: 'stopping', // Stop requested, waiting for SDK to halt
   AWAITING_PERMISSION: 'awaiting_permission',
@@ -94,6 +95,7 @@ export function isTerminalTaskStatus(status: TaskStatus | undefined): boolean {
  * pre-executor row and QUEUED is waiting for a future turn.
  */
 export const EXECUTING_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
+  TaskStatus.DISPATCHING,
   TaskStatus.RUNNING,
   TaskStatus.STOPPING,
   TaskStatus.AWAITING_PERMISSION,
@@ -256,7 +258,9 @@ export interface Task {
   session_md5?: string;
 
   created_at: string;
-  started_at?: string; // When task status changed to RUNNING (UTC ISO string)
+  started_at?: string; // When task execution was dispatched (UTC ISO string)
+  /** Server timestamp recorded when the authenticated executor claims the task. */
+  executor_connected_at?: string; // UTC ISO string
   /** Latest heartbeat emitted by the executor while this task is active. */
   last_executor_heartbeat_at?: string; // UTC ISO string
   completed_at?: string; // When task reached terminal status (UTC ISO string)

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -87,6 +87,11 @@ export class AgorExecutor {
       this.client = await createFeathersClient(this.config.daemonUrl, this.config.sessionToken);
       executorDebug('[executor] Connected to daemon');
 
+      // Authentication is complete. Atomically claim the daemon-dispatched task
+      // before starting heartbeats or SDK work; a late executor cannot revive a
+      // stopped or terminal task.
+      await this.client.service('tasks').connectExecutor({ task_id: this.config.taskId });
+
       // Setup event listeners
       this.setupEventListeners();
 

--- a/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/permissions/permission-hooks.test.ts
@@ -130,6 +130,12 @@ describe('createCanUseToolCallback', () => {
       expect(result.updatedInput).toEqual({ command: 'ls' });
       // No persistence rule emitted when remember=false.
       expect(result.updatedPermissions).toBeUndefined();
+      expect(deps.tasksService.patch).toHaveBeenNthCalledWith(1, taskId, {
+        status: 'awaiting_permission',
+      });
+      expect(deps.tasksService.patch).toHaveBeenNthCalledWith(2, taskId, {
+        status: 'running',
+      });
       // Lock was acquired AND released.
       expect(deps.permissionLocks.size).toBe(0);
     });

--- a/packages/executor/src/sdk-handlers/copilot/permission-mapper.test.ts
+++ b/packages/executor/src/sdk-handlers/copilot/permission-mapper.test.ts
@@ -1,0 +1,44 @@
+import type { SessionID, TaskID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { createPermissionHandler } from './permission-mapper.js';
+
+describe('createPermissionHandler', () => {
+  it('restores a task to running after interactive permission approval', async () => {
+    const sessionId = 'test-session' as SessionID;
+    const taskId = 'test-task' as TaskID;
+    const tasksService = { patch: vi.fn().mockResolvedValue(undefined) };
+    const handler = createPermissionHandler(sessionId, taskId, 'ask', {
+      permissionService: {
+        emitRequest: vi.fn(),
+        waitForDecision: vi.fn().mockResolvedValue({
+          allow: true,
+          timedOut: false,
+          remember: false,
+          decidedBy: 'test-user',
+        }),
+        cancelPendingRequests: vi.fn(),
+      } as any,
+      tasksService: tasksService as any,
+      sessionsRepo: {} as any,
+      messagesRepo: { findBySessionId: vi.fn().mockResolvedValue([]) } as any,
+      messagesService: {
+        create: vi.fn().mockResolvedValue(undefined),
+        patch: vi.fn().mockResolvedValue(undefined),
+      } as any,
+      sessionsService: { patch: vi.fn().mockResolvedValue(undefined) } as any,
+      permissionLocks: new Map(),
+    });
+
+    const result = await handler({
+      kind: 'shell',
+      command: 'ls',
+      toolCallId: 'call-1',
+    } as any);
+
+    expect(result).toEqual({ kind: 'approved' });
+    expect(tasksService.patch).toHaveBeenNthCalledWith(1, taskId, {
+      status: 'awaiting_permission',
+    });
+    expect(tasksService.patch).toHaveBeenNthCalledWith(2, taskId, { status: 'running' });
+  });
+});


### PR DESCRIPTION
## Linked issue

Fixes #1860

Related: #1888

## Summary

- Add an explicit `dispatching` Task state between daemon selection and executor connection.
- Record a server-authored `executor_connected_at` timestamp when the authenticated executor claims the Task as `running`.
- Carry the lifecycle boundary through persistence, migrations, API schemas, executor and daemon behavior, queue/recovery semantics, UI copy, documentation, and focused tests.

## Why / context

Task startup previously used `running` before the executor had actually connected. That made a submitted executor indistinguishable from one actively running its SDK turn, especially when startup was remote or delayed.

This change reports accepted work as `dispatching` until the executor authenticates and connects. `running` therefore means that the executor connection has actually been established.

## Implementation notes

- Non-CLI launches persist `dispatching` before executor spawn or submission.
- The authenticated, task-scoped executor uses `connectExecutor` to transition its Task to `running` and receive a server-generated connection timestamp.
- The connection claim is idempotent for the same connected executor, rejects ordinary and wrong-task clients, and does not trust client-authored timestamps.
- `claude-code-cli` remains the intentional exception and transitions directly to `running` because it does not use the executor connection path.
- After connection, only the matching task-scoped executor may resume its Task from `awaiting_permission` or `awaiting_input`; the original connection timestamp is preserved.
- Terminal Task state is immutable at the repository mutation boundary, preventing late connection or resume writes from reviving completed, failed, cancelled, or stopped work.
- SQLite `0071` and PostgreSQL `0064` add the nullable `executor_connected_at` column. Existing rows remain valid.
- Task schemas, client methods, busy/stop/orphan handling, startup cleanup, queue behavior, status icons, timers, and the `Starting executor…` UI state understand `dispatching`.
- A launch failure before executor connection transitions the Task from `dispatching` to `failed` instead of leaving it busy indefinitely.

## Validation / test plan

- [x] REST, Socket, and executor-token lifecycle coverage for pre-claim rejection, authenticated and idempotent connection, server timestamp ownership, permission/input resume, completion, terminal refusal, and pre-connection launch failure
- [x] Deterministic and concurrent terminal-versus-resume coverage, including repeated SQLite contention and PostgreSQL row-lock validation
- [x] Focused core, daemon, executor, callback, migration, CLI, and UI tests
- [x] Typechecks for affected packages
- [x] Formatting and whitespace checks for changed files
- [x] API and lifecycle documentation contract checks

This is the accepted #1888 change reapplied onto the current `main` migration history. The resulting diff is one commit across 40 files: +1,210 / −70.

## Screenshots / demos

Not applicable. The UI change is limited to representing `dispatching` as executor startup and using the correct timer/status copy.

## Risks / rollout / rollback

- Consumers that treat every nonterminal Task as `running` must include `dispatching`; the API schema, client types, busy checks, queue handling, and UI are updated together.
- The migration is additive and nullable, so existing Task rows remain valid.
- Rollback is straightforward: revert the commit and its additive migrations to restore direct-to-`running` launch behavior.

## Out of scope / follow-ups

- No executor startup watchdog or timeout policy.
- No attempt history, task retry, runtime-vitals redesign, or generalized lifecycle framework.
- No session-status redesign or stale-heartbeat policy change.
