### PR TITLE
feat(launch-auth): host-bound exchange, fail-closed RS256, direct-host entry

### DIFF
--- a/apps/agor-daemon/src/auth/__fixtures__/launch-exchange-request.json
+++ b/apps/agor-daemon/src/auth/__fixtures__/launch-exchange-request.json
@@ -1,0 +1,10 @@
+{
+  "$comment": "Canonical one-time launch-code exchange request body the daemon POSTs to the configured issuer exchange endpoint. Shared contract fixture: it MUST stay aligned with the issuer's canonical exchange schema so the two sides cannot drift. `request_host` is present only when host-bound launch is configured. `audience` and `instance_id` are compatibility fields; a correct issuer derives authority from its own records and the authenticated exchange credential, never from these caller-supplied values.",
+  "required": ["launch_code"],
+  "properties": {
+    "launch_code": "opaque one-time code captured from the browser URL",
+    "audience": "configured runtime audience (compatibility echo)",
+    "instance_id": "configured runtime instance id (compatibility echo, optional)",
+    "request_host": "normalized inbound browser host, only when forward_request_host is enabled"
+  }
+}

--- a/apps/agor-daemon/src/auth/__fixtures__/launch-exchange-request.json
+++ b/apps/agor-daemon/src/auth/__fixtures__/launch-exchange-request.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Canonical one-time launch-code exchange request body the daemon POSTs to the configured issuer exchange endpoint. Shared contract fixture: it MUST stay aligned with the issuer's canonical exchange schema so the two sides cannot drift. `request_host` is present only when host-bound launch is configured. `audience` and `instance_id` are compatibility fields; a correct issuer derives authority from its own records and the authenticated exchange credential, never from these caller-supplied values.",
+  "$comment": "One-time launch-code exchange request body the daemon POSTs to the configured issuer exchange endpoint. Daemon-side contract tripwire: this fixture pins the request shape the daemon emits so an accidental daemon-side change is caught in review. It does not and cannot mechanically prevent the issuer from drifting — the issuer's canonical exchange schema is the source of truth and must be kept in sync out of band. `request_host` is present only when host-bound launch is configured. `audience` and `instance_id` are compatibility fields; a correct issuer derives authority from its own records and the authenticated exchange credential, never from these caller-supplied values.",
   "required": ["launch_code"],
   "properties": {
     "launch_code": "opaque one-time code captured from the browser URL",

--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -412,7 +412,7 @@ describe('one-time launch auth service', () => {
     ).rejects.toBeInstanceOf(NotAuthenticated);
   });
 
