### PR TITLE
feat(onboarding): import Codex ChatGPT login (paste auth.json) in the wizard

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -461,6 +461,7 @@ export const TENANT_OWNED_SERVICE_PATHS = [
 // units of work at the call site instead of holding an HTTP-long transaction.
 const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'check-auth',
+  'codex-auth/device',
   'codex-auth/import',
   'claude-models',
   'copilot-models',

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -461,6 +461,7 @@ export const TENANT_OWNED_SERVICE_PATHS = [
 // units of work at the call site instead of holding an HTTP-long transaction.
 const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'check-auth',
+  'codex-auth/import',
   'claude-models',
   'copilot-models',
   'cursor-models',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -79,6 +79,7 @@ import { createCardsService } from './services/cards.js';
 import { createCheckAuthService } from './services/check-auth.js';
 import { createClaudeModelsService } from './services/claude-models.js';
 import { createCodexAuthImportService } from './services/codex-auth-import.js';
+import { createCodexDeviceAuthService } from './services/codex-device-auth.js';
 import { createConfigService } from './services/config.js';
 import { createContextService } from './services/context.js';
 import { createCopilotModelsService } from './services/copilot-models.js';
@@ -566,6 +567,14 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // method to subscription. Token material never leaves the daemon.
   app.use('/codex-auth/import', createCodexAuthImportService(app, db));
   app.service('/codex-auth/import').hooks({ before: { create: [ctx.requireAuth] } });
+
+  // ChatGPT device-code sign-in: create starts an attempt (code + verification
+  // URL back to the UI, daemon polls OpenAI for approval); find reports the
+  // caller's attempt status. Tokens stay daemon-side end to end.
+  app.use('/codex-auth/device', createCodexDeviceAuthService(app, db));
+  app
+    .service('/codex-auth/device')
+    .hooks({ before: { create: [ctx.requireAuth], find: [ctx.requireAuth] } });
 
   // Claude dynamic model discovery via @anthropic-ai/sdk's models.list().
   // Resolves ANTHROPIC_API_KEY per-user (with config.yaml + env fallback)

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -78,6 +78,7 @@ import { createCardTypesService } from './services/card-types.js';
 import { createCardsService } from './services/cards.js';
 import { createCheckAuthService } from './services/check-auth.js';
 import { createClaudeModelsService } from './services/claude-models.js';
+import { createCodexAuthImportService } from './services/codex-auth-import.js';
 import { createConfigService } from './services/config.js';
 import { createContextService } from './services/context.js';
 import { createCopilotModelsService } from './services/copilot-models.js';
@@ -559,6 +560,12 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
 
   app.use('/check-auth', createCheckAuthService(db));
   app.service('/check-auth').hooks({ before: { create: [ctx.requireAuth] } });
+
+  // Imports a pasted Codex CLI auth.json for the authenticated user — writes
+  // it 0600 into the Unix identity that runs Codex and flips their auth
+  // method to subscription. Token material never leaves the daemon.
+  app.use('/codex-auth/import', createCodexAuthImportService(app, db));
+  app.service('/codex-auth/import').hooks({ before: { create: [ctx.requireAuth] } });
 
   // Claude dynamic model discovery via @anthropic-ai/sdk's models.list().
   // Resolves ANTHROPIC_API_KEY per-user (with config.yaml + env fallback)

--- a/apps/agor-daemon/src/services/check-auth.test.ts
+++ b/apps/agor-daemon/src/services/check-auth.test.ts
@@ -2,7 +2,9 @@ import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
 import { runWithTenantContext } from '@agor/core/db';
 import { Claude } from '@agor/core/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readCodexAuthFile } from '../utils/codex-auth-file.js';
 import { createCheckAuthService } from './check-auth';
+import { resolveCodexUnixIdentity } from './codex-auth-import.js';
 
 vi.mock('@agor/core/config', async () => {
   const actual = await vi.importActual<typeof import('@agor/core/config')>('@agor/core/config');
@@ -19,9 +21,25 @@ vi.mock('@agor/core/sdk', () => ({
   },
 }));
 
+vi.mock('../utils/codex-auth-file.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/codex-auth-file.js')>(
+    '../utils/codex-auth-file.js'
+  );
+  return {
+    ...actual,
+    readCodexAuthFile: vi.fn(),
+  };
+});
+
+vi.mock('./codex-auth-import.js', () => ({
+  resolveCodexUnixIdentity: vi.fn(),
+}));
+
 const resolveApiKeyMock = vi.mocked(resolveApiKey);
 const isTenantAgenticToolEnabledMock = vi.mocked(isTenantAgenticToolEnabled);
 const claudeQueryMock = vi.mocked(Claude.query);
+const readCodexAuthFileMock = vi.mocked(readCodexAuthFile);
+const resolveCodexUnixIdentityMock = vi.mocked(resolveCodexUnixIdentity);
 const TEST_DB = { run: vi.fn() } as never;
 
 function mockClaudeAccount(account: Record<string, unknown> | null) {
@@ -206,5 +224,76 @@ describe('check-auth tri-state', () => {
     const result = await service().create({ tool: 'claude-code', apiKey: 'sk-typed' }, params);
     expect(result.status).toBe('unauthenticated');
     fetchMock.mockRestore();
+  });
+});
+
+// Codex subscription login is verified against the auth.json of the Unix
+// identity that runs Codex. The probe must stay honestly tri-state: only a
+// genuinely absent/malformed file is "unauthenticated"; failures to LOOK
+// (sudo/permission/transport) are "unknown".
+describe('check-auth codex auth.json probe', () => {
+  const params = { user: { user_id: 'user-1' } } as never;
+
+  function fakeJwt(payload: Record<string, unknown>): string {
+    const enc = (obj: Record<string, unknown>) =>
+      Buffer.from(JSON.stringify(obj)).toString('base64url');
+    return `${enc({ alg: 'RS256' })}.${enc(payload)}.sig`;
+  }
+
+  beforeEach(() => {
+    resolveApiKeyMock.mockResolvedValue({ apiKey: undefined, source: 'user', useNativeAuth: true });
+    resolveCodexUnixIdentityMock.mockResolvedValue({ ok: true, unixUser: null });
+  });
+
+  it('valid ChatGPT tokens → authenticated via oauth with a plan hint', async () => {
+    readCodexAuthFileMock.mockReturnValue({
+      ok: true,
+      content: JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          id_token: fakeJwt({ 'https://api.openai.com/auth': { chatgpt_plan_type: 'plus' } }),
+          access_token: 'a',
+          refresh_token: 'r',
+        },
+      }),
+    });
+
+    const result = await service().create({ tool: 'codex' }, params);
+    expect(result).toMatchObject({ status: 'authenticated', method: 'oauth' });
+    expect(result.hint).toContain('plus');
+  });
+
+  it('genuinely absent auth.json → unauthenticated', async () => {
+    readCodexAuthFileMock.mockReturnValue({ ok: false, reason: 'not-found' });
+    const result = await service().create({ tool: 'codex' }, params);
+    expect(result.status).toBe('unauthenticated');
+  });
+
+  it('unreadable auth.json (sudo/permission failure) → unknown, never unauthenticated', async () => {
+    readCodexAuthFileMock.mockReturnValue({ ok: false, reason: 'unreadable' });
+    const result = await service().create({ tool: 'codex' }, params);
+    expect(result.status).toBe('unknown');
+  });
+
+  it('malformed auth.json → unauthenticated (positive evidence of a broken login)', async () => {
+    readCodexAuthFileMock.mockReturnValue({ ok: true, content: 'not json at all' });
+    const result = await service().create({ tool: 'codex' }, params);
+    expect(result.status).toBe('unauthenticated');
+  });
+
+  it('identity resolution failure → unknown; missing unix_username → unauthenticated', async () => {
+    resolveCodexUnixIdentityMock.mockResolvedValue({
+      ok: false,
+      reason: 'resolve-failed',
+      message: 'x',
+    });
+    expect((await service().create({ tool: 'codex' }, params)).status).toBe('unknown');
+
+    resolveCodexUnixIdentityMock.mockResolvedValue({
+      ok: false,
+      reason: 'missing-username',
+      message: 'x',
+    });
+    expect((await service().create({ tool: 'codex' }, params)).status).toBe('unauthenticated');
   });
 });

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -16,12 +16,13 @@
  * variables are not credential fallbacks.
  */
 
-import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
+import { isTenantAgenticToolEnabled, loadConfigSync, resolveApiKey } from '@agor/core/config';
 import {
   getCurrentTenantId,
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
+  UsersRepository,
 } from '@agor/core/db';
 import type { SDKUserMessage } from '@agor/core/sdk';
 import { Claude } from '@agor/core/sdk';
@@ -33,6 +34,12 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { TOOL_API_KEY_NAMES } from '@agor/core/types';
+import {
+  resolveUnixUserForImpersonation,
+  type UnixUserMode,
+  validateResolvedUnixUser,
+} from '@agor/core/unix';
+import { parseCodexAuthJson, readCodexAuthFile } from '../utils/codex-auth-file.js';
 import { isRealAuthSource } from './check-auth-helpers.js';
 
 const FETCH_TIMEOUT_MS = 8_000;
@@ -229,6 +236,84 @@ function resultFromKeyStatus(status: AuthCheckStatus, rejectedHint: string): Aut
   return unknown('Could not reach the provider to verify this key.');
 }
 
+/**
+ * Probe the Codex `auth.json` belonging to the Unix identity that will run
+ * Codex for this user (daemon user in simple mode, shared executor user in
+ * insulated, the caller's own account in strict). File contents stay on the
+ * daemon side; only shape/metadata drive the result.
+ *
+ * An embedded API key is verified against the provider; ChatGPT login tokens
+ * cannot be verified without consuming a refresh, so a well-formed token set
+ * counts as authenticated — Codex refreshes it at session start.
+ */
+async function probeCodexAuthFile(
+  userId: UserID | undefined,
+  withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>
+): Promise<AuthCheckResult> {
+  const config = loadConfigSync();
+  const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
+
+  let unixUsername: string | null = null;
+  if (mode === 'strict') {
+    if (!userId) {
+      return unknown('Cannot resolve a Unix identity for this Codex login check.');
+    }
+    const row = await withTenantDatabase((tenantDb) =>
+      new UsersRepository(tenantDb).findById(userId)
+    );
+    unixUsername = row?.unix_username ?? null;
+    if (!unixUsername) {
+      return unauthenticated(
+        'none',
+        'Codex subscription login needs a Unix account — ask an admin to set your unix_username.'
+      );
+    }
+  }
+
+  let asUser: string | null;
+  try {
+    const resolved = resolveUnixUserForImpersonation({
+      mode,
+      userUnixUsername: unixUsername,
+      executorUnixUser: config.execution?.executor_unix_user,
+    });
+    validateResolvedUnixUser(mode, resolved.unixUser);
+    asUser = resolved.unixUser;
+  } catch {
+    return unknown('Could not resolve the Unix account that holds the Codex login.');
+  }
+
+  const raw = readCodexAuthFile(asUser);
+  if (raw === null) {
+    return unauthenticated(
+      'none',
+      'No Codex login found on this server — import your auth.json or run `codex login` from a branch terminal.'
+    );
+  }
+
+  const parsed = parseCodexAuthJson(raw);
+  if (!parsed.ok) {
+    return unauthenticated(
+      'none',
+      'The Codex auth file on this server is malformed — import a fresh auth.json or run `codex login` again.'
+    );
+  }
+
+  if (parsed.summary.authMode === 'api_key' && parsed.summary.apiKey) {
+    return resultFromKeyStatus(
+      await validateApiKey('codex', parsed.summary.apiKey),
+      'The API key inside the Codex auth file was rejected — import a fresh auth.json.'
+    );
+  }
+
+  return authed(
+    'oauth',
+    parsed.summary.planType
+      ? `ChatGPT login found (${parsed.summary.planType} plan).`
+      : 'ChatGPT login found.'
+  );
+}
+
 export function createCheckAuthService(db: TenantScopeAwareDatabase) {
   return {
     async create(
@@ -310,9 +395,7 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
       }
 
       if (tool === 'codex' && useNativeAuth) {
-        return unknown(
-          'Codex subscription login is configured for this user but can only be verified when Codex runs.'
-        );
+        return probeCodexAuthFile(userId, withTenantDatabase);
       }
 
       if (tool === 'claude-code') {

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -16,13 +16,12 @@
  * variables are not credential fallbacks.
  */
 
-import { isTenantAgenticToolEnabled, loadConfigSync, resolveApiKey } from '@agor/core/config';
+import { isTenantAgenticToolEnabled, resolveApiKey } from '@agor/core/config';
 import {
   getCurrentTenantId,
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
-  UsersRepository,
 } from '@agor/core/db';
 import type { SDKUserMessage } from '@agor/core/sdk';
 import { Claude } from '@agor/core/sdk';
@@ -34,13 +33,9 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { TOOL_API_KEY_NAMES } from '@agor/core/types';
-import {
-  resolveUnixUserForImpersonation,
-  type UnixUserMode,
-  validateResolvedUnixUser,
-} from '@agor/core/unix';
 import { parseCodexAuthJson, readCodexAuthFile } from '../utils/codex-auth-file.js';
 import { isRealAuthSource } from './check-auth-helpers.js';
+import { resolveCodexUnixIdentity } from './codex-auth-import.js';
 
 const FETCH_TIMEOUT_MS = 8_000;
 const SDK_AUTH_PROBE_TIMEOUT_MS = 10_000;
@@ -250,48 +245,32 @@ async function probeCodexAuthFile(
   userId: UserID | undefined,
   withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>
 ): Promise<AuthCheckResult> {
-  const config = loadConfigSync();
-  const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
-
-  let unixUsername: string | null = null;
-  if (mode === 'strict') {
-    if (!userId) {
-      return unknown('Cannot resolve a Unix identity for this Codex login check.');
-    }
-    const row = await withTenantDatabase((tenantDb) =>
-      new UsersRepository(tenantDb).findById(userId)
-    );
-    unixUsername = row?.unix_username ?? null;
-    if (!unixUsername) {
-      return unauthenticated(
-        'none',
-        'Codex subscription login needs a Unix account — ask an admin to set your unix_username.'
-      );
-    }
+  const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+  if (!identity.ok) {
+    // A missing unix_username is a real configuration gap (no credential can
+    // exist for this user yet); any other resolution failure is inconclusive.
+    return identity.reason === 'missing-username'
+      ? unauthenticated(
+          'none',
+          'Codex subscription login needs a Unix account — ask an admin to set your unix_username.'
+        )
+      : unknown('Could not resolve the Unix account that holds the Codex login.');
   }
 
-  let asUser: string | null;
-  try {
-    const resolved = resolveUnixUserForImpersonation({
-      mode,
-      userUnixUsername: unixUsername,
-      executorUnixUser: config.execution?.executor_unix_user,
-    });
-    validateResolvedUnixUser(mode, resolved.unixUser);
-    asUser = resolved.unixUser;
-  } catch {
-    return unknown('Could not resolve the Unix account that holds the Codex login.');
+  const read = readCodexAuthFile(identity.unixUser);
+  if (!read.ok) {
+    // Only a genuinely absent file proves "no login". Permission/sudo/
+    // transport failures mean we could not LOOK, which must never surface as
+    // the persistent "credentials aren't working" state.
+    return read.reason === 'not-found'
+      ? unauthenticated(
+          'none',
+          'No Codex login found on this server — import your auth.json or run `codex login` from a branch terminal.'
+        )
+      : unknown('Could not read the Codex auth file — check daemon logs and sudo configuration.');
   }
 
-  const raw = readCodexAuthFile(asUser);
-  if (raw === null) {
-    return unauthenticated(
-      'none',
-      'No Codex login found on this server — import your auth.json or run `codex login` from a branch terminal.'
-    );
-  }
-
-  const parsed = parseCodexAuthJson(raw);
+  const parsed = parseCodexAuthJson(read.content);
   if (!parsed.ok) {
     return unauthenticated(
       'none',

--- a/apps/agor-daemon/src/services/codex-auth-import.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.test.ts
@@ -1,0 +1,152 @@
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import { runWithTenantContext } from '@agor/core/db';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readCodexAuthFile, writeCodexAuthFile } from '../utils/codex-auth-file.js';
+import { createCodexAuthImportService } from './codex-auth-import';
+
+vi.mock('@agor/core/config', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/config')>('@agor/core/config');
+  return {
+    ...actual,
+    isTenantAgenticToolEnabled: vi.fn(),
+    loadConfigSync: vi.fn(),
+  };
+});
+
+vi.mock('../utils/codex-auth-file.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/codex-auth-file.js')>(
+    '../utils/codex-auth-file.js'
+  );
+  return {
+    ...actual,
+    writeCodexAuthFile: vi.fn(),
+    readCodexAuthFile: vi.fn(),
+  };
+});
+
+const isTenantAgenticToolEnabledMock = vi.mocked(isTenantAgenticToolEnabled);
+const loadConfigSyncMock = vi.mocked(loadConfigSync);
+const writeCodexAuthFileMock = vi.mocked(writeCodexAuthFile);
+const readCodexAuthFileMock = vi.mocked(readCodexAuthFile);
+
+const TEST_DB = { run: vi.fn() } as never;
+
+const VALID_AUTH_JSON = JSON.stringify({
+  OPENAI_API_KEY: null,
+  tokens: {
+    id_token: 'header.payload.sig',
+    access_token: 'access-abc',
+    refresh_token: 'refresh-xyz',
+    account_id: 'acct-1',
+  },
+  last_refresh: '2026-07-16T12:00:00.000000Z',
+});
+
+function makeApp() {
+  const usersService = {
+    get: vi.fn(async () => ({ agentic_auth_methods: { 'claude-code': 'api_key' } })),
+    patch: vi.fn(async () => ({})),
+  };
+  return { app: { service: () => usersService }, usersService };
+}
+
+const AUTH_PARAMS = {
+  user: { user_id: 'user-1', email: 'u@example.com', role: 'member' },
+} as never;
+
+function service(app: { service: () => unknown }) {
+  const delegate = createCodexAuthImportService(app as never, TEST_DB);
+  return {
+    create: (...args: Parameters<typeof delegate.create>) =>
+      runWithTenantContext('tenant-test', () => delegate.create(...args)),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isTenantAgenticToolEnabledMock.mockResolvedValue(true);
+  loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'simple' } } as never);
+  readCodexAuthFileMock.mockReturnValue(VALID_AUTH_JSON);
+});
+
+describe('codex-auth-import', () => {
+  it('rejects unauthenticated callers before touching anything', async () => {
+    const { app } = makeApp();
+    await expect(service(app).create({ authJson: VALID_AUTH_JSON })).rejects.toThrow(/Sign in/);
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects hosted multi-tenant mode', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      multi_tenancy: { mode: 'required_from_auth' },
+    } as never);
+    const { app } = makeApp();
+    await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
+      /hosted multi-tenant/
+    );
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when codex is disabled for the workspace', async () => {
+    isTenantAgenticToolEnabledMock.mockResolvedValue(false);
+    const { app } = makeApp();
+    await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
+      /disabled/
+    );
+  });
+
+  it('rejects garbage input with a friendly error and never writes', async () => {
+    const { app } = makeApp();
+    await expect(service(app).create({ authJson: 'not json' }, AUTH_PARAMS)).rejects.toThrow(
+      /valid JSON/
+    );
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a credential-free file', async () => {
+    const { app } = makeApp();
+    await expect(
+      service(app).create({ authJson: JSON.stringify({ tokens: {} }) }, AUTH_PARAMS)
+    ).rejects.toThrow(/codex login/);
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('writes, verifies, flips the auth method, and returns non-secret metadata only', async () => {
+    const { app, usersService } = makeApp();
+    const result = await service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS);
+
+    expect(writeCodexAuthFileMock).toHaveBeenCalledTimes(1);
+    const [writtenContent, asUser] = writeCodexAuthFileMock.mock.calls[0];
+    expect(JSON.parse(writtenContent)).toEqual(JSON.parse(VALID_AUTH_JSON));
+    expect(asUser).toBeNull();
+
+    expect(usersService.patch).toHaveBeenCalledWith(
+      'user-1',
+      { agentic_auth_methods: { 'claude-code': 'api_key', codex: 'subscription' } },
+      expect.objectContaining({ authenticated: true })
+    );
+
+    expect(result).toMatchObject({ status: 'authenticated', authMode: 'chatgpt' });
+    expect(JSON.stringify(result)).not.toContain('refresh-xyz');
+    expect(JSON.stringify(result)).not.toContain('access-abc');
+  });
+
+  it('surfaces a friendly error when the readback verification fails', async () => {
+    readCodexAuthFileMock.mockReturnValue(null);
+    const { app, usersService } = makeApp();
+    await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
+      /verification/
+    );
+    expect(usersService.patch).not.toHaveBeenCalled();
+  });
+
+  it('maps write failures to a friendly error without token material', async () => {
+    writeCodexAuthFileMock.mockImplementation(() => {
+      throw new Error('sudo: a password is required');
+    });
+    const { app } = makeApp();
+    await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
+      /Could not write/
+    );
+  });
+});

--- a/apps/agor-daemon/src/services/codex-auth-import.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.test.ts
@@ -85,7 +85,15 @@ beforeEach(() => {
   vi.clearAllMocks();
   isTenantAgenticToolEnabledMock.mockResolvedValue(true);
   loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'simple' } } as never);
-  readCodexAuthFileMock.mockReturnValue({ ok: true, content: VALID_AUTH_JSON });
+  // Readback verification is byte-exact against what was written, so the
+  // read mock returns whatever the write mock captured.
+  let written = '';
+  writeCodexAuthFileMock.mockImplementation((content: string) => {
+    written = content;
+  });
+  readCodexAuthFileMock.mockImplementation(() =>
+    written ? { ok: true, content: written } : { ok: false, reason: 'not-found' }
+  );
 });
 
 describe('codex-auth-import', () => {
@@ -154,7 +162,7 @@ describe('codex-auth-import', () => {
     readCodexAuthFileMock.mockReturnValue({ ok: false, reason: 'unreadable' });
     const { app, usersService } = makeApp();
     await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
-      /verification/
+      /verified/
     );
     // One retry on a transient-looking read failure, then give up.
     expect(readCodexAuthFileMock).toHaveBeenCalledTimes(2);
@@ -162,13 +170,25 @@ describe('codex-auth-import', () => {
   });
 
   it('retries the readback once and succeeds on a transient read failure', async () => {
-    readCodexAuthFileMock
-      .mockReturnValueOnce({ ok: false, reason: 'unreadable' })
-      .mockReturnValueOnce({ ok: true, content: VALID_AUTH_JSON });
+    // First read fails transiently; the retry falls through to the capture
+    // implementation and returns the written bytes.
+    readCodexAuthFileMock.mockReturnValueOnce({ ok: false, reason: 'unreadable' });
     const { app, usersService } = makeApp();
     const result = await service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS);
     expect(result.status).toBe('authenticated');
     expect(usersService.patch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when the readback bytes differ from what was written', async () => {
+    readCodexAuthFileMock.mockReturnValue({
+      ok: true,
+      content: '{"OPENAI_API_KEY":"sk-someone-elses-import"}\n',
+    });
+    const { app, usersService } = makeApp();
+    await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
+      /verified/
+    );
+    expect(usersService.patch).not.toHaveBeenCalled();
   });
 
   it('maps write failures to a friendly error and logs only the error class', async () => {

--- a/apps/agor-daemon/src/services/codex-auth-import.test.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.test.ts
@@ -1,5 +1,5 @@
 import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
-import { runWithTenantContext } from '@agor/core/db';
+import { runWithTenantContext, UsersRepository } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { readCodexAuthFile, writeCodexAuthFile } from '../utils/codex-auth-file.js';
 import { createCodexAuthImportService } from './codex-auth-import';
@@ -10,6 +10,24 @@ vi.mock('@agor/core/config', async () => {
     ...actual,
     isTenantAgenticToolEnabled: vi.fn(),
     loadConfigSync: vi.fn(),
+  };
+});
+
+vi.mock('@agor/core/db', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/db')>('@agor/core/db');
+  return {
+    ...actual,
+    UsersRepository: vi.fn(),
+  };
+});
+
+vi.mock('@agor/core/unix', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/unix')>('@agor/core/unix');
+  return {
+    ...actual,
+    // The real validator asserts against /etc/passwd — the mocked Unix
+    // accounts in these tests don't exist on the test host.
+    validateResolvedUnixUser: vi.fn(),
   };
 });
 
@@ -28,6 +46,7 @@ const isTenantAgenticToolEnabledMock = vi.mocked(isTenantAgenticToolEnabled);
 const loadConfigSyncMock = vi.mocked(loadConfigSync);
 const writeCodexAuthFileMock = vi.mocked(writeCodexAuthFile);
 const readCodexAuthFileMock = vi.mocked(readCodexAuthFile);
+const usersRepositoryMock = vi.mocked(UsersRepository);
 
 const TEST_DB = { run: vi.fn() } as never;
 
@@ -66,7 +85,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   isTenantAgenticToolEnabledMock.mockResolvedValue(true);
   loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'simple' } } as never);
