### PR TITLE
fix(ci): skip image publishing for fork PRs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,11 +8,11 @@
 # rather than `agor-live@latest` on npm.
 #
 # Publish model: the :<full-sha> image is built and pushed on pushes to
-# main, v* tags, AND every PR commit (tagged by the PR
-# *head* SHA, with :pr-<n> re-pointed on each update), so any commit is
-# deployable by its own SHA. Publishing unmerged PR builds under preset/agor
-# is intentional — pre-merge deploy testing needs it. The boot smoke test
-# below gates every publish. Plus a branch tag, and `latest` on main only.
+# main, v* tags, AND every in-repository PR commit (tagged by the PR *head*
+# SHA, with :pr-<n> re-pointed on each update), so trusted commits are
+# deployable by their own SHA. Fork PRs still build and run the boot smoke
+# test, but cannot publish because GitHub intentionally withholds repository
+# secrets from them. Plus a branch tag, and `latest` on main only.
 #
 # Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
 # (Settings → Secrets and variables → Actions):
@@ -59,9 +59,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # We push on every event (including PRs), so always log in. preset-io/agor
-      # PRs come from in-repo branches, so the secrets are available.
+      # Fork PRs cannot access repository secrets. Keep their build and smoke
+      # test useful without attempting to authenticate or publish.
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -127,9 +128,10 @@ jobs:
           docker logs agor-smoke
           exit 1
 
-      # Publish on every event (push + PR), gated only by the smoke test
-      # above.
+      # Publish trusted events after the smoke test. Fork PRs stop here after
+      # validating the same production image locally.
       - name: Push image
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,9 +10,9 @@
 # Publish model: the :<full-sha> image is built and pushed on pushes to
 # main, v* tags, AND every in-repository PR commit (tagged by the PR *head*
 # SHA, with :pr-<n> re-pointed on each update), so trusted commits are
-# deployable by their own SHA. Fork PRs still build and run the boot smoke
-# test, but cannot publish because GitHub intentionally withholds repository
-# secrets from them. Plus a branch tag, and `latest` on main only.
+# deployable by their own SHA. Fork and Dependabot PRs still build and run the
+# boot smoke test, but cannot publish because GitHub intentionally withholds
+# repository secrets from them. Plus a branch tag, and `latest` on main only.
 #
 # Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
 # (Settings → Secrets and variables → Actions):
@@ -59,10 +59,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Fork PRs cannot access repository secrets. Keep their build and smoke
-      # test useful without attempting to authenticate or publish.
+      # Fork and Dependabot PRs cannot access repository secrets. Keep their
+      # build and smoke test useful without authenticating or publishing.
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          github.event_name != 'pull_request' ||
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.user.login != 'dependabot[bot]'
+          )
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -128,10 +133,15 @@ jobs:
           docker logs agor-smoke
           exit 1
 
-      # Publish trusted events after the smoke test. Fork PRs stop here after
-      # validating the same production image locally.
+      # Publish trusted events after the smoke test. Fork and Dependabot PRs
+      # stop here after validating the same production image locally.
       - name: Push image
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          github.event_name != 'pull_request' ||
+          (
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event.pull_request.user.login != 'dependabot[bot]'
+          )
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Linked issue

Not linked.

## Summary

- skip Docker Hub authentication and image publication for fork and Dependabot pull requests
- keep building and smoke-testing the production image when repository secrets are unavailable
- preserve image publication for pushes, tags, manual runs, and normal in-repository pull requests

## Why / context

Repository secrets are not exposed to workflows triggered by fork or Dependabot pull requests. The image workflow previously attempted to authenticate and publish for every pull request, so otherwise-valid contributions failed before completing the useful build and boot smoke test.

## Implementation notes

- gates Docker Hub login and image publication on trusted events
- identifies trusted pull requests by both repository ownership and a non-Dependabot author
- leaves checkout, production-image build, cache use, and boot smoke testing enabled for untrusted pull requests
- preserves SHA and PR image publication for normal in-repository branches

## Validation / test plan

- [x] workflow YAML parses successfully
- [x] event-condition matrix covers fork, Dependabot, normal in-repository, push, tag, and manual events
- [x] fork path: production image build and boot smoke test passed while login and publication were skipped ([run](https://github.com/preset-io/agor/actions/runs/29606257200))
- [x] in-repository path: login, production image build, boot smoke test, and publication passed ([run](https://github.com/preset-io/agor/actions/runs/29738038883))
- [ ] refreshed provider checks pending for the rebased head

## Screenshots / demos

Not applicable; this changes CI workflow behavior only.

## Risks / rollout / rollback

Low risk. Pushes, tags, manual runs, and normal in-repository pull requests retain publication behavior. Fork and Dependabot pull requests no longer publish images, but still validate the production container locally. Reverting the commits restores the previous behavior.

## Out of scope / follow-ups

- changes to image tags, registries, or release publication policy
