### PR TITLE
fix(onboarding): align teammate first-session handoff

### DIFF
--- a/apps/agor-docs/content/blog/agor-assistants.mdx
+++ b/apps/agor-docs/content/blog/agor-assistants.mdx
@@ -21,7 +21,7 @@ That experiment proved the concept: an agent that bootstrapped itself, spawned p
 
 Since then, I've been running teammates daily at [Preset](https://preset.io?utm_source=agor.live&utm_medium=referral&utm_campaign=agor-docs&utm_content=blog-agor-assistants), and the pattern has evolved from "cool experiment" to "how did we work without this?" This post covers what AI teammates are, how they work in practice, and what I've learned from running four of them across my team.
 
-For the full technical reference — BOOTSTRAP.md, BOARD.md, HEARTBEAT.md, memory layout, skills — see the [Teammates guide](/guide/teammates).
+For the full technical reference — ONBOARDING.md, BOARD.md, HEARTBEAT.md, memory layout, skills — see the [Teammates guide](/guide/teammates).
 
 ---
 
@@ -147,7 +147,7 @@ Running teammates inside Agor gives you capabilities that standalone agent frame
 2. **From Settings** — Go to Settings > Teammates > Create AI teammate
 3. **From the CLI** — Run `agor init` and follow the prompts
 