-  readCodexAuthFileMock.mockReturnValue(VALID_AUTH_JSON);
+  readCodexAuthFileMock.mockReturnValue({ ok: true, content: VALID_AUTH_JSON });
 });
 
 describe('codex-auth-import', () => {
@@ -131,22 +150,77 @@ describe('codex-auth-import', () => {
     expect(JSON.stringify(result)).not.toContain('access-abc');
   });
 
-  it('surfaces a friendly error when the readback verification fails', async () => {
-    readCodexAuthFileMock.mockReturnValue(null);
+  it('surfaces a friendly error when the readback verification fails persistently', async () => {
+    readCodexAuthFileMock.mockReturnValue({ ok: false, reason: 'unreadable' });
     const { app, usersService } = makeApp();
     await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
       /verification/
     );
+    // One retry on a transient-looking read failure, then give up.
+    expect(readCodexAuthFileMock).toHaveBeenCalledTimes(2);
     expect(usersService.patch).not.toHaveBeenCalled();
   });
 
-  it('maps write failures to a friendly error without token material', async () => {
-    writeCodexAuthFileMock.mockImplementation(() => {
-      throw new Error('sudo: a password is required');
+  it('retries the readback once and succeeds on a transient read failure', async () => {
+    readCodexAuthFileMock
+      .mockReturnValueOnce({ ok: false, reason: 'unreadable' })
+      .mockReturnValueOnce({ ok: true, content: VALID_AUTH_JSON });
+    const { app, usersService } = makeApp();
+    const result = await service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS);
+    expect(result.status).toBe('authenticated');
+    expect(usersService.patch).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps write failures to a friendly error and logs only the error class', async () => {
+    writeCodexAuthFileMock.mockImplementationOnce(() => {
+      throw new Error('sudo: a password is required; stderr: refresh-xyz');
     });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { app } = makeApp();
+      await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
+        /Could not write/
+      );
+      const logged = errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+      expect(logged).toContain('Error');
+      expect(logged).not.toContain('refresh-xyz');
+      expect(logged).not.toContain('password is required');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('strict mode targets the caller’s unix_username', async () => {
+    loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'strict' } } as never);
+    // `new UsersRepository(db)` — the implementation must be constructible.
+    usersRepositoryMock.mockImplementation(function mockRepo() {
+      return { findById: vi.fn(async () => ({ unix_username: 'alice' })) };
+    } as never);
+    const { app } = makeApp();
+    const result = await service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS);
+    expect(result.status).toBe('authenticated');
+    expect(writeCodexAuthFileMock).toHaveBeenCalledWith(expect.any(String), 'alice');
+  });
+
+  it('strict mode without a unix_username rejects before writing', async () => {
+    loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'strict' } } as never);
+    usersRepositoryMock.mockImplementation(function mockRepo() {
+      return { findById: vi.fn(async () => ({ unix_username: null })) };
+    } as never);
     const { app } = makeApp();
     await expect(service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS)).rejects.toThrow(
-      /Could not write/
+      /Unix account/
     );
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('insulated mode targets the configured executor user', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      execution: { unix_user_mode: 'insulated', executor_unix_user: 'agor_executor' },
+    } as never);
+    const { app } = makeApp();
+    const result = await service(app).create({ authJson: VALID_AUTH_JSON }, AUTH_PARAMS);
+    expect(result.status).toBe('authenticated');
+    expect(writeCodexAuthFileMock).toHaveBeenCalledWith(expect.any(String), 'agor_executor');
   });
 });

--- a/apps/agor-daemon/src/services/codex-auth-import.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.ts
@@ -39,6 +39,7 @@ import {
   validateResolvedUnixUser,
 } from '@agor/core/unix';
 import {
+  type CodexAuthSummary,
   parseCodexAuthJson,
   readCodexAuthFile,
   writeCodexAuthFile,
@@ -54,7 +55,7 @@ interface UsersServiceLike {
   ): Promise<unknown>;
 }
 
-interface AppLike {
+export interface AppLike {
   service(path: string): unknown;
 }
 
@@ -119,6 +120,66 @@ export async function resolveCodexUnixIdentity(
   }
 }
 
