### PR TITLE
feat(onboarding): guided "Sign in with ChatGPT" device-code flow for Codex

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -451,6 +451,7 @@ export const TENANT_OWNED_SERVICE_PATHS = [
 // units of work at the call site instead of holding an HTTP-long transaction.
 const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'check-auth',
+  'codex-auth/device',
   'codex-auth/import',
   'claude-models',
   'copilot-models',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -81,6 +81,7 @@ import { createCardsService } from './services/cards.js';
 import { createCheckAuthService } from './services/check-auth.js';
 import { createClaudeModelsService } from './services/claude-models.js';
 import { createCodexAuthImportService } from './services/codex-auth-import.js';
+import { createCodexDeviceAuthService } from './services/codex-device-auth.js';
 import { createConfigService } from './services/config.js';
 import { createContextService } from './services/context.js';
 import { createCopilotModelsService } from './services/copilot-models.js';
@@ -556,6 +557,14 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   // method to subscription. Token material never leaves the daemon.
   app.use('/codex-auth/import', createCodexAuthImportService(app, db));
   app.service('/codex-auth/import').hooks({ before: { create: [ctx.requireAuth] } });
+
+  // ChatGPT device-code sign-in: create starts an attempt (code + verification
+  // URL back to the UI, daemon polls OpenAI for approval); find reports the
+  // caller's attempt status. Tokens stay daemon-side end to end.
+  app.use('/codex-auth/device', createCodexDeviceAuthService(app, db));
+  app
+    .service('/codex-auth/device')
+    .hooks({ before: { create: [ctx.requireAuth], find: [ctx.requireAuth] } });
 
   // Claude dynamic model discovery via @anthropic-ai/sdk's models.list().
   // Resolves ANTHROPIC_API_KEY per-user (with config.yaml + env fallback)

--- a/apps/agor-daemon/src/services/codex-auth-import.ts
+++ b/apps/agor-daemon/src/services/codex-auth-import.ts
@@ -39,6 +39,7 @@ import {
   validateResolvedUnixUser,
 } from '@agor/core/unix';
 import {
+  type CodexAuthSummary,
   parseCodexAuthJson,
   readCodexAuthFile,
   writeCodexAuthFile,
@@ -54,7 +55,7 @@ interface UsersServiceLike {
   ): Promise<unknown>;
 }
 
-interface AppLike {
+export interface AppLike {
   service(path: string): unknown;
 }
 
@@ -119,6 +120,66 @@ export async function resolveCodexUnixIdentity(
   }
 }
 
+/**
+ * Persist a validated auth.json for a user: write it 0600 as the target Unix
+ * user, verify by reading it back, then flip the user's Codex auth method to
+ * `subscription` so executors resolve native auth. Shared by the paste-import
+ * and device-code sign-in flows. Throws `BadRequest` with user-facing,
+ * secret-free messages.
+ */
+export async function persistVerifiedCodexAuth(options: {
+  app: AppLike;
+  normalized: string;
+  targetUnixUser: string | null;
+  userId: UserID;
+  authUser: NonNullable<AuthenticatedParams['user']>;
+}): Promise<CodexAuthSummary> {
+  const { app, normalized, targetUnixUser, userId, authUser } = options;
+
+  try {
+    writeCodexAuthFile(normalized, targetUnixUser);
+  } catch (err) {
+    // The error may carry sudo/bash stderr; log a class-level summary only
+    // so token material (or its absence) never reaches daemon logs.
+    console.error(
+      `[CodexAuth] Failed to write auth.json${targetUnixUser ? ` as ${targetUnixUser}` : ''}: ${
+        err instanceof Error ? err.constructor.name : 'unknown error'
+      }`
+    );
+    throw new BadRequest(
+      'Could not write the Codex credentials file on the server. Check daemon logs and sudo configuration, or use an API key instead.'
+    );
+  }
+
+  // Read-back verification: the file must contain exactly the bytes just
+  // written — "some valid credential is there" would let a concurrent
+  // import/refresh be mistaken for this one. A transient read failure gets
+  // one retry (the write already succeeded by exit status). Failing out
+  // leaves the file on disk with the auth method unflipped; that state is
+  // harmless because a re-import cleanly overwrites both.
+  let readBack = readCodexAuthFile(targetUnixUser);
+  if (!readBack.ok && readBack.reason === 'unreadable') {
+    readBack = readCodexAuthFile(targetUnixUser);
+  }
+  const verified =
+    readBack.ok && readBack.content === normalized ? parseCodexAuthJson(readBack.content) : null;
+  if (!verified?.ok) {
+    throw new BadRequest(
+      'The Codex credentials file was written but could not be verified back — try again.'
+    );
+  }
+
+  const usersService = app.service('users') as UsersServiceLike;
+  const current = await usersService.get(userId, { user: authUser, authenticated: true });
+  await usersService.patch(
+    userId,
+    { agentic_auth_methods: { ...current.agentic_auth_methods, codex: 'subscription' } },
+    { user: authUser, authenticated: true }
+  );
+
+  return verified.summary;
+}
+
 export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareDatabase) {
   return {
     async create(
@@ -158,54 +219,15 @@ export function createCodexAuthImportService(app: AppLike, db: TenantScopeAwareD
           `Cannot determine which Unix account should hold this Codex login: ${identity.message}`
         );
       }
-      const targetUnixUser = identity.unixUser;
 
-      try {
-        writeCodexAuthFile(parsed.normalized, targetUnixUser);
-      } catch (err) {
-        // The error may carry sudo/bash stderr; log a class-level summary only
-        // so token material (or its absence) never reaches daemon logs.
-        console.error(
-          `[CodexAuthImport] Failed to write auth.json${
-            targetUnixUser ? ` as ${targetUnixUser}` : ''
-          }: ${err instanceof Error ? err.constructor.name : 'unknown error'}`
-        );
-        throw new BadRequest(
-          'Could not write the Codex credentials file on the server. Check daemon logs and sudo configuration, or use an API key instead.'
-        );
-      }
-
-      // Read-back verification: the file must contain exactly the bytes just
-      // written — "some valid credential is there" would let a concurrent
-      // import/refresh be mistaken for this one. A transient read failure
-      // gets one retry (the write already succeeded by exit status). Failing
-      // out leaves the file on disk with the auth method unflipped; that
-      // state is harmless because a re-import cleanly overwrites both.
-      let readBack = readCodexAuthFile(targetUnixUser);
-      if (!readBack.ok && readBack.reason === 'unreadable') {
-        readBack = readCodexAuthFile(targetUnixUser);
-      }
-      const verified =
-        readBack.ok && readBack.content === parsed.normalized
-          ? parseCodexAuthJson(readBack.content)
-          : null;
-      if (!verified?.ok) {
-        throw new BadRequest(
-          'The Codex credentials file was written but could not be verified back — try again.'
-        );
-      }
-
-      // Flip the user's Codex auth method so executors resolve native auth
-      // (auth.json) instead of expecting an OPENAI_API_KEY.
-      const usersService = app.service('users') as UsersServiceLike;
-      const current = await usersService.get(userId, { user: authUser, authenticated: true });
-      await usersService.patch(
+      const summary = await persistVerifiedCodexAuth({
+        app,
+        normalized: parsed.normalized,
+        targetUnixUser: identity.unixUser,
         userId,
-        { agentic_auth_methods: { ...current.agentic_auth_methods, codex: 'subscription' } },
-        { user: authUser, authenticated: true }
-      );
+        authUser,
+      });
 
-      const { summary } = verified;
       return {
         status: 'authenticated',
         authMode: summary.authMode,

--- a/apps/agor-daemon/src/services/codex-device-auth.test.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.test.ts
@@ -78,7 +78,9 @@ beforeEach(() => {
   writeCodexAuthFileMock.mockImplementation((content: string) => {
     written = content;
   });
-  readCodexAuthFileMock.mockImplementation(() => written || null);
+  readCodexAuthFileMock.mockImplementation(() =>
+    written ? { ok: true, content: written } : { ok: false, reason: 'not-found' }
+  );
   fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
 });
@@ -147,6 +149,8 @@ describe('codex-device-auth', () => {
       );
 
     await withTenant(() => service.create({}, AUTH_PARAMS));
+    // interval "1" is floored to MIN_POLL_INTERVAL_MS (2s) — each 2.1s
+    // advance crosses exactly one scheduled poll.
     await vi.advanceTimersByTimeAsync(2100); // first poll (pending)
     await vi.advanceTimersByTimeAsync(2100); // second poll (approved + exchange)
 
@@ -179,6 +183,85 @@ describe('codex-device-auth', () => {
     const callsAfterSuccess = fetchMock.mock.calls.length;
     await vi.advanceTimersByTimeAsync(10_000);
     expect(fetchMock.mock.calls.length).toBe(callsAfterSuccess);
+  });
+
+  it('a provider 5xx mid-window is transient — polling continues instead of erroring', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(502, {}))
+      .mockResolvedValueOnce(jsonResponse(403, {}));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100); // 502 → keep polling
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).phase).toBe('pending');
+    await vi.advanceTimersByTimeAsync(2100); // 403 → still pending
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).phase).toBe('pending');
+    expect(fetchMock.mock.calls.length).toBe(3); // usercode + two polls
+  });
+
+  it('a non-pending 4xx during polling is terminal', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock.mockResolvedValueOnce(jsonResponse(410, {}));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100);
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).phase).toBe('error');
+  });
+
+  it('an approved response missing the PKCE fields is terminal (contract break)', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { authorization_code: 'authz-1' }));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100);
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('error');
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('overlapping create calls do not leave an orphaned poll loop', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+
+    // First create's usercode response is held until after the second create
+    // fully completes — the classic double-click race.
+    let releaseFirst: (() => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFirst = () =>
+            resolve(
+              jsonResponse(200, { device_auth_id: 'dev-1', user_code: 'ABCD-1234', interval: '1' })
+            );
+        })
+    );
+    const first = withTenant(() => service.create({}, AUTH_PARAMS));
+    await Promise.resolve(); // let the first create reach its awaited fetch
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { device_auth_id: 'dev-2', user_code: 'WXYZ-9876', interval: '1' })
+    );
+    const second = await withTenant(() => service.create({}, AUTH_PARAMS));
+    expect(second.userCode).toBe('WXYZ-9876');
+
+    releaseFirst?.();
+    await first;
+
+    // Only the second attempt is registered and polling.
+    expect((await withTenant(() => service.find(AUTH_PARAMS))).userCode).toBe('WXYZ-9876');
+    fetchMock.mockResolvedValue(jsonResponse(403, {}));
+    await vi.advanceTimersByTimeAsync(2100);
+    const pollBodies = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes('/deviceauth/token'))
+      .map(([, init]) => JSON.parse((init as RequestInit).body as string).device_auth_id);
+    expect(pollBodies).not.toContain('dev-1');
+    expect(pollBodies).toContain('dev-2');
   });
 
   it('hard-stops at code expiry and reports expired', async () => {

--- a/apps/agor-daemon/src/services/codex-device-auth.test.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.test.ts
@@ -1,0 +1,235 @@
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import { runWithTenantContext } from '@agor/core/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readCodexAuthFile, writeCodexAuthFile } from '../utils/codex-auth-file.js';
+import { createCodexDeviceAuthService } from './codex-device-auth';
+
+vi.mock('@agor/core/config', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/config')>('@agor/core/config');
+  return {
+    ...actual,
+    isTenantAgenticToolEnabled: vi.fn(),
+    loadConfigSync: vi.fn(),
+  };
+});
+
+vi.mock('../utils/codex-auth-file.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/codex-auth-file.js')>(
+    '../utils/codex-auth-file.js'
+  );
+  return {
+    ...actual,
+    writeCodexAuthFile: vi.fn(),
+    readCodexAuthFile: vi.fn(),
+  };
+});
+
+const isTenantAgenticToolEnabledMock = vi.mocked(isTenantAgenticToolEnabled);
+const loadConfigSyncMock = vi.mocked(loadConfigSync);
+const writeCodexAuthFileMock = vi.mocked(writeCodexAuthFile);
+const readCodexAuthFileMock = vi.mocked(readCodexAuthFile);
+
+const TEST_DB = { run: vi.fn() } as never;
+
+function fakeJwt(payload: Record<string, unknown>): string {
+  const enc = (obj: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${enc({ alg: 'RS256' })}.${enc(payload)}.signature`;
+}
+
+const ID_TOKEN = fakeJwt({
+  'https://api.openai.com/auth': { chatgpt_plan_type: 'pro', chatgpt_account_id: 'acct-9' },
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+function makeApp() {
+  const usersService = {
+    get: vi.fn(async () => ({ agentic_auth_methods: {} })),
+    patch: vi.fn(async () => ({})),
+  };
+  return { app: { service: () => usersService }, usersService };
+}
+
+const AUTH_PARAMS = {
+  user: { user_id: 'user-1', email: 'u@example.com', role: 'member' },
+} as never;
+
+function withTenant<T>(work: () => Promise<T>): Promise<T> {
+  return runWithTenantContext('tenant-test', work);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  isTenantAgenticToolEnabledMock.mockResolvedValue(true);
+  loadConfigSyncMock.mockReturnValue({ execution: { unix_user_mode: 'simple' } } as never);
+  // Readback verification returns whatever the service wrote.
+  let written = '';
+  writeCodexAuthFileMock.mockImplementation((content: string) => {
+    written = content;
+  });
+  readCodexAuthFileMock.mockImplementation(() => written || null);
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function mockUserCodeIssued() {
+  fetchMock.mockResolvedValueOnce(
+    jsonResponse(200, { device_auth_id: 'dev-1', user_code: 'ABCD-1234', interval: '1' })
+  );
+}
+
+describe('codex-device-auth', () => {
+  it('starts an attempt and reports a pending status with the code and verification URL', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+
+    const status = await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    expect(status.phase).toBe('pending');
+    expect(status.userCode).toBe('ABCD-1234');
+    expect(status.verificationUrl).toBe('https://auth.openai.com/codex/device');
+    expect(status.expiresAt).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth.openai.com/api/accounts/deviceauth/usercode',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('maps a gated account (404 on usercode) to the unavailable phase with guidance', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    fetchMock.mockResolvedValueOnce(jsonResponse(404, {}));
+
+    const status = await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    expect(status.phase).toBe('unavailable');
+    expect(status.hint).toMatch(/Device code authorization for Codex/);
+    expect(status.userCode).toBeUndefined();
+  });
+
+  it('polls until approval, exchanges the code, persists auth.json, and reports success', async () => {
+    const { app, usersService } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    // First poll: pending. Second poll: approved. Then the token exchange.
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(403, {}))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_code: 'authz-1',
+          code_challenge: 'chal',
+          code_verifier: 'verif',
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id_token: ID_TOKEN,
+          access_token: 'access-tok',
+          refresh_token: 'refresh-tok',
+        })
+      );
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100); // first poll (pending)
+    await vi.advanceTimersByTimeAsync(2100); // second poll (approved + exchange)
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('success');
+    expect(status.planType).toBe('pro');
+    expect(JSON.stringify(status)).not.toContain('refresh-tok');
+    expect(JSON.stringify(status)).not.toContain('access-tok');
+
+    const written = JSON.parse(writeCodexAuthFileMock.mock.calls[0][0]);
+    expect(written).toMatchObject({
+      auth_mode: 'chatgpt',
+      OPENAI_API_KEY: null,
+      tokens: {
+        id_token: ID_TOKEN,
+        access_token: 'access-tok',
+        refresh_token: 'refresh-tok',
+        account_id: 'acct-9',
+      },
+    });
+    expect(typeof written.last_refresh).toBe('string');
+
+    expect(usersService.patch).toHaveBeenCalledWith(
+      'user-1',
+      { agentic_auth_methods: { codex: 'subscription' } },
+      expect.objectContaining({ authenticated: true })
+    );
+
+    // Terminal phase: no further polling.
+    const callsAfterSuccess = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(fetchMock.mock.calls.length).toBe(callsAfterSuccess);
+  });
+
+  it('hard-stops at code expiry and reports expired', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock.mockResolvedValue(jsonResponse(403, {}));
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(16 * 60 * 1000);
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('expired');
+    expect(writeCodexAuthFileMock).not.toHaveBeenCalled();
+  });
+
+  it('starting a new attempt cancels and replaces the previous one', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { device_auth_id: 'dev-2', user_code: 'WXYZ-9876', interval: '1' })
+    );
+    const status = await withTenant(() => service.create({}, AUTH_PARAMS));
+
+    expect(status.phase).toBe('pending');
+    expect(status.userCode).toBe('WXYZ-9876');
+  });
+
+  it('find with no attempt reports idle; unauthenticated callers are rejected', async () => {
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('idle');
+
+    await expect(withTenant(() => service.create({}, undefined))).rejects.toThrow(/Sign in/);
+  });
+
+  it('rejects hosted multi-tenant mode before contacting OpenAI', async () => {
+    loadConfigSyncMock.mockReturnValue({
+      multi_tenancy: { mode: 'required_from_auth' },
+    } as never);
+    const { app } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+
+    await expect(withTenant(() => service.create({}, AUTH_PARAMS))).rejects.toThrow(
+      /hosted multi-tenant/
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/codex-device-auth.test.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.test.ts
@@ -201,6 +201,35 @@ describe('codex-device-auth', () => {
     expect(fetchMock.mock.calls.length).toBe(3); // usercode + two polls
   });
 
+  it('retries the post-approval token exchange once on a provider 5xx', async () => {
+    const { app, usersService } = makeApp();
+    const service = createCodexDeviceAuthService(app as never, TEST_DB);
+    mockUserCodeIssued();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          authorization_code: 'authz-1',
+          code_challenge: 'chal',
+          code_verifier: 'verif',
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse(502, {}))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id_token: ID_TOKEN,
+          access_token: 'access-tok',
+          refresh_token: 'refresh-tok',
+        })
+      );
+
+    await withTenant(() => service.create({}, AUTH_PARAMS));
+    await vi.advanceTimersByTimeAsync(2100);
+
+    const status = await withTenant(() => service.find(AUTH_PARAMS));
+    expect(status.phase).toBe('success');
+    expect(usersService.patch).toHaveBeenCalledTimes(1);
+  });
+
   it('a non-pending 4xx during polling is terminal', async () => {
     const { app } = makeApp();
     const service = createCodexDeviceAuthService(app as never, TEST_DB);

--- a/apps/agor-daemon/src/services/codex-device-auth.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.ts
@@ -174,7 +174,7 @@ async function exchangeCodeForTokens(approved: ApprovedCode): Promise<ExchangedT
       code_verifier: approved.codeVerifier,
     }).toString(),
   });
-  if (!res.ok) throw new Error(`token exchange failed with status ${res.status}`);
+  if (!res.ok) throw providerStatusError('token exchange', res.status);
 
   const body = (await res.json()) as Record<string, unknown>;
   const { id_token, access_token, refresh_token } = body;
@@ -183,9 +183,26 @@ async function exchangeCodeForTokens(approved: ApprovedCode): Promise<ExchangedT
     typeof access_token !== 'string' ||
     typeof refresh_token !== 'string'
   ) {
-    throw new Error('token exchange response missing expected fields');
+    throw new DeviceAuthProviderError(
+      'terminal',
+      'token exchange response missing expected fields'
+    );
   }
   return { idToken: id_token, accessToken: access_token, refreshToken: refresh_token };
+}
+
+/**
+ * The exchange runs once, AFTER the user already approved — a provider blip
+ * here would otherwise force a whole new code+approval round-trip. One retry
+ * on a transient failure mirrors the poll loop's own policy.
+ */
+async function exchangeWithOneRetry(approved: ApprovedCode): Promise<ExchangedTokens> {
+  try {
+    return await exchangeCodeForTokens(approved);
+  } catch (err) {
+    if (err instanceof DeviceAuthProviderError && err.disposition === 'terminal') throw err;
+    return exchangeCodeForTokens(approved);
+  }
 }
 
 /** Codex-format auth.json content for a fresh ChatGPT login. */
@@ -206,6 +223,7 @@ export function buildDeviceAuthJson(tokens: ExchangedTokens): string {
 }
 
 interface DeviceAuthAttempt {
+  key: string;
   userId: UserID;
   tenantId: TenantID | string;
   authUser: NonNullable<AuthenticatedParams['user']>;
@@ -304,8 +322,11 @@ export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareD
     }
 
     try {
-      const tokens = await exchangeCodeForTokens(approved);
-      if (attempt.cancelled) return;
+      const tokens = await exchangeWithOneRetry(approved);
+      // Ownership check in addition to the cancelled flag: a replacement
+      // attempt registered during the exchange must not have its freshly
+      // written credential clobbered by this older one.
+      if (attempt.cancelled || attempts.get(attempt.key) !== attempt) return;
       const summary = await runWithTenantDatabaseScope(db, attempt.tenantId, () =>
         persistVerifiedCodexAuth({
           app,
@@ -402,6 +423,7 @@ export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareD
       cancelAttempt(key);
       pruneFinishedAttempts();
       const attempt: DeviceAuthAttempt = {
+        key,
         userId,
         tenantId,
         authUser,

--- a/apps/agor-daemon/src/services/codex-device-auth.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.ts
@@ -48,7 +48,7 @@ import { codexIdTokenClaims } from '../utils/codex-auth-file.js';
 import {
   type AppLike,
   persistVerifiedCodexAuth,
-  resolveCodexAuthTargetUser,
+  resolveCodexUnixIdentity,
 } from './codex-auth-import.js';
 
 const CODEX_AUTH_ISSUER = 'https://auth.openai.com';
@@ -73,6 +73,28 @@ async function fetchWithTimeout(url: string, init: RequestInit): Promise<Respons
   }
 }
 
+/**
+ * Provider failure with an explicit retry disposition, so callers never have
+ * to infer transient-vs-terminal from message text. 5xx are transient (a
+ * provider blip must not kill a 15-minute approval window); non-pending 4xx
+ * and contract breaks (missing response fields) are terminal.
+ */
+class DeviceAuthProviderError extends Error {
+  constructor(
+    readonly disposition: 'transient' | 'terminal',
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+function providerStatusError(endpoint: string, status: number): DeviceAuthProviderError {
+  return new DeviceAuthProviderError(
+    status >= 500 ? 'transient' : 'terminal',
+    `${endpoint} failed with status ${status}`
+  );
+}
+
 interface UserCodeGrant {
   deviceAuthId: string;
   userCode: string;
@@ -87,13 +109,13 @@ async function requestUserCode(): Promise<UserCodeGrant | 'unavailable'> {
     body: JSON.stringify({ client_id: CODEX_CLIENT_ID }),
   });
   if (res.status === 404 || res.status === 403) return 'unavailable';
-  if (!res.ok) throw new Error(`usercode request failed with status ${res.status}`);
+  if (!res.ok) throw providerStatusError('usercode request', res.status);
 
   const body = (await res.json()) as Record<string, unknown>;
   const deviceAuthId = body.device_auth_id;
   const userCode = body.user_code ?? body.usercode;
   if (typeof deviceAuthId !== 'string' || typeof userCode !== 'string') {
-    throw new Error('usercode response missing expected fields');
+    throw new DeviceAuthProviderError('terminal', 'usercode response missing expected fields');
   }
   // The server sends `interval` as a decimal string (seconds).
   const intervalSeconds = Number.parseInt(String(body.interval ?? ''), 10);
@@ -122,13 +144,14 @@ async function pollDeviceToken(
     body: JSON.stringify({ device_auth_id: deviceAuthId, user_code: userCode }),
   });
   if (res.status === 403 || res.status === 404) return 'pending';
-  if (!res.ok) throw new Error(`device token poll failed with status ${res.status}`);
+  if (!res.ok) throw providerStatusError('device token poll', res.status);
 
   const body = (await res.json()) as Record<string, unknown>;
   const authorizationCode = body.authorization_code;
   const codeVerifier = body.code_verifier;
   if (typeof authorizationCode !== 'string' || typeof codeVerifier !== 'string') {
-    throw new Error('device token response missing expected fields');
+    // The response contract broke — retrying the same request cannot help.
+    throw new DeviceAuthProviderError('terminal', 'device token response missing expected fields');
   }
   return { authorizationCode, codeVerifier };
 }
@@ -196,12 +219,18 @@ interface DeviceAuthAttempt {
   hint?: string;
   timer?: ReturnType<typeof setTimeout>;
   cancelled: boolean;
+  finishedAtMs?: number;
 }
+
+/** How long a finished attempt stays queryable before eviction. */
+const TERMINAL_ATTEMPT_TTL_MS = 60 * 60 * 1000;
 
 function statusOf(attempt: DeviceAuthAttempt | undefined): CodexDeviceAuthStatus {
   if (!attempt) return { phase: 'idle' };
   const base: CodexDeviceAuthStatus = { phase: attempt.phase };
-  if (attempt.phase === 'pending') {
+  // userCode is empty while the slot is reserved but the provider has not
+  // answered yet — don't surface a blank code for that sub-second window.
+  if (attempt.phase === 'pending' && attempt.userCode) {
     base.userCode = attempt.userCode;
     base.verificationUrl = `${CODEX_AUTH_ISSUER}/codex/device`;
     base.expiresAt = new Date(attempt.expiresAtMs).toISOString();
@@ -227,9 +256,23 @@ export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareD
     hint?: string
   ): void {
     attempt.phase = phase;
+    attempt.finishedAtMs = Date.now();
     if (hint) attempt.hint = hint;
     if (attempt.timer) clearTimeout(attempt.timer);
     attempt.timer = undefined;
+  }
+
+  /**
+   * Abandoned flows would otherwise grow the map forever on long-running
+   * daemons — one entry per user who started and never finished a sign-in.
+   */
+  function pruneFinishedAttempts(): void {
+    const cutoff = Date.now() - TERMINAL_ATTEMPT_TTL_MS;
+    for (const [key, attempt] of attempts) {
+      if (attempt.phase !== 'pending' && (attempt.finishedAtMs ?? 0) < cutoff) {
+        attempts.delete(key);
+      }
+    }
   }
 
   async function pollTick(attempt: DeviceAuthAttempt): Promise<void> {
@@ -243,10 +286,10 @@ export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareD
     try {
       approved = await pollDeviceToken(attempt.deviceAuthId, attempt.userCode);
     } catch (err) {
-      // Transient transport errors should not kill a 15-minute window; only
-      // an unexpected provider status is terminal.
-      const message = err instanceof Error ? err.message : '';
-      if (message.includes('status')) {
+      // Network blips and provider 5xx are transient — keep polling until the
+      // code expires. Only a definitive rejection or contract break ends the
+      // attempt early.
+      if (err instanceof DeviceAuthProviderError && err.disposition === 'terminal') {
         finish(attempt, 'error', 'ChatGPT sign-in failed — get a new code and try again.');
         return;
       }
@@ -281,9 +324,13 @@ export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareD
           : 'Signed in with ChatGPT.'
       );
     } catch (err) {
+      // Messages reaching this catch are already sanitized: the raw-token
+      // write path rethrows as BadRequest with operator-safe text inside
+      // persistVerifiedCodexAuth, and everything else is service/DB failures
+      // whose messages help operators.
       console.error(
         `[CodexDeviceAuth] Finalizing sign-in failed: ${
-          err instanceof Error ? err.constructor.name : 'unknown error'
+          err instanceof Error ? `${err.constructor.name}: ${err.message}` : 'unknown error'
         }`
       );
       finish(
@@ -341,65 +388,66 @@ export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareD
 
       // Resolve the destination identity up front so a strict-mode user with
       // no unix_username fails fast instead of after approving the code.
-      let targetUnixUser: string | null;
-      try {
-        targetUnixUser = await resolveCodexAuthTargetUser(userId, withTenantDatabase);
-      } catch (err) {
+      const identity = await resolveCodexUnixIdentity(userId, withTenantDatabase);
+      if (!identity.ok) {
         throw new BadRequest(
-          `Cannot determine which Unix account should hold this Codex login: ${
-            err instanceof Error ? err.message : String(err)
-          }`
+          `Cannot determine which Unix account should hold this Codex login: ${identity.message}`
         );
       }
 
+      // Reserve the per-user slot BEFORE any await: an overlapping create()
+      // (double-click, impatient retry) then cancels THIS attempt instead of
+      // racing past a not-yet-registered one and leaving its poll loop
+      // orphaned against OpenAI for the full 15-minute window.
       cancelAttempt(key);
-
-      let grant: UserCodeGrant | 'unavailable';
-      try {
-        grant = await requestUserCode();
-      } catch {
-        throw new BadRequest(
-          'Could not reach ChatGPT to start the sign-in — check the server’s network access and try again.'
-        );
-      }
-
-      if (grant === 'unavailable') {
-        const attempt: DeviceAuthAttempt = {
-          userId,
-          tenantId,
-          authUser,
-          targetUnixUser,
-          phase: 'unavailable',
-          deviceAuthId: '',
-          userCode: '',
-          intervalMs: 0,
-          expiresAtMs: 0,
-          hint: UNAVAILABLE_HINT,
-          cancelled: false,
-        };
-        attempts.set(key, attempt);
-        return statusOf(attempt);
-      }
-
+      pruneFinishedAttempts();
       const attempt: DeviceAuthAttempt = {
         userId,
         tenantId,
         authUser,
-        targetUnixUser,
+        targetUnixUser: identity.unixUser,
         phase: 'pending',
-        deviceAuthId: grant.deviceAuthId,
-        userCode: grant.userCode,
-        intervalMs: grant.intervalMs,
+        deviceAuthId: '',
+        userCode: '',
+        intervalMs: 0,
         expiresAtMs: Date.now() + DEVICE_CODE_LIFETIME_MS,
         cancelled: false,
       };
       attempts.set(key, attempt);
+
+      let grant: UserCodeGrant | 'unavailable';
+      try {
+        grant = await requestUserCode();
+      } catch (err) {
+        if (!attempt.cancelled) {
+          finish(attempt, 'error', 'Could not get a sign-in code from ChatGPT.');
+        }
+        const terminal = err instanceof DeviceAuthProviderError && err.disposition === 'terminal';
+        throw new BadRequest(
+          terminal
+            ? 'ChatGPT rejected the sign-in request — try again later, or paste an auth.json / use an API key instead.'
+            : 'Could not reach ChatGPT to start the sign-in — check the server’s network access and try again.'
+        );
+      }
+      // A newer attempt replaced this one while the provider was answering.
+      if (attempt.cancelled) return statusOf(attempts.get(key));
+
+      if (grant === 'unavailable') {
+        finish(attempt, 'unavailable', UNAVAILABLE_HINT);
+        return statusOf(attempt);
+      }
+
+      attempt.deviceAuthId = grant.deviceAuthId;
+      attempt.userCode = grant.userCode;
+      attempt.intervalMs = grant.intervalMs;
+      attempt.expiresAtMs = Date.now() + DEVICE_CODE_LIFETIME_MS;
       scheduleNext(attempt);
       return statusOf(attempt);
     },
 
     async find(params?: AuthenticatedParams): Promise<CodexDeviceAuthStatus> {
       const { key } = await requireContext(params);
+      pruneFinishedAttempts();
       return statusOf(attempts.get(key));
     },
   };

--- a/apps/agor-daemon/src/services/codex-device-auth.ts
+++ b/apps/agor-daemon/src/services/codex-device-auth.ts
@@ -1,0 +1,406 @@
+/**
+ * Codex Device-Code Sign-In Service
+ *
+ * Drives OpenAI's ChatGPT device-code authorization for Codex natively from
+ * the daemon, so the onboarding wizard can sign a user in without a terminal:
+ *
+ *   1. `create` → POST auth.openai.com/api/accounts/deviceauth/usercode with
+ *      Codex's public client id → `{device_auth_id, user_code, interval}`.
+ *      The UI shows the code + verification URL; the daemon starts polling.
+ *   2. Poll POST .../deviceauth/token with `{device_auth_id, user_code}` at
+ *      the server-specified interval. 403/404 mean "not approved yet"; codes
+ *      hard-expire after 15 minutes.
+ *   3. On approval the server returns an authorization code plus a
+ *      server-generated PKCE pair, exchanged at /oauth/token
+ *      (grant_type=authorization_code) for id/access/refresh tokens.
+ *   4. Tokens are persisted as a Codex-format auth.json (0600, as the Unix
+ *      identity that runs Codex for this user) and the user's Codex auth
+ *      method flips to `subscription`.
+ *
+ * Protocol verified against openai/codex `codex-rs/login/src/device_code_auth.rs`
+ * and `server.rs` (July 2026).
+ *
+ * One in-flight attempt per user: starting a new attempt cancels and replaces
+ * the previous one. Attempts live in daemon memory only — a restart discards
+ * them and the user simply requests a fresh code.
+ *
+ * SECURITY CONTRACT: tokens transit UI ↔ daemon ↔ auth.openai.com and the
+ * target user's filesystem only. Status responses carry the user code and
+ * non-secret metadata; token material is never returned, logged, or exposed
+ * to any agent/LLM context. Callers act only on their own credentials.
+ */
+
+import { isTenantAgenticToolEnabled, loadConfigSync } from '@agor/core/config';
+import {
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
+import { BadRequest, NotAuthenticated } from '@agor/core/feathers';
+import type {
+  AuthenticatedParams,
+  CodexDeviceAuthStatus,
+  TenantID,
+  UserID,
+} from '@agor/core/types';
+import { codexIdTokenClaims } from '../utils/codex-auth-file.js';
+import {
+  type AppLike,
+  persistVerifiedCodexAuth,
+  resolveCodexAuthTargetUser,
+} from './codex-auth-import.js';
+
+const CODEX_AUTH_ISSUER = 'https://auth.openai.com';
+/** Codex CLI's public OAuth client id (codex-rs/login/src/auth/manager.rs). */
+const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+/** Server-side validity window for a device code (fixed by OpenAI). */
+const DEVICE_CODE_LIFETIME_MS = 15 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_S = 5;
+const MIN_POLL_INTERVAL_MS = 2_000;
+const FETCH_TIMEOUT_MS = 15_000;
+
+const UNAVAILABLE_HINT =
+  'Your ChatGPT account does not allow device-code sign-in. Personal accounts can turn it on under ChatGPT Settings → Security → "Device code authorization for Codex"; workspace accounts need an admin to enable it. You can also paste an auth.json or use an API key instead.';
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface UserCodeGrant {
+  deviceAuthId: string;
+  userCode: string;
+  intervalMs: number;
+}
+
+/** `unavailable` maps the server's refusal to issue a code (gated account/workspace). */
+async function requestUserCode(): Promise<UserCodeGrant | 'unavailable'> {
+  const res = await fetchWithTimeout(`${CODEX_AUTH_ISSUER}/api/accounts/deviceauth/usercode`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: CODEX_CLIENT_ID }),
+  });
+  if (res.status === 404 || res.status === 403) return 'unavailable';
+  if (!res.ok) throw new Error(`usercode request failed with status ${res.status}`);
+
+  const body = (await res.json()) as Record<string, unknown>;
+  const deviceAuthId = body.device_auth_id;
+  const userCode = body.user_code ?? body.usercode;
+  if (typeof deviceAuthId !== 'string' || typeof userCode !== 'string') {
+    throw new Error('usercode response missing expected fields');
+  }
+  // The server sends `interval` as a decimal string (seconds).
+  const intervalSeconds = Number.parseInt(String(body.interval ?? ''), 10);
+  const intervalMs = Math.max(
+    (Number.isFinite(intervalSeconds) && intervalSeconds > 0
+      ? intervalSeconds
+      : DEFAULT_POLL_INTERVAL_S) * 1000,
+    MIN_POLL_INTERVAL_MS
+  );
+  return { deviceAuthId, userCode, intervalMs };
+}
+
+interface ApprovedCode {
+  authorizationCode: string;
+  codeVerifier: string;
+}
+
+/** 403/404 are the server's "authorization pending" signals for this endpoint. */
+async function pollDeviceToken(
+  deviceAuthId: string,
+  userCode: string
+): Promise<ApprovedCode | 'pending'> {
+  const res = await fetchWithTimeout(`${CODEX_AUTH_ISSUER}/api/accounts/deviceauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ device_auth_id: deviceAuthId, user_code: userCode }),
+  });
+  if (res.status === 403 || res.status === 404) return 'pending';
+  if (!res.ok) throw new Error(`device token poll failed with status ${res.status}`);
+
+  const body = (await res.json()) as Record<string, unknown>;
+  const authorizationCode = body.authorization_code;
+  const codeVerifier = body.code_verifier;
+  if (typeof authorizationCode !== 'string' || typeof codeVerifier !== 'string') {
+    throw new Error('device token response missing expected fields');
+  }
+  return { authorizationCode, codeVerifier };
+}
+
+interface ExchangedTokens {
+  idToken: string;
+  accessToken: string;
+  refreshToken: string;
+}
+
+async function exchangeCodeForTokens(approved: ApprovedCode): Promise<ExchangedTokens> {
+  const res = await fetchWithTimeout(`${CODEX_AUTH_ISSUER}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code: approved.authorizationCode,
+      redirect_uri: `${CODEX_AUTH_ISSUER}/deviceauth/callback`,
+      client_id: CODEX_CLIENT_ID,
+      code_verifier: approved.codeVerifier,
+    }).toString(),
+  });
+  if (!res.ok) throw new Error(`token exchange failed with status ${res.status}`);
+
+  const body = (await res.json()) as Record<string, unknown>;
+  const { id_token, access_token, refresh_token } = body;
+  if (
+    typeof id_token !== 'string' ||
+    typeof access_token !== 'string' ||
+    typeof refresh_token !== 'string'
+  ) {
+    throw new Error('token exchange response missing expected fields');
+  }
+  return { idToken: id_token, accessToken: access_token, refreshToken: refresh_token };
+}
+
+/** Codex-format auth.json content for a fresh ChatGPT login. */
+export function buildDeviceAuthJson(tokens: ExchangedTokens): string {
+  const { accountId } = codexIdTokenClaims(tokens.idToken);
+  const authDotJson = {
+    auth_mode: 'chatgpt',
+    OPENAI_API_KEY: null,
+    tokens: {
+      id_token: tokens.idToken,
+      access_token: tokens.accessToken,
+      refresh_token: tokens.refreshToken,
+      account_id: accountId ?? null,
+    },
+    last_refresh: new Date().toISOString(),
+  };
+  return `${JSON.stringify(authDotJson, null, 2)}\n`;
+}
+
+interface DeviceAuthAttempt {
+  userId: UserID;
+  tenantId: TenantID | string;
+  authUser: NonNullable<AuthenticatedParams['user']>;
+  targetUnixUser: string | null;
+  phase: CodexDeviceAuthStatus['phase'];
+  deviceAuthId: string;
+  userCode: string;
+  intervalMs: number;
+  expiresAtMs: number;
+  planType?: string;
+  hint?: string;
+  timer?: ReturnType<typeof setTimeout>;
+  cancelled: boolean;
+}
+
+function statusOf(attempt: DeviceAuthAttempt | undefined): CodexDeviceAuthStatus {
+  if (!attempt) return { phase: 'idle' };
+  const base: CodexDeviceAuthStatus = { phase: attempt.phase };
+  if (attempt.phase === 'pending') {
+    base.userCode = attempt.userCode;
+    base.verificationUrl = `${CODEX_AUTH_ISSUER}/codex/device`;
+    base.expiresAt = new Date(attempt.expiresAtMs).toISOString();
+  }
+  if (attempt.planType) base.planType = attempt.planType;
+  if (attempt.hint) base.hint = attempt.hint;
+  return base;
+}
+
+export function createCodexDeviceAuthService(app: AppLike, db: TenantScopeAwareDatabase) {
+  const attempts = new Map<string, DeviceAuthAttempt>();
+
+  function cancelAttempt(key: string): void {
+    const existing = attempts.get(key);
+    if (!existing) return;
+    existing.cancelled = true;
+    if (existing.timer) clearTimeout(existing.timer);
+  }
+
+  function finish(
+    attempt: DeviceAuthAttempt,
+    phase: DeviceAuthAttempt['phase'],
+    hint?: string
+  ): void {
+    attempt.phase = phase;
+    if (hint) attempt.hint = hint;
+    if (attempt.timer) clearTimeout(attempt.timer);
+    attempt.timer = undefined;
+  }
+
+  async function pollTick(attempt: DeviceAuthAttempt): Promise<void> {
+    if (attempt.cancelled || attempt.phase !== 'pending') return;
+    if (Date.now() >= attempt.expiresAtMs) {
+      finish(attempt, 'expired', 'The sign-in code expired — get a new one and try again.');
+      return;
+    }
+
+    let approved: ApprovedCode | 'pending';
+    try {
+      approved = await pollDeviceToken(attempt.deviceAuthId, attempt.userCode);
+    } catch (err) {
+      // Transient transport errors should not kill a 15-minute window; only
+      // an unexpected provider status is terminal.
+      const message = err instanceof Error ? err.message : '';
+      if (message.includes('status')) {
+        finish(attempt, 'error', 'ChatGPT sign-in failed — get a new code and try again.');
+        return;
+      }
+      scheduleNext(attempt);
+      return;
+    }
+    if (attempt.cancelled) return;
+
+    if (approved === 'pending') {
+      scheduleNext(attempt);
+      return;
+    }
+
+    try {
+      const tokens = await exchangeCodeForTokens(approved);
+      if (attempt.cancelled) return;
+      const summary = await runWithTenantDatabaseScope(db, attempt.tenantId, () =>
+        persistVerifiedCodexAuth({
+          app,
+          normalized: buildDeviceAuthJson(tokens),
+          targetUnixUser: attempt.targetUnixUser,
+          userId: attempt.userId,
+          authUser: attempt.authUser,
+        })
+      );
+      attempt.planType = summary.planType;
+      finish(
+        attempt,
+        'success',
+        summary.planType
+          ? `Signed in with ChatGPT (${summary.planType} plan).`
+          : 'Signed in with ChatGPT.'
+      );
+    } catch (err) {
+      console.error(
+        `[CodexDeviceAuth] Finalizing sign-in failed: ${
+          err instanceof Error ? err.constructor.name : 'unknown error'
+        }`
+      );
+      finish(
+        attempt,
+        'error',
+        err instanceof BadRequest && err.message
+          ? err.message
+          : 'Signing in succeeded but saving the login failed — try again.'
+      );
+    }
+  }
+
+  function scheduleNext(attempt: DeviceAuthAttempt): void {
+    if (attempt.cancelled || attempt.phase !== 'pending') return;
+    const delay = Math.min(attempt.intervalMs, Math.max(attempt.expiresAtMs - Date.now(), 0));
+    attempt.timer = setTimeout(() => {
+      void pollTick(attempt);
+    }, delay);
+    attempt.timer.unref?.();
+  }
+
+  async function requireContext(params?: AuthenticatedParams): Promise<{
+    authUser: NonNullable<AuthenticatedParams['user']>;
+    userId: UserID;
+    tenantId: TenantID | string;
+    key: string;
+  }> {
+    const authUser = params?.user;
+    if (!authUser?.user_id) {
+      throw new NotAuthenticated('Sign in before starting a ChatGPT device sign-in.');
+    }
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing active tenant context for Codex device auth');
+    const userId = authUser.user_id as UserID;
+    return { authUser, userId, tenantId, key: `${tenantId}:${userId}` };
+  }
+
+  return {
+    async create(_data: unknown, params?: AuthenticatedParams): Promise<CodexDeviceAuthStatus> {
+      const { authUser, userId, tenantId, key } = await requireContext(params);
+
+      const config = loadConfigSync();
+      if (config.multi_tenancy?.mode === 'required_from_auth') {
+        throw new BadRequest(
+          'Codex subscription login is unavailable in hosted multi-tenant mode — use an OpenAI API key instead.'
+        );
+      }
+      const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) =>
+        runWithTenantDatabaseScope(db, tenantId, work);
+      if (
+        !(await withTenantDatabase((tenantDb) => isTenantAgenticToolEnabled('codex', tenantDb)))
+      ) {
+        throw new BadRequest('Codex is disabled for this workspace.');
+      }
+
+      // Resolve the destination identity up front so a strict-mode user with
+      // no unix_username fails fast instead of after approving the code.
+      let targetUnixUser: string | null;
+      try {
+        targetUnixUser = await resolveCodexAuthTargetUser(userId, withTenantDatabase);
+      } catch (err) {
+        throw new BadRequest(
+          `Cannot determine which Unix account should hold this Codex login: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+
+      cancelAttempt(key);
+
+      let grant: UserCodeGrant | 'unavailable';
+      try {
+        grant = await requestUserCode();
+      } catch {
+        throw new BadRequest(
+          'Could not reach ChatGPT to start the sign-in — check the server’s network access and try again.'
+        );
+      }
+
+      if (grant === 'unavailable') {
+        const attempt: DeviceAuthAttempt = {
+          userId,
+          tenantId,
+          authUser,
+          targetUnixUser,
+          phase: 'unavailable',
+          deviceAuthId: '',
+          userCode: '',
+          intervalMs: 0,
+          expiresAtMs: 0,
+          hint: UNAVAILABLE_HINT,
+          cancelled: false,
+        };
+        attempts.set(key, attempt);
+        return statusOf(attempt);
+      }
+
+      const attempt: DeviceAuthAttempt = {
+        userId,
+        tenantId,
+        authUser,
+        targetUnixUser,
+        phase: 'pending',
+        deviceAuthId: grant.deviceAuthId,
+        userCode: grant.userCode,
+        intervalMs: grant.intervalMs,
+        expiresAtMs: Date.now() + DEVICE_CODE_LIFETIME_MS,
+        cancelled: false,
+      };
+      attempts.set(key, attempt);
+      scheduleNext(attempt);
+      return statusOf(attempt);
+    },
+
+    async find(params?: AuthenticatedParams): Promise<CodexDeviceAuthStatus> {
+      const { key } = await requireContext(params);
+      return statusOf(attempts.get(key));
+    },
+  };
+}

