### PR TITLE
fix(ui): keep branch header pill content-sized in fluid layouts

### DIFF
--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.teammate.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.teammate.test.tsx
@@ -13,8 +13,8 @@ vi.mock('../BranchCard', () => ({
 }));
 
 vi.mock('../BranchHeaderPill', () => ({
-  BranchHeaderPill: ({ fluid }: { fluid?: boolean }) => (
-    <div data-testid="branch-header-pill" data-fluid={String(fluid)} />
+  BranchHeaderPill: ({ truncateToFit }: { truncateToFit?: boolean }) => (
+    <div data-testid="branch-header-pill" data-truncate-to-fit={String(truncateToFit)} />
   ),
 }));
 
@@ -51,6 +51,9 @@ describe('BoardTeammatePanel teammate tab', () => {
     expect(screen.getByTestId('teammate-session-sections')).toHaveTextContent(
       'defaultExpanded:true'
     );
-    expect(screen.getByTestId('branch-header-pill')).toHaveAttribute('data-fluid', 'true');
+    expect(screen.getByTestId('branch-header-pill')).toHaveAttribute(
+      'data-truncate-to-fit',
+      'true'
+    );
   });
 });

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -6,7 +6,6 @@ import {
   App as AntApp,
   Button,
   Empty,
-  Flex,
   Select,
   Skeleton,
   Space,
@@ -30,11 +29,10 @@ import { mapToArray } from '../../utils/mapHelpers';
 import { BranchSessionSections } from '../BranchCard';
 import { BranchHeaderPill } from '../BranchHeaderPill';
 import { BoardSessionList } from '../BranchListDrawer';
+import { BranchMetadataRow } from '../BranchMetadataRow';
 import type { BranchModalTab } from '../BranchModal';
 import { CommentsPanel } from '../CommentsPanel';
 import { MarkdownRenderer } from '../MarkdownRenderer';
-import { CreatedByTag } from '../metadata';
-import { IssuePill, PullRequestPill } from '../Pill';
 
 export type BoardTeammatePanelTab = 'teammate' | 'all-sessions' | 'comments';
 
@@ -300,9 +298,13 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               </div>
             </div>
 
-            {/* Branch pill first; metadata links flow after it on the same
-                line and wrap below when the row runs out of room. */}
-            <Flex wrap gap={token.sizeUnit} align="center" style={{ minWidth: 0 }}>
+            <BranchMetadataRow
+              branch={primaryTeammateBranch}
+              repo={primaryTeammateRepo}
+              userById={userById}
+              currentUserId={currentUserId}
+              style={{ minWidth: 0 }}
+            >
               <BranchHeaderPill
                 repo={primaryTeammateRepo}
                 branch={primaryTeammateBranch}
@@ -310,29 +312,9 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
                 onOpenBranch={onOpenSettings}
                 showEnvButtons={false}
                 compact
-                fluid
+                truncateToFit
               />
-              {primaryTeammateBranch.created_by && (
-                <CreatedByTag
-                  createdBy={primaryTeammateBranch.created_by}
-                  currentUserId={currentUserId}
-                  userById={userById}
-                  prefix="Created by"
-                />
-              )}
-              {primaryTeammateBranch.issue_url && (
-                <IssuePill
-                  issueUrl={primaryTeammateBranch.issue_url}
-                  currentRepo={primaryTeammateRepo}
-                />
-              )}
-              {primaryTeammateBranch.pull_request_url && (
-                <PullRequestPill
-                  prUrl={primaryTeammateBranch.pull_request_url}
-                  currentRepo={primaryTeammateRepo}
-                />
-              )}
-            </Flex>
+            </BranchMetadataRow>
             {teammateDescription && (
               <div className="markdown-compact" style={{ color: token.colorTextSecondary }}>
                 <MarkdownRenderer content={teammateDescription} compact showControls={false} />

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -300,7 +300,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               </div>
             </div>
 
-            <Flex vertical style={{ minWidth: 0 }}>
+            <Flex vertical align="flex-start" style={{ minWidth: 0 }}>
               <BranchHeaderPill
                 repo={primaryTeammateRepo}
                 branch={primaryTeammateBranch}

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -300,7 +300,9 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               </div>
             </div>
 
-            <Flex vertical align="flex-start" style={{ minWidth: 0 }}>
+            {/* Branch pill first; metadata links flow after it on the same
+                line and wrap below when the row runs out of room. */}
+            <Flex wrap gap={token.sizeUnit} align="center" style={{ minWidth: 0 }}>
               <BranchHeaderPill
                 repo={primaryTeammateRepo}
                 branch={primaryTeammateBranch}
@@ -310,31 +312,25 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
                 compact
                 fluid
               />
-              {(primaryTeammateBranch.created_by ||
-                primaryTeammateBranch.issue_url ||
-                primaryTeammateBranch.pull_request_url) && (
-                <Flex gap={token.sizeUnit} wrap style={{ marginTop: token.sizeUnit }}>
-                  {primaryTeammateBranch.created_by && (
-                    <CreatedByTag
-                      createdBy={primaryTeammateBranch.created_by}
-                      currentUserId={currentUserId}
-                      userById={userById}
-                      prefix="Created by"
-                    />
-                  )}
-                  {primaryTeammateBranch.issue_url && (
-                    <IssuePill
-                      issueUrl={primaryTeammateBranch.issue_url}
-                      currentRepo={primaryTeammateRepo}
-                    />
-                  )}
-                  {primaryTeammateBranch.pull_request_url && (
-                    <PullRequestPill
-                      prUrl={primaryTeammateBranch.pull_request_url}
-                      currentRepo={primaryTeammateRepo}
-                    />
-                  )}
-                </Flex>
+              {primaryTeammateBranch.created_by && (
+                <CreatedByTag
+                  createdBy={primaryTeammateBranch.created_by}
+                  currentUserId={currentUserId}
+                  userById={userById}
+                  prefix="Created by"
+                />
+              )}
+              {primaryTeammateBranch.issue_url && (
+                <IssuePill
+                  issueUrl={primaryTeammateBranch.issue_url}
+                  currentRepo={primaryTeammateRepo}
+                />
+              )}
+              {primaryTeammateBranch.pull_request_url && (
+                <PullRequestPill
+                  prUrl={primaryTeammateBranch.pull_request_url}
+                  currentRepo={primaryTeammateRepo}
+                />
               )}
             </Flex>
             {teammateDescription && (

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
@@ -13,7 +13,14 @@ vi.mock('antd', async () => {
       ...props
     }: React.ButtonHTMLAttributes<HTMLButtonElement> & { icon?: React.ReactNode }) =>
       React.createElement('button', props, icon, children),
-    Spin: () => React.createElement('span', null, 'loading'),
+    Spin: ({
+      indicator,
+      size: _size,
+      ...props
+    }: React.HTMLAttributes<HTMLSpanElement> & {
+      indicator?: React.ReactNode;
+      size?: string;
+    }) => React.createElement('span', props, indicator ?? 'loading'),
     Tooltip: ({
       children,
       trigger,
@@ -173,10 +180,13 @@ describe('BranchHeaderPill', () => {
       flex: '1 1 auto',
       minWidth: '0',
     });
+    // Content-sized pill: capped at the row width, never stretched to fill it.
     expect(identity.parentElement).toHaveStyle({
-      width: '100%',
+      display: 'inline-flex',
+      maxWidth: '100%',
       minWidth: '0',
     });
+    expect(identity.parentElement?.style.width).toBe('');
 
     expect(screen.getByText(repo.slug)).toHaveStyle({
       overflow: 'hidden',
@@ -210,5 +220,25 @@ describe('BranchHeaderPill', () => {
         minWidth: '20px',
       });
     }
+  });
+
+  it('renders the starting-environment spinner as an icon aligned with sibling status icons', () => {
+    render(
+      <BranchHeaderPill
+        {...defaultProps}
+        branch={{ ...branch, environment_instance: { status: 'starting' } } as Branch}
+      />
+    );
+
+    // Spin uses a LoadingOutlined indicator sized like the other status icons.
+    const indicator = screen.getByRole('img', { name: 'loading' });
+    expect(indicator.className).toContain('anticon-spin');
+    expect(indicator).toHaveStyle({ fontSize: '11px' });
+    // The Spin wrapper centers the indicator instead of leaving it on the
+    // inherited 22px text baseline.
+    expect(indicator.parentElement).toHaveStyle({
+      display: 'inline-flex',
+      alignItems: 'center',
+    });
   });
 });

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.test.tsx
@@ -107,8 +107,8 @@ const defaultProps = {
 };
 
 describe('BranchHeaderPill', () => {
-  it('keeps compact fluid actions at the default width and hides the destructive action', () => {
-    render(<BranchHeaderPill {...defaultProps} compact fluid />);
+  it('keeps compact truncateToFit actions at the default width and hides the destructive action', () => {
+    render(<BranchHeaderPill {...defaultProps} compact truncateToFit />);
 
     expect(
       screen.getByRole('button', {
@@ -167,9 +167,13 @@ describe('BranchHeaderPill', () => {
     expect(link).toHaveAttribute('href', '/ui/s/abc123/');
   });
 
-  it('keeps a fluid identity accessible and selects the narrow action-button variant', () => {
+  it('keeps a truncateToFit identity accessible and selects the narrow action-button variant', () => {
     render(
-      <BranchHeaderPill {...defaultProps} identityLink="https://agor.example/ui/s/abc123/" fluid />
+      <BranchHeaderPill
+        {...defaultProps}
+        identityLink="https://agor.example/ui/s/abc123/"
+        truncateToFit
+      />
     );
 
     const identity = screen.getByRole('link', {

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -3,25 +3,22 @@ import {
   ApartmentOutlined,
   BranchesOutlined,
   CalendarOutlined,
-  CheckCircleOutlined,
-  CloseCircleOutlined,
   EditOutlined,
   FileTextOutlined,
   FireOutlined,
   FolderOutlined,
   GlobalOutlined,
-  LoadingOutlined,
   PlayCircleOutlined,
   StopOutlined,
   TeamOutlined,
-  WarningOutlined,
 } from '@ant-design/icons';
-import { Button, Spin, Tooltip, theme } from 'antd';
+import { Button, Tooltip, theme } from 'antd';
 import { Link } from 'react-router-dom';
 import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import type { BranchModalTab } from '../BranchModal/BranchModal';
+import { EnvironmentStatusIcon } from '../EnvironmentPill';
 import { ENTITY_PILL_COLORS } from '../Pill/Pill';
 import { Tag } from '../Tag';
 
@@ -43,7 +40,7 @@ interface BranchHeaderPillProps {
   /** Optional link for the branch identity area. Used by session surfaces for deep links. */
   identityLink?: string | null;
   /** Cap the pill at the available row width and shrink the identity before action sections. */
-  fluid?: boolean;
+  truncateToFit?: boolean;
   /**
    * Compact rendering for constrained side panels.
    * Hides the repo slug in the identity section and omits destructive environment actions.
@@ -63,13 +60,14 @@ const DEFAULT_ACTION_BUTTON_STYLE: React.CSSProperties = {
 };
 
 // The configured environment and shortcut sections cannot shrink. Reclaim two
-// pixels per action only in the constrained, non-compact fluid layout so the
-// complete action row fits before identity text collapses to its ellipsis.
-const FLUID_ACTION_BUTTON_WIDTH = 20;
-const FLUID_ACTION_BUTTON_STYLE: React.CSSProperties = {
+// pixels per action only in the constrained, non-compact truncateToFit layout
+// so the complete action row fits before identity text collapses to its
+// ellipsis.
+const NARROW_ACTION_BUTTON_WIDTH = 20;
+const NARROW_ACTION_BUTTON_STYLE: React.CSSProperties = {
   height: ACTION_BUTTON_HEIGHT,
-  width: FLUID_ACTION_BUTTON_WIDTH,
-  minWidth: FLUID_ACTION_BUTTON_WIDTH,
+  width: NARROW_ACTION_BUTTON_WIDTH,
+  minWidth: NARROW_ACTION_BUTTON_WIDTH,
   padding: 0,
 };
 
@@ -87,7 +85,7 @@ export function BranchHeaderPill({
   showEnvButtons = true,
   showNukeEnvironment = true,
   identityLink,
-  fluid = false,
+  truncateToFit = false,
   compact = false,
 }: BranchHeaderPillProps) {
   const { token } = theme.useToken();
@@ -106,7 +104,7 @@ export function BranchHeaderPill({
     ? undefined
     : "Requires branch 'all' permission or admin access";
   const actionButtonStyle =
-    fluid && !compact ? FLUID_ACTION_BUTTON_STYLE : DEFAULT_ACTION_BUTTON_STYLE;
+    truncateToFit && !compact ? NARROW_ACTION_BUTTON_STYLE : DEFAULT_ACTION_BUTTON_STYLE;
 
   const status = env?.status || 'stopped';
   const isRunning = status === 'running';
@@ -147,7 +145,7 @@ export function BranchHeaderPill({
             style={{
               fontFamily: token.fontFamilyCode,
               fontSize: token.fontSizeSM,
-              ...(fluid
+              ...(truncateToFit
                 ? {
                     flex: '0 1 auto',
                     minWidth: 0,
@@ -167,7 +165,9 @@ export function BranchHeaderPill({
         style={{
           fontFamily: token.fontFamilyCode,
           fontSize: token.fontSizeSM,
-          ...(fluid ? { flex: '1 1 auto', minWidth: 0 } : { maxWidth: compact ? 220 : 180 }),
+          ...(truncateToFit
+            ? { flex: '1 1 auto', minWidth: 0 }
+            : { maxWidth: compact ? 220 : 180 }),
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
@@ -179,35 +179,6 @@ export function BranchHeaderPill({
   );
 
   // --- Environment status helpers ---
-
-  const getStatusIcon = () => {
-    const size = 11;
-    switch (inferredState) {
-      case 'stopped':
-        return <StopOutlined style={{ color: token.colorTextDisabled, fontSize: size }} />;
-      case 'starting':
-      case 'stopping':
-        // Match sibling status icons: the default dot indicator ignores
-        // fontSize and misaligns in the 22px pill row.
-        return (
-          <Spin
-            size="small"
-            indicator={<LoadingOutlined spin style={{ fontSize: size }} />}
-            style={{ display: 'inline-flex', alignItems: 'center' }}
-          />
-        );
-      case 'healthy':
-        return <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: size }} />;
-      case 'unhealthy':
-        return <WarningOutlined style={{ color: token.colorWarning, fontSize: size }} />;
-      case 'running':
-        return <CheckCircleOutlined style={{ color: token.colorInfo, fontSize: size }} />;
-      case 'error':
-        return <CloseCircleOutlined style={{ color: token.colorError, fontSize: size }} />;
-      default:
-        return <StopOutlined style={{ color: token.colorTextDisabled, fontSize: size }} />;
-    }
-  };
 
   const getEnvTooltip = () => {
     if (!hasConfig) return 'Click to configure environment';
@@ -245,7 +216,7 @@ export function BranchHeaderPill({
     height: PILL_HEIGHT,
     color: 'inherit',
     textDecoration: 'none',
-    ...(fluid ? { flex: '1 1 auto', minWidth: 0, overflow: 'hidden' } : {}),
+    ...(truncateToFit ? { flex: '1 1 auto', minWidth: 0, overflow: 'hidden' } : {}),
   };
   const isInternalIdentityLink = identityLink?.startsWith('/');
 
@@ -264,7 +235,7 @@ export function BranchHeaderPill({
         cursor: 'default',
         // Content-sized, but never wider than the row: the identity section
         // truncates before the action sections are pushed out of view.
-        ...(fluid ? { maxWidth: '100%', minWidth: 0 } : {}),
+        ...(truncateToFit ? { maxWidth: '100%', minWidth: 0 } : {}),
       }}
     >
       {/* Section 1: Repo + Branch — click opens either the supplied identity URL or the branch modal. */}
@@ -303,7 +274,7 @@ export function BranchHeaderPill({
               border: 'none',
               color: 'inherit',
               font: 'inherit',
-              ...(fluid ? { flex: '1 1 auto', minWidth: 0, overflow: 'hidden' } : {}),
+              ...(truncateToFit ? { flex: '1 1 auto', minWidth: 0, overflow: 'hidden' } : {}),
             }}
           >
             {identityContent}
@@ -343,7 +314,7 @@ export function BranchHeaderPill({
                       padding: '0 2px',
                     }}
                   >
-                    {getStatusIcon()}
+                    <EnvironmentStatusIcon state={inferredState} size={11} />
                     <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
                   </a>
                 </Tooltip>
@@ -364,7 +335,7 @@ export function BranchHeaderPill({
                       font: 'inherit',
                     }}
                   >
-                    {getStatusIcon()}
+                    <EnvironmentStatusIcon state={inferredState} size={11} />
                     <span style={{ fontFamily: token.fontFamilyCode, fontSize: 11 }}>env</span>
                   </button>
                 </Tooltip>

--- a/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
+++ b/apps/agor-ui/src/components/BranchHeaderPill/BranchHeaderPill.tsx
@@ -10,6 +10,7 @@ import {
   FireOutlined,
   FolderOutlined,
   GlobalOutlined,
+  LoadingOutlined,
   PlayCircleOutlined,
   StopOutlined,
   TeamOutlined,
@@ -41,7 +42,7 @@ interface BranchHeaderPillProps {
   showNukeEnvironment?: boolean;
   /** Optional link for the branch identity area. Used by session surfaces for deep links. */
   identityLink?: string | null;
-  /** Fill the available row width and let the identity shrink before action sections. */
+  /** Cap the pill at the available row width and shrink the identity before action sections. */
   fluid?: boolean;
   /**
    * Compact rendering for constrained side panels.
@@ -186,7 +187,15 @@ export function BranchHeaderPill({
         return <StopOutlined style={{ color: token.colorTextDisabled, fontSize: size }} />;
       case 'starting':
       case 'stopping':
-        return <Spin size="small" style={{ fontSize: size }} />;
+        // Match sibling status icons: the default dot indicator ignores
+        // fontSize and misaligns in the 22px pill row.
+        return (
+          <Spin
+            size="small"
+            indicator={<LoadingOutlined spin style={{ fontSize: size }} />}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
+          />
+        );
       case 'healthy':
         return <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: size }} />;
       case 'unhealthy':
@@ -228,7 +237,7 @@ export function BranchHeaderPill({
 
   const identityTooltip = `${repo.slug} / ${branch.name} · ${identityLink ? 'Open session' : 'Open branch settings'}`;
   const identityLinkStyle: React.CSSProperties = {
-    display: fluid ? 'flex' : 'inline-flex',
+    display: 'inline-flex',
     alignItems: 'center',
     gap: 4,
     padding: compact ? '0 6px' : '0 8px',
@@ -250,10 +259,12 @@ export function BranchHeaderPill({
         padding: 0,
         overflow: 'hidden',
         lineHeight: `${PILL_HEIGHT}px`,
-        display: fluid ? 'flex' : 'inline-flex',
+        display: 'inline-flex',
         alignItems: 'stretch',
         cursor: 'default',
-        ...(fluid ? { width: '100%', minWidth: 0, maxWidth: '100%' } : {}),
+        // Content-sized, but never wider than the row: the identity section
+        // truncates before the action sections are pushed out of view.
+        ...(fluid ? { maxWidth: '100%', minWidth: 0 } : {}),
       }}
     >
       {/* Section 1: Repo + Branch — click opens either the supplied identity URL or the branch modal. */}

--- a/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.test.tsx
+++ b/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.test.tsx
@@ -1,0 +1,61 @@
+import type { Branch, Repo, User } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BranchMetadataRow } from './BranchMetadataRow';
+
+const repo = { repo_id: 'repo-1', slug: 'preset-io/agor' } as Repo;
+
+const branch = {
+  branch_id: 'branch-1',
+  repo_id: repo.repo_id,
+  name: 'feature/layout',
+  created_by: 'user-2',
+  issue_url: 'https://github.com/preset-io/agor/issues/1',
+  pull_request_url: 'https://github.com/preset-io/agor/pull/2',
+} as Branch;
+
+const userById = new Map<string, User>([
+  ['user-2', { user_id: 'user-2', name: 'sam', email: 'sam@example.com' } as User],
+]);
+
+describe('BranchMetadataRow', () => {
+  it('renders the pill and metadata links inline in a single wrapping row', () => {
+    render(
+      <BranchMetadataRow branch={branch} repo={repo} userById={userById} currentUserId="user-1">
+        <div data-testid="branch-pill" />
+      </BranchMetadataRow>
+    );
+
+    const pill = screen.getByTestId('branch-pill');
+    const issue = screen.getByText(/Issue:/);
+    const pr = screen.getByText(/PR:/);
+    const createdBy = screen.getByText('sam');
+
+    // All items share ONE row container (no stacked second row), pill first.
+    const row = pill.parentElement as HTMLElement;
+    for (const item of [issue, pr, createdBy]) {
+      expect(row.contains(item)).toBe(true);
+    }
+    expect(row.firstElementChild).toBe(pill);
+    // Pill precedes every metadata link in document order.
+    for (const item of [createdBy, issue, pr]) {
+      expect(pill.compareDocumentPosition(item) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+  });
+
+  it('omits metadata links the branch does not have and created-by without a user map', () => {
+    render(
+      <BranchMetadataRow
+        branch={{ ...branch, issue_url: undefined, pull_request_url: undefined } as Branch}
+        repo={repo}
+      >
+        <div data-testid="branch-pill" />
+      </BranchMetadataRow>
+    );
+
+    expect(screen.getByTestId('branch-pill')).toBeInTheDocument();
+    expect(screen.queryByText(/Issue:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/PR:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('sam')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.tsx
+++ b/apps/agor-ui/src/components/BranchMetadataRow/BranchMetadataRow.tsx
@@ -1,0 +1,52 @@
+import type { Branch, Repo, User } from '@agor-live/client';
+import { Flex, theme } from 'antd';
+import { CreatedByTag } from '../metadata';
+import { IssuePill, PullRequestPill } from '../Pill';
+
+interface BranchMetadataRowProps {
+  branch: Branch;
+  repo?: Repo | null;
+  /** Leading branch pill; renders first so the metadata links flow after it. */
+  children: React.ReactNode;
+  /** Users map enabling the "Created by" tag when the branch has a creator. */
+  userById?: Map<string, User>;
+  /** Suppresses the "Created by" tag for the viewer's own branches. */
+  currentUserId?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Single wrapping row for a branch pill and its metadata links: the pill owns
+ * the leading slot, and created-by/issue/PR links sit on the same line when
+ * there is room, wrapping to the next line when there is not.
+ */
+export function BranchMetadataRow({
+  branch,
+  repo,
+  children,
+  userById,
+  currentUserId,
+  style,
+}: BranchMetadataRowProps) {
+  const { token } = theme.useToken();
+
+  return (
+    <Flex wrap gap={token.sizeUnit} align="center" style={style}>
+      {children}
+      {branch.created_by && userById && (
+        <CreatedByTag
+          createdBy={branch.created_by}
+          currentUserId={currentUserId}
+          userById={userById}
+          prefix="Created by"
+        />
+      )}
+      {branch.issue_url && (
+        <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
+      )}
+      {branch.pull_request_url && (
+        <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo ?? undefined} />
+      )}
+    </Flex>
+  );
+}

--- a/apps/agor-ui/src/components/BranchMetadataRow/index.ts
+++ b/apps/agor-ui/src/components/BranchMetadataRow/index.ts
@@ -1,0 +1,1 @@
+export { BranchMetadataRow } from './BranchMetadataRow';

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentPill.tsx
@@ -1,20 +1,18 @@
 import type { Branch, Repo } from '@agor-live/client';
 import {
-  CheckCircleOutlined,
-  CloseCircleOutlined,
   EditOutlined,
   FileTextOutlined,
   FireOutlined,
   GlobalOutlined,
   PlayCircleOutlined,
   StopOutlined,
-  WarningOutlined,
 } from '@ant-design/icons';
-import { Button, Space, Spin, Tooltip, theme } from 'antd';
+import { Button, Space, Tooltip, theme } from 'antd';
 import { useConfirmNukeEnvironment } from '../../hooks/useConfirmNukeEnvironment';
 import { getEffectiveEnv } from '../../utils/environmentConfig';
 import { getEnvironmentState } from '../../utils/environmentState';
 import { Tag } from '../Tag';
+import { EnvironmentStatusIcon } from './EnvironmentStatusIcon';
 
 interface EnvironmentPillProps {
   repo: Repo; // Need repo for environment_config
@@ -83,32 +81,6 @@ export function EnvironmentPill({
 
   // Infer environment state by combining runtime status + health check
   const inferredState = getEnvironmentState(env);
-
-  // Case 2 & 3: Config exists - show status with health awareness
-  const getStatusIcon = () => {
-    switch (inferredState) {
-      case 'stopped':
-        return <StopOutlined style={{ color: token.colorTextDisabled, fontSize: 12 }} />;
-      case 'starting':
-      case 'stopping':
-        return (
-          <Spin
-            size="small"
-            style={{ display: 'inline-flex', alignItems: 'center', fontSize: 12 }}
-          />
-        );
-      case 'healthy':
-        return <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 12 }} />;
-      case 'unhealthy':
-        return <WarningOutlined style={{ color: token.colorWarning, fontSize: 12 }} />;
-      case 'running':
-        return <CheckCircleOutlined style={{ color: token.colorInfo, fontSize: 12 }} />;
-      case 'error':
-        return <CloseCircleOutlined style={{ color: token.colorError, fontSize: 12 }} />;
-      default:
-        return <StopOutlined style={{ color: token.colorTextDisabled, fontSize: 12 }} />;
-    }
-  };
 
   const handleEdit = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -223,7 +195,7 @@ export function EnvironmentPill({
               }}
             >
               <Space size={4} align="center">
-                {getStatusIcon()}
+                <EnvironmentStatusIcon state={inferredState} size={12} />
                 <span style={{ fontFamily: token.fontFamilyCode, lineHeight: 1 }}>env</span>
               </Space>
             </a>
@@ -239,7 +211,7 @@ export function EnvironmentPill({
               }}
             >
               <Space size={4} align="center">
-                {getStatusIcon()}
+                <EnvironmentStatusIcon state={inferredState} size={12} />
                 <span style={{ fontFamily: token.fontFamilyCode, lineHeight: 1 }}>env</span>
               </Space>
             </div>

--- a/apps/agor-ui/src/components/EnvironmentPill/EnvironmentStatusIcon.tsx
+++ b/apps/agor-ui/src/components/EnvironmentPill/EnvironmentStatusIcon.tsx
@@ -1,0 +1,46 @@
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  LoadingOutlined,
+  StopOutlined,
+  WarningOutlined,
+} from '@ant-design/icons';
+import { Spin, theme } from 'antd';
+import type { EnvironmentInferredState } from '../../utils/environmentState';
+
+interface EnvironmentStatusIconProps {
+  state: EnvironmentInferredState;
+  /** Icon font size in px. */
+  size?: number;
+}
+
+/**
+ * Status icon for an environment's inferred state, shared by the environment
+ * pill surfaces so they render the same iconography and spinner.
+ */
+export function EnvironmentStatusIcon({ state, size = 12 }: EnvironmentStatusIconProps) {
+  const { token } = theme.useToken();
+  switch (state) {
+    case 'starting':
+    case 'stopping':
+      // Match sibling status icons: Spin's default dot indicator ignores
+      // fontSize and misaligns against the pills' inherited line-height.
+      return (
+        <Spin
+          size="small"
+          indicator={<LoadingOutlined spin style={{ fontSize: size }} />}
+          style={{ display: 'inline-flex', alignItems: 'center' }}
+        />
+      );
+    case 'healthy':
+      return <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: size }} />;
+    case 'unhealthy':
+      return <WarningOutlined style={{ color: token.colorWarning, fontSize: size }} />;
+    case 'running':
+      return <CheckCircleOutlined style={{ color: token.colorInfo, fontSize: size }} />;
+    case 'error':
+      return <CloseCircleOutlined style={{ color: token.colorError, fontSize: size }} />;
+    default:
+      return <StopOutlined style={{ color: token.colorTextDisabled, fontSize: size }} />;
+  }
+}

--- a/apps/agor-ui/src/components/EnvironmentPill/index.ts
+++ b/apps/agor-ui/src/components/EnvironmentPill/index.ts
@@ -1,1 +1,2 @@
 export { EnvironmentPill } from './EnvironmentPill';
+export { EnvironmentStatusIcon } from './EnvironmentStatusIcon';

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -9,7 +9,7 @@ import {
   VerticalAlignBottomOutlined,
   VerticalAlignTopOutlined,
 } from '@ant-design/icons';
-import { Alert, Button, Divider, Flex, Space, Tabs, Tooltip, Typography, theme } from 'antd';
+import { Alert, Button, Divider, Space, Tabs, Tooltip, Typography, theme } from 'antd';
 import React from 'react';
 import { useAppActions } from '../../contexts/AppActionsContext';
 import { useAgorStore } from '../../store/agorStore';
@@ -17,10 +17,10 @@ import { selectMcpServerById, selectRepoById, selectUserById } from '../../store
 import { copyToClipboard } from '../../utils/clipboard';
 import { useThemedMessage } from '../../utils/message';
 import { BranchHeaderPill } from '../BranchHeaderPill';
+import { BranchMetadataRow } from '../BranchMetadataRow';
 import { ConversationView } from '../ConversationView';
 import { EmbeddedTerminal } from '../EmbeddedTerminal/EmbeddedTerminalLazy';
 import { ForkSpawnModal } from '../ForkSpawnModal';
-import { IssuePill, PullRequestPill } from '../Pill';
 
 export interface SessionPanelContentProps {
   client: AgorClient | null;
@@ -134,11 +134,9 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             gap: token.sizeUnit * 2,
           }}
         >
-          {/* Pills section (only shown if there's content). Branch pill first;
-              issue/PR links flow after it on the same line and wrap below when
-              the row runs out of room. */}
+          {/* Pills section (only shown if there's content) */}
           {branch && (
-            <Flex wrap gap={token.sizeUnit} align="center" style={{ flex: '1 1 0', minWidth: 0 }}>
+            <BranchMetadataRow branch={branch} repo={repo} style={{ flex: '1 1 0', minWidth: 0 }}>
               {repo && (
                 <BranchHeaderPill
                   repo={repo}
@@ -149,16 +147,10 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                   onNukeEnvironment={onNukeEnvironment}
                   onViewLogs={onViewLogs}
                   identityLink={sessionPath(session.session_id)}
-                  fluid
+                  truncateToFit
                 />
               )}
-              {branch.issue_url && (
-                <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
-              )}
-              {branch.pull_request_url && (
-                <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo ?? undefined} />
-              )}
-            </Flex>
+            </BranchMetadataRow>
           )}
           {/* Spacer if no pills */}
           {!branch && <div style={{ flex: 1 }} />}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -136,7 +136,7 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
         >
           {/* Pills section (only shown if there's content) */}
           {branch && (
-            <Flex vertical style={{ flex: '1 1 0', minWidth: 0 }}>
+            <Flex vertical align="flex-start" style={{ flex: '1 1 0', minWidth: 0 }}>
               {/* Unified Branch Pill — owns the first row so its actions keep priority. */}
               {repo && (
                 <BranchHeaderPill

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanelContent.tsx
@@ -134,10 +134,11 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
             gap: token.sizeUnit * 2,
           }}
         >
-          {/* Pills section (only shown if there's content) */}
+          {/* Pills section (only shown if there's content). Branch pill first;
+              issue/PR links flow after it on the same line and wrap below when
+              the row runs out of room. */}
           {branch && (
-            <Flex vertical align="flex-start" style={{ flex: '1 1 0', minWidth: 0 }}>
-              {/* Unified Branch Pill — owns the first row so its actions keep priority. */}
+            <Flex wrap gap={token.sizeUnit} align="center" style={{ flex: '1 1 0', minWidth: 0 }}>
               {repo && (
                 <BranchHeaderPill
                   repo={repo}
@@ -151,18 +152,11 @@ export const SessionPanelContent = React.memo<SessionPanelContentProps>(
                   fluid
                 />
               )}
-              {(branch.issue_url || branch.pull_request_url) && (
-                <Space size={token.sizeUnit * 2} wrap style={{ marginTop: token.sizeUnit }}>
-                  {branch.issue_url && (
-                    <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
-                  )}
-                  {branch.pull_request_url && (
-                    <PullRequestPill
-                      prUrl={branch.pull_request_url}
-                      currentRepo={repo ?? undefined}
-                    />
-                  )}
-                </Space>
+              {branch.issue_url && (
+                <IssuePill issueUrl={branch.issue_url} currentRepo={repo ?? undefined} />
+              )}
+              {branch.pull_request_url && (
+                <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo ?? undefined} />
               )}
             </Flex>
           )}


### PR DESCRIPTION
## Root cause

#1889 (`546a55b7`) introduced a `fluid` mode on `BranchHeaderPill` to keep its action buttons visible when branch names are long, but implemented it with `width: '100%'` on the outer `Tag` — so the pill always stretches across the row, even with short content. Both call sites that pass `fluid` (the conversation header in `SessionPanelContent` and the Assistant/Teammate left panel in `BoardTeammatePanel`) also wrap the pill in `Flex vertical`, whose default cross-axis stretch widens it further.

The same PR's env sub-pill spinner used `<Spin size="small" style={{ fontSize: 11 }} />` — the default dot indicator ignores `fontSize` (it's fixed at 14px for `small`) and its inner icon sits on the pill's inherited 22px line-height baseline, so it rendered oversized and vertically off relative to the sibling status icons.

## Fix

- `fluid` now means "cap at the available row width": `maxWidth: '100%'` + `minWidth: 0` instead of `width: '100%'`, keeping `display: inline-flex` so the pill stays content-sized. The identity section still ellipsizes before the action sections shrink, so #1889's original goal (actions always visible) is preserved.
- Both `Flex vertical` wrappers get `align="flex-start"` (public AntD prop) so children no longer stretch to the column width.
- The starting/stopping spinner uses Spin's public `indicator` API with `LoadingOutlined spin` sized like the sibling status icons (11px), plus the same inline-flex centering `EnvironmentPill` already uses. Colors stay token-driven (Spin default = `colorPrimary`).

## Tests & checks

- Updated the fluid sizing contract test: asserts `maxWidth: 100%` / `minWidth: 0` / `inline-flex` and that no `width` is set; truncation, tooltip triggers, and narrow action-button assertions unchanged.
- New regression test for the spinner: semantic `LoadingOutlined` indicator (`anticon-spin`), 11px sizing, and centered (non-baseline) wrapper.
- `pnpm test BranchHeaderPill BoardTeammatePanel SessionPanelContent SessionPanel` — 14 files, 78 tests passed.
- Biome check on touched files — clean.
- `pnpm typecheck` (agor-ui) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)