### PR TITLE
fix(ui): theme Streamdown table fullscreen portal

### DIFF
--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
@@ -296,9 +296,13 @@
 }
 
 /* Unlike Mermaid, Streamdown portals table fullscreen views directly to body.
-   StreamdownPortalApp mirrors the active Ant semantic variables there. */
-[data-streamdown="table-fullscreen"] {
+   StreamdownPortalApp mirrors the active Ant semantic variables there. Keep
+   this selector more specific than Streamdown's later [data-streamdown]
+   font-family reset, and own the opaque surface instead of relying solely on
+   the generated bg-background utility. */
+body > [data-streamdown="table-fullscreen"] {
   z-index: var(--streamdown-fullscreen-z-index);
+  background: var(--ant-color-bg-container);
   color: var(--ant-color-text);
   font-family: var(--ant-font-family);
 }

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.css
@@ -282,7 +282,7 @@
 [data-streamdown="mermaid-fullscreen"] {
   position: fixed;
   inset: 0;
-  z-index: var(--streamdown-mermaid-z-index);
+  z-index: var(--streamdown-fullscreen-z-index);
   box-sizing: border-box;
   display: flex;
   width: 100vw;
@@ -293,6 +293,14 @@
   background: color-mix(in srgb, var(--ant-color-bg-elevated) 95%, transparent);
   color: var(--ant-color-text);
   backdrop-filter: blur(var(--ant-size-xxs));
+}
+
+/* Unlike Mermaid, Streamdown portals table fullscreen views directly to body.
+   StreamdownPortalApp mirrors the active Ant semantic variables there. */
+[data-streamdown="table-fullscreen"] {
+  z-index: var(--streamdown-fullscreen-z-index);
+  color: var(--ant-color-text);
+  font-family: var(--ant-font-family);
 }
 
 [data-streamdown="mermaid-fullscreen"] > [role="presentation"],

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import { ConfigProvider } from 'antd';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  STREAMDOWN_MERMAID_Z_INDEX_VARIABLE,
+  STREAMDOWN_FULLSCREEN_Z_INDEX_VARIABLE,
   STREAMDOWN_PORTAL_ROOT_CLASS_NAME,
   StreamdownPortalApp,
 } from '../StreamdownPortalApp';
@@ -49,7 +49,9 @@ const fenced = (language: string, lines: string[], closed = true) =>
 
 const fullscreenTheme = {
   token: {
+    colorBgContainer: '#234567',
     colorBgElevated: '#123456',
+    fontFamily: 'Portal Test Sans',
     zIndexPopupBase: 4321,
   },
 };