--- a/apps/agor-daemon/src/utils/codex-auth-file.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.ts
@@ -67,13 +67,26 @@ function decodeJwtClaims(token: string): Record<string, unknown> | null {
 /** Codex id_tokens nest account metadata under this claim key. */
 const OPENAI_AUTH_CLAIM = 'https://api.openai.com/auth';
 
-function planTypeFromIdToken(idToken: unknown): string | undefined {
-  if (typeof idToken !== 'string' || !idToken) return undefined;
+/**
+ * Mine display/bookkeeping metadata from a Codex id_token: the ChatGPT plan
+ * type and the account id Codex records as `tokens.account_id`. Best-effort —
+ * an unparseable token yields an empty result, never an error.
+ */
+export function codexIdTokenClaims(idToken: unknown): {
+  planType?: string;
+  accountId?: string;
+} {
+  if (typeof idToken !== 'string' || !idToken) return {};
   const claims = decodeJwtClaims(idToken);
   const authClaim = claims?.[OPENAI_AUTH_CLAIM];
-  if (!authClaim || typeof authClaim !== 'object') return undefined;
-  const planType = (authClaim as Record<string, unknown>).chatgpt_plan_type;
-  return typeof planType === 'string' && planType ? planType : undefined;
+  if (!authClaim || typeof authClaim !== 'object') return {};
+  const record = authClaim as Record<string, unknown>;
+  const planType = record.chatgpt_plan_type;
+  const accountId = record.chatgpt_account_id;
+  return {
+    ...(typeof planType === 'string' && planType ? { planType } : {}),
+    ...(typeof accountId === 'string' && accountId ? { accountId } : {}),
+  };
 }
 
 /**
@@ -135,7 +148,7 @@ export function parseCodexAuthJson(raw: string | undefined | null): ParseCodexAu
   const summary: CodexAuthSummary = hasChatgptLogin
     ? {
         authMode: 'chatgpt',
-        planType: planTypeFromIdToken(tokens?.id_token),
+        planType: codexIdTokenClaims(tokens?.id_token).planType,
         lastRefresh: typeof record.last_refresh === 'string' ? record.last_refresh : undefined,
       }
     : { authMode: 'api_key', apiKey };

--- a/apps/agor-daemon/src/utils/codex-auth-file.ts
+++ b/apps/agor-daemon/src/utils/codex-auth-file.ts
@@ -47,46 +47,44 @@ export type ParseCodexAuthResult =
   | { ok: true; normalized: string; summary: CodexAuthSummary }
   | { ok: false; error: string };
 
-/**
- * Decode a JWT payload segment without verifying the signature. We only mine
- * display metadata (plan type) from a token the user already possesses, so
- * verification adds nothing — treat every field as untrusted display data.
- */
-function decodeJwtClaims(token: string): Record<string, unknown> | null {
-  const segments = token.split('.');
-  if (segments.length !== 3) return null;
-  try {
-    const payload = Buffer.from(segments[1], 'base64url').toString('utf8');
-    const claims = JSON.parse(payload) as unknown;
-    return claims && typeof claims === 'object' ? (claims as Record<string, unknown>) : null;
-  } catch {
-    return null;
-  }
-}
-
 /** Codex id_tokens nest account metadata under this claim key. */
 const OPENAI_AUTH_CLAIM = 'https://api.openai.com/auth';
 
 /**
- * Mine display/bookkeeping metadata from a Codex id_token: the ChatGPT plan
- * type and the account id Codex records as `tokens.account_id`. Best-effort —
- * an unparseable token yields an empty result, never an error.
+ * Mine metadata from a Codex id_token payload (unverified — the signature is
+ * not checked): the ChatGPT plan type and the account id Codex records as
+ * `tokens.account_id`. Best-effort — an unparseable token yields an empty
+ * result, never an error.
+ *
+ * Trust note: "unverified" here means safe against parse errors, not a trust
+ * statement. When these claims matter (the device flow writing account_id
+ * into auth.json), trust flows from having received the id_token over the
+ * provider's TLS token endpoint — not from this parse.
  */
 export function codexIdTokenClaims(idToken: unknown): {
   planType?: string;
   accountId?: string;
 } {
-  if (typeof idToken !== 'string' || !idToken) return {};
-  const claims = decodeJwtClaims(idToken);
-  const authClaim = claims?.[OPENAI_AUTH_CLAIM];
-  if (!authClaim || typeof authClaim !== 'object') return {};
-  const record = authClaim as Record<string, unknown>;
-  const planType = record.chatgpt_plan_type;
-  const accountId = record.chatgpt_account_id;
-  return {
-    ...(typeof planType === 'string' && planType ? { planType } : {}),
-    ...(typeof accountId === 'string' && accountId ? { accountId } : {}),
-  };
+  if (typeof idToken !== 'string') return {};
+  const segments = idToken.split('.');
+  if (segments.length !== 3) return {};
+  try {
+    const claims = JSON.parse(Buffer.from(segments[1], 'base64url').toString('utf8')) as unknown;
+    const authClaim =
+      claims && typeof claims === 'object'
+        ? (claims as Record<string, unknown>)[OPENAI_AUTH_CLAIM]
+        : undefined;
+    if (!authClaim || typeof authClaim !== 'object') return {};
+    const record = authClaim as Record<string, unknown>;
+    const planType = record.chatgpt_plan_type;
+    const accountId = record.chatgpt_account_id;
+    return {
+      ...(typeof planType === 'string' && planType ? { planType } : {}),
+      ...(typeof accountId === 'string' && accountId ? { accountId } : {}),
+    };
+  } catch {
+    return {};
+  }
 }
 
 /**

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
@@ -1,0 +1,361 @@
+/**
+ * Tests for the Codex authentication management pane (settings surface).
+ *
+ * Unlike the onboarding wizard, this is a management view: it probes the live
+ * connection, surfaces a stored-but-broken credential as a prominent error, and
+ * keeps every sign-in path reachable while connected.
+ *
+ * Query style mirrors OnboardingWizard.test.tsx — plain text queries with
+ * `.closest('button')`, never `getByRole`, because computing an accessible name
+ * while an antd `Tag`/`Segmented` is mounted walks a CSS shorthand rule that
+ * crashes jsdom's `cssstyle`.
+ */
+
+import type { AgenticAuthMethod, AuthCheckResult } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+import { TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
+import { CodexAuthSettings } from './CodexAuthSettings';
+
+const UNKNOWN: AuthCheckResult = { status: 'unknown', authenticated: false, method: 'none' };
+
+interface HarnessOptions {
+  initialMethod?: AgenticAuthMethod;
+  fieldStatus?: Record<string, boolean>;
+  checkAuth?: ReturnType<typeof vi.fn>;
+  importCreate?: ReturnType<typeof vi.fn>;
+  deviceCreate?: ReturnType<typeof vi.fn>;
+  deviceFind?: ReturnType<typeof vi.fn>;
+  onSaveField?: ReturnType<typeof vi.fn>;
+  onClearField?: ReturnType<typeof vi.fn>;
+}
+
+// The pane never mutates the persisted method itself — the method is a
+// consequence of the credential the user configures (a key save / a completed
+// device sign-in or import), which the real settings modal drives — so the
+// harness holds authMethod fixed and asserts selection stays non-destructive.
+function Harness({
+  initialMethod = 'api_key',
+  fieldStatus = {},
+  checkAuth,
+  importCreate,
+  deviceCreate,
+  deviceFind,
+  onSaveField,
+  onClearField,
+}: HarnessOptions) {
+  const services: Record<string, unknown> = {
+    'check-auth': { create: checkAuth ?? vi.fn(async () => UNKNOWN) },
+    'codex-auth/import': {
+      create: importCreate ?? vi.fn(async () => ({ status: 'authenticated' })),
+    },
+    'codex-auth/device': {
+      create: deviceCreate ?? vi.fn(async () => ({ phase: 'idle' })),
+      find: deviceFind ?? vi.fn(async () => ({ phase: 'idle' })),
+    },
+  };
+  // Stable client identity across rerenders (mirrors the real modal, where the
+  // client outlives authMethod changes) — so a rerender that flips only
+  // authMethod exercises the method-change path, not a client swap.
+  const clientRef = useRef<unknown>(undefined);
+  if (clientRef.current === undefined) {
+    clientRef.current = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) => services[name] ?? {}),
+    };
+  }
+  const client = clientRef.current as never;
+
+  return (
+    <CodexAuthSettings
+      client={client}
+      authMethod={initialMethod}
+      apiKeyFields={TOOL_FIELD_CONFIGS.codex}
+      fieldStatus={fieldStatus}
+      onSaveField={onSaveField ?? vi.fn(async () => undefined)}
+      onClearField={onClearField ?? vi.fn(async () => undefined)}
+      savingFields={{}}
+    />
+  );
+}
+
+function clickText(text: string | RegExp) {
+  const el = screen.getByText(text);
+  const clickable = el.closest('button') ?? el.closest('label') ?? el;
+  fireEvent.click(clickable);
+}
+
+describe('CodexAuthSettings', () => {
+  it('shows a Connected banner when the probe reports an authenticated API key', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'api-key',
+      })
+    );
+    render(<Harness initialMethod="api_key" checkAuth={checkAuth} />);
+
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+    expect(screen.getByText('Your OpenAI API key is working.')).toBeInTheDocument();
+    await waitFor(() => expect(checkAuth).toHaveBeenCalledWith({ tool: 'codex' }));
+  });
+
+  it('surfaces a missing subscription login as a prominent "Login not found" error', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'none',
+      })
+    );
+    render(<Harness initialMethod="subscription" checkAuth={checkAuth} />);
+
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
+    expect(screen.getByText(/Codex login no longer found on this server/i)).toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+  });
+
+  it('flags a stored-but-rejected API key as "Key not working"', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'api-key',
+      })
+    );
+    render(
+      <Harness
+        initialMethod="api_key"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+
+    expect(await screen.findByText('Key not working')).toBeInTheDocument();
+    expect(screen.queryByText('Login not found')).not.toBeInTheDocument();
+  });
+
+  it('stays silent when no key is stored and the probe is negative (fail safe)', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'none',
+      })
+    );
+    render(<Harness initialMethod="api_key" fieldStatus={{}} checkAuth={checkAuth} />);
+
+    // Give the probe a chance to resolve before asserting the banner is absent.
+    await waitFor(() => expect(checkAuth).toHaveBeenCalled());
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+    expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
+  });
+
+  it('never affirms a ChatGPT login while the effective method is api_key (banner tracks stored method)', async () => {
+    // Mixed state: method=api_key (keyless) with a login the probe can see. The
+    // executor won't use that login for api_key, so the banner must not claim
+    // "connected" — the sessions-broken-but-banner-connected contradiction.
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'native',
+      })
+    );
+    render(<Harness initialMethod="api_key" fieldStatus={{}} checkAuth={checkAuth} />);
+
+    await waitFor(() => expect(checkAuth).toHaveBeenCalled());
+    expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
+    expect(screen.queryByText('A ChatGPT login is active on this server.')).not.toBeInTheDocument();
+  });
+
+  it('drops a stale negative verdict when the method flips (no false "Login not found")', async () => {
+    // An api-key probe rejects; then the method flips to subscription, as a
+    // completed ChatGPT sign-in would. The stale api-key rejection must not be
+    // reinterpreted as a subscription failure — even while the re-probe for the
+    // new method is still in flight (and would persist if that re-probe failed).
+    let releaseSecond: (v: AuthCheckResult) => void = () => {};
+    const checkAuth = vi
+      .fn<[], Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce({ status: 'unauthenticated', authenticated: false, method: 'api-key' })
+      .mockImplementationOnce(
+        () =>
+          new Promise<AuthCheckResult>((resolve) => {
+            releaseSecond = resolve;
+          })
+      );
+    const { rerender } = render(
+      <Harness
+        initialMethod="api_key"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+    expect(await screen.findByText('Key not working')).toBeInTheDocument();
+
+    // Flip to subscription; the second probe is in flight and unresolved.
+    rerender(
+      <Harness
+        initialMethod="subscription"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+    await waitFor(() => expect(checkAuth).toHaveBeenCalledTimes(2));
+    // Neither the stale api-key rejection nor a subscription failure is shown.
+    expect(screen.queryByText('Login not found')).not.toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+
+    // Once the new probe resolves under the new method, the correct verdict shows.
+    releaseSecond({ status: 'unauthenticated', authenticated: false, method: 'none' });
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
+  });
+
+  it('saves an OpenAI API key through the API-key pane', async () => {
+    const onSaveField = vi.fn(async () => undefined);
+    render(<Harness initialMethod="api_key" onSaveField={onSaveField} />);
+
+    const input = screen.getByPlaceholderText('sk-proj-...');
+    fireEvent.change(input, { target: { value: 'sk-proj-abc123' } });
+    // Two "Save" buttons render (key + base URL); the key field is first.
+    const saveButtons = screen.getAllByText('Save').map((el) => el.closest('button'));
+    fireEvent.click(saveButtons[0] as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(onSaveField).toHaveBeenCalledWith('OPENAI_API_KEY', 'sk-proj-abc123')
+    );
+  });
+
+  it('starts the device flow deliberately (no OpenAI request on mere tab view)', async () => {
+    const deviceFind = vi.fn(async () => ({ phase: 'idle' }));
+    const deviceCreate = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'ABCD-1234',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    }));
+    render(
+      <Harness initialMethod="subscription" deviceFind={deviceFind} deviceCreate={deviceCreate} />
+    );
+
+    clickText('Sign in with ChatGPT');
+
+    // Deliberate-start: a code is only requested after an explicit click.
+    expect(await screen.findByText('Get a sign-in code')).toBeInTheDocument();
+    expect(deviceCreate).not.toHaveBeenCalled();
+
+    clickText('Get a sign-in code');
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('ABCD-1234')).toBeInTheDocument();
+  });
+
+  it('switches methods as a pure view — no selection persists a credential', async () => {
+    // Selecting a tab is never destructive: the method follows the credential
+    // you configure, so no key-save/clear is triggered by mere navigation.
+    const onSaveField = vi.fn(async () => undefined);
+    const onClearField = vi.fn(async () => undefined);
+    render(
+      <Harness initialMethod="api_key" onSaveField={onSaveField} onClearField={onClearField} />
+    );
+
+    clickText('Sign in with ChatGPT');
+    expect(await screen.findByText(/Sign in with your ChatGPT account/i)).toBeInTheDocument();
+    clickText('Import login file');
+    expect(await screen.findByLabelText('Codex auth.json contents')).toBeInTheDocument();
+    clickText('API key');
+    expect(await screen.findByPlaceholderText('sk-proj-...')).toBeInTheDocument();
+
+    expect(onSaveField).not.toHaveBeenCalled();
+    expect(onClearField).not.toHaveBeenCalled();
+  });
+
+  it('opening the API-key tab from a subscription login is non-destructive (no silent break)', async () => {
+    // Regression guard: a user with a working ChatGPT login who clicks "API key"
+    // to look at the fields must not have their login deactivated. The pane
+    // exposes no method-flip callback, and selection triggers no persistence.
+    const onSaveField = vi.fn(async () => undefined);
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'native',
+      })
+    );
+    render(
+      <Harness initialMethod="subscription" checkAuth={checkAuth} onSaveField={onSaveField} />
+    );
+
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+    expect(screen.getByText('A ChatGPT login is active on this server.')).toBeInTheDocument();
+
+    clickText('API key');
+    expect(await screen.findByPlaceholderText('sk-proj-...')).toBeInTheDocument();
+    // The login banner is unaffected — nothing was persisted or re-probed away.
+    expect(screen.getByText('Codex is connected')).toBeInTheDocument();
+    expect(onSaveField).not.toHaveBeenCalled();
+  });
+
+  it('does not adopt a stale success in settings — re-signing-in stays reachable', async () => {
+    // A device sign-in that succeeded within the daemon's adopt-TTL must not
+    // wall off the management surface: the deliberate-start button remains.
+    const deviceFind = vi.fn(async () => ({ phase: 'success', hint: 'Signed in with ChatGPT.' }));
+    const deviceCreate = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'WXYZ-9876',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    }));
+    render(
+      <Harness initialMethod="subscription" deviceFind={deviceFind} deviceCreate={deviceCreate} />
+    );
+
+    clickText('Sign in with ChatGPT');
+    // Success is not adopted (autoStart=false) — the restart button shows instead.
+    expect(await screen.findByText('Get a sign-in code')).toBeInTheDocument();
+    expect(screen.queryByText('Signed in with ChatGPT.')).not.toBeInTheDocument();
+
+    clickText('Get a sign-in code');
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('WXYZ-9876')).toBeInTheDocument();
+  });
+
+  it('imports a pasted login file and re-probes the connection', async () => {
+    const importCreate = vi.fn(async () => ({ status: 'authenticated', authMode: 'chatgpt' }));
+    const checkAuth = vi
+      .fn<[], Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce(UNKNOWN)
+      .mockResolvedValue({ status: 'authenticated', authenticated: true, method: 'native' });
+    render(
+      <Harness initialMethod="subscription" importCreate={importCreate} checkAuth={checkAuth} />
+    );
+
+    clickText('Import login file');
+    const pasted = '{"tokens":{"refresh_token":"r"}}';
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: pasted },
+    });
+    clickText('Import login');
+
+    await waitFor(() => expect(importCreate).toHaveBeenCalledWith({ authJson: pasted }));
+    // onImported triggers a fresh probe, which now reports connected.
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+  });
+
+  it('shows the daemon rejection message when an imported login file is invalid', async () => {
+    const importCreate = vi.fn(async () => {
+      throw new Error('This file has no ChatGPT login tokens and no API key.');
+    });
+    render(<Harness initialMethod="subscription" importCreate={importCreate} />);
+
+    clickText('Import login file');
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: '{"tokens":{}}' },
+    });
+    clickText('Import login');
+
+    expect(
+      await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -1,0 +1,284 @@
+import type {
+  AgenticAuthMethod,
+  AgenticToolConfigField,
+  AgorClient,
+  AuthCheckResult,
+} from '@agor-live/client';
+import { Alert, Button, Segmented, Space, Typography, theme } from 'antd';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { type AgenticToolFieldConfig, ApiKeyFields, type FieldStatus } from '../ApiKeyFields';
+import { type CodexAuthFallback, CodexDeviceSignIn } from './CodexDeviceSignIn';
+import { CodexImportAuthJson } from './CodexImportAuthJson';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+/**
+ * Which sub-pane the management surface is showing. The persisted auth method is
+ * only two-valued (`api_key` | `subscription`) because "sign in with ChatGPT"
+ * and "import auth.json" both land the same server-side ChatGPT login — so the
+ * two subscription entry points are distinguished here as a local view choice.
+ */
+type CodexMethodView = 'api_key' | 'chatgpt' | 'import';
+
+function viewForMethod(method: AgenticAuthMethod, prev: CodexMethodView): CodexMethodView {
+  if (method === 'api_key') return 'api_key';
+  return prev === 'import' ? 'import' : 'chatgpt';
+}
+
+export interface CodexAuthSettingsProps {
+  client: AgorClient | null;
+  /**
+   * Persisted Codex auth method for this user. Read-only here: the method is a
+   * consequence of the credential you configure (saving an OpenAI key flips it
+   * to `api_key`; a completed device sign-in / import flips it to
+   * `subscription` daemon-side), never of merely selecting a tab — so switching
+   * views can't silently deactivate a working login.
+   */
+  authMethod: AgenticAuthMethod;
+  /** Codex credential field definitions (OpenAI key + base URL). */
+  apiKeyFields: AgenticToolFieldConfig[];
+  /** Per-field set/unset flags for the API-key pane. */
+  fieldStatus: FieldStatus;
+  onSaveField: (field: AgenticToolConfigField, value: string) => Promise<void>;
+  onClearField: (field: AgenticToolConfigField) => Promise<void>;
+  savingFields: Partial<Record<AgenticToolConfigField, boolean>>;
+  publicValues?: Partial<Record<AgenticToolConfigField, string>>;
+}
+
+/**
+ * Codex authentication management pane — the three ways in (API key, ChatGPT
+ * device sign-in, imported login file) plus a live connection probe. Unlike the
+ * onboarding wizard, this is a management view: re-signing-in or re-importing
+ * stays reachable while connected, and a stored-but-broken credential surfaces
+ * as a prominent error rather than being hidden behind a "connected" collapse.
+ */
+export function CodexAuthSettings({
+  client,
+  authMethod,
+  apiKeyFields,
+  fieldStatus,
+  onSaveField,
+  onClearField,
+  savingFields,
+  publicValues,
+}: CodexAuthSettingsProps) {
+  const { token } = useToken();
+  const [view, setView] = useState<CodexMethodView>(() => viewForMethod(authMethod, 'chatgpt'));
+  const [probe, setProbe] = useState<AuthCheckResult | null>(null);
+  const [probing, setProbing] = useState(false);
+
+  // Keep the visible sub-pane in step with the persisted method (e.g. a
+  // successful device/import flips it to subscription), while preserving which
+  // subscription entry point the user is looking at.
+  useEffect(() => {
+    setView((prev) => viewForMethod(authMethod, prev));
+  }, [authMethod]);
+
+  // A transport failure is NOT proof of a missing login — leave the prior
+  // verdict untouched on error so the pane never flashes a false "not
+  // connected" state (mirrors App.handleCheckAuth's fail-safe contract).
+  // A monotonic generation guards against overlapping probes (a method switch
+  // mid-recheck): only the latest request commits its verdict or clears the
+  // spinner, so an older response can't land last and mislabel the banner.
+  const probeGenRef = useRef(0);
+  // Bump the generation synchronously when the client OR the effective method
+  // changes (and on unmount), before any in-flight probe can resolve, and clear
+  // the prior verdict. Two reasons a stale verdict must not survive a change:
+  //  - client swap: an old identity's probe still owns the current generation
+  //    in the window before the next probe starts (and if the replacement
+  //    client is null, runProbe returns before incrementing, so the stale
+  //    request would never be invalidated).
+  //  - method flip: a verdict captured under the PREVIOUS method must not be
+  //    re-interpreted by the banner under the new one — e.g. a rejected api-key
+  //    probe becoming a false "Login not found" after a ChatGPT sign-in flips
+  //    the method to subscription (and persisting there if the re-probe then
+  //    fails, since transport failures keep the last verdict). Clearing to null
+  //    means the banner shows nothing until a verdict for the NEW method lands.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: client/authMethod are the change triggers; the body invalidates rather than reading them.
+  useLayoutEffect(() => {
+    probeGenRef.current++;
+    setProbe(null);
+    setProbing(false);
+    // Invalidate on unmount from the layout cleanup (synchronous, during the
+    // commit) — a passive cleanup can be deferred past unmount, letting a
+    // settled probe commit its verdict/spinner after teardown.
+    return () => {
+      probeGenRef.current++;
+    };
+  }, [client, authMethod]);
+  const runProbe = useCallback(async () => {
+    if (!client) return;
+    const gen = ++probeGenRef.current;
+    setProbing(true);
+    try {
+      const result = (await client
+        .service('check-auth')
+        .create({ tool: 'codex' })) as AuthCheckResult;
+      if (probeGenRef.current === gen) setProbe(result);
+    } catch {
+      // Unknown — keep the last verdict.
+    } finally {
+      if (probeGenRef.current === gen) setProbing(false);
+    }
+  }, [client]);
+
+  // Re-probe when the persisted method changes: the daemon checks whichever
+  // credential the server's active method points at, so a verdict captured for
+  // the previous method would otherwise be mislabelled by the banner.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authMethod is a deliberate re-probe trigger, not a value read by runProbe.
+  useEffect(() => {
+    void runProbe();
+  }, [runProbe, authMethod]);
+
+  // Device sign-in and login-file import both persist `subscription` daemon-side
+  // as part of the flow, so here we only re-probe to refresh the banner.
+  const handleAuthenticated = useCallback(() => {
+    void runProbe();
+  }, [runProbe]);
+
+  // Selecting a method is a pure view switch — it never persists the auth
+  // method. Persisting on selection is destructive in BOTH directions: choosing
+  // a subscription view would deactivate a working API key before a ChatGPT
+  // login exists, and choosing "API key" would deactivate a working ChatGPT
+  // login before any key is stored (a silent, non-undoable break). The method
+  // instead follows the credential you actually configure — saving a key flips
+  // it to api_key; a completed device/import flips it to subscription.
+  const handleFallback = useCallback((target: CodexAuthFallback) => {
+    setView(target === 'import' ? 'import' : 'api_key');
+  }, []);
+
+  const handleSelect = useCallback((next: CodexMethodView) => {
+    setView(next);
+  }, []);
+
+  // The banner reflects the EFFECTIVE auth — the persisted method plus a probe
+  // of that method's credential — never the currently-viewed tab. Crucially, a
+  // "connected" verdict is only shown when the probe actually exercised the
+  // stored method: an authenticated api-key probe can't render "ChatGPT login
+  // active" and an authenticated login probe can't render "API key working".
+  // This makes the sessions-broken-but-banner-says-connected contradiction
+  // impossible even if the daemon's probe ever reported a credential the
+  // executor wouldn't use for the stored method.
+  const connectionBanner = (() => {
+    if (!probe) return null;
+    const authenticated = probe.status === 'authenticated';
+    const unauthenticated = probe.status === 'unauthenticated';
+    if (authMethod === 'subscription') {
+      if (authenticated && probe.method !== 'api-key') {
+        return (
+          <Alert
+            type="success"
+            showIcon
+            message="Codex is connected"
+            description="A ChatGPT login is active on this server."
+          />
+        );
+      }
+      if (unauthenticated) {
+        return (
+          <Alert
+            type="error"
+            showIcon
+            message="Login not found"
+            description={
+              probe.hint ??
+              'Codex login no longer found on this server — sign in with ChatGPT or import it again.'
+            }
+          />
+        );
+      }
+      return null;
+    }
+    // authMethod === 'api_key': the effective credential is the OpenAI key.
+    if (authenticated && probe.method === 'api-key') {
+      return (
+        <Alert
+          type="success"
+          showIcon
+          message="Codex is connected"
+          description="Your OpenAI API key is working."
+        />
+      );
+    }
+    // Only a stored-but-rejected key is worth flagging; an empty key just means
+    // the user hasn't set one yet (and a login on disk is irrelevant here —
+    // sessions use the api_key method, not that login).
+    if (unauthenticated && fieldStatus.OPENAI_API_KEY) {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          message="Key not working"
+          description={probe.hint ?? 'Key stored but not working — enter a new one.'}
+        />
+      );
+    }
+    // 'unknown', or authenticated via a credential the stored method won't use,
+    // or unset-and-empty — surface nothing (fail safe).
+    return null;
+  })();
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Text type="secondary">
+        Personal credentials are encrypted at rest and injected only into the agent runtime.
+      </Text>
+
+      {connectionBanner && (
+        <Space direction="vertical" size="small" style={{ width: '100%' }}>
+          {connectionBanner}
+          <Button
+            type="link"
+            size="small"
+            loading={probing}
+            onClick={() => void runProbe()}
+            style={{ paddingInline: 0 }}
+          >
+            Recheck connection
+          </Button>
+        </Space>
+      )}
+
+      <Segmented<CodexMethodView>
+        block
+        value={view}
+        onChange={handleSelect}
+        options={[
+          { label: 'API key', value: 'api_key' },
+          { label: 'Sign in with ChatGPT', value: 'chatgpt' },
+          { label: 'Import login file', value: 'import' },
+        ]}
+      />
+
+      {view === 'api_key' && (
+        <ApiKeyFields
+          tool="codex"
+          fields={apiKeyFields}
+          fieldStatus={fieldStatus}
+          onSave={onSaveField}
+          onClear={onClearField}
+          saving={savingFields}
+          publicValues={publicValues}
+        />
+      )}
+      {view === 'chatgpt' && (
+        <div>
+          <Text type="secondary" style={{ display: 'block', marginBottom: token.marginSM }}>
+            Sign in with your ChatGPT account — no OpenAI API key stored in Agor. The login is
+            shared per server user, so signing in replaces any Codex login already on this server.
+          </Text>
+          <CodexDeviceSignIn
+            client={client}
+            onVerified={handleAuthenticated}
+            onUseFallback={handleFallback}
+            autoStart={false}
+          />
+        </div>
+      )}
+      {view === 'import' && (
+        <CodexImportAuthJson client={client} onImported={handleAuthenticated} />
+      )}
+    </Space>
+  );
+}

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
@@ -1,0 +1,321 @@
+import type { AgorClient, CodexDeviceAuthStatus } from '@agor-live/client';
+import { CheckCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { Alert, Button, Typography, theme } from 'antd';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+/**
+ * Where a gated ChatGPT account can go instead of device sign-in. Kept neutral
+ * (not tied to any one surface's method enum) so both the onboarding wizard and
+ * the settings pane can map it onto their own auth-method state.
+ */
+export type CodexAuthFallback = 'import' | 'api-key';
+
+const DEVICE_STATUS_POLL_MS = 2000;
+
+function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(Math.floor(remainingMs / 1000), 0);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+export interface CodexDeviceSignInProps {
+  client: AgorClient | null;
+  /** Fired once the daemon confirms tokens were saved for this user. */
+  onVerified: () => void;
+  /** Switch to another codex auth method (gated-account fallback). */
+  onUseFallback: (target: CodexAuthFallback) => void;
+  /**
+   * Request a code as soon as the pane mounts. The onboarding wizard reveals
+   * this pane only on an explicit "Sign in with ChatGPT" choice, so eager start
+   * is right there. A management surface (settings) mounts it as one tab among
+   * several, so it defaults to a deliberate button press instead of firing an
+   * OpenAI device request every time the tab is viewed. A still-live *pending*
+   * attempt is always adopted regardless of this flag; a terminal *success* is
+   * adopted only when autoStart is true (the wizard, which reflects the verified
+   * state after toggling away and back). A management surface tells its
+   * connection story via a separate probe, so it must not adopt a stale success
+   * — that would wall off re-signing-in until the daemon prunes the attempt.
+   */
+  autoStart?: boolean;
+}
+
+/**
+ * Self-contained device-code pane: requests a code, shows it with the
+ * verification link and a countdown, and polls the daemon for approval.
+ * Memoized with its own state so the 1s countdown and 2s status polls
+ * re-render only this pane, never the surface that hosts it.
+ */
+export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
+  client,
+  onVerified,
+  onUseFallback,
+  autoStart = true,
+}: CodexDeviceSignInProps) {
+  const { token } = useToken();
+  const [status, setStatus] = useState<CodexDeviceAuthStatus>({ phase: 'idle' });
+  const [starting, setStarting] = useState(false);
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+
+  const deviceService = useMemo(
+    () =>
+      client
+        ? (client.service('codex-auth/device') as unknown as {
+            create(data: Record<string, never>): Promise<unknown>;
+            find(): Promise<unknown>;
+          })
+        : null,
+    [client]
+  );
+
+  // Tracks the service the pane currently talks to, so an in-flight
+  // requestCode issued against a swapped-out client can't land its state
+  // updates over the replacement's. A layout effect syncs the identity
+  // before paint and before the passive effects below; resetting `starting`
+  // here matters because a stale request's guarded finally deliberately
+  // won't clear it, and a replacement that ADOPTS an attempt never calls
+  // requestCode — without the reset the spinner would cover a live code.
+  // Reset status/countdown too: a client/identity swap must not leave the
+  // previous client's pending code (and its polling loop) on screen — the
+  // adopt-or-request effect below then decides what THIS service should show.
+  // Without this, an autoStart=false surface that doesn't re-request would
+  // keep displaying and polling the old code against the new service.
+  const latestServiceRef = useRef(deviceService);
+  useLayoutEffect(() => {
+    latestServiceRef.current = deviceService;
+    setStarting(false);
+    setStatus({ phase: 'idle' });
+    setRemainingMs(null);
+  }, [deviceService]);
+
+  const requestCode = useCallback(async () => {
+    if (!deviceService) return;
+    setStarting(true);
+    try {
+      const next = (await deviceService.create({})) as CodexDeviceAuthStatus;
+      if (latestServiceRef.current !== deviceService) return;
+      setStatus(next);
+    } catch (err) {
+      if (latestServiceRef.current !== deviceService) return;
+      setStatus({
+        phase: 'error',
+        hint:
+          err instanceof Error && err.message
+            ? err.message
+            : 'Could not start the ChatGPT sign-in — try again.',
+      });
+    } finally {
+      if (latestServiceRef.current === deviceService) setStarting(false);
+    }
+  }, [deviceService]);
+
+  // On mount (and on client swap), adopt a still-live attempt (user toggled
+  // away and back) instead of burning a fresh code; otherwise request one.
+  // Continuations are guarded by both `cancelled` (StrictMode / normal cleanup)
+  // and the service ref: React runs the client-swap layout reset before this
+  // effect's cleanup, so a stale find() resolving in that window must not
+  // restore the previous client's code — matching requestCode's own guard.
+  useEffect(() => {
+    if (!deviceService) return;
+    let cancelled = false;
+    const stillCurrent = () => !cancelled && latestServiceRef.current === deviceService;
+    void (async () => {
+      try {
+        const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (!stillCurrent()) return;
+        // Adopt a live pending attempt always; adopt a terminal success only for
+        // eager (wizard) mounts — a management surface must stay able to restart.
+        if (existing.phase === 'pending' || (existing.phase === 'success' && autoStart)) {
+          setStatus(existing);
+          return;
+        }
+      } catch {
+        // No adoptable attempt — fall through to a fresh request.
+      }
+      if (stillCurrent() && autoStart) await requestCode();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceService, requestCode, autoStart]);
+
+  // Poll while pending; terminal phases stop the loop. A self-scheduling
+  // timeout (next poll armed only after the previous response lands) keeps
+  // slow responses from overlapping and regressing a terminal phase with an
+  // out-of-order pending. Identity-preserving setState keeps unchanged polls
+  // from re-rendering even this pane.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !deviceService) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
+      try {
+        const next = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (cancelled || latestServiceRef.current !== deviceService) return;
+        setStatus((prev) =>
+          prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
+            ? prev
+            : next
+        );
+      } catch {
+        // Transient — keep polling until the code expires.
+      }
+      if (!cancelled) timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    };
+    timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [status.phase, deviceService]);
+
+  // 1s countdown while a code is live.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !status.expiresAt) {
+      setRemainingMs(null);
+      return;
+    }
+    const expiresAtMs = Date.parse(status.expiresAt);
+    const update = () => setRemainingMs(Math.max(expiresAtMs - Date.now(), 0));
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [status.phase, status.expiresAt]);
+
+  useEffect(() => {
+    if (status.phase === 'success') onVerified();
+  }, [status.phase, onVerified]);
+
+  if (starting || (status.phase === 'idle' && autoStart)) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 14 }} />
+        <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
+          {client ? 'Getting your sign-in code…' : 'Waiting for the server connection…'}
+        </Text>
+      </div>
+    );
+  }
+
+  // Deliberate-start surfaces (autoStart=false) with no adoptable attempt: offer
+  // the button rather than firing an OpenAI device request on mount.
+  if (status.phase === 'idle') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0' }}>
+        <Button type="primary" disabled={!client} onClick={requestCode}>
+          Get a sign-in code
+        </Button>
+        {!client && (
+          <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
+            Waiting for the server connection…
+          </Text>
+        )}
+      </div>
+    );
+  }
+
+  if (status.phase === 'pending') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+        <Text style={{ color: token.colorTextSecondary, fontSize: 13 }}>
+          Open the link below, sign in to ChatGPT, and enter this one-time code:
+        </Text>
+        <Text
+          copyable
+          aria-label="ChatGPT sign-in code"
+          style={{
+            color: token.colorText,
+            fontFamily: 'monospace',
+            fontSize: 26,
+            fontWeight: 600,
+            letterSpacing: 4,
+          }}
+        >
+          {status.userCode}
+        </Text>
+        {status.verificationUrl && (
+          <Typography.Link
+            href={status.verificationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: 13 }}
+          >
+            Open {status.verificationUrl} →
+          </Typography.Link>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
+          <Text style={{ color: token.colorTextTertiary, fontSize: 12 }}>
+            Waiting for approval — we finish automatically once you approve.
+            {remainingMs !== null && ` Code expires in ${formatCountdown(remainingMs)}.`}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  if (status.phase === 'success') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 14 }} />
+        <Text style={{ color: token.colorSuccess, fontSize: 13 }}>
+          {status.hint ?? 'Signed in with ChatGPT.'}
+        </Text>
+      </div>
+    );
+  }
+
+  if (status.phase === 'unavailable') {
+    return (
+      <Alert
+        type="warning"
+        showIcon
+        style={{ fontSize: 12 }}
+        message="Device sign-in is turned off for this ChatGPT account"
+        description={
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <span>
+              Personal accounts: enable it under ChatGPT Settings → Security → “Device code
+              authorization for Codex”, then try again. Workspace accounts: a workspace admin has to
+              enable it. Either way, the two options below work right now.
+            </span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              <Button size="small" onClick={() => onUseFallback('import')}>
+                Paste a login file
+              </Button>
+              <Button size="small" onClick={() => onUseFallback('api-key')}>
+                Use an API key
+              </Button>
+              <Button size="small" type="text" onClick={requestCode}>
+                Try again
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    );
+  }
+
+  // expired / error
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+      <Alert
+        type={status.phase === 'expired' ? 'warning' : 'error'}
+        showIcon
+        style={{ fontSize: 12 }}
+        message={
+          status.hint ??
+          (status.phase === 'expired' ? 'The sign-in code expired.' : 'The ChatGPT sign-in failed.')
+        }
+      />
+      <div>
+        <Button size="small" onClick={requestCode}>
+          Get a new code
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -1,0 +1,132 @@
+import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
+import { Alert, Button, Input, Space, Typography, theme } from 'antd';
+import { memo, useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+export interface CodexImportAuthJsonProps {
+  client: AgorClient | null;
+  /**
+   * Fired after the daemon accepts the pasted login and persists it. The pasted
+   * token material is already dropped from this component's state by the time
+   * this runs — the surface follows up (advance a step, re-probe status) without
+   * ever holding the secret itself.
+   */
+  onImported: (result: CodexAuthImportResult) => void;
+  /** Label for the submit action; surfaces frame it differently. */
+  submitLabel?: string;
+}
+
+/**
+ * Self-contained pane for pasting a `~/.codex/auth.json` login file and handing
+ * it to the daemon. Owns its own paste value, submit, and error state so a
+ * rejected import never leaks into the hosting surface's form state, and so the
+ * secret is cleared from memory the moment the daemon confirms it landed.
+ */
+export const CodexImportAuthJson = memo(function CodexImportAuthJson({
+  client,
+  onImported,
+  submitLabel = 'Import login',
+}: CodexImportAuthJsonProps) {
+  const { token } = useToken();
+  const [authJson, setAuthJson] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // A client/identity swap (or unmount) must never carry a pasted secret across
+  // it, nor let an import in flight against the old client apply to — or lock —
+  // the replacement. A generation bumped synchronously on client change (before
+  // the old request can resolve) invalidates any in-flight submit; the swap also
+  // drops the paste value and releases the submit lock so the new identity can
+  // import right away. The unmount bump prevents a settled request from calling
+  // setState after teardown.
+  const submitGenRef = useRef(0);
+  // Invalidate any in-flight submit synchronously whenever the client changes
+  // OR the pane unmounts. A layout effect (setup + cleanup) runs during the
+  // commit phase, before a settled request's continuation could — a passive
+  // cleanup can be deferred past unmount, letting a stale success still fire
+  // onImported/setState after teardown. Setup also drops the pasted secret and
+  // releases the submit lock so the replacement identity can import at once.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: client is the change trigger; the body invalidates/clears rather than reading it.
+  useLayoutEffect(() => {
+    submitGenRef.current++;
+    setAuthJson('');
+    setError(null);
+    setSubmitting(false);
+    return () => {
+      submitGenRef.current++;
+    };
+  }, [client]);
+
+  const handleImport = useCallback(async () => {
+    if (!client || !authJson.trim() || submitting) return;
+    const gen = ++submitGenRef.current;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = (await client
+        .service('codex-auth/import')
+        .create({ authJson })) as CodexAuthImportResult;
+      // Superseded by a client swap or unmount mid-flight — this result belongs
+      // to the old identity; drop it rather than clearing the replacement's pane
+      // or firing onImported as though it applied here.
+      if (submitGenRef.current !== gen) return;
+      // Drop the pasted token material as soon as the daemon has it — nothing
+      // here needs it after a successful import.
+      setAuthJson('');
+      onImported(result);
+    } catch (err) {
+      if (submitGenRef.current !== gen) return;
+      setError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Could not import the Codex login — try again.'
+      );
+    } finally {
+      if (submitGenRef.current === gen) setSubmitting(false);
+    }
+  }, [authJson, client, onImported, submitting]);
+
+  return (
+    <Space direction="vertical" size="small" style={{ width: '100%' }}>
+      <Alert
+        type="info"
+        showIcon
+        style={{ fontSize: token.fontSizeSM }}
+        message={
+          <span>
+            Already use Codex on your own machine? Its credential file lives there at{' '}
+            <Text code>~/.codex/auth.json</Text>. On that machine, print it with{' '}
+            <Text code>cat ~/.codex/auth.json</Text> and paste the whole thing below — this replaces
+            the Codex login already stored on this server, which in shared setups is one login for
+            the whole server, not one per person. Or skip the copy-paste entirely: open a branch
+            terminal on this server and run <Text code>codex login --device-auth</Text>.
+          </span>
+        }
+      />
+      <Input.Password
+        aria-label="Codex auth.json contents"
+        placeholder="Paste the JSON from ~/.codex/auth.json…"
+        value={authJson}
+        onChange={(e) => {
+          setAuthJson(e.target.value);
+          setError(null);
+        }}
+        onPressEnter={handleImport}
+        style={{ fontFamily: 'monospace', fontSize: token.fontSizeSM }}
+      />
+      <Button
+        type="primary"
+        loading={submitting}
+        disabled={!client || !authJson.trim()}
+        onClick={handleImport}
+      >
+        {submitLabel}
+      </Button>
+      {error && (
+        <Alert type="error" showIcon message={error} style={{ fontSize: token.fontSizeSM }} />
+      )}
+    </Space>
+  );
+});

