### PR TITLE
fix(executor): honor allow-all for Codex app tools

### DIFF
--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -324,8 +324,8 @@ describe('CodexPromptService - prompt flow client initialization', () => {
 
   it.each([
     {
-      name: 'allow-all',
-      permissionMode: 'allow-all',
+      name: 'persisted allow-all',
+      persistedPermissionMode: 'allow-all',
       codexPermissions: {
         sandboxMode: 'workspace-write',
         approvalPolicy: 'never',
@@ -338,8 +338,44 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       },
     },
     {
+      name: 'prompt allow-all overriding persisted auto',
+      persistedPermissionMode: 'auto',
+      promptPermissionMode: 'allow-all',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      },
+      expectedApps: {
+        _default: {
+          default_tools_approval_mode: 'approve',
+        },
+      },
+    },
+    {
+      name: 'prompt auto overriding persisted allow-all',
+      persistedPermissionMode: 'allow-all',
+      promptPermissionMode: 'auto',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      },
+      expectedApps: undefined,
+    },
+    {
+      name: 'mode-less legacy session using the Codex system default',
+      persistedPermissionMode: undefined,
+      codexPermissions: {},
+      expectedApps: {
+        _default: {
+          default_tools_approval_mode: 'approve',
+        },
+      },
+    },
+    {
       name: 'allow-all with the k8s sandbox override',
-      permissionMode: 'allow-all',
+      persistedPermissionMode: 'allow-all',
       codexPermissions: {
         sandboxMode: 'workspace-write',
         approvalPolicy: 'never',
@@ -353,8 +389,19 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       },
     },
     {
+      name: 'allow-all with a read-only sandbox environment override',
+      persistedPermissionMode: 'allow-all',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      },
+      sandboxModeEnvOverride: 'read-only',
+      expectedApps: undefined,
+    },
+    {
       name: 'allow-all with network disabled',
-      permissionMode: 'allow-all',
+      persistedPermissionMode: 'allow-all',
       codexPermissions: {
         sandboxMode: 'workspace-write',
         approvalPolicy: 'never',
@@ -364,7 +411,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
     },
     {
       name: 'allow-all with approval required',
-      permissionMode: 'allow-all',
+      persistedPermissionMode: 'allow-all',
       codexPermissions: {
         sandboxMode: 'workspace-write',
         approvalPolicy: 'on-request',
@@ -373,8 +420,8 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       expectedApps: undefined,
     },
     {
-      name: 'allow-all with a read-only sandbox',
-      permissionMode: 'allow-all',
+      name: 'allow-all with a configured read-only sandbox',
+      persistedPermissionMode: 'allow-all',
       codexPermissions: {
         sandboxMode: 'read-only',
         approvalPolicy: 'never',
@@ -383,8 +430,8 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       expectedApps: undefined,
     },
     {
-      name: 'auto mode with never approval',
-      permissionMode: 'auto',
+      name: 'persisted auto mode with never approval',
+      persistedPermissionMode: 'auto',
       codexPermissions: {
         sandboxMode: 'workspace-write',
         approvalPolicy: 'never',
@@ -393,7 +440,8 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       expectedApps: undefined,
     },
   ])('builds session config for $name permissions and uses the configured accessor', async ({
-    permissionMode,
+    persistedPermissionMode,
+    promptPermissionMode,
     codexPermissions,
     sandboxModeEnvOverride,
     expectedApps,
@@ -431,7 +479,10 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       branch_id: 'branch-1',
       created_at: new Date().toISOString(),
       sdk_session_id: null,
-      permission_config: { mode: permissionMode, codex: codexPermissions },
+      permission_config: {
+        ...(persistedPermissionMode ? { mode: persistedPermissionMode } : {}),
+        codex: codexPermissions,
+      },
       model_config: {},
       mcp_token: 'test-token',
     });
@@ -453,7 +504,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       'session-flow' as any,
       'review',
       undefined,
-      permissionMode as PermissionMode
+      promptPermissionMode as PermissionMode | undefined
     )) {
       emitted.push(event as Record<string, unknown>);
     }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -20,6 +20,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PermissionMode } from '../../types.js';
 
 const appServerMocks = vi.hoisted(() => ({
   forkCodexThreadViaAppServer: vi.fn(),
@@ -317,13 +318,19 @@ describe('CodexPromptService - prompt flow client initialization', () => {
     mockClosedInstanceIds = [];
     mockStreamEvents = [];
     delete process.env.OPENAI_BASE_URL;
+    delete process.env.AGOR_CODEX_SANDBOX_MODE;
     vi.clearAllMocks();
   });
 
   it.each([
     {
       name: 'allow-all',
-      codexPermissions: {},
+      permissionMode: 'allow-all',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      },
       expectedApps: {
         _default: {
           default_tools_approval_mode: 'approve',
@@ -331,18 +338,70 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       },
     },
     {
-      name: 'approval-requiring',
+      name: 'allow-all with the k8s sandbox override',
+      permissionMode: 'allow-all',
       codexPermissions: {
         sandboxMode: 'workspace-write',
-        approvalPolicy: 'on-request',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      },
+      sandboxModeEnvOverride: 'danger-full-access',
+      expectedApps: {
+        _default: {
+          default_tools_approval_mode: 'approve',
+        },
+      },
+    },
+    {
+      name: 'allow-all with network disabled',
+      permissionMode: 'allow-all',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'never',
         networkAccess: false,
       },
       expectedApps: undefined,
     },
+    {
+      name: 'allow-all with approval required',
+      permissionMode: 'allow-all',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'on-request',
+        networkAccess: true,
+      },
+      expectedApps: undefined,
+    },
+    {
+      name: 'allow-all with a read-only sandbox',
+      permissionMode: 'allow-all',
+      codexPermissions: {
+        sandboxMode: 'read-only',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      },
+      expectedApps: undefined,
+    },
+    {
+      name: 'auto mode with never approval',
+      permissionMode: 'auto',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'never',
+        networkAccess: true,
+      },
+      expectedApps: undefined,
+    },
   ])('builds session config for $name permissions and uses the configured accessor', async ({
+    permissionMode,
     codexPermissions,
+    sandboxModeEnvOverride,
     expectedApps,
   }) => {
+    if (sandboxModeEnvOverride) {
+      process.env.AGOR_CODEX_SANDBOX_MODE = sandboxModeEnvOverride;
+    }
+
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -372,7 +431,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       branch_id: 'branch-1',
       created_at: new Date().toISOString(),
       sdk_session_id: null,
-      permission_config: { codex: codexPermissions },
+      permission_config: { mode: permissionMode, codex: codexPermissions },
       model_config: {},
       mcp_token: 'test-token',
     });
@@ -390,7 +449,12 @@ describe('CodexPromptService - prompt flow client initialization', () => {
     ];
 
     const emitted: Array<Record<string, unknown>> = [];
-    for await (const event of service.promptSessionStreaming('session-flow' as any, 'review')) {
+    for await (const event of service.promptSessionStreaming(
+      'session-flow' as any,
+      'review',
+      undefined,
+      permissionMode as PermissionMode
+    )) {
       emitted.push(event as Record<string, unknown>);
     }
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -320,7 +320,29 @@ describe('CodexPromptService - prompt flow client initialization', () => {
     vi.clearAllMocks();
   });
 
-  it('builds session config, initializes the Codex client, and uses the configured accessor', async () => {
+  it.each([
+    {
+      name: 'allow-all',
+      codexPermissions: {},
+      expectedApps: {
+        _default: {
+          default_tools_approval_mode: 'approve',
+        },
+      },
+    },
+    {
+      name: 'approval-requiring',
+      codexPermissions: {
+        sandboxMode: 'workspace-write',
+        approvalPolicy: 'on-request',
+        networkAccess: false,
+      },
+      expectedApps: undefined,
+    },
+  ])('builds session config for $name permissions and uses the configured accessor', async ({
+    codexPermissions,
+    expectedApps,
+  }) => {
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -350,7 +372,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       branch_id: 'branch-1',
       created_at: new Date().toISOString(),
       sdk_session_id: null,
-      permission_config: { codex: {} },
+      permission_config: { codex: codexPermissions },
       model_config: {},
       mcp_token: 'test-token',
     });
@@ -382,6 +404,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
             default_tools_approval_mode: 'approve',
           },
         },
+        ...(expectedApps ? { apps: expectedApps } : {}),
       },
     ]);
     expect(emitted.find((event) => event.type === 'complete')).toMatchObject({

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -90,6 +90,9 @@ type CodexConfigValue = CodexConfigObject[string];
  * clears the prompt.
  */
 const MCP_AUTO_APPROVE: CodexConfigObject = { default_tools_approval_mode: 'approve' };
+const CODEX_APPS_AUTO_APPROVE: CodexConfigObject = {
+  _default: { default_tools_approval_mode: 'approve' },
+};
 const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 
 const DEBUG_CODEX = process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex');
@@ -1048,6 +1051,12 @@ export class CodexPromptService {
     const codexConfigPayload: CodexConfigObject = {
       model_instructions_file: instructionsFile,
       ...(Object.keys(mcpServersConfig).length > 0 ? { mcp_servers: mcpServersConfig } : {}),
+      // Codex Apps (for example the GitHub connector supplied by a plugin)
+      // use the separate `apps` policy namespace rather than `mcp_servers`.
+      // In headless SDK sessions, an approval prompt cannot be answered and
+      // is otherwise reported as "user cancelled MCP tool call". Match the
+      // effective allow-all policy without broadening restrictive sessions.
+      ...(approvalPolicy === 'never' ? { apps: CODEX_APPS_AUTO_APPROVE } : {}),
     };
 
     // Recreate Codex instance only if the per-session config payload (or

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -34,7 +34,10 @@ import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { CodexSandboxMode, ContextUsageSnapshot, EffortLevel } from '@agor/core/types';
 import { isGatewaySession } from '@agor/core/types';
-import { getDefaultCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
+import {
+  getDefaultCodexPermissionConfig,
+  mapToCodexPermissionConfig,
+} from '@agor/core/utils/permission-mode-mapper';
 import { getDaemonUrl } from '../../config.js';
 import type {
   BranchRepository,
@@ -90,9 +93,6 @@ type CodexConfigValue = CodexConfigObject[string];
  * clears the prompt.
  */
 const MCP_AUTO_APPROVE: CodexConfigObject = { default_tools_approval_mode: 'approve' };
-const CODEX_APPS_AUTO_APPROVE: CodexConfigObject = {
-  _default: { default_tools_approval_mode: 'approve' },
-};
 const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 
 const DEBUG_CODEX = process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex');
@@ -1004,17 +1004,30 @@ export class CodexPromptService {
     // The daemon resolver (`resolvePermissionConfig`) always emits a full
     // codex sub-config for new sessions, so this fallback only fires for
     // legacy sessions in the DB with a partial / missing `permission_config`.
-    // It delegates to `getDefaultCodexPermissionConfig` so we have one source
-    // of truth for what "system default" means across daemon + executor.
+    // Derive partial-field fallbacks from the effective mode when available;
+    // only sessions without a recorded mode use the system default.
     const codexConfig = session.permission_config?.codex;
-    const defaults = getDefaultCodexPermissionConfig();
+    const effectivePermissionMode = permissionMode ?? session.permission_config?.mode;
+    const defaults = effectivePermissionMode
+      ? mapToCodexPermissionConfig(effectivePermissionMode)
+      : getDefaultCodexPermissionConfig();
     // workspace-write uses bwrap not available in pods; override with danger-full-access for k8s.
     const sandboxModeEnvOverride = process.env.AGOR_CODEX_SANDBOX_MODE as
       | CodexSandboxMode
       | undefined;
-    const sandboxMode = sandboxModeEnvOverride ?? codexConfig?.sandboxMode ?? defaults.sandboxMode;
+    const configuredSandboxMode = codexConfig?.sandboxMode ?? defaults.sandboxMode;
+    const sandboxMode = sandboxModeEnvOverride ?? configuredSandboxMode;
     const approvalPolicy = codexConfig?.approvalPolicy ?? defaults.approvalPolicy;
     const networkAccess = codexConfig?.networkAccess ?? defaults.networkAccess;
+    // Apps can mutate remote systems outside the filesystem sandbox. Only
+    // remove their approval gate for explicit allow-all intent when no
+    // per-field or environment override makes the effective policy stricter.
+    const shouldAutoApproveApps =
+      effectivePermissionMode === 'allow-all' &&
+      configuredSandboxMode !== 'read-only' &&
+      sandboxMode !== 'read-only' &&
+      approvalPolicy === 'never' &&
+      networkAccess === true;
 
     codexDebug(
       `   Using Codex permissions: sandboxMode=${sandboxMode}, approvalPolicy=${approvalPolicy}, networkAccess=${networkAccess}`
@@ -1056,7 +1069,9 @@ export class CodexPromptService {
       // In headless SDK sessions, an approval prompt cannot be answered and
       // is otherwise reported as "user cancelled MCP tool call". Match the
       // effective allow-all policy without broadening restrictive sessions.
-      ...(approvalPolicy === 'never' ? { apps: CODEX_APPS_AUTO_APPROVE } : {}),
+      ...(shouldAutoApproveApps
+        ? { apps: { _default: { default_tools_approval_mode: 'approve' } } }
+        : {}),
     };
 
     // Recreate Codex instance only if the per-session config payload (or

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -33,11 +33,8 @@ import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import type { CodexSandboxMode, ContextUsageSnapshot, EffortLevel } from '@agor/core/types';
-import { isGatewaySession } from '@agor/core/types';
-import {
-  getDefaultCodexPermissionConfig,
-  mapToCodexPermissionConfig,
-} from '@agor/core/utils/permission-mode-mapper';
+import { getDefaultPermissionMode, isGatewaySession } from '@agor/core/types';
+import { mapToCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
 import { getDaemonUrl } from '../../config.js';
 import type {
   BranchRepository,
@@ -1004,13 +1001,12 @@ export class CodexPromptService {
     // The daemon resolver (`resolvePermissionConfig`) always emits a full
     // codex sub-config for new sessions, so this fallback only fires for
     // legacy sessions in the DB with a partial / missing `permission_config`.
-    // Derive partial-field fallbacks from the effective mode when available;
-    // only sessions without a recorded mode use the system default.
+    // Derive partial-field fallbacks from the effective mode;
+    // mode-less legacy sessions use the same canonical system default.
     const codexConfig = session.permission_config?.codex;
-    const effectivePermissionMode = permissionMode ?? session.permission_config?.mode;
-    const defaults = effectivePermissionMode
-      ? mapToCodexPermissionConfig(effectivePermissionMode)
-      : getDefaultCodexPermissionConfig();
+    const effectivePermissionMode =
+      permissionMode ?? session.permission_config?.mode ?? getDefaultPermissionMode('codex');
+    const defaults = mapToCodexPermissionConfig(effectivePermissionMode);
     // workspace-write uses bwrap not available in pods; override with danger-full-access for k8s.
     const sandboxModeEnvOverride = process.env.AGOR_CODEX_SANDBOX_MODE as
       | CodexSandboxMode


### PR DESCRIPTION
## Linked issue

Fixes #1974

## Summary

- Auto-approve Codex App tools only for effective `allow-all` sessions.
- Preserve restrictive sandbox, approval, and network overrides.
- Cover prompt/persisted mode precedence and legacy mode-less sessions.

## Why / context

Codex Apps use a separate approval namespace from configured MCP servers. In a headless SDK session, an unanswered App write approval was surfaced as `user cancelled MCP tool call`, even when the Agor session was configured as `allow-all`.

## Implementation notes

- Set `apps._default.default_tools_approval_mode = "approve"` for effective `allow-all` sessions.
- Require a non-read-only configured and effective sandbox, `approvalPolicy = "never"`, and network access.
- Resolve the effective mode from the prompt, persisted session configuration, then the canonical Codex default for legacy sessions.
- Leave existing `mcp_servers` construction unchanged.

## Validation / test plan

- [x] Focused prompt-service suite: 50/50 tests passed.
- [x] Executor TypeScript check (`tsc --noEmit`).
- [x] Biome checks and pre-commit hook.
- [x] Independent code review after both review findings were addressed: no findings.
- [x] Live A/B check: omitting the Apps policy reproduced the false cancellation; supplying it passed the approval layer and reached GitHub.
- [ ] Successful provider mutation was not exercised because the test repository rejected the connector credentials with HTTP 403; no provider state changed.

## Risks / rollout / rollback

Remote tool calls are auto-approved only when the effective session policy is explicitly permissive and all supporting fields remain permissive. Restrictive and read-only combinations omit the Apps policy. Rollback is limited to removing the conditional Apps configuration.

## Out of scope / follow-ups

Repository access granted to connector credentials is separate from the headless approval behavior fixed here.
