### PR TITLE
fix(executor): one-shot 401 retry + single-flight reauth on live socket

### DIFF
--- a/packages/executor/src/services/feathers-client.test.ts
+++ b/packages/executor/src/services/feathers-client.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type LiveAuthErrorContext,
+  recoverFromLiveAuthError,
+  singleFlight,
+} from './feathers-client.js';
+
+/** A deferred promise whose resolution the test controls explicitly. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('singleFlight', () => {
+  it('coalesces concurrent calls into one underlying invocation', async () => {
+    const gate = deferred<boolean>();
+    const fn = vi.fn(() => gate.promise);
+    const wrapped = singleFlight(fn);
+
+    // A single token expiry rejects many acks at once — simulate the burst.
+    const a = wrapped();
+    const b = wrapped();
+    const c = wrapped();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    gate.resolve(true);
+    // Every concurrent caller observes the REAL shared outcome, not an
+    // optimistic "already in progress" value.
+    await expect(Promise.all([a, b, c])).resolves.toEqual([true, true, true]);
+  });
+
+  it('re-runs after the in-flight promise settles (later expiry)', async () => {
+    let n = 0;
+    const wrapped = singleFlight(async () => {
+      n += 1;
+      return n;
+    });
+
+    await expect(wrapped()).resolves.toBe(1);
+    await expect(wrapped()).resolves.toBe(2);
+  });
+
+  it('releases the slot even when the underlying call rejects', async () => {
+    let attempt = 0;
+    const wrapped = singleFlight(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('boom');
+      return attempt;
+    });
+
+    await expect(wrapped()).rejects.toThrow('boom');
+    // Slot released after rejection, so the next call runs again.
+    await expect(wrapped()).resolves.toBe(2);
+  });
+});
+
+function makeContext(overrides: Partial<LiveAuthErrorContext>): LiveAuthErrorContext {
+  return {
+    path: 'sessions',
+    method: 'patch',
+    service: {} as LiveAuthErrorContext['service'],
+    params: {},
+    error: { code: 401, name: 'NotAuthenticated' },
+    ...overrides,
+  };
+}
+
+describe('recoverFromLiveAuthError', () => {
+  it('passes through non-auth errors untouched', async () => {
+    const reauth = vi.fn(async () => true);
+    const context = makeContext({ error: { code: 500, name: 'GeneralError' } });
+
+    await recoverFromLiveAuthError(context, reauth);
+
+    expect(reauth).not.toHaveBeenCalled();
+    expect(context.error).toEqual({ code: 500, name: 'GeneralError' });
+    expect(context.result).toBeUndefined();
+  });
+
+  it('never intercepts the authentication service (would recurse)', async () => {
+    const reauth = vi.fn(async () => true);
+    const context = makeContext({ path: 'authentication' });
+
+    await recoverFromLiveAuthError(context, reauth);
+
+    expect(reauth).not.toHaveBeenCalled();
+    expect(context.error).toEqual({ code: 401, name: 'NotAuthenticated' });
+  });
+
+  it('re-authenticates and replays the original call once, clearing the error', async () => {
+    const patch = vi.fn(async () => ({ id: 's1', status: 'ok' }));
+    const reauth = vi.fn(async () => true);
+    const onExpired = vi.fn();
+    const context = makeContext({
+      method: 'patch',
+      id: 's1',
+      data: { status: 'ok' },
+      params: { query: { keep: 1 } },
+      service: { patch } as unknown as LiveAuthErrorContext['service'],
+    });
+
+    await recoverFromLiveAuthError(context, reauth, onExpired);
+
+    expect(onExpired).toHaveBeenCalledWith('sessions.patch');
+    expect(reauth).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledTimes(1);
+    // Retry carries the original params plus the one-shot retry flag.
+    expect(patch).toHaveBeenCalledWith(
+      's1',
+      { status: 'ok' },
+      {
+        query: { keep: 1 },
+        __executorReauthRetried: true,
+      }
+    );
+    expect(context.error).toBeNull();
+    expect(context.result).toEqual({ id: 's1', status: 'ok' });
+  });
+
+  it('does not retry a request that was already retried once', async () => {
+    const reauth = vi.fn(async () => true);
+    const patch = vi.fn();
+    const context = makeContext({
+      params: { __executorReauthRetried: true },
+      service: { patch } as unknown as LiveAuthErrorContext['service'],
+    });
+
+    await recoverFromLiveAuthError(context, reauth);
+
+    expect(reauth).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+    expect(context.error).toEqual({ code: 401, name: 'NotAuthenticated' });
+  });
+
+  it('surfaces the original error when re-authentication fails', async () => {
+    const patch = vi.fn();
+    const reauth = vi.fn(async () => false);
+    const context = makeContext({
+      service: { patch } as unknown as LiveAuthErrorContext['service'],
+    });
+
+    await recoverFromLiveAuthError(context, reauth);
+
+    expect(reauth).toHaveBeenCalledTimes(1);
+    expect(patch).not.toHaveBeenCalled();
+    expect(context.error).toEqual({ code: 401, name: 'NotAuthenticated' });
+  });
+
+  it('surfaces the retry error if the replayed call also fails', async () => {
+    const retryError = Object.assign(new Error('still bad'), { code: 403 });
+    const patch = vi.fn(async () => {
+      throw retryError;
+    });
+    const reauth = vi.fn(async () => true);
+    const context = makeContext({
+      service: { patch } as unknown as LiveAuthErrorContext['service'],
+    });
+
+    await recoverFromLiveAuthError(context, reauth);
+
+    expect(context.error).toBe(retryError);
+    expect(context.result).toBeUndefined();
+  });
+
+  it('does not blind-retry unknown/custom methods', async () => {
+    const reauth = vi.fn(async () => true);
+    const context = makeContext({ method: 'customThing', service: {} as never });
+
+    await recoverFromLiveAuthError(context, reauth);
+
+    // Re-auth still runs, but the custom method is not replayed.
+    expect(reauth).toHaveBeenCalledTimes(1);
+    expect(context.error).toEqual({ code: 401, name: 'NotAuthenticated' });
+  });
+
+  it('recognizes a 401 by name even without a numeric code', async () => {
+    const get = vi.fn(async () => ({ id: 'x' }));
+    const reauth = vi.fn(async () => true);
+    const context = makeContext({
+      method: 'get',
+      id: 'x',
+      error: { name: 'NotAuthenticated' },
+      service: { get } as unknown as LiveAuthErrorContext['service'],
+    });
+
+    await recoverFromLiveAuthError(context, reauth);
+
+    expect(get).toHaveBeenCalledWith('x', { __executorReauthRetried: true });
+    expect(context.error).toBeNull();
+  });
+
+  it('drives exactly one re-auth for a burst of concurrent 401s (single-flight)', async () => {
+    const gate = deferred<boolean>();
+    const rawReauth = vi.fn(() => gate.promise);
+    const reauthenticate = singleFlight(rawReauth);
+
+    const patch = vi.fn(async () => ({ ok: true }));
+    const makeCall = () =>
+      recoverFromLiveAuthError(
+        makeContext({ service: { patch } as unknown as LiveAuthErrorContext['service'] }),
+        () => reauthenticate()
+      );
+
+    // Three acks rejected by the same token expiry, all in flight together.
+    const calls = [makeCall(), makeCall(), makeCall()];
+    // Let the microtasks reach the awaited reauthenticate().
+    await Promise.resolve();
+    expect(rawReauth).toHaveBeenCalledTimes(1);
+
+    gate.resolve(true);
+    const results = await Promise.all(calls);
+
+    // One shared re-auth, but each request is independently replayed.
+    expect(rawReauth).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledTimes(3);
+    for (const context of results) {
+      expect(context.error).toBeNull();
+      expect(context.result).toEqual({ ok: true });
+    }
+  });
+});

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -13,6 +13,116 @@ export type { AgorClient } from '@agor/core/api';
 const DEBUG_FEATHERS_CLIENT =
   process.env.AGOR_DEBUG_FEATHERS_CLIENT === '1' || process.env.DEBUG?.includes('feathers-client');
 
+/**
+ * Coalesce concurrent invocations behind a single shared promise.
+ *
+ * An access-token expiry on a live socket can reject many in-flight acks at
+ * once — each landing in the 401 error hook and each wanting to re-authenticate.
+ * Wrapping the re-auth in single-flight makes that burst drive ONE re-auth: the
+ * first caller runs it, every concurrent caller awaits the same promise, and
+ * they all observe the REAL outcome (not an optimistic "already in progress"
+ * true that would let a retry fire before the socket is actually
+ * re-authenticated). The slot is released once the promise settles, so a later
+ * expiry re-authenticates again.
+ */
+export function singleFlight<T>(fn: () => Promise<T>): () => Promise<T> {
+  let inFlight: Promise<T> | null = null;
+  return () => {
+    if (inFlight) return inFlight;
+    const promise = (async () => fn())().finally(() => {
+      if (inFlight === promise) inFlight = null;
+    });
+    inFlight = promise;
+    return promise;
+  };
+}
+
+/** The Feathers error-hook context fields the live-401 recovery reads/writes. */
+export interface LiveAuthErrorContext {
+  path?: string;
+  method?: string;
+  service: Record<string, (...args: unknown[]) => Promise<unknown>>;
+  params?: Record<string, unknown>;
+  id?: unknown;
+  data?: unknown;
+  result?: unknown;
+  error?: { code?: number; name?: string } | null;
+}
+
+// Marks a request that has already been retried once after a re-auth, so a
+// second consecutive 401 surfaces instead of looping forever.
+const REAUTH_RETRY_FLAG = '__executorReauthRetried';
+
+/**
+ * Recover from an access-token expiry on a LIVE (still-connected) socket.
+ *
+ * The daemon mints short-lived access tokens. A long executor turn can outlive
+ * that TTL while the socket stays open, so the token expires WITHOUT a
+ * disconnect. The next service call's ack then rejects with a 401
+ * NotAuthenticated error and — with no disconnect/reconnect event to drive the
+ * socket handlers — it would bubble up unhandled, kill the executor (exit 1),
+ * and the daemon would mark the session `failed`.
+ *
+ * This is a method-agnostic, one-shot recovery: on a 401 it re-authenticates
+ * (via the caller-supplied single-flight `reauthenticate`) and transparently
+ * replays the original call once with the retry flag set. Ported from the
+ * reviewed UI-side pattern in #1058. It never intercepts the `authentication`
+ * service (the re-auth path itself) and never blind-retries custom methods.
+ */
+export async function recoverFromLiveAuthError(
+  context: LiveAuthErrorContext,
+  reauthenticate: (label: string) => Promise<boolean>,
+  onExpired?: (detail: string) => void
+): Promise<LiveAuthErrorContext> {
+  // Never intercept the authentication service itself: reauthenticate() calls
+  // it, so retrying here would recurse.
+  if (context.path === 'authentication') return context;
+
+  const isAuthError = context.error?.code === 401 || context.error?.name === 'NotAuthenticated';
+  if (!isAuthError) return context;
+
+  const params = context.params ?? {};
+  if (params[REAUTH_RETRY_FLAG]) return context; // already retried once
+
+  onExpired?.(`${context.path}.${context.method}`);
+  const reauthenticated = await reauthenticate('live request 401');
+  if (!reauthenticated) return context;
+
+  const retryParams = { ...params, [REAUTH_RETRY_FLAG]: true };
+  const service = context.service;
+  try {
+    switch (context.method) {
+      case 'find':
+        context.result = await service.find(retryParams);
+        break;
+      case 'get':
+        context.result = await service.get(context.id, retryParams);
+        break;
+      case 'create':
+        context.result = await service.create(context.data, retryParams);
+        break;
+      case 'update':
+        context.result = await service.update(context.id, context.data, retryParams);
+        break;
+      case 'patch':
+        context.result = await service.patch(context.id, context.data, retryParams);
+        break;
+      case 'remove':
+        context.result = await service.remove(context.id, retryParams);
+        break;
+      default:
+        // Unknown/custom method: don't blind-retry, just surface the error.
+        return context;
+    }
+    // Swallow the original error now that the retry succeeded. Feathers returns
+    // context.result (now defined) instead of throwing.
+    context.error = null;
+  } catch (retryError) {
+    context.error = retryError as { code?: number; name?: string };
+  }
+  return context;
+}
+
 const SERVER_DISCONNECT_RECONNECT_BASE_DELAY_MS = 1000;
 const SERVER_DISCONNECT_RECONNECT_MAX_DELAY_MS = 30_000;
 const SERVER_DISCONNECT_RECONNECT_MAX_ATTEMPTS = 8;