--- a/apps/agor-ui/src/components/CodexAuth/index.ts
+++ b/apps/agor-ui/src/components/CodexAuth/index.ts
@@ -1,0 +1,7 @@
+export { CodexAuthSettings, type CodexAuthSettingsProps } from './CodexAuthSettings';
+export {
+  type CodexAuthFallback,
+  CodexDeviceSignIn,
+  type CodexDeviceSignInProps,
+} from './CodexDeviceSignIn';
+export { CodexImportAuthJson, type CodexImportAuthJsonProps } from './CodexImportAuthJson';

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
@@ -63,6 +63,53 @@ describe('OnboardingBanners probe effect', () => {
     await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
   });
 
+  it('re-probes and clears the banner when a Codex subscription login lands via a user patch (no remount)', async () => {
+    // The daemon device-sign-in / auth.json-import flows persist
+    // agentic_auth_methods.codex server-side; it arrives as a user patch with no
+    // stored key and no credentialVersion bump — the case that previously left
+    // the banner stuck until a page refresh.
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+    await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
+    const callsBefore = onCheckAuth.mock.calls.length;
+
+    onCheckAuth.mockImplementation(async () => result('authenticated'));
+    rerender(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', {
+            agentic_auth_methods: { codex: 'subscription' },
+          } as Partial<User>),
+          onCheckAuth,
+        })}
+      />
+    );
+
+    // Same identity → same component instance (no remount); the method-marker
+    // dep change re-fires the probe, which now clears the banner.
+    await waitFor(() => expect(screen.queryByText(/No AI connected/)).not.toBeInTheDocument());
+    expect(onCheckAuth.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('does not re-probe on an unrelated user-record patch (e.g. a name edit)', async () => {
+    const onCheckAuth = vi.fn(async () => result('authenticated'));
+    const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(1));
+
+    // A field that touches neither identity, stored keys, nor auth methods must
+    // NOT spawn another ~5–10s probe.
+    rerender(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', { name: 'Renamed' } as Partial<User>),
+          onCheckAuth,
+        })}
+      />
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onCheckAuth).toHaveBeenCalledTimes(1);
+  });
+
   it('treats CLAUDE_CODE_OAUTH_TOKEN in user env vars as Claude auth (probes claude-code, no banner)', async () => {
     const onCheckAuth = vi.fn(async () => result('authenticated'));
     render(

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -108,11 +108,25 @@ export function OnboardingBanners({
   const credentialOwner = preferredCredentialOwner(probeSettings);
   const canManageWorkspaceCredentials = user?.role === 'admin' || user?.role === 'superadmin';
 
+  // Auth-method markers for the subscription/native paths (ChatGPT device
+  // sign-in, imported Codex login, Claude subscription token). These land
+  // server-side via their own services and flow back on the users `patched`
+  // event WITHOUT a stored key or a credentialVersion bump — so hasLlm alone
+  // can't see them. They are primitives ('api_key' | 'subscription' |
+  // undefined) that change only on a genuine method flip, never on unrelated
+  // user-record patches, keeping the ~5–10s probe from firing on name/emoji
+  // edits. `agentic_auth_methods` only ever carries these two tools.
+  const codexAuthMethod = user?.agentic_auth_methods?.codex;
+  const claudeAuthMethod = user?.agentic_auth_methods?.['claude-code'];
+
   // One probe (plus a bounded fallback) per identity/credential change. Deps are
   // primitives/stable so the effect never re-fires on board navigation or
   // unrelated re-renders of the persistent App shell — each claude-code probe
   // spawns a ~5–10s subprocess. userId resets stale state on a user switch;
-  // credentialVersion is a trigger-only dep re-probing after a credential save.
+  // credentialVersion is a trigger-only dep re-probing after a legacy key save;
+  // codexAuthMethod/claudeAuthMethod re-probe after a subscription/native login
+  // lands server-side (device sign-in, auth.json import) — paths that bump
+  // neither hasLlm nor credentialVersion — and cover a second browser tab too.
   // biome-ignore lint/correctness/useExhaustiveDependencies: credentialVersion is an intentional trigger dep
   useEffect(() => {
     if (!onboardingCompleted) {
@@ -135,7 +149,16 @@ export function OnboardingBanners({
     return () => {
       cancelled = true;
     };
-  }, [userId, onboardingCompleted, probeAgent, hasLlm, onCheckAuth, credentialVersion]);
+  }, [
+    userId,
+    onboardingCompleted,
+    probeAgent,
+    hasLlm,
+    onCheckAuth,
+    credentialVersion,
+    codexAuthMethod,
+    claudeAuthMethod,
+  ]);
 
   const decision = decideBanner({
     onboardingCompleted,

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -545,7 +545,8 @@ describe('Codex ChatGPT login import', () => {
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: pasted },
     });
-    clickButton(/^connect →/i);
+    // The import pane owns its own submit; success self-advances the wizard.
+    clickButton('Import login');
 
     await waitFor(() => expect(importCreate).toHaveBeenCalledWith({ authJson: pasted }));
     expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
@@ -562,7 +563,7 @@ describe('Codex ChatGPT login import', () => {
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"tokens":{}}' },
     });
-    clickButton(/^connect →/i);
+    clickButton('Import login');
 
     expect(
       await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
@@ -582,7 +583,7 @@ describe('Codex ChatGPT login import', () => {
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"a":1}' },
     });
-    clickButton(/^connect →/i);
+    clickButton('Import login');
     expect(
       await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
     ).toBeInTheDocument();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -595,6 +595,29 @@ describe('Codex ChatGPT login import', () => {
       screen.queryByText(/This file has no ChatGPT login tokens and no API key\./)
     ).not.toBeInTheDocument();
   });
+
+  it('describes a broken ChatGPT login in subscription terms, not API-key terms', async () => {
+    // Stored method is subscription but the server-side auth.json is gone
+    // (wipe / `codex logout`) — the probe reports unauthenticated.
+    const onCheckAuth = vi.fn(async () => ({
+      status: 'unauthenticated' as const,
+      authenticated: false,
+    }));
+    renderWizard({
+      initialStep: 'llm',
+      user: makeUser({ agentic_auth_methods: { codex: 'subscription' } } as never),
+      onCheckAuth,
+    });
+
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+
+    clickButton('GPT');
+    expect(
+      await screen.findByText(/Codex login no longer found on this server/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Key stored but not working/)).not.toBeInTheDocument();
+  });
 });
 
 describe('Codex ChatGPT device sign-in', () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -711,6 +711,8 @@ describe('Codex ChatGPT device sign-in', () => {
     openDevicePane();
 
     expect(await screen.findByText('KEEP-0001')).toBeInTheDocument();
+    // The adopted attempt's expiry drives the countdown just like a fresh one.
+    expect(await screen.findByText(/code expires in/i)).toBeInTheDocument();
     expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -521,9 +521,9 @@ describe('Codex ChatGPT login import', () => {
 
     clickButton('GPT');
     expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
-    expect(screen.getByText('Import login')).toBeInTheDocument();
+    expect(screen.getByText('Import auth.json')).toBeInTheDocument();
 
-    clickButton('Import login');
+    clickButton('Import auth.json');
     expect(screen.getByLabelText('Codex auth.json contents')).toBeInTheDocument();
     // Inline help: where the file lives, how to print it, and the overwrite caveat.
     expect(screen.getByText(/cat ~\/\.codex\/auth\.json/)).toBeInTheDocument();
@@ -540,7 +540,7 @@ describe('Codex ChatGPT login import', () => {
     const { importCreate } = renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('Import login');
+    clickButton('Import auth.json');
     const pasted = JSON.stringify({ OPENAI_API_KEY: null, tokens: { refresh_token: 'r' } });
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: pasted },
@@ -558,7 +558,7 @@ describe('Codex ChatGPT login import', () => {
     renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('Import login');
+    clickButton('Import auth.json');
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"tokens":{}}' },
     });
@@ -578,7 +578,7 @@ describe('Codex ChatGPT login import', () => {
     renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('Import login');
+    clickButton('Import auth.json');
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"a":1}' },
     });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -520,9 +520,10 @@ describe('Codex ChatGPT login import', () => {
     renderWizard({ initialStep: 'llm' });
 
     clickButton('GPT');
-    expect(screen.getByText('ChatGPT login')).toBeInTheDocument();
+    expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+    expect(screen.getByText('Import login')).toBeInTheDocument();
 
-    clickButton('ChatGPT login');
+    clickButton('Import login');
     expect(screen.getByLabelText('Codex auth.json contents')).toBeInTheDocument();
     // Inline help: where the file lives, how to print it, and the overwrite caveat.
     expect(screen.getByText(/cat ~\/\.codex\/auth\.json/)).toBeInTheDocument();
@@ -539,7 +540,7 @@ describe('Codex ChatGPT login import', () => {
     const { importCreate } = renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('ChatGPT login');
+    clickButton('Import login');
     const pasted = JSON.stringify({ OPENAI_API_KEY: null, tokens: { refresh_token: 'r' } });
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: pasted },
@@ -557,7 +558,7 @@ describe('Codex ChatGPT login import', () => {
     renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('ChatGPT login');
+    clickButton('Import login');
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"tokens":{}}' },
     });
@@ -577,7 +578,7 @@ describe('Codex ChatGPT login import', () => {
     renderWithCodexImport(create);
 
     clickButton('GPT');
-    clickButton('ChatGPT login');
+    clickButton('Import login');
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"a":1}' },
     });
@@ -593,5 +594,123 @@ describe('Codex ChatGPT login import', () => {
     expect(
       screen.queryByText(/This file has no ChatGPT login tokens and no API key\./)
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('Codex ChatGPT device sign-in', () => {
+  // Client harness with a controllable codex-auth/device service.
+  function renderWithDeviceService(overrides: {
+    create?: ReturnType<typeof vi.fn>;
+    find?: ReturnType<typeof vi.fn>;
+  }) {
+    const create =
+      overrides.create ??
+      vi.fn(async () => ({
+        phase: 'pending',
+        userCode: 'ABCD-1234',
+        verificationUrl: 'https://auth.openai.com/codex/device',
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      }));
+    const find = overrides.find ?? vi.fn(async () => ({ phase: 'idle' }));
+    const client = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) =>
+        name === 'codex-auth/device' ? { create, find } : { create: vi.fn(), find: vi.fn() }
+      ),
+    };
+    const rendered = renderWizard({ initialStep: 'llm', client: client as never });
+    return { ...rendered, deviceCreate: create, deviceFind: find };
+  }
+
+  function openDevicePane() {
+    clickButton('GPT');
+    clickButton('Sign in with ChatGPT');
+  }
+
+  it('requests a code on selection and shows it with the verification link and expiry', async () => {
+    const { deviceCreate } = renderWithDeviceService({});
+    openDevicePane();
+
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('ABCD-1234')).toBeInTheDocument();
+    expect(screen.getByText(/auth\.openai\.com\/codex\/device/)).toBeInTheDocument();
+    expect(screen.getByText(/waiting for approval/i)).toBeInTheDocument();
+    expect(screen.getByText(/code expires in/i)).toBeInTheDocument();
+    // Approval has not happened — Connect stays disabled.
+    expect(screen.getByText(/^connect →/i).closest('button')).toBeDisabled();
+  });
+
+  it('advances once the daemon reports success', async () => {
+    const find = vi.fn().mockResolvedValueOnce({ phase: 'idle' }).mockResolvedValue({
+      phase: 'success',
+      planType: 'pro',
+      hint: 'Signed in with ChatGPT (pro plan).',
+    });
+    renderWithDeviceService({ find });
+    openDevicePane();
+
+    // The 2s status poll flips the pane to success.
+    expect(
+      await screen.findByText(/signed in with chatgpt \(pro plan\)/i, {}, { timeout: 5000 })
+    ).toBeInTheDocument();
+
+    // The pane reports success to the parent via effect — enablement lands a tick later.
+    await waitFor(() => expect(screen.getByText(/^connect →/i).closest('button')).toBeEnabled());
+    const connect = screen.getByText(/^connect →/i).closest('button');
+    fireEvent.click(connect as HTMLButtonElement);
+    expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
+  });
+
+  it('treats a gated account as a first-class state with working fallbacks', async () => {
+    const create = vi.fn(async () => ({
+      phase: 'unavailable',
+      hint: 'Your ChatGPT account does not allow device-code sign-in.',
+    }));
+    renderWithDeviceService({ create });
+    openDevicePane();
+
+    expect(
+      await screen.findByText(/device sign-in is turned off for this chatgpt account/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/device code authorization for codex/i)).toBeInTheDocument();
+
+    clickButton('Paste a login file');
+    expect(screen.getByLabelText('Codex auth.json contents')).toBeInTheDocument();
+  });
+
+  it('offers a fresh code after expiry', async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({
+        phase: 'expired',
+        hint: 'The sign-in code expired — get a new one and try again.',
+      })
+      .mockResolvedValue({
+        phase: 'pending',
+        userCode: 'WXYZ-9876',
+        verificationUrl: 'https://auth.openai.com/codex/device',
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      });
+    renderWithDeviceService({ create });
+    openDevicePane();
+
+    expect(await screen.findByText(/code expired/i)).toBeInTheDocument();
+    await findAndClickButton(/get a new code/i);
+    expect(await screen.findByText('WXYZ-9876')).toBeInTheDocument();
+  });
+
+  it('adopts a still-pending attempt instead of burning a fresh code', async () => {
+    const find = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'KEEP-0001',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    }));
+    const create = vi.fn();
+    renderWithDeviceService({ create, find });
+    openDevicePane();
+
+    expect(await screen.findByText('KEEP-0001')).toBeInTheDocument();
+    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -65,7 +65,7 @@ const AUTH_METHOD_OPTIONS: Partial<
   codex: [
     { label: 'API key', value: 'api-key' },
     { label: 'Sign in with ChatGPT', value: 'codex-device-auth' },
-    { label: 'Import login', value: 'codex-auth-json' },
+    { label: 'Import auth.json', value: 'codex-auth-json' },
   ],
 };
 
@@ -1780,13 +1780,13 @@ export function OnboardingWizard({
                           style={{ marginBottom: 10, fontSize: 12 }}
                           message={
                             <span>
-                              Already signed in to Codex on your laptop? Your login lives in{' '}
-                              <code>~/.codex/auth.json</code> there. Print it with{' '}
+                              Already use Codex on your own machine? Its credential file lives there
+                              at <code>~/.codex/auth.json</code>. On that machine, print it with{' '}
                               <code>cat ~/.codex/auth.json</code> and paste the whole thing below —
                               this replaces the Codex login already stored on this server, which in
                               shared setups is one login for the whole server, not one per person.
-                              Prefer a terminal? Run <code>codex login --device-auth</code> from a
-                              branch terminal instead.
+                              Or skip the copy-paste entirely: open a branch terminal on this server
+                              and run <code>codex login --device-auth</code>.
                             </span>
                           }
                         />

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,8 +9,6 @@ import type {
   AgenticToolName,
   AgorClient,
   AuthCheckResult,
-  CodexAuthImportResult,
-  CodexDeviceAuthStatus,
   UpdateUserInput,
   User,
   UserPreferences,
@@ -24,18 +22,10 @@ import {
   LoadingOutlined,
 } from '@ant-design/icons';
 import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
-import {
-  Fragment,
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
+import { type CodexAuthFallback, CodexDeviceSignIn, CodexImportAuthJson } from '../CodexAuth';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 
 const { Text, Title, Paragraph } = Typography;
@@ -379,7 +369,8 @@ function keyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-k
 
 function getKeyLabel(agent: AgenticToolName, authMethod: AuthMethod): string {
   if (authMethod === 'claude-subscription-token') return 'Subscription token';
-  if (authMethod === 'codex-auth-json') return 'Codex login file (auth.json)';
+  // Note: the codex-auth-json method renders its own pane (CodexImportAuthJson)
+  // and never reaches this label, so no case is needed for it here.
   switch (agent) {
     case 'claude-code':
       return 'Anthropic API key';
@@ -470,272 +461,6 @@ const PARTICLE_DIRS = [
   [-72, 0],
   [-51, -51],
 ] as const;
-
-// ─── Codex device-code sign-in pane ──────────────────────────────────────────
-
-const DEVICE_STATUS_POLL_MS = 2000;
-
-function formatCountdown(remainingMs: number): string {
-  const totalSeconds = Math.max(Math.floor(remainingMs / 1000), 0);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
-}
-
-interface CodexDeviceSignInProps {
-  client: AgorClient | null;
-  /** Fired once the daemon confirms tokens were saved for this user. */
-  onVerified: () => void;
-  /** Switch to another codex auth method (gated-account fallback). */
-  onUseFallback: (method: AuthMethod) => void;
-}
-
-/**
- * Self-contained device-code pane: requests a code, shows it with the
- * verification link and a countdown, and polls the daemon for approval.
- * Memoized with its own state so the 1s countdown and 2s status polls
- * re-render only this pane, never the whole wizard.
- */
-const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
-  client,
-  onVerified,
-  onUseFallback,
-}: CodexDeviceSignInProps) {
-  const { token } = useToken();
-  const [status, setStatus] = useState<CodexDeviceAuthStatus>({ phase: 'idle' });
-  const [starting, setStarting] = useState(false);
-  const [remainingMs, setRemainingMs] = useState<number | null>(null);
-
-  const deviceService = useMemo(
-    () =>
-      client
-        ? (client.service('codex-auth/device') as unknown as {
-            create(data: Record<string, never>): Promise<unknown>;
-            find(): Promise<unknown>;
-          })
-        : null,
-    [client]
-  );
-
-  // Tracks the service the pane currently talks to, so an in-flight
-  // requestCode issued against a swapped-out client can't land its state
-  // updates over the replacement's. A layout effect syncs the identity
-  // before paint and before the passive effects below; resetting `starting`
-  // here matters because a stale request's guarded finally deliberately
-  // won't clear it, and a replacement that ADOPTS an attempt never calls
-  // requestCode — without the reset the spinner would cover a live code.
-  const latestServiceRef = useRef(deviceService);
-  useLayoutEffect(() => {
-    latestServiceRef.current = deviceService;
-    setStarting(false);
-  }, [deviceService]);
-
-  const requestCode = useCallback(async () => {
-    if (!deviceService) return;
-    setStarting(true);
-    try {
-      const next = (await deviceService.create({})) as CodexDeviceAuthStatus;
-      if (latestServiceRef.current !== deviceService) return;
-      setStatus(next);
-    } catch (err) {
-      if (latestServiceRef.current !== deviceService) return;
-      setStatus({
-        phase: 'error',
-        hint:
-          err instanceof Error && err.message
-            ? err.message
-            : 'Could not start the ChatGPT sign-in — try again.',
-      });
-    } finally {
-      if (latestServiceRef.current === deviceService) setStarting(false);
-    }
-  }, [deviceService]);
-
-  // On mount (and on client swap), adopt a still-live attempt (user toggled
-  // away and back) instead of burning a fresh code; otherwise request one.
-  // The cancellation guard makes this StrictMode-safe — a superseded run
-  // never fires its requestCode/setStatus continuation.
-  useEffect(() => {
-    if (!deviceService) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
-        if (cancelled) return;
-        if (existing.phase === 'pending' || existing.phase === 'success') {
-          setStatus(existing);
-          return;
-        }
-      } catch {
-        // No adoptable attempt — fall through to a fresh request.
-      }
-      if (!cancelled) await requestCode();
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [deviceService, requestCode]);
-
-  // Poll while pending; terminal phases stop the loop. A self-scheduling
-  // timeout (next poll armed only after the previous response lands) keeps
-  // slow responses from overlapping and regressing a terminal phase with an
-  // out-of-order pending. Identity-preserving setState keeps unchanged polls
-  // from re-rendering even this pane.
-  useEffect(() => {
-    if (status.phase !== 'pending' || !deviceService) return;
-    let cancelled = false;
-    let timer: ReturnType<typeof setTimeout>;
-    const tick = async () => {
-      try {
-        const next = (await deviceService.find()) as CodexDeviceAuthStatus;
-        if (cancelled) return;
-        setStatus((prev) =>
-          prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
-            ? prev
-            : next
-        );
-      } catch {
-        // Transient — keep polling until the code expires.
-      }
-      if (!cancelled) timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
-    };
-    timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [status.phase, deviceService]);
-
-  // 1s countdown while a code is live.
-  useEffect(() => {
-    if (status.phase !== 'pending' || !status.expiresAt) {
-      setRemainingMs(null);
-      return;
-    }
-    const expiresAtMs = Date.parse(status.expiresAt);
-    const update = () => setRemainingMs(Math.max(expiresAtMs - Date.now(), 0));
-    update();
-    const id = setInterval(update, 1000);
-    return () => clearInterval(id);
-  }, [status.phase, status.expiresAt]);
-
-  useEffect(() => {
-    if (status.phase === 'success') onVerified();
-  }, [status.phase, onVerified]);
-
-  if (starting || status.phase === 'idle') {
-    return (
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
-        <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 14 }} />
-        <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
-          {client ? 'Getting your sign-in code…' : 'Waiting for the server connection…'}
-        </Text>
-      </div>
-    );
-  }
-
-  if (status.phase === 'pending') {
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
-        <Text style={{ color: token.colorTextSecondary, fontSize: 13 }}>
-          Open the link below, sign in to ChatGPT, and enter this one-time code:
-        </Text>
-        <Text
-          copyable
-          aria-label="ChatGPT sign-in code"
-          style={{
-            color: token.colorText,
-            fontFamily: 'monospace',
-            fontSize: 26,
-            fontWeight: 600,
-            letterSpacing: 4,
-          }}
-        >
-          {status.userCode}
-        </Text>
-        {status.verificationUrl && (
-          <Typography.Link
-            href={status.verificationUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ fontSize: 13 }}
-          >
-            Open {status.verificationUrl} →
-          </Typography.Link>
-        )}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
-          <Text style={{ color: token.colorTextTertiary, fontSize: 12 }}>
-            Waiting for approval — we finish automatically once you approve.
-            {remainingMs !== null && ` Code expires in ${formatCountdown(remainingMs)}.`}
-          </Text>
-        </div>
-      </div>
-    );
-  }
-
-  if (status.phase === 'success') {
-    return (
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
-        <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 14 }} />
-        <Text style={{ color: token.colorSuccess, fontSize: 13 }}>
-          {status.hint ?? 'Signed in with ChatGPT.'}
-        </Text>
-      </div>
-    );
-  }
-
-  if (status.phase === 'unavailable') {
-    return (
-      <Alert
-        type="warning"
-        showIcon
-        style={{ fontSize: 12 }}
-        message="Device sign-in is turned off for this ChatGPT account"
-        description={
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <span>
-              Personal accounts: enable it under ChatGPT Settings → Security → “Device code
-              authorization for Codex”, then try again. Workspace accounts: a workspace admin has to
-              enable it. Either way, the two options below work right now.
-            </span>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-              <Button size="small" onClick={() => onUseFallback('codex-auth-json')}>
-                Paste a login file
-              </Button>
-              <Button size="small" onClick={() => onUseFallback('api-key')}>
-                Use an API key
-              </Button>
-              <Button size="small" type="text" onClick={requestCode}>
-                Try again
-              </Button>
-            </div>
-          </div>
-        }
-      />
-    );
-  }
-
-  // expired / error
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
-      <Alert
-        type={status.phase === 'expired' ? 'warning' : 'error'}
-        showIcon
-        style={{ fontSize: 12 }}
-        message={
-          status.hint ??
-          (status.phase === 'expired' ? 'The sign-in code expired.' : 'The ChatGPT sign-in failed.')
-        }
-      />
-      <div>
-        <Button size="small" onClick={requestCode}>
-          Get a new code
-        </Button>
-      </div>
-    </div>
-  );
-});
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -1011,19 +736,22 @@ export function OnboardingWizard({
       case 'llm': {
         if (!selectedAgent) return false;
         if (agentIsVerifiedConnected(selectedAgent)) return true;
-        // Device sign-in has no typed input — it enables once the daemon
+        // Device sign-in and login-file import both complete inside their own
+        // pane — no typed input to validate. They enable once the daemon
         // confirms the login (llmAuthVerified flips before the user record
         // refresh that agentIsVerifiedConnected depends on).
-        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth')
+        if (
+          selectedAgent === 'codex' &&
+          (authMethod === 'codex-device-auth' || authMethod === 'codex-auth-json')
+        )
           return llmAuthVerified.codex === true;
         // Key stored, check still in progress — keep enabled so user isn't stuck
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return true;
         // Require a new key with valid format (stored key absent or broken)
         if (!apiKey.trim()) return false;
-        // Subscription tokens and pasted auth files have no fixed format —
-        // any non-empty string is accepted (the daemon validates the file)
-        if (authMethod === 'claude-subscription-token' || authMethod === 'codex-auth-json')
-          return true;
+        // Subscription tokens have no fixed format — any non-empty string is
+        // accepted (the daemon validates the token).
+        if (authMethod === 'claude-subscription-token') return true;
         return validateLlmKeyPattern(selectedAgent, apiKey.trim()) === null;
       }
       case 'workspace':
@@ -1059,13 +787,13 @@ export function OnboardingWizard({
             ? null
             : 'Approve the sign-in code in ChatGPT first';
         }
+        if (selectedAgent === 'codex' && authMethod === 'codex-auth-json') {
+          return llmAuthVerified.codex === true ? null : 'Import your Codex login to continue';
+        }
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return null;
         if (!apiKey.trim()) {
-          return authMethod === 'codex-auth-json'
-            ? 'Paste your auth.json contents to continue'
-            : 'Enter your API key to continue';
+          return 'Enter your API key to continue';
         }
-        if (authMethod === 'codex-auth-json') return null;
         const err = validateLlmKeyPattern(selectedAgent, apiKey.trim());
         return err ?? null;
       }
@@ -1152,11 +880,18 @@ export function OnboardingWizard({
     setLlmAuthVerified((prev) => (prev.codex === true ? prev : { ...prev, codex: true }));
   }, []);
 
-  const handleCodexAuthMethodFallback = useCallback((method: AuthMethod) => {
-    setAuthMethod(method);
+  const handleCodexAuthMethodFallback = useCallback((target: CodexAuthFallback) => {
+    setAuthMethod(target === 'import' ? 'codex-auth-json' : 'api-key');
     setApiKey('');
     setLlmError(null);
   }, []);
+
+  // Login-file import completes inside its own pane; mirror the device flow by
+  // marking codex verified so the primary button advances to the next step.
+  const handleCodexImported = useCallback(() => {
+    setLlmAuthVerified((prev) => (prev.codex === true ? prev : { ...prev, codex: true }));
+    goToStep('workspace');
+  }, [goToStep]);
 
   const handleBack = useCallback(() => {
     if (stepIndex > 0) goToStep(STEPS[stepIndex - 1]);
@@ -1182,9 +917,13 @@ export function OnboardingWizard({
           goToStep('workspace');
           return;
         }
-        // Device sign-in completes daemon-side; the primary button only ever
-        // advances once the attempt succeeded (button is disabled until then).
-        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth') {
+        // Device sign-in and login-file import both complete inside their own
+        // pane; the primary button only ever advances once the attempt
+        // succeeded (button is disabled until then).
+        if (
+          selectedAgent === 'codex' &&
+          (authMethod === 'codex-device-auth' || authMethod === 'codex-auth-json')
+        ) {
           if (llmAuthVerified.codex === true) goToStep('workspace');
           return;
         }
@@ -1194,34 +933,6 @@ export function OnboardingWizard({
           return;
         }
         if (!user || !apiKey.trim()) return;
-        // Pasted auth.json goes to the daemon as-is: it validates the shape,
-        // writes the file 0600 for the right Unix identity, and flips the
-        // user's Codex auth method to subscription. The pasted secret never
-        // touches user records or agent context.
-        if (selectedAgent === 'codex' && authMethod === 'codex-auth-json') {
-          if (!client) return;
-          setLlmSaving(true);
-          setLlmError(null);
-          try {
-            (await client
-              .service('codex-auth/import')
-              .create({ authJson: apiKey })) as CodexAuthImportResult;
-            setLlmAuthVerified((prev) => ({ ...prev, codex: true }));
-            // Drop the pasted token material from React state as soon as the
-            // daemon has it — nothing needs it after a successful import.
-            setApiKey('');
-            goToStep('workspace');
-          } catch (err) {
-            setLlmError(
-              err instanceof Error && err.message
-                ? err.message
-                : 'Could not import the Codex login — try again.'
-            );
-          } finally {
-            setLlmSaving(false);
-          }
-          return;
-        }
         // Subscription tokens have no fixed format (see primaryEnabled/disabledReason
         // above, which already treat them as exempt) — only pattern-validate API keys.
         if (authMethod !== 'claude-subscription-token') {
@@ -1740,7 +1451,7 @@ export function OnboardingWizard({
                       </div>
                     )}
 
-                    {authMethod !== 'codex-device-auth' && (
+                    {authMethod !== 'codex-device-auth' && authMethod !== 'codex-auth-json' && (
                       <div
                         style={{
                           display: 'flex',
@@ -1773,39 +1484,7 @@ export function OnboardingWizard({
                         onUseFallback={handleCodexAuthMethodFallback}
                       />
                     ) : authMethod === 'codex-auth-json' ? (
-                      <>
-                        <Alert
-                          type="info"
-                          showIcon
-                          style={{ marginBottom: 10, fontSize: 12 }}
-                          message={
-                            <span>
-                              Already use Codex on your own machine? Its credential file lives there
-                              at <code>~/.codex/auth.json</code>. On that machine, print it with{' '}
-                              <code>cat ~/.codex/auth.json</code> and paste the whole thing below —
-                              this replaces the Codex login already stored on this server, which in
-                              shared setups is one login for the whole server, not one per person.
-                              Or skip the copy-paste entirely: open a branch terminal on this server
-                              and run <code>codex login --device-auth</code>.
-                            </span>
-                          }
-                        />
-                        <Input.Password
-                          aria-label="Codex auth.json contents"
-                          placeholder="Paste the JSON from ~/.codex/auth.json…"
-                          value={apiKey}
-                          onChange={(e) => {
-                            setApiKey(e.target.value);
-                            setLlmError(null);
-                          }}
-                          style={{
-                            background: 'rgba(0,0,0,0.3)',
-                            borderColor: 'rgba(255,255,255,0.12)',
-                            fontFamily: 'monospace',
-                            fontSize: 13,
-                          }}
-                        />
-                      </>
+                      <CodexImportAuthJson client={client} onImported={handleCodexImported} />
                     ) : authMethod === 'claude-subscription-token' ? (
                       <>
                         <Alert

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -24,7 +24,16 @@ import {
   LoadingOutlined,
 } from '@ant-design/icons';
 import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
-import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
@@ -510,11 +519,15 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
 
   // Tracks the service the pane currently talks to, so an in-flight
   // requestCode issued against a swapped-out client can't land its state
-  // updates over the replacement's. Synced via effect (before the others,
-  // which run in declaration order) rather than mutated during render.
+  // updates over the replacement's. A layout effect syncs the identity
+  // before paint and before the passive effects below; resetting `starting`
+  // here matters because a stale request's guarded finally deliberately
+  // won't clear it, and a replacement that ADOPTS an attempt never calls
+  // requestCode — without the reset the spinner would cover a live code.
   const latestServiceRef = useRef(deviceService);
-  useEffect(() => {
+  useLayoutEffect(() => {
     latestServiceRef.current = deviceService;
+    setStarting(false);
   }, [deviceService]);
 
   const requestCode = useCallback(async () => {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -508,12 +508,24 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
     [client]
   );
 
+  // Tracks the service the pane currently talks to, so an in-flight
+  // requestCode issued against a swapped-out client can't land its state
+  // updates over the replacement's. Synced via effect (before the others,
+  // which run in declaration order) rather than mutated during render.
+  const latestServiceRef = useRef(deviceService);
+  useEffect(() => {
+    latestServiceRef.current = deviceService;
+  }, [deviceService]);
+
   const requestCode = useCallback(async () => {
     if (!deviceService) return;
     setStarting(true);
     try {
-      setStatus((await deviceService.create({})) as CodexDeviceAuthStatus);
+      const next = (await deviceService.create({})) as CodexDeviceAuthStatus;
+      if (latestServiceRef.current !== deviceService) return;
+      setStatus(next);
     } catch (err) {
+      if (latestServiceRef.current !== deviceService) return;
       setStatus({
         phase: 'error',
         hint:
@@ -522,7 +534,7 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
             : 'Could not start the ChatGPT sign-in — try again.',
       });
     } finally {
-      setStarting(false);
+      if (latestServiceRef.current === deviceService) setStarting(false);
     }
   }, [deviceService]);
 

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1506,6 +1506,13 @@ export function OnboardingWizard({
             const isVerified = llmAuthVerified[option.agent];
             const effectiveHasKey = hasKey && isVerified === true;
             const keyBroken = hasKey && isVerified === false;
+            // Codex "connected" may mean a subscription login (auth.json on
+            // the server), not a stored key — a failed probe then means the
+            // login file is gone, and API-key wording would mislead.
+            const subscriptionBroken =
+              keyBroken &&
+              option.agent === 'codex' &&
+              user?.agentic_auth_methods?.codex === 'subscription';
             const methodOptions = AUTH_METHOD_OPTIONS[option.agent];
             return (
               <div
@@ -1593,7 +1600,7 @@ export function OnboardingWizard({
                           color="error"
                           style={{ fontSize: 10, lineHeight: '16px', padding: '0 5px' }}
                         >
-                          Key not working
+                          {subscriptionBroken ? 'Login not found' : 'Key not working'}
                         </Tag>
                       )}
                     </div>
@@ -1675,7 +1682,11 @@ export function OnboardingWizard({
                     {keyBroken && (
                       <Alert
                         type="warning"
-                        message="Key stored but not working - enter a new one."
+                        message={
+                          subscriptionBroken
+                            ? 'Codex login no longer found on this server — sign in with ChatGPT or import it again.'
+                            : 'Key stored but not working - enter a new one.'
+                        }
                         showIcon
                         style={{ marginTop: 12, marginBottom: 8, fontSize: 12 }}
                       />

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -10,6 +10,7 @@ import type {
   AgorClient,
   AuthCheckResult,
   CodexAuthImportResult,
+  CodexDeviceAuthStatus,
   UpdateUserInput,
   User,
   UserPreferences,
@@ -23,7 +24,7 @@ import {
   LoadingOutlined,
 } from '@ant-design/icons';
 import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
@@ -34,7 +35,12 @@ const { useToken } = theme;
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export type WizardStep = 'persona' | 'llm' | 'workspace' | 'integrations' | 'done';
-type AuthMethod = 'api-key' | 'claude-subscription-token' | 'codex-cli-auth' | 'codex-auth-json';
+type AuthMethod =
+  | 'api-key'
+  | 'claude-subscription-token'
+  | 'codex-cli-auth'
+  | 'codex-auth-json'
+  | 'codex-device-auth';
 
 /**
  * Per-agent auth-method toggle entries. Agents absent here have exactly one
@@ -49,7 +55,8 @@ const AUTH_METHOD_OPTIONS: Partial<
   ],
   codex: [
     { label: 'API key', value: 'api-key' },
-    { label: 'ChatGPT login', value: 'codex-auth-json' },
+    { label: 'Sign in with ChatGPT', value: 'codex-device-auth' },
+    { label: 'Import login', value: 'codex-auth-json' },
   ],
 };
 
@@ -455,6 +462,240 @@ const PARTICLE_DIRS = [
   [-51, -51],
 ] as const;
 
+// ─── Codex device-code sign-in pane ──────────────────────────────────────────
+
+const DEVICE_STATUS_POLL_MS = 2000;
+
+function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(Math.floor(remainingMs / 1000), 0);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+interface CodexDeviceSignInProps {
+  client: AgorClient | null;
+  /** Fired once the daemon confirms tokens were saved for this user. */
+  onVerified: () => void;
+  /** Switch to another codex auth method (gated-account fallback). */
+  onUseFallback: (method: AuthMethod) => void;
+}
+
+/**
+ * Self-contained device-code pane: requests a code, shows it with the
+ * verification link and a countdown, and polls the daemon for approval.
+ * Memoized with its own state so the 1s countdown and 2s status polls
+ * re-render only this pane, never the whole wizard.
+ */
+const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
+  client,
+  onVerified,
+  onUseFallback,
+}: CodexDeviceSignInProps) {
+  const { token } = useToken();
+  const [status, setStatus] = useState<CodexDeviceAuthStatus>({ phase: 'idle' });
+  const [starting, setStarting] = useState(false);
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+
+  const deviceService = useMemo(
+    () =>
+      client
+        ? (client.service('codex-auth/device') as unknown as {
+            create(data: Record<string, never>): Promise<unknown>;
+            find(): Promise<unknown>;
+          })
+        : null,
+    [client]
+  );
+
+  const requestCode = useCallback(async () => {
+    if (!deviceService) return;
+    setStarting(true);
+    try {
+      setStatus((await deviceService.create({})) as CodexDeviceAuthStatus);
+    } catch (err) {
+      setStatus({
+        phase: 'error',
+        hint:
+          err instanceof Error && err.message
+            ? err.message
+            : 'Could not start the ChatGPT sign-in — try again.',
+      });
+    } finally {
+      setStarting(false);
+    }
+  }, [deviceService]);
+
+  // On mount, adopt a still-live attempt (user toggled away and back) instead
+  // of burning a fresh code; otherwise request one.
+  const bootstrappedRef = useRef(false);
+  useEffect(() => {
+    if (bootstrappedRef.current || !deviceService) return;
+    bootstrappedRef.current = true;
+    void (async () => {
+      try {
+        const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (existing.phase === 'pending' || existing.phase === 'success') {
+          setStatus(existing);
+          return;
+        }
+      } catch {
+        // No adoptable attempt — fall through to a fresh request.
+      }
+      await requestCode();
+    })();
+  }, [deviceService, requestCode]);
+
+  // Poll while pending; terminal phases stop the loop. Identity-preserving
+  // setState keeps unchanged polls from re-rendering even this pane.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !deviceService) return;
+    const id = setInterval(async () => {
+      try {
+        const next = (await deviceService.find()) as CodexDeviceAuthStatus;
+        setStatus((prev) =>
+          prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
+            ? prev
+            : next
+        );
+      } catch {
+        // Transient — keep polling until the code expires.
+      }
+    }, DEVICE_STATUS_POLL_MS);
+    return () => clearInterval(id);
+  }, [status.phase, deviceService]);
+
+  // 1s countdown while a code is live.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !status.expiresAt) {
+      setRemainingMs(null);
+      return;
+    }
+    const expiresAtMs = Date.parse(status.expiresAt);
+    const update = () => setRemainingMs(Math.max(expiresAtMs - Date.now(), 0));
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [status.phase, status.expiresAt]);
+
+  useEffect(() => {
+    if (status.phase === 'success') onVerified();
+  }, [status.phase, onVerified]);
+
+  if (starting || status.phase === 'idle') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 14 }} />
+        <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
+          Getting your sign-in code…
+        </Text>
+      </div>
+    );
+  }
+
+  if (status.phase === 'pending') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+        <Text style={{ color: token.colorTextSecondary, fontSize: 13 }}>
+          Open the link below, sign in to ChatGPT, and enter this one-time code:
+        </Text>
+        <Text
+          copyable
+          aria-label="ChatGPT sign-in code"
+          style={{
+            color: token.colorText,
+            fontFamily: 'monospace',
+            fontSize: 26,
+            fontWeight: 600,
+            letterSpacing: 4,
+          }}
+        >
+          {status.userCode}
+        </Text>
+        {status.verificationUrl && (
+          <Typography.Link
+            href={status.verificationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: 13 }}
+          >
+            Open {status.verificationUrl} →
+          </Typography.Link>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
+          <Text style={{ color: token.colorTextTertiary, fontSize: 12 }}>
+            Waiting for approval — we finish automatically once you approve.
+            {remainingMs !== null && ` Code expires in ${formatCountdown(remainingMs)}.`}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  if (status.phase === 'success') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 14 }} />
+        <Text style={{ color: token.colorSuccess, fontSize: 13 }}>
+          {status.hint ?? 'Signed in with ChatGPT.'}
+        </Text>
+      </div>
+    );
+  }
+
+  if (status.phase === 'unavailable') {
+    return (
+      <Alert
+        type="warning"
+        showIcon
+        style={{ fontSize: 12 }}
+        message="Device sign-in is turned off for this ChatGPT account"
+        description={
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <span>
+              Personal accounts: enable it under ChatGPT Settings → Security → “Device code
+              authorization for Codex”, then try again. Workspace accounts: a workspace admin has to
+              enable it. Either way, the two options below work right now.
+            </span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              <Button size="small" onClick={() => onUseFallback('codex-auth-json')}>
+                Paste a login file
+              </Button>
+              <Button size="small" onClick={() => onUseFallback('api-key')}>
+                Use an API key
+              </Button>
+              <Button size="small" type="text" onClick={requestCode}>
+                Try again
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    );
+  }
+
+  // expired / error
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+      <Alert
+        type={status.phase === 'expired' ? 'warning' : 'error'}
+        showIcon
+        style={{ fontSize: 12 }}
+        message={
+          status.hint ??
+          (status.phase === 'expired' ? 'The sign-in code expired.' : 'The ChatGPT sign-in failed.')
+        }
+      />
+      <div>
+        <Button size="small" onClick={requestCode}>
+          Get a new code
+        </Button>
+      </div>
+    </div>
+  );
+});
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface OnboardingWizardProps {
@@ -729,6 +970,11 @@ export function OnboardingWizard({
       case 'llm': {
         if (!selectedAgent) return false;
         if (agentIsVerifiedConnected(selectedAgent)) return true;
+        // Device sign-in has no typed input — it enables once the daemon
+        // confirms the login (llmAuthVerified flips before the user record
+        // refresh that agentIsVerifiedConnected depends on).
+        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth')
+          return llmAuthVerified.codex === true;
         // Key stored, check still in progress — keep enabled so user isn't stuck
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return true;
         // Require a new key with valid format (stored key absent or broken)
@@ -767,6 +1013,11 @@ export function OnboardingWizard({
       case 'llm': {
         if (!selectedAgent) return 'Choose an AI model first';
         if (agentIsVerifiedConnected(selectedAgent)) return null;
+        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth') {
+          return llmAuthVerified.codex === true
+            ? null
+            : 'Approve the sign-in code in ChatGPT first';
+        }
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return null;
         if (!apiKey.trim()) {
           return authMethod === 'codex-auth-json'
@@ -854,6 +1105,18 @@ export function OnboardingWizard({
     setCurrentStep(step);
   }, []);
 
+  // Stable handlers for the memoized device sign-in pane — identity-preserving
+  // so its internal timers never force wizard-wide re-renders.
+  const handleCodexDeviceVerified = useCallback(() => {
+    setLlmAuthVerified((prev) => (prev.codex === true ? prev : { ...prev, codex: true }));
+  }, []);
+
+  const handleCodexAuthMethodFallback = useCallback((method: AuthMethod) => {
+    setAuthMethod(method);
+    setApiKey('');
+    setLlmError(null);
+  }, []);
+
   const handleBack = useCallback(() => {
     if (stepIndex > 0) goToStep(STEPS[stepIndex - 1]);
   }, [stepIndex, goToStep]);
@@ -876,6 +1139,12 @@ export function OnboardingWizard({
         if (!selectedAgent) return;
         if (agentIsVerifiedConnected(selectedAgent)) {
           goToStep('workspace');
+          return;
+        }
+        // Device sign-in completes daemon-side; the primary button only ever
+        // advances once the attempt succeeded (button is disabled until then).
+        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth') {
+          if (llmAuthVerified.codex === true) goToStep('workspace');
           return;
         }
         // Key stored, auth check still running — proceed optimistically
@@ -1419,31 +1688,39 @@ export function OnboardingWizard({
                       </div>
                     )}
 
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        marginTop: !methodOptions && !keyBroken ? 12 : 0,
-                        marginBottom: 8,
-                      }}
-                    >
-                      <Text style={{ color: TEXT_PRIMARY, fontSize: 13, fontWeight: 500 }}>
-                        {getKeyLabel(option.agent, authMethod)}
-                      </Text>
-                      {option.keyLink && authMethod === 'api-key' && (
-                        <Typography.Link
-                          href={option.keyLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{ fontSize: 12, color: PRIMARY }}
-                        >
-                          Get your key at {option.keyLinkLabel} →
-                        </Typography.Link>
-                      )}
-                    </div>
+                    {authMethod !== 'codex-device-auth' && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center',
+                          marginTop: !methodOptions && !keyBroken ? 12 : 0,
+                          marginBottom: 8,
+                        }}
+                      >
+                        <Text style={{ color: TEXT_PRIMARY, fontSize: 13, fontWeight: 500 }}>
+                          {getKeyLabel(option.agent, authMethod)}
+                        </Text>
+                        {option.keyLink && authMethod === 'api-key' && (
+                          <Typography.Link
+                            href={option.keyLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ fontSize: 12, color: PRIMARY }}
+                          >
+                            Get your key at {option.keyLinkLabel} →
+                          </Typography.Link>
+                        )}
+                      </div>
+                    )}
 
-                    {authMethod === 'codex-auth-json' ? (
+                    {authMethod === 'codex-device-auth' ? (
+                      <CodexDeviceSignIn
+                        client={client}
+                        onVerified={handleCodexDeviceVerified}
+                        onUseFallback={handleCodexAuthMethodFallback}
+                      />
+                    ) : authMethod === 'codex-auth-json' ? (
                       <>
                         <Alert
                           type="info"

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -526,16 +526,17 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
     }
   }, [deviceService]);
 
-  // On mount, adopt a still-live attempt (user toggled away and back) instead
-  // of burning a fresh code; otherwise request one. Keyed by service identity
-  // so a client swap mid-flow re-bootstraps against the new connection.
-  const bootstrappedForRef = useRef<unknown>(null);
+  // On mount (and on client swap), adopt a still-live attempt (user toggled
+  // away and back) instead of burning a fresh code; otherwise request one.
+  // The cancellation guard makes this StrictMode-safe — a superseded run
+  // never fires its requestCode/setStatus continuation.
   useEffect(() => {
-    if (!deviceService || bootstrappedForRef.current === deviceService) return;
-    bootstrappedForRef.current = deviceService;
+    if (!deviceService) return;
+    let cancelled = false;
     void (async () => {
       try {
         const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (cancelled) return;
         if (existing.phase === 'pending' || existing.phase === 'success') {
           setStatus(existing);
           return;
@@ -543,17 +544,26 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
       } catch {
         // No adoptable attempt — fall through to a fresh request.
       }
-      await requestCode();
+      if (!cancelled) await requestCode();
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [deviceService, requestCode]);
 
-  // Poll while pending; terminal phases stop the loop. Identity-preserving
-  // setState keeps unchanged polls from re-rendering even this pane.
+  // Poll while pending; terminal phases stop the loop. A self-scheduling
+  // timeout (next poll armed only after the previous response lands) keeps
+  // slow responses from overlapping and regressing a terminal phase with an
+  // out-of-order pending. Identity-preserving setState keeps unchanged polls
+  // from re-rendering even this pane.
   useEffect(() => {
     if (status.phase !== 'pending' || !deviceService) return;
-    const id = setInterval(async () => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
       try {
         const next = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (cancelled) return;
         setStatus((prev) =>
           prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
             ? prev
@@ -562,8 +572,13 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
       } catch {
         // Transient — keep polling until the code expires.
       }
-    }, DEVICE_STATUS_POLL_MS);
-    return () => clearInterval(id);
+      if (!cancelled) timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    };
+    timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [status.phase, deviceService]);
 
   // 1s countdown while a code is live.

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -527,11 +527,12 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   }, [deviceService]);
 
   // On mount, adopt a still-live attempt (user toggled away and back) instead
-  // of burning a fresh code; otherwise request one.
-  const bootstrappedRef = useRef(false);
+  // of burning a fresh code; otherwise request one. Keyed by service identity
+  // so a client swap mid-flow re-bootstraps against the new connection.
+  const bootstrappedForRef = useRef<unknown>(null);
   useEffect(() => {
-    if (bootstrappedRef.current || !deviceService) return;
-    bootstrappedRef.current = true;
+    if (!deviceService || bootstrappedForRef.current === deviceService) return;
+    bootstrappedForRef.current = deviceService;
     void (async () => {
       try {
         const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
@@ -587,7 +588,7 @@ const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
         <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 14 }} />
         <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
-          Getting your sign-in code…
+          {client ? 'Getting your sign-in code…' : 'Waiting for the server connection…'}
         </Text>
       </div>
     );

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -152,7 +152,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('shows Codex authentication choices when subscription mode hides API-key fields', async () => {
+  it('offers the three Codex authentication methods, defaulting to the sign-in view for a subscription', async () => {
     const user = makeUser({ agentic_auth_methods: { codex: 'subscription' } });
     renderWithApp(
       <UserSettingsModal
@@ -167,8 +167,12 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
 
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }));
     await screen.findByRole('heading', { name: 'Codex' });
-    expect(screen.getByText('ChatGPT subscription')).toBeInTheDocument();
-    expect(screen.getByText('Use Codex CLI subscription authentication')).toBeInTheDocument();
+    // The method selector surfaces all three ways in.
+    expect(screen.getByText('API key')).toBeInTheDocument();
+    expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+    expect(screen.getByText('Import login file')).toBeInTheDocument();
+    // A stored subscription lands on the ChatGPT sign-in view.
+    expect(screen.getByText(/Sign in with your ChatGPT account/i)).toBeInTheDocument();
   });
 
   it('saves a Claude model alias before closing', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -53,6 +53,7 @@ import {
   getFormValuesFromConfig,
 } from '../AgenticToolConfigForm';
 import { ApiKeyFields, type FieldStatus, TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
+import { CodexAuthSettings } from '../CodexAuth';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { EnvVarEditor } from '../EnvVarEditor';
 import { SessionMcpServersField } from '../MCPServerSelect';
@@ -1151,13 +1152,35 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   </Popconfirm>
                 </Space>
               )
+            ) : canonicalTool === 'codex' ? (
+              <CodexAuthSettings
+                client={client}
+                authMethod={authMethod ?? 'api_key'}
+                apiKeyFields={allToolFields}
+                fieldStatus={fieldStatus}
+                onSaveField={(field, value) =>
+                  handleToolFieldSave(credentialToolName, field, value)
+                }
+                onClearField={(field) => handleToolFieldClear(credentialToolName, field)}
+                savingFields={Object.fromEntries(
+                  allToolFields.map((c) => [
+                    c.field,
+                    !!savingToolField[`${credentialToolName}.${c.field}`],
+                  ])
+                )}
+                publicValues={
+                  user?.agentic_tools_public_values?.[credentialToolName] as
+                    | Partial<Record<AgenticToolConfigField, string>>
+                    | undefined
+                }
+              />
             ) : (
               <>
                 <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
                   Personal credentials are encrypted at rest and injected only into the agent
                   runtime.
                 </Typography.Paragraph>
-                {(canonicalTool === 'claude-code' || canonicalTool === 'codex') && (
+                {canonicalTool === 'claude-code' && (
                   <Radio.Group
                     value={authMethod}
                     onChange={(event) =>
@@ -1165,34 +1188,23 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                     }
                     style={{ marginBottom: 16 }}
                   >
-                    <Radio.Button value="subscription">
-                      {canonicalTool === 'codex' ? 'ChatGPT subscription' : 'Claude subscription'}
-                    </Radio.Button>
+                    <Radio.Button value="subscription">Claude subscription</Radio.Button>
                     <Radio.Button value="api_key">API key</Radio.Button>
                   </Radio.Group>
                 )}
-                {canonicalTool === 'codex' && authMethod === 'subscription' ? (
-                  <Alert
-                    type="info"
-                    showIcon
-                    title="Use Codex CLI subscription authentication"
-                    description="Agor will use the Codex CLI login belonging to this session's Unix user. Run `codex login` in a terminal as that same user. This declaration does not prove that the login is still valid."
-                  />
-                ) : (
-                  <ApiKeyFields
-                    tool={toolName}
-                    fields={toolFields}
-                    fieldStatus={fieldStatus}
-                    onSave={(field, value) => handleToolFieldSave(credentialToolName, field, value)}
-                    onClear={(field) => handleToolFieldClear(credentialToolName, field)}
-                    saving={savingForTool}
-                    publicValues={
-                      user?.agentic_tools_public_values?.[credentialToolName] as
-                        | Partial<Record<AgenticToolConfigField, string>>
-                        | undefined
-                    }
-                  />
-                )}
+                <ApiKeyFields
+                  tool={toolName}
+                  fields={toolFields}
+                  fieldStatus={fieldStatus}
+                  onSave={(field, value) => handleToolFieldSave(credentialToolName, field, value)}
+                  onClear={(field) => handleToolFieldClear(credentialToolName, field)}
+                  saving={savingForTool}
+                  publicValues={
+                    user?.agentic_tools_public_values?.[credentialToolName] as
+                      | Partial<Record<AgenticToolConfigField, string>>
+                      | undefined
+                  }
+                />
               </>
             )}
           </>

--- a/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
+++ b/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
@@ -23,6 +23,26 @@ describe('buildAgenticToolCredentialPatch', () => {
     });
   });
 
+  it('flips the Codex method to api_key when an OpenAI key is saved (the only deliberate api_key act)', () => {
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_API_KEY', 'sk-proj-test')).toEqual({
+      agentic_tools: {
+        codex: { OPENAI_API_KEY: 'sk-proj-test' },
+      },
+      agentic_auth_methods: { codex: 'api_key' },
+    });
+  });
+
+  it('does not flip the Codex method when only the base URL is set or a key is cleared', () => {
+    // A non-credential field must not activate api_key…
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_BASE_URL', 'https://gw')).toEqual({
+      agentic_tools: { codex: { OPENAI_BASE_URL: 'https://gw' } },
+    });
+    // …and clearing the key must not assert any method (leaves the flip to a real save).
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_API_KEY', null)).toEqual({
+      agentic_tools: { codex: { OPENAI_API_KEY: null } },
+    });
+  });
+
   it('clears a token by sending null at the same canonical field path', () => {
     expect(buildAgenticToolCredentialPatch('claude-code', 'CLAUDE_CODE_OAUTH_TOKEN', null)).toEqual(
       {

--- a/packages/core/src/types/agentic-tool.ts
+++ b/packages/core/src/types/agentic-tool.ts
@@ -233,6 +233,43 @@ export interface CodexAuthImportResult {
 }
 
 /**
+ * Lifecycle of a ChatGPT device-code sign-in attempt driven by the daemon's
+ * `/codex-auth/device` endpoints.
+ * - `idle`: no attempt exists for this user.
+ * - `pending`: a code was issued; the daemon is polling for approval.
+ * - `success`: tokens were exchanged and persisted to the user's Codex home.
+ * - `expired`: the code's 15-minute window elapsed without approval.
+ * - `unavailable`: OpenAI's server refused to issue a code — device-code
+ *   authorization is disabled for this account/workspace (a common, first-class
+ *   state, not an edge case).
+ * - `error`: the attempt failed for another reason; start a fresh one.
+ */
+export type CodexDeviceAuthPhase =
+  | 'idle'
+  | 'pending'
+  | 'success'
+  | 'expired'
+  | 'unavailable'
+  | 'error';
+
+/**
+ * Non-secret status of a device-code sign-in attempt. The user code and
+ * verification URL are meant to be displayed; tokens never appear here.
+ */
+export interface CodexDeviceAuthStatus {
+  phase: CodexDeviceAuthPhase;
+  /** One-time code the user enters on the verification page (pending only). */
+  userCode?: string;
+  /** Page where the user approves the code (pending only). */
+  verificationUrl?: string;
+  /** ISO timestamp when the pending code stops working. */
+  expiresAt?: string;
+  /** ChatGPT plan type parsed from the id_token after success, when present. */
+  planType?: string;
+  hint?: string;
+}
+
+/**
  * Canonical mapping from AgenticToolName to the env-var name that holds its primary API key.
  * Tools that authenticate without a key (opencode) are intentionally absent.
  *


### PR DESCRIPTION
> **Stacked PR** — based on #1954 (`codex-oauth-onboarding`). Merge that first; this diff only shows the device-code work on top of it.

## Problem

#1954 gives Codex users a paste-an-`auth.json` path. This PR adds the fully guided option: the wizard drives OpenAI's device-code authorization itself, so a user can sign in with ChatGPT without ever leaving the browser or touching a terminal.

## Protocol (verified against openai/codex source — `codex-rs/login/src/device_code_auth.rs` + `server.rs`, client id from `auth/manager.rs`)

1. `POST auth.openai.com/api/accounts/deviceauth/usercode` with Codex's public client id (`app_EMoamEEZ73f0CkXaXp7hrann`) → `{device_auth_id, user_code, interval}`. **404/403 here means device-code auth is disabled for the account/workspace** — a server-side gate that will hit many users.
2. Poll `POST .../deviceauth/token` with `{device_auth_id, user_code}` at the server-specified interval; 403/404 are the "authorization pending" signals; codes hard-expire after 15 minutes.
3. On approval the server returns an `authorization_code` **plus a server-generated PKCE pair**, exchanged at `POST /oauth/token` (`grant_type=authorization_code`, `redirect_uri=…/deviceauth/callback`) for `id_token` / `access_token` / `refresh_token`.
4. The daemon writes a Codex-format `auth.json` (`auth_mode: "chatgpt"`, `OPENAI_API_KEY: null`, `tokens.account_id` mined from the id_token's `chatgpt_account_id` claim, `last_refresh` ISO) — byte-shape matched to codex-rs `AuthDotJson`/`TokenData` serde — and flips the user's Codex auth method to `subscription`.

## Approach

**Daemon — `/codex-auth/device`** (`apps/agor-daemon/src/services/codex-device-auth.ts`)
- `create`: guards (session auth, hosted-multi-tenant rejection, workspace tool toggle, fail-fast Unix-identity resolution), then starts an attempt and returns `{phase, userCode, verificationUrl, expiresAt}`. One in-flight attempt per user — new attempts cancel and replace the old. The gated case returns `phase: "unavailable"` with guidance rather than an error.
- Daemon-side polling honors the server interval (floor 2s), treats transport blips as retryable, hard-stops at expiry, and on success reuses #1954's shared `persistVerifiedCodexAuth` (write 0600 as the target Unix user → read-back verify → flip auth method).
- `find`: reports the **caller's own** attempt only (`idle/pending/success/expired/unavailable/error`). Attempts are in-memory; a daemon restart discards them and the UI just requests a fresh code.

**Wizard** — the GPT toggle becomes **API key | Sign in with ChatGPT | Import login**. The sign-in pane auto-requests a code (or adopts a still-pending attempt instead of burning a new one), shows the code with copy, the `auth.openai.com/codex/device` link, a live countdown, and a waiting indicator; approval enables Continue, expiry offers "Get a new code". The `unavailable` phase renders as a first-class explanation — personal accounts: ChatGPT Settings → Security → "Device code authorization for Codex"; workspace accounts: admin toggle — with one-click switches to the paste-import and API-key methods.

## Perf notes

The pane is a memoized child component with its own state and stable parent callbacks, so its 1s countdown tick and 2s status polls re-render only the pane, never the wizard. Status polling uses identity-preserving `setState`, stops on terminal phases and on unmount.

## Security notes
- **Shared-identity trust model (recorded decision):** in `unix_user_mode: simple` or `insulated`, every user resolves to a single Unix identity, so importing or signing in replaces the one server-wide Codex login — the same semantics the pre-existing `codex login`-in-a-terminal path has always had. This is Agor's documented mode-1/2 trust model (personal instances / trusted teams), not a regression introduced here; per-user credential isolation requires `strict` mode. The wizard copy states that the overwrite is server-wide.

- Tokens flow auth.openai.com ↔ daemon ↔ target user's filesystem. The UI sees only the display code, verification URL, expiry, phase, and plan type. Nothing token-shaped is logged (finalization failures log the error class only) and nothing enters agent/LLM context.
- The attempt's target Unix identity is resolved from the authenticated caller at start; `find` is scoped to the caller's own attempt.

## Tests

- `codex-device-auth.test.ts` (fake timers + fetch mock): pending status shape, gated→`unavailable`, poll→exchange→persist→success (asserting the exact `auth.json` shape and that status JSON carries no tokens, and that polling stops after terminal), 15-minute expiry hard-stop, cancel-and-replace, idle/unauthenticated, hosted-multi-tenant rejection before any network call.
- Wizard tests: code display with link/countdown and disabled Continue, success→enabled Continue→advance, gated guidance with working fallback switch, new-code-after-expiry, pending-attempt adoption without burning a code.
- Full `pnpm check` passes; daemon suite 83 files / 956 tests green; core suite green.

## Manual verification worth doing

- A real end-to-end sign-in against auth.openai.com (needs an account with device-code auth enabled) — the protocol is source-verified but not live-tested from this environment.
- Confirm the gated-workspace copy matches what ChatGPT's settings UI currently calls the toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
