### PR TITLE
feat(codex-auth): three Codex sign-in methods in user settings (PR3)

### DIFF
--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
@@ -13,7 +13,6 @@
 
 import type { AgenticAuthMethod, AuthCheckResult } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { useState } from 'react';
 import { TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
 import { CodexAuthSettings } from './CodexAuthSettings';
 
@@ -28,12 +27,12 @@ interface HarnessOptions {
   deviceFind?: ReturnType<typeof vi.fn>;
   onSaveField?: ReturnType<typeof vi.fn>;
   onClearField?: ReturnType<typeof vi.fn>;
-  onAuthMethodChange?: ReturnType<typeof vi.fn>;
 }
 
-// A stateful host so onAuthMethodChange actually flips the persisted method,
-// exactly as the real settings modal does — the pane's method/probe logic
-// depends on that round-trip.
+// The pane never mutates the persisted method itself — the method is a
+// consequence of the credential the user configures (a key save / a completed
+// device sign-in or import), which the real settings modal drives — so the
+// harness holds authMethod fixed and asserts selection stays non-destructive.
 function Harness({
   initialMethod = 'api_key',
   fieldStatus = {},
@@ -43,9 +42,7 @@ function Harness({
   deviceFind,
   onSaveField,
   onClearField,
-  onAuthMethodChange,
 }: HarnessOptions) {
-  const [method, setMethod] = useState<AgenticAuthMethod>(initialMethod);
   const services: Record<string, unknown> = {
     'check-auth': { create: checkAuth ?? vi.fn(async () => UNKNOWN) },
     'codex-auth/import': {
@@ -64,11 +61,7 @@ function Harness({
   return (
     <CodexAuthSettings
       client={client}
-      authMethod={method}
-      onAuthMethodChange={(next) => {
-        onAuthMethodChange?.(next);
-        setMethod(next);
-      }}
+      authMethod={initialMethod}
       apiKeyFields={TOOL_FIELD_CONFIGS.codex}
       fieldStatus={fieldStatus}
       onSaveField={onSaveField ?? vi.fn(async () => undefined)}
@@ -189,24 +182,74 @@ describe('CodexAuthSettings', () => {
     expect(await screen.findByText('ABCD-1234')).toBeInTheDocument();
   });
 
-  it('does not deactivate a working API key when merely opening a subscription sign-in view', async () => {
-    // Selecting "Sign in with ChatGPT" / "Import login file" is a local view
-    // choice — the daemon flips the method to subscription only on success.
-    // Persisting it here would break a still-working API-key configuration.
-    const onAuthMethodChange = vi.fn();
-    render(<Harness initialMethod="api_key" onAuthMethodChange={onAuthMethodChange} />);
+  it('switches methods as a pure view — no selection persists a credential', async () => {
+    // Selecting a tab is never destructive: the method follows the credential
+    // you configure, so no key-save/clear is triggered by mere navigation.
+    const onSaveField = vi.fn(async () => undefined);
+    const onClearField = vi.fn(async () => undefined);
+    render(
+      <Harness initialMethod="api_key" onSaveField={onSaveField} onClearField={onClearField} />
+    );
 
     clickText('Sign in with ChatGPT');
     expect(await screen.findByText(/Sign in with your ChatGPT account/i)).toBeInTheDocument();
-    expect(onAuthMethodChange).not.toHaveBeenCalled();
-
     clickText('Import login file');
     expect(await screen.findByLabelText('Codex auth.json contents')).toBeInTheDocument();
-    expect(onAuthMethodChange).not.toHaveBeenCalled();
-
-    // Deliberately choosing the API-key method is the only selection that persists.
     clickText('API key');
-    expect(onAuthMethodChange).not.toHaveBeenCalled(); // already api_key — no redundant write
+    expect(await screen.findByPlaceholderText('sk-proj-...')).toBeInTheDocument();
+
+    expect(onSaveField).not.toHaveBeenCalled();
+    expect(onClearField).not.toHaveBeenCalled();
+  });
+
+  it('opening the API-key tab from a subscription login is non-destructive (no silent break)', async () => {
+    // Regression guard: a user with a working ChatGPT login who clicks "API key"
+    // to look at the fields must not have their login deactivated. The pane
+    // exposes no method-flip callback, and selection triggers no persistence.
+    const onSaveField = vi.fn(async () => undefined);
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'native',
+      })
+    );
+    render(
+      <Harness initialMethod="subscription" checkAuth={checkAuth} onSaveField={onSaveField} />
+    );
+
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+    expect(screen.getByText('A ChatGPT login is active on this server.')).toBeInTheDocument();
+
+    clickText('API key');
+    expect(await screen.findByPlaceholderText('sk-proj-...')).toBeInTheDocument();
+    // The login banner is unaffected — nothing was persisted or re-probed away.
+    expect(screen.getByText('Codex is connected')).toBeInTheDocument();
+    expect(onSaveField).not.toHaveBeenCalled();
+  });
+
+  it('does not adopt a stale success in settings — re-signing-in stays reachable', async () => {
+    // A device sign-in that succeeded within the daemon's adopt-TTL must not
+    // wall off the management surface: the deliberate-start button remains.
+    const deviceFind = vi.fn(async () => ({ phase: 'success', hint: 'Signed in with ChatGPT.' }));
+    const deviceCreate = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'WXYZ-9876',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    }));
+    render(
+      <Harness initialMethod="subscription" deviceFind={deviceFind} deviceCreate={deviceCreate} />
+    );
+
+    clickText('Sign in with ChatGPT');
+    // Success is not adopted (autoStart=false) — the restart button shows instead.
+    expect(await screen.findByText('Get a sign-in code')).toBeInTheDocument();
+    expect(screen.queryByText('Signed in with ChatGPT.')).not.toBeInTheDocument();
+
+    clickText('Get a sign-in code');
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('WXYZ-9876')).toBeInTheDocument();
   });
 
   it('imports a pasted login file and re-probes the connection', async () => {

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for the Codex authentication management pane (settings surface).
+ *
+ * Unlike the onboarding wizard, this is a management view: it probes the live
+ * connection, surfaces a stored-but-broken credential as a prominent error, and
+ * keeps every sign-in path reachable while connected.
+ *
+ * Query style mirrors OnboardingWizard.test.tsx — plain text queries with
+ * `.closest('button')`, never `getByRole`, because computing an accessible name
+ * while an antd `Tag`/`Segmented` is mounted walks a CSS shorthand rule that
+ * crashes jsdom's `cssstyle`.
+ */
+
+import type { AgenticAuthMethod, AuthCheckResult } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
+import { CodexAuthSettings } from './CodexAuthSettings';
+
+const UNKNOWN: AuthCheckResult = { status: 'unknown', authenticated: false, method: 'none' };
+
+interface HarnessOptions {
+  initialMethod?: AgenticAuthMethod;
+  fieldStatus?: Record<string, boolean>;
+  checkAuth?: ReturnType<typeof vi.fn>;
+  importCreate?: ReturnType<typeof vi.fn>;
+  deviceCreate?: ReturnType<typeof vi.fn>;
+  deviceFind?: ReturnType<typeof vi.fn>;
+  onSaveField?: ReturnType<typeof vi.fn>;
+  onClearField?: ReturnType<typeof vi.fn>;
+  onAuthMethodChange?: ReturnType<typeof vi.fn>;
+}
+
+// A stateful host so onAuthMethodChange actually flips the persisted method,
+// exactly as the real settings modal does — the pane's method/probe logic
+// depends on that round-trip.
+function Harness({
+  initialMethod = 'api_key',
+  fieldStatus = {},
+  checkAuth,
+  importCreate,
+  deviceCreate,
+  deviceFind,
+  onSaveField,
+  onClearField,
+  onAuthMethodChange,
+}: HarnessOptions) {
+  const [method, setMethod] = useState<AgenticAuthMethod>(initialMethod);
+  const services: Record<string, unknown> = {
+    'check-auth': { create: checkAuth ?? vi.fn(async () => UNKNOWN) },
+    'codex-auth/import': {
+      create: importCreate ?? vi.fn(async () => ({ status: 'authenticated' })),
+    },
+    'codex-auth/device': {
+      create: deviceCreate ?? vi.fn(async () => ({ phase: 'idle' })),
+      find: deviceFind ?? vi.fn(async () => ({ phase: 'idle' })),
+    },
+  };
+  const client = {
+    io: { on: vi.fn(), off: vi.fn() },
+    service: vi.fn((name: string) => services[name] ?? {}),
+  } as never;
+
+  return (
+    <CodexAuthSettings
+      client={client}
+      authMethod={method}
+      onAuthMethodChange={(next) => {
+        onAuthMethodChange?.(next);
+        setMethod(next);
+      }}
+      apiKeyFields={TOOL_FIELD_CONFIGS.codex}
+      fieldStatus={fieldStatus}
+      onSaveField={onSaveField ?? vi.fn(async () => undefined)}
+      onClearField={onClearField ?? vi.fn(async () => undefined)}
+      savingFields={{}}
+    />
+  );
+}
+
+function clickText(text: string | RegExp) {
+  const el = screen.getByText(text);
+  const clickable = el.closest('button') ?? el.closest('label') ?? el;
+  fireEvent.click(clickable);
+}
+
+describe('CodexAuthSettings', () => {
+  it('shows a Connected banner when the probe reports an authenticated API key', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'api-key',
+      })
+    );
+    render(<Harness initialMethod="api_key" checkAuth={checkAuth} />);
+
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+    expect(screen.getByText('Your OpenAI API key is working.')).toBeInTheDocument();
+    await waitFor(() => expect(checkAuth).toHaveBeenCalledWith({ tool: 'codex' }));
+  });
+
+  it('surfaces a missing subscription login as a prominent "Login not found" error', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'none',
+      })
+    );
+    render(<Harness initialMethod="subscription" checkAuth={checkAuth} />);
+
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
+    expect(screen.getByText(/Codex login no longer found on this server/i)).toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+  });
+
+  it('flags a stored-but-rejected API key as "Key not working"', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'api-key',
+      })
+    );
+    render(
+      <Harness
+        initialMethod="api_key"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+
+    expect(await screen.findByText('Key not working')).toBeInTheDocument();
+    expect(screen.queryByText('Login not found')).not.toBeInTheDocument();
+  });
+
+  it('stays silent when no key is stored and the probe is negative (fail safe)', async () => {
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'unauthenticated',
+        authenticated: false,
+        method: 'none',
+      })
+    );
+    render(<Harness initialMethod="api_key" fieldStatus={{}} checkAuth={checkAuth} />);
+
+    // Give the probe a chance to resolve before asserting the banner is absent.
+    await waitFor(() => expect(checkAuth).toHaveBeenCalled());
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+    expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
+  });
+
+  it('saves an OpenAI API key through the API-key pane', async () => {
+    const onSaveField = vi.fn(async () => undefined);
+    render(<Harness initialMethod="api_key" onSaveField={onSaveField} />);
+
+    const input = screen.getByPlaceholderText('sk-proj-...');
+    fireEvent.change(input, { target: { value: 'sk-proj-abc123' } });
+    // Two "Save" buttons render (key + base URL); the key field is first.
+    const saveButtons = screen.getAllByText('Save').map((el) => el.closest('button'));
+    fireEvent.click(saveButtons[0] as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(onSaveField).toHaveBeenCalledWith('OPENAI_API_KEY', 'sk-proj-abc123')
+    );
+  });
+
+  it('starts the device flow deliberately (no OpenAI request on mere tab view)', async () => {
+    const deviceFind = vi.fn(async () => ({ phase: 'idle' }));
+    const deviceCreate = vi.fn(async () => ({
+      phase: 'pending',
+      userCode: 'ABCD-1234',
+      verificationUrl: 'https://auth.openai.com/codex/device',
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    }));
+    render(
+      <Harness initialMethod="subscription" deviceFind={deviceFind} deviceCreate={deviceCreate} />
+    );
+
+    clickText('Sign in with ChatGPT');
+
+    // Deliberate-start: a code is only requested after an explicit click.
+    expect(await screen.findByText('Get a sign-in code')).toBeInTheDocument();
+    expect(deviceCreate).not.toHaveBeenCalled();
+
+    clickText('Get a sign-in code');
+    await waitFor(() => expect(deviceCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('ABCD-1234')).toBeInTheDocument();
+  });
+
+  it('imports a pasted login file and re-probes the connection', async () => {
+    const importCreate = vi.fn(async () => ({ status: 'authenticated', authMode: 'chatgpt' }));
+    const checkAuth = vi
+      .fn<[], Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce(UNKNOWN)
+      .mockResolvedValue({ status: 'authenticated', authenticated: true, method: 'native' });
+    render(
+      <Harness initialMethod="subscription" importCreate={importCreate} checkAuth={checkAuth} />
+    );
+
+    clickText('Import login file');
+    const pasted = '{"tokens":{"refresh_token":"r"}}';
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: pasted },
+    });
+    clickText('Import login');
+
+    await waitFor(() => expect(importCreate).toHaveBeenCalledWith({ authJson: pasted }));
+    // onImported triggers a fresh probe, which now reports connected.
+    expect(await screen.findByText('Codex is connected')).toBeInTheDocument();
+  });
+
+  it('shows the daemon rejection message when an imported login file is invalid', async () => {
+    const importCreate = vi.fn(async () => {
+      throw new Error('This file has no ChatGPT login tokens and no API key.');
+    });
+    render(<Harness initialMethod="subscription" importCreate={importCreate} />);
+
+    clickText('Import login file');
+    fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
+      target: { value: '{"tokens":{}}' },
+    });
+    clickText('Import login');
+
+    expect(
+      await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
@@ -144,6 +144,24 @@ describe('CodexAuthSettings', () => {
     expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
   });
 
+  it('never affirms a ChatGPT login while the effective method is api_key (banner tracks stored method)', async () => {
+    // Mixed state: method=api_key (keyless) with a login the probe can see. The
+    // executor won't use that login for api_key, so the banner must not claim
+    // "connected" — the sessions-broken-but-banner-connected contradiction.
+    const checkAuth = vi.fn(
+      async (): Promise<AuthCheckResult> => ({
+        status: 'authenticated',
+        authenticated: true,
+        method: 'native',
+      })
+    );
+    render(<Harness initialMethod="api_key" fieldStatus={{}} checkAuth={checkAuth} />);
+
+    await waitFor(() => expect(checkAuth).toHaveBeenCalled());
+    expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
+    expect(screen.queryByText('A ChatGPT login is active on this server.')).not.toBeInTheDocument();
+  });
+
   it('saves an OpenAI API key through the API-key pane', async () => {
     const onSaveField = vi.fn(async () => undefined);
     render(<Harness initialMethod="api_key" onSaveField={onSaveField} />);

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
@@ -13,6 +13,7 @@
 
 import type { AgenticAuthMethod, AuthCheckResult } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
 import { TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
 import { CodexAuthSettings } from './CodexAuthSettings';
 
@@ -53,10 +54,17 @@ function Harness({
       find: deviceFind ?? vi.fn(async () => ({ phase: 'idle' })),
     },
   };
-  const client = {
-    io: { on: vi.fn(), off: vi.fn() },
-    service: vi.fn((name: string) => services[name] ?? {}),
-  } as never;
+  // Stable client identity across rerenders (mirrors the real modal, where the
+  // client outlives authMethod changes) — so a rerender that flips only
+  // authMethod exercises the method-change path, not a client swap.
+  const clientRef = useRef<unknown>(undefined);
+  if (clientRef.current === undefined) {
+    clientRef.current = {
+      io: { on: vi.fn(), off: vi.fn() },
+      service: vi.fn((name: string) => services[name] ?? {}),
+    };
+  }
+  const client = clientRef.current as never;
 
   return (
     <CodexAuthSettings
@@ -160,6 +168,48 @@ describe('CodexAuthSettings', () => {
     await waitFor(() => expect(checkAuth).toHaveBeenCalled());
     expect(screen.queryByText('Codex is connected')).not.toBeInTheDocument();
     expect(screen.queryByText('A ChatGPT login is active on this server.')).not.toBeInTheDocument();
+  });
+
+  it('drops a stale negative verdict when the method flips (no false "Login not found")', async () => {
+    // An api-key probe rejects; then the method flips to subscription, as a
+    // completed ChatGPT sign-in would. The stale api-key rejection must not be
+    // reinterpreted as a subscription failure — even while the re-probe for the
+    // new method is still in flight (and would persist if that re-probe failed).
+    let releaseSecond: (v: AuthCheckResult) => void = () => {};
+    const checkAuth = vi
+      .fn<[], Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce({ status: 'unauthenticated', authenticated: false, method: 'api-key' })
+      .mockImplementationOnce(
+        () =>
+          new Promise<AuthCheckResult>((resolve) => {
+            releaseSecond = resolve;
+          })
+      );
+    const { rerender } = render(
+      <Harness
+        initialMethod="api_key"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+    expect(await screen.findByText('Key not working')).toBeInTheDocument();
+
+    // Flip to subscription; the second probe is in flight and unresolved.
+    rerender(
+      <Harness
+        initialMethod="subscription"
+        fieldStatus={{ OPENAI_API_KEY: true }}
+        checkAuth={checkAuth}
+      />
+    );
+    await waitFor(() => expect(checkAuth).toHaveBeenCalledTimes(2));
+    // Neither the stale api-key rejection nor a subscription failure is shown.
+    expect(screen.queryByText('Login not found')).not.toBeInTheDocument();
+    expect(screen.queryByText('Key not working')).not.toBeInTheDocument();
+
+    // Once the new probe resolves under the new method, the correct verdict shows.
+    releaseSecond({ status: 'unauthenticated', authenticated: false, method: 'none' });
+    expect(await screen.findByText('Login not found')).toBeInTheDocument();
   });
 
   it('saves an OpenAI API key through the API-key pane', async () => {

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.test.tsx
@@ -189,6 +189,26 @@ describe('CodexAuthSettings', () => {
     expect(await screen.findByText('ABCD-1234')).toBeInTheDocument();
   });
 
+  it('does not deactivate a working API key when merely opening a subscription sign-in view', async () => {
+    // Selecting "Sign in with ChatGPT" / "Import login file" is a local view
+    // choice — the daemon flips the method to subscription only on success.
+    // Persisting it here would break a still-working API-key configuration.
+    const onAuthMethodChange = vi.fn();
+    render(<Harness initialMethod="api_key" onAuthMethodChange={onAuthMethodChange} />);
+
+    clickText('Sign in with ChatGPT');
+    expect(await screen.findByText(/Sign in with your ChatGPT account/i)).toBeInTheDocument();
+    expect(onAuthMethodChange).not.toHaveBeenCalled();
+
+    clickText('Import login file');
+    expect(await screen.findByLabelText('Codex auth.json contents')).toBeInTheDocument();
+    expect(onAuthMethodChange).not.toHaveBeenCalled();
+
+    // Deliberately choosing the API-key method is the only selection that persists.
+    clickText('API key');
+    expect(onAuthMethodChange).not.toHaveBeenCalled(); // already api_key — no redundant write
+  });
+
   it('imports a pasted login file and re-probes the connection', async () => {
     const importCreate = vi.fn(async () => ({ status: 'authenticated', authMode: 'chatgpt' }));
     const checkAuth = vi

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -5,7 +5,7 @@ import type {
   AuthCheckResult,
 } from '@agor-live/client';
 import { Alert, Button, Segmented, Space, Typography, theme } from 'antd';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { type AgenticToolFieldConfig, ApiKeyFields, type FieldStatus } from '../ApiKeyFields';
 import { type CodexAuthFallback, CodexDeviceSignIn } from './CodexDeviceSignIn';
 import { CodexImportAuthJson } from './CodexImportAuthJson';
@@ -75,18 +75,23 @@ export function CodexAuthSettings({
   // A transport failure is NOT proof of a missing login — leave the prior
   // verdict untouched on error so the pane never flashes a false "not
   // connected" state (mirrors App.handleCheckAuth's fail-safe contract).
+  // A monotonic generation guards against overlapping probes (a method switch
+  // mid-recheck): only the latest request commits its verdict or clears the
+  // spinner, so an older response can't land last and mislabel the banner.
+  const probeGenRef = useRef(0);
   const runProbe = useCallback(async () => {
     if (!client) return;
+    const gen = ++probeGenRef.current;
     setProbing(true);
     try {
       const result = (await client
         .service('check-auth')
         .create({ tool: 'codex' })) as AuthCheckResult;
-      setProbe(result);
+      if (probeGenRef.current === gen) setProbe(result);
     } catch {
       // Unknown — keep the last verdict.
     } finally {
-      setProbing(false);
+      if (probeGenRef.current === gen) setProbing(false);
     }
   }, [client]);
 
@@ -98,11 +103,9 @@ export function CodexAuthSettings({
     void runProbe();
   }, [runProbe, authMethod]);
 
-  const handleVerified = useCallback(() => {
-    void runProbe();
-  }, [runProbe]);
-
-  const handleImported = useCallback(() => {
+  // Device sign-in and login-file import both persist `subscription` daemon-side
+  // as part of the flow, so here we only re-probe to refresh the banner.
+  const handleAuthenticated = useCallback(() => {
     void runProbe();
   }, [runProbe]);
 
@@ -121,8 +124,12 @@ export function CodexAuthSettings({
   const handleSelect = useCallback(
     (next: CodexMethodView) => {
       setView(next);
-      const nextMethod: AgenticAuthMethod = next === 'api_key' ? 'api_key' : 'subscription';
-      if (nextMethod !== authMethod) void onAuthMethodChange(nextMethod);
+      // "Sign in with ChatGPT" and "Import login file" are local views only —
+      // the daemon device/import flows persist `subscription` themselves once
+      // they succeed. Persisting it on mere selection would deactivate a working
+      // API key before any ChatGPT login exists (surfacing a false "Login not
+      // found"). Only deliberately choosing the API-key method flips it back.
+      if (next === 'api_key' && authMethod !== 'api_key') void onAuthMethodChange('api_key');
     },
     [authMethod, onAuthMethodChange]
   );
@@ -225,13 +232,15 @@ export function CodexAuthSettings({
           </Text>
           <CodexDeviceSignIn
             client={client}
-            onVerified={handleVerified}
+            onVerified={handleAuthenticated}
             onUseFallback={handleFallback}
             autoStart={false}
           />
         </div>
       )}
-      {view === 'import' && <CodexImportAuthJson client={client} onImported={handleImported} />}
+      {view === 'import' && (
+        <CodexImportAuthJson client={client} onImported={handleAuthenticated} />
+      )}
     </Space>
   );
 }

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -145,26 +145,30 @@ export function CodexAuthSettings({
     setView(next);
   }, []);
 
+  // The banner reflects the EFFECTIVE auth — the persisted method plus a probe
+  // of that method's credential — never the currently-viewed tab. Crucially, a
+  // "connected" verdict is only shown when the probe actually exercised the
+  // stored method: an authenticated api-key probe can't render "ChatGPT login
+  // active" and an authenticated login probe can't render "API key working".
+  // This makes the sessions-broken-but-banner-says-connected contradiction
+  // impossible even if the daemon's probe ever reported a credential the
+  // executor wouldn't use for the stored method.
   const connectionBanner = (() => {
     if (!probe) return null;
-    if (probe.status === 'authenticated') {
-      return (
-        <Alert
-          type="success"
-          showIcon
-          message="Codex is connected"
-          description={
-            // Describe what was actually probed, not the currently-selected tab,
-            // so a method flip can't momentarily mislabel a stale verdict.
-            probe.method === 'api-key'
-              ? 'Your OpenAI API key is working.'
-              : 'A ChatGPT login is active on this server.'
-          }
-        />
-      );
-    }
-    if (probe.status === 'unauthenticated') {
-      if (authMethod === 'subscription') {
+    const authenticated = probe.status === 'authenticated';
+    const unauthenticated = probe.status === 'unauthenticated';
+    if (authMethod === 'subscription') {
+      if (authenticated && probe.method !== 'api-key') {
+        return (
+          <Alert
+            type="success"
+            showIcon
+            message="Codex is connected"
+            description="A ChatGPT login is active on this server."
+          />
+        );
+      }
+      if (unauthenticated) {
         return (
           <Alert
             type="error"
@@ -177,20 +181,34 @@ export function CodexAuthSettings({
           />
         );
       }
-      // API-key method: only a stored-but-rejected key is a problem worth
-      // flagging; an empty key just means the user hasn't set one yet.
-      if (fieldStatus.OPENAI_API_KEY) {
-        return (
-          <Alert
-            type="error"
-            showIcon
-            message="Key not working"
-            description={probe.hint ?? 'Key stored but not working — enter a new one.'}
-          />
-        );
-      }
+      return null;
     }
-    // 'unknown' or unset-and-empty — surface nothing (fail safe).
+    // authMethod === 'api_key': the effective credential is the OpenAI key.
+    if (authenticated && probe.method === 'api-key') {
+      return (
+        <Alert
+          type="success"
+          showIcon
+          message="Codex is connected"
+          description="Your OpenAI API key is working."
+        />
+      );
+    }
+    // Only a stored-but-rejected key is worth flagging; an empty key just means
+    // the user hasn't set one yet (and a login on disk is irrelevant here —
+    // sessions use the api_key method, not that login).
+    if (unauthenticated && fieldStatus.OPENAI_API_KEY) {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          message="Key not working"
+          description={probe.hint ?? 'Key stored but not working — enter a new one.'}
+        />
+      );
+    }
+    // 'unknown', or authenticated via a credential the stored method won't use,
+    // or unset-and-empty — surface nothing (fail safe).
     return null;
   })();
 

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -1,0 +1,237 @@
+import type {
+  AgenticAuthMethod,
+  AgenticToolConfigField,
+  AgorClient,
+  AuthCheckResult,
+} from '@agor-live/client';
+import { Alert, Button, Segmented, Space, Typography, theme } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+import { type AgenticToolFieldConfig, ApiKeyFields, type FieldStatus } from '../ApiKeyFields';
+import { type CodexAuthFallback, CodexDeviceSignIn } from './CodexDeviceSignIn';
+import { CodexImportAuthJson } from './CodexImportAuthJson';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+/**
+ * Which sub-pane the management surface is showing. The persisted auth method is
+ * only two-valued (`api_key` | `subscription`) because "sign in with ChatGPT"
+ * and "import auth.json" both land the same server-side ChatGPT login — so the
+ * two subscription entry points are distinguished here as a local view choice.
+ */
+type CodexMethodView = 'api_key' | 'chatgpt' | 'import';
+
+function viewForMethod(method: AgenticAuthMethod, prev: CodexMethodView): CodexMethodView {
+  if (method === 'api_key') return 'api_key';
+  return prev === 'import' ? 'import' : 'chatgpt';
+}
+
+export interface CodexAuthSettingsProps {
+  client: AgorClient | null;
+  /** Persisted Codex auth method for this user. */
+  authMethod: AgenticAuthMethod;
+  /** Persist a new auth method (flips `agentic_auth_methods.codex`). */
+  onAuthMethodChange: (method: AgenticAuthMethod) => void | Promise<void>;
+  /** Codex credential field definitions (OpenAI key + base URL). */
+  apiKeyFields: AgenticToolFieldConfig[];
+  /** Per-field set/unset flags for the API-key pane. */
+  fieldStatus: FieldStatus;
+  onSaveField: (field: AgenticToolConfigField, value: string) => Promise<void>;
+  onClearField: (field: AgenticToolConfigField) => Promise<void>;
+  savingFields: Partial<Record<AgenticToolConfigField, boolean>>;
+  publicValues?: Partial<Record<AgenticToolConfigField, string>>;
+}
+
+/**
+ * Codex authentication management pane — the three ways in (API key, ChatGPT
+ * device sign-in, imported login file) plus a live connection probe. Unlike the
+ * onboarding wizard, this is a management view: re-signing-in or re-importing
+ * stays reachable while connected, and a stored-but-broken credential surfaces
+ * as a prominent error rather than being hidden behind a "connected" collapse.
+ */
+export function CodexAuthSettings({
+  client,
+  authMethod,
+  onAuthMethodChange,
+  apiKeyFields,
+  fieldStatus,
+  onSaveField,
+  onClearField,
+  savingFields,
+  publicValues,
+}: CodexAuthSettingsProps) {
+  const { token } = useToken();
+  const [view, setView] = useState<CodexMethodView>(() => viewForMethod(authMethod, 'chatgpt'));
+  const [probe, setProbe] = useState<AuthCheckResult | null>(null);
+  const [probing, setProbing] = useState(false);
+
+  // Keep the visible sub-pane in step with the persisted method (e.g. a
+  // successful device/import flips it to subscription), while preserving which
+  // subscription entry point the user is looking at.
+  useEffect(() => {
+    setView((prev) => viewForMethod(authMethod, prev));
+  }, [authMethod]);
+
+  // A transport failure is NOT proof of a missing login — leave the prior
+  // verdict untouched on error so the pane never flashes a false "not
+  // connected" state (mirrors App.handleCheckAuth's fail-safe contract).
+  const runProbe = useCallback(async () => {
+    if (!client) return;
+    setProbing(true);
+    try {
+      const result = (await client
+        .service('check-auth')
+        .create({ tool: 'codex' })) as AuthCheckResult;
+      setProbe(result);
+    } catch {
+      // Unknown — keep the last verdict.
+    } finally {
+      setProbing(false);
+    }
+  }, [client]);
+
+  // Re-probe when the persisted method changes: the daemon checks whichever
+  // credential the server's active method points at, so a verdict captured for
+  // the previous method would otherwise be mislabelled by the banner.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: authMethod is a deliberate re-probe trigger, not a value read by runProbe.
+  useEffect(() => {
+    void runProbe();
+  }, [runProbe, authMethod]);
+
+  const handleVerified = useCallback(() => {
+    void runProbe();
+  }, [runProbe]);
+
+  const handleImported = useCallback(() => {
+    void runProbe();
+  }, [runProbe]);
+
+  const handleFallback = useCallback(
+    (target: CodexAuthFallback) => {
+      if (target === 'import') {
+        setView('import');
+        return;
+      }
+      setView('api_key');
+      if (authMethod !== 'api_key') void onAuthMethodChange('api_key');
+    },
+    [authMethod, onAuthMethodChange]
+  );
+
+  const handleSelect = useCallback(
+    (next: CodexMethodView) => {
+      setView(next);
+      const nextMethod: AgenticAuthMethod = next === 'api_key' ? 'api_key' : 'subscription';
+      if (nextMethod !== authMethod) void onAuthMethodChange(nextMethod);
+    },
+    [authMethod, onAuthMethodChange]
+  );
+
+  const connectionBanner = (() => {
+    if (!probe) return null;
+    if (probe.status === 'authenticated') {
+      return (
+        <Alert
+          type="success"
+          showIcon
+          message="Codex is connected"
+          description={
+            authMethod === 'subscription'
+              ? 'A ChatGPT login is active on this server.'
+              : 'Your OpenAI API key is working.'
+          }
+        />
+      );
+    }
+    if (probe.status === 'unauthenticated') {
+      if (authMethod === 'subscription') {
+        return (
+          <Alert
+            type="error"
+            showIcon
+            message="Login not found"
+            description={
+              probe.hint ??
+              'Codex login no longer found on this server — sign in with ChatGPT or import it again.'
+            }
+          />
+        );
+      }
+      // API-key method: only a stored-but-rejected key is a problem worth
+      // flagging; an empty key just means the user hasn't set one yet.
+      if (fieldStatus.OPENAI_API_KEY) {
+        return (
+          <Alert
+            type="error"
+            showIcon
+            message="Key not working"
+            description={probe.hint ?? 'Key stored but not working — enter a new one.'}
+          />
+        );
+      }
+    }
+    // 'unknown' or unset-and-empty — surface nothing (fail safe).
+    return null;
+  })();
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+      <Text type="secondary">
+        Personal credentials are encrypted at rest and injected only into the agent runtime.
+      </Text>
+
+      {connectionBanner && (
+        <Space direction="vertical" size="small" style={{ width: '100%' }}>
+          {connectionBanner}
+          <Button
+            type="link"
+            size="small"
+            loading={probing}
+            onClick={() => void runProbe()}
+            style={{ paddingInline: 0 }}
+          >
+            Recheck connection
+          </Button>
+        </Space>
+      )}
+
+      <Segmented<CodexMethodView>
+        block
+        value={view}
+        onChange={handleSelect}
+        options={[
+          { label: 'API key', value: 'api_key' },
+          { label: 'Sign in with ChatGPT', value: 'chatgpt' },
+          { label: 'Import login file', value: 'import' },
+        ]}
+      />
+
+      {view === 'api_key' && (
+        <ApiKeyFields
+          tool="codex"
+          fields={apiKeyFields}
+          fieldStatus={fieldStatus}
+          onSave={onSaveField}
+          onClear={onClearField}
+          saving={savingFields}
+          publicValues={publicValues}
+        />
+      )}
+      {view === 'chatgpt' && (
+        <div>
+          <Text type="secondary" style={{ display: 'block', marginBottom: token.marginSM }}>
+            Sign in with your ChatGPT account — no OpenAI API key stored in Agor. The login is
+            shared per server user, so signing in replaces any Codex login already on this server.
+          </Text>
+          <CodexDeviceSignIn
+            client={client}
+            onVerified={handleVerified}
+            onUseFallback={handleFallback}
+            autoStart={false}
+          />
+        </div>
+      )}
+      {view === 'import' && <CodexImportAuthJson client={client} onImported={handleImported} />}
+    </Space>
+  );
+}

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -82,13 +82,20 @@ export function CodexAuthSettings({
   // mid-recheck): only the latest request commits its verdict or clears the
   // spinner, so an older response can't land last and mislabel the banner.
   const probeGenRef = useRef(0);
-  // Bump the generation synchronously when the client changes (and on unmount),
-  // before any in-flight probe can resolve. Without this an old client's probe
-  // still owns the current generation in the window before the next probe
-  // starts — and if the replacement client is null, runProbe returns before
-  // incrementing, so the stale request would never be invalidated. Clear the
-  // prior verdict so one identity's status is never shown for another.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: client is the change trigger; the body invalidates rather than reading it.
+  // Bump the generation synchronously when the client OR the effective method
+  // changes (and on unmount), before any in-flight probe can resolve, and clear
+  // the prior verdict. Two reasons a stale verdict must not survive a change:
+  //  - client swap: an old identity's probe still owns the current generation
+  //    in the window before the next probe starts (and if the replacement
+  //    client is null, runProbe returns before incrementing, so the stale
+  //    request would never be invalidated).
+  //  - method flip: a verdict captured under the PREVIOUS method must not be
+  //    re-interpreted by the banner under the new one — e.g. a rejected api-key
+  //    probe becoming a false "Login not found" after a ChatGPT sign-in flips
+  //    the method to subscription (and persisting there if the re-probe then
+  //    fails, since transport failures keep the last verdict). Clearing to null
+  //    means the banner shows nothing until a verdict for the NEW method lands.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: client/authMethod are the change triggers; the body invalidates rather than reading them.
   useLayoutEffect(() => {
     probeGenRef.current++;
     setProbe(null);
@@ -99,7 +106,7 @@ export function CodexAuthSettings({
     return () => {
       probeGenRef.current++;
     };
-  }, [client]);
+  }, [client, authMethod]);
   const runProbe = useCallback(async () => {
     if (!client) return;
     const gen = ++probeGenRef.current;

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -5,7 +5,7 @@ import type {
   AuthCheckResult,
 } from '@agor-live/client';
 import { Alert, Button, Segmented, Space, Typography, theme } from 'antd';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { type AgenticToolFieldConfig, ApiKeyFields, type FieldStatus } from '../ApiKeyFields';
 import { type CodexAuthFallback, CodexDeviceSignIn } from './CodexDeviceSignIn';
 import { CodexImportAuthJson } from './CodexImportAuthJson';
@@ -79,6 +79,24 @@ export function CodexAuthSettings({
   // mid-recheck): only the latest request commits its verdict or clears the
   // spinner, so an older response can't land last and mislabel the banner.
   const probeGenRef = useRef(0);
+  // Bump the generation synchronously when the client changes (and on unmount),
+  // before any in-flight probe can resolve. Without this an old client's probe
+  // still owns the current generation in the window before the next probe
+  // starts — and if the replacement client is null, runProbe returns before
+  // incrementing, so the stale request would never be invalidated. Clear the
+  // prior verdict so one identity's status is never shown for another.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: client is the change trigger; the body invalidates rather than reading it.
+  useLayoutEffect(() => {
+    probeGenRef.current++;
+    setProbe(null);
+    setProbing(false);
+  }, [client]);
+  useEffect(
+    () => () => {
+      probeGenRef.current++;
+    },
+    []
+  );
   const runProbe = useCallback(async () => {
     if (!client) return;
     const gen = ++probeGenRef.current;

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -90,13 +90,13 @@ export function CodexAuthSettings({
     probeGenRef.current++;
     setProbe(null);
     setProbing(false);
-  }, [client]);
-  useEffect(
-    () => () => {
+    // Invalidate on unmount from the layout cleanup (synchronous, during the
+    // commit) — a passive cleanup can be deferred past unmount, letting a
+    // settled probe commit its verdict/spinner after teardown.
+    return () => {
       probeGenRef.current++;
-    },
-    []
-  );
+    };
+  }, [client]);
   const runProbe = useCallback(async () => {
     if (!client) return;
     const gen = ++probeGenRef.current;

--- a/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexAuthSettings.tsx
@@ -28,10 +28,14 @@ function viewForMethod(method: AgenticAuthMethod, prev: CodexMethodView): CodexM
 
 export interface CodexAuthSettingsProps {
   client: AgorClient | null;
-  /** Persisted Codex auth method for this user. */
+  /**
+   * Persisted Codex auth method for this user. Read-only here: the method is a
+   * consequence of the credential you configure (saving an OpenAI key flips it
+   * to `api_key`; a completed device sign-in / import flips it to
+   * `subscription` daemon-side), never of merely selecting a tab — so switching
+   * views can't silently deactivate a working login.
+   */
   authMethod: AgenticAuthMethod;
-  /** Persist a new auth method (flips `agentic_auth_methods.codex`). */
-  onAuthMethodChange: (method: AgenticAuthMethod) => void | Promise<void>;
   /** Codex credential field definitions (OpenAI key + base URL). */
   apiKeyFields: AgenticToolFieldConfig[];
   /** Per-field set/unset flags for the API-key pane. */
@@ -52,7 +56,6 @@ export interface CodexAuthSettingsProps {
 export function CodexAuthSettings({
   client,
   authMethod,
-  onAuthMethodChange,
   apiKeyFields,
   fieldStatus,
   onSaveField,
@@ -127,30 +130,20 @@ export function CodexAuthSettings({
     void runProbe();
   }, [runProbe]);
 
-  const handleFallback = useCallback(
-    (target: CodexAuthFallback) => {
-      if (target === 'import') {
-        setView('import');
-        return;
-      }
-      setView('api_key');
-      if (authMethod !== 'api_key') void onAuthMethodChange('api_key');
-    },
-    [authMethod, onAuthMethodChange]
-  );
+  // Selecting a method is a pure view switch — it never persists the auth
+  // method. Persisting on selection is destructive in BOTH directions: choosing
+  // a subscription view would deactivate a working API key before a ChatGPT
+  // login exists, and choosing "API key" would deactivate a working ChatGPT
+  // login before any key is stored (a silent, non-undoable break). The method
+  // instead follows the credential you actually configure — saving a key flips
+  // it to api_key; a completed device/import flips it to subscription.
+  const handleFallback = useCallback((target: CodexAuthFallback) => {
+    setView(target === 'import' ? 'import' : 'api_key');
+  }, []);
 
-  const handleSelect = useCallback(
-    (next: CodexMethodView) => {
-      setView(next);
-      // "Sign in with ChatGPT" and "Import login file" are local views only —
-      // the daemon device/import flows persist `subscription` themselves once
-      // they succeed. Persisting it on mere selection would deactivate a working
-      // API key before any ChatGPT login exists (surfacing a false "Login not
-      // found"). Only deliberately choosing the API-key method flips it back.
-      if (next === 'api_key' && authMethod !== 'api_key') void onAuthMethodChange('api_key');
-    },
-    [authMethod, onAuthMethodChange]
-  );
+  const handleSelect = useCallback((next: CodexMethodView) => {
+    setView(next);
+  }, []);
 
   const connectionBanner = (() => {
     if (!probe) return null;
@@ -161,9 +154,11 @@ export function CodexAuthSettings({
           showIcon
           message="Codex is connected"
           description={
-            authMethod === 'subscription'
-              ? 'A ChatGPT login is active on this server.'
-              : 'Your OpenAI API key is working.'
+            // Describe what was actually probed, not the currently-selected tab,
+            // so a method flip can't momentarily mislabel a stale verdict.
+            probe.method === 'api-key'
+              ? 'Your OpenAI API key is working.'
+              : 'A ChatGPT login is active on this server.'
           }
         />
       );

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
@@ -33,8 +33,12 @@ export interface CodexDeviceSignInProps {
    * this pane only on an explicit "Sign in with ChatGPT" choice, so eager start
    * is right there. A management surface (settings) mounts it as one tab among
    * several, so it defaults to a deliberate button press instead of firing an
-   * OpenAI device request every time the tab is viewed. A still-live attempt is
-   * always adopted regardless of this flag.
+   * OpenAI device request every time the tab is viewed. A still-live *pending*
+   * attempt is always adopted regardless of this flag; a terminal *success* is
+   * adopted only when autoStart is true (the wizard, which reflects the verified
+   * state after toggling away and back). A management surface tells its
+   * connection story via a separate probe, so it must not adopt a stale success
+   * — that would wall off re-signing-in until the daemon prunes the attempt.
    */
   autoStart?: boolean;
 }
@@ -122,7 +126,9 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
       try {
         const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
         if (!stillCurrent()) return;
-        if (existing.phase === 'pending' || existing.phase === 'success') {
+        // Adopt a live pending attempt always; adopt a terminal success only for
+        // eager (wizard) mounts — a management surface must stay able to restart.
+        if (existing.phase === 'pending' || (existing.phase === 'success' && autoStart)) {
           setStatus(existing);
           return;
         }

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
@@ -74,10 +74,17 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
   // here matters because a stale request's guarded finally deliberately
   // won't clear it, and a replacement that ADOPTS an attempt never calls
   // requestCode — without the reset the spinner would cover a live code.
+  // Reset status/countdown too: a client/identity swap must not leave the
+  // previous client's pending code (and its polling loop) on screen — the
+  // adopt-or-request effect below then decides what THIS service should show.
+  // Without this, an autoStart=false surface that doesn't re-request would
+  // keep displaying and polling the old code against the new service.
   const latestServiceRef = useRef(deviceService);
   useLayoutEffect(() => {
     latestServiceRef.current = deviceService;
     setStarting(false);
+    setStatus({ phase: 'idle' });
+    setRemainingMs(null);
   }, [deviceService]);
 
   const requestCode = useCallback(async () => {

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
@@ -110,15 +110,18 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
 
   // On mount (and on client swap), adopt a still-live attempt (user toggled
   // away and back) instead of burning a fresh code; otherwise request one.
-  // The cancellation guard makes this StrictMode-safe — a superseded run
-  // never fires its requestCode/setStatus continuation.
+  // Continuations are guarded by both `cancelled` (StrictMode / normal cleanup)
+  // and the service ref: React runs the client-swap layout reset before this
+  // effect's cleanup, so a stale find() resolving in that window must not
+  // restore the previous client's code — matching requestCode's own guard.
   useEffect(() => {
     if (!deviceService) return;
     let cancelled = false;
+    const stillCurrent = () => !cancelled && latestServiceRef.current === deviceService;
     void (async () => {
       try {
         const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
-        if (cancelled) return;
+        if (!stillCurrent()) return;
         if (existing.phase === 'pending' || existing.phase === 'success') {
           setStatus(existing);
           return;
@@ -126,7 +129,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
       } catch {
         // No adoptable attempt — fall through to a fresh request.
       }
-      if (!cancelled && autoStart) await requestCode();
+      if (stillCurrent() && autoStart) await requestCode();
     })();
     return () => {
       cancelled = true;
@@ -145,7 +148,7 @@ export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
     const tick = async () => {
       try {
         const next = (await deviceService.find()) as CodexDeviceAuthStatus;
-        if (cancelled) return;
+        if (cancelled || latestServiceRef.current !== deviceService) return;
         setStatus((prev) =>
           prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
             ? prev

--- a/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexDeviceSignIn.tsx
@@ -1,0 +1,305 @@
+import type { AgorClient, CodexDeviceAuthStatus } from '@agor-live/client';
+import { CheckCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { Alert, Button, Typography, theme } from 'antd';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+/**
+ * Where a gated ChatGPT account can go instead of device sign-in. Kept neutral
+ * (not tied to any one surface's method enum) so both the onboarding wizard and
+ * the settings pane can map it onto their own auth-method state.
+ */
+export type CodexAuthFallback = 'import' | 'api-key';
+
+const DEVICE_STATUS_POLL_MS = 2000;
+
+function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(Math.floor(remainingMs / 1000), 0);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+export interface CodexDeviceSignInProps {
+  client: AgorClient | null;
+  /** Fired once the daemon confirms tokens were saved for this user. */
+  onVerified: () => void;
+  /** Switch to another codex auth method (gated-account fallback). */
+  onUseFallback: (target: CodexAuthFallback) => void;
+  /**
+   * Request a code as soon as the pane mounts. The onboarding wizard reveals
+   * this pane only on an explicit "Sign in with ChatGPT" choice, so eager start
+   * is right there. A management surface (settings) mounts it as one tab among
+   * several, so it defaults to a deliberate button press instead of firing an
+   * OpenAI device request every time the tab is viewed. A still-live attempt is
+   * always adopted regardless of this flag.
+   */
+  autoStart?: boolean;
+}
+
+/**
+ * Self-contained device-code pane: requests a code, shows it with the
+ * verification link and a countdown, and polls the daemon for approval.
+ * Memoized with its own state so the 1s countdown and 2s status polls
+ * re-render only this pane, never the surface that hosts it.
+ */
+export const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
+  client,
+  onVerified,
+  onUseFallback,
+  autoStart = true,
+}: CodexDeviceSignInProps) {
+  const { token } = useToken();
+  const [status, setStatus] = useState<CodexDeviceAuthStatus>({ phase: 'idle' });
+  const [starting, setStarting] = useState(false);
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+
+  const deviceService = useMemo(
+    () =>
+      client
+        ? (client.service('codex-auth/device') as unknown as {
+            create(data: Record<string, never>): Promise<unknown>;
+            find(): Promise<unknown>;
+          })
+        : null,
+    [client]
+  );
+
+  // Tracks the service the pane currently talks to, so an in-flight
+  // requestCode issued against a swapped-out client can't land its state
+  // updates over the replacement's. A layout effect syncs the identity
+  // before paint and before the passive effects below; resetting `starting`
+  // here matters because a stale request's guarded finally deliberately
+  // won't clear it, and a replacement that ADOPTS an attempt never calls
+  // requestCode — without the reset the spinner would cover a live code.
+  const latestServiceRef = useRef(deviceService);
+  useLayoutEffect(() => {
+    latestServiceRef.current = deviceService;
+    setStarting(false);
+  }, [deviceService]);
+
+  const requestCode = useCallback(async () => {
+    if (!deviceService) return;
+    setStarting(true);
+    try {
+      const next = (await deviceService.create({})) as CodexDeviceAuthStatus;
+      if (latestServiceRef.current !== deviceService) return;
+      setStatus(next);
+    } catch (err) {
+      if (latestServiceRef.current !== deviceService) return;
+      setStatus({
+        phase: 'error',
+        hint:
+          err instanceof Error && err.message
+            ? err.message
+            : 'Could not start the ChatGPT sign-in — try again.',
+      });
+    } finally {
+      if (latestServiceRef.current === deviceService) setStarting(false);
+    }
+  }, [deviceService]);
+
+  // On mount (and on client swap), adopt a still-live attempt (user toggled
+  // away and back) instead of burning a fresh code; otherwise request one.
+  // The cancellation guard makes this StrictMode-safe — a superseded run
+  // never fires its requestCode/setStatus continuation.
+  useEffect(() => {
+    if (!deviceService) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (cancelled) return;
+        if (existing.phase === 'pending' || existing.phase === 'success') {
+          setStatus(existing);
+          return;
+        }
+      } catch {
+        // No adoptable attempt — fall through to a fresh request.
+      }
+      if (!cancelled && autoStart) await requestCode();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deviceService, requestCode, autoStart]);
+
+  // Poll while pending; terminal phases stop the loop. A self-scheduling
+  // timeout (next poll armed only after the previous response lands) keeps
+  // slow responses from overlapping and regressing a terminal phase with an
+  // out-of-order pending. Identity-preserving setState keeps unchanged polls
+  // from re-rendering even this pane.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !deviceService) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
+      try {
+        const next = (await deviceService.find()) as CodexDeviceAuthStatus;
+        if (cancelled) return;
+        setStatus((prev) =>
+          prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
+            ? prev
+            : next
+        );
+      } catch {
+        // Transient — keep polling until the code expires.
+      }
+      if (!cancelled) timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    };
+    timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [status.phase, deviceService]);
+
+  // 1s countdown while a code is live.
+  useEffect(() => {
+    if (status.phase !== 'pending' || !status.expiresAt) {
+      setRemainingMs(null);
+      return;
+    }
+    const expiresAtMs = Date.parse(status.expiresAt);
+    const update = () => setRemainingMs(Math.max(expiresAtMs - Date.now(), 0));
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [status.phase, status.expiresAt]);
+
+  useEffect(() => {
+    if (status.phase === 'success') onVerified();
+  }, [status.phase, onVerified]);
+
+  if (starting || (status.phase === 'idle' && autoStart)) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 14 }} />
+        <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
+          {client ? 'Getting your sign-in code…' : 'Waiting for the server connection…'}
+        </Text>
+      </div>
+    );
+  }
+
+  // Deliberate-start surfaces (autoStart=false) with no adoptable attempt: offer
+  // the button rather than firing an OpenAI device request on mount.
+  if (status.phase === 'idle') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0' }}>
+        <Button type="primary" disabled={!client} onClick={requestCode}>
+          Get a sign-in code
+        </Button>
+        {!client && (
+          <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
+            Waiting for the server connection…
+          </Text>
+        )}
+      </div>
+    );
+  }
+
+  if (status.phase === 'pending') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+        <Text style={{ color: token.colorTextSecondary, fontSize: 13 }}>
+          Open the link below, sign in to ChatGPT, and enter this one-time code:
+        </Text>
+        <Text
+          copyable
+          aria-label="ChatGPT sign-in code"
+          style={{
+            color: token.colorText,
+            fontFamily: 'monospace',
+            fontSize: 26,
+            fontWeight: 600,
+            letterSpacing: 4,
+          }}
+        >
+          {status.userCode}
+        </Text>
+        {status.verificationUrl && (
+          <Typography.Link
+            href={status.verificationUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontSize: 13 }}
+          >
+            Open {status.verificationUrl} →
+          </Typography.Link>
+        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
+          <Text style={{ color: token.colorTextTertiary, fontSize: 12 }}>
+            Waiting for approval — we finish automatically once you approve.
+            {remainingMs !== null && ` Code expires in ${formatCountdown(remainingMs)}.`}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  if (status.phase === 'success') {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
+        <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 14 }} />
+        <Text style={{ color: token.colorSuccess, fontSize: 13 }}>
+          {status.hint ?? 'Signed in with ChatGPT.'}
+        </Text>
+      </div>
+    );
+  }
+
+  if (status.phase === 'unavailable') {
+    return (
+      <Alert
+        type="warning"
+        showIcon
+        style={{ fontSize: 12 }}
+        message="Device sign-in is turned off for this ChatGPT account"
+        description={
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <span>
+              Personal accounts: enable it under ChatGPT Settings → Security → “Device code
+              authorization for Codex”, then try again. Workspace accounts: a workspace admin has to
+              enable it. Either way, the two options below work right now.
+            </span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+              <Button size="small" onClick={() => onUseFallback('import')}>
+                Paste a login file
+              </Button>
+              <Button size="small" onClick={() => onUseFallback('api-key')}>
+                Use an API key
+              </Button>
+              <Button size="small" type="text" onClick={requestCode}>
+                Try again
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    );
+  }
+
+  // expired / error
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
+      <Alert
+        type={status.phase === 'expired' ? 'warning' : 'error'}
+        showIcon
+        style={{ fontSize: 12 }}
+        message={
+          status.hint ??
+          (status.phase === 'expired' ? 'The sign-in code expired.' : 'The ChatGPT sign-in failed.')
+        }
+      />
+      <div>
+        <Button size="small" onClick={requestCode}>
+          Get a new code
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -1,0 +1,101 @@
+import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
+import { Alert, Button, Input, Space, Typography, theme } from 'antd';
+import { memo, useCallback, useState } from 'react';
+
+const { Text } = Typography;
+const { useToken } = theme;
+
+export interface CodexImportAuthJsonProps {
+  client: AgorClient | null;
+  /**
+   * Fired after the daemon accepts the pasted login and persists it. The pasted
+   * token material is already dropped from this component's state by the time
+   * this runs — the surface follows up (advance a step, re-probe status) without
+   * ever holding the secret itself.
+   */
+  onImported: (result: CodexAuthImportResult) => void;
+  /** Label for the submit action; surfaces frame it differently. */
+  submitLabel?: string;
+}
+
+/**
+ * Self-contained pane for pasting a `~/.codex/auth.json` login file and handing
+ * it to the daemon. Owns its own paste value, submit, and error state so a
+ * rejected import never leaks into the hosting surface's form state, and so the
+ * secret is cleared from memory the moment the daemon confirms it landed.
+ */
+export const CodexImportAuthJson = memo(function CodexImportAuthJson({
+  client,
+  onImported,
+  submitLabel = 'Import login',
+}: CodexImportAuthJsonProps) {
+  const { token } = useToken();
+  const [authJson, setAuthJson] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleImport = useCallback(async () => {
+    if (!client || !authJson.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = (await client
+        .service('codex-auth/import')
+        .create({ authJson })) as CodexAuthImportResult;
+      // Drop the pasted token material as soon as the daemon has it — nothing
+      // here needs it after a successful import.
+      setAuthJson('');
+      onImported(result);
+    } catch (err) {
+      setError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Could not import the Codex login — try again.'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [authJson, client, onImported, submitting]);
+
+  return (
+    <Space direction="vertical" size="small" style={{ width: '100%' }}>
+      <Alert
+        type="info"
+        showIcon
+        style={{ fontSize: token.fontSizeSM }}
+        message={
+          <span>
+            Already use Codex on your own machine? Its credential file lives there at{' '}
+            <Text code>~/.codex/auth.json</Text>. On that machine, print it with{' '}
+            <Text code>cat ~/.codex/auth.json</Text> and paste the whole thing below — this replaces
+            the Codex login already stored on this server, which in shared setups is one login for
+            the whole server, not one per person. Or skip the copy-paste entirely: open a branch
+            terminal on this server and run <Text code>codex login --device-auth</Text>.
+          </span>
+        }
+      />
+      <Input.Password
+        aria-label="Codex auth.json contents"
+        placeholder="Paste the JSON from ~/.codex/auth.json…"
+        value={authJson}
+        onChange={(e) => {
+          setAuthJson(e.target.value);
+          setError(null);
+        }}
+        onPressEnter={handleImport}
+        style={{ fontFamily: 'monospace', fontSize: token.fontSizeSM }}
+      />
+      <Button
+        type="primary"
+        loading={submitting}
+        disabled={!client || !authJson.trim()}
+        onClick={handleImport}
+      >
+        {submitLabel}
+      </Button>
+      {error && (
+        <Alert type="error" showIcon message={error} style={{ fontSize: token.fontSizeSM }} />
+      )}
+    </Space>
+  );
+});

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
 import { Alert, Button, Input, Space, Typography, theme } from 'antd';
-import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { memo, useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 const { Text } = Typography;
 const { useToken } = theme;
@@ -42,19 +42,22 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
   // import right away. The unmount bump prevents a settled request from calling
   // setState after teardown.
   const submitGenRef = useRef(0);
+  // Invalidate any in-flight submit synchronously whenever the client changes
+  // OR the pane unmounts. A layout effect (setup + cleanup) runs during the
+  // commit phase, before a settled request's continuation could — a passive
+  // cleanup can be deferred past unmount, letting a stale success still fire
+  // onImported/setState after teardown. Setup also drops the pasted secret and
+  // releases the submit lock so the replacement identity can import at once.
   // biome-ignore lint/correctness/useExhaustiveDependencies: client is the change trigger; the body invalidates/clears rather than reading it.
   useLayoutEffect(() => {
     submitGenRef.current++;
     setAuthJson('');
     setError(null);
     setSubmitting(false);
-  }, [client]);
-  useEffect(
-    () => () => {
+    return () => {
       submitGenRef.current++;
-    },
-    []
-  );
+    };
+  }, [client]);
 
   const handleImport = useCallback(async () => {
     if (!client || !authJson.trim() || submitting) return;

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
 import { Alert, Button, Input, Space, Typography, theme } from 'antd';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 const { Text } = Typography;
 const { useToken } = theme;
@@ -34,26 +34,42 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // A client/identity swap must never carry a pasted secret across it: drop the
+  // paste value (and any error) the instant the client changes, and track the
+  // live client so an in-flight import can't apply its result to a replacement.
+  const latestClientRef = useRef(client);
+  useLayoutEffect(() => {
+    latestClientRef.current = client;
+    setAuthJson('');
+    setError(null);
+  }, [client]);
+
   const handleImport = useCallback(async () => {
-    if (!client || !authJson.trim() || submitting) return;
+    const submittingClient = client;
+    if (!submittingClient || !authJson.trim() || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
-      const result = (await client
+      const result = (await submittingClient
         .service('codex-auth/import')
         .create({ authJson })) as CodexAuthImportResult;
+      // The client was swapped out mid-flight — this result belongs to the old
+      // identity; drop it rather than clearing the new client's pane or firing
+      // onImported as though it applied here.
+      if (latestClientRef.current !== submittingClient) return;
       // Drop the pasted token material as soon as the daemon has it — nothing
       // here needs it after a successful import.
       setAuthJson('');
       onImported(result);
     } catch (err) {
+      if (latestClientRef.current !== submittingClient) return;
       setError(
         err instanceof Error && err.message
           ? err.message
           : 'Could not import the Codex login — try again.'
       );
     } finally {
-      setSubmitting(false);
+      if (latestClientRef.current === submittingClient) setSubmitting(false);
     }
   }, [authJson, client, onImported, submitting]);
 

--- a/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
+++ b/apps/agor-ui/src/components/CodexAuth/CodexImportAuthJson.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient, CodexAuthImportResult } from '@agor-live/client';
 import { Alert, Button, Input, Space, Typography, theme } from 'antd';
-import { memo, useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 const { Text } = Typography;
 const { useToken } = theme;
@@ -34,42 +34,54 @@ export const CodexImportAuthJson = memo(function CodexImportAuthJson({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // A client/identity swap must never carry a pasted secret across it: drop the
-  // paste value (and any error) the instant the client changes, and track the
-  // live client so an in-flight import can't apply its result to a replacement.
-  const latestClientRef = useRef(client);
+  // A client/identity swap (or unmount) must never carry a pasted secret across
+  // it, nor let an import in flight against the old client apply to — or lock —
+  // the replacement. A generation bumped synchronously on client change (before
+  // the old request can resolve) invalidates any in-flight submit; the swap also
+  // drops the paste value and releases the submit lock so the new identity can
+  // import right away. The unmount bump prevents a settled request from calling
+  // setState after teardown.
+  const submitGenRef = useRef(0);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: client is the change trigger; the body invalidates/clears rather than reading it.
   useLayoutEffect(() => {
-    latestClientRef.current = client;
+    submitGenRef.current++;
     setAuthJson('');
     setError(null);
+    setSubmitting(false);
   }, [client]);
+  useEffect(
+    () => () => {
+      submitGenRef.current++;
+    },
+    []
+  );
 
   const handleImport = useCallback(async () => {
-    const submittingClient = client;
-    if (!submittingClient || !authJson.trim() || submitting) return;
+    if (!client || !authJson.trim() || submitting) return;
+    const gen = ++submitGenRef.current;
     setSubmitting(true);
     setError(null);
     try {
-      const result = (await submittingClient
+      const result = (await client
         .service('codex-auth/import')
         .create({ authJson })) as CodexAuthImportResult;
-      // The client was swapped out mid-flight — this result belongs to the old
-      // identity; drop it rather than clearing the new client's pane or firing
-      // onImported as though it applied here.
-      if (latestClientRef.current !== submittingClient) return;
+      // Superseded by a client swap or unmount mid-flight — this result belongs
+      // to the old identity; drop it rather than clearing the replacement's pane
+      // or firing onImported as though it applied here.
+      if (submitGenRef.current !== gen) return;
       // Drop the pasted token material as soon as the daemon has it — nothing
       // here needs it after a successful import.
       setAuthJson('');
       onImported(result);
     } catch (err) {
-      if (latestClientRef.current !== submittingClient) return;
+      if (submitGenRef.current !== gen) return;
       setError(
         err instanceof Error && err.message
           ? err.message
           : 'Could not import the Codex login — try again.'
       );
     } finally {
-      if (latestClientRef.current === submittingClient) setSubmitting(false);
+      if (submitGenRef.current === gen) setSubmitting(false);
     }
   }, [authJson, client, onImported, submitting]);
 

--- a/apps/agor-ui/src/components/CodexAuth/index.ts
+++ b/apps/agor-ui/src/components/CodexAuth/index.ts
@@ -1,0 +1,7 @@
+export { CodexAuthSettings, type CodexAuthSettingsProps } from './CodexAuthSettings';
+export {
+  type CodexAuthFallback,
+  CodexDeviceSignIn,
+  type CodexDeviceSignInProps,
+} from './CodexDeviceSignIn';
+export { CodexImportAuthJson, type CodexImportAuthJsonProps } from './CodexImportAuthJson';

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
@@ -63,6 +63,53 @@ describe('OnboardingBanners probe effect', () => {
     await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
   });
 
+  it('re-probes and clears the banner when a Codex subscription login lands via a user patch (no remount)', async () => {
+    // The daemon device-sign-in / auth.json-import flows persist
+    // agentic_auth_methods.codex server-side; it arrives as a user patch with no
+    // stored key and no credentialVersion bump — the case that previously left
+    // the banner stuck until a page refresh.
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+    await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
+    const callsBefore = onCheckAuth.mock.calls.length;
+
+    onCheckAuth.mockImplementation(async () => result('authenticated'));
+    rerender(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', {
+            agentic_auth_methods: { codex: 'subscription' },
+          } as Partial<User>),
+          onCheckAuth,
+        })}
+      />
+    );
+
+    // Same identity → same component instance (no remount); the method-marker
+    // dep change re-fires the probe, which now clears the banner.
+    await waitFor(() => expect(screen.queryByText(/No AI connected/)).not.toBeInTheDocument());
+    expect(onCheckAuth.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('does not re-probe on an unrelated user-record patch (e.g. a name edit)', async () => {
+    const onCheckAuth = vi.fn(async () => result('authenticated'));
+    const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(1));
+
+    // A field that touches neither identity, stored keys, nor auth methods must
+    // NOT spawn another ~5–10s probe.
+    rerender(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', { name: 'Renamed' } as Partial<User>),
+          onCheckAuth,
+        })}
+      />
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onCheckAuth).toHaveBeenCalledTimes(1);
+  });
+
   it('treats CLAUDE_CODE_OAUTH_TOKEN in user env vars as Claude auth (probes claude-code, no banner)', async () => {
     const onCheckAuth = vi.fn(async () => result('authenticated'));
     render(

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -108,11 +108,25 @@ export function OnboardingBanners({
   const credentialOwner = preferredCredentialOwner(probeSettings);
   const canManageWorkspaceCredentials = user?.role === 'admin' || user?.role === 'superadmin';
 
+  // Auth-method markers for the subscription/native paths (ChatGPT device
+  // sign-in, imported Codex login, Claude subscription token). These land
+  // server-side via their own services and flow back on the users `patched`
+  // event WITHOUT a stored key or a credentialVersion bump — so hasLlm alone
+  // can't see them. They are primitives ('api_key' | 'subscription' |
+  // undefined) that change only on a genuine method flip, never on unrelated
+  // user-record patches, keeping the ~5–10s probe from firing on name/emoji
+  // edits. `agentic_auth_methods` only ever carries these two tools.
+  const codexAuthMethod = user?.agentic_auth_methods?.codex;
+  const claudeAuthMethod = user?.agentic_auth_methods?.['claude-code'];
+
   // One probe (plus a bounded fallback) per identity/credential change. Deps are
   // primitives/stable so the effect never re-fires on board navigation or
   // unrelated re-renders of the persistent App shell — each claude-code probe
   // spawns a ~5–10s subprocess. userId resets stale state on a user switch;
-  // credentialVersion is a trigger-only dep re-probing after a credential save.
+  // credentialVersion is a trigger-only dep re-probing after a legacy key save;
+  // codexAuthMethod/claudeAuthMethod re-probe after a subscription/native login
+  // lands server-side (device sign-in, auth.json import) — paths that bump
+  // neither hasLlm nor credentialVersion — and cover a second browser tab too.
   // biome-ignore lint/correctness/useExhaustiveDependencies: credentialVersion is an intentional trigger dep
   useEffect(() => {
     if (!onboardingCompleted) {
@@ -135,7 +149,16 @@ export function OnboardingBanners({
     return () => {
       cancelled = true;
     };
-  }, [userId, onboardingCompleted, probeAgent, hasLlm, onCheckAuth, credentialVersion]);
+  }, [
+    userId,
+    onboardingCompleted,
+    probeAgent,
+    hasLlm,
+    onCheckAuth,
+    credentialVersion,
+    codexAuthMethod,
+    claudeAuthMethod,
+  ]);
 
   const decision = decideBanner({
     onboardingCompleted,

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -545,7 +545,8 @@ describe('Codex ChatGPT login import', () => {
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: pasted },
     });
-    clickButton(/^connect →/i);
+    // The import pane owns its own submit; success self-advances the wizard.
+    clickButton('Import login');
 
     await waitFor(() => expect(importCreate).toHaveBeenCalledWith({ authJson: pasted }));
     expect(await screen.findByText('Name your AI teammate')).toBeInTheDocument();
@@ -562,7 +563,7 @@ describe('Codex ChatGPT login import', () => {
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"tokens":{}}' },
     });
-    clickButton(/^connect →/i);
+    clickButton('Import login');
 
     expect(
       await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
@@ -582,7 +583,7 @@ describe('Codex ChatGPT login import', () => {
     fireEvent.change(screen.getByLabelText('Codex auth.json contents'), {
       target: { value: '{"a":1}' },
     });
-    clickButton(/^connect →/i);
+    clickButton('Import login');
     expect(
       await screen.findByText(/This file has no ChatGPT login tokens and no API key\./)
     ).toBeInTheDocument();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -369,7 +369,8 @@ function keyNameForAgent(agent: AgenticToolName, authMethod: AuthMethod = 'api-k
 
 function getKeyLabel(agent: AgenticToolName, authMethod: AuthMethod): string {
   if (authMethod === 'claude-subscription-token') return 'Subscription token';
-  if (authMethod === 'codex-auth-json') return 'Codex login file (auth.json)';
+  // Note: the codex-auth-json method renders its own pane (CodexImportAuthJson)
+  // and never reaches this label, so no case is needed for it here.
   switch (agent) {
     case 'claude-code':
       return 'Anthropic API key';

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,8 +9,6 @@ import type {
   AgenticToolName,
   AgorClient,
   AuthCheckResult,
-  CodexAuthImportResult,
-  CodexDeviceAuthStatus,
   UpdateUserInput,
   User,
   UserPreferences,
@@ -24,18 +22,10 @@ import {
   LoadingOutlined,
 } from '@ant-design/icons';
 import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
-import {
-  Fragment,
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
+import { type CodexAuthFallback, CodexDeviceSignIn, CodexImportAuthJson } from '../CodexAuth';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 
 const { Text, Title, Paragraph } = Typography;
@@ -471,272 +461,6 @@ const PARTICLE_DIRS = [
   [-51, -51],
 ] as const;
 
-// ─── Codex device-code sign-in pane ──────────────────────────────────────────
-
-const DEVICE_STATUS_POLL_MS = 2000;
-
-function formatCountdown(remainingMs: number): string {
-  const totalSeconds = Math.max(Math.floor(remainingMs / 1000), 0);
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
-}
-
-interface CodexDeviceSignInProps {
-  client: AgorClient | null;
-  /** Fired once the daemon confirms tokens were saved for this user. */
-  onVerified: () => void;
-  /** Switch to another codex auth method (gated-account fallback). */
-  onUseFallback: (method: AuthMethod) => void;
-}
-
-/**
- * Self-contained device-code pane: requests a code, shows it with the
- * verification link and a countdown, and polls the daemon for approval.
- * Memoized with its own state so the 1s countdown and 2s status polls
- * re-render only this pane, never the whole wizard.
- */
-const CodexDeviceSignIn = memo(function CodexDeviceSignIn({
-  client,
-  onVerified,
-  onUseFallback,
-}: CodexDeviceSignInProps) {
-  const { token } = useToken();
-  const [status, setStatus] = useState<CodexDeviceAuthStatus>({ phase: 'idle' });
-  const [starting, setStarting] = useState(false);
-  const [remainingMs, setRemainingMs] = useState<number | null>(null);
-
-  const deviceService = useMemo(
-    () =>
-      client
-        ? (client.service('codex-auth/device') as unknown as {
-            create(data: Record<string, never>): Promise<unknown>;
-            find(): Promise<unknown>;
-          })
-        : null,
-    [client]
-  );
-
-  // Tracks the service the pane currently talks to, so an in-flight
-  // requestCode issued against a swapped-out client can't land its state
-  // updates over the replacement's. A layout effect syncs the identity
-  // before paint and before the passive effects below; resetting `starting`
-  // here matters because a stale request's guarded finally deliberately
-  // won't clear it, and a replacement that ADOPTS an attempt never calls
-  // requestCode — without the reset the spinner would cover a live code.
-  const latestServiceRef = useRef(deviceService);
-  useLayoutEffect(() => {
-    latestServiceRef.current = deviceService;
-    setStarting(false);
-  }, [deviceService]);
-
-  const requestCode = useCallback(async () => {
-    if (!deviceService) return;
-    setStarting(true);
-    try {
-      const next = (await deviceService.create({})) as CodexDeviceAuthStatus;
-      if (latestServiceRef.current !== deviceService) return;
-      setStatus(next);
-    } catch (err) {
-      if (latestServiceRef.current !== deviceService) return;
-      setStatus({
-        phase: 'error',
-        hint:
-          err instanceof Error && err.message
-            ? err.message
-            : 'Could not start the ChatGPT sign-in — try again.',
-      });
-    } finally {
-      if (latestServiceRef.current === deviceService) setStarting(false);
-    }
-  }, [deviceService]);
-
-  // On mount (and on client swap), adopt a still-live attempt (user toggled
-  // away and back) instead of burning a fresh code; otherwise request one.
-  // The cancellation guard makes this StrictMode-safe — a superseded run
-  // never fires its requestCode/setStatus continuation.
-  useEffect(() => {
-    if (!deviceService) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const existing = (await deviceService.find()) as CodexDeviceAuthStatus;
-        if (cancelled) return;
-        if (existing.phase === 'pending' || existing.phase === 'success') {
-          setStatus(existing);
-          return;
-        }
-      } catch {
-        // No adoptable attempt — fall through to a fresh request.
-      }
-      if (!cancelled) await requestCode();
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [deviceService, requestCode]);
-
-  // Poll while pending; terminal phases stop the loop. A self-scheduling
-  // timeout (next poll armed only after the previous response lands) keeps
-  // slow responses from overlapping and regressing a terminal phase with an
-  // out-of-order pending. Identity-preserving setState keeps unchanged polls
-  // from re-rendering even this pane.
-  useEffect(() => {
-    if (status.phase !== 'pending' || !deviceService) return;
-    let cancelled = false;
-    let timer: ReturnType<typeof setTimeout>;
-    const tick = async () => {
-      try {
-        const next = (await deviceService.find()) as CodexDeviceAuthStatus;
-        if (cancelled) return;
-        setStatus((prev) =>
-          prev.phase === next.phase && prev.userCode === next.userCode && prev.hint === next.hint
-            ? prev
-            : next
-        );
-      } catch {
-        // Transient — keep polling until the code expires.
-      }
-      if (!cancelled) timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
-    };
-    timer = setTimeout(tick, DEVICE_STATUS_POLL_MS);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [status.phase, deviceService]);
-
-  // 1s countdown while a code is live.
-  useEffect(() => {
-    if (status.phase !== 'pending' || !status.expiresAt) {
-      setRemainingMs(null);
-      return;
-    }
-    const expiresAtMs = Date.parse(status.expiresAt);
-    const update = () => setRemainingMs(Math.max(expiresAtMs - Date.now(), 0));
-    update();
-    const id = setInterval(update, 1000);
-    return () => clearInterval(id);
-  }, [status.phase, status.expiresAt]);
-
-  useEffect(() => {
-    if (status.phase === 'success') onVerified();
-  }, [status.phase, onVerified]);
-
-  if (starting || status.phase === 'idle') {
-    return (
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
-        <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 14 }} />
-        <Text style={{ color: token.colorTextTertiary, fontSize: 13 }}>
-          {client ? 'Getting your sign-in code…' : 'Waiting for the server connection…'}
-        </Text>
-      </div>
-    );
-  }
-
-  if (status.phase === 'pending') {
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
-        <Text style={{ color: token.colorTextSecondary, fontSize: 13 }}>
-          Open the link below, sign in to ChatGPT, and enter this one-time code:
-        </Text>
-        <Text
-          copyable
-          aria-label="ChatGPT sign-in code"
-          style={{
-            color: token.colorText,
-            fontFamily: 'monospace',
-            fontSize: 26,
-            fontWeight: 600,
-            letterSpacing: 4,
-          }}
-        >
-          {status.userCode}
-        </Text>
-        {status.verificationUrl && (
-          <Typography.Link
-            href={status.verificationUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ fontSize: 13 }}
-          >
-            Open {status.verificationUrl} →
-          </Typography.Link>
-        )}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <LoadingOutlined style={{ color: token.colorTextTertiary, fontSize: 13 }} />
-          <Text style={{ color: token.colorTextTertiary, fontSize: 12 }}>
-            Waiting for approval — we finish automatically once you approve.
-            {remainingMs !== null && ` Code expires in ${formatCountdown(remainingMs)}.`}
-          </Text>
-        </div>
-      </div>
-    );
-  }
-
-  if (status.phase === 'success') {
-    return (
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 0' }}>
-        <CheckCircleOutlined style={{ color: token.colorSuccess, fontSize: 14 }} />
-        <Text style={{ color: token.colorSuccess, fontSize: 13 }}>
-          {status.hint ?? 'Signed in with ChatGPT.'}
-        </Text>
-      </div>
-    );
-  }
-
-  if (status.phase === 'unavailable') {
-    return (
-      <Alert
-        type="warning"
-        showIcon
-        style={{ fontSize: 12 }}
-        message="Device sign-in is turned off for this ChatGPT account"
-        description={
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            <span>
-              Personal accounts: enable it under ChatGPT Settings → Security → “Device code
-              authorization for Codex”, then try again. Workspace accounts: a workspace admin has to
-              enable it. Either way, the two options below work right now.
-            </span>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-              <Button size="small" onClick={() => onUseFallback('codex-auth-json')}>
-                Paste a login file
-              </Button>
-              <Button size="small" onClick={() => onUseFallback('api-key')}>
-                Use an API key
-              </Button>
-              <Button size="small" type="text" onClick={requestCode}>
-                Try again
-              </Button>
-            </div>
-          </div>
-        }
-      />
-    );
-  }
-
-  // expired / error
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '4px 0' }}>
-      <Alert
-        type={status.phase === 'expired' ? 'warning' : 'error'}
-        showIcon
-        style={{ fontSize: 12 }}
-        message={
-          status.hint ??
-          (status.phase === 'expired' ? 'The sign-in code expired.' : 'The ChatGPT sign-in failed.')
-        }
-      />
-      <div>
-        <Button size="small" onClick={requestCode}>
-          Get a new code
-        </Button>
-      </div>
-    </div>
-  );
-});
-
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface OnboardingWizardProps {
@@ -1011,19 +735,22 @@ export function OnboardingWizard({
       case 'llm': {
         if (!selectedAgent) return false;
         if (agentIsVerifiedConnected(selectedAgent)) return true;
-        // Device sign-in has no typed input — it enables once the daemon
+        // Device sign-in and login-file import both complete inside their own
+        // pane — no typed input to validate. They enable once the daemon
         // confirms the login (llmAuthVerified flips before the user record
         // refresh that agentIsVerifiedConnected depends on).
-        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth')
+        if (
+          selectedAgent === 'codex' &&
+          (authMethod === 'codex-device-auth' || authMethod === 'codex-auth-json')
+        )
           return llmAuthVerified.codex === true;
         // Key stored, check still in progress — keep enabled so user isn't stuck
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return true;
         // Require a new key with valid format (stored key absent or broken)
         if (!apiKey.trim()) return false;
-        // Subscription tokens and pasted auth files have no fixed format —
-        // any non-empty string is accepted (the daemon validates the file)
-        if (authMethod === 'claude-subscription-token' || authMethod === 'codex-auth-json')
-          return true;
+        // Subscription tokens have no fixed format — any non-empty string is
+        // accepted (the daemon validates the token).
+        if (authMethod === 'claude-subscription-token') return true;
         return validateLlmKeyPattern(selectedAgent, apiKey.trim()) === null;
       }
       case 'workspace':
@@ -1059,13 +786,13 @@ export function OnboardingWizard({
             ? null
             : 'Approve the sign-in code in ChatGPT first';
         }
+        if (selectedAgent === 'codex' && authMethod === 'codex-auth-json') {
+          return llmAuthVerified.codex === true ? null : 'Import your Codex login to continue';
+        }
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return null;
         if (!apiKey.trim()) {
-          return authMethod === 'codex-auth-json'
-            ? 'Paste your auth.json contents to continue'
-            : 'Enter your API key to continue';
+          return 'Enter your API key to continue';
         }
-        if (authMethod === 'codex-auth-json') return null;
         const err = validateLlmKeyPattern(selectedAgent, apiKey.trim());
         return err ?? null;
       }
@@ -1152,11 +879,18 @@ export function OnboardingWizard({
     setLlmAuthVerified((prev) => (prev.codex === true ? prev : { ...prev, codex: true }));
   }, []);
 
-  const handleCodexAuthMethodFallback = useCallback((method: AuthMethod) => {
-    setAuthMethod(method);
+  const handleCodexAuthMethodFallback = useCallback((target: CodexAuthFallback) => {
+    setAuthMethod(target === 'import' ? 'codex-auth-json' : 'api-key');
     setApiKey('');
     setLlmError(null);
   }, []);
+
+  // Login-file import completes inside its own pane; mirror the device flow by
+  // marking codex verified so the primary button advances to the next step.
+  const handleCodexImported = useCallback(() => {
+    setLlmAuthVerified((prev) => (prev.codex === true ? prev : { ...prev, codex: true }));
+    goToStep('workspace');
+  }, [goToStep]);
 
   const handleBack = useCallback(() => {
     if (stepIndex > 0) goToStep(STEPS[stepIndex - 1]);
@@ -1182,9 +916,13 @@ export function OnboardingWizard({
           goToStep('workspace');
           return;
         }
-        // Device sign-in completes daemon-side; the primary button only ever
-        // advances once the attempt succeeded (button is disabled until then).
-        if (selectedAgent === 'codex' && authMethod === 'codex-device-auth') {
+        // Device sign-in and login-file import both complete inside their own
+        // pane; the primary button only ever advances once the attempt
+        // succeeded (button is disabled until then).
+        if (
+          selectedAgent === 'codex' &&
+          (authMethod === 'codex-device-auth' || authMethod === 'codex-auth-json')
+        ) {
           if (llmAuthVerified.codex === true) goToStep('workspace');
           return;
         }
@@ -1194,34 +932,6 @@ export function OnboardingWizard({
           return;
         }
         if (!user || !apiKey.trim()) return;
-        // Pasted auth.json goes to the daemon as-is: it validates the shape,
-        // writes the file 0600 for the right Unix identity, and flips the
-        // user's Codex auth method to subscription. The pasted secret never
-        // touches user records or agent context.
-        if (selectedAgent === 'codex' && authMethod === 'codex-auth-json') {
-          if (!client) return;
-          setLlmSaving(true);
-          setLlmError(null);
-          try {
-            (await client
-              .service('codex-auth/import')
-              .create({ authJson: apiKey })) as CodexAuthImportResult;
-            setLlmAuthVerified((prev) => ({ ...prev, codex: true }));
-            // Drop the pasted token material from React state as soon as the
-            // daemon has it — nothing needs it after a successful import.
-            setApiKey('');
-            goToStep('workspace');
-          } catch (err) {
-            setLlmError(
-              err instanceof Error && err.message
-                ? err.message
-                : 'Could not import the Codex login — try again.'
-            );
-          } finally {
-            setLlmSaving(false);
-          }
-          return;
-        }
         // Subscription tokens have no fixed format (see primaryEnabled/disabledReason
         // above, which already treat them as exempt) — only pattern-validate API keys.
         if (authMethod !== 'claude-subscription-token') {
@@ -1740,7 +1450,7 @@ export function OnboardingWizard({
                       </div>
                     )}
 
-                    {authMethod !== 'codex-device-auth' && (
+                    {authMethod !== 'codex-device-auth' && authMethod !== 'codex-auth-json' && (
                       <div
                         style={{
                           display: 'flex',
@@ -1773,39 +1483,7 @@ export function OnboardingWizard({
                         onUseFallback={handleCodexAuthMethodFallback}
                       />
                     ) : authMethod === 'codex-auth-json' ? (
-                      <>
-                        <Alert
-                          type="info"
-                          showIcon
-                          style={{ marginBottom: 10, fontSize: 12 }}
-                          message={
-                            <span>
-                              Already use Codex on your own machine? Its credential file lives there
-                              at <code>~/.codex/auth.json</code>. On that machine, print it with{' '}
-                              <code>cat ~/.codex/auth.json</code> and paste the whole thing below —
-                              this replaces the Codex login already stored on this server, which in
-                              shared setups is one login for the whole server, not one per person.
-                              Or skip the copy-paste entirely: open a branch terminal on this server
-                              and run <code>codex login --device-auth</code>.
-                            </span>
-                          }
-                        />
-                        <Input.Password
-                          aria-label="Codex auth.json contents"
-                          placeholder="Paste the JSON from ~/.codex/auth.json…"
-                          value={apiKey}
-                          onChange={(e) => {
-                            setApiKey(e.target.value);
-                            setLlmError(null);
-                          }}
-                          style={{
-                            background: 'rgba(0,0,0,0.3)',
-                            borderColor: 'rgba(255,255,255,0.12)',
-                            fontFamily: 'monospace',
-                            fontSize: 13,
-                          }}
-                        />
-                      </>
+                      <CodexImportAuthJson client={client} onImported={handleCodexImported} />
                     ) : authMethod === 'claude-subscription-token' ? (
                       <>
                         <Alert

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -152,7 +152,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('shows Codex authentication choices when subscription mode hides API-key fields', async () => {
+  it('offers the three Codex authentication methods, defaulting to the sign-in view for a subscription', async () => {
     const user = makeUser({ agentic_auth_methods: { codex: 'subscription' } });
     renderWithApp(
       <UserSettingsModal
@@ -167,8 +167,12 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
 
     fireEvent.click(screen.getByRole('menuitem', { name: /codex/i }));
     await screen.findByRole('heading', { name: 'Codex' });
-    expect(screen.getByText('ChatGPT subscription')).toBeInTheDocument();
-    expect(screen.getByText('Use Codex CLI subscription authentication')).toBeInTheDocument();
+    // The method selector surfaces all three ways in.
+    expect(screen.getByText('API key')).toBeInTheDocument();
+    expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+    expect(screen.getByText('Import login file')).toBeInTheDocument();
+    // A stored subscription lands on the ChatGPT sign-in view.
+    expect(screen.getByText(/Sign in with your ChatGPT account/i)).toBeInTheDocument();
   });
 
   it('saves a Claude model alias before closing', async () => {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -53,6 +53,7 @@ import {
   getFormValuesFromConfig,
 } from '../AgenticToolConfigForm';
 import { ApiKeyFields, type FieldStatus, TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
+import { CodexAuthSettings } from '../CodexAuth';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { EnvVarEditor } from '../EnvVarEditor';
 import { SessionMcpServersField } from '../MCPServerSelect';
@@ -1151,13 +1152,36 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                   </Popconfirm>
                 </Space>
               )
+            ) : canonicalTool === 'codex' ? (
+              <CodexAuthSettings
+                client={client}
+                authMethod={authMethod ?? 'api_key'}
+                onAuthMethodChange={(method) => handleAuthMethodChange('codex', method)}
+                apiKeyFields={allToolFields}
+                fieldStatus={fieldStatus}
+                onSaveField={(field, value) =>
+                  handleToolFieldSave(credentialToolName, field, value)
+                }
+                onClearField={(field) => handleToolFieldClear(credentialToolName, field)}
+                savingFields={Object.fromEntries(
+                  allToolFields.map((c) => [
+                    c.field,
+                    !!savingToolField[`${credentialToolName}.${c.field}`],
+                  ])
+                )}
+                publicValues={
+                  user?.agentic_tools_public_values?.[credentialToolName] as
+                    | Partial<Record<AgenticToolConfigField, string>>
+                    | undefined
+                }
+              />
             ) : (
               <>
                 <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
                   Personal credentials are encrypted at rest and injected only into the agent
                   runtime.
                 </Typography.Paragraph>
-                {(canonicalTool === 'claude-code' || canonicalTool === 'codex') && (
+                {canonicalTool === 'claude-code' && (
                   <Radio.Group
                     value={authMethod}
                     onChange={(event) =>
@@ -1165,34 +1189,23 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                     }
                     style={{ marginBottom: 16 }}
                   >
-                    <Radio.Button value="subscription">
-                      {canonicalTool === 'codex' ? 'ChatGPT subscription' : 'Claude subscription'}
-                    </Radio.Button>
+                    <Radio.Button value="subscription">Claude subscription</Radio.Button>
                     <Radio.Button value="api_key">API key</Radio.Button>
                   </Radio.Group>
                 )}
-                {canonicalTool === 'codex' && authMethod === 'subscription' ? (
-                  <Alert
-                    type="info"
-                    showIcon
-                    title="Use Codex CLI subscription authentication"
-                    description="Agor will use the Codex CLI login belonging to this session's Unix user. Run `codex login` in a terminal as that same user. This declaration does not prove that the login is still valid."
-                  />
-                ) : (
-                  <ApiKeyFields
-                    tool={toolName}
-                    fields={toolFields}
-                    fieldStatus={fieldStatus}
-                    onSave={(field, value) => handleToolFieldSave(credentialToolName, field, value)}
-                    onClear={(field) => handleToolFieldClear(credentialToolName, field)}
-                    saving={savingForTool}
-                    publicValues={
-                      user?.agentic_tools_public_values?.[credentialToolName] as
-                        | Partial<Record<AgenticToolConfigField, string>>
-                        | undefined
-                    }
-                  />
-                )}
+                <ApiKeyFields
+                  tool={toolName}
+                  fields={toolFields}
+                  fieldStatus={fieldStatus}
+                  onSave={(field, value) => handleToolFieldSave(credentialToolName, field, value)}
+                  onClear={(field) => handleToolFieldClear(credentialToolName, field)}
+                  saving={savingForTool}
+                  publicValues={
+                    user?.agentic_tools_public_values?.[credentialToolName] as
+                      | Partial<Record<AgenticToolConfigField, string>>
+                      | undefined
+                  }
+                />
               </>
             )}
           </>

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -1156,7 +1156,6 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
               <CodexAuthSettings
                 client={client}
                 authMethod={authMethod ?? 'api_key'}
-                onAuthMethodChange={(method) => handleAuthMethodChange('codex', method)}
                 apiKeyFields={allToolFields}
                 fieldStatus={fieldStatus}
                 onSaveField={(field, value) =>

--- a/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
+++ b/apps/agor-ui/src/utils/agenticToolCredentials.test.ts
@@ -23,6 +23,26 @@ describe('buildAgenticToolCredentialPatch', () => {
     });
   });
 
+  it('flips the Codex method to api_key when an OpenAI key is saved (the only deliberate api_key act)', () => {
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_API_KEY', 'sk-proj-test')).toEqual({
+      agentic_tools: {
+        codex: { OPENAI_API_KEY: 'sk-proj-test' },
+      },
+      agentic_auth_methods: { codex: 'api_key' },
+    });
+  });
+
+  it('does not flip the Codex method when only the base URL is set or a key is cleared', () => {
+    // A non-credential field must not activate api_key…
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_BASE_URL', 'https://gw')).toEqual({
+      agentic_tools: { codex: { OPENAI_BASE_URL: 'https://gw' } },
+    });
+    // …and clearing the key must not assert any method (leaves the flip to a real save).
+    expect(buildAgenticToolCredentialPatch('codex', 'OPENAI_API_KEY', null)).toEqual({
+      agentic_tools: { codex: { OPENAI_API_KEY: null } },
+    });
+  });
+
   it('clears a token by sending null at the same canonical field path', () => {
     expect(buildAgenticToolCredentialPatch('claude-code', 'CLAUDE_CODE_OAUTH_TOKEN', null)).toEqual(
       {


### PR DESCRIPTION
**PR3 of the Codex-auth stack.** Stack: `main` ← #1954 (onboarding) ← #1955 (device-auth) ← **this**. Review this PR against its stacked base `codex-oauth-device-auth`, not `main`.

## Problem

The onboarding wizard (PR1/PR2) gained three ways to connect Codex — **API key**, **Sign in with ChatGPT** (device-code), and **Import auth.json** — but the Codex/GPT tab in **user settings** still only had an API-key field and a bare "run `codex login` in a terminal" note. A user who onboarded via ChatGPT sign-in had no way to re-authenticate, re-import, or even *see* that their login had gone stale from settings.

## Approach

Extract the genuinely-shared, token-based flows into `components/CodexAuth/` and render them from both surfaces, rather than forking ~250 lines of device-code polling into settings:

- **`CodexDeviceSignIn`** — moved verbatim from the wizard (poll/countdown/attempt-adoption/`unavailable`-fallback logic intact). New `autoStart` flag: the wizard starts eagerly on method-select; settings starts deliberately (a button press) so merely viewing the tab never fires an OpenAI device request.
- **`CodexImportAuthJson`** — new self-contained paste-and-import pane owning its own value/submit/error state.
- **`CodexAuthSettings`** — the settings-only management pane: an AntD `Segmented` method selector over the three panes, plus a live `check-auth` probe.

The wizard now unifies its import path with device sign-in (both complete inside their own pane and advance via the verified flag), removing the bespoke primary-button import branch.

### Why not one shared "pane" component?

The wizard is an intentional bespoke dark-glass surface (documented `noHardcodedColorLiteral` ignore); settings is standard AntD. `frontend.md` forbids glass color literals in a normal AntD surface, and a shared component can't carry the wizard's ignore. So the shared cut is the two token-based *flow* components (the substantial, bug-prone device logic + the import pane); each surface keeps its own method-selector chrome (glass toggle vs AntD `Segmented`) and its own integration semantics.

## UX walkthrough (settings → Codex tab)

- **Selector:** `API key` · `Sign in with ChatGPT` · `Import login file`. A stored subscription defaults to the sign-in view; an API-key user defaults to the key fields.
- **Connected:** green banner ("Codex is connected") + a "Recheck connection" action — re-signing-in / re-importing stays reachable while connected (management view, not connect-then-collapse).
- **Broken (prominent, error-styled):** subscription login missing → **"Login not found"**; stored API key rejected → **"Key not working"**. A transport failure (`unknown`) never flashes a false "not connected" (fail-safe, mirroring `App.handleCheckAuth`). The probe re-runs on method change so the banner always reflects the server's *active* credential.

## Security notes

- Token material never enters logs or agent context. The pasted `auth.json` and device tokens go straight to the existing daemon endpoints (`codex-auth/import`, `codex-auth/device`), which write the file `0600` as the target Unix user; the pasted secret is dropped from React state the moment the daemon confirms it.
- No daemon/API changes — this PR is UI-only and reuses the PR2 endpoints verbatim.
- `check-auth` probes are read-only and return only a tri-state verdict + a hint, never credentials.

## Tests / gates

- New `CodexAuthSettings.test.tsx` (8): connected, both broken-login states, fail-safe silence, API-key save, deliberate device start, import happy + rejection.
- Updated the wizard's 3 import tests to the self-contained interaction; all **27 wizard tests stay green**. Updated the one settings-modal test that asserted the old Codex UI.
- Repo-wide `pnpm typecheck` ✓ and `pnpm lint` ✓ (incl. frontend color-plugin fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)