@@ -112,10 +222,12 @@ export async function createExecutorClient(
     }
   };
 
-  let reauthenticating = false;
-  const reauthenticateSocket = async (label: string): Promise<boolean> => {
-    if (reauthenticating) return true;
-    reauthenticating = true;
+  // Coalesce concurrent re-auth requests behind one shared promise so a burst
+  // of rejected acks from a single token expiry drives exactly one re-auth and
+  // every caller observes the real outcome. See singleFlight() for the rationale.
+  let reauthLabel = 'reconnect';
+  const runReauthenticate = singleFlight(async (): Promise<boolean> => {
+    const label = reauthLabel;
     try {
       // Try reAuthenticate first — uses stored credentials from MemoryStorage
       await client.reAuthenticate(true);
@@ -138,9 +250,11 @@ export async function createExecutorClient(
         console.error(`[executor] Re-authentication failed after ${label}:`, error);
         return false;
       }
-    } finally {
-      reauthenticating = false;
     }
+  });
+  const reauthenticateSocket = (label: string): Promise<boolean> => {
+    reauthLabel = label;
+    return runReauthenticate();
   };
 
   const scheduleServerDisconnectReconnect = () => {
@@ -264,6 +378,22 @@ export async function createExecutorClient(
   client.io.io.on('reconnect', async (attemptNumber: number) => {
     logSocketEvent('reconnected', `attempt ${attemptNumber}; re-authenticating`);
     await reauthenticateSocket('reconnect');
+  });
+
+  // Recover from access-token expiry on a LIVE (still-connected) socket, where
+  // no disconnect/reconnect event fires to drive the handlers above. See
+  // recoverFromLiveAuthError() for the failure chain this closes.
+  client.hooks({
+    error: {
+      all: [
+        async (rawContext) =>
+          recoverFromLiveAuthError(
+            rawContext as unknown as LiveAuthErrorContext,
+            reauthenticateSocket,
+            (detail) => logSocketEvent('live_request_auth_expired', detail)
+          ) as unknown as typeof rawContext,
+      ],
+    },
   });
 
   return client;


### PR DESCRIPTION
## Summary

Follow-up to #1910 (closed as superseded). Recovers the **executor** client from an access-token expiry that happens **on a live, still-connected socket** — the case the existing disconnect/reconnect handlers can't see because no disconnect event fires.

### Why this is the smaller follow-up @mistercrunch asked for

Per @mistercrunch's review on #1910: the originally-reported ~15-minute root cause was already fixed by #1819 (e99b84e5), an ancestor of that PR's base. Machine-token logins now keep the original executor JWT (24h for prompt executors), so a periodic **proactive re-auth timer only reuses the same JWT without extending its expiry** — it can't help. That timer is dropped here.

What's preserved is the strongest, method-agnostic idea, matching the reviewed UI-side #1058 pattern:

- **Single-flight re-auth** — coalesce concurrent re-auth requests behind one shared promise. A burst of rejected acks from a single token expiry drives **exactly one** re-auth, and every caller observes the *real* outcome instead of an optimistic "already in progress" `true` (which would let a retry fire before the socket is actually re-authenticated).
- **Method-agnostic one-shot 401 retry** — a client `error` hook catches `401` / `NotAuthenticated` on a live socket, re-authenticates via the single-flight path, and transparently replays the original call **once**. Guarded against loops with a retry flag; never intercepts the `authentication` service (would recurse); never blind-retries custom methods.
- **No proactive timer.**

## Changes

- `packages/executor/src/services/feathers-client.ts`
  - Extract `singleFlight()` and wrap `reauthenticateSocket` in it (replaces the old boolean latch that returned an optimistic `true`).
  - Extract `recoverFromLiveAuthError()` and register it as a client `error` hook.
- `packages/executor/src/services/feathers-client.test.ts` (new)
  - Unit tests for both helpers, including the **concurrent-401 / reconnect-race** case (a burst of live 401s drives one shared re-auth while each request is independently replayed).

## Test plan

- [x] `pnpm --filter @agor/executor exec vitest run src/services/feathers-client.test.ts` — 12 passing.
- [ ] Run a long executor turn and force an access-token expiry mid-turn; observe a `live_request_auth_expired` log followed by a successful re-auth + retried call, with the turn completing instead of failing.

## Related

- #1910 — superseded (this is its focused follow-up)
- #1058 — UI-side dynamic refresh + 401 retry (same pattern)
- #1819 — machine-token login keeps the long-lived executor JWT
- #1753 — executor socket reconnect re-auth (disconnect path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)