+/**
+ * Persist a validated auth.json for a user: write it 0600 as the target Unix
+ * user, verify by reading it back, then flip the user's Codex auth method to
+ * `subscription` so executors resolve native auth. Shared by the paste-import
+ * and device-code sign-in flows. Throws `BadRequest` with user-facing,
+ * secret-free messages.
+ */
+export async function persistVerifiedCodexAuth(options: {
+  app: AppLike;
+  normalized: string;
+  targetUnixUser: string | null;
+  userId: UserID;
+  authUser: NonNullable<AuthenticatedParams['user']>;
+}): Promise<CodexAuthSummary> {
+  const { app, normalized, targetUnixUser, userId, authUser } = options;
+
+  try {
+    writeCodexAuthFile(normalized, targetUnixUser);
+  } catch (err) {
+    // The error may carry sudo/bash stderr; log a class-level summary only
+    // so token material (or its absence) never reaches daemon logs.
+    console.error(
+      `[CodexAuth] Failed to write auth.json${targetUnixUser ? ` as ${targetUnixUser}` : ''}: ${
+        err instanceof Error ? err.constructor.name : 'unknown error'
+      }`
+    );
+    throw new BadRequest(
+      'Could not write the Codex credentials file on the server. Check daemon logs and sudo configuration, or use an API key instead.'
+    );
+  }
+
+  // Read-back verification: the file must contain exactly the bytes just
+  // written — "some valid credential is there" would let a concurrent
+  // import/refresh be mistaken for this one. A transient read failure gets
+  // one retry (the write already succeeded by exit status). Failing out
+  // leaves the file on disk with the auth method unflipped; that state is
+  // harmless because a re-import cleanly overwrites both.
+  let readBack = readCodexAuthFile(targetUnixUser);
+  if (!readBack.ok && readBack.reason === 'unreadable') {
+    readBack = readCodexAuthFile(targetUnixUser);
+  }
+  const verified =
+    readBack.ok && readBack.content === normalized ? parseCodexAuthJson(readBack.content) : null;
+  if (!verified?.ok) {
+    throw new BadRequest(
+      'The Codex credentials file was written but could not be verified back — try again.'
+    );
+  }
+
+  const usersService = app.service('users') as UsersServiceLike;
+  const current = await usersService.get(userId, { user: authUser, authenticated: true });
+  await usersService.patch(
+    userId,
+    { agentic_auth_methods: { ...current.agentic_auth_methods, codex: 'subscription' } },
+    { user: authUser, authenticated: true }
+  );
+
+  return verified.summary;
+}
+
 export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareDatabase) {
   return {
     async create(
@@ -158,54 +219,15 @@ export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareD
           `Cannot determine which Unix account should hold this Codex login: ${identity.message}`
         );
       }
-      const targetUnixUser = identity.unixUser;
 
-      try {
-        writeCodexAuthFile(parsed.normalized, targetUnixUser);
-      } catch (err) {
-        // The error may carry sudo/bash stderr; log a class-level summary only
-        // so token material (or its absence) never reaches daemon logs.
-        console.error(
-          `[CodexAuthImport] Failed to write auth.json${
-            targetUnixUser ? ` as ${targetUnixUser}` : ''
-          }: ${err instanceof Error ? err.constructor.name : 'unknown error'}`
-        );
-        throw new BadRequest(
-          'Could not write the Codex credentials file on the server. Check daemon logs and sudo configuration, or use an API key instead.'
-        );
-      }
-
-      // Read-back verification: the file must contain exactly the bytes just
-      // written — "some valid credential is there" would let a concurrent
-      // import/refresh be mistaken for this one. A transient read failure
-      // gets one retry (the write already succeeded by exit status). Failing
-      // out leaves the file on disk with the auth method unflipped; that
-      // state is harmless because a re-import cleanly overwrites both.
-      let readBack = readCodexAuthFile(targetUnixUser);
-      if (!readBack.ok && readBack.reason === 'unreadable') {
-        readBack = readCodexAuthFile(targetUnixUser);
-      }
-      const verified =
-        readBack.ok && readBack.content === parsed.normalized
-          ? parseCodexAuthJson(readBack.content)
-          : null;
-      if (!verified?.ok) {
-        throw new BadRequest(
-          'The Codex credentials file was written but could not be verified back — try again.'
-        );
-      }
-
-      // Flip the user's Codex auth method so executors resolve native auth
-      // (auth.json) instead of expecting an OPENAI_API_KEY.
-      const usersService = app.service('users') as UsersServiceLike;
-      const current = await usersService.get(userId, { user: authUser, authenticated: true });
-      await usersService.patch(
+      const summary = await persistVerifiedCodexAuth({
+        app,
+        normalized: parsed.normalized,
+        targetUnixUser: identity.unixUser,
         userId,
-        { agentic_auth_methods: { ...current.agentic_auth_methods, codex: 'subscription' } },
-        { user: authUser, authenticated: true }
-      );
+        authUser,
+      });
 
-      const { summary } = verified;
       return {
         status: 'authenticated',
         authMode: summary.authMode,

--- a/apps/agor-daemon/src/services/codex-auth-import.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.ts
@@ -1,0 +1,185 @@
+/**
+ * Codex Auth Import Service
+ *
+ * Accepts the contents of a Codex CLI `auth.json` pasted in the browser
+ * (onboarding wizard / settings), validates its shape, writes it 0600 into the
+ * Codex home of the Unix identity that will run Codex for this user, verifies
+ * it back, and flips the user's Codex auth method to `subscription` so
+ * executors use the file instead of an env API key.
+ *
+ * SECURITY CONTRACT:
+ * - The pasted payload is token material: browser → daemon → target user's
+ *   filesystem only. It is never logged, never echoed back, and never enters
+ *   any agent/LLM context. The response carries non-secret metadata only.
+ * - The write happens AS the target Unix user (sudo, content over stdin), so
+ *   ownership and 0600 permissions hold in insulated/strict modes.
+ * - Callers act only on their own credentials — the target identity is always
+ *   derived from the authenticated user, never from request data.
+ */
+
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
+import type {
+  AgenticAuthMethods,
+  AuthenticatedParams,
+  CodexAuthImportResult,
+  User,
+  UserID,
+} from '@agor/core/types';
+import {
+  resolveUnixUserForImpersonation,
+  type UnixUserMode,
+  validateResolvedUnixUser,
+} from '@agor/core/unix';
+import {
+  type CodexAuthSummary,
+  parseCodexAuthJson,
+  readCodexAuthFile,
+  writeCodexAuthFile,
+} from '../utils/codex-auth-file.js';
+
+/** Minimal users-service surface — mirrors the widget handlers' structural typing. */
+interface UsersServiceLike {
+  get(id: UserID, params?: unknown): Promise<User>;
+  patch(
+    id: UserID,
+    data: { agentic_auth_methods: AgenticAuthMethods },
+    params?: unknown
+  ): Promise<unknown>;
+}
+
+interface AppLike {
+  service(path: string): unknown;
+}
+
+function importHint(summary: CodexAuthSummary): string {
+  if (summary.authMode === 'api_key') {
+    return 'Imported a Codex auth file carrying an OpenAI API key.';
+  }
+  return summary.planType
+    ? `Signed in with ChatGPT (${summary.planType} plan).`
+    : 'Signed in with ChatGPT.';
+}
+
+/**
+ * Resolve the Unix account whose `~/.codex/auth.json` Codex will actually read
+ * for this user: the daemon user (simple), the shared executor user
+ * (insulated), or the caller's own Unix account (strict).
+ */
+export async function resolveCodexAuthTargetUser(
+  userId: UserID,
+  withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>
+): Promise<string | null> {
+  const config = loadConfigSync();
+  const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
+
+  let unixUsername: string | null = null;
+  if (mode === 'strict') {
+    const row = await withTenantDatabase((tenantDb) =>
+      new UsersRepository(tenantDb).findById(userId)
+    );
+    unixUsername = row?.unix_username ?? null;
+  }
+
+  const resolved = resolveUnixUserForImpersonation({
+    mode,
+    userUnixUsername: unixUsername,
+    executorUnixUser: config.execution?.executor_unix_user,
+  });
+  validateResolvedUnixUser(mode, resolved.unixUser);
+  return resolved.unixUser;
+}
+
+export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareDatabase) {
+  return {
+    async create(
+      data: { authJson?: string },
+      params?: AuthenticatedParams
+    ): Promise<CodexAuthImportResult> {
+      const authUser = params?.user;
+      if (!authUser?.user_id) {
+        throw new NotAuthenticated('Sign in before importing Codex credentials.');
+      }
+      const userId = authUser.user_id as UserID;
+
+      const config = loadConfigSync();
+      if (config.multi_tenancy?.mode === 'required_from_auth') {
+        throw new BadRequest(
+          'Codex subscription login is unavailable in hosted multi-tenant mode — use an OpenAI API key instead.'
+        );
+      }
+
+      const tenantId = getCurrentTenantId();
+      if (!tenantId) throw new Error('Missing active tenant context for Codex auth import');
+      const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) =>
+        runWithTenantDatabaseScope(db, tenantId, work);
+
+      if (
+        !(await withTenantDatabase((tenantDb) => isTenantAgenticToolEnabled('codex', tenantDb)))
+      ) {
+        throw new BadRequest('Codex is disabled for this workspace.');
+      }
+
+      const parsed = parseCodexAuthJson(data?.authJson);
+      if (!parsed.ok) throw new BadRequest(parsed.error);
+
+      let targetUnixUser: string | null;
+      try {
+        targetUnixUser = await resolveCodexAuthTargetUser(userId, withTenantDatabase);
+      } catch (err) {
+        throw new BadRequest(
+          `Cannot determine which Unix account should hold this Codex login: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+
+      try {
+        writeCodexAuthFile(parsed.normalized, targetUnixUser);
+      } catch (err) {
+        // The error may carry sudo/bash stderr; log a class-level summary only
+        // so token material (or its absence) never reaches daemon logs.
+        console.error(
+          `[CodexAuthImport] Failed to write auth.json${
+            targetUnixUser ? ` as ${targetUnixUser}` : ''
+          }: ${err instanceof Error ? err.constructor.name : 'unknown error'}`
+        );
+        throw new BadRequest(
+          'Could not write the Codex credentials file on the server. Check daemon logs and sudo configuration, or use an API key instead.'
+        );
+      }
+
+      const readBack = readCodexAuthFile(targetUnixUser);
+      const verified = readBack ? parseCodexAuthJson(readBack) : null;
+      if (!verified?.ok) {
+        throw new BadRequest(
+          'The Codex credentials file was written but could not be read back for verification — try again.'
+        );
+      }
+
+      // Flip the user's Codex auth method so executors resolve native auth
+      // (auth.json) instead of expecting an OPENAI_API_KEY.
+      const usersService = app.service('users') as UsersServiceLike;
+      const current = await usersService.get(userId, { user: authUser, authenticated: true });
+      await usersService.patch(
+        userId,
+        { agentic_auth_methods: { ...current.agentic_auth_methods, codex: 'subscription' } },
+        { user: authUser, authenticated: true }
+      );
+
+      return {
+        status: 'authenticated',
+        authMode: verified.summary.authMode,
+        ...(verified.summary.planType ? { planType: verified.summary.planType } : {}),
+        hint: importHint(verified.summary),
+      };
+    },
+  };
+}

--- a/apps/agor-daemon/src/services/codex-auth-import.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.ts
@@ -39,7 +39,6 @@ import {
   validateResolvedUnixUser,
 } from '@agor/core/unix';
 import {
-  type CodexAuthSummary,
   parseCodexAuthJson,
   readCodexAuthFile,
   writeCodexAuthFile,
@@ -59,42 +58,65 @@ interface AppLike {
   service(path: string): unknown;
 }
 
-function importHint(summary: CodexAuthSummary): string {
-  if (summary.authMode === 'api_key') {
-    return 'Imported a Codex auth file carrying an OpenAI API key.';
-  }
-  return summary.planType
-    ? `Signed in with ChatGPT (${summary.planType} plan).`
-    : 'Signed in with ChatGPT.';
-}
+export type CodexUnixIdentityResolution =
+  | { ok: true; unixUser: string | null }
+  | { ok: false; reason: 'missing-username' | 'resolve-failed'; message: string };
 
 /**
  * Resolve the Unix account whose `~/.codex/auth.json` Codex will actually read
  * for this user: the daemon user (simple), the shared executor user
  * (insulated), or the caller's own Unix account (strict).
+ *
+ * Returns a discriminated result rather than throwing so callers with
+ * different failure semantics (the import endpoint rejects, the check-auth
+ * probe must distinguish "no identity configured" from "could not resolve")
+ * don't have to grep error messages.
  */
-export async function resolveCodexAuthTargetUser(
-  userId: UserID,
+export async function resolveCodexUnixIdentity(
+  userId: UserID | undefined,
   withTenantDatabase: <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) => Promise<T>
-): Promise<string | null> {
+): Promise<CodexUnixIdentityResolution> {
   const config = loadConfigSync();
   const mode = (config.execution?.unix_user_mode ?? 'simple') as UnixUserMode;
 
   let unixUsername: string | null = null;
   if (mode === 'strict') {
+    if (!userId) {
+      return {
+        ok: false,
+        reason: 'resolve-failed',
+        message: 'Strict Unix user mode requires an authenticated user context.',
+      };
+    }
     const row = await withTenantDatabase((tenantDb) =>
       new UsersRepository(tenantDb).findById(userId)
     );
     unixUsername = row?.unix_username ?? null;
+    if (!unixUsername) {
+      return {
+        ok: false,
+        reason: 'missing-username',
+        message:
+          'Strict Unix user mode requires a unix_username — ask an admin to set one for your account.',
+      };
+    }
   }
 
-  const resolved = resolveUnixUserForImpersonation({
-    mode,
-    userUnixUsername: unixUsername,
-    executorUnixUser: config.execution?.executor_unix_user,
-  });
-  validateResolvedUnixUser(mode, resolved.unixUser);
-  return resolved.unixUser;
+  try {
+    const resolved = resolveUnixUserForImpersonation({
+      mode,
+      userUnixUsername: unixUsername,
+      executorUnixUser: config.execution?.executor_unix_user,
+    });
+    validateResolvedUnixUser(mode, resolved.unixUser);
+    return { ok: true, unixUser: resolved.unixUser };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'resolve-failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareDatabase) {
@@ -130,16 +152,13 @@ export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareD
       const parsed = parseCodexAuthJson(data?.authJson);
       if (!parsed.ok) throw new BadRequest(parsed.error);
 
-      let targetUnixUser: string | null;
-      try {
-        targetUnixUser = await resolveCodexAuthTargetUser(userId, withTenantDatabase);
-      } catch (err) {
+      const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+      if (!identity.ok) {
         throw new BadRequest(
-          `Cannot determine which Unix account should hold this Codex login: ${
-            err instanceof Error ? err.message : String(err)
-          }`
+          `Cannot determine which Unix account should hold this Codex login: ${identity.message}`
         );
       }
+      const targetUnixUser = identity.unixUser;
 
       try {
         writeCodexAuthFile(parsed.normalized, targetUnixUser);
@@ -156,8 +175,16 @@ export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareD
         );
       }
 
-      const readBack = readCodexAuthFile(targetUnixUser);
-      const verified = readBack ? parseCodexAuthJson(readBack) : null;
+      // Read-back verification. A transient read failure gets one retry —
+      // the write already succeeded by exit status, so a persistent read
+      // failure here is an environment problem, not bad input. Failing out
+      // leaves the file on disk with the auth method unflipped; that state is
+      // harmless because a re-import cleanly overwrites both.
+      let readBack = readCodexAuthFile(targetUnixUser);
+      if (!readBack.ok && readBack.reason === 'unreadable') {
+        readBack = readCodexAuthFile(targetUnixUser);
+      }
+      const verified = readBack.ok ? parseCodexAuthJson(readBack.content) : null;
       if (!verified?.ok) {
         throw new BadRequest(
           'The Codex credentials file was written but could not be read back for verification — try again.'
@@ -174,11 +201,17 @@ export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareD
         { user: authUser, authenticated: true }
       );
 
+      const { summary } = verified;
       return {
         status: 'authenticated',
-        authMode: verified.summary.authMode,
-        ...(verified.summary.planType ? { planType: verified.summary.planType } : {}),
-        hint: importHint(verified.summary),
+        authMode: summary.authMode,
+        ...(summary.planType ? { planType: summary.planType } : {}),
+        hint:
+          summary.authMode === 'api_key'
+            ? 'Imported a Codex auth file carrying an OpenAI API key.'
+            : summary.planType
+              ? `Signed in with ChatGPT (${summary.planType} plan).`
+              : 'Signed in with ChatGPT.',
       };
     },
   };

--- a/apps/agor-daemon/src/services/codex-auth-import.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.ts
@@ -175,19 +175,23 @@ export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareD
         );
       }
 
-      // Read-back verification. A transient read failure gets one retry —
-      // the write already succeeded by exit status, so a persistent read
-      // failure here is an environment problem, not bad input. Failing out
-      // leaves the file on disk with the auth method unflipped; that state is
-      // harmless because a re-import cleanly overwrites both.
+      // Read-back verification: the file must contain exactly the bytes just
+      // written — "some valid credential is there" would let a concurrent
+      // import/refresh be mistaken for this one. A transient read failure
+      // gets one retry (the write already succeeded by exit status). Failing
+      // out leaves the file on disk with the auth method unflipped; that
+      // state is harmless because a re-import cleanly overwrites both.
       let readBack = readCodexAuthFile(targetUnixUser);
       if (!readBack.ok && readBack.reason === 'unreadable') {
         readBack = readCodexAuthFile(targetUnixUser);
       }
-      const verified = readBack.ok ? parseCodexAuthJson(readBack.content) : null;
+      const verified =
+        readBack.ok && readBack.content === parsed.normalized
+          ? parseCodexAuthJson(readBack.content)
+          : null;
       if (!verified?.ok) {
         throw new BadRequest(
-          'The Codex credentials file was written but could not be read back for verification — try again.'
+          'The Codex credentials file was written but could not be verified back — try again.'
         );
       }
 

--- a/apps/agor-daemon/src/services/codex-device-auth.test.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.test.ts
@@ -1,0 +1,347 @@
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import { runWithTenantContext } from '@agor/core/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readCodexAuthFile, writeCodexAuthFile } from '../utils/codex-auth-file.js';
+import { createCodexDeviceAuthService } from './codex-device-auth';
+
+vi.mock('@agor/core/config', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/config')>('@agor/core/config');
+  return {
+    ...actual,
+    isTenantAgenticToolEnabled: vi.fn(),
+    loadConfigSync: vi.fn(),
+  };
+});
+
+vi.mock('../utils/codex-auth-file.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/codex-auth-file.js')>(
+    '../utils/codex-auth-file.js'
+  );
+  return {
+    ...actual,
+    writeCodexAuthFile: vi.fn(),
+    readCodexAuthFile: vi.fn(),
+  };
+});
+
+const isTenantAgenticToolEnabledMock = vi.mocked(isTenantAgenticToolEnabled);
+const loadConfigSyncMock = vi.mocked(loadConfigSync);
+const writeCodexAuthFileMock = vi.mocked(writeCodexAuthFile);
+const readCodexAuthFileMock = vi.mocked(readCodexAuthFile);
+
+const TEST_DB = { run: vi.fn() } as never;
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const enc = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${enc({ alg: 'RS256' })}.${enc(payload)}.signature`;
+}
+
+const ID_TOKEN = fakeJwt({
+  'https://api.openai.com/auth': { chatgpt_plan_type: 'pro', chatgpt_account_id: 'acct-9' },
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function makeApp() {
+  const usersService = {
+    get: vi.fn(async () => ({ agentic_auth_methods: {} })),
+    patch: vi.fn(async () => ({})),
+  };
+  return { app: { service: () => usersService }, usersService };
+}
+
+const AUTH_PARAMS = {
+  user: { user_id: 'user-1', email: 'u@example.com', role: 'member' },
+} as never;
+
+function withTenant<T>(work: () => Promise<T>): Promise<T> {
+  return runWithTenantContext('tenant-test', work);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  isTenantAgenticToolEnabledMock.mockResolvedValue(true);
+  loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'simple' } } as never);
+  // Readback verification returns whatever the service wrote.
+  let written = '';
+  writeCodexAuthFileMock.mockImplementation((content: string) => {
+    written = content;
+  });
+  readCodexAuthFileMock.mockImplementation(() =>
+    written ? { ok: true, content: written } : { ok: false, reason: 'not-found' }
+  );
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function mockUserCodeIssued() {
+  fetchMock.mockResolvedValueOnce(
+    jsonResponse(200, { device_auth_id: 'dev-1', user_code: 'ABCD-1234', interval: '1' })
+  );
+}
+
+describe('codex-device-auth', () => {
+  it('starts an attempt and reports a pending status with the code and verification URL', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+
+    const status = await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    expect(status.phase).toBe('pending');
+    expect(status.userCode).toBe('ABCD-1234');
+    expect(status.verificationUrl).toBe('https://auth.openai.com/codex/device');
+    expect(status.expiresAt).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth.openai.com/api/accounts/deviceauth/usercode',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('maps a gated account (404 on usercode) to the unavailable phase with guidance', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    fetchMock.mockResolvedValueOnce(jsonResponse(404, {}));
+
+    const status = await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    expect(status.phase).toBe('unavailable');
+    expect(status.hint).toMatch(/Device code authorization for Codex/);
+    expect(status.userCode).toBeUndefined();
+  });
+
+  it('polls until approval, exchanges the code, persists auth.json, and reports success', async () => {
+    const { app, usersService } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    // First poll: pending. Second poll: approved. Then the token exchange.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(403, {}))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_code: 'authz-1',
+          code_challenge: 'chal',
+          code_verifier: 'verif',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id_token: ID_TOKEN,
+          access_token: 'access-tok',
+          refresh_token: 'refresh-tok',
+        })
+      );
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    // interval "1" is floored to MIN_POLL_INTERVAL_MS (2s) — each 2.1s
+    // advance crosses exactly one scheduled poll.
+    await vi.advanceTimersByTimeAsync(2100); // first poll (pending)
+    await vi.advanceTimersByTimeAsync(2100); // second poll (approved + exchange)
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('success');
+    expect(status.planType).toBe('pro');
+    expect(JSON.stringify(status)).not.toContain('refresh-tok');
+    expect(JSON.stringify(status)).not.toContain('access-tok');
+
+    const written = JSON.parse(writeCodexAuthFileMock.mock.calls[0][0]);
+    expect(written).toMatchObject({
+      auth_mode: 'chatgpt',
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: ID_TOKEN,
+        access_token: 'access-tok',
+        refresh_token: 'refresh-tok',
+        account_id: 'acct-9',
+      },
+    });
+    expect(typeof written.last_refresh).toBe('string');
+
+    expect(usersService.patch).toHaveBeenCalledWith(
+      'user-1',
+      { agentic_auth_methods: { codex: 'subscription' } },
+      expect.objectContaining({ authenticated: true })
+    );
+
+    // Terminal phase: no further polling.
+    const callsAfterSuccess = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(fetchMock.mock.calls.length).toBe(callsAfterSuccess);
+  });
+
+  it('a provider 5xx mid-window is transient — polling continues instead of erroring', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(502, {}))
+      .mockResolvedValueOnce(jsonResponse(403, {}));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100); // 502 → keep polling
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).phase).toBe('pending');
+    await vi.advanceTimersByTimeAsync(2100); // 403 → still pending
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).phase).toBe('pending');
+    expect(fetchMock.mock.calls.length).toBe(3); // usercode + two polls
+  });
+
+  it('retries the post-approval token exchange once on a provider 5xx', async () => {
+    const { app, usersService } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_code: 'authz-1',
+          code_challenge: 'chal',
+          code_verifier: 'verif',
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse(502, {}))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id_token: ID_TOKEN,
+          access_token: 'access-tok',
+          refresh_token: 'refresh-tok',
+        })
+      );
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100);
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('success');
+    expect(usersService.patch).toHaveBeenCalledTimes(1);
+  });
+
+  it('a non-pending 4xx during polling is terminal', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock.mockResolvedValueOnce(jsonResponse(410, {}));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100);
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).phase).toBe('error');
+  });
+
+  it('an approved response missing the PKCE fields is terminal (contract break)', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { authorization_code: 'authz-1' }));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100);
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('error');
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('overlapping create calls do not leave an orphaned poll loop', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+
+    // First create's usercode response is held until after the second create
+    // fully completes — the classic double-click race.
+    let releaseFirst: (() => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFirst = () =>
+            resolve(
+              jsonResponse(200, { device_auth_id: 'dev-1', user_code: 'ABCD-1234', interval: '1' })
+            );
+        })
+    );
+    const first = withTenant(() => service.create({}, AUTH_PARAMS));
+    await Promise.resolve(); // let the first create reach its awaited fetch
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { device_auth_id: 'dev-2', user_code: 'WXYZ-9876', interval: '1' })
+    );
+    const second = await withTenant(() => service.create({}, AUTH_PARAMS));
+    expect(second.userCode).toBe('WXYZ-9876');
+
+    releaseFirst?.();
+    await first;
+
+    // Only the second attempt is registered and polling.
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).userCode).toBe('WXYZ-9876');
+    fetchMock.mockResolvedValue(jsonResponse(403, {}));
+    await vi.advanceTimersByTimeAsync(2100);
+    const pollBodies = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes('/deviceauth/token'))
+      .map(([, init]) => JSON.parse((init as RequestInit).body as string).device_auth_id);
+    expect(pollBodies).not.toContain('dev-1');
+    expect(pollBodies).toContain('dev-2');
+  });
+
+  it('hard-stops at code expiry and reports expired', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock.mockResolvedValue(jsonResponse(403, {}));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(16 * 60 * 1000);
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('expired');
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('starting a new attempt cancels and replaces the previous one', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { device_auth_id: 'dev-2', user_code: 'WXYZ-9876', interval: '1' })
+    );
+    const status = await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    expect(status.phase).toBe('pending');
+    expect(status.userCode).toBe('WXYZ-9876');
+  });
+
+  it('find with no attempt reports idle; unauthenticated callers are rejected', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('idle');
+
+    await expect(withTenant(() => service.create({}, undefined))).rejects.toThrow(/Sign in/);
+  });
+
+  it('rejects hosted multi-tenant mode before contacting OpenAI', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      multi_tenancy: { mode: 'required_from_auth' },
+    } as never);
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+
+    await expect(withTenant(() => service.create({}, AUTH_PARAMS))).rejects.toThrow(
+      /hosted multi-tenant/
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/codex-device-auth.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.ts
@@ -1,0 +1,476 @@
+/**
+ * Codex Device-Code Sign-In Service
+ *
+ * Drives OpenAI's ChatGPT device-code authorization for Codex natively from
+ * the daemon, so the onboarding wizard can sign a user in without a terminal:
+ *
+ *   1. `create` → POST auth.openai.com/api/accounts/deviceauth/usercode with
+ *      Codex's public client id → `{device_auth_id, user_code, interval}`.
+ *      The UI shows the code + verification URL; the daemon starts polling.
+ *   2. Poll POST .../deviceauth/token with `{device_auth_id, user_code}` at
+ *      the server-specified interval. 403/404 mean "not approved yet"; codes
+ *      hard-expire after 15 minutes.
+ *   3. On approval the server returns an authorization code plus a
+ *      server-generated PKCE pair, exchanged at /oauth/token
+ *      (grant_type=authorization_code) for id/access/refresh tokens.
+ *   4. Tokens are persisted as a Codex-format auth.json (0600, as the Unix
+ *      identity that runs Codex for this user) and the user's Codex auth
+ *      method flips to `subscription`.
+ *
+ * Protocol verified against openai/codex `codex-rs/login/src/device_code_auth.rs`
+ * and `server.rs` (July 2026).
+ *
+ * One in-flight attempt per user: starting a new attempt cancels and replaces
+ * the previous one. Attempts live in daemon memory only — a restart discards
+ * them and the user simply requests a fresh code.
+ *
+ * SECURITY CONTRACT: tokens transit UI ↔ daemon ↔ auth.openai.com and the
+ * target user's filesystem only. Status responses carry the user code and
+ * non-secret metadata; token material is never returned, logged, or exposed
+ * to any agent/LLM context. Callers act only on their own credentials.
+ */
+
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
+import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
+import type {
+  AuthenticatedParams,
+  CodexDeviceAuthStatus,
+  TenantID,
+  UserID,
+} from '@agor/core/types';
+import { codexIdTokenClaims } from '../utils/codex-auth-file.js';
+import {
+  type AppLike,
+  persistVerifiedCodexAuth,
+  resolveCodexUnixIdentity,
+} from './codex-auth-import.js';
+
+const CODEX_AUTH_ISSUER = 'https://auth.openai.com';
+/** Codex CLI's public OAuth client id (codex-rs/login/src/auth/manager.rs). */
+const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+/** Server-side validity window for a device code (fixed by OpenAI). */
+const DEVICE_CODE_LIFETIME_MS = 15 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_S = 5;
+const MIN_POLL_INTERVAL_MS = 2_000;
+const FETCH_TIMEOUT_MS = 15_000;
+
+const UNAVAILABLE_HINT =
+  'Your ChatGPT account does not allow device-code sign-in. Personal accounts can turn it on under ChatGPT Settings → Security → "Device code authorization for Codex"; workspace accounts need an admin to enable it. You can also paste an auth.json or use an API key instead.';
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Provider failure with an explicit retry disposition, so callers never have
+ * to infer transient-vs-terminal from message text. 5xx are transient (a
+ * provider blip must not kill a 15-minute approval window); non-pending 4xx
+ * and contract breaks (missing response fields) are terminal.
+ */
+class DeviceAuthProviderError extends Error {
+  constructor(
+    readonly disposition: 'transient' | 'terminal',
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+function providerStatusError(endpoint: string, status: number): DeviceAuthProviderError {
+  return new DeviceAuthProviderError(
+    status >= 500 ? 'transient' : 'terminal',
+    `${endpoint} failed with status ${status}`
+  );
+}
+
+interface UserCodeGrant {
+  deviceAuthId: string;
+  userCode: string;
+  intervalMs: number;
+}
+
+/** `unavailable` maps the server's refusal to issue a code (gated account/workspace). */
+async function requestUserCode(): Promise<UserCodeGrant | 'unavailable'> {
+  const res = await fetchWithTimeout(`${CODEX_AUTH_ISSUER}/api/accounts/deviceauth/usercode`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: CODEX_CLIENT_ID }),
+  });
+  if (res.status === 404 || res.status === 403) return 'unavailable';
+  if (!res.ok) throw providerStatusError('usercode request', res.status);
+
+  const body = (await res.json()) as Record<string, unknown>;
+  const deviceAuthId = body.device_auth_id;
+  const userCode = body.user_code ?? body.usercode;
+  if (typeof deviceAuthId !== 'string' || typeof userCode !== 'string') {
+    throw new DeviceAuthProviderError('terminal', 'usercode response missing expected fields');
+  }
+  // The server sends `interval` as a decimal string (seconds).
+  const intervalSeconds = Number.parseInt(String(body.interval ?? ''), 10);
+  const intervalMs = Math.max(
+    (Number.isFinite(intervalSeconds) && intervalSeconds > 0
+      ? intervalSeconds
+      : DEFAULT_POLL_INTERVAL_S) * 1000,
+    MIN_POLL_INTERVAL_MS
+  );
+  return { deviceAuthId, userCode, intervalMs };
+}
+
+interface ApprovedCode {
+  authorizationCode: string;
+  codeVerifier: string;
+}
+
+/** 403/404 are the server's "authorization pending" signals for this endpoint. */
+async function pollDeviceToken(
+  deviceAuthId: string,
+  userCode: string
+): Promise<ApprovedCode | 'pending'> {
+  const res = await fetchWithTimeout(`${CODEX_AUTH_ISSUER}/api/accounts/deviceauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ device_auth_id: deviceAuthId, user_code: userCode }),
+  });
+  if (res.status === 403 || res.status === 404) return 'pending';
+  if (!res.ok) throw providerStatusError('device token poll', res.status);
+
+  const body = (await res.json()) as Record<string, unknown>;
+  const authorizationCode = body.authorization_code;
+  const codeVerifier = body.code_verifier;
+  if (typeof authorizationCode !== 'string' || typeof codeVerifier !== 'string') {
+    // The response contract broke — retrying the same request cannot help.
+    throw new DeviceAuthProviderError('terminal', 'device token response missing expected fields');
+  }
+  return { authorizationCode, codeVerifier };
+}
+
+interface ExchangedTokens {
+  idToken: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+async function exchangeCodeForTokens(approved: ApprovedCode): Promise<ExchangedTokens> {
+  const res = await fetchWithTimeout(`${CODEX_AUTH_ISSUER}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: approved.authorizationCode,
+      redirect_uri: `${CODEX_AUTH_ISSUER}/deviceauth/callback`,
+      client_id: CODEX_CLIENT_ID,
+      code_verifier: approved.codeVerifier,
+    }).toString(),
+  });
+  if (!res.ok) throw providerStatusError('token exchange', res.status);
+
+  const body = (await res.json()) as Record<string, unknown>;
+  const { id_token, access_token, refresh_token } = body;
+  if (
+    typeof id_token !== 'string' ||
+    typeof access_token !== 'string' ||
+    typeof refresh_token !== 'string'
+  ) {
+    throw new DeviceAuthProviderError(
+      'terminal',
+      'token exchange response missing expected fields'
+    );
+  }
+  return { idToken: id_token, accessToken: access_token, refreshToken: refresh_token };
+}
+
+/**
+ * The exchange runs once, AFTER the user already approved — a provider blip
+ * here would otherwise force a whole new code+approval round-trip. One retry
+ * on a transient failure mirrors the poll loop's own policy.
+ */
+async function exchangeWithOneRetry(approved: ApprovedCode): Promise<ExchangedTokens> {
+  try {
+    return await exchangeCodeForTokens(approved);
+  } catch (err) {
+    if (err instanceof DeviceAuthProviderError && err.disposition === 'terminal') throw err;
+    return exchangeCodeForTokens(approved);
+  }
+}
+
+/** Codex-format auth.json content for a fresh ChatGPT login. */
+export function buildDeviceAuthJson(tokens: ExchangedTokens): string {
+  const { accountId } = codexIdTokenClaims(tokens.idToken);
+  const authDotJson = {
+    auth_mode: 'chatgpt',
+    OPENAI_API_KEY: null,
+    tokens: {
+      id_token: tokens.idToken,
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      account_id: accountId ?? null,
+    },
+    last_refresh: new Date().toISOString(),
+  };
+  return `${JSON.stringify(authDotJson, null, 2)}\n`;
+}
+
+interface DeviceAuthAttempt {
+  key: string;
+  userId: UserID;
+  tenantId: TenantID | string;
+  authUser: NonNullable<AuthenticatedParams['user']>;
+  targetUnixUser: string | null;
+  phase: CodexDeviceAuthStatus['phase'];
+  deviceAuthId: string;
+  userCode: string;
+  intervalMs: number;
+  expiresAtMs: number;
+  planType?: string;
+  hint?: string;
+  timer?: ReturnType<typeof setTimeout>;
+  cancelled: boolean;
+  finishedAtMs?: number;
+}
+
+/** How long a finished attempt stays queryable before eviction. */
+const TERMINAL_ATTEMPT_TTL_MS = 60 * 60 * 1000;
+
+function statusOf(attempt: DeviceAuthAttempt | undefined): CodexDeviceAuthStatus {
+  if (!attempt) return { phase: 'idle' };
+  const base: CodexDeviceAuthStatus = { phase: attempt.phase };
+  // userCode is empty while the slot is reserved but the provider has not
+  // answered yet — don't surface a blank code for that sub-second window.
+  if (attempt.phase === 'pending' && attempt.userCode) {
+    base.userCode = attempt.userCode;
+    base.verificationUrl = `${CODEX_AUTH_ISSUER}/codex/device`;
+    base.expiresAt = new Date(attempt.expiresAtMs).toISOString();
+  }
+  if (attempt.planType) base.planType = attempt.planType;
+  if (attempt.hint) base.hint = attempt.hint;
+  return base;
+}
+
+export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareDatabase) {
+  const attempts = new Map<string, DeviceAuthAttempt>();
+
+  function cancelAttempt(key: string): void {
+    const existing = attempts.get(key);
+    if (!existing) return;
+    existing.cancelled = true;
+    if (existing.timer) clearTimeout(existing.timer);
+  }
+
+  function finish(
+    attempt: DeviceAuthAttempt,
+    phase: DeviceAuthAttempt['phase'],
+    hint?: string
+  ): void {
+    attempt.phase = phase;
+    attempt.finishedAtMs = Date.now();
+    if (hint) attempt.hint = hint;
+    if (attempt.timer) clearTimeout(attempt.timer);
+    attempt.timer = undefined;
+  }
+
+  /**
+   * Abandoned flows would otherwise grow the map forever on long-running
+   * daemons — one entry per user who started and never finished a sign-in.
+   */
+  function pruneFinishedAttempts(): void {
+    const cutoff = Date.now() - TERMINAL_ATTEMPT_TTL_MS;
+    for (const [key, attempt] of attempts) {
+      if (attempt.phase !== 'pending' && (attempt.finishedAtMs ?? 0) < cutoff) {
+        attempts.delete(key);
+      }
+    }
+  }
+
+  async function pollTick(attempt: DeviceAuthAttempt): Promise<void> {
+    if (attempt.cancelled || attempt.phase !== 'pending') return;
+    if (Date.now() >= attempt.expiresAtMs) {
+      finish(attempt, 'expired', 'The sign-in code expired — get a new one and try again.');
+      return;
+    }
+
+    let approved: ApprovedCode | 'pending';
+    try {
+      approved = await pollDeviceToken(attempt.deviceAuthId, attempt.userCode);
+    } catch (err) {
+      // Network blips and provider 5xx are transient — keep polling until the
+      // code expires. Only a definitive rejection or contract break ends the
+      // attempt early.
+      if (err instanceof DeviceAuthProviderError && err.disposition === 'terminal') {
+        finish(attempt, 'error', 'ChatGPT sign-in failed — get a new code and try again.');
+        return;
+      }
+      scheduleNext(attempt);
+      return;
+    }
+    if (attempt.cancelled) return;
+
+    if (approved === 'pending') {
+      scheduleNext(attempt);
+      return;
+    }
+
+    try {
+      const tokens = await exchangeWithOneRetry(approved);
+      // Ownership check in addition to the cancelled flag: a replacement
+      // attempt registered during the exchange must not have its freshly
+      // written credential clobbered by this older one.
+      if (attempt.cancelled || attempts.get(attempt.key) !== attempt) return;
+      const summary = await runWithTenantDatabaseScope(db, attempt.tenantId, () =>
+        persistVerifiedCodexAuth({
+          app,
+          normalized: buildDeviceAuthJson(tokens),
+          targetUnixUser: attempt.targetUnixUser,
+          userId: attempt.userId,
+          authUser: attempt.authUser,
+        })
+      );
+      attempt.planType = summary.planType;
+      finish(
+        attempt,
+        'success',
+        summary.planType
+          ? `Signed in with ChatGPT (${summary.planType} plan).`
+          : 'Signed in with ChatGPT.'
+      );
+    } catch (err) {
+      // Messages reaching this catch are already sanitized: the raw-token
+      // write path rethrows as BadRequest with operator-safe text inside
+      // persistVerifiedCodexAuth, and everything else is service/DB failures
+      // whose messages help operators.
+      console.error(
+        `[CodexDeviceAuth] Finalizing sign-in failed: ${
+          err instanceof Error ? `${err.constructor.name}: ${err.message}` : 'unknown error'
+        }`
+      );
+      finish(
+        attempt,
+        'error',
+        err instanceof BadRequest && err.message
+          ? err.message
+          : 'Signing in succeeded but saving the login failed — try again.'
+      );
+    }
+  }
+
+  function scheduleNext(attempt: DeviceAuthAttempt): void {
+    if (attempt.cancelled || attempt.phase !== 'pending') return;
+    const delay = Math.min(attempt.intervalMs, Math.max(attempt.expiresAtMs - Date.now(), 0));
+    attempt.timer = setTimeout(() => {
+      void pollTick(attempt);
+    }, delay);
+    attempt.timer.unref?.();
+  }
+
+  async function requireContext(params?: AuthenticatedParams): Promise<{
+    authUser: NonNullable<AuthenticatedParams['user']>;
+    userId: UserID;
+    tenantId: TenantID | string;
+    key: string;
+  }> {
+    const authUser = params?.user;
+    if (!authUser?.user_id) {
+      throw new NotAuthenticated('Sign in before starting a ChatGPT device sign-in.');
+    }
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for Codex device auth');
+    const userId = authUser.user_id as UserID;
+    return { authUser, userId, tenantId, key: `${tenantId}:${userId}` };
+  }
+
+  return {
+    async create(_data: unknown, params?: AuthenticatedParams): Promise<CodexDeviceAuthStatus> {
+      const { authUser, userId, tenantId, key } = await requireContext(params);
+
+      const config = loadConfigSync();
+      if (config.multi_tenancy?.mode === 'required_from_auth') {
+        throw new BadRequest(
+          'Codex subscription login is unavailable in hosted multi-tenant mode — use an OpenAI API key instead.'
+        );
+      }
+      const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) =>
+        runWithTenantDatabaseScope(db, tenantId, work);
+      if (
+        !(await withTenantDatabase((tenantDb) => isTenantAgenticToolEnabled('codex', tenantDb)))
+      ) {
+        throw new BadRequest('Codex is disabled for this workspace.');
+      }
+
+      // Resolve the destination identity up front so a strict-mode user with
+      // no unix_username fails fast instead of after approving the code.
+      const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+      if (!identity.ok) {
+        throw new BadRequest(
+          `Cannot determine which Unix account should hold this Codex login: ${identity.message}`
+        );
+      }
+
+      // Reserve the per-user slot BEFORE any await: an overlapping create()
+      // (double-click, impatient retry) then cancels THIS attempt instead of
+      // racing past a not-yet-registered one and leaving its poll loop
+      // orphaned against OpenAI for the full 15-minute window.
+      cancelAttempt(key);
+      pruneFinishedAttempts();
+      const attempt: DeviceAuthAttempt = {
+        key,
+        userId,
+        tenantId,
+        authUser,
+        targetUnixUser: identity.unixUser,
+        phase: 'pending',
+        deviceAuthId: '',
+        userCode: '',
+        intervalMs: 0,
+        expiresAtMs: Date.now() + DEVICE_CODE_LIFETIME_MS,
+        cancelled: false,
+      };
+      attempts.set(key, attempt);
+
+      let grant: UserCodeGrant | 'unavailable';
+      try {
+        grant = await requestUserCode();
+      } catch (err) {
+        if (!attempt.cancelled) {
+          finish(attempt, 'error', 'Could not get a sign-in code from ChatGPT.');
+        }
+        const terminal = err instanceof DeviceAuthProviderError && err.disposition === 'terminal';
+        throw new BadRequest(
+          terminal
+            ? 'ChatGPT rejected the sign-in request — try again later, or paste an auth.json / use an API key instead.'
+            : 'Could not reach ChatGPT to start the sign-in — check the server’s network access and try again.'
+        );
+      }
+      // A newer attempt replaced this one while the provider was answering.
+      if (attempt.cancelled) return statusOf(attempts.get(key));
+
+      if (grant === 'unavailable') {
+        finish(attempt, 'unavailable', UNAVAILABLE_HINT);
+        return statusOf(attempt);
+      }
+
+      attempt.deviceAuthId = grant.deviceAuthId;
+      attempt.userCode = grant.userCode;
+      attempt.intervalMs = grant.intervalMs;
+      attempt.expiresAtMs = Date.now() + DEVICE_CODE_LIFETIME_MS;
+      scheduleNext(attempt);
+      return statusOf(attempt);
+    },
+
+    async find(params?: AuthenticatedParams): Promise<CodexDeviceAuthStatus> {
+      const { key } = await requireContext(params);
+      pruneFinishedAttempts();
+      return statusOf(attempts.get(key));
+    },
+  };
+}

