### PR TITLE
fix: harden gateway and MCP tenant isolation

### DIFF
--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -1,3 +1,4 @@
+import { request as httpRequest } from 'node:http';
 import { getCurrentTenantId } from '@agor/core/db';
 import type { Request, Response } from 'express';
 import express from 'express';
@@ -667,6 +668,62 @@ describe('POST /mcp with personal API keys', () => {
         multi_tenancy: {
           mode: 'required_from_auth',
           auth_claim: 'tenant_id',
+        },
+      }
+    );
+  });
+
+  it('rejects duplicate on-wire trusted tenant headers before API-key lookup', async () => {
+    const { UserApiKeysRepository } = await import('@agor/core/db');
+    const verifyKey = vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey');
+
+    await withMcpServer(
+      {},
+      async (baseUrl) => {
+        const requestBody = JSON.stringify({
+          jsonrpc: '2.0',
+          id: 24,
+          method: 'tools/call',
+          params: { name: 'agor_users_get_current', arguments: {} },
+        });
+        const response = await new Promise<{ status: number | undefined; body: string }>(
+          (resolve, reject) => {
+            const req = httpRequest(
+              `${baseUrl}/mcp`,
+              {
+                method: 'POST',
+                headers: {
+                  Accept: 'application/json, text/event-stream',
+                  'Content-Type': 'application/json',
+                  'Content-Length': Buffer.byteLength(requestBody),
+                  'X-API-Key': 'agor_sk_valid',
+                  'X-Agor-Tenant-Id': ['tenant-a', 'tenant-b'],
+                },
+              },
+              (res) => {
+                let body = '';
+                res.setEncoding('utf8');
+                res.on('data', (chunk: string) => {
+                  body += chunk;
+                });
+                res.on('end', () => resolve({ status: res.statusCode, body }));
+              }
+            );
+            req.on('error', reject);
+            req.end(requestBody);
+          }
+        );
+
+        expect(response.status, response.body).toBe(401);
+        expect(JSON.parse(response.body)).toMatchObject({
+          error: { message: 'Conflicting tenant identities' },
+        });
+        expect(verifyKey).not.toHaveBeenCalled();
+      },
+      {
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          trusted_header: 'x-agor-tenant-id',
         },
       }
     );

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -1,7 +1,17 @@
+import { getCurrentTenantId } from '@agor/core/db';
 import type { Request, Response } from 'express';
 import express from 'express';
+import jwt from 'jsonwebtoken';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildRegistry, coerceJsonRecord, setupMCPRoutes } from './server.js';
+import { initMcpTokens, MCP_TOKEN_AUDIENCE, MCP_TOKEN_ISSUER } from './tokens.js';
+
+function testSqliteDb() {
+  // Tenant scopes are transaction-free on SQLite. The MCP route tests mock the
+  // repositories themselves, but still provide the backend discriminator used
+  // by runWithTenantDatabaseScope.
+  return { run: vi.fn() } as never;
+}
 
 describe('coerceJsonRecord', () => {
   it('passes through a plain object unchanged', () => {
@@ -94,12 +104,15 @@ describe('MCP tool registry', () => {
  * token-source validation branches can be tested without spinning up
  * the full FeathersJS stack.
  */
-function captureMcpHandler() {
+function captureMcpHandler(
+  config: Parameters<typeof setupMCPRoutes>[3] = { multi_tenancy: undefined }
+) {
   let handler: ((req: Request, res: Response) => Promise<unknown> | unknown) | null = null;
   const register = (_path: string, fn: typeof handler) => {
     handler = fn;
   };
   const app = {
+    settings: { authentication: { secret: 'mcp-server-test-secret' } },
     post: register,
     get: register,
     delete: register,
@@ -114,7 +127,7 @@ function captureMcpHandler() {
       };
     },
   } as unknown as Parameters<typeof setupMCPRoutes>[0];
-  setupMCPRoutes(app, {} as never, /* toolSearchEnabled */ false);
+  setupMCPRoutes(app, testSqliteDb(), /* toolSearchEnabled */ false, config);
   if (!handler) throw new Error('MCP handler was not registered');
   return handler;
 }
@@ -207,6 +220,49 @@ describe('POST /mcp token source', () => {
     expect(body.error?.message).toMatch(/invalid personal api key/i);
   });
 
+  it('rejects an internal MCP token replayed under a conflicting trusted tenant', async () => {
+    initMcpTokens({ db: testSqliteDb() });
+    const now = Math.floor(Date.now() / 1000);
+    const token = jwt.sign(
+      {
+        sub: 'session-shared-looking',
+        uid: 'user-shared-looking',
+        tid: 'tenant-a',
+        aud: MCP_TOKEN_AUDIENCE,
+        iss: MCP_TOKEN_ISSUER,
+        iat: now,
+        exp: now + 60,
+        jti: 'token-jti',
+      },
+      'mcp-server-test-secret',
+      { algorithm: 'HS256' }
+    );
+    const handler = captureMcpHandler({
+      multi_tenancy: {
+        mode: 'required_from_auth',
+        trusted_header: 'x-agor-tenant-id',
+      },
+    });
+    const req = {
+      method: 'POST',
+      query: {},
+      headers: {
+        authorization: `Bearer ${token}`,
+        'x-agor-tenant-id': 'tenant-b',
+      },
+      body: { id: 11 },
+      ip: '127.0.0.1',
+      socket: { remoteAddress: '127.0.0.1' },
+    } as unknown as Request;
+    const res = buildRes();
+
+    await handler(req, res as unknown as Response);
+
+    expect(res.statusCode).toBe(403);
+    const body = res.body as { error?: { message?: string } };
+    expect(body.error?.message).toMatch(/tenant identity mismatch/i);
+  });
+
   it('rejects even when query has both ?sessionToken= and an Authorization header (query wins → 400)', async () => {
     const handler = captureMcpHandler();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -297,7 +353,8 @@ describe('POST /mcp with personal API keys', () => {
 
   async function withMcpServer(
     services: Record<string, unknown>,
-    fn: (baseUrl: string) => Promise<void>
+    fn: (baseUrl: string) => Promise<void>,
+    config: Parameters<typeof setupMCPRoutes>[3] = { multi_tenancy: undefined }
   ) {
     const webApp = express();
     webApp.use(express.json());
@@ -307,7 +364,7 @@ describe('POST /mcp with personal API keys', () => {
       return svc;
     };
 
-    setupMCPRoutes(webApp as never, {} as never, /* toolSearchEnabled */ false);
+    setupMCPRoutes(webApp as never, testSqliteDb(), /* toolSearchEnabled */ false, config);
 
     const httpServer = webApp.listen(0);
     try {
@@ -332,13 +389,18 @@ describe('POST /mcp with personal API keys', () => {
     };
   }
 
-  async function initializeStatefulMcp(baseUrl: string, apiKey = 'agor_sk_valid') {
+  async function initializeStatefulMcp(
+    baseUrl: string,
+    apiKey = 'agor_sk_valid',
+    extraHeaders: Record<string, string> = {}
+  ) {
     const resp = await fetch(`${baseUrl}/mcp`, {
       method: 'POST',
       headers: {
         Accept: 'application/json, text/event-stream',
         'Content-Type': 'application/json',
         'X-API-Key': apiKey,
+        ...extraHeaders,
       },
       body: JSON.stringify({
         jsonrpc: '2.0',
@@ -422,7 +484,7 @@ describe('POST /mcp with personal API keys', () => {
       return { get: getUser };
     };
 
-    setupMCPRoutes(webApp as never, {} as never, /* toolSearchEnabled */ false);
+    setupMCPRoutes(webApp as never, testSqliteDb(), /* toolSearchEnabled */ false);
 
     const httpServer = webApp.listen(0);
     try {
@@ -457,7 +519,12 @@ describe('POST /mcp with personal API keys', () => {
       expect(body.error).toBeUndefined();
       const result = JSON.parse(body.result!.content[0].text);
       expect(result.user_id).toBe('user-1');
-      expect(getUser).toHaveBeenCalledWith('user-1');
+      expect(getUser).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          tenant: { tenant_id: 'default', source: 'static' },
+        })
+      );
       expect(UserApiKeysRepository.prototype.updateLastUsed).toHaveBeenCalledWith('key-1');
     } finally {
       await new Promise<void>((resolve, reject) => {
@@ -510,12 +577,16 @@ describe('POST /mcp with personal API keys', () => {
 
   it('carries authenticated user tenant into service params for MCP tool calls and session validation', async () => {
     await mockPersonalApiKeyUser();
-    const getUser = vi.fn(async () => ({
-      user_id: 'user-1',
-      email: 'alice@example.com',
-      role: 'member',
-      tenant_id: 'tenant-a',
-    }));
+    const seenTenantIds: Array<string | undefined> = [];
+    const getUser = vi.fn(async () => {
+      seenTenantIds.push(getCurrentTenantId() as string | undefined);
+      return {
+        user_id: 'user-1',
+        email: 'alice@example.com',
+        role: 'member',
+        tenant_id: 'tenant-a',
+      };
+    });
     const getSession = vi.fn(async () => ({ session_id: 'session-full-id' }));
 
     await withMcpServer(
@@ -527,6 +598,7 @@ describe('POST /mcp with personal API keys', () => {
             Accept: 'application/json, text/event-stream',
             'Content-Type': 'application/json',
             'X-API-Key': 'agor_sk_valid',
+            'X-Agor-Tenant-Id': 'tenant-a',
             'X-Agor-Session-Id': 'session-short',
           },
           body: JSON.stringify({
@@ -544,7 +616,7 @@ describe('POST /mcp with personal API keys', () => {
           expect.objectContaining({
             authenticated: true,
             provider: 'mcp',
-            tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+            tenant: { tenant_id: 'tenant-a', source: 'trusted_header' },
           })
         );
         expect(getUser).toHaveBeenCalledWith(
@@ -552,9 +624,50 @@ describe('POST /mcp with personal API keys', () => {
           expect.objectContaining({
             authenticated: true,
             provider: 'mcp',
-            tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+            tenant: { tenant_id: 'tenant-a', source: 'trusted_header' },
           })
         );
+        expect(seenTenantIds.every((tenantId) => tenantId === 'tenant-a')).toBe(true);
+      },
+      {
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          trusted_header: 'x-agor-tenant-id',
+        },
+      }
+    );
+  });
+
+  it('fails before personal API-key lookup when required tenant identity is missing', async () => {
+    const { UserApiKeysRepository } = await import('@agor/core/db');
+    const verifyKey = vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey');
+
+    await withMcpServer(
+      {},
+      async (baseUrl) => {
+        const resp = await fetch(`${baseUrl}/mcp`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'X-API-Key': 'agor_sk_valid',
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 23,
+            method: 'tools/call',
+            params: { name: 'agor_users_get_current', arguments: {} },
+          }),
+        });
+
+        expect(resp.status).toBe(401);
+        expect(verifyKey).not.toHaveBeenCalled();
+      },
+      {
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          auth_claim: 'tenant_id',
+        },
       }
     );
   });
@@ -697,6 +810,51 @@ describe('POST /mcp with personal API keys', () => {
       const body = (await resp.json()) as { error?: { message?: string } };
       expect(body.error?.message).toMatch(/different user/i);
     });
+  });
+
+  it('rejects a stateful MCP request replayed in another tenant for the same user id', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async (id: string) => ({
+      user_id: id,
+      email: `${id}@example.com`,
+      role: 'member',
+      tenant_id: getCurrentTenantId(),
+    }));
+
+    await withMcpServer(
+      { users: { get: getUser } },
+      async (baseUrl) => {
+        const mcpSessionId = await initializeStatefulMcp(baseUrl, 'agor_sk_valid', {
+          'X-Agor-Tenant-Id': 'tenant-a',
+        });
+        const resp = await fetch(`${baseUrl}/mcp`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'X-API-Key': 'agor_sk_valid',
+            'X-Agor-Tenant-Id': 'tenant-b',
+            'Mcp-Session-Id': mcpSessionId,
+          },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 61,
+            method: 'tools/call',
+            params: { name: 'agor_users_get_current', arguments: {} },
+          }),
+        });
+
+        expect(resp.status).toBe(403);
+        const body = (await resp.json()) as { error?: { message?: string } };
+        expect(body.error?.message).toMatch(/different tenant/i);
+      },
+      {
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          trusted_header: 'x-agor-tenant-id',
+        },
+      }
+    );
   });
 
   it('DELETE closes a stateful MCP session and subsequent use returns 404', async () => {

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -812,6 +812,82 @@ describe('POST /mcp with personal API keys', () => {
     });
   });
 
+  it('rejects a stateful MCP request when its personal API key is revoked', async () => {
+    await mockPersonalApiKeyUser();
+    const { UserApiKeysRepository } = await import('@agor/core/db');
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+
+    await withMcpServer({ users: { get: getUser } }, async (baseUrl) => {
+      const mcpSessionId = await initializeStatefulMcp(baseUrl);
+      vi.mocked(UserApiKeysRepository.prototype.verifyKey).mockResolvedValue(null);
+
+      const { resp } = await callCurrentUserStatefully(baseUrl, mcpSessionId);
+      expect(resp.status).toBe(401);
+    });
+  });
+
+  it('rejects a stateful MCP request when credentials are omitted', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+
+    await withMcpServer({ users: { get: getUser } }, async (baseUrl) => {
+      const mcpSessionId = await initializeStatefulMcp(baseUrl);
+      const resp = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'Content-Type': 'application/json',
+          'Mcp-Session-Id': mcpSessionId,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 60,
+          method: 'tools/call',
+          params: { name: 'agor_users_get_current', arguments: {} },
+        }),
+      });
+
+      expect(resp.status).toBe(401);
+    });
+  });
+
+  it('retains and re-authorizes an omitted Agor session binding on later requests', async () => {
+    await mockPersonalApiKeyUser();
+    const getUser = vi.fn(async () => ({
+      user_id: 'user-1',
+      email: 'alice@example.com',
+      role: 'member',
+    }));
+    const getSession = vi.fn(async () => ({ session_id: 'session-full-id' }));
+
+    await withMcpServer(
+      { users: { get: getUser }, sessions: { get: getSession } },
+      async (baseUrl) => {
+        const mcpSessionId = await initializeStatefulMcp(baseUrl, 'agor_sk_valid', {
+          'X-Agor-Session-Id': 'session-full-id',
+        });
+
+        // Both continuation requests omit X-Agor-Session-Id. The immutable
+        // initialize-time binding is retained and checked through sessions.get.
+        await markStatefulMcpInitialized(baseUrl, mcpSessionId);
+        const { resp, parsed } = await callCurrentUserStatefully(baseUrl, mcpSessionId);
+
+        expect(resp.status).toBe(200);
+        expect(parsed.error).toBeUndefined();
+        expect(getSession).toHaveBeenCalledTimes(3);
+        expect(getSession).toHaveBeenLastCalledWith('session-full-id', expect.any(Object));
+      }
+    );
+  });
+
   it('rejects a stateful MCP request replayed in another tenant for the same user id', async () => {
     await mockPersonalApiKeyUser();
     const getUser = vi.fn(async (id: string) => ({

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -673,7 +673,21 @@ describe('POST /mcp with personal API keys', () => {
     );
   });
 
-  it('rejects duplicate on-wire trusted tenant headers before API-key lookup', async () => {
+  it.each([
+    {
+      label: 'conflicting',
+      tenantHeaders: ['tenant-a', 'tenant-b'],
+      errorMessage: 'Conflicting tenant identities',
+    },
+    {
+      label: 'identical',
+      tenantHeaders: ['tenant-a', 'tenant-a'],
+      errorMessage: 'Invalid trusted tenant header x-agor-tenant-id',
+    },
+  ])('rejects $label duplicate on-wire trusted tenant headers before API-key lookup', async ({
+    tenantHeaders,
+    errorMessage,
+  }) => {
     const { UserApiKeysRepository } = await import('@agor/core/db');
     const verifyKey = vi.spyOn(UserApiKeysRepository.prototype, 'verifyKey');
 
@@ -697,7 +711,7 @@ describe('POST /mcp with personal API keys', () => {
                   'Content-Type': 'application/json',
                   'Content-Length': Buffer.byteLength(requestBody),
                   'X-API-Key': 'agor_sk_valid',
-                  'X-Agor-Tenant-Id': ['tenant-a', 'tenant-b'],
+                  'X-Agor-Tenant-Id': tenantHeaders,
                 },
               },
               (res) => {
@@ -716,7 +730,7 @@ describe('POST /mcp with personal API keys', () => {
 
         expect(response.status, response.body).toBe(401);
         expect(JSON.parse(response.body)).toMatchObject({
-          error: { message: 'Conflicting tenant identities' },
+          error: { message: errorMessage },
         });
         expect(verifyKey).not.toHaveBeenCalled();
       },

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -467,6 +467,19 @@ export function setupMCPRoutes(
     return coerceString(Array.isArray(xApiKey) ? xApiKey[0] : xApiKey);
   };
 
+  /**
+   * Preserve duplicate on-wire header fields for tenant resolution. Node's
+   * normalized `headers` map comma-coalesces most duplicate names;
+   * `headersDistinct` lets the resolver compare every trusted tenant value.
+   * Non-Node test adapters may not expose it, so retain the normalized map as
+   * a fail-closed fallback (the resolver rejects comma/list values).
+   */
+  const getTenantResolutionHeaders = (req: Request): Record<string, unknown> => {
+    const distinct = (req as Request & { headersDistinct?: Record<string, string[] | undefined> })
+      .headersDistinct;
+    return distinct ?? (req.headers as Record<string, unknown>);
+  };
+
   const getRequestedSessionId = (req: Request): string | undefined => {
     const fromQuery = coerceString(req.query.sessionId);
     if (fromQuery) return fromQuery;
@@ -522,7 +535,7 @@ export function setupMCPRoutes(
           // the tenant-owned key table. Auth-claim-only hosted deployments must
           // use an internal tenant-bound MCP token instead.
           tenant = resolveTenantContext(multiTenancy, {
-            headers: req.headers as Record<string, unknown>,
+            headers: getTenantResolutionHeaders(req),
           });
         } catch (error) {
           if (error instanceof TenantResolutionError) {
@@ -582,7 +595,7 @@ export function setupMCPRoutes(
           // agree with it before the token's session is looked up.
           tenant = resolveTenantContext(multiTenancy, {
             params: { tenant_id: verifiedToken.tenantId },
-            headers: req.headers as Record<string, unknown>,
+            headers: getTenantResolutionHeaders(req),
           });
         } catch (error) {
           if (error instanceof TenantResolutionError) {

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -14,8 +14,19 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import type { AgorConfig } from '@agor/core/config';
+import {
+  resolveMultiTenancyConfig,
+  resolveTenantContext,
+  TenantResolutionError,
+} from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import { shortId, UserApiKeysRepository } from '@agor/core/db';
+import {
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+  shortId,
+  UserApiKeysRepository,
+} from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { SessionID, TenantContext, UserID } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
@@ -26,7 +37,7 @@ import type { Request, Response } from 'express';
 import { toJSONSchema } from 'zod/v4-mini';
 import type { AuthenticatedParams, AuthenticatedUser } from '../declarations.js';
 import { tenantScopedToolProxy } from './tenant-scope.js';
-import { validateSessionToken } from './tokens.js';
+import { validateVerifiedSessionToken, verifySessionToken } from './tokens.js';
 import { formatDomainDescriptionsForInstructions, ToolRegistry } from './tool-registry.js';
 import { registerAnalyticsTools } from './tools/analytics.js';
 import { registerArtifactTools } from './tools/artifacts.js';
@@ -57,11 +68,9 @@ function mcpRequestDebug(...args: unknown[]): void {
   }
 }
 
-function tenantFromAuthenticatedUser(user: AuthenticatedUser): TenantContext | undefined {
+function authenticatedUserTenantMatches(user: AuthenticatedUser, tenant: TenantContext): boolean {
   const tenantId = typeof user.tenant_id === 'string' ? user.tenant_id.trim() : '';
-  return tenantId
-    ? { tenant_id: tenantId as TenantContext['tenant_id'], source: 'auth_claim' }
-    : undefined;
+  return !tenantId || tenantId === tenant.tenant_id;
 }
 
 /**
@@ -363,7 +372,8 @@ function createMcpServer(ctx: McpContext, toolSearchEnabled: boolean): McpServer
 export function setupMCPRoutes(
   app: Application,
   db: TenantScopeAwareDatabase,
-  toolSearchEnabled = true
+  toolSearchEnabled = true,
+  config: Pick<AgorConfig, 'multi_tenancy'> = { multi_tenancy: undefined }
 ): void {
   // Eagerly build the registry at startup so first request isn't slower
   if (toolSearchEnabled) {
@@ -372,6 +382,7 @@ export function setupMCPRoutes(
   }
 
   const personalApiKeys = new UserApiKeysRepository(db);
+  const multiTenancy = resolveMultiTenancyConfig(config);
 
   type StatefulTransportEntry = {
     transport: StreamableHTTPServerTransport;
@@ -379,6 +390,8 @@ export function setupMCPRoutes(
     /** Mutable context object captured by registered tool handlers. */
     context: McpContext;
     userId: UserID;
+    /** Immutable tenant binding established at MCP initialize time. */
+    tenantId: TenantContext['tenant_id'];
     /** Immutable Agor session binding established at MCP initialize time, if any. */
     sessionId?: SessionID;
     lastUsedAt: number;
@@ -499,10 +512,32 @@ export function setupMCPRoutes(
       let authenticatedUser: AuthenticatedUser;
       let userId: UserID;
       let sessionId: SessionID | undefined;
+      let tenant: TenantContext;
       const isPersonalApiKey = credential.startsWith('agor_sk_');
 
       if (isPersonalApiKey) {
-        const keyRow = await personalApiKeys.verifyKey(credential);
+        try {
+          // Opaque personal keys do not contain a signed tenant claim. Resolve
+          // static mode or the configured trusted edge header before touching
+          // the tenant-owned key table. Auth-claim-only hosted deployments must
+          // use an internal tenant-bound MCP token instead.
+          tenant = resolveTenantContext(multiTenancy, {
+            headers: req.headers as Record<string, unknown>,
+          });
+        } catch (error) {
+          if (error instanceof TenantResolutionError) {
+            return res.status(401).json({
+              ...jsonRpcError(req, -32001, error.message),
+            });
+          }
+          throw error;
+        }
+
+        const keyRow = await runWithTenantContext(tenant.tenant_id, () =>
+          runWithTenantDatabaseScope(db, tenant.tenant_id, () =>
+            personalApiKeys.verifyKey(credential)
+          )
+        );
         if (!keyRow) {
           console.warn('⚠️  Invalid MCP personal API key');
           return res.status(401).json({
@@ -510,13 +545,19 @@ export function setupMCPRoutes(
           });
         }
 
-        personalApiKeys.updateLastUsed(keyRow.id).catch((err: unknown) => {
+        void runWithTenantContext(tenant.tenant_id, () =>
+          runWithTenantDatabaseScope(db, tenant.tenant_id, () =>
+            personalApiKeys.updateLastUsed(keyRow.id)
+          )
+        ).catch((err: unknown) => {
           console.warn('Failed to update MCP personal API key last_used_at:', err);
         });
 
         userId = keyRow.user_id as UserID;
         try {
-          authenticatedUser = await app.service('users').get(userId);
+          authenticatedUser = await runWithTenantContext(tenant.tenant_id, () =>
+            app.service('users').get(userId, { tenant } as AuthenticatedParams)
+          );
         } catch (error) {
           if (error instanceof NotFoundError) {
             return res.status(401).json({
@@ -527,7 +568,32 @@ export function setupMCPRoutes(
         }
         sessionId = getRequestedSessionId(req) as SessionID | undefined;
       } else {
-        const context = await validateSessionToken(app, credential);
+        const verifiedToken = verifySessionToken(app, credential);
+        if (!verifiedToken) {
+          console.warn('⚠️  Invalid MCP session token');
+          return res.status(401).json({
+            ...jsonRpcError(req, -32001, 'Invalid or expired session token'),
+          });
+        }
+
+        try {
+          // The signed token binding is an authenticated tenant signal. Static
+          // configuration and a configured trusted header, when present, must
+          // agree with it before the token's session is looked up.
+          tenant = resolveTenantContext(multiTenancy, {
+            params: { tenant_id: verifiedToken.tenantId },
+            headers: req.headers as Record<string, unknown>,
+          });
+        } catch (error) {
+          if (error instanceof TenantResolutionError) {
+            return res.status(403).json({
+              ...jsonRpcError(req, -32003, 'Forbidden: tenant identity mismatch'),
+            });
+          }
+          throw error;
+        }
+
+        const context = await validateVerifiedSessionToken(verifiedToken);
         if (!context) {
           console.warn('⚠️  Invalid MCP session token');
           return res.status(401).json({
@@ -539,7 +605,9 @@ export function setupMCPRoutes(
         sessionId = context.sessionId;
 
         try {
-          authenticatedUser = await app.service('users').get(userId);
+          authenticatedUser = await runWithTenantContext(tenant.tenant_id, () =>
+            app.service('users').get(userId, { tenant } as AuthenticatedParams)
+          );
         } catch (error) {
           if (error instanceof NotFoundError) {
             return res.status(401).json({
@@ -550,192 +618,209 @@ export function setupMCPRoutes(
         }
       }
 
-      const tenant = tenantFromAuthenticatedUser(authenticatedUser);
-      const baseServiceParams: Pick<
-        AuthenticatedParams,
-        'user' | 'authenticated' | 'provider' | 'tenant'
-      > = {
-        user: {
-          user_id: authenticatedUser.user_id,
-          email: authenticatedUser.email,
-          role: authenticatedUser.role,
-        },
-        authenticated: true,
-        provider: 'mcp',
-        ...(tenant ? { tenant } : {}),
-      };
-
-      // Personal API key callers may optionally bind a current-session context
-      // using a header/query param. Validate through the normal sessions
-      // service so branch RBAC and short-ID resolution stay identical to REST.
-      if (isPersonalApiKey && sessionId) {
-        try {
-          const session = await app.service('sessions').get(sessionId, baseServiceParams);
-          sessionId = session.session_id;
-        } catch {
-          return res.status(403).json({
-            ...jsonRpcError(
-              req,
-              -32003,
-              'Forbidden: X-Agor-Session-Id / ?sessionId is invalid or not accessible to this API key user.'
-            ),
-          });
-        }
+      if (!authenticatedUserTenantMatches(authenticatedUser, tenant)) {
+        console.warn('⚠️  MCP authenticated user tenant does not match request tenant');
+        return res.status(401).json({
+          ...jsonRpcError(req, -32001, 'Authenticated identity is not valid for this tenant'),
+        });
       }
 
-      mcpRequestDebug(
-        `🔌 MCP request authenticated (user: ${shortId(userId)}, session: ${sessionId ? shortId(sessionId) : 'none'})`
-      );
+      // Keep tenant identity ambient for the complete MCP request without
+      // holding a database transaction. Tool/repository operations open their
+      // own short tenant units of work.
+      return runWithTenantContext(tenant.tenant_id, async () => {
+        const baseServiceParams: Pick<
+          AuthenticatedParams,
+          'user' | 'authenticated' | 'provider' | 'tenant'
+        > = {
+          user: {
+            user_id: authenticatedUser.user_id,
+            email: authenticatedUser.email,
+            role: authenticatedUser.role,
+          },
+          authenticated: true,
+          provider: 'mcp',
+          tenant,
+        };
 
-      const mcpContext: McpContext = {
-        app,
-        db,
-        userId,
-        sessionId,
-        authenticatedUser,
-        baseServiceParams,
-      };
-
-      const mcpSessionHeader = req.headers['mcp-session-id'];
-      const mcpSessionId = coerceString(
-        Array.isArray(mcpSessionHeader) ? mcpSessionHeader[0] : mcpSessionHeader
-      );
-
-      if (req.method === 'GET' || req.method === 'DELETE' || mcpSessionId) {
-        if (!mcpSessionId) {
-          return res.status(400).json({
-            ...jsonRpcError(req, -32000, 'Bad Request: Mcp-Session-Id header is required'),
-          });
-        }
-        const entry = statefulTransports.get(mcpSessionId);
-        if (!entry) {
-          return res.status(404).json({
-            ...jsonRpcError(req, -32001, 'Session not found for Mcp-Session-Id'),
-          });
-        }
-        if (entry.userId !== userId) {
-          return res.status(403).json({
-            ...jsonRpcError(req, -32003, 'Forbidden: MCP session belongs to a different user'),
-          });
-        }
-
-        // A stateful MCP transport's Agor session binding is immutable. Tool
-        // handlers close over `entry.context`, so allowing callers to add or
-        // change X-Agor-Session-Id on later requests would be confusing at
-        // best and a stale-context authorization footgun at worst.
-        if (!entry.sessionId && sessionId) {
-          return res.status(403).json({
-            ...jsonRpcError(
-              req,
-              -32003,
-              'Forbidden: MCP session was initialized without X-Agor-Session-Id / ?sessionId context; start a new MCP session with session context instead.'
-            ),
-          });
-        }
-        if (entry.sessionId && sessionId && entry.sessionId !== sessionId) {
-          return res.status(403).json({
-            ...jsonRpcError(
-              req,
-              -32003,
-              'Forbidden: MCP session is already bound to a different X-Agor-Session-Id / ?sessionId context'
-            ),
-          });
-        }
-
-        armStatefulTransportTtl(mcpSessionId, entry);
-
-        // Rebuild the mutable context captured by registered handlers on each
-        // stateful request. Credentials have just been re-authenticated and
-        // the user was reloaded, so this keeps role/user data fresh for
-        // long-lived streamable HTTP sessions. If the immutable Agor session
-        // binding is no longer accessible to this user, evict the MCP session.
-        if (entry.sessionId) {
+        // Personal API key callers may optionally bind a current-session context
+        // using a header/query param. Validate through the normal sessions
+        // service so branch RBAC and short-ID resolution stay identical to REST.
+        if (isPersonalApiKey && sessionId) {
           try {
-            const session = await app.service('sessions').get(entry.sessionId, baseServiceParams);
-            entry.sessionId = session.session_id;
+            const session = await app.service('sessions').get(sessionId, baseServiceParams);
+            sessionId = session.session_id;
           } catch {
-            closeStatefulTransport(mcpSessionId);
             return res.status(403).json({
               ...jsonRpcError(
                 req,
                 -32003,
-                'Forbidden: the X-Agor-Session-Id / ?sessionId context bound to this MCP session is no longer accessible.'
+                'Forbidden: X-Agor-Session-Id / ?sessionId is invalid or not accessible to this API key user.'
               ),
             });
           }
         }
-        entry.context.userId = userId;
-        entry.context.sessionId = entry.sessionId;
-        entry.context.authenticatedUser = authenticatedUser;
-        entry.context.baseServiceParams = baseServiceParams;
 
-        await entry.transport.handleRequest(req, res, req.body);
-        return;
-      }
+        mcpRequestDebug(
+          `🔌 MCP request authenticated (user: ${shortId(userId)}, session: ${sessionId ? shortId(sessionId) : 'none'})`
+        );
 
-      if (req.method === 'POST' && isInitializeRequest(req.body)) {
-        evictOldestStatefulTransportIfNeeded();
-
-        const mcpServer = createMcpServer(mcpContext, toolSearchEnabled);
-        let transport: StreamableHTTPServerTransport;
-        transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: () => randomUUID(),
-          onsessioninitialized: (newSessionId) => {
-            const ttlTimer = setTimeout(
-              () => closeStatefulTransport(newSessionId),
-              STATEFUL_TRANSPORT_TTL_MS
-            );
-            ttlTimer.unref?.();
-            const entry: StatefulTransportEntry = {
-              transport,
-              server: mcpServer,
-              context: mcpContext,
-              userId,
-              sessionId,
-              lastUsedAt: Date.now(),
-              ttlTimer,
-            };
-            statefulTransports.set(newSessionId, entry);
-          },
-          onsessionclosed: (closedSessionId) => {
-            if (closedSessionId) closeStatefulTransport(closedSessionId);
-          },
-        });
-
-        transport.onclose = () => {
-          const sid = transport.sessionId;
-          if (sid) {
-            const entry = statefulTransports.get(sid);
-            statefulTransports.delete(sid);
-            if (entry) clearTimeout(entry.ttlTimer);
-          }
+        const mcpContext: McpContext = {
+          app,
+          db,
+          userId,
+          sessionId,
+          authenticatedUser,
+          baseServiceParams,
         };
 
+        const mcpSessionHeader = req.headers['mcp-session-id'];
+        const mcpSessionId = coerceString(
+          Array.isArray(mcpSessionHeader) ? mcpSessionHeader[0] : mcpSessionHeader
+        );
+
+        if (req.method === 'GET' || req.method === 'DELETE' || mcpSessionId) {
+          if (!mcpSessionId) {
+            return res.status(400).json({
+              ...jsonRpcError(req, -32000, 'Bad Request: Mcp-Session-Id header is required'),
+            });
+          }
+          const entry = statefulTransports.get(mcpSessionId);
+          if (!entry) {
+            return res.status(404).json({
+              ...jsonRpcError(req, -32001, 'Session not found for Mcp-Session-Id'),
+            });
+          }
+          if (entry.tenantId !== tenant.tenant_id) {
+            return res.status(403).json({
+              ...jsonRpcError(req, -32003, 'Forbidden: MCP session belongs to a different tenant'),
+            });
+          }
+          if (entry.userId !== userId) {
+            return res.status(403).json({
+              ...jsonRpcError(req, -32003, 'Forbidden: MCP session belongs to a different user'),
+            });
+          }
+
+          // A stateful MCP transport's Agor session binding is immutable. Tool
+          // handlers close over `entry.context`, so allowing callers to add or
+          // change X-Agor-Session-Id on later requests would be confusing at
+          // best and a stale-context authorization footgun at worst.
+          if (!entry.sessionId && sessionId) {
+            return res.status(403).json({
+              ...jsonRpcError(
+                req,
+                -32003,
+                'Forbidden: MCP session was initialized without X-Agor-Session-Id / ?sessionId context; start a new MCP session with session context instead.'
+              ),
+            });
+          }
+          if (entry.sessionId && sessionId && entry.sessionId !== sessionId) {
+            return res.status(403).json({
+              ...jsonRpcError(
+                req,
+                -32003,
+                'Forbidden: MCP session is already bound to a different X-Agor-Session-Id / ?sessionId context'
+              ),
+            });
+          }
+
+          armStatefulTransportTtl(mcpSessionId, entry);
+
+          // Rebuild the mutable context captured by registered handlers on each
+          // stateful request. Credentials have just been re-authenticated and
+          // the user was reloaded, so this keeps role/user data fresh for
+          // long-lived streamable HTTP sessions. If the immutable Agor session
+          // binding is no longer accessible to this user, evict the MCP session.
+          if (entry.sessionId) {
+            try {
+              const session = await app.service('sessions').get(entry.sessionId, baseServiceParams);
+              entry.sessionId = session.session_id;
+            } catch {
+              closeStatefulTransport(mcpSessionId);
+              return res.status(403).json({
+                ...jsonRpcError(
+                  req,
+                  -32003,
+                  'Forbidden: the X-Agor-Session-Id / ?sessionId context bound to this MCP session is no longer accessible.'
+                ),
+              });
+            }
+          }
+          entry.context.userId = userId;
+          entry.context.sessionId = entry.sessionId;
+          entry.context.authenticatedUser = authenticatedUser;
+          entry.context.baseServiceParams = baseServiceParams;
+
+          await entry.transport.handleRequest(req, res, req.body);
+          return;
+        }
+
+        if (req.method === 'POST' && isInitializeRequest(req.body)) {
+          evictOldestStatefulTransportIfNeeded();
+
+          const mcpServer = createMcpServer(mcpContext, toolSearchEnabled);
+          let transport: StreamableHTTPServerTransport;
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: (newSessionId) => {
+              const ttlTimer = setTimeout(
+                () => closeStatefulTransport(newSessionId),
+                STATEFUL_TRANSPORT_TTL_MS
+              );
+              ttlTimer.unref?.();
+              const entry: StatefulTransportEntry = {
+                transport,
+                server: mcpServer,
+                context: mcpContext,
+                userId,
+                tenantId: tenant.tenant_id,
+                sessionId,
+                lastUsedAt: Date.now(),
+                ttlTimer,
+              };
+              statefulTransports.set(newSessionId, entry);
+            },
+            onsessionclosed: (closedSessionId) => {
+              if (closedSessionId) closeStatefulTransport(closedSessionId);
+            },
+          });
+
+          transport.onclose = () => {
+            const sid = transport.sessionId;
+            if (sid) {
+              const entry = statefulTransports.get(sid);
+              statefulTransports.delete(sid);
+              if (entry) clearTimeout(entry.ttlTimer);
+            }
+          };
+
+          await mcpServer.connect(transport);
+          await transport.handleRequest(req, res, req.body);
+          return;
+        }
+
+        if (req.method !== 'POST') {
+          return res.status(405).json({
+            ...jsonRpcError(req, -32005, `Method ${req.method} not allowed on /mcp`),
+          });
+        }
+
+        const mcpServer = createMcpServer(mcpContext, toolSearchEnabled);
+
+        // Create stateless transport (one per request, no session tracking)
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+        });
+
+        // Connect and handle the request
         await mcpServer.connect(transport);
         await transport.handleRequest(req, res, req.body);
-        return;
-      }
 
-      if (req.method !== 'POST') {
-        return res.status(405).json({
-          ...jsonRpcError(req, -32005, `Method ${req.method} not allowed on /mcp`),
+        // Clean up after response is done
+        res.on('close', () => {
+          mcpServer.close().catch(() => {});
         });
-      }
-
-      const mcpServer = createMcpServer(mcpContext, toolSearchEnabled);
-
-      // Create stateless transport (one per request, no session tracking)
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-      });
-
-      // Connect and handle the request
-      await mcpServer.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-
-      // Clean up after response is done
-      res.on('close', () => {
-        mcpServer.close().catch(() => {});
       });
     } catch (error) {
       console.error('❌ MCP request failed:', error);

--- a/apps/agor-daemon/src/mcp/tokens.test.ts
+++ b/apps/agor-daemon/src/mcp/tokens.test.ts
@@ -21,6 +21,7 @@ import {
   generateId,
   insert,
   RepoRepository,
+  runWithTenantContext,
   sessions,
   shortId,
 } from '@agor/core/db';
@@ -49,6 +50,15 @@ const JWT_SECRET = 'test-jwt-secret-do-not-use-in-production';
  */
 function makeApp(): any {
   return { settings: { authentication: { secret: JWT_SECRET } } };
+}
+
+function mintSessionToken(
+  app: ReturnType<typeof makeApp>,
+  sessionId: SessionID,
+  userId: UserID,
+  tenantId = 'tenant-a'
+): Promise<string> {
+  return runWithTenantContext(tenantId, () => generateSessionToken(app, sessionId, userId));
 }
 
 async function seedSession(
@@ -110,7 +120,7 @@ describe('generateSessionToken', () => {
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
     const app = makeApp();
 
-    const token = await generateSessionToken(app, sessionId, 'user-1' as UserID);
+    const token = await mintSessionToken(app, sessionId, 'user-1' as UserID);
 
     const decoded = jwt.verify(token, JWT_SECRET, {
       audience: MCP_TOKEN_AUDIENCE,
@@ -118,6 +128,7 @@ describe('generateSessionToken', () => {
 
     expect(decoded.sub).toBe(sessionId);
     expect(decoded.uid).toBe('user-1');
+    expect(decoded.tid).toBe('tenant-a');
     expect(decoded.aud).toBe(MCP_TOKEN_AUDIENCE);
     expect(decoded.iss).toBe(MCP_TOKEN_ISSUER);
     expect(typeof decoded.jti).toBe('string');
@@ -134,12 +145,12 @@ describe('generateSessionToken', () => {
       initMcpTokens({ db, expirationMs: 60_000 });
       const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
 
-      const t1 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
-      const t2 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
+      const t1 = await mintSessionToken(makeApp(), sessionId, 'u' as UserID);
+      const t2 = await mintSessionToken(makeApp(), sessionId, 'u' as UserID);
       expect(t2).toBe(t1);
 
       vi.setSystemTime(new Date(baseMs + 31_000));
-      const t3 = await generateSessionToken(makeApp(), sessionId, 'u' as UserID);
+      const t3 = await mintSessionToken(makeApp(), sessionId, 'u' as UserID);
       const d1 = jwt.decode(t1) as { jti?: string };
       const d3 = jwt.decode(t3) as { jti?: string };
 
@@ -154,9 +165,30 @@ describe('generateSessionToken', () => {
   dbTest('throws when the session does not exist', async ({ db }) => {
     initMcpTokens({ db });
     const missingSessionId = generateId() as SessionID;
-    await expect(generateSessionToken(makeApp(), missingSessionId, 'u1' as UserID)).rejects.toThrow(
+    await expect(mintSessionToken(makeApp(), missingSessionId, 'u1' as UserID)).rejects.toThrow(
       /not found/
     );
+  });
+
+  dbTest('fails closed when issuance has no tenant context', async ({ db }) => {
+    initMcpTokens({ db });
+    const sessionId = await seedSession(db);
+
+    await expect(generateSessionToken(makeApp(), sessionId, 'u1' as UserID)).rejects.toThrow(
+      /missing active tenant context/
+    );
+  });
+
+  dbTest('keeps cached tokens distinct across tenant bindings', async ({ db }) => {
+    initMcpTokens({ db });
+    const sessionId = await seedSession(db);
+
+    const tenantA = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-a');
+    const tenantB = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-b');
+
+    expect(tenantA).not.toBe(tenantB);
+    expect((jwt.decode(tenantA) as { tid?: string }).tid).toBe('tenant-a');
+    expect((jwt.decode(tenantB) as { tid?: string }).tid).toBe('tenant-b');
   });
 });
 
@@ -168,12 +200,13 @@ describe('validateSessionToken', () => {
   dbTest('accepts a freshly minted token', async ({ db }) => {
     initMcpTokens({ db });
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
-    const token = await generateSessionToken(makeApp(), sessionId, 'u1' as UserID);
+    const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID);
 
     const ctx = await validateSessionToken(makeApp(), token);
     expect(ctx).not.toBeNull();
     expect(ctx?.sessionId).toBe(sessionId);
     expect(ctx?.userId).toBe('u1');
+    expect(ctx?.tenantId).toBe('tenant-a');
     expect(typeof ctx?.jti).toBe('string');
   });
 
@@ -187,7 +220,7 @@ describe('validateSessionToken', () => {
     try {
       initMcpTokens({ db, expirationMs: 60_000 });
       const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
-      const token = await generateSessionToken(makeApp(), sessionId, 'u1' as UserID);
+      const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID);
 
       // Still valid right after issuance.
       expect(await validateSessionToken(makeApp(), token)).not.toBeNull();
@@ -204,7 +237,7 @@ describe('validateSessionToken', () => {
   dbTest('rejects tokens for sessions that have been deleted', async ({ db }) => {
     initMcpTokens({ db });
     const sessionId = await seedSession(db, { sessionId: generateId() as SessionID });
-    const token = await generateSessionToken(makeApp(), sessionId, 'u1' as UserID);
+    const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID);
 
     // Simulate the session being deleted out from under us.
     await deleteFrom(db, sessions).where(eq(sessions.session_id, sessionId)).run();
@@ -223,6 +256,7 @@ describe('validateSessionToken', () => {
       {
         sub: sessionId,
         uid: 'u1',
+        tid: 'tenant-a',
         aud: MCP_TOKEN_AUDIENCE,
         iss: 'not-agor',
         iat: nowSec,
@@ -266,6 +300,7 @@ describe('validateSessionToken', () => {
       {
         sub: sessionId,
         uid: 'u1',
+        tid: 'tenant-a',
         aud: MCP_TOKEN_AUDIENCE,
         iss: MCP_TOKEN_ISSUER,
         jti: generateId(),
@@ -287,6 +322,7 @@ describe('validateSessionToken', () => {
       {
         sub: sessionId,
         uid: 'u1',
+        tid: 'tenant-a',
         aud: MCP_TOKEN_AUDIENCE,
         iss: MCP_TOKEN_ISSUER,
         iat: nowSec,
@@ -299,4 +335,19 @@ describe('validateSessionToken', () => {
 
     expect(await validateSessionToken(makeApp(), forged)).toBeNull();
   });
+
+  dbTest(
+    'rejects replay against a different expected tenant before session lookup',
+    async ({ db }) => {
+      initMcpTokens({ db });
+      const sessionId = await seedSession(db);
+      const token = await mintSessionToken(makeApp(), sessionId, 'u1' as UserID, 'tenant-a');
+
+      expect(await validateSessionToken(makeApp(), token, 'tenant-b')).toBeNull();
+      expect(await validateSessionToken(makeApp(), token, 'tenant-a')).toMatchObject({
+        sessionId,
+        tenantId: 'tenant-a',
+      });
+    }
+  );
 });

--- a/apps/agor-daemon/src/mcp/tokens.ts
+++ b/apps/agor-daemon/src/mcp/tokens.ts
@@ -6,6 +6,7 @@
  *
  * - `sub`  — session id
  * - `uid`  — user id
+ * - `tid`  — tenant id
  * - `aud`  — `agor:mcp:internal`
  * - `iss`  — `agor`
  * - `iat`  — unix seconds, standard JWT "issued at"
@@ -13,7 +14,7 @@
  * - `jti`  — per-issuance UUID (useful for log correlation)
  *
  * No revocation mechanics. Tokens are minted lazily and cached briefly per
- * `(session,user)` so high-frequency `session.get` calls don't perform
+ * `(tenant,session,user)` so high-frequency `session.get` calls don't perform
  * redundant JWT signing and session-existence probes. Tokens carry a short
  * `exp` (default 24h); any suspected
  * compromise is addressed by rotating the JWT signing secret or letting the
@@ -27,6 +28,9 @@
 import { MCP_TOKEN } from '@agor/core/config';
 import {
   generateId,
+  requireCurrentTenantId,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
   SessionRepository,
   shortId,
   type TenantScopeAwareDatabase,
@@ -36,6 +40,7 @@ import {
   MCP_TOKEN_AUDIENCE,
   MCP_TOKEN_ISSUER,
   type SessionID,
+  type TenantID,
   type UserID,
 } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
@@ -59,6 +64,7 @@ export { MCP_TOKEN_AUDIENCE, MCP_TOKEN_ISSUER } from '@agor/core/types';
 interface McpTokenPayload {
   sub: SessionID;
   uid: UserID;
+  tid: TenantID;
   aud: string;
   iss?: string;
   iat?: number;
@@ -69,6 +75,7 @@ interface McpTokenPayload {
 export interface McpTokenContext {
   sessionId: SessionID;
   userId: UserID;
+  tenantId: TenantID;
   jti: string;
 }
 
@@ -85,6 +92,7 @@ export interface McpTokenInitOptions {
 // ============================================================================
 
 interface ModuleState {
+  db: TenantScopeAwareDatabase;
   sessionRepo: SessionRepository;
   expirationMs: number;
   now: () => number;
@@ -121,6 +129,7 @@ export function initMcpTokens(options: McpTokenInitOptions): void {
   const now = options.now ?? (() => Date.now());
 
   _state = {
+    db: options.db,
     sessionRepo: new SessionRepository(options.db),
     expirationMs,
     now,
@@ -160,6 +169,9 @@ export async function generateSessionToken(
   }
 
   const nowMs = s.now();
+  const tenantId = requireCurrentTenantId(
+    'MCP token generation failed: missing active tenant context'
+  ) as TenantID;
   if (nowMs - s.lastCachePruneAtMs > 5 * 60 * 1000) {
     for (const [key, entry] of s.tokenCache) {
       if (entry.expiresAtMs <= nowMs) {
@@ -169,7 +181,7 @@ export async function generateSessionToken(
     s.lastCachePruneAtMs = nowMs;
   }
 
-  const cacheKey = `${sessionId}:${userId}`;
+  const cacheKey = `${tenantId}:${sessionId}:${userId}`;
   const cached = s.tokenCache.get(cacheKey);
   // Keep a buffer so callers never receive a token that is about to expire.
   const refreshBufferMs = Math.min(5 * 60 * 1000, Math.max(30 * 1000, s.expirationMs * 0.1));
@@ -178,7 +190,9 @@ export async function generateSessionToken(
     return cached.token;
   }
 
-  const sessionExists = await s.sessionRepo.exists(sessionId);
+  const sessionExists = await runWithTenantDatabaseScope(s.db, tenantId, () =>
+    s.sessionRepo.exists(sessionId)
+  );
   if (!sessionExists) {
     s.tokenCache.delete(cacheKey);
     throw new Error(
@@ -194,6 +208,7 @@ export async function generateSessionToken(
   const payload: McpTokenPayload = {
     sub: sessionId,
     uid: userId,
+    tid: tenantId,
     aud: MCP_TOKEN_AUDIENCE,
     iss: MCP_TOKEN_ISSUER,
     iat: nowSec,
@@ -219,20 +234,18 @@ export const getTokenForSession = generateSessionToken;
 // ============================================================================
 
 /**
- * Validate an MCP token and extract `{ sessionId, userId, jti }`.
+ * Cryptographically verify an MCP token without touching tenant-owned data.
+ * Callers can use the signed tenant binding to establish the tenant scope
+ * before validating session/user existence.
  *
  * Rejection reasons:
  *  - bad signature / wrong audience / wrong issuer / expired (`jsonwebtoken.verify`)
- *  - missing `jti`/`exp` claims (pre-rollout tokens are rejected outright)
- *  - session no longer exists
+ *  - missing `tid`/`jti`/`exp` claims (pre-rollout tokens are rejected outright)
  *
  * Returns `null` on any failure.
  */
-export async function validateSessionToken(
-  app: Application,
-  token: string
-): Promise<McpTokenContext | null> {
-  const s = requireState();
+export function verifySessionToken(app: Application, token: string): McpTokenContext | null {
+  requireState();
   const jwtSecret = app.settings.authentication?.secret;
   if (!jwtSecret) {
     console.error('[mcp-tokens] JWT secret not configured in app settings');
@@ -259,8 +272,16 @@ export async function validateSessionToken(
 
   const sessionId = payload.sub;
   const userId = payload.uid;
-  if (!sessionId || !userId) {
-    console.warn('[mcp-tokens] token rejected: missing sub/uid');
+  const tenantId = payload.tid;
+  if (
+    typeof sessionId !== 'string' ||
+    !sessionId ||
+    typeof userId !== 'string' ||
+    !userId ||
+    typeof tenantId !== 'string' ||
+    !tenantId.trim()
+  ) {
+    console.warn('[mcp-tokens] token rejected: missing sub/uid/tid');
     return null;
   }
 
@@ -273,13 +294,48 @@ export async function validateSessionToken(
     return null;
   }
 
-  // Reject tokens whose session has been deleted — protects against stale
-  // tokens outliving their session until `exp`.
-  const sessionExists = await s.sessionRepo.exists(sessionId);
+  return { sessionId, userId, tenantId: tenantId.trim() as TenantID, jti: payload.jti };
+}
+
+/**
+ * Validate the tenant-owned state referenced by an already verified token.
+ * The signed tenant is entered before the session lookup, and the transaction
+ * lasts only for that lookup.
+ */
+export async function validateVerifiedSessionToken(
+  context: McpTokenContext
+): Promise<McpTokenContext | null> {
+  const s = requireState();
+  const sessionExists = await runWithTenantContext(context.tenantId, () =>
+    runWithTenantDatabaseScope(s.db, context.tenantId, () =>
+      s.sessionRepo.exists(context.sessionId)
+    )
+  );
   if (!sessionExists) {
-    console.warn(`[mcp-tokens] token rejected: session ${shortId(sessionId)} not found`);
+    console.warn(
+      `[mcp-tokens] token rejected: session ${shortId(context.sessionId)} not found in bound tenant`
+    );
     return null;
   }
 
-  return { sessionId, userId, jti: payload.jti };
+  return context;
+}
+
+/**
+ * Verify a token and validate its session inside the signed tenant.
+ * `expectedTenantId` lets an HTTP boundary require agreement with a static or
+ * trusted-header tenant before any database lookup occurs.
+ */
+export async function validateSessionToken(
+  app: Application,
+  token: string,
+  expectedTenantId?: TenantID | string
+): Promise<McpTokenContext | null> {
+  const context = verifySessionToken(app, token);
+  if (!context) return null;
+  if (expectedTenantId && expectedTenantId !== context.tenantId) {
+    console.warn('[mcp-tokens] token rejected: tenant binding mismatch');
+    return null;
+  }
+  return validateVerifiedSessionToken(context);
 }

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3965,7 +3965,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   if (config.daemon?.mcpEnabled !== false) {
     const { setupMCPRoutes } = await import('./mcp/server.js');
     const toolSearchEnabled = config.daemon?.mcpToolSearch !== false;
-    setupMCPRoutes(app, db, toolSearchEnabled);
+    setupMCPRoutes(app, db, toolSearchEnabled, config);
     console.log(
       `✅ MCP server enabled at POST /mcp${toolSearchEnabled ? ' (tool search mode)' : ''}`
     );

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1,7 +1,7 @@
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import {
   attachHiddenTenant,
-  GatewayChannelRepository,
+  GatewayListenerDiscoveryRepository,
   getCurrentTenantDatabaseScope,
   getCurrentTenantId,
   runWithTenantContext,
@@ -242,8 +242,8 @@ describe('GatewayService multi-tenant process state', () => {
       [];
     const startedInTenants: Array<string | undefined> = [];
     const handledInTenants: Array<string | undefined> = [];
-    const findEnabledRefs = vi
-      .spyOn(GatewayChannelRepository.prototype, 'findEnabledRefs')
+    const findEnabledTenantRefs = vi
+      .spyOn(GatewayListenerDiscoveryRepository.prototype, 'findEnabledTenantRefs')
       .mockResolvedValue([
         { channel_id: 'same-channel' as never, tenant_id: 'tenant-a' },
         { channel_id: 'same-channel' as never, tenant_id: 'tenant-b' },
@@ -287,14 +287,44 @@ describe('GatewayService multi-tenant process state', () => {
       callbacks[1]({ threadId: 'thread-b', text: 'b', userId: 'user-b' });
       await vi.waitFor(() => expect(handledInTenants).toEqual(['tenant-a', 'tenant-b']));
     } finally {
-      findEnabledRefs.mockRestore();
+      findEnabledTenantRefs.mockRestore();
     }
+  });
+
+  it('starts static-tenant listeners and refreshes the fast path with one channel scan', async () => {
+    const service = new GatewayService({ run: vi.fn() } as never, { service: vi.fn() } as never);
+    const channel = attachHiddenTenant(
+      {
+        ...slackChannel,
+        id: 'static-channel' as never,
+        config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+      },
+      { tenant_id: 'static-tenant' }
+    );
+    const channelRepo = { findAll: vi.fn(async () => [channel]) };
+    (service as unknown as { channelRepo: typeof channelRepo }).channelRepo = channelRepo;
+    const startListening = vi.fn(async () => undefined);
+    vi.mocked(getConnector).mockReturnValue({
+      startListening,
+      sendMessage: vi.fn(async () => 'sent'),
+    });
+
+    await runWithTenantContext('static-tenant', () => service.startListeners());
+
+    expect(channelRepo.findAll).toHaveBeenCalledOnce();
+    expect(startListening).toHaveBeenCalledOnce();
+    expect(
+      (service as unknown as { activeChannelTenants: Set<string> }).activeChannelTenants
+    ).toEqual(new Set(['static-tenant']));
+    expect([
+      ...(service as unknown as { activeListeners: Map<string, unknown> }).activeListeners.keys(),
+    ]).toEqual(['static-tenant\0static-channel']);
   });
 
   it('fails closed on a discovered tenant mismatch while continuing other tenants', async () => {
     const service = new GatewayService({ run: vi.fn() } as never, { service: vi.fn() } as never);
-    const findEnabledRefs = vi
-      .spyOn(GatewayChannelRepository.prototype, 'findEnabledRefs')
+    const findEnabledTenantRefs = vi
+      .spyOn(GatewayListenerDiscoveryRepository.prototype, 'findEnabledTenantRefs')
       .mockResolvedValue([
         { channel_id: 'forged-channel' as never, tenant_id: 'tenant-a' },
         { channel_id: 'valid-channel' as never, tenant_id: 'tenant-b' },
@@ -329,7 +359,7 @@ describe('GatewayService multi-tenant process state', () => {
       expect(error.mock.calls.flat().join(' ')).toMatch(/tenant mismatch/i);
     } finally {
       error.mockRestore();
-      findEnabledRefs.mockRestore();
+      findEnabledTenantRefs.mockRestore();
     }
   });
 });

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1,6 +1,7 @@
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import {
   attachHiddenTenant,
+  GatewayChannelRepository,
   getCurrentTenantDatabaseScope,
   getCurrentTenantId,
   runWithTenantContext,
@@ -121,6 +122,16 @@ function makeGatewayHarness(args: {
     if (getCurrentTenantDatabaseScope()) return create(data);
     return runWithTenantDatabaseScope(db, 'tenant-channel', () => create(data));
   };
+  const routeMessage = service.routeMessage.bind(service);
+  service.routeMessage = (data) => {
+    if (getCurrentTenantId()) return routeMessage(data);
+    return runWithTenantContext('tenant-channel', () => routeMessage(data));
+  };
+  const handleMessageStreamingEvent = service.handleMessageStreamingEvent.bind(service);
+  service.handleMessageStreamingEvent = (event, data) => {
+    if (getCurrentTenantId()) return handleMessageStreamingEvent(event, data);
+    return runWithTenantContext('tenant-channel', () => handleMessageStreamingEvent(event, data));
+  };
   const channelRepo = {
     findByKey: vi.fn(async () => channel),
     findById: vi.fn(async () => channel),
@@ -155,8 +166,10 @@ function makeGatewayHarness(args: {
   };
   (
     service as unknown as { activeListeners: Map<string, Record<string, unknown>> }
-  ).activeListeners.set(channel.id, args.connector ?? {});
-  (service as unknown as { hasActiveChannels: boolean }).hasActiveChannels = true;
+  ).activeListeners.set(`tenant-channel\0${channel.id}`, args.connector ?? {});
+  (service as unknown as { activeChannelTenants: Set<string> }).activeChannelTenants.add(
+    'tenant-channel'
+  );
 
   return {
     service,
@@ -179,6 +192,145 @@ describe('gateway tenant metadata helpers', () => {
 
     expect(tenantIdFromGatewayChannel(channel)).toBe('tenant-channel');
     expect(Object.keys(channel)).not.toContain('tenant_id');
+  });
+});
+
+describe('GatewayService multi-tenant process state', () => {
+  it("does not let one tenant's empty channel set suppress another tenant's delivery", async () => {
+    const sendMessage = vi.fn(async () => 'sent-1');
+    const service = new GatewayService({ run: vi.fn() } as never, { service: vi.fn() } as never);
+    const tenantAChannel = attachHiddenTenant(
+      { ...slackChannel, id: 'shared-looking-channel' as never },
+      { tenant_id: 'tenant-a' }
+    );
+    const mapping = makeMapping({ channel_id: tenantAChannel.id });
+    const channelRepo = {
+      findAll: vi.fn(async () => (getCurrentTenantId() === 'tenant-a' ? [tenantAChannel] : [])),
+      findById: vi.fn(async () => tenantAChannel),
+      updateLastMessage: vi.fn(async () => undefined),
+    };
+    const threadMapRepo = {
+      findBySession: vi.fn(async () => mapping),
+      updateLastMessage: vi.fn(async () => undefined),
+      findById: vi.fn(async () => mapping),
+      updateMetadata: vi.fn(async () => undefined),
+    };
+    (service as unknown as { channelRepo: typeof channelRepo }).channelRepo = channelRepo;
+    (service as unknown as { threadMapRepo: typeof threadMapRepo }).threadMapRepo = threadMapRepo;
+    (
+      service as unknown as { activeListeners: Map<string, Record<string, unknown>> }
+    ).activeListeners.set('tenant-a\0shared-looking-channel', { sendMessage });
+
+    await runWithTenantContext('tenant-a', () => service.refreshChannelState());
+    await runWithTenantContext('tenant-b', () => service.refreshChannelState());
+
+    const result = await runWithTenantContext('tenant-a', () =>
+      service.routeMessage({ session_id: 'sess-1', message: 'hello tenant A' })
+    );
+
+    expect(result).toEqual({ routed: true, channelType: 'slack' });
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(
+      (service as unknown as { activeChannelTenants: Set<string> }).activeChannelTenants
+    ).toEqual(new Set(['tenant-a']));
+  });
+
+  it('discovers and starts same-looking channel IDs independently in two tenant contexts', async () => {
+    const db = { run: vi.fn() } as never;
+    const service = new GatewayService(db, { service: vi.fn() } as never);
+    const callbacks: Array<(message: { threadId: string; text: string; userId: string }) => void> =
+      [];
+    const startedInTenants: Array<string | undefined> = [];
+    const handledInTenants: Array<string | undefined> = [];
+    const findEnabledRefs = vi
+      .spyOn(GatewayChannelRepository.prototype, 'findEnabledRefs')
+      .mockResolvedValue([
+        { channel_id: 'same-channel' as never, tenant_id: 'tenant-a' },
+        { channel_id: 'same-channel' as never, tenant_id: 'tenant-b' },
+      ]);
+    const channelRepo = {
+      findById: vi.fn(async () =>
+        attachHiddenTenant(
+          {
+            ...slackChannel,
+            id: 'same-channel' as never,
+            channel_key: `${getCurrentTenantId()}-key`,
+            config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+          },
+          { tenant_id: getCurrentTenantId() }
+        )
+      ),
+    };
+    (service as unknown as { channelRepo: typeof channelRepo }).channelRepo = channelRepo;
+    vi.spyOn(service, 'create').mockImplementation(async () => {
+      handledInTenants.push(getCurrentTenantId());
+      return { success: true, sessionId: 'sess-1', created: false };
+    });
+    vi.mocked(getConnector).mockImplementation(() => ({
+      startListening: vi.fn(async (callback) => {
+        startedInTenants.push(getCurrentTenantId());
+        callbacks.push(callback);
+      }),
+      sendMessage: vi.fn(async () => 'sent'),
+    }));
+
+    try {
+      await service.startListenersAcrossTenants();
+
+      expect(startedInTenants).toEqual(['tenant-a', 'tenant-b']);
+      expect(channelRepo.findById.mock.calls).toHaveLength(2);
+      expect([
+        ...(service as unknown as { activeListeners: Map<string, unknown> }).activeListeners.keys(),
+      ]).toEqual(['tenant-a\0same-channel', 'tenant-b\0same-channel']);
+
+      callbacks[0]({ threadId: 'thread-a', text: 'a', userId: 'user-a' });
+      callbacks[1]({ threadId: 'thread-b', text: 'b', userId: 'user-b' });
+      await vi.waitFor(() => expect(handledInTenants).toEqual(['tenant-a', 'tenant-b']));
+    } finally {
+      findEnabledRefs.mockRestore();
+    }
+  });
+
+  it('fails closed on a discovered tenant mismatch while continuing other tenants', async () => {
+    const service = new GatewayService({ run: vi.fn() } as never, { service: vi.fn() } as never);
+    const findEnabledRefs = vi
+      .spyOn(GatewayChannelRepository.prototype, 'findEnabledRefs')
+      .mockResolvedValue([
+        { channel_id: 'forged-channel' as never, tenant_id: 'tenant-a' },
+        { channel_id: 'valid-channel' as never, tenant_id: 'tenant-b' },
+      ]);
+    const channelRepo = {
+      findById: vi.fn(async (channelId: string) =>
+        attachHiddenTenant(
+          {
+            ...slackChannel,
+            id: channelId as never,
+            config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+          },
+          { tenant_id: channelId === 'forged-channel' ? 'tenant-x' : 'tenant-b' }
+        )
+      ),
+    };
+    (service as unknown as { channelRepo: typeof channelRepo }).channelRepo = channelRepo;
+    const startListening = vi.fn(async () => undefined);
+    vi.mocked(getConnector).mockReturnValue({
+      startListening,
+      sendMessage: vi.fn(async () => 'sent'),
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await service.startListenersAcrossTenants();
+
+      expect(startListening).toHaveBeenCalledOnce();
+      expect([
+        ...(service as unknown as { activeListeners: Map<string, unknown> }).activeListeners.keys(),
+      ]).toEqual(['tenant-b\0valid-channel']);
+      expect(error.mock.calls.flat().join(' ')).toMatch(/tenant mismatch/i);
+    } finally {
+      error.mockRestore();
+      findEnabledRefs.mockRestore();
+    }
   });
 });
 

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -16,6 +16,7 @@ import {
   BranchRepository,
   bindRepositoryToTenantUnitOfWork,
   GatewayChannelRepository,
+  GatewayListenerDiscoveryRepository,
   GatewayOutboundMessageRepository,
   getCurrentTenantId,
   getHiddenTenantId,
@@ -2777,7 +2778,7 @@ export class GatewayService {
     const refs = await runWithSystemDatabaseScope(
       this.db,
       'gateway listener discovery',
-      (systemDb) => new GatewayChannelRepository(systemDb).findEnabledRefs(),
+      (systemDb) => new GatewayListenerDiscoveryRepository(systemDb).findEnabledTenantRefs(),
       { capability: 'gateway_listener_discovery' }
     );
 
@@ -2787,12 +2788,6 @@ export class GatewayService {
     }
 
     for (const ref of refs) {
-      if (!ref.tenant_id) {
-        console.error(
-          `[gateway] Refusing to start channel ${ref.channel_id}: discovery row has no tenant identity`
-        );
-        continue;
-      }
       const tenantId = ref.tenant_id;
 
       try {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -20,7 +20,9 @@ import {
   getCurrentTenantId,
   getHiddenTenantId,
   MCPServerRepository,
+  requireCurrentTenantId,
   runWithoutTenantDatabaseScope,
+  runWithSystemDatabaseScope,
   runWithTenantContext,
   runWithTenantDatabaseScope,
   SessionRepository,
@@ -634,16 +636,16 @@ export class GatewayService {
   private db: TenantScopeAwareDatabase;
   private app: Application;
 
-  /** Active Socket Mode listeners keyed by channel ID */
+  /** Active listeners keyed by immutable tenant + channel identity. */
   private activeListeners = new Map<string, GatewayConnector>();
 
   /**
-   * In-memory flag: true when at least one gateway channel exists.
+   * Tenants with at least one enabled gateway channel.
    * Allows routeMessage() to skip the DB lookup entirely when the
-   * gateway feature is not in use (the common case for most instances).
-   * Updated on startup and whenever channels are created/deleted.
+   * gateway feature is not in use for the current tenant. A tenant-local
+   * refresh must never suppress another tenant's delivery.
    */
-  private hasActiveChannels = false;
+  private activeChannelTenants = new Set<string>();
 
   /**
    * GitHub message buffer: keyed by session_id, stores the latest message text.
@@ -687,15 +689,33 @@ export class GatewayService {
     this.app = app;
   }
 
-  /**
-   * Refresh the in-memory hasActiveChannels flag.
-   * Called at startup and should be called when channels are created/deleted.
-   */
+  private listenerKey(tenantId: TenantID | string, channelId: string): string {
+    return `${tenantId}\0${channelId}`;
+  }
+
+  private getActiveListener(channelId: string): GatewayConnector | undefined {
+    const tenantId = getCurrentTenantId();
+    return tenantId ? this.activeListeners.get(this.listenerKey(tenantId, channelId)) : undefined;
+  }
+
+  private currentTenantHasActiveChannels(): boolean {
+    const tenantId = getCurrentTenantId();
+    return !!tenantId && this.activeChannelTenants.has(tenantId);
+  }
+
+  /** Refresh the current tenant's process-local channel fast path. */
   async refreshChannelState(): Promise<void> {
+    const tenantId = requireCurrentTenantId(
+      'Missing tenant context while refreshing gateway channel state'
+    );
     const channels = await this.channelRepo.findAll();
-    this.hasActiveChannels = channels.some((ch) => ch.enabled);
+    if (channels.some((ch) => ch.enabled)) {
+      this.activeChannelTenants.add(tenantId);
+    } else {
+      this.activeChannelTenants.delete(tenantId);
+    }
     console.log(
-      `[gateway] refreshChannelState: found ${channels.length} channels, ${channels.filter((ch) => ch.enabled).length} enabled`
+      `[gateway] refreshChannelState: tenant=${tenantId} found ${channels.length} channels, ${channels.filter((ch) => ch.enabled).length} enabled`
     );
   }
 
@@ -723,7 +743,7 @@ export class GatewayService {
       // store ConversationReferences in memory on the listener instance.
       // Creating a new connector via getConnector() would lose that state.
       const connector =
-        this.activeListeners.get(channel.id) ??
+        this.getActiveListener(channel.id) ??
         getConnector(channel.channel_type as ChannelType, channel.config);
       connector
         .sendMessage({
@@ -1211,7 +1231,7 @@ export class GatewayService {
   }
 
   private async updateProgressNow(data: GatewayProgressData): Promise<void> {
-    if (!this.hasActiveChannels) return;
+    if (!this.currentTenantHasActiveChannels()) return;
 
     const mapping = await this.threadMapRepo.findBySession(data.session_id);
     if (!mapping) return;
@@ -1269,7 +1289,7 @@ export class GatewayService {
     };
 
     const connector =
-      this.activeListeners.get(channel.id) ??
+      this.getActiveListener(channel.id) ??
       getConnector(channel.channel_type as ChannelType, channel.config);
     const activeTaskId =
       typeof metadata.slack_status_task_id === 'string' ? metadata.slack_status_task_id : undefined;
@@ -1323,7 +1343,7 @@ export class GatewayService {
     event: 'streaming:start' | 'streaming:chunk' | 'streaming:end' | 'streaming:error',
     data: Record<string, unknown>
   ): Promise<void> {
-    if (!this.hasActiveChannels) return;
+    if (!this.currentTenantHasActiveChannels()) return;
 
     const sessionId = typeof data.session_id === 'string' ? data.session_id : undefined;
     const messageId = typeof data.message_id === 'string' ? data.message_id : undefined;
@@ -1346,7 +1366,7 @@ export class GatewayService {
     if (!channel?.enabled || channel.channel_type !== 'slack') return;
 
     const connector =
-      this.activeListeners.get(channel.id) ??
+      this.getActiveListener(channel.id) ??
       getConnector(channel.channel_type as ChannelType, channel.config);
 
     const streamConnector = connector as GatewayConnector & {
@@ -2336,7 +2356,7 @@ export class GatewayService {
             ? mappingMetadata.slack_last_delivered_ts
             : undefined;
         const connector =
-          this.activeListeners.get(channel.id) ??
+          this.getActiveListener(channel.id) ??
           getConnector(channel.channel_type as ChannelType, channel.config);
         const historyConnector = connector as Partial<SlackHistoryConnector>;
         if (currentTs && typeof historyConnector.fetchThreadHistory === 'function') {
@@ -2539,7 +2559,7 @@ export class GatewayService {
    */
   async routeMessage(data: RouteMessageData): Promise<RouteMessageResult> {
     // Fast path: skip DB lookup entirely when no channels are configured
-    if (!this.hasActiveChannels) {
+    if (!this.currentTenantHasActiveChannels()) {
       return { routed: false };
     }
 
@@ -2588,7 +2608,7 @@ export class GatewayService {
       // Prefer the active listener instance — webhook-based connectors (e.g. Teams)
       // store ConversationReferences in memory on the listener instance.
       const connector =
-        this.activeListeners.get(channel.id) ??
+        this.getActiveListener(channel.id) ??
         getConnector(channel.channel_type as ChannelType, channel.config);
 
       const systemMeta = data.metadata?.system as Record<string, unknown> | undefined;
@@ -2725,7 +2745,15 @@ export class GatewayService {
    * the gateway's create() method (same path as webhook POST).
    */
   async startListeners(): Promise<void> {
+    const tenantId = requireCurrentTenantId(
+      'Missing tenant context while starting gateway listeners'
+    );
     const channels = await this.channelRepo.findAll();
+    if (channels.some((channel) => channel.enabled)) {
+      this.activeChannelTenants.add(tenantId);
+    } else {
+      this.activeChannelTenants.delete(tenantId);
+    }
     const eligible = channels.filter(
       (ch) => ch.enabled && hasConnector(ch.channel_type as ChannelType) && hasListeningConfig(ch)
     );
@@ -2736,7 +2764,71 @@ export class GatewayService {
     }
 
     for (const channel of eligible) {
-      await this.startChannelListener(channel);
+      await this.startChannelListener(channel, tenantId);
+    }
+  }
+
+  /**
+   * Discover enabled channels across tenants at daemon startup. The system
+   * transaction returns only channel and tenant IDs. Credentials and all
+   * connector-owned work are reloaded under the discovered tenant's RLS scope.
+   */
+  async startListenersAcrossTenants(): Promise<void> {
+    const refs = await runWithSystemDatabaseScope(
+      this.db,
+      'gateway listener discovery',
+      (systemDb) => new GatewayChannelRepository(systemDb).findEnabledRefs(),
+      { capability: 'gateway_listener_discovery' }
+    );
+
+    if (refs.length === 0) {
+      console.log('[gateway] No enabled channels found during listener discovery');
+      return;
+    }
+
+    for (const ref of refs) {
+      if (!ref.tenant_id) {
+        console.error(
+          `[gateway] Refusing to start channel ${ref.channel_id}: discovery row has no tenant identity`
+        );
+        continue;
+      }
+      const tenantId = ref.tenant_id;
+
+      try {
+        await runWithTenantContext(tenantId, async () => {
+          const channel = await this.channelRepo.findById(ref.channel_id);
+          if (!channel) {
+            console.warn(
+              `[gateway] Channel ${ref.channel_id} disappeared before tenant-scoped listener startup`
+            );
+            return;
+          }
+
+          const rowTenantId = tenantIdFromGatewayChannel(channel);
+          if (rowTenantId !== tenantId) {
+            throw new Error(
+              `Gateway listener discovery tenant mismatch for channel ${ref.channel_id}`
+            );
+          }
+          if (!channel.enabled) {
+            console.warn(
+              `[gateway] Channel ${ref.channel_id} was disabled before tenant-scoped listener startup`
+            );
+            return;
+          }
+
+          this.activeChannelTenants.add(tenantId);
+          if (hasConnector(channel.channel_type as ChannelType) && hasListeningConfig(channel)) {
+            await this.startChannelListener(channel, tenantId);
+          }
+        });
+      } catch (error) {
+        console.error(
+          `[gateway] Refusing listener startup for channel ${ref.channel_id} in tenant ${tenantId}:`,
+          error
+        );
+      }
     }
   }
 
@@ -2745,6 +2837,9 @@ export class GatewayService {
    * (public wrapper for hook usage)
    */
   async startListenerForChannel(channelId: string): Promise<void> {
+    const tenantId = requireCurrentTenantId(
+      'Missing tenant context while managing a gateway listener'
+    );
     const channel = await this.channelRepo.findById(channelId);
     if (!channel) {
       console.warn(`[gateway] Cannot manage listener: channel ${channelId} not found`);
@@ -2776,7 +2871,7 @@ export class GatewayService {
     // startChannelListener() is a no-op if a listener already exists,
     // so we must tear down the old one before creating a new connector
     // with the updated config (e.g. enable_channels toggled).
-    if (this.activeListeners.has(channelId)) {
+    if (this.activeListeners.has(this.listenerKey(tenantId, channelId))) {
       console.log(
         `[gateway] Restarting listener for channel "${channel.name}" to pick up config changes`
       );
@@ -2784,21 +2879,25 @@ export class GatewayService {
     }
 
     // Start with fresh config
-    await this.startChannelListener(channel);
+    await this.startChannelListener(channel, tenantId);
   }
 
   /**
    * Stop a Socket Mode listener for a single channel
    */
   async stopChannelListener(channelId: string): Promise<void> {
-    const connector = this.activeListeners.get(channelId);
+    const tenantId = requireCurrentTenantId(
+      'Missing tenant context while stopping a gateway listener'
+    );
+    const key = this.listenerKey(tenantId, channelId);
+    const connector = this.activeListeners.get(key);
     if (!connector) {
       return; // Not listening
     }
 
     // Always remove from activeListeners so a fresh start can proceed,
     // even if stopListening() throws (e.g. socket already closed).
-    this.activeListeners.delete(channelId);
+    this.activeListeners.delete(key);
 
     try {
       if (connector.stopListening) {
@@ -2818,12 +2917,19 @@ export class GatewayService {
   /**
    * Start a Socket Mode listener for a single channel
    */
-  private async startChannelListener(channel: GatewayChannel): Promise<void> {
-    if (this.activeListeners.has(channel.id)) {
-      return; // Already listening
+  private async startChannelListener(
+    channel: GatewayChannel,
+    listenerTenantId: TenantID | string
+  ): Promise<void> {
+    const rowTenantId = tenantIdFromGatewayChannel(channel);
+    if (rowTenantId && rowTenantId !== listenerTenantId) {
+      throw new Error(`Gateway listener tenant mismatch for channel ${channel.id}`);
     }
 
-    const listenerTenantId = tenantIdFromGatewayChannel(channel) ?? getCurrentTenantId();
+    const key = this.listenerKey(listenerTenantId, channel.id);
+    if (this.activeListeners.has(key)) {
+      return; // Already listening
+    }
 
     return runWithoutTenantDatabaseScope(async () => {
       try {
@@ -2843,7 +2949,7 @@ export class GatewayService {
         };
 
         await connector.startListening(callback);
-        this.activeListeners.set(channel.id, connector);
+        this.activeListeners.set(key, connector);
         console.log(`[gateway] Socket Mode listener started for channel "${channel.name}"`);
       } catch (error) {
         console.error(`[gateway] Failed to start listener for channel "${channel.name}":`, error);
@@ -2876,17 +2982,18 @@ export class GatewayService {
    * Stop all active listeners (called on shutdown)
    */
   async stopListeners(): Promise<void> {
-    for (const [channelId, connector] of this.activeListeners) {
+    for (const [listenerKey, connector] of this.activeListeners) {
       try {
         if (connector.stopListening) {
           await connector.stopListening();
         }
-        console.log(`[gateway] Listener stopped for channel ${shortId(channelId)}`);
+        console.log(`[gateway] Listener stopped for ${listenerKey.replace('\0', '/')}`);
       } catch (error) {
-        console.error(`[gateway] Error stopping listener for ${channelId}:`, error);
+        console.error(`[gateway] Error stopping listener for ${listenerKey}:`, error);
       }
     }
     this.activeListeners.clear();
+    this.activeChannelTenants.clear();
   }
 }
 

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -695,10 +695,7 @@ export async function startup(ctx: StartupContext): Promise<void> {
     const multiTenancy = resolveMultiTenancyConfig(config);
     const startGateway =
       multiTenancy.mode === 'static'
-        ? runWithTenantContext(multiTenancy.static_tenant_id, async () => {
-            await gatewayService.refreshChannelState();
-            await gatewayService.startListeners();
-          })
+        ? runWithTenantContext(multiTenancy.static_tenant_id, () => gatewayService.startListeners())
         : gatewayService.startListenersAcrossTenants();
     void startGateway.catch((error: unknown) => {
       console.error('[gateway] Failed to start listeners:', error);

--- a/apps/agor-daemon/src/startup.ts
+++ b/apps/agor-daemon/src/startup.ts
@@ -16,6 +16,7 @@ import {
 } from '@agor/core/config';
 import {
   MessagesRepository,
+  runWithTenantContext,
   runWithTenantDatabaseScope,
   SessionRepository,
   shortId,
@@ -686,16 +687,22 @@ export async function startup(ctx: StartupContext): Promise<void> {
   app.set('knowledgeEmbeddingIndexer', knowledgeEmbeddingIndexer);
   console.log('🧠 Knowledge embedding indexer started');
 
-  // 8. Initialize gateway: refresh channel state cache, then start Socket Mode listeners
+  // 8. Initialize gateway listeners. Static mode preserves the historical
+  // tenant. Auth-resolved mode performs narrow global ID discovery, then
+  // reloads and starts each channel under its immutable tenant identity.
   const gatewayService = safeService('gateway') as unknown as GatewayService | undefined;
   if (gatewayService) {
-    runStartupTenantDatabaseScope(ctx, () => gatewayService.refreshChannelState())
-      .then(() => {
-        return runStartupTenantDatabaseScope(ctx, () => gatewayService.startListeners());
-      })
-      .catch((error: unknown) => {
-        console.error('[gateway] Failed to start listeners:', error);
-      });
+    const multiTenancy = resolveMultiTenancyConfig(config);
+    const startGateway =
+      multiTenancy.mode === 'static'
+        ? runWithTenantContext(multiTenancy.static_tenant_id, async () => {
+            await gatewayService.refreshChannelState();
+            await gatewayService.startListeners();
+          })
+        : gatewayService.startListenersAcrossTenants();
+    void startGateway.catch((error: unknown) => {
+      console.error('[gateway] Failed to start listeners:', error);
+    });
   }
 
   // 8. Graceful shutdown handler

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -155,15 +155,16 @@ Because an MCP token binds `uid` to the authorized caller and lets the bearer
 act as that user on the MCP channel, it is only issued to callers who are
 allowed to receive a token for the session:
 
-- **`GET /sessions/:id`** issues a token to the creator themselves (provided they are still
-  `member+`), a superadmin, or the executor's service identity
-  (`role: 'service'`, used when spawning the child process). A plain
-  `member+` with `view` permission on the branch does **not** receive a
-  token. View permission alone does not grant the session-scoped execution
-  authority represented by the token.
+- **`GET /sessions/:id`** first applies normal session and branch
+  authorization, then issues a caller-scoped token to any authenticated
+  `member+` or to the executor's service identity (`role: 'service'`, used when
+  spawning the child process). The caller need not be the session creator:
+  MCP tools continue to act as that caller and enforce their normal
+  authorization checks.
 - For **`POST /sessions`**, the caller is the creator by construction, so
   `member+` is the only gate here.
-- **Viewers** never receive an `mcp_token` on either path. They cannot
+- Callers with the account role **viewer** never receive an `mcp_token` on
+  either path. They cannot
   prompt via REST either, so MCP would be useless for them regardless.
 
 ### Config knobs

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -110,8 +110,9 @@ In hosted `required_from_auth` deployments:
 - Personal API keys are opaque and do not contain a signed tenant. Using them
   at `/mcp` therefore requires `multi_tenancy.trusted_header`; the trusted
   reverse proxy must remove any client-supplied value and set the header from
-  its authenticated routing decision. Do not expose the daemon directly when
-  this mode relies on a trusted header.
+  its authenticated routing decision. It must send exactly one tenant value;
+  duplicate or comma/list-valued tenant headers are rejected. Do not expose the
+  daemon directly when this mode relies on a trusted header.
 - If more than one tenant signal is present, all signals must agree. Missing or
   conflicting identity fails closed before tenant-owned authentication data is
   queried.

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -23,7 +23,7 @@ This is the foundational layer: [teammates](/guide/teammates), [scheduled prompt
 ## Key Ideas
 
 - **Agents as first-class users:** Every MCP tool wraps a FeathersJS service. Sessions, branches, boards, zones, users, environments. Anything you can click or reach via the `agor` CLI is available as JSON-RPC.
-- **Self-aware sessions:** Each session is auto-issued a scoped MCP token, so the agent already knows *which* session, branch, and board it's in, and can act on that context.
+- **Self-aware sessions:** Each session is auto-issued a scoped MCP token, so the agent already knows _which_ session, branch, and board it's in, and can act on that context.
 - **No separate server:** MCP is part of the daemon. Nothing to install, nothing extra to run.
 - **Remote access:** External agents and dashboards can connect over HTTP to drive Agor (create boards, branches, or even invite new users).
 
@@ -31,15 +31,15 @@ This is the foundational layer: [teammates](/guide/teammates), [scheduled prompt
 
 ## Capabilities At a Glance
 
-| Domain                 | What agents can do                                                                                      |
-| ---------------------- | ------------------------------------------------------------------------------------------------------- |
-| **Sessions**           | Introspect the current session, list siblings, spawn child sessions with prompts, archive/complete work |
-| **Repositories**       | List repositories, clone remote repos, register local repos, manage repo metadata                       |
-| **Branches & Boards** | List or fetch branches, create new ones, assign them to boards, update metadata, move cards spatially  |
-| **Board Zones**        | Create zones on boards, update zone properties (position, size, color), manage zone triggers            |
-| **Tasks & Reports**    | Fetch task history, create follow-up tasks, log progress, generate reports                              |
-| **Users & Teams**      | Create users, update profiles or avatars, assign roles, invite collaborators                            |
-| **Context Resources**  | Enumerate context files, load concept docs, ingest repo metadata                                        |
+| Domain                | What agents can do                                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Sessions**          | Introspect the current session, list siblings, spawn child sessions with prompts, archive/complete work |
+| **Repositories**      | List repositories, clone remote repos, register local repos, manage repo metadata                       |
+| **Branches & Boards** | List or fetch branches, create new ones, assign them to boards, update metadata, move cards spatially   |
+| **Board Zones**       | Create zones on boards, update zone properties (position, size, color), manage zone triggers            |
+| **Tasks & Reports**   | Fetch task history, create follow-up tasks, log progress, generate reports                              |
+| **Users & Teams**     | Create users, update profiles or avatars, assign roles, invite collaborators                            |
+| **Context Resources** | Enumerate context files, load concept docs, ingest repo metadata                                        |
 
 Because tools route through FeathersJS services, every action emits the same events the UI listens to. Real-time updates appear instantly for everyone watching the board.
 
@@ -97,6 +97,32 @@ External agents can use the same MCP endpoint:
 
 This makes Agor a control plane for other AI systems, enabling remote triage bots, automation pipelines, or custom dashboards to work against live boards.
 
+### Multi-tenant authentication boundary
+
+The default `multi_tenancy.mode: static` behavior is unchanged: MCP requests
+use `multi_tenancy.static_tenant_id`, and clients do not send a tenant header.
+
+In hosted `required_from_auth` deployments:
+
+- Internal MCP session JWTs carry a signed tenant binding. The daemon verifies
+  that binding before it reads the session or user, and a token cannot be
+  replayed with another tenant header.
+- Personal API keys are opaque and do not contain a signed tenant. Using them
+  at `/mcp` therefore requires `multi_tenancy.trusted_header`; the trusted
+  reverse proxy must remove any client-supplied value and set the header from
+  its authenticated routing decision. Do not expose the daemon directly when
+  this mode relies on a trusted header.
+- If more than one tenant signal is present, all signals must agree. Missing or
+  conflicting identity fails closed before tenant-owned authentication data is
+  queried.
+- Streamable HTTP sessions retain their initialize-time tenant, user, and
+  optional Agor-session bindings. Every later GET, POST, or DELETE request is
+  re-authenticated and must reproduce those bindings.
+
+Tenant identity is ambient for the MCP operation, but it does not hold a
+database transaction open. Individual service and repository calls use short
+tenant-scoped units of work.
+
 ## Best Practices
 
 - **Keep permission policies tight.** MCP calls respect Agor’s permission system. Configure approvals so agents only do what the team expects.
@@ -107,27 +133,32 @@ This makes Agor a control plane for other AI systems, enabling remote triage bot
 ## MCP Tokens
 
 MCP session tokens are short-lived JWTs (aud `agor:mcp:internal`) embedding
-a `jti` (per-issuance ID) and an `exp`. Tokens are re-minted fresh on every
-`GET /sessions/:id` and `POST /sessions`.
+the session (`sub`), authenticated caller (`uid`), tenant (`tid`), a
+per-issuance ID (`jti`), and an expiry (`exp`). A still-valid token may be
+reused from a cache keyed by tenant, session, and user; otherwise `GET
+/sessions/:id` or `POST /sessions` mints a new one.
 
 There is no revocation mechanics, no per-jti ledger, no session-generation
 counter. The authorised blast radius of a leak is bounded by `exp` (default
-24h). Validation additionally rejects tokens whose session has been deleted.
-If/when MCP is opened externally we'd design auth from scratch (OAuth / API
-keys) rather than extending this.
+24h). Validation additionally rejects tokens whose session has been deleted
+from the signed tenant. Tokens issued before the tenant binding was introduced
+are rejected and are replaced the next time the session is fetched or created.
+These session tokens are for daemon-to-executor use; external clients should
+use personal API keys rather than treating this JWT format as a general-purpose
+authentication protocol.
 
 ### Access gating
 
-Because an MCP token binds `uid = session.created_by` and lets the bearer
-act AS the creator on the MCP channel, it's only issued to callers who are
-already allowed to act as that creator:
+Because an MCP token binds `uid` to the authorized caller and lets the bearer
+act as that user on the MCP channel, it is only issued to callers who are
+allowed to receive a token for the session:
 
 - **`GET /sessions/:id`** issues a token to the creator themselves (provided they are still
   `member+`), a superadmin, or the executor's service identity
   (`role: 'service'`, used when spawning the child process). A plain
   `member+` with `view` permission on the branch does **not** receive a
-  token. Handing one out would let them impersonate the creator, sidestepping
-  the `session`-tier "own sessions only" rule enforced elsewhere.
+  token. View permission alone does not grant the session-scoped execution
+  authority represented by the token.
 - For **`POST /sessions`**, the caller is the creator by construction, so
   `member+` is the only gate here.
 - **Viewers** never receive an `mcp_token` on either path. They cannot
@@ -138,16 +169,17 @@ already allowed to act as that creator:
 ```yaml
 execution:
   # Token lifetime — keep short to cap the damage from a leak.
-  mcp_token_expiration_ms: 86400000            # 24h (default)
+  mcp_token_expiration_ms: 86400000 # 24h (default)
 ```
 
 ### Troubleshooting
 
-| Symptom                                            | Likely cause                                               | Fix                                           |
-|----------------------------------------------------|------------------------------------------------------------|-----------------------------------------------|
-| `token rejected: expired`                          | Token past its `exp`                                       | Session will re-mint on next `GET /sessions`  |
-| `token rejected: session … not found`              | Token's session was deleted                                | Expected, token can no longer be used         |
-| `token rejected: missing jti`                      | Pre-rollout token (no `jti`/`exp`)                         | Re-prompt / restart the session to re-mint    |
+| Symptom                               | Likely cause                          | Fix                                          |
+| ------------------------------------- | ------------------------------------- | -------------------------------------------- |
+| `token rejected: expired`             | Token past its `exp`                  | Session will re-mint on next `GET /sessions` |
+| `token rejected: session … not found` | Token's session was deleted           | Expected — token can no longer be used       |
+| `token rejected: missing sub/uid/tid` | Pre-tenant-binding or malformed token | Fetch / recreate the session to re-mint      |
+| `token rejected: missing jti or exp`  | Pre-expiry-binding or malformed token | Fetch / recreate the session to re-mint      |
 
 ## Related Reading
 

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -117,7 +117,9 @@ In hosted `required_from_auth` deployments:
   queried.
 - Streamable HTTP sessions retain their initialize-time tenant, user, and
   optional Agor-session bindings. Every later GET, POST, or DELETE request is
-  re-authenticated and must reproduce those bindings.
+  re-authenticated. Tenant and user identity must still match; an optional
+  Agor-session binding may be omitted and reused, but cannot be added or
+  replaced, and is re-authorized before each request.
 
 Tenant identity is ambient for the MCP operation, but it does not hold a
 database transaction open. Individual service and repository calls use short

--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -39,7 +39,13 @@ The Message Gateway connects external messaging platforms to Agor's agent sessio
 <img
   src="/screenshots/marketing/agor-marketing-slack-thread.png"
   alt="Slack thread where a user mentions an Agor teammate and the bot creates an Agor session, replies with a view-session link, and starts reading context"
-  style={{ maxWidth: '920px', width: '100%', borderRadius: '14px', marginTop: '16px', marginBottom: '28px' }}
+  style={{
+    maxWidth: '920px',
+    width: '100%',
+    borderRadius: '14px',
+    marginTop: '16px',
+    marginBottom: '28px',
+  }}
 />
 
 ## What is a Channel?
@@ -95,6 +101,29 @@ Slack DM                    Agor Daemon                    Agent
 ```
 
 The outbound routing is a lightweight after-hook on message creation. For sessions without a gateway mapping (the vast majority), it's a single database lookup that returns immediately, effectively a no-op.
+
+### Multi-tenant listener lifecycle
+
+Static and single-tenant installations require no new configuration. Listener
+startup uses the configured static tenant exactly as before.
+
+With `multi_tenancy.mode: required_from_auth`, the daemon restarts enabled
+gateway channels for every tenant after a daemon restart. Startup performs one
+narrow PostgreSQL discovery query that can return only enabled channel and
+tenant IDs. It then leaves system scope, reloads the full channel (including
+credentials) under that tenant's normal RLS scope, and starts the connector
+with an immutable tenant binding. Provider callbacks re-enter that captured
+tenant before reading mappings or creating sessions.
+
+Listener instances and the outbound fast path are also tenant-qualified. A
+channel refresh in a tenant with no enabled channels cannot stop or suppress
+delivery for another tenant. Missing, stale, or inconsistent discovery
+metadata is skipped rather than falling back to the static tenant.
+
+PostgreSQL migration `0066_gateway_listener_discovery` installs the narrowly
+named read policy used by this startup phase. Apply normal Agor migrations
+before serving traffic with the upgraded daemon; no database role with
+`BYPASSRLS` and no superuser daemon connection is required.
 
 ### Outbound branch binding
 

--- a/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
+++ b/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
@@ -67,7 +67,8 @@ raw connection or a superuser/BYPASSRLS daemon role.
 
 1. **One request tenant:** every available trusted tenant signal must agree.
    Static configuration, verified token binding, configured trusted header,
-   authenticated claim, and explicit internal context may not disagree.
+   authenticated claim, and explicit internal context may not disagree. The
+   trusted header is a singleton: duplicate or comma/list values fail closed.
 2. **Bootstrap before data:** no personal-key, user, session, or other
    tenant-owned lookup runs before the MCP request tenant is established.
    Personal API keys in auth-resolved mode therefore require the configured

--- a/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
+++ b/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
@@ -1,0 +1,117 @@
+# Gateway and MCP multi-tenancy hardening
+
+## Scope and operating models
+
+This note records the pre-implementation audit for the gateway/MCP hardening
+follow-up to #1903. It covers two supported operating models:
+
+- **Static/single tenant:** SQLite or PostgreSQL, with one configured
+  `multi_tenancy.static_tenant_id`. Existing callers do not need to send a
+  tenant header.
+- **Auth-resolved multi tenant:** PostgreSQL with
+  `multi_tenancy.mode: required_from_auth`. Tenant identity must come from a
+  verified credential, a configured trusted edge header, or explicit internal
+  routing metadata. Missing or conflicting identity fails before tenant-owned
+  data is read.
+
+The database transaction remains a short unit of work. An MCP tool call,
+listener lifetime, provider poll, or outbound network request must not hold a
+tenant transaction open.
+
+## Audited trust boundaries
+
+### MCP bootstrap
+
+Before this change, `/mcp` verified personal API keys through
+`user_api_keys`, loaded the user, and validated internal session tokens through
+`sessions` before it had established a request tenant. That is both rejected by
+the guarded database proxy in `required_from_auth` and unsafe on a database
+role that can bypass RLS. Internal MCP JWTs signed `session/user/jti/exp`, but
+not the tenant, so a token did not carry a cryptographic tenant binding.
+
+The MCP Streamable HTTP transport already keeps an immutable user and optional
+Agor-session binding, but it did not retain or compare an immutable tenant
+binding. Tenant context was inferred later from the loaded user, which is too
+late for authentication bootstrap.
+
+### Gateway lifecycle and dispatch
+
+Gateway channel rows are tenant owned. Startup nevertheless refreshed and
+started listeners inside the configured bootstrap/static tenant scope, so an
+auth-resolved deployment did not reconcile other tenants after a restart.
+`GatewayService.hasActiveChannels` was one process-wide boolean populated by a
+tenant-local query; refreshing a tenant with no enabled channels could suppress
+outbound routing and progress delivery for every other tenant.
+
+Slack (Socket Mode), GitHub and Shortcut (polling), and Teams (webhook server)
+all implement the same connector contract: `startListening(callback)`, optional
+`stopListening()`, and `sendMessage()`. Provider callbacks do not carry an Agor
+tenant. The shared gateway layer must therefore capture the channel tenant when
+the listener is created and re-enter it before any tenant-owned work. No
+connector-specific tenant behavior is required.
+
+### Global discovery
+
+The only gateway operation that needs cross-tenant visibility is startup
+discovery of enabled channel routing references. It may return only
+`(tenant_id, channel_id)`. Channel configuration, credentials, mappings,
+sessions, users, and outbound rows remain tenant-local and are reloaded after
+entering the discovered tenant.
+
+PostgreSQL `FORCE ROW LEVEL SECURITY` means an unscoped query sees only the
+implicit `default` tenant even for the table owner. Gateway discovery therefore
+needs an explicit, narrowly named database capability rather than relying on a
+raw connection or a superuser/BYPASSRLS daemon role.
+
+## Security invariants
+
+1. **One request tenant:** every available trusted tenant signal must agree.
+   Static configuration, verified token binding, configured trusted header,
+   authenticated claim, and explicit internal context may not disagree.
+2. **Bootstrap before data:** no personal-key, user, session, or other
+   tenant-owned lookup runs before the MCP request tenant is established.
+   Personal API keys in auth-resolved mode therefore require the configured
+   trusted header; unlike internal JWTs, existing opaque keys contain no signed
+   tenant claim.
+3. **Tenant-bound internal tokens:** every newly issued internal MCP JWT signs a
+   non-empty tenant id. Issuance requires an active tenant; cache keys include
+   it; validation rejects legacy/unbound tokens and checks session existence
+   inside the signed tenant.
+4. **Immutable stateful binding:** an MCP Streamable HTTP session is bound at
+   initialize time to `(tenant, user, optional Agor session)`. Every subsequent
+   request re-authenticates and must reproduce all three bindings before the
+   stored handler context is refreshed.
+5. **Short database units:** MCP authentication probes, tool repository calls,
+   gateway discovery, channel reloads, and dispatch lookups each use short
+   scopes. Transport sessions and provider network work retain tenant identity
+   only, never a database transaction.
+6. **Narrow global discovery:** startup uses an explicit system scope plus a
+   PostgreSQL RLS capability that can discover enabled gateway routing refs.
+   Each ref must include a tenant; the full channel is then reloaded in that
+   tenant before credentials are used or a listener starts.
+7. **Tenant-aware process state:** listener keys and the enabled-channel fast
+   path include tenant identity. Refreshing/stopping one tenant cannot suppress,
+   replace, or reuse another tenant's state.
+8. **Callback and outbound scope:** listener callbacks enter the captured
+   tenant before calling the gateway. Outbound/progress/stream dispatch uses
+   only the current tenant's fast-path state and repositories.
+9. **Fail closed:** absent, conflicting, stale, or forged tenant identity causes
+   authentication failure or skips background work; it never falls back to the
+   bootstrap tenant in `required_from_auth`.
+
+## Deliberate follow-ups
+
+- Scheduler and health-monitor cross-tenant discovery use the same conceptual
+  system-scope pattern but do not receive the new gateway-specific RLS
+  capability in this change. They should be audited separately rather than
+  broadening gateway review into a generic control-plane rewrite.
+- Other startup jobs, including orphan/restart reconciliation and the knowledge
+  embedding indexer, still use bootstrap/static tenant parameters. Making those
+  jobs genuinely cross-tenant needs job-specific discovery contracts and is a
+  separate startup-services audit; the gateway capability must not be reused.
+- Gateway listener stop/start serialization and persisted provider polling
+  cursors are existing reliability topics, not tenant-isolation prerequisites.
+- Opaque personal API keys could eventually embed a signed tenant routing hint,
+  removing the trusted-header requirement for external MCP API-key clients in
+  auth-claim-only deployments. That would require a versioned key format and
+  migration/rotation plan and is intentionally out of scope.

--- a/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
+++ b/docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md
@@ -79,8 +79,9 @@ raw connection or a superuser/BYPASSRLS daemon role.
    inside the signed tenant.
 4. **Immutable stateful binding:** an MCP Streamable HTTP session is bound at
    initialize time to `(tenant, user, optional Agor session)`. Every subsequent
-   request re-authenticates and must reproduce all three bindings before the
-   stored handler context is refreshed.
+   request re-authenticates; tenant and user must match. The optional Agor
+   session may be omitted and retained, but cannot be added or replaced, and is
+   re-authorized before the stored handler context is refreshed.
 5. **Short database units:** MCP authentication probes, tool repository calls,
    gateway discovery, channel reloads, and dispatch lookups each use short
    scopes. Transport sessions and provider network work retain tenant identity

--- a/packages/core/drizzle/postgres/0066_gateway_listener_discovery.sql
+++ b/packages/core/drizzle/postgres/0066_gateway_listener_discovery.sql
@@ -1,0 +1,13 @@
+-- Permit only the gateway startup discovery transaction to see enabled
+-- channel routing metadata across tenants. The daemon sets agor.system_scope
+-- transaction-locally, leaves this scope immediately after reading IDs and
+-- tenant IDs, then reloads every channel under its tenant's normal RLS scope.
+
+DROP POLICY IF EXISTS "gateway_listener_discovery" ON "gateway_channels";
+--> statement-breakpoint
+CREATE POLICY "gateway_listener_discovery" ON "gateway_channels"
+  FOR SELECT
+  USING (
+    "enabled" = true
+    AND current_setting('agor.system_scope', true) = 'gateway_listener_discovery'
+  );

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1784555000000,
       "tag": "0065_executor_heartbeat_timezone",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1784555100000,
+      "tag": "0066_gateway_listener_discovery",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -199,6 +199,20 @@ describe('multi-tenancy config and tenant resolution', () => {
     ).toThrow(/Invalid trusted tenant header/);
   });
 
+  it('rejects a comma-coalesced trusted header as an ambiguous HTTP list', () => {
+    expect(() =>
+      resolveTenantContext(
+        {
+          multi_tenancy: {
+            mode: 'required_from_auth',
+            trusted_header: 'x-agor-tenant-id',
+          },
+        },
+        { headers: { 'x-agor-tenant-id': 'tenant-a, tenant-b' } }
+      )
+    ).toThrow(/Invalid trusted tenant header/);
+  });
+
   it('fails closed in required_from_auth mode when tenant context is missing', () => {
     expect(() =>
       resolveTenantContext({

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -118,10 +118,19 @@ describe('multi-tenancy config and tenant resolution', () => {
       },
     },
     {
-      label: 'authentication payload and authenticated user',
+      label: 'decoded payload and authenticated user',
       input: {
         authPayload: { tenant_id: 'tenant-a' },
         params: { user: { tenant_id: 'tenant-b' } },
+      },
+    },
+    {
+      label: 'Feathers authentication payload and authenticated user',
+      input: {
+        params: {
+          authentication: { payload: { tenant_id: 'tenant-a' } },
+          user: { tenant_id: 'tenant-b' },
+        },
       },
     },
   ])('rejects conflicting auth claims from $label', ({ input }) => {
@@ -148,6 +157,46 @@ describe('multi-tenancy config and tenant resolution', () => {
         }
       )
     ).toThrow(/Conflicting tenant identities/);
+  });
+
+  it.each([
+    {
+      label: 'a multi-valued header',
+      headers: { 'x-agor-tenant-id': ['tenant-a', 'tenant-b'] },
+    },
+    {
+      label: 'case-insensitive duplicate keys',
+      headers: {
+        'x-agor-tenant-id': 'tenant-a',
+        'X-Agor-Tenant-Id': 'tenant-b',
+      },
+    },
+  ])('rejects conflicting tenant identities within $label', ({ headers }) => {
+    expect(() =>
+      resolveTenantContext(
+        {
+          multi_tenancy: {
+            mode: 'required_from_auth',
+            trusted_header: 'x-agor-tenant-id',
+          },
+        },
+        { headers }
+      )
+    ).toThrow(/Conflicting tenant identities/);
+  });
+
+  it('rejects a malformed duplicate trusted-header value instead of ignoring it', () => {
+    expect(() =>
+      resolveTenantContext(
+        {
+          multi_tenancy: {
+            mode: 'required_from_auth',
+            trusted_header: 'x-agor-tenant-id',
+          },
+        },
+        { headers: { 'x-agor-tenant-id': ['tenant-a', ''] } }
+      )
+    ).toThrow(/Invalid trusted tenant header/);
   });
 
   it('fails closed in required_from_auth mode when tenant context is missing', () => {

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -199,6 +199,32 @@ describe('multi-tenancy config and tenant resolution', () => {
     ).toThrow(/Invalid trusted tenant header/);
   });
 
+  it.each([
+    {
+      label: 'identical multi-valued header',
+      headers: { 'x-agor-tenant-id': ['tenant-a', 'tenant-a'] },
+    },
+    {
+      label: 'identical case-insensitive duplicate keys',
+      headers: {
+        'x-agor-tenant-id': 'tenant-a',
+        'X-Agor-Tenant-Id': 'tenant-a',
+      },
+    },
+  ])('rejects $label because the trusted header is a singleton', ({ headers }) => {
+    expect(() =>
+      resolveTenantContext(
+        {
+          multi_tenancy: {
+            mode: 'required_from_auth',
+            trusted_header: 'x-agor-tenant-id',
+          },
+        },
+        { headers }
+      )
+    ).toThrow(/Invalid trusted tenant header/);
+  });
+
   it('rejects a comma-coalesced trusted header as an ambiguous HTTP list', () => {
     expect(() =>
       resolveTenantContext(

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -109,6 +109,47 @@ describe('multi-tenancy config and tenant resolution', () => {
     ).toThrow(/Conflicting tenant identities/);
   });
 
+  it.each([
+    {
+      label: 'decoded and Feathers authentication payloads',
+      input: {
+        authPayload: { tenant_id: 'tenant-a' },
+        params: { authentication: { payload: { tenant_id: 'tenant-b' } } },
+      },
+    },
+    {
+      label: 'authentication payload and authenticated user',
+      input: {
+        authPayload: { tenant_id: 'tenant-a' },
+        params: { user: { tenant_id: 'tenant-b' } },
+      },
+    },
+  ])('rejects conflicting auth claims from $label', ({ input }) => {
+    expect(() =>
+      resolveTenantContext(
+        { multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' } },
+        input
+      )
+    ).toThrow(/Conflicting tenant identities/);
+  });
+
+  it('rejects conflicting trusted headers from request and Feathers params', () => {
+    expect(() =>
+      resolveTenantContext(
+        {
+          multi_tenancy: {
+            mode: 'required_from_auth',
+            trusted_header: 'x-agor-tenant-id',
+          },
+        },
+        {
+          headers: { 'x-agor-tenant-id': 'tenant-a' },
+          params: { headers: { 'X-Agor-Tenant-Id': 'tenant-b' } },
+        }
+      )
+    ).toThrow(/Conflicting tenant identities/);
+  });
+
   it('fails closed in required_from_auth mode when tenant context is missing', () => {
     expect(() =>
       resolveTenantContext({

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -23,6 +23,15 @@ describe('multi-tenancy config and tenant resolution', () => {
     ).toEqual({ tenant_id: 'acme', source: 'static' });
   });
 
+  it('rejects an explicit tenant that conflicts with static mode', () => {
+    expect(() =>
+      resolveTenantContext(
+        { multi_tenancy: { mode: 'static', static_tenant_id: 'tenant-a' } },
+        { params: { tenant_id: 'tenant-b' } }
+      )
+    ).toThrow(/Conflicting tenant identities/);
+  });
+
   it('rejects required_from_auth on SQLite because SQLite has no tenant columns/RLS', () => {
     vi.stubEnv('AGOR_DB_DIALECT', '');
     vi.stubEnv('DATABASE_URL', '');
@@ -80,6 +89,24 @@ describe('multi-tenancy config and tenant resolution', () => {
       { headers: { 'X-Agor-Tenant-Id': 'tenant-b' } }
     );
     expect(ctx).toEqual({ tenant_id: 'tenant-b', source: 'trusted_header' });
+  });
+
+  it('rejects conflicting authenticated and trusted-header tenant identities', () => {
+    expect(() =>
+      resolveTenantContext(
+        {
+          multi_tenancy: {
+            mode: 'required_from_auth',
+            auth_claim: 'tenant_id',
+            trusted_header: 'x-agor-tenant-id',
+          },
+        },
+        {
+          authPayload: { tenant_id: 'tenant-a' },
+          headers: { 'x-agor-tenant-id': 'tenant-b' },
+        }
+      )
+    ).toThrow(/Conflicting tenant identities/);
   });
 
   it('fails closed in required_from_auth mode when tenant context is missing', () => {

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -99,6 +99,12 @@ function readHeaderValues(
       values.push(tenantId);
     }
   }
+  if (values.length > 1) {
+    if (new Set(values).size > 1) {
+      throw new TenantResolutionError('Conflicting tenant identities');
+    }
+    throw new TenantResolutionError(`Invalid trusted tenant header ${header}`);
+  }
   return values;
 }
 

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -86,6 +86,12 @@ function readHeaderValues(
   for (const [key, value] of Object.entries(headers)) {
     if (key.toLowerCase() !== wanted) continue;
     for (const rawValue of Array.isArray(value) ? value : [value]) {
+      // A trusted tenant header contains one identifier, never an HTTP list.
+      // Reject coalesced duplicates even if an adapter discarded their
+      // original on-wire multiplicity.
+      if (typeof rawValue === 'string' && rawValue.includes(',')) {
+        throw new TenantResolutionError(`Invalid trusted tenant header ${header}`);
+      }
       const tenantId = normalizeTenantId(rawValue);
       if (!tenantId) {
         throw new TenantResolutionError(`Invalid trusted tenant header ${header}`);

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -149,16 +149,20 @@ export function resolveTenantContext(
   if (resolved.mode === 'static') {
     candidates.push({ tenant_id: resolved.static_tenant_id, source: 'static' });
   } else {
-    const claimTenant =
-      readClaim(input.authPayload, resolved.auth_claim) ??
-      readClaim(readAuthenticationPayload(params?.authentication), resolved.auth_claim) ??
-      readClaim(params?.user, resolved.auth_claim);
-    if (claimTenant) candidates.push({ tenant_id: claimTenant, source: 'auth_claim' });
+    for (const tenantId of [
+      readClaim(input.authPayload, resolved.auth_claim),
+      readClaim(readAuthenticationPayload(params?.authentication), resolved.auth_claim),
+      readClaim(params?.user, resolved.auth_claim),
+    ]) {
+      if (tenantId) candidates.push({ tenant_id: tenantId, source: 'auth_claim' });
+    }
 
-    const headerTenant =
-      readHeader(input.headers, resolved.trusted_header) ??
-      readHeader(params?.headers, resolved.trusted_header);
-    if (headerTenant) candidates.push({ tenant_id: headerTenant, source: 'trusted_header' });
+    for (const tenantId of [
+      readHeader(input.headers, resolved.trusted_header),
+      readHeader(params?.headers, resolved.trusted_header),
+    ]) {
+      if (tenantId) candidates.push({ tenant_id: tenantId, source: 'trusted_header' });
+    }
   }
 
   if (candidates.length > 0) {

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -138,24 +138,36 @@ export function resolveTenantContext(
 ): TenantContext {
   const resolved = 'static_tenant_id' in config ? config : resolveMultiTenancyConfig(config);
   const params = input.params;
-  if (params?.tenant) return params.tenant;
+  const candidates: TenantContext[] = [];
+  const paramsTenantId = normalizeTenantId(params?.tenant?.tenant_id);
+  if (paramsTenantId) {
+    candidates.push({ tenant_id: paramsTenantId, source: params?.tenant?.source ?? 'explicit' });
+  }
   const explicit = normalizeTenantId(params?.tenant_id);
-  if (explicit) return { tenant_id: explicit, source: 'explicit' };
+  if (explicit) candidates.push({ tenant_id: explicit, source: 'explicit' });
 
   if (resolved.mode === 'static') {
-    return { tenant_id: resolved.static_tenant_id, source: 'static' };
+    candidates.push({ tenant_id: resolved.static_tenant_id, source: 'static' });
+  } else {
+    const claimTenant =
+      readClaim(input.authPayload, resolved.auth_claim) ??
+      readClaim(readAuthenticationPayload(params?.authentication), resolved.auth_claim) ??
+      readClaim(params?.user, resolved.auth_claim);
+    if (claimTenant) candidates.push({ tenant_id: claimTenant, source: 'auth_claim' });
+
+    const headerTenant =
+      readHeader(input.headers, resolved.trusted_header) ??
+      readHeader(params?.headers, resolved.trusted_header);
+    if (headerTenant) candidates.push({ tenant_id: headerTenant, source: 'trusted_header' });
   }
 
-  const claimTenant =
-    readClaim(input.authPayload, resolved.auth_claim) ??
-    readClaim(readAuthenticationPayload(params?.authentication), resolved.auth_claim) ??
-    readClaim(params?.user, resolved.auth_claim);
-  if (claimTenant) return { tenant_id: claimTenant, source: 'auth_claim' };
-
-  const headerTenant =
-    readHeader(input.headers, resolved.trusted_header) ??
-    readHeader(params?.headers, resolved.trusted_header);
-  if (headerTenant) return { tenant_id: headerTenant, source: 'trusted_header' };
+  if (candidates.length > 0) {
+    const tenantId = candidates[0].tenant_id;
+    if (candidates.some((candidate) => candidate.tenant_id !== tenantId)) {
+      throw new TenantResolutionError('Conflicting tenant identities');
+    }
+    return candidates[0];
+  }
 
   throw new TenantResolutionError('Missing tenant context for multi_tenancy.required_from_auth');
 }

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -76,18 +76,24 @@ function readClaim(payload: unknown, claim: string | undefined): TenantID | null
   return normalizeTenantId(value);
 }
 
-function readHeader(
+function readHeaderValues(
   headers: Record<string, unknown> | undefined,
   header: string | undefined
-): TenantID | null {
-  if (!headers || !header) return null;
+): TenantID[] {
+  if (!headers || !header) return [];
   const wanted = header.toLowerCase();
+  const values: TenantID[] = [];
   for (const [key, value] of Object.entries(headers)) {
     if (key.toLowerCase() !== wanted) continue;
-    if (Array.isArray(value)) return normalizeTenantId(value[0]);
-    return normalizeTenantId(value);
+    for (const rawValue of Array.isArray(value) ? value : [value]) {
+      const tenantId = normalizeTenantId(rawValue);
+      if (!tenantId) {
+        throw new TenantResolutionError(`Invalid trusted tenant header ${header}`);
+      }
+      values.push(tenantId);
+    }
   }
-  return null;
+  return values;
 }
 
 export function resolveMultiTenancyConfig(
@@ -158,10 +164,10 @@ export function resolveTenantContext(
     }
 
     for (const tenantId of [
-      readHeader(input.headers, resolved.trusted_header),
-      readHeader(params?.headers, resolved.trusted_header),
+      ...readHeaderValues(input.headers, resolved.trusted_header),
+      ...readHeaderValues(params?.headers, resolved.trusted_header),
     ]) {
-      if (tenantId) candidates.push({ tenant_id: tenantId, source: 'trusted_header' });
+      candidates.push({ tenant_id: tenantId, source: 'trusted_header' });
     }
   }
 

--- a/packages/core/src/db/multitenancy-schema.test.ts
+++ b/packages/core/src/db/multitenancy-schema.test.ts
@@ -63,4 +63,16 @@ describe('Postgres multitenancy schema coverage', () => {
     expect(sqliteSchema).not.toContain('tenant_id');
     expect(sqliteSchema).not.toContain("tenant_id'");
   });
+
+  it('limits cross-tenant gateway discovery to enabled rows and an explicit capability', () => {
+    const migration = readRepoFile(
+      'packages/core/drizzle/postgres/0066_gateway_listener_discovery.sql'
+    );
+
+    expect(migration).toContain('FOR SELECT');
+    expect(migration).toContain('"enabled" = true');
+    expect(migration).toContain("current_setting('agor.system_scope', true)");
+    expect(migration).toContain("= 'gateway_listener_discovery'");
+    expect(migration).not.toContain('WITH CHECK');
+  });
 });

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -72,28 +72,6 @@ describe('GatewayChannelRepository', () => {
     expect(channel.mcp_server_ids).toEqual(['mcp-one']);
   });
 
-  dbTest('discovers only enabled listener refs in static SQLite mode', async ({ db }) => {
-    const branch = await seedBranch(db);
-    const repo = new GatewayChannelRepository(db);
-    const enabled = await repo.create({
-      name: 'Enabled Slack',
-      created_by: generateId() as UUID,
-      target_branch_id: branch.branch_id as UUID,
-      channel_type: 'slack',
-      enabled: true,
-      config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
-    });
-    await repo.create({
-      name: 'Disabled Slack',
-      created_by: generateId() as UUID,
-      target_branch_id: branch.branch_id as UUID,
-      channel_type: 'slack',
-      enabled: false,
-    });
-
-    expect(await repo.findEnabledRefs()).toEqual([{ channel_id: enabled.id }]);
-  });
-
   describe('enabled requires secrets invariant', () => {
     dbTest('creates a disabled channel without secrets', async ({ db }) => {
       const branch = await seedBranch(db);

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -72,6 +72,28 @@ describe('GatewayChannelRepository', () => {
     expect(channel.mcp_server_ids).toEqual(['mcp-one']);
   });
 
+  dbTest('discovers only enabled listener refs in static SQLite mode', async ({ db }) => {
+    const branch = await seedBranch(db);
+    const repo = new GatewayChannelRepository(db);
+    const enabled = await repo.create({
+      name: 'Enabled Slack',
+      created_by: generateId() as UUID,
+      target_branch_id: branch.branch_id as UUID,
+      channel_type: 'slack',
+      enabled: true,
+      config: { bot_token: 'xoxb-test', app_token: 'xapp-test' },
+    });
+    await repo.create({
+      name: 'Disabled Slack',
+      created_by: generateId() as UUID,
+      target_branch_id: branch.branch_id as UUID,
+      channel_type: 'slack',
+      enabled: false,
+    });
+
+    expect(await repo.findEnabledRefs()).toEqual([{ channel_id: enabled.id }]);
+  });
+
   describe('enabled requires secrets invariant', () => {
     dbTest('creates a disabled channel without secrets', async ({ db }) => {
       const branch = await seedBranch(db);

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -11,6 +11,7 @@ import type {
   GatewayChannel,
   GatewayChannelID,
   GatewayEnvVar,
+  TenantID,
   UUID,
 } from '@agor/core/types';
 import {
@@ -21,7 +22,7 @@ import {
 } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
-import type { Database } from '../client';
+import type { Database, SystemDatabase } from '../client';
 import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
 import { decryptApiKey, encryptApiKey } from '../encryption';
 import { type GatewayChannelInsert, type GatewayChannelRow, gatewayChannels } from '../schema';
@@ -35,7 +36,46 @@ import {
 
 export interface EnabledGatewayChannelRef {
   channel_id: GatewayChannelID;
-  tenant_id?: string;
+  tenant_id: TenantID;
+}
+
+/**
+ * Capability-specific repository for process-wide listener discovery.
+ *
+ * This deliberately exposes no full-channel read or credential decryption
+ * operations. Callers receive only immutable routing references, leave system
+ * scope, and reload each channel through GatewayChannelRepository in its
+ * discovered tenant scope.
+ */
+export class GatewayListenerDiscoveryRepository {
+  constructor(private db: SystemDatabase) {}
+
+  async findEnabledTenantRefs(): Promise<EnabledGatewayChannelRef[]> {
+    const tenantColumn = (gatewayChannels as unknown as { tenant_id?: unknown }).tenant_id;
+    if (!isPostgresDatabase(this.db) || !tenantColumn) {
+      throw new RepositoryError('Gateway listener discovery requires PostgreSQL tenant metadata');
+    }
+
+    const rows = await select(this.db, {
+      channel_id: gatewayChannels.id,
+      tenant_id: tenantColumn,
+    })
+      .from(gatewayChannels)
+      .where(eq(gatewayChannels.enabled, true))
+      .all();
+
+    return (rows as Array<{ channel_id: string; tenant_id?: unknown }>).map((row) => {
+      if (typeof row.tenant_id !== 'string' || row.tenant_id.length === 0) {
+        throw new RepositoryError(
+          `Gateway listener discovery returned channel ${row.channel_id} without a tenant identity`
+        );
+      }
+      return {
+        channel_id: row.channel_id as GatewayChannelID,
+        tenant_id: row.tenant_id as TenantID,
+      };
+    });
+  }
 }
 
 /**
@@ -344,31 +384,6 @@ export class GatewayChannelRepository
         error
       );
     }
-  }
-
-  /**
-   * Process-wide listener discovery query. Returns routing metadata only so
-   * callers can leave system scope and re-enter the row's tenant before
-   * loading credentials or starting a connector.
-   */
-  async findEnabledRefs(): Promise<EnabledGatewayChannelRef[]> {
-    const tenantColumn = (gatewayChannels as unknown as { tenant_id?: unknown }).tenant_id;
-    const columns =
-      isPostgresDatabase(this.db) && tenantColumn
-        ? { channel_id: gatewayChannels.id, tenant_id: tenantColumn }
-        : { channel_id: gatewayChannels.id };
-
-    const rows = await select(this.db, columns)
-      .from(gatewayChannels)
-      .where(eq(gatewayChannels.enabled, true))
-      .all();
-
-    return (rows as Array<{ channel_id: string; tenant_id?: unknown }>).map((row) => ({
-      channel_id: row.channel_id as GatewayChannelID,
-      ...(typeof row.tenant_id === 'string' && row.tenant_id.length > 0
-        ? { tenant_id: row.tenant_id }
-        : {}),
-    }));
   }
 
   /**

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -22,7 +22,7 @@ import {
 import { eq, like } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { deleteFrom, insert, isPostgresDatabase, select, update } from '../database-wrapper';
 import { decryptApiKey, encryptApiKey } from '../encryption';
 import { type GatewayChannelInsert, type GatewayChannelRow, gatewayChannels } from '../schema';
 import {
@@ -32,6 +32,11 @@ import {
   EntityNotFoundError,
   RepositoryError,
 } from './base';
+
+export interface EnabledGatewayChannelRef {
+  channel_id: GatewayChannelID;
+  tenant_id?: string;
+}
 
 /**
  * Encrypt sensitive fields within a config object
@@ -339,6 +344,31 @@ export class GatewayChannelRepository
         error
       );
     }
+  }
+
+  /**
+   * Process-wide listener discovery query. Returns routing metadata only so
+   * callers can leave system scope and re-enter the row's tenant before
+   * loading credentials or starting a connector.
+   */
+  async findEnabledRefs(): Promise<EnabledGatewayChannelRef[]> {
+    const tenantColumn = (gatewayChannels as unknown as { tenant_id?: unknown }).tenant_id;
+    const columns =
+      isPostgresDatabase(this.db) && tenantColumn
+        ? { channel_id: gatewayChannels.id, tenant_id: tenantColumn }
+        : { channel_id: gatewayChannels.id };
+
+    const rows = await select(this.db, columns)
+      .from(gatewayChannels)
+      .where(eq(gatewayChannels.enabled, true))
+      .all();
+
+    return (rows as Array<{ channel_id: string; tenant_id?: unknown }>).map((row) => ({
+      channel_id: row.channel_id as GatewayChannelID,
+      ...(typeof row.tenant_id === 'string' && row.tenant_id.length > 0
+        ? { tenant_id: row.tenant_id }
+        : {}),
+    }));
   }
 
   /**

--- a/packages/core/src/db/tenant-context.ts
+++ b/packages/core/src/db/tenant-context.ts
@@ -7,9 +7,13 @@ export interface TenantDatabaseScope {
   kind: 'tenant' | 'system';
   tenantId?: TenantID | string;
   systemReason?: string;
+  systemCapability?: SystemDatabaseCapability;
   postCommitCallbacks?: Array<() => Promise<void>>;
   afterCommitCallbacks?: Array<() => Promise<void> | void>;
 }
+
+/** Narrow RLS capabilities available to explicit system database work. */
+export type SystemDatabaseCapability = 'gateway_listener_discovery';
 
 export interface TenantContextScope {
   tenantId: TenantID | string;

--- a/packages/core/src/db/tenant-scope.test.ts
+++ b/packages/core/src/db/tenant-scope.test.ts
@@ -288,4 +288,47 @@ describe('tenant-scoped database proxy', () => {
       )
     ).rejects.toThrow(/Cannot enter tenant scope tenant-a from active system database scope/);
   });
+
+  it('sets narrow Postgres system capabilities transaction-locally', async () => {
+    const tx = {
+      execute: vi.fn(async () => []),
+      marker: vi.fn(() => 'tx'),
+    };
+    const base = {
+      transaction: vi.fn(async (callback: (db: unknown) => Promise<unknown>) => callback(tx)),
+      marker: vi.fn(() => 'base'),
+    };
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: true,
+    });
+
+    await runWithSystemDatabaseScope(
+      db,
+      'gateway discovery test',
+      async (systemDb) => {
+        expect((systemDb as unknown as { marker(): string }).marker()).toBe('tx');
+        expect(getCurrentTenantDatabaseScope()).toMatchObject({
+          kind: 'system',
+          systemCapability: 'gateway_listener_discovery',
+        });
+      },
+      { capability: 'gateway_listener_discovery' }
+    );
+
+    expect(base.transaction).toHaveBeenCalledTimes(1);
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects changing capability inside an active system scope', async () => {
+    const db = { run: vi.fn() } as unknown as Database;
+
+    await expect(
+      runWithSystemDatabaseScope(
+        db,
+        'gateway discovery test',
+        async () => runWithSystemDatabaseScope(db, 'generic nested work', async () => undefined),
+        { capability: 'gateway_listener_discovery' }
+      )
+    ).rejects.toThrow(/Cannot change system database capability/);
+  });
 });

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -2,10 +2,12 @@ import { sql } from 'drizzle-orm';
 import type { TenantID } from '../types/tenant';
 import {
   runWithoutTenantDatabaseScope,
+  type SystemDatabaseCapability,
   tenantContextScope,
   tenantDatabaseScope,
 } from './tenant-context';
 
+export type { SystemDatabaseCapability } from './tenant-context';
 export {
   enqueueAfterTenantDatabaseCommit,
   enqueueTenantDatabasePostCommitCallback,
@@ -195,7 +197,8 @@ async function drainAfterTenantDatabaseCommitCallbacks(
 export async function runWithSystemDatabaseScope<T>(
   db: TenantScopeAwareDatabase | RawDatabase | Database,
   reason: string,
-  work: (db: SystemDatabase) => Promise<T>
+  work: (db: SystemDatabase) => Promise<T>,
+  options: { capability?: SystemDatabaseCapability } = {}
 ): Promise<T> {
   const operationTenantId = tenantContextScope.getStore()?.tenantId;
   if (operationTenantId) {
@@ -210,13 +213,39 @@ export async function runWithSystemDatabaseScope<T>(
         `Cannot enter system database scope (${reason}) from active tenant scope ${existingScope.tenantId}`
       );
     }
+    if (existingScope.systemCapability !== options.capability) {
+      throw new Error(
+        `Cannot change system database capability from ${existingScope.systemCapability ?? 'none'} to ${options.capability ?? 'none'} (${reason})`
+      );
+    }
     return work(existingScope.db as SystemDatabase);
   }
 
   const baseDb = unwrapTenantScopedDatabaseProxy(db);
-  return tenantDatabaseScope.run({ db: baseDb, kind: 'system', systemReason: reason }, () =>
-    work(baseDb as SystemDatabase)
-  );
+  const scope = (scopedDb: Database) =>
+    tenantDatabaseScope.run(
+      {
+        db: scopedDb,
+        kind: 'system',
+        systemReason: reason,
+        ...(options.capability ? { systemCapability: options.capability } : {}),
+      },
+      () => work(scopedDb as SystemDatabase)
+    );
+
+  if (!options.capability || !isPostgresDatabase(baseDb)) {
+    return scope(baseDb);
+  }
+
+  // Capabilities are transaction-local Postgres GUCs consumed by narrowly
+  // scoped RLS policies. They must never leak onto a pooled connection.
+  return baseDb.transaction(async (tx) => {
+    const scopedDb = tx as unknown as Database;
+    await (scopedDb as unknown as { execute(query: unknown): Promise<unknown> }).execute(
+      sql`SELECT set_config('agor.system_scope', ${options.capability}, true)`
+    );
+    return scope(scopedDb);
+  });
 }
 
 async function drainTenantDatabasePostCommitCallbacks(

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -138,7 +138,10 @@ const checks = [
     // Agor store/tenant transaction wrapper once introduced.
     baseline: {
       'packages/core/src/db/database-wrapper.ts': 1,
-      'packages/core/src/db/tenant-scope.ts': 1,
+      // Tenant scopes use one transaction for agor.tenant_id. Narrow system
+      // capabilities use a second transaction path so their RLS GUC is local
+      // to one pooled connection checkout and cannot leak after discovery.
+      'packages/core/src/db/tenant-scope.ts': 2,
       'packages/core/src/db/repositories/tasks.ts': 1,
       'packages/core/src/db/repositories/branches.ts': 1,
       'packages/core/src/db/repositories/knowledge.ts': 7,


### PR DESCRIPTION
## Summary

Hardens the MCP authentication boundary and gateway listener lifecycle for `multi_tenancy.mode: required_from_auth`, while preserving the existing static/single-tenant path.

This is the dedicated follow-up to the multi-tenancy concerns deferred from #1903. The implementation stays in the shared MCP/gateway layers; no connector-specific Shortcut behavior changes.

## Threat model and invariants

The pre-fix architecture had three unsafe/incorrect edges:

1. `/mcp` could query tenant-owned API-key, user, or session data before a trustworthy tenant was established. Internal MCP JWTs and stateful transports had no immutable tenant binding.
2. Gateway restart discovery ran in the bootstrap/static tenant, so other tenants' listeners were not reconciled after restart.
3. A process-global `hasActiveChannels` value was derived from a tenant-local query, allowing one tenant's empty result to suppress another tenant's outbound delivery.

The new invariants are:

- every available tenant signal must agree; missing/conflicting identity fails closed;
- no tenant-owned auth lookup occurs before tenant bootstrap;
- internal MCP JWTs sign `(tenant, session, user, jti, exp)` and stateful MCP sessions retain immutable tenant/user/session bindings;
- long MCP calls and provider operations retain identity only, never a long-lived DB transaction;
- global gateway work is limited to enabled `(tenant_id, channel_id)` discovery through an explicit RLS capability;
- full channel credentials and all listener/outbound work are loaded and executed only after re-entering the discovered tenant;
- listener keys and enabled-channel fast paths are tenant-qualified.

The full audit and operating-model analysis is in `docs/internal/gateway-mcp-multitenancy-hardening-2026-07-16.md`.

## Implementation

### MCP

- Resolves static or trusted-header tenant identity before opaque personal API-key verification.
- Treats a verified internal token's signed `tid` as an authenticated tenant signal and rejects disagreement with static/trusted-header identity before DB access.
- Adds `tid` to MCP JWTs, requires an active tenant at issuance, and keys the token cache by tenant/session/user.
- Splits cryptographic verification from tenant-scoped session validation so bootstrap happens in the correct order.
- Re-authenticates every stateful MCP request and compares its tenant against the initialize-time binding.
- Rejects legacy/unbound internal tokens rather than falling back to a default tenant.

### Gateway

- Adds a narrowly named, transaction-local `gateway_listener_discovery` system capability.
- Adds Postgres migration `0066_gateway_listener_discovery`, whose read-only RLS policy exposes only enabled gateway rows while that exact capability is active.
- Discovers only tenant/channel references globally, then reloads each full channel under normal tenant RLS before starting a connector.
- Captures the immutable channel tenant in every provider callback.
- Replaces process-global listener/fast-path state with tenant-qualified keys and sets.
- Keeps static startup on the configured static tenant with no new operator configuration.

## Operating-model impact / rollout

- **Static/single tenant:** no configuration or client changes.
- **Required-from-auth internal MCP:** existing unbound MCP JWTs are rejected and naturally re-minted on session fetch/create.
- **Required-from-auth personal API keys:** because existing keys are opaque, `/mcp` requires a configured `multi_tenancy.trusted_header`. The trusted proxy must strip client-supplied values and set the header from authenticated routing; direct daemon exposure is unsafe in that model.
- **Postgres:** apply the normal migration set before serving traffic with the upgraded daemon. The daemon continues to use a non-superuser/non-`BYPASSRLS` role.

No data backfill is required.

## Tests

Regression coverage includes:

- conflicting static/explicit, auth-claim/header, and signed-token/header tenants;
- duplicate and comma-coalesced tenant headers rejected at the real MCP HTTP boundary before API-key lookup;
- personal-key bootstrap failing before key lookup when tenant identity is absent;
- tenant-bound token issuance/cache/validation and cross-tenant replay rejection;
- stateful MCP replay rejection for the same user ID in a different tenant;
- transaction-local system capability behavior with a guarded DB proxy;
- RLS migration capability/read-only/enabled-row contract;
- two tenants with same-looking gateway channel IDs starting and dispatching independently;
- forged discovery tenant mismatch failing closed while other tenants continue;
- a tenant with no enabled channels not suppressing another tenant's outbound delivery;
- static SQLite enabled-channel discovery.

Validation run:

- `pnpm --filter @agor/core test` — 2,791 passed, 2 skipped
- `pnpm --filter @agor/daemon test` — 1,724 passed, 31 skipped
- `pnpm typecheck` — 11/11 workspace tasks successful
- `pnpm lint`
- `pnpm check:multitenancy-boundaries`
- `pnpm check:shortid`

The repository does not currently provide a live Postgres/RLS CI fixture, so Postgres coverage here exercises the guarded transaction/GUC boundary and migration policy contract without bypassing the isolation abstractions.

## Deliberate follow-ups

Kept out of this PR to avoid turning gateway hardening into a broad control-plane rewrite:

- scheduler/health-monitor global discovery capabilities;
- orphan/restart reconciliation and knowledge embedding startup behavior outside the static tenant;
- gateway listener lifecycle serialization and persisted polling cursors;
- a future versioned personal-key format with a signed tenant routing hint.

