### PR TITLE
fix(ui): restore Markdown link styling

### DIFF
--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -100,6 +100,15 @@ describe('MarkdownRenderer', () => {
     expect(container.querySelector('a.markdown-heading-anchor[href="#foo-1"]')).toBeInTheDocument();
   });
 
+  it('renders ordinary Markdown links as anchors', async () => {
+    render(<MarkdownRenderer content={'[Streamdown docs](https://streamdown.ai/docs)'} />);
+
+    const link = await screen.findByRole('link', { name: 'Streamdown docs' });
+    expect(link).toHaveAttribute('href', 'https://streamdown.ai/docs');
+    expect(link).toHaveAttribute('data-streamdown', 'link');
+    expect(screen.queryByRole('button', { name: 'Streamdown docs' })).not.toBeInTheDocument();
+  });
+
   it('renders GitHub alert syntax as a semantic, themed callout', async () => {
     const { container } = render(
       <MarkdownRenderer content={'> [!WARNING]\n> Deployments are paused.'} />

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -13,7 +13,7 @@
 
 import { Typography, theme } from 'antd';
 import React, { useMemo } from 'react';
-import { defaultRehypePlugins, Streamdown } from 'streamdown';
+import { defaultRehypePlugins, type LinkSafetyConfig, Streamdown } from 'streamdown';
 import { rehypeHeadingAnchors } from '../../utils/headingAnchors';
 import { highlightMentionsInMarkdown } from '../../utils/highlightMentions';
 import { isDarkTheme } from '../../utils/theme';
@@ -66,6 +66,7 @@ interface MarkdownRendererProps {
 }
 
 const MAX_VEGA_LITE_CHARTS_PER_DOCUMENT = 4;
+const LINK_SAFETY_CONFIG: LinkSafetyConfig = { enabled: false };
 
 // Memoized: Streamdown does meaningful per-render work (syntax highlighting,
 // Mermaid, KaTeX) and this component is rendered once per text block in every
@@ -150,6 +151,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
           className={inline ? 'inline-markdown' : 'markdown-content'}
           isAnimating={isStreaming} // Disable buttons during streaming
           controls={showControls} // Show/hide controls based on context
+          linkSafety={LINK_SAFETY_CONFIG}
           mermaid={{ config: mermaidConfig }} // Set Mermaid theme based on current theme mode
           plugins={plugins}
           components={components}


### PR DESCRIPTION
## Linked issue

Fixes #1991

## Summary

- Disable Streamdown link safety once in the shared `MarkdownRenderer`.
- Restore ordinary Markdown links to anchor rendering and the pre-upgrade scoped link appearance.
- Add regression coverage for link semantics, destination, and Streamdown scoping.

## Why / context

Streamdown 2 enables link safety by default and renders Markdown links as buttons. Its button reset relies on Tailwind utilities that Agor does not provide, so native white button chrome leaked into Markdown content, especially in dark mode.

## Implementation notes

A stable module-level `LinkSafetyConfig` is passed to the sole production `<Streamdown>` instance. This avoids caller-by-caller configuration and global CSS changes. Streamdown sanitization, unsafe-URL blocking, and external-link hardening remain enabled.

## Validation / test plan

- [x] Regression test failed before the fix because the link rendered as a button.
- [x] MarkdownRenderer tests: 17 passed.
- [x] Full Agor UI test suite: 1,013 passed across 156 files.
- [x] Biome checks on both changed files.
- [x] `git diff --check`.
- [x] Independent fixed-base code review: clean, no findings.
- [x] Live isolated SQLite Agor instance at `buildSha=9d3a153`.
- [x] Dark-mode branch note rendered one `a[data-streamdown="link"]` and zero `button[data-streamdown="link"]`.
- [x] Live computed styles showed a transparent background, no border, underline, primary theme color, and zero padding.
- [x] An unrelated application link retained its Ant Design classes and had no `data-streamdown` attribute.
- [ ] UI typecheck could not complete because existing workspace package declarations for `@agor-live/client` and `@agor/core` were unavailable.

## Screenshots / demos
<img width="347" height="150" alt="Screenshot 2026-07-22 at 21 42 07" src="https://github.com/user-attachments/assets/f888a20c-8861-4d9b-a53a-188f91cf860e" />


## Risks / rollout / rollback

This restores the direct-link behavior used before the Streamdown 2 upgrade, so external links open without Streamdown's confirmation interstitial. Sanitization, unsafe-URL blocking, `target="_blank"`, and `rel="noopener noreferrer"` remain active. Roll back by reverting the commit.

## Out of scope / follow-ups

No global CSS utilities, caller-specific flags, or `MarkdownAnchor` behavior changes are included.
