### PR TITLE
fix(ui): pan to the selected session row only when it isn't already visible

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -710,7 +710,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             : undefined
         }
       >
-        <div style={sessionRowStyle(session)} onClick={() => onSessionClick?.(session.session_id)}>
+        <div
+          style={sessionRowStyle(session)}
+          data-session-id={session.session_id}
+          onClick={() => onSessionClick?.(session.session_id)}
+        >
           <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             <SessionRelationshipIcon session={session} size={10} />
@@ -835,6 +839,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       >
         <div
           style={sessionRowStyle(session)}
+          data-session-id={session.session_id}
           onClick={() => onSessionClick?.(session.session_id)}
           onContextMenu={(e) => {
             if (onForkSession || onSpawnSession) {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1025,7 +1025,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // boardObjectById lookup through every caller, we accept the logical
     // id and fall back to a `data.artifactId` scan when `getNode` misses.
     const recenterOnNode = useCallback(
-      (nodeId: string, subTarget?: { sessionId?: string }): boolean => {
+      (nodeId: string, subTarget?: { sessionId?: string; ensureVisible?: boolean }): boolean => {
         const instance = reactFlowInstanceRef.current;
         if (!instance) return false;
         const allNodes = instance.getNodes();
@@ -1060,6 +1060,56 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             const nodeRect = nodeEl.getBoundingClientRect();
             const rowRect = rowEl.getBoundingClientRect();
             centerY = absPos.y + (rowRect.top - nodeRect.top + rowRect.height / 2) / zoom;
+
+            // Ensure-visible mode (session selection): don't move the
+            // camera when the row is already fully on screen — a pan on
+            // every click is disorienting and costs the user their
+            // context. When the row is off screen or cut off, pan just
+            // enough to bring it into view (with a small margin) rather
+            // than re-centering. See CanvasNavigationContext for why
+            // deliberate gestures skip this.
+            if (subTarget.ensureVisible) {
+              const paneEl = nodeEl.closest('.react-flow');
+              if (paneEl) {
+                // The canvas root defaults to `height: 100vh` (see the
+                // `height` prop) but sits below the app header inside an
+                // overflow-clipped panel, so the pane element extends past
+                // the bottom of the window by the header's height. Clamp
+                // the pane rect to the window so "visible" means what the
+                // user can actually see — unclamped, rows panned to the
+                // pane's bottom edge land hidden below the fold, and rows
+                // already in that phantom strip are wrongly treated as
+                // on-screen.
+                const paneRect = paneEl.getBoundingClientRect();
+                const viewLeft = Math.max(paneRect.left, 0);
+                const viewTop = Math.max(paneRect.top, 0);
+                const viewRight = Math.min(paneRect.right, document.documentElement.clientWidth);
+                const viewBottom = Math.min(paneRect.bottom, document.documentElement.clientHeight);
+                const margin = 32;
+                let shiftX = 0;
+                let shiftY = 0;
+                if (rowRect.left < viewLeft + margin) {
+                  shiftX = viewLeft + margin - rowRect.left;
+                } else if (rowRect.right > viewRight - margin) {
+                  shiftX = viewRight - margin - rowRect.right;
+                }
+                if (rowRect.top < viewTop + margin) {
+                  shiftY = viewTop + margin - rowRect.top;
+                } else if (rowRect.bottom > viewBottom - margin) {
+                  shiftY = viewBottom - margin - rowRect.bottom;
+                }
+                // Already fully visible — leave the camera where it is.
+                if (shiftX === 0 && shiftY === 0) return true;
+                // Pan by the screen-space delta (viewport transform is in
+                // screen px), keeping zoom unchanged.
+                const vp = instance.getViewport();
+                instance.setViewport(
+                  { x: vp.x + shiftX, y: vp.y + shiftY, zoom: vp.zoom },
+                  { duration: 400 }
+                );
+                return true;
+              }
+            }
           }
         }
         instance.setCenter(centerX, centerY, {
@@ -1506,7 +1556,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         // Falls back to fitView when the pending target isn't on this board
         // either (stale/unknown id).
         const pending = consumePendingRecenter();
-        if (pending && recenterOnNode(pending.nodeId, { sessionId: pending.sessionId })) {
+        if (
+          pending &&
+          recenterOnNode(pending.nodeId, {
+            sessionId: pending.sessionId,
+            ensureVisible: pending.ensureVisible,
+          })
+        ) {
           lastFitBoardIdRef.current = board?.board_id ?? null;
           return;
         }
@@ -2417,20 +2473,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     ]);
 
     // Node click handler for eraser mode and comment placement
-    // Double-clicking a branch card pans the camera onto it — the same
-    // movement as the "Go to card on board" locator button. When the
-    // double-click lands on a session row inside the card, aim at that
-    // row instead so the gesture agrees with single-click selection.
-    const handleNodeDoubleClick = useCallback(
-      (event: React.MouseEvent, node: Node) => {
-        if (node.type !== 'branchNode') return;
-        const row = (event.target as HTMLElement | null)?.closest?.('[data-session-id]');
-        const sessionId = row?.getAttribute('data-session-id') ?? undefined;
-        recenterOnNode(node.id, { sessionId });
-      },
-      [recenterOnNode]
-    );
-
     const handleNodeClick = useCallback(
       (event: React.MouseEvent, node: Node) => {
         if (activeTool === 'eraser') {
@@ -2557,7 +2599,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             onNodeDrag={handleNodeDrag}
             onNodeDragStop={handleNodeDragStop}
             onNodeClick={handleNodeClick}
-            onNodeDoubleClick={handleNodeDoubleClick}
             onPaneClick={handlePaneClick}
             onInit={(instance) => {
               reactFlowInstanceRef.current = instance;
@@ -2586,10 +2627,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             // Disable React Flow's keyboard shortcuts that conflict with typing/spatial messages.
             // Keep modifier-scroll zoom enabled so Command/Control + scroll behaves like Figma.
             deleteKeyCode={null}
-            // Double-click recenters branch cards (onNodeDoubleClick above);
-            // d3-zoom's dblclick.zoom would fight that animation, so the
-            // default double-click zoom is disabled.
-            zoomOnDoubleClick={false}
             selectionKeyCode={null}
             multiSelectionKeyCode={null}
             panActivationKeyCode={null}

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1024,27 +1024,52 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // logical `artifact_id` on `data.artifactId`). Rather than thread a
     // boardObjectById lookup through every caller, we accept the logical
     // id and fall back to a `data.artifactId` scan when `getNode` misses.
-    const recenterOnNode = useCallback((nodeId: string): boolean => {
-      const instance = reactFlowInstanceRef.current;
-      if (!instance) return false;
-      const allNodes = instance.getNodes();
-      let node = instance.getNode(nodeId);
-      if (!node) {
-        // Logical-id fallback: artifact callers pass artifact_id; find
-        // the node whose data references it. Extendable to other
-        // logical-id mismatches in the future.
-        node = allNodes.find((n) => n.data?.artifactId === nodeId);
-      }
-      if (!node) return false;
-      const absPos = getNodeAbsolutePosition(node, allNodes);
-      const width = node.width ?? 500;
-      const height = node.height ?? 200;
-      instance.setCenter(absPos.x + width / 2, absPos.y + height / 2, {
-        zoom: instance.getZoom(),
-        duration: 400,
-      });
-      return true;
-    }, []);
+    const recenterOnNode = useCallback(
+      (nodeId: string, subTarget?: { sessionId?: string }): boolean => {
+        const instance = reactFlowInstanceRef.current;
+        if (!instance) return false;
+        const allNodes = instance.getNodes();
+        let node = instance.getNode(nodeId);
+        if (!node) {
+          // Logical-id fallback: artifact callers pass artifact_id; find
+          // the node whose data references it. Extendable to other
+          // logical-id mismatches in the future.
+          node = allNodes.find((n) => n.data?.artifactId === nodeId);
+        }
+        if (!node) return false;
+        const absPos = getNodeAbsolutePosition(node, allNodes);
+        const width = node.width ?? 500;
+        const height = node.height ?? 200;
+        const zoom = instance.getZoom() || 1;
+        const centerX = absPos.x + width / 2;
+        let centerY = absPos.y + height / 2;
+        // Session sub-target: aim at the session row inside the card
+        // instead of the card center, so selecting a session lands the
+        // camera on that item rather than the card head. Measured from
+        // the DOM (row offset within the node wrapper, screen px → flow
+        // units via zoom); falls back to card center when the row isn't
+        // rendered (collapsed tree, session not on this card).
+        if (subTarget?.sessionId) {
+          const nodeEl = document.querySelector(
+            `.react-flow__node[data-id="${CSS.escape(node.id)}"]`
+          );
+          const rowEl = nodeEl?.querySelector(
+            `[data-session-id="${CSS.escape(subTarget.sessionId)}"]`
+          );
+          if (nodeEl && rowEl) {
+            const nodeRect = nodeEl.getBoundingClientRect();
+            const rowRect = rowEl.getBoundingClientRect();
+            centerY = absPos.y + (rowRect.top - nodeRect.top + rowRect.height / 2) / zoom;
+          }
+        }
+        instance.setCenter(centerX, centerY, {
+          zoom: instance.getZoom(),
+          duration: 400,
+        });
+        return true;
+      },
+      []
+    );
 
     useRegisterRecenter(recenterOnNode);
 
@@ -1480,8 +1505,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         // lives on this (newly-loaded) board, honor it instead of fitView.
         // Falls back to fitView when the pending target isn't on this board
         // either (stale/unknown id).
-        const pendingId = consumePendingRecenter();
-        if (pendingId && recenterOnNode(pendingId)) {
+        const pending = consumePendingRecenter();
+        if (pending && recenterOnNode(pending.nodeId, { sessionId: pending.sessionId })) {
           lastFitBoardIdRef.current = board?.board_id ?? null;
           return;
         }
@@ -2392,6 +2417,20 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     ]);
 
     // Node click handler for eraser mode and comment placement
+    // Double-clicking a branch card pans the camera onto it — the same
+    // movement as the "Go to card on board" locator button. When the
+    // double-click lands on a session row inside the card, aim at that
+    // row instead so the gesture agrees with single-click selection.
+    const handleNodeDoubleClick = useCallback(
+      (event: React.MouseEvent, node: Node) => {
+        if (node.type !== 'branchNode') return;
+        const row = (event.target as HTMLElement | null)?.closest?.('[data-session-id]');
+        const sessionId = row?.getAttribute('data-session-id') ?? undefined;
+        recenterOnNode(node.id, { sessionId });
+      },
+      [recenterOnNode]
+    );
+
     const handleNodeClick = useCallback(
       (event: React.MouseEvent, node: Node) => {
         if (activeTool === 'eraser') {
@@ -2518,6 +2557,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             onNodeDrag={handleNodeDrag}
             onNodeDragStop={handleNodeDragStop}
             onNodeClick={handleNodeClick}
+            onNodeDoubleClick={handleNodeDoubleClick}
             onPaneClick={handlePaneClick}
             onInit={(instance) => {
               reactFlowInstanceRef.current = instance;
@@ -2546,6 +2586,10 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             // Disable React Flow's keyboard shortcuts that conflict with typing/spatial messages.
             // Keep modifier-scroll zoom enabled so Command/Control + scroll behaves like Figma.
             deleteKeyCode={null}
+            // Double-click recenters branch cards (onNodeDoubleClick above);
+            // d3-zoom's dblclick.zoom would fight that animation, so the
+            // default double-click zoom is disabled.
+            zoomOnDoubleClick={false}
             selectionKeyCode={null}
             multiSelectionKeyCode={null}
             panActivationKeyCode={null}

--- a/apps/agor-ui/src/contexts/CanvasNavigationContext.tsx
+++ b/apps/agor-ui/src/contexts/CanvasNavigationContext.tsx
@@ -32,18 +32,27 @@ import {
  * position and falls back to the card center when the row isn't
  * rendered (collapsed tree, session not on this card).
  *
+ * Ensure-visible: pass `opts.ensureVisible` alongside a `sessionId` to
+ * make the pan conditional — the camera stays put when the row is already
+ * fully on screen, and otherwise pans just enough to bring it into view
+ * (rather than re-centering). This is what session *selection* uses: a
+ * pan on every click is disorienting and loses the user's context, so we
+ * only move when the row isn't already visible. Deliberate gestures
+ * (double-click, "go to card" locator) omit it and always re-center.
+ *
  * Returns `true` if the camera moved synchronously or a cross-board hop is
  * in flight, `false` otherwise (no canvas mounted, unknown id, no
  * switcher).
  */
-export type RecenterSubTarget = { sessionId?: string };
+export type RecenterSubTarget = { sessionId?: string; ensureVisible?: boolean };
 export type RecenterMapFn = (nodeId: string, subTarget?: RecenterSubTarget) => boolean;
-export type RecenterOpts = { boardId?: string; sessionId?: string };
+export type RecenterOpts = { boardId?: string; sessionId?: string; ensureVisible?: boolean };
 export type BoardSwitcherFn = (boardId: string) => void;
 
 interface PendingRecenter {
   nodeId: string;
   sessionId?: string;
+  ensureVisible?: boolean;
   expiresAt: number;
 }
 
@@ -102,6 +111,7 @@ export function useRegisterBoardSwitcher(fn: BoardSwitcherFn): void {
 export function useConsumePendingRecenter(): () => {
   nodeId: string;
   sessionId?: string;
+  ensureVisible?: boolean;
 } | null {
   const ctx = useContext(CanvasNavigationContext);
   return useCallback(() => {
@@ -112,7 +122,11 @@ export function useConsumePendingRecenter(): () => {
       return null;
     }
     ctx!.pendingRef.current = null;
-    return { nodeId: pending.nodeId, sessionId: pending.sessionId };
+    return {
+      nodeId: pending.nodeId,
+      sessionId: pending.sessionId,
+      ensureVisible: pending.ensureVisible,
+    };
   }, [ctx]);
 }
 
@@ -125,13 +139,17 @@ export function useRecenterMap(): (nodeId: string, opts?: RecenterOpts) => boole
       // Try a synchronous recenter first — covers the common case where the
       // target is on the visible board (or the caller didn't bother to look
       // up `boardId`).
-      const sync = ctx.recenterRef.current?.(nodeId, { sessionId: opts?.sessionId });
+      const sync = ctx.recenterRef.current?.(nodeId, {
+        sessionId: opts?.sessionId,
+        ensureVisible: opts?.ensureVisible,
+      });
       if (sync) return true;
       // Cross-board: stash + switch if we have a target board and a switcher.
       if (opts?.boardId && ctx.boardSwitcherRef.current) {
         ctx.pendingRef.current = {
           nodeId,
           sessionId: opts?.sessionId,
+          ensureVisible: opts?.ensureVisible,
           expiresAt: Date.now() + PENDING_TTL_MS,
         };
         ctx.boardSwitcherRef.current(opts.boardId);

--- a/apps/agor-ui/src/contexts/CanvasNavigationContext.tsx
+++ b/apps/agor-ui/src/contexts/CanvasNavigationContext.tsx
@@ -26,16 +26,24 @@ import {
  * different board. The hook stashes the target, asks App to switch boards,
  * and the new SessionCanvas drains the pending target once its nodes load.
  *
+ * Sub-target: pass `opts.sessionId` to aim the camera at a specific
+ * session row rendered inside the target card (the genealogy-tree item)
+ * instead of the card's center. The canvas measures the row's DOM
+ * position and falls back to the card center when the row isn't
+ * rendered (collapsed tree, session not on this card).
+ *
  * Returns `true` if the camera moved synchronously or a cross-board hop is
  * in flight, `false` otherwise (no canvas mounted, unknown id, no
  * switcher).
  */
-export type RecenterMapFn = (nodeId: string) => boolean;
-export type RecenterOpts = { boardId?: string };
+export type RecenterSubTarget = { sessionId?: string };
+export type RecenterMapFn = (nodeId: string, subTarget?: RecenterSubTarget) => boolean;
+export type RecenterOpts = { boardId?: string; sessionId?: string };
 export type BoardSwitcherFn = (boardId: string) => void;
 
 interface PendingRecenter {
   nodeId: string;
+  sessionId?: string;
   expiresAt: number;
 }
 
@@ -90,8 +98,11 @@ export function useRegisterBoardSwitcher(fn: BoardSwitcherFn): void {
 }
 
 /** SessionCanvas drains the stash once its new board's nodes are ready.
- *  Returns the pending node id (and clears it) if one is live, else null. */
-export function useConsumePendingRecenter(): () => string | null {
+ *  Returns the pending target (and clears it) if one is live, else null. */
+export function useConsumePendingRecenter(): () => {
+  nodeId: string;
+  sessionId?: string;
+} | null {
   const ctx = useContext(CanvasNavigationContext);
   return useCallback(() => {
     const pending = ctx?.pendingRef.current;
@@ -101,7 +112,7 @@ export function useConsumePendingRecenter(): () => string | null {
       return null;
     }
     ctx!.pendingRef.current = null;
-    return pending.nodeId;
+    return { nodeId: pending.nodeId, sessionId: pending.sessionId };
   }, [ctx]);
 }
 
@@ -114,12 +125,13 @@ export function useRecenterMap(): (nodeId: string, opts?: RecenterOpts) => boole
       // Try a synchronous recenter first — covers the common case where the
       // target is on the visible board (or the caller didn't bother to look
       // up `boardId`).
-      const sync = ctx.recenterRef.current?.(nodeId);
+      const sync = ctx.recenterRef.current?.(nodeId, { sessionId: opts?.sessionId });
       if (sync) return true;
       // Cross-board: stash + switch if we have a target board and a switcher.
       if (opts?.boardId && ctx.boardSwitcherRef.current) {
         ctx.pendingRef.current = {
           nodeId,
+          sessionId: opts?.sessionId,
           expiresAt: Date.now() + PENDING_TTL_MS,
         };
         ctx.boardSwitcherRef.current(opts.boardId);

--- a/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
+++ b/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
@@ -144,7 +144,9 @@ describe('useAppNavigation.goToSession', () => {
     // The reported bug was the camera jerking to the branch card's head
     // when a session was selected. The fix keeps the pan but aims it at
     // the session's own row inside the card: the recenter must carry the
-    // session id as a sub-target.
+    // session id as a sub-target, and `ensureVisible` so the camera only
+    // moves when that row isn't already on screen (no jump on a re-click
+    // of a session that's already in view).
     const session = {
       session_id: NEW_SESSION_ID,
       branch_id: EXISTING_BRANCH_ID,
@@ -172,7 +174,10 @@ describe('useAppNavigation.goToSession', () => {
       result.current.nav.goToSession(NEW_SESSION_ID);
     });
 
-    expect(recenter).toHaveBeenCalledWith(EXISTING_BRANCH_ID, { sessionId: NEW_SESSION_ID });
+    expect(recenter).toHaveBeenCalledWith(EXISTING_BRANCH_ID, {
+      sessionId: NEW_SESSION_ID,
+      ensureVisible: true,
+    });
     expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
   });
 });

--- a/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
+++ b/apps/agor-ui/src/hooks/useAppNavigation.test.tsx
@@ -8,8 +8,9 @@
  * resolves. The socket-driven `sessionById` update may arrive a tick later,
  * so a strict `if (!session) return` guard inside `goToSession` would
  * silently strand the user on the prior URL — the very regression this
- * fix addresses. The lookup is now scoped to the same-URL recenter
- * fallback (where it actually matters) instead of gating the navigation.
+ * fix addresses. The session lookup is scoped to the same-URL recenter
+ * fallback (where it aims the camera at the session's row inside its
+ * branch card) instead of gating the navigation.
  *
  * The same contract applies to `goToBranch` and `goToBoard` — used by the
  * post-create handlers in `App/App.tsx` (handleCreateBranch,
@@ -21,8 +22,8 @@ import type { Branch, Session } from '@agor-live/client';
 import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
-import { CanvasNavigationProvider } from '../contexts/CanvasNavigationContext';
+import { describe, expect, it, vi } from 'vitest';
+import { CanvasNavigationProvider, useRegisterRecenter } from '../contexts/CanvasNavigationContext';
 import { useAppNavigation } from './useAppNavigation';
 
 // A real UUIDv7. `shortId` strips hyphens and keeps the first
@@ -115,9 +116,9 @@ describe('useAppNavigation.goToSession', () => {
 
   it('does not blow up on same-URL re-click when session is unknown', () => {
     // Already on the target session URL but sessionById is empty (deep-link
-    // load where data hasn't streamed in yet). The same-URL fallback used
-    // to dereference `session.branch_id` — assert it's safe with a missing
-    // session.
+    // load where data hasn't streamed in yet). The same-URL fallback
+    // dereferences `session.branch_id` — assert it's safe with a missing
+    // session (no navigation, no crash).
     const { result } = renderHook(
       () =>
         useTestNav({
@@ -136,6 +137,42 @@ describe('useAppNavigation.goToSession', () => {
     }).not.toThrow();
 
     // No navigation should have happened — already on this URL.
+    expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
+  });
+
+  it('recenters onto the session row (not the card head) on same-URL re-click of a known session', () => {
+    // The reported bug was the camera jerking to the branch card's head
+    // when a session was selected. The fix keeps the pan but aims it at
+    // the session's own row inside the card: the recenter must carry the
+    // session id as a sub-target.
+    const session = {
+      session_id: NEW_SESSION_ID,
+      branch_id: EXISTING_BRANCH_ID,
+    } as Session;
+    const branch = {
+      branch_id: EXISTING_BRANCH_ID,
+      board_id: EXISTING_BOARD_ID,
+    } as Branch;
+
+    const recenter = vi.fn(() => true);
+    const { result } = renderHook(
+      () => {
+        useRegisterRecenter(recenter);
+        return useTestNav({
+          boardById: new Map(),
+          sessionById: new Map([[session.session_id, session]]),
+          branchById: new Map([[branch.branch_id, branch]]),
+          artifactById: new Map(),
+        });
+      },
+      { wrapper: wrap(`/s/${NEW_SESSION_SHORT}/`) }
+    );
+
+    act(() => {
+      result.current.nav.goToSession(NEW_SESSION_ID);
+    });
+
+    expect(recenter).toHaveBeenCalledWith(EXISTING_BRANCH_ID, { sessionId: NEW_SESSION_ID });
     expect(result.current.pathname).toBe(`/s/${NEW_SESSION_SHORT}/`);
   });
 });

--- a/apps/agor-ui/src/hooks/useAppNavigation.ts
+++ b/apps/agor-ui/src/hooks/useAppNavigation.ts
@@ -55,8 +55,9 @@ export interface NavigationOpts {
 }
 
 export interface AppNavigation {
-  /** Navigate to a session's conversation view. Pushes `/s/<short>/`.
-   *  Same-URL clicks (already on this session) just recenter the camera. */
+  /** Navigate to a session's conversation view. Pushes `/s/<short>/` —
+   *  useUrlState recenters onto the session's row inside its branch card.
+   *  Same-URL clicks (already on this session) recenter the row directly. */
   goToSession: (sessionId: string, opts?: NavigationOpts) => void;
   /** Navigate to a branch. Pushes `/w/<short>/` — useUrlState
    *  resolves the branch, switches boards if needed, and recenters. */
@@ -144,13 +145,14 @@ export function useAppNavigation({
       if (!pushPath(sessionPath(sessionId as SessionID), opts)) {
         // Same-URL click on the already-open session — no history
         // transition, so the URL→state recenter effect won't run. Fall
-        // back to a direct recenter via the branch when we have it.
+        // back to a direct recenter aimed at the session's row inside
+        // its branch card (not the card head).
         const session = (sessionByIdRef.current ?? agorStore.getState().sessionById).get(sessionId);
         const branch = session?.branch_id
           ? (branchByIdRef.current ?? agorStore.getState().branchById).get(session.branch_id)
           : undefined;
         if (branch?.board_id) {
-          recenterMap(branch.branch_id, { boardId: branch.board_id });
+          recenterMap(branch.branch_id, { boardId: branch.board_id, sessionId });
         }
       }
     },

--- a/apps/agor-ui/src/hooks/useAppNavigation.ts
+++ b/apps/agor-ui/src/hooks/useAppNavigation.ts
@@ -152,7 +152,14 @@ export function useAppNavigation({
           ? (branchByIdRef.current ?? agorStore.getState().branchById).get(session.branch_id)
           : undefined;
         if (branch?.board_id) {
-          recenterMap(branch.branch_id, { boardId: branch.board_id, sessionId });
+          // ensureVisible: selecting an already-open session shouldn't
+          // yank the camera when its row is already on screen — only
+          // nudge it into view when it isn't. See CanvasNavigationContext.
+          recenterMap(branch.branch_id, {
+            boardId: branch.board_id,
+            sessionId,
+            ensureVisible: true,
+          });
         }
       }
     },

--- a/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
+++ b/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
@@ -263,7 +263,8 @@ describe('useUrlState — session selection recenters onto the session row', () 
       // currentBoardId === the session's board → same-board selection.
       // The recenter must carry the session id so the canvas aims at the
       // session's row inside the card instead of jerking to the card head
-      // (the reported bug).
+      // (the reported bug), plus `ensureVisible` so the pan is conditional
+      // — the camera holds still when the row is already on screen.
       renderAt(
         `/s/${SESSION_SHORT}/`,
         baseOptions({
@@ -279,7 +280,10 @@ describe('useUrlState — session selection recenters onto the session row', () 
         vi.advanceTimersByTime(100);
       });
 
-      expect(recenter).toHaveBeenCalledWith(BRANCH_ID, { sessionId: SESSION_ID });
+      expect(recenter).toHaveBeenCalledWith(BRANCH_ID, {
+        sessionId: SESSION_ID,
+        ensureVisible: true,
+      });
     } finally {
       vi.useRealTimers();
     }
@@ -313,7 +317,10 @@ describe('useUrlState — session selection recenters onto the session row', () 
         vi.advanceTimersByTime(100);
       });
 
-      expect(recenter).toHaveBeenCalledWith(BRANCH_ID, { sessionId: SESSION_ID });
+      expect(recenter).toHaveBeenCalledWith(BRANCH_ID, {
+        sessionId: SESSION_ID,
+        ensureVisible: true,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
+++ b/apps/agor-ui/src/hooks/useUrlState.integration.test.tsx
@@ -22,7 +22,11 @@ import type { Branch, Session } from '@agor-live/client';
 import { act, render } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
-import { CanvasNavigationProvider } from '../contexts/CanvasNavigationContext';
+import {
+  CanvasNavigationProvider,
+  type RecenterMapFn,
+  useRegisterRecenter,
+} from '../contexts/CanvasNavigationContext';
 import { type UseUrlStateOptions, useUrlState } from './useUrlState';
 
 const SESSION_ID = '019e9999-0000-7000-8000-000000000001';
@@ -36,10 +40,15 @@ const BOARD_ID = '019e7777-0000-7000-8000-000000000001';
 function HookHost({
   options,
   pathRef,
+  recenter,
 }: {
   options: UseUrlStateOptions;
   pathRef: { current: string };
+  recenter?: RecenterMapFn;
 }) {
+  // Register a recenter impl so the camera channel isn't a no-op — lets
+  // tests assert whether session URLs fire (or suppress) a recenter.
+  useRegisterRecenter(recenter ?? (() => true));
   useUrlState(options);
   pathRef.current = useLocation().pathname;
   return null;
@@ -48,7 +57,7 @@ function HookHost({
 /** Mount HookHost inside the session-deep-link route so `useParams`
  *  inside `useUrlState` sees `sessionShortId`. Mirrors the routing
  *  shape declared in `apps/agor-ui/src/App.tsx`. */
-function renderAt(pathname: string, options: UseUrlStateOptions) {
+function renderAt(pathname: string, options: UseUrlStateOptions, recenter?: RecenterMapFn) {
   const pathRef = { current: pathname };
   const tree = (opts: UseUrlStateOptions) => (
     <MemoryRouter initialEntries={[pathname]}>
@@ -56,14 +65,20 @@ function renderAt(pathname: string, options: UseUrlStateOptions) {
         <Routes>
           <Route
             path="/s/:sessionShortId/"
-            element={<HookHost options={opts} pathRef={pathRef} />}
+            element={<HookHost options={opts} pathRef={pathRef} recenter={recenter} />}
           />
-          <Route path="/b/:boardParam/" element={<HookHost options={opts} pathRef={pathRef} />} />
+          <Route
+            path="/b/:boardParam/"
+            element={<HookHost options={opts} pathRef={pathRef} recenter={recenter} />}
+          />
           <Route
             path="/w/:branchShortId/"
-            element={<HookHost options={opts} pathRef={pathRef} />}
+            element={<HookHost options={opts} pathRef={pathRef} recenter={recenter} />}
           />
-          <Route path="/*" element={<HookHost options={opts} pathRef={pathRef} />} />
+          <Route
+            path="/*"
+            element={<HookHost options={opts} pathRef={pathRef} recenter={recenter} />}
+          />
         </Routes>
       </CanvasNavigationProvider>
     </MemoryRouter>
@@ -232,5 +247,75 @@ describe('useUrlState — navigating away from a session clears selection', () =
     });
 
     expect(onSessionChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('useUrlState — session selection recenters onto the session row', () => {
+  const OTHER_BOARD_ID = '019e6666-0000-7000-8000-000000000001';
+
+  it('recenters with the session sub-target on same-board selection (not the bare card)', () => {
+    vi.useFakeTimers();
+    try {
+      const recenter = vi.fn<RecenterMapFn>(() => true);
+      const session = { session_id: SESSION_ID, branch_id: BRANCH_ID } as Session;
+      const branch = { branch_id: BRANCH_ID, board_id: BOARD_ID } as Branch;
+
+      // currentBoardId === the session's board → same-board selection.
+      // The recenter must carry the session id so the canvas aims at the
+      // session's row inside the card instead of jerking to the card head
+      // (the reported bug).
+      renderAt(
+        `/s/${SESSION_SHORT}/`,
+        baseOptions({
+          currentBoardId: BOARD_ID,
+          sessionById: new Map([[session.session_id, session]]),
+          branchById: new Map([[branch.branch_id, branch]]),
+        }),
+        recenter
+      );
+
+      // Drain the ~50ms deferred-recenter timer.
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(recenter).toHaveBeenCalledWith(BRANCH_ID, { sessionId: SESSION_ID });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('recenters with the session sub-target when a session link switches boards', () => {
+    vi.useFakeTimers();
+    try {
+      const recenter = vi.fn<RecenterMapFn>(() => true);
+      const session = { session_id: SESSION_ID, branch_id: BRANCH_ID } as Session;
+      const branch = { branch_id: BRANCH_ID, board_id: BOARD_ID } as Branch;
+
+      // currentBoardId differs from the session's board → cross-board hop,
+      // so the user needs the camera to land on the session's row on the
+      // board they just landed on.
+      renderAt(
+        `/s/${SESSION_SHORT}/`,
+        baseOptions({
+          currentBoardId: OTHER_BOARD_ID,
+          boardById: new Map([
+            [BOARD_ID, { board_id: BOARD_ID, slug: 'board' }],
+            [OTHER_BOARD_ID, { board_id: OTHER_BOARD_ID, slug: 'other' }],
+          ]),
+          sessionById: new Map([[session.session_id, session]]),
+          branchById: new Map([[branch.branch_id, branch]]),
+        }),
+        recenter
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(recenter).toHaveBeenCalledWith(BRANCH_ID, { sessionId: SESSION_ID });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/agor-ui/src/hooks/useUrlState.ts
+++ b/apps/agor-ui/src/hooks/useUrlState.ts
@@ -3,7 +3,8 @@
  *
  * Bidirectional sync between URL and React state for board/session
  * selection, plus URL→state recenter side effects for entity deep
- * links (branches, artifacts).
+ * links (sessions aim at their row inside the branch card; branches
+ * and artifacts center on the node).
  *
  * URL shape — flat entity URLs. Boards are addressable in their own
  * right; sub-entities (session/branch/artifact) are keyed by their
@@ -332,6 +333,10 @@ export function useUrlState(options: UseUrlStateOptions) {
     let resolvedSessionId: string | null = null;
     let recenterTargetId: string | null = null;
     let activeUrlTarget: ActiveUrlTarget | null = null;
+    // Set for session URLs: aims the recenter at the session's row inside
+    // the branch card instead of the card center, so selecting a session
+    // pans to the item itself rather than jerking to the card head.
+    let recenterSessionId: string | null = null;
 
     if (urlBoardParam) {
       resolvedBoardId = resolveBoardFromUrl(urlBoardParam);
@@ -350,6 +355,7 @@ export function useUrlState(options: UseUrlStateOptions) {
         if (wt?.board_id) {
           resolvedBoardId = wt.board_id;
           recenterTargetId = wt.branch_id;
+          recenterSessionId = resolvedSessionId;
         }
       }
     } else {
@@ -426,14 +432,18 @@ export function useUrlState(options: UseUrlStateOptions) {
     // commit + ResizeObserver firing; invisible against the 400ms
     // recenter animation. Stored in a ref so a follow-up URL change
     // can cancel a stale pending recenter before it fires.
+    // Session URLs carry `sessionId` so the canvas aims at the session's
+    // row inside the card (not the card head — that jerk was the reported
+    // bug). Branch/artifact deep links center on the node itself.
     if (urlParamsChanged && recenterTargetId && resolvedBoardId) {
       // Any pending timer was cleared at the top of this effect when
       // `urlParamsChanged` flipped — safe to schedule fresh.
       const target = recenterTargetId;
       const boardId = resolvedBoardId;
+      const sessionId = recenterSessionId ?? undefined;
       deferredRecenterTimerRef.current = setTimeout(() => {
         deferredRecenterTimerRef.current = null;
-        recenterMap(target, { boardId });
+        recenterMap(target, { boardId, sessionId });
       }, 50);
     }
   }, [

--- a/apps/agor-ui/src/hooks/useUrlState.ts
+++ b/apps/agor-ui/src/hooks/useUrlState.ts
@@ -434,7 +434,11 @@ export function useUrlState(options: UseUrlStateOptions) {
     // can cancel a stale pending recenter before it fires.
     // Session URLs carry `sessionId` so the canvas aims at the session's
     // row inside the card (not the card head — that jerk was the reported
-    // bug). Branch/artifact deep links center on the node itself.
+    // bug). `ensureVisible` keeps the pan conditional: if the row is
+    // already on screen (e.g. selecting another session on the same
+    // visible card) the camera holds still; deep links and cross-board
+    // hops still bring the off-screen row into view. Branch/artifact deep
+    // links center on the node itself.
     if (urlParamsChanged && recenterTargetId && resolvedBoardId) {
       // Any pending timer was cleared at the top of this effect when
       // `urlParamsChanged` flipped — safe to schedule fresh.
@@ -443,7 +447,7 @@ export function useUrlState(options: UseUrlStateOptions) {
       const sessionId = recenterSessionId ?? undefined;
       deferredRecenterTimerRef.current = setTimeout(() => {
         deferredRecenterTimerRef.current = null;
-        recenterMap(target, { boardId, sessionId });
+        recenterMap(target, { boardId, sessionId, ensureVisible: sessionId != null });
       }, 50);
     }
   }, [


### PR DESCRIPTION
## Problem

Selecting a session (from the session list, a deep link, or re-clicking the currently open session) recentered the board camera on its branch card's **center/head** — so the view jerked away from the row the user clicked, and a pan fired on *every* click even when the session was already right there on screen. Both were disorienting and cost the user their place on the canvas.

## Fix

Selection still aims at the session's own row (not the card head), but the pan is now **conditional**. An `ensureVisible` mode threads through the recenter channel end to end:

- **`CanvasNavigationContext`** — `RecenterMapFn`, `RecenterOpts`/`RecenterSubTarget`, and the cross-board pending-recenter stash carry an optional `sessionId` and an `ensureVisible` flag alongside the node id.
- **`SessionCanvas.recenterOnNode`** — measures the session row's DOM offset inside the card (rows are tagged with `data-session-id`). In `ensureVisible` mode it compares the row against the visible pane rect — **clamped to the window** so rows in the header-offset phantom strip below the fold aren't mistaken for on-screen — and:
  - holds the camera still when the row is already fully visible;
  - otherwise pans by just the screen-space delta needed to bring it into view (with a small margin), keeping zoom unchanged, instead of re-centering.
  - Falls back to centering on the card when the row isn't rendered (collapsed tree, session not on this card).
- **`useUrlState`** / **`useAppNavigation.goToSession`** — session selection (deep link, same-URL re-click, same-board and cross-board hops) passes `ensureVisible: true`. Deliberate gestures and non-session deep links still re-center.
- **Double-click recenter removed** — the previous double-click-to-recenter handler is dropped and React Flow's default `zoomOnDoubleClick` is restored.

## Testing

- `useAppNavigation` test: same-URL re-click of a known session recenters with `{ sessionId, ensureVisible: true }`.
- `useUrlState` integration tests: session URL selection carries the session sub-target and `ensureVisible` on both same-board and cross-board recenters.
- `pnpm vitest run src/hooks/useAppNavigation.test.tsx src/hooks/useUrlState.integration.test.tsx` — 16/16 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