-  it('builds an exchange body whose keys stay within the shared contract fixture', async () => {
+  it('builds an exchange body whose keys stay within the daemon-side contract tripwire fixture', async () => {
     const fetchMock = mockExchange(signClaims());
     await service(hostConfig()).create({ launchCode: 'code' }, {
       headers: { host: 'primary.cloud.agor.live' },
@@ -490,6 +490,102 @@ describe('one-time launch auth service', () => {
         multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
       }).create({ launchCode: 'code' })
     ).rejects.toBeInstanceOf(NotAuthenticated);
+  });
+
+  it('derives tenant scope only from the signed claim, never a trusted header', async () => {
+    // Legal required_from_auth config that allows a header fallback for the
+    // generic request path. On the launch path the header must NOT be trusted:
+    // the assertion omits the tenant claim but a tenant header is present, so
+    // the exchange must reject and create no session.
+    mockExchange(signClaims({ sub: 'header-tenant-user', email: 'header-tenant@example.test' }));
+    await expect(
+      service({
+        ...baseConfig(),
+        database: { dialect: 'postgresql' },
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          auth_claim: 'tenant_id',
+          trusted_header: 'x-agor-tenant-id',
+        },
+      }).create({ launchCode: 'code' }, {
+        headers: { 'x-agor-tenant-id': 'tenant-from-header' },
+      } as never)
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+
+    const rows = await select(db).from(users).all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it('rejects asymmetric verification configured with an HS* algorithm', async () => {
+    mockExchange(signClaims());
+    const { dev_shared_secret: _dev, ...rest } = baseConfig().external_launch as Record<
+      string,
+      unknown
+    >;
+
+    await expect(
+      service({
+        external_launch: { ...rest, public_key: 'pem-placeholder', algorithms: ['HS256'] },
+      }).create({ launchCode: 'code' })
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+
+    await expect(
+      service({
+        external_launch: {
+          ...rest,
+          jwks_url: 'https://issuer.example.test/jwks',
+          algorithms: ['HS384'],
+        },
+      }).create({ launchCode: 'code' })
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+  });
+
+  it('accepts a non-RS256 asymmetric algorithm when explicitly configured (ES256)', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const { dev_shared_secret: _dev, ...rest } = baseConfig().external_launch as Record<
+      string,
+      unknown
+    >;
+    const es256Config: AgorConfig = {
+      external_launch: { ...rest, public_key: publicKeyPem, algorithms: ['ES256'] },
+    };
+
+    const token = jwt.sign({ sub: 'es-user', instance_id: 'instance-1' }, privateKeyPem, {
+      algorithm: 'ES256',
+      keyid: 'k1',
+      expiresIn: '5m',
+      issuer: 'https://issuer.example.test',
+      audience: 'runtime:test',
+    });
+    mockExchange(token);
+    const ok = await service(es256Config).create({ launchCode: 'code' });
+    expect(ok.user.user_id).toBeTruthy();
+  });
+
+  it('logs a coarse, secret-safe diagnostic on expected launch failures', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const launchCode = 'otc_super_secret_launch_code_9999';
+    const serviceCredential = 'exchange-credential-do-not-log-abcdef';
+
+    // Exchange returns no assertion -> NotAuthenticated thrown inside the
+    // try/catch (the expected-failure path).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => Response.json({}, { status: 200 }))
+    );
+    await expect(
+      service({
+        external_launch: { ...baseConfig().external_launch, service_credential: serviceCredential },
+      }).create({ launchCode })
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+
+    expect(warn).toHaveBeenCalled();
+    const logged = warn.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logged).toContain('[auth/launch]');
+    expect(logged).not.toContain(launchCode);
+    expect(logged).not.toContain(serviceCredential);
   });
 });
 

--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { generateKeyPairSync } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgorConfig } from '@agor/core/config';
@@ -344,6 +345,152 @@ describe('one-time launch auth service', () => {
     expect(second.user.email).not.toBe('same@example.test');
     expect(second.user.email).toContain('+launch-');
   });
+
+  function exchangeBody(fetchMock: ReturnType<typeof mockExchange>): Record<string, unknown> {
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    return JSON.parse((init?.body as string) ?? '{}');
+  }
+
+  function hostConfig(overrides: Record<string, unknown> = {}): AgorConfig {
+    return {
+      external_launch: {
+        ...baseConfig().external_launch,
+        forward_request_host: true,
+        ...overrides,
+      },
+    };
+  }
+
+  it('forwards request_host from the trusted Host header when configured', async () => {
+    const fetchMock = mockExchange(signClaims());
+    await service(hostConfig()).create({ launchCode: 'code' }, {
+      headers: { host: 'primary.cloud.agor.live' },
+    } as never);
+    expect(exchangeBody(fetchMock).request_host).toBe('primary.cloud.agor.live');
+  });
+
+  it('omits request_host when host forwarding is not configured', async () => {
+    const fetchMock = mockExchange(signClaims());
+    await service().create({ launchCode: 'code' }, {
+      headers: { host: 'primary.cloud.agor.live' },
+    } as never);
+    expect(exchangeBody(fetchMock)).not.toHaveProperty('request_host');
+  });
+
+  it('reads only the configured trusted header, ignoring spoofable x-forwarded-host', async () => {
+    const fetchMock = mockExchange(signClaims());
+    await service(hostConfig()).create({ launchCode: 'code' }, {
+      headers: { host: 'primary.cloud.agor.live', 'x-forwarded-host': 'attacker.example' },
+    } as never);
+    expect(exchangeBody(fetchMock).request_host).toBe('primary.cloud.agor.live');
+  });
+
+  it('honors a configurable trusted host header set by a trusted edge', async () => {
+    const fetchMock = mockExchange(signClaims());
+    await service(hostConfig({ trusted_host_header: 'x-forwarded-host' })).create(
+      { launchCode: 'code' },
+      {
+        headers: { host: 'internal-service:4000', 'x-forwarded-host': 'primary.cloud.agor.live' },
+      } as never
+    );
+    expect(exchangeBody(fetchMock).request_host).toBe('primary.cloud.agor.live');
+  });
+
+  it('fails closed on ambiguous multi-valued or comma-joined request hosts', async () => {
+    mockExchange(signClaims());
+    await expect(
+      service(hostConfig()).create({ launchCode: 'code' }, {
+        headers: { host: ['a.example', 'b.example'] },
+      } as never)
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+
+    mockExchange(signClaims());
+    await expect(
+      service(hostConfig()).create({ launchCode: 'code' }, {
+        headers: { host: 'a.example, b.example' },
+      } as never)
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+  });
+
+  it('builds an exchange body whose keys stay within the shared contract fixture', async () => {
+    const fetchMock = mockExchange(signClaims());
+    await service(hostConfig()).create({ launchCode: 'code' }, {
+      headers: { host: 'primary.cloud.agor.live' },
+    } as never);
+    const body = exchangeBody(fetchMock);
+    const contract = JSON.parse(
+      readFileSync(new URL('./__fixtures__/launch-exchange-request.json', import.meta.url), 'utf8')
+    ) as { required: string[]; properties: Record<string, unknown> };
+    const allowed = new Set(Object.keys(contract.properties));
+    for (const key of Object.keys(body)) {
+      expect(allowed.has(key)).toBe(true);
+    }
+    for (const required of contract.required) {
+      expect(body).toHaveProperty(required);
+    }
+  });
+
+  it('accepts a valid RS256 assertion and rejects HS256 algorithm confusion', async () => {
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }).toString();
+    const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const { dev_shared_secret: _dev, ...rest } = baseConfig().external_launch as Record<
+      string,
+      unknown
+    >;
+    const rsaConfig: AgorConfig = { external_launch: { ...rest, public_key: publicKeyPem } };
+
+    const good = jwt.sign({ sub: 'rs-user', instance_id: 'instance-1' }, privateKeyPem, {
+      algorithm: 'RS256',
+      keyid: 'k1',
+      expiresIn: '5m',
+      issuer: 'https://issuer.example.test',
+      audience: 'runtime:test',
+    });
+    mockExchange(good);
+    const ok = await service(rsaConfig).create({ launchCode: 'code' });
+    expect(ok.user.user_id).toBeTruthy();
+
+    // Attacker re-signs with HS256 using the PEM public key as the HMAC secret.
+    const forged = jwt.sign({ sub: 'rs-user', instance_id: 'instance-1' }, publicKeyPem, {
+      algorithm: 'HS256',
+      keyid: 'k1',
+      expiresIn: '5m',
+      issuer: 'https://issuer.example.test',
+      audience: 'runtime:test',
+    });
+    mockExchange(forged);
+    await expect(service(rsaConfig).create({ launchCode: 'code2' })).rejects.toBeInstanceOf(
+      NotAuthenticated
+    );
+  });
+
+  it('rejects an alg:none assertion', async () => {
+    const none = jwt.sign(
+      {
+        sub: 'none-user',
+        instance_id: 'instance-1',
+        iss: 'https://issuer.example.test',
+        aud: 'runtime:test',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+      null as unknown as jwt.Secret,
+      { algorithm: 'none' }
+    );
+    mockExchange(none);
+    await expect(service().create({ launchCode: 'code' })).rejects.toBeInstanceOf(NotAuthenticated);
+  });
+
+  it('fails closed with no session when a required tenant claim is missing', async () => {
+    mockExchange(signClaims({ sub: 'no-tenant-user', email: 'no-tenant@example.test' }));
+    await expect(
+      service({
+        ...baseConfig(),
+        database: { dialect: 'postgresql' },
+        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+      }).create({ launchCode: 'code' })
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+  });
 });
 
 describe('public one-time launch auth settings', () => {
@@ -362,11 +509,51 @@ describe('public one-time launch auth settings', () => {
     expect(result).toEqual({
       enabled: true,
       loginRedirectUrl: 'https://workspace.example.test/open',
+      returnHostParam: 'return_host',
     });
     expect(result).not.toHaveProperty('exchangeUrl');
     expect(result).not.toHaveProperty('serviceCredential');
     expect(result).not.toHaveProperty('audience');
     expect(result).not.toHaveProperty('issuer');
+  });
+
+  it('exposes a default return-host param alongside a login redirect', () => {
+    const result = resolvePublicLaunchAuthSettings({
+      external_launch: {
+        ...baseConfig().external_launch,
+        login_redirect_url: 'https://console.example.test/launch-init',
+      },
+    });
+    expect(result.returnHostParam).toBe('return_host');
+  });
+
+  it('honors a configured return-host param name', () => {
+    const result = resolvePublicLaunchAuthSettings({
+      external_launch: {
+        ...baseConfig().external_launch,
+        login_redirect_url: 'https://console.example.test/launch-init',
+        return_host_param: 'workspace_host',
+      },
+    });
+    expect(result.returnHostParam).toBe('workspace_host');
+  });
+
+  it('does not expose a return-host param without a login redirect', () => {
+    const result = resolvePublicLaunchAuthSettings({
+      external_launch: { ...baseConfig().external_launch },
+    });
+    expect(result).not.toHaveProperty('returnHostParam');
+  });
+
+  it('never exposes the exchange service credential in public settings', () => {
+    const result = resolvePublicLaunchAuthSettings({
+      external_launch: {
+        ...baseConfig().external_launch,
+        service_credential: 'exchange-only-credential',
+        login_redirect_url: 'https://console.example.test/launch-init',
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('exchange-only-credential');
   });
 
   it('does not expose an inactive login redirect URL', () => {

--- a/apps/agor-daemon/src/auth/launch-auth.test.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.test.ts
@@ -587,6 +587,46 @@ describe('one-time launch auth service', () => {
     expect(logged).not.toContain(launchCode);
     expect(logged).not.toContain(serviceCredential);
   });
+
+  it('never logs an unexpected error message carrying a query credential', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const launchCode = 'otc_unexpected_secret_code_4242';
+    // The exchange fetch throws an unexpected (non-Feathers) error whose message
+    // embeds a credential-bearing URL the structural redactor does not match on.
+    // The classifier must keep that free text out of the log entirely.
+    const leakyUrl = 'https://issuer.example.test/exchange?access_token=supersecret';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error(`connect ECONNREFUSED ${leakyUrl}`);
+      })
+    );
+
+    await expect(service().create({ launchCode })).rejects.toBeInstanceOf(NotAuthenticated);
+
+    expect(warn).toHaveBeenCalled();
+    const logged = warn.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logged).toContain('[auth/launch] unexpected_error');
+    expect(logged).not.toContain('supersecret');
+    expect(logged).not.toContain('access_token');
+    expect(logged).not.toContain(launchCode);
+  });
+
+  it('fails closed before the network call with a static diagnostic on an invalid host', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchMock = mockExchange(signClaims());
+
+    await expect(
+      service(hostConfig()).create({ launchCode: 'code' }, {
+        headers: { host: 'a.example, b.example' },
+      } as never)
+    ).rejects.toBeInstanceOf(NotAuthenticated);
+
+    // No launch code ever leaves the daemon: the exchange fetch is never called.
+    expect(fetchMock).not.toHaveBeenCalled();
+    const logged = warn.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logged).toContain('[auth/launch] request_host_invalid');
+  });
 });
 
 describe('public one-time launch auth settings', () => {

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -62,7 +62,6 @@ interface ResolvedLaunchSettings {
   algorithms?: string[];
   forwardRequestHost: boolean;
   trustedHostHeader: string;
-  returnHostParam?: string;
 }
 
 export interface PublicLaunchAuthSettings {
@@ -146,7 +145,6 @@ export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSetting
     forwardRequestHost:
       envFlag(process.env[DEFAULT_FORWARD_REQUEST_HOST_ENV]) ?? raw?.forward_request_host === true,
     trustedHostHeader: (raw?.trusted_host_header || DEFAULT_TRUSTED_HOST_HEADER).toLowerCase(),
-    returnHostParam: raw?.return_host_param || undefined,
   };
 }
 
@@ -192,6 +190,15 @@ function assertConfigured(settings: ResolvedLaunchSettings): void {
   }
   if (configuredKeyCount > 1) {
     rejectConfig('multiple assertion verification methods configured');
+  }
+  // Asymmetric verification (jwks_url/public_key) must never be paired with a
+  // symmetric HS* algorithm. Pinning this makes the algorithm-confusion defense
+  // independent of the jsonwebtoken default allow-list: even if an operator
+  // overrides `algorithms`, an asymmetric public key can never be coerced into
+  // an HMAC secret. The RS256 default for asymmetric methods is preserved.
+  const usesAsymmetricKey = Boolean(settings.jwksUrl || settings.publicKey);
+  if (usesAsymmetricKey && settings.algorithms?.some((alg) => /^hs/i.test(alg))) {
+    rejectConfig('asymmetric verification cannot be configured with HS* algorithms');
   }
 }
 
@@ -630,11 +637,13 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
           throw new NotAuthenticated('Invalid one-time launch exchange response');
         }
         const claims = await verifyLaunchAssertion(exchange.assertion, settings);
