### PR TITLE
feat(board-ui): surface branch storage mode (clone vs worktree) on cards

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -24,7 +24,7 @@ import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import { EnvironmentPill } from '../EnvironmentPill';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 import { CreatedByTag } from '../metadata';
-import { IssuePill, PullRequestPill } from '../Pill';
+import { IssuePill, PullRequestPill, StorageModePill } from '../Pill';
 import { BranchSessionPeekSection } from './BranchSessionPeekSection';
 import { BranchSessionSections } from './BranchSessionSections';
 import { estimateBranchSessionSectionsHeight } from './branchCardLayout';
@@ -518,6 +518,7 @@ const BranchCardComponent = ({
               prefix="Created by"
             />
           )}
+          <StorageModePill storageMode={branch.storage_mode} />
           {branch.issue_url && <IssuePill issueUrl={branch.issue_url} currentRepo={repo} />}
           {branch.pull_request_url && (
             <PullRequestPill prUrl={branch.pull_request_url} currentRepo={repo} />

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -14,6 +14,7 @@ import {
   FileTextOutlined,
   ForkOutlined,
   GithubOutlined,
+  HddOutlined,
   IdcardOutlined,
   LinkOutlined,
   MessageOutlined,
@@ -27,6 +28,7 @@ import {
 } from '@ant-design/icons';
 import { Badge, Collapse, Popover, Tooltip, theme } from 'antd';
 import type React from 'react';
+import type { BranchStorageMode } from '../../utils/branchStorage';
 import { copyToClipboard } from '../../utils/clipboard';
 import { resolveContextWindowPercentage } from '../../utils/contextWindow';
 import { parseGitStateSha } from '../../utils/gitState';
@@ -818,6 +820,32 @@ export const DirtyStatePill: React.FC<DirtyStatePillProps> = ({ style }) => {
     <Tag icon={<EditOutlined />} color={PILL_COLORS.warning} style={style}>
       <span style={{ fontFamily: token.fontFamilyCode }}>uncommitted changes</span>
     </Tag>
+  );
+};
+
+interface StorageModePillProps extends BasePillProps {
+  storageMode?: BranchStorageMode;
+}
+
+/**
+ * Storage-mode indicator for a branch: git `worktree` (shared parent repo,
+ * the common default) vs a self-standing `clone` (independent repository copy).
+ *
+ * Worktree is intentionally quiet — it's the default on the vast majority of
+ * branches, so we render nothing to keep the board uncluttered. Only the rarer
+ * `clone` gets a pill, making it easy to spot at a glance.
+ */
+export const StorageModePill: React.FC<StorageModePillProps> = ({ storageMode, style }) => {
+  const { token } = theme.useToken();
+
+  if (storageMode !== 'clone') return null;
+
+  return (
+    <Tooltip title="Self-standing git clone — an independent repository copy, not a shared worktree">
+      <Tag icon={<HddOutlined />} color={PILL_COLORS.spawn} style={style}>
+        <span style={{ fontFamily: token.fontFamilyCode }}>clone</span>
+      </Tag>
+    </Tooltip>
   );
 };
 

--- a/apps/agor-ui/src/components/Pill/index.ts
+++ b/apps/agor-ui/src/components/Pill/index.ts
@@ -25,6 +25,7 @@ export {
   SessionPill,
   SpawnPill,
   StatusPill,
+  StorageModePill,
   TeammatePill,
   TokenCountPill,
   ToolCountPill,


### PR DESCRIPTION
## What

Adds an at-a-glance indicator on the board branch card showing whether a branch is backed by a self-standing git **clone** vs a native **worktree**.

## Why

Every branch already carries a `storage_mode` field (`worktree` default | `clone`, see `context/explorations/clone-redesign.md`), but there was no way to tell a branch's storage type on the board without opening it.

## Design

- New `StorageModePill` in `apps/agor-ui/src/components/Pill/Pill.tsx`, following the existing pill conventions (antd `Tag` + `Tooltip`, `PILL_COLORS`, monospace label, 12px icon).
- **Worktree stays visually quiet.** It's the default on the vast majority of branches, so the pill renders **nothing** for it — zero board noise.
- **Clone is easy to spot.** Self-standing clones get a distinct `HddOutlined` pill (purple) with a tooltip explaining it's an independent repository copy.
- Wired into the `BranchCard` metadata pill row alongside the existing created-by / issue / PR / environment pills.
- Uses the canonical `BranchStorageMode` type from `utils/branchStorage` rather than re-inlining the union.

### Deviation note

The task framed this as "distinguishing clone vs worktree", but since the same task also asked to keep worktree quiet and make clone easy to spot, I render a pill **only** for `clone` (absence = worktree, the default). This keeps the common case entirely uncluttered while making the notable case pop. Easy to add a muted worktree pill later if an explicit marker is preferred.

## Serialization

No backend/serialization changes were needed — `storage_mode` already flows through `rowToBranch` → core `Branch` type → Feathers response → the `branch` prop consumed by `BranchCard` (snake_case `branch.storage_mode` at every UI-facing layer). Verified end-to-end during the trace.

## Verification

- `pnpm typecheck` (agor-ui) — passes
- `pnpm biome check` on touched files — clean
- `pnpm vitest run src/components/Pill` — 32/32 pass
- Pre-commit hooks ran (not bypassed)

## Files touched

- `apps/agor-ui/src/components/Pill/Pill.tsx` — new `StorageModePill`, `HddOutlined` import
- `apps/agor-ui/src/components/Pill/index.ts` — export
- `apps/agor-ui/src/components/BranchCard/BranchCard.tsx` — render pill in metadata row

🤖 Generated with [Claude Code](https://claude.com/claude-code)