### PR TITLE
chore(config): retire obsolete tenant defaults

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3772,13 +3772,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           // flag exists so the UI can skip rendering buttons that would fail.
           // Defaults to true when the config key is unset.
           webTerminal: config.execution?.allow_web_terminal !== false,
-          // Legacy managed-environment minimum-role value retained for
-          // compatibility with older clients. Current environment control
-          // authorization is enforced by the branches service from effective
-          // branch `all` permission or admin access.
-          // Value: 'none' | 'viewer' | 'member' | 'admin' | 'superadmin'.
-          // Defaults to 'member' when unset.
-          managedEnvsMinimumRole: config.execution?.managed_envs_minimum_role ?? 'member',
           // How managed environment lifecycle fields execute. In
           // webhook-only mode the UI/MCP may still show env controls, but
           // non-URL rendered commands are rejected server-side.

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -713,7 +713,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   }
 
   /**
-   * Override create to inject config-driven branch defaults.
+   * Override create to inject board permission defaults.
    */
   async create(
     data: Partial<Branch> | Partial<Branch>[],

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -674,19 +674,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       return withDefaults;
     }
 
-    const config = await loadConfig();
-    const defaults = config.branches;
-    if (!defaults) return withDefaults;
-
-    if (defaults.others_can_default !== undefined && withDefaults.others_can === undefined) {
-      withDefaults.others_can = defaults.others_can_default;
-    }
-    if (
-      defaults.others_fs_access_default !== undefined &&
-      withDefaults.others_fs_access === undefined
-    ) {
-      withDefaults.others_fs_access = defaults.others_fs_access_default;
-    }
     return withDefaults;
   }
 