-        const tenant = resolveTenantContext(multiTenancy, {
-          params,
-          authPayload: claims,
-          headers: params?.headers as Record<string, unknown> | undefined,
-        });
+        // Tenant scope for the runtime DB/RLS must derive ONLY from the
+        // verified, signed assertion — never from params, params.tenant, or
+        // request headers, all of which are attacker-influenced on the launch
+        // request. We deliberately pass just the signed claims to the generic
+        // resolver so `required_from_auth` cannot fall back to a trusted_header
+        // or an explicit params tenant; an absent claim fails closed below.
+        const tenant = resolveTenantContext(multiTenancy, { authPayload: claims });
         return await runWithTenantDatabaseScope(options.db, tenant.tenant_id, async () => {
           const user = await upsertLaunchUser(options, claims, tenant);
           return issueRuntimeTokens(
@@ -647,21 +656,28 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
           );
         });
       } catch (error) {
+        // Every expected launch failure emits exactly one coarse, secret-safe
+        // operator diagnostic before rethrowing. The launch code, assertion,
+        // bearer credential, request host, cookies and DB URLs must never reach
+        // logs/telemetry, so the reason is scrubbed through safeLaunchDiagnostic.
+        const logLaunchFailure = (reason: string): void => {
+          console.warn(
+            safeLaunchDiagnostic(reason, [
+              launchCode,
+              settings.serviceCredential,
+              settings.devSharedSecret,
+            ])
+          );
+        };
         if (error instanceof BadRequest || error instanceof NotAuthenticated) {
+          logLaunchFailure(error.message);
           throw error;
         }
         if (error instanceof TenantResolutionError) {
+          logLaunchFailure(error.message);
           throw new NotAuthenticated(error.message);
         }
-        // Operator diagnostic only — the launch code, assertion, bearer
-        // credential and request host must never reach logs/telemetry.
-        console.warn(
-          safeLaunchDiagnostic(error instanceof Error ? error.message : 'exchange failed', [
-            launchCode,
-            settings.serviceCredential,
-            settings.devSharedSecret,
-          ])
-        );
+        logLaunchFailure(error instanceof Error ? error.message : 'exchange failed');
         throw new NotAuthenticated('Invalid or expired one-time launch code');
       }
     },

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -29,6 +29,7 @@ import type {
 } from '@agor/core/types';
 import { normalizeRole, ROLES } from '@agor/core/types';
 import jwt, { type JwtHeader, type JwtPayload, type SignOptions } from 'jsonwebtoken';
+import { safeLaunchDiagnostic } from './launch-redaction.js';
 import { issueRuntimeTokenPair, runtimeTenantClaims } from './runtime-tokens.js';
 import { authTokenIssuedAtClaim } from './token-invalidation.js';
 import { redactUserAuthMetadata } from './user-redaction.js';
@@ -40,6 +41,9 @@ const DEFAULT_EXCHANGE_URL_ENV = 'AGOR_EXTERNAL_LAUNCH_EXCHANGE_URL';
 const DEFAULT_ISSUER_ENV = 'AGOR_EXTERNAL_LAUNCH_ISSUER';
 const DEFAULT_AUDIENCE_ENV = 'AGOR_EXTERNAL_LAUNCH_AUDIENCE';
 const DEFAULT_INSTANCE_ID_ENV = 'AGOR_EXTERNAL_LAUNCH_INSTANCE_ID';
+const DEFAULT_FORWARD_REQUEST_HOST_ENV = 'AGOR_EXTERNAL_LAUNCH_FORWARD_REQUEST_HOST';
+const DEFAULT_TRUSTED_HOST_HEADER = 'host';
+const DEFAULT_RETURN_HOST_PARAM = 'return_host';
 
 interface ResolvedLaunchSettings {
   enabled: boolean;
@@ -56,11 +60,16 @@ interface ResolvedLaunchSettings {
   trustVerifiedEmailForLinking: boolean;
   requestTimeoutMs: number;
   algorithms?: string[];
+  forwardRequestHost: boolean;
+  trustedHostHeader: string;
+  returnHostParam?: string;
 }
 
 export interface PublicLaunchAuthSettings {
   enabled: boolean;
   loginRedirectUrl?: string;
+  /** Query parameter the UI uses to carry the current host to launch-init. */
+  returnHostParam?: string;
 }
 
 interface LaunchExchangeResponse {
@@ -134,16 +143,27 @@ export function resolveLaunchSettings(config: AgorConfig): ResolvedLaunchSetting
     trustVerifiedEmailForLinking: raw?.trust_verified_email_for_linking === true,
     requestTimeoutMs: raw?.request_timeout_ms ?? DEFAULT_TIMEOUT_MS,
     algorithms: raw?.algorithms,
+    forwardRequestHost:
+      envFlag(process.env[DEFAULT_FORWARD_REQUEST_HOST_ENV]) ?? raw?.forward_request_host === true,
+    trustedHostHeader: (raw?.trusted_host_header || DEFAULT_TRUSTED_HOST_HEADER).toLowerCase(),
+    returnHostParam: raw?.return_host_param || undefined,
   };
 }
 
 export function resolvePublicLaunchAuthSettings(config: AgorConfig): PublicLaunchAuthSettings {
   const raw = config.external_launch;
   const enabled = envFlag(process.env.AGOR_EXTERNAL_LAUNCH_ENABLED) ?? raw?.enabled === true;
+  // Only advertise a return-host param when a launch-init redirect exists to
+  // append it to; the param name itself is public routing metadata, not a secret.
+  const returnHostParam =
+    enabled && raw?.login_redirect_url
+      ? raw?.return_host_param || DEFAULT_RETURN_HOST_PARAM
+      : undefined;
 
   return {
     enabled,
     ...(enabled && raw?.login_redirect_url ? { loginRedirectUrl: raw.login_redirect_url } : {}),
+    ...(returnHostParam ? { returnHostParam } : {}),
   };
 }
 
@@ -403,9 +423,51 @@ async function fetchJson(url: string, init: RequestInit, timeoutMs: number): Pro
   }
 }
 
