### PR TITLE
fix(terminal): short ZELLIJ_SOCKET_DIR so web terminal works on macOS

### DIFF
--- a/packages/executor/src/commands/zellij.test.ts
+++ b/packages/executor/src/commands/zellij.test.ts
@@ -7,9 +7,43 @@ import {
   createReconnectGrace,
   ensurePrivateZellijCacheDirectory,
   forceZellijRepaint,
+  getZellijSocketDir,
   waitForZellijReady,
   zellijListingHasSession,
 } from './zellij.js';
+
+describe('getZellijSocketDir', () => {
+  it('preserves an explicit environment override', () => {
+    expect(getZellijSocketDir('/custom/zellij-sockets', 1000, '/home/user/.cache/sockets')).toBe(
+      '/custom/zellij-sockets'
+    );
+  });
+
+  it('keeps a real Agor session socket comfortably below the macOS limit', () => {
+    const socketDir = getZellijSocketDir(
+      undefined,
+      4_294_967_295,
+      '/home/user/.cache/sockets',
+      'darwin'
+    );
+    const sessionName = `agor-${'a'.repeat(24)}`;
+    const socketPath = join(socketDir, 'contract_version_1', sessionName);
+
+    expect(Buffer.byteLength(socketPath)).toBeLessThan(80);
+    expect(Buffer.byteLength(socketPath)).toBeLessThan(103);
+  });
+
+  it('separates macOS fallback directories by Unix user', () => {
+    expect(getZellijSocketDir(undefined, 1000, '/shared', 'darwin')).toBe('/tmp/agor-zellij-1000');
+    expect(getZellijSocketDir(undefined, 1001, '/shared', 'darwin')).toBe('/tmp/agor-zellij-1001');
+  });
+
+  it('keeps the owner-local socket directory on non-macOS runtimes', () => {
+    expect(getZellijSocketDir(undefined, 1000, '/home/user/.cache/zellij/sockets', 'linux')).toBe(
+      '/home/user/.cache/zellij/sockets'
+    );
+  });
+});
 
 describe('buildZellijLaunchArgs', () => {
   it('attaches directly when an active or exited session is known', () => {

--- a/packages/executor/src/commands/zellij.ts
+++ b/packages/executor/src/commands/zellij.ts
@@ -84,6 +84,24 @@ export function ensurePrivateZellijCacheDirectory(directory: string): void {
 }
 
 /**
+ * Select the Zellij socket base without regressing owner-local container reuse.
+ * macOS needs the short fallback because its default paths can exceed sun_path.
+ */
+export function getZellijSocketDir(
+  socketDir: string | undefined,
+  uid: number | undefined,
+  ownerLocalSocketDir: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  if (socketDir !== undefined) return socketDir;
+  if (platform !== 'darwin') return ownerLocalSocketDir;
+  if (uid === undefined) {
+    throw new Error('Cannot choose a per-user Zellij socket directory without a Unix uid');
+  }
+  return `/tmp/agor-zellij-${uid}`;
+}
+
+/**
  * Lifecycle invariants for an Agor-managed attach. Pass these explicitly so
  * existing persistent homes receive the current resurrection contract without
  * overwriting their user-owned Zellij configuration.
@@ -449,8 +467,13 @@ export async function handleZellijAttach(
     // cross-host protocol: topologies whose home is a network filesystem must
     // still advertise terminal capability=false unless one workspace runtime
     // owns both the socket and PTY.
-    const zellijSocketDir = `${zellijCacheDir}/sockets`;
-    ensurePrivateZellijCacheDirectory(zellijSocketDir);
+    const ownerLocalSocketDir = `${zellijCacheDir}/sockets`;
+    ensurePrivateZellijCacheDirectory(ownerLocalSocketDir);
+    const zellijSocketDir = getZellijSocketDir(
+      cleanEnv.ZELLIJ_SOCKET_DIR,
+      process.getuid?.(),
+      ownerLocalSocketDir
+    );
     process.env.ZELLIJ_SOCKET_DIR = zellijSocketDir;
 
     const zellijEnv = {


### PR DESCRIPTION
## Problem

On macOS the web terminal always fails with `[Terminal exited with code 1]`. The zellij PTY exits 1 immediately with:

```
Error: the IPC socket path is too long (108 bytes, max 103):
  /var/folders/.../T/zellij-<uid>/contract_version_1/agor-<user-id>
This is usually caused by a long $TMPDIR path.
```

With no override, Zellij places its Unix-domain control socket below the platform temp directory, including a `zellij-<uid>` component. macOS's default `$TMPDIR` is a long `/var/folders/...` path, and Agor session names are `agor-<24-char-user-id>`, so the combined socket path can exceed the ~103-byte `sun_path` limit and Zellij aborts before it can attach.

## Fix

Select the `ZELLIJ_SOCKET_DIR` in `handleZellijAttach` while preserving an explicit environment override. Zellij 0.43.1 uses an explicit override directly and appends only its protocol/version directory and session name. On macOS, Agor therefore uses the short, per-user fallback `/tmp/agor-zellij-<uid>`. On other platforms it retains the owner-local cache socket directory introduced for same-host container reuse. This keeps macOS paths short without making strict-mode users share a socket directory or regressing the container persistence contract.

## Testing

- Added focused tests for explicit override preservation, per-UID separation, and total socket-path length with a 24-character Agor session identifier.
- The longest practical UID used by the test produces a 76-byte path including `contract_version_1` and the session name, comfortably below 103 bytes.
- Reproduced the original failure via a node-pty harness using the daemon's real session name and environment; the short socket base attaches cleanly and streams the Zellij UI.

