### PR TITLE
fix(ci): skip image publishing for fork PRs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,11 +8,11 @@
 # rather than `agor-live@latest` on npm.
 #
 # Publish model: the :<full-sha> image is built and pushed on pushes to
-# main, v* tags, AND every PR commit (tagged by the PR
-# *head* SHA, with :pr-<n> re-pointed on each update), so any commit is
-# deployable by its own SHA. Publishing unmerged PR builds under preset/agor
-# is intentional — pre-merge deploy testing needs it. The boot smoke test
-# below gates every publish. Plus a branch tag, and `latest` on main only.
+# main, v* tags, AND every in-repository PR commit (tagged by the PR *head*
+# SHA, with :pr-<n> re-pointed on each update), so trusted commits are
+# deployable by their own SHA. Fork PRs still build and run the boot smoke
+# test, but cannot publish because GitHub intentionally withholds repository
+# secrets from them. Plus a branch tag, and `latest` on main only.
 #
 # Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
 # (Settings → Secrets and variables → Actions):
@@ -59,9 +59,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # We push on every event (including PRs), so always log in. preset-io/agor
-      # PRs come from in-repo branches, so the secrets are available.
+      # Fork PRs cannot access repository secrets. Keep their build and smoke
+      # test useful without attempting to authenticate or publish.
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -127,9 +128,10 @@ jobs:
           docker logs agor-smoke
           exit 1
 
-      # Publish on every event (push + PR), gated only by the smoke test
-      # above.
+      # Publish trusted events after the smoke test. Fork PRs stop here after
+      # validating the same production image locally.
       - name: Push image
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Linked issue

Not linked.

## Summary

- skip Docker Hub authentication for pull requests from forks
- keep building and smoke-testing the production image for fork pull requests
- skip image publication when repository secrets are unavailable

## Why / context

GitHub does not expose repository secrets to workflows triggered by fork pull requests. The image workflow previously attempted to authenticate and publish for every pull request, so otherwise-valid fork contributions failed before completing the useful build and boot smoke test.

## Implementation notes

- gates Docker Hub login and image publication on trusted push events or in-repository pull requests
- leaves checkout, production-image build, cache use, and boot smoke testing enabled for fork pull requests
- preserves SHA and PR image publication for in-repository branches

## Validation / test plan

- [x] workflow parsed and completed successfully for the original in-repository pull-request commit
- [x] fork-specific path: production image build and boot smoke test passed while login and publication were skipped ([run](https://github.com/preset-io/agor/actions/runs/29606257200))
- [ ] full CI is currently blocked by a pre-existing formatter failure in `apps/agor-docs/app/styles.css` on `main`

## Screenshots / demos

Not applicable; this changes CI workflow behavior only.

## Risks / rollout / rollback

Low risk. Pushes, tags, and in-repository pull requests retain the existing publication behavior. Fork pull requests no longer publish images, but still validate the production container locally. Reverting the commit restores the previous behavior.

## Out of scope / follow-ups

- changes to image tags, registries, or release publication policy
