### PR TITLE
fix(docs): biome format apps/agor-docs/app/styles.css

### DIFF
--- a/apps/agor-docs/app/styles.css
+++ b/apps/agor-docs/app/styles.css
@@ -257,15 +257,15 @@ code span[style*="--shiki-dark:#6A737D"] {
  * and a light tint so pages read less like a wall of white. Distinct from
  * the teal link color; scoped away from the landing page (its headings carry
  * their own styles). */
-body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
-  font-family: var(--font-display), 'Space Grotesk', system-ui, sans-serif;
+body:not(:has([class*="landingShell"])) main :is(h1, h2, h3) {
+  font-family: var(--font-display), "Space Grotesk", system-ui, sans-serif;
   letter-spacing: -0.01em;
 }
 
-.dark body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
+.dark body:not(:has([class*="landingShell"])) main :is(h1, h2, h3) {
   color: #c9efe7;
 }
 
-html:not(.dark) body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
+html:not(.dark) body:not(:has([class*="landingShell"])) main :is(h1, h2, h3) {
   color: #0d6f5f;
 }


### PR DESCRIPTION
b357aa73 (Docs cleanup wave 3) landed on main without the lint workflow running, leaving a biome format violation in `apps/agor-docs/app/styles.css` (single quotes where biome wants double). This is the pure `biome format --write` output for that file — no hand edits — and unblocks the lint check on every open PR's merge ref.

## Test plan
- [x] `pnpm lint` now exits 0 (was failing with 1 format error before this fix)
- [x] `pnpm typecheck` passes (11/11 tasks)