### PR TITLE
fix(executor): method-agnostic 401 retry + single-flight reauth on live socket

### DIFF
--- a/packages/executor/src/services/auth-errors.test.ts
+++ b/packages/executor/src/services/auth-errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { isDefiniteAuthFailure, isTransientConnectionError } from './auth-errors';
+
+describe('isDefiniteAuthFailure', () => {
+  it('returns true for 401 / 403 via `code`, `status`, `statusCode`', () => {
+    expect(isDefiniteAuthFailure({ code: 401 })).toBe(true);
+    expect(isDefiniteAuthFailure({ status: 403 })).toBe(true);
+    expect(isDefiniteAuthFailure({ statusCode: 401 })).toBe(true);
+  });
+
+  it('returns true for Feathers NotAuthenticated by name or className', () => {
+    expect(isDefiniteAuthFailure({ name: 'NotAuthenticated' })).toBe(true);
+    expect(isDefiniteAuthFailure({ className: 'not-authenticated' })).toBe(true);
+  });
+
+  it('returns false for transient / unknown errors', () => {
+    expect(isDefiniteAuthFailure({ code: 500 })).toBe(false);
+    expect(isDefiniteAuthFailure({ code: 429 })).toBe(false);
+    expect(isDefiniteAuthFailure(new TypeError('Failed to fetch'))).toBe(false);
+    expect(isDefiniteAuthFailure(null)).toBe(false);
+    expect(isDefiniteAuthFailure(undefined)).toBe(false);
+    expect(isDefiniteAuthFailure('just a string')).toBe(false);
+  });
+});
+
+describe('isTransientConnectionError', () => {
+  it('returns true for 5xx, 408, 429, and status 0', () => {
+    expect(isTransientConnectionError({ code: 500 })).toBe(true);
+    expect(isTransientConnectionError({ code: 503 })).toBe(true);
+    expect(isTransientConnectionError({ status: 408 })).toBe(true);
+    expect(isTransientConnectionError({ status: 429 })).toBe(true);
+    expect(isTransientConnectionError({ statusCode: 0 })).toBe(true);
+  });
+
+  it('returns true for network-style TypeError fetch failures', () => {
+    expect(isTransientConnectionError(new TypeError('Failed to fetch'))).toBe(true);
+  });
+
+  it('returns true for transport / websocket message patterns', () => {
+    expect(isTransientConnectionError(new Error('websocket connection closed'))).toBe(true);
+    expect(isTransientConnectionError(new Error('Network Error'))).toBe(true);
+    expect(isTransientConnectionError(new Error('ping timeout'))).toBe(true);
+  });
+
+  it('returns false for definite auth failures even if message looks transient', () => {
+    // A 401 that happens to have a transport-ish message must NOT be
+    // classified as transient — that would burn a retry attempt on a
+    // definite rejection instead of surfacing it after the one-shot reauth.
+    const err = Object.assign(new Error('connection refused'), { code: 401 });
+    expect(isTransientConnectionError(err)).toBe(false);
+  });
+
+  it('returns false for plain errors with no transient signal', () => {
+    expect(isTransientConnectionError(new Error('something boring'))).toBe(false);
+    expect(isTransientConnectionError(null)).toBe(false);
+    expect(isTransientConnectionError(undefined)).toBe(false);
+  });
+});

