### PR TITLE
Docs cleanup wave 3: FAQ cards, executor diagram, trees, tables, mermaid zoom

### DIFF
--- a/apps/agor-docs/app/(docs)/layout.tsx
+++ b/apps/agor-docs/app/(docs)/layout.tsx
@@ -1,12 +1,14 @@
 import { getPageMap } from 'nextra/page-map';
 import { Layout } from 'nextra-theme-docs';
 import type { ReactNode } from 'react';
+import { MermaidZoom } from '../../components/MermaidZoom';
 import { footer, navbar, sharedLayoutProps } from '../docsTheme';
 
 export default async function DocsLayout({ children }: { children: ReactNode }) {
   return (
     <Layout navbar={navbar} pageMap={await getPageMap()} footer={footer} {...sharedLayoutProps}>
       {children}
+      <MermaidZoom />
     </Layout>
   );
 }

--- a/apps/agor-docs/app/styles.css
+++ b/apps/agor-docs/app/styles.css
@@ -252,3 +252,20 @@ code span[style*="--shiki-dark:#6A737D"] {
 .nextra-navbar nav > button:not(.navbar-cloud-cta) {
   order: 4;
 }
+
+/* Docs content headings — adopt the marketing display font (Space Grotesk)
+ * and a light tint so pages read less like a wall of white. Distinct from
+ * the teal link color; scoped away from the landing page (its headings carry
+ * their own styles). */
+body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
+  font-family: var(--font-display), 'Space Grotesk', system-ui, sans-serif;
+  letter-spacing: -0.01em;
+}
+
+.dark body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
+  color: #c9efe7;
+}
+
+html:not(.dark) body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
+  color: #0d6f5f;
+}

--- a/apps/agor-docs/components/ExecutorDiagram.tsx
+++ b/apps/agor-docs/components/ExecutorDiagram.tsx
@@ -1,0 +1,226 @@
+// Hand-authored SVG for the daemon↔executor flow. Built by hand (not mermaid)
+// because the routing is deliberate: the edges sweep around the perimeter to
+// form a loop — down the left (daemon → spawn → local → executor), straight
+// down the center, and back up the right (executor → WebSocket → daemon) —
+// which mermaid's auto-layout can't express.
+
+const LINE = '#aeb8b5';
+const CODE = '#7fe8df';
+const MUTED = '#9fb4ae';
+const INK = '#eafff9';
+
+// Reusable box (rounded rect + centered multi-line text).
+function Box({
+  x,
+  y,
+  w,
+  h,
+  stroke = 'rgba(255,255,255,0.14)',
+  fill = '#10201d',
+  children,
+}: {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  stroke?: string;
+  fill?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={w}
+        height={h}
+        rx={10}
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={1.5}
+      />
+      {children}
+    </g>
+  );
+}
+
+export function ExecutorDiagram() {
+  return (
+    <svg
+      viewBox="0 0 780 620"
+      role="img"
+      aria-label="Daemon spawns executors locally or in containers over stdin; executors connect back over WebSocket"
+      style={{ width: '100%', height: 'auto', margin: '1.5rem 0', maxWidth: 780 }}
+      fontFamily="var(--font-body-stack, system-ui, sans-serif)"
+    >
+      <defs>
+        <marker
+          id="arrow"
+          viewBox="0 0 10 10"
+          refX="8"
+          refY="5"
+          markerWidth="7"
+          markerHeight="7"
+          orient="auto-start-reverse"
+        >
+          <path d="M0,0 L10,5 L0,10 z" fill={LINE} />
+        </marker>
+      </defs>
+
+      {/* ---- Connectors (drawn first, behind the boxes) ---- */}
+      <g fill="none" stroke={LINE} strokeWidth={1.6}>
+        {/* Left loop: Daemon left → spawn(L) → Local → Executor left */}
+        <path d="M283,95 C205,95 120,105 120,168" markerEnd="url(#arrow)" />
+        <path d="M120,222 L120,262" markerEnd="url(#arrow)" />
+        <path d="M118,360 C118,430 210,470 292,486" markerEnd="url(#arrow)" />
+
+        {/* Center spine: Daemon → spawn(C) → Containerized → Executor */}
+        <path d="M410,158 L410,168" markerEnd="url(#arrow)" />
+        <path d="M410,222 L410,262" markerEnd="url(#arrow)" />
+        <path d="M410,360 L410,398" markerEnd="url(#arrow)" />
+
+        {/* Right loop (return): Executor right → WebSocket → Daemon right */}
+        <path d="M530,486 C650,486 662,392 662,330" />
+        <path d="M662,270 C662,150 605,108 539,100" markerEnd="url(#arrow)" />
+      </g>
+
+      {/* ---- Boxes ---- */}
+      {/* Daemon */}
+      <Box x={283} y={22} w={256} h={130} stroke="#34e6c4">
+        <text textAnchor="middle" fill={INK}>
+          <tspan x={411} y={54} fontWeight="700">
+            Daemon — orchestration
+          </tspan>
+          <tspan x={411} y={80} fill={MUTED} fontSize={13}>
+            REST + WebSocket API (FeathersJS)
+          </tspan>
+          <tspan x={411} y={100} fill={MUTED} fontSize={13}>
+            database · auth · executor tokens
+          </tspan>
+        </text>
+      </Box>
+
+      {/* Spawn label pills */}
+      <Box x={25} y={170} w={190} h={52} fill="#1c2926" stroke="rgba(255,255,255,0.1)">
+        <text textAnchor="middle" fill={MUTED} fontSize={13}>
+          <tspan x={120} y={192}>
+            spawn · typed JSON
+          </tspan>
+          <tspan x={120} y={210}>
+            via stdin
+          </tspan>
+        </text>
+      </Box>
+      <Box x={315} y={170} w={190} h={52} fill="#1c2926" stroke="rgba(255,255,255,0.1)">
+        <text textAnchor="middle" fill={MUTED} fontSize={13}>
+          <tspan x={410} y={192}>
+            spawn · typed JSON
+          </tspan>
+          <tspan x={410} y={210}>
+            via stdin
+          </tspan>
+        </text>
+      </Box>
+
+      {/* Local */}
+      <Box x={18} y={262} w={204} h={98}>
+        <text textAnchor="middle">
+          <tspan x={120} y={294} fill={INK} fontWeight="700">
+            Local
+          </tspan>
+          <tspan fill={MUTED} fontWeight="400">
+            {' '}
+            (default)
+          </tspan>
+          <tspan
+            x={120}
+            y={324}
+            fill={CODE}
+            fontSize={13}
+            fontFamily="var(--font-mono-stack, monospace)"
+          >
+            node executor --stdin
+          </tspan>
+        </text>
+      </Box>
+
+      {/* Containerized */}
+      <Box x={288} y={262} w={244} h={98}>
+        <text textAnchor="middle">
+          <tspan x={410} y={292} fill={INK} fontWeight="700">
+            Containerized
+          </tspan>
+          <tspan
+            x={410}
+            y={318}
+            fill={CODE}
+            fontSize={12.5}
+            fontFamily="var(--font-mono-stack, monospace)"
+          >
+            executor_command_template
+          </tspan>
+          <tspan
+            x={410}
+            y={338}
+            fill={CODE}
+            fontSize={12.5}
+            fontFamily="var(--font-mono-stack, monospace)"
+          >
+            via sh -c
+          </tspan>
+        </text>
+      </Box>
+
+      {/* Executor */}
+      <Box x={296} y={398} w={230} h={202} stroke="#e8c468">
+        <text textAnchor="middle">
+          <tspan x={411} y={430} fill={INK} fontWeight="700">
+            Executor — isolation
+          </tspan>
+          <tspan x={411} y={450} fill={INK} fontWeight="700">
+            boundary
+          </tspan>
+          <tspan fill={MUTED} fontWeight="400">
+            {' '}
+            (ephemeral)
+          </tspan>
+          <tspan x={411} y={484} fill={INK} fontSize={13} fontWeight="700">
+            Harnesses
+          </tspan>
+          <tspan x={411} y={503} fill={MUTED} fontSize={12.5}>
+            Claude Code · Codex · Gemini
+          </tspan>
+          <tspan x={411} y={521} fill={MUTED} fontSize={12.5}>
+            OpenCode · Copilot · Cursor
+          </tspan>
+          <tspan x={411} y={550} fill={INK} fontSize={13} fontWeight="700">
+            Git
+          </tspan>
+          <tspan fill={MUTED} fontSize={12.5} fontWeight="400">
+            {' '}
+            clone · branch
+          </tspan>
+          <tspan x={411} y={575} fill={INK} fontSize={13} fontWeight="700">
+            Terminals
+          </tspan>
+          <tspan fill={MUTED} fontSize={12.5} fontWeight="400">
+            {' '}
+            Zellij + node-pty
+          </tspan>
+        </text>
+      </Box>
+
+      {/* WebSocket return label */}
+      <Box x={575} y={272} w={180} h={54} fill="#1c2926" stroke="rgba(255,255,255,0.1)">
+        <text textAnchor="middle" fill={MUTED} fontSize={13}>
+          <tspan x={665} y={295}>
+            results + events
+          </tspan>
+          <tspan x={665} y={313}>
+            via WebSocket
+          </tspan>
+        </text>
+      </Box>
+    </svg>
+  );
+}