--- a/apps/agor-daemon/src/services/config.ts
+++ b/apps/agor-daemon/src/services/config.ts
@@ -140,8 +140,8 @@ export class ConfigService {
     // This method returns plaintext secret material and is only for trusted
     // daemon/executor flows. External callers must authenticate either as the
     // service account or with a task-scoped executor runtime JWT. Normal
-    // user/API-key auth may read masked config via /config but must not resolve
-    // raw configured keys.
+    // user/API-key auth must not resolve raw configured keys. The former
+    // general-purpose /config read endpoint no longer exists.
     let executorPayload = getExecutorTokenPayload(params);
     if (!executorPayload && params?.provider && data.executorSessionToken) {
       const sessionTokenService = (

--- a/apps/agor-daemon/src/setup/first-run-admin.test.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.test.ts
@@ -117,7 +117,19 @@ describe('warnDeprecatedConfig', () => {
     expect(written).toContain('onboarding.teammatePending: true');
     expect(written).toContain('onboarding.frameworkRepoUrl: https://example.test/repo.git');
     expect(written).toContain('teammates.framework_repo_url');
-    expect(written).toContain('Onboarding progress is stored');
+    expect(written).toContain('onboarding progress is stored');
+  });
+
+  it('warns about retired branch defaults and managed-environment role config', () => {
+    warnDeprecatedConfig({
+      execution: { managed_envs_minimum_role: 'admin' },
+      branches: { others_can_default: 'view', others_fs_access_default: 'none' },
+    } as unknown as AgorConfig);
+    expect(written).toContain('execution.managed_envs_minimum_role: admin');
+    expect(written).toContain('branches.others_can_default: view');
+    expect(written).toContain('branches.others_fs_access_default: none');
+    expect(written).toContain('typed board defaults');
+    expect(written).toContain('effective branch permissions');
   });
 });
 

--- a/apps/agor-daemon/src/setup/first-run-admin.ts
+++ b/apps/agor-daemon/src/setup/first-run-admin.ts
@@ -261,13 +261,6 @@ export function logFirstRunAdminBootstrap(result: DaemonBootstrapResult): void {
 }
 
 /**
- * Keys that used to control the (now-removed) anonymous-mode path. Surfaced
- * as deprecation warnings on startup so operators upgrading from an older
- * release see a clear migration note instead of a silent ignore.
- */
-const DEPRECATED_ANONYMOUS_KEYS = ['allowAnonymous', 'requireAuth'] as const;
-
-/**
  * Print a clear stderr banner if the loaded config still carries retired
  * upgrade-only keys. The keys have no runtime effect anymore — this is purely
  * an operator-UX nudge.
@@ -278,15 +271,18 @@ const DEPRECATED_ANONYMOUS_KEYS = ['allowAnonymous', 'requireAuth'] as const;
  */
 export function warnDeprecatedConfig(config: AgorConfig): void {
   const legacy = config as AgorConfig & {
+    daemon?: Record<string, unknown>;
     defaults?: Record<string, unknown>;
     display?: Record<string, unknown>;
+    execution?: Record<string, unknown>;
+    branches?: Record<string, unknown>;
     onboarding?: Record<string, unknown>;
   };
-  const daemon = (config as { daemon?: Record<string, unknown> }).daemon;
+  const daemon = legacy.daemon;
   const display = legacy.display;
 
-  const present = daemon
-    ? DEPRECATED_ANONYMOUS_KEYS.filter((key) => Object.hasOwn(daemon, key))
+  const presentDaemon = daemon
+    ? RETIRED_CONFIG_KEYS.daemon.filter((key) => Object.hasOwn(daemon, key))
     : [];
   const presentDisplay = display
     ? RETIRED_CONFIG_KEYS.display.filter((key) => Object.hasOwn(display, key))
@@ -294,15 +290,23 @@ export function warnDeprecatedConfig(config: AgorConfig): void {
   const presentDefaults = legacy.defaults
     ? RETIRED_CONFIG_KEYS.defaults.filter((key) => Object.hasOwn(legacy.defaults!, key))
     : [];
+  const presentExecution = legacy.execution
+    ? RETIRED_CONFIG_KEYS.execution.filter((key) => Object.hasOwn(legacy.execution!, key))
+    : [];
+  const presentBranches = legacy.branches
+    ? RETIRED_CONFIG_KEYS.branches.filter((key) => Object.hasOwn(legacy.branches!, key))
+    : [];
   const presentOnboarding = legacy.onboarding
     ? RETIRED_CONFIG_KEYS.onboarding.filter((key) => Object.hasOwn(legacy.onboarding!, key))
     : [];
   const hasLegacyFrameworkRepoUrl =
     !!legacy.onboarding && Object.hasOwn(legacy.onboarding, 'frameworkRepoUrl');
   if (
-    present.length === 0 &&
+    presentDaemon.length === 0 &&
     presentDisplay.length === 0 &&
     presentDefaults.length === 0 &&
+    presentExecution.length === 0 &&
+    presentBranches.length === 0 &&
     presentOnboarding.length === 0 &&
     !hasLegacyFrameworkRepoUrl
   )
@@ -315,7 +319,7 @@ export function warnDeprecatedConfig(config: AgorConfig): void {
     '----------------------------------------------------------------',
     '  Your config.yaml contains:',
   ];
-  for (const key of present) {
+  for (const key of presentDaemon) {
     lines.push(`    daemon.${key}: ${String(daemon?.[key])}`);
   }
   for (const key of presentDisplay) {
@@ -323,6 +327,12 @@ export function warnDeprecatedConfig(config: AgorConfig): void {
   }
   for (const key of presentDefaults) {
     lines.push(`    defaults.${key}: ${String(legacy.defaults?.[key])}`);
+  }
+  for (const key of presentExecution) {
+    lines.push(`    execution.${key}: ${String(legacy.execution?.[key])}`);
+  }
+  for (const key of presentBranches) {
+    lines.push(`    branches.${key}: ${String(legacy.branches?.[key])}`);
   }
   for (const key of presentOnboarding) {
     lines.push(`    onboarding.${key}: ${String(legacy.onboarding?.[key])}`);
@@ -335,13 +345,15 @@ export function warnDeprecatedConfig(config: AgorConfig): void {
   }
   lines.push(
     '',
-    '  Retired keys no longer have any effect. Onboarding progress is stored',
-    '  per user. The renamed framework repository key remains a compatibility',
-    '  fallback, but new configuration should use the replacement shown above.',
+    '  Retired keys no longer have any effect. Branch creation permissions now',
+    '  come from typed board defaults, managed-environment control comes from',
+    '  effective branch permissions, and onboarding progress is stored per user.',
+    '  The renamed framework repository key remains a compatibility fallback,',
+    '  but new configuration should use the replacement shown above.',
     '',
     '  Action: remove these keys from your config.yaml at your convenience.'
   );
-  if (present.length > 0) {
+  if (presentDaemon.length > 0) {
     lines.push(
       '  If you previously ran anonymously, the daemon has auto-generated',
       `  admin credentials at ${getAdminCredentialsPath()}`,

--- a/apps/agor-daemon/src/utils/authorization.test.ts
+++ b/apps/agor-daemon/src/utils/authorization.test.ts
@@ -9,12 +9,7 @@ import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type { AuthenticatedParams, HookContext } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import {
-  ensureCanTriggerManagedEnv,
-  ensureMinimumRole,
-  registerAuthenticatedRoute,
-  requireMinimumRole,
-} from './authorization';
+import { ensureMinimumRole, registerAuthenticatedRoute, requireMinimumRole } from './authorization';
 
 /** Helper to create authenticated params for a given role and provider */
 function makeParams(role: string, provider: string | undefined = 'rest'): AuthenticatedParams {
@@ -139,69 +134,6 @@ describe('ensureMinimumRole', () => {
       } as AuthenticatedParams;
       expect(() => ensureMinimumRole(params, ROLES.ADMIN)).not.toThrow();
     });
-  });
-});
-
-describe('ensureCanTriggerManagedEnv', () => {
-  it('defaults to MEMBER when minimumRole is undefined', () => {
-    expect(() =>
-      ensureCanTriggerManagedEnv(undefined, makeParams(ROLES.MEMBER), 'start env')
-    ).not.toThrow();
-    expect(() =>
-      ensureCanTriggerManagedEnv(undefined, makeParams(ROLES.VIEWER), 'start env')
-    ).toThrow(Forbidden);
-  });
-
-  it("'none' kill-switch throws Forbidden for any external caller, even superadmin", () => {
-    expect(() =>
-      ensureCanTriggerManagedEnv('none', makeParams(ROLES.SUPERADMIN), 'start env')
-    ).toThrow(Forbidden);
-    expect(() => ensureCanTriggerManagedEnv('none', makeParams(ROLES.ADMIN), 'start env')).toThrow(
-      Forbidden
-    );
-  });
-
-  it("'none' kill-switch allows internal calls (no provider)", () => {
-    // Daemon-initiated health loops, scheduler, etc. must not be blocked.
-    const internal = {
-      user: { user_id: 'u1', email: 'a@b.c', role: ROLES.ADMIN },
-      authenticated: true,
-    } as AuthenticatedParams;
-    expect(() => ensureCanTriggerManagedEnv('none', internal, 'start env')).not.toThrow();
-    expect(() => ensureCanTriggerManagedEnv('none', undefined, 'start env')).not.toThrow();
-  });
-
-  it("'admin' blocks members but allows admins/superadmins", () => {
-    expect(() =>
-      ensureCanTriggerManagedEnv(ROLES.ADMIN, makeParams(ROLES.MEMBER), 'start env')
-    ).toThrow(Forbidden);
-    expect(() =>
-      ensureCanTriggerManagedEnv(ROLES.ADMIN, makeParams(ROLES.ADMIN), 'start env')
-    ).not.toThrow();
-    expect(() =>
-      ensureCanTriggerManagedEnv(ROLES.ADMIN, makeParams(ROLES.SUPERADMIN), 'start env')
-    ).not.toThrow();
-  });
-
-  it('enforces MCP provider parity with REST', () => {
-    // MCP tools must hit the same gate as REST routes.
-    expect(() =>
-      ensureCanTriggerManagedEnv(ROLES.ADMIN, makeParams(ROLES.MEMBER, 'mcp'), 'start env')
-    ).toThrow(Forbidden);
-  });
-
-  it('service accounts bypass the gate (same as ensureMinimumRole)', () => {
-    const svc = {
-      user: {
-        user_id: 'svc',
-        email: 'svc@internal',
-        role: ROLES.VIEWER,
-        _isServiceAccount: true,
-      },
-      authenticated: true,
-      provider: 'rest',
-    } as AuthenticatedParams;
-    expect(() => ensureCanTriggerManagedEnv(ROLES.ADMIN, svc, 'start env')).not.toThrow();
   });
 });
 

--- a/apps/agor-daemon/src/utils/authorization.ts
+++ b/apps/agor-daemon/src/utils/authorization.ts
@@ -2,7 +2,6 @@
  * Authorization utilities for Feathers services and custom routes.
  */
 
-import type { ManagedEnvsMinimumRole } from '@agor/core/config';
 import { Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type { AuthenticatedParams, HookContext, UserRole } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
@@ -49,41 +48,6 @@ export function requireMinimumRole(minimumRole: Role, action?: string) {
     ensureMinimumRole(context.params, minimumRole, action);
     return context;
   };
-}
-
-/**
- * Default minimum role for triggering managed environment commands.
- * Keep in sync with `AgorExecutionSettings.managed_envs_minimum_role`.
- */
-const DEFAULT_MANAGED_ENVS_MINIMUM_ROLE: UserRole = ROLES.MEMBER;
-
-/**
- * Enforce the `execution.managed_envs_minimum_role` config on managed
- * environment triggers (start/stop/nuke/logs).
- *
- * - `'none'` is a kill switch: throws Forbidden regardless of caller role.
- * - Otherwise delegates to `ensureMinimumRole`, so internal calls and service
- *   accounts bypass (same semantics as other role gates).
- *
- * Canonical enforcement point — called from the service layer so that REST,
- * WebSocket, *and* MCP tool invocations all pass through the same gate.
- */
-export function ensureCanTriggerManagedEnv(
-  minimumRole: ManagedEnvsMinimumRole | undefined,
-  params: AuthenticatedParams | undefined,
-  action: string
-): void {
-  const value = minimumRole ?? DEFAULT_MANAGED_ENVS_MINIMUM_ROLE;
-
-  if (value === 'none') {
-    // Internal calls still bypass (daemon-initiated health loops, etc.)
-    if (!params?.provider) return;
-    throw new Forbidden(
-      `Managed environments are disabled (execution.managed_envs_minimum_role: 'none'); cannot ${action}`
-    );
-  }
-
-  ensureMinimumRole(params, value, action);
 }
 
 /**

--- a/apps/agor-ui/src/hooks/useAuthConfig.ts
+++ b/apps/agor-ui/src/hooks/useAuthConfig.ts
@@ -32,14 +32,6 @@ export interface FeaturesConfig {
    */
   webTerminal?: boolean;
   /**
-   * Minimum role required to trigger managed environment commands
-   * (start/stop/nuke/logs). Value: 'none' | 'viewer' | 'member' | 'admin' |
-   * 'superadmin'. UI uses this to disable trigger buttons with a tooltip for
-   * users below the threshold. Server-side enforcement in
-   * services/branches.ts is the source of truth. Defaults to 'member'.
-   */
-  managedEnvsMinimumRole?: 'none' | 'viewer' | 'member' | 'admin' | 'superadmin';
-  /**
    * How managed environment lifecycle fields are handled by this instance.
    * Defaults to 'hybrid': shell commands and URL webhooks are both supported.
    */

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -274,6 +274,8 @@ describe('loadConfig', () => {
         daemon: { allowAnonymous: false, requireAuth: true },
         defaults: { board: 'main', agent: 'claude-code' },
         display: { shortIdLength: 12, tableStyle: 'ascii', colorOutput: false },
+        execution: { managed_envs_minimum_role: 'admin' },
+        branches: { others_can_default: 'view', others_fs_access_default: 'none' },
         onboarding: { teammatePending: true, frameworkRepoUrl: 'https://example.test/repo.git' },
       }),
       'utf-8'
@@ -282,6 +284,8 @@ describe('loadConfig', () => {
       daemon: { allowAnonymous: false, requireAuth: true },
       defaults: { board: 'main', agent: 'claude-code' },
       display: { shortIdLength: 12, tableStyle: 'ascii', colorOutput: false },
+      execution: { managed_envs_minimum_role: 'admin' },
+      branches: { others_can_default: 'view', others_fs_access_default: 'none' },
       onboarding: { teammatePending: true, frameworkRepoUrl: 'https://example.test/repo.git' },
     });
   });
@@ -806,16 +810,24 @@ describe('getConfigValue', () => {
     expect(value).toBeUndefined();
   });
 
-  it('ignores retired display settings from an existing config file', async () => {
+  it('ignores retired settings from an existing config file', async () => {
     await saveConfig({
+      daemon: { allowAnonymous: false, requireAuth: true },
       defaults: { board: 'legacy', agent: 'legacy-agent' },
       display: { tableStyle: 'ascii', colorOutput: false },
+      execution: { managed_envs_minimum_role: 'admin' },
+      branches: { others_can_default: 'view', others_fs_access_default: 'none' },
       onboarding: { teammatePending: true },
     } as unknown as AgorConfig);
 
+    expect(await getConfigValue('daemon.allowAnonymous')).toBeUndefined();
+    expect(await getConfigValue('daemon.requireAuth')).toBeUndefined();
     expect(await getConfigValue('defaults.board')).toBeUndefined();
     expect(await getConfigValue('display.tableStyle')).toBeUndefined();
     expect(await getConfigValue('display.colorOutput')).toBeUndefined();
+    expect(await getConfigValue('execution.managed_envs_minimum_role')).toBeUndefined();
+    expect(await getConfigValue('branches.others_can_default')).toBeUndefined();
+    expect(await getConfigValue('branches.others_fs_access_default')).toBeUndefined();
     expect(await getConfigValue('onboarding.teammatePending')).toBeUndefined();
   });
 
@@ -839,9 +851,14 @@ describe('setConfigValue', () => {
   });
 
   it.each([
+    'daemon.allowAnonymous',
+    'daemon.requireAuth',
     'display.tableStyle',
     'display.colorOutput',
     'display.shortIdLength',
+    'execution.managed_envs_minimum_role',
+    'branches.others_can_default',
+    'branches.others_fs_access_default',
   ])('rejects newly setting retired key %s', async (key) => {
     await expect(setConfigValue(key, 'legacy')).rejects.toThrow(/has been retired/);
   });

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -23,8 +23,11 @@ import {
 } from './types';
 
 export const RETIRED_CONFIG_KEYS = {
+  daemon: ['allowAnonymous', 'requireAuth'],
   defaults: ['board', 'agent'],
   display: ['tableStyle', 'colorOutput', 'shortIdLength'],
+  execution: ['managed_envs_minimum_role'],
+  branches: ['others_can_default', 'others_fs_access_default'],
   onboarding: ['teammatePending', 'assistantPending', 'persistedAgentPending'],
 } as const;
 
@@ -35,8 +38,11 @@ export const RETIRED_CONFIG_PATHS = new Set<string>(
 );
 
 type LegacyConfig = AgorConfig & {
+  daemon?: AgorConfig['daemon'] & Record<string, unknown>;
   defaults?: Record<string, unknown>;
   display?: Record<string, unknown>;
+  execution?: AgorConfig['execution'] & Record<string, unknown>;
+  branches?: Record<string, unknown>;
   onboarding?: Record<string, unknown>;
 };
 
@@ -304,8 +310,7 @@ function validateConfig(config: AgorConfig): void {
     'cors_allow_sandpack',
     'cors_origins',
     'trust_proxy_hops',
-    'allowAnonymous',
-    'requireAuth',
+    ...RETIRED_CONFIG_KEYS.daemon,
   ]);
   only(config.ui, 'ui', ['base_url', 'port', 'host']);
   only(config.external_launch, 'external_launch', [
@@ -370,7 +375,7 @@ function validateConfig(config: AgorConfig): void {
     'stateless_fs_mode',
     'executor_command_template',
     'required_user_env_vars',
-    'managed_envs_minimum_role',
+    ...RETIRED_CONFIG_KEYS.execution,
     'managed_envs_execution_mode',
     'branch_storage',
   ]);
@@ -409,7 +414,7 @@ function validateConfig(config: AgorConfig): void {
     'extras',
     'override',
   ]);
-  only(config.branches, 'branches', ['others_can_default', 'others_fs_access_default']);
+  only(legacyConfig.branches, 'branches', RETIRED_CONFIG_KEYS.branches);
   only(config.teammates, 'teammates', ['framework_repo_url']);
   only(config.paths, 'paths', ['data_home']);
   only(config.analytics, 'analytics', ['enabled', 'client', 'filters', 'plugins']);
@@ -711,21 +716,30 @@ export async function getConfigValue(key: string): Promise<string | boolean | nu
   const {
     defaults: _retiredDefaults,
     display: _retiredDisplay,
+    branches: _retiredBranches,
     onboarding: _retiredOnboarding,
     ...activeConfig
   } = config as AgorConfig & {
     defaults?: unknown;
     display?: unknown;
+    branches?: unknown;
     onboarding?: unknown;
   };
+  const {
+    allowAnonymous: _retiredAllowAnonymous,
+    requireAuth: _retiredRequireAuth,
+    ...activeDaemon
+  } = (config.daemon ?? {}) as NonNullable<AgorConfig['daemon']> & Record<string, unknown>;
+  const { managed_envs_minimum_role: _retiredManagedEnvsMinimumRole, ...activeExecution } =
+    (config.execution ?? {}) as NonNullable<AgorConfig['execution']> & Record<string, unknown>;
 
   // Merge config with defaults (deep merge for sections)
   const merged = {
     ...defaults,
     ...activeConfig,
-    daemon: { ...defaults.daemon, ...config.daemon },
+    daemon: { ...defaults.daemon, ...activeDaemon },
     ui: { ...defaults.ui, ...config.ui },
-    execution: { ...defaults.execution, ...config.execution },
+    execution: { ...defaults.execution, ...activeExecution },
     paths: { ...defaults.paths, ...config.paths },
     analytics: { ...defaults.analytics, ...config.analytics },
     telemetry: { ...defaults.telemetry, ...config.telemetry },

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -3,17 +3,9 @@
  */
 
 import type { ManagedEnvExecutionMode } from '../environment/webhook';
-import type { BranchPermissionLevel } from '../types/branch';
-import type { UserRole } from '../types/user';
 
 export type { ManagedEnvExecutionMode };
 export type ManagedEnvsExecutionMode = ManagedEnvExecutionMode;
-
-/**
- * Minimum role allowed to trigger managed environment commands
- * (start/stop/nuke/logs). `'none'` disables the feature entirely.
- */
-export type ManagedEnvsMinimumRole = 'none' | UserRole;
 
 /**
  * Type for user-provided JSON data where structure is unknown or dynamic
@@ -483,28 +475,6 @@ export interface AgorExecutionSettings {
   required_user_env_vars?: string[];
 
   /**
-   * Minimum role required to *trigger* managed environment commands
-   * (start/stop/nuke/logs) for a branch.
-   *
-   * - `'none'` — disables triggers for everyone (kill switch; authoring is still allowed)
-   * - `'viewer'` — any authenticated user
-   * - `'member'` — default; members and above
-   * - `'admin'` — admins and superadmins only
-   * - `'superadmin'` — superadmins only
-   *
-   * Default: `'member'`.
-   *
-   * Note: *authoring* env commands (`start_command`, `stop_command`, …, or
-   * `environment_config` on repos) is always gated to admins via
-   * `requireAdminForEnvConfig`. This flag is orthogonal and controls who can
-   * *trigger* those admin-authored commands.
-   *
-   * Branch-level RBAC (`others_can` on each branch) still applies on top
-   * of this flag when `branch_rbac: true`.
-   */
-  managed_envs_minimum_role?: ManagedEnvsMinimumRole;
-
-  /**
    * Managed environment lifecycle execution policy.
    *
    * - `'hybrid'` — default/backwards-compatible mode. Rendered lifecycle
@@ -908,40 +878,6 @@ export interface AgorAnalyticsModulePluginSettings {
   };
 }
 
-/**
- * Branch-level defaults.
- *
- * Top-level `branches:` section (not under `execution:`) because these
- * settings shape *how branches are created*, not how sessions execute.
- * Ignored when `execution.branch_rbac: false` (open-access mode has no
- * per-branch ACL to default).
- */
-export interface AgorBranchesSettings {
-  /**
-   * Default value for a new branch's `others_can` when the caller doesn't
-   * specify one. Controls what non-owners can do on the branch.
-   *
-   * - `'none'`  — private to owners
-   * - `'view'`  — read-only access
-   * - `'session'` (default) — can create own sessions
-   * - `'prompt'` — can prompt others' sessions (inherits their OS identity)
-   * - `'all'`   — full control
-   *
-   * Default: `'session'` (matches current repository-layer default).
-   */
-  others_can_default?: BranchPermissionLevel;
-
-  /**
-   * Default filesystem access tier for non-owners on new branches.
-   * Only meaningful in `unix_user_mode: insulated` or `strict`.
-   *
-   * - `'none'`  — no filesystem access
-   * - `'read'`  (default) — read-only via branch group
-   * - `'write'` — full write access via branch group
-   */
-  others_fs_access_default?: 'none' | 'read' | 'write';
-}
-
 /** Operator-owned defaults for creating AI teammates. */
 export interface AgorTeammateSettings {
   /** Repository cloned by the onboarding wizard when creating the first teammate. */
@@ -1053,9 +989,6 @@ export interface AgorConfig {
   /** Security headers & CORS (CSP extras/override, CORS mode/origins, etc.) */
   security?: AgorSecuritySettings;
 
-  /** Branch-level defaults (others_can_default, others_fs_access_default) */
-  branches?: AgorBranchesSettings;
-
   /** Operator-owned teammate bootstrap settings. */
   teammates?: AgorTeammateSettings;
 
@@ -1095,7 +1028,6 @@ export type ConfigKey =
   | `external_launch.${keyof AgorExternalLaunchSettings}`
   | `execution.${keyof AgorExecutionSettings}`
   | `security.${keyof AgorSecuritySettings}`
-  | `branches.${keyof AgorBranchesSettings}`
   | `teammates.${keyof AgorTeammateSettings}`
   | `paths.${keyof AgorPathSettings}`
   | `analytics.${keyof AgorAnalyticsSettings}`


### PR DESCRIPTION
## Summary

- retire `branches.others_can_default` and `branches.others_fs_access_default` from the canonical config schema and branch-creation path
- rely exclusively on typed board defaults for new branch permissions
- remove the unused `execution.managed_envs_minimum_role` type, authorization helper, health payload, and UI compatibility field
- centralize retired-key handling, including the legacy anonymous-mode keys
- keep existing YAML loadable for upgrades while ignoring retired values, warning operators at startup, and rejecting new CLI writes
- correct the stale comment referring to the removed general `/config` endpoint

## Upgrade behavior

Existing `config.yaml` files containing these keys continue to load so operators receive actionable startup guidance. The values no longer affect runtime behavior, `config get` does not expose them as effective settings, and `config set` rejects attempts to add them again. Operators can remove them with `config unset` or edit the YAML directly.

## Validation

- `pnpm i`
- `pnpm check`
- `pnpm exec vitest run src/config/config-manager.test.ts` — 114 tests
- `pnpm exec vitest run src/utils/authorization.test.ts src/setup/first-run-admin.test.ts src/services/branches.test.ts` — 96 tests