+/**
+ * Read the normalized inbound browser Host from the trusted local request
+ * context. The value comes from a single configured request header that the
+ * trusted proxy / edge owns and overwrites — never from a client-supplied body
+ * field. Multiple, array or comma-joined host values are treated as ambiguous
+ * and rejected so a caller cannot smuggle a second host past the edge.
+ *
+ * Returns `undefined` when host forwarding is disabled. Throws (fail closed)
+ * when forwarding is enabled but no unambiguous host is available.
+ */
+export function resolveRequestHost(
+  settings: ResolvedLaunchSettings,
+  headers: Record<string, unknown> | undefined
+): string | undefined {
+  if (!settings.forwardRequestHost) return undefined;
+
+  const wanted = settings.trustedHostHeader;
+  let raw: unknown;
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    if (key.toLowerCase() === wanted) {
+      raw = value;
+      break;
+    }
+  }
+
+  if (Array.isArray(raw)) {
+    if (raw.length !== 1) {
+      throw new NotAuthenticated('Ambiguous launch request host');
+    }
+    raw = raw[0];
+  }
+  if (typeof raw !== 'string') {
+    throw new NotAuthenticated('Missing launch request host');
+  }
+  const host = raw.trim().toLowerCase();
+  if (!host || host.includes(',') || /\s/.test(host)) {
+    throw new NotAuthenticated('Invalid launch request host');
+  }
+  return host;
+}
+
 async function exchangeLaunchCode(
   launchCode: string,
-  settings: ResolvedLaunchSettings
+  settings: ResolvedLaunchSettings,
+  requestHost: string | undefined
 ): Promise<LaunchExchangeResponse> {
   const headers: Record<string, string> = {
     Accept: 'application/json',
@@ -417,6 +479,9 @@ async function exchangeLaunchCode(
     launch_code: launchCode,
     audience: settings.audience,
     instance_id: settings.instanceId,
+    // Host-bound launch: the issuer binds the code to the exact route the
+    // browser entered. Only sent when configured; kept opaque to the daemon.
+    ...(settings.forwardRequestHost && requestHost ? { request_host: requestHost } : {}),
   };
 
   const json = await fetchJson(
@@ -464,12 +529,21 @@ async function verifyLaunchAssertion(
     throw new NotAuthenticated('Invalid one-time launch assertion');
   }
 
+  // Fail closed on the unsigned `none` algorithm regardless of configuration.
+  if (!decoded.header.alg || decoded.header.alg.toLowerCase() === 'none') {
+    throw new NotAuthenticated('Launch assertion verification failed');
+  }
+
   const key = await resolveVerificationKey(decoded.header, settings);
-  const algorithms = settings.algorithms ?? (settings.devSharedSecret ? ['HS256'] : undefined);
+  // Production verification is asymmetric and must pin an explicit algorithm
+  // allow-list. Defaulting to RS256 for the non-dev path prevents algorithm
+  // confusion (e.g. a public key coerced into HS256). The dev symmetric path
+  // stays HS256-only. An operator may still narrow/extend via `algorithms`.
+  const algorithms = settings.algorithms ?? (settings.devSharedSecret ? ['HS256'] : ['RS256']);
   const claims = jwt.verify(assertion, key, {
     issuer: settings.issuer,
     audience: settings.audience,
-    algorithms: algorithms as jwt.Algorithm[] | undefined,
+    algorithms: algorithms as jwt.Algorithm[],
   }) as LaunchClaims;
 
   validateLaunchClaims(claims, settings);
@@ -541,8 +615,17 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
       const settings = resolveLaunchSettings(options.config);
       assertConfigured(settings);
 
+      // Preserve the browser Host from the trusted local request context so a
+      // code minted for one host cannot be exchanged through another. Resolved
+      // before the network call so an ambiguous host fails closed with no code
+      // ever leaving the daemon.
+      const requestHost = resolveRequestHost(
+        settings,
+        params?.headers as Record<string, unknown> | undefined
+      );
+
       try {
-        const exchange = await exchangeLaunchCode(launchCode, settings);
+        const exchange = await exchangeLaunchCode(launchCode, settings, requestHost);
         if (!exchange.assertion) {
           throw new NotAuthenticated('Invalid one-time launch exchange response');
         }
@@ -570,6 +653,15 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
         if (error instanceof TenantResolutionError) {
           throw new NotAuthenticated(error.message);
         }
+        // Operator diagnostic only — the launch code, assertion, bearer
+        // credential and request host must never reach logs/telemetry.
+        console.warn(
+          safeLaunchDiagnostic(error instanceof Error ? error.message : 'exchange failed', [
+            launchCode,
+            settings.serviceCredential,
+            settings.devSharedSecret,
+          ])
+        );
         throw new NotAuthenticated('Invalid or expired one-time launch code');
       }
     },

--- a/apps/agor-daemon/src/auth/launch-auth.ts
+++ b/apps/agor-daemon/src/auth/launch-auth.ts
@@ -581,6 +581,71 @@ function validateLaunchClaims(claims: LaunchClaims, settings: ResolvedLaunchSett
   }
 }
 
+/**
+ * Closed, reviewed set of secret-safe launch-failure reason codes. These are
+ * the ONLY strings ever written to the operator log for a failed launch. An
+ * error's free-text `message` is never logged: an unexpected error (a fetch/DNS
+ * failure, a driver/DB error, a dependency exception, a re-thrown assertion or
+ * verification detail) can embed a credential-bearing URL such as
+ * `?access_token=…`, cookie/header text or connection strings, none of which
+ * the structural redactor is guaranteed to catch. Classifying to a static code
+ * gives operators useful differentiation while keeping arbitrary text out of
+ * logs entirely.
+ */
+const LAUNCH_FAILURE_REASONS = {
+  BAD_REQUEST: 'bad_request',
+  EXCHANGE_REJECTED: 'exchange_rejected',
+  EXCHANGE_RESPONSE_INVALID: 'exchange_response_invalid',
+  ASSERTION_INVALID: 'assertion_invalid',
+  ASSERTION_VERIFICATION_FAILED: 'assertion_verification_failed',
+  ASSERTION_CLAIMS_INVALID: 'assertion_claims_invalid',
+  REQUEST_HOST_INVALID: 'request_host_invalid',
+  TENANT_RESOLUTION_FAILED: 'tenant_resolution_failed',
+  LAUNCH_REJECTED: 'launch_rejected',
+  UNEXPECTED: 'unexpected_error',
+} as const;
+
+/**
+ * Strict allow-list mapping the module's own static rejection messages to a
+ * differentiated reason code. Membership is tested only to SELECT a code — the
+ * message itself is never emitted — so this stays a closed enum-like lookup and
+ * degrades safely (to the coarse class-based code below) if a message drifts.
+ */
+const KNOWN_LAUNCH_FAILURE_REASONS: ReadonlyMap<string, string> = new Map([
+  ['launchCode is required', LAUNCH_FAILURE_REASONS.BAD_REQUEST],
+  ['launchCode is too long', LAUNCH_FAILURE_REASONS.BAD_REQUEST],
+  ['Invalid or expired one-time launch code', LAUNCH_FAILURE_REASONS.EXCHANGE_REJECTED],
+  ['Invalid one-time launch exchange response', LAUNCH_FAILURE_REASONS.EXCHANGE_RESPONSE_INVALID],
+  ['Invalid one-time launch assertion', LAUNCH_FAILURE_REASONS.ASSERTION_INVALID],
+  ['Launch assertion verification failed', LAUNCH_FAILURE_REASONS.ASSERTION_VERIFICATION_FAILED],
+  ['Invalid one-time launch assertion issuer', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Invalid one-time launch assertion subject', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Invalid one-time launch assertion expiration', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Invalid one-time launch assertion instance', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Invalid one-time launch assertion id', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Invalid one-time launch assertion nonce', LAUNCH_FAILURE_REASONS.ASSERTION_CLAIMS_INVALID],
+  ['Ambiguous launch request host', LAUNCH_FAILURE_REASONS.REQUEST_HOST_INVALID],
+  ['Missing launch request host', LAUNCH_FAILURE_REASONS.REQUEST_HOST_INVALID],
+  ['Invalid launch request host', LAUNCH_FAILURE_REASONS.REQUEST_HOST_INVALID],
+]);
+
+/**
+ * Map any launch failure to a static, secret-safe reason code. The raw message
+ * is used ONLY as an allow-list lookup key and is never returned or logged; the
+ * result is always a compile-time constant from {@link LAUNCH_FAILURE_REASONS}.
+ */
+export function classifyLaunchFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : '';
+  const known = KNOWN_LAUNCH_FAILURE_REASONS.get(message);
+  if (known) return known;
+  if (error instanceof BadRequest) return LAUNCH_FAILURE_REASONS.BAD_REQUEST;
+  if (error instanceof TenantResolutionError) {
+    return LAUNCH_FAILURE_REASONS.TENANT_RESOLUTION_FAILED;
+  }
+  if (error instanceof NotAuthenticated) return LAUNCH_FAILURE_REASONS.LAUNCH_REJECTED;
+  return LAUNCH_FAILURE_REASONS.UNEXPECTED;
+}
+
 function issueRuntimeTokens(
   user: User,
   jwtSecret: string,
@@ -622,16 +687,17 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
       const settings = resolveLaunchSettings(options.config);
       assertConfigured(settings);
 
-      // Preserve the browser Host from the trusted local request context so a
-      // code minted for one host cannot be exchanged through another. Resolved
-      // before the network call so an ambiguous host fails closed with no code
-      // ever leaving the daemon.
-      const requestHost = resolveRequestHost(
-        settings,
-        params?.headers as Record<string, unknown> | undefined
-      );
-
       try {
+        // Resolve the browser Host from the trusted local request context BEFORE
+        // the exchange network call so a code minted for one host cannot be
+        // presented through another, and a missing/ambiguous/invalid host fails
+        // closed with no launch code ever leaving the daemon. Kept inside the
+        // try so a host failure also yields a static, secret-safe diagnostic.
+        const requestHost = resolveRequestHost(
+          settings,
+          params?.headers as Record<string, unknown> | undefined
+        );
+
         const exchange = await exchangeLaunchCode(launchCode, settings, requestHost);
         if (!exchange.assertion) {
           throw new NotAuthenticated('Invalid one-time launch exchange response');
@@ -656,28 +722,26 @@ export function createLaunchAuthService(options: LaunchAuthServiceOptions) {
           );
         });
       } catch (error) {
-        // Every expected launch failure emits exactly one coarse, secret-safe
-        // operator diagnostic before rethrowing. The launch code, assertion,
-        // bearer credential, request host, cookies and DB URLs must never reach
-        // logs/telemetry, so the reason is scrubbed through safeLaunchDiagnostic.
-        const logLaunchFailure = (reason: string): void => {
-          console.warn(
-            safeLaunchDiagnostic(reason, [
-              launchCode,
-              settings.serviceCredential,
-              settings.devSharedSecret,
-            ])
-          );
-        };
+        // Every launch failure — expected or unexpected — emits exactly one
+        // coarse operator diagnostic before rethrowing. Only a static reason
+        // code from the closed classification is logged; the raw error message
+        // is never emitted, so a credential-bearing URL (e.g. ?access_token=…),
+        // assertion/verification text, cookies, DB URLs or dependency exception
+        // text can never reach logs/telemetry. safeLaunchDiagnostic additionally
+        // scrubs the per-request code/credential as defense in depth.
+        console.warn(
+          safeLaunchDiagnostic(classifyLaunchFailure(error), [
+            launchCode,
+            settings.serviceCredential,
+            settings.devSharedSecret,
+          ])
+        );
         if (error instanceof BadRequest || error instanceof NotAuthenticated) {
-          logLaunchFailure(error.message);
           throw error;
         }
         if (error instanceof TenantResolutionError) {
-          logLaunchFailure(error.message);
           throw new NotAuthenticated(error.message);
         }
-        logLaunchFailure(error instanceof Error ? error.message : 'exchange failed');
         throw new NotAuthenticated('Invalid or expired one-time launch code');
       }
     },

--- a/apps/agor-daemon/src/auth/launch-redaction.test.ts
+++ b/apps/agor-daemon/src/auth/launch-redaction.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { redactLaunchSecrets, safeLaunchDiagnostic } from './launch-redaction.js';
+
+describe('launch secret redaction', () => {
+  it('redacts explicit secret literals (codes, assertions, credentials)', () => {
+    const code = 'otc_abcdef123456';
+    const assertion = 'eyJhbGciOiJSUzI1NiJ9.payload.signature';
+    const bearer = 'exchange-credential-xyz';
+    const message = `exchange failed for ${code} using ${assertion} and ${bearer}`;
+
+    const out = redactLaunchSecrets(message, [code, assertion, bearer]);
+
+    expect(out).not.toContain(code);
+    expect(out).not.toContain(assertion);
+    expect(out).not.toContain(bearer);
+    expect(out).toContain('[redacted]');
+  });
+
+  it('redacts Authorization/Bearer values structurally', () => {
+    expect(redactLaunchSecrets('Authorization: Bearer supersecrettoken')).not.toContain(
+      'supersecrettoken'
+    );
+    expect(redactLaunchSecrets('sent Bearer supersecrettoken to issuer')).toBe(
+      'sent Bearer [redacted] to issuer'
+    );
+  });
+
+  it('redacts Set-Cookie / Cookie headers', () => {
+    const out = redactLaunchSecrets('set-cookie: agor-access=abc; Path=/; HttpOnly');
+    expect(out).not.toContain('agor-access=abc');
+    expect(out).toContain('[redacted]');
+  });
+
+  it('redacts credentialed database URLs', () => {
+    const out = redactLaunchSecrets('db=postgres://user:s3cr3t@db.internal:5432/agor');
+    expect(out).not.toContain('s3cr3t');
+    expect(out).toContain('[redacted]');
+  });
+
+  it('ignores short/empty secret literals to avoid over-redaction', () => {
+    expect(redactLaunchSecrets('normal message', ['', 'ab', undefined])).toBe('normal message');
+  });
+
+  it('safeLaunchDiagnostic prefixes and scrubs', () => {
+    const out = safeLaunchDiagnostic('failed with token tok_longsecret', ['tok_longsecret']);
+    expect(out.startsWith('[auth/launch] ')).toBe(true);
+    expect(out).not.toContain('tok_longsecret');
+  });
+});