--- a/apps/agor-daemon/src/utils/codex-auth-file.test.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { parseCodexAuthJson } from './codex-auth-file';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { parseCodexAuthJson, readCodexAuthFile } from './codex-auth-file';
 
 /** Build an unsigned JWT with the given payload — enough for claim mining. */
 function fakeJwt(payload: Record<string, unknown>): string {
@@ -97,5 +100,41 @@ describe('parseCodexAuthJson', () => {
       expect(JSON.parse(result.normalized)).toEqual(withExtras);
       expect(result.normalized.endsWith('\n')).toBe(true);
     }
+  });
+});
+
+describe('readCodexAuthFile (daemon-user path)', () => {
+  // The daemon-user branch honors $CODEX_HOME, which lets these tests point
+  // it at a throwaway directory.
+  const originalCodexHome = process.env.CODEX_HOME;
+  let tmpHome: string;
+
+  afterEach(() => {
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  function useTmpCodexHome(): string {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-auth-test-'));
+    process.env.CODEX_HOME = tmpHome;
+    return tmpHome;
+  }
+
+  it('returns the file content when present', () => {
+    const home = useTmpCodexHome();
+    fs.writeFileSync(path.join(home, 'auth.json'), '{"OPENAI_API_KEY":"sk-x"}');
+    expect(readCodexAuthFile(null)).toEqual({ ok: true, content: '{"OPENAI_API_KEY":"sk-x"}' });
+  });
+
+  it('distinguishes a genuinely absent file (not-found) from other failures', () => {
+    useTmpCodexHome();
+    expect(readCodexAuthFile(null)).toEqual({ ok: false, reason: 'not-found' });
+  });
+
+  it('reports unreadable (not not-found) when the path exists but cannot be read as a file', () => {
+    const home = useTmpCodexHome();
+    fs.mkdirSync(path.join(home, 'auth.json'));
+    expect(readCodexAuthFile(null)).toEqual({ ok: false, reason: 'unreadable' });
   });
 });

--- a/apps/agor-daemon/src/utils/codex-auth-file.test.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { parseCodexAuthJson } from './codex-auth-file';
+
+/** Build an unsigned JWT with the given payload — enough for claim mining. */
+function fakeJwt(payload: Record<string, unknown>): string {
+  const enc = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${enc({ alg: 'RS256' })}.${enc(payload)}.signature`;
+}
+
+const CHATGPT_AUTH_JSON = {
+  OPENAI_API_KEY: null,
+  tokens: {
+    id_token: fakeJwt({
+      'https://api.openai.com/auth': { chatgpt_plan_type: 'plus', chatgpt_account_id: 'acct-1' },
+    }),
+    access_token: 'access-abc',
+    refresh_token: 'refresh-xyz',
+    account_id: 'acct-1',
+  },
+  last_refresh: '2026-07-16T12:00:00.000000Z',
+};
+
+describe('parseCodexAuthJson', () => {
+  it('rejects empty and whitespace-only input', () => {
+    for (const raw of ['', '   \n ', undefined, null]) {
+      const result = parseCodexAuthJson(raw);
+      expect(result.ok).toBe(false);
+    }
+  });
+
+  it('rejects non-JSON input with a friendly error that never echoes the input', () => {
+    const result = parseCodexAuthJson('sk-proj-not-json-at-all');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('cat ~/.codex/auth.json');
+      expect(result.error).not.toContain('sk-proj');
+    }
+  });
+
+  it('rejects JSON that is not an object', () => {
+    expect(parseCodexAuthJson('[1,2,3]').ok).toBe(false);
+    expect(parseCodexAuthJson('"a string"').ok).toBe(false);
+  });
+
+  it('rejects an object with neither login tokens nor an API key', () => {
+    const result = parseCodexAuthJson(
+      JSON.stringify({ OPENAI_API_KEY: null, tokens: { id_token: 'x' } })
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('codex login');
+  });
+
+  it('rejects oversized payloads', () => {
+    const huge = JSON.stringify({ OPENAI_API_KEY: 'x'.repeat(70 * 1024) });
+    expect(parseCodexAuthJson(huge).ok).toBe(false);
+  });
+
+  it('accepts a ChatGPT login file and mines plan type from the id_token', () => {
+    const result = parseCodexAuthJson(JSON.stringify(CHATGPT_AUTH_JSON));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.summary.authMode).toBe('chatgpt');
+      expect(result.summary.planType).toBe('plus');
+      expect(result.summary.lastRefresh).toBe('2026-07-16T12:00:00.000000Z');
+      expect(result.summary.apiKey).toBeUndefined();
+    }
+  });
+
+  it('tolerates an unparseable id_token — plan type is best-effort display data', () => {
+    const withBadIdToken = {
+      ...CHATGPT_AUTH_JSON,
+      tokens: { ...CHATGPT_AUTH_JSON.tokens, id_token: 'not-a-jwt' },
+    };
+    const result = parseCodexAuthJson(JSON.stringify(withBadIdToken));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.summary.authMode).toBe('chatgpt');
+      expect(result.summary.planType).toBeUndefined();
+    }
+  });
+
+  it('accepts an API-key-only file', () => {
+    const result = parseCodexAuthJson(JSON.stringify({ OPENAI_API_KEY: 'sk-proj-123' }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.summary.authMode).toBe('api_key');
+      expect(result.summary.apiKey).toBe('sk-proj-123');
+    }
+  });
+
+  it('round-trips unknown fields — Codex owns this schema', () => {
+    const withExtras = { ...CHATGPT_AUTH_JSON, auth_mode: 'chatgpt', future_field: { a: 1 } };
+    const result = parseCodexAuthJson(JSON.stringify(withExtras));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(JSON.parse(result.normalized)).toEqual(withExtras);
+      expect(result.normalized.endsWith('\n')).toBe(true);
+    }
+  });
+});

--- a/apps/agor-daemon/src/utils/codex-auth-file.test.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { parseCodexAuthJson, readCodexAuthFile } from './codex-auth-file';
+import { parseCodexAuthJson, readCodexAuthFile, writeCodexAuthFile } from './codex-auth-file';
 
 /** Build an unsigned JWT with the given payload — enough for claim mining. */
 function fakeJwt(payload: Record<string, unknown>): string {
@@ -52,6 +52,13 @@ describe('parseCodexAuthJson', () => {
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain('codex login');
+  });
+
+  it('rejects a whitespace-only refresh token — not a usable credential', () => {
+    const result = parseCodexAuthJson(
+      JSON.stringify({ OPENAI_API_KEY: null, tokens: { refresh_token: '   ' } })
+    );
+    expect(result.ok).toBe(false);
   });
 
   it('rejects oversized payloads', () => {
@@ -136,5 +143,16 @@ describe('readCodexAuthFile (daemon-user path)', () => {
     const home = useTmpCodexHome();
     fs.mkdirSync(path.join(home, 'auth.json'));
     expect(readCodexAuthFile(null)).toEqual({ ok: false, reason: 'unreadable' });
+  });
+
+  it('write round-trips exactly and leaves no staging files behind', () => {
+    const home = useTmpCodexHome();
+    writeCodexAuthFile('{"OPENAI_API_KEY":"sk-first"}\n', null);
+    writeCodexAuthFile('{"OPENAI_API_KEY":"sk-second"}\n', null);
+    expect(readCodexAuthFile(null)).toEqual({
+      ok: true,
+      content: '{"OPENAI_API_KEY":"sk-second"}\n',
+    });
+    expect(fs.readdirSync(home)).toEqual(['auth.json']);
   });
 });

--- a/apps/agor-daemon/src/utils/codex-auth-file.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.ts
@@ -1,0 +1,207 @@
+/**
+ * Codex `auth.json` helpers — parse/validate the credential file the Codex CLI
+ * keeps at `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`), and read or
+ * write it on behalf of the Unix identity that will actually run Codex.
+ *
+ * Transplanting `auth.json` between machines is officially supported by
+ * OpenAI (their container docs copy the file in verbatim); Codex refreshes
+ * the tokens itself and persists them back to disk, so a one-time import is
+ * a durable login.
+ *
+ * SECURITY CONTRACT:
+ * - File contents are token material. Callers must never log them; helpers
+ *   here never include file contents or parse failures' raw input in thrown
+ *   errors.
+ * - When a target Unix user is given, all filesystem access happens AS that
+ *   user via `sudo -n -u` with content piped over stdin — token bytes never
+ *   appear in argv, and ownership/0600 perms are guaranteed by `umask 077`
+ *   plus an explicit `chmod` for the overwrite case.
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { isValidUnixUsername } from '@agor/core/unix';
+
+/** Matches run-as-user's default; a local `cat`/`mkdir` never needs longer. */
+const SUDO_TIMEOUT_MS = 5000;
+
+/** Sanity cap — a real auth.json is a few KB; anything bigger is not one. */
+const MAX_AUTH_JSON_BYTES = 64 * 1024;
+
+export interface CodexAuthSummary {
+  /** `chatgpt` when login tokens are present, `api_key` when only a key is. */
+  authMode: 'chatgpt' | 'api_key';
+  /** ChatGPT plan type from the id_token claims (e.g. "plus", "pro"), when parseable. */
+  planType?: string;
+  /** The `OPENAI_API_KEY` value when authMode is `api_key`. SECRET — never echo. */
+  apiKey?: string;
+  /** `last_refresh` ISO timestamp as recorded by Codex, when present. */
+  lastRefresh?: string;
+}
+
+export type ParseCodexAuthResult =
+  | { ok: true; normalized: string; summary: CodexAuthSummary }
+  | { ok: false; error: string };
+
+/**
+ * Decode a JWT payload segment without verifying the signature. We only mine
+ * display metadata (plan type) from a token the user already possesses, so
+ * verification adds nothing — treat every field as untrusted display data.
+ */
+function decodeJwtClaims(token: string): Record<string, unknown> | null {
+  const segments = token.split('.');
+  if (segments.length !== 3) return null;
+  try {
+    const payload = Buffer.from(segments[1], 'base64url').toString('utf8');
+    const claims = JSON.parse(payload) as unknown;
+    return claims && typeof claims === 'object' ? (claims as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Codex id_tokens nest account metadata under this claim key. */
+const OPENAI_AUTH_CLAIM = 'https://api.openai.com/auth';
+
+function planTypeFromIdToken(idToken: unknown): string | undefined {
+  if (typeof idToken !== 'string' || !idToken) return undefined;
+  const claims = decodeJwtClaims(idToken);
+  const authClaim = claims?.[OPENAI_AUTH_CLAIM];
+  if (!authClaim || typeof authClaim !== 'object') return undefined;
+  const planType = (authClaim as Record<string, unknown>).chatgpt_plan_type;
+  return typeof planType === 'string' && planType ? planType : undefined;
+}
+
+/**
+ * Validate a pasted `auth.json` and normalize it for writing.
+ *
+ * Accepts any JSON object that carries at least one usable credential:
+ * `tokens.refresh_token` (ChatGPT login) or a non-empty `OPENAI_API_KEY`.
+ * Unknown fields are preserved verbatim — Codex owns this file's schema and
+ * adds fields between releases; stripping them would break round-tripping.
+ *
+ * Error strings are user-facing and never contain the pasted input.
+ */
+export function parseCodexAuthJson(raw: string | undefined | null): ParseCodexAuthResult {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  if (!trimmed) {
+    return { ok: false, error: 'Paste the contents of your auth.json file first.' };
+  }
+  if (Buffer.byteLength(trimmed, 'utf8') > MAX_AUTH_JSON_BYTES) {
+    return {
+      ok: false,
+      error: 'That is much larger than an auth.json file — copy just the file contents.',
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return {
+      ok: false,
+      error:
+        'That does not look like valid JSON. Copy the entire file — on the machine where Codex works, run: cat ~/.codex/auth.json',
+    };
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: 'auth.json should be a JSON object with a "tokens" section or an "OPENAI_API_KEY".',
+    };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const tokens =
+    record.tokens && typeof record.tokens === 'object' && !Array.isArray(record.tokens)
+      ? (record.tokens as Record<string, unknown>)
+      : null;
+  const refreshToken = tokens?.refresh_token;
+  const hasChatgptLogin = typeof refreshToken === 'string' && refreshToken.length > 0;
+  const apiKey = typeof record.OPENAI_API_KEY === 'string' ? record.OPENAI_API_KEY.trim() : '';
+
+  if (!hasChatgptLogin && !apiKey) {
+    return {
+      ok: false,
+      error:
+        'This file has no ChatGPT login tokens and no API key. Sign in on the other machine first (`codex login`), then copy the fresh ~/.codex/auth.json.',
+    };
+  }
+
+  const summary: CodexAuthSummary = hasChatgptLogin
+    ? {
+        authMode: 'chatgpt',
+        planType: planTypeFromIdToken(tokens?.id_token),
+        lastRefresh: typeof record.last_refresh === 'string' ? record.last_refresh : undefined,
+      }
+    : { authMode: 'api_key', apiKey };
+
+  return { ok: true, normalized: `${JSON.stringify(record, null, 2)}\n`, summary };
+}
+
+/** `$CODEX_HOME` only applies to the daemon's own account; impersonated users get their default. */
+function daemonCodexHome(): string {
+  return process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+}
+
+/**
+ * Write `auth.json` (0600) into the Codex home of the given Unix user, or of
+ * the daemon user when `asUser` is null/undefined.
+ *
+ * The impersonated path pipes content over stdin — token bytes never appear
+ * in argv (`/proc/<pid>/cmdline`). `umask 077` covers fresh creation and the
+ * explicit `chmod 600` covers overwriting a pre-existing looser file.
+ */
+export function writeCodexAuthFile(content: string, asUser?: string | null): void {
+  if (asUser) {
+    if (!isValidUnixUsername(asUser)) {
+      throw new Error(`writeCodexAuthFile: invalid Unix username: ${JSON.stringify(asUser)}`);
+    }
+    const script =
+      'umask 077; mkdir -p "$HOME/.codex"; cat > "$HOME/.codex/auth.json"; chmod 600 "$HOME/.codex/auth.json"';
+    execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script], {
+      input: content,
+      stdio: ['pipe', 'ignore', 'pipe'],
+      timeout: SUDO_TIMEOUT_MS,
+    });
+    return;
+  }
+
+  const codexHome = daemonCodexHome();
+  fs.mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+  const authPath = path.join(codexHome, 'auth.json');
+  fs.writeFileSync(authPath, content, { mode: 0o600 });
+  fs.chmodSync(authPath, 0o600);
+}
+
+/**
+ * Read `auth.json` from the given Unix user's Codex home (or the daemon's).
+ * Returns null when the file is absent or unreadable — callers treat that as
+ * "no Codex login", not as an error. Contents are SECRET; never log them.
+ */
+export function readCodexAuthFile(asUser?: string | null): string | null {
+  if (asUser) {
+    if (!isValidUnixUsername(asUser)) return null;
+    try {
+      return execFileSync(
+        'sudo',
+        ['-n', '-u', asUser, 'bash', '-c', 'cat "$HOME/.codex/auth.json"'],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: SUDO_TIMEOUT_MS,
+        }
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    return fs.readFileSync(path.join(daemonCodexHome(), 'auth.json'), 'utf8');
+  } catch {
+    return null;
+  }
+}

--- a/apps/agor-daemon/src/utils/codex-auth-file.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.ts
@@ -166,8 +166,11 @@ export function writeCodexAuthFile(content: string, asUser?: string | null): voi
     }
     // `set -eu` so any step failing aborts with a non-zero exit before the
     // rename can publish a bad file. mktemp creates the staging file 0600.
+    // The EXIT trap removes an orphaned staging file on any failure so
+    // aborted writes never accumulate token fragments; after a successful
+    // rename the path is gone and the trap's rm is a no-op.
     const script =
-      'set -eu; umask 077; mkdir -p "$HOME/.codex"; tmp="$(mktemp "$HOME/.codex/.auth.json.XXXXXX")"; cat > "$tmp"; chmod 600 "$tmp"; mv -f -- "$tmp" "$HOME/.codex/auth.json"';
+      'set -eu; umask 077; mkdir -p "$HOME/.codex"; tmp="$(mktemp "$HOME/.codex/.auth.json.XXXXXX")"; trap \'rm -f -- "$tmp"\' EXIT; cat > "$tmp"; chmod 600 "$tmp"; mv -f -- "$tmp" "$HOME/.codex/auth.json"';
     execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script], {
       input: content,
       stdio: ['pipe', 'ignore', 'pipe'],

--- a/apps/agor-daemon/src/utils/codex-auth-file.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.ts
@@ -159,8 +159,11 @@ export function writeCodexAuthFile(content: string, asUser?: string | null): voi
     if (!isValidUnixUsername(asUser)) {
       throw new Error(`writeCodexAuthFile: invalid Unix username: ${JSON.stringify(asUser)}`);
     }
+    // `set -eu` so a mid-stream `cat` failure (disk full, quota) aborts the
+    // script with a non-zero exit instead of leaving a truncated file that a
+    // still-running `chmod` would silently bless as success.
     const script =
-      'umask 077; mkdir -p "$HOME/.codex"; cat > "$HOME/.codex/auth.json"; chmod 600 "$HOME/.codex/auth.json"';
+      'set -eu; umask 077; mkdir -p "$HOME/.codex"; cat > "$HOME/.codex/auth.json"; chmod 600 "$HOME/.codex/auth.json"';
     execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script], {
       input: content,
       stdio: ['pipe', 'ignore', 'pipe'],
@@ -171,37 +174,60 @@ export function writeCodexAuthFile(content: string, asUser?: string | null): voi
 
   const codexHome = daemonCodexHome();
   fs.mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+  // mkdirSync's mode is masked by the process umask and never applied to a
+  // pre-existing directory — chmod explicitly so the containing dir is 0700.
+  fs.chmodSync(codexHome, 0o700);
   const authPath = path.join(codexHome, 'auth.json');
   fs.writeFileSync(authPath, content, { mode: 0o600 });
   fs.chmodSync(authPath, 0o600);
 }
 
+export type ReadCodexAuthResult =
+  | { ok: true; content: string }
+  | { ok: false; reason: 'not-found' | 'unreadable' };
+
+/** Sentinel exit code the impersonated read script uses for "file absent". */
+const READ_NOT_FOUND_EXIT = 3;
+
 /**
  * Read `auth.json` from the given Unix user's Codex home (or the daemon's).
- * Returns null when the file is absent or unreadable — callers treat that as
- * "no Codex login", not as an error. Contents are SECRET; never log them.
+ *
+ * `not-found` (file genuinely absent) is positive evidence of "no Codex
+ * login"; `unreadable` (permission/sudo/transport failure) is NOT — callers
+ * doing auth checks must map it to their "could not verify" state, never to
+ * "unauthenticated". The impersonated script signals absence via a sentinel
+ * exit code so the distinction survives the sudo boundary without parsing
+ * locale-dependent stderr. Contents are SECRET; never log them.
  */
-export function readCodexAuthFile(asUser?: string | null): string | null {
+export function readCodexAuthFile(asUser?: string | null): ReadCodexAuthResult {
   if (asUser) {
-    if (!isValidUnixUsername(asUser)) return null;
+    if (!isValidUnixUsername(asUser)) return { ok: false, reason: 'unreadable' };
+    const script = `[ -e "$HOME/.codex/auth.json" ] || exit ${READ_NOT_FOUND_EXIT}; cat "$HOME/.codex/auth.json"`;
     try {
-      return execFileSync(
-        'sudo',
-        ['-n', '-u', asUser, 'bash', '-c', 'cat "$HOME/.codex/auth.json"'],
-        {
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'ignore'],
-          timeout: SUDO_TIMEOUT_MS,
-        }
-      );
-    } catch {
-      return null;
+      const content = execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: SUDO_TIMEOUT_MS,
+      });
+      return { ok: true, content };
+    } catch (err) {
+      const exitStatus = (err as { status?: unknown }).status;
+      return {
+        ok: false,
+        reason: exitStatus === READ_NOT_FOUND_EXIT ? 'not-found' : 'unreadable',
+      };
     }
   }
 
   try {
-    return fs.readFileSync(path.join(daemonCodexHome(), 'auth.json'), 'utf8');
-  } catch {
-    return null;
+    return {
+      ok: true,
+      content: fs.readFileSync(path.join(daemonCodexHome(), 'auth.json'), 'utf8'),
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: (err as { code?: unknown }).code === 'ENOENT' ? 'not-found' : 'unreadable',
+    };
   }
 }

--- a/apps/agor-daemon/src/utils/codex-auth-file.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.ts
@@ -47,33 +47,44 @@ export type ParseCodexAuthResult =
   | { ok: true; normalized: string; summary: CodexAuthSummary }
   | { ok: false; error: string };
 
-/**
- * Decode a JWT payload segment without verifying the signature. We only mine
- * display metadata (plan type) from a token the user already possesses, so
- * verification adds nothing — treat every field as untrusted display data.
- */
-function decodeJwtClaims(token: string): Record<string, unknown> | null {
-  const segments = token.split('.');
-  if (segments.length !== 3) return null;
-  try {
-    const payload = Buffer.from(segments[1], 'base64url').toString('utf8');
-    const claims = JSON.parse(payload) as unknown;
-    return claims && typeof claims === 'object' ? (claims as Record<string, unknown>) : null;
-  } catch {
-    return null;
-  }
-}
-
 /** Codex id_tokens nest account metadata under this claim key. */
 const OPENAI_AUTH_CLAIM = 'https://api.openai.com/auth';
 
-function planTypeFromIdToken(idToken: unknown): string | undefined {
-  if (typeof idToken !== 'string' || !idToken) return undefined;
-  const claims = decodeJwtClaims(idToken);
-  const authClaim = claims?.[OPENAI_AUTH_CLAIM];
-  if (!authClaim || typeof authClaim !== 'object') return undefined;
-  const planType = (authClaim as Record<string, unknown>).chatgpt_plan_type;
-  return typeof planType === 'string' && planType ? planType : undefined;
+/**
+ * Mine metadata from a Codex id_token payload (unverified — the signature is
+ * not checked): the ChatGPT plan type and the account id Codex records as
+ * `tokens.account_id`. Best-effort — an unparseable token yields an empty
+ * result, never an error.
+ *
+ * Trust note: "unverified" here means safe against parse errors, not a trust
+ * statement. When these claims matter (the device flow writing account_id
+ * into auth.json), trust flows from having received the id_token over the
+ * provider's TLS token endpoint — not from this parse.
+ */
+export function codexIdTokenClaims(idToken: unknown): {
+  planType?: string;
+  accountId?: string;
+} {
+  if (typeof idToken !== 'string') return {};
+  const segments = idToken.split('.');
+  if (segments.length !== 3) return {};
+  try {
+    const claims = JSON.parse(Buffer.from(segments[1], 'base64url').toString('utf8')) as unknown;
+    const authClaim =
+      claims && typeof claims === 'object'
+        ? (claims as Record<string, unknown>)[OPENAI_AUTH_CLAIM]
+        : undefined;
+    if (!authClaim || typeof authClaim !== 'object') return {};
+    const record = authClaim as Record<string, unknown>;
+    const planType = record.chatgpt_plan_type;
+    const accountId = record.chatgpt_account_id;
+    return {
+      ...(typeof planType === 'string' && planType ? { planType } : {}),
+      ...(typeof accountId === 'string' && accountId ? { accountId } : {}),
+    };
+  } catch {
+    return {};
+  }
 }
 
 /**
@@ -135,7 +146,7 @@ export function parseCodexAuthJson(raw: string | undefined | null): ParseCodexAu
   const summary: CodexAuthSummary = hasChatgptLogin
     ? {
         authMode: 'chatgpt',
-        planType: planTypeFromIdToken(tokens?.id_token),
+        planType: codexIdTokenClaims(tokens?.id_token).planType,
         lastRefresh: typeof record.last_refresh === 'string' ? record.last_refresh : undefined,
       }
     : { authMode: 'api_key', apiKey };

--- a/apps/agor-daemon/src/utils/codex-auth-file.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.ts
@@ -14,11 +14,13 @@
  *   errors.
  * - When a target Unix user is given, all filesystem access happens AS that
  *   user via `sudo -n -u` with content piped over stdin — token bytes never
- *   appear in argv, and ownership/0600 perms are guaranteed by `umask 077`
- *   plus an explicit `chmod` for the overwrite case.
+ *   appear in argv. Writes stage a 0600 temp file and atomically rename it
+ *   into place, so readers never see a torn write and a pre-existing symlink
+ *   is replaced rather than followed.
  */
 
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -119,7 +121,7 @@ export function parseCodexAuthJson(raw: string | undefined | null): ParseCodexAu
       ? (record.tokens as Record<string, unknown>)
       : null;
   const refreshToken = tokens?.refresh_token;
-  const hasChatgptLogin = typeof refreshToken === 'string' && refreshToken.length > 0;
+  const hasChatgptLogin = typeof refreshToken === 'string' && refreshToken.trim().length > 0;
   const apiKey = typeof record.OPENAI_API_KEY === 'string' ? record.OPENAI_API_KEY.trim() : '';
 
   if (!hasChatgptLogin && !apiKey) {
@@ -151,19 +153,21 @@ function daemonCodexHome(): string {
  * the daemon user when `asUser` is null/undefined.
  *
  * The impersonated path pipes content over stdin — token bytes never appear
- * in argv (`/proc/<pid>/cmdline`). `umask 077` covers fresh creation and the
- * explicit `chmod 600` covers overwriting a pre-existing looser file.
+ * in argv (`/proc/<pid>/cmdline`). Both paths stage a 0600 temp file in the
+ * Codex home and atomically rename it into place: a concurrently running
+ * Codex never observes a torn half-write, a mid-stream failure (disk full)
+ * leaves the previous file intact, and rename replaces a pre-existing
+ * symlink itself instead of following it.
  */
 export function writeCodexAuthFile(content: string, asUser?: string | null): void {
   if (asUser) {
     if (!isValidUnixUsername(asUser)) {
       throw new Error(`writeCodexAuthFile: invalid Unix username: ${JSON.stringify(asUser)}`);
     }
-    // `set -eu` so a mid-stream `cat` failure (disk full, quota) aborts the
-    // script with a non-zero exit instead of leaving a truncated file that a
-    // still-running `chmod` would silently bless as success.
+    // `set -eu` so any step failing aborts with a non-zero exit before the
+    // rename can publish a bad file. mktemp creates the staging file 0600.
     const script =
-      'set -eu; umask 077; mkdir -p "$HOME/.codex"; cat > "$HOME/.codex/auth.json"; chmod 600 "$HOME/.codex/auth.json"';
+      'set -eu; umask 077; mkdir -p "$HOME/.codex"; tmp="$(mktemp "$HOME/.codex/.auth.json.XXXXXX")"; cat > "$tmp"; chmod 600 "$tmp"; mv -f -- "$tmp" "$HOME/.codex/auth.json"';
     execFileSync('sudo', ['-n', '-u', asUser, 'bash', '-c', script], {
       input: content,
       stdio: ['pipe', 'ignore', 'pipe'],
@@ -177,9 +181,14 @@ export function writeCodexAuthFile(content: string, asUser?: string | null): voi
   // mkdirSync's mode is masked by the process umask and never applied to a
   // pre-existing directory — chmod explicitly so the containing dir is 0700.
   fs.chmodSync(codexHome, 0o700);
-  const authPath = path.join(codexHome, 'auth.json');
-  fs.writeFileSync(authPath, content, { mode: 0o600 });
-  fs.chmodSync(authPath, 0o600);
+  const tmpPath = path.join(codexHome, `.auth.json.${randomBytes(6).toString('hex')}`);
+  try {
+    fs.writeFileSync(tmpPath, content, { mode: 0o600 });
+    fs.renameSync(tmpPath, path.join(codexHome, 'auth.json'));
+  } catch (err) {
+    fs.rmSync(tmpPath, { force: true });
+    throw err;
+  }
 }
 
 export type ReadCodexAuthResult =

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
@@ -1,0 +1,361 @@
+/**
+ * Tests for the Codex authentication management pane (settings surface).
+ *
+ * Unlike the onboarding wizard, this is a management view: it probes the live
+ * connection, surfaces a stored-but-broken credential as a prominent error, and
+ * keeps every sign-in path reachable while connected.
+ *
+ * Query style mirrors OnboardingWizard.test.tsx — plain text queries with
+ * `.closest('button')`, never `getByRole`, because computing an accessible name
+ * while an antd `Tag`/`Segmented` is mounted walks a CSS shorthand rule that
+ * crashes jsdom's `cssstyle`.
+ */
+
+import type { AgenticAuthMethod, AuthCheckResult } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+import { TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
+import { CodexAuthSettings } from './CodexAuthSettings';
+
+const UNKNOWN: AuthCheckResult = { status: 'unknown', authenticated: false, method: 'none' };
+
+interface HarnessOptions {
+  initialMethod?: AgenticAuthMethod;
+  fieldStatus?: Record<string, boolean>;
+  checkAuth?: ReturnType<typeof vi.fn>;
+  importCreate?: ReturnType<typeof vi.fn>;
+  deviceCreate?: ReturnType<typeof vi.fn>;
+  deviceFind?: ReturnType<typeof vi.fn>;
+  onSaveField?: ReturnType<typeof vi.fn>;
+  onClearField?: ReturnType<typeof vi.fn>;
+}
+
+// The pane never mutates the persisted method itself — the method is a
+// consequence of the credential the user configures (a key save / a completed
+// device sign-in or import), which the real settings modal drives — so the
+// harness holds authMethod fixed and asserts selection stays non-destructive.
+function Harness({
+  initialMethod = 'api_key',
+  fieldStatus = {},
+  checkAuth,
+  importCreate,
+  deviceCreate,
+  deviceFind,
+  onSaveField,
+  onClearField,
+}: HarnessOptions) {
+  const services: Record<string, unknown> = {
+    'check-auth': { create: checkAuth ?? vi.fn(async () => UNKNOWN) },
+    'codex-auth/import': {
+      create: importCreate ?? vi.fn(async () => ({ status: 'authenticated' })),
+    },
+    'codex-auth/device': {
+      create: deviceCreate ?? vi.fn(async () => ({ phase: 'idle' })),
+      find: deviceFind ?? vi.fn(async () => ({ phase: 'idle' })),
+    },
+  };
+  // Stable client identity across rerenders (mirrors the real modal, where the
+  // client outlives authMethod changes) — so a rerender that flips only
+  // authMethod exercises the method-change path, not a client swap.
+  const clientRef = useRef<unknown>(undefined);
+  if (clientRef.current === undefined) {
+    clientRef.current = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) => services[name] ?? {}),
+    };
+  }
+  const client = clientRef.current as never;
+
+  return (
+    <CodexAuthSettings
+      client={client}
+      authMethod={initialMethod}
+      apiKeyFields={TOOL_FIELD_CONFIGS.codex}
+      fieldStatus={fieldStatus}
+      onSaveField={onSaveField ?? vi.fn(async () => undefined)}
+      onClearField={onClearField ?? vi.fn(async () => undefined)}
+      savingFields={{}}
+    />
+  );
+}
+
+function clickText(text: string | RegExp) {
+  const el = screen.getByText(text);
+  const clickable = el.closest('button') ?? el.closest('label') ?? el;
+  fireEvent.click(clickable);
+}
+
+describe('CodexAuthSettings', () => {
+  it('shows a Connected banner when the probe reports an authenticated API key', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'api-key',
+      })
+    );
+    render(<Harness initialMethod="api_key" checkAuth={checkAuth} />);
+
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+    expect(screen.getByText('Your OpenAI API key is working.')).toBeInTheDocument();
+    await waitFor(() => expect(checkAuth).toHaveBeenCalledWith({ tool: 'codex' }));
+  });
+
+  it('surfaces a missing subscription login as a prominent "Login not found" error', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'none',
+      })
+    );
+    render(<Harness initialMethod="subscription" checkAuth={checkAuth} />);
+
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
+    expect(screen.getByText(/Codex login no longer found on this server/i)).toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+  });
+
+  it('flags a stored-but-rejected API key as "Key not working"', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'api-key',
+      })
+    );
+    render(
+      <Harness
+        initialMethod="api_key"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+
+    expect(await screen.findByText('Key not working')).toBeInTheDocument();
+    expect(screen.queryByText('Login not found')).not.toBeInTheDocument();
+  });
+
+  it('stays silent when no key is stored and the probe is negative (fail safe)', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'none',
+      })
+    );
+    render(<Harness initialMethod="api_key" fieldStatus={{}} checkAuth={checkAuth} />);
+
+    // Give the probe a chance to resolve before asserting the banner is absent.
+    await waitFor(() => expect(checkAuth).toHaveBeenCalled());
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+    expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
+  });
+
+  it('never affirms a ChatGPT login while the effective method is api_key (banner tracks stored method)', async () => {
+    // Mixed state: method=api_key (keyless) with a login the probe can see. The
+    // executor won't use that login for api_key, so the banner must not claim
+    // "connected" — the sessions-broken-but-banner-connected contradiction.
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'native',
+      })
+    );
+    render(<Harness initialMethod="api_key" fieldStatus={{}} checkAuth={checkAuth} />);
+
+    await waitFor(() => expect(checkAuth).toHaveBeenCalled());
+    expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
+    expect(screen.queryByText('A ChatGPT login is active on this server.')).not.toBeInTheDocument();
+  });
+
+  it('drops a stale negative verdict when the method flips (no false "Login not found")', async () => {
+    // An api-key probe rejects; then the method flips to subscription, as a
+    // completed ChatGPT sign-in would. The stale api-key rejection must not be
+    // reinterpreted as a subscription failure — even while the re-probe for the
+    // new method is still in flight (and would persist if that re-probe failed).
+    let releaseSecond: (v: AuthCheckResult) => void = () => {};
+    const checkAuth = vi
+      .fn<[], Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce({ status: 'unauthenticated', authenticated: false, method: 'api-key' })
+      .mockImplementationOnce(
+        () =>
+          new Promise<AuthCheckResult>((resolve) => {
+            releaseSecond = resolve;
+          })
+      );
+    const { rerender } = render(
+      <Harness
+        initialMethod="api_key"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+    expect(await screen.findByText('Key not working')).toBeInTheDocument();
+
+    // Flip to subscription; the second probe is in flight and unresolved.
+    rerender(
+      <Harness
+        initialMethod="subscription"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+    await waitFor(() => expect(checkAuth).toHaveBeenCalledTimes(2));
+    // Neither the stale api-key rejection nor a subscription failure is shown.
+    expect(screen.queryByText('Login not found')).not.toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+
+    // Once the new probe resolves under the new method, the correct verdict shows.
+    releaseSecond({ status: 'unauthenticated', authenticated: false, method: 'none' });
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
+  });
+
+  it('saves an OpenAI API key through the API-key pane', async () => {
+    const onSaveField = vi.fn(async () => undefined);
+    render(<Harness initialMethod="api_key" onSaveField={onSaveField} />);
+
+    const input = screen.getByPlaceholderText('sk-proj-...');
+    fireEvent.change(input, { target: { value: 'sk-proj-abc123' } });
+    // Two "Save" buttons render (key + base URL); the key field is first.
+    const saveButtons = screen.getAllByText('Save').map((el) => el.closest('button'));
+    fireEvent.click(saveButtons[0] as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(onSaveField).toHaveBeenCalledWith('OPENAI_API_KEY', 'sk-proj-abc123')
+    );
+  });
+
+  it('starts the device flow deliberately (no OpenAI request on mere tab view)', async () => {
+    const deviceFind = vi.fn(async () => ({ phase: 'idle' }));
+    const deviceCreate = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'ABCD-1234',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    }));
+    render(
+      <Harness initialMethod="subscription" deviceFind={deviceFind} deviceCreate={deviceCreate} />
+    );
+
+    clickText('Sign in with ChatGPT');
+
+    // Deliberate-start: a code is only requested after an explicit click.
+    expect(await screen.findByText('Get a sign-in code')).toBeInTheDocument();
+    expect(deviceCreate).not.toHaveBeenCalled();
+
+    clickText('Get a sign-in code');
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('ABCD-1234')).toBeInTheDocument();
+  });
+
+  it('switches methods as a pure view — no selection persists a credential', async () => {
+    // Selecting a tab is never destructive: the method follows the credential
+    // you configure, so no key-save/clear is triggered by mere navigation.
+    const onSaveField = vi.fn(async () => undefined);
+    const onClearField = vi.fn(async () => undefined);
+    render(
+      <Harness initialMethod="api_key" onSaveField={onSaveField} onClearField={onClearField} />
+    );
+
+    clickText('Sign in with ChatGPT');
+    expect(await screen.findByText(/Sign in with your ChatGPT account/i)).toBeInTheDocument();
+    clickText('Import login file');
+    expect(await screen.findByLabelText('Codex auth.json contents')).toBeInTheDocument();
+    clickText('API key');
+    expect(await screen.findByPlaceholderText('sk-proj-...')).toBeInTheDocument();
+
+    expect(onSaveField).not.toHaveBeenCalled();
+    expect(onClearField).not.toHaveBeenCalled();
+  });
+
+  it('opening the API-key tab from a subscription login is non-destructive (no silent break)', async () => {
+    // Regression guard: a user with a working ChatGPT login who clicks "API key"
+    // to look at the fields must not have their login deactivated. The pane
+    // exposes no method-flip callback, and selection triggers no persistence.
+    const onSaveField = vi.fn(async () => undefined);
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'native',
+      })
+    );
+    render(
+      <Harness initialMethod="subscription" checkAuth={checkAuth} onSaveField={onSaveField} />
+    );
+
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+    expect(screen.getByText('A ChatGPT login is active on this server.')).toBeInTheDocument();
+
+    clickText('API key');
+    expect(await screen.findByPlaceholderText('sk-proj-...')).toBeInTheDocument();
+    // The login banner is unaffected — nothing was persisted or re-probed away.
+    expect(screen.getByText('Codex is connected')).toBeInTheDocument();
+    expect(onSaveField).not.toHaveBeenCalled();
+  });
+
+  it('does not adopt a stale success in settings — re-signing-in stays reachable', async () => {
+    // A device sign-in that succeeded within the daemon's adopt-TTL must not
+    // wall off the management surface: the deliberate-start button remains.
+    const deviceFind = vi.fn(async () => ({ phase: 'success', hint: 'Signed in with ChatGPT.' }));
+    const deviceCreate = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'WXYZ-9876',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    }));
+    render(
+      <Harness initialMethod="subscription" deviceFind={deviceFind} deviceCreate={deviceCreate} />
+    );
+
+    clickText('Sign in with ChatGPT');
+    // Success is not adopted (autoStart=false) — the restart button shows instead.
+    expect(await screen.findByText('Get a sign-in code')).toBeInTheDocument();
+    expect(screen.queryByText('Signed in with ChatGPT.')).not.toBeInTheDocument();
+
+    clickText('Get a sign-in code');
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('WXYZ-9876')).toBeInTheDocument();
+  });
+
+  it('imports a pasted login file and re-probes the connection', async () => {
+    const importCreate = vi.fn(async () => ({ status: 'authenticated', authMode: 'chatgpt' }));
+    const checkAuth = vi
+      .fn<[], Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce(UNKNOWN)
+      .mockResolvedValue({ status: 'authenticated', authenticated: true, method: 'native' });
+    render(
+      <Harness initialMethod="subscription" importCreate={importCreate} checkAuth={checkAuth} />
+    );
+
+    clickText('Import login file');
+    const pasted = '{"tokens":{"refresh_token":"r"}}';
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: pasted },
+    });
+    clickText('Import login');
+
+    await waitFor(() => expect(importCreate).toHaveBeenCalledWith({ authJson: pasted }));
+    // onImported triggers a fresh probe, which now reports connected.
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+  });
+
+  it('shows the daemon rejection message when an imported login file is invalid', async () => {
+    const importCreate = vi.fn(async () => {
+      throw new Error('This file has no ChatGPT login tokens and no API key.');
+    });
+    render(<Harness initialMethod="subscription" importCreate={importCreate} />);
+
+    clickText('Import login file');
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: '{"tokens":{}}' },
+    });
+    clickText('Import login');
+
+    expect(
+      await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -1,0 +1,284 @@
+import type {
+  AgenticAuthMethod,
+  AgenticToolConfigField,
+  AgorClient,
+  AuthCheckResult,
+} from '@agor-live/client';
+import { Alert, Button, Segmented, Space, Typography, theme } from 'antd';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { type AgenticToolFieldConfig, ApiKeyFields, type FieldStatus } from '../ApiKeyFields';
+import { type CodexAuthFallback, CodexDeviceSignIn } from './CodexDeviceSignIn';
+import { CodexImportAuthJson } from './CodexImportAuthJson';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+/**
+ * Which sub-pane the management surface is showing. The persisted auth method is
+ * only two-valued (`api_key` | `subscription`) because "sign in with ChatGPT"
+ * and "import auth.json" both land the same server-side ChatGPT login — so the
+ * two subscription entry points are distinguished here as a local view choice.
+ */
+type CodexMethodView = 'api_key' | 'chatgpt' | 'import';
+
+function viewForMethod(method: AgenticAuthMethod, prev: CodexMethodView): CodexMethodView {
+  if (method === 'api_key') return 'api_key';
+  return prev === 'import' ? 'import' : 'chatgpt';
+}
+
+export interface CodexAuthSettingsProps {
+  client: AgorClient | null;
+  /**
+   * Persisted Codex auth method for this user. Read-only here: the method is a
+   * consequence of the credential you configure (saving an OpenAI key flips it
+   * to `api_key`; a completed device sign-in / import flips it to
+   * `subscription` daemon-side), never of merely selecting a tab — so switching
+   * views can't silently deactivate a working login.
+   */
+  authMethod: AgenticAuthMethod;
+  /** Codex credential field definitions (OpenAI key + base URL). */
+  apiKeyFields: AgenticToolFieldConfig[];
+  /** Per-field set/unset flags for the API-key pane. */
+  fieldStatus: FieldStatus;
+  onSaveField: (field: AgenticToolConfigField, value: string) => Promise<void>;
+  onClearField: (field: AgenticToolConfigField) => Promise<void>;
+  savingFields: Partial<Record<AgenticToolConfigField, boolean>>;
+  publicValues?: Partial<Record<AgenticToolConfigField, string>>;
+}
+
+/**
+ * Codex authentication management pane — the three ways in (API key, ChatGPT
+ * device sign-in, imported login file) plus a live connection probe. Unlike the
+ * onboarding wizard, this is a management view: re-signing-in or re-importing
+ * stays reachable while connected, and a stored-but-broken credential surfaces
+ * as a prominent error rather than being hidden behind a "connected" collapse.
+ */
+export function CodexAuthSettings({
+  client,
+  authMethod,
+  apiKeyFields,
+  fieldStatus,
+  onSaveField,
+  onClearField,
+  savingFields,
+  publicValues,
+}: CodexAuthSettingsProps) {
+  const { token } = useToken();
+  const [view, setView] = useState<CodexMethodView>(() => viewForMethod(authMethod, 'chatgpt'));
+  const [probe, setProbe] = useState<AuthCheckResult | null>(null);
+  const [probing, setProbing] = useState(false);
+
+  // Keep the visible sub-pane in step with the persisted method (e.g. a
+  // successful device/import flips it to subscription), while preserving which
+  // subscription entry point the user is looking at.
+  useEffect(() => {
+    setView((prev) => viewForMethod(authMethod, prev));
+  }, [authMethod]);
+
+  // A transport failure is NOT proof of a missing login — leave the prior
+  // verdict untouched on error so the pane never flashes a false "not
+  // connected" state (mirrors App.handleCheckAuth's fail-safe contract).
+  // A monotonic generation guards against overlapping probes (a method switch
+  // mid-recheck): only the latest request commits its verdict or clears the
+  // spinner, so an older response can't land last and mislabel the banner.
+  const probeGenRef = useRef(0);
+  // Bump the generation synchronously when the client OR the effective method
+  // changes (and on unmount), before any in-flight probe can resolve, and clear
+  // the prior verdict. Two reasons a stale verdict must not survive a change:
+  //  - client swap: an old identity's probe still owns the current generation
+  //    in the window before the next probe starts (and if the replacement
+  //    client is null, runProbe returns before incrementing, so the stale
+  //    request would never be invalidated).
+  //  - method flip: a verdict captured under the PREVIOUS method must not be
+  //    re-interpreted by the banner under the new one — e.g. a rejected api-key
+  //    probe becoming a false "Login not found" after a ChatGPT sign-in flips
+  //    the method to subscription (and persisting there if the re-probe then
+  //    fails, since transport failures keep the last verdict). Clearing to null
+  //    means the banner shows nothing until a verdict for the NEW method lands.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: client/authMethod are the change triggers; the body invalidates rather than reading them.
+  useLayoutEffect(() => {
+    probeGenRef.current++;
+    setProbe(null);
+    setProbing(false);
+    // Invalidate on unmount from the layout cleanup (synchronous, during the
+    // commit) — a passive cleanup can be deferred past unmount, letting a
+    // settled probe commit its verdict/spinner after teardown.
+    return () => {
+      probeGenRef.current++;
+    };
+  }, [client, authMethod]);
+  const runProbe = useCallback(async () => {
+    if (!client) return;
+    const gen = ++probeGenRef.current;
+    setProbing(true);
+    try {
+      const result = (await client
+        .service('check-auth')
+        .create({ tool: 'codex' })) as AuthCheckResult;
+      if (probeGenRef.current === gen) setProbe(result);
+    } catch {
+      // Unknown — keep the last verdict.
+    } finally {
+      if (probeGenRef.current === gen) setProbing(false);
+    }
+  }, [client]);
+
+  // Re-probe when the persisted method changes: the daemon checks whichever
+  // credential the server's active method points at, so a verdict captured for
+  // the previous method would otherwise be mislabelled by the banner.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authMethod is a deliberate re-probe trigger, not a value read by runProbe.
+  useEffect(() => {
+    void runProbe();
+  }, [runProbe, authMethod]);
+
+  // Device sign-in and login-file import both persist `subscription` daemon-side
+  // as part of the flow, so here we only re-probe to refresh the banner.
+  const handleAuthenticated = useCallback(() => {
+    void runProbe();
+  }, [runProbe]);
+
+  // Selecting a method is a pure view switch — it never persists the auth
+  // method. Persisting on selection is destructive in BOTH directions: choosing
+  // a subscription view would deactivate a working API key before a ChatGPT
+  // login exists, and choosing "API key" would deactivate a working ChatGPT
+  // login before any key is stored (a silent, non-undoable break). The method
+  // instead follows the credential you actually configure — saving a key flips
+  // it to api_key; a completed device/import flips it to subscription.
+  const handleFallback = useCallback((target: CodexAuthFallback) => {
+    setView(target === 'import' ? 'import' : 'api_key');
+  }, []);
+
+  const handleSelect = useCallback((next: CodexMethodView) => {
+    setView(next);
+  }, []);
+
+  // The banner reflects the EFFECTIVE auth — the persisted method plus a probe
+  // of that method's credential — never the currently-viewed tab. Crucially, a
+  // "connected" verdict is only shown when the probe actually exercised the
+  // stored method: an authenticated api-key probe can't render "ChatGPT login
+  // active" and an authenticated login probe can't render "API key working".
+  // This makes the sessions-broken-but-banner-says-connected contradiction
+  // impossible even if the daemon's probe ever reported a credential the
+  // executor wouldn't use for the stored method.
+  const connectionBanner = (() => {
+    if (!probe) return null;
+    const authenticated = probe.status === 'authenticated';
+    const unauthenticated = probe.status === 'unauthenticated';
+    if (authMethod === 'subscription') {
+      if (authenticated && probe.method !== 'api-key') {
+        return (
+          <Alert
+            type="success"
+            showIcon
+            message="Codex is connected"
+            description="A ChatGPT login is active on this server."
+          />
+        );
+      }
+      if (unauthenticated) {
+        return (
+          <Alert
+            type="error"
+            showIcon
+            message="Login not found"
+            description={
+              probe.hint ??
+              'Codex login no longer found on this server — sign in with ChatGPT or import it again.'
+            }
+          />
+        );
+      }
+      return null;
+    }
+    // authMethod === 'api_key': the effective credential is the OpenAI key.
+    if (authenticated && probe.method === 'api-key') {
+      return (
+        <Alert
+          type="success"
+          showIcon
+          message="Codex is connected"
+          description="Your OpenAI API key is working."
+        />
+      );
+    }
+    // Only a stored-but-rejected key is worth flagging; an empty key just means
+    // the user hasn't set one yet (and a login on disk is irrelevant here —
+    // sessions use the api_key method, not that login).
+    if (unauthenticated && fieldStatus.OPENAI_API_KEY) {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          message="Key not working"
+          description={probe.hint ?? 'Key stored but not working — enter a new one.'}
+        />
+      );
+    }
+    // 'unknown', or authenticated via a credential the stored method won't use,
+    // or unset-and-empty — surface nothing (fail safe).
+    return null;
+  })();
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Text type="secondary">
+        Personal credentials are encrypted at rest and injected only into the agent runtime.
+      </Text>
+
+      {connectionBanner && (
+        <Space direction="vertical" size="small" style={{ width: '100%' }}>
+          {connectionBanner}
+          <Button
+            type="link"
+            size="small"
+            loading={probing}
+            onClick={() => void runProbe()}
+            style={{ paddingInline: 0 }}
+          >
+            Recheck connection
+          </Button>
+        </Space>
+      )}
+
+      <Segmented<CodexMethodView>
+        block
+        value={view}
+        onChange={handleSelect}
+        options={[
+          { label: 'API key', value: 'api_key' },
+          { label: 'Sign in with ChatGPT', value: 'chatgpt' },
+          { label: 'Import login file', value: 'import' },
+        ]}
+      />
+
+      {view === 'api_key' && (
+        <ApiKeyFields
+          tool="codex"
+          fields={apiKeyFields}
+          fieldStatus={fieldStatus}
+          onSave={onSaveField}
+          onClear={onClearField}
+          saving={savingFields}
+          publicValues={publicValues}
+        />
+      )}
+      {view === 'chatgpt' && (
+        <div>
+          <Text type="secondary" style={{ display: 'block', marginBottom: token.marginSM }}>
+            Sign in with your ChatGPT account — no OpenAI API key stored in Agor. The login is
+            shared per server user, so signing in replaces any Codex login already on this server.
+          </Text>
+          <CodexDeviceSignIn
+            client={client}
+            onVerified={handleAuthenticated}
+            onUseFallback={handleFallback}
+            autoStart={false}
+          />
+        </div>
+      )}
+      {view === 'import' && (
+        <CodexImportAuthJson client={client} onImported={handleAuthenticated} />
+      )}
+    </Space>
+  );
+}

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
@@ -1,0 +1,321 @@
+import type { AgorClient, CodexDeviceAuthStatus } from '@agor-live/client';
+import { CheckCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { Alert, Button, Typography, theme } from 'antd';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+/**
+ * Where a gated ChatGPT account can go instead of device sign-in. Kept neutral
+ * (not tied to any one surface's method enum) so both the onboarding wizard and
+ * the settings pane can map it onto their own auth-method state.
+ */
+export type CodexAuthFallback = 'import' | 'api-key';
+
+const DEVICE_STATUS_POLL_MS = 2000;
+
+function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(Math.floor(remainingMs / 1000), 0);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+export interface CodexDeviceSignInProps {
+  client: AgorClient | null;
+  /** Fired once the daemon confirms tokens were saved for this user. */
+  onVerified: () => void;
+  /** Switch to another codex auth method (gated-account fallback). */
+  onUseFallback: (target: CodexAuthFallback) => void;
+  /**
+   * Request a code as soon as the pane mounts. The onboarding wizard reveals
+   * this pane only on an explicit "Sign in with ChatGPT" choice, so eager start
+   * is right there. A management surface (settings) mounts it as one tab among
+   * several, so it defaults to a deliberate button press instead of firing an
+   * OpenAI device request every time the tab is viewed. A still-live *pending*
+   * attempt is always adopted regardless of this flag; a terminal *success* is
+   * adopted only when autoStart is true (the wizard, which reflects the verified
+   * state after toggling away and back). A management surface tells its
+   * connection story via a separate probe, so it must not adopt a stale success
+   * — that would wall off re-signing-in until the daemon prunes the attempt.
+   */
+  autoStart?: boolean;
+}
+
+/**
+ * Self-contained device-code pane: requests a code, shows it with the
+ * verification link and a countdown, and polls the daemon for approval.
+ * Memoized with its own state so the 1s countdown and 2s status polls
+ * re-render only this pane, never the surface that hosts it.
+ */
+export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
+  client,
+  onVerified,
+  onUseFallback,
+  autoStart = true,
+}: CodexDeviceSignInProps) {
+  const { token } = useToken();
+  const [status, setStatus] = useState<CodexDeviceAuthStatus>({ phase: 'idle' });
+  const [starting, setStarting] = useState(false);
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+
+  const deviceService = useMemo(
+    () =>
+      client
+        ? (client.service('codex-auth/device') as unknown as {
+            create(data: Record<string, never>): Promise<unknown>;
+            find(): Promise<unknown>;
+          })
+        : null,
+    [client]
+  );
+
+  // Tracks the service the pane currently talks to, so an in-flight
+  // requestCode issued against a swapped-out client can't land its state
+  // updates over the replacement's. A layout effect syncs the identity
+  // before paint and before the passive effects below; resetting `starting`
+  // here matters because a stale request's guarded finally deliberately
+  // won't clear it, and a replacement that ADOPTS an attempt never calls
+  // requestCode — without the reset the spinner would cover a live code.
+  // Reset status/countdown too: a client/identity swap must not leave the
+  // previous client's pending code (and its polling loop) on screen — the
+  // adopt-or-request effect below then decides what THIS service should show.
+  // Without this, an autoStart=false surface that doesn't re-request would
+  // keep displaying and polling the old code against the new service.
+  const latestServiceRef = useRef(deviceService);
+  useLayoutEffect(() => {
+    latestServiceRef.current = deviceService;
+    setStarting(false);
+    setStatus({ phase: 'idle' });
+    setRemainingMs(null);
+  }, [deviceService]);
+
+  const requestCode = useCallback(async () => {
+    if (!deviceService) return;
+    setStarting(true);
+    try {
+      const next = (await deviceService.create({})) as CodexDeviceAuthStatus;
+      if (latestServiceRef.current !== deviceService) return;
+      setStatus(next);
+    } catch (err) {
+      if (latestServiceRef.current !== deviceService) return;
+      setStatus({
+        phase: 'error',
+        hint:
+          err instanceof Error && err.message
+            ? err.message
+            : 'Could not start the ChatGPT sign-in — try again.',
+      });
+    } finally {
+      if (latestServiceRef.current === deviceService) setStarting(false);
+    }
+  }, [deviceService]);
+
+  // On mount (and on client swap), adopt a still-live attempt (user toggled
+  // away and back) instead of burning a fresh code; otherwise request one.
+  // Continuations are guarded by both `cancelled` (StrictMode / normal cleanup)
+  // and the service ref: React runs the client-swap layout reset before this
+  // effect's cleanup, so a stale find() resolving in that window must not
+  // restore the previous client's code — matching requestCode's own guard.
+  useEffect(() => {
+    if (!deviceService) return;
+    let cancelled = false;
+    const stillCurrent = () => !cancelled && latestServiceRef.current === deviceService;
+    void (async () => {
+      try {
+        const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (!stillCurrent()) return;
+        // Adopt a live pending attempt always; adopt a terminal success only for
+        // eager (wizard) mounts — a management surface must stay able to restart.
+        if (existing.phase === 'pending' || (existing.phase === 'success' && autoStart)) {
+          setStatus(existing);
+          return;
+        }
+      } catch {
+        // No adoptable attempt — fall through to a fresh request.
+      }
+      if (stillCurrent() && autoStart) await requestCode();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceService, requestCode, autoStart]);
+
+  // Poll while pending; terminal phases stop the loop. A self-scheduling
+  // timeout (next poll armed only after the previous response lands) keeps
+  // slow responses from overlapping and regressing a terminal phase with an
+  // out-of-order pending. Identity-preserving setState keeps unchanged polls
+  // from re-rendering even this pane.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !deviceService) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
+      try {
+        const next = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (cancelled || latestServiceRef.current !== deviceService) return;
+        setStatus((prev) =>
+          prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
+            ? prev
+            : next
+        );
+      } catch {
+        // Transient — keep polling until the code expires.
+      }
+      if (!cancelled) timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    };
+    timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [status.phase, deviceService]);
+
+  // 1s countdown while a code is live.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !status.expiresAt) {
+      setRemainingMs(null);
+      return;
+    }
+    const expiresAtMs = Date.parse(status.expiresAt);
+    const update = () => setRemainingMs(Math.max(expiresAtMs - Date.now(), 0));
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [status.phase, status.expiresAt]);
+
+  useEffect(() => {
+    if (status.phase === 'success') onVerified();
+  }, [status.phase, onVerified]);
+
+  if (starting || (status.phase === 'idle' && autoStart)) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 14 }} />
+        <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
+          {client ? 'Getting your sign-in code…' : 'Waiting for the server connection…'}
+        </Text>
+      </div>
+    );
+  }
+
+  // Deliberate-start surfaces (autoStart=false) with no adoptable attempt: offer
+  // the button rather than firing an OpenAI device request on mount.
+  if (status.phase === 'idle') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0' }}>
+        <Button type="primary" disabled={!client} onClick={requestCode}>
+          Get a sign-in code
+        </Button>
+        {!client && (
+          <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
+            Waiting for the server connection…
+          </Text>
+        )}
+      </div>
+    );
+  }
+
+  if (status.phase === 'pending') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+        <Text style={{ color: token.colorTextSecondary, fontSize: 13 }}>
+          Open the link below, sign in to ChatGPT, and enter this one-time code:
+        </Text>
+        <Text
+          copyable
+          aria-label="ChatGPT sign-in code"
+          style={{
+            color: token.colorText,
+            fontFamily: 'monospace',
+            fontSize: 26,
+            fontWeight: 600,
+            letterSpacing: 4,
+          }}
+        >
+          {status.userCode}
+        </Text>
+        {status.verificationUrl && (
+          <Typography.Link
+            href={status.verificationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: 13 }}
+          >
+            Open {status.verificationUrl} →
+          </Typography.Link>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
+          <Text style={{ color: token.colorTextTertiary, fontSize: 12 }}>
+            Waiting for approval — we finish automatically once you approve.
+            {remainingMs !== null && ` Code expires in ${formatCountdown(remainingMs)}.`}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  if (status.phase === 'success') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 14 }} />
+        <Text style={{ color: token.colorSuccess, fontSize: 13 }}>
+          {status.hint ?? 'Signed in with ChatGPT.'}
+        </Text>
+      </div>
+    );
+  }
+
+  if (status.phase === 'unavailable') {
+    return (
+      <Alert
+        type="warning"
+        showIcon
+        style={{ fontSize: 12 }}
+        message="Device sign-in is turned off for this ChatGPT account"
+        description={
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <span>
+              Personal accounts: enable it under ChatGPT Settings → Security → “Device code
+              authorization for Codex”, then try again. Workspace accounts: a workspace admin has to
+              enable it. Either way, the two options below work right now.
+            </span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              <Button size="small" onClick={() => onUseFallback('import')}>
+                Paste a login file
+              </Button>
+              <Button size="small" onClick={() => onUseFallback('api-key')}>
+                Use an API key
+              </Button>
+              <Button size="small" type="text" onClick={requestCode}>
+                Try again
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    );
+  }
+
+  // expired / error
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+      <Alert
+        type={status.phase === 'expired' ? 'warning' : 'error'}
+        showIcon
+        style={{ fontSize: 12 }}
+        message={
+          status.hint ??
+          (status.phase === 'expired' ? 'The sign-in code expired.' : 'The ChatGPT sign-in failed.')
+        }
+      />
+      <div>
+        <Button size="small" onClick={requestCode}>
+          Get a new code
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -1,0 +1,132 @@
+import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
+import { Alert, Button, Input, Space, Typography, theme } from 'antd';
+import { memo, useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+export interface CodexImportAuthJsonProps {
+  client: AgorClient | null;
+  /**
+   * Fired after the daemon accepts the pasted login and persists it. The pasted
+   * token material is already dropped from this component's state by the time
+   * this runs — the surface follows up (advance a step, re-probe status) without
+   * ever holding the secret itself.
+   */
+  onImported: (result: CodexAuthImportResult) => void;
+  /** Label for the submit action; surfaces frame it differently. */
+  submitLabel?: string;
+}
+
+/**
+ * Self-contained pane for pasting a `~/.codex/auth.json` login file and handing
+ * it to the daemon. Owns its own paste value, submit, and error state so a
+ * rejected import never leaks into the hosting surface's form state, and so the
+ * secret is cleared from memory the moment the daemon confirms it landed.
+ */
+export const CodexImportAuthJson = memo(function CodexImportAuthJson({
+  client,
+  onImported,
+  submitLabel = 'Import login',
+}: CodexImportAuthJsonProps) {
+  const { token } = useToken();
+  const [authJson, setAuthJson] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // A client/identity swap (or unmount) must never carry a pasted secret across
+  // it, nor let an import in flight against the old client apply to — or lock —
+  // the replacement. A generation bumped synchronously on client change (before
+  // the old request can resolve) invalidates any in-flight submit; the swap also
+  // drops the paste value and releases the submit lock so the new identity can
+  // import right away. The unmount bump prevents a settled request from calling
+  // setState after teardown.
+  const submitGenRef = useRef(0);
+  // Invalidate any in-flight submit synchronously whenever the client changes
+  // OR the pane unmounts. A layout effect (setup + cleanup) runs during the
+  // commit phase, before a settled request's continuation could — a passive
+  // cleanup can be deferred past unmount, letting a stale success still fire
+  // onImported/setState after teardown. Setup also drops the pasted secret and
+  // releases the submit lock so the replacement identity can import at once.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: client is the change trigger; the body invalidates/clears rather than reading it.
+  useLayoutEffect(() => {
+    submitGenRef.current++;
+    setAuthJson('');
+    setError(null);
+    setSubmitting(false);
+    return () => {
+      submitGenRef.current++;
+    };
+  }, [client]);
+
+  const handleImport = useCallback(async () => {
+    if (!client || !authJson.trim() || submitting) return;
+    const gen = ++submitGenRef.current;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = (await client
+        .service('codex-auth/import')
+        .create({ authJson })) as CodexAuthImportResult;
+      // Superseded by a client swap or unmount mid-flight — this result belongs
+      // to the old identity; drop it rather than clearing the replacement's pane
+      // or firing onImported as though it applied here.
+      if (submitGenRef.current !== gen) return;
+      // Drop the pasted token material as soon as the daemon has it — nothing
+      // here needs it after a successful import.
+      setAuthJson('');
+      onImported(result);
+    } catch (err) {
+      if (submitGenRef.current !== gen) return;
+      setError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Could not import the Codex login — try again.'
+      );
+    } finally {
+      if (submitGenRef.current === gen) setSubmitting(false);
+    }
+  }, [authJson, client, onImported, submitting]);
+
+  return (
+    <Space direction="vertical" size="small" style={{ width: '100%' }}>
+      <Alert
+        type="info"
+        showIcon
+        style={{ fontSize: token.fontSizeSM }}
+        message={
+          <span>
+            Already use Codex on your own machine? Its credential file lives there at{' '}
+            <Text code>~/.codex/auth.json</Text>. On that machine, print it with{' '}
+            <Text code>cat ~/.codex/auth.json</Text> and paste the whole thing below — this replaces
+            the Codex login already stored on this server, which in shared setups is one login for
+            the whole server, not one per person. Or skip the copy-paste entirely: open a branch
+            terminal on this server and run <Text code>codex login --device-auth</Text>.
+          </span>
+        }
+      />
+      <Input.Password
+        aria-label="Codex auth.json contents"
+        placeholder="Paste the JSON from ~/.codex/auth.json…"
+        value={authJson}
+        onChange={(e) => {
+          setAuthJson(e.target.value);
+          setError(null);
+        }}
+        onPressEnter={handleImport}
+        style={{ fontFamily: 'monospace', fontSize: token.fontSizeSM }}
+      />
+      <Button
+        type="primary"
+        loading={submitting}
+        disabled={!client || !authJson.trim()}
+        onClick={handleImport}
+      >
+        {submitLabel}
+      </Button>
+      {error && (
+        <Alert type="error" showIcon message={error} style={{ fontSize: token.fontSizeSM }} />
+      )}
+    </Space>
+  );
+});

--- a/apps/agor-ui/src/components/CodexAuth/index.ts
+++ b/apps/agor-ui/src/components/CodexAuth/index.ts
@@ -1,0 +1,7 @@
+export { CodexAuthSettings, type CodexAuthSettingsProps } from './CodexAuthSettings';
+export {
+  type CodexAuthFallback,
+  CodexDeviceSignIn,
+  type CodexDeviceSignInProps,
+} from './CodexDeviceSignIn';
+export { CodexImportAuthJson, type CodexImportAuthJsonProps } from './CodexImportAuthJson';

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
@@ -63,6 +63,53 @@ describe('OnboardingBanners probe effect', () => {
     await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
   });
 
+  it('re-probes and clears the banner when a Codex subscription login lands via a user patch (no remount)', async () => {
+    // The daemon device-sign-in / auth.json-import flows persist
+    // agentic_auth_methods.codex server-side; it arrives as a user patch with no
+    // stored key and no credentialVersion bump — the case that previously left
+    // the banner stuck until a page refresh.
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+    await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
+    const callsBefore = onCheckAuth.mock.calls.length;
+
+    onCheckAuth.mockImplementation(async () => result('authenticated'));
+    rerender(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', {
+            agentic_auth_methods: { codex: 'subscription' },
+          } as Partial<User>),
+          onCheckAuth,
+        })}
+      />
+    );
+
+    // Same identity → same component instance (no remount); the method-marker
+    // dep change re-fires the probe, which now clears the banner.
+    await waitFor(() => expect(screen.queryByText(/No AI connected/)).not.toBeInTheDocument());
+    expect(onCheckAuth.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('does not re-probe on an unrelated user-record patch (e.g. a name edit)', async () => {
+    const onCheckAuth = vi.fn(async () => result('authenticated'));
+    const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(1));
+
+    // A field that touches neither identity, stored keys, nor auth methods must
+    // NOT spawn another ~5–10s probe.
+    rerender(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', { name: 'Renamed' } as Partial<User>),
+          onCheckAuth,
+        })}
+      />
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onCheckAuth).toHaveBeenCalledTimes(1);
+  });
+
   it('treats CLAUDE_CODE_OAUTH_TOKEN in user env vars as Claude auth (probes claude-code, no banner)', async () => {
     const onCheckAuth = vi.fn(async () => result('authenticated'));
     render(

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -108,11 +108,25 @@ export function OnboardingBanners({
   const credentialOwner = preferredCredentialOwner(probeSettings);
   const canManageWorkspaceCredentials = user?.role === 'admin' || user?.role === 'superadmin';
 
+  // Auth-method markers for the subscription/native paths (ChatGPT device
+  // sign-in, imported Codex login, Claude subscription token). These land
+  // server-side via their own services and flow back on the users `patched`
+  // event WITHOUT a stored key or a credentialVersion bump — so hasLlm alone
+  // can't see them. They are primitives ('api_key' | 'subscription' |
+  // undefined) that change only on a genuine method flip, never on unrelated
+  // user-record patches, keeping the ~5–10s probe from firing on name/emoji
+  // edits. `agentic_auth_methods` only ever carries these two tools.
+  const codexAuthMethod = user?.agentic_auth_methods?.codex;
+  const claudeAuthMethod = user?.agentic_auth_methods?.['claude-code'];
+
   // One probe (plus a bounded fallback) per identity/credential change. Deps are
   // primitives/stable so the effect never re-fires on board navigation or
   // unrelated re-renders of the persistent App shell — each claude-code probe
   // spawns a ~5–10s subprocess. userId resets stale state on a user switch;
-  // credentialVersion is a trigger-only dep re-probing after a credential save.
+  // credentialVersion is a trigger-only dep re-probing after a legacy key save;
+  // codexAuthMethod/claudeAuthMethod re-probe after a subscription/native login
+  // lands server-side (device sign-in, auth.json import) — paths that bump
+  // neither hasLlm nor credentialVersion — and cover a second browser tab too.
   // biome-ignore lint/correctness/useExhaustiveDependencies: credentialVersion is an intentional trigger dep
   useEffect(() => {
     if (!onboardingCompleted) {
@@ -135,7 +149,16 @@ export function OnboardingBanners({
     return () => {
       cancelled = true;
     };
-  }, [userId, onboardingCompleted, probeAgent, hasLlm, onCheckAuth, credentialVersion]);
+  }, [
+    userId,
+    onboardingCompleted,
+    probeAgent,
+    hasLlm,
+    onCheckAuth,
+    credentialVersion,
+    codexAuthMethod,
+    claudeAuthMethod,
+  ]);
 
   const decision = decideBanner({
     onboardingCompleted,

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -499,3 +499,85 @@ describe('OnboardingWizard', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Codex ChatGPT login import', () => {
+  // Client harness whose codex-auth/import service is controllable per test.
+  function renderWithCodexImport(create: ReturnType<typeof vi.fn>) {
+    const boardsService = {
+      create: vi.fn(async () => ({ board_id: 'board-1', created_by: 'user-1' })),
+    };
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) =>
+        name === 'boards' ? boardsService : name === 'codex-auth/import' ? { create } : {}
+      ),
+    };
+    const rendered = renderWizard({ initialStep: 'llm', client: client as never });
+    return { ...rendered, importCreate: create };
+  }
+
+  it('offers an auth-method toggle for GPT and reveals the paste flow with inline help', async () => {
+    renderWizard({ initialStep: 'llm' });
+
+    clickButton('GPT');
+    expect(screen.getByText('ChatGPT login')).toBeInTheDocument();
+
+    clickButton('ChatGPT login');
+    expect(screen.getByLabelText('Codex auth.json contents')).toBeInTheDocument();
+    // Inline help: where the file lives, how to print it, and the overwrite caveat.
+    expect(screen.getByText(/cat ~\/\.codex\/auth\.json/)).toBeInTheDocument();
+    expect(screen.getByText(/replaces any Codex login/i)).toBeInTheDocument();
+    // No API-key format validation applies to a pasted file.
+    expect(screen.queryByText(/OpenAI keys start with/i)).not.toBeInTheDocument();
+  });
+
+  it('submits the pasted auth.json to the daemon and advances on success', async () => {
+    const create = vi.fn(async () => ({ status: 'authenticated', authMode: 'chatgpt' }));
+    const { importCreate } = renderWithCodexImport(create);
+
+    clickButton('GPT');
+    clickButton('ChatGPT login');
+    const pasted = JSON.stringify({ OPENAI_API_KEY: null, tokens: { refresh_token: 'r' } });
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: pasted },
+    });
+    clickButton(/^connect →/i);
+
+    await waitFor(() => expect(importCreate).toHaveBeenCalledWith({ authJson: pasted }));
+    expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
+  });
+
+  it('shows the daemon rejection message and stays on the LLM step', async () => {
+    const create = vi.fn(async () => {
+      throw new Error('This file has no ChatGPT login tokens and no API key.');
+    });
+    renderWithCodexImport(create);
+
+    clickButton('GPT');
+    clickButton('ChatGPT login');
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: '{"tokens":{}}' },
+    });
+    clickButton(/^connect →/i);
+
+    expect(
+      await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Connect your AI')).toBeInTheDocument();
+    expect(screen.queryByText('Name your AI teammate')).not.toBeInTheDocument();
+  });
+
+  it('switching auth methods clears the pasted value and error state', async () => {
+    renderWizard({ initialStep: 'llm' });
+
+    clickButton('GPT');
+    clickButton('ChatGPT login');
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: '{"a":1}' },
+    });
+
+    clickButton('API key');
+    const keyInput = screen.getByLabelText('OpenAI API key') as HTMLInputElement;
+    expect(keyInput.value).toBe('');
+  });
+});

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -568,16 +568,27 @@ describe('Codex ChatGPT login import', () => {
   });
 
   it('switching auth methods clears the pasted value and error state', async () => {
-    renderWizard({ initialStep: 'llm' });
+    const create = vi.fn(async () => {
+      throw new Error('This file has no ChatGPT login tokens and no API key.');
+    });
+    renderWithCodexImport(create);
 
     clickButton('GPT');
     clickButton('ChatGPT login');
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"a":1}' },
     });
+    clickButton(/^connect →/i);
+    expect(
+      await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
+    ).toBeInTheDocument();
 
     clickButton('API key');
     const keyInput = screen.getByLabelText('OpenAI API key') as HTMLInputElement;
     expect(keyInput.value).toBe('');
+    // A stale rejection from the paste attempt must not linger on the API-key pane.
+    expect(
+      screen.queryByText(/This file has no ChatGPT login tokens and no API key\./)
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -526,7 +526,10 @@ describe('Codex ChatGPT login import', () => {
     expect(screen.getByLabelText('Codex auth.json contents')).toBeInTheDocument();
     // Inline help: where the file lives, how to print it, and the overwrite caveat.
     expect(screen.getByText(/cat ~\/\.codex\/auth\.json/)).toBeInTheDocument();
-    expect(screen.getByText(/replaces any Codex login/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/replaces the Codex login already stored on this server/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/one login for the whole server/i)).toBeInTheDocument();
     // No API-key format validation applies to a pasted file.
     expect(screen.queryByText(/OpenAI keys start with/i)).not.toBeInTheDocument();
   });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -520,9 +520,10 @@ describe('Codex ChatGPT login import', () => {
     renderWizard({ initialStep: 'llm' });
 
     clickButton('GPT');
-    expect(screen.getByText('ChatGPT login')).toBeInTheDocument();
+    expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+    expect(screen.getByText('Import auth.json')).toBeInTheDocument();
 
-    clickButton('ChatGPT login');
+    clickButton('Import auth.json');
     expect(screen.getByLabelText('Codex auth.json contents')).toBeInTheDocument();
     // Inline help: where the file lives, how to print it, and the overwrite caveat.
     expect(screen.getByText(/cat ~\/\.codex\/auth\.json/)).toBeInTheDocument();
@@ -539,12 +540,13 @@ describe('Codex ChatGPT login import', () => {
     const { importCreate } = renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('ChatGPT login');
+    clickButton('Import auth.json');
     const pasted = JSON.stringify({ OPENAI_API_KEY: null, tokens: { refresh_token: 'r' } });
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: pasted },
     });
-    clickButton(/^connect →/i);
+    // The import pane owns its own submit; success self-advances the wizard.
+    clickButton('Import login');
 
     await waitFor(() => expect(importCreate).toHaveBeenCalledWith({ authJson: pasted }));
     expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
@@ -557,11 +559,11 @@ describe('Codex ChatGPT login import', () => {
     renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('ChatGPT login');
+    clickButton('Import auth.json');
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"tokens":{}}' },
     });
-    clickButton(/^connect →/i);
+    clickButton('Import login');
 
     expect(
       await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
@@ -577,11 +579,11 @@ describe('Codex ChatGPT login import', () => {
     renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('ChatGPT login');
+    clickButton('Import auth.json');
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"a":1}' },
     });
-    clickButton(/^connect →/i);
+    clickButton('Import login');
     expect(
       await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
     ).toBeInTheDocument();
@@ -593,5 +595,148 @@ describe('Codex ChatGPT login import', () => {
     expect(
       screen.queryByText(/This file has no ChatGPT login tokens and no API key\./)
     ).not.toBeInTheDocument();
+  });
+
+  it('describes a broken ChatGPT login in subscription terms, not API-key terms', async () => {
+    // Stored method is subscription but the server-side auth.json is gone
+    // (wipe / `codex logout`) — the probe reports unauthenticated.
+    const onCheckAuth = vi.fn(async () => ({
+      status: 'unauthenticated' as const,
+      authenticated: false,
+    }));
+    renderWizard({
+      initialStep: 'llm',
+      user: makeUser({ agentic_auth_methods: { codex: 'subscription' } } as never),
+      onCheckAuth,
+    });
+
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+
+    clickButton('GPT');
+    expect(
+      await screen.findByText(/Codex login no longer found on this server/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Key stored but not working/)).not.toBeInTheDocument();
+  });
+});
+
+describe('Codex ChatGPT device sign-in', () => {
+  // Client harness with a controllable codex-auth/device service.
+  function renderWithDeviceService(overrides: {
+    create?: ReturnType<typeof vi.fn>;
+    find?: ReturnType<typeof vi.fn>;
+  }) {
+    const create =
+      overrides.create ??
+      vi.fn(async () => ({
+        phase: 'pending',
+        userCode: 'ABCD-1234',
+        verificationUrl: 'https://auth.openai.com/codex/device',
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      }));
+    const find = overrides.find ?? vi.fn(async () => ({ phase: 'idle' }));
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) =>
+        name === 'codex-auth/device' ? { create, find } : { create: vi.fn(), find: vi.fn() }
+      ),
+    };
+    const rendered = renderWizard({ initialStep: 'llm', client: client as never });
+    return { ...rendered, deviceCreate: create, deviceFind: find };
+  }
+
+  function openDevicePane() {
+    clickButton('GPT');
+    clickButton('Sign in with ChatGPT');
+  }
+
+  it('requests a code on selection and shows it with the verification link and expiry', async () => {
+    const { deviceCreate } = renderWithDeviceService({});
+    openDevicePane();
+
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('ABCD-1234')).toBeInTheDocument();
+    expect(screen.getByText(/auth\.openai\.com\/codex\/device/)).toBeInTheDocument();
+    expect(screen.getByText(/waiting for approval/i)).toBeInTheDocument();
+    expect(screen.getByText(/code expires in/i)).toBeInTheDocument();
+    // Approval has not happened — Connect stays disabled.
+    expect(screen.getByText(/^connect →/i).closest('button')).toBeDisabled();
+  });
+
+  it('advances once the daemon reports success', async () => {
+    const find = vi.fn().mockResolvedValueOnce({ phase: 'idle' }).mockResolvedValue({
+      phase: 'success',
+      planType: 'pro',
+      hint: 'Signed in with ChatGPT (pro plan).',
+    });
+    renderWithDeviceService({ find });
+    openDevicePane();
+
+    // The 2s status poll flips the pane to success.
+    expect(
+      await screen.findByText(/signed in with chatgpt \(pro plan\)/i, {}, { timeout: 5000 })
+    ).toBeInTheDocument();
+
+    // The pane reports success to the parent via effect — enablement lands a tick later.
+    await waitFor(() => expect(screen.getByText(/^connect →/i).closest('button')).toBeEnabled());
+    const connect = screen.getByText(/^connect →/i).closest('button');
+    fireEvent.click(connect as HTMLButtonElement);
+    expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
+  });
+
+  it('treats a gated account as a first-class state with working fallbacks', async () => {
+    const create = vi.fn(async () => ({
+      phase: 'unavailable',
+      hint: 'Your ChatGPT account does not allow device-code sign-in.',
+    }));
+    renderWithDeviceService({ create });
+    openDevicePane();
+
+    expect(
+      await screen.findByText(/device sign-in is turned off for this chatgpt account/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/device code authorization for codex/i)).toBeInTheDocument();
+
+    clickButton('Paste a login file');
+    expect(screen.getByLabelText('Codex auth.json contents')).toBeInTheDocument();
+  });
+
+  it('offers a fresh code after expiry', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({
+        phase: 'expired',
+        hint: 'The sign-in code expired — get a new one and try again.',
+      })
+      .mockResolvedValue({
+        phase: 'pending',
+        userCode: 'WXYZ-9876',
+        verificationUrl: 'https://auth.openai.com/codex/device',
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      });
+    renderWithDeviceService({ create });
+    openDevicePane();
+
+    expect(await screen.findByText(/code expired/i)).toBeInTheDocument();
+    await findAndClickButton(/get a new code/i);
+    expect(await screen.findByText('WXYZ-9876')).toBeInTheDocument();
+  });
+
+  it('adopts a still-pending attempt instead of burning a fresh code', async () => {
+    const find = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'KEEP-0001',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    }));
+    const create = vi.fn();
+    renderWithDeviceService({ create, find });
+    openDevicePane();
+
+    expect(await screen.findByText('KEEP-0001')).toBeInTheDocument();
+    // The adopted attempt's expiry drives the countdown just like a fresh one.
+    expect(await screen.findByText(/code expires in/i)).toBeInTheDocument();
+    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,7 +9,6 @@ import type {
   AgenticToolName,
   AgorClient,
   AuthCheckResult,
-  CodexAuthImportResult,
   UpdateUserInput,
   User,
   UserPreferences,
@@ -26,6 +25,7 @@ import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } fr
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
+import { type CodexAuthFallback, CodexDeviceSignIn, CodexImportAuthJson } from '../CodexAuth';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 
 const { Text, Title, Paragraph } = Typography;
@@ -34,7 +34,12 @@ const { useToken } = theme;
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type WizardStep = 'persona' | 'llm' | 'workspace' | 'integrations' | 'done';
-type AuthMethod = 'api-key' | 'claude-subscription-token' | 'codex-cli-auth' | 'codex-auth-json';
+type AuthMethod =
+  | 'api-key'
+  | 'claude-subscription-token'
+  | 'codex-cli-auth'
+  | 'codex-auth-json'
+  | 'codex-device-auth';
 
 /**
  * Per-agent auth-method toggle entries. Agents absent here have exactly one
@@ -49,7 +54,8 @@ const AUTH_METHOD_OPTIONS: Partial<
   ],
   codex: [
     { label: 'API key', value: 'api-key' },
-    { label: 'ChatGPT login', value: 'codex-auth-json' },
+    { label: 'Sign in with ChatGPT', value: 'codex-device-auth' },
+    { label: 'Import auth.json', value: 'codex-auth-json' },
   ],
 };
 
@@ -363,7 +369,8 @@ function keyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-k
 
 function getKeyLabel(agent: AgenticToolName, authMethod: AuthMethod): string {
   if (authMethod === 'claude-subscription-token') return 'Subscription token';
-  if (authMethod === 'codex-auth-json') return 'Codex login file (auth.json)';
+  // Note: the codex-auth-json method renders its own pane (CodexImportAuthJson)
+  // and never reaches this label, so no case is needed for it here.
   switch (agent) {
     case 'claude-code':
       return 'Anthropic API key';
@@ -729,14 +736,22 @@ export function OnboardingWizard({
       case 'llm': {
         if (!selectedAgent) return false;
         if (agentIsVerifiedConnected(selectedAgent)) return true;
+        // Device sign-in and login-file import both complete inside their own
+        // pane — no typed input to validate. They enable once the daemon
+        // confirms the login (llmAuthVerified flips before the user record
+        // refresh that agentIsVerifiedConnected depends on).
+        if (
+          selectedAgent === 'codex' &&
+          (authMethod === 'codex-device-auth' || authMethod === 'codex-auth-json')
+        )
+          return llmAuthVerified.codex === true;
         // Key stored, check still in progress — keep enabled so user isn't stuck
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return true;
         // Require a new key with valid format (stored key absent or broken)
         if (!apiKey.trim()) return false;
-        // Subscription tokens and pasted auth files have no fixed format —
-        // any non-empty string is accepted (the daemon validates the file)
-        if (authMethod === 'claude-subscription-token' || authMethod === 'codex-auth-json')
-          return true;
+        // Subscription tokens have no fixed format — any non-empty string is
+        // accepted (the daemon validates the token).
+        if (authMethod === 'claude-subscription-token') return true;
         return validateLlmKeyPattern(selectedAgent, apiKey.trim()) === null;
       }
       case 'workspace':
@@ -767,13 +782,18 @@ export function OnboardingWizard({
       case 'llm': {
         if (!selectedAgent) return 'Choose an AI model first';
         if (agentIsVerifiedConnected(selectedAgent)) return null;
+        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth') {
+          return llmAuthVerified.codex === true
+            ? null
+            : 'Approve the sign-in code in ChatGPT first';
+        }
+        if (selectedAgent === 'codex' && authMethod === 'codex-auth-json') {
+          return llmAuthVerified.codex === true ? null : 'Import your Codex login to continue';
+        }
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return null;
         if (!apiKey.trim()) {
-          return authMethod === 'codex-auth-json'
-            ? 'Paste your auth.json contents to continue'
-            : 'Enter your API key to continue';
+          return 'Enter your API key to continue';
         }
-        if (authMethod === 'codex-auth-json') return null;
         const err = validateLlmKeyPattern(selectedAgent, apiKey.trim());
         return err ?? null;
       }
@@ -854,6 +874,25 @@ export function OnboardingWizard({
     setCurrentStep(step);
   }, []);
 
+  // Stable handlers for the memoized device sign-in pane — identity-preserving
+  // so its internal timers never force wizard-wide re-renders.
+  const handleCodexDeviceVerified = useCallback(() => {
+    setLlmAuthVerified((prev) => (prev.codex === true ? prev : { ...prev, codex: true }));
+  }, []);
+
+  const handleCodexAuthMethodFallback = useCallback((target: CodexAuthFallback) => {
+    setAuthMethod(target === 'import' ? 'codex-auth-json' : 'api-key');
+    setApiKey('');
+    setLlmError(null);
+  }, []);
+
+  // Login-file import completes inside its own pane; mirror the device flow by
+  // marking codex verified so the primary button advances to the next step.
+  const handleCodexImported = useCallback(() => {
+    setLlmAuthVerified((prev) => (prev.codex === true ? prev : { ...prev, codex: true }));
+    goToStep('workspace');
+  }, [goToStep]);
+
   const handleBack = useCallback(() => {
     if (stepIndex > 0) goToStep(STEPS[stepIndex - 1]);
   }, [stepIndex, goToStep]);
@@ -878,40 +917,22 @@ export function OnboardingWizard({
           goToStep('workspace');
           return;
         }
+        // Device sign-in and login-file import both complete inside their own
+        // pane; the primary button only ever advances once the attempt
+        // succeeded (button is disabled until then).
+        if (
+          selectedAgent === 'codex' &&
+          (authMethod === 'codex-device-auth' || authMethod === 'codex-auth-json')
+        ) {
+          if (llmAuthVerified.codex === true) goToStep('workspace');
+          return;
+        }
         // Key stored, auth check still running — proceed optimistically
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) {
           goToStep('workspace');
           return;
         }
         if (!user || !apiKey.trim()) return;
-        // Pasted auth.json goes to the daemon as-is: it validates the shape,
-        // writes the file 0600 for the right Unix identity, and flips the
-        // user's Codex auth method to subscription. The pasted secret never
-        // touches user records or agent context.
-        if (selectedAgent === 'codex' && authMethod === 'codex-auth-json') {
-          if (!client) return;
-          setLlmSaving(true);
-          setLlmError(null);
-          try {
-            (await client
-              .service('codex-auth/import')
-              .create({ authJson: apiKey })) as CodexAuthImportResult;
-            setLlmAuthVerified((prev) => ({ ...prev, codex: true }));
-            // Drop the pasted token material from React state as soon as the
-            // daemon has it — nothing needs it after a successful import.
-            setApiKey('');
-            goToStep('workspace');
-          } catch (err) {
-            setLlmError(
-              err instanceof Error && err.message
-                ? err.message
-                : 'Could not import the Codex login — try again.'
-            );
-          } finally {
-            setLlmSaving(false);
-          }
-          return;
-        }
         // Subscription tokens have no fixed format (see primaryEnabled/disabledReason
         // above, which already treat them as exempt) — only pattern-validate API keys.
         if (authMethod !== 'claude-subscription-token') {
@@ -1196,6 +1217,13 @@ export function OnboardingWizard({
             const isVerified = llmAuthVerified[option.agent];
             const effectiveHasKey = hasKey && isVerified === true;
             const keyBroken = hasKey && isVerified === false;
+            // Codex "connected" may mean a subscription login (auth.json on
+            // the server), not a stored key — a failed probe then means the
+            // login file is gone, and API-key wording would mislead.
+            const subscriptionBroken =
+              keyBroken &&
+              option.agent === 'codex' &&
+              user?.agentic_auth_methods?.codex === 'subscription';
             const methodOptions = AUTH_METHOD_OPTIONS[option.agent];
             return (
               <div
@@ -1283,7 +1311,7 @@ export function OnboardingWizard({
                           color="error"
                           style={{ fontSize: 10, lineHeight: '16px', padding: '0 5px' }}
                         >
-                          Key not working
+                          {subscriptionBroken ? 'Login not found' : 'Key not working'}
                         </Tag>
                       )}
                     </div>
@@ -1365,7 +1393,11 @@ export function OnboardingWizard({
                     {keyBroken && (
                       <Alert
                         type="warning"
-                        message="Key stored but not working - enter a new one."
+                        message={
+                          subscriptionBroken
+                            ? 'Codex login no longer found on this server — sign in with ChatGPT or import it again.'
+                            : 'Key stored but not working - enter a new one.'
+                        }
                         showIcon
                         style={{ marginTop: 12, marginBottom: 8, fontSize: 12 }}
                       />
@@ -1419,64 +1451,40 @@ export function OnboardingWizard({
                       </div>
                     )}
 
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        marginTop: !methodOptions && !keyBroken ? 12 : 0,
-                        marginBottom: 8,
-                      }}
-                    >
-                      <Text style={{ color: TEXT_PRIMARY, fontSize: 13, fontWeight: 500 }}>
-                        {getKeyLabel(option.agent, authMethod)}
-                      </Text>
-                      {option.keyLink && authMethod === 'api-key' && (
-                        <Typography.Link
-                          href={option.keyLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{ fontSize: 12, color: PRIMARY }}
-                        >
-                          Get your key at {option.keyLinkLabel} →
-                        </Typography.Link>
-                      )}
-                    </div>
+                    {authMethod !== 'codex-device-auth' && authMethod !== 'codex-auth-json' && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          marginTop: !methodOptions && !keyBroken ? 12 : 0,
+                          marginBottom: 8,
+                        }}
+                      >
+                        <Text style={{ color: TEXT_PRIMARY, fontSize: 13, fontWeight: 500 }}>
+                          {getKeyLabel(option.agent, authMethod)}
+                        </Text>
+                        {option.keyLink && authMethod === 'api-key' && (
+                          <Typography.Link
+                            href={option.keyLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ fontSize: 12, color: PRIMARY }}
+                          >
+                            Get your key at {option.keyLinkLabel} →
+                          </Typography.Link>
+                        )}
+                      </div>
+                    )}
 
-                    {authMethod === 'codex-auth-json' ? (
-                      <>
-                        <Alert
-                          type="info"
-                          showIcon
-                          style={{ marginBottom: 10, fontSize: 12 }}
-                          message={
-                            <span>
-                              Already signed in to Codex on your laptop? Your login lives in{' '}
-                              <code>~/.codex/auth.json</code> there. Print it with{' '}
-                              <code>cat ~/.codex/auth.json</code> and paste the whole thing below —
-                              this replaces the Codex login already stored on this server, which in
-                              shared setups is one login for the whole server, not one per person.
-                              Prefer a terminal? Run <code>codex login --device-auth</code> from a
-                              branch terminal instead.
-                            </span>
-                          }
-                        />
-                        <Input.Password
-                          aria-label="Codex auth.json contents"
-                          placeholder="Paste the JSON from ~/.codex/auth.json…"
-                          value={apiKey}
-                          onChange={(e) => {
-                            setApiKey(e.target.value);
-                            setLlmError(null);
-                          }}
-                          style={{
-                            background: 'rgba(0,0,0,0.3)',
-                            borderColor: 'rgba(255,255,255,0.12)',
-                            fontFamily: 'monospace',
-                            fontSize: 13,
-                          }}
-                        />
-                      </>
+                    {authMethod === 'codex-device-auth' ? (
+                      <CodexDeviceSignIn
+                        client={client}
+                        onVerified={handleCodexDeviceVerified}
+                        onUseFallback={handleCodexAuthMethodFallback}
+                      />
+                    ) : authMethod === 'codex-auth-json' ? (
+                      <CodexImportAuthJson client={client} onImported={handleCodexImported} />
                     ) : authMethod === 'claude-subscription-token' ? (
                       <>
                         <Alert

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1454,9 +1454,10 @@ export function OnboardingWizard({
                               Already signed in to Codex on your laptop? Your login lives in{' '}
                               <code>~/.codex/auth.json</code> there. Print it with{' '}
                               <code>cat ~/.codex/auth.json</code> and paste the whole thing below —
-                              this replaces any Codex login already on this server. Prefer a
-                              terminal? Run <code>codex login --device-auth</code> from a branch
-                              terminal instead.
+                              this replaces the Codex login already stored on this server, which in
+                              shared setups is one login for the whole server, not one per person.
+                              Prefer a terminal? Run <code>codex login --device-auth</code> from a
+                              branch terminal instead.
                             </span>
                           }
                         />

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -897,6 +897,9 @@ export function OnboardingWizard({
               .service('codex-auth/import')
               .create({ authJson: apiKey })) as CodexAuthImportResult;
             setLlmAuthVerified((prev) => ({ ...prev, codex: true }));
+            // Drop the pasted token material from React state as soon as the
+            // daemon has it — nothing needs it after a successful import.
+            setApiKey('');
             goToStep('workspace');
           } catch (err) {
             setLlmError(

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,6 +9,7 @@ import type {
   AgenticToolName,
   AgorClient,
   AuthCheckResult,
+  CodexAuthImportResult,
   UpdateUserInput,
   User,
   UserPreferences,
@@ -33,7 +34,24 @@ const { useToken } = theme;
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type WizardStep = 'persona' | 'llm' | 'workspace' | 'integrations' | 'done';
-type AuthMethod = 'api-key' | 'claude-subscription-token' | 'codex-cli-auth';
+type AuthMethod = 'api-key' | 'claude-subscription-token' | 'codex-cli-auth' | 'codex-auth-json';
+
+/**
+ * Per-agent auth-method toggle entries. Agents absent here have exactly one
+ * way in (an API key / endpoint URL) and render no toggle.
+ */
+const AUTH_METHOD_OPTIONS: Partial<
+  Record<AgenticToolName, { label: string; value: AuthMethod }[]>
+> = {
+  'claude-code': [
+    { label: 'API key', value: 'api-key' },
+    { label: 'Subscription token', value: 'claude-subscription-token' },
+  ],
+  codex: [
+    { label: 'API key', value: 'api-key' },
+    { label: 'ChatGPT login', value: 'codex-auth-json' },
+  ],
+};
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -328,6 +346,7 @@ function hasAnyLlmKey(user: User | null | undefined): boolean {
     claude?.ANTHROPIC_API_KEY ||
     claude?.CLAUDE_CODE_OAUTH_TOKEN ||
     codex?.OPENAI_API_KEY ||
+    user.agentic_auth_methods?.codex === 'subscription' ||
     gemini?.GEMINI_API_KEY ||
     user.env_vars?.ANTHROPIC_API_KEY ||
     user.env_vars?.OPENAI_API_KEY ||
@@ -344,6 +363,7 @@ function keyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-k
 
 function getKeyLabel(agent: AgenticToolName, authMethod: AuthMethod): string {
   if (authMethod === 'claude-subscription-token') return 'Subscription token';
+  if (authMethod === 'codex-auth-json') return 'Codex login file (auth.json)';
   switch (agent) {
     case 'claude-code':
       return 'Anthropic API key';
@@ -599,7 +619,11 @@ export function OnboardingWizard({
         user?.env_vars?.ANTHROPIC_API_KEY
       ) {
         setSelectedAgent('claude-code');
-      } else if (codex?.OPENAI_API_KEY || user?.env_vars?.OPENAI_API_KEY) {
+      } else if (
+        codex?.OPENAI_API_KEY ||
+        user?.agentic_auth_methods?.codex === 'subscription' ||
+        user?.env_vars?.OPENAI_API_KEY
+      ) {
         setSelectedAgent('codex');
       } else if (gemini?.GEMINI_API_KEY || user?.env_vars?.GEMINI_API_KEY) {
         setSelectedAgent('gemini');
@@ -633,7 +657,13 @@ export function OnboardingWizard({
           user.env_vars?.ANTHROPIC_API_KEY
         );
       }
-      if (agent === 'codex') return !!(codex?.OPENAI_API_KEY || user.env_vars?.OPENAI_API_KEY);
+      if (agent === 'codex') {
+        return !!(
+          codex?.OPENAI_API_KEY ||
+          user.agentic_auth_methods?.codex === 'subscription' ||
+          user.env_vars?.OPENAI_API_KEY
+        );
+      }
       if (agent === 'gemini') return !!(gemini?.GEMINI_API_KEY || user.env_vars?.GEMINI_API_KEY);
       if (agent === 'opencode') {
         const opencode = user.agentic_tools?.opencode;
@@ -703,8 +733,10 @@ export function OnboardingWizard({
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return true;
         // Require a new key with valid format (stored key absent or broken)
         if (!apiKey.trim()) return false;
-        // Subscription tokens have no fixed format — any non-empty string is accepted
-        if (authMethod === 'claude-subscription-token') return true;
+        // Subscription tokens and pasted auth files have no fixed format —
+        // any non-empty string is accepted (the daemon validates the file)
+        if (authMethod === 'claude-subscription-token' || authMethod === 'codex-auth-json')
+          return true;
         return validateLlmKeyPattern(selectedAgent, apiKey.trim()) === null;
       }
       case 'workspace':
@@ -736,7 +768,12 @@ export function OnboardingWizard({
         if (!selectedAgent) return 'Choose an AI model first';
         if (agentIsVerifiedConnected(selectedAgent)) return null;
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return null;
-        if (!apiKey.trim()) return 'Enter your API key to continue';
+        if (!apiKey.trim()) {
+          return authMethod === 'codex-auth-json'
+            ? 'Paste your auth.json contents to continue'
+            : 'Enter your API key to continue';
+        }
+        if (authMethod === 'codex-auth-json') return null;
         const err = validateLlmKeyPattern(selectedAgent, apiKey.trim());
         return err ?? null;
       }
@@ -754,6 +791,7 @@ export function OnboardingWizard({
     agentHasKey,
     llmAuthVerified,
     apiKey,
+    authMethod,
     hasExistingBoard,
     teammateName,
     llmSaving,
@@ -846,6 +884,31 @@ export function OnboardingWizard({
           return;
         }
         if (!user || !apiKey.trim()) return;
+        // Pasted auth.json goes to the daemon as-is: it validates the shape,
+        // writes the file 0600 for the right Unix identity, and flips the
+        // user's Codex auth method to subscription. The pasted secret never
+        // touches user records or agent context.
+        if (selectedAgent === 'codex' && authMethod === 'codex-auth-json') {
+          if (!client) return;
+          setLlmSaving(true);
+          setLlmError(null);
+          try {
+            (await client
+              .service('codex-auth/import')
+              .create({ authJson: apiKey })) as CodexAuthImportResult;
+            setLlmAuthVerified((prev) => ({ ...prev, codex: true }));
+            goToStep('workspace');
+          } catch (err) {
+            setLlmError(
+              err instanceof Error && err.message
+                ? err.message
+                : 'Could not import the Codex login — try again.'
+            );
+          } finally {
+            setLlmSaving(false);
+          }
+          return;
+        }
         // Subscription tokens have no fixed format (see primaryEnabled/disabledReason
         // above, which already treat them as exempt) — only pattern-validate API keys.
         if (authMethod !== 'claude-subscription-token') {
@@ -1130,6 +1193,7 @@ export function OnboardingWizard({
             const isVerified = llmAuthVerified[option.agent];
             const effectiveHasKey = hasKey && isVerified === true;
             const keyBroken = hasKey && isVerified === false;
+            const methodOptions = AUTH_METHOD_OPTIONS[option.agent];
             return (
               <div
                 key={option.id}
@@ -1304,8 +1368,8 @@ export function OnboardingWizard({
                       />
                     )}
 
-                    {/* Auth method toggle — Claude only */}
-                    {option.agent === 'claude-code' && (
+                    {/* Auth method toggle — agents with more than one way in */}
+                    {methodOptions && (
                       <div
                         style={{
                           display: 'flex',
@@ -1321,12 +1385,7 @@ export function OnboardingWizard({
                           boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.08)',
                         }}
                       >
-                        {(
-                          [
-                            { label: 'API key', value: 'api-key' },
-                            { label: 'Subscription token', value: 'claude-subscription-token' },
-                          ] as { label: string; value: AuthMethod }[]
-                        ).map((opt, idx) => {
+                        {methodOptions.map((opt, idx) => {
                           const active = authMethod === opt.value;
                           return (
                             <button
@@ -1362,12 +1421,7 @@ export function OnboardingWizard({
                         display: 'flex',
                         justifyContent: 'space-between',
                         alignItems: 'center',
-                        marginTop:
-                          option.agent !== 'claude-code' && keyBroken
-                            ? 0
-                            : option.agent !== 'claude-code'
-                              ? 12
-                              : 0,
+                        marginTop: !methodOptions && !keyBroken ? 12 : 0,
                         marginBottom: 8,
                       }}
                     >
@@ -1386,7 +1440,40 @@ export function OnboardingWizard({
                       )}
                     </div>
 
-                    {authMethod === 'claude-subscription-token' ? (
+                    {authMethod === 'codex-auth-json' ? (
+                      <>
+                        <Alert
+                          type="info"
+                          showIcon
+                          style={{ marginBottom: 10, fontSize: 12 }}
+                          message={
+                            <span>
+                              Already signed in to Codex on your laptop? Your login lives in{' '}
+                              <code>~/.codex/auth.json</code> there. Print it with{' '}
+                              <code>cat ~/.codex/auth.json</code> and paste the whole thing below —
+                              this replaces any Codex login already on this server. Prefer a
+                              terminal? Run <code>codex login --device-auth</code> from a branch
+                              terminal instead.
+                            </span>
+                          }
+                        />
+                        <Input.Password
+                          aria-label="Codex auth.json contents"
+                          placeholder="Paste the JSON from ~/.codex/auth.json…"
+                          value={apiKey}
+                          onChange={(e) => {
+                            setApiKey(e.target.value);
+                            setLlmError(null);
+                          }}
+                          style={{
+                            background: 'rgba(0,0,0,0.3)',
+                            borderColor: 'rgba(255,255,255,0.12)',
+                            fontFamily: 'monospace',
+                            fontSize: 13,
+                          }}
+                        />
+                      </>
+                    ) : authMethod === 'claude-subscription-token' ? (
                       <>
                         <Alert
                           type="info"

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -152,7 +152,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('shows Codex authentication choices when subscription mode hides API-key fields', async () => {
+  it('offers the three Codex authentication methods, defaulting to the sign-in view for a subscription', async () => {
     const user = makeUser({ agentic_auth_methods: { codex: 'subscription' } });
     renderWithApp(
       <UserSettingsModal
@@ -167,8 +167,12 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
 
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }));
     await screen.findByRole('heading', { name: 'Codex' });
-    expect(screen.getByText('ChatGPT subscription')).toBeInTheDocument();
-    expect(screen.getByText('Use Codex CLI subscription authentication')).toBeInTheDocument();
+    // The method selector surfaces all three ways in.
+    expect(screen.getByText('API key')).toBeInTheDocument();
+    expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+    expect(screen.getByText('Import login file')).toBeInTheDocument();
+    // A stored subscription lands on the ChatGPT sign-in view.
+    expect(screen.getByText(/Sign in with your ChatGPT account/i)).toBeInTheDocument();
   });
 
   it('saves a Claude model alias before closing', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -53,6 +53,7 @@ import {
   getFormValuesFromConfig,
 } from '../AgenticToolConfigForm';
 import { ApiKeyFields, type FieldStatus, TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
+import { CodexAuthSettings } from '../CodexAuth';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { EnvVarEditor } from '../EnvVarEditor';
 import { SessionMcpServersField } from '../MCPServerSelect';
@@ -1143,13 +1144,35 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   </Popconfirm>
                 </Space>
               )
+            ) : canonicalTool === 'codex' ? (
+              <CodexAuthSettings
+                client={client}
+                authMethod={authMethod ?? 'api_key'}
+                apiKeyFields={allToolFields}
+                fieldStatus={fieldStatus}
+                onSaveField={(field, value) =>
+                  handleToolFieldSave(credentialToolName, field, value)
+                }
+                onClearField={(field) => handleToolFieldClear(credentialToolName, field)}
+                savingFields={Object.fromEntries(
+                  allToolFields.map((c) => [
+                    c.field,
+                    !!savingToolField[`${credentialToolName}.${c.field}`],
+                  ])
+                )}
+                publicValues={
+                  user?.agentic_tools_public_values?.[credentialToolName] as
+                    | Partial<Record<AgenticToolConfigField, string>>
+                    | undefined
+                }
+              />
             ) : (
               <>
                 <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
                   Personal credentials are encrypted at rest and injected only into the agent
                   runtime.
                 </Typography.Paragraph>
-                {(canonicalTool === 'claude-code' || canonicalTool === 'codex') && (
+                {canonicalTool === 'claude-code' && (
                   <Radio.Group
                     value={authMethod}
                     onChange={(event) =>
@@ -1157,34 +1180,23 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                     }
                     style={{ marginBottom: 16 }}
                   >
-                    <Radio.Button value="subscription">
-                      {canonicalTool === 'codex' ? 'ChatGPT subscription' : 'Claude subscription'}
-                    </Radio.Button>
+                    <Radio.Button value="subscription">Claude subscription</Radio.Button>
                     <Radio.Button value="api_key">API key</Radio.Button>
                   </Radio.Group>
                 )}
-                {canonicalTool === 'codex' && authMethod === 'subscription' ? (
-                  <Alert
-                    type="info"
-                    showIcon
-                    title="Use Codex CLI subscription authentication"
-                    description="Agor will use the Codex CLI login belonging to this session's Unix user. Run `codex login` in a terminal as that same user. This declaration does not prove that the login is still valid."
-                  />
-                ) : (
-                  <ApiKeyFields
-                    tool={toolName}
-                    fields={toolFields}
-                    fieldStatus={fieldStatus}
-                    onSave={(field, value) => handleToolFieldSave(credentialToolName, field, value)}
-                    onClear={(field) => handleToolFieldClear(credentialToolName, field)}
-                    saving={savingForTool}
-                    publicValues={
-                      user?.agentic_tools_public_values?.[credentialToolName] as
-                        | Partial<Record<AgenticToolConfigField, string>>
-                        | undefined
-                    }
-                  />
-                )}
+                <ApiKeyFields
+                  tool={toolName}
+                  fields={toolFields}
+                  fieldStatus={fieldStatus}
+                  onSave={(field, value) => handleToolFieldSave(credentialToolName, field, value)}
+                  onClear={(field) => handleToolFieldClear(credentialToolName, field)}
+                  saving={savingForTool}
+                  publicValues={
+                    user?.agentic_tools_public_values?.[credentialToolName] as
+                      | Partial<Record<AgenticToolConfigField, string>>
+                      | undefined
+                  }
+                />
               </>
             )}
           </>

--- a/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
+++ b/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
@@ -23,6 +23,26 @@ describe('buildAgenticToolCredentialPatch', () => {
     });
   });
 
+  it('flips the Codex method to api_key when an OpenAI key is saved (the only deliberate api_key act)', () => {
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_API_KEY', 'sk-proj-test')).toEqual({
+      agentic_tools: {
+        codex: { OPENAI_API_KEY: 'sk-proj-test' },
+      },
+      agentic_auth_methods: { codex: 'api_key' },
+    });
+  });
+
+  it('does not flip the Codex method when only the base URL is set or a key is cleared', () => {
+    // A non-credential field must not activate api_key…
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_BASE_URL', 'https://gw')).toEqual({
+      agentic_tools: { codex: { OPENAI_BASE_URL: 'https://gw' } },
+    });
+    // …and clearing the key must not assert any method (leaves the flip to a real save).
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_API_KEY', null)).toEqual({
+      agentic_tools: { codex: { OPENAI_API_KEY: null } },
+    });
+  });
+
   it('clears a token by sending null at the same canonical field path', () => {
     expect(buildAgenticToolCredentialPatch('claude-code', 'CLAUDE_CODE_OAUTH_TOKEN', null)).toEqual(
       {

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -241,6 +241,43 @@ export interface CodexAuthImportResult {
 }
 
 /**
+ * Lifecycle of a ChatGPT device-code sign-in attempt driven by the daemon's
+ * `/codex-auth/device` endpoints.
+ * - `idle`: no attempt exists for this user.
+ * - `pending`: a code was issued; the daemon is polling for approval.
+ * - `success`: tokens were exchanged and persisted to the user's Codex home.
+ * - `expired`: the code's 15-minute window elapsed without approval.
+ * - `unavailable`: OpenAI's server refused to issue a code — device-code
+ *   authorization is disabled for this account/workspace (a common, first-class
+ *   state, not an edge case).
+ * - `error`: the attempt failed for another reason; start a fresh one.
+ */
+export type CodexDeviceAuthPhase =
+  | 'idle'
+  | 'pending'
+  | 'success'
+  | 'expired'
+  | 'unavailable'
+  | 'error';
+
+/**
+ * Non-secret status of a device-code sign-in attempt. The user code and
+ * verification URL are meant to be displayed; tokens never appear here.
+ */
+export interface CodexDeviceAuthStatus {
+  phase: CodexDeviceAuthPhase;
+  /** One-time code the user enters on the verification page (pending only). */
+  userCode?: string;
+  /** Page where the user approves the code (pending only). */
+  verificationUrl?: string;
+  /** ISO timestamp when the pending code stops working. */
+  expiresAt?: string;
+  /** ChatGPT plan type parsed from the id_token after success, when present. */
+  planType?: string;
+  hint?: string;
+}
+
+/**
  * Canonical mapping from AgenticToolName to the env-var name that holds its primary API key.
  * Tools that authenticate without a key (opencode) are intentionally absent.
  *

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -227,6 +227,20 @@ export interface AuthCheckResult {
 }
 
 /**
+ * Result of importing a Codex `auth.json` via the daemon's `/codex-auth/import`
+ * endpoint. Carries ONLY non-secret metadata — token material stays on the
+ * daemon/filesystem side and never transits back to callers.
+ */
+export interface CodexAuthImportResult {
+  status: 'authenticated';
+  /** Whether the imported file carries ChatGPT login tokens or a bare API key. */
+  authMode: 'chatgpt' | 'api_key';
+  /** ChatGPT plan type parsed from the id_token claims (e.g. "plus", "pro"), when present. */
+  planType?: string;
+  hint?: string;
+}
+
+/**
  * Canonical mapping from AgenticToolName to the env-var name that holds its primary API key.
  * Tools that authenticate without a key (opencode) are intentionally absent.
  *


### PR DESCRIPTION
## Problem

Codex (OpenAI) users on a ChatGPT subscription have no smooth path through the onboarding wizard: the browser `codex login` flow binds to `localhost:1455`, which is useless against a remote Agor server, so the wizard could only offer an API key or "go run a CLI command in a terminal."

Transplanting `~/.codex/auth.json` between machines is officially supported by OpenAI (their container docs `docker cp` it in verbatim), and Codex auto-refreshes and re-persists the tokens — so a one-time import is a durable login.

## Approach

**Daemon — `POST /codex-auth/import`** (`apps/agor-daemon/src/services/codex-auth-import.ts`)
- Validates the pasted JSON shape: must carry `tokens.refresh_token` (ChatGPT login) or a non-empty `OPENAI_API_KEY`; garbage gets a friendly, input-free error.
- Writes the file 0600 into the Codex home of the Unix identity that will actually run Codex for the caller: daemon user (`simple`), shared executor user (`insulated`), or the caller's own Unix account (`strict`) — same resolution executors use.
- Verifies by reading the file back, then flips the user's `agentic_auth_methods.codex` to `subscription` so executors resolve native auth instead of expecting an env API key.
- Rejected in hosted multi-tenant mode (`multi_tenancy.mode: required_from_auth`), mirroring the existing native-auth guard.

**check-auth** — the codex-native branch used to return a permanent `unknown` ("can only be verified when Codex runs"). It now probes the same `auth.json` (per-Unix-identity): valid ChatGPT tokens → `authenticated` with plan-type hint; embedded API key → verified against the provider; missing/malformed file → `unauthenticated` with recovery guidance.

**Wizard** — the GPT card gains an auth-method toggle (**API key | ChatGPT login**), matching the existing Claude toggle. The login pane explains where `auth.json` lives (`cat ~/.codex/auth.json`), notes that importing replaces any existing login on the server, takes the paste in a masked field, and keeps `codex login --device-auth` in a terminal as the documented fallback. API-key and terminal paths are unchanged.

## UX walkthrough

1. Onboarding → "Connect your AI" → pick **GPT** → toggle **ChatGPT login**.
2. On the machine where Codex already works: `cat ~/.codex/auth.json`, copy, paste, **Connect →**.
3. Daemon validates/writes/verifies; wizard advances to the workspace step. Rejections (not JSON, no credentials, write failure) render inline with actionable copy.

## Security notes
- **Shared-identity trust model (recorded decision):** in `unix_user_mode: simple` or `insulated`, every user resolves to a single Unix identity, so importing or signing in replaces the one server-wide Codex login — the same semantics the pre-existing `codex login`-in-a-terminal path has always had. This is Agor's documented mode-1/2 trust model (personal instances / trusted teams), not a regression introduced here; per-user credential isolation requires `strict` mode. The wizard copy states that the overwrite is server-wide.

- Token material flows browser → daemon → target user's filesystem, and nowhere else. It is never logged (write-failure logs record the error *class* only), never echoed back (responses carry `authMode`/`planType` metadata only), and never enters agent/LLM context.
- Impersonated writes/reads go through `sudo -n -u <user>` with content piped over **stdin** — token bytes never appear in argv (`/proc/*/cmdline`). `umask 077` + explicit `chmod 600` cover both fresh creation and overwrite of a looser pre-existing file.
- The target identity is always derived from the authenticated caller; request data cannot redirect the write.

## Tests

- `apps/agor-daemon/src/utils/codex-auth-file.test.ts` — parse/validation matrix, id_token plan-type mining, unknown-field round-trip.
- `apps/agor-daemon/src/services/codex-auth-import.test.ts` — auth/tenancy guards, garbage rejection, write/verify/patch happy path, no-secret-in-response assertion, failure mapping.
- Wizard tests — toggle discovery, inline help, submit-and-advance, daemon rejection stays on step, method-switch clears state.
- Full `pnpm check` (typecheck, biome, shortid, multitenancy boundaries, build) and the daemon + core test suites pass.

## Manual verification worth doing

- `insulated`/`strict` deployments: confirm the sudoers grant covers the auth.json write path and that a Codex session picks up the imported login immediately.
- A real ChatGPT-plan `auth.json` end-to-end (I validated shape handling against the codex-rs source, not against a live account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