--- a/packages/executor/src/services/auth-errors.ts
+++ b/packages/executor/src/services/auth-errors.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared classification helpers for Feathers/HTTP auth errors.
+ *
+ * Mirrored from the UI's `apps/agor-ui/src/utils/authErrors.ts` (PR #1058) so
+ * the executor's socket client classifies auth failures the same way the
+ * browser client does. The two live in separate build graphs (UI app vs.
+ * executor package) so the logic is duplicated rather than imported; keep them
+ * in sync when either changes.
+ *
+ * Two classifiers:
+ *
+ * - {@link isDefiniteAuthFailure} — "the server rejected our credentials."
+ *   Callers should attempt a single re-authentication and, if that also fails,
+ *   surface the error rather than looping.
+ * - {@link isTransientConnectionError} — "the server is unreachable or is
+ *   temporarily failing." Callers should NOT treat this as an auth failure;
+ *   the socket transport's own reconnect handles it. Definite auth failures are
+ *   excluded so a true value is always safe to treat as "retry later, keep
+ *   credentials."
+ */
+
+type FeathersLikeError = {
+  name?: string;
+  code?: unknown;
+  status?: unknown;
+  statusCode?: unknown;
+  className?: string;
+  message?: string;
+};
+
+function statusOf(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const e = err as FeathersLikeError;
+  if (typeof e.code === 'number') return e.code;
+  if (typeof e.statusCode === 'number') return e.statusCode;
+  if (typeof e.status === 'number') return e.status;
+  return undefined;
+}
+
+/**
+ * True when the error represents a definite auth failure: the credentials
+ * were rejected (401 / 403), or Feathers explicitly raised NotAuthenticated.
+ * The executor's 401-retry hook treats this as "the socket lost its auth —
+ * try re-authenticating once with the still-valid session JWT."
+ */
+export function isDefiniteAuthFailure(err: unknown): boolean {
+  const status = statusOf(err);
+  if (status === 401 || status === 403) return true;
+  if (!err || typeof err !== 'object') return false;
+  const e = err as FeathersLikeError;
+  if (e.name === 'NotAuthenticated') return true;
+  if (e.className === 'not-authenticated') return true;
+  return false;
+}
+
+/**
+ * True when the error looks like a transient connection/server issue
+ * (network drop, 5xx, timeout, rate-limit) rather than a rejected
+ * credential. Definite auth failures always return false so a true value
+ * is safely "retry later without re-authenticating."
+ */
+export function isTransientConnectionError(err: unknown): boolean {
+  if (isDefiniteAuthFailure(err)) return false;
+
+  const status = statusOf(err);
+  if (status === 0 || status === 408 || status === 429) return true;
+  if (status !== undefined && status >= 500) return true;
+
+  if (!err || typeof err !== 'object') return false;
+  const e = err as FeathersLikeError;
+  const message = typeof e.message === 'string' ? e.message.toLowerCase() : '';
+  const name = err instanceof Error ? err.constructor.name : '';
+
+  if (name === 'TypeError' && message.includes('fetch')) return true;
+
+  return (
+    message.includes('connection') ||
+    message.includes('timeout') ||
+    message.includes('websocket') ||
+    message.includes('transport') ||
+    message.includes('failed to fetch') ||
+    message.includes('networkerror') ||
+    message.includes('network error') ||
+    message.includes('load failed') ||
+    name === 'TransportError' ||
+    name === 'WebSocketError'
+  );
+}