--- a/apps/agor-daemon/src/auth/launch-redaction.ts
+++ b/apps/agor-daemon/src/auth/launch-redaction.ts
@@ -1,0 +1,51 @@
+/**
+ * Redaction helpers for one-time launch authentication.
+ *
+ * Launch codes, returned assertions, the exchange bearer credential,
+ * session cookies and database URLs must never reach daemon/UI errors, logs or
+ * telemetry. These helpers scrub known secret shapes and any caller-supplied
+ * literal secrets before a value is logged.
+ */
+
+const REDACTED = '[redacted]';
+
+// `Authorization`/`Cookie` header values (`Header: value` or `Header=value`).
+const HEADER_SECRET_RE =
+  /\b(authorization|proxy-authorization|set-cookie|cookie)\b(\s*[:=]\s*)[^\n\r,;]+/gi;
+// Bare `Bearer <token>` occurrences not attached to a header name.
+const BEARER_RE = /\bBearer\s+[\w.\-+/=]+/gi;
+// Credentialed database / connection URLs, e.g. postgres://user:pass@host/db.
+const DB_URL_RE = /\b[a-z][a-z0-9+.-]*:\/\/[^\s:@/]+:[^\s:@/]+@\S+/gi;
+
+/**
+ * Scrub known secret shapes and any explicit secret literals from a string.
+ * Explicit secrets are matched literally so per-request codes/assertions do not
+ * leak even when they do not match a structural pattern.
+ */
+export function redactLaunchSecrets(
+  input: string,
+  secrets: Array<string | undefined> = []
+): string {
+  let output = input;
+  for (const secret of secrets) {
+    if (typeof secret === 'string' && secret.length >= 4) {
+      output = output.split(secret).join(REDACTED);
+    }
+  }
+  return output
+    .replace(HEADER_SECRET_RE, (_m, name: string, sep: string) => `${name}${sep}${REDACTED}`)
+    .replace(BEARER_RE, `Bearer ${REDACTED}`)
+    .replace(DB_URL_RE, REDACTED);
+}
+
+/**
+ * Build a secret-safe one-line operator diagnostic for a failed launch
+ * exchange. Never includes the code, assertion, bearer credential or host
+ * beyond a coarse reason label.
+ */
+export function safeLaunchDiagnostic(
+  reason: string,
+  secrets: Array<string | undefined> = []
+): string {
+  return `[auth/launch] ${redactLaunchSecrets(reason, secrets)}`;
+}

--- a/apps/agor-docs/content/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/content/guide/one-time-launch-auth.mdx
@@ -17,7 +17,7 @@ same runtime access and refresh tokens used by normal login.
    subject.
 5. The daemon verifies issuer, audience, expiration, subject, and the configured
    instance ID; then it maps or creates a local user by `(provider, issuer,
-subject)`.
+   subject)`.
 6. The daemon returns normal runtime auth tokens. The UI stores those tokens and
    removes `launch_code` from the URL with `replaceState`.
 
@@ -154,6 +154,21 @@ Required when `external_launch.instance_id` is configured:
 
 - `instance_id` or `runtime_instance_id`: must match configured `instance_id`
 
+## Compatibility and upgrade notes
+
+- **Non-RS256 asymmetric signing must be declared before upgrading.** Asymmetric
+  verification (`jwks_url` / `public_key`) defaults to an `RS256`-only allow-list
+  and refuses HS\* algorithms. If your issuer signs assertions with another
+  asymmetric algorithm (`RS384`, `ES256`, `PS256`, …) and previously relied on
+  library defaults, set `algorithms` explicitly to the intended asymmetric
+  algorithm **before** upgrading, or assertions will stop verifying.
+- **`login_redirect_url` deployments begin receiving a return-host parameter.**
+  When `login_redirect_url` is enabled, direct-host entry appends the configured
+  `return_host_param` (default `return_host`) to that URL. Existing deployments
+  are therefore not unchanged: the issuer's launch-init endpoint will start
+  receiving this query parameter and should tolerate and/or consume it. Leave
+  `login_redirect_url` unset if the issuer should not receive it.
+
 ## Security notes
 
 - Put only an opaque, short-lived, one-time code in the browser URL.
@@ -167,4 +182,4 @@ Required when `external_launch.instance_id` is configured:
 - Configure exactly one assertion verification method (`jwks_url`, `public_key`,
   or dev-only `dev_shared_secret`).
 - Local users are mapped by stable external identity `(provider, issuer,
-subject)`. A matching email alone never merges identities.
+  subject)`. A matching email alone never merges identities.

--- a/apps/agor-docs/content/guide/one-time-launch-auth.mdx
+++ b/apps/agor-docs/content/guide/one-time-launch-auth.mdx
@@ -17,7 +17,7 @@ same runtime access and refresh tokens used by normal login.
    subject.
 5. The daemon verifies issuer, audience, expiration, subject, and the configured
    instance ID; then it maps or creates a local user by `(provider, issuer,
-   subject)`.
+subject)`.
 6. The daemon returns normal runtime auth tokens. The UI stores those tokens and
    removes `launch_code` from the URL with `replaceState`.
 
@@ -43,6 +43,18 @@ external_launch:
   # Optional: primary action shown when launch sign-in cannot continue.
   # Must be http:// or https://.
   login_redirect_url: https://workspace.example.com/open
+
+  # Optional host-bound launch for a single daemon that serves several hosts.
+  # When enabled, the daemon forwards the normalized inbound browser Host to the
+  # exchange endpoint as an opaque `request_host`, letting the issuer bind a code
+  # to the exact route the browser entered.
+  forward_request_host: false
+  # Header the daemon reads the browser Host from. The trusted proxy / edge owns
+  # host normalization and must overwrite it. Default: host.
+  trusted_host_header: host
+  # Query param appended to login_redirect_url carrying the current host as an
+  # opaque return context for direct-host entry. Default: return_host.
+  return_host_param: return_host
 ```
 
 For local development only, a symmetric assertion secret can be used:
@@ -72,6 +84,19 @@ fallback.
 
 If `login_redirect_url` is omitted, the normal local login screen is unchanged.
 
+### Direct-host entry
+
+A browser can also navigate straight to a workspace host. If a valid session
+already exists for that host it opens immediately with no new code. Runtime
+sessions are stored in origin-scoped `localStorage` — never a `Domain`-wide
+cookie — so a session on one host is never sent to another. If there is no
+host-local session, the unauthenticated screen sends the browser to
+`login_redirect_url` with `return_to` (the current relative Agor route) and, when
+`return_host_param` is configured, the current host. The issuer allow-lists that
+host, mints a fresh code and returns to the same host for the normal exchange.
+Agor only ever redirects to the operator-configured URL, so it adds no open
+redirect.
+
 ## Exchange contract
 
 The daemon sends a JSON `POST` to `exchange_url`:
@@ -80,12 +105,26 @@ The daemon sends a JSON `POST` to `exchange_url`:
 {
   "launch_code": "opaque-one-time-code",
   "audience": "agor-runtime:my-instance",
-  "instance_id": "my-instance"
+  "instance_id": "my-instance",
+  "request_host": "primary.workspace.example.com"
 }
 ```
 
+`request_host` is included only when `forward_request_host` is enabled; it is the
+normalized inbound Host read from the trusted `trusted_host_header` (default
+`Host`), never a client-supplied body field or arbitrary forwarded header.
+`audience` and `instance_id` are compatibility echoes — a correct issuer derives
+authority from its own records and the authenticated exchange credential.
+
 If `service_credential` or `service_credential_env` is configured, the daemon
-also sends `Authorization: Bearer <credential>`.
+also sends `Authorization: Bearer <credential>`. This server-to-server exchange
+credential is never returned to the browser, exposed in the public `/health`
+settings, or written to logs.
+
+Production verification fails closed: the `none` algorithm is always rejected;
+`jwks_url` / `public_key` verification defaults to an `RS256` allow-list to
+prevent algorithm confusion; and a missing issuer, audience, `exp`, `sub`, or
+required tenant claim creates no session.
 
 The exchange endpoint should consume the launch code exactly once and return:
 
@@ -128,4 +167,4 @@ Required when `external_launch.instance_id` is configured:
 - Configure exactly one assertion verification method (`jwks_url`, `public_key`,
   or dev-only `dev_shared_secret`).
 - Local users are mapped by stable external identity `(provider, issuer,
-  subject)`. A matching email alone never merges identities.
+subject)`. A matching email alone never merges identities.

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -873,6 +873,11 @@ function AppContent() {
             ? authConfig.externalLaunch.loginRedirectUrl
             : undefined
         }
+        externalLaunchReturnHostParam={
+          authConfig?.externalLaunch?.enabled
+            ? authConfig.externalLaunch.returnHostParam
+            : undefined
+        }
       />
     );
   }

