### PR TITLE
fix(ci): format docs styles

### DIFF
--- a/apps/agor-docs/app/styles.css
+++ b/apps/agor-docs/app/styles.css
@@ -257,15 +257,15 @@ code span[style*="--shiki-dark:#6A737D"] {
  * and a light tint so pages read less like a wall of white. Distinct from
  * the teal link color; scoped away from the landing page (its headings carry
  * their own styles). */
-body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
-  font-family: var(--font-display), 'Space Grotesk', system-ui, sans-serif;
+body:not(:has([class*="landingShell"])) main :is(h1, h2, h3) {
+  font-family: var(--font-display), "Space Grotesk", system-ui, sans-serif;
   letter-spacing: -0.01em;
 }
 
-.dark body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
+.dark body:not(:has([class*="landingShell"])) main :is(h1, h2, h3) {
   color: #c9efe7;
 }
 
-html:not(.dark) body:not(:has([class*='landingShell'])) main :is(h1, h2, h3) {
+html:not(.dark) body:not(:has([class*="landingShell"])) main :is(h1, h2, h3) {
   color: #0d6f5f;
 }


### PR DESCRIPTION
## Linked issue

Related: #1964, #1966, #1967

## Summary

- apply the repository formatter to the affected docs style selectors
- unblock repository-wide lint checks for branches that do not already carry the formatting correction

## Why / context

`main` contains single-quoted CSS attribute selectors and a font name that Biome reformats with double quotes. Because CI runs lint across the entire repository, otherwise-unrelated pull requests fail on this existing file.

## Implementation notes

This is formatting-only and matches the correction already present in #1964. It does not change CSS behavior.

## Validation / test plan

- [x] `pnpm exec biome check apps/agor-docs/app/styles.css`
- [x] `git diff --check`

## Screenshots / demos

Not applicable; there is no visual or behavioral change.

## Risks / rollout / rollback

Minimal risk. The change only normalizes quote style. Reverting the commit restores the prior formatting and the CI failure.

## Out of scope / follow-ups

- unrelated lint warnings reported by the full repository check