--- a/apps/agor-docs/components/ExecutorDiagram.tsx
+++ b/apps/agor-docs/components/ExecutorDiagram.tsx
@@ -9,6 +9,33 @@ const CODE = '#7fe8df';
 const MUTED = '#9fb4ae';
 const INK = '#eafff9';
 
+// Corner radius shared by every bend, so all four loop corners match.
+// 0 = sharp rectangle · large = more circular.
+const R = 26;
+
+// Orthogonal path through waypoints with a uniform rounded corner at each
+// interior point (quadratic bend of radius R). Keeps every corner identical.
+function roundPath(pts: Array<[number, number]>): string {
+  let d = `M${pts[0][0]},${pts[0][1]}`;
+  for (let i = 1; i < pts.length - 1; i++) {
+    const [px, py] = pts[i - 1];
+    const [cx, cy] = pts[i];
+    const [nx, ny] = pts[i + 1];
+    const inLen = Math.hypot(cx - px, cy - py);
+    const outLen = Math.hypot(nx - cx, ny - cy);
+    const ri = Math.min(R, inLen / 2);
+    const ro = Math.min(R, outLen / 2);
+    const ex = cx - ((cx - px) / inLen) * ri;
+    const ey = cy - ((cy - py) / inLen) * ri;
+    const xx = cx + ((nx - cx) / outLen) * ro;
+    const xy = cy + ((ny - cy) / outLen) * ro;
+    d += ` L${ex.toFixed(1)},${ey.toFixed(1)} Q${cx},${cy} ${xx.toFixed(1)},${xy.toFixed(1)}`;
+  }
+  const [lx, ly] = pts[pts.length - 1];
+  d += ` L${lx},${ly}`;
+  return d;
+}
+
 // Reusable box (rounded rect + centered multi-line text).
 function Box({
   x,
@@ -67,21 +94,44 @@ export function ExecutorDiagram() {
         </marker>
       </defs>
 
-      {/* ---- Connectors (drawn first, behind the boxes) ---- */}
+      {/* ---- Connectors (drawn first, behind the boxes). Every corner uses
+             the shared radius R via roundPath, so all four bends match. ---- */}
       <g fill="none" stroke={LINE} strokeWidth={1.6}>
-        {/* Left loop: Daemon left → spawn(L) → Local → Executor left */}
-        <path d="M283,95 C205,95 120,105 120,168" markerEnd="url(#arrow)" />
+        {/* Left arc: Daemon.left → spawn(L).top (corner) */}
+        <path
+          d={roundPath([
+            [283, 87],
+            [120, 87],
+            [120, 170],
+          ])}
+          markerEnd="url(#arrow)"
+        />
         <path d="M120,222 L120,262" markerEnd="url(#arrow)" />
-        <path d="M118,360 C118,430 210,470 292,486" markerEnd="url(#arrow)" />
+        {/* Left arc: Local.bottom → Executor.left (corner) */}
+        <path
+          d={roundPath([
+            [120, 360],
+            [120, 499],
+            [292, 499],
+          ])}
+          markerEnd="url(#arrow)"
+        />
 
-        {/* Center spine: Daemon → spawn(C) → Containerized → Executor */}
-        <path d="M410,158 L410,168" markerEnd="url(#arrow)" />
+        {/* Center spine (straight) */}
+        <path d="M410,152 L410,168" markerEnd="url(#arrow)" />
         <path d="M410,222 L410,262" markerEnd="url(#arrow)" />
-        <path d="M410,360 L410,398" markerEnd="url(#arrow)" />
+        <path d="M411,360 L411,396" markerEnd="url(#arrow)" />
 
-        {/* Right loop (return): Executor right → WebSocket → Daemon right */}
-        <path d="M530,486 C650,486 662,392 662,330" />
-        <path d="M662,270 C662,150 605,108 539,100" markerEnd="url(#arrow)" />
+        {/* Right arc (return): Executor.right → up → Daemon.right (two corners) */}
+        <path
+          d={roundPath([
+            [526, 499],
+            [662, 499],
+            [662, 87],
+            [543, 87],
+          ])}
+          markerEnd="url(#arrow)"
+        />
       </g>
 
       {/* ---- Boxes ---- */}

--- a/apps/agor-docs/components/ExecutorDiagram.tsx
+++ b/apps/agor-docs/components/ExecutorDiagram.tsx
@@ -94,20 +94,21 @@ export function ExecutorDiagram() {
         </marker>
       </defs>
 
-      {/* ---- Connectors (drawn first, behind the boxes). Every corner uses
-             the shared radius R via roundPath, so all four bends match. ---- */}
+      {/* ---- Connectors (drawn first, behind the boxes). The spawn/WebSocket
+             pills are labels that sit ON these lines — each edge is one
+             continuous line with a single arrowhead at its destination NODE,
+             so no pill has an inbound arrow. Every corner shares radius R. ---- */}
       <g fill="none" stroke={LINE} strokeWidth={1.6}>
-        {/* Left arc: Daemon.left → spawn(L).top (corner) */}
+        {/* Left branch: Daemon.left → Local.top (left spawn pill sits on it) */}
         <path
           d={roundPath([
-            [283, 87],
-            [120, 87],
-            [120, 170],
+            [283, 74],
+            [120, 74],
+            [120, 262],
           ])}
           markerEnd="url(#arrow)"
         />
-        <path d="M120,222 L120,262" markerEnd="url(#arrow)" />
-        {/* Left arc: Local.bottom → Executor.left (corner) */}
+        {/* Local.bottom → Executor.left */}
         <path
           d={roundPath([
             [120, 360],
@@ -117,18 +118,19 @@ export function ExecutorDiagram() {
           markerEnd="url(#arrow)"
         />
 
-        {/* Center spine (straight) */}
-        <path d="M410,152 L410,168" markerEnd="url(#arrow)" />
-        <path d="M410,222 L410,262" markerEnd="url(#arrow)" />
+        {/* Center branch: Daemon.bottom → Containerized.top (spawn pill on it) */}
+        <path d="M410,126 L410,262" markerEnd="url(#arrow)" />
+        {/* Containerized.bottom → Executor.top */}
         <path d="M411,360 L411,396" markerEnd="url(#arrow)" />
 
-        {/* Right arc (return): Executor.right → up → Daemon.right (two corners) */}
+        {/* Right branch (return): Executor.right → Daemon.right (WebSocket pill
+            sits on it) */}
         <path
           d={roundPath([
             [526, 499],
-            [662, 499],
-            [662, 87],
-            [543, 87],
+            [665, 499],
+            [665, 74],
+            [539, 74],
           ])}
           markerEnd="url(#arrow)"
         />
@@ -136,15 +138,15 @@ export function ExecutorDiagram() {
 
       {/* ---- Boxes ---- */}
       {/* Daemon */}
-      <Box x={283} y={22} w={256} h={130} stroke="#34e6c4">
+      <Box x={283} y={22} w={256} h={104} stroke="#34e6c4">
         <text textAnchor="middle" fill={INK}>
-          <tspan x={411} y={54} fontWeight="700">
+          <tspan x={411} y={52} fontWeight="700">
             Daemon — orchestration
           </tspan>
-          <tspan x={411} y={80} fill={MUTED} fontSize={13}>
+          <tspan x={411} y={77} fill={MUTED} fontSize={13}>
             REST + WebSocket API (FeathersJS)
           </tspan>
-          <tspan x={411} y={100} fill={MUTED} fontSize={13}>
+          <tspan x={411} y={97} fill={MUTED} fontSize={13}>
             database · auth · executor tokens
           </tspan>
         </text>

--- a/apps/agor-docs/components/FaqSection.module.css
+++ b/apps/agor-docs/components/FaqSection.module.css
@@ -1,0 +1,51 @@
+.card {
+  position: relative;
+  margin: 1.5rem 0;
+  padding: 1.5rem 1.75rem 1.75rem;
+  border: 1px solid rgba(52, 230, 196, 0.14);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(52, 230, 196, 0.035), transparent 120px), rgba(9, 20, 18, 0.5);
+}
+
+/* Mint accent rail down the left edge — the visual cue that breaks the wall
+ * of text into discrete answers without collapsing anything. */
+.card::before {
+  content: "";
+  position: absolute;
+  top: 1.4rem;
+  bottom: 1.4rem;
+  left: 0;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: linear-gradient(180deg, #34e6c4, rgba(52, 230, 196, 0.15));
+}
+
+/* The question heading becomes the card header — kill the default large top
+ * margin and the theme's under-heading border so it reads as a title. */
+.card :global(h2) {
+  margin-top: 0;
+  margin-bottom: 0.9rem;
+  padding-bottom: 0;
+  border-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.card :global(h2 a) {
+  color: var(--agor-teal, #34e6c4);
+}
+
+/* First child (usually the lead paragraph or heading) shouldn't add top gap. */
+.card > :first-child {
+  margin-top: 0;
+}
+
+.card > :last-child {
+  margin-bottom: 0;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.25rem 1.25rem 1.4rem;
+  }
+}

--- a/apps/agor-docs/components/FaqSection.tsx
+++ b/apps/agor-docs/components/FaqSection.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+import styles from './FaqSection.module.css';
+
+// Presentational container for one FAQ question + answer. The `## heading`
+// stays as real markdown inside `children` so Nextra's TOC/anchors keep
+// working — this only adds the card chrome around each section.
+export function FaqSection({ children }: { children: ReactNode }) {
+  return <section className={styles.card}>{children}</section>;
+}

--- a/apps/agor-docs/components/MermaidZoom.module.css
+++ b/apps/agor-docs/components/MermaidZoom.module.css
@@ -1,0 +1,107 @@
+/* Affordance on inline mermaid diagrams. */
+.host {
+  position: relative;
+  cursor: zoom-in;
+  transition: outline-color 140ms ease;
+  outline: 1px solid transparent;
+  border-radius: 8px;
+}
+
+.host:hover {
+  outline-color: rgba(52, 230, 196, 0.4);
+}
+
+.host::after {
+  content: "⤢ click to enlarge";
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: rgba(8, 18, 16, 0.85);
+  color: #7fe8df;
+  font-size: 11px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease;
+}
+
+.host:hover::after {
+  opacity: 1;
+}
+
+/* Lightbox. */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  background: rgba(4, 10, 9, 0.82);
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  animation: mzFade 180ms ease both;
+}
+
+@keyframes mzFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.viewport {
+  flex: 1;
+  overflow: auto;
+  cursor: grab;
+  padding: 4vh 4vw;
+}
+
+.viewport:active {
+  cursor: grabbing;
+}
+
+.stage {
+  width: max-content;
+  margin: auto;
+  transform-origin: center center;
+}
+
+/* Enlarge the cloned SVG well past its inline size as the zoom baseline. */
+.stage svg {
+  width: min(1600px, 88vw);
+  height: auto;
+}
+
+.toolbar {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1;
+  display: flex;
+  gap: 6px;
+}
+
+.toolbar button {
+  min-width: 40px;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid rgba(52, 230, 196, 0.3);
+  border-radius: 8px;
+  background: rgba(8, 18, 16, 0.9);
+  color: #cfe0db;
+  font-size: 15px;
+  cursor: pointer;
+}
+
+.toolbar button:hover {
+  border-color: rgba(52, 230, 196, 0.6);
+  color: #34e6c4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backdrop {
+    animation-duration: 1ms;
+  }
+}

--- a/apps/agor-docs/components/MermaidZoom.tsx
+++ b/apps/agor-docs/components/MermaidZoom.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import styles from './MermaidZoom.module.css';
+
+// Mounted once in the docs layout. Nextra renders mermaid diagrams inline and
+// they're often too small to read; this makes every mermaid SVG click-to-open
+// in a lightbox with wheel/button zoom and drag-to-pan. Diagrams render
+// client-side and async, so a MutationObserver catches ones that appear late.
+export function MermaidZoom() {
+  const [svgHtml, setSvgHtml] = useState<string | null>(null);
+  const [scale, setScale] = useState(1);
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setSvgHtml(null), []);
+
+  // Tag mermaid diagrams with an affordance + click handler.
+  useEffect(() => {
+    const enhance = () => {
+      const svgs = document.querySelectorAll<SVGSVGElement>(
+        'main svg[id^="mermaid"], main svg[aria-roledescription]'
+      );
+      for (const svg of svgs) {
+        const host = svg.closest<HTMLElement>('[data-mermaid-zoom]') ?? svg.parentElement;
+        if (!host || host.dataset.mermaidZoom === 'on') {
+          continue;
+        }
+        host.dataset.mermaidZoom = 'on';
+        host.classList.add(styles.host);
+        host.addEventListener('click', () => {
+          setScale(1);
+          setSvgHtml(svg.outerHTML);
+        });
+      }
+    };
+    enhance();
+    const mo = new MutationObserver(enhance);
+    mo.observe(document.body, { childList: true, subtree: true });
+    return () => mo.disconnect();
+  }, []);
+
+  // Escape to close.
+  useEffect(() => {
+    if (!svgHtml) {
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [svgHtml, close]);
+
+  // Wheel = zoom toward a clamped range.
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    setScale((s) => Math.min(6, Math.max(0.4, s * (e.deltaY < 0 ? 1.12 : 0.89))));
+  };
+
+  // Drag to pan the scroll viewport.
+  const drag = useRef<{ x: number; y: number; l: number; t: number } | null>(null);
+  const onPointerDown = (e: React.PointerEvent) => {
+    const vp = viewportRef.current;
+    if (!vp) {
+      return;
+    }
+    vp.setPointerCapture(e.pointerId);
+    drag.current = { x: e.clientX, y: e.clientY, l: vp.scrollLeft, t: vp.scrollTop };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    const vp = viewportRef.current;
+    if (!vp || !drag.current) {
+      return;
+    }
+    vp.scrollLeft = drag.current.l - (e.clientX - drag.current.x);
+    vp.scrollTop = drag.current.t - (e.clientY - drag.current.y);
+  };
+  const onPointerUp = () => {
+    drag.current = null;
+  };
+
+  if (!svgHtml) {
+    return null;
+  }
+
+  return (
+    <div
+      className={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Enlarged diagram"
+      onClick={close}
+      onKeyDown={(e) => e.key === 'Escape' && close()}
+    >
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: buttons carry their own handlers; this only stops backdrop close */}
+      <div className={styles.toolbar} onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          aria-label="Zoom out"
+          onClick={() => setScale((s) => Math.max(0.4, s * 0.83))}
+        >
+          −
+        </button>
+        <button type="button" aria-label="Reset zoom" onClick={() => setScale(1)}>
+          {Math.round(scale * 100)}%
+        </button>
+        <button
+          type="button"
+          aria-label="Zoom in"
+          onClick={() => setScale((s) => Math.min(6, s * 1.2))}
+        >
+          +
+        </button>
+        <button type="button" aria-label="Close" onClick={close}>
+          ✕
+        </button>
+      </div>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop handles keys; this just stops propagation */}
+      <div
+        ref={viewportRef}
+        className={styles.viewport}
+        onClick={(e) => e.stopPropagation()}
+        onWheel={onWheel}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+      >
+        <div
+          className={styles.stage}
+          style={{ transform: `scale(${scale})` }}
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: cloning our own already-rendered mermaid SVG, not user input
+          dangerouslySetInnerHTML={{ __html: svgHtml }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/agor-docs/components/ScrollTable.module.css
+++ b/apps/agor-docs/components/ScrollTable.module.css
@@ -1,0 +1,61 @@
+.scroll {
+  margin: 1.25rem 0;
+  overflow-x: auto;
+  /* Visible scroll affordance: a thin always-styled scrollbar. */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(52, 230, 196, 0.4) transparent;
+}
+
+.scroll::-webkit-scrollbar {
+  height: 8px;
+}
+.scroll::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background: rgba(52, 230, 196, 0.4);
+}
+.scroll::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.scroll table {
+  margin: 0;
+  width: max-content;
+  min-width: 100%;
+  /* Nextra makes tables their own overflow-x:auto scroll container; undo that
+   * so THIS wrapper is the sole scroll container and sticky cells stick to it. */
+  display: table;
+  overflow: visible;
+  /* separate (not collapse) so position: sticky works on cells; spacing 0
+   * keeps it visually collapsed. Cells carry their own right/bottom borders. */
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.scroll :is(th, td) {
+  border: 0;
+  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* Pin the first column. */
+.scroll :is(th, td):first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+.scroll thead th:first-child {
+  z-index: 2;
+}
+
+/* Opaque background + a soft shadow on the frozen column's right edge so it
+ * reads as pinned while the rest scrolls under it. Light is the base; the
+ * global .dark theme class (not a module-scoped one) overrides for dark. */
+.scroll :is(th, td):first-child {
+  background: #fff;
+  box-shadow: 7px 0 9px -7px rgba(0, 0, 0, 0.18);
+}
+
+:global(.dark) .scroll :is(th, td):first-child {
+  background: #0b1613;
+  box-shadow: 7px 0 9px -7px rgba(0, 0, 0, 0.7);
+}

--- a/apps/agor-docs/components/ScrollTable.tsx
+++ b/apps/agor-docs/components/ScrollTable.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+import styles from './ScrollTable.module.css';
+
+// Wraps a wide markdown table in a horizontal scroll container with the first
+// column pinned (frozen) and a visible scroll affordance. Author a normal
+// markdown table inside <ScrollTable>.
+export function ScrollTable({ children }: { children: ReactNode }) {
+  return <div className={styles.scroll}>{children}</div>;
+}

--- a/apps/agor-docs/components/Tree.module.css
+++ b/apps/agor-docs/components/Tree.module.css
@@ -1,0 +1,85 @@
+.tree {
+  margin: 1.25rem 0;
+  padding: 16px 20px;
+  border: 1px solid rgba(52, 230, 196, 0.14);
+  border-radius: 12px;
+  background: rgba(9, 20, 18, 0.5);
+  font-family: var(--font-mono-stack, ui-monospace, monospace);
+  font-size: 0.84rem;
+  line-height: 1.85;
+  overflow-x: auto;
+}
+
+.tree ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Root rows (branch/session/parent): brighter, small gap between trees. */
+.tree > ul > li {
+  margin-top: 0.55rem;
+  color: var(--agor-ink, #eafff9);
+}
+
+.tree > ul > li:first-child {
+  margin-top: 0;
+}
+
+/* Nested lists indent under their parent row. */
+.tree li ul {
+  margin-left: 3px;
+  padding-left: 17px;
+}
+
+/* Nested rows get the connector glyphs + muted color. */
+.tree li li {
+  position: relative;
+  padding-left: 20px;
+  color: var(--agor-muted, #9fb4ae);
+}
+
+/* Vertical guide (│). Spans the row's full height so it reaches the next
+ * sibling; the last child truncates it into an └ below. */
+.tree li li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-left: 1px solid rgba(148, 178, 170, 0.38);
+}
+
+/* Horizontal tick (─) into each row. */
+.tree li li::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.92em;
+  width: 12px;
+  border-top: 1px solid rgba(148, 178, 170, 0.38);
+}
+
+/* Last child: stop the vertical at the tick so it reads as └ not ├. */
+.tree li li:last-child::before {
+  bottom: auto;
+  height: 0.92em;
+}
+
+.tree code {
+  padding: 0 4px;
+  border-radius: 4px;
+  background: rgba(52, 230, 196, 0.08);
+  color: #7fe8df;
+  font-size: 0.95em;
+}
+
+/* Emphasis is used for inline annotations ("same branch"). */
+.tree em {
+  color: #6f928c;
+  font-style: normal;
+}
+
+.tree em::before {
+  content: "← ";
+}

--- a/apps/agor-docs/components/Tree.tsx
+++ b/apps/agor-docs/components/Tree.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+import styles from './Tree.module.css';
+
+// Styles a plain nested markdown list as an ASCII-style tree (├─ └─ │ drawn
+// with CSS borders). Author the content as a normal markdown list inside
+// <Tree> — no bespoke data structure, stays maintainable and diffable.
+export function Tree({ children }: { children: ReactNode }) {
+  return <div className={styles.tree}>{children}</div>;
+}

--- a/apps/agor-docs/content/faq.mdx
+++ b/apps/agor-docs/content/faq.mdx
@@ -3,7 +3,11 @@ title: FAQ
 description: Frequently asked questions about branches, multi-repo workflows, session forking, spawning, and Agor's multiplayer workflow
 ---
 
+import { FaqSection } from '../components/FaqSection';
+
 # FAQ
+
+<FaqSection>
 
 ## What's a branch?
 
@@ -36,6 +40,10 @@ Each branch is completely isolated - changes in one don't affect the other. This
 
 **Agor manages the git branches for you** - no need to run `git worktree add` manually. Just create a branch in the UI or CLI, and Agor handles the git operations.
 
+</FaqSection>
+
+<FaqSection>
+
 ## Can Agor work on multiple repos or branches?
 
 Yes. Agor can support workflows that span multiple repositories and branches. The right pattern depends on how those repos relate to each other.
@@ -55,6 +63,10 @@ For coordinated work across independent repos, create Agor branches for the same
 The orchestrating agent can do the cross-repo work itself, or it can spawn and coordinate agents in each branch.
 
 Agor's strength is the control plane: multiple isolated branches, visible on boards, with agents that can coordinate across them. A single OS working directory is still one branch/workspace, but Agor makes multi-repo work natural through orchestration, branch alignment, and multi-agent visibility.
+
+</FaqSection>
+
+<FaqSection>
 
 ## Session trees? WTF?
 
@@ -95,6 +107,10 @@ Most people don't know you can do this! Context engineering is usually about:
 4. Inspect the entire tree to understand how work evolved
 
 **Visual organization**: On boards, you see branches (projects) containing session trees (conversation genealogy). It's like Trello for AI conversations, but with git-style branching.
+
+</FaqSection>
+
+<FaqSection>
 
 ## Why a spatial layout for AI coding sessions?
 
@@ -185,6 +201,10 @@ Figma revolutionized design collaboration with:
 **The spatial layout isn't just "pretty"** - it's a fundamental match for how humans organize complex, multi-threaded work with multiple collaborators.
 
 You wouldn't manage a large codebase without a file tree. Why manage AI sessions without spatial organization?
+
+</FaqSection>
+
+<FaqSection>
 
 ## Zones? Zone "triggers"?
 
@@ -346,6 +366,10 @@ AI: "Reviewing implementation of https://github.com/myorg/repo/issues/123..."
 
 Drag to trigger. Context flows automatically. No manual copy-paste.
 
+</FaqSection>
+
+<FaqSection>
+
 ## What happens when I "fork" a session?
 
 **Forking creates a sibling session with a COPY of the conversation context at that moment** - perfect for parallel work streams that need the same starting knowledge but different focus.
@@ -385,6 +409,10 @@ Forks **share the branch** (same filesystem) but **copy the context** (snapshot 
 You're not exploring alternative implementations (they'd conflict on disk!) - you're doing parallel work that starts from the same knowledge but different focus.
 
 ---
+
+</FaqSection>
+
+<FaqSection>
 
 ## What happens when I "spawn" a subsession?
 
@@ -457,6 +485,10 @@ Parent orchestrates, children execute focused subsessions with clean context.
 
 ---
 
+</FaqSection>
+
+<FaqSection>
+
 ## Fork vs Spawn: Quick Reference
 
 |                         | **Fork**                                   | **Spawn**                                      |
@@ -472,6 +504,10 @@ Parent orchestrates, children execute focused subsessions with clean context.
 | **Reports back?**       | No                                         | No (currently, may add callback)               |
 
 ---
+
+</FaqSection>
+
+<FaqSection>
 
 ## When should I fork a session vs create a new branch?
 
@@ -512,6 +548,10 @@ Branch "payment-feature" (issue #124, PR #457)  <- Different feature = different
 
 ---
 
+</FaqSection>
+
+<FaqSection>
+
 ## Best Practices
 
 ### ✅ DO:
@@ -528,6 +568,10 @@ Branch "payment-feature" (issue #124, PR #457)  <- Different feature = different
 - Don't nest spawns too deeply (2-3 levels max)
 
 ---
+
+</FaqSection>
+
+<FaqSection>
 
 ## Summary
 
@@ -547,9 +591,13 @@ Example: Build Feature 1 once. Fork 3 times:
 
 All running in parallel, same codebase, each starting from the same understanding.
 
-<a id="open-source-telemetry" />
+</FaqSection>
+
+<FaqSection>
 
 ## What does Agor's open-source telemetry collect?
+
+<a id="open-source-telemetry" />
 
 During `agor init`, Agor explains its open-source telemetry and asks whether to enable ongoing anonymous telemetry. Agor sends one anonymous install result so the maintainers can count installs and whether ongoing telemetry was enabled. To disable all telemetry, including that one-time install result, set `AGOR_TELEMETRY=0` before running Agor.
 
@@ -573,3 +621,5 @@ agor telemetry
 
 `DO_NOT_TRACK=1` and `AGOR_TELEMETRY=0` disable telemetry regardless of config.
 `AGOR_TELEMETRY=1` explicitly enables telemetry and creates an anonymous install ID if one has not been configured yet.
+
+</FaqSection>

--- a/apps/agor-docs/content/faq.mdx
+++ b/apps/agor-docs/content/faq.mdx
@@ -4,6 +4,7 @@ description: Frequently asked questions about branches, multi-repo workflows, se
 ---
 
 import { FaqSection } from '../components/FaqSection';
+import { Tree } from '../components/Tree';
 
 # FAQ
 
@@ -24,17 +25,18 @@ Agor uses **git branches** under the hood (same concept as `git branch` command)
 
 **Best practice**: 1 branch = 1 issue = 1 PR = 1 feature
 
-```
-Branch "auth-feature" (issue #123, PR #456)
-├─ Working directory: ~/.agor/worktrees/myapp/auth-feature
-├─ Git ref: feature/oauth2-auth
-└─ Sessions: All AI sessions working on this feature
+<Tree>
 
-Branch "payment-integration" (issue #124, PR #457)
-├─ Working directory: ~/.agor/worktrees/myapp/payment-integration
-├─ Git ref: feature/stripe-integration
-└─ Sessions: All AI sessions working on this feature
-```
+- Branch `auth-feature` (issue #123, PR #456)
+  - Working directory: `~/.agor/worktrees/myapp/auth-feature`
+  - Git ref: `feature/oauth2-auth`
+  - Sessions: All AI sessions working on this feature
+- Branch `payment-integration` (issue #124, PR #457)
+  - Working directory: `~/.agor/worktrees/myapp/payment-integration`
+  - Git ref: `feature/stripe-integration`
+  - Sessions: All AI sessions working on this feature
+
+</Tree>
 
 Each branch is completely isolated - changes in one don't affect the other. This lets you work on multiple features simultaneously without switching branches or stashing changes.
 
@@ -72,13 +74,15 @@ Agor's strength is the control plane: multiple isolated branches, visible on boa
 
 **Sessions in Agor can fork and spawn, creating genealogy trees** - this is what makes Agor fundamentally different from linear CLI tools.
 
-```
-Session: "Build authentication system"
-├─ Fork: "Write tests for auth"
-├─ Fork: "Build user profile that uses auth"
-└─ Spawn: "Research OAuth2 best practices"
-   └─ Spawn: "Evaluate PKCE vs implicit flow"
-```
+<Tree>
+
+- Session: "Build authentication system"
+  - Fork: "Write tests for auth"
+  - Fork: "Build user profile that uses auth"
+  - Spawn: "Research OAuth2 best practices"
+    - Spawn: "Evaluate PKCE vs implicit flow"
+
+</Tree>
 
 ### Why this matters:
 
@@ -387,12 +391,14 @@ After forking, the conversations diverge. The fork has its own independent conve
 
 **Parallelize work that needs the same starting context**
 
-```
-Session: "Built user authentication feature" <- snapshot taken here
-├─ Fork A: "Write comprehensive unit tests for auth"
-├─ Fork B: "Build user profile page that uses auth"
-└─ Fork C: "Generate API documentation"
-```
+<Tree>
+
+- Session: "Built user authentication feature" _snapshot taken here_
+  - Fork A: "Write comprehensive unit tests for auth"
+  - Fork B: "Build user profile page that uses auth"
+  - Fork C: "Generate API documentation"
+
+</Tree>
 
 Each fork starts with the full context of how auth works, then builds its own conversation. They work on different files so no conflicts.
 
@@ -465,21 +471,25 @@ Then later, prompt the parent: `"Read /tmp/payment-report.md and integrate the p
 
 **Break down complex work**
 
-```
-Parent: "Build complete e-commerce checkout flow"
-├─ Spawn: "Implement payment gateway integration"
-├─ Spawn: "Build inventory validation service"
-└─ Spawn: "Create order confirmation email templates"
-```
+<Tree>
+
+- Parent: "Build complete e-commerce checkout flow"
+  - Spawn: "Implement payment gateway integration"
+  - Spawn: "Build inventory validation service"
+  - Spawn: "Create order confirmation email templates"
+
+</Tree>
 
 **Delegate to different agents**
 
-```
-Parent (Claude): "Refactor legacy codebase"
-├─ Spawn (Codex): "Write comprehensive unit tests"
-├─ Spawn (Gemini): "Generate API documentation"
-└─ Spawn (Claude): "Extract common utilities"
-```
+<Tree>
+
+- Parent (Claude): "Refactor legacy codebase"
+  - Spawn (Codex): "Write comprehensive unit tests"
+  - Spawn (Gemini): "Generate API documentation"
+  - Spawn (Claude): "Extract common utilities"
+
+</Tree>
 
 Parent orchestrates, children execute focused subsessions with clean context.
 
@@ -533,16 +543,17 @@ Parent orchestrates, children execute focused subsessions with clean context.
 
 **Example:**
 
-```
-Branch "auth-feature" (issue #123, PR #456)
-└─ Session: "Build OAuth2 authentication"
-   ├─ Fork: "Write unit tests for OAuth2"        <- Same branch
-   ├─ Fork: "Build user profile that uses auth"  <- Same branch
-   └─ Fork: "Document OAuth2 API"                <- Same branch
+<Tree>
 
-Branch "payment-feature" (issue #124, PR #457)  <- Different feature = different branch
-└─ Session: "Build Stripe integration"
-```
+- Branch `auth-feature` (issue #123, PR #456)
+  - Session: "Build OAuth2 authentication"
+    - Fork: "Write unit tests for OAuth2" _same branch_
+    - Fork: "Build user profile that uses auth" _same branch_
+    - Fork: "Document OAuth2 API" _same branch_
+- Branch `payment-feature` (issue #124, PR #457) _different feature = different branch_
+  - Session: "Build Stripe integration"
+
+</Tree>
 
 **Rule of thumb**: If they're working on the same issue/feature and won't conflict on disk, fork the session. If they're different features or would conflict, use a different Agor branch.
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -3,6 +3,8 @@ title: Containerized Execution
 description: Running Agor executors in Kubernetes, Docker, or other containerized environments with shared storage
 ---
 
+import { ExecutorDiagram } from '../../components/ExecutorDiagram';
+
 # Containerized Execution
 
 This guide covers running Agor's executor component in containerized environments like Kubernetes, enabling scalable and isolated execution of AI coding agents.
@@ -18,24 +20,7 @@ Agor's architecture separates the **daemon** (orchestration layer) from the **ex
 
 ### The Executor Model
 
-```mermaid
-graph TB
-    Daemon["<b>Daemon — orchestration</b><br/>REST + WebSocket API (FeathersJS)<br/>database · auth · executor tokens"]
-    Local["<b>Local</b> (default)<br/><code>node executor --stdin</code>"]
-    Remote["<b>Containerized</b><br/><code>executor_command_template</code> via <code>sh -c</code>"]
-    Executor["<b>Executor — isolation boundary</b> (ephemeral)<br/>Harnesses: Claude Code · Codex · Gemini<br/>OpenCode · Copilot · Cursor<br/>Git mutations (clone · branch) · Terminals (Zellij + node-pty)"]
-
-    Daemon ==>|"spawn · typed JSON via stdin"| Local
-    Daemon ==>|"spawn · typed JSON via stdin"| Remote
-    Local --> Executor
-    Remote --> Executor
-    Executor -.->|"results + events via WebSocket"| Daemon
-
-    classDef trusted stroke:#34e6c4,stroke-width:1.5px;
-    classDef iso stroke:#e8c468,stroke-width:1.5px;
-    class Daemon trusted;
-    class Executor iso;
-```
+<ExecutorDiagram />
 
 The daemon owns orchestration and delegates all git **mutations** to the executor — it still runs read-only git probes (remote URL, default branch) and credential scrubbing itself. Each executor process handles a single command and exits, except terminal (Zellij) executors, which stay alive until closed.
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -22,12 +22,14 @@ Agor's architecture separates the **daemon** (orchestration layer) from the **ex
 %%{init: {'flowchart': {'curve': 'step', 'wrappingWidth': 340}}}%%
 graph TB
     Daemon["<b>Daemon — orchestration</b><br/>REST + WebSocket API (FeathersJS)<br/>database · auth · executor tokens"]
+    Spawn["spawn · typed JSON payload via stdin"]
     Local["<b>Local</b> (default)<br/><code>node executor --stdin</code>"]
     Remote["<b>Containerized</b><br/><code>executor_command_template</code> via <code>sh -c</code>"]
     Executor["<b>Executor — isolation boundary</b><br/>ephemeral · one per command<br/>&nbsp;<br/><b>Harnesses</b>&nbsp; Claude Code · Codex · Gemini<br/>OpenCode · Copilot · Cursor<br/><b>Git</b>&nbsp; clone · branch<br/><b>Terminals</b>&nbsp; Zellij + node-pty"]
 
-    Daemon -->|"spawn · typed JSON via stdin"| Local
-    Daemon -->|"spawn · typed JSON via stdin"| Remote
+    Daemon --> Spawn
+    Spawn --> Local
+    Spawn --> Remote
     Local --> Executor
     Remote --> Executor
     Executor -.->|"results + events via WebSocket"| Daemon

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -18,37 +18,32 @@ Agor's architecture separates the **daemon** (orchestration layer) from the **ex
 
 ### The Executor Model
 
+```mermaid
+graph TB
+    Daemon["<b>Daemon — orchestration</b><br/>REST + WebSocket API (FeathersJS)<br/>database · auth · executor tokens"]
+    Local["<b>Local</b> (default)<br/><code>node executor --stdin</code>"]
+    Remote["<b>Containerized</b><br/><code>executor_command_template</code> via <code>sh -c</code>"]
+    Executor["<b>Executor — isolation boundary</b> (ephemeral)<br/>Harnesses: Claude Code · Codex · Gemini<br/>OpenCode · Copilot · Cursor<br/>Git mutations (clone · branch) · Terminals (Zellij + node-pty)"]
+
+    Daemon ==>|"spawn · typed JSON via stdin"| Local
+    Daemon ==>|"spawn · typed JSON via stdin"| Remote
+    Local --> Executor
+    Remote --> Executor
+    Executor -.->|"results + events via WebSocket"| Daemon
+
+    classDef trusted stroke:#34e6c4,stroke-width:1.5px;
+    classDef iso stroke:#e8c468,stroke-width:1.5px;
+    class Daemon trusted;
+    class Executor iso;
 ```
-┌─────────────────────────────────────────────────────────────┐
-│  Daemon (Orchestration Layer)                               │
-│  - REST/WebSocket API                                       │
-│  - Database (sessions, tasks, branches)                    │
-│  - User authentication                                      │
-│  - Never touches git data directly                          │
-│                                                             │
-│  Spawns executor via:                                       │
-│  - Local: spawn('agor-executor', ['--stdin'])              │
-│  - Remote: template → kubectl run ... | agor-executor      │
-└─────────────────────────────────────────────────────────────┘
-                          │
-                          │ JSON payload via stdin
-                          ▼
-┌─────────────────────────────────────────────────────────────┐
-│  Executor (Isolation Boundary)                              │
-│  - Receives typed JSON payload                              │
-│  - Connects back to daemon via WebSocket                    │
-│  - Runs agent SDKs (Claude, Gemini, Codex)                 │
-│  - Manages git operations (clone, branch)                 │
-│  - Handles terminal sessions (Zellij)                       │
-│  - Short-lived: exits when command completes                │
-└─────────────────────────────────────────────────────────────┘
-```
+
+The daemon owns orchestration and delegates all git **mutations** to the executor — it still runs read-only git probes (remote URL, default branch) and credential scrubbing itself. Each executor process handles a single command and exits, except terminal (Zellij) executors, which stay alive until closed.
 
 ### What the Executor Does
 
 | Command               | Purpose                                        |
 | --------------------- | ---------------------------------------------- |
-| `prompt`              | Execute agent SDK (Claude Code, Gemini, Codex) |
+| `prompt`              | Run an agent harness (Claude Code, Codex, Gemini, OpenCode, Copilot, Cursor) |
 | `git.clone`           | Clone repository with Unix group setup         |
 | `git.branch.add`    | Create git branch with permissions           |
 | `git.branch.remove` | Remove branch and cleanup                    |

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -19,7 +19,7 @@ Agor's architecture separates the **daemon** (orchestration layer) from the **ex
 ### The Executor Model
 
 ```mermaid
-%%{init: {'flowchart': {'curve': 'step', 'wrappingWidth': 340}}}%%
+%%{init: {'flowchart': {'wrappingWidth': 340}}}%%
 graph TB
     Daemon["<b>Daemon — orchestration</b><br/>REST + WebSocket API (FeathersJS)<br/>database · auth · executor tokens"]
     Spawn["spawn · typed JSON payload via stdin"]

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -19,17 +19,14 @@ Agor's architecture separates the **daemon** (orchestration layer) from the **ex
 ### The Executor Model
 
 ```mermaid
-%%{init: {'flowchart': {'wrappingWidth': 340}}}%%
 graph TB
     Daemon["<b>Daemon — orchestration</b><br/>REST + WebSocket API (FeathersJS)<br/>database · auth · executor tokens"]
-    Spawn["spawn · typed JSON payload via stdin"]
     Local["<b>Local</b> (default)<br/><code>node executor --stdin</code>"]
     Remote["<b>Containerized</b><br/><code>executor_command_template</code> via <code>sh -c</code>"]
-    Executor["<b>Executor — isolation boundary</b><br/>ephemeral · one per command<br/>&nbsp;<br/><b>Harnesses</b>&nbsp; Claude Code · Codex · Gemini<br/>OpenCode · Copilot · Cursor<br/><b>Git</b>&nbsp; clone · branch<br/><b>Terminals</b>&nbsp; Zellij + node-pty"]
+    Executor["<b>Executor — isolation boundary</b> (ephemeral)<br/>Harnesses: Claude Code · Codex · Gemini<br/>OpenCode · Copilot · Cursor<br/>Git mutations (clone · branch) · Terminals (Zellij + node-pty)"]
 
-    Daemon --> Spawn
-    Spawn --> Local
-    Spawn --> Remote
+    Daemon ==>|"spawn · typed JSON via stdin"| Local
+    Daemon ==>|"spawn · typed JSON via stdin"| Remote
     Local --> Executor
     Remote --> Executor
     Executor -.->|"results + events via WebSocket"| Daemon

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -19,14 +19,15 @@ Agor's architecture separates the **daemon** (orchestration layer) from the **ex
 ### The Executor Model
 
 ```mermaid
+%%{init: {'flowchart': {'curve': 'step', 'wrappingWidth': 340}}}%%
 graph TB
     Daemon["<b>Daemon — orchestration</b><br/>REST + WebSocket API (FeathersJS)<br/>database · auth · executor tokens"]
     Local["<b>Local</b> (default)<br/><code>node executor --stdin</code>"]
     Remote["<b>Containerized</b><br/><code>executor_command_template</code> via <code>sh -c</code>"]
-    Executor["<b>Executor — isolation boundary</b> (ephemeral)<br/>Harnesses: Claude Code · Codex · Gemini<br/>OpenCode · Copilot · Cursor<br/>Git mutations (clone · branch) · Terminals (Zellij + node-pty)"]
+    Executor["<b>Executor — isolation boundary</b><br/>ephemeral · one per command<br/>&nbsp;<br/><b>Harnesses</b>&nbsp; Claude Code · Codex · Gemini<br/>OpenCode · Copilot · Cursor<br/><b>Git</b>&nbsp; clone · branch<br/><b>Terminals</b>&nbsp; Zellij + node-pty"]
 
-    Daemon ==>|"spawn · typed JSON via stdin"| Local
-    Daemon ==>|"spawn · typed JSON via stdin"| Remote
+    Daemon -->|"spawn · typed JSON via stdin"| Local
+    Daemon -->|"spawn · typed JSON via stdin"| Remote
     Local --> Executor
     Remote --> Executor
     Executor -.->|"results + events via WebSocket"| Daemon

--- a/apps/agor-docs/content/guide/rich-chat-ux.mdx
+++ b/apps/agor-docs/content/guide/rich-chat-ux.mdx
@@ -150,31 +150,31 @@ You don't have to wait for a long-running prompt to finish before you start writ
 
 **See session activity at a glance, even in background browser tabs.** The favicon shows live status dots:
 
-<div style={{ display: 'flex', gap: '20px', alignItems: 'center' }}>
-  <div style={{ textAlign: 'center' }}>
+<div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap', alignItems: 'flex-start' }}>
+  <figure style={{ margin: 0, flex: '1 1 200px', maxWidth: '260px', textAlign: 'center' }}>
     <img
       src="/screenshots/favicon-white-dot.png"
-      alt="White dot lower-left: agent working"
-      style={{ width: '48px', height: '48px' }}
+      alt="Browser tab with the Agor favicon showing a white dot at lower-left"
+      style={{ width: '100%', height: 'auto', borderRadius: '8px' }}
     />
-    <p style={{ fontSize: '12px', marginTop: '8px' }}>⚪ Agent working</p>
-  </div>
-  <div style={{ textAlign: 'center' }}>
+    <figcaption style={{ fontSize: '13px', marginTop: '8px' }}>⚪ Agent working</figcaption>
+  </figure>
+  <figure style={{ margin: 0, flex: '1 1 200px', maxWidth: '260px', textAlign: 'center' }}>
     <img
       src="/screenshots/favicon-green-dot.png"
-      alt="Green dot lower-right: ready for prompt"
-      style={{ width: '48px', height: '48px' }}
+      alt="Browser tab with the Agor favicon showing a green dot at lower-right"
+      style={{ width: '100%', height: 'auto', borderRadius: '8px' }}
     />
-    <p style={{ fontSize: '12px', marginTop: '8px' }}>🟢 Ready for prompt</p>
-  </div>
-  <div style={{ textAlign: 'center' }}>
+    <figcaption style={{ fontSize: '13px', marginTop: '8px' }}>🟢 Ready for prompt</figcaption>
+  </figure>
+  <figure style={{ margin: 0, flex: '1 1 200px', maxWidth: '260px', textAlign: 'center' }}>
     <img
       src="/screenshots/favicon-both.png"
-      alt="Both dots: working + ready"
-      style={{ width: '48px', height: '48px' }}
+      alt="Browser tab with the Agor favicon showing both a white and a green dot"
+      style={{ width: '100%', height: 'auto', borderRadius: '8px' }}
     />
-    <p style={{ fontSize: '12px', marginTop: '8px' }}>⚪🟢 Both states</p>
-  </div>
+    <figcaption style={{ fontSize: '13px', marginTop: '8px' }}>⚪🟢 Both states</figcaption>
+  </figure>
 </div>
 
 White dot (lower-left) means _something is running_. Green dot (lower-right) means _something is ready for input_. Both can show at once. Updates in real time over WebSocket.

--- a/apps/agor-docs/content/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/content/guide/sdk-comparison.mdx
@@ -3,11 +3,15 @@ title: SDK Feature Comparison
 description: Compare AI coding agent capabilities in agor. Feature matrix for Claude Code, Codex, Gemini, GitHub Copilot, and OpenCode integrations including streaming, tool approval, and SDK differences.
 ---
 
+import { ScrollTable } from '../../components/ScrollTable';
+
 # SDK Feature Comparison
 
 Agor integrates with multiple AI coding agents. Each SDK has different capabilities based on their native features and API design.
 
 ## Feature Matrix
+
+<ScrollTable>
 
 | Feature                     | Claude Code         | Codex                     | Gemini              | Copilot                   | OpenCode                  | Notes                                                                                       |
 | --------------------------- | ------------------- | ------------------------- | ------------------- | ------------------------- | ------------------------- | ------------------------------------------------------------------------------------------- |
@@ -22,6 +26,8 @@ Agor integrates with multiple AI coding agents. Each SDK has different capabilit
 | **Session continuity**      | ✅ SDK-managed      | ✅ History-based          | ✅ History-based    | ✅ SDK-managed            | ✅ SDK-managed            | OpenCode, Claude, and Copilot use SDK session IDs; others replay message history            |
 | **Token usage tracking**    | ✅ Full             | ✅ Full                   | ❌ No               | ⚠️ Via events             | ✅ Via step-finish        | OpenCode provides token counts and cost via `step-finish` message parts                     |
 | **Context window tracking** | 🟡 Estimated        | 🟡 Estimated              | ❌ No               | 🟡 Estimated              | 🟡 Estimated              | Agor derives cumulative conversation usage from SDK metrics                                 |
+
+</ScrollTable>
 
 **Legend:**
 


### PR DESCRIPTION
Docs polish pass, branched off main. Independent of #1933 (wave 2).

## FAQ page
- **Answers as cards** — each Q&A wrapped in a `FaqSection` (mint accent rail) instead of one wall of text; no accordions, TOC/anchors preserved.
- **ASCII trees → `<Tree>`** — the six `├─ └─` trees are now styled nested markdown lists (connectors drawn in CSS), so content stays authorable. Real code snippets left as code blocks.

## Executor diagram (containerized-execution)
- Fact-checked against the codebase and corrected drift (git-mutation delegation, the full 6-harness list, real spawn commands, Zellij/node-pty terminals).
- Ended up as a **hand-authored SVG** (`ExecutorDiagram`) after mermaid couldn't express the perimeter-loop routing — clean rounded-rectangle corners, continuous edges, teal/amber theming. (History includes the mermaid iterations that led there.)

## Site-wide docs polish
- **Headings** adopt the marketing display font (Space Grotesk) + a light mint tint — distinct from links, less wall-of-white.
- **`ScrollTable`** — wide tables (Feature Matrix) get a pinned first column + scroll affordance. Handles Nextra's table-overflow and the `border-collapse` sticky gotcha.
- **`MermaidZoom`** — every mermaid diagram is click-to-enlarge in a lightbox with wheel/button zoom, drag-to-pan, and scroll.
- **Favicon status images** fixed (were 332×82 crushed into 48×48 squares).

New reusable components: `FaqSection`, `Tree`, `ScrollTable`, `MermaidZoom`, `ExecutorDiagram`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)