--- a/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
+++ b/apps/agor-ui/src/components/LoginPage/LoginPage.tsx
@@ -8,39 +8,18 @@ import { LockOutlined, MailOutlined } from '@ant-design/icons';
 import { Alert, Button, Card, Divider, Form, Input, Space, Typography, theme } from 'antd';
 import { useState } from 'react';
 import { BRAND, brandMarkHref } from '../../branding/brand';
+import { buildLaunchInitUrl } from '../../utils/launchInitUrl';
 import { BrandLogo } from '../BrandLogo';
 import { ParticleBackground } from './ParticleBackground';
 
 const { Text } = Typography;
-
-function currentReturnToPath(): string | null {
-  if (typeof window === 'undefined') return null;
-
-  // Send only a relative Agor route to the external launcher. Avoiding an
-  // absolute URL keeps this from becoming an open-redirect primitive if the
-  // launcher blindly follows `return_to`.
-  const pathname = window.location.pathname.startsWith('//') ? '/' : window.location.pathname;
-  return `${pathname}${window.location.search}${window.location.hash}`;
-}
-
-function addReturnToParam(loginRedirectUrl: string): string {
-  const returnTo = currentReturnToPath();
-  if (!returnTo) return loginRedirectUrl;
-
-  try {
-    const url = new URL(loginRedirectUrl);
-    url.searchParams.set('return_to', returnTo);
-    return url.toString();
-  } catch {
-    return loginRedirectUrl;
-  }
-}
 
 interface LoginPageProps {
   onLogin: (email: string, password: string) => Promise<boolean>;
   loading?: boolean;
   error?: string | null;
   externalLaunchLoginRedirectUrl?: string;
+  externalLaunchReturnHostParam?: string;
 }
 
 export function LoginPage({
@@ -48,6 +27,7 @@ export function LoginPage({
   loading = false,
   error,
   externalLaunchLoginRedirectUrl,
+  externalLaunchReturnHostParam,
 }: LoginPageProps) {
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
@@ -55,7 +35,7 @@ export function LoginPage({
   const { token } = theme.useToken();
   const useExternalLaunch = !!externalLaunchLoginRedirectUrl;
   const externalLaunchHref = externalLaunchLoginRedirectUrl
-    ? addReturnToParam(externalLaunchLoginRedirectUrl)
+    ? buildLaunchInitUrl(externalLaunchLoginRedirectUrl, externalLaunchReturnHostParam)
     : undefined;
   const showLoginForm = !useExternalLaunch || showLocalLogin;
   const isLaunchError = error?.startsWith('Launch sign-in failed') ?? false;

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -15,6 +15,12 @@ interface AuthConfig {
   externalLaunch?: {
     enabled?: boolean;
     loginRedirectUrl?: string;
+    /**
+     * Query parameter name the UI appends to `loginRedirectUrl` carrying the
+     * current browser host as an opaque return context for direct-host entry.
+     * The launch issuer allow-lists this value against its routing records.
+     */
+    returnHostParam?: string;
   };
 }
 

--- a/apps/agor-ui/src/utils/launchAuth.test.ts
+++ b/apps/agor-ui/src/utils/launchAuth.test.ts
@@ -47,7 +47,7 @@ describe('launch auth utilities', () => {
     expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('refresh');
   });
 
-  it('stores the session in origin-scoped storage and sets no cross-host cookie', async () => {
+  it('stores tokens in localStorage and writes no cookie during the exchange', async () => {
     const cookieBefore = document.cookie;
     const client = {
       service: vi.fn(() => ({
@@ -61,10 +61,12 @@ describe('launch auth utilities', () => {
 
     await exchangeLaunchCode(client, 'code');
 
-    // Runtime sessions live in localStorage (per-origin) — never a Domain-wide
-    // cookie — so a session established on one workspace host is not
-    // automatically sent to another workspace host.
+    // Verifiable claim: the exchange persists the runtime session in
+    // origin-scoped localStorage and writes no cookie. (Cross-host isolation
+    // follows from localStorage being per-origin, but that is a browser
+    // property this unit test cannot itself exercise.)
     expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('access');
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('refresh');
     expect(document.cookie).toBe(cookieBefore);
   });
 });

--- a/apps/agor-ui/src/utils/launchAuth.test.ts
+++ b/apps/agor-ui/src/utils/launchAuth.test.ts
@@ -46,4 +46,25 @@ describe('launch auth utilities', () => {
     expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('access');
     expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('refresh');
   });
+
+  it('stores the session in origin-scoped storage and sets no cross-host cookie', async () => {
+    const cookieBefore = document.cookie;
+    const client = {
+      service: vi.fn(() => ({
+        create: vi.fn(async () => ({
+          accessToken: 'access',
+          refreshToken: 'refresh',
+          user: { user_id: 'u1', email: 'u@example.test' },
+        })),
+      })),
+    } as any;
+
+    await exchangeLaunchCode(client, 'code');
+
+    // Runtime sessions live in localStorage (per-origin) — never a Domain-wide
+    // cookie — so a session established on one workspace host is not
+    // automatically sent to another workspace host.
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe('access');
+    expect(document.cookie).toBe(cookieBefore);
+  });
 });

--- a/apps/agor-ui/src/utils/launchInitUrl.test.ts
+++ b/apps/agor-ui/src/utils/launchInitUrl.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildLaunchInitUrl } from './launchInitUrl';
+
+describe('buildLaunchInitUrl (direct-host entry)', () => {
+  afterEach(() => {
+    window.history.replaceState({}, '', '/ui/');
+  });
+
+  it('appends the current host under the configured return-host param', () => {
+    window.history.replaceState({}, '', '/ui/s/session-1/');
+    const href = buildLaunchInitUrl('https://console.example.test/launch-init', 'return_host');
+    const url = new URL(href);
+    expect(url.origin).toBe('https://console.example.test');
+    expect(url.searchParams.get('return_host')).toBe(window.location.host);
+    // deep-link path is preserved as a relative return_to
+    expect(url.searchParams.get('return_to')).toBe('/ui/s/session-1/');
+  });
+
+  it('omits the host param when none is configured', () => {
+    const href = buildLaunchInitUrl('https://console.example.test/launch-init');
+    const url = new URL(href);
+    expect(url.searchParams.has('return_host')).toBe(false);
+    expect(url.searchParams.get('return_to')).toBe('/ui/');
+  });
+
+  it('only ever targets the operator-configured launch-init origin', () => {
+    const href = buildLaunchInitUrl('https://console.example.test/launch-init', 'return_host');
+    expect(new URL(href).origin).toBe('https://console.example.test');
+  });
+
+  it('returns the input unchanged when it is not a valid URL', () => {
+    expect(buildLaunchInitUrl('not a url', 'return_host')).toBe('not a url');
+  });
+});

--- a/apps/agor-ui/src/utils/launchInitUrl.test.ts
+++ b/apps/agor-ui/src/utils/launchInitUrl.test.ts
@@ -31,4 +31,24 @@ describe('buildLaunchInitUrl (direct-host entry)', () => {
   it('returns the input unchanged when it is not a valid URL', () => {
     expect(buildLaunchInitUrl('not a url', 'return_host')).toBe('not a url');
   });
+
+  it('keeps return_to intact when the host param has a distinct name', () => {
+    window.history.replaceState({}, '', '/ui/s/session-1/');
+    const href = buildLaunchInitUrl('https://console.example.test/launch-init', 'return_host');
+    const url = new URL(href);
+    expect(url.searchParams.get('return_to')).toBe('/ui/s/session-1/');
+    expect(url.searchParams.get('return_host')).toBe(window.location.host);
+  });
+
+  it('demonstrates the hazard that config validation prevents: a return_to host param clobbers the deep-link', () => {
+    // If the return-host param were allowed to reuse the reserved `return_to`
+    // name, the host set (which runs after return_to) would overwrite the
+    // relative deep-link. Core config validation rejects this name for exactly
+    // this reason; this test pins the hazard the guard prevents.
+    window.history.replaceState({}, '', '/ui/s/session-1/');
+    const href = buildLaunchInitUrl('https://console.example.test/launch-init', 'return_to');
+    const url = new URL(href);
+    expect(url.searchParams.get('return_to')).toBe(window.location.host);
+    expect(url.searchParams.get('return_to')).not.toBe('/ui/s/session-1/');
+  });
 });

--- a/apps/agor-ui/src/utils/launchInitUrl.ts
+++ b/apps/agor-ui/src/utils/launchInitUrl.ts
@@ -1,0 +1,41 @@
+/**
+ * Build the external launch-init URL for direct-host entry.
+ *
+ * When a browser lands directly on a workspace host without a local runtime
+ * session, the unauthenticated screen sends it to the issuer's configured
+ * launch-init endpoint. We attach:
+ *
+ * - `return_to`: the current *relative* Agor route, so deep links survive a
+ *   fresh launch. Only a relative path is sent so this can never become an
+ *   open-redirect primitive on the launcher side.
+ * - the configured return-host param: the exact host the browser landed on, so
+ *   the issuer can resolve/allow-list the return host from its own routing
+ *   records and mint a code scoped to it. It is opaque to the daemon.
+ *
+ * The browser is only ever sent to the operator-configured launch-init URL, so
+ * Agor itself introduces no open redirect regardless of these query values.
+ */
+export function currentReturnToPath(): string | null {
+  if (typeof window === 'undefined') return null;
+  const pathname = window.location.pathname.startsWith('//') ? '/' : window.location.pathname;
+  return `${pathname}${window.location.search}${window.location.hash}`;
+}
+
+export function currentHost(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.location.host || null;
+}
+
+export function buildLaunchInitUrl(loginRedirectUrl: string, returnHostParam?: string): string {
+  const returnTo = currentReturnToPath();
+  const host = currentHost();
+
+  try {
+    const url = new URL(loginRedirectUrl);
+    if (returnTo) url.searchParams.set('return_to', returnTo);
+    if (returnHostParam && host) url.searchParams.set(returnHostParam, host);
+    return url.toString();
+  } catch {
+    return loginRedirectUrl;
+  }
+}

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -49,6 +49,19 @@ external_launch:
   # missing, expired, already used, invalid, or otherwise cannot be exchanged.
   # Must be http:// or https://.
   login_redirect_url: https://workspace.example.com/open
+
+  # Optional host-bound launch (multi-host single daemon). When enabled the
+  # daemon forwards the normalized inbound browser Host to the exchange endpoint
+  # as an opaque `request_host`, so the issuer can bind a code to the exact route
+  # the browser entered and reject a code minted for host A presented on host B.
+  forward_request_host: false
+  # Header the daemon reads the browser Host from. The trusted proxy / edge in
+  # front of the daemon owns host normalization and MUST overwrite this header.
+  # Default: host. Only set to x-forwarded-host when a trusted edge sets it.
+  trusted_host_header: host
+  # Query parameter appended to login_redirect_url carrying the current host as
+  # an opaque return context for direct-host entry. Default: return_host.
+  return_host_param: return_host
 ```
 
 For local development only, a symmetric assertion secret can be used:
@@ -80,11 +93,30 @@ The daemon sends a JSON `POST` to `exchange_url`:
 {
   "launch_code": "opaque-one-time-code",
   "audience": "agor-runtime:my-instance",
-  "instance_id": "my-instance"
+  "instance_id": "my-instance",
+  "request_host": "primary.workspace.example.com"
 }
 ```
 
-If `service_credential` or `service_credential_env` is configured, the daemon also sends `Authorization: Bearer <credential>`.
+`request_host` is present only when `forward_request_host` is enabled. It is the
+normalized inbound browser Host read from the configured `trusted_host_header`
+(default `Host`) of the daemon's own request — never from a client-supplied body
+field or an arbitrary forwarded header. The daemon treats it as opaque; the
+issuer maps it to the intended route and rejects a code presented on the wrong
+host. Ambiguous host values (multiple, array or comma-joined) fail closed before
+any code leaves the daemon. `audience` and `instance_id` are compatibility
+echoes; a correct issuer derives authority from its own records and the
+authenticated exchange credential, not from these caller-supplied fields. The
+canonical request shape is pinned by the shared contract fixture
+`apps/agor-daemon/src/auth/__fixtures__/launch-exchange-request.json`, which must
+stay aligned with the issuer's canonical exchange schema so the two sides cannot
+drift.
+
+If `service_credential` or `service_credential_env` is configured, the daemon also sends `Authorization: Bearer <credential>`. This static bearer is a
+server-to-server exchange credential: it is read only from config/env (in
+production, from a mounted Kubernetes Secret), is never included in the public
+`/health` launch settings, and is never returned to the browser or written to
+logs, errors or telemetry.
 
 The exchange endpoint should consume the launch code exactly once and return:
 
@@ -112,6 +144,41 @@ Required when `external_launch.instance_id` is configured:
 
 - `instance_id` or `runtime_instance_id`: must match configured `instance_id`
 
+## Direct-host entry
+
+Clicking a launch link is not required. A browser can navigate straight to a
+workspace host:
+
+- If a valid runtime session already exists for that host, the app opens
+  immediately with no new code or exchange. Runtime sessions live in
+  origin-scoped `localStorage`, never a `Domain`-wide cookie, so a session
+  established on `primary` is not automatically sent to `secondary`.
+- If there is no host-local session, the unauthenticated screen sends the
+  browser to the configured `login_redirect_url` (the issuer's launch-init
+  endpoint) with two query params: `return_to` (the current **relative** Agor
+  route, so deep links survive) and the configured `return_host_param` carrying
+  the exact current host. The issuer allow-lists that host against its own
+  routing records, mints a fresh code and redirects back to that exact host,
+  which then runs the normal exchange. Agor only ever sends the browser to the
+  operator-configured launch-init URL, so it introduces no open redirect; the
+  issuer owns return-host validation.
+
+## Fail-closed verification
+
+Production verification is asymmetric and fails closed:
+
+- The `none` algorithm is always rejected.
+- When verifying with `jwks_url` or `public_key`, the algorithm allow-list
+  defaults to `RS256` (override with `algorithms`), preventing algorithm
+  confusion (e.g. a public key coerced into an HS256 secret). The dev
+  `dev_shared_secret` path stays HS256-only.
+- JWKS assertions must carry a `kid` that matches a signing key whose `use` is
+  `sig` and whose `alg` matches the token header.
+- A missing/invalid issuer, audience, `exp`, `sub`, or (when
+  `multi_tenancy.mode: required_from_auth`) the configured tenant claim, creates
+  **no session**. Tenant scope applied to the runtime DB/RLS always equals the
+  signed tenant claim.
+
 ## Security notes
 
 - Put only an opaque, short-lived, one-time code in the browser URL.
@@ -120,3 +187,22 @@ Required when `external_launch.instance_id` is configured:
 - Assertions should be audience-bound to the runtime, instance-bound when `instance_id` is configured, and expire quickly.
 - Configure exactly one assertion verification method (`jwks_url`, `public_key`, or dev-only `dev_shared_secret`).
 - Local users are mapped by stable external identity `(provider, issuer, subject)`. A matching email alone never merges identities.
+- Launch codes, returned assertions, the exchange bearer credential, cookies and
+  database URLs are redacted from daemon errors, logs and telemetry
+  (`apps/agor-daemon/src/auth/launch-redaction.ts`). Exchange failures log only a
+  coarse, secret-safe reason.
+
+## Production-only operational validation
+
+The following cannot be exercised by unit tests and must be confirmed against a
+real deployment with a real issuer:
+
+- Public JWKS resolves to stable RS256 JSON from the signer (not an HTML
+  fallthrough) and the runtime verifies against it.
+- A code minted for host A and presented on host B is rejected end-to-end
+  (`request_host` binding), and a wrong/revoked/wrong-scope exchange credential
+  fails.
+- Two hosts sharing one daemon each establish sessions scoped to their own
+  `tenant_id`, and cross-tenant reads/writes fail under RLS.
+- No launch code, assertion, bearer credential, cookie or DB URL appears in
+  daemon/proxy logs, audit or analytics for the test window.

--- a/context/guides/one-time-launch-auth.md
+++ b/context/guides/one-time-launch-auth.md
@@ -107,10 +107,11 @@ host. Ambiguous host values (multiple, array or comma-joined) fail closed before
 any code leaves the daemon. `audience` and `instance_id` are compatibility
 echoes; a correct issuer derives authority from its own records and the
 authenticated exchange credential, not from these caller-supplied fields. The
-canonical request shape is pinned by the shared contract fixture
-`apps/agor-daemon/src/auth/__fixtures__/launch-exchange-request.json`, which must
-stay aligned with the issuer's canonical exchange schema so the two sides cannot
-drift.
+request shape the daemon emits is pinned by a daemon-side contract tripwire
+fixture `apps/agor-daemon/src/auth/__fixtures__/launch-exchange-request.json`: it
+catches an accidental daemon-side change in review, but it does not and cannot
+mechanically prevent the issuer from drifting. The issuer's canonical exchange
+schema remains the source of truth and must be kept in sync out of band.
 
 If `service_credential` or `service_credential_env` is configured, the daemon also sends `Authorization: Bearer <credential>`. This static bearer is a
 server-to-server exchange credential: it is read only from config/env (in
@@ -172,12 +173,31 @@ Production verification is asymmetric and fails closed:
   defaults to `RS256` (override with `algorithms`), preventing algorithm
   confusion (e.g. a public key coerced into an HS256 secret). The dev
   `dev_shared_secret` path stays HS256-only.
-- JWKS assertions must carry a `kid` that matches a signing key whose `use` is
-  `sig` and whose `alg` matches the token header.
+- JWKS assertions must carry a `kid` that matches a signing key. A key that
+  omits `use`/`alg` metadata is accepted; when either is present it must be
+  consistent (`use: sig`, and `alg` matching the token header). Only conflicting
+  metadata is rejected — the code intentionally treats those fields as optional.
 - A missing/invalid issuer, audience, `exp`, `sub`, or (when
   `multi_tenancy.mode: required_from_auth`) the configured tenant claim, creates
   **no session**. Tenant scope applied to the runtime DB/RLS always equals the
   signed tenant claim.
+
+## Compatibility and upgrade notes
+
+- **Non-RS256 asymmetric signing must be declared before upgrading.** Asymmetric
+  verification (`jwks_url` / `public_key`) now defaults to an `RS256`-only
+  allow-list and refuses HS\* algorithms outright. A deployment that signs
+  assertions with a different asymmetric algorithm (e.g. `RS384`, `ES256`,
+  `PS256`) and previously relied on library defaults must set `algorithms`
+  explicitly to the intended asymmetric algorithm **before** upgrading, or its
+  assertions will stop verifying.
+- **`login_redirect_url` deployments begin receiving a return-host query
+  parameter.** When `login_redirect_url` is enabled, direct-host entry appends
+  the configured `return_host_param` (default `return_host`) to that URL. This is
+  not inert for existing deployments: the issuer's launch-init endpoint will
+  start receiving this query parameter and must tolerate and/or consume it
+  (allow-listing the host against its own routing records). If the issuer should
+  not receive it, leave `login_redirect_url` unset.
 
 ## Security notes
 

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -345,6 +345,72 @@ describe('loadConfig', () => {
 
     await expect(loadConfig()).rejects.toThrow(/external_launch\.login_redirect_url.*http/i);
   });
+
+  it('rejects external_launch.return_host_param equal to the reserved return_to', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({
+        external_launch: { enabled: true, return_host_param: 'return_to' },
+      }),
+      'utf-8'
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/return_host_param.*return_to/i);
+  });
+
+  it('accepts a custom external_launch.return_host_param', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({
+        external_launch: { enabled: true, return_host_param: 'workspace_host' },
+      }),
+      'utf-8'
+    );
+
+    const loaded = await loadConfig();
+    expect(loaded.external_launch?.return_host_param).toBe('workspace_host');
+  });
+
+  it('allows an empty external_launch.return_host_param (falls back to the default)', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({
+        external_launch: { enabled: true, return_host_param: '' },
+      }),
+      'utf-8'
+    );
+
+    const loaded = await loadConfig();
+    expect(loaded.external_launch?.return_host_param).toBe('');
+  });
+
+  it('rejects an external_launch.return_host_param with invalid characters', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      yaml.dump({
+        external_launch: { enabled: true, return_host_param: 'return host&x' },
+      }),
+      'utf-8'
+    );
+
+    await expect(loadConfig()).rejects.toThrow(/return_host_param.*letters/i);
+  });
 });
 
 describe('loadConfig cache', () => {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -326,6 +326,9 @@ function validateConfig(config: AgorConfig): void {
     'allow_admin_roles',
     'trust_verified_email_for_linking',
     'login_redirect_url',
+    'forward_request_host',
+    'trusted_host_header',
+    'return_host_param',
   ]);
   only(config.database, 'database', ['dialect', 'sqlite', 'postgresql']);
   only(config.database?.sqlite, 'database.sqlite', ['path', 'walMode', 'busyTimeout']);

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -512,6 +512,42 @@ function validateConfig(config: AgorConfig): void {
     'login_redirect_url',
     'external_launch.login_redirect_url'
   );
+
+  validateExternalLaunchReturnHostParam(config);
+}
+
+/**
+ * Query-parameter name the UI reserves for the relative deep-link it forwards
+ * to the launch-init endpoint (see apps/agor-ui/src/utils/launchInitUrl.ts). The
+ * host param must never reuse this name: the UI sets `return_to` first and then
+ * the host param, so an equal name would overwrite the deep-link with the host.
+ */
+const RESERVED_RETURN_TO_PARAM = 'return_to';
+
+function validateExternalLaunchReturnHostParam(config: AgorConfig): void {
+  const raw = config.external_launch?.return_host_param;
+  if (raw === undefined) return;
+  if (typeof raw !== 'string') {
+    throw new Error('Config error: external_launch.return_host_param must be a string');
+  }
+  // An empty value intentionally falls back to the default (`return_host`) at
+  // resolve time, so it is left untouched here.
+  if (raw === '') return;
+  if (raw === RESERVED_RETURN_TO_PARAM) {
+    throw new Error(
+      `Config error: external_launch.return_host_param must not be "${RESERVED_RETURN_TO_PARAM}" — ` +
+        'that name is reserved for the relative deep-link the UI forwards to the launch-init ' +
+        'endpoint, and reusing it would overwrite the deep-link with the return host.'
+    );
+  }
+  // Conservative query-parameter-name charset: the value becomes a URL query
+  // key, so restrict it to opaque identifier characters and reject separators.
+  if (!/^[A-Za-z0-9_.-]+$/.test(raw)) {
+    throw new Error(
+      'Config error: external_launch.return_host_param may only contain letters, digits, ' +
+        'underscore, hyphen, and dot'
+    );
+  }
 }
 
 function validateOptionalHttpUrl(

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -226,6 +226,34 @@ export interface AgorExternalLaunchSettings {
    * sign-in is unavailable, missing, expired, or invalid.
    */
   login_redirect_url?: string;
+
+  /**
+   * Forward the normalized inbound browser Host to the exchange endpoint as an
+   * opaque `request_host` field. Enable when the launch issuer binds a code to
+   * the exact route the browser entered (host-bound launch). Default: false.
+   *
+   * The value is read from a trusted local request header — never from an
+   * arbitrary client-supplied body field — so the daemon cannot be tricked into
+   * presenting a code minted for one host through a different host.
+   */
+  forward_request_host?: boolean;
+
+  /**
+   * Request header the daemon reads the normalized browser Host from when
+   * `forward_request_host` is enabled. The trusted proxy / edge in front of the
+   * daemon owns host normalization and must overwrite this header. Default:
+   * `host`. Set to e.g. `x-forwarded-host` only when a trusted edge sets it.
+   */
+  trusted_host_header?: string;
+
+  /**
+   * Query parameter appended to `login_redirect_url` carrying the current
+   * browser host as an opaque return context, so a direct visit to a workspace
+   * host that has no local session can start the issuer's launch-init flow and
+   * be returned to the exact host it came from. The issuer must allow-list this
+   * value against its own routing records. Default: `return_host`.
+   */
+  return_host_param?: string;
 }
 
 /**

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -252,6 +252,10 @@ export interface AgorExternalLaunchSettings {
    * host that has no local session can start the issuer's launch-init flow and
    * be returned to the exact host it came from. The issuer must allow-list this
    * value against its own routing records. Default: `return_host`.
+   *
+   * Must not be `return_to`: that name is reserved for the relative deep-link
+   * the UI forwards to the launch-init endpoint, and reusing it would overwrite
+   * the deep-link with the host. Rejected during config validation.
    */
   return_host_param?: string;
 }


