### PR TITLE
Add unified validation for API token and credential inputs

### DIFF
--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -231,15 +231,43 @@ function resultFromKeyStatus(status: AuthCheckStatus, rejectedHint: string): Aut
 export function createCheckAuthService(db: TenantScopeAwareDatabase) {
   return {
     async create(
-      data: { tool: string; apiKey?: string },
+      data: { tool: string; apiKey?: string; field?: string },
       params?: AuthenticatedParams
     ): Promise<AuthCheckResult> {
-      const { tool, apiKey: rawKey } = data;
+      // `field` scopes a stored-credential verify to the exact env-var the UI's
+      // Verify button sits under (e.g. CLAUDE_CODE_OAUTH_TOKEN vs ANTHROPIC_API_KEY
+      // when both are stored). Ignored when `apiKey` is provided.
+      const { tool, apiKey: rawKey, field } = data;
       const userId = params?.user?.user_id as UserID | undefined;
       const tenantId = getCurrentTenantId();
       if (!tenantId) throw new Error('Missing active tenant context for agent authentication');
       const withTenantDatabase = <T>(work: (tenantDb: TenantScopedDatabase) => Promise<T>) =>
         runWithTenantDatabaseScope(db, tenantId, work);
+
+      // Resolve + validate the stored Claude subscription token specifically.
+      const verifyStoredSubscription = async (): Promise<AuthCheckResult> => {
+        const resolution = await withTenantDatabase((tenantDb) =>
+          resolveApiKey('CLAUDE_CODE_OAUTH_TOKEN', { userId, db: tenantDb, tool: 'claude-code' })
+        );
+        if (resolution.decryptionFailed) {
+          return unauthenticated(
+            'none',
+            'Stored Claude subscription token could not be decrypted (master-secret mismatch). Re-enter it in Settings → Agent Setup.'
+          );
+        }
+        if (!resolution.apiKey) {
+          return unauthenticated('none', 'No usable Claude subscription token is stored.');
+        }
+        const status = await validateClaudeSubscriptionToken(resolution.apiKey);
+        if (status === 'authenticated') return authed('oauth');
+        if (status === 'unauthenticated') {
+          return unauthenticated(
+            'none',
+            'Stored Claude subscription token was rejected — update it in Settings → Agent Setup.'
+          );
+        }
+        return unknown('Could not verify the Claude subscription token — try again.');
+      };
 
       if (
         !(await withTenantDatabase((tenantDb) =>
@@ -283,11 +311,20 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
         );
       }
 
-      // Otherwise resolve from the tenant's explicit user/workspace policy.
+      // The Verify button under the Claude subscription field asks specifically
+      // about the stored OAuth token, not the API key that resolveApiKey would
+      // otherwise pick first.
+      if (field === 'CLAUDE_CODE_OAUTH_TOKEN') {
+        return verifyStoredSubscription();
+      }
+
+      // Otherwise resolve from the tenant's explicit user/workspace policy, using
+      // the requested field when one was given (else the tool's primary key).
       const toolName = tool as AgenticToolName;
+      const resolveKeyName = (field as typeof keyName | undefined) ?? keyName;
       const { apiKey, decryptionFailed, connection, useNativeAuth } = await withTenantDatabase(
         (tenantDb) =>
-          resolveApiKey(keyName, {
+          resolveApiKey(resolveKeyName, {
             userId,
             db: tenantDb,
             tool: toolName,
@@ -314,37 +351,21 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
         );
       }
 
-      if (tool === 'claude-code') {
-        const subscriptionResolution = await withTenantDatabase((tenantDb) =>
-          resolveApiKey('CLAUDE_CODE_OAUTH_TOKEN', {
-            userId,
-            db: tenantDb,
-            tool: 'claude-code',
-          })
-        );
-
-        if (subscriptionResolution.decryptionFailed) {
-          return unauthenticated(
-            'none',
-            'Stored Claude subscription token could not be decrypted (master-secret mismatch). Re-enter it in Settings → Agent Setup.'
-          );
-        }
-
-        const subscriptionToken = subscriptionResolution.apiKey;
-        if (subscriptionToken) {
-          const status = await validateClaudeSubscriptionToken(subscriptionToken);
-          if (status === 'authenticated') return authed('oauth');
-          if (status === 'unauthenticated') {
-            return unauthenticated(
-              'none',
-              'Stored Claude subscription token was rejected — update it in Settings → Agent Setup.'
-            );
-          }
-          return unknown('Could not verify the Claude subscription token — try again.');
+      // No explicit field: fall back to the Claude subscription token so the
+      // banner probe reports "connected" when only a subscription is stored.
+      if (!field && tool === 'claude-code') {
+        const subscription = await verifyStoredSubscription();
+        // Absence of a stored subscription here isn't a rejection of the api key
+        // path — fall through to the generic "nothing usable" message below.
+        if (subscription.hint !== 'No usable Claude subscription token is stored.') {
+          return subscription;
         }
       }
 
-      return unauthenticated('none', `No usable ${keyName} is available under workspace policy.`);
+      return unauthenticated(
+        'none',
+        `No usable ${resolveKeyName} is available under workspace policy.`
+      );
     },
   };
 }

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -245,28 +245,42 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
         runWithTenantDatabaseScope(db, tenantId, work);
 
       // Resolve + validate the stored Claude subscription token specifically.
-      const verifyStoredSubscription = async (): Promise<AuthCheckResult> => {
+      // `present: false` means no token is stored (distinct from a probe result)
+      // so callers branch on structure, not on user-facing copy.
+      type StoredSubscriptionOutcome =
+        | { present: false }
+        | { present: true; result: AuthCheckResult };
+      const verifyStoredSubscription = async (): Promise<StoredSubscriptionOutcome> => {
         const resolution = await withTenantDatabase((tenantDb) =>
           resolveApiKey('CLAUDE_CODE_OAUTH_TOKEN', { userId, db: tenantDb, tool: 'claude-code' })
         );
         if (resolution.decryptionFailed) {
-          return unauthenticated(
-            'none',
-            'Stored Claude subscription token could not be decrypted (master-secret mismatch). Re-enter it in Settings → Agent Setup.'
-          );
+          return {
+            present: true,
+            result: unauthenticated(
+              'none',
+              'Stored Claude subscription token could not be decrypted (master-secret mismatch). Re-enter it in Settings → Agent Setup.'
+            ),
+          };
         }
         if (!resolution.apiKey) {
-          return unauthenticated('none', 'No usable Claude subscription token is stored.');
+          return { present: false };
         }
         const status = await validateClaudeSubscriptionToken(resolution.apiKey);
-        if (status === 'authenticated') return authed('oauth');
+        if (status === 'authenticated') return { present: true, result: authed('oauth') };
         if (status === 'unauthenticated') {
-          return unauthenticated(
-            'none',
-            'Stored Claude subscription token was rejected — update it in Settings → Agent Setup.'
-          );
+          return {
+            present: true,
+            result: unauthenticated(
+              'none',
+              'Stored Claude subscription token was rejected — update it in Settings → Agent Setup.'
+            ),
+          };
         }
-        return unknown('Could not verify the Claude subscription token — try again.');
+        return {
+          present: true,
+          result: unknown('Could not verify the Claude subscription token — try again.'),
+        };
       };
 
       if (
@@ -315,7 +329,10 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
       // about the stored OAuth token, not the API key that resolveApiKey would
       // otherwise pick first.
       if (field === 'CLAUDE_CODE_OAUTH_TOKEN') {
-        return verifyStoredSubscription();
+        const subscription = await verifyStoredSubscription();
+        return subscription.present
+          ? subscription.result
+          : unauthenticated('none', 'No usable Claude subscription token is stored.');
       }
 
       // Otherwise resolve from the tenant's explicit user/workspace policy, using
@@ -353,13 +370,10 @@ export function createCheckAuthService(db: TenantScopeAwareDatabase) {
 
       // No explicit field: fall back to the Claude subscription token so the
       // banner probe reports "connected" when only a subscription is stored.
+      // Absence of a stored subscription falls through to the generic message.
       if (!field && tool === 'claude-code') {
         const subscription = await verifyStoredSubscription();
-        // Absence of a stored subscription here isn't a rejection of the api key
-        // path — fall through to the generic "nothing usable" message below.
-        if (subscription.hint !== 'No usable Claude subscription token is stored.') {
-          return subscription;
-        }
+        if (subscription.present) return subscription.result;
       }
 
       return unauthenticated(

--- a/apps/agor-daemon/src/services/users.agentic-backstop.test.ts
+++ b/apps/agor-daemon/src/services/users.agentic-backstop.test.ts
@@ -1,0 +1,33 @@
+/**
+ * At-rest backstop for agentic_tools credentials (the path from the original bug
+ * report). The daemon must strip only edge whitespace + invisible characters and
+ * NEVER auto-fix internal whitespace or wrapping quotes — a value the user chose
+ * to keep (declined the opt-in "Clean it up") is stored byte-for-byte.
+ */
+
+import { decryptApiKey } from '@agor/core/db';
+import { describe, expect, it } from 'vitest';
+import { applyAgenticToolsPatch } from './users';
+
+function storedValue(input: string): string {
+  const next = applyAgenticToolsPatch({}, { 'claude-code': { ANTHROPIC_API_KEY: input } });
+  const bucket = next['claude-code'] as Record<string, string>;
+  return decryptApiKey(bucket.ANTHROPIC_API_KEY);
+}
+
+describe('applyAgenticToolsPatch — at-rest backstop', () => {
+  it('strips edge whitespace and invisible characters', () => {
+    const bom = '﻿';
+    expect(storedValue(`  ${bom}sk-ant-api03-clean0123456789  `)).toBe(
+      'sk-ant-api03-clean0123456789'
+    );
+  });
+
+  it('does NOT collapse internal whitespace at rest (declined fix stored as-is)', () => {
+    expect(storedValue('sk-ant-api03-abc def0123456789')).toBe('sk-ant-api03-abc def0123456789');
+  });
+
+  it('does NOT unwrap wrapping quotes at rest', () => {
+    expect(storedValue('"sk-ant-api03-token0123456789"')).toBe('"sk-ant-api03-token0123456789"');
+  });
+});

--- a/apps/agor-daemon/src/services/users.git-env.test.ts
+++ b/apps/agor-daemon/src/services/users.git-env.test.ts
@@ -119,6 +119,39 @@ describe('UsersService.getGitEnvironment — permission checks', () => {
     expect(env.GITHUB_TOKEN).toBe(`ghp_${'x'.repeat(36)}`);
   });
 
+  dbTest(
+    'at-rest normalization leaves a curly-quoted NON-credential env var untouched',
+    async ({ db }) => {
+      const service = new UsersService(db);
+      const userId = await makeUser(service);
+
+      // An unknown env var name is not a credential — the backstop must only
+      // edge-trim + strip zero-width, never convert quotes or collapse internal
+      // whitespace. A curly-quoted value with an internal space must survive.
+      const arbitrary = '“hello world”';
+      await service.patch(userId, { env_vars: { MY_APP_CONFIG: arbitrary } });
+
+      const env = await service.getGitEnvironment({ userId }, {});
+      expect(env.MY_APP_CONFIG).toBe(arbitrary);
+    }
+  );
+
+  dbTest(
+    'at-rest normalization repairs a wrapping-quoted KNOWN credential env var',
+    async ({ db }) => {
+      const service = new UsersService(db);
+      const userId = await makeUser(service);
+
+      // GH_TOKEN is a known credential: a value wrapped in quotes gets the quote
+      // pair stripped at rest (isLikelyGitToken would otherwise reject it).
+      const token = `ghp_${'x'.repeat(36)}`;
+      await service.patch(userId, { env_vars: { GH_TOKEN: `"${token}"` } });
+
+      const env = await service.getGitEnvironment({ userId }, {});
+      expect(env.GH_TOKEN).toBe(token);
+    }
+  );
+
   dbTest('returns empty object for nonexistent user', async ({ db }) => {
     const service = new UsersService(db);
     const fakeId = '019e0000-0000-7000-8000-000000000000';

--- a/apps/agor-daemon/src/services/users.git-env.test.ts
+++ b/apps/agor-daemon/src/services/users.git-env.test.ts
@@ -120,14 +120,13 @@ describe('UsersService.getGitEnvironment — permission checks', () => {
   });
 
   dbTest(
-    'at-rest normalization leaves a curly-quoted NON-credential env var untouched',
+    'at-rest backstop leaves a curly-quoted NON-credential env var untouched',
     async ({ db }) => {
       const service = new UsersService(db);
       const userId = await makeUser(service);
 
-      // An unknown env var name is not a credential — the backstop must only
-      // edge-trim + strip zero-width, never convert quotes or collapse internal
-      // whitespace. A curly-quoted value with an internal space must survive.
+      // An unknown env var name is not a credential — the backstop only edge-trims
+      // + strips zero-width, never unwraps quotes or collapses internal whitespace.
       const arbitrary = '“hello world”';
       await service.patch(userId, { env_vars: { MY_APP_CONFIG: arbitrary } });
 
@@ -137,18 +136,21 @@ describe('UsersService.getGitEnvironment — permission checks', () => {
   );
 
   dbTest(
-    'at-rest normalization repairs a wrapping-quoted KNOWN credential env var',
+    'at-rest backstop stores a KNOWN credential with internal whitespace byte-for-byte (declined fix)',
     async ({ db }) => {
       const service = new UsersService(db);
       const userId = await makeUser(service);
 
-      // GH_TOKEN is a known credential: a value wrapped in quotes gets the quote
-      // pair stripped at rest (isLikelyGitToken would otherwise reject it).
-      const token = `ghp_${'x'.repeat(36)}`;
-      await service.patch(userId, { env_vars: { GH_TOKEN: `"${token}"` } });
+      // OPENAI_API_KEY is a known credential, but the daemon must NOT collapse the
+      // internal space — if the user declined the opt-in "Clean it up" action, we
+      // store exactly what they saved (aside from always-safe edge cleanup).
+      const withInternalSpace = 'sk-proj-abc def0123456789';
+      await service.patch(userId, {
+        env_vars: { OPENAI_API_KEY: `  ${withInternalSpace}  ` },
+      });
 
       const env = await service.getGitEnvironment({ userId }, {});
-      expect(env.GH_TOKEN).toBe(token);
+      expect(env.OPENAI_API_KEY).toBe(withInternalSpace);
     }
   );
 

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -170,7 +170,7 @@ function ensureCanExactEmailLookup(params: Params | undefined, email: string): v
  *
  * Returns the next stored shape (caller writes it back to `data.agentic_tools`).
  */
-function applyAgenticToolsPatch(
+export function applyAgenticToolsPatch(
   current: StoredAgenticTools,
   patch: AgenticToolsUpdate
 ): StoredAgenticTools {

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -17,6 +17,7 @@ import {
   type StoredEnvVar,
   validateEnvVar,
 } from '@agor/core/config';
+import { normalizeCredential } from '@agor/core/credentials';
 import {
   and,
   compare,
@@ -184,7 +185,10 @@ function applyAgenticToolsPatch(
         delete bucket[field];
       } else {
         try {
-          bucket[field] = encryptApiKey(value);
+          // At-rest normalization backstop: repair terminal-paste artifacts
+          // (edge/zero-width/quote/internal whitespace) regardless of client.
+          const normalized = normalizeCredential(field, value).value;
+          bucket[field] = encryptApiKey(normalized);
           console.log(`🔐 Encrypted user agentic_tools.${tool}.${field}`);
         } catch (err) {
           console.error(`Failed to encrypt agentic_tools.${tool}.${field}:`, err);
@@ -517,12 +521,19 @@ export class UsersService {
       const nextEnvVars: Record<string, StoredEnvVar> = { ...normalizedExisting };
 
       if (data.env_vars) {
-        for (const [key, value] of Object.entries(data.env_vars)) {
+        for (const [key, rawValue] of Object.entries(data.env_vars)) {
           // Validate variable name
           if (!isEnvVarAllowed(key)) {
             const reason = getEnvVarBlockReason(key);
             throw new Error(`Cannot set environment variable "${key}": ${reason}`);
           }
+
+          // Normalize credential-shaped values at rest (terminal-paste repair)
+          // before any format check, so a stray space is fixed, not rejected.
+          const value =
+            rawValue === null || rawValue === undefined
+              ? rawValue
+              : normalizeCredential(key, rawValue).value;
 
           // Git tokens are embedded into a git-credentials file and a clone URL
           // at runtime. Reject at ingest anything that doesn't match the

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -17,7 +17,7 @@ import {
   type StoredEnvVar,
   validateEnvVar,
 } from '@agor/core/config';
-import { normalizeCredential } from '@agor/core/credentials';
+import { sanitizeCredential } from '@agor/core/credentials';
 import {
   and,
   compare,
@@ -185,10 +185,11 @@ function applyAgenticToolsPatch(
         delete bucket[field];
       } else {
         try {
-          // At-rest normalization backstop: repair terminal-paste artifacts
-          // (edge/zero-width/quote/internal whitespace) regardless of client.
-          const normalized = normalizeCredential(field, value).value;
-          bucket[field] = encryptApiKey(normalized);
+          // At-rest safety net: strip only edge whitespace + invisible chars.
+          // The daemon must NOT rewrite internal whitespace or unwrap quotes —
+          // that content is the user's choice (opt-in cleanup lives in the UI).
+          const sanitized = sanitizeCredential(value);
+          bucket[field] = encryptApiKey(sanitized);
           console.log(`🔐 Encrypted user agentic_tools.${tool}.${field}`);
         } catch (err) {
           console.error(`Failed to encrypt agentic_tools.${tool}.${field}:`, err);
@@ -528,12 +529,12 @@ export class UsersService {
             throw new Error(`Cannot set environment variable "${key}": ${reason}`);
           }
 
-          // Normalize credential-shaped values at rest (terminal-paste repair)
-          // before any format check, so a stray space is fixed, not rejected.
+          // At-rest safety net: strip only edge whitespace + invisible chars.
+          // We do NOT collapse internal whitespace or unwrap quotes here — a
+          // value the user chose to keep is stored as-is (the UI offers opt-in
+          // cleanup). A genuinely malformed git token is still rejected below.
           const value =
-            rawValue === null || rawValue === undefined
-              ? rawValue
-              : normalizeCredential(key, rawValue).value;
+            rawValue === null || rawValue === undefined ? rawValue : sanitizeCredential(rawValue);
 
           // Git tokens are embedded into a git-credentials file and a clone URL
           // at runtime. Reject at ingest anything that doesn't match the

--- a/apps/agor-ui/src/components/ApiKeyFields.test.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.test.tsx
@@ -23,22 +23,28 @@ function renderFields(overrides?: Partial<Parameters<typeof ApiKeyFields>[0]>) {
 const DIRTY = 'sk-ant-api03-abc DEF0123456789';
 const CLEAN = 'sk-ant-api03-abcDEF0123456789';
 
-describe('ApiKeyFields — save-path normalization', () => {
-  it('normalizes a mid-token space before saving when pressing Enter', async () => {
+describe('ApiKeyFields — save honors the displayed value (no silent auto-fix)', () => {
+  it('saves the value WITH the internal space when the user did not opt into the fix', async () => {
     const { onSave } = renderFields();
     const input = screen.getByPlaceholderText('sk-ant-api03-...');
 
     fireEvent.change(input, { target: { value: DIRTY } });
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
 
-    await waitFor(() => expect(onSave).toHaveBeenCalledWith('ANTHROPIC_API_KEY', CLEAN));
+    // Not silently cleaned — saved as displayed (only always-safe edge cleanup).
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('ANTHROPIC_API_KEY', DIRTY));
   });
 
-  it('normalizes before saving when clicking Save', async () => {
+  it('offers "Clean it up" on blur, and after clicking it, Save persists the cleaned value', async () => {
     const { onSave } = renderFields();
     const input = screen.getByPlaceholderText('sk-ant-api03-...');
 
     fireEvent.change(input, { target: { value: DIRTY } });
+    fireEvent.blur(input);
+
+    const cleanBtn = await screen.findByRole('button', { name: /clean it up/i });
+    fireEvent.click(cleanBtn);
+
     const saveButton = screen.getAllByRole('button', { name: /^save$/i })[0];
     fireEvent.click(saveButton);
 

--- a/apps/agor-ui/src/components/ApiKeyFields.test.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiKeyFields } from './ApiKeyFields';
+
+function renderFields(overrides?: Partial<Parameters<typeof ApiKeyFields>[0]>) {
+  const onSave = vi.fn(async () => {});
+  const onClear = vi.fn(async () => {});
+  render(
+    <AntApp>
+      <ApiKeyFields
+        tool="claude-code"
+        fieldStatus={{}}
+        onSave={onSave}
+        onClear={onClear}
+        {...overrides}
+      />
+    </AntApp>
+  );
+  return { onSave, onClear };
+}
+
+const DIRTY = 'sk-ant-api03-abc DEF0123456789';
+const CLEAN = 'sk-ant-api03-abcDEF0123456789';
+
+describe('ApiKeyFields — save-path normalization', () => {
+  it('normalizes a mid-token space before saving when pressing Enter', async () => {
+    const { onSave } = renderFields();
+    const input = screen.getByPlaceholderText('sk-ant-api03-...');
+
+    fireEvent.change(input, { target: { value: DIRTY } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('ANTHROPIC_API_KEY', CLEAN));
+  });
+
+  it('normalizes before saving when clicking Save', async () => {
+    const { onSave } = renderFields();
+    const input = screen.getByPlaceholderText('sk-ant-api03-...');
+
+    fireEvent.change(input, { target: { value: DIRTY } });
+    const saveButton = screen.getAllByRole('button', { name: /^save$/i })[0];
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith('ANTHROPIC_API_KEY', CLEAN));
+  });
+});

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -1,14 +1,70 @@
-import type { AgenticToolConfigField, AgenticToolName } from '@agor-live/client';
+import type {
+  AgenticToolConfigField,
+  AgenticToolName,
+  AuthCheckResult,
+  CredentialSpecKey,
+} from '@agor-live/client';
+import { normalizeCredential, resolveCredentialSpec } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
   DeleteOutlined,
   InfoCircleOutlined,
+  SafetyCertificateOutlined,
 } from '@ant-design/icons';
 import { Button, Input, Space, Tooltip, Typography, theme } from 'antd';
 import { useState } from 'react';
 import { ClaudeSubscriptionTokenInstructions } from './ClaudeSubscriptionTokenInstructions';
+import { CredentialFieldFeedback } from './credentials/CredentialFieldFeedback';
+import { useCredentialFields } from './credentials/useCredentialField';
 import { Tag } from './Tag';
+
+/** Spec kinds that have a live `check-auth` probe worth surfacing a Verify affordance for. */
+const VERIFIABLE_SPEC_KEYS = new Set<CredentialSpecKey>([
+  'anthropic-api-key',
+  'anthropic-oauth-token',
+  'openai-api-key',
+  'gemini-api-key',
+  'github-token',
+  'cursor-api-key',
+]);
+
+const isVerifiableField = (field: AgenticToolConfigField): boolean => {
+  const spec = resolveCredentialSpec(field);
+  return !!spec && VERIFIABLE_SPEC_KEYS.has(spec.key);
+};
+
+/** Live-verify (Layer 3) result line. `unknown` is a fail-safe, not a rejection. */
+const VerifyResultText: React.FC<{
+  verify?: { verifying: boolean; result?: AuthCheckResult };
+  providerName?: string;
+}> = ({ verify, providerName }) => {
+  const { token } = theme.useToken();
+  const result = verify?.result;
+  if (!result || verify?.verifying) return null;
+  const provider = providerName || 'the provider';
+
+  if (result.status === 'authenticated') {
+    return (
+      <Text type="success" style={{ fontSize: token.fontSizeSM }}>
+        Verified with {provider}
+      </Text>
+    );
+  }
+  if (result.status === 'unauthenticated') {
+    return (
+      <Text type="danger" style={{ fontSize: token.fontSizeSM }}>
+        {result.hint ??
+          `${provider} rejected this key. It may have been revoked or copied incompletely — regenerate and paste again.`}
+      </Text>
+    );
+  }
+  return (
+    <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+      {result.hint ?? `Couldn't verify with ${provider} right now — try again in a moment.`}
+    </Text>
+  );
+};
 
 const { Text, Link } = Typography;
 
@@ -174,6 +230,13 @@ export interface ApiKeyFieldsProps {
   onSave: (field: AgenticToolConfigField, value: string) => Promise<void>;
   /** Clear the stored value for one field. */
   onClear: (field: AgenticToolConfigField) => Promise<void>;
+  /**
+   * Live-verify a credential via the daemon `check-auth` probe (Layer 3). Called
+   * with the freshly-saved value right after save, and with no value when the
+   * user clicks Verify on an already-stored key (the daemon resolves it). Omit to
+   * hide the Verify affordance entirely.
+   */
+  onVerify?: (field: AgenticToolConfigField, value?: string) => Promise<AuthCheckResult>;
   /** Per-field saving spinner state. */
   saving?: Partial<Record<AgenticToolConfigField, boolean>>;
   /** Disable all inputs (e.g. while RBAC is loading). */
@@ -196,11 +259,17 @@ export interface ApiKeyFieldsProps {
   publicValues?: Partial<Record<AgenticToolConfigField, string>>;
 }
 
+interface VerifyState {
+  verifying: boolean;
+  result?: AuthCheckResult;
+}
+
 export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
   tool,
   fieldStatus,
   onSave,
   onClear,
+  onVerify,
   saving = {},
   disabled = false,
   fields,
@@ -210,15 +279,40 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
   const [inputValues, setInputValues] = useState<Partial<Record<AgenticToolConfigField, string>>>(
     {}
   );
+  const [verifyByField, setVerifyByField] = useState<
+    Partial<Record<AgenticToolConfigField, VerifyState>>
+  >({});
+  const credentials = useCredentialFields();
 
   const configs = fields ?? TOOL_FIELD_CONFIGS[tool] ?? [];
 
+  const runVerify = async (field: AgenticToolConfigField, value?: string) => {
+    if (!onVerify) return;
+    setVerifyByField((prev) => ({ ...prev, [field]: { verifying: true } }));
+    try {
+      const result = await onVerify(field, value);
+      setVerifyByField((prev) => ({ ...prev, [field]: { verifying: false, result } }));
+    } catch {
+      setVerifyByField((prev) => ({ ...prev, [field]: { verifying: false } }));
+    }
+  };
+
+  // Normalize a raw value (paste/blur) and reflect the repair + lint.
+  const normalizeInput = (field: AgenticToolConfigField, raw: string) => {
+    if (!raw) return;
+    const normalized = credentials.normalizeOnInput(field, raw);
+    setInputValues((prev) => ({ ...prev, [field]: normalized }));
+    credentials.lintOnBlur(field, normalized);
+  };
+
   const handleSave = async (field: AgenticToolConfigField) => {
-    const value = inputValues[field]?.trim();
+    const value = normalizeCredential(field, inputValues[field] ?? '').value;
     if (!value) return;
 
     await onSave(field, value);
     setInputValues((prev) => ({ ...prev, [field]: '' }));
+    credentials.reset(field);
+    if (isVerifiableField(field)) void runVerify(field, value);
   };
 
   const renderField = (config: AgenticToolFieldConfig) => {
@@ -229,6 +323,10 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
     // value echoed back to the owner so they can verify the exact value
     // without clearing and retyping. Secret fields never show plaintext.
     const visibleSavedValue = type === 'text' && isSet ? publicValues?.[field] : undefined;
+    const feedback = credentials.get(field);
+    const verify = verifyByField[field];
+    const canVerify = !!onVerify && isVerifiableField(field);
+    const providerName = resolveCredentialSpec(field)?.provider;
 
     return (
       <div key={field} style={{ marginBottom: token.marginLG }}>
@@ -263,41 +361,75 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
           </Space>
 
           {isSet ? (
-            <Space wrap size="small" style={{ width: '100%' }}>
-              {visibleSavedValue && (
-                <Text code copyable style={{ fontSize: token.fontSizeSM, wordBreak: 'break-all' }}>
-                  {visibleSavedValue}
-                </Text>
-              )}
-              <Button
-                danger
-                icon={<DeleteOutlined />}
-                onClick={() => onClear(field)}
-                loading={saving[field]}
-                disabled={disabled}
-              >
-                Clear
-              </Button>
+            <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+              <Space wrap size="small" style={{ width: '100%' }}>
+                {visibleSavedValue && (
+                  <Text
+                    code
+                    copyable
+                    style={{ fontSize: token.fontSizeSM, wordBreak: 'break-all' }}
+                  >
+                    {visibleSavedValue}
+                  </Text>
+                )}
+                {canVerify && (
+                  <Button
+                    icon={<SafetyCertificateOutlined />}
+                    onClick={() => runVerify(field)}
+                    loading={verify?.verifying}
+                    disabled={disabled}
+                  >
+                    Verify
+                  </Button>
+                )}
+                <Button
+                  danger
+                  icon={<DeleteOutlined />}
+                  onClick={() => onClear(field)}
+                  loading={saving[field]}
+                  disabled={disabled}
+                >
+                  Clear
+                </Button>
+              </Space>
+              <VerifyResultText verify={verify} providerName={providerName} />
             </Space>
           ) : (
-            <Space.Compact style={{ width: '100%' }}>
-              <InputComponent
-                placeholder={placeholder}
-                value={inputValues[field] || ''}
-                onChange={(e) => setInputValues((prev) => ({ ...prev, [field]: e.target.value }))}
-                onPressEnter={() => handleSave(field)}
-                style={{ flex: 1 }}
-                disabled={disabled}
+            <>
+              <Space.Compact style={{ width: '100%' }}>
+                <InputComponent
+                  placeholder={placeholder}
+                  value={inputValues[field] || ''}
+                  onChange={(e) => {
+                    setInputValues((prev) => ({ ...prev, [field]: e.target.value }));
+                    credentials.reset(field);
+                  }}
+                  onPaste={(e) => {
+                    // The input's value updates after the paste event; read it
+                    // from the DOM on the next tick (state is still stale here).
+                    const el = e.currentTarget;
+                    window.setTimeout(() => normalizeInput(field, el.value), 0);
+                  }}
+                  onBlur={() => normalizeInput(field, inputValues[field] ?? '')}
+                  onPressEnter={() => handleSave(field)}
+                  style={{ flex: 1 }}
+                  disabled={disabled}
+                />
+                <Button
+                  type="primary"
+                  onClick={() => handleSave(field)}
+                  loading={saving[field]}
+                  disabled={disabled || !inputValues[field]?.trim()}
+                >
+                  Save
+                </Button>
+              </Space.Compact>
+              <CredentialFieldFeedback
+                lint={feedback.lint}
+                internalFixVisible={feedback.showInternalFix}
+                onDismissInternalFix={() => credentials.dismissInternalFix(field)}
               />
-              <Button
-                type="primary"
-                onClick={() => handleSave(field)}
-                loading={saving[field]}
-                disabled={disabled || !inputValues[field]?.trim()}
-              >
-                Save
-              </Button>
-            </Space.Compact>
+            </>
           )}
 
           {docUrl && (

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -4,7 +4,7 @@ import type {
   AuthCheckResult,
   CredentialSpecKey,
 } from '@agor-live/client';
-import { normalizeCredential, resolveCredentialSpec } from '@agor-live/client';
+import { resolveCredentialSpec, sanitizeCredential } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
@@ -300,16 +300,23 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
     }
   };
 
-  // Normalize a raw value (paste/blur) and reflect the repair + lint.
-  const normalizeInput = (field: AgenticToolConfigField, raw: string) => {
+  // Paste/blur: apply the always-safe sanitize and surface the opt-in fix + lint.
+  const inspectInput = (field: AgenticToolConfigField, raw: string) => {
     if (!raw) return;
-    const normalized = credentials.normalizeOnInput(field, raw);
-    setInputValues((prev) => ({ ...prev, [field]: normalized }));
-    credentials.lintOnBlur(field, normalized);
+    const sanitized = credentials.inspect(field, raw);
+    setInputValues((prev) => ({ ...prev, [field]: sanitized }));
+  };
+
+  // "Clean it up" — the only place the opt-in fix is applied, on explicit click.
+  const cleanUp = (field: AgenticToolConfigField) => {
+    const fixed = credentials.applyFix(field, inputValues[field] ?? '');
+    setInputValues((prev) => ({ ...prev, [field]: fixed }));
   };
 
   const handleSave = async (field: AgenticToolConfigField) => {
-    const value = normalizeCredential(field, inputValues[field] ?? '').value;
+    // Save exactly what's displayed (minus always-safe edge/invisible cleanup) —
+    // if the user declined the opt-in fix, we honor their value verbatim.
+    const value = sanitizeCredential(inputValues[field] ?? '');
     if (!value) return;
 
     await onSave(field, value);
@@ -411,9 +418,9 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
                     // The input's value updates after the paste event; read it
                     // from the DOM on the next tick (state is still stale here).
                     const el = e.currentTarget;
-                    window.setTimeout(() => normalizeInput(field, el.value), 0);
+                    window.setTimeout(() => inspectInput(field, el.value), 0);
                   }}
-                  onBlur={() => normalizeInput(field, inputValues[field] ?? '')}
+                  onBlur={() => inspectInput(field, inputValues[field] ?? '')}
                   onPressEnter={() => handleSave(field)}
                   style={{ flex: 1 }}
                   disabled={disabled}
@@ -429,8 +436,8 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
               </Space.Compact>
               <CredentialFieldFeedback
                 lint={feedback.lint}
-                internalFixVisible={feedback.showInternalFix}
-                onDismissInternalFix={() => credentials.dismissInternalFix(field)}
+                fix={feedback.fix}
+                onApplyFix={() => cleanUp(field)}
               />
             </>
           )}

--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -52,13 +52,16 @@ const VerifyResultText: React.FC<{
     );
   }
   if (result.status === 'unauthenticated') {
+    // On a definitive rejection the user must see the provider named, so prefer
+    // our provider-attributed copy over the daemon's generic rejection hint.
     return (
       <Text type="danger" style={{ fontSize: token.fontSizeSM }}>
-        {result.hint ??
-          `${provider} rejected this key. It may have been revoked or copied incompletely — regenerate and paste again.`}
+        {`${provider} rejected this key. It may have been revoked or copied incompletely — regenerate and paste again.`}
       </Text>
     );
   }
+  // 'unknown' is a failure to VERIFY (transport/timeout), not a rejection — keep
+  // the daemon's specific hint here.
   return (
     <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
       {result.hint ?? `Couldn't verify with ${provider} right now — try again in a moment.`}

--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -2,7 +2,7 @@ import {
   ENV_VAR_SCOPES_V05,
   type EnvVarMetadata,
   type EnvVarScope,
-  normalizeCredential,
+  sanitizeCredential,
 } from '@agor-live/client';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { Alert, Button, Input, Select, Space, Table, Tooltip, Typography } from 'antd';
@@ -81,19 +81,21 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   const [error, setError] = useState<string | null>(null);
   const credentials = useCredentialFields();
 
-  // Normalize the value against the variable NAME — only known credential names
-  // (e.g. GITHUB_TOKEN) trigger internal-whitespace repair / lint; others are
-  // edge-trimmed only. `credentials` state is keyed by the variable name.
-  const normalizeFor = (name: string, raw: string, setter: (v: string) => void) => {
+  // Paste/blur: apply the always-safe sanitize and surface the opt-in fix + lint
+  // (keyed by the variable NAME — only known credential names get a suggestion).
+  const inspectFor = (name: string, raw: string, setter: (v: string) => void) => {
     if (!raw) return;
-    const normalized = credentials.normalizeOnInput(name, raw);
-    setter(normalized);
-    credentials.lintOnBlur(name, normalized);
+    setter(credentials.inspect(name, raw));
+  };
+
+  // "Clean it up" — apply the opt-in fix on explicit user action only.
+  const cleanUpFor = (name: string, current: string, setter: (v: string) => void) => {
+    setter(credentials.applyFix(name, current));
   };
 
   const handleAdd = async () => {
     const name = newKey.trim();
-    const value = normalizeCredential(name, newValue).value;
+    const value = sanitizeCredential(newValue);
     if (!name || !value) return;
 
     try {
@@ -110,7 +112,7 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   };
 
   const handleUpdate = async (key: string, scope: EnvVarScope) => {
-    const value = normalizeCredential(key, editingValue).value;
+    const value = sanitizeCredential(editingValue);
     if (!value) return;
 
     try {
@@ -200,9 +202,9 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
                   }}
                   onPaste={(e) => {
                     const el = e.currentTarget;
-                    window.setTimeout(() => normalizeFor(record.key, el.value, setEditingValue), 0);
+                    window.setTimeout(() => inspectFor(record.key, el.value, setEditingValue), 0);
                   }}
-                  onBlur={() => normalizeFor(record.key, editingValue, setEditingValue)}
+                  onBlur={() => inspectFor(record.key, editingValue, setEditingValue)}
                   onPressEnter={() => handleUpdate(record.key, record.scope)}
                   autoFocus
                   disabled={disabled}
@@ -222,8 +224,8 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
               </Space.Compact>
               <CredentialFieldFeedback
                 lint={feedback.lint}
-                internalFixVisible={feedback.showInternalFix}
-                onDismissInternalFix={() => credentials.dismissInternalFix(record.key)}
+                fix={feedback.fix}
+                onApplyFix={() => cleanUpFor(record.key, editingValue, setEditingValue)}
               />
             </Space>
           );
@@ -334,9 +336,9 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
             }}
             onPaste={(e) => {
               const el = e.currentTarget;
-              window.setTimeout(() => normalizeFor(newKey.trim(), el.value, setNewValue), 0);
+              window.setTimeout(() => inspectFor(newKey.trim(), el.value, setNewValue), 0);
             }}
-            onBlur={() => normalizeFor(newKey.trim(), newValue, setNewValue)}
+            onBlur={() => inspectFor(newKey.trim(), newValue, setNewValue)}
             onPressEnter={handleAdd}
             style={{ flex: 1 }}
             disabled={disabled}
@@ -352,8 +354,8 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
         </Space.Compact>
         <CredentialFieldFeedback
           lint={credentials.get(newKey.trim()).lint}
-          internalFixVisible={credentials.get(newKey.trim()).showInternalFix}
-          onDismissInternalFix={() => credentials.dismissInternalFix(newKey.trim())}
+          fix={credentials.get(newKey.trim()).fix}
+          onApplyFix={() => cleanUpFor(newKey.trim(), newValue, setNewValue)}
         />
       </Space>
     </Space>

--- a/apps/agor-ui/src/components/EnvVarEditor.tsx
+++ b/apps/agor-ui/src/components/EnvVarEditor.tsx
@@ -1,7 +1,14 @@
-import { ENV_VAR_SCOPES_V05, type EnvVarMetadata, type EnvVarScope } from '@agor-live/client';
+import {
+  ENV_VAR_SCOPES_V05,
+  type EnvVarMetadata,
+  type EnvVarScope,
+  normalizeCredential,
+} from '@agor-live/client';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { Alert, Button, Input, Select, Space, Table, Tooltip, Typography } from 'antd';
 import { useMemo, useState } from 'react';
+import { CredentialFieldFeedback } from './credentials/CredentialFieldFeedback';
+import { useCredentialFields } from './credentials/useCredentialField';
 import { Tag } from './Tag';
 
 const { Text } = Typography;
@@ -72,16 +79,30 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   const [editingKey, setEditingKey] = useState<string | null>(null);
   const [editingValue, setEditingValue] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const credentials = useCredentialFields();
+
+  // Normalize the value against the variable NAME — only known credential names
+  // (e.g. GITHUB_TOKEN) trigger internal-whitespace repair / lint; others are
+  // edge-trimmed only. `credentials` state is keyed by the variable name.
+  const normalizeFor = (name: string, raw: string, setter: (v: string) => void) => {
+    if (!raw) return;
+    const normalized = credentials.normalizeOnInput(name, raw);
+    setter(normalized);
+    credentials.lintOnBlur(name, normalized);
+  };
 
   const handleAdd = async () => {
-    if (!newKey.trim() || !newValue.trim()) return;
+    const name = newKey.trim();
+    const value = normalizeCredential(name, newValue).value;
+    if (!name || !value) return;
 
     try {
       setError(null);
-      await onSave(newKey.trim(), newValue.trim(), newScope);
+      await onSave(name, value, newScope);
       setNewKey('');
       setNewValue('');
       setNewScope('global');
+      credentials.reset(name);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to save environment variable';
       setError(message);
@@ -89,13 +110,15 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
   };
 
   const handleUpdate = async (key: string, scope: EnvVarScope) => {
-    if (!editingValue.trim()) return;
+    const value = normalizeCredential(key, editingValue).value;
+    if (!value) return;
 
     try {
       setError(null);
-      await onSave(key, editingValue.trim(), scope);
+      await onSave(key, value, scope);
       setEditingKey(null);
       setEditingValue('');
+      credentials.reset(key);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to update environment variable';
       setError(message);
@@ -164,29 +187,45 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
         const isEditing = editingKey === record.key;
 
         if (isEditing) {
+          const feedback = credentials.get(record.key);
           return (
-            <Space.Compact style={{ width: '100%' }}>
-              <Input.Password
-                placeholder="Enter new value"
-                value={editingValue}
-                onChange={(e) => setEditingValue(e.target.value)}
-                onPressEnter={() => handleUpdate(record.key, record.scope)}
-                autoFocus
-                disabled={disabled}
-                style={{ flex: 1, minWidth: 180 }}
+            <Space orientation="vertical" size="small" style={{ width: '100%' }}>
+              <Space.Compact style={{ width: '100%' }}>
+                <Input.Password
+                  placeholder="Enter new value"
+                  value={editingValue}
+                  onChange={(e) => {
+                    setEditingValue(e.target.value);
+                    credentials.reset(record.key);
+                  }}
+                  onPaste={(e) => {
+                    const el = e.currentTarget;
+                    window.setTimeout(() => normalizeFor(record.key, el.value, setEditingValue), 0);
+                  }}
+                  onBlur={() => normalizeFor(record.key, editingValue, setEditingValue)}
+                  onPressEnter={() => handleUpdate(record.key, record.scope)}
+                  autoFocus
+                  disabled={disabled}
+                  style={{ flex: 1, minWidth: 180 }}
+                />
+                <Button
+                  type="primary"
+                  onClick={() => handleUpdate(record.key, record.scope)}
+                  loading={loading[record.key]}
+                  disabled={disabled || !editingValue.trim()}
+                >
+                  Save
+                </Button>
+                <Button onClick={() => setEditingKey(null)} disabled={disabled}>
+                  Cancel
+                </Button>
+              </Space.Compact>
+              <CredentialFieldFeedback
+                lint={feedback.lint}
+                internalFixVisible={feedback.showInternalFix}
+                onDismissInternalFix={() => credentials.dismissInternalFix(record.key)}
               />
-              <Button
-                type="primary"
-                onClick={() => handleUpdate(record.key, record.scope)}
-                loading={loading[record.key]}
-                disabled={disabled || !editingValue.trim()}
-              >
-                Save
-              </Button>
-              <Button onClick={() => setEditingKey(null)} disabled={disabled}>
-                Cancel
-              </Button>
-            </Space.Compact>
+            </Space>
           );
         }
 
@@ -289,7 +328,15 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
           <Input.Password
             placeholder="Value"
             value={newValue}
-            onChange={(e) => setNewValue(e.target.value)}
+            onChange={(e) => {
+              setNewValue(e.target.value);
+              credentials.reset(newKey.trim());
+            }}
+            onPaste={(e) => {
+              const el = e.currentTarget;
+              window.setTimeout(() => normalizeFor(newKey.trim(), el.value, setNewValue), 0);
+            }}
+            onBlur={() => normalizeFor(newKey.trim(), newValue, setNewValue)}
             onPressEnter={handleAdd}
             style={{ flex: 1 }}
             disabled={disabled}
@@ -303,6 +350,11 @@ export const EnvVarEditor: React.FC<EnvVarEditorProps> = ({
             Add
           </Button>
         </Space.Compact>
+        <CredentialFieldFeedback
+          lint={credentials.get(newKey.trim()).lint}
+          internalFixVisible={credentials.get(newKey.trim()).showInternalFix}
+          onDismissInternalFix={() => credentials.dismissInternalFix(newKey.trim())}
+        />
       </Space>
     </Space>
   );

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -20,6 +20,7 @@ import {
 } from 'antd';
 import { useEffect, useRef, useState } from 'react';
 import { useThemedMessage } from '@/utils/message';
+import { useFormCredential } from '../credentials/useFormCredential';
 import { extractOAuthConfigForTesting, validateHeadersJSON } from './mcp-oauth-utils';
 
 const { TextArea } = Input;
@@ -109,6 +110,12 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
   const watchedClientId = Form.useWatch('oauth_client_id', form);
   const watchedClientSecret = Form.useWatch('oauth_client_secret', form);
   const watchedOauthMode = Form.useWatch('oauth_mode', form);
+  // Credential feedback for the secret fields — opt-in "Clean it up" for raw
+  // tokens, skipped for `{{ … }}` templates whose whitespace is meaningful.
+  const bearerCred = useFormCredential(form, 'auth_token', { allowTemplates: true });
+  const jwtTokenCred = useFormCredential(form, 'jwt_api_token', { allowTemplates: true });
+  const jwtSecretCred = useFormCredential(form, 'jwt_api_secret', { allowTemplates: true });
+  const oauthSecretCred = useFormCredential(form, 'oauth_client_secret', { allowTemplates: true });
   const watchedEnv = Form.useWatch('env', form);
   const watchedHeaders = Form.useWatch('headers', form);
   const hasEnvConfigured = typeof watchedEnv === 'string' && watchedEnv.trim().length > 0;
@@ -502,14 +509,20 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           </Form.Item>
 
           {authType === 'bearer' && (
-            <Form.Item
-              label="Token"
-              name="auth_token"
-              rules={[{ required: true, message: 'Please enter a bearer token' }]}
-              tooltip="Bearer token. Supports templates like {{ user.env.API_TOKEN }}"
-            >
-              <Input.Password placeholder="{{ user.env.API_TOKEN }} or raw token" />
-            </Form.Item>
+            <>
+              <Form.Item
+                label="Token"
+                name="auth_token"
+                rules={[{ required: true, message: 'Please enter a bearer token' }]}
+                tooltip="Bearer token. Supports templates like {{ user.env.API_TOKEN }}"
+              >
+                <Input.Password
+                  placeholder="{{ user.env.API_TOKEN }} or raw token"
+                  {...bearerCred.inputProps}
+                />
+              </Form.Item>
+              {bearerCred.feedback}
+            </>
           )}
 
           {authType === 'jwt' && (
@@ -528,16 +541,24 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                 rules={[{ required: true, message: 'Please enter the API token' }]}
                 tooltip="JWT API token. Supports templates like {{ user.env.JWT_TOKEN }}"
               >
-                <Input.Password placeholder="{{ user.env.JWT_TOKEN }} or raw token" />
+                <Input.Password
+                  placeholder="{{ user.env.JWT_TOKEN }} or raw token"
+                  {...jwtTokenCred.inputProps}
+                />
               </Form.Item>
+              {jwtTokenCred.feedback}
               <Form.Item
                 label="API Secret"
                 name="jwt_api_secret"
                 rules={[{ required: true, message: 'Please enter the API secret' }]}
                 tooltip="JWT API secret. Supports templates like {{ user.env.JWT_SECRET }}"
               >
-                <Input.Password placeholder="{{ user.env.JWT_SECRET }} or raw secret" />
+                <Input.Password
+                  placeholder="{{ user.env.JWT_SECRET }} or raw secret"
+                  {...jwtSecretCred.inputProps}
+                />
               </Form.Item>
+              {jwtSecretCred.feedback}
             </>
           )}
         </>
@@ -752,8 +773,10 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                     <Input.Password
                       placeholder="Enter client secret or {{ user.env.OAUTH_CLIENT_SECRET }}"
                       allowClear
+                      {...oauthSecretCred.inputProps}
                     />
                   </Form.Item>
+                  {oauthSecretCred.feedback}
                   <Form.Item
                     label="OAuth Mode"
                     name="oauth_mode"

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -159,6 +159,26 @@ describe('buildAuthFromValues', () => {
     expect(auth).toEqual({ type: 'bearer', token: 'tok' });
   });
 
+  describe('at-rest sanitize backstop', () => {
+    it('strips edge whitespace from a bearer token', () => {
+      const auth = buildAuthFromValues({ auth_type: 'bearer', auth_token: '  tok-clean  ' });
+      expect(auth?.token).toBe('tok-clean');
+    });
+
+    it('does NOT collapse internal whitespace or unwrap quotes (kept as-is)', () => {
+      const auth = buildAuthFromValues({ auth_type: 'bearer', auth_token: '"tok en"' });
+      expect(auth?.token).toBe('"tok en"');
+    });
+
+    it('leaves a template value untouched (internal whitespace is meaningful)', () => {
+      const auth = buildAuthFromValues({
+        auth_type: 'bearer',
+        auth_token: '{{ user.env.API_TOKEN }}',
+      });
+      expect(auth?.token).toBe('{{ user.env.API_TOKEN }}');
+    });
+  });
+
   it('omits bearer token when not a string', () => {
     const auth = buildAuthFromValues({ auth_type: 'bearer' });
     expect(auth).toEqual({ type: 'bearer' });

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -1,4 +1,4 @@
-import { normalizeCredential } from '@agor/core/credentials';
+import { sanitizeCredential } from '@agor/core/credentials';
 import {
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
@@ -53,10 +53,7 @@ export function extractOAuthConfig(values: Record<string, unknown>): OAuthConfig
 
   // Only include client secret if it's provided
   if (values.oauth_client_secret && typeof values.oauth_client_secret === 'string') {
-    config.oauth_client_secret = normalizeMcpSecret(
-      'oauth_client_secret',
-      values.oauth_client_secret
-    );
+    config.oauth_client_secret = normalizeMcpSecret(values.oauth_client_secret);
   }
 
   // Only include scope if it's provided
@@ -161,14 +158,14 @@ export interface BuiltAuth {
  * an outer if/else.
  */
 /**
- * Normalize an MCP secret. These fields accept `{{ user.env.VAR }}` templates
+ * Sanitize an MCP secret. These fields accept `{{ user.env.VAR }}` templates
  * whose internal whitespace is meaningful, so templates are left untouched and
- * raw values get only edge / zero-width / smart-quote cleanup (the unregistered
- * field name resolves to the generic normalization path — no internal collapse).
+ * raw values get only the always-safe cleanup (edge whitespace + zero-width
+ * chars) — never internal-whitespace collapse or quote-unwrap.
  */
-function normalizeMcpSecret(field: string, value: string): string {
+function normalizeMcpSecret(value: string): string {
   if (isTemplateValue(value)) return value;
-  return normalizeCredential(field, value).value;
+  return sanitizeCredential(value);
 }
 
 export function buildAuthFromValues(values: Record<string, unknown>): BuiltAuth | undefined {
@@ -177,14 +174,13 @@ export function buildAuthFromValues(values: Record<string, unknown>): BuiltAuth 
 
   const auth: BuiltAuth = { type: authType };
   if (authType === 'bearer') {
-    if (typeof values.auth_token === 'string')
-      auth.token = normalizeMcpSecret('auth_token', values.auth_token);
+    if (typeof values.auth_token === 'string') auth.token = normalizeMcpSecret(values.auth_token);
   } else if (authType === 'jwt') {
     if (typeof values.jwt_api_url === 'string') auth.api_url = values.jwt_api_url.trim();
     if (typeof values.jwt_api_token === 'string')
-      auth.api_token = normalizeMcpSecret('jwt_api_token', values.jwt_api_token);
+      auth.api_token = normalizeMcpSecret(values.jwt_api_token);
     if (typeof values.jwt_api_secret === 'string')
-      auth.api_secret = normalizeMcpSecret('jwt_api_secret', values.jwt_api_secret);
+      auth.api_secret = normalizeMcpSecret(values.jwt_api_secret);
   } else {
     Object.assign(auth, extractOAuthConfig(values));
   }

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -1,3 +1,4 @@
+import { normalizeCredential } from '@agor/core/credentials';
 import {
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
@@ -52,7 +53,10 @@ export function extractOAuthConfig(values: Record<string, unknown>): OAuthConfig
 
   // Only include client secret if it's provided
   if (values.oauth_client_secret && typeof values.oauth_client_secret === 'string') {
-    config.oauth_client_secret = values.oauth_client_secret;
+    config.oauth_client_secret = normalizeMcpSecret(
+      'oauth_client_secret',
+      values.oauth_client_secret
+    );
   }
 
   // Only include scope if it's provided
@@ -156,17 +160,31 @@ export interface BuiltAuth {
  * so callers can do `payload.auth = buildAuthFromValues(values)` without
  * an outer if/else.
  */
+/**
+ * Normalize an MCP secret. These fields accept `{{ user.env.VAR }}` templates
+ * whose internal whitespace is meaningful, so templates are left untouched and
+ * raw values get only edge / zero-width / smart-quote cleanup (the unregistered
+ * field name resolves to the generic normalization path — no internal collapse).
+ */
+function normalizeMcpSecret(field: string, value: string): string {
+  if (isTemplateValue(value)) return value;
+  return normalizeCredential(field, value).value;
+}
+
 export function buildAuthFromValues(values: Record<string, unknown>): BuiltAuth | undefined {
   const authType = values.auth_type;
   if (authType !== 'bearer' && authType !== 'jwt' && authType !== 'oauth') return undefined;
 
   const auth: BuiltAuth = { type: authType };
   if (authType === 'bearer') {
-    if (typeof values.auth_token === 'string') auth.token = values.auth_token;
+    if (typeof values.auth_token === 'string')
+      auth.token = normalizeMcpSecret('auth_token', values.auth_token);
   } else if (authType === 'jwt') {
-    if (typeof values.jwt_api_url === 'string') auth.api_url = values.jwt_api_url;
-    if (typeof values.jwt_api_token === 'string') auth.api_token = values.jwt_api_token;
-    if (typeof values.jwt_api_secret === 'string') auth.api_secret = values.jwt_api_secret;
+    if (typeof values.jwt_api_url === 'string') auth.api_url = values.jwt_api_url.trim();
+    if (typeof values.jwt_api_token === 'string')
+      auth.api_token = normalizeMcpSecret('jwt_api_token', values.jwt_api_token);
+    if (typeof values.jwt_api_secret === 'string')
+      auth.api_secret = normalizeMcpSecret('jwt_api_secret', values.jwt_api_secret);
   } else {
     Object.assign(auth, extractOAuthConfig(values));
   }

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -195,9 +195,12 @@ describe('OnboardingWizard', () => {
 
     clickButton('Claude');
     const input = screen.getByLabelText('Anthropic API key');
+    // Validation is surfaced on blur (never on keystroke) via the shared
+    // credential lint registry.
     fireEvent.change(input, { target: { value: 'not-a-real-key' } });
+    fireEvent.blur(input);
 
-    const errorText = await screen.findByText(/Claude keys start with sk-ant-/i);
+    const errorText = await screen.findByText(/Anthropic keys usually start with sk-ant-api/i);
     expect(errorText).toBeInTheDocument();
     const connectButton = screen.getByText(/^connect →/i).closest('button');
     expect(connectButton).toBeDisabled();

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,12 +9,19 @@ import type {
   AgenticToolName,
   AgorClient,
   AuthCheckResult,
+  CredentialFixSuggestion,
   CredentialLintResult,
   UpdateUserInput,
   User,
   UserPreferences,
 } from '@agor-live/client';
-import { lintCredential, normalizeCredential, TOOL_API_KEY_NAMES } from '@agor-live/client';
+import {
+  applyCredentialFix,
+  detectCredentialFix,
+  lintCredential,
+  sanitizeCredential,
+  TOOL_API_KEY_NAMES,
+} from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CheckOutlined,
@@ -516,25 +523,34 @@ export function OnboardingWizard({
   const [authMethod, setAuthMethod] = useState<AuthMethod>('api-key');
   const [llmSaving, setLlmSaving] = useState(false);
   const [llmError, setLlmError] = useState<string | null>(null);
-  const [llmKeyFixed, setLlmKeyFixed] = useState(false);
+  const [llmFix, setLlmFix] = useState<CredentialFixSuggestion | null>(null);
   const [llmLint, setLlmLint] = useState<CredentialLintResult | null>(null);
   const [llmAuthChecking, setLlmAuthChecking] = useState<AgenticToolName | null>(null);
   const [llmAuthVerified, setLlmAuthVerified] = useState<Partial<Record<AgenticToolName, boolean>>>(
     {}
   );
 
-  // Silent normalization (paste/blur) for the LLM key inputs. Repairs
-  // terminal-paste artifacts and flags an internal-whitespace fix for the notice.
-  // Lint runs against the ACTUAL field (incl. the subscription-token field) so a
-  // cross-paste — e.g. an API key dropped in the subscription box — is surfaced.
-  // `raw` is the DOM value on paste (state is stale there).
-  const normalizeLlmKey = (raw: string) => {
+  // Paste/blur: apply the always-safe sanitize (edge/invisible) to the displayed
+  // value, then DETECT the opt-in fix + lint on the ACTUAL field (incl. the
+  // subscription-token field, so a cross-paste is still surfaced). The opt-in fix
+  // is never applied automatically. `raw` is the DOM value on paste.
+  const inspectLlmKey = (raw: string) => {
     if (!selectedAgent) return;
     const field = keyNameForAgent(selectedAgent, authMethod);
-    const result = normalizeCredential(field, raw);
-    setApiKey(result.value);
-    if (result.internalWhitespaceFixed) setLlmKeyFixed(true);
-    setLlmLint(lintCredential(field, result.value));
+    const sanitized = sanitizeCredential(raw);
+    setApiKey(sanitized);
+    setLlmFix(detectCredentialFix(field, sanitized));
+    setLlmLint(lintCredential(field, sanitized));
+  };
+
+  // "Clean it up" — apply the opt-in fix on explicit user action only.
+  const cleanUpLlmKey = () => {
+    if (!selectedAgent) return;
+    const field = keyNameForAgent(selectedAgent, authMethod);
+    const fixed = applyCredentialFix(field, apiKey);
+    setApiKey(fixed);
+    setLlmFix(null);
+    setLlmLint(lintCredential(field, fixed));
   };
 
   // ── Step 3: workspace — name the user's first AI teammate ─────────────────
@@ -851,7 +867,9 @@ export function OnboardingWizard({
         }
         if (!user || !apiKey.trim()) return;
         const keyField = keyNameForAgent(selectedAgent, authMethod);
-        const normalizedKey = normalizeCredential(keyField, apiKey).value;
+        // Save exactly what's shown (minus always-safe edge/invisible cleanup) —
+        // a declined opt-in fix is honored, and verify will guide them if it fails.
+        const normalizedKey = sanitizeCredential(apiKey);
         // Subscription tokens have no fixed format (see primaryEnabled/disabledReason
         // above, which already treat them as exempt) — only pattern-validate API keys.
         if (authMethod !== 'claude-subscription-token') {
@@ -1422,13 +1440,14 @@ export function OnboardingWizard({
                           onChange={(e) => {
                             setApiKey(e.target.value);
                             setLlmError(null);
-                            setLlmKeyFixed(false);
+                            setLlmFix(null);
+                            setLlmLint(null);
                           }}
                           onPaste={(e) => {
                             const el = e.currentTarget;
-                            window.setTimeout(() => normalizeLlmKey(el.value), 0);
+                            window.setTimeout(() => inspectLlmKey(el.value), 0);
                           }}
-                          onBlur={() => normalizeLlmKey(apiKey)}
+                          onBlur={() => inspectLlmKey(apiKey)}
                           style={{
                             background: 'rgba(0,0,0,0.3)',
                             borderColor: 'rgba(255,255,255,0.12)',
@@ -1446,14 +1465,14 @@ export function OnboardingWizard({
                           // Validate on blur/paste, never on keystroke.
                           setApiKey(e.target.value);
                           setLlmError(null);
-                          setLlmKeyFixed(false);
+                          setLlmFix(null);
                           setLlmLint(null);
                         }}
                         onPaste={(e) => {
                           const el = e.currentTarget;
-                          window.setTimeout(() => normalizeLlmKey(el.value), 0);
+                          window.setTimeout(() => inspectLlmKey(el.value), 0);
                         }}
-                        onBlur={() => normalizeLlmKey(apiKey)}
+                        onBlur={() => inspectLlmKey(apiKey)}
                         style={{
                           background: 'rgba(0,0,0,0.3)',
                           borderColor: 'rgba(255,255,255,0.12)',
@@ -1468,12 +1487,12 @@ export function OnboardingWizard({
                     >
                       Stored securely - never shared or logged.
                     </Text>
-                    {(llmKeyFixed || llmLint) && (
+                    {(llmFix || llmLint) && (
                       <div style={{ marginTop: 10 }}>
                         <CredentialFieldFeedback
                           lint={llmLint}
-                          internalFixVisible={llmKeyFixed}
-                          onDismissInternalFix={() => setLlmKeyFixed(false)}
+                          fix={llmFix}
+                          onApplyFix={cleanUpLlmKey}
                         />
                       </div>
                     )}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -1488,7 +1488,7 @@ export function OnboardingWizard({
                       Stored securely - never shared or logged.
                     </Text>
                     {(llmFix || llmLint) && (
-                      <div style={{ marginTop: 10 }}>
+                      <div style={{ marginTop: token.marginSM }}>
                         <CredentialFieldFeedback
                           lint={llmLint}
                           fix={llmFix}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -13,7 +13,7 @@ import type {
   User,
   UserPreferences,
 } from '@agor-live/client';
-import { TOOL_API_KEY_NAMES } from '@agor-live/client';
+import { lintCredential, normalizeCredential, TOOL_API_KEY_NAMES } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   CheckOutlined,
@@ -287,36 +287,22 @@ const PERSONA_MCP_RECS: Record<string, McpRecommendation[]> = {
   ],
 };
 
+// Backed by the shared credential registry so prefix/length/cross-paste rules
+// live in one place. opencode expects a base URL, which the registry doesn't lint.
 function validateLlmKeyPattern(agent: AgenticToolName, key: string): string | null {
   const k = key.trim();
   if (!k) return null;
-  switch (agent) {
-    case 'claude-code':
-      if (!k.startsWith('sk-ant-')) return 'Claude keys start with sk-ant-…';
-      if (k.startsWith('sk-ant-oat'))
-        return 'That looks like a subscription token - use the Subscription token option above.';
-      if (k.length < 50) return 'Key looks incomplete - copy the full key.';
+  if (agent === 'opencode') {
+    try {
+      new URL(k);
       return null;
-    case 'codex':
-      if (k.startsWith('sk-ant-')) return 'That looks like a Claude key - pick Claude above.';
-      if (!k.startsWith('sk-')) return 'OpenAI keys start with sk-…';
-      if (k.length < 30) return 'Key looks incomplete.';
-      return null;
-    case 'gemini':
-      if (!k.startsWith('AIzaSy')) return 'Gemini keys start with AIzaSy…';
-      if (k.length < 20) return 'Key looks incomplete.';
-      return null;
-    case 'opencode': {
-      try {
-        new URL(k);
-        return null;
-      } catch {
-        return 'Enter a valid URL starting with https://';
-      }
+    } catch {
+      return 'Enter a valid URL starting with https://';
     }
-    default:
-      return null;
   }
+  const field = TOOL_API_KEY_NAMES[agent];
+  if (!field) return null;
+  return lintCredential(field, k)?.message ?? null;
 }
 
 function hasAnyLlmKey(user: User | null | undefined): boolean {
@@ -528,10 +514,27 @@ export function OnboardingWizard({
   const [authMethod, setAuthMethod] = useState<AuthMethod>('api-key');
   const [llmSaving, setLlmSaving] = useState(false);
   const [llmError, setLlmError] = useState<string | null>(null);
+  const [llmKeyFixed, setLlmKeyFixed] = useState(false);
   const [llmAuthChecking, setLlmAuthChecking] = useState<AgenticToolName | null>(null);
   const [llmAuthVerified, setLlmAuthVerified] = useState<Partial<Record<AgenticToolName, boolean>>>(
     {}
   );
+
+  // Silent normalization (paste/blur) for the LLM key inputs. Repairs
+  // terminal-paste artifacts and flags an internal-whitespace fix for the notice.
+  // `raw` is the DOM value on paste (state is stale there).
+  const normalizeLlmKey = (raw: string) => {
+    if (!selectedAgent) return;
+    const field = keyNameForAgent(selectedAgent, authMethod);
+    const result = normalizeCredential(field, raw);
+    setApiKey(result.value);
+    if (result.internalWhitespaceFixed) setLlmKeyFixed(true);
+    setLlmError(
+      authMethod === 'claude-subscription-token'
+        ? null
+        : validateLlmKeyPattern(selectedAgent, result.value)
+    );
+  };
 
   // ── Step 3: workspace — name the user's first AI teammate ─────────────────
   // The teammate's name/emoji also names the board the wizard creates for them,
@@ -846,10 +849,12 @@ export function OnboardingWizard({
           return;
         }
         if (!user || !apiKey.trim()) return;
+        const keyField = keyNameForAgent(selectedAgent, authMethod);
+        const normalizedKey = normalizeCredential(keyField, apiKey).value;
         // Subscription tokens have no fixed format (see primaryEnabled/disabledReason
         // above, which already treat them as exempt) — only pattern-validate API keys.
         if (authMethod !== 'claude-subscription-token') {
-          const patternErr = validateLlmKeyPattern(selectedAgent, apiKey.trim());
+          const patternErr = validateLlmKeyPattern(selectedAgent, normalizedKey);
           if (patternErr) {
             setLlmError(patternErr);
             return;
@@ -859,7 +864,7 @@ export function OnboardingWizard({
         setLlmError(null);
         if (onCheckAuth) {
           try {
-            const authResult = await onCheckAuth(selectedAgent, apiKey.trim());
+            const authResult = await onCheckAuth(selectedAgent, normalizedKey);
             // Only block on a definitive rejection; 'unknown' (transient/transport
             // failure) proceeds to save rather than rejecting a possibly-valid key.
             if (authResult.status === 'unauthenticated') {
@@ -1415,7 +1420,13 @@ export function OnboardingWizard({
                           onChange={(e) => {
                             setApiKey(e.target.value);
                             setLlmError(null);
+                            setLlmKeyFixed(false);
                           }}
+                          onPaste={(e) => {
+                            const el = e.currentTarget;
+                            window.setTimeout(() => normalizeLlmKey(el.value), 0);
+                          }}
+                          onBlur={() => normalizeLlmKey(apiKey)}
                           style={{
                             background: 'rgba(0,0,0,0.3)',
                             borderColor: 'rgba(255,255,255,0.12)',
@@ -1430,10 +1441,16 @@ export function OnboardingWizard({
                         placeholder={option.placeholder}
                         value={apiKey}
                         onChange={(e) => {
+                          // Validate on blur/paste, never on keystroke.
                           setApiKey(e.target.value);
-                          if (selectedAgent)
-                            setLlmError(validateLlmKeyPattern(selectedAgent, e.target.value));
+                          setLlmError(null);
+                          setLlmKeyFixed(false);
                         }}
+                        onPaste={(e) => {
+                          const el = e.currentTarget;
+                          window.setTimeout(() => normalizeLlmKey(el.value), 0);
+                        }}
+                        onBlur={() => normalizeLlmKey(apiKey)}
                         style={{
                           background: 'rgba(0,0,0,0.3)',
                           borderColor: 'rgba(255,255,255,0.12)',
@@ -1448,6 +1465,16 @@ export function OnboardingWizard({
                     >
                       Stored securely - never shared or logged.
                     </Text>
+                    {llmKeyFixed && (
+                      <Alert
+                        type="warning"
+                        message="We removed spaces or line breaks from this key — a common side effect of copying from a terminal. Check that it verifies below."
+                        showIcon
+                        closable
+                        onClose={() => setLlmKeyFixed(false)}
+                        style={{ marginTop: 10, fontSize: 12 }}
+                      />
+                    )}
                     {llmError && (
                       <Alert
                         type="error"

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -9,6 +9,7 @@ import type {
   AgenticToolName,
   AgorClient,
   AuthCheckResult,
+  CredentialLintResult,
   UpdateUserInput,
   User,
   UserPreferences,
@@ -25,6 +26,7 @@ import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } fr
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { ONBOARDING_PERSONAS } from '../../utils/onboardingPersonas';
+import { CredentialFieldFeedback } from '../credentials/CredentialFieldFeedback';
 import { EmojiPickerInput } from '../EmojiPickerInput/EmojiPickerInput';
 
 const { Text, Title, Paragraph } = Typography;
@@ -515,6 +517,7 @@ export function OnboardingWizard({
   const [llmSaving, setLlmSaving] = useState(false);
   const [llmError, setLlmError] = useState<string | null>(null);
   const [llmKeyFixed, setLlmKeyFixed] = useState(false);
+  const [llmLint, setLlmLint] = useState<CredentialLintResult | null>(null);
   const [llmAuthChecking, setLlmAuthChecking] = useState<AgenticToolName | null>(null);
   const [llmAuthVerified, setLlmAuthVerified] = useState<Partial<Record<AgenticToolName, boolean>>>(
     {}
@@ -522,6 +525,8 @@ export function OnboardingWizard({
 
   // Silent normalization (paste/blur) for the LLM key inputs. Repairs
   // terminal-paste artifacts and flags an internal-whitespace fix for the notice.
+  // Lint runs against the ACTUAL field (incl. the subscription-token field) so a
+  // cross-paste — e.g. an API key dropped in the subscription box — is surfaced.
   // `raw` is the DOM value on paste (state is stale there).
   const normalizeLlmKey = (raw: string) => {
     if (!selectedAgent) return;
@@ -529,11 +534,7 @@ export function OnboardingWizard({
     const result = normalizeCredential(field, raw);
     setApiKey(result.value);
     if (result.internalWhitespaceFixed) setLlmKeyFixed(true);
-    setLlmError(
-      authMethod === 'claude-subscription-token'
-        ? null
-        : validateLlmKeyPattern(selectedAgent, result.value)
-    );
+    setLlmLint(lintCredential(field, result.value));
   };
 
   // ── Step 3: workspace — name the user's first AI teammate ─────────────────
@@ -879,11 +880,12 @@ export function OnboardingWizard({
             // auth check failure is non-fatal — proceed to save anyway
           }
         }
-        const keyName = keyNameForAgent(selectedAgent, authMethod);
         try {
           await onUpdateUser(user.user_id, {
             agentic_tools: {
-              [selectedAgent]: { [keyName]: apiKey.trim() },
+              // Save the normalized value (the client must not rely on the
+              // daemon backstop to repair a terminal-paste artifact).
+              [selectedAgent]: { [keyField]: normalizedKey },
             } as UpdateUserInput['agentic_tools'],
           });
           goToStep('workspace');
@@ -1445,6 +1447,7 @@ export function OnboardingWizard({
                           setApiKey(e.target.value);
                           setLlmError(null);
                           setLlmKeyFixed(false);
+                          setLlmLint(null);
                         }}
                         onPaste={(e) => {
                           const el = e.currentTarget;
@@ -1465,15 +1468,14 @@ export function OnboardingWizard({
                     >
                       Stored securely - never shared or logged.
                     </Text>
-                    {llmKeyFixed && (
-                      <Alert
-                        type="warning"
-                        message="We removed spaces or line breaks from this key — a common side effect of copying from a terminal. Check that it verifies below."
-                        showIcon
-                        closable
-                        onClose={() => setLlmKeyFixed(false)}
-                        style={{ marginTop: 10, fontSize: 12 }}
-                      />
+                    {(llmKeyFixed || llmLint) && (
+                      <div style={{ marginTop: 10 }}>
+                        <CredentialFieldFeedback
+                          lint={llmLint}
+                          internalFixVisible={llmKeyFixed}
+                          onDismissInternalFix={() => setLlmKeyFixed(false)}
+                        />
+                      </div>
                     )}
                     {llmError && (
                       <Alert

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -240,7 +240,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                                   setSaving((state) => ({ ...state, [field]: false }));
                                 }
                               }}
-                              onVerify={async (_field, value) => {
+                              onVerify={async (field, value) => {
                                 if (!client) {
                                   return {
                                     status: 'unknown',
@@ -252,6 +252,7 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                                   return (await client.service('check-auth').create({
                                     tool: tool as AgenticToolName,
                                     apiKey: value,
+                                    field,
                                   })) as AuthCheckResult;
                                 } catch {
                                   return {

--- a/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/AgenticToolsSection.tsx
@@ -2,6 +2,7 @@ import type {
   AgenticToolConfigField,
   AgenticToolName,
   AgorClient,
+  AuthCheckResult,
   ProviderResolutionPolicy,
   TenantAgenticToolName,
   TenantAgenticToolSettings,
@@ -237,6 +238,28 @@ export const AgenticToolsSection: React.FC<AgenticToolsSectionProps> = ({ client
                                   await patch(tool, { connection: { [field]: null } });
                                 } finally {
                                   setSaving((state) => ({ ...state, [field]: false }));
+                                }
+                              }}
+                              onVerify={async (_field, value) => {
+                                if (!client) {
+                                  return {
+                                    status: 'unknown',
+                                    authenticated: false,
+                                    method: 'none',
+                                  };
+                                }
+                                try {
+                                  return (await client.service('check-auth').create({
+                                    tool: tool as AgenticToolName,
+                                    apiKey: value,
+                                  })) as AuthCheckResult;
+                                } catch {
+                                  return {
+                                    status: 'unknown',
+                                    authenticated: false,
+                                    method: 'none',
+                                    hint: 'Connection check failed.',
+                                  };
                                 }
                               }}
                               saving={saving}

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -26,6 +26,7 @@ import type {
 } from '@agor-live/client';
 import {
   GATEWAY_REDACTED_SENTINEL,
+  normalizeCredential,
   resolveSlackAgentTools,
   SLACK_AGENT_TOOL_DEFAULTS,
 } from '@agor-live/client';
@@ -3251,7 +3252,10 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         config.app_id = Number(values.github_app_id);
       }
       if (values.github_private_key) {
-        config.private_key = values.github_private_key;
+        config.private_key = normalizeCredential(
+          'private_key',
+          values.github_private_key as string
+        ).value;
       }
       if (values.github_installation_id) {
         config.installation_id = Number(values.github_installation_id);
@@ -3271,13 +3275,21 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       }
     } else if (values.channel_type === 'teams') {
       if (values.teams_app_id) config.app_id = values.teams_app_id;
-      if (values.teams_app_password) config.app_password = values.teams_app_password;
+      if (values.teams_app_password)
+        config.app_password = normalizeCredential(
+          'app_password',
+          values.teams_app_password as string
+        ).value;
       config.tenant_id = values.teams_tenant_id;
       config.webhook_port = (values.teams_webhook_port as number) ?? 3978;
       config.webhook_path = (values.teams_webhook_path as string) || '/api/messages';
       config.require_mention = values.teams_require_mention ?? true;
     } else if (values.channel_type === 'shortcut') {
-      if (values.shortcut_api_token) config.api_token = values.shortcut_api_token;
+      if (values.shortcut_api_token)
+        config.api_token = normalizeCredential(
+          'api_token',
+          values.shortcut_api_token as string
+        ).value;
       if (values.shortcut_agent_member_id) {
         config.agent_member_id = values.shortcut_agent_member_id;
       } else {
@@ -3304,8 +3316,10 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         }
       }
     } else if (values.channel_type === 'slack') {
-      if (values.bot_token) config.bot_token = values.bot_token;
-      if (values.app_token) config.app_token = values.app_token;
+      if (values.bot_token)
+        config.bot_token = normalizeCredential('bot_token', values.bot_token as string).value;
+      if (values.app_token)
+        config.app_token = normalizeCredential('app_token', values.app_token as string).value;
       // The Slack wizard only creates inbound/Socket-Mode channels (bot + app
       // token, Socket Mode required), so record that intent by default. This
       // makes getRequiredSecretFields require app_token for UI-created inbound

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -26,9 +26,9 @@ import type {
 } from '@agor-live/client';
 import {
   GATEWAY_REDACTED_SENTINEL,
-  normalizeCredential,
   resolveSlackAgentTools,
   SLACK_AGENT_TOOL_DEFAULTS,
+  sanitizeCredential,
 } from '@agor-live/client';
 import {
   CheckCircleOutlined,
@@ -3252,10 +3252,7 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         config.app_id = Number(values.github_app_id);
       }
       if (values.github_private_key) {
-        config.private_key = normalizeCredential(
-          'private_key',
-          values.github_private_key as string
-        ).value;
+        config.private_key = sanitizeCredential(values.github_private_key as string);
       }
       if (values.github_installation_id) {
         config.installation_id = Number(values.github_installation_id);
@@ -3276,20 +3273,14 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     } else if (values.channel_type === 'teams') {
       if (values.teams_app_id) config.app_id = values.teams_app_id;
       if (values.teams_app_password)
-        config.app_password = normalizeCredential(
-          'app_password',
-          values.teams_app_password as string
-        ).value;
+        config.app_password = sanitizeCredential(values.teams_app_password as string);
       config.tenant_id = values.teams_tenant_id;
       config.webhook_port = (values.teams_webhook_port as number) ?? 3978;
       config.webhook_path = (values.teams_webhook_path as string) || '/api/messages';
       config.require_mention = values.teams_require_mention ?? true;
     } else if (values.channel_type === 'shortcut') {
       if (values.shortcut_api_token)
-        config.api_token = normalizeCredential(
-          'api_token',
-          values.shortcut_api_token as string
-        ).value;
+        config.api_token = sanitizeCredential(values.shortcut_api_token as string);
       if (values.shortcut_agent_member_id) {
         config.agent_member_id = values.shortcut_agent_member_id;
       } else {
@@ -3316,10 +3307,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         }
       }
     } else if (values.channel_type === 'slack') {
-      if (values.bot_token)
-        config.bot_token = normalizeCredential('bot_token', values.bot_token as string).value;
-      if (values.app_token)
-        config.app_token = normalizeCredential('app_token', values.app_token as string).value;
+      if (values.bot_token) config.bot_token = sanitizeCredential(values.bot_token as string);
+      if (values.app_token) config.app_token = sanitizeCredential(values.app_token as string);
       // The Slack wizard only creates inbound/Socket-Mode channels (bot + app
       // token, Socket Mode required), so record that intent by default. This
       // makes getRequiredSecretFields require app_token for UI-created inbound

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -85,6 +85,7 @@ import {
 } from '../AgenticToolConfigurationPicker';
 import { AgentSelectionGrid } from '../AgentSelectionGrid';
 import { AVAILABLE_AGENTS } from '../AgentSelectionGrid/availableAgents';
+import { useFormCredential } from '../credentials/useFormCredential';
 import { HighlightMatch } from '../HighlightMatch';
 import { JSONEditor, validateJSON } from '../JSONEditor';
 import { BranchSelect } from './BranchSelect';
@@ -830,6 +831,8 @@ const SlackSetupWizard: React.FC<{
   const { token } = theme.useToken();
   const { showError } = useThemedMessage();
   const [copied, setCopied] = useState(false);
+  const botTokenCred = useFormCredential(form, 'bot_token');
+  const appTokenCred = useFormCredential(form, 'app_token');
 
   const appName = (Form.useWatch('slack_app_name', form) as string) ?? '';
   const enableChannels = Form.useWatch('enable_channels', form) ?? false;
@@ -1221,8 +1224,9 @@ const SlackSetupWizard: React.FC<{
           rules={[{ required: true, message: 'Bot token is required' }]}
           tooltip="OAuth & Permissions → Bot User OAuth Token (xoxb-...)"
         >
-          <Input.Password placeholder="xoxb-..." />
+          <Input.Password placeholder="xoxb-..." {...botTokenCred.inputProps} />
         </Form.Item>
+        {botTokenCred.feedback}
 
         <Form.Item
           label="App Token"
@@ -1230,8 +1234,9 @@ const SlackSetupWizard: React.FC<{
           rules={[{ required: true, message: 'App token is required' }]}
           tooltip="Basic Information → App-Level Tokens (xapp-...)"
         >
-          <Input.Password placeholder="xapp-..." />
+          <Input.Password placeholder="xapp-..." {...appTokenCred.inputProps} />
         </Form.Item>
+        {appTokenCred.feedback}
 
         <Button
           icon={<ThunderboltOutlined />}
@@ -1369,6 +1374,9 @@ const ChannelFormFields: React.FC<{
 }) => {
   const { showError } = useThemedMessage();
   const { token } = theme.useToken();
+  const botTokenCred = useFormCredential(form, 'bot_token');
+  const appTokenCred = useFormCredential(form, 'app_token');
+  const teamsPasswordCred = useFormCredential(form, 'teams_app_password');
 
   // Watch message source settings for showing warnings/scope requirements. A
   // watched value is `undefined` while its (lazily-rendered) Collapse panel is
@@ -2016,8 +2024,10 @@ const ChannelFormFields: React.FC<{
                     >
                       <Input.Password
                         placeholder={mode === 'edit' ? '••••••••' : 'Client secret value'}
+                        {...teamsPasswordCred.inputProps}
                       />
                     </Form.Item>
+                    {teamsPasswordCred.feedback}
 
                     <Form.Item
                       label="Tenant ID"
@@ -2527,8 +2537,12 @@ const ChannelFormFields: React.FC<{
                           : 'No token stored yet. Enter the bot token (xoxb-...).'
                       }
                     >
-                      <Input.Password placeholder={botTokenStored ? '••••••••' : 'xoxb-...'} />
+                      <Input.Password
+                        placeholder={botTokenStored ? '••••••••' : 'xoxb-...'}
+                        {...botTokenCred.inputProps}
+                      />
                     </Form.Item>
+                    {botTokenCred.feedback}
 
                     <Form.Item
                       label={
@@ -2544,8 +2558,12 @@ const ChannelFormFields: React.FC<{
                           : 'No token stored yet. Enter the app token (xapp-...).'
                       }
                     >
-                      <Input.Password placeholder={appTokenStored ? '••••••••' : 'xapp-...'} />
+                      <Input.Password
+                        placeholder={appTokenStored ? '••••••••' : 'xapp-...'}
+                        {...appTokenCred.inputProps}
+                      />
                     </Form.Item>
+                    {appTokenCred.feedback}
 
                     <CompactAlert
                       type="info"

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -3,6 +3,7 @@ import type {
   AgenticToolConfigField,
   AgenticToolName,
   AgorClient,
+  AuthCheckResult,
   EnvVarMetadata,
   EnvVarScope,
   Group,
@@ -501,6 +502,28 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       throw err;
     } finally {
       setSavingToolField((prev) => ({ ...prev, [spinnerKey]: false }));
+    }
+  };
+
+  // Live-verify a credential (Layer 3). With a value, probe the freshly-entered
+  // key; without one, the daemon resolves the stored key for this tool.
+  const handleToolFieldVerify = async (
+    tool: AgenticToolName,
+    _field: AgenticToolConfigField,
+    value?: string
+  ): Promise<AuthCheckResult> => {
+    if (!client) return { status: 'unknown', authenticated: false, method: 'none' };
+    try {
+      return (await client
+        .service('check-auth')
+        .create({ tool, apiKey: value })) as AuthCheckResult;
+    } catch {
+      return {
+        status: 'unknown',
+        authenticated: false,
+        method: 'none',
+        hint: 'Connection check failed.',
+      };
     }
   };
 
@@ -1185,6 +1208,9 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
                     fieldStatus={fieldStatus}
                     onSave={(field, value) => handleToolFieldSave(credentialToolName, field, value)}
                     onClear={(field) => handleToolFieldClear(credentialToolName, field)}
+                    onVerify={(field, value) =>
+                      handleToolFieldVerify(credentialToolName, field, value)
+                    }
                     saving={savingForTool}
                     publicValues={
                       user?.agentic_tools_public_values?.[credentialToolName] as

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -506,17 +506,18 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   };
 
   // Live-verify a credential (Layer 3). With a value, probe the freshly-entered
-  // key; without one, the daemon resolves the stored key for this tool.
+  // key; without one, the daemon resolves the STORED key for this exact field
+  // (so Verify under the subscription token checks the token, not the API key).
   const handleToolFieldVerify = async (
     tool: AgenticToolName,
-    _field: AgenticToolConfigField,
+    field: AgenticToolConfigField,
     value?: string
   ): Promise<AuthCheckResult> => {
     if (!client) return { status: 'unknown', authenticated: false, method: 'none' };
     try {
       return (await client
         .service('check-auth')
-        .create({ tool, apiKey: value })) as AuthCheckResult;
+        .create({ tool, apiKey: value, field })) as AuthCheckResult;
     } catch {
       return {
         status: 'unknown',

--- a/apps/agor-ui/src/components/Widgets/GatewayTokenWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/GatewayTokenWidget.tsx
@@ -21,7 +21,7 @@
  */
 
 import type { AgorClient, WidgetMessageMetadata } from '@agor-live/client';
-import { hasMinimumRole, normalizeCredential, ROLES } from '@agor-live/client';
+import { hasMinimumRole, ROLES, sanitizeCredential } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   ExclamationCircleOutlined,
@@ -148,10 +148,11 @@ interface FieldRowProps {
   field: string;
   value: string;
   onChange: (next: string) => void;
-  /** Normalize the current value (blur) or an explicit pasted value (paste). */
-  onNormalize: (raw?: string) => void;
+  /** Sanitize + inspect the current value (blur) or an explicit pasted value (paste). */
+  onInspect: (raw?: string) => void;
+  /** Apply the opt-in fix on explicit user action. */
+  onApplyFix: () => void;
   feedback: CredentialFieldState;
-  onDismissInternalFix: () => void;
   error?: string;
   disabled: boolean;
 }
@@ -160,9 +161,9 @@ const FieldRow: React.FC<FieldRowProps> = ({
   field,
   value,
   onChange,
-  onNormalize,
+  onInspect,
+  onApplyFix,
   feedback,
-  onDismissInternalFix,
   error,
   disabled,
 }) => {
@@ -176,10 +177,10 @@ const FieldRow: React.FC<FieldRowProps> = ({
     value,
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
       onChange(e.target.value),
-    onBlur: () => onNormalize(),
+    onBlur: () => onInspect(),
     onPaste: (e: React.ClipboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const el = e.currentTarget;
-      window.setTimeout(() => onNormalize(el.value), 0);
+      window.setTimeout(() => onInspect(el.value), 0);
     },
     placeholder: presentation.placeholder,
     disabled,
@@ -263,11 +264,7 @@ const FieldRow: React.FC<FieldRowProps> = ({
           {error}
         </Text>
       ) : null}
-      <CredentialFieldFeedback
-        lint={feedback.lint}
-        internalFixVisible={feedback.showInternalFix}
-        onDismissInternalFix={onDismissInternalFix}
-      />
+      <CredentialFieldFeedback lint={feedback.lint} fix={feedback.fix} onApplyFix={onApplyFix} />
     </Space>
   );
 };
@@ -296,15 +293,19 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
   const resolvingRef = useRef(false);
   const credentials = useCredentialFields();
 
-  // Silent normalization (paste/blur). Repairs terminal-paste artifacts and
-  // surfaces the internal-fix notice + format lint. `raw` is the DOM value on
-  // paste (state is stale there); on blur we read the committed state value.
-  const normalizeField = (field: string, raw?: string) => {
+  // Paste/blur: apply the always-safe sanitize, surface the opt-in fix + lint.
+  // `raw` is the DOM value on paste (state is stale there); on blur we read state.
+  const inspectField = (field: string, raw?: string) => {
     const source = raw ?? values[field] ?? '';
     if (!source) return;
-    const normalized = credentials.normalizeOnInput(field, source);
-    setValues((prev) => ({ ...prev, [field]: normalized }));
-    credentials.lintOnBlur(field, normalized);
+    const sanitized = credentials.inspect(field, source);
+    setValues((prev) => ({ ...prev, [field]: sanitized }));
+  };
+
+  // "Clean it up" — apply the opt-in fix on explicit user action only.
+  const cleanUpField = (field: string) => {
+    const fixed = credentials.applyFix(field, values[field] ?? '');
+    setValues((prev) => ({ ...prev, [field]: fixed }));
   };
 
   // Resolve the current user's role from the CANONICAL store row (mirrors
@@ -355,8 +356,9 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
     setValidationMessage(null);
     setFieldErrors({});
     const tokens: Record<string, string> = {};
-    for (const field of fields)
-      tokens[field] = normalizeCredential(field, values[field] ?? '').value;
+    // Save exactly what's shown (minus always-safe edge/invisible cleanup); a
+    // declined opt-in fix is honored rather than silently applied.
+    for (const field of fields) tokens[field] = sanitizeCredential(values[field] ?? '');
     try {
       await post('submit', { tokens });
       setLocalResolution('submitted');
@@ -455,8 +457,8 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
             value={values[field] ?? ''}
             error={fieldErrors[field]}
             feedback={credentials.get(field)}
-            onNormalize={(raw) => normalizeField(field, raw)}
-            onDismissInternalFix={() => credentials.dismissInternalFix(field)}
+            onInspect={(raw) => inspectField(field, raw)}
+            onApplyFix={() => cleanUpField(field)}
             disabled={submitting || dismissing}
             onChange={(next) => {
               setValidationMessage(null);

--- a/apps/agor-ui/src/components/Widgets/GatewayTokenWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/GatewayTokenWidget.tsx
@@ -21,7 +21,7 @@
  */
 
 import type { AgorClient, WidgetMessageMetadata } from '@agor-live/client';
-import { hasMinimumRole, ROLES } from '@agor-live/client';
+import { hasMinimumRole, normalizeCredential, ROLES } from '@agor-live/client';
 import {
   CheckCircleOutlined,
   ExclamationCircleOutlined,
@@ -34,6 +34,8 @@ import { useMemo, useRef, useState } from 'react';
 import { useAuth } from '@/hooks';
 import { useAgorStore } from '@/store/agorStore';
 import { useThemedMessage } from '@/utils/message';
+import { CredentialFieldFeedback } from '../credentials/CredentialFieldFeedback';
+import { type CredentialFieldState, useCredentialFields } from '../credentials/useCredentialField';
 import { registerWidgetComponent, type WidgetComponentProps } from '../MessageBlock/WidgetBlock';
 
 const { Text } = Typography;
@@ -146,11 +148,24 @@ interface FieldRowProps {
   field: string;
   value: string;
   onChange: (next: string) => void;
+  /** Normalize the current value (blur) or an explicit pasted value (paste). */
+  onNormalize: (raw?: string) => void;
+  feedback: CredentialFieldState;
+  onDismissInternalFix: () => void;
   error?: string;
   disabled: boolean;
 }
 
-const FieldRow: React.FC<FieldRowProps> = ({ field, value, onChange, error, disabled }) => {
+const FieldRow: React.FC<FieldRowProps> = ({
+  field,
+  value,
+  onChange,
+  onNormalize,
+  feedback,
+  onDismissInternalFix,
+  error,
+  disabled,
+}) => {
   const { token } = theme.useToken();
   const presentation = presentationFor(field);
   // Secure multi-line fields (GitHub PEM) start revealed for entry, then
@@ -161,6 +176,11 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, value, onChange, error, disa
     value,
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
       onChange(e.target.value),
+    onBlur: () => onNormalize(),
+    onPaste: (e: React.ClipboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const el = e.currentTarget;
+      window.setTimeout(() => onNormalize(el.value), 0);
+    },
     placeholder: presentation.placeholder,
     disabled,
     'aria-label': `Value for ${presentation.label}`,
@@ -243,6 +263,11 @@ const FieldRow: React.FC<FieldRowProps> = ({ field, value, onChange, error, disa
           {error}
         </Text>
       ) : null}
+      <CredentialFieldFeedback
+        lint={feedback.lint}
+        internalFixVisible={feedback.showInternalFix}
+        onDismissInternalFix={onDismissInternalFix}
+      />
     </Space>
   );
 };
@@ -269,6 +294,18 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [localResolution, setLocalResolution] = useState<'submitted' | 'dismissed' | null>(null);
   const resolvingRef = useRef(false);
+  const credentials = useCredentialFields();
+
+  // Silent normalization (paste/blur). Repairs terminal-paste artifacts and
+  // surfaces the internal-fix notice + format lint. `raw` is the DOM value on
+  // paste (state is stale there); on blur we read the committed state value.
+  const normalizeField = (field: string, raw?: string) => {
+    const source = raw ?? values[field] ?? '';
+    if (!source) return;
+    const normalized = credentials.normalizeOnInput(field, source);
+    setValues((prev) => ({ ...prev, [field]: normalized }));
+    credentials.lintOnBlur(field, normalized);
+  };
 
   // Resolve the current user's role from the CANONICAL store row (mirrors
   // App.tsx) rather than the SLIM auth user, which carries no `role`. Setting a
@@ -285,17 +322,14 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
     [fields, values]
   );
 
+  // Only genuinely-blocking conditions (a missing required value) belong here.
+  // Format mismatches are surfaced as non-blocking lint warnings via
+  // `CredentialFieldFeedback` — a stale prefix rule must never block a save.
   const validate = (): Record<string, string> => {
     const errors: Record<string, string> = {};
     for (const field of fields) {
-      const value = values[field]?.trim() ?? '';
-      if (!value) {
+      if (!(values[field]?.trim() ?? '')) {
         errors[field] = 'Enter a value.';
-        continue;
-      }
-      const prefix = presentationFor(field).prefix;
-      if (prefix && !value.startsWith(prefix)) {
-        errors[field] = `Expected a value starting with ${prefix}.`;
       }
     }
     return errors;
@@ -321,7 +355,8 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
     setValidationMessage(null);
     setFieldErrors({});
     const tokens: Record<string, string> = {};
-    for (const field of fields) tokens[field] = values[field]?.trim() ?? '';
+    for (const field of fields)
+      tokens[field] = normalizeCredential(field, values[field] ?? '').value;
     try {
       await post('submit', { tokens });
       setLocalResolution('submitted');
@@ -419,11 +454,15 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
             field={field}
             value={values[field] ?? ''}
             error={fieldErrors[field]}
+            feedback={credentials.get(field)}
+            onNormalize={(raw) => normalizeField(field, raw)}
+            onDismissInternalFix={() => credentials.dismissInternalFix(field)}
             disabled={submitting || dismissing}
             onChange={(next) => {
               setValidationMessage(null);
               setFieldErrors((prev) => ({ ...prev, [field]: '' }));
               setValues((prev) => ({ ...prev, [field]: next }));
+              credentials.reset(field);
             }}
           />
         ))}

--- a/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.test.tsx
+++ b/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.test.tsx
@@ -1,7 +1,8 @@
+import type { CredentialFixSuggestion } from '@agor-live/client';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
-import { CREDENTIAL_INTERNAL_FIX_NOTICE, CredentialFieldFeedback } from './CredentialFieldFeedback';
+import { CredentialFieldFeedback } from './CredentialFieldFeedback';
 
 function renderFeedback(props: Parameters<typeof CredentialFieldFeedback>[0]) {
   return render(
@@ -11,19 +12,30 @@ function renderFeedback(props: Parameters<typeof CredentialFieldFeedback>[0]) {
   );
 }
 
+const FIX: CredentialFixSuggestion = {
+  message: 'This key has extra spaces or line breaks in it — a common side effect.',
+  fixedValue: 'sk-ant-api03-abcDEF',
+  kinds: ['internal-whitespace'],
+};
+
 describe('CredentialFieldFeedback', () => {
-  it('renders nothing when there is no notice and no lint', () => {
+  it('renders nothing when there is no fix and no lint', () => {
     const { container } = renderFeedback({});
     expect(container.textContent).toBe('');
   });
 
-  it('shows the dismissible internal-fix notice and dismisses it', () => {
-    const onDismiss = vi.fn();
-    renderFeedback({ internalFixVisible: true, onDismissInternalFix: onDismiss });
+  it('shows the opt-in fix warning with a "Clean it up" action that opts in', () => {
+    const onApplyFix = vi.fn();
+    renderFeedback({ fix: FIX, onApplyFix });
 
-    expect(screen.getByText(CREDENTIAL_INTERNAL_FIX_NOTICE)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: /close/i }));
-    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(FIX.message)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /clean it up/i }));
+    expect(onApplyFix).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the action button when no handler is provided', () => {
+    renderFeedback({ fix: FIX });
+    expect(screen.queryByRole('button', { name: /clean it up/i })).not.toBeInTheDocument();
   });
 
   it('renders a warning lint message', () => {

--- a/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.test.tsx
+++ b/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { CREDENTIAL_INTERNAL_FIX_NOTICE, CredentialFieldFeedback } from './CredentialFieldFeedback';
+
+function renderFeedback(props: Parameters<typeof CredentialFieldFeedback>[0]) {
+  return render(
+    <AntApp>
+      <CredentialFieldFeedback {...props} />
+    </AntApp>
+  );
+}
+
+describe('CredentialFieldFeedback', () => {
+  it('renders nothing when there is no notice and no lint', () => {
+    const { container } = renderFeedback({});
+    expect(container.textContent).toBe('');
+  });
+
+  it('shows the dismissible internal-fix notice and dismisses it', () => {
+    const onDismiss = vi.fn();
+    renderFeedback({ internalFixVisible: true, onDismissInternalFix: onDismiss });
+
+    expect(screen.getByText(CREDENTIAL_INTERNAL_FIX_NOTICE)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a warning lint message', () => {
+    renderFeedback({
+      lint: { severity: 'warning', code: 'prefix', message: 'Looks off — double-check it.' },
+    });
+    expect(screen.getByText('Looks off — double-check it.')).toBeInTheDocument();
+  });
+
+  it('renders an error lint message', () => {
+    renderFeedback({
+      lint: { severity: 'error', code: 'charset', message: 'Invalid characters in this key.' },
+    });
+    expect(screen.getByText('Invalid characters in this key.')).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.tsx
+++ b/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.tsx
@@ -1,0 +1,50 @@
+import type { CredentialLintResult } from '@agor-live/client';
+import { Alert, Space, Typography, theme } from 'antd';
+
+const { Text } = Typography;
+
+export interface CredentialFieldFeedbackProps {
+  /** Layer-2 lint finding for the field, if any. */
+  lint?: CredentialLintResult | null;
+  /** Whether the dismissible "we repaired internal whitespace" notice is showing. */
+  internalFixVisible?: boolean;
+  /** Dismiss the internal-fix notice. */
+  onDismissInternalFix?: () => void;
+}
+
+/**
+ * Inline validation messages shared by every credential input surface: the
+ * dismissible "we removed spaces/line breaks" notice (Layer 1) and the
+ * non-blocking format-lint warning/error (Layer 2). Renders nothing when clean.
+ */
+export const CredentialFieldFeedback: React.FC<CredentialFieldFeedbackProps> = ({
+  lint,
+  internalFixVisible,
+  onDismissInternalFix,
+}) => {
+  const { token } = theme.useToken();
+  if (!internalFixVisible && !lint) return null;
+
+  return (
+    <Space orientation="vertical" size={token.marginXXS} style={{ width: '100%' }}>
+      {internalFixVisible && (
+        <Alert
+          type="warning"
+          showIcon
+          closable
+          onClose={onDismissInternalFix}
+          message="We removed spaces or line breaks from this key — a common side effect of copying from a terminal. Check that it verifies below."
+          style={{ fontSize: token.fontSizeSM }}
+        />
+      )}
+      {lint && (
+        <Text
+          type={lint.severity === 'error' ? 'danger' : 'warning'}
+          style={{ fontSize: token.fontSizeSM }}
+        >
+          {lint.message}
+        </Text>
+      )}
+    </Space>
+  );
+};

--- a/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.tsx
+++ b/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.tsx
@@ -1,47 +1,52 @@
-import type { CredentialLintResult } from '@agor-live/client';
-import { Alert, Space, Typography, theme } from 'antd';
+import type { CredentialFixSuggestion, CredentialLintResult } from '@agor-live/client';
+import { Alert, Button, Space, Typography, theme } from 'antd';
 
 const { Text } = Typography;
 
-/**
- * Canonical copy for the Layer-1 internal-fix notice. Covers internal-whitespace
- * collapse AND wrapping-quote strips (both flagged as `internalWhitespaceFixed`).
- * Exported so any surface that can't render the component reuses the same words.
- */
-export const CREDENTIAL_INTERNAL_FIX_NOTICE =
-  'We removed spaces, line breaks, or wrapping quotes from this key — a common side effect of copying from a terminal. Check that it verifies below.';
+/** Label for the opt-in one-click cleanup action. */
+export const CREDENTIAL_CLEAN_UP_LABEL = 'Clean it up';
 
 export interface CredentialFieldFeedbackProps {
   /** Layer-2 lint finding for the field, if any. */
   lint?: CredentialLintResult | null;
-  /** Whether the dismissible "we repaired internal whitespace" notice is showing. */
-  internalFixVisible?: boolean;
-  /** Dismiss the internal-fix notice. */
-  onDismissInternalFix?: () => void;
+  /**
+   * Layer-1 opt-in fix suggestion (internal whitespace / wrapping quotes). We
+   * NEVER apply this automatically — the user clicks the action to opt in.
+   */
+  fix?: CredentialFixSuggestion | null;
+  /** Apply the opt-in fix (sets the field to `fix.fixedValue`). */
+  onApplyFix?: () => void;
 }
 
 /**
  * Inline validation messages shared by every credential input surface: the
- * dismissible "we removed spaces/line breaks" notice (Layer 1) and the
- * non-blocking format-lint warning/error (Layer 2). Renders nothing when clean.
+ * opt-in "Clean it up" fix suggestion (Layer 1) and the non-blocking format-lint
+ * warning/error (Layer 2). Renders nothing when clean. The fix is only ever
+ * applied when the user clicks the action — the field's value is never rewritten
+ * behind their back.
  */
 export const CredentialFieldFeedback: React.FC<CredentialFieldFeedbackProps> = ({
   lint,
-  internalFixVisible,
-  onDismissInternalFix,
+  fix,
+  onApplyFix,
 }) => {
   const { token } = theme.useToken();
-  if (!internalFixVisible && !lint) return null;
+  if (!fix && !lint) return null;
 
   return (
     <Space orientation="vertical" size={token.marginXXS} style={{ width: '100%' }}>
-      {internalFixVisible && (
+      {fix && (
         <Alert
           type="warning"
           showIcon
-          closable
-          onClose={onDismissInternalFix}
-          message={CREDENTIAL_INTERNAL_FIX_NOTICE}
+          message={fix.message}
+          action={
+            onApplyFix ? (
+              <Button size="small" type="link" onClick={onApplyFix}>
+                {CREDENTIAL_CLEAN_UP_LABEL}
+              </Button>
+            ) : undefined
+          }
           style={{ fontSize: token.fontSizeSM }}
         />
       )}

--- a/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.tsx
+++ b/apps/agor-ui/src/components/credentials/CredentialFieldFeedback.tsx
@@ -3,6 +3,14 @@ import { Alert, Space, Typography, theme } from 'antd';
 
 const { Text } = Typography;
 
+/**
+ * Canonical copy for the Layer-1 internal-fix notice. Covers internal-whitespace
+ * collapse AND wrapping-quote strips (both flagged as `internalWhitespaceFixed`).
+ * Exported so any surface that can't render the component reuses the same words.
+ */
+export const CREDENTIAL_INTERNAL_FIX_NOTICE =
+  'We removed spaces, line breaks, or wrapping quotes from this key — a common side effect of copying from a terminal. Check that it verifies below.';
+
 export interface CredentialFieldFeedbackProps {
   /** Layer-2 lint finding for the field, if any. */
   lint?: CredentialLintResult | null;
@@ -33,7 +41,7 @@ export const CredentialFieldFeedback: React.FC<CredentialFieldFeedbackProps> = (
           showIcon
           closable
           onClose={onDismissInternalFix}
-          message="We removed spaces or line breaks from this key — a common side effect of copying from a terminal. Check that it verifies below."
+          message={CREDENTIAL_INTERNAL_FIX_NOTICE}
           style={{ fontSize: token.fontSizeSM }}
         />
       )}

--- a/apps/agor-ui/src/components/credentials/useCredentialField.test.tsx
+++ b/apps/agor-ui/src/components/credentials/useCredentialField.test.tsx
@@ -1,0 +1,64 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CredentialFieldFeedback } from './CredentialFieldFeedback';
+import { useCredentialFields } from './useCredentialField';
+
+const FIELD = 'ANTHROPIC_API_KEY';
+
+// Mirrors the paste pattern every surface uses: the input value updates AFTER
+// the paste event, so the handler defers and reads the DOM value on the next tick.
+function Harness() {
+  const cred = useCredentialFields();
+  const [value, setValue] = useState('');
+  const state = cred.get(FIELD);
+  return (
+    <AntApp>
+      <input
+        aria-label="key"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+          cred.reset(FIELD);
+        }}
+        onPaste={(e) => {
+          const el = e.currentTarget;
+          window.setTimeout(() => {
+            const normalized = cred.normalizeOnInput(FIELD, el.value);
+            setValue(normalized);
+            cred.lintOnBlur(FIELD, normalized);
+          }, 0);
+        }}
+      />
+      <CredentialFieldFeedback lint={state.lint} internalFixVisible={state.showInternalFix} />
+    </AntApp>
+  );
+}
+
+describe('useCredentialFields — paste timing (deferred DOM read)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('normalizes the pasted value on the next tick and surfaces the internal-fix notice', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText<HTMLInputElement>('key');
+
+    // Simulate the browser applying the paste (DOM value set) before our
+    // deferred handler reads it. The value carries a mid-token space.
+    input.value = 'sk-ant-api03-abc DEF0123456789';
+    fireEvent.paste(input);
+
+    // Before the timer fires, nothing is normalized yet.
+    expect(screen.queryByText(/we removed/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(input.value).toBe('sk-ant-api03-abcDEF0123456789');
+    expect(
+      screen.getByText(/we removed spaces, line breaks, or wrapping quotes/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/credentials/useCredentialField.test.tsx
+++ b/apps/agor-ui/src/components/credentials/useCredentialField.test.tsx
@@ -24,41 +24,45 @@ function Harness() {
         }}
         onPaste={(e) => {
           const el = e.currentTarget;
-          window.setTimeout(() => {
-            const normalized = cred.normalizeOnInput(FIELD, el.value);
-            setValue(normalized);
-            cred.lintOnBlur(FIELD, normalized);
-          }, 0);
+          window.setTimeout(() => setValue(cred.inspect(FIELD, el.value)), 0);
         }}
       />
-      <CredentialFieldFeedback lint={state.lint} internalFixVisible={state.showInternalFix} />
+      <CredentialFieldFeedback
+        lint={state.lint}
+        fix={state.fix}
+        onApplyFix={() => setValue(cred.applyFix(FIELD, value))}
+      />
     </AntApp>
   );
 }
 
-describe('useCredentialFields — paste timing (deferred DOM read)', () => {
+describe('useCredentialFields — paste timing + opt-in fix', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it('normalizes the pasted value on the next tick and surfaces the internal-fix notice', () => {
+  it('sanitizes edges on paste but keeps the internal space, then fixes only on click', () => {
     render(<Harness />);
     const input = screen.getByLabelText<HTMLInputElement>('key');
 
-    // Simulate the browser applying the paste (DOM value set) before our
-    // deferred handler reads it. The value carries a mid-token space.
-    input.value = 'sk-ant-api03-abc DEF0123456789';
+    // Browser applies the paste (DOM value set) before our deferred handler reads
+    // it. The value has edge whitespace AND a mid-token space.
+    input.value = '  sk-ant-api03-abc DEF0123456789  ';
     fireEvent.paste(input);
-
-    // Before the timer fires, nothing is normalized yet.
-    expect(screen.queryByText(/we removed/i)).not.toBeInTheDocument();
 
     act(() => {
       vi.runAllTimers();
     });
 
+    // Always-safe cleanup trimmed the edges; the internal space is PRESERVED.
+    expect(input.value).toBe('sk-ant-api03-abc DEF0123456789');
+    // A warning offers the opt-in fix — nothing was rewritten automatically.
+    expect(screen.getByText(/extra spaces or line breaks/i)).toBeInTheDocument();
+
+    // The user opts in.
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /clean it up/i }));
+    });
     expect(input.value).toBe('sk-ant-api03-abcDEF0123456789');
-    expect(
-      screen.getByText(/we removed spaces, line breaks, or wrapping quotes/i)
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/extra spaces or line breaks/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/credentials/useCredentialField.ts
+++ b/apps/agor-ui/src/components/credentials/useCredentialField.ts
@@ -1,19 +1,29 @@
-import { type CredentialLintResult, lintCredential, normalizeCredential } from '@agor-live/client';
+import {
+  applyCredentialFix,
+  type CredentialFixSuggestion,
+  type CredentialLintResult,
+  detectCredentialFix,
+  lintCredential,
+  sanitizeCredential,
+} from '@agor-live/client';
 import { useCallback, useState } from 'react';
 
 export interface CredentialFieldState {
   /** Most recent lint finding (null when clean or not yet linted). */
   lint: CredentialLintResult | null;
-  /** Whether the dismissible internal-whitespace notice should show. */
-  showInternalFix: boolean;
+  /** Opt-in fix suggestion (null when clean). Never applied automatically. */
+  fix: CredentialFixSuggestion | null;
 }
 
-const EMPTY: CredentialFieldState = { lint: null, showInternalFix: false };
+const EMPTY: CredentialFieldState = { lint: null, fix: null };
 
 /**
  * Per-field credential validation state. Timing follows the design contract:
- * `normalizeOnInput` fires on paste/blur (silent repair + internal-fix notice),
- * `lintOnBlur` fires on blur (format warnings). Never call these on keystroke.
+ * `inspect` fires on paste/blur — it applies the always-safe sanitize (edge +
+ * invisible chars) and returns that value for the caller to display, while
+ * detecting (but NOT applying) the opt-in fixes and running the format lint.
+ * `applyFix` runs only when the user clicks "Clean it up". Never call these on
+ * keystroke.
  *
  * Keyed by field id so one hook serves a whole surface (e.g. all agent-tool
  * inputs) without breaking the rules of hooks.
@@ -30,31 +40,39 @@ export function useCredentialFields() {
     setStates((prev) => ({ ...prev, [field]: { ...(prev[field] ?? EMPTY), ...next } }));
   }, []);
 
-  /** Normalize a raw value; surfaces the internal-fix notice when one was applied. */
-  const normalizeOnInput = useCallback(
+  /**
+   * Sanitize a raw value (always-safe edge + invisible-char cleanup), then detect
+   * the opt-in fix + lint on the sanitized value. Returns the sanitized value for
+   * the caller to write back to the field. Does NOT collapse internal whitespace
+   * or unwrap quotes — those are surfaced as an opt-in suggestion only.
+   */
+  const inspect = useCallback(
     (field: string, raw: string): string => {
-      const result = normalizeCredential(field, raw);
-      if (result.internalWhitespaceFixed) patch(field, { showInternalFix: true });
-      return result.value;
+      const sanitized = sanitizeCredential(raw);
+      patch(field, {
+        fix: detectCredentialFix(field, sanitized),
+        lint: lintCredential(field, sanitized),
+      });
+      return sanitized;
     },
     [patch]
   );
 
-  /** Run format lint for a field (call on blur). */
-  const lintOnBlur = useCallback(
-    (field: string, value: string) => {
-      patch(field, { lint: lintCredential(field, value) });
+  /**
+   * Apply the opt-in fix to the current value (user clicked "Clean it up").
+   * Returns the cleaned value and clears the suggestion (re-linting the result).
+   */
+  const applyFix = useCallback(
+    (field: string, currentValue: string): string => {
+      const fixed = applyCredentialFix(field, currentValue);
+      patch(field, { fix: null, lint: lintCredential(field, fixed) });
+      return fixed;
     },
     [patch]
   );
 
-  const dismissInternalFix = useCallback(
-    (field: string) => patch(field, { showInternalFix: false }),
-    [patch]
-  );
-
-  /** Clear all transient state for a field (e.g. after save/clear). */
+  /** Clear all transient state for a field (e.g. on manual edit or after save). */
   const reset = useCallback((field: string) => patch(field, { ...EMPTY }), [patch]);
 
-  return { get, normalizeOnInput, lintOnBlur, dismissInternalFix, reset };
+  return { get, inspect, applyFix, reset };
 }

--- a/apps/agor-ui/src/components/credentials/useCredentialField.ts
+++ b/apps/agor-ui/src/components/credentials/useCredentialField.ts
@@ -1,0 +1,60 @@
+import { type CredentialLintResult, lintCredential, normalizeCredential } from '@agor-live/client';
+import { useCallback, useState } from 'react';
+
+export interface CredentialFieldState {
+  /** Most recent lint finding (null when clean or not yet linted). */
+  lint: CredentialLintResult | null;
+  /** Whether the dismissible internal-whitespace notice should show. */
+  showInternalFix: boolean;
+}
+
+const EMPTY: CredentialFieldState = { lint: null, showInternalFix: false };
+
+/**
+ * Per-field credential validation state. Timing follows the design contract:
+ * `normalizeOnInput` fires on paste/blur (silent repair + internal-fix notice),
+ * `lintOnBlur` fires on blur (format warnings). Never call these on keystroke.
+ *
+ * Keyed by field id so one hook serves a whole surface (e.g. all agent-tool
+ * inputs) without breaking the rules of hooks.
+ */
+export function useCredentialFields() {
+  const [states, setStates] = useState<Record<string, CredentialFieldState>>({});
+
+  const get = useCallback(
+    (field: string): CredentialFieldState => states[field] ?? EMPTY,
+    [states]
+  );
+
+  const patch = useCallback((field: string, next: Partial<CredentialFieldState>) => {
+    setStates((prev) => ({ ...prev, [field]: { ...(prev[field] ?? EMPTY), ...next } }));
+  }, []);
+
+  /** Normalize a raw value; surfaces the internal-fix notice when one was applied. */
+  const normalizeOnInput = useCallback(
+    (field: string, raw: string): string => {
+      const result = normalizeCredential(field, raw);
+      if (result.internalWhitespaceFixed) patch(field, { showInternalFix: true });
+      return result.value;
+    },
+    [patch]
+  );
+
+  /** Run format lint for a field (call on blur). */
+  const lintOnBlur = useCallback(
+    (field: string, value: string) => {
+      patch(field, { lint: lintCredential(field, value) });
+    },
+    [patch]
+  );
+
+  const dismissInternalFix = useCallback(
+    (field: string) => patch(field, { showInternalFix: false }),
+    [patch]
+  );
+
+  /** Clear all transient state for a field (e.g. after save/clear). */
+  const reset = useCallback((field: string) => patch(field, { ...EMPTY }), [patch]);
+
+  return { get, normalizeOnInput, lintOnBlur, dismissInternalFix, reset };
+}

--- a/apps/agor-ui/src/components/credentials/useFormCredential.tsx
+++ b/apps/agor-ui/src/components/credentials/useFormCredential.tsx
@@ -1,0 +1,67 @@
+import { sanitizeCredential } from '@agor-live/client';
+import type { FormInstance } from 'antd';
+import type React from 'react';
+import { CredentialFieldFeedback } from './CredentialFieldFeedback';
+import { useCredentialFields } from './useCredentialField';
+
+/** True when the value carries a `{{ user.env.X }}` style template variable. */
+function isTemplateValue(value: string): boolean {
+  return value.includes('{{') && value.includes('}}');
+}
+
+export interface FormCredentialField {
+  /** Spread onto the credential Input inside its Form.Item. */
+  inputProps: {
+    onBlur: () => void;
+    onPaste: (e: React.ClipboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  };
+  /** Render below the Form.Item — the opt-in "Clean it up" warning + lint. */
+  feedback: React.ReactNode;
+}
+
+/**
+ * Wire an antd Form field to the shared credential feedback: always-safe sanitize
+ * on paste/blur, an opt-in "Clean it up" action for internal whitespace / wrapping
+ * quotes, and the format lint. The field value is never rewritten automatically.
+ *
+ * `allowTemplates` (MCP secret fields) skips fix detection when the value is a
+ * `{{ … }}` template — collapsing whitespace there would corrupt the template —
+ * while still sanitizing edge/invisible noise.
+ */
+export function useFormCredential(
+  form: FormInstance,
+  name: string,
+  options: { allowTemplates?: boolean } = {}
+): FormCredentialField {
+  const credentials = useCredentialFields();
+
+  const inspect = (raw?: string) => {
+    const current = raw ?? form.getFieldValue(name);
+    if (typeof current !== 'string' || !current) return;
+    if (options.allowTemplates && isTemplateValue(current)) {
+      form.setFieldsValue({ [name]: sanitizeCredential(current) });
+      credentials.reset(name);
+      return;
+    }
+    form.setFieldsValue({ [name]: credentials.inspect(name, current) });
+  };
+
+  const cleanUp = () => {
+    const current = form.getFieldValue(name);
+    if (typeof current !== 'string') return;
+    form.setFieldsValue({ [name]: credentials.applyFix(name, current) });
+  };
+
+  const state = credentials.get(name);
+
+  return {
+    inputProps: {
+      onBlur: () => inspect(),
+      onPaste: (e) => {
+        const el = e.currentTarget;
+        window.setTimeout(() => inspect(el.value), 0);
+      },
+    },
+    feedback: <CredentialFieldFeedback lint={state.lint} fix={state.fix} onApplyFix={cleanUp} />,
+  };
+}

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -3974,6 +3974,9 @@ export function KnowledgePage({
                           }
                           autoComplete="off"
                         />
+                        {/* No `lint` prop: api_key maps to the generic-secret
+                            spec (no prefix/charset), so there's nothing to lint —
+                            only the opt-in cleanup fix applies here. */}
                         <CredentialFieldFeedback
                           fix={knowledgeApiKey.get('api_key').fix}
                           onApplyFix={cleanUpKnowledgeApiKey}

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -23,7 +23,7 @@ import {
   validateKnowledgePath as validateSharedKnowledgePath,
 } from '@agor/core/types';
 import type { AgorClient, Group, User } from '@agor-live/client';
-import { normalizeCredential } from '@agor-live/client';
+import { sanitizeCredential } from '@agor-live/client';
 import {
   ApartmentOutlined,
   ArrowLeftOutlined,
@@ -819,13 +819,14 @@ export function KnowledgePage({
   const [settingsApiKeyDraft, setSettingsApiKeyDraft] = useState('');
   const knowledgeApiKey = useCredentialFields();
 
-  // Silent normalization (paste/blur) for the embedding API key — repairs the
-  // terminal-paste artifacts (edge/zero-width/wrapping-quote/internal space) that
-  // would otherwise be stored verbatim. `raw` is the DOM value on paste.
-  const normalizeKnowledgeApiKey = (raw: string) => {
+  // Paste/blur: always-safe sanitize (edge/invisible), then surface the opt-in
+  // fix + lint. Never collapses internal whitespace or unwraps quotes on its own.
+  const inspectKnowledgeApiKey = (raw: string) => {
     if (!raw) return;
-    const normalized = knowledgeApiKey.normalizeOnInput('api_key', raw);
-    setSettingsApiKeyDraft(normalized);
+    setSettingsApiKeyDraft(knowledgeApiKey.inspect('api_key', raw));
+  };
+  const cleanUpKnowledgeApiKey = () => {
+    setSettingsApiKeyDraft(knowledgeApiKey.applyFix('api_key', settingsApiKeyDraft));
   };
   const [settingsForm] = Form.useForm<KnowledgeSemanticSettings>();
   const [namespaceEditorOpen, setNamespaceEditorOpen] = useState(false);
@@ -1414,8 +1415,8 @@ export function KnowledgePage({
           ...(values.indexing ?? {}),
         },
       };
-      const normalizedApiKey = normalizeCredential('api_key', settingsApiKeyDraft).value;
-      if (normalizedApiKey) patch.api_key = normalizedApiKey;
+      const sanitizedApiKey = sanitizeCredential(settingsApiKeyDraft);
+      if (sanitizedApiKey) patch.api_key = sanitizedApiKey;
       const next = await client.service('kb/settings').create(patch);
       setKnowledgeSettings(next as KnowledgeSemanticSettingsPublic);
       setSettingsApiKeyDraft('');
@@ -3963,9 +3964,9 @@ export function KnowledgePage({
                           }}
                           onPaste={(event) => {
                             const el = event.currentTarget;
-                            window.setTimeout(() => normalizeKnowledgeApiKey(el.value), 0);
+                            window.setTimeout(() => inspectKnowledgeApiKey(el.value), 0);
                           }}
-                          onBlur={() => normalizeKnowledgeApiKey(settingsApiKeyDraft)}
+                          onBlur={() => inspectKnowledgeApiKey(settingsApiKeyDraft)}
                           placeholder={
                             knowledgeSettings?.api_key_configured
                               ? 'Configured — enter a new key to replace'
@@ -3974,8 +3975,8 @@ export function KnowledgePage({
                           autoComplete="off"
                         />
                         <CredentialFieldFeedback
-                          internalFixVisible={knowledgeApiKey.get('api_key').showInternalFix}
-                          onDismissInternalFix={() => knowledgeApiKey.dismissInternalFix('api_key')}
+                          fix={knowledgeApiKey.get('api_key').fix}
+                          onApplyFix={cleanUpKnowledgeApiKey}
                         />
                       </Form.Item>
                       <Flex gap={12} wrap="wrap">

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -23,6 +23,7 @@ import {
   validateKnowledgePath as validateSharedKnowledgePath,
 } from '@agor/core/types';
 import type { AgorClient, Group, User } from '@agor-live/client';
+import { normalizeCredential } from '@agor-live/client';
 import {
   ApartmentOutlined,
   ArrowLeftOutlined,
@@ -93,6 +94,8 @@ import {
   kbMentionFromDocument,
 } from '../components/AutocompleteTextarea';
 import { BrandLogo } from '../components/BrandLogo';
+import { CredentialFieldFeedback } from '../components/credentials/CredentialFieldFeedback';
+import { useCredentialFields } from '../components/credentials/useCredentialField';
 import { AgorEmojiPicker } from '../components/EmojiPickerInput';
 import { GlobalUserMenu } from '../components/GlobalUserMenu';
 import { HighlightMatch } from '../components/HighlightMatch';
@@ -814,6 +817,16 @@ export function KnowledgePage({
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [settingsError, setSettingsError] = useState<string | null>(null);
   const [settingsApiKeyDraft, setSettingsApiKeyDraft] = useState('');
+  const knowledgeApiKey = useCredentialFields();
+
+  // Silent normalization (paste/blur) for the embedding API key — repairs the
+  // terminal-paste artifacts (edge/zero-width/wrapping-quote/internal space) that
+  // would otherwise be stored verbatim. `raw` is the DOM value on paste.
+  const normalizeKnowledgeApiKey = (raw: string) => {
+    if (!raw) return;
+    const normalized = knowledgeApiKey.normalizeOnInput('api_key', raw);
+    setSettingsApiKeyDraft(normalized);
+  };
   const [settingsForm] = Form.useForm<KnowledgeSemanticSettings>();
   const [namespaceEditorOpen, setNamespaceEditorOpen] = useState(false);
   const [namespaceEditing, setNamespaceEditing] = useState<KnowledgeNamespace | null>(null);
@@ -1401,7 +1414,8 @@ export function KnowledgePage({
           ...(values.indexing ?? {}),
         },
       };
-      if (settingsApiKeyDraft.trim()) patch.api_key = settingsApiKeyDraft.trim();
+      const normalizedApiKey = normalizeCredential('api_key', settingsApiKeyDraft).value;
+      if (normalizedApiKey) patch.api_key = normalizedApiKey;
       const next = await client.service('kb/settings').create(patch);
       setKnowledgeSettings(next as KnowledgeSemanticSettingsPublic);
       setSettingsApiKeyDraft('');
@@ -3943,13 +3957,25 @@ export function KnowledgePage({
                       <Form.Item label="OpenAI API key">
                         <Input.Password
                           value={settingsApiKeyDraft}
-                          onChange={(event) => setSettingsApiKeyDraft(event.target.value)}
+                          onChange={(event) => {
+                            setSettingsApiKeyDraft(event.target.value);
+                            knowledgeApiKey.reset('api_key');
+                          }}
+                          onPaste={(event) => {
+                            const el = event.currentTarget;
+                            window.setTimeout(() => normalizeKnowledgeApiKey(el.value), 0);
+                          }}
+                          onBlur={() => normalizeKnowledgeApiKey(settingsApiKeyDraft)}
                           placeholder={
                             knowledgeSettings?.api_key_configured
                               ? 'Configured — enter a new key to replace'
                               : 'sk-...'
                           }
                           autoComplete="off"
+                        />
+                        <CredentialFieldFeedback
+                          internalFixVisible={knowledgeApiKey.get('api_key').showInternalFix}
+                          onDismissInternalFix={() => knowledgeApiKey.dismissInternalFix('api_key')}
                         />
                       </Form.Item>
                       <Flex gap={12} wrap="wrap">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,6 +94,12 @@
       "import": "./dist/permissions/index.js",
       "require": "./dist/permissions/index.cjs"
     },
+    "./credentials": {
+      "source": "./src/credentials/index.ts",
+      "types": "./dist/credentials/index.d.ts",
+      "import": "./dist/credentials/index.js",
+      "require": "./dist/credentials/index.cjs"
+    },
     "./feathers": {
       "source": "./src/feathers/index.ts",
       "types": "./dist/feathers/index.d.ts",

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -37,6 +37,21 @@ export {
 
 export * from '../config/browser.js';
 export type { AgorConfig } from '../config/types.js';
+// Shared credential normalization + format-lint — pure, browser-safe. Every
+// credential input surface consumes these so paste/blur behavior stays uniform.
+export {
+  CREDENTIAL_SPECS,
+  type CredentialLintResult,
+  type CredentialLintSeverity,
+  type CredentialNormalizationChanges,
+  type CredentialSpec,
+  type CredentialSpecKey,
+  isKnownCredentialField,
+  lintCredential,
+  type NormalizeCredentialResult,
+  normalizeCredential,
+  resolveCredentialSpec,
+} from '../credentials/index.js';
 // Global-search field registry — same module on client (V1 in-memory filter)
 // and server (future V2 SQL fan-out per design doc §5.7).
 export {

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -40,17 +40,19 @@ export type { AgorConfig } from '../config/types.js';
 // Shared credential normalization + format-lint — pure, browser-safe. Every
 // credential input surface consumes these so paste/blur behavior stays uniform.
 export {
+  applyCredentialFix,
   CREDENTIAL_SPECS,
+  type CredentialFixKind,
+  type CredentialFixSuggestion,
   type CredentialLintResult,
   type CredentialLintSeverity,
-  type CredentialNormalizationChanges,
   type CredentialSpec,
   type CredentialSpecKey,
+  detectCredentialFix,
   isKnownCredentialField,
   lintCredential,
-  type NormalizeCredentialResult,
-  normalizeCredential,
   resolveCredentialSpec,
+  sanitizeCredential,
 } from '../credentials/index.js';
 // Global-search field registry — same module on client (V1 in-memory filter)
 // and server (future V2 SQL fan-out per design doc §5.7).

--- a/packages/core/src/credentials/credentials.test.ts
+++ b/packages/core/src/credentials/credentials.test.ts
@@ -33,10 +33,38 @@ describe('normalizeCredential', () => {
     expect(r.internalWhitespaceFixed).toBe(false);
   });
 
-  it('replaces smart/curly quotes with straight quotes', () => {
+  it('strips smart quotes wrapping the whole value and flags an internal fix', () => {
     const r = normalizeCredential('ANTHROPIC_BASE_URL', '“https://api.example.com”');
-    expect(r.value).toBe('"https://api.example.com"');
-    expect(r.changes.fixedQuotes).toBe(true);
+    expect(r.value).toBe('https://api.example.com');
+    expect(r.changes.strippedWrappingQuotes).toBe(true);
+    expect(r.internalWhitespaceFixed).toBe(true);
+  });
+
+  it('strips ASCII double quotes wrapping a token (no quote char left behind)', () => {
+    const r = normalizeCredential('ANTHROPIC_API_KEY', '"sk-ant-api03-abcDEF0123456789abcDEF"');
+    expect(r.value).toBe('sk-ant-api03-abcDEF0123456789abcDEF');
+    expect(r.changes.strippedWrappingQuotes).toBe(true);
+    expect(r.internalWhitespaceFixed).toBe(true);
+  });
+
+  it('strips wrapping backticks', () => {
+    const r = normalizeCredential('OPENAI_API_KEY', '`sk-proj-abcdefghijklmnopqrstuv`');
+    expect(r.value).toBe('sk-proj-abcdefghijklmnopqrstuv');
+    expect(r.changes.strippedWrappingQuotes).toBe(true);
+  });
+
+  it('leaves a quote in the MIDDLE of the value untouched (charset lint owns it)', () => {
+    const r = normalizeCredential('OPENAI_API_KEY', 'sk-proj-abc"def0123456789012');
+    expect(r.value).toBe('sk-proj-abc"def0123456789012');
+    expect(r.changes.strippedWrappingQuotes).toBe(false);
+    expect(lintCredential('OPENAI_API_KEY', r.value)?.code).toBe('charset');
+  });
+
+  it('does NOT strip wrapping quotes for unknown fields (arbitrary values preserved)', () => {
+    const r = normalizeCredential('SOME_RANDOM_VAR', '“hello world”');
+    expect(r.value).toBe('“hello world”');
+    expect(r.changed).toBe(false);
+    expect(r.internalWhitespaceFixed).toBe(false);
   });
 
   it('leaves a clean token untouched', () => {
@@ -123,8 +151,33 @@ describe('resolveCredentialSpec', () => {
     expect(resolveCredentialSpec('UNKNOWN')).toBeUndefined();
   });
 
+  it('maps generic single-line secrets (gateway secrets + embedding api_key)', () => {
+    for (const field of [
+      'app_password',
+      'api_token',
+      'signing_secret',
+      'webhook_secret',
+      'api_key',
+    ]) {
+      expect(resolveCredentialSpec(field)?.key).toBe('generic-secret');
+    }
+  });
+
   it('reports known-credential fields for the env editor', () => {
     expect(isKnownCredentialField('COPILOT_GITHUB_TOKEN')).toBe(true);
     expect(isKnownCredentialField('MY_APP_FLAG')).toBe(false);
+  });
+});
+
+describe('generic-secret specs (gateway secrets + embedding api_key)', () => {
+  it('collapses an internal space and flags the fix, without any lint', () => {
+    const r = normalizeCredential('signing_secret', 'abc def12345678');
+    expect(r.value).toBe('abcdef12345678');
+    expect(r.internalWhitespaceFixed).toBe(true);
+    expect(lintCredential('signing_secret', r.value)).toBeNull();
+  });
+
+  it('does not prefix- or charset-lint a generic embedding api_key', () => {
+    expect(lintCredential('api_key', 'anything-goes_here.123')).toBeNull();
   });
 });

--- a/packages/core/src/credentials/credentials.test.ts
+++ b/packages/core/src/credentials/credentials.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { lintCredential } from './lint.js';
+import { normalizeCredential } from './normalize.js';
+import { isKnownCredentialField, resolveCredentialSpec } from './specs.js';
+
+describe('normalizeCredential', () => {
+  it('strips edge whitespace and newlines', () => {
+    const r = normalizeCredential('ANTHROPIC_API_KEY', '  sk-ant-api03-abcDEF123456  \n');
+    expect(r.value).toBe('sk-ant-api03-abcDEF123456');
+    expect(r.changed).toBe(true);
+    expect(r.internalWhitespaceFixed).toBe(false);
+  });
+
+  it('removes a mid-token space and flags the internal fix (the terminal-paste bug)', () => {
+    const r = normalizeCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-abc DEF123456');
+    expect(r.value).toBe('sk-ant-api03-abcDEF123456');
+    expect(r.internalWhitespaceFixed).toBe(true);
+    expect(r.changes.collapsedInternal).toBe(true);
+  });
+
+  it('removes a mid-token newline and flags the internal fix', () => {
+    const r = normalizeCredential('OPENAI_API_KEY', 'sk-proj-abc\ndef123456789012345');
+    expect(r.value).toBe('sk-proj-abcdef123456789012345');
+    expect(r.internalWhitespaceFixed).toBe(true);
+  });
+
+  it('strips zero-width characters without flagging an internal fix', () => {
+    const zwsp = '​';
+    const bom = '﻿';
+    const r = normalizeCredential('GEMINI_API_KEY', `AIza${zwsp}abcdef${bom}123456`);
+    expect(r.value).toBe('AIzaabcdef123456');
+    expect(r.changes.strippedZeroWidth).toBe(true);
+    expect(r.internalWhitespaceFixed).toBe(false);
+  });
+
+  it('replaces smart/curly quotes with straight quotes', () => {
+    const r = normalizeCredential('ANTHROPIC_BASE_URL', '“https://api.example.com”');
+    expect(r.value).toBe('"https://api.example.com"');
+    expect(r.changes.fixedQuotes).toBe(true);
+  });
+
+  it('leaves a clean token untouched', () => {
+    const r = normalizeCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-cleanTOKEN0123456789');
+    expect(r.changed).toBe(false);
+    expect(r.value).toBe('sk-ant-api03-cleanTOKEN0123456789');
+  });
+
+  it('edge-trims a PEM private key but never touches internal newlines', () => {
+    const pem = '-----BEGIN PRIVATE KEY-----\nLINE1\nLINE2\n-----END PRIVATE KEY-----';
+    const r = normalizeCredential('private_key', `\n  ${pem}  \n`);
+    expect(r.value).toBe(pem);
+    expect(r.internalWhitespaceFixed).toBe(false);
+    expect(r.changes.collapsedInternal).toBe(false);
+  });
+
+  it('does not collapse internal whitespace for unknown fields', () => {
+    const r = normalizeCredential('SOME_RANDOM_VAR', 'a b c');
+    expect(r.value).toBe('a b c');
+    expect(r.internalWhitespaceFixed).toBe(false);
+  });
+});
+
+describe('lintCredential', () => {
+  it('returns null for a well-formed Anthropic API key', () => {
+    expect(
+      lintCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-abcDEF0123456789abcDEF0123456789xyz')
+    ).toBeNull();
+  });
+
+  it('warns about a truncated (too short) key', () => {
+    const r = lintCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-short');
+    expect(r?.severity).toBe('warning');
+    expect(r?.code).toBe('length');
+  });
+
+  it('warns about a wrong prefix', () => {
+    const r = lintCredential('GEMINI_API_KEY', 'ya29-abcdefghijklmnop');
+    expect(r?.severity).toBe('warning');
+    expect(r?.code).toBe('prefix');
+  });
+
+  it('detects Anthropic OAuth token pasted into the API-key field', () => {
+    const r = lintCredential('ANTHROPIC_API_KEY', 'sk-ant-oat01-abcDEF0123456789abcDEF0123456789');
+    expect(r?.code).toBe('cross-paste');
+    expect(r?.suggestField).toBe('CLAUDE_CODE_OAUTH_TOKEN');
+  });
+
+  it('detects Anthropic API key pasted into the subscription field', () => {
+    const r = lintCredential(
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'sk-ant-api03-abcDEF0123456789abcDEF0123456789'
+    );
+    expect(r?.code).toBe('cross-paste');
+    expect(r?.suggestField).toBe('ANTHROPIC_API_KEY');
+  });
+
+  it('errors on an impossible charset (stray space that survived)', () => {
+    const r = lintCredential('OPENAI_API_KEY', 'sk-proj-abc def with spaces here 12345');
+    expect(r?.severity).toBe('error');
+    expect(r?.code).toBe('charset');
+  });
+
+  it('never lints an unknown field', () => {
+    expect(lintCredential('SOME_RANDOM_VAR', 'anything at all')).toBeNull();
+  });
+
+  it('does not lint a base URL by prefix/charset', () => {
+    expect(lintCredential('ANTHROPIC_BASE_URL', 'https://api.example.com/v1')).toBeNull();
+  });
+
+  it('recognizes both OpenAI prefixes', () => {
+    expect(lintCredential('OPENAI_API_KEY', 'sk-proj-abcdefghijklmnopqrstuvwx')).toBeNull();
+    expect(lintCredential('OPENAI_API_KEY', 'sk-abcdefghijklmnopqrstuvwxyz012')).toBeNull();
+  });
+});
+
+describe('resolveCredentialSpec', () => {
+  it('maps env var names, gateway keys, and spec keys', () => {
+    expect(resolveCredentialSpec('ANTHROPIC_API_KEY')?.key).toBe('anthropic-api-key');
+    expect(resolveCredentialSpec('bot_token')?.key).toBe('slack-bot-token');
+    expect(resolveCredentialSpec('GH_TOKEN')?.key).toBe('github-token');
+    expect(resolveCredentialSpec('slack-app-token')?.key).toBe('slack-app-token');
+    expect(resolveCredentialSpec('UNKNOWN')).toBeUndefined();
+  });
+
+  it('reports known-credential fields for the env editor', () => {
+    expect(isKnownCredentialField('COPILOT_GITHUB_TOKEN')).toBe(true);
+    expect(isKnownCredentialField('MY_APP_FLAG')).toBe(false);
+  });
+});

--- a/packages/core/src/credentials/credentials.test.ts
+++ b/packages/core/src/credentials/credentials.test.ts
@@ -1,90 +1,99 @@
 import { describe, expect, it } from 'vitest';
 import { lintCredential } from './lint.js';
-import { normalizeCredential } from './normalize.js';
+import { applyCredentialFix, detectCredentialFix, sanitizeCredential } from './normalize.js';
 import { isKnownCredentialField, resolveCredentialSpec } from './specs.js';
 
-describe('normalizeCredential', () => {
+describe('sanitizeCredential (always-safe automatic cleanup)', () => {
   it('strips edge whitespace and newlines', () => {
-    const r = normalizeCredential('ANTHROPIC_API_KEY', '  sk-ant-api03-abcDEF123456  \n');
-    expect(r.value).toBe('sk-ant-api03-abcDEF123456');
-    expect(r.changed).toBe(true);
-    expect(r.internalWhitespaceFixed).toBe(false);
+    expect(sanitizeCredential('  sk-ant-api03-abcDEF123456  \n')).toBe('sk-ant-api03-abcDEF123456');
   });
 
-  it('removes a mid-token space and flags the internal fix (the terminal-paste bug)', () => {
-    const r = normalizeCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-abc DEF123456');
-    expect(r.value).toBe('sk-ant-api03-abcDEF123456');
-    expect(r.internalWhitespaceFixed).toBe(true);
-    expect(r.changes.collapsedInternal).toBe(true);
-  });
-
-  it('removes a mid-token newline and flags the internal fix', () => {
-    const r = normalizeCredential('OPENAI_API_KEY', 'sk-proj-abc\ndef123456789012345');
-    expect(r.value).toBe('sk-proj-abcdef123456789012345');
-    expect(r.internalWhitespaceFixed).toBe(true);
-  });
-
-  it('strips zero-width characters without flagging an internal fix', () => {
+  it('strips zero-width / invisible characters', () => {
     const zwsp = '​';
     const bom = '﻿';
-    const r = normalizeCredential('GEMINI_API_KEY', `AIza${zwsp}abcdef${bom}123456`);
-    expect(r.value).toBe('AIzaabcdef123456');
-    expect(r.changes.strippedZeroWidth).toBe(true);
-    expect(r.internalWhitespaceFixed).toBe(false);
+    expect(sanitizeCredential(`AIza${zwsp}abcdef${bom}123456`)).toBe('AIzaabcdef123456');
   });
 
-  it('strips smart quotes wrapping the whole value and flags an internal fix', () => {
-    const r = normalizeCredential('ANTHROPIC_BASE_URL', '“https://api.example.com”');
-    expect(r.value).toBe('https://api.example.com');
-    expect(r.changes.strippedWrappingQuotes).toBe(true);
-    expect(r.internalWhitespaceFixed).toBe(true);
+  it('NEVER collapses internal whitespace (the user keeps what they typed)', () => {
+    expect(sanitizeCredential('sk-ant-api03-abc DEF123456')).toBe('sk-ant-api03-abc DEF123456');
   });
 
-  it('strips ASCII double quotes wrapping a token (no quote char left behind)', () => {
-    const r = normalizeCredential('ANTHROPIC_API_KEY', '"sk-ant-api03-abcDEF0123456789abcDEF"');
-    expect(r.value).toBe('sk-ant-api03-abcDEF0123456789abcDEF');
-    expect(r.changes.strippedWrappingQuotes).toBe(true);
-    expect(r.internalWhitespaceFixed).toBe(true);
-  });
-
-  it('strips wrapping backticks', () => {
-    const r = normalizeCredential('OPENAI_API_KEY', '`sk-proj-abcdefghijklmnopqrstuv`');
-    expect(r.value).toBe('sk-proj-abcdefghijklmnopqrstuv');
-    expect(r.changes.strippedWrappingQuotes).toBe(true);
-  });
-
-  it('leaves a quote in the MIDDLE of the value untouched (charset lint owns it)', () => {
-    const r = normalizeCredential('OPENAI_API_KEY', 'sk-proj-abc"def0123456789012');
-    expect(r.value).toBe('sk-proj-abc"def0123456789012');
-    expect(r.changes.strippedWrappingQuotes).toBe(false);
-    expect(lintCredential('OPENAI_API_KEY', r.value)?.code).toBe('charset');
-  });
-
-  it('does NOT strip wrapping quotes for unknown fields (arbitrary values preserved)', () => {
-    const r = normalizeCredential('SOME_RANDOM_VAR', '“hello world”');
-    expect(r.value).toBe('“hello world”');
-    expect(r.changed).toBe(false);
-    expect(r.internalWhitespaceFixed).toBe(false);
+  it('NEVER unwraps quotes', () => {
+    expect(sanitizeCredential('"sk-ant-api03-token"')).toBe('"sk-ant-api03-token"');
+    expect(sanitizeCredential('“https://api.example.com”')).toBe('“https://api.example.com”');
   });
 
   it('leaves a clean token untouched', () => {
-    const r = normalizeCredential('ANTHROPIC_API_KEY', 'sk-ant-api03-cleanTOKEN0123456789');
-    expect(r.changed).toBe(false);
-    expect(r.value).toBe('sk-ant-api03-cleanTOKEN0123456789');
+    expect(sanitizeCredential('sk-ant-api03-cleanTOKEN0123456789')).toBe(
+      'sk-ant-api03-cleanTOKEN0123456789'
+    );
+  });
+});
+
+describe('detectCredentialFix (opt-in — never applied automatically)', () => {
+  it('detects a mid-token space on a known field', () => {
+    const fix = detectCredentialFix('ANTHROPIC_API_KEY', 'sk-ant-api03-abc DEF123456');
+    expect(fix?.kinds).toContain('internal-whitespace');
+    expect(fix?.fixedValue).toBe('sk-ant-api03-abcDEF123456');
+    expect(fix?.message).toMatch(/spaces or line breaks/i);
   });
 
-  it('edge-trims a PEM private key but never touches internal newlines', () => {
+  it('detects a mid-token newline', () => {
+    const fix = detectCredentialFix('OPENAI_API_KEY', 'sk-proj-abc\ndef123456789012345');
+    expect(fix?.kinds).toContain('internal-whitespace');
+    expect(fix?.fixedValue).toBe('sk-proj-abcdef123456789012345');
+  });
+
+  it('detects wrapping quotes (ASCII, smart, backtick)', () => {
+    expect(detectCredentialFix('ANTHROPIC_API_KEY', '"sk-ant-api03-token0000"')?.kinds).toEqual([
+      'wrapping-quotes',
+    ]);
+    expect(detectCredentialFix('ANTHROPIC_BASE_URL', '“https://api.example.com”')?.fixedValue).toBe(
+      'https://api.example.com'
+    );
+    expect(detectCredentialFix('OPENAI_API_KEY', '`sk-proj-token00000`')?.fixedValue).toBe(
+      'sk-proj-token00000'
+    );
+  });
+
+  it('reports both kinds when the value is quoted AND has internal whitespace', () => {
+    const fix = detectCredentialFix('ANTHROPIC_API_KEY', '"sk-ant-api03-abc DEF"');
+    expect(fix?.kinds).toEqual(['wrapping-quotes', 'internal-whitespace']);
+    expect(fix?.fixedValue).toBe('sk-ant-api03-abcDEF');
+    expect(fix?.message).toMatch(/wrapping quotes/i);
+  });
+
+  it('returns null for a clean known token', () => {
+    expect(detectCredentialFix('ANTHROPIC_API_KEY', 'sk-ant-api03-clean0123456789')).toBeNull();
+  });
+
+  it('returns null for unknown fields (arbitrary values are never touched)', () => {
+    expect(detectCredentialFix('SOME_RANDOM_VAR', 'a b c')).toBeNull();
+    expect(detectCredentialFix('SOME_RANDOM_VAR', '“hello world”')).toBeNull();
+  });
+
+  it('returns null for multi-line PEM fields', () => {
     const pem = '-----BEGIN PRIVATE KEY-----\nLINE1\nLINE2\n-----END PRIVATE KEY-----';
-    const r = normalizeCredential('private_key', `\n  ${pem}  \n`);
-    expect(r.value).toBe(pem);
-    expect(r.internalWhitespaceFixed).toBe(false);
-    expect(r.changes.collapsedInternal).toBe(false);
+    expect(detectCredentialFix('private_key', pem)).toBeNull();
   });
 
-  it('does not collapse internal whitespace for unknown fields', () => {
-    const r = normalizeCredential('SOME_RANDOM_VAR', 'a b c');
-    expect(r.value).toBe('a b c');
-    expect(r.internalWhitespaceFixed).toBe(false);
+  it('ignores invisible/edge noise (only genuine internal issues trigger it)', () => {
+    const bom = '﻿';
+    expect(detectCredentialFix('GEMINI_API_KEY', `  AIzaClean0123456789${bom}  `)).toBeNull();
+  });
+});
+
+describe('applyCredentialFix (only invoked on explicit user action)', () => {
+  it('collapses internal whitespace and unwraps quotes for known single-line fields', () => {
+    expect(applyCredentialFix('ANTHROPIC_API_KEY', '"sk-ant-api03-abc DEF"')).toBe(
+      'sk-ant-api03-abcDEF'
+    );
+  });
+
+  it('is edge/invisible-only (no-op beyond sanitize) for unknown or PEM fields', () => {
+    expect(applyCredentialFix('SOME_RANDOM_VAR', '“a b c”')).toBe('“a b c”');
+    const pem = '-----BEGIN KEY-----\nA B\n-----END KEY-----';
+    expect(applyCredentialFix('private_key', `  ${pem}  `)).toBe(pem);
   });
 });
 
@@ -170,11 +179,11 @@ describe('resolveCredentialSpec', () => {
 });
 
 describe('generic-secret specs (gateway secrets + embedding api_key)', () => {
-  it('collapses an internal space and flags the fix, without any lint', () => {
-    const r = normalizeCredential('signing_secret', 'abc def12345678');
-    expect(r.value).toBe('abcdef12345678');
-    expect(r.internalWhitespaceFixed).toBe(true);
-    expect(lintCredential('signing_secret', r.value)).toBeNull();
+  it('offers an opt-in internal-space fix without any lint', () => {
+    const fix = detectCredentialFix('signing_secret', 'abc def12345678');
+    expect(fix?.fixedValue).toBe('abcdef12345678');
+    expect(fix?.kinds).toContain('internal-whitespace');
+    expect(lintCredential('signing_secret', 'abc def12345678')).toBeNull();
   });
 
   it('does not prefix- or charset-lint a generic embedding api_key', () => {

--- a/packages/core/src/credentials/index.ts
+++ b/packages/core/src/credentials/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared credential normalization + format-lint. Single source of truth consumed
+ * by every credential surface (agent tools, onboarding, gateway, MCP, env vars)
+ * and the daemon's at-rest normalization backstop.
+ *
+ * - Layer 1 (`normalizeCredential`): silent repair, safe on paste/blur/write.
+ * - Layer 2 (`lintCredential`): non-blocking format warnings.
+ * - Layer 3 (live verify) is provided per-surface via the check-auth service.
+ */
+
+export {
+  type CredentialLintResult,
+  type CredentialLintSeverity,
+  lintCredential,
+} from './lint.js';
+export {
+  type CredentialNormalizationChanges,
+  type NormalizeCredentialResult,
+  normalizeCredential,
+} from './normalize.js';
+export {
+  CREDENTIAL_SPECS,
+  type CredentialSpec,
+  type CredentialSpecKey,
+  isKnownCredentialField,
+  resolveCredentialSpec,
+} from './specs.js';

--- a/packages/core/src/credentials/index.ts
+++ b/packages/core/src/credentials/index.ts
@@ -3,7 +3,11 @@
  * by every credential surface (agent tools, onboarding, gateway, MCP, env vars)
  * and the daemon's at-rest normalization backstop.
  *
- * - Layer 1 (`normalizeCredential`): silent repair, safe on paste/blur/write.
+ * - Layer 1a (`sanitizeCredential`): always-safe automatic cleanup (edge +
+ *   invisible chars), safe on paste/blur/write and as a daemon backstop.
+ * - Layer 1b (`detectCredentialFix` / `applyCredentialFix`): opt-in cleanup
+ *   (internal whitespace, wrapping quotes) — detected automatically, applied only
+ *   on explicit user action. Never rewritten silently.
  * - Layer 2 (`lintCredential`): non-blocking format warnings.
  * - Layer 3 (live verify) is provided per-surface via the check-auth service.
  */
@@ -14,9 +18,11 @@ export {
   lintCredential,
 } from './lint.js';
 export {
-  type CredentialNormalizationChanges,
-  type NormalizeCredentialResult,
-  normalizeCredential,
+  applyCredentialFix,
+  type CredentialFixKind,
+  type CredentialFixSuggestion,
+  detectCredentialFix,
+  sanitizeCredential,
 } from './normalize.js';
 export {
   CREDENTIAL_SPECS,

--- a/packages/core/src/credentials/lint.ts
+++ b/packages/core/src/credentials/lint.ts
@@ -1,0 +1,96 @@
+/**
+ * Credential format lint (Layer 2).
+ *
+ * Warnings, never blockers — providers change formats, and a stale hard block is
+ * worse than no check. Returns at most one finding (the most actionable) so a
+ * surface can render a single inline message. `error` severity is reserved for an
+ * impossible charset; everything else is a `warning`.
+ *
+ * Cross-paste detection is special-cased for the two Anthropic fields, which are
+ * easy to swap and where the fix ("paste it in the other field") is unambiguous.
+ */
+
+import { CREDENTIAL_SPECS, type CredentialSpec, resolveCredentialSpec } from './specs.js';
+
+export type CredentialLintSeverity = 'warning' | 'error';
+
+export interface CredentialLintResult {
+  severity: CredentialLintSeverity;
+  code: 'cross-paste' | 'charset' | 'prefix' | 'length';
+  message: string;
+  /** Field the value likely belongs in (cross-paste only). */
+  suggestField?: string;
+}
+
+const startsWithAny = (value: string, prefixes: string[]): boolean =>
+  prefixes.some((prefix) => value.startsWith(prefix));
+
+/** Anthropic API-key ↔ subscription-token swap detection. Returns null if not applicable. */
+function detectCrossPaste(spec: CredentialSpec, value: string): CredentialLintResult | null {
+  if (
+    spec.key === 'anthropic-api-key' &&
+    startsWithAny(value, CREDENTIAL_SPECS['anthropic-oauth-token'].prefixes)
+  ) {
+    return {
+      severity: 'warning',
+      code: 'cross-paste',
+      message:
+        'This looks like a Claude Pro/Max token (sk-ant-oat…). Paste it in the Claude subscription field instead.',
+      suggestField: 'CLAUDE_CODE_OAUTH_TOKEN',
+    };
+  }
+  if (
+    spec.key === 'anthropic-oauth-token' &&
+    startsWithAny(value, CREDENTIAL_SPECS['anthropic-api-key'].prefixes)
+  ) {
+    return {
+      severity: 'warning',
+      code: 'cross-paste',
+      message:
+        'This looks like an Anthropic API key (sk-ant-api…). Paste it in the Anthropic API Key field instead.',
+      suggestField: 'ANTHROPIC_API_KEY',
+    };
+  }
+  return null;
+}
+
+/**
+ * Lint a (preferably normalized) credential value for format smells. Returns null
+ * when the value is empty or looks fine. Never throws and never blocks save.
+ */
+export function lintCredential(field: string, value: string): CredentialLintResult | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const spec = resolveCredentialSpec(field);
+  if (!spec) return null;
+
+  const crossPaste = detectCrossPaste(spec, trimmed);
+  if (crossPaste) return crossPaste;
+
+  if (spec.charset && spec.singleLine && !spec.charset.test(trimmed)) {
+    return {
+      severity: 'error',
+      code: 'charset',
+      message: `This ${spec.provider} key contains characters that aren't valid for a token — check for a stray space or a copy/paste error.`,
+    };
+  }
+
+  if (spec.prefixes.length > 0 && !startsWithAny(trimmed, spec.prefixes)) {
+    return {
+      severity: 'warning',
+      code: 'prefix',
+      message: `${spec.provider} keys usually start with ${spec.prefixHint}. Double-check you copied the right key.`,
+    };
+  }
+
+  if (spec.minLength && trimmed.length < spec.minLength) {
+    return {
+      severity: 'warning',
+      code: 'length',
+      message: `This ${spec.provider} key looks incomplete — it may have been truncated when copied.`,
+    };
+  }
+
+  return null;
+}

--- a/packages/core/src/credentials/normalize.ts
+++ b/packages/core/src/credentials/normalize.ts
@@ -1,15 +1,16 @@
 /**
- * Silent credential normalization (Layer 1).
+ * Credential cleanup (Layer 1), split by how much consent it needs.
  *
- * Repairs the artifacts of copying a token through a terminal or rich-text
- * editor. Every value gets edge whitespace and zero-width characters removed.
- * For KNOWN credential fields we also strip a quote pair (smart/ASCII/backtick)
- * that wraps the entire value, and — for single-line tokens — collapse internal
- * whitespace/newlines. Both of those are flagged (`internalWhitespaceFixed`) so
- * the UI surfaces a dismissible notice, since either could mask a truncated
- * paste. Unknown fields (arbitrary env vars) get edge-trim + zero-width strip
- * ONLY — never quote or internal rewriting — so we don't silently mangle a value
- * we don't understand. Multi-line values (PEM keys) keep their internal newlines.
+ * `sanitizeCredential` is the ALWAYS-automatic part: it strips edge whitespace
+ * and invisible/zero-width characters. These are never visible and never
+ * intentional, so there is nothing for a user to notice — safe to apply on
+ * paste/blur/save and as a daemon backstop.
+ *
+ * `detectCredentialFix` / `applyCredentialFix` are the OPT-IN part: internal
+ * whitespace (the mid-token space/newline) and a quote pair wrapping the whole
+ * value. We NEVER rewrite these behind the user's back — a token is content they
+ * chose. Instead the UI detects them and offers a one-click "Clean it up" action
+ * that calls `applyCredentialFix`. Multi-line values (PEM keys) are exempt.
  */
 
 import { resolveCredentialSpec } from './specs.js';
@@ -23,73 +24,90 @@ const ZERO_WIDTH = /​|‌|‍|⁠|﻿/g;
 // and primes. Used to detect a quote pair wrapping the whole value.
 const QUOTE_CHAR = /["'`‘’‚‛′“”„‟″]/;
 const INTERNAL_WHITESPACE = /\s+/g;
-
-export interface CredentialNormalizationChanges {
-  edgeTrimmed: boolean;
-  strippedZeroWidth: boolean;
-  /** A quote pair wrapping the entire value was removed (known fields only). */
-  strippedWrappingQuotes: boolean;
-  /** Internal whitespace/newlines were removed (single-line known fields only). */
-  collapsedInternal: boolean;
-}
-
-export interface NormalizeCredentialResult {
-  value: string;
-  original: string;
-  changed: boolean;
-  changes: CredentialNormalizationChanges;
-  /**
-   * True when an internal fix was applied (internal-whitespace collapse or a
-   * wrapping-quote strip). The UI must surface a dismissible warning: the fix is
-   * usually correct, but could hide a truncated copy.
-   */
-  internalWhitespaceFixed: boolean;
-}
+const HAS_WHITESPACE = /\s/;
 
 const isQuote = (ch: string): boolean => QUOTE_CHAR.test(ch);
 
-export function normalizeCredential(field: string, value: string): NormalizeCredentialResult {
+/**
+ * Always-safe automatic cleanup: strip zero-width/invisible characters and edge
+ * whitespace. Field-independent (safe for single-line tokens and multi-line PEM
+ * alike — internal content is never touched).
+ */
+export function sanitizeCredential(value: string): string {
+  return value.replace(ZERO_WIDTH, '').trim();
+}
+
+export type CredentialFixKind = 'internal-whitespace' | 'wrapping-quotes';
+
+export interface CredentialFixSuggestion {
+  /** Warning text describing the issue (the action label lives in the UI). */
+  message: string;
+  /** The value with the opt-in fix applied — what the one-click action sets. */
+  fixedValue: string;
+  /** Which issues were detected. */
+  kinds: CredentialFixKind[];
+}
+
+/** Strip quote pairs wrapping the whole value (loops for nested wrappers). */
+function unwrapQuotes(value: string): string {
+  let working = value;
+  while (working.length >= 2 && isQuote(working[0]) && isQuote(working[working.length - 1])) {
+    working = working.slice(1, -1).trim();
+  }
+  return working;
+}
+
+/**
+ * Apply the OPT-IN fixes (quote-unwrap + internal-whitespace collapse) on top of
+ * sanitization. Only eligible for known single-line credential fields; returns
+ * the value unchanged for unknown or multi-line fields. Called only when the
+ * user explicitly asks to clean the value up.
+ */
+export function applyCredentialFix(field: string, value: string): string {
   const spec = resolveCredentialSpec(field);
-  const singleLine = spec?.singleLine ?? false;
+  if (!spec?.singleLine) return sanitizeCredential(value);
+  return unwrapQuotes(sanitizeCredential(value)).replace(INTERNAL_WHITESPACE, '');
+}
 
-  const withoutZeroWidth = value.replace(ZERO_WIDTH, '');
-  const trimmed = withoutZeroWidth.trim();
-
-  let working = trimmed;
-
-  // Known credential fields only: strip a quote pair that wraps the whole value
-  // (a paste artifact — a real token never starts and ends with a quote). Loop
-  // to handle nested wrappers, re-trimming inside each layer. Any quote left in
-  // the middle is intentionally NOT touched — the charset lint flags it instead.
-  let strippedWrappingQuotes = false;
-  if (spec) {
-    while (working.length >= 2 && isQuote(working[0]) && isQuote(working[working.length - 1])) {
-      working = working.slice(1, -1).trim();
-      strippedWrappingQuotes = true;
-    }
+function messageForKinds(kinds: CredentialFixKind[]): string {
+  const hasInternal = kinds.includes('internal-whitespace');
+  const hasQuotes = kinds.includes('wrapping-quotes');
+  if (hasInternal && hasQuotes) {
+    return 'This key has extra spaces, line breaks, or wrapping quotes in it — a common side effect of copying from a terminal.';
   }
-
-  let collapsedInternal = false;
-  if (singleLine) {
-    const withoutInternal = working.replace(INTERNAL_WHITESPACE, '');
-    if (withoutInternal !== working) {
-      working = withoutInternal;
-      collapsedInternal = true;
-    }
+  if (hasQuotes) {
+    return "This key is wrapped in quotation marks — that's usually an accidental copy artifact.";
   }
+  return 'This key has extra spaces or line breaks in it — a common side effect of copying from a terminal.';
+}
 
-  const changes: CredentialNormalizationChanges = {
-    edgeTrimmed: trimmed !== withoutZeroWidth,
-    strippedZeroWidth: withoutZeroWidth !== value,
-    strippedWrappingQuotes,
-    collapsedInternal,
-  };
+/**
+ * Detect an opt-in-fixable issue on a value. Returns null when clean, or when the
+ * field isn't an eligible single-line credential. Operates on the sanitized value
+ * so invisible/edge noise never triggers it — only genuine internal whitespace or
+ * wrapping quotes do. Does NOT mutate; the caller decides whether to apply the fix.
+ */
+export function detectCredentialFix(field: string, value: string): CredentialFixSuggestion | null {
+  const spec = resolveCredentialSpec(field);
+  if (!spec?.singleLine) return null;
+
+  const sanitized = sanitizeCredential(value);
+  if (!sanitized) return null;
+
+  const kinds: CredentialFixKind[] = [];
+  let body = sanitized;
+  if (body.length >= 2 && isQuote(body[0]) && isQuote(body[body.length - 1])) {
+    kinds.push('wrapping-quotes');
+    body = unwrapQuotes(body);
+  }
+  if (HAS_WHITESPACE.test(body)) {
+    kinds.push('internal-whitespace');
+  }
+  if (kinds.length === 0) return null;
 
   return {
-    value: working,
-    original: value,
-    changed: working !== value,
-    changes,
-    internalWhitespaceFixed: collapsedInternal || strippedWrappingQuotes,
+    message: messageForKinds(kinds),
+    fixedValue: applyCredentialFix(field, sanitized),
+    kinds,
   };
 }

--- a/packages/core/src/credentials/normalize.ts
+++ b/packages/core/src/credentials/normalize.ts
@@ -1,0 +1,84 @@
+/**
+ * Silent credential normalization (Layer 1).
+ *
+ * Repairs the artifacts of copying a token through a terminal or rich-text
+ * editor: edge whitespace, zero-width characters, and smart/curly quotes are
+ * always removed. For single-line tokens, internal whitespace/newlines are also
+ * stripped — but that fix is flagged (`internalWhitespaceFixed`) so the UI can
+ * warn, since it could otherwise mask a truncated paste. Multi-line values (PEM
+ * private keys) get edge-trim only; their internal newlines are structural.
+ */
+
+import { resolveCredentialSpec } from './specs.js';
+
+// Codepoints kept as \u escapes so the (invisible / look-alike) characters never
+// appear as literals in source. Zero-width space, ZWNJ, ZWJ, word joiner, BOM \u2014
+// written as an alternation (not a char class) since a ZWJ in a class trips
+// biome's noMisleadingCharacterClass.
+const ZERO_WIDTH = /\u200B|\u200C|\u200D|\u2060|\uFEFF/g;
+// Curly/smart double quotes + prime → straight ASCII double quote.
+const SMART_DOUBLE_QUOTE = /[\u201C\u201D\u201E\u201F\u2033]/g;
+// Curly/smart single quotes + prime → straight ASCII single quote.
+const SMART_SINGLE_QUOTE = /[\u2018\u2019\u201A\u201B\u2032]/g;
+const INTERNAL_WHITESPACE = /\s+/g;
+
+export interface CredentialNormalizationChanges {
+  edgeTrimmed: boolean;
+  strippedZeroWidth: boolean;
+  fixedQuotes: boolean;
+  /** Internal whitespace/newlines were removed (single-line tokens only). */
+  collapsedInternal: boolean;
+}
+
+export interface NormalizeCredentialResult {
+  value: string;
+  original: string;
+  changed: boolean;
+  changes: CredentialNormalizationChanges;
+  /**
+   * True when an internal fix was applied. The UI must surface a dismissible
+   * warning: the fix is usually correct, but could hide a truncated copy.
+   */
+  internalWhitespaceFixed: boolean;
+}
+
+/**
+ * Normalize a credential value for a given field. Safe to call on every paste
+ * and blur. Unknown fields get the conservative path (edge/zero-width/quotes,
+ * never internal collapsing) since we can't assume they are single-line.
+ */
+export function normalizeCredential(field: string, value: string): NormalizeCredentialResult {
+  const spec = resolveCredentialSpec(field);
+  const singleLine = spec?.singleLine ?? false;
+
+  const withoutZeroWidth = value.replace(ZERO_WIDTH, '');
+  const withStraightQuotes = withoutZeroWidth
+    .replace(SMART_DOUBLE_QUOTE, '"')
+    .replace(SMART_SINGLE_QUOTE, "'");
+  const edgeTrimmed = withStraightQuotes.trim();
+
+  let normalized = edgeTrimmed;
+  let collapsedInternal = false;
+  if (singleLine) {
+    const withoutInternal = edgeTrimmed.replace(INTERNAL_WHITESPACE, '');
+    if (withoutInternal !== edgeTrimmed) {
+      normalized = withoutInternal;
+      collapsedInternal = true;
+    }
+  }
+
+  const changes: CredentialNormalizationChanges = {
+    edgeTrimmed: edgeTrimmed !== withStraightQuotes,
+    strippedZeroWidth: withoutZeroWidth !== value,
+    fixedQuotes: withStraightQuotes !== withoutZeroWidth,
+    collapsedInternal,
+  };
+
+  return {
+    value: normalized,
+    original: value,
+    changed: normalized !== value,
+    changes,
+    internalWhitespaceFixed: collapsedInternal,
+  };
+}

--- a/packages/core/src/credentials/normalize.ts
+++ b/packages/core/src/credentials/normalize.ts
@@ -2,31 +2,34 @@
  * Silent credential normalization (Layer 1).
  *
  * Repairs the artifacts of copying a token through a terminal or rich-text
- * editor: edge whitespace, zero-width characters, and smart/curly quotes are
- * always removed. For single-line tokens, internal whitespace/newlines are also
- * stripped — but that fix is flagged (`internalWhitespaceFixed`) so the UI can
- * warn, since it could otherwise mask a truncated paste. Multi-line values (PEM
- * private keys) get edge-trim only; their internal newlines are structural.
+ * editor. Every value gets edge whitespace and zero-width characters removed.
+ * For KNOWN credential fields we also strip a quote pair (smart/ASCII/backtick)
+ * that wraps the entire value, and — for single-line tokens — collapse internal
+ * whitespace/newlines. Both of those are flagged (`internalWhitespaceFixed`) so
+ * the UI surfaces a dismissible notice, since either could mask a truncated
+ * paste. Unknown fields (arbitrary env vars) get edge-trim + zero-width strip
+ * ONLY — never quote or internal rewriting — so we don't silently mangle a value
+ * we don't understand. Multi-line values (PEM keys) keep their internal newlines.
  */
 
 import { resolveCredentialSpec } from './specs.js';
 
 // Codepoints kept as \u escapes so the (invisible / look-alike) characters never
-// appear as literals in source. Zero-width space, ZWNJ, ZWJ, word joiner, BOM \u2014
+// appear as literals in source. Zero-width space, ZWNJ, ZWJ, word joiner, BOM —
 // written as an alternation (not a char class) since a ZWJ in a class trips
 // biome's noMisleadingCharacterClass.
-const ZERO_WIDTH = /\u200B|\u200C|\u200D|\u2060|\uFEFF/g;
-// Curly/smart double quotes + prime → straight ASCII double quote.
-const SMART_DOUBLE_QUOTE = /[\u201C\u201D\u201E\u201F\u2033]/g;
-// Curly/smart single quotes + prime → straight ASCII single quote.
-const SMART_SINGLE_QUOTE = /[\u2018\u2019\u201A\u201B\u2032]/g;
+const ZERO_WIDTH = /​|‌|‍|⁠|﻿/g;
+// A single quote character: ASCII double/single/backtick + smart/curly variants
+// and primes. Used to detect a quote pair wrapping the whole value.
+const QUOTE_CHAR = /["'`‘’‚‛′“”„‟″]/;
 const INTERNAL_WHITESPACE = /\s+/g;
 
 export interface CredentialNormalizationChanges {
   edgeTrimmed: boolean;
   strippedZeroWidth: boolean;
-  fixedQuotes: boolean;
-  /** Internal whitespace/newlines were removed (single-line tokens only). */
+  /** A quote pair wrapping the entire value was removed (known fields only). */
+  strippedWrappingQuotes: boolean;
+  /** Internal whitespace/newlines were removed (single-line known fields only). */
   collapsedInternal: boolean;
 }
 
@@ -36,49 +39,57 @@ export interface NormalizeCredentialResult {
   changed: boolean;
   changes: CredentialNormalizationChanges;
   /**
-   * True when an internal fix was applied. The UI must surface a dismissible
-   * warning: the fix is usually correct, but could hide a truncated copy.
+   * True when an internal fix was applied (internal-whitespace collapse or a
+   * wrapping-quote strip). The UI must surface a dismissible warning: the fix is
+   * usually correct, but could hide a truncated copy.
    */
   internalWhitespaceFixed: boolean;
 }
 
-/**
- * Normalize a credential value for a given field. Safe to call on every paste
- * and blur. Unknown fields get the conservative path (edge/zero-width/quotes,
- * never internal collapsing) since we can't assume they are single-line.
- */
+const isQuote = (ch: string): boolean => QUOTE_CHAR.test(ch);
+
 export function normalizeCredential(field: string, value: string): NormalizeCredentialResult {
   const spec = resolveCredentialSpec(field);
   const singleLine = spec?.singleLine ?? false;
 
   const withoutZeroWidth = value.replace(ZERO_WIDTH, '');
-  const withStraightQuotes = withoutZeroWidth
-    .replace(SMART_DOUBLE_QUOTE, '"')
-    .replace(SMART_SINGLE_QUOTE, "'");
-  const edgeTrimmed = withStraightQuotes.trim();
+  const trimmed = withoutZeroWidth.trim();
 
-  let normalized = edgeTrimmed;
+  let working = trimmed;
+
+  // Known credential fields only: strip a quote pair that wraps the whole value
+  // (a paste artifact — a real token never starts and ends with a quote). Loop
+  // to handle nested wrappers, re-trimming inside each layer. Any quote left in
+  // the middle is intentionally NOT touched — the charset lint flags it instead.
+  let strippedWrappingQuotes = false;
+  if (spec) {
+    while (working.length >= 2 && isQuote(working[0]) && isQuote(working[working.length - 1])) {
+      working = working.slice(1, -1).trim();
+      strippedWrappingQuotes = true;
+    }
+  }
+
   let collapsedInternal = false;
   if (singleLine) {
-    const withoutInternal = edgeTrimmed.replace(INTERNAL_WHITESPACE, '');
-    if (withoutInternal !== edgeTrimmed) {
-      normalized = withoutInternal;
+    const withoutInternal = working.replace(INTERNAL_WHITESPACE, '');
+    if (withoutInternal !== working) {
+      working = withoutInternal;
       collapsedInternal = true;
     }
   }
 
   const changes: CredentialNormalizationChanges = {
-    edgeTrimmed: edgeTrimmed !== withStraightQuotes,
+    edgeTrimmed: trimmed !== withoutZeroWidth,
     strippedZeroWidth: withoutZeroWidth !== value,
-    fixedQuotes: withStraightQuotes !== withoutZeroWidth,
+    strippedWrappingQuotes,
     collapsedInternal,
   };
 
   return {
-    value: normalized,
+    value: working,
     original: value,
-    changed: normalized !== value,
+    changed: working !== value,
     changes,
-    internalWhitespaceFixed: collapsedInternal,
+    internalWhitespaceFixed: collapsedInternal || strippedWrappingQuotes,
   };
 }

--- a/packages/core/src/credentials/specs.ts
+++ b/packages/core/src/credentials/specs.ts
@@ -20,7 +20,8 @@ export type CredentialSpecKey =
   | 'slack-bot-token'
   | 'slack-app-token'
   | 'pem-private-key'
-  | 'base-url';
+  | 'base-url'
+  | 'generic-secret';
 
 export interface CredentialSpec {
   key: CredentialSpecKey;
@@ -151,6 +152,17 @@ export const CREDENTIAL_SPECS: Record<CredentialSpecKey, CredentialSpec> = {
     prefixes: [],
     singleLine: true,
   },
+  'generic-secret': {
+    // Machine-generated single-line secret with no stable public format
+    // (semantic-search embedding key, gateway signing/webhook secrets, Teams
+    // app password, Shortcut API token). Gets full single-line repair
+    // (edge/zero-width/wrapping-quote/internal collapse) but no prefix or
+    // charset lint, since the shape is provider-defined and unknown to us.
+    key: 'generic-secret',
+    provider: '',
+    prefixes: [],
+    singleLine: true,
+  },
 };
 
 /**
@@ -176,6 +188,13 @@ const FIELD_TO_SPEC: Record<string, CredentialSpecKey> = {
   bot_token: 'slack-bot-token',
   app_token: 'slack-app-token',
   private_key: 'pem-private-key',
+  // Generic single-line secrets — machine-generated, no stable public format.
+  app_password: 'generic-secret',
+  api_token: 'generic-secret',
+  signing_secret: 'generic-secret',
+  webhook_secret: 'generic-secret',
+  // Semantic-search embedding provider key (KnowledgePage).
+  api_key: 'generic-secret',
 };
 
 /** Every spec key is also accepted verbatim as a field identifier. */

--- a/packages/core/src/credentials/specs.ts
+++ b/packages/core/src/credentials/specs.ts
@@ -190,11 +190,20 @@ const FIELD_TO_SPEC: Record<string, CredentialSpecKey> = {
   private_key: 'pem-private-key',
   // Generic single-line secrets — machine-generated, no stable public format.
   app_password: 'generic-secret',
+  // Teams form field name (config key is `app_password`).
+  teams_app_password: 'generic-secret',
   api_token: 'generic-secret',
   signing_secret: 'generic-secret',
   webhook_secret: 'generic-secret',
   // Semantic-search embedding provider key (KnowledgePage).
   api_key: 'generic-secret',
+  // MCP server auth secrets (MCPServerFormFields). These fields ALSO accept
+  // `{{ user.env.X }}` templates whose whitespace is meaningful — the UI only
+  // offers the opt-in fix when the value is a raw (non-template) secret.
+  auth_token: 'generic-secret',
+  jwt_api_token: 'generic-secret',
+  jwt_api_secret: 'generic-secret',
+  oauth_client_secret: 'generic-secret',
 };
 
 /** Every spec key is also accepted verbatim as a field identifier. */

--- a/packages/core/src/credentials/specs.ts
+++ b/packages/core/src/credentials/specs.ts
@@ -1,0 +1,191 @@
+/**
+ * Per-provider credential specs — the single source of truth for how every
+ * token/key field across Agor is normalized and format-linted.
+ *
+ * A "field" is the identifier a surface knows a credential by: the env-var name
+ * on the agent-tools screen (`ANTHROPIC_API_KEY`), the gateway config key
+ * (`bot_token`), or a user-typed env var name in the env editor. `resolveCredentialSpec`
+ * maps any of those to the canonical spec so all surfaces normalize/lint identically.
+ */
+
+/** Canonical spec identifier for one class of credential. */
+export type CredentialSpecKey =
+  | 'anthropic-api-key'
+  | 'anthropic-oauth-token'
+  | 'anthropic-auth-token'
+  | 'openai-api-key'
+  | 'gemini-api-key'
+  | 'github-token'
+  | 'cursor-api-key'
+  | 'slack-bot-token'
+  | 'slack-app-token'
+  | 'pem-private-key'
+  | 'base-url';
+
+export interface CredentialSpec {
+  key: CredentialSpecKey;
+  /** Human provider name used in messages ("Anthropic", "Slack"). */
+  provider: string;
+  /**
+   * `check-auth` tool identifier when this credential is live-verifiable.
+   * Absent for credentials with no probe (Slack, PEM, base URL, proxy token).
+   */
+  authTool?: 'claude-code' | 'codex' | 'gemini' | 'copilot' | 'cursor';
+  /** Prefixes a valid value usually starts with. Empty ⇒ no prefix lint. */
+  prefixes: string[];
+  /** Shortest prefix shown in "usually start with …" hints. */
+  prefixHint?: string;
+  /**
+   * Whether the value is a one-line token. Single-line values get internal
+   * whitespace/newlines stripped on normalize (the terminal-paste bug). Multi-line
+   * values (PEM keys) get edge-trim only, never internal collapsing.
+   */
+  singleLine: boolean;
+  /** Rough minimum length; shorter ⇒ "looks incomplete" warning. */
+  minLength?: number;
+  /** Characters allowed in a single-line token body. Violations ⇒ charset error. */
+  charset?: RegExp;
+}
+
+const TOKEN_CHARSET = /^[A-Za-z0-9._-]+$/;
+
+export const CREDENTIAL_SPECS: Record<CredentialSpecKey, CredentialSpec> = {
+  'anthropic-api-key': {
+    key: 'anthropic-api-key',
+    provider: 'Anthropic',
+    authTool: 'claude-code',
+    prefixes: ['sk-ant-api'],
+    prefixHint: 'sk-ant-api',
+    singleLine: true,
+    minLength: 40,
+    charset: TOKEN_CHARSET,
+  },
+  'anthropic-oauth-token': {
+    key: 'anthropic-oauth-token',
+    provider: 'Anthropic',
+    prefixes: ['sk-ant-oat'],
+    prefixHint: 'sk-ant-oat',
+    singleLine: true,
+    minLength: 40,
+    charset: TOKEN_CHARSET,
+  },
+  'anthropic-auth-token': {
+    // Proxy / enterprise bearer token — format is gateway-defined, so no prefix
+    // or charset lint. Still single-line, so it benefits from whitespace repair.
+    key: 'anthropic-auth-token',
+    provider: 'Anthropic',
+    prefixes: [],
+    singleLine: true,
+  },
+  'openai-api-key': {
+    key: 'openai-api-key',
+    provider: 'OpenAI',
+    authTool: 'codex',
+    prefixes: ['sk-proj-', 'sk-'],
+    prefixHint: 'sk-',
+    singleLine: true,
+    minLength: 30,
+    charset: TOKEN_CHARSET,
+  },
+  'gemini-api-key': {
+    key: 'gemini-api-key',
+    provider: 'Google',
+    authTool: 'gemini',
+    prefixes: ['AIza'],
+    prefixHint: 'AIza',
+    singleLine: true,
+    minLength: 20,
+    charset: TOKEN_CHARSET,
+  },
+  'github-token': {
+    key: 'github-token',
+    provider: 'GitHub',
+    authTool: 'copilot',
+    prefixes: ['ghp_', 'github_pat_', 'gho_', 'ghu_', 'ghs_', 'ghr_'],
+    prefixHint: 'ghp_ or github_pat_',
+    singleLine: true,
+    minLength: 20,
+    charset: TOKEN_CHARSET,
+  },
+  'cursor-api-key': {
+    key: 'cursor-api-key',
+    provider: 'Cursor',
+    authTool: 'cursor',
+    prefixes: ['key_'],
+    prefixHint: 'key_',
+    singleLine: true,
+    minLength: 20,
+    charset: TOKEN_CHARSET,
+  },
+  'slack-bot-token': {
+    key: 'slack-bot-token',
+    provider: 'Slack',
+    prefixes: ['xoxb-'],
+    prefixHint: 'xoxb-',
+    singleLine: true,
+    minLength: 20,
+    charset: TOKEN_CHARSET,
+  },
+  'slack-app-token': {
+    key: 'slack-app-token',
+    provider: 'Slack',
+    prefixes: ['xapp-'],
+    prefixHint: 'xapp-',
+    singleLine: true,
+    minLength: 20,
+    charset: TOKEN_CHARSET,
+  },
+  'pem-private-key': {
+    // Multi-line PEM. Edge-trim only — internal newlines are structural.
+    key: 'pem-private-key',
+    provider: 'GitHub',
+    prefixes: ['-----BEGIN'],
+    prefixHint: '-----BEGIN',
+    singleLine: false,
+  },
+  'base-url': {
+    // Non-secret endpoint URL. Single-line (URLs never contain whitespace) but
+    // no prefix/charset lint — any valid URL shape is acceptable.
+    key: 'base-url',
+    provider: '',
+    prefixes: [],
+    singleLine: true,
+  },
+};
+
+/**
+ * Field-name → spec mapping. Covers agent-tool env var names, gateway config
+ * keys, and the common env var names users type into the env editor. Unknown
+ * names resolve to `undefined` (generic conservative normalization, no lint).
+ */
+const FIELD_TO_SPEC: Record<string, CredentialSpecKey> = {
+  // Agentic tool env var fields (ApiKeyFields / OnboardingWizard)
+  ANTHROPIC_API_KEY: 'anthropic-api-key',
+  CLAUDE_CODE_OAUTH_TOKEN: 'anthropic-oauth-token',
+  ANTHROPIC_AUTH_TOKEN: 'anthropic-auth-token',
+  ANTHROPIC_BASE_URL: 'base-url',
+  OPENAI_API_KEY: 'openai-api-key',
+  OPENAI_BASE_URL: 'base-url',
+  GEMINI_API_KEY: 'gemini-api-key',
+  COPILOT_GITHUB_TOKEN: 'github-token',
+  CURSOR_API_KEY: 'cursor-api-key',
+  // Common git tokens users store as raw env vars
+  GH_TOKEN: 'github-token',
+  GITHUB_TOKEN: 'github-token',
+  // Gateway channel config keys (GatewayTokenWidget / GatewayChannelsTable)
+  bot_token: 'slack-bot-token',
+  app_token: 'slack-app-token',
+  private_key: 'pem-private-key',
+};
+
+/** Every spec key is also accepted verbatim as a field identifier. */
+export function resolveCredentialSpec(field: string): CredentialSpec | undefined {
+  if (field in CREDENTIAL_SPECS) return CREDENTIAL_SPECS[field as CredentialSpecKey];
+  const key = FIELD_TO_SPEC[field];
+  return key ? CREDENTIAL_SPECS[key] : undefined;
+}
+
+/** True when a field maps to a known credential spec (used by the env editor). */
+export function isKnownCredentialField(field: string): boolean {
+  return resolveCredentialSpec(field) !== undefined;
+}

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -14,9 +14,10 @@ import {
 import { describe, expect, it } from 'vitest';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
+import { decryptApiKey } from '../encryption';
 import { dbTest } from '../test-helpers';
 import { BranchRepository } from './branches';
-import { GatewayChannelRepository } from './gateway-channels';
+import { encryptConfig, GatewayChannelRepository } from './gateway-channels';
 import { RepoRepository } from './repos';
 
 async function seedBranch(db: Database) {
@@ -283,6 +284,28 @@ describe('GatewayChannelRepository', () => {
       expect(
         getRequiredSecretFields('slack', { outbound_enabled: true, enable_channels: true })
       ).toEqual(['bot_token', 'app_token']);
+    });
+  });
+
+  describe('encryptConfig — at-rest backstop', () => {
+    const stored = (value: string): string =>
+      decryptApiKey(encryptConfig({ bot_token: value }).bot_token as string);
+
+    it('strips edge whitespace and invisible characters', () => {
+      const bom = '﻿';
+      expect(stored(`  ${bom}xoxb-clean-token  `)).toBe('xoxb-clean-token');
+    });
+
+    it('does NOT collapse internal whitespace at rest (declined fix stored as-is)', () => {
+      expect(stored('xoxb-abc def-token')).toBe('xoxb-abc def-token');
+    });
+
+    it('does NOT unwrap wrapping quotes at rest', () => {
+      expect(stored('"xoxb-quoted-token"')).toBe('"xoxb-quoted-token"');
+    });
+
+    it('preserves the redaction sentinel', () => {
+      expect(stored(GATEWAY_REDACTED_SENTINEL)).toBe(GATEWAY_REDACTED_SENTINEL);
     });
   });
 });

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -37,7 +37,7 @@ import {
 /**
  * Encrypt sensitive fields within a config object
  */
-function encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+export function encryptConfig(config: Record<string, unknown>): Record<string, unknown> {
   const encrypted = { ...config };
   for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
     if (typeof encrypted[field] === 'string' && encrypted[field]) {

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -20,6 +20,7 @@ import {
   prefixToLikePattern,
 } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
+import { normalizeCredential } from '../../credentials/index.js';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
@@ -40,7 +41,11 @@ function encryptConfig(config: Record<string, unknown>): Record<string, unknown>
   const encrypted = { ...config };
   for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
     if (typeof encrypted[field] === 'string' && encrypted[field]) {
-      encrypted[field] = encryptApiKey(encrypted[field] as string);
+      const raw = encrypted[field] as string;
+      // Skip the redaction sentinel (an unchanged secret on patch); otherwise
+      // normalize terminal-paste artifacts at rest before encrypting.
+      const value = raw === GATEWAY_REDACTED_SENTINEL ? raw : normalizeCredential(field, raw).value;
+      encrypted[field] = encryptApiKey(value);
     }
   }
   return encrypted;

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -20,7 +20,7 @@ import {
   prefixToLikePattern,
 } from '@agor/core/types';
 import { eq, like } from 'drizzle-orm';
-import { normalizeCredential } from '../../credentials/index.js';
+import { sanitizeCredential } from '../../credentials/index.js';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
@@ -43,8 +43,10 @@ function encryptConfig(config: Record<string, unknown>): Record<string, unknown>
     if (typeof encrypted[field] === 'string' && encrypted[field]) {
       const raw = encrypted[field] as string;
       // Skip the redaction sentinel (an unchanged secret on patch); otherwise
-      // normalize terminal-paste artifacts at rest before encrypting.
-      const value = raw === GATEWAY_REDACTED_SENTINEL ? raw : normalizeCredential(field, raw).value;
+      // apply only the always-safe cleanup (edge whitespace + invisible chars).
+      // Internal whitespace / wrapping quotes are the user's choice — never
+      // rewritten at rest (opt-in cleanup lives in the UI).
+      const value = raw === GATEWAY_REDACTED_SENTINEL ? raw : sanitizeCredential(raw);
       encrypted[field] = encryptApiKey(value);
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@
 export * from './api/index.js';
 export * from './config/index.js';
 export { getBranchesDir, getBranchPath, getReposDir } from './config/index.js';
+export * from './credentials/index.js';
 export * from './db/index.js';
 export * from './design/board-backgrounds.js';
 export * from './environment/render-snapshot.js';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     'config/index': 'src/config/index.ts',
     'config/browser': 'src/config/browser.ts', // Browser-safe config utilities
     'permissions/index': 'src/permissions/index.ts',
+    'credentials/index': 'src/credentials/index.ts', // Shared credential sanitize/lint registry
     'feathers/index': 'src/feathers/index.ts', // FeathersJS runtime re-exports
     'lib/feathers-validation': 'src/lib/feathers-validation.ts', // FeathersJS query validation schemas
     'templates/handlebars-helpers': 'src/templates/handlebars-helpers.ts', // Handlebars helpers

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,7 @@ overrides:
   smol-toml: '>=1.6.1 <2'
   socket.io-parser: '>=4.2.6 <5'
   systeminformation: '>=5.31.0 <6'
+  tar: '>=7.5.19'
   undici: '>=7.25.0 <8'
   vite: '>=8.0.10 <9'
   yaml: '>=2.8.3 <3'
@@ -2478,6 +2479,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@joshua.litt/get-ripgrep@0.0.3':
     resolution: {integrity: sha512-rycdieAKKqXi2bsM7G2ayDiNk5CAX8ZOzsTQsirfOqUKPef04Xw40BWGGyimaOOuvPgLWYt3tPnLLG3TvPXi5Q==}
@@ -5180,6 +5185,10 @@ packages:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
 
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
@@ -7536,10 +7545,6 @@ packages:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -7547,6 +7552,10 @@ packages:
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mj-context-menu@0.6.1:
     resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
@@ -8852,10 +8861,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
+    engines: {node: '>=18'}
 
   teeny-request@10.1.3:
     resolution: {integrity: sha512-5yDliI1uWkYPo7W+Zvrxg6YmoWuj5iC5EydewqrRTvc68nyMTZhlPPlLg6cptUGfbQAb+N9XDPDPzF6N081lug==}
@@ -9624,6 +9632,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -11591,6 +11603,11 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+    optional: true
 
   '@joshua.litt/get-ripgrep@0.0.3(supports-color@8.1.1)':
     dependencies:
@@ -14569,7 +14586,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.21
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -14678,6 +14695,9 @@ snapshots:
     optional: true
 
   chownr@2.0.0:
+    optional: true
+
+  chownr@3.0.0:
     optional: true
 
   cjs-module-lexer@2.2.0: {}
@@ -17683,15 +17703,17 @@ snapshots:
       yallist: 4.0.0
     optional: true
 
-  minipass@5.0.0:
-    optional: true
-
   minipass@7.1.2: {}
 
   minizlib@2.1.2:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    optional: true
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.2
     optional: true
 
   mj-context-menu@0.6.1: {}
@@ -17904,7 +17926,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.5
-      tar: 6.2.1
+      tar: 7.5.21
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -19252,7 +19274,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.21
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -19449,14 +19471,13 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  tar@6.2.1:
+  tar@7.5.21:
     dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
     optional: true
 
   teeny-request@10.1.3:
@@ -20276,6 +20297,9 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@4.0.0:
+    optional: true
+
+  yallist@5.0.0:
     optional: true
 
   yaml@2.9.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,9 @@ overrides:
   smol-toml: '>=1.6.1 <2'
   socket.io-parser: '>=4.2.6 <5'
   systeminformation: '>=5.31.0 <6'
+  # Patch critical DoS GHSA-23hp-3jrh-7fpw (tar <=7.5.18). Transitive via
+  # drizzle-orm > sqlite3 > node-gyp/cacache > tar. No 6.x fix exists.
+  tar: '>=7.5.19'
   undici: '>=7.25.0 <8'
   vite: '>=8.0.10 <9'
   yaml: '>=2.8.3 <3'


### PR DESCRIPTION
# Add unified validation for API token and credential inputs

## The problem

A user pasted a Claude token copied from a narrow terminal window. The terminal had
silently converted a line break inside the token into a space. Every credential field
in Agor trims *leading and trailing* whitespace, but whitespace in the *middle* of a
token passes every check we have. The token saved fine, looked fine, and failed
silently at session time. Finding this cost days of debugging and about fifteen token
regenerations. And it isn't a one-off — other users have hit the same silent failure.

This PR fixes the whole class of bug, for every provider and every place in Agor where
a credential can be entered.

## The approach: three layers

Validation is layered by how confident we can be, so we fix silently only what cannot
be intentional, warn on what merely looks wrong, and let the provider be the final
authority.

### Layer 1: Flag what cannot be intentional, let the user apply the fix

API tokens are machine-generated, single-line strings. Whitespace, zero-width
characters, or smart quotes inside one are never valid — but we don't rewrite what
someone pasted without asking. On paste and on blur we detect the issue and show an
inline warning with a one-click fix, rather than silently mutating the field:

> This key has extra spaces or line breaks in it — a common side effect of copying
> from a terminal. [Clean it up]

Clicking "Clean it up" applies the fix; leaving it alone leaves the value exactly as
pasted. Editing pasted credentials without consent is the kind of thing that erodes
trust in exactly the field where trust matters most, so detection is automatic but the
fix is opt-in. Multi-line secrets (GitHub PEM private keys) are exempt from this check;
their line breaks are legitimate.

### Layer 2: Warn on format smells, never block

A shared per-provider registry describes what each credential should look like:
expected prefix (`sk-ant-api…`, `sk-ant-oat…`, `sk-proj-…`, `AIza…`, `ghp_…`,
`xoxb-…`, …), allowed characters, and rough length. On blur, a mismatch shows a
*warning* under the field — for example:

> Anthropic API keys usually start with sk-ant-api. Double-check you copied the
> right key.

It also catches a common mixup between the two Anthropic fields:

> This looks like a Claude Pro/Max token (sk-ant-oat…). Paste it in the Claude
> subscription field instead.

Warnings never block saving. Providers change key formats without telling us, and a
stale hard block would be worse than no check at all.

### Layer 3: Verify with the provider

The only message that truly ends "is my token OK?" anxiety is the provider saying yes.
The existing `check-auth` service (already used by the onboarding wizard) is now wired
into the Settings credential fields: an explicit Verify action plus an automatic check
after save. Success shows "Verified with Anthropic" (provider name per field); failure
shows a provider-attributed message rather than a vague "invalid":

> Anthropic rejected this key. It may have been revoked or copied incompletely —
> regenerate and paste again.

## Implementation notes

- One shared module (`credentialSpecs` registry + `sanitizeCredential` +
  `detectCredentialFix`/`applyCredentialFix` + `lintCredential`) consumed by all
  credential surfaces: Settings API key fields,
  onboarding wizard, gateway token widget, gateway channels table, MCP server forms,
  and the env var editor (when the variable name matches a known credential).
- What's automatic vs. opt-in: edge whitespace and invisible/zero-width characters are
  stripped automatically (never intentional, never visible, nothing to consent to).
  Internal whitespace collapse and wrapping-quote removal are surfaced as a warning
  with a one-click fix — applied only if the user chooses to.
- Daemon-side backstop mirrors only the automatic part (edge/invisible-character
  cleanup) at rest. It never rewrites token content a user chose to keep as pasted.
  The daemon never lint-rejects — normalization only.
- Timing: validation runs on paste and on blur, never on keystroke.
- Unit tests cover the failure that started this: mid-token space, newline, zero-width
  characters, truncated keys, wrong-field cross-paste, and PEM keys left untouched.


---

_Also patches an unrelated pre-existing critical CVE in a transitive dependency (tar, via drizzle-orm/sqlite3, GHSA-23hp-3jrh-7fpw) that was blocking the `pnpm audit` CI gate on every PR against main, not just this one._