--- a/packages/executor/src/services/feathers-auth-retry.test.ts
+++ b/packages/executor/src/services/feathers-auth-retry.test.ts
@@ -1,0 +1,274 @@
+import type { AgorClient } from '@agor/core/api';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type AroundHookContext,
+  createAuthRetryAroundHook,
+  createSingleFlight,
+} from './feathers-auth-retry';
+
+/** A Feathers-shaped NotAuthenticated error (401). */
+function make401(message = 'jwt expired'): Error {
+  const err = new Error(message) as Error & { name: string; code: number; className: string };
+  err.name = 'NotAuthenticated';
+  err.code = 401;
+  err.className = 'not-authenticated';
+  return err;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * A tiny Feathers-like dispatcher that runs the around hook for every service
+ * call AND routes the hook's own retry re-invocation
+ * (`client.service(path)[method](...)`) back through the same hook — mirroring
+ * how a real Feathers app re-runs the hook chain on the retry. This is what
+ * makes the one-shot guard testable end-to-end.
+ */
+function createHarness(opts: {
+  /** Called for every raw service call; throw to simulate a server rejection. */
+  server: (ctx: { path: string; method: string; args: unknown[]; callIndex: number }) => unknown;
+  /** Result of a reauth attempt. */
+  reauthResult?: boolean;
+  /** Side effect run inside the (single-flight) reauth, e.g. flipping auth on. */
+  onReauth?: () => void;
+  /** Delay inside reauth so overlapping callers coalesce. */
+  reauthDelayMs?: number;
+}) {
+  let serverCalls = 0;
+  let reauthCalls = 0;
+
+  const reauthenticate = createSingleFlight(async (_label: string): Promise<boolean> => {
+    reauthCalls += 1;
+    if (opts.reauthDelayMs) await delay(opts.reauthDelayMs);
+    opts.onReauth?.();
+    return opts.reauthResult ?? true;
+  });
+
+  // Forward-declared so client.service can reach it.
+  let dispatch!: (path: string, method: string, ...args: unknown[]) => Promise<unknown>;
+
+  const client = {
+    service: (path: string) =>
+      new Proxy(
+        {},
+        {
+          get:
+            (_target, method: string) =>
+            (...args: unknown[]) =>
+              dispatch(path, method, ...args),
+        }
+      ),
+  } as unknown as AgorClient;
+
+  const hook = createAuthRetryAroundHook({ client, reauthenticate });
+
+  dispatch = async (path: string, method: string, ...args: unknown[]): Promise<unknown> => {
+    const last = args[args.length - 1];
+    const params =
+      last && typeof last === 'object' && !Array.isArray(last)
+        ? (last as Record<string, unknown>)
+        : {};
+    const context: AroundHookContext = { path, method, arguments: args, params };
+    const next = async () => {
+      const callIndex = serverCalls;
+      serverCalls += 1;
+      context.result = opts.server({ path, method, args, callIndex });
+    };
+    await hook(context, next);
+    return context.result;
+  };
+
+  return {
+    dispatch,
+    reauthenticate,
+    getServerCalls: () => serverCalls,
+    getReauthCalls: () => reauthCalls,
+  };
+}
+
+describe('createSingleFlight', () => {
+  it('coalesces concurrent calls into one run, then allows a fresh run', async () => {
+    let runs = 0;
+    const sf = createSingleFlight(async () => {
+      runs += 1;
+      await delay(10);
+      return runs;
+    });
+
+    const [a, b, c] = await Promise.all([sf(), sf(), sf()]);
+    expect(runs).toBe(1);
+    expect([a, b, c]).toEqual([1, 1, 1]);
+
+    // After the in-flight settles, a new call starts fresh.
+    const d = await sf();
+    expect(runs).toBe(2);
+    expect(d).toBe(2);
+  });
+
+  it('clears the in-flight slot even when the run rejects', async () => {
+    let runs = 0;
+    const sf = createSingleFlight(async () => {
+      runs += 1;
+      await delay(5);
+      throw new Error(`boom ${runs}`);
+    });
+
+    await expect(Promise.all([sf(), sf()])).rejects.toThrow('boom 1');
+    expect(runs).toBe(1);
+    await expect(sf()).rejects.toThrow('boom 2');
+    expect(runs).toBe(2);
+  });
+});
+
+describe('createAuthRetryAroundHook', () => {
+  it('concurrent-401: N simultaneous 401s trigger exactly ONE reauth and all retry once and succeed', async () => {
+    let authed = false;
+    const harness = createHarness({
+      reauthDelayMs: 15,
+      onReauth: () => {
+        authed = true;
+      },
+      server: () => {
+        if (!authed) throw make401();
+        return { ok: true };
+      },
+    });
+
+    const N = 8;
+    const results = await Promise.all(
+      Array.from({ length: N }, (_v, i) => harness.dispatch('messages', 'find', { query: { i } }))
+    );
+
+    // Exactly one reauth despite N concurrent 401s (single-flight).
+    expect(harness.getReauthCalls()).toBe(1);
+    // Each request hit the server twice: original 401 + one successful retry.
+    expect(harness.getServerCalls()).toBe(N * 2);
+    for (const r of results) expect(r).toEqual({ ok: true });
+  });
+
+  it('reconnect-race: an overlapping reconnect reauth and a 401-driven reauth do not double-authenticate or deadlock', async () => {
+    let authed = false;
+    const harness = createHarness({
+      reauthDelayMs: 20,
+      onReauth: () => {
+        authed = true;
+      },
+      server: () => {
+        if (!authed) throw make401();
+        return { ok: true };
+      },
+    });
+
+    // Kick off a socket-reconnect reauth (as the reconnect handler would)...
+    const reconnectReauth = harness.reauthenticate('reconnect');
+    // ...while a live request fails with 401 and drives its own reauth.
+    const request = harness.dispatch('sessions', 'get', 'session-1', {});
+
+    const [reconnectOk, result] = await Promise.all([reconnectReauth, request]);
+
+    expect(reconnectOk).toBe(true);
+    expect(result).toEqual({ ok: true });
+    // Both paths coalesced into a single reauth.
+    expect(harness.getReauthCalls()).toBe(1);
+    // Original 401 + one retry.
+    expect(harness.getServerCalls()).toBe(2);
+  });
+
+  it('one-shot guard: a call that 401s, reauths, then 401s again fails after exactly one retry', async () => {
+    // Server always rejects with 401 even after a "successful" reauth
+    // (e.g. the underlying credential is genuinely dead but reauth reports ok).
+    const harness = createHarness({
+      reauthResult: true,
+      server: () => {
+        throw make401();
+      },
+    });
+
+    await expect(harness.dispatch('messages', 'find', { query: {} })).rejects.toMatchObject({
+      name: 'NotAuthenticated',
+    });
+
+    // Reauth ran once; the retry's own 401 is short-circuited by the guard.
+    expect(harness.getReauthCalls()).toBe(1);
+    // Exactly two server calls: original + one retry. No infinite loop.
+    expect(harness.getServerCalls()).toBe(2);
+  });
+
+  it('fails cleanly without retry when reauth itself fails (dead session JWT)', async () => {
+    const harness = createHarness({
+      reauthResult: false, // reauth cannot recover — nothing valid to present
+      server: () => {
+        throw make401();
+      },
+    });
+
+    await expect(harness.dispatch('messages', 'find', {})).rejects.toMatchObject({
+      name: 'NotAuthenticated',
+    });
+
+    expect(harness.getReauthCalls()).toBe(1);
+    // Only the original call — no retry attempted once reauth reports failure.
+    expect(harness.getServerCalls()).toBe(1);
+  });
+
+  it('does not reauth or retry on transient (non-auth) errors', async () => {
+    const transient = Object.assign(new Error('service unavailable'), { code: 503 });
+    const harness = createHarness({
+      server: () => {
+        throw transient;
+      },
+    });
+
+    await expect(harness.dispatch('messages', 'find', {})).rejects.toThrow('service unavailable');
+    expect(harness.getReauthCalls()).toBe(0);
+    expect(harness.getServerCalls()).toBe(1);
+  });
+
+  it('skips the authentication service so reauth cannot recurse', async () => {
+    const reauthenticate = vi.fn(async () => true);
+    const client = {
+      service: () => ({}),
+    } as unknown as AgorClient;
+    const hook = createAuthRetryAroundHook({ client, reauthenticate });
+
+    const context: AroundHookContext = {
+      path: 'authentication',
+      method: 'create',
+      arguments: [{}],
+      params: {},
+    };
+    const next = vi.fn(async () => {
+      throw make401();
+    });
+
+    await expect(hook(context, next)).rejects.toMatchObject({ name: 'NotAuthenticated' });
+    // The auth path is excluded, so no reauth is attempted on its 401.
+    expect(reauthenticate).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries custom (non-CRUD) methods generically via context.arguments', async () => {
+    let authed = false;
+    const harness = createHarness({
+      reauthDelayMs: 5,
+      onReauth: () => {
+        authed = true;
+      },
+      server: ({ method }) => {
+        if (!authed) throw make401();
+        return { method };
+      },
+    });
+
+    // A custom method name that no CRUD switch would handle.
+    const result = await harness.dispatch('sessions/session-1/mcp-servers', 'customAction', {
+      forUserId: 'u1',
+    });
+
+    expect(result).toEqual({ method: 'customAction' });
+    expect(harness.getReauthCalls()).toBe(1);
+    expect(harness.getServerCalls()).toBe(2);
+  });
+});

--- a/packages/executor/src/services/feathers-auth-retry.ts
+++ b/packages/executor/src/services/feathers-auth-retry.ts
@@ -1,0 +1,167 @@
+/**
+ * Method-agnostic 401 retry with single-flight re-authentication for the
+ * executor's Feathers socket client.
+ *
+ * Modeled on the reviewed UI pattern in `apps/agor-ui/src/hooks/useAgorClient.ts`
+ * (PR #1058), adapted for the executor:
+ *
+ *   - The UI refreshes an access token (rotating refresh tokens), so its
+ *     single-flight guards against rotating the refresh token N times. The
+ *     executor holds a long-lived (~24h) session JWT and simply re-presents it
+ *     via `reAuthenticate()` / `authenticate()`, so here the single-flight
+ *     coalesces concurrent socket re-auths into one and — critically — makes
+ *     every caller await the SAME real result rather than an optimistic early
+ *     `true`.
+ *
+ *   - There is NO proactive refresh timer. Re-presenting a JWT cannot extend
+ *     its baked-in expiry, so a timer would be useless. Recovery is reactive:
+ *     a call fails with 401 → single-flight reauth → retry the original call
+ *     once.
+ *
+ * The retry can only succeed while a still-valid credential exists to
+ * re-authenticate with. If the underlying session JWT has itself expired,
+ * reauth also fails, `reauthenticate` resolves `false`, and the call fails
+ * cleanly after one attempt — no loop. Refreshable machine tokens are out of
+ * scope.
+ */
+
+import type { AgorClient } from '@agor/core/api';
+import { isDefiniteAuthFailure } from './auth-errors';
+
+/**
+ * Wrap an async function so concurrent invocations share a single in-flight
+ * promise. The first caller runs `fn`; callers that arrive while it is pending
+ * receive the same promise (and therefore the same resolved/rejected result).
+ * Once it settles, the slot clears so a later call starts fresh.
+ *
+ * Coalescing is by wall-clock overlap only — the winner's arguments are used
+ * for the shared run; concurrent callers' arguments are ignored (they differ
+ * only in a logging label here).
+ */
+export function createSingleFlight<A extends unknown[], T>(
+  fn: (...args: A) => Promise<T>
+): (...args: A) => Promise<T> {
+  let inflight: Promise<T> | null = null;
+  return (...args: A): Promise<T> => {
+    if (inflight) return inflight;
+    const run = fn(...args).finally(() => {
+      if (inflight === run) inflight = null;
+    });
+    inflight = run;
+    return inflight;
+  };
+}
+
+/**
+ * Feathers v5 hooks pass a mutable context object and a `next` continuation to
+ * `around` hooks. We type the subset we touch loosely to avoid pulling
+ * `@feathersjs/feathers` into the executor's dependency graph.
+ */
+export interface AroundHookContext {
+  path?: string;
+  method?: string;
+  params?: Record<string, unknown>;
+  arguments?: unknown[];
+  result?: unknown;
+}
+
+export type AroundHookNext = () => Promise<void>;
+
+/** Default flag key stamped on retried calls to break the retry loop. */
+export const DEFAULT_RETRY_FLAG = '_reauthRetried';
+
+/**
+ * Service paths whose calls must NOT be wrapped by the retry. The reauth
+ * routine itself calls the `authentication` service; retrying those on 401
+ * would recurse/deadlock. Mirrors the UI's exact-match skip set so
+ * auth-adjacent routes (e.g. `authentication/impersonate`) still flow through
+ * the retry like any other service call.
+ */
+export const DEFAULT_AUTH_PATHS_TO_SKIP = new Set(['authentication', 'authentication/refresh']);
+
+export interface AuthRetryHookOptions {
+  /**
+   * Re-authenticate the socket. Must be single-flight (see
+   * {@link createSingleFlight}) so concurrent 401s trigger exactly one reauth.
+   * Resolves `true` when the socket is authenticated again, `false` when reauth
+   * failed (e.g. the underlying credential is itself expired) — in which case
+   * the original call is surfaced without retry.
+   */
+  reauthenticate: (label: string) => Promise<boolean>;
+  /** The client used to re-invoke the original service method on retry. */
+  client: AgorClient;
+  authPathsToSkip?: Set<string>;
+  retryFlag?: string;
+}
+
+/**
+ * Build a method-agnostic `around.all` hook that, on a definite auth failure,
+ * runs single-flight reauth and retries the ORIGINAL call exactly once.
+ *
+ * Method-agnostic: instead of switching over find/get/create/patch/…, it
+ * replays the call generically via `context.arguments` +
+ * `service[context.method](...args)`, so custom (non-CRUD) service methods
+ * retry too. A `retryFlag` stamped on the trailing params object stops the
+ * retry from looping if it also 401s.
+ */
+export function createAuthRetryAroundHook(
+  options: AuthRetryHookOptions
+): (context: AroundHookContext, next: AroundHookNext) => Promise<void> {
+  const skip = options.authPathsToSkip ?? DEFAULT_AUTH_PATHS_TO_SKIP;
+  const retryFlag = options.retryFlag ?? DEFAULT_RETRY_FLAG;
+  const { client, reauthenticate } = options;
+
+  return async (context: AroundHookContext, next: AroundHookNext): Promise<void> => {
+    const path = context.path;
+
+    // Never wrap the reauth call itself — it would recurse/deadlock.
+    if (typeof path === 'string' && skip.has(path)) {
+      await next();
+      return;
+    }
+
+    try {
+      await next();
+    } catch (err) {
+      // Only recover from definite auth failures. Transient connection/5xx
+      // errors are left to the socket transport's own reconnect — treating
+      // them as auth failures would burn the one-shot retry pointlessly.
+      if (!isDefiniteAuthFailure(err)) throw err;
+
+      // One-shot guard: if this call is already a retry, don't retry again.
+      const currentParams = (context.params ?? {}) as Record<string, unknown>;
+      if (currentParams[retryFlag]) throw err;
+
+      if (typeof path !== 'string') throw err;
+
+      // Single-flight reauth: many concurrent 401s coalesce into one.
+      const reauthed = await reauthenticate('401 retry');
+      if (!reauthed) throw err;
+
+      // Replay the original call via its raw argument list so custom
+      // (non-CRUD) service methods retry correctly too. Feathers service
+      // methods always end with a `params` arg; stamp the retry flag there to
+      // stop recursion if the retry itself 401s.
+      const args = context.arguments ? [...context.arguments] : [];
+      const lastIdx = args.length - 1;
+      const lastArg = args[lastIdx];
+      const isParamsObject =
+        lastArg !== null && typeof lastArg === 'object' && !Array.isArray(lastArg);
+      const retryParams = {
+        ...(isParamsObject ? (lastArg as Record<string, unknown>) : {}),
+        [retryFlag]: true,
+      };
+      if (isParamsObject) {
+        args[lastIdx] = retryParams;
+      } else {
+        args.push(retryParams);
+      }
+
+      const service = client.service(path) as unknown as Record<string, unknown>;
+      const method = context.method as string;
+      const methodFn = service[method];
+      if (typeof methodFn !== 'function') throw err;
+      context.result = await (methodFn as (...a: unknown[]) => unknown).call(service, ...args);
+    }
+  };
+}

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -7,6 +7,7 @@
 
 import { type AgorClient, createClient } from '@agor/core/api';
 import { SOCKET_IO_MAX_BUFFER_SIZE_BYTES } from '@agor/core/config';
+import { createAuthRetryAroundHook, createSingleFlight } from './feathers-auth-retry';
 
 // Re-export AgorClient type for use in other executor files
 export type { AgorClient } from '@agor/core/api';
@@ -150,10 +151,13 @@ export async function createExecutorClient(
     }
   };
 
-  let reauthenticating = false;
-  const reauthenticateSocket = async (label: string): Promise<boolean> => {
-    if (reauthenticating) return true;
-    reauthenticating = true;
+  // Single-flight re-authentication. Both the socket-reconnect handlers and the
+  // 401-retry hook below funnel through this, so overlapping reauth attempts
+  // (e.g. a reconnect reauth racing a burst of in-flight-request 401s) coalesce
+  // into exactly ONE reAuthenticate/authenticate round-trip. Every caller
+  // awaits its REAL result — not an optimistic early `true` — so a caller that
+  // sees `true` knows the socket is genuinely re-authenticated.
+  const reauthenticateSocket = createSingleFlight(async (label: string): Promise<boolean> => {
     try {
       // Try reAuthenticate first — uses stored credentials from MemoryStorage
       await client.reAuthenticate(true);
@@ -173,13 +177,23 @@ export async function createExecutorClient(
         await hooks?.onReauthenticated?.();
         return true;
       } catch (error) {
+        // The underlying session JWT is itself invalid/expired — nothing left
+        // to re-authenticate with. Report failure so the 401-retry hook fails
+        // the original call cleanly after one attempt instead of looping.
         console.error(`[executor] Re-authentication failed after ${label}:`, error);
         return false;
       }
-    } finally {
-      reauthenticating = false;
     }
-  };
+  });
+
+  // Method-agnostic, one-shot 401 retry. Any service call that fails with a
+  // definite auth failure (401 / NotAuthenticated) runs single-flight reauth
+  // and retries the ORIGINAL call exactly once, replaying via the raw hook
+  // arguments so custom (non-CRUD) methods retry too. There is deliberately NO
+  // proactive refresh timer: re-presenting the JWT cannot extend its expiry, so
+  // recovery is purely reactive. See feathers-auth-retry.ts.
+  const authRetryHook = createAuthRetryAroundHook({ client, reauthenticate: reauthenticateSocket });
+  client.hooks({ around: { all: [authRetryHook] } } as Parameters<AgorClient['hooks']>[0]);
 
   const scheduleServerDisconnectReconnect = () => {
     if (serverDisconnectReconnectTimer) return;


### PR DESCRIPTION
## Summary

Hardens the **executor**'s Feathers socket client against `401` / `NotAuthenticated` rejections that arrive on a **live, still-connected socket** — the case the existing disconnect/reconnect handlers can't see because no disconnect event fires. Mirrors the reviewed UI-side pattern in #1058, and reconciles the #1910 → #1946 chain into one method-agnostic implementation.

### What this actually delivers

Post-#1819 the socket credential **is** the 24h session token, so a *true* token expiry can't be recovered by re-presenting the same JWT (as the machine-token docs concede). This PR is therefore not an "expiry recovery" — it delivers three concrete correctness improvements:

1. **Single-flight reauth correctness** — replaces the optimistic-`true` reauth latch still on `main` (flagged in #1753's review) with one that makes every caller await the **real** reauth outcome, so a retry never fires before the socket is actually re-authenticated.
2. **Reconnect/reauth race recovery** — a request-driven reauth and a socket-reconnect reauth that overlap coalesce into a single round-trip instead of racing, closing the window where an in-flight call could 401 during reconnect.
3. **Clean one-shot failure on real expiry** — a genuinely-expired token 401s, drives exactly one reauth + retry, and then fails cleanly (no retry storm, no silent hang).

## What's here

- **`auth-errors.ts`** (new) — dedicated classifiers mirrored 1:1 from the UI's `apps/agor-ui/src/utils/authErrors.ts`:
  - `isDefiniteAuthFailure` — treats 401/403, `NotAuthenticated`, and `className: 'not-authenticated'` as credential rejections (broader than 401-only).
  - `isTransientConnectionError` — separates network / 5xx / timeout / rate-limit so the socket transport's own reconnect handles those instead of burning the one-shot retry.
- **`feathers-auth-retry.ts`** (new) — `createSingleFlight` (generic over args) + `createAuthRetryAroundHook`:
  - An `around.all` hook that, on a definite auth failure, runs single-flight reauth and replays the **original** call exactly once via raw `context.arguments` — so **custom (non-CRUD) service methods retry too**, not just find/get/create/update/patch/remove.
  - Guarded by a `_reauthRetried` flag; never intercepts the `authentication` / `authentication/refresh` services (would recurse).
- **`feathers-client.ts`** (modified) — wires the single-flight reauth (shared by both the socket-reconnect handlers and the 401-retry hook) and registers the hook.

### No proactive timer
Recovery is purely reactive: 401 → single-flight reauth → retry once. There is deliberately **no** proactive refresh timer, because re-presenting a JWT cannot extend its baked-in expiry (per #1819, machine-token logins keep the long-lived executor JWT).

## Tests

- `createSingleFlight`: concurrent-call coalescing + slot release on rejection.
- `createAuthRetryAroundHook`: **concurrent-401 burst** (N=8 → one reauth, each request retried once); **reconnect-race** (a reconnect reauth overlapping a request-driven reauth coalesce into one); one-shot guard (401 → reauth → 401 again fails after exactly one retry); reauth-failure clean-fail; transient-error skip; `authentication`-service skip; **custom-method replay**.
- `auth-errors`: dedicated unit tests for both classifiers, mirrored from the UI.

## Test plan

- [x] `pnpm --filter @agor/executor exec vitest run src/services/auth-errors.test.ts src/services/feathers-auth-retry.test.ts` — 17 passing (re-run against a tree merged with current `main`, incl. #2042).
- [x] `tsc --noEmit` on `packages/executor` — clean.
- [x] Rebased onto current `main`; the single import-line collision with #2042 (`SOCKET_IO_MAX_BUFFER_SIZE_BYTES`) is resolved by keeping both imports. The retry composes safely with #2042's no-retry rule (ack timeouts aren't classified as auth failures; a 401 rejects before any create).
- [ ] Force a `NotAuthenticated` on a live executor socket mid-turn; observe a single reauth round-trip followed by a retried call succeeding (race-window case), or a clean one-shot failure (true-expiry case).

## Related

- #1946 — superseded (leaner CRUD-switch / `error`-hook draft of the same task)
- #1910 — superseded predecessor
- #1058 — UI-side dynamic refresh + 401 retry (same pattern)
- #1819 — machine-token login keeps the long-lived executor JWT
- #1753 — executor socket reconnect re-auth (disconnect path); this fixes its optimistic-`true` reauth latch
- #2042 — ack timeout + size guard (import-line rebase collision, resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