### PR DESCRIPTION
## Linked issue

None.

## Summary

- Bind external one-time launch-code exchange to an optional trusted request host for multi-host daemons.
- Harden JWT/JWKS verification, signed-tenant enforcement, failure diagnostics, and secret redaction.
- Add direct-host launch initialization, configuration validation, tests, and operator documentation.

## Why / context

A single daemon may serve multiple workspace hostnames. Previously, the issuer received the launch code and audience but not the browser route context, so it could not reject a code minted for host A when presented through host B. This change forwards an opt-in, normalized host as opaque context while keeping host-to-identity policy and signing in the issuer.

## Implementation notes

- `forward_request_host` reads exactly one configured trusted header and rejects missing, array, comma-joined, or whitespace-bearing values before the code leaves the daemon.
- Asymmetric verification defaults to RS256, rejects `none`, rejects HS* configuration with `jwks_url`/`public_key`, and validates JWKS `kid` plus any declared `use`/`alg` metadata. Non-RS256 asymmetric deployments must explicitly configure their algorithm before upgrading.
- External launch tenant resolution uses only verified assertion claims; request parameters and trusted tenant headers cannot substitute for a missing required claim.
- Launch diagnostics use a closed set of static failure codes. Raw dependency, network, JWT, URL, and database exception messages are never logged; known-secret redaction remains defense in depth.
- `return_host_param` rejects the reserved `return_to` name and unsafe query-key characters, preventing the host value from overwriting the relative deep-link.
- Enabled `login_redirect_url` deployments now receive `return_host` by default; issuers must tolerate or consume it. Runtime sessions remain origin-scoped in `localStorage`.
- The exchange fixture is a daemon-side contract tripwire; cross-system issuer compatibility still requires coordination.