-The teammate framework repo ([preset-io/agor-teammate](https://github.com/preset-io/agor-teammate)) provides the scaffolding: BOOTSTRAP.md for first-boot setup, memory structure, identity files. Say "hello" and the bootstrap takes it from there.
+The teammate framework repo ([preset-io/agor-teammate](https://github.com/preset-io/agor-teammate)) provides the scaffolding: ONBOARDING.md for the guided first interactions, memory structure, and identity files. Start a session and the onboarding guide takes it from there.
 
 For the full reference, see the [Teammates guide](/guide/teammates).
 

--- a/apps/agor-docs/content/guide/teammates.mdx
+++ b/apps/agor-docs/content/guide/teammates.mdx
@@ -31,15 +31,15 @@ An AI teammate is a special branch backed by the **framework repository** — a 
 1. Forks the framework repo into a new branch
 2. Tags the branch with teammate metadata (name, framework version)
 3. Creates a dedicated board for the teammate's work
-4. Launches your first session — triggering `BOOTSTRAP.md`
+4. Launches your first session — beginning the guided experience in `ONBOARDING.md`
 
 From there, every session in that branch picks up the teammate's accumulated memory and context.
 
 ## Key concepts
 
-### BOOTSTRAP.md — First boot
+### ONBOARDING.md — Starting the working relationship
 
-When a teammate is created for the first time, it runs through `BOOTSTRAP.md` — the initialization script that sets up identity, preferences, and initial state. This is where the teammate introduces itself, learns about you, and configures its working environment. Think of it as the teammate's "first day" checklist.
+During a teammate's first interactions, `ONBOARDING.md` guides the conversation toward a real outcome. It keeps a concise progress record across early sessions so the teammate can understand the user's goal, use relevant context, and continue naturally. Onboarding finishes after a useful working relationship has been established; it is not a one-time identity or configuration checklist.
 
 ### Memory across sessions
 
@@ -117,7 +117,7 @@ When you first log into Agor, choose **"Set up your AI teammate"**. The wizard w
 2. Create a personal board
 3. Set up a branch with your own branch
 4. Configure API keys
-5. Launch your first session (which runs `BOOTSTRAP.md`)
+5. Launch your first session (which follows `ONBOARDING.md`)
 
 ### From Settings
 

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -64,7 +64,10 @@ import { initializeAudioOnInteraction } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
 import { hasExplicitEntityRouteTarget } from '../../utils/routeTargets';
 import { startTeammateBootstrapSession } from '../../utils/startTeammateBootstrapSession';
-import { buildTeammateBootstrapPrompt } from '../../utils/teammateBootstrapPrompt';
+import {
+  buildTeammateBootstrapPrompt,
+  buildTeammateOnboardingSessionTitle,
+} from '../../utils/teammateBootstrapPrompt';
 import { createTeammateBranch } from '../../utils/teammateCreation';
 import { AppHeader } from '../AppHeader';
 import type { BoardTeammatePanelTab } from '../BoardTeammatePanel';
@@ -915,7 +918,7 @@ export const App: React.FC<AppProps> = ({
       branch_id: branch.branch_id,
       agent: result.agent,
       agenticToolPresetId: result.agenticToolPresetId,
-      title: `${result.emoji ? `${result.emoji} ` : ''}${result.displayName} bootstrap`,
+      title: buildTeammateOnboardingSessionTitle(result),
       initialPrompt: buildTeammateBootstrapPrompt({
         displayName: result.displayName,
         emoji: result.emoji,

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -81,7 +81,7 @@ describe('seedOnboardingTeammate', () => {
     expect(initialPrompt).toContain('developer');
     expect(initialPrompt).toContain('- Suggested integrations: Slack, GitHub');
     expect(initialPrompt).toContain('Read ONBOARDING.md');
-    expect(initialPrompt).not.toContain('BOOTSTRAP.md');
+    expect(initialPrompt).toContain('otherwise, read BOOTSTRAP.md');
 
     expect(result).toEqual({ sessionId: 'session-1' });
     expect(onWarn).not.toHaveBeenCalled();

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -40,7 +40,7 @@ function setup(overrides: Partial<SeedOnboardingTeammateInput> = {}) {
 describe('seedOnboardingTeammate', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('creates a teammate branch + persona-primed bootstrap session when the framework repo is present', async () => {
+  it('creates a teammate branch + persona-primed onboarding session when the framework repo is present', async () => {
     createTeammateBranchMock.mockResolvedValue({
       branch_id: 'branch-1',
       board_id: 'board-1',
@@ -62,20 +62,26 @@ describe('seedOnboardingTeammate', () => {
       expect.objectContaining({ onCreateBranch, onUpdateBranch })
     );
 
-    // Bootstrap session is started for the created branch.
+    // Onboarding session is started for the created branch.
     expect(startTeammateBootstrapSessionMock).toHaveBeenCalledTimes(1);
     const sessionArg = startTeammateBootstrapSessionMock.mock.calls[0][0];
     expect(sessionArg).toEqual(
       expect.objectContaining({ branchId: 'branch-1', boardId: 'board-1', onCreateSession })
     );
-    // Agent choice + persona are threaded through to the bootstrap prompt.
+    // Agent choice + persona are threaded through to the onboarding prompt.
     expect(sessionArg.sessionConfig).toEqual(
-      expect.objectContaining({ branch_id: 'branch-1', agent: 'claude-code' })
+      expect.objectContaining({
+        branch_id: 'branch-1',
+        agent: 'claude-code',
+        title: '🤖 Rusty onboarding',
+      })
     );
     const initialPrompt = (sessionArg.sessionConfig as { initialPrompt: string }).initialPrompt;
     expect(initialPrompt).toContain('Rusty');
     expect(initialPrompt).toContain('developer');
     expect(initialPrompt).toContain('- Suggested integrations: Slack, GitHub');
+    expect(initialPrompt).toContain('Read ONBOARDING.md');
+    expect(initialPrompt).not.toContain('BOOTSTRAP.md');
 
     expect(result).toEqual({ sessionId: 'session-1' });
     expect(onWarn).not.toHaveBeenCalled();

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -1,6 +1,9 @@
 import type { AgenticToolName, AgorClient, Repo } from '@agor-live/client';
 import { startTeammateBootstrapSession } from './startTeammateBootstrapSession';
-import { buildTeammateBootstrapPrompt } from './teammateBootstrapPrompt';
+import {
+  buildTeammateBootstrapPrompt,
+  buildTeammateOnboardingSessionTitle,
+} from './teammateBootstrapPrompt';
 import { createTeammateBranch, type TeammateCreationDeps } from './teammateCreation';
 
 export interface SeedOnboardingTeammateInput {
@@ -79,7 +82,10 @@ export async function seedOnboardingTeammate(
       sessionConfig: {
         branch_id: branch.branch_id,
         agent: input.agent ?? 'claude-code',
-        title: `${input.teammateEmoji ? `${input.teammateEmoji} ` : ''}${teammateName} onboarding`,
+        title: buildTeammateOnboardingSessionTitle({
+          displayName: teammateName,
+          emoji: input.teammateEmoji,
+        }),
         initialPrompt: buildTeammateBootstrapPrompt({
           displayName: teammateName,
           emoji: input.teammateEmoji,

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -12,7 +12,7 @@ export interface SeedOnboardingTeammateInput {
   teammateEmoji?: string;
   /** Agent chosen in the LLM step; defaults to claude-code. */
   agent?: AgenticToolName | null;
-  /** Persona-tailored MCP integration names to suggest in the bootstrap prompt. */
+  /** Persona-tailored MCP integration names to suggest in the onboarding prompt. */
   suggestedIntegrations?: string[];
   user?: { name?: string | null; email?: string | null; persona?: string | null } | null;
   client: AgorClient | null;
@@ -26,13 +26,13 @@ export interface SeedOnboardingTeammateInput {
 
 /**
  * Seeds the user's first AI teammate at the end of onboarding: a branch on the
- * framework repo plus a persona-primed bootstrap session, reusing the board the
+ * framework repo plus a persona-primed onboarding session, reusing the board the
  * wizard already created.
  *
  * Best-effort by contract: if the framework repo isn't ready yet, or branch /
  * session creation throws, it surfaces a non-fatal warning and resolves without
  * a session so the caller can still finish onboarding on the board. Returns the
- * bootstrap session id when one was created.
+ * onboarding session id when one was created.
  */
 export async function seedOnboardingTeammate(
   input: SeedOnboardingTeammateInput
@@ -79,7 +79,7 @@ export async function seedOnboardingTeammate(
       sessionConfig: {
         branch_id: branch.branch_id,
         agent: input.agent ?? 'claude-code',
-        title: `${input.teammateEmoji ? `${input.teammateEmoji} ` : ''}${teammateName} bootstrap`,
+        title: `${input.teammateEmoji ? `${input.teammateEmoji} ` : ''}${teammateName} onboarding`,
         initialPrompt: buildTeammateBootstrapPrompt({
           displayName: teammateName,
           emoji: input.teammateEmoji,

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -14,12 +14,13 @@ describe('buildTeammateBootstrapPrompt', () => {
       userEmail: 'max@example.com',
     });
 
-    expect(prompt).toContain('### First boot instructions for Agor AI teammate');
+    expect(prompt).toContain('### First-session onboarding instructions for Agor AI teammate');
     expect(prompt).toContain('- AI teammate: PR Reviewer 🧐');
     expect(prompt).toContain('- AI teammate description: Reviews pull requests');
     expect(prompt).toContain('- User: Max <max@example.com>');
-    expect(prompt).toContain('- User: Max <max@example.com>\n\nRead BOOTSTRAP.md');
-    expect(prompt).toContain('ask only the next useful questions');
+    expect(prompt).toContain('- User: Max <max@example.com>\n\nRead ONBOARDING.md');
+    expect(prompt).toContain('ask only the next useful question');
+    expect(prompt).not.toContain('BOOTSTRAP.md');
     expect(prompt).not.toContain("don't re-ask");
     expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
   });

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, it } from 'vitest';
 import {
   buildTeammateBootstrapPrompt,
   buildTeammateBootstrapPromptContext,
+  buildTeammateOnboardingSessionTitle,
 } from './teammateBootstrapPrompt';
 
 describe('buildTeammateBootstrapPrompt', () => {
+  it('uses onboarding terminology for the visible first-session title', () => {
+    expect(buildTeammateOnboardingSessionTitle({ displayName: 'Rusty', emoji: '🤖' })).toBe(
+      '🤖 Rusty onboarding'
+    );
+    expect(buildTeammateOnboardingSessionTitle({ displayName: 'Rusty' })).toBe('Rusty onboarding');
+  });
+
   it('formats teammate identity params without browser-side Handlebars rendering', () => {
     const prompt = buildTeammateBootstrapPrompt({
       displayName: 'PR Reviewer',

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -26,9 +26,10 @@ describe('buildTeammateBootstrapPrompt', () => {
     expect(prompt).toContain('- AI teammate: PR Reviewer 🧐');
     expect(prompt).toContain('- AI teammate description: Reviews pull requests');
     expect(prompt).toContain('- User: Max <max@example.com>');
-    expect(prompt).toContain('- User: Max <max@example.com>\n\nRead ONBOARDING.md');
+    expect(prompt).toContain(
+      '- User: Max <max@example.com>\n\nRead ONBOARDING.md if it exists; otherwise, read BOOTSTRAP.md'
+    );
     expect(prompt).toContain('ask only the next useful question');
-    expect(prompt).not.toContain('BOOTSTRAP.md');
     expect(prompt).not.toContain("don't re-ask");
     expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
   });

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -27,6 +27,13 @@ export interface TeammateBootstrapPromptContext {
   firstSession: true;
 }
 
+export function buildTeammateOnboardingSessionTitle({
+  displayName,
+  emoji,
+}: Pick<TeammateBootstrapPromptInput, 'displayName' | 'emoji'>): string {
+  return `${emoji ? `${emoji} ` : ''}${displayName} onboarding`;
+}
+
 function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext): string {
   const lines = [
     '### First-session onboarding instructions for Agor AI teammate',

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -29,7 +29,7 @@ export interface TeammateBootstrapPromptContext {
 
 function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext): string {
   const lines = [
-    '### First boot instructions for Agor AI teammate',
+    '### First-session onboarding instructions for Agor AI teammate',
     '',
     'Context:',
     `- AI teammate: ${context.teammate.displayName} ${context.teammate.emoji}`,
@@ -58,7 +58,7 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
 
   lines.push('');
   lines.push(
-    'Read BOOTSTRAP.md, then say hello and ask only the next useful questions to shape this AI teammate.'
+    "Read ONBOARDING.md, then respond to the user. Use the supplied context and live Agor state, and ask only the next useful question if the user's goal is not already clear."
   );
 
   return lines.join('\n');

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -65,7 +65,7 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
 
   lines.push('');
   lines.push(
-    "Read ONBOARDING.md, then respond to the user. Use the supplied context and live Agor state, and ask only the next useful question if the user's goal is not already clear."
+    "Read ONBOARDING.md if it exists; otherwise, read BOOTSTRAP.md. Then respond to the user. Use the supplied context and live Agor state, and ask only the next useful question if the user's goal is not already clear."
   );
 
   return lines.join('\n');


### PR DESCRIPTION
## Linked issue

Not linked.

## Summary

- point the first teammate session at `ONBOARDING.md` and make its handoff goal-aware
- preserve `BOOTSTRAP.md` as a fallback for unsynchronized legacy/private framework forks
- use consistent onboarding terminology for first-session titles across wizard and manual teammate creation
- update the teammate guide, current Teammates blog, and focused tests for the current onboarding framework

## Why / context

The teammate framework replaced its one-time `BOOTSTRAP.md` flow with a live `ONBOARDING.md` guide, but Agor still generated a prompt that referenced the removed file. This left the first teammate session with contradictory startup instructions and stale user-facing terminology.

## Implementation notes

- keeps the onboarding wizard unchanged
- preserves the existing persona and `suggestedIntegrations` handoff
- centralizes the visible onboarding session title so wizard and manual creation paths stay aligned
- prefers `ONBOARDING.md` while retaining a `BOOTSTRAP.md` fallback for framework forks that have not migrated yet
- leaves internal bootstrap-named utility APIs unchanged to keep this patch focused on user-visible and runtime behavior

## Validation / test plan

- [x] focused teammate prompt and seeding tests: 2 files, 12 tests
- [x] touched TypeScript lint checks
- [x] pre-commit checks
- [x] `git diff --check`

## Screenshots / demos

Not applicable; this changes generated session context, session titles, and documentation.

## Risks / rollout / rollback

Low risk. The change is limited to startup prompt text, visible onboarding session titles, tests, and documentation. Current framework branches prefer `ONBOARDING.md`, while unsynchronized legacy/private forks can continue through `BOOTSTRAP.md`. Reverting the commits restores the previous behavior.

## Out of scope / follow-ups

- onboarding wizard changes
- changes to persona-derived integration suggestions
- MCP/OAuth connection flow improvements
- onboarding evaluation or analytics work