@@ -303,7 +305,7 @@ describe('MarkdownRenderer', () => {
     expect(portalRootStyle.getPropertyValue('--ant-color-bg-elevated').trim()).toBe(
       fullscreenTheme.token.colorBgElevated
     );
-    expect(portalRootStyle.getPropertyValue(STREAMDOWN_MERMAID_Z_INDEX_VARIABLE).trim()).toBe(
+    expect(portalRootStyle.getPropertyValue(STREAMDOWN_FULLSCREEN_Z_INDEX_VARIABLE).trim()).toBe(
       String(fullscreenTheme.token.zIndexPopupBase)
     );
     await waitFor(() => expect(document.body.style.overflow).toBe('hidden'));
@@ -340,6 +342,34 @@ describe('MarkdownRenderer', () => {
     fireEvent.keyDown(document, { key: 'Escape' });
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     expect(document.body.style.overflow).toBe('');
+  });
+
+  it('themes body-portaled table fullscreen views and stacks them above the app', async () => {
+    render(
+      <ConfigProvider theme={fullscreenTheme}>
+        <StreamdownPortalApp>
+          <MarkdownRenderer content={'| Name | Value |\n| --- | ---: |\n| Alpha | 1 |'} />
+        </StreamdownPortalApp>
+      </ConfigProvider>
+    );
+
+    fireEvent.click(await screen.findByTitle('View fullscreen'));
+
+    const dialog = await screen.findByRole('dialog', { name: 'View fullscreen' });
+    expect(dialog).toHaveAttribute('data-streamdown', 'table-fullscreen');
+    expect(document.body).toContainElement(dialog);
+    expect(document.body.style.getPropertyValue('--ant-color-bg-container')).toBe(
+      fullscreenTheme.token.colorBgContainer
+    );
+    expect(document.body.style.getPropertyValue('--ant-font-family')).toBe(
+      fullscreenTheme.token.fontFamily
+    );
+    expect(document.body.style.getPropertyValue(STREAMDOWN_FULLSCREEN_Z_INDEX_VARIABLE)).toBe(
+      String(fullscreenTheme.token.zIndexPopupBase)
+    );
+    expect(markdownRendererStyles).toContain(
+      `[data-streamdown="table-fullscreen"] {\n  z-index: var(${STREAMDOWN_FULLSCREEN_Z_INDEX_VARIABLE});`
+    );
   });
 
   it('keeps an incomplete Vega-Lite fence as copyable code while streaming', async () => {

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -368,7 +368,8 @@ describe('MarkdownRenderer', () => {
       String(fullscreenTheme.token.zIndexPopupBase)
     );
     expect(markdownRendererStyles).toContain(
-      `[data-streamdown="table-fullscreen"] {\n  z-index: var(${STREAMDOWN_FULLSCREEN_Z_INDEX_VARIABLE});`
+      // biome-ignore lint/plugin/noDirectAntCssVar: asserting the contents of the non-React CSS portal contract
+      `body > [data-streamdown="table-fullscreen"] {\n  z-index: var(${STREAMDOWN_FULLSCREEN_Z_INDEX_VARIABLE});\n  background: var(--ant-color-bg-container);`
     );
   });
 

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.layout.test.tsx
@@ -1,0 +1,26 @@
+import type { Message } from '@agor-live/client';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MessageBlock } from './MessageBlock';
+
+describe('MessageBlock layout', () => {
+  it('lets a user bubble shrink around intrinsically wide markdown', () => {
+    const message = {
+      message_id: 'message-1',
+      session_id: 'session-1',
+      type: 'message',
+      role: 'user',
+      index: 0,
+      timestamp: '2026-07-23T00:00:00.000Z',
+      content: '```json\n{"path":"/an/intrinsically/very/wide/path"}\n```',
+      content_preview: 'wide code',
+    } as unknown as Message;
+
+    const { container } = render(<MessageBlock message={message} />);
+    const bubble = container.querySelector<HTMLElement>('.ant-bubble');
+    const body = container.querySelector<HTMLElement>('.ant-bubble-body');
+
+    expect(bubble).toHaveStyle({ maxWidth: '100%' });
+    expect(body).toHaveStyle({ minWidth: '0' });
+  });
+});

--- a/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
+++ b/apps/agor-ui/src/components/MessageBlock/MessageBlock.tsx
@@ -728,6 +728,14 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
                 }
                 variant={isUser || isCallback ? 'filled' : 'outlined'}
                 styles={{
+                  // Bubble.body defaults to min-width:auto. A wide intrinsic
+                  // child (notably Streamdown's max-content code <pre>) can
+                  // therefore make an end-aligned user bubble wider than the
+                  // conversation viewport and push its left edge off-screen.
+                  // Bound the whole row (including avatar) and allow the body
+                  // to shrink; the code body then owns horizontal scrolling.
+                  root: { maxWidth: '100%' },
+                  body: { minWidth: 0 },
                   content: {
                     backgroundColor: isCallback
                       ? token.colorWarningBg
@@ -856,15 +864,17 @@ const MessageBlockInner: React.FC<MessageBlockProps> = ({
                   </CopyableContent>
                 }
                 variant={isCallback ? 'filled' : 'outlined'}
-                styles={
-                  isCallback
+                styles={{
+                  root: { maxWidth: '100%' },
+                  body: { minWidth: 0 },
+                  ...(isCallback
                     ? {
                         content: {
                           backgroundColor: token.colorWarningBg,
                         },
                       }
-                    : undefined
-                }
+                    : {}),
+                }}
               />
             </div>
           );

--- a/apps/agor-ui/src/components/StreamdownPortalApp.tsx
+++ b/apps/agor-ui/src/components/StreamdownPortalApp.tsx
@@ -1,24 +1,71 @@
 import { App as AntApp, theme } from 'antd';
 import type React from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 export const STREAMDOWN_PORTAL_ROOT_CLASS_NAME = 'streamdown-portal-root';
-export const STREAMDOWN_MERMAID_Z_INDEX_VARIABLE = '--streamdown-mermaid-z-index';
+export const STREAMDOWN_FULLSCREEN_Z_INDEX_VARIABLE = '--streamdown-fullscreen-z-index';
 
 interface StreamdownPortalStyle extends React.CSSProperties {
-  '--streamdown-mermaid-z-index': number;
+  '--streamdown-fullscreen-z-index': number;
 }
 
 /**
- * Keeps Streamdown's Mermaid fullscreen portal inside Ant App's CSS-variable
- * scope and exposes the non-emitted popup stacking token to scoped CSS.
+ * Keeps Streamdown portals aligned with Ant Design's theme.
+ *
+ * Mermaid accepts Ant App's popup container and stays inside its CSS-variable
+ * scope. Streamdown's table fullscreen view, however, portals directly to
+ * `document.body`. Mirror the semantic variables used by Streamdown onto body
+ * so that portal also inherits the active light, dark, or custom theme.
  */
 export const StreamdownPortalApp: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { token } = theme.useToken();
   const style = useMemo<StreamdownPortalStyle>(
-    () => ({ '--streamdown-mermaid-z-index': token.zIndexPopupBase }),
+    () => ({ '--streamdown-fullscreen-z-index': token.zIndexPopupBase }),
     [token.zIndexPopupBase]
   );
+  const bodyPortalTokens = useMemo(
+    () => ({
+      '--ant-color-bg-container': token.colorBgContainer,
+      '--ant-color-bg-layout': token.colorBgLayout,
+      '--ant-color-border-secondary': token.colorBorderSecondary,
+      '--ant-color-fill-tertiary': token.colorFillTertiary,
+      '--ant-color-primary': token.colorPrimary,
+      '--ant-color-text': token.colorText,
+      '--ant-color-text-light-solid': token.colorTextLightSolid,
+      '--ant-color-text-secondary': token.colorTextSecondary,
+      '--ant-font-family': token.fontFamily,
+      '--streamdown-fullscreen-z-index': String(token.zIndexPopupBase),
+    }),
+    [
+      token.colorBgContainer,
+      token.colorBgLayout,
+      token.colorBorderSecondary,
+      token.colorFillTertiary,
+      token.colorPrimary,
+      token.colorText,
+      token.colorTextLightSolid,
+      token.colorTextSecondary,
+      token.fontFamily,
+      token.zIndexPopupBase,
+    ]
+  );
+
+  useEffect(() => {
+    const previousValues = new Map<string, string>();
+    for (const [name, value] of Object.entries(bodyPortalTokens)) {
+      previousValues.set(name, document.body.style.getPropertyValue(name));
+      document.body.style.setProperty(name, value);
+    }
+    return () => {
+      for (const [name, value] of previousValues) {
+        if (value) {
+          document.body.style.setProperty(name, value);
+        } else {
+          document.body.style.removeProperty(name);
+        }
+      }
+    };
+  }, [bodyPortalTokens]);
 
   return (
     <AntApp className={STREAMDOWN_PORTAL_ROOT_CLASS_NAME} style={style}>


### PR DESCRIPTION
## Summary

Fix Streamdown data-table fullscreen views rendering as an effectively invisible overlay.

Streamdown portals table fullscreen content directly to `document.body`, outside Ant Design's CSS-variable scope. Its generated `bg-background` and semantic color utilities therefore resolved to transparent/initial values even though Mermaid fullscreen worked through Ant App's popup container.

## Changes

- mirror the small set of Streamdown semantic Ant tokens onto `document.body` for body-level portals
- apply the active text color and font family to table fullscreen content
- use the configured Ant popup z-index so the fullscreen view stacks above the application shell
- generalize the existing Mermaid-only fullscreen z-index token for both fullscreen renderers
- add regression coverage for body portal theming and stacking

## Validation

- MarkdownRenderer tests: **18 passed**
- UI typecheck passed
- Biome passed
- Playwright verified the fullscreen table in dark mode:
  - opaque themed background
  - readable themed text
  - Ant font family
  - z-index `1000`
  - body scroll locked while open