## Validation / test plan

- [x] `pnpm typecheck` — passed, 11/11 tasks.
- [x] `pnpm build` — passed, 7/7 current non-docs tasks.
- [x] CI-required test filters from `.github/workflows/ci.yml` — passed: core 2810, daemon 1786, UI 974.
- [x] Reviewer re-validation — daemon launch-auth/redaction 40/40, core config-manager 113/113, UI launch utilities 10/10.
- [ ] Full 11-package `pnpm test` — reports reproduced pre-existing/out-of-scope failures in `@agor/git`, `@agor/executor`, and daemon MCP tests under full-suite concurrency; all touched and CI-required scopes pass.
- [ ] Production validation with the real issuer, proxy, JWKS, RLS, and logging stack remains required before merge.

## Risks / rollout / rollback

- Existing asymmetric issuers using algorithms other than RS256 must set an explicit asymmetric `algorithms` value before rollout.
- Existing launch-init endpoints will receive the default `return_host` query parameter and must tolerate or validate it.
- The trusted edge must overwrite the configured host header; direct daemon access can otherwise bypass edge normalization.
- Roll back by reverting this PR's commits and restoring the previous configuration. Do not partially enable host forwarding without issuer support.

## Out of scope / follow-ups

- The issuer remains responsible for host allow-listing, code minting/consumption, route-to-identity mapping, and assertion signing.
- Production-only validation is intentionally deferred to the deployment environment and must be completed before merge.
- Pre-existing unrelated full-suite failures are not changed by this PR.