### PR TITLE
fix(codex): downgrade nonfatal stream-lag warning

### DIFF
--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1161,6 +1161,88 @@ describe('CodexPromptService - tool payload mapping', () => {
       })()
     ).rejects.toThrow('Codex stream error: stream exploded');
   });
+
+  it('logs Codex stream-lag warnings without persisting them as item errors', async () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+
+    const serviceWithPrivates = service as any;
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-mock.md');
+    serviceWithPrivates.buildMcpServersConfig = vi
+      .fn()
+      .mockResolvedValue({ servers: {}, total: 0 });
+    await serviceWithPrivates.ensureCodexClient({
+      model_instructions_file: '/tmp/agor-codex-instructions-mock.md',
+    });
+    serviceWithPrivates.ensureCodexClient = vi.fn();
+    serviceWithPrivates.refreshClient = vi.fn();
+
+    mockSessionsRepo.findById.mockResolvedValue({
+      session_id: 'session-1',
+      branch_id: 'branch-1',
+      created_at: new Date().toISOString(),
+      sdk_session_id: null,
+      permission_config: { codex: {} },
+      model_config: {},
+      mcp_token: 'test-token',
+    });
+    mockBranchesRepo.findById.mockResolvedValue({
+      branch_id: 'branch-1',
+      path: process.cwd(),
+    });
+
+    mockStreamEvents = [
+      { type: 'turn.started' },
+      {
+        type: 'item.completed',
+        item: {
+          id: 'warning-1',
+          type: 'error',
+          message: 'in-process app-server event stream lagged; dropped 111 events',
+        },
+      },
+      {
+        type: 'item.completed',
+        item: {
+          id: 'error-1',
+          type: 'error',
+          message: 'a real item failure',
+        },
+      },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 5 },
+      },
+    ];
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const emitted: Array<Record<string, unknown>> = [];
+    for await (const event of service.promptSessionStreaming('session-1' as any, 'review')) {
+      emitted.push(event as Record<string, unknown>);
+    }
+
+    const emittedText = emitted
+      .flatMap((event) => (Array.isArray(event.content) ? event.content : []))
+      .map((block) => (block as { text?: string }).text)
+      .filter(Boolean);
+    expect(emittedText).not.toContain(
+      '[Codex item error] in-process app-server event stream lagged; dropped 111 events'
+    );
+    expect(emittedText).toContain('[Codex item error] a real item failure');
+    expect(warn).toHaveBeenCalledWith(
+      '⚠️  [Codex] Non-fatal stream backpressure: in-process app-server event stream lagged; dropped 111 events'
+    );
+    warn.mockRestore();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -94,6 +94,13 @@ const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 
 const DEBUG_CODEX = process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex');
 
+// `codex exec --json` currently serializes its non-fatal in-process transport
+// lag warning as an item with type="error". Keep the match deliberately exact:
+// every other item-level error must still reach the conversation. See upstream
+// openai/codex#19689.
+const CODEX_STREAM_LAG_WARNING =
+  /^in-process app-server event stream lagged; dropped \d+ events?$/i;
+
 function codexDebug(...args: unknown[]): void {
   if (DEBUG_CODEX) {
     console.debug(...args);
@@ -1433,6 +1440,10 @@ export class CodexPromptService {
               // Surface non-fatal item-level errors as assistant text so users can see
               // what happened instead of dropping them silently.
               if ('message' in event.item && event.item.type === 'error') {
+                if (CODEX_STREAM_LAG_WARNING.test(event.item.message)) {
+                  console.warn(`⚠️  [Codex] Non-fatal stream backpressure: ${event.item.message}`);
+                  break;
+                }
                 const errorContent = [
                   { type: 'text', text: `[Codex item error] ${event.item.message}` },
                 ];


### PR DESCRIPTION
## Summary

- recognize Codex's exact non-fatal `in-process app-server event stream lagged; dropped N events` JSONL warning
- keep it in executor logs as a backpressure warning instead of persisting it as an assistant `[Codex item error]`
- preserve all other item errors unchanged

## Why

OpenAI Codex currently maps this internal, non-terminal lag warning to an `item.completed` event whose item type is `error`. The CLI still treats it as a warning and can complete successfully; upstream tracks the misleading JSONL classification in [openai/codex#19689](https://github.com/openai/codex/issues/19689).

The investigated Agor incident produced four such assistant messages (146 dropped best-effort events total) during a long, output-heavy task, then continued running until the user stopped it. The deployed SDK and bundled CLI are both 0.144.0. Codex 0.144.4 has no relevant source change, so a dependency bump would not address this.

The matcher is deliberately exact so genuine Codex item errors remain visible.

## Validation

- `pnpm exec biome check --diagnostic-level=warn packages/executor/src/sdk-handlers/codex/prompt-service.ts packages/executor/src/sdk-handlers/codex/prompt-service.test.ts`
- `pnpm --filter @agor/executor test -- src/sdk-handlers/codex/prompt-service.test.ts` (42 tests)
- `git diff --check`

Full executor typecheck was not a useful fresh-worktree check because generated outputs for workspace dependencies were absent; per repository instructions, no build was